### PR TITLE
Fix file tree clicks being ignored

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -326,6 +326,11 @@ struct SidebarView: View {
                 }
             }
         }
+        .onChange(of: viewModel.selectedFile) { _, newFile in
+            if let file = newFile {
+                viewModel.selectFile(file)
+            }
+        }
         .listStyle(.sidebar)
         .navigationTitle("Files")
         .frame(minWidth: 180, idealWidth: 220)
@@ -369,7 +374,6 @@ struct FileNodeRow: View {
         } else {
             Label(node.name, systemImage: iconForFile(node.name))
                 .tag(node)
-                .onTapGesture { viewModel.selectFile(node) }
         }
     }
 

--- a/Pine/FileTreeViewModel.swift
+++ b/Pine/FileTreeViewModel.swift
@@ -120,7 +120,6 @@ final class FileTreeViewModel {
 
     func selectFile(_ node: FileNode) {
         guard !node.isDirectory else { return }
-        selectedFile = node
 
         // Если файл уже открыт — просто переключаемся на его вкладку
         if openTabs.contains(where: { $0.id == node.url }) {


### PR DESCRIPTION
## Summary
- Replaced `.onTapGesture` on file rows with `.onChange(of: selectedFile)` on the `List`, fixing the conflict between the tap gesture and SwiftUI's built-in `List` selection handling
- Removed redundant `selectedFile = node` assignment from `selectFile()` since selection is now managed solely by the `List` binding

Closes #22

## Test plan
- [ ] Click files in the sidebar — each click should reliably open the file
- [ ] Rapidly click different files — all should open without misses
- [ ] Verify already-open files switch tabs correctly when clicked again

🤖 Generated with [Claude Code](https://claude.com/claude-code)