### PR TITLE
fix: update Homebrew tap with versioned DMG filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,6 +245,7 @@ jobs:
           cd $RUNNER_TEMP/homebrew-tap
           sed -i '' "s/version \".*\"/version \"$VERSION\"/" Casks/pine-editor.rb
           sed -i '' "s/sha256 \".*\"/sha256 \"$SHA256\"/" Casks/pine-editor.rb
+          sed -i '' "s|Pine.dmg|Pine-#{version}.dmg|" Casks/pine-editor.rb
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Casks/pine-editor.rb


### PR DESCRIPTION
## Summary

- After #192 renamed DMG to `Pine-{VERSION}.dmg` for Sparkle appcast, the Homebrew tap update step still generated a cask with the old `Pine.dmg` URL
- Adds `sed` to update the DMG URL in the cask formula during release

## Fix applied

- **This repo**: workflow now updates the URL pattern in cask formula
- **homebrew-tap**: already fixed directly (batonogov/homebrew-tap@1d5e786) so `brew upgrade pine-editor` works for v1.3.0