### PR TITLE
Add Homebrew Tap for Pine distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,23 @@ jobs:
             --title "Pine ${{ steps.version.outputs.VERSION }}" \
             --generate-notes
 
+      - name: Update Homebrew Tap
+        env:
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          SHA256=$(shasum -a 256 "$RUNNER_TEMP/Pine.dmg" | awk '{print $1}')
+
+          git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/batonogov/homebrew-tap.git $RUNNER_TEMP/homebrew-tap
+          cd $RUNNER_TEMP/homebrew-tap
+          sed -i '' "s/version \".*\"/version \"$VERSION\"/" Casks/pine.rb
+          sed -i '' "s/sha256 \".*\"/sha256 \"$SHA256\"/" Casks/pine.rb
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/pine.rb
+          git commit -m "Update Pine to $VERSION"
+          git push
+
       - name: Cleanup keychain
         if: always()
         run: security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true


### PR DESCRIPTION
## Summary

- Created [`batonogov/homebrew-tap`](https://github.com/batonogov/homebrew-tap) repository with Cask formula for Pine v0.2.0
- Added auto-update step to `release.yml` that updates the tap on every new release

## How it works

After the GitHub Release is created, the workflow:
1. Computes SHA256 of the DMG
2. Clones `batonogov/homebrew-tap`
3. Updates `version` and `sha256` in `Casks/pine.rb` via `sed`
4. Commits and pushes the change

## Setup required

Add a `TAP_GITHUB_TOKEN` secret to the Pine repo — a Personal Access Token (classic) with `repo` scope to push to `homebrew-tap`.

## Usage

```bash
brew tap batonogov/tap
brew install --cask pine
```

Closes #40

## Test plan

- [ ] Add `TAP_GITHUB_TOKEN` secret to repo settings
- [ ] Create a test tag/release and verify the tap gets updated
- [ ] Test `brew tap batonogov/tap && brew install --cask pine`

🤖 Generated with [Claude Code](https://claude.com/claude-code)