### PR TITLE
feat: show formatted changelog in Sparkle update dialog

### DIFF
--- a/.github/scripts/changelog_to_html.py
+++ b/.github/scripts/changelog_to_html.py
@@ -19,7 +19,7 @@ REPO_URL = "https://github.com/batonogov/pine"
 
 HTML_TEMPLATE = """\
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <style>
@@ -63,7 +63,7 @@ HTML_TEMPLATE = """\
 
 FALLBACK_HTML = """\
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head><meta charset="utf-8">
 <style>
   body {{

--- a/.github/scripts/test_changelog_to_html.py
+++ b/.github/scripts/test_changelog_to_html.py
@@ -73,10 +73,11 @@ class TestExtractSection(unittest.TestCase):
         section = extract_section(SAMPLE_CHANGELOG, "9.9.9")
         assert section is None
 
-    def test_strips_v_prefix_not_needed(self):
-        # extract_section expects version without 'v'
-        section = extract_section(SAMPLE_CHANGELOG, "1.2.1")
+    def test_extracts_section_with_empty_subsections(self):
+        changelog = "## [2.0.0](url) (date)\n\n\n### Features\n\n* feat one\n"
+        section = extract_section(changelog, "2.0.0")
         assert section is not None
+        assert "feat one" in section
 
 
 class TestMdToHtml(unittest.TestCase):
@@ -110,7 +111,31 @@ class TestMdToHtml(unittest.TestCase):
         assert html == ""
 
 
-class TestInline(unittest.TestCase):
+class TestMdToHtmlShellSafety(unittest.TestCase):
+    """Ensure output is safe when interpolated in shell heredocs."""
+
+    def test_dollar_signs_preserved(self):
+        # $ is not an HTML special char — it passes through escape() as-is.
+        # This is safe because the HTML is written to a file and read by
+        # Python (not interpolated in a shell heredoc).
+        md = "### Bug Fixes\n\n* fix $HOME expansion in path"
+        html = md_to_html(md)
+        assert "fix $HOME expansion in path" in html
+
+    def test_backticks_converted_to_code_tags(self):
+        md = "### Features\n\n* add `$PATH` helper"
+        html = md_to_html(md)
+        # Backticks should become <code> tags, no raw backticks in output
+        assert "`" not in html
+        assert "<code>" in html
+
+    def test_backslash_preserved(self):
+        md = "### Bug Fixes\n\n* fix path\\separator issue"
+        html = md_to_html(md)
+        assert "path\\separator" in html
+
+
+
     def test_link(self):
         result = _inline("[text](https://example.com)")
         assert '<a href="https://example.com">text</a>' in result
@@ -148,6 +173,7 @@ class TestCLI(unittest.TestCase):
         )
         assert result.returncode == 0
         assert "<!DOCTYPE html>" in result.stdout
+        assert '<html lang="en">' in result.stdout
         assert "show abbreviated path" in result.stdout
 
     def test_missing_version_outputs_fallback(self):

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,8 @@ jobs:
           python3 .github/scripts/changelog_to_html.py "$VERSION" > "$RUNNER_TEMP/release-notes.html"
 
       - name: Generate appcast.xml
+        env:
+          APPCAST_BUILD_NUMBER: ${{ github.run_number }}
         run: |
           VERSION=${{ steps.version.outputs.VERSION }}
           PUB_DATE=$(date -u +"%a, %d %b %Y %H:%M:%S %z")
@@ -159,28 +161,37 @@ jobs:
           ED_SIGNATURE=$(echo "$SPARKLE_SIGNATURE" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')
           LENGTH=$(echo "$SPARKLE_SIGNATURE" | sed -n 's/.*length="\([^"]*\)".*/\1/p')
 
-          RELEASE_NOTES=$(cat "$RUNNER_TEMP/release-notes.html")
+          APPCAST_VERSION="$VERSION" \
+          APPCAST_PUB_DATE="$PUB_DATE" \
+          APPCAST_ED_SIGNATURE="$ED_SIGNATURE" \
+          APPCAST_LENGTH="$LENGTH" \
+          APPCAST_NOTES_FILE="$RUNNER_TEMP/release-notes.html" \
+          python3 -c '
+          import os
+          from pathlib import Path
 
-          cat > "$RUNNER_TEMP/appcast.xml" << APPCAST_EOF
-          <?xml version="1.0" encoding="utf-8"?>
+          notes = Path(os.environ["APPCAST_NOTES_FILE"]).read_text()
+          version = os.environ["APPCAST_VERSION"]
+
+          print(f"""<?xml version="1.0" encoding="utf-8"?>
           <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
             <channel>
               <title>Pine</title>
               <item>
-                <title>Version ${VERSION}</title>
-                <pubDate>${PUB_DATE}</pubDate>
-                <sparkle:version>${GITHUB_RUN_NUMBER}</sparkle:version>
-                <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
+                <title>Version {version}</title>
+                <pubDate>{os.environ["APPCAST_PUB_DATE"]}</pubDate>
+                <sparkle:version>{os.environ["APPCAST_BUILD_NUMBER"]}</sparkle:version>
+                <sparkle:shortVersionString>{version}</sparkle:shortVersionString>
                 <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-                <description><![CDATA[${RELEASE_NOTES}]]></description>
-                <enclosure url="https://github.com/batonogov/pine/releases/download/v${VERSION}/Pine-${VERSION}.dmg"
-                  sparkle:edSignature="${ED_SIGNATURE}"
-                  length="${LENGTH}"
+                <description><![CDATA[{notes}]]></description>
+                <enclosure url="https://github.com/batonogov/pine/releases/download/v{version}/Pine-{version}.dmg"
+                  sparkle:edSignature="{os.environ["APPCAST_ED_SIGNATURE"]}"
+                  length="{os.environ["APPCAST_LENGTH"]}"
                   type="application/octet-stream" />
               </item>
             </channel>
-          </rss>
-          APPCAST_EOF
+          </rss>""")
+          ' > "$RUNNER_TEMP/appcast.xml"
 
       - name: Upload DMG to GitHub Release
         env:


### PR DESCRIPTION
## Summary

- Replace raw GitHub Releases page with clean, styled HTML in Sparkle update dialog
- Add Python script (`.github/scripts/changelog_to_html.py`) that extracts version section from `CHANGELOG.md` and converts to HTML
- HTML uses system fonts (`-apple-system`), supports light/dark mode via `prefers-color-scheme`, transparent background
- Fallback to GitHub link if version not found in changelog
- 19 unit + integration tests for the script

## How it works

1. New CI step "Generate release notes HTML" runs the Python script before appcast generation
2. In `appcast.xml`, `<sparkle:releaseNotesLink>` (pointing to GitHub) is replaced with inline `<description><![CDATA[...]]></description>` containing the styled HTML
3. No changes to Swift code — Sparkle renders the inline HTML natively in its WebView

Closes #188

## Test plan

- [x] Unit tests for `extract_section`, `md_to_html`, `_inline` (15 tests)
- [x] CLI integration tests: valid version, missing version, missing file, no args (4 tests)
- [x] XSS protection: HTML entities are escaped before Markdown processing
- [ ] Visual verification: trigger a test release and check the Sparkle update dialog