### PR TITLE
Add unsaved changes indicator and close confirmation

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -112,7 +112,34 @@ struct EditorTabBar: View {
         }
         .background(.bar)
         .frame(height: 30)
-        .fixedSize(horizontal: false, vertical: true) // Не позволяем сжать по вертикали
+        .fixedSize(horizontal: false, vertical: true)
+        .alert(
+            "Unsaved Changes",
+            isPresented: Binding(
+                get: { viewModel.tabPendingClose != nil },
+                set: { if !$0 { viewModel.tabPendingClose = nil } }
+            )
+        ) {
+            Button("Save") {
+                if let tab = viewModel.tabPendingClose {
+                    viewModel.saveAndCloseTab(tab)
+                    viewModel.tabPendingClose = nil
+                }
+            }
+            Button("Don't Save", role: .destructive) {
+                if let tab = viewModel.tabPendingClose {
+                    viewModel.forceCloseTab(tab)
+                    viewModel.tabPendingClose = nil
+                }
+            }
+            Button("Cancel", role: .cancel) {
+                viewModel.tabPendingClose = nil
+            }
+        } message: {
+            if let tab = viewModel.tabPendingClose {
+                Text("Do you want to save changes to \"\(tab.name)\"?")
+            }
+        }
     }
 }
 
@@ -128,14 +155,22 @@ struct EditorTabItem: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            // Крестик закрытия слева
-            Button(action: onClose) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 9, weight: .bold))
-                    .foregroundStyle(.secondary)
+            // Крестик закрытия или индикатор несохранённых изменений
+            if isHovering {
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            } else if tab.hasUnsavedChanges {
+                Circle()
+                    .fill(.white.opacity(0.7))
+                    .frame(width: 8, height: 8)
+            } else {
+                // Невидимый placeholder для стабильной ширины
+                Color.clear.frame(width: 9, height: 9)
             }
-            .buttonStyle(.plain)
-            .opacity(isHovering || isActive ? 1 : 0) // Виден при наведении или если активна
 
             // Иконка файла + имя
             Image(systemName: iconForFile(tab.name))

--- a/Pine/FileTreeViewModel.swift
+++ b/Pine/FileTreeViewModel.swift
@@ -14,6 +14,10 @@ struct EditorTab: Identifiable, Hashable {
     let name: String     // Имя файла (отображается на вкладке)
     let url: URL         // Полный путь
     var content: String  // Содержимое файла
+    var savedContent: String // Содержимое на момент последнего сохранения
+
+    /// Есть ли несохранённые изменения
+    var hasUnsavedChanges: Bool { content != savedContent }
 
     // Hashable по id (не по content — содержимое меняется)
     static func == (lhs: EditorTab, rhs: EditorTab) -> Bool { lhs.id == rhs.id }
@@ -127,12 +131,13 @@ final class FileTreeViewModel {
         // Иначе — читаем файл и создаём новую вкладку
         do {
             let content = try String(contentsOf: node.url, encoding: .utf8)
-            let tab = EditorTab(id: node.url, name: node.name, url: node.url, content: content)
+            let tab = EditorTab(id: node.url, name: node.name, url: node.url, content: content, savedContent: content)
             openTabs.append(tab)
             activeTabID = tab.id
         } catch {
+            let errorText = "// Error: \(error.localizedDescription)"
             let tab = EditorTab(id: node.url, name: node.name, url: node.url,
-                                content: "// Error: \(error.localizedDescription)")
+                                content: errorText, savedContent: errorText)
             openTabs.append(tab)
             activeTabID = tab.id
         }
@@ -140,7 +145,33 @@ final class FileTreeViewModel {
 
     // MARK: - Закрытие вкладки
 
+    /// Вкладка, ожидающая подтверждения закрытия (для алерта)
+    var tabPendingClose: EditorTab?
+
     func closeTab(_ tab: EditorTab) {
+        // Если есть несохранённые изменения — показываем алерт
+        if tab.hasUnsavedChanges {
+            tabPendingClose = tab
+            return
+        }
+        forceCloseTab(tab)
+    }
+
+    /// Сохраняет и закрывает вкладку
+    func saveAndCloseTab(_ tab: EditorTab) {
+        if let index = openTabs.firstIndex(where: { $0.id == tab.id }) {
+            do {
+                try openTabs[index].content.write(to: openTabs[index].url, atomically: true, encoding: .utf8)
+                openTabs[index].savedContent = openTabs[index].content
+            } catch {
+                print("Error saving file: \(error.localizedDescription)")
+            }
+        }
+        forceCloseTab(tab)
+    }
+
+    /// Закрывает вкладку без сохранения
+    func forceCloseTab(_ tab: EditorTab) {
         openTabs.removeAll { $0.id == tab.id }
 
         // Если закрыли активную — переключаемся на последнюю оставшуюся
@@ -152,10 +183,13 @@ final class FileTreeViewModel {
     // MARK: - Сохранение файла
 
     func saveCurrentFile() {
-        guard let tab = activeTab else { return }
+        guard let id = activeTabID,
+              let index = openTabs.firstIndex(where: { $0.id == id })
+        else { return }
 
         do {
-            try tab.content.write(to: tab.url, atomically: true, encoding: .utf8)
+            try openTabs[index].content.write(to: openTabs[index].url, atomically: true, encoding: .utf8)
+            openTabs[index].savedContent = openTabs[index].content
         } catch {
             print("Error saving file: \(error.localizedDescription)")
         }


### PR DESCRIPTION
## Summary
- **Unsaved indicator (#1):** White dot appears on tabs with unsaved changes; replaced by close button on hover
- **Close confirmation (#2):** Alert with Save / Don't Save / Cancel when closing a tab with modifications
- Saved state resets on Cmd+S and when saving from the alert dialog

## Test plan
- [ ] Edit a file → dot appears on tab
- [ ] Cmd+S → dot disappears
- [ ] Close unmodified tab → closes immediately, no alert
- [ ] Close modified tab → alert appears with three options
- [ ] Cancel → tab stays open
- [ ] Don't Save → tab closes, changes discarded
- [ ] Save → tab closes, changes persisted
- [ ] Multiple tabs show correct indicators independently

Closes #1, Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)