### PR TITLE
feat: add C and C++ syntax highlighting grammars

### DIFF
--- a/Pine/Grammars/c.json
+++ b/Pine/Grammars/c.json
@@ -1,0 +1,56 @@
+{
+    "name": "C",
+    "extensions": ["c", "h"],
+    "rules": [
+        {
+            "pattern": "//.*$",
+            "scope": "comment",
+            "options": ["anchorsMatchLines"]
+        },
+        {
+            "pattern": "/\\*[\\s\\S]*?\\*/",
+            "scope": "comment"
+        },
+        {
+            "pattern": "\"(?:[^\"\\\\]|\\\\.)*\"",
+            "scope": "string"
+        },
+        {
+            "pattern": "'(?:[^'\\\\]|\\\\.)'",
+            "scope": "string"
+        },
+        {
+            "pattern": "#\\s*(include|define|undef|ifdef|ifndef|if|elif|else|endif|pragma|error|warning|line)\\b.*$",
+            "scope": "attribute",
+            "options": ["anchorsMatchLines"]
+        },
+        {
+            "pattern": "\\b(if|else|for|while|do|switch|case|default|break|continue|return|goto|typedef|struct|union|enum|sizeof|static|extern|inline|volatile|const|register|restrict|_Alignas|_Alignof|_Atomic|_Generic|_Noreturn|_Static_assert|_Thread_local)\\b",
+            "scope": "keyword"
+        },
+        {
+            "pattern": "\\b(true|false|NULL)\\b",
+            "scope": "keyword"
+        },
+        {
+            "pattern": "\\b(int|char|float|double|void|short|long|signed|unsigned|size_t|ssize_t|ptrdiff_t|intptr_t|uintptr_t|int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|bool|FILE|wchar_t)\\b",
+            "scope": "type"
+        },
+        {
+            "pattern": "\\b(printf|fprintf|sprintf|snprintf|scanf|fscanf|sscanf|malloc|calloc|realloc|free|memcpy|memset|memmove|strlen|strcpy|strncpy|strcmp|strncmp|strcat|strncat|fopen|fclose|fread|fwrite|fgets|fputs|exit|abort|assert)\\b",
+            "scope": "function"
+        },
+        {
+            "pattern": "\\b\\d+(\\.\\d+)?([eE][+-]?\\d+)?[fFlLuU]*\\b",
+            "scope": "number"
+        },
+        {
+            "pattern": "0x[0-9a-fA-F]+[uUlL]*",
+            "scope": "number"
+        },
+        {
+            "pattern": "0b[01]+[uUlL]*",
+            "scope": "number"
+        }
+    ]
+}

--- a/Pine/Grammars/cpp.json
+++ b/Pine/Grammars/cpp.json
@@ -1,0 +1,76 @@
+{
+    "name": "C++",
+    "extensions": ["cpp", "cc", "cxx", "hpp", "hxx", "hh"],
+    "rules": [
+        {
+            "pattern": "//.*$",
+            "scope": "comment",
+            "options": ["anchorsMatchLines"]
+        },
+        {
+            "pattern": "/\\*[\\s\\S]*?\\*/",
+            "scope": "comment"
+        },
+        {
+            "pattern": "R\"\\([^)]*\\)\"",
+            "scope": "string"
+        },
+        {
+            "pattern": "\"(?:[^\"\\\\]|\\\\.)*\"",
+            "scope": "string"
+        },
+        {
+            "pattern": "'(?:[^'\\\\]|\\\\.)'",
+            "scope": "string"
+        },
+        {
+            "pattern": "#\\s*(include|define|undef|ifdef|ifndef|if|elif|else|endif|pragma|error|warning|line)\\b.*$",
+            "scope": "attribute",
+            "options": ["anchorsMatchLines"]
+        },
+        {
+            "pattern": "\\b(if|else|for|while|do|switch|case|default|break|continue|return|goto|typedef|struct|union|enum|sizeof|static|extern|inline|volatile|const|register|class|namespace|template|typename|public|private|protected|virtual|override|final|friend|operator|new|delete|this|throw|try|catch|noexcept|constexpr|consteval|constinit|decltype|static_assert|static_cast|dynamic_cast|reinterpret_cast|const_cast|using|concept|requires|co_await|co_return|co_yield|export|module|import|mutable|explicit)\\b",
+            "scope": "keyword"
+        },
+        {
+            "pattern": "\\b(true|false|nullptr|NULL)\\b",
+            "scope": "keyword"
+        },
+        {
+            "pattern": "\\b(int|char|float|double|void|short|long|signed|unsigned|bool|auto|size_t|ssize_t|ptrdiff_t|intptr_t|uintptr_t|int8_t|int16_t|int32_t|int64_t|uint8_t|uint16_t|uint32_t|uint64_t|wchar_t|char8_t|char16_t|char32_t)\\b",
+            "scope": "type"
+        },
+        {
+            "pattern": "\\b(string|wstring|vector|map|unordered_map|set|unordered_set|list|deque|array|pair|tuple|optional|variant|any|unique_ptr|shared_ptr|weak_ptr|span|string_view|function|thread|mutex|atomic|future|promise|iostream|ostream|istream|fstream|stringstream)\\b",
+            "scope": "type"
+        },
+        {
+            "pattern": "\\b(std|cout|cin|cerr|clog|endl)\\b",
+            "scope": "type"
+        },
+        {
+            "pattern": "\\b\\d+(\\.\\d+)?([eE][+-]?\\d+)?[fFlLuU]*\\b",
+            "scope": "number"
+        },
+        {
+            "pattern": "0x[0-9a-fA-F]+[uUlL]*",
+            "scope": "number"
+        },
+        {
+            "pattern": "0b[01]+[uUlL]*",
+            "scope": "number"
+        },
+        {
+            "pattern": "\\b[A-Z_][A-Z0-9_]{2,}\\b",
+            "scope": "attribute"
+        },
+        {
+            "pattern": "\\b\\w+(?=\\s*\\()",
+            "scope": "function"
+        },
+        {
+            "pattern": "->|::|<<|>>",
+            "scope": "keyword"
+        }
+    ]
+}

--- a/PineTests/CGrammarTests.swift
+++ b/PineTests/CGrammarTests.swift
@@ -1,0 +1,77 @@
+//
+//  CGrammarTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+struct CGrammarTests {
+
+    let grammar: Grammar
+
+    init() throws {
+        let grammarDir = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Pine/Grammars")
+
+        let url = grammarDir.appendingPathComponent("c.json")
+        let data = try Data(contentsOf: url)
+        grammar = try JSONDecoder().decode(Grammar.self, from: data)
+    }
+
+    @Test func grammarMetadata() {
+        #expect(grammar.name == "C")
+        #expect(grammar.extensions.contains("c"))
+        #expect(grammar.extensions.contains("h"))
+    }
+
+    @Test func hasExpectedScopes() {
+        let scopes = Set(grammar.rules.map(\.scope))
+        #expect(scopes.contains("comment"))
+        #expect(scopes.contains("string"))
+        #expect(scopes.contains("keyword"))
+        #expect(scopes.contains("type"))
+        #expect(scopes.contains("number"))
+        #expect(scopes.contains("function"))
+        #expect(scopes.contains("attribute"))
+    }
+
+    @Test func lineCommentRule() throws {
+        let rule = grammar.rules.first { $0.scope == "comment" && $0.pattern.contains("//") }
+        #expect(rule != nil)
+        #expect(rule?.options?.contains("anchorsMatchLines") == true)
+    }
+
+    @Test func blockCommentRule() {
+        let rule = grammar.rules.first { $0.scope == "comment" && $0.pattern.contains("*") }
+        #expect(rule != nil)
+    }
+
+    @Test func stringRule() {
+        let rule = grammar.rules.first { $0.scope == "string" && $0.pattern.contains("\"") }
+        #expect(rule != nil)
+    }
+
+    @Test func preprocessorRule() {
+        let rule = grammar.rules.first { $0.scope == "attribute" && $0.pattern.contains("#") }
+        #expect(rule != nil)
+    }
+
+    @Test func keywordsIncludeReturn() {
+        let rule = grammar.rules.first { $0.scope == "keyword" && $0.pattern.contains("return") }
+        #expect(rule != nil)
+    }
+
+    @Test func typesIncludeInt() {
+        let rule = grammar.rules.first { $0.scope == "type" && $0.pattern.contains("int") }
+        #expect(rule != nil)
+    }
+
+    @Test func numberRules() {
+        let numberRules = grammar.rules.filter { $0.scope == "number" }
+        #expect(numberRules.count >= 2)
+    }
+}

--- a/PineTests/CppGrammarTests.swift
+++ b/PineTests/CppGrammarTests.swift
@@ -1,0 +1,86 @@
+//
+//  CppGrammarTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+struct CppGrammarTests {
+
+    let grammar: Grammar
+
+    init() throws {
+        let grammarDir = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Pine/Grammars")
+
+        let url = grammarDir.appendingPathComponent("cpp.json")
+        let data = try Data(contentsOf: url)
+        grammar = try JSONDecoder().decode(Grammar.self, from: data)
+    }
+
+    @Test func grammarMetadata() {
+        #expect(grammar.name == "C++")
+        #expect(grammar.extensions.contains("cpp"))
+        #expect(grammar.extensions.contains("cc"))
+        #expect(grammar.extensions.contains("cxx"))
+        #expect(grammar.extensions.contains("hpp"))
+        #expect(grammar.extensions.contains("hxx"))
+        #expect(grammar.extensions.contains("hh"))
+    }
+
+    @Test func hasExpectedScopes() {
+        let scopes = Set(grammar.rules.map(\.scope))
+        #expect(scopes.contains("comment"))
+        #expect(scopes.contains("string"))
+        #expect(scopes.contains("keyword"))
+        #expect(scopes.contains("type"))
+        #expect(scopes.contains("number"))
+        #expect(scopes.contains("function"))
+        #expect(scopes.contains("attribute"))
+    }
+
+    @Test func cppSpecificKeywords() {
+        let keywordRules = grammar.rules.filter { $0.scope == "keyword" }
+        let allPatterns = keywordRules.map(\.pattern).joined()
+        #expect(allPatterns.contains("class"))
+        #expect(allPatterns.contains("template"))
+        #expect(allPatterns.contains("namespace"))
+        #expect(allPatterns.contains("virtual"))
+        #expect(allPatterns.contains("override"))
+        #expect(allPatterns.contains("nullptr"))
+    }
+
+    @Test func cppSpecificTypes() {
+        let typeRules = grammar.rules.filter { $0.scope == "type" }
+        let allPatterns = typeRules.map(\.pattern).joined()
+        #expect(allPatterns.contains("string"))
+        #expect(allPatterns.contains("vector"))
+        #expect(allPatterns.contains("unique_ptr"))
+        #expect(allPatterns.contains("shared_ptr"))
+    }
+
+    @Test func preprocessorRule() {
+        let rule = grammar.rules.first { $0.scope == "attribute" && $0.pattern.contains("#") }
+        #expect(rule != nil)
+    }
+
+    @Test func rawStringRule() {
+        let rule = grammar.rules.first { $0.scope == "string" && $0.pattern.contains("R\"") }
+        #expect(rule != nil)
+    }
+
+    @Test func lineCommentRule() throws {
+        let rule = grammar.rules.first { $0.scope == "comment" && $0.pattern.contains("//") }
+        #expect(rule != nil)
+        #expect(rule?.options?.contains("anchorsMatchLines") == true)
+    }
+
+    @Test func numberRules() {
+        let numberRules = grammar.rules.filter { $0.scope == "number" }
+        #expect(numberRules.count >= 2)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Pine/Grammars/c.json` with extensions `["c", "h"]`
- Add `Pine/Grammars/cpp.json` with extensions `["cpp", "cc", "cxx", "hpp", "hxx", "hh"]`
- Cover comments, strings, preprocessor directives, keywords, types, numbers, and functions for both languages
- C++ grammar additionally supports raw strings, templates, namespaces, STL types, smart pointers

## Test plan
- [x] `CGrammarTests` — 9 tests covering metadata, all scopes, comments, strings, preprocessor, keywords, types, numbers
- [x] `CppGrammarTests` — 8 tests covering metadata, all scopes, C++-specific keywords/types, raw strings, preprocessor, numbers
- [x] Existing `bundledGrammarFilesAreValidJSON` test validates both new grammars automatically
- [x] SwiftLint clean

Closes #70