### PR TITLE
fix: sync sidebar selection after session restore

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -79,6 +79,9 @@ struct ContentView: View {
             refreshLineDiffs()
             projectManager.saveSession()
         }
+        .onChange(of: workspace.rootNodes) { _, _ in
+            syncSidebarSelection()
+        }
         .onChange(of: tabManager.tabs.count) { _, _ in
             projectManager.saveSession()
         }


### PR DESCRIPTION
## Summary

- Fixes sidebar not highlighting the active file after session restore from Welcome window's Recent Projects
- Root cause: `syncSidebarSelection()` runs in `onAppear` before `workspace.rootNodes` finishes async loading, so `findNode()` returns `nil`
- Fix: added `.onChange(of: workspace.rootNodes)` to re-sync sidebar selection once the file tree loads

Closes #126

## Test plan

- [ ] Open a project and open several files as tabs
- [ ] Close the project window
- [ ] Reopen from Welcome → Recent Projects
- [ ] Verify the active tab's file is highlighted in the sidebar