### PR TITLE
feat: rewrite landing page and README for "fast, minimal, native" positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If VS Code feels heavy and Xcode feels like overkill for everyday editing, Pine 
 | `Cmd+Shift+S` | Save As |
 | `Cmd+Shift+D` | Duplicate tab |
 | `Cmd+W` | Close tab |
-| Cmd+\` | Toggle terminal |
+| ``Cmd+` `` | Toggle terminal |
 | `Cmd+Shift+B` | Switch branch |
 | `Cmd+Shift+P` | Toggle Markdown preview |
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1011,12 +1011,12 @@
                     <article class="feature-card feature-wide">
                         <div class="feature-badge">01</div>
                         <h3 data-i18n="features.01title">Open a repo and start working immediately.</h3>
-                        <p data-i18n="features.01desc">Folders-first file tree, clean empty states, hidden files skipped by default, native window tabs, and unsaved-change protection.</p>
+                        <p data-i18n="features.01desc">Folders-first file tree, clean empty states, hidden files skipped by default, editor tabs, and unsaved-change protection.</p>
                     </article>
                     <article class="feature-card">
                         <div class="feature-badge">02</div>
                         <h3 data-i18n="features.02title">Write code without visual drag.</h3>
-                        <p data-i18n="features.02desc">Line numbers, current-line highlight, undo, find bar, smart indent, and grammar-based syntax highlighting for the core working set.</p>
+                        <p data-i18n="features.02desc">Line numbers, current-line highlight, undo, find bar, smart indent, and syntax highlighting for Swift, TypeScript, JavaScript, Python, Go, Rust, and more.</p>
                     </article>
                     <article class="feature-card">
                         <div class="feature-badge">03</div>
@@ -1158,9 +1158,9 @@
                 "features.title": "The essentials, done like a Mac app.",
                 "features.desc": "Pine is not trying to become a platform. It is trying to cover the everyday loop with less friction.",
                 "features.01title": "Open a repo and start working immediately.",
-                "features.01desc": "Folders-first file tree, clean empty states, hidden files skipped by default, native window tabs, and unsaved-change protection.",
+                "features.01desc": "Folders-first file tree, clean empty states, hidden files skipped by default, editor tabs, and unsaved-change protection.",
                 "features.02title": "Write code without visual drag.",
-                "features.02desc": "Line numbers, current-line highlight, undo, find bar, smart indent, and grammar-based syntax highlighting for the core working set.",
+                "features.02desc": "Line numbers, current-line highlight, undo, find bar, smart indent, and syntax highlighting for Swift, TypeScript, JavaScript, Python, Go, Rust, and more.",
                 "features.03title": "Run commands in the same window.",
                 "features.03desc": "Multiple terminal tabs powered by SwiftTerm — a full VT100/xterm emulator with colors, oh-my-zsh, and TUI app support.",
                 "features.04title": "See git context where decisions happen.",
@@ -1250,9 +1250,9 @@
                 "features.title": "Все необходимое, как и должно быть в нормальном Mac-приложении.",
                 "features.desc": "Pine не пытается стать платформой. Он просто закрывает повседневные задачи разработчика без лишней возни.",
                 "features.01title": "Открыл репозиторий и сразу работаешь.",
-                "features.01desc": "Дерево файлов с папками сверху, понятные пустые экраны, скрытые файлы не мешают по умолчанию, нативные вкладки и защита от потери несохраненных изменений.",
+                "features.01desc": "Дерево файлов с папками сверху, понятные пустые экраны, скрытые файлы не мешают по умолчанию, вкладки редактора и защита от потери несохранённых изменений.",
                 "features.02title": "Пишешь код без визуального шума.",
-                "features.02desc": "Номера строк, подсветка текущей строки, отмена, поиск, умные отступы и подсветка синтаксиса на основе грамматик.",
+                "features.02desc": "Номера строк, подсветка текущей строки, отмена, поиск, умные отступы и подсветка синтаксиса для Swift, TypeScript, JavaScript, Python, Go, Rust и других.",
                 "features.03title": "Запускаешь команды в том же окне.",
                 "features.03desc": "Несколько вкладок терминала на SwiftTerm: полноценный VT100/xterm-эмулятор с цветами, oh-my-zsh и поддержкой TUI-приложений.",
                 "features.04title": "Git-контекст там, где ты принимаешь решения.",
@@ -1342,9 +1342,9 @@
                 "features.title": "Das Wesentliche, gemacht wie eine Mac-App.",
                 "features.desc": "Pine versucht nicht, eine Plattform zu werden. Es versucht, den täglichen Arbeitszyklus mit weniger Reibung abzudecken.",
                 "features.01title": "Repo öffnen und sofort loslegen.",
-                "features.01desc": "Ordner-first-Dateibaum, saubere Leerzustände, versteckte Dateien standardmäßig ausgeblendet, native Fenster-Tabs und Schutz vor ungespeicherten Änderungen.",
+                "features.01desc": "Ordner-first-Dateibaum, saubere Leerzustände, versteckte Dateien standardmäßig ausgeblendet, Editor-Tabs und Schutz vor ungespeicherten Änderungen.",
                 "features.02title": "Code schreiben ohne visuelles Rauschen.",
-                "features.02desc": "Zeilennummern, aktuelle Zeile hervorgehoben, Undo, Suchleiste, intelligenter Einzug und grammatikbasierte Syntaxhervorhebung.",
+                "features.02desc": "Zeilennummern, aktuelle Zeile hervorgehoben, Undo, Suchleiste, intelligenter Einzug und Syntaxhervorhebung für Swift, TypeScript, JavaScript, Python, Go, Rust und mehr.",
                 "features.03title": "Befehle im selben Fenster ausführen.",
                 "features.03desc": "Mehrere Terminal-Tabs mit SwiftTerm — ein vollständiger VT100/xterm-Emulator mit Farben, oh-my-zsh und TUI-App-Unterstützung.",
                 "features.04title": "Git-Kontext dort, wo Entscheidungen fallen.",
@@ -1434,9 +1434,9 @@
                 "features.title": "Lo esencial, hecho como una app de Mac.",
                 "features.desc": "Pine no intenta ser una plataforma. Intenta cubrir el ciclo diario con menos fricción.",
                 "features.01title": "Abrir un repo y empezar a trabajar de inmediato.",
-                "features.01desc": "Árbol de archivos con carpetas primero, estados vacíos limpios, archivos ocultos omitidos por defecto, pestañas nativas y protección de cambios sin guardar.",
+                "features.01desc": "Árbol de archivos con carpetas primero, estados vacíos limpios, archivos ocultos omitidos por defecto, pestañas del editor y protección de cambios sin guardar.",
                 "features.02title": "Escribir código sin ruido visual.",
-                "features.02desc": "Números de línea, resaltado de línea actual, deshacer, barra de búsqueda, indentación inteligente y resaltado de sintaxis basado en gramáticas.",
+                "features.02desc": "Números de línea, resaltado de línea actual, deshacer, barra de búsqueda, indentación inteligente y resaltado de sintaxis para Swift, TypeScript, JavaScript, Python, Go, Rust y más.",
                 "features.03title": "Ejecutar comandos en la misma ventana.",
                 "features.03desc": "Múltiples pestañas de terminal con SwiftTerm — un emulador VT100/xterm completo con colores, oh-my-zsh y soporte para apps TUI.",
                 "features.04title": "Ver el contexto de Git donde se toman las decisiones.",
@@ -1526,9 +1526,9 @@
                 "features.title": "L'essentiel, fait comme une app Mac.",
                 "features.desc": "Pine n'essaie pas de devenir une plateforme. Il essaie de couvrir le cycle quotidien avec moins de friction.",
                 "features.01title": "Ouvrir un dépôt et commencer immédiatement.",
-                "features.01desc": "Arborescence dossiers-first, états vides propres, fichiers cachés masqués par défaut, onglets natifs et protection des modifications non enregistrées.",
+                "features.01desc": "Arborescence dossiers-first, états vides propres, fichiers cachés masqués par défaut, onglets de l'éditeur et protection des modifications non enregistrées.",
                 "features.02title": "Écrire du code sans bruit visuel.",
-                "features.02desc": "Numéros de ligne, mise en surbrillance de la ligne courante, annulation, barre de recherche, indentation intelligente et coloration syntaxique basée sur les grammaires.",
+                "features.02desc": "Numéros de ligne, mise en surbrillance de la ligne courante, annulation, barre de recherche, indentation intelligente et coloration syntaxique pour Swift, TypeScript, JavaScript, Python, Go, Rust et plus.",
                 "features.03title": "Lancer des commandes dans la même fenêtre.",
                 "features.03desc": "Plusieurs onglets de terminal avec SwiftTerm — un émulateur VT100/xterm complet avec couleurs, oh-my-zsh et support des apps TUI.",
                 "features.04title": "Voir le contexte Git là où les décisions se prennent.",
@@ -1618,9 +1618,9 @@
                 "features.title": "Mac アプリらしく作られた、必要な機能。",
                 "features.desc": "Pine はプラットフォームになろうとはしていません。日常のループをより少ない摩擦でカバーしようとしています。",
                 "features.01title": "リポジトリを開いてすぐに作業開始。",
-                "features.01desc": "フォルダ優先のファイルツリー、クリーンな空の状態、デフォルトで隠しファイルをスキップ、ネイティブウィンドウタブ、未保存の変更保護。",
+                "features.01desc": "フォルダ優先のファイルツリー、クリーンな空の状態、デフォルトで隠しファイルをスキップ、エディタタブ、未保存の変更保護。",
                 "features.02title": "視覚的なノイズなくコードを書く。",
-                "features.02desc": "行番号、現在行ハイライト、アンドゥ、検索バー、スマートインデント、文法ベースのシンタックスハイライト。",
+                "features.02desc": "行番号、現在行ハイライト、アンドゥ、検索バー、スマートインデント、Swift・TypeScript・JavaScript・Python・Go・Rust 等のシンタックスハイライト。",
                 "features.03title": "同じウィンドウでコマンドを実行。",
                 "features.03desc": "SwiftTerm による複数ターミナルタブ — カラー、oh-my-zsh、TUI アプリ対応の完全な VT100/xterm エミュレータ。",
                 "features.04title": "判断を下す場所に Git コンテキスト。",
@@ -1710,9 +1710,9 @@
                 "features.title": "Mac 앱답게 만든 필수 기능.",
                 "features.desc": "Pine은 플랫폼이 되려 하지 않습니다. 일상적인 루프를 더 적은 마찰로 커버하려 합니다.",
                 "features.01title": "리포를 열고 즉시 작업 시작.",
-                "features.01desc": "폴더 우선 파일 트리, 깔끔한 빈 상태, 숨김 파일 기본 스킵, 네이티브 윈도우 탭, 미저장 변경 보호.",
+                "features.01desc": "폴더 우선 파일 트리, 깔끔한 빈 상태, 숨김 파일 기본 스킵, 편집기 탭, 미저장 변경 보호.",
                 "features.02title": "시각적 노이즈 없이 코드 작성.",
-                "features.02desc": "줄 번호, 현재 줄 강조, 실행 취소, 검색 바, 스마트 들여쓰기, 문법 기반 구문 강조.",
+                "features.02desc": "줄 번호, 현재 줄 강조, 실행 취소, 검색 바, 스마트 들여쓰기, Swift·TypeScript·JavaScript·Python·Go·Rust 등의 구문 강조.",
                 "features.03title": "같은 창에서 명령 실행.",
                 "features.03desc": "SwiftTerm 기반 다중 터미널 탭 — 색상, oh-my-zsh, TUI 앱을 지원하는 완전한 VT100/xterm 에뮬레이터.",
                 "features.04title": "결정이 이루어지는 곳에서 Git 컨텍스트 확인.",
@@ -1802,9 +1802,9 @@
                 "features.title": "O essencial, feito como um app de Mac.",
                 "features.desc": "Pine não tenta ser uma plataforma. Tenta cobrir o ciclo diário com menos atrito.",
                 "features.01title": "Abrir um repo e começar a trabalhar imediatamente.",
-                "features.01desc": "Árvore de arquivos com pastas primeiro, estados vazios limpos, arquivos ocultos ignorados por padrão, abas nativas e proteção de alterações não salvas.",
+                "features.01desc": "Árvore de arquivos com pastas primeiro, estados vazios limpos, arquivos ocultos ignorados por padrão, abas do editor e proteção de alterações não salvas.",
                 "features.02title": "Escrever código sem ruído visual.",
-                "features.02desc": "Números de linha, destaque da linha atual, desfazer, barra de busca, indentação inteligente e destaque de sintaxe baseado em gramáticas.",
+                "features.02desc": "Números de linha, destaque da linha atual, desfazer, barra de busca, indentação inteligente e destaque de sintaxe para Swift, TypeScript, JavaScript, Python, Go, Rust e mais.",
                 "features.03title": "Rodar comandos na mesma janela.",
                 "features.03desc": "Múltiplas abas de terminal com SwiftTerm — um emulador VT100/xterm completo com cores, oh-my-zsh e suporte a apps TUI.",
                 "features.04title": "Ver o contexto Git onde as decisões acontecem.",
@@ -1894,9 +1894,9 @@
                 "features.title": "必备功能，Mac 应用般的体验。",
                 "features.desc": "Pine 不试图成为平台，只是用更少的摩擦覆盖日常工作循环。",
                 "features.01title": "打开仓库，立即开始工作。",
-                "features.01desc": "文件夹优先的文件树、干净的空状态、默认隐藏隐藏文件、原生窗口标签页和未保存更改保护。",
+                "features.01desc": "文件夹优先的文件树、干净的空状态、默认隐藏隐藏文件、编辑器标签页和未保存更改保护。",
                 "features.02title": "无视觉干扰地编写代码。",
-                "features.02desc": "行号、当前行高亮、撤销、搜索栏、智能缩进和基于语法的代码高亮。",
+                "features.02desc": "行号、当前行高亮、撤销、搜索栏、智能缩进，以及 Swift、TypeScript、JavaScript、Python、Go、Rust 等语言的语法高亮。",
                 "features.03title": "在同一窗口运行命令。",
                 "features.03desc": "基于 SwiftTerm 的多终端标签页——完整的 VT100/xterm 模拟器，支持颜色、oh-my-zsh 和 TUI 应用。",
                 "features.04title": "在做决策的地方查看 Git 上下文。",


### PR DESCRIPTION
## Summary

- Rewrite README with accurate feature list, full keyboard shortcuts table, and "A fast, minimal, native macOS code editor" tagline
- Rewrite landing page hero, manifesto, and features to match the new positioning
- Remove false "native window tabs" claim (app uses internal SwiftUI tab bar) — replaced with "editor tabs"
- Replace "Swift 6" install badge with "SwiftUI + AppKit"
- Add syntax highlighting language list (Swift, TypeScript, JS, Python, Go, Rust…) to feature card
- Add Markdown preview and Quick Look to landing page features
- Add SEO meta tags: og:url, canonical, Twitter Cards, theme-color
- Add Screenshots link to navigation
- Remove `loading="lazy"` from hero image (above the fold)
- Add 7 new languages to landing page (de, es, fr, ja, ko, pt-BR, zh-Hans) — now matches all 9 app localizations
- Replace language toggle button with `<select>` dropdown

## Test plan

- [ ] Open `docs/index.html` locally, verify all 9 languages switch correctly
- [ ] Verify nav links (Why, Features, Install, Screenshots) scroll to correct sections
- [ ] Validate OG/Twitter tags with https://www.opengraph.xyz/ after deploy
- [ ] Confirm README renders correctly on GitHub (especially ``Cmd+` `` in shortcuts table)