### PR TITLE
Auto-set app version from git tag in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,14 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security list-keychain -d user -s $KEYCHAIN_PATH
 
+      - name: Set version from tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          BUILD_NUMBER=${GITHUB_RUN_NUMBER}
+          echo "Setting version to $VERSION ($BUILD_NUMBER)"
+          sed -i '' "s/MARKETING_VERSION = .*;/MARKETING_VERSION = $VERSION;/" Pine.xcodeproj/project.pbxproj
+          sed -i '' "s/CURRENT_PROJECT_VERSION = .*;/CURRENT_PROJECT_VERSION = $BUILD_NUMBER;/" Pine.xcodeproj/project.pbxproj
+
       - name: Build archive
         run: |
           xcodebuild archive \


### PR DESCRIPTION
## Summary
- Automatically derive `MARKETING_VERSION` from git tag (e.g. `v0.2.0` → `0.2.0`)
- Set `CURRENT_PROJECT_VERSION` (build number) from `GITHUB_RUN_NUMBER` for auto-increment
- No more manual version bumps — just push a tag

## Test plan
- [ ] Push a new tag and verify the built app shows the correct version in About

🤖 Generated with [Claude Code](https://claude.com/claude-code)