### PR TITLE
chore: upgrade actions/checkout from v4 to v6 (Node.js 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: SwiftLint
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install SwiftLint
         run: brew install swiftlint
@@ -23,7 +23,7 @@ jobs:
     name: Build & Test
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select Xcode
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Select Xcode
         run: |


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from v4 to v6 in `ci.yml` and `release.yml`
- v5 added Node.js 24 runtime, v6 improved credential security (stores in `$RUNNER_TEMP` instead of `.git/config`)
- `googleapis/release-please-action` remains at v4 — no major update available

Closes #122

## Test plan

- [ ] CI workflows (lint, build & test) pass on this PR
- [ ] Verify no checkout-related errors in workflow logs