### PR TITLE
fix: show text content for files with unrecognized extensions

### DIFF
--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -348,18 +348,17 @@ final class TabManager {
 
     /// Determines if a file should be opened as a Quick Look preview
     /// rather than in the text editor.
+    ///
+    /// Uses a whitelist approach: only known binary types (images, audio,
+    /// video, PDF, fonts) get a preview. Everything else opens as text,
+    /// which is the expected behavior for a code editor.
     func isPreviewFile(url: URL) -> Bool {
-        guard let type = UTType(filenameExtension: url.pathExtension),
-              !type.conforms(to: .text),
-              !type.conforms(to: .sourceCode)
-        else { return false }
-
-        // Additional check: files with no extension or unknown types
-        // default to text editor
-        if type == .item || type == .data {
+        guard let type = UTType(filenameExtension: url.pathExtension) else {
             return false
         }
-
-        return true
+        return type.conforms(to: .image)
+            || type.conforms(to: .audiovisualContent)
+            || type.conforms(to: .pdf)
+            || type.conforms(to: .font)
     }
 }

--- a/PineTests/TabManagerTests.swift
+++ b/PineTests/TabManagerTests.swift
@@ -609,6 +609,20 @@ struct TabManagerTests {
         #expect(manager.isPreviewFile(url: dir.appendingPathComponent("Makefile")) == false)
     }
 
+    @Test("isPreviewFile returns false for unrecognized plain-text extensions")
+    func isPreviewFileUnrecognizedExtensions() {
+        let manager = TabManager()
+        let dir = FileManager.default.temporaryDirectory
+        #expect(manager.isPreviewFile(url: dir.appendingPathComponent("main.go")) == false)
+        #expect(manager.isPreviewFile(url: dir.appendingPathComponent("go.mod")) == false)
+        #expect(manager.isPreviewFile(url: dir.appendingPathComponent("go.sum")) == false)
+        #expect(manager.isPreviewFile(url: dir.appendingPathComponent("coverage.out")) == false)
+        #expect(manager.isPreviewFile(url: dir.appendingPathComponent("Cargo.toml")) == false)
+        #expect(manager.isPreviewFile(url: dir.appendingPathComponent("Cargo.lock")) == false)
+        #expect(manager.isPreviewFile(url: dir.appendingPathComponent(".gitignore")) == false)
+        #expect(manager.isPreviewFile(url: dir.appendingPathComponent("Dockerfile")) == false)
+    }
+
     @Test("openTab for image creates preview tab")
     func openTabPreviewFile() {
         let manager = TabManager()

--- a/PineUITests/EditorWindowTests.swift
+++ b/PineUITests/EditorWindowTests.swift
@@ -220,6 +220,44 @@ final class EditorWindowTests: PineUITestCase {
     //     ...
     // }
 
+    // MARK: - P1: Unrecognized file extensions open as text, not preview
+
+    func testUnrecognizedExtensionOpensAsText() throws {
+        // Create a project with a .go file (unrecognized by macOS UTType as text)
+        let goProjectURL = try createTempProject(files: [
+            "main.go": "package main\n\nfunc main() {}\n"
+        ])
+        defer { cleanupProject(goProjectURL) }
+
+        launchWithProject(goProjectURL)
+
+        let sidebar = app.outlines["sidebar"]
+        XCTAssertTrue(waitForExistence(sidebar, timeout: 10), "Sidebar should appear")
+
+        let fileRow = app.staticTexts["fileNode_main.go"]
+        guard waitForExistence(fileRow, timeout: 5) else {
+            XCTFail("main.go should appear in the sidebar")
+            return
+        }
+        fileRow.click()
+
+        let tab = editorTab("main.go")
+        XCTAssertTrue(waitForExistence(tab, timeout: 5), "Editor tab for main.go should appear")
+
+        // The code editor should be shown, not Quick Look preview
+        let codeEditor = app.textViews["codeEditor"].firstMatch
+        let quickLook = app.descendants(matching: .any)["quickLookPreview"].firstMatch
+
+        XCTAssertTrue(
+            waitForExistence(codeEditor, timeout: 5),
+            "Code editor should be displayed for .go files"
+        )
+        XCTAssertFalse(
+            quickLook.exists,
+            "Quick Look preview should NOT be displayed for .go files"
+        )
+    }
+
     // MARK: - P1: Status bar terminal toggle visible
 
     func testTerminalToggleButtonVisible() throws {


### PR DESCRIPTION
## Summary

- Switch `isPreviewFile()` from blacklist (reject non-text UTTypes) to whitelist (allow only known binary types: image, audio/video, PDF, font)
- All files with unrecognized extensions (`.go`, `.mod`, `.sum`, `.out`, etc.) now open as text instead of showing a Finder-style icon
- Add unit tests for unrecognized extensions (`.go`, `.mod`, `.sum`, `.out`, `.toml`, `.lock`, `.gitignore`, `Dockerfile`)
- Add UI test verifying `.go` files open in the code editor, not Quick Look preview

Fixes #143

## Test plan

- [x] Unit tests pass locally (214 tests)
- [ ] UI test `testUnrecognizedExtensionOpensAsText` runs in CI
- [ ] Open a `.go` / `.mod` / `.sum` / `.out` file — should show text content
- [ ] Open an image / PDF — should still show Quick Look preview