### PR TITLE
Show dotfiles in sidebar file tree

### DIFF
--- a/Pine/FileNode.swift
+++ b/Pine/FileNode.swift
@@ -36,15 +36,19 @@ final class FileNode: Identifiable, Hashable {
 
     // MARK: - Загрузка содержимого папки
 
+    /// Names always hidden from the file tree.
+    private static let hiddenNames: Set<String> = [".git", ".DS_Store"]
+
     private static func loadContents(of url: URL) -> [FileNode] {
         do {
             let contents = try FileManager.default.contentsOfDirectory(
                 at: url,
                 includingPropertiesForKeys: [.isDirectoryKey],
-                options: [.skipsHiddenFiles]
+                options: []
             )
 
             return contents
+                .filter { !hiddenNames.contains($0.lastPathComponent) }
                 .map { FileNode(url: $0) }
                 .sorted { lhs, rhs in
                     if lhs.isDirectory == rhs.isDirectory {

--- a/PineTests/FileNodeTests.swift
+++ b/PineTests/FileNodeTests.swift
@@ -85,20 +85,35 @@ struct FileNodeTests {
         #expect(node.children?[1].isDirectory == false)
     }
 
-    @Test func hiddenFilesAreExcluded() throws {
+    @Test func dotfilesAreVisibleButGitIsHidden() throws {
         let tempDir = try makeTempDirectory()
         defer { cleanup(tempDir) }
 
         FileManager.default.createFile(
-            atPath: tempDir.appendingPathComponent(".hidden").path, contents: nil
+            atPath: tempDir.appendingPathComponent(".gitignore").path, contents: nil
+        )
+        FileManager.default.createFile(
+            atPath: tempDir.appendingPathComponent(".swiftlint.yml").path, contents: nil
+        )
+        try FileManager.default.createDirectory(
+            at: tempDir.appendingPathComponent(".git"),
+            withIntermediateDirectories: true
+        )
+        FileManager.default.createFile(
+            atPath: tempDir.appendingPathComponent(".DS_Store").path, contents: nil
         )
         FileManager.default.createFile(
             atPath: tempDir.appendingPathComponent("visible.txt").path, contents: nil
         )
 
         let node = FileNode(url: tempDir)
-        #expect(node.children?.count == 1)
-        #expect(node.children?[0].name == "visible.txt")
+        let names = node.children?.map(\.name) ?? []
+        #expect(names.contains(".gitignore"))
+        #expect(names.contains(".swiftlint.yml"))
+        #expect(names.contains("visible.txt"))
+        #expect(!names.contains(".git"))
+        #expect(!names.contains(".DS_Store"))
+        #expect(node.children?.count == 3)
     }
 
     @Test func emptyDirectoryHasNilOptionalChildren() throws {


### PR DESCRIPTION
## Summary

- Replace blanket `.skipsHiddenFiles` option with an explicit blocklist (`.git`, `.DS_Store`) so config dotfiles like `.gitignore`, `.swiftlint.yml`, and `.github/` are visible in the sidebar
- Update unit test to verify dotfiles are shown while `.git` and `.DS_Store` remain hidden

Closes #61

## Test plan

- [ ] Open a project containing `.gitignore`, `.swiftlint.yml`, `.github/` — verify they appear in the sidebar
- [ ] Verify `.git` directory and `.DS_Store` files are still hidden
- [ ] Run `PineTests/FileNodeTests` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)