### PR TITLE
Use semantic system colors instead of hardcoded values

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -43,7 +43,7 @@ struct CodeEditorView: NSViewRepresentable {
         scrollView.hasHorizontalScroller = false
         scrollView.autohidesScrollers = true
         scrollView.drawsBackground = true
-        scrollView.backgroundColor = NSColor(white: 0.12, alpha: 1.0)
+        scrollView.backgroundColor = .textBackgroundColor
         scrollView.autoresizingMask = [.width, .height]
 
         // ── Текстовый стек: Storage → LayoutManager → Container → TextView ──
@@ -74,9 +74,9 @@ struct CodeEditorView: NSViewRepresentable {
         textView.isRichText = false
 
         textView.font = editorFont
-        textView.backgroundColor = NSColor(white: 0.12, alpha: 1.0)
-        textView.textColor = NSColor(white: 0.9, alpha: 1.0)
-        textView.insertionPointColor = .white
+        textView.backgroundColor = .textBackgroundColor
+        textView.textColor = .textColor
+        textView.insertionPointColor = .textColor
 
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -165,7 +165,7 @@ struct EditorTabItem: View {
                 .buttonStyle(.plain)
             } else if tab.hasUnsavedChanges {
                 Circle()
-                    .fill(.white.opacity(0.7))
+                    .fill(.secondary)
                     .frame(width: 8, height: 8)
             } else {
                 // Невидимый placeholder для стабильной ширины
@@ -182,7 +182,7 @@ struct EditorTabItem: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 6)
-        .background(isActive ? .white.opacity(0.1) : .clear)
+        .background(isActive ? Color.primary.opacity(0.1) : .clear)
         // Тонкий разделитель справа между вкладками
         .overlay(alignment: .trailing) {
             Divider().frame(height: 16)
@@ -292,7 +292,7 @@ struct TerminalTabItem: View {
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
-        .background(isActive ? .white.opacity(0.1) : .clear)
+        .background(isActive ? Color.primary.opacity(0.1) : .clear)
         .cornerRadius(4)
         .contentShape(Rectangle())
         .onTapGesture(perform: onSelect)

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -13,9 +13,9 @@ final class LineNumberView: NSView {
     weak var textView: NSTextView?
 
     private let gutterFont = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
-    private let gutterTextColor = NSColor(white: 0.45, alpha: 1.0)
-    private let gutterBgColor = NSColor(white: 0.10, alpha: 1.0)
-    private let separatorColor = NSColor(white: 0.20, alpha: 1.0)
+    private let gutterTextColor = NSColor.secondaryLabelColor
+    private let gutterBgColor = NSColor.controlBackgroundColor
+    private let separatorColor = NSColor.separatorColor
 
     var gutterWidth: CGFloat = 40
 

--- a/Pine/SyntaxHighlighter.swift
+++ b/Pine/SyntaxHighlighter.swift
@@ -31,16 +31,29 @@ struct Grammar: Codable {
 struct Theme {
     let colors: [String: NSColor]
 
-    /// Тема по умолчанию — тёмная, похожая на Xcode Dark.
-    static let defaultDark = Theme(colors: [
-        "comment":   NSColor(red: 0.42, green: 0.68, blue: 0.40, alpha: 1),  // Зелёный
-        "string":    NSColor(red: 0.89, green: 0.49, blue: 0.33, alpha: 1),  // Оранжевый
-        "keyword":   NSColor(red: 0.89, green: 0.36, blue: 0.60, alpha: 1),  // Розовый
-        "number":    NSColor(red: 0.82, green: 0.76, blue: 0.42, alpha: 1),  // Жёлтый
-        "type":      NSColor(red: 0.40, green: 0.78, blue: 0.82, alpha: 1),  // Голубой
-        "attribute": NSColor(red: 0.68, green: 0.51, blue: 0.85, alpha: 1),  // Фиолетовый
-        "function":  NSColor(red: 0.40, green: 0.60, blue: 0.90, alpha: 1),  // Синий
+    /// Тема по умолчанию — адаптируется к light/dark mode.
+    static let `default` = Theme(colors: [
+        "comment":   dynamicColor(light: (0.35, 0.55, 0.33), dark: (0.42, 0.68, 0.40)),
+        "string":    dynamicColor(light: (0.76, 0.32, 0.18), dark: (0.89, 0.49, 0.33)),
+        "keyword":   dynamicColor(light: (0.72, 0.20, 0.45), dark: (0.89, 0.36, 0.60)),
+        "number":    dynamicColor(light: (0.64, 0.58, 0.20), dark: (0.82, 0.76, 0.42)),
+        "type":      dynamicColor(light: (0.22, 0.55, 0.60), dark: (0.40, 0.78, 0.82)),
+        "attribute": dynamicColor(light: (0.52, 0.35, 0.70), dark: (0.68, 0.51, 0.85)),
+        "function":  dynamicColor(light: (0.25, 0.42, 0.75), dark: (0.40, 0.60, 0.90)),
     ])
+
+    private static func dynamicColor(
+        light: (CGFloat, CGFloat, CGFloat),
+        dark: (CGFloat, CGFloat, CGFloat)
+    ) -> NSColor {
+        NSColor(name: nil) { appearance in
+            if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
+                return NSColor(red: dark.0, green: dark.1, blue: dark.2, alpha: 1)
+            } else {
+                return NSColor(red: light.0, green: light.1, blue: light.2, alpha: 1)
+            }
+        }
+    }
 
     func color(for scope: String) -> NSColor? {
         colors[scope]
@@ -68,7 +81,7 @@ final class SyntaxHighlighter {
     private var compiledRules: [String: [(regex: NSRegularExpression, scope: String)]] = [:]
 
     /// Текущая тема
-    var theme: Theme = .defaultDark
+    var theme: Theme = .default
 
     private init() {
         loadGrammars()
@@ -177,7 +190,7 @@ final class SyntaxHighlighter {
         // Сбрасываем на базовый стиль
         textStorage.beginEditing()
         textStorage.addAttributes([
-            .foregroundColor: NSColor(white: 0.9, alpha: 1.0),
+            .foregroundColor: NSColor.textColor,
             .font: font
         ], range: fullRange)
 

--- a/Pine/TerminalContentView.swift
+++ b/Pine/TerminalContentView.swift
@@ -33,9 +33,9 @@ struct TerminalContentView: NSViewRepresentable {
 
         // Моноширинный шрифт, тёмный фон
         textView.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-        textView.backgroundColor = NSColor(white: 0.08, alpha: 1.0)
-        textView.textColor = NSColor(white: 0.9, alpha: 1.0)
-        textView.insertionPointColor = .white
+        textView.backgroundColor = .textBackgroundColor
+        textView.textColor = .textColor
+        textView.insertionPointColor = .textColor
 
         // Текст растягивается по ширине
         textView.textContainer?.widthTracksTextView = true


### PR DESCRIPTION
## Summary
- Replaced all hardcoded `NSColor(white:)` values with semantic system colors (`textBackgroundColor`, `textColor`, `controlBackgroundColor`, `secondaryLabelColor`, `separatorColor`)
- Syntax highlighting colors now use `NSColor(name:dynamicProvider:)` with separate light/dark variants for readable contrast in both appearances
- SwiftUI tab bar colors use `.secondary` and `Color.primary.opacity()` instead of `.white`
- App now fully adapts to macOS light/dark mode automatically

Closes #13

## Test plan
- [ ] Dark mode: editor, terminal, gutter, tabs look correct
- [ ] Light mode: switch appearance in System Settings — all UI adapts
- [ ] Syntax highlighting is readable in both modes
- [ ] Cursor is visible in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)