### PR TITLE
chore!: prepare for 1.0.0 release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

- Remove `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` flags from `release-please-config.json`
- Project transitions to stable semver: `feat:` → minor bump, `feat!:`/`BREAKING CHANGE:` → major bump
- After merge, Release Please will create a release PR with version **1.0.0**

## Plan

1. Merge PR #134 (release 0.12.5)
2. Merge this PR
3. Release Please автоматически создаст PR с версией 1.0.0