### PR TITLE
Update CLAUDE.md with recent project changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit, zero ext
 
 **Pattern:** MVVM with SwiftUI views backed by AppKit via `NSViewRepresentable`.
 
-**State management:** `FileTreeViewModel` (@Observable) is the central state object managing file tree, editor tabs, and terminal tabs. It communicates with views via SwiftUI observation and with menu commands via NotificationCenter.
+**State management:** `FileTreeViewModel` (@Observable) is the central state object managing file tree, editor tabs, and terminal tabs. It communicates with views via SwiftUI observation and with menu commands via NotificationCenter. `ProjectManager` handles project-level operations.
 
 **AppKit bridges:**
 - `CodeEditorView` — wraps NSScrollView + custom `GutterTextView` (NSTextView subclass) + `LineNumberView` for the code editor
@@ -26,7 +26,9 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit, zero ext
 
 **Text system stack:** NSTextStorage → NSLayoutManager → NSTextContainer → GutterTextView (shifts text right for line number gutter)
 
-**Terminal:** Uses `openpty()` (Darwin/BSD) to spawn `/bin/zsh` with a pseudo-terminal. `TerminalSession` manages the PTY lifecycle, ANSI stripping, and output parsing.
+**Terminal:** Uses `openpty()` (Darwin/BSD) to spawn `/bin/zsh` with a pseudo-terminal. `TerminalSession` manages the PTY lifecycle, ANSI stripping, and output parsing. Terminal tabs use native macOS tab bar with shared state across editor windows.
+
+**Git integration:** `GitStatusProvider` runs `git status` and `git diff` to show file status indicators in the sidebar and diff markers (added/modified/deleted) in the editor gutter. Branch switching is available in the UI.
 
 **Syntax highlighting:** `SyntaxHighlighter` singleton loads JSON grammar files from `Pine/Grammars/` at startup. Each grammar defines regex rules with scopes (comment, string, keyword, etc.) and a priority system prevents nested matches (comments > strings > keywords).
 
@@ -41,6 +43,16 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit, zero ext
 - `LineNumberGutter.swift` — Line number rendering (enumerates only visible line fragments)
 - `TerminalSession.swift` — PTY management, process lifecycle, output parsing
 - `TerminalContentView.swift` — Terminal NSViewRepresentable with custom key handling
+- `GitStatusProvider.swift` — Git status/diff parsing for sidebar indicators and gutter markers
+- `ProjectManager.swift` — Project-level operations
+
+## Release & CI
+
+- GitHub Actions workflow (`.github/workflows/release.yml`) triggers on `v*` tags
+- Pipeline: build → code sign → notarize → create DMG → GitHub Release → update Homebrew Tap
+- Secrets: `CERTIFICATE_P12`, `CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID`, `TAP_GITHUB_TOKEN`
+- To release: `git tag v0.X.0 && git push origin v0.X.0` — CI handles the rest
+- Homebrew: `brew install batonogov/tap/pine`
 
 ## Conventions
 
@@ -48,7 +60,9 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit, zero ext
 - Models are either structs (EditorTab) or @Observable classes (FileNode, TerminalTab) depending on identity semantics
 - Grammar files are JSON in `Pine/Grammars/` — add new languages by adding a new JSON file following the existing format
 - Keyboard shortcuts flow through NotificationCenter (PineApp → ContentView → FileTreeViewModel)
-- All UI colors are currently hardcoded dark theme values (migration to semantic colors planned)
+- UI uses semantic system colors (migrated from hardcoded dark theme values)
+- Editor features: auto-indent on newline, current line highlight, git diff gutter markers
+- Editor tabs use native macOS window tabs (not custom tab bar)
 
 ## GitHub Issues
 


### PR DESCRIPTION
## Summary
- Add git integration and native terminal tabs to architecture docs
- Add `GitStatusProvider.swift` and `ProjectManager.swift` to key files
- Add new **Release & CI** section with pipeline, secrets, and Homebrew info
- Update conventions: semantic colors, auto-indent, current line highlight, native editor tabs

## Test plan
- [ ] Review documentation accuracy against current codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)