### PR TITLE
Add Git integration: status, diff markers, branch switcher

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -118,6 +118,7 @@ struct CodeEditorView: NSViewRepresentable {
     @Binding var text: String
     var language: String
     var fileName: String?
+    var lineDiffs: [GitLineDiff] = []
 
     private let editorFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
 
@@ -213,8 +214,9 @@ struct CodeEditorView: NSViewRepresentable {
             textView.scrollRangeToVisible(NSRange(location: 0, length: 0))
         }
 
-        // Обновляем размер LineNumberView
+        // Обновляем размер и diff-данные LineNumberView
         if let lineNumberView = context.coordinator.lineNumberView {
+            lineNumberView.lineDiffs = lineDiffs
             lineNumberView.frame = NSRect(
                 x: 0, y: 0,
                 width: lineNumberView.gutterWidth,

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -131,6 +131,8 @@ struct ContentView: View {
     @State private var terminalTabs: [TerminalTab] = [TerminalTab(name: "Terminal")]
     @State private var activeTerminalID: UUID?
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    @State private var lineDiffs: [GitLineDiff] = []
+    @State private var showBranchSwitcher = false
 
     private var hasUnsavedChanges: Bool {
         fileContent != savedContent
@@ -150,15 +152,25 @@ struct ContentView: View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             SidebarView(projectManager: projectManager, selectedFile: $selectedNode)
         } detail: {
-            if isTerminalVisible {
-                VSplitView {
+            VStack(spacing: 0) {
+                if isTerminalVisible {
+                    VSplitView {
+                        editorArea
+                            .frame(maxWidth: .infinity, minHeight: 200, maxHeight: .infinity)
+                        terminalArea
+                            .frame(maxWidth: .infinity, minHeight: 100, idealHeight: 150, maxHeight: .infinity)
+                    }
+                    .frame(maxHeight: .infinity)
+                } else {
                     editorArea
-                        .frame(maxWidth: .infinity, minHeight: 200, maxHeight: .infinity)
-                    terminalArea
-                        .frame(maxWidth: .infinity, minHeight: 100, idealHeight: 150, maxHeight: .infinity)
+                        .frame(maxHeight: .infinity)
                 }
-            } else {
-                editorArea
+                if projectManager.rootURL != nil && projectManager.gitProvider.isGitRepository {
+                    StatusBarView(
+                        gitProvider: projectManager.gitProvider,
+                        showBranchSwitcher: $showBranchSwitcher
+                    )
+                }
             }
         }
         .frame(minWidth: 800, minHeight: 500)
@@ -190,6 +202,11 @@ struct ContentView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .toggleTerminal)) { _ in
             withAnimation { isTerminalVisible.toggle() }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .switchBranch)) { _ in
+            if projectManager.gitProvider.isGitRepository {
+                showBranchSwitcher.toggle()
+            }
         }
     }
 
@@ -228,10 +245,12 @@ struct ContentView: View {
             let content = try String(contentsOf: url, encoding: .utf8)
             fileContent = content
             savedContent = content
+            lineDiffs = projectManager.gitProvider.diffForFile(at: url)
         } catch {
             let errorText = "// Error: \(error.localizedDescription)"
             fileContent = errorText
             savedContent = errorText
+            lineDiffs = []
         }
     }
 
@@ -241,6 +260,9 @@ struct ContentView: View {
             try fileContent.write(to: url, atomically: true, encoding: .utf8)
             savedContent = fileContent
             NSApp.keyWindow?.isDocumentEdited = false
+            // Refresh git status after save
+            projectManager.gitProvider.refresh()
+            lineDiffs = projectManager.gitProvider.diffForFile(at: url)
         } catch {
             print("Error saving file: \(error.localizedDescription)")
         }
@@ -254,7 +276,8 @@ struct ContentView: View {
             CodeEditorView(
                 text: $fileContent,
                 language: (currentFileName as NSString).pathExtension.lowercased(),
-                fileName: currentFileName
+                fileName: currentFileName,
+                lineDiffs: lineDiffs
             )
         } else {
             ContentUnavailableView {
@@ -460,6 +483,14 @@ struct SidebarView: View {
 
 struct FileNodeRow: View {
     var node: FileNode
+    @Environment(ProjectManager.self) var projectManager
+
+    private var gitStatus: GitFileStatus? {
+        let provider = projectManager.gitProvider
+        return node.isDirectory
+            ? provider.statusForDirectory(at: node.url)
+            : provider.statusForFile(at: node.url)
+    }
 
     var body: some View {
         if node.isDirectory {
@@ -477,10 +508,11 @@ struct FileNodeRow: View {
                 }
             } label: {
                 Label(node.name, systemImage: "folder")
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(gitStatus?.color ?? .primary)
             }
         } else {
             Label(node.name, systemImage: iconForFile(node.name))
+                .foregroundStyle(gitStatus?.color ?? .primary)
                 .tag(node)
         }
     }
@@ -498,6 +530,147 @@ struct FileNodeRow: View {
         case "py":                             return "doc.text"
         case "png", "jpg", "jpeg", "gif":      return "photo"
         default:                               return "doc"
+        }
+    }
+}
+
+// MARK: - Status Bar
+
+struct StatusBarView: View {
+    var gitProvider: GitStatusProvider
+    @Binding var showBranchSwitcher: Bool
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Button {
+                showBranchSwitcher.toggle()
+            } label: {
+                HStack(spacing: 3) {
+                    Image(systemName: "arrow.triangle.branch")
+                        .font(.system(size: 10))
+                    Text(gitProvider.currentBranch)
+                        .font(.system(size: 11))
+                }
+                .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .popover(isPresented: $showBranchSwitcher, arrowEdge: .top) {
+                BranchSwitcherView(gitProvider: gitProvider, isPresented: $showBranchSwitcher)
+            }
+
+            // Git file change summary
+            if !gitProvider.fileStatuses.isEmpty {
+                let counts = gitStatusCounts
+                HStack(spacing: 8) {
+                    if counts.modified > 0 {
+                        Label("\(counts.modified)", systemImage: "pencil")
+                            .foregroundStyle(.orange)
+                    }
+                    if counts.added > 0 {
+                        Label("\(counts.added)", systemImage: "plus")
+                            .foregroundStyle(.green)
+                    }
+                    if counts.untracked > 0 {
+                        Label("\(counts.untracked)", systemImage: "questionmark")
+                            .foregroundStyle(.teal)
+                    }
+                }
+                .font(.system(size: 10))
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 8)
+        .frame(height: 22)
+        .background(.bar)
+    }
+
+    private var gitStatusCounts: (modified: Int, added: Int, untracked: Int) {
+        var m = 0, a = 0, u = 0
+        for (_, status) in gitProvider.fileStatuses {
+            switch status {
+            case .modified, .mixed: m += 1
+            case .staged, .added:   a += 1
+            case .untracked:        u += 1
+            default: break
+            }
+        }
+        return (m, a, u)
+    }
+}
+
+// MARK: - Branch Switcher
+
+struct BranchSwitcherView: View {
+    var gitProvider: GitStatusProvider
+    @Binding var isPresented: Bool
+    @State private var searchText = ""
+    @State private var errorMessage = ""
+
+    private var filteredBranches: [String] {
+        if searchText.isEmpty { return gitProvider.branches }
+        return gitProvider.branches.filter {
+            $0.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TextField("Filter branches...", text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .padding(8)
+
+            Divider()
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(filteredBranches, id: \.self) { branch in
+                        Button {
+                            switchToBranch(branch)
+                        } label: {
+                            HStack {
+                                Image(systemName: branch == gitProvider.currentBranch
+                                      ? "checkmark.circle.fill" : "arrow.triangle.branch")
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(branch == gitProvider.currentBranch ? .green : .secondary)
+                                    .frame(width: 16)
+                                Text(branch)
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(branch == gitProvider.currentBranch ? .primary : .secondary)
+                                Spacer()
+                            }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 5)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+            .frame(maxHeight: 300)
+
+            if !errorMessage.isEmpty {
+                Divider()
+                Text(errorMessage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.red)
+                    .padding(8)
+            }
+        }
+        .frame(width: 250)
+    }
+
+    private func switchToBranch(_ branch: String) {
+        guard branch != gitProvider.currentBranch else {
+            isPresented = false
+            return
+        }
+        let result = gitProvider.checkoutBranch(branch)
+        if result.success {
+            errorMessage = ""
+            isPresented = false
+        } else {
+            errorMessage = result.error
         }
     }
 }

--- a/Pine/GitStatusProvider.swift
+++ b/Pine/GitStatusProvider.swift
@@ -1,0 +1,317 @@
+//
+//  GitStatusProvider.swift
+//  Pine
+//
+//  Created by Claude on 10.03.2026.
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - Models
+
+enum GitFileStatus: Equatable {
+    case untracked
+    case modified
+    case staged
+    case added
+    case deleted
+    case conflict
+    case mixed // staged + unstaged changes
+}
+
+extension GitFileStatus {
+    var color: Color {
+        switch self {
+        case .modified, .mixed: return .orange
+        case .staged:           return .green
+        case .added:            return Color(.systemGreen)
+        case .untracked:        return Color(.systemTeal)
+        case .deleted:          return .red
+        case .conflict:         return .red
+        }
+    }
+}
+
+struct GitLineDiff: Equatable {
+    enum Kind { case added, modified, deleted }
+    let line: Int
+    let kind: Kind
+}
+
+// MARK: - GitStatusProvider
+
+@Observable
+final class GitStatusProvider {
+    var currentBranch: String = ""
+    var fileStatuses: [String: GitFileStatus] = [:]
+    var isGitRepository: Bool = false
+    var branches: [String] = []
+
+    private var repositoryURL: URL?
+    private var gitRootPath: String?
+
+    // MARK: - Setup & Refresh
+
+    func setup(repositoryURL: URL) {
+        self.repositoryURL = repositoryURL
+        let result = runGit(["rev-parse", "--show-toplevel"], at: repositoryURL)
+        isGitRepository = result.exitCode == 0
+        if isGitRepository {
+            gitRootPath = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+            refresh()
+        } else {
+            currentBranch = ""
+            fileStatuses = [:]
+            branches = []
+        }
+    }
+
+    func refresh() {
+        guard isGitRepository, let url = repositoryURL else { return }
+        refreshBranch(at: url)
+        refreshFileStatuses(at: url)
+        refreshBranches(at: url)
+    }
+
+    // MARK: - Status Queries
+
+    func statusForFile(at url: URL) -> GitFileStatus? {
+        let relativePath = relativePath(for: url)
+        return relativePath.flatMap { fileStatuses[$0] }
+    }
+
+    func statusForDirectory(at url: URL) -> GitFileStatus? {
+        guard let dirPath = relativePath(for: url) else { return nil }
+        let prefix = dirPath.hasSuffix("/") ? dirPath : dirPath + "/"
+
+        var hasModified = false
+        var hasStaged = false
+        var hasUntracked = false
+        var hasConflict = false
+
+        for (path, status) in fileStatuses {
+            guard path.hasPrefix(prefix) else { continue }
+            switch status {
+            case .conflict:           hasConflict = true
+            case .modified, .mixed:   hasModified = true
+            case .staged, .added:     hasStaged = true
+            case .untracked:          hasUntracked = true
+            case .deleted:            hasModified = true
+            }
+        }
+
+        if hasConflict { return .conflict }
+        if hasModified { return .modified }
+        if hasStaged { return .staged }
+        if hasUntracked { return .untracked }
+        return nil
+    }
+
+    // MARK: - Diff for Gutter
+
+    func diffForFile(at url: URL) -> [GitLineDiff] {
+        guard isGitRepository, let repoURL = repositoryURL else { return [] }
+        // Check if HEAD exists (new repo without commits)
+        let headCheck = runGit(["rev-parse", "HEAD"], at: repoURL)
+        guard headCheck.exitCode == 0 else { return [] }
+
+        let result = runGit(["diff", "HEAD", "--unified=0", "--", url.path], at: repoURL)
+        guard result.exitCode == 0, !result.output.isEmpty else { return [] }
+        return parseDiff(result.output)
+    }
+
+    // MARK: - Branch Operations
+
+    func checkoutBranch(_ branch: String) -> (success: Bool, error: String) {
+        guard let url = repositoryURL else { return (false, "No repository") }
+        let result = runGit(["switch", branch], at: url)
+        if result.exitCode == 0 {
+            refresh()
+            return (true, "")
+        }
+        return (false, result.errorOutput.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    // MARK: - Private Helpers
+
+    private func relativePath(for url: URL) -> String? {
+        guard let rootPath = gitRootPath else { return nil }
+        let filePath = url.path
+        let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        guard filePath.hasPrefix(prefix) else { return nil }
+        return String(filePath.dropFirst(prefix.count))
+    }
+
+    private func refreshBranch(at url: URL) {
+        let result = runGit(["rev-parse", "--abbrev-ref", "HEAD"], at: url)
+        if result.exitCode == 0 {
+            currentBranch = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
+    private func refreshFileStatuses(at url: URL) {
+        let result = runGit(["status", "--porcelain"], at: url)
+        guard result.exitCode == 0 else { return }
+
+        var statuses: [String: GitFileStatus] = [:]
+
+        for line in result.output.components(separatedBy: "\n") {
+            guard line.count >= 3 else { continue }
+            let indexChar = line[line.startIndex]
+            let workTreeChar = line[line.index(after: line.startIndex)]
+            var path = String(line.dropFirst(3))
+
+            // Handle renames: "R  old -> new"
+            if path.contains(" -> ") {
+                let parts = path.components(separatedBy: " -> ")
+                if parts.count == 2 { path = parts[1] }
+            }
+
+            let status: GitFileStatus
+            switch (indexChar, workTreeChar) {
+            case ("?", "?"):
+                status = .untracked
+            case ("U", _), (_, "U"), ("A", "A"), ("D", "D"):
+                status = .conflict
+            case ("A", " "):
+                status = .added
+            case ("D", " "), (" ", "D"):
+                status = .deleted
+            case ("M", " "), ("R", " "):
+                status = .staged
+            case (" ", "M"):
+                status = .modified
+            case ("M", "M"):
+                status = .mixed
+            default:
+                if indexChar != " " && indexChar != "?" {
+                    status = workTreeChar != " " && workTreeChar != "?" ? .mixed : .staged
+                } else {
+                    status = .modified
+                }
+            }
+
+            statuses[path] = status
+        }
+
+        fileStatuses = statuses
+    }
+
+    private func refreshBranches(at url: URL) {
+        let result = runGit(["branch", "--sort=-committerdate", "--format=%(refname:short)"], at: url)
+        guard result.exitCode == 0 else { return }
+        branches = result.output
+            .components(separatedBy: "\n")
+            .filter { !$0.isEmpty }
+    }
+
+    // MARK: - Diff Parser
+
+    private func parseDiff(_ diffOutput: String) -> [GitLineDiff] {
+        var diffs: [GitLineDiff] = []
+        let lines = diffOutput.components(separatedBy: "\n")
+
+        var i = 0
+        while i < lines.count {
+            let line = lines[i]
+
+            guard line.hasPrefix("@@") else {
+                i += 1
+                continue
+            }
+
+            // Parse @@ -old[,count] +new[,count] @@
+            guard let newStart = parseHunkNewStart(line) else {
+                i += 1
+                continue
+            }
+
+            i += 1
+            var newLine = newStart
+
+            while i < lines.count && !lines[i].hasPrefix("@@") && !lines[i].hasPrefix("diff ") {
+                let hl = lines[i]
+
+                if hl.hasPrefix("-") || hl.hasPrefix("+") {
+                    // Collect consecutive block of -/+ lines
+                    var deletions = 0
+                    var additions = 0
+                    let blockNewLine = newLine
+
+                    while i < lines.count && lines[i].hasPrefix("-") {
+                        deletions += 1
+                        i += 1
+                    }
+                    // Skip "\ No newline at end of file"
+                    while i < lines.count && lines[i].hasPrefix("\\") { i += 1 }
+
+                    while i < lines.count && lines[i].hasPrefix("+") {
+                        additions += 1
+                        i += 1
+                    }
+                    while i < lines.count && lines[i].hasPrefix("\\") { i += 1 }
+
+                    let modifiedCount = min(deletions, additions)
+                    let addedCount = additions - modifiedCount
+
+                    for j in 0..<modifiedCount {
+                        diffs.append(GitLineDiff(line: blockNewLine + j, kind: .modified))
+                    }
+                    for j in 0..<addedCount {
+                        diffs.append(GitLineDiff(line: blockNewLine + modifiedCount + j, kind: .added))
+                    }
+                    if deletions > 0 && additions == 0 {
+                        diffs.append(GitLineDiff(line: blockNewLine, kind: .deleted))
+                    }
+
+                    newLine = blockNewLine + additions
+                } else if hl.hasPrefix("\\") {
+                    i += 1
+                } else {
+                    // Context line
+                    newLine += 1
+                    i += 1
+                }
+            }
+        }
+
+        return diffs
+    }
+
+    private func parseHunkNewStart(_ header: String) -> Int? {
+        // Format: @@ -old[,count] +new[,count] @@
+        guard let plusIndex = header.firstIndex(of: "+") else { return nil }
+        let afterPlus = header[header.index(after: plusIndex)...]
+        guard let endIndex = afterPlus.firstIndex(where: { $0 == "," || $0 == " " }) else { return nil }
+        return Int(afterPlus[..<endIndex])
+    }
+
+    // MARK: - Git Command Runner
+
+    private func runGit(_ arguments: [String], at directory: URL) -> (output: String, errorOutput: String, exitCode: Int32) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = arguments
+        process.currentDirectoryURL = directory
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+            let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+            return (
+                String(data: outData, encoding: .utf8) ?? "",
+                String(data: errData, encoding: .utf8) ?? "",
+                process.terminationStatus
+            )
+        } catch {
+            return ("", error.localizedDescription, -1)
+        }
+    }
+}

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -18,6 +18,19 @@ final class LineNumberView: NSView {
     private let separatorColor = NSColor.separatorColor
 
     var gutterWidth: CGFloat = 40
+    var lineDiffs: [GitLineDiff] = [] {
+        didSet { needsDisplay = true }
+    }
+
+    /// Pre-indexed diff lookup: line number → kind
+    private var diffMap: [Int: GitLineDiff.Kind] {
+        Dictionary(lineDiffs.map { ($0.line, $0.kind) }, uniquingKeysWith: { _, last in last })
+    }
+
+    // Diff marker colors
+    private let addedColor = NSColor.systemGreen
+    private let modifiedColor = NSColor.systemBlue
+    private let deletedColor = NSColor.systemRed
 
     override var isFlipped: Bool { true }
 
@@ -130,6 +143,8 @@ final class LineNumberView: NSView {
         // ── Рисуем номера видимых строк через enumerateLineFragments ──
         // Этот метод проходит только по видимым фрагментам строк — быстро.
         var previousLineCharIndex = -1
+        let currentDiffMap = self.diffMap
+        let diffBarWidth: CGFloat = 3
 
         layoutManager.enumerateLineFragments(
             forGlyphRange: visibleGlyphRange
@@ -158,6 +173,40 @@ final class LineNumberView: NSView {
                 let size = numStr.size(withAttributes: attrs)
                 let x = self.gutterWidth - size.width - 8
                 numStr.draw(at: NSPoint(x: x, y: y), withAttributes: attrs)
+
+                // ── Git diff marker ──
+                if let diffKind = currentDiffMap[lineNumber] {
+                    let markerColor: NSColor
+                    switch diffKind {
+                    case .added:    markerColor = self.addedColor
+                    case .modified: markerColor = self.modifiedColor
+                    case .deleted:  markerColor = self.deletedColor
+                    }
+
+                    if diffKind == .deleted {
+                        // Deleted: small red triangle at the gutter edge
+                        let triangleSize: CGFloat = 5
+                        let triX = self.gutterWidth - diffBarWidth
+                        let triY = y
+                        let path = NSBezierPath()
+                        path.move(to: NSPoint(x: triX, y: triY))
+                        path.line(to: NSPoint(x: triX + triangleSize, y: triY + triangleSize / 2))
+                        path.line(to: NSPoint(x: triX, y: triY + triangleSize))
+                        path.close()
+                        markerColor.setFill()
+                        path.fill()
+                    } else {
+                        // Added/Modified: colored bar at the right edge of gutter
+                        let barRect = NSRect(
+                            x: self.gutterWidth - diffBarWidth,
+                            y: y,
+                            width: diffBarWidth,
+                            height: lineRect.height
+                        )
+                        markerColor.setFill()
+                        barRect.fill()
+                    }
+                }
 
                 lineNumber += 1
             }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -35,6 +35,13 @@ struct PineApp: App {
                 }
                 .keyboardShortcut("`", modifiers: .command)
             }
+            // Cmd+Shift+B — переключение веток
+            CommandMenu("Git") {
+                Button("Switch Branch...") {
+                    NotificationCenter.default.post(name: .switchBranch, object: nil)
+                }
+                .keyboardShortcut("b", modifiers: [.command, .shift])
+            }
             // Cmd+S — сохранить файл
             CommandGroup(replacing: .saveItem) {
                 Button("Save") {
@@ -78,4 +85,5 @@ extension Notification.Name {
     static let saveFile = Notification.Name("saveFile")
     static let openFolder = Notification.Name("openFolder")
     static let toggleTerminal = Notification.Name("toggleTerminal")
+    static let switchBranch = Notification.Name("switchBranch")
 }

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -14,6 +14,7 @@ final class ProjectManager {
     var rootNodes: [FileNode] = []
     var projectName: String = "No Project"
     var rootURL: URL?
+    let gitProvider = GitStatusProvider()
 
     func openFolder() {
         let panel = NSOpenPanel()
@@ -34,5 +35,7 @@ final class ProjectManager {
         let root = FileNode(url: url)
         root.loadChildren()
         rootNodes = root.children ?? []
+
+        gitProvider.setup(repositoryURL: url)
     }
 }


### PR DESCRIPTION
## Summary

- **Git status in file tree** — files and directories colored by status: modified (orange), staged (green), untracked (teal), deleted/conflict (red). Directories propagate child status.
- **Diff markers in editor gutter** — green bar for added lines, blue bar for modified lines, red triangle for deleted lines (relative to HEAD).
- **Current branch in status bar** — bottom bar shows branch name + change summary (modified/staged/untracked counts). Visible when a git project is open.
- **Branch switcher** — popover with search/filter, accessible by clicking branch name or Cmd+Shift+B. Shows current branch with checkmark.
- **Git menu** — new top-level menu with "Switch Branch..." command.

New file: `GitStatusProvider.swift` — runs git commands (`status --porcelain`, `diff HEAD`, `branch`, `rev-parse`, `switch`) and parses output.

Closes #31, closes #32, closes #33, closes #34

## Test plan

- [ ] Open a git repository, verify branch name appears in status bar
- [ ] Modify a tracked file, verify orange color in file tree and diff markers in gutter
- [ ] Add a new untracked file, verify teal color in file tree
- [ ] Stage changes, verify green color in file tree
- [ ] Open branch switcher (Cmd+Shift+B or click branch name), verify branch list and switching
- [ ] Open a non-git folder, verify no status bar or git indicators appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)