### PR TITLE
Fix tabs restoring as separate windows after Cmd+Q

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Targets 
 - Type-check a single file (no sudo needed): `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -typecheck -target arm64-apple-macos26.0 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk <file.swift>`
 - **Dependency:** SwiftTerm added via Xcode SPM (File > Add Package Dependencies > `https://github.com/migueldeicaza/SwiftTerm.git`)
 - No other third-party dependencies
-- **SwiftLint:** `brew install swiftlint` — runs as a build phase; config in `.swiftlint.yml`. Run `swiftlint` before every commit and fix all warnings/errors
-- **Tests:** `xcodebuild test -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS'`
+- **SwiftLint:** `brew install swiftlint` — runs as a build phase; config in `.swiftlint.yml`. Run `swiftlint` before every commit and fix all warnings/errors. If `swiftlint` crashes with `sourcekitdInProc` error, prefix with `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer`
+- **Tests:** `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS'`
 - Test target: `PineTests` (Swift Testing framework) — covers git parsing, grammar models, file tree
 
 ## Architecture
@@ -36,11 +36,16 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Targets 
 
 **Syntax highlighting:** `SyntaxHighlighter` singleton loads JSON grammar files from `Pine/Grammars/` at startup. Each grammar defines regex rules with scopes (comment, string, keyword, etc.) and a priority system prevents nested matches (comments > strings > keywords).
 
+**Window & tab management:** Uses `WindowGroup(for: URL.self)` — each editor tab is a native macOS window identified by its file URL. `AppDelegate` sets `NSWindow.allowsAutomaticWindowTabbing = true` and `tabbingMode = .preferred` on every new window. `WindowBridge` (NSViewRepresentable in ContentView) configures `representedURL` and `isDocumentEdited` on the host NSWindow. `WindowCloseInterceptor` (proxy NSWindowDelegate) intercepts close to show unsaved-changes dialog. When opening new tabs programmatically via `openWindow(value:)`, windows must be merged into a tab group explicitly with `NSWindow.addTabbedWindow(_:ordered:)`.
+
+**Session persistence:** `SessionState` (Codable struct) saves project path + open file paths to UserDefaults. `AppDelegate` triggers save on window close and app termination. `ContentView.restoreSessionIfNeeded()` runs once (static flag) on first empty window: loads project, opens first file in current window, remaining files via `openWindow`, then merges into tab group.
+
 ## Key Files
 
-- `PineApp.swift` — @main entry point, keyboard shortcuts (Cmd+S, Cmd+Shift+O, Cmd+`)
-- `ContentView.swift` — NavigationSplitView layout: sidebar (file tree) + detail (editor tabs + terminal)
-- `ProjectManager.swift` — Central state: file tree, terminal tabs, git provider, project I/O
+- `PineApp.swift` — @main entry point, AppDelegate (window tabbing config, session save on close/terminate), keyboard shortcuts (Cmd+S, Cmd+Shift+O, Cmd+`), mergeRestoredWindowsIntoTabs()
+- `ContentView.swift` — NavigationSplitView layout: sidebar (file tree) + detail (editor tabs + terminal), WindowBridge, WindowCloseInterceptor, session restoration
+- `SessionState.swift` — Codable session persistence (project path + open file paths) via UserDefaults
+- `ProjectManager.swift` — Central state: file tree, terminal tabs, git provider, project I/O, saveSession()
 - `FileNode.swift` — Recursive tree model for filesystem
 - `CodeEditorView.swift` — NSViewRepresentable editor with GutterTextView and LineNumberView
 - `SyntaxHighlighter.swift` — Grammar loading, regex compilation, theme colors, highlighting application

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -49,6 +49,7 @@ class WindowBridgeView: NSView {
         if let window, closeInterceptor == nil {
             hostWindow = window
             window.tabbingMode = .preferred
+            window.tabbingIdentifier = AppDelegate.editorTabbingID
 
             // Перехватываем закрытие окна для диалога сохранения
             let interceptor = WindowCloseInterceptor(
@@ -59,6 +60,9 @@ class WindowBridgeView: NSView {
             closeInterceptor = interceptor
 
             applyIfPossible()
+
+            // Signal that this editor window is ready for tab merging
+            NotificationCenter.default.post(name: .editorWindowReady, object: nil)
         }
     }
 
@@ -182,6 +186,10 @@ struct ContentView: View {
         ))
         .onAppear {
             if let url = fileURL {
+                // SwiftUI may restore windows with a non-nil fileURL (Codable persistence).
+                // In that case restoreSessionIfNeeded() won't run, so we need to
+                // load the project directory here to populate the sidebar.
+                restoreProjectDirectoryIfNeeded()
                 loadFileFromURL(url)
                 // New window tabs get fileURL as initial state (onChange won't fire),
                 // so save session here to capture the newly opened tab.
@@ -298,6 +306,15 @@ struct ContentView: View {
 
     // MARK: - Session restoration
 
+    /// When SwiftUI auto-restores windows with non-nil fileURL,
+    /// restoreSessionIfNeeded() is skipped (guard fileURL == nil fails).
+    /// This method ensures the project directory is still loaded for the sidebar.
+    private func restoreProjectDirectoryIfNeeded() {
+        guard workspace.rootURL == nil,
+              let session = SessionState.load() else { return }
+        workspace.loadDirectory(url: session.projectURL)
+    }
+
     private func restoreSessionIfNeeded() {
         guard !Self.didRestoreSession else { return }
         Self.didRestoreSession = true
@@ -317,7 +334,8 @@ struct ContentView: View {
         // Open the first file in the current (empty) window
         fileURL = fileURLs.first
 
-        // Open remaining files in new window tabs
+        // Open remaining files in new window tabs.
+        // The debounced merge in AppDelegate handles grouping them.
         for url in fileURLs.dropFirst() {
             openWindow(value: url)
         }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -68,8 +68,22 @@ struct PineApp: App {
 class AppDelegate: NSObject, NSApplicationDelegate {
     var projectManager: ProjectManager?
 
+    /// Session state cached at launch — immune to saveSession() overwrites during startup.
+    /// Cleared after 3s (safety) or after first successful reorder (whichever comes first).
+    private var cachedSession: SessionState?
+    /// Debounced work item for the next merge attempt.
+    private var mergeWorkItem: DispatchWorkItem?
+    /// One-shot flag: active-tab restore runs only once,
+    /// so subsequent merges don't steal focus from the user.
+    private var didRestoreActiveTab = false
+
+    static let editorTabbingID = "pine-editor"
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSWindow.allowsAutomaticWindowTabbing = true
+
+        // Cache session BEFORE any saveSession() call can overwrite UserDefaults.
+        cachedSession = SessionState.load()
 
         // Устанавливаем tabbingMode для каждого нового окна
         NotificationCenter.default.addObserver(
@@ -93,10 +107,105 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.projectManager?.saveSession()
             }
         }
+
+        // Each .editorWindowReady triggers a debounced merge.
+        // Merge is idempotent — always safe to call, no phase gate.
+        // This handles both startup restoration and runtime tab creation.
+        NotificationCenter.default.addObserver(
+            forName: .editorWindowReady,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.scheduleMerge()
+        }
+
+        // Clear cachedSession after 3s — stops reordering/active-tab restore,
+        // but merge itself keeps working for any future windows.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+            self?.cachedSession = nil
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {
         projectManager?.saveSession()
+    }
+
+    // MARK: - Debounced idempotent tab merge
+
+    /// Schedules a debounced merge. No phase gate — always responds.
+    /// The 150ms debounce coalesces rapid window appearances.
+    private func scheduleMerge() {
+        mergeWorkItem?.cancel()
+        let item = DispatchWorkItem { [weak self] in
+            self?.mergeEditorWindowsIntoTabs()
+        }
+        mergeWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: item)
+    }
+
+    /// Idempotent merge: finds editor windows not yet in a tab group
+    /// and adds them to the primary window's tab group, then reorders
+    /// all tabs to match the saved session order via NSWindowTabGroup.
+    /// Safe to call multiple times — already-tabbed windows are skipped,
+    /// reorder is skipped when tabs already match session order.
+    private func mergeEditorWindowsIntoTabs() {
+        let editorWindows = NSApplication.shared.windows.filter {
+            $0.isVisible && $0.tabbingIdentifier == Self.editorTabbingID
+        }
+        guard editorWindows.count > 1 else { return }
+
+        // Phase 1: Add ungrouped windows into a single tab group.
+        // Pick primary: prefer a window that already has a tab group.
+        // Use tabGroup.windows (not tabbedWindows) — tabbedWindows returns nil
+        // when the tab bar is hidden, but tabGroup.windows is always authoritative.
+        let primary = editorWindows.first { ($0.tabGroup?.windows.count ?? 0) > 1 }
+            ?? editorWindows[0]
+
+        let alreadyTabbed: Set<ObjectIdentifier>
+        if let groupWindows = primary.tabGroup?.windows, !groupWindows.isEmpty {
+            alreadyTabbed = Set(groupWindows.map { ObjectIdentifier($0) })
+        } else {
+            alreadyTabbed = [ObjectIdentifier(primary)]
+        }
+
+        let ungrouped = editorWindows.filter { !alreadyTabbed.contains(ObjectIdentifier($0)) }
+        for window in ungrouped {
+            primary.addTabbedWindow(window, ordered: .above)
+        }
+
+        // Phase 2: Reorder tabs to match saved session order via NSWindowTabGroup.
+        // Runs on every merge while cachedSession exists — idempotent, so late
+        // windows that arrive after the first merge are also placed correctly.
+        if let session = cachedSession, let tabGroup = primary.tabGroup {
+            let sessionPaths = session.openFilePaths
+            let currentWindows = tabGroup.windows
+            let desired = currentWindows.sorted { windowA, windowB in
+                let indexA = sessionPaths.firstIndex(of: windowA.representedURL?.path ?? "") ?? Int.max
+                let indexB = sessionPaths.firstIndex(of: windowB.representedURL?.path ?? "") ?? Int.max
+                return indexA < indexB
+            }
+
+            if desired.map(ObjectIdentifier.init) != currentWindows.map(ObjectIdentifier.init) {
+                for window in desired.dropFirst().reversed() {
+                    tabGroup.removeWindow(window)
+                }
+                for (index, window) in desired.dropFirst().enumerated() {
+                    tabGroup.insertWindow(window, at: index + 1)
+                }
+            }
+        }
+
+        // Phase 3: Restore active tab — one-shot, only when the target window exists.
+        // Flag is set only on successful match, so if the active tab window hasn't
+        // appeared yet, the next merge will retry.
+        if !didRestoreActiveTab, let session = cachedSession,
+           let activeURL = session.activeFileURL {
+            if let activeWindow = editorWindows.first(where: { $0.representedURL == activeURL }) {
+                didRestoreActiveTab = true
+                activeWindow.makeKeyAndOrderFront(nil)
+            }
+            // else: active tab window not yet restored — retry on next merge
+        }
     }
 }
 
@@ -111,4 +220,6 @@ extension Notification.Name {
     static let fileRenamed = Notification.Name("fileRenamed")
     /// userInfo: ["url": URL]
     static let fileDeleted = Notification.Name("fileDeleted")
+    /// Posted by WindowBridgeView when an editor window is fully configured.
+    static let editorWindowReady = Notification.Name("editorWindowReady")
 }

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -15,14 +15,36 @@ final class ProjectManager {
     let terminal = TerminalManager()
 
     /// Persists current session (project + open file tabs) to UserDefaults.
+    /// Collects from all tab groups via tabbedWindows to preserve tab strip order.
     /// Only includes file URLs that live under the current project root.
     func saveSession() {
         guard let rootURL = workspace.rootURL else { return }
         let rootPath = rootURL.path + "/"
-        let openFileURLs = NSApplication.shared.windows
-            .compactMap(\.representedURL)
-            .filter { $0.path.hasPrefix(rootPath) }
-        SessionState.save(projectURL: rootURL, openFileURLs: openFileURLs)
+
+        // Use tabGroup.windows for authoritative visual tab order.
+        // tabbedWindows returns nil when the tab bar is hidden (NSWindow.h:714),
+        // but tabGroup.windows always reflects the correct order.
+        // The seen set deduplicates across groups.
+        var openFileURLs: [URL] = []
+        var seen = Set<String>()
+        for window in NSApplication.shared.windows
+            where window.tabbingIdentifier == AppDelegate.editorTabbingID {
+            let orderedTabs = window.tabGroup?.windows ?? [window]
+            for tab in orderedTabs {
+                guard let url = tab.representedURL,
+                      url.path.hasPrefix(rootPath),
+                      !seen.contains(url.path) else { continue }
+                seen.insert(url.path)
+                openFileURLs.append(url)
+            }
+        }
+
+        let activeFileURL = NSApp.keyWindow?.representedURL
+        SessionState.save(
+            projectURL: rootURL,
+            openFileURLs: openFileURLs,
+            activeFileURL: activeFileURL
+        )
     }
 
     // MARK: - Convenience accessors (workspace)

--- a/Pine/SessionState.swift
+++ b/Pine/SessionState.swift
@@ -11,6 +11,7 @@ import Foundation
 struct SessionState: Codable {
     var projectPath: String
     var openFilePaths: [String]
+    var activeFilePath: String?
 
     // MARK: - UserDefaults key
 
@@ -18,10 +19,16 @@ struct SessionState: Codable {
 
     // MARK: - Save
 
-    static func save(projectURL: URL, openFileURLs: [URL], defaults: UserDefaults = .standard) {
+    static func save(
+        projectURL: URL,
+        openFileURLs: [URL],
+        activeFileURL: URL? = nil,
+        defaults: UserDefaults = .standard
+    ) {
         let state = SessionState(
             projectPath: projectURL.path,
-            openFilePaths: openFileURLs.map(\.path)
+            openFilePaths: openFileURLs.map(\.path),
+            activeFilePath: activeFileURL?.path
         )
         guard let data = try? JSONEncoder().encode(state) else { return }
         defaults.set(data, forKey: defaultsKey)
@@ -54,5 +61,12 @@ struct SessionState: Codable {
             let url = URL(fileURLWithPath: path)
             return FileManager.default.fileExists(atPath: path) ? url : nil
         }
+    }
+
+    /// The active file URL if it still exists on disk.
+    var activeFileURL: URL? {
+        guard let path = activeFilePath,
+              FileManager.default.fileExists(atPath: path) else { return nil }
+        return URL(fileURLWithPath: path)
     }
 }

--- a/PineTests/SessionStateTests.swift
+++ b/PineTests/SessionStateTests.swift
@@ -153,6 +153,74 @@ struct SessionStateTests {
         #expect(loaded == nil)
     }
 
+    // MARK: - Active file round-trip
+
+    @Test func activeFilePathRoundTrip() throws {
+        let tempDir = try makeTempDirectory()
+        defer { cleanup(tempDir) }
+
+        let file1 = tempDir.appendingPathComponent("a.swift")
+        let file2 = tempDir.appendingPathComponent("b.swift")
+        FileManager.default.createFile(atPath: file1.path, contents: nil)
+        FileManager.default.createFile(atPath: file2.path, contents: nil)
+
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        SessionState.save(
+            projectURL: tempDir,
+            openFileURLs: [file1, file2],
+            activeFileURL: file2,
+            defaults: defaults
+        )
+
+        let loaded = SessionState.load(defaults: defaults)
+        #expect(loaded?.activeFilePath == file2.path)
+        #expect(loaded?.activeFileURL == file2)
+    }
+
+    @Test func activeFileURLReturnsNilWhenFileDeleted() throws {
+        let tempDir = try makeTempDirectory()
+        defer { cleanup(tempDir) }
+
+        let file = tempDir.appendingPathComponent("gone.swift")
+
+        let state = SessionState(
+            projectPath: tempDir.path,
+            openFilePaths: [],
+            activeFilePath: file.path
+        )
+
+        #expect(state.activeFileURL == nil)
+    }
+
+    @Test func activeFileURLReturnsNilWhenNotSet() throws {
+        let state = SessionState(
+            projectPath: "/tmp",
+            openFilePaths: [],
+            activeFilePath: nil
+        )
+        #expect(state.activeFileURL == nil)
+    }
+
+    @Test func backwardsCompatibleWithoutActiveFilePath() throws {
+        let tempDir = try makeTempDirectory()
+        defer { cleanup(tempDir) }
+
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        // Simulate old format without activeFilePath
+        let oldState = ["projectPath": tempDir.path, "openFilePaths": [String]()] as [String: Any]
+        let data = try JSONSerialization.data(withJSONObject: oldState)
+        defaults.set(data, forKey: "lastSessionState")
+
+        let loaded = SessionState.load(defaults: defaults)
+        #expect(loaded != nil)
+        #expect(loaded?.activeFilePath == nil)
+        #expect(loaded?.activeFileURL == nil)
+    }
+
     // MARK: - File as project path (not directory)
 
     @Test func loadReturnsNilWhenProjectPathIsFile() throws {


### PR DESCRIPTION
Closes #81

## Summary

- After session restoration, explicitly merge all opened windows into a single tab group using `NSWindow.addTabbedWindow(_:ordered:)` — SwiftUI's `openWindow(value:)` creates independent windows that don't auto-join a tab group
- Added `mergeRestoredWindowsIntoTabs()` to `AppDelegate`, called from `restoreSessionIfNeeded()` after all windows are opened
- Updated CLAUDE.md with window/tab management architecture, session persistence details, and `DEVELOPER_DIR` hints for CLI tools

## Test plan

- [ ] Open a project, open 3+ files as tabs in a single window
- [ ] Quit with Cmd+Q
- [ ] Relaunch Pine — all tabs should appear in one window (not separate windows)
- [ ] Verify clicking files still opens them as new tabs correctly
- [ ] Verify unsaved changes dialog still works on Cmd+W