### PR TITLE
Fix folders not collapsing in sidebar file tree

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -487,7 +487,7 @@ struct FileNodeRow: View {
         if node.isDirectory {
             DisclosureGroup(
                 isExpanded: Binding(
-                    get: { !(node.children?.isEmpty ?? true) || expandedState },
+                    get: { expandedState },
                     set: { isExpanded in
                         expandedState = isExpanded
                         if isExpanded { node.loadChildren() }


### PR DESCRIPTION
## Summary
- Fix bug where sidebar folders could be expanded but never collapsed back
- The `DisclosureGroup` binding getter in `FileNodeRow` used OR logic (`!(node.children?.isEmpty ?? true) || expandedState`) that always returned `true` once children were loaded, making collapse impossible
- Simplified getter to `expandedState` so it correctly reflects user intent

Fixes #49

## Test plan
- [ ] Open a project with nested folders
- [ ] Expand a folder — children should appear
- [ ] Click to collapse — folder should collapse
- [ ] Re-expand and verify children still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)