### PR TITLE
fix: reset top content margins on Welcome recent projects list

### DIFF
--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -85,6 +85,7 @@ struct WelcomeView: View {
                         .accessibilityIdentifier(AccessibilityID.welcomeRecentProject(url.lastPathComponent))
                     }
                     .listStyle(.plain)
+                    .contentMargins(.top, 0, for: .scrollContent)
                     .accessibilityIdentifier(AccessibilityID.welcomeRecentProjectsList)
                 }
             }


### PR DESCRIPTION
## Summary

- On macOS 26 with Liquid Glass, `List` with `.listStyle(.plain)` adds negative top content margins, causing the first item in the recent projects list to be clipped behind the "Недавние проекты" header
- Added `.contentMargins(.top, 0, for: .scrollContent)` to reset margins to zero

Closes #114

## Test plan

- [ ] Launch Pine without open projects → Welcome window appears
- [ ] Verify the first recent project name is fully visible, not clipped at the top
- [ ] Verify spacing between "Недавние проекты" header and the first list item looks correct