### PR TITLE
fix: rename DMG file before upload to match appcast URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,24 @@ jobs:
           </rss>
           APPCAST_EOF
 
+      - name: Validate appcast.xml
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          DMG_FILENAME="Pine-${VERSION}.dmg"
+          EXPECTED_URL="https://github.com/batonogov/pine/releases/download/v${VERSION}/${DMG_FILENAME}"
+          ACTUAL_URL=$(sed -n 's/.*enclosure url="\([^"]*\)".*/\1/p' "$RUNNER_TEMP/appcast.xml" | tr -d ' ')
+          if [ "$ACTUAL_URL" != "$EXPECTED_URL" ]; then
+            echo "::error::Appcast DMG URL mismatch"
+            echo "  Expected: $EXPECTED_URL"
+            echo "  Actual:   $ACTUAL_URL"
+            exit 1
+          fi
+          if [ ! -f "$RUNNER_TEMP/$DMG_FILENAME" ]; then
+            echo "::error::DMG file not found: $DMG_FILENAME"
+            exit 1
+          fi
+          echo "Appcast URL and DMG file validated successfully"
+
       - name: Upload DMG to GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Sparkle in-app update failed because the DMG asset name didn't match the URL in `appcast.xml`
- `gh release upload` with `file#label` syntax only sets the display label, not the asset filename — DMG was uploaded as `Pine.dmg` but appcast referenced `Pine-{version}.dmg` → **404**
- Added a rename step (`mv Pine.dmg Pine-{version}.dmg`) before upload so the asset filename matches the appcast URL

Closes #189

## Test plan

- [ ] Trigger a release build and verify the DMG asset in GitHub Release is named `Pine-{version}.dmg`
- [ ] Verify the `enclosure url` in `appcast.xml` resolves (no 404)
- [ ] Verify Sparkle in-app update downloads and installs successfully
- [ ] Verify `brew upgrade pine-editor` still works (SHA256 computed from renamed file)