### PR TITLE
fix: increase default window size and sidebar width

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -597,7 +597,7 @@ struct SidebarView: View {
             }
         }
         .listStyle(.sidebar)
-        .frame(minWidth: 180, idealWidth: 220)
+        .frame(minWidth: 200, idealWidth: 250)
         .toolbar {
             ToolbarItem {
                 Button {

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -20,7 +20,7 @@ struct PineApp: App {
                 ProjectWindowView(projectURL: projectURL, registry: registry, appDelegate: appDelegate)
             }
         }
-        .defaultSize(width: 1100, height: 700)
+        .defaultSize(width: 1280, height: 800)
         .defaultLaunchBehavior(.suppressed)
         .commands {
             // Убираем стандартный "New Window" (Cmd+N) — табы создаются кликом по файлу


### PR DESCRIPTION
## Summary

- Increase default window size from 1100×700 to 1280×800
- Increase sidebar `idealWidth` from 220 to 250 and `minWidth` from 180 to 200
- Long file names (e.g. `.pre-commit-config.yaml`, `.release-please-config.json`) no longer get clipped in the sidebar

## Test plan

- [ ] Open a project — verify window is larger by default
- [ ] Verify sidebar shows full file names without truncation
- [ ] Verify sidebar is still resizable

Closes #123