### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,19 @@
+# Xcode
 xcuserdata/
+*.xcscmblueprint
+*.xccheckout
+
+# Build
+build/
+DerivedData/
+
+# Swift Package Manager
+.build/
+.swiftpm/
+
+# macOS
+.DS_Store
+
+# Debug symbols
+*.dSYM.zip
+*.dSYM/


### PR DESCRIPTION
## Summary
- Add `.gitignore` with `xcuserdata/` rule to exclude Xcode user-specific workspace data from version control

## Test plan
- [ ] Verify `Pine.xcodeproj/project.xcworkspace/xcuserdata/` no longer shows in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)