### PR TITLE
feat: add native Markdown preview with source/preview/split modes

### DIFF
--- a/Pine.xcodeproj/project.pbxproj
+++ b/Pine.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		9FA7317B2F61803400E91711 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 9FA7317A2F61803400E91711 /* SwiftTerm */; };
+		CF0000030000000000000003 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = CF0000030000000000000002 /* Markdown */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +58,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9FA7317B2F61803400E91711 /* SwiftTerm in Frameworks */,
+				CF0000030000000000000003 /* Markdown in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -119,6 +121,7 @@
 			name = Pine;
 			packageProductDependencies = (
 				9FA7317A2F61803400E91711 /* SwiftTerm */,
+				CF0000030000000000000002 /* Markdown */,
 			);
 			productName = Pine;
 			productReference = 9FA1A7282F5EFA8100BDDA8C /* Pine.app */;
@@ -208,6 +211,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				9FA731792F61803400E91711 /* XCRemoteSwiftPackageReference "SwiftTerm" */,
+				CF0000030000000000000001 /* XCRemoteSwiftPackageReference "swift-markdown" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 9FA1A7292F5EFA8100BDDA8C /* Products */;
@@ -627,6 +631,14 @@
 				minimumVersion = 1.5.0;
 			};
 		};
+		CF0000030000000000000001 /* XCRemoteSwiftPackageReference "swift-markdown" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/swiftlang/swift-markdown.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.5.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -634,6 +646,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9FA731792F61803400E91711 /* XCRemoteSwiftPackageReference "SwiftTerm" */;
 			productName = SwiftTerm;
+		};
+		CF0000030000000000000002 /* Markdown */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CF0000030000000000000001 /* XCRemoteSwiftPackageReference "swift-markdown" */;
+			productName = Markdown;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "34fc6ded3af11d97770b2e20b5e3cfd72f9d3309ae17ef3278b95041f16c02dc",
+  "originHash" : "7f812f9ee550d78f026ba3a43058b91e674e4be31e9646f612637871ebea91b6",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -8,6 +8,24 @@
       "state" : {
         "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
         "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
+        "version" : "0.7.1"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-markdown.git",
+      "state" : {
+        "revision" : "7d9a5ce307528578dfa777d505496bd5f544ad94",
+        "version" : "0.7.3"
       }
     },
     {

--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -34,6 +34,10 @@ enum AccessibilityID {
     static let maximizeTerminalButton = "maximizeTerminalButton"
     static let hideTerminalButton = "hideTerminalButton"
 
+    // MARK: - Markdown Preview
+    static let markdownPreviewToggle = "markdownPreviewToggle"
+    static let markdownPreviewView = "markdownPreviewView"
+
     // MARK: - Status bar
     static let statusBar = "statusBar"
     static let terminalToggleButton = "terminalToggleButton"

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -145,6 +145,17 @@ struct ContentView: View {
             tabManager.openTab(url: url)
         }
 
+        // Restore preview modes for markdown tabs
+        if let previewModes = session.previewModes {
+            for index in tabManager.tabs.indices {
+                let path = tabManager.tabs[index].url.path
+                if let rawMode = previewModes[path],
+                   let mode = MarkdownPreviewMode(rawValue: rawMode) {
+                    tabManager.tabs[index].previewMode = mode
+                }
+            }
+        }
+
         if let activeURL = session.activeFileURL,
            let tab = tabManager.tab(for: activeURL) {
             tabManager.activeTabID = tab.id
@@ -305,33 +316,39 @@ struct ContentView: View {
                 EditorTabBar(
                     tabManager: tabManager,
                     onCloseTab: { tab in closeTabWithConfirmation(tab) },
-                    onReorder: { projectManager.saveSession() }
+                    onReorder: { projectManager.saveSession() },
+                    isMarkdownFile: activeTab?.isMarkdownFile ?? false,
+                    previewMode: activeTab?.previewMode ?? .source,
+                    onTogglePreview: { tabManager.togglePreviewMode() }
                 )
             }
 
             if let tab = activeTab {
-                if tab.kind == .preview {
-                    QuickLookPreviewView(url: tab.url)
-                        .id(tab.id)
-                        .accessibilityIdentifier(AccessibilityID.quickLookPreview)
-                } else {
-                    CodeEditorView(
-                        text: Binding(
-                            get: { tab.content },
-                            set: { tabManager.updateContent($0) }
-                        ),
-                        language: tab.language,
-                        fileName: tab.fileName,
-                        lineDiffs: lineDiffs,
-                        initialCursorPosition: tab.cursorPosition,
-                        initialScrollOffset: tab.scrollOffset,
-                        onStateChange: { cursor, scroll in
-                            tabManager.updateEditorState(cursorPosition: cursor, scrollOffset: scroll)
+                Group {
+                    if tab.kind == .preview {
+                        QuickLookPreviewView(url: tab.url)
+                            .accessibilityIdentifier(AccessibilityID.quickLookPreview)
+                    } else if tab.isMarkdownFile {
+                        switch tab.previewMode {
+                        case .source:
+                            codeEditorView(for: tab)
+                        case .preview:
+                            MarkdownPreviewView(content: tab.content)
+                                .accessibilityIdentifier(AccessibilityID.markdownPreviewView)
+                        case .split:
+                            HSplitView {
+                                codeEditorView(for: tab)
+                                    .frame(minWidth: 200)
+                                MarkdownPreviewView(content: tab.content)
+                                    .accessibilityIdentifier(AccessibilityID.markdownPreviewView)
+                                    .frame(minWidth: 200)
+                            }
                         }
-                    )
-                    .id(tab.id)
-                    .accessibilityIdentifier(AccessibilityID.codeEditor)
+                    } else {
+                        codeEditorView(for: tab)
+                    }
                 }
+                .id(tab.id)
             } else {
                 ContentUnavailableView {
                     Label(Strings.noFileSelected, systemImage: "doc.text")
@@ -341,6 +358,25 @@ struct ContentView: View {
                 .accessibilityIdentifier(AccessibilityID.editorPlaceholder)
             }
         }
+    }
+
+    @ViewBuilder
+    private func codeEditorView(for tab: EditorTab) -> some View {
+        CodeEditorView(
+            text: Binding(
+                get: { tab.content },
+                set: { tabManager.updateContent($0) }
+            ),
+            language: tab.language,
+            fileName: tab.fileName,
+            lineDiffs: lineDiffs,
+            initialCursorPosition: tab.cursorPosition,
+            initialScrollOffset: tab.scrollOffset,
+            onStateChange: { cursor, scroll in
+                tabManager.updateEditorState(cursorPosition: cursor, scrollOffset: scroll)
+            }
+        )
+        .accessibilityIdentifier(AccessibilityID.codeEditor)
     }
 
     // MARK: - Область терминала

--- a/Pine/EditorTab.swift
+++ b/Pine/EditorTab.swift
@@ -27,7 +27,16 @@ struct EditorTab: Identifiable, Hashable {
     /// Used to detect external changes by comparing with the current stat.
     var lastModDate: Date?
 
+    /// Markdown preview mode (source/preview/split). Only meaningful for markdown files.
+    var previewMode: MarkdownPreviewMode = .source
+
     var isDirty: Bool { kind == .text && content != savedContent }
+
+    /// Whether this tab's file is a Markdown file (.md or .markdown).
+    var isMarkdownFile: Bool {
+        let ext = (url.lastPathComponent as NSString).pathExtension.lowercased()
+        return ext == "md" || ext == "markdown"
+    }
 
     var fileName: String { url.lastPathComponent }
 

--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -16,8 +16,22 @@ struct EditorTabBar: View {
     var onCloseTab: (EditorTab) -> Void
     /// Called after tabs are reordered via drag-and-drop.
     var onReorder: (() -> Void)?
+    /// Whether the active tab is a Markdown file.
+    var isMarkdownFile: Bool = false
+    /// Current preview mode of the active tab.
+    var previewMode: MarkdownPreviewMode = .source
+    /// Called when the user toggles the Markdown preview mode.
+    var onTogglePreview: (() -> Void)?
 
     @State private var draggingTabID: UUID?
+
+    private var previewIcon: String {
+        switch previewMode {
+        case .source: "doc.plaintext"
+        case .preview: "eye"
+        case .split: "rectangle.split.2x1"
+        }
+    }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -46,6 +60,21 @@ struct EditorTabBar: View {
             }
 
             Spacer()
+
+            if isMarkdownFile {
+                Button {
+                    onTogglePreview?()
+                } label: {
+                    Image(systemName: previewIcon)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 24, height: 24)
+                }
+                .buttonStyle(.plain)
+                .help(Strings.menuTogglePreview)
+                .accessibilityIdentifier(AccessibilityID.markdownPreviewToggle)
+                .padding(.trailing, 4)
+            }
         }
         .frame(height: 30)
         .background(.bar)

--- a/Pine/MarkdownPreviewMode.swift
+++ b/Pine/MarkdownPreviewMode.swift
@@ -1,0 +1,18 @@
+//
+//  MarkdownPreviewMode.swift
+//  Pine
+//
+
+/// Markdown preview display mode: source code, rendered preview, or side-by-side split.
+enum MarkdownPreviewMode: String, Codable {
+    case source, preview, split
+
+    /// Cycles through modes: source → split → preview → source.
+    var next: Self {
+        switch self {
+        case .source: .split
+        case .split: .preview
+        case .preview: .source
+        }
+    }
+}

--- a/Pine/MarkdownPreviewView.swift
+++ b/Pine/MarkdownPreviewView.swift
@@ -1,0 +1,65 @@
+//
+//  MarkdownPreviewView.swift
+//  Pine
+//
+
+import SwiftUI
+
+/// Renders Markdown content as a read-only attributed string in a scrollable NSTextView.
+struct MarkdownPreviewView: NSViewRepresentable {
+    let content: String
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = .textBackgroundColor
+
+        let textView = NSTextView()
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isAutomaticLinkDetectionEnabled = true
+        textView.drawsBackground = true
+        textView.backgroundColor = .textBackgroundColor
+        textView.textContainerInset = NSSize(width: 20, height: 20)
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.widthTracksTextView = true
+
+        scrollView.documentView = textView
+        context.coordinator.textView = textView
+        context.coordinator.scheduleRender(content: content)
+
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        context.coordinator.scheduleRender(content: content)
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator {
+        weak var textView: NSTextView?
+        private let renderer = MarkdownRenderer()
+        private var pendingContent: String?
+        private var renderWorkItem: DispatchWorkItem?
+
+        func scheduleRender(content: String) {
+            renderWorkItem?.cancel()
+            pendingContent = content
+
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self, let content = self.pendingContent else { return }
+                self.pendingContent = nil
+                let attributed = self.renderer.render(content)
+                self.textView?.textStorage?.setAttributedString(attributed)
+            }
+            renderWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: workItem)
+        }
+    }
+}

--- a/Pine/MarkdownRenderer.swift
+++ b/Pine/MarkdownRenderer.swift
@@ -1,0 +1,398 @@
+//
+//  MarkdownRenderer.swift
+//  Pine
+//
+
+import AppKit
+import Markdown
+
+/// Renders Markdown text into an `NSAttributedString` using Apple's swift-markdown parser.
+/// Uses system colors for automatic light/dark mode support.
+final class MarkdownRenderer {
+
+    // MARK: - Font configuration
+
+    private static let bodySize: CGFloat = 15
+    private static let codeSize: CGFloat = 13
+    private static let h1Size: CGFloat = 28
+    private static let h2Size: CGFloat = 24
+    private static let h3Size: CGFloat = 20
+    private static let h4Size: CGFloat = 17
+
+    static let bodyFont = NSFont.systemFont(ofSize: bodySize)
+    static let boldFont = NSFont.boldSystemFont(ofSize: bodySize)
+    static let italicFont = NSFont.systemFont(ofSize: bodySize).withTraits(.italicFontMask)
+    static let codeFont = NSFont.monospacedSystemFont(ofSize: codeSize, weight: .regular)
+
+    static func headingFont(level: Int) -> NSFont {
+        let size: CGFloat
+        switch level {
+        case 1: size = h1Size
+        case 2: size = h2Size
+        case 3: size = h3Size
+        default: size = h4Size
+        }
+        return NSFont.boldSystemFont(ofSize: size)
+    }
+
+    // MARK: - Render
+
+    func render(_ markdown: String) -> NSAttributedString {
+        let document = Document(parsing: markdown)
+        var builder = AttributedStringBuilder()
+        return builder.visit(document)
+    }
+}
+
+// MARK: - NSFont helper
+
+private extension NSFont {
+    func withTraits(_ traits: NSFontTraitMask) -> NSFont {
+        let descriptor = fontDescriptor.withSymbolicTraits(NSFontDescriptor.SymbolicTraits(rawValue: UInt32(traits.rawValue)))
+        return NSFont(descriptor: descriptor, size: pointSize) ?? self
+    }
+}
+
+// MARK: - AttributedStringBuilder
+
+private struct AttributedStringBuilder: MarkupVisitor {
+    typealias Result = NSAttributedString
+
+    private var listDepth = 0
+    private var orderedListCounters: [Int] = []
+    private var isFirstBlock = true
+
+    private func bodyAttributes() -> [NSAttributedString.Key: Any] {
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = 4
+        return [
+            .font: MarkdownRenderer.bodyFont,
+            .foregroundColor: NSColor.labelColor,
+            .paragraphStyle: style
+        ]
+    }
+
+    // MARK: - Default
+
+    mutating func defaultVisit(_ markup: any Markup) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        for child in markup.children {
+            result.append(visit(child))
+        }
+        return result
+    }
+
+    // MARK: - Document
+
+    mutating func visitDocument(_ document: Document) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        for child in document.children {
+            result.append(visit(child))
+        }
+        return result
+    }
+
+    // MARK: - Block-level spacing
+
+    private mutating func blockPrefix() -> String {
+        if isFirstBlock {
+            isFirstBlock = false
+            return ""
+        }
+        return "\n\n"
+    }
+
+    // MARK: - Heading
+
+    mutating func visitHeading(_ heading: Heading) -> NSAttributedString {
+        let prefix = blockPrefix()
+        let result = NSMutableAttributedString()
+        if !prefix.isEmpty {
+            result.append(NSAttributedString(string: prefix))
+        }
+
+        let font = MarkdownRenderer.headingFont(level: heading.level)
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = 4
+        style.paragraphSpacingBefore = 8
+
+        let headingAttrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.labelColor,
+            .paragraphStyle: style
+        ]
+
+        for child in heading.children {
+            let childStr = visitInline(child)
+            let mutable = NSMutableAttributedString(attributedString: childStr)
+            mutable.addAttributes(headingAttrs, range: NSRange(location: 0, length: mutable.length))
+            result.append(mutable)
+        }
+
+        return result
+    }
+
+    // MARK: - Paragraph
+
+    mutating func visitParagraph(_ paragraph: Paragraph) -> NSAttributedString {
+        let prefix = blockPrefix()
+        let result = NSMutableAttributedString()
+        if !prefix.isEmpty {
+            result.append(NSAttributedString(string: prefix))
+        }
+
+        for child in paragraph.children {
+            result.append(visitInline(child))
+        }
+
+        // Apply paragraph style only — don't override inline fonts/colors
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = 4
+        let contentRange = NSRange(location: prefix.count, length: result.length - prefix.count)
+        result.addAttribute(.paragraphStyle, value: style, range: contentRange)
+
+        return result
+    }
+
+    // MARK: - Inline visitors
+
+    private mutating func visitInline(_ markup: any Markup) -> NSAttributedString {
+        visit(markup)
+    }
+
+    // MARK: - Text
+
+    mutating func visitText(_ text: Text) -> NSAttributedString {
+        NSAttributedString(string: text.string, attributes: bodyAttributes())
+    }
+
+    // MARK: - Strong (bold)
+
+    mutating func visitStrong(_ strong: Strong) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        for child in strong.children {
+            result.append(visitInline(child))
+        }
+        result.addAttribute(.font, value: MarkdownRenderer.boldFont,
+                            range: NSRange(location: 0, length: result.length))
+        return result
+    }
+
+    // MARK: - Emphasis (italic)
+
+    mutating func visitEmphasis(_ emphasis: Emphasis) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        for child in emphasis.children {
+            result.append(visitInline(child))
+        }
+        result.addAttribute(.font, value: MarkdownRenderer.italicFont,
+                            range: NSRange(location: 0, length: result.length))
+        return result
+    }
+
+    // MARK: - Inline code
+
+    mutating func visitInlineCode(_ inlineCode: InlineCode) -> NSAttributedString {
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: MarkdownRenderer.codeFont,
+            .foregroundColor: NSColor.systemPink,
+            .backgroundColor: NSColor.quaternaryLabelColor
+        ]
+        return NSAttributedString(string: inlineCode.code, attributes: attrs)
+    }
+
+    // MARK: - Code block
+
+    mutating func visitCodeBlock(_ codeBlock: CodeBlock) -> NSAttributedString {
+        let prefix = blockPrefix()
+        let code = codeBlock.code.hasSuffix("\n")
+            ? String(codeBlock.code.dropLast())
+            : codeBlock.code
+
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = 2
+        style.headIndent = 16
+        style.firstLineHeadIndent = 16
+        style.tailIndent = -16
+
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: MarkdownRenderer.codeFont,
+            .foregroundColor: NSColor.labelColor,
+            .backgroundColor: NSColor.quaternaryLabelColor,
+            .paragraphStyle: style
+        ]
+
+        let result = NSMutableAttributedString()
+        if !prefix.isEmpty {
+            result.append(NSAttributedString(string: prefix))
+        }
+        result.append(NSAttributedString(string: code, attributes: attrs))
+        return result
+    }
+
+    // MARK: - Link
+
+    mutating func visitLink(_ link: Link) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        for child in link.children {
+            result.append(visitInline(child))
+        }
+        let range = NSRange(location: 0, length: result.length)
+        result.addAttribute(.foregroundColor, value: NSColor.systemBlue, range: range)
+        result.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+        if let dest = link.destination, let url = URL(string: dest) {
+            result.addAttribute(.link, value: url, range: range)
+        }
+        return result
+    }
+
+    // MARK: - Unordered list
+
+    mutating func visitUnorderedList(_ unorderedList: UnorderedList) -> NSAttributedString {
+        let prefix = listDepth == 0 ? blockPrefix() : ""
+        let result = NSMutableAttributedString()
+        if !prefix.isEmpty {
+            result.append(NSAttributedString(string: prefix))
+        }
+
+        listDepth += 1
+        for (index, item) in unorderedList.listItems.enumerated() {
+            if index > 0 { result.append(NSAttributedString(string: "\n")) }
+            let indent = String(repeating: "    ", count: listDepth - 1)
+            let bullet: String
+            if let checkbox = item.checkbox {
+                bullet = checkbox == .checked ? "\(indent)  \u{2611} " : "\(indent)  \u{2610} "
+            } else {
+                bullet = "\(indent)  \u{2022} "
+            }
+            result.append(NSAttributedString(string: bullet, attributes: bodyAttributes()))
+            result.append(visitListItemContent(item))
+        }
+        listDepth -= 1
+
+        return result
+    }
+
+    // MARK: - Ordered list
+
+    mutating func visitOrderedList(_ orderedList: OrderedList) -> NSAttributedString {
+        let prefix = listDepth == 0 ? blockPrefix() : ""
+        let result = NSMutableAttributedString()
+        if !prefix.isEmpty {
+            result.append(NSAttributedString(string: prefix))
+        }
+
+        listDepth += 1
+        for (index, item) in orderedList.listItems.enumerated() {
+            if index > 0 { result.append(NSAttributedString(string: "\n")) }
+            let indent = String(repeating: "    ", count: listDepth - 1)
+            let number = "\(indent)  \(index + 1). "
+            result.append(NSAttributedString(string: number, attributes: bodyAttributes()))
+            result.append(visitListItemContent(item))
+        }
+        listDepth -= 1
+
+        return result
+    }
+
+    // MARK: - List item content
+
+    private mutating func visitListItemContent(_ item: ListItem) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        // Save/restore isFirstBlock so list items don't add extra spacing
+        let saved = isFirstBlock
+        isFirstBlock = true
+        for child in item.children {
+            if let para = child as? Paragraph {
+                // Inline paragraph content without extra newlines
+                for inline in para.children {
+                    result.append(visitInline(inline))
+                }
+            } else {
+                result.append(visit(child))
+            }
+        }
+        isFirstBlock = saved
+        return result
+    }
+
+    // MARK: - Blockquote
+
+    mutating func visitBlockQuote(_ blockQuote: BlockQuote) -> NSAttributedString {
+        let prefix = blockPrefix()
+        let result = NSMutableAttributedString()
+        if !prefix.isEmpty {
+            result.append(NSAttributedString(string: prefix))
+        }
+
+        let saved = isFirstBlock
+        isFirstBlock = true
+        let inner = NSMutableAttributedString()
+        for child in blockQuote.children {
+            inner.append(visit(child))
+        }
+        isFirstBlock = saved
+
+        let range = NSRange(location: 0, length: inner.length)
+        inner.addAttribute(.foregroundColor, value: NSColor.secondaryLabelColor, range: range)
+
+        let style = NSMutableParagraphStyle()
+        style.headIndent = 20
+        style.firstLineHeadIndent = 20
+        style.lineSpacing = 4
+        inner.addAttribute(.paragraphStyle, value: style, range: range)
+
+        result.append(inner)
+        return result
+    }
+
+    // MARK: - Strikethrough
+
+    mutating func visitStrikethrough(_ strikethrough: Strikethrough) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        for child in strikethrough.children {
+            result.append(visitInline(child))
+        }
+        result.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue,
+                            range: NSRange(location: 0, length: result.length))
+        return result
+    }
+
+    // MARK: - Thematic break (horizontal rule)
+
+    mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) -> NSAttributedString {
+        let prefix = blockPrefix()
+        let rule = String(repeating: "\u{2500}", count: 20)
+        let line = "\n\(rule)\n"
+        let attrs: [NSAttributedString.Key: Any] = [
+            .foregroundColor: NSColor.separatorColor,
+            .font: MarkdownRenderer.bodyFont
+        ]
+        let result = NSMutableAttributedString()
+        if !prefix.isEmpty {
+            result.append(NSAttributedString(string: prefix))
+        }
+        result.append(NSAttributedString(string: line, attributes: attrs))
+        return result
+    }
+
+    // MARK: - Soft/hard break
+
+    mutating func visitSoftBreak(_ softBreak: SoftBreak) -> NSAttributedString {
+        NSAttributedString(string: " ")
+    }
+
+    mutating func visitLineBreak(_ lineBreak: LineBreak) -> NSAttributedString {
+        NSAttributedString(string: "\n")
+    }
+
+    // MARK: - Image (show alt text)
+
+    mutating func visitImage(_ image: Image) -> NSAttributedString {
+        let altText = image.plainText.isEmpty ? "[image]" : "[\(image.plainText)]"
+        return NSAttributedString(string: altText, attributes: [
+            .foregroundColor: NSColor.secondaryLabelColor,
+            .font: MarkdownRenderer.italicFont
+        ])
+    }
+}

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -39,6 +39,12 @@ struct PineApp: App {
                     pm.terminal.isTerminalVisible.toggle()
                 }
                 .keyboardShortcut("`", modifiers: .command)
+
+                Button(Strings.menuTogglePreview) {
+                    guard let pm = focusedProject else { return }
+                    pm.tabManager.togglePreviewMode()
+                }
+                .keyboardShortcut("p", modifiers: [.command, .shift])
             }
             // Cmd+Shift+B — переключение веток
             CommandMenu(Strings.menuGit) {

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -27,10 +27,21 @@ final class ProjectManager {
 
         let activeFileURL = tabManager.activeTab?.url
 
+        // Collect preview modes for markdown tabs that aren't in default (.source) state
+        var previewModes: [String: String]?
+        let mdTabs = tabManager.tabs.filter { $0.isMarkdownFile && $0.previewMode != .source }
+        if !mdTabs.isEmpty {
+            previewModes = [:]
+            for tab in mdTabs {
+                previewModes?[tab.url.path] = tab.previewMode.rawValue
+            }
+        }
+
         SessionState.save(
             projectURL: rootURL,
             openFileURLs: openFileURLs,
-            activeFileURL: activeFileURL
+            activeFileURL: activeFileURL,
+            previewModes: previewModes
         )
     }
 

--- a/Pine/SessionState.swift
+++ b/Pine/SessionState.swift
@@ -14,6 +14,9 @@ struct SessionState: Codable {
     var projectPath: String
     var openFilePaths: [String]
     var activeFilePath: String?
+    /// Preview modes for markdown files. Key is file path, value is MarkdownPreviewMode raw value.
+    /// Optional for backwards compatibility with sessions saved before this field existed.
+    var previewModes: [String: String]?
 
     // MARK: - UserDefaults keys
 
@@ -48,12 +51,14 @@ struct SessionState: Codable {
         projectURL: URL,
         openFileURLs: [URL],
         activeFileURL: URL? = nil,
+        previewModes: [String: String]? = nil,
         defaults: UserDefaults = .standard
     ) {
         let state = SessionState(
             projectPath: projectURL.path,
             openFilePaths: openFileURLs.map(\.path),
-            activeFilePath: activeFileURL?.path
+            activeFilePath: activeFileURL?.path,
+            previewModes: previewModes
         )
         guard let data = try? JSONEncoder().encode(state) else { return }
         defaults.set(data, forKey: key(for: projectURL))

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -106,6 +106,7 @@ enum Strings {
 
     // MARK: - Menu Commands
 
+    static let menuTogglePreview: LocalizedStringKey = "menu.togglePreview"
     static let menuView: LocalizedStringKey = "menu.view"
     static let menuGit: LocalizedStringKey = "menu.git"
     static let menuOpenFolder: LocalizedStringKey = "menu.openFolder"

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -265,6 +265,14 @@ final class TabManager {
         }
     }
 
+    // MARK: - Markdown preview
+
+    /// Cycles the preview mode for the active tab if it's a Markdown file.
+    func togglePreviewMode() {
+        guard let index = activeTabIndex, tabs[index].isMarkdownFile else { return }
+        tabs[index].previewMode = tabs[index].previewMode.next
+    }
+
     // MARK: - External change detection
 
     /// Describes an external change that requires user action (dirty tab conflict).

--- a/PineTests/MarkdownPreviewModeTests.swift
+++ b/PineTests/MarkdownPreviewModeTests.swift
@@ -1,0 +1,55 @@
+//
+//  MarkdownPreviewModeTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("MarkdownPreviewMode")
+struct MarkdownPreviewModeTests {
+
+    @Test func defaultIsSource() {
+        let mode = MarkdownPreviewMode.source
+        #expect(mode == .source)
+    }
+
+    @Test func cycleSourceSplitPreviewSource() {
+        var mode = MarkdownPreviewMode.source
+        mode = mode.next
+        #expect(mode == .split)
+        mode = mode.next
+        #expect(mode == .preview)
+        mode = mode.next
+        #expect(mode == .source)
+    }
+
+    @Test func isCodable() throws {
+        let original = MarkdownPreviewMode.preview
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(MarkdownPreviewMode.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test func isMarkdownForMd() {
+        let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/readme.md"))
+        #expect(tab.isMarkdownFile == true)
+    }
+
+    @Test func isMarkdownForMarkdown() {
+        let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/notes.markdown"))
+        #expect(tab.isMarkdownFile == true)
+    }
+
+    @Test func isMarkdownForSwift() {
+        let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/main.swift"))
+        #expect(tab.isMarkdownFile == false)
+    }
+
+    @Test func isMarkdownForUppercaseMD() {
+        let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/README.MD"))
+        #expect(tab.isMarkdownFile == true)
+    }
+}

--- a/PineTests/MarkdownRendererTests.swift
+++ b/PineTests/MarkdownRendererTests.swift
@@ -1,0 +1,156 @@
+//
+//  MarkdownRendererTests.swift
+//  PineTests
+//
+
+import AppKit
+import Testing
+
+@testable import Pine
+
+@Suite("MarkdownRenderer")
+struct MarkdownRendererTests {
+
+    private let renderer = MarkdownRenderer()
+
+    // MARK: - Headings
+
+    @Test func rendersHeading1() {
+        let result = renderer.render("# Hello")
+        let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(font?.pointSize == 28)
+    }
+
+    @Test func rendersHeading2SmallerFont() {
+        let result = renderer.render("## Sub")
+        let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(font?.pointSize == 24)
+    }
+
+    @Test func rendersHeading3() {
+        let result = renderer.render("### Sub sub")
+        let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(font?.pointSize == 20)
+    }
+
+    // MARK: - Inline formatting
+
+    @Test func rendersBold() {
+        let result = renderer.render("**bold**")
+        let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(font == MarkdownRenderer.boldFont)
+    }
+
+    @Test func rendersItalic() {
+        let result = renderer.render("*italic*")
+        let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(font == MarkdownRenderer.italicFont)
+    }
+
+    @Test func rendersInlineCode() {
+        let result = renderer.render("`code`")
+        let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(font == MarkdownRenderer.codeFont)
+        let bgColor = result.attribute(.backgroundColor, at: 0, effectiveRange: nil) as? NSColor
+        #expect(bgColor != nil)
+    }
+
+    // MARK: - Code block
+
+    @Test func rendersCodeBlock() {
+        let result = renderer.render("```\nlet x = 1\n```")
+        #expect(result.string.contains("let x = 1"))
+        guard let range = result.string.range(of: "let") else {
+            Issue.record("Expected 'let' in rendered output")
+            return
+        }
+        let offset = result.string.distance(from: result.string.startIndex, to: range.lowerBound)
+        let font = result.attribute(.font, at: offset, effectiveRange: nil) as? NSFont
+        #expect(font?.isFixedPitch == true)
+    }
+
+    // MARK: - Lists
+
+    @Test func rendersUnorderedList() {
+        let result = renderer.render("- one\n- two")
+        #expect(result.string.contains("\u{2022}"))
+        #expect(result.string.contains("one"))
+        #expect(result.string.contains("two"))
+    }
+
+    @Test func rendersOrderedList() {
+        let result = renderer.render("1. first\n2. second")
+        #expect(result.string.contains("1."))
+        #expect(result.string.contains("2."))
+        #expect(result.string.contains("first"))
+    }
+
+    // MARK: - Link
+
+    @Test func rendersLink() {
+        let result = renderer.render("[click](https://example.com)")
+        #expect(result.string.contains("click"))
+        let color = result.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        #expect(color == NSColor.systemBlue)
+        let link = result.attribute(.link, at: 0, effectiveRange: nil) as? URL
+        #expect(link?.absoluteString == "https://example.com")
+    }
+
+    // MARK: - Blockquote
+
+    @Test func rendersBlockquote() {
+        let result = renderer.render("> quoted text")
+        #expect(result.string.contains("quoted text"))
+        guard let range = result.string.range(of: "quoted") else {
+            Issue.record("Expected 'quoted' in rendered output")
+            return
+        }
+        let offset = result.string.distance(from: result.string.startIndex, to: range.lowerBound)
+        let color = result.attribute(.foregroundColor, at: offset, effectiveRange: nil) as? NSColor
+        #expect(color == NSColor.secondaryLabelColor)
+    }
+
+    // MARK: - Strikethrough
+
+    @Test func rendersStrikethrough() {
+        let result = renderer.render("~~deleted~~")
+        #expect(result.string.contains("deleted"))
+        let strike = result.attribute(.strikethroughStyle, at: 0, effectiveRange: nil) as? Int
+        #expect(strike == NSUnderlineStyle.single.rawValue)
+    }
+
+    // MARK: - Task list
+
+    @Test func rendersTaskList() {
+        let result = renderer.render("- [ ] todo\n- [x] done")
+        #expect(result.string.contains("\u{2610}")) // unchecked
+        #expect(result.string.contains("\u{2611}")) // checked
+    }
+
+    // MARK: - Horizontal rule
+
+    @Test func rendersHorizontalRule() {
+        let result = renderer.render("---")
+        #expect(result.string.contains("\u{2500}"))
+    }
+
+    // MARK: - Edge cases
+
+    @Test func emptyStringProducesEmptyResult() {
+        let result = renderer.render("")
+        #expect(result.length == 0)
+    }
+
+    @Test func plainTextRendersAsParagraph() {
+        let result = renderer.render("just text")
+        #expect(result.string.contains("just text"))
+        let font = result.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
+        #expect(font == MarkdownRenderer.bodyFont)
+    }
+
+    @Test func usesSystemColors() {
+        let result = renderer.render("hello")
+        let color = result.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        #expect(color == NSColor.labelColor)
+    }
+}

--- a/PineTests/SessionStateTests.swift
+++ b/PineTests/SessionStateTests.swift
@@ -256,6 +256,45 @@ struct SessionStateTests {
         #expect(loaded == nil)
     }
 
+    // MARK: - Preview modes
+
+    @Test func previewModesRoundTrip() throws {
+        let tempDir = try makeTempDirectory()
+        defer { cleanup(tempDir) }
+
+        let file = tempDir.appendingPathComponent("readme.md")
+        FileManager.default.createFile(atPath: file.path, contents: nil)
+
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let modes = [file.path: "split"]
+        SessionState.save(
+            projectURL: tempDir,
+            openFileURLs: [file],
+            previewModes: modes,
+            defaults: defaults
+        )
+
+        let loaded = SessionState.load(for: tempDir, defaults: defaults)
+        #expect(loaded?.previewModes?[file.path] == "split")
+    }
+
+    @Test func legacySessionWithoutPreviewModesLoadsDefaults() throws {
+        let tempDir = try makeTempDirectory()
+        defer { cleanup(tempDir) }
+
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        // Save without preview modes (simulating older format)
+        SessionState.save(projectURL: tempDir, openFileURLs: [], defaults: defaults)
+
+        let loaded = SessionState.load(for: tempDir, defaults: defaults)
+        #expect(loaded != nil)
+        #expect(loaded?.previewModes == nil)
+    }
+
     // MARK: - Corrupt data
 
     @Test func loadReturnsNilOnCorruptData() throws {

--- a/PineTests/TabManagerTests.swift
+++ b/PineTests/TabManagerTests.swift
@@ -644,6 +644,56 @@ struct TabManagerTests {
         #expect(tab.isDirty == false)
     }
 
+    // MARK: - Markdown preview mode
+
+    @Test("Toggle preview mode cycles for markdown file")
+    func togglePreviewModeCyclesForMarkdown() {
+        let manager = TabManager()
+        let url = tempFileURL(name: "readme.md", content: "# Hello")
+
+        manager.openTab(url: url)
+        #expect(manager.activeTab?.previewMode == .source)
+
+        manager.togglePreviewMode()
+        #expect(manager.activeTab?.previewMode == .split)
+
+        manager.togglePreviewMode()
+        #expect(manager.activeTab?.previewMode == .preview)
+
+        manager.togglePreviewMode()
+        #expect(manager.activeTab?.previewMode == .source)
+    }
+
+    @Test("Toggle preview mode ignores non-markdown file")
+    func togglePreviewModeIgnoresNonMarkdown() {
+        let manager = TabManager()
+        let url = tempFileURL(name: "main.swift", content: "let x = 1")
+
+        manager.openTab(url: url)
+        #expect(manager.activeTab?.previewMode == .source)
+
+        manager.togglePreviewMode()
+        #expect(manager.activeTab?.previewMode == .source)
+    }
+
+    @Test("Preview mode preserved across tab switch")
+    func previewModePreservedAcrossTabSwitch() {
+        let manager = TabManager()
+        let mdURL = tempFileURL(name: "readme.md", content: "# Hello")
+        let swiftURL = tempFileURL(name: "main.swift", content: "let x = 1")
+
+        manager.openTab(url: mdURL)
+        manager.togglePreviewMode() // → split
+        #expect(manager.activeTab?.previewMode == .split)
+
+        manager.openTab(url: swiftURL)
+        #expect(manager.activeTab?.url == swiftURL)
+
+        // Switch back to markdown tab
+        manager.activeTabID = manager.tabs[0].id
+        #expect(manager.activeTab?.previewMode == .split)
+    }
+
     @Test("Rename preserves editor state")
     func renamePreservesEditorState() {
         let manager = TabManager()


### PR DESCRIPTION
## Summary

Closes #56

- Add native Markdown preview using Apple's [swift-markdown](https://github.com/swiftlang/swift-markdown) for AST parsing and `NSAttributedString` + `NSTextView` for rendering — no WKWebView
- Three display modes: **source** (code editor), **preview** (rendered), **split** (side-by-side `HSplitView`)
- Toggle via toolbar button (icon changes per mode) or **Cmd+Shift+P** keyboard shortcut
- Supports headings (H1-H4), bold, italic, inline code, code blocks, unordered/ordered lists, task lists (`[x]`/`[ ]`), links (clickable), blockquotes, strikethrough, horizontal rules, images (alt text)
- System colors (`NSColor.labelColor`, `.secondaryLabelColor`, `.systemBlue`) for automatic light/dark mode
- Preview mode persisted per-tab in `SessionState` with full backwards compatibility (optional `previewModes` dictionary)
- Debounced rendering (300ms) in `MarkdownPreviewView` to avoid lag during typing in split mode

### New files
| File | Purpose |
|------|---------|
| `Pine/MarkdownPreviewMode.swift` | `enum source/preview/split` with cyclic `.next` |
| `Pine/MarkdownRenderer.swift` | `MarkupVisitor` → `NSAttributedString` |
| `Pine/MarkdownPreviewView.swift` | `NSViewRepresentable` read-only scrollable preview |
| `PineTests/MarkdownPreviewModeTests.swift` | 7 tests |
| `PineTests/MarkdownRendererTests.swift` | 17 tests |

### Modified files
| File | Changes |
|------|---------|
| `EditorTab.swift` | + `previewMode`, `isMarkdownFile` |
| `TabManager.swift` | + `togglePreviewMode()` |
| `ContentView.swift` | `editorArea` switches by `previewMode`, `HSplitView` for split, session restore |
| `EditorTabBar.swift` | + preview toggle button |
| `PineApp.swift` | + Cmd+Shift+P in View menu |
| `Strings.swift` | + `menuTogglePreview` |
| `SessionState.swift` | + `previewModes: [String: String]?` |
| `ProjectManager.swift` | `saveSession()` persists preview modes |
| `AccessibilityIdentifiers.swift` | + markdown preview IDs |

## Test plan

- [x] `MarkdownPreviewModeTests` — 7/7 passed (enum cycling, Codable, isMarkdownFile)
- [x] `MarkdownRendererTests` — 17/17 passed (all element types, edge cases, system colors)
- [x] `TabManagerTests` — 32/32 passed (+3 new: toggle cycles, ignores non-md, preserves across switch)
- [x] `SessionStateTests` — 16/16 passed (+2 new: previewModes round-trip, legacy compatibility)
- [x] SwiftLint — 0 violations
- [ ] Manual: open `.md` file → verify toggle source/preview/split, Cmd+Shift+P
- [ ] Manual: verify preview renders headings, bold, italic, code, lists, links correctly
- [ ] Manual: verify split mode with live editing updates preview
- [ ] Manual: close and reopen project — verify preview mode is restored