### PR TITLE
Add SwiftLint pre-commit reminder to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Targets 
 - Type-check a single file (no sudo needed): `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -typecheck -target arm64-apple-macos26.0 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk <file.swift>`
 - **Dependency:** SwiftTerm added via Xcode SPM (File > Add Package Dependencies > `https://github.com/migueldeicaza/SwiftTerm.git`)
 - No other third-party dependencies
-- **SwiftLint:** `brew install swiftlint` — runs as a build phase; config in `.swiftlint.yml`
+- **SwiftLint:** `brew install swiftlint` — runs as a build phase; config in `.swiftlint.yml`. Run `swiftlint` before every commit and fix all warnings/errors
 - **Tests:** `xcodebuild test -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS'`
 - Test target: `PineTests` (Swift Testing framework) — covers git parsing, grammar models, file tree
 


### PR DESCRIPTION
## Summary
- Added a reminder to run `swiftlint` before every commit and fix all warnings/errors in the CLAUDE.md build instructions

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub