### PR TITLE
feat: add lightbox for landing page screenshots

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -454,6 +454,8 @@
             max-height: 90vh;
             border-radius: var(--radius-md);
             display: block;
+            object-fit: contain;
+            cursor: pointer;
         }
 
         .screenshot-gallery figcaption {
@@ -2075,9 +2077,7 @@
         });
 
         lightbox.addEventListener("click", function(e) {
-            if (e.target === lightbox) {
-                lightbox.close();
-            }
+            lightbox.close();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary

- Screenshots on the landing page are now clickable — opens a native `<dialog>` lightbox with the full-size image
- Hover effect (`scale` + enhanced shadow) indicates interactivity
- Click outside or press Escape to close; no external dependencies

Closes #197

## Test plan

- [ ] Open `docs/index.html` in a browser
- [ ] Click each screenshot — verify the lightbox opens with the correct full-size image
- [ ] Click outside the image (on the backdrop) — verify the lightbox closes
- [ ] Press Escape — verify the lightbox closes
- [ ] Hover over screenshots — verify the subtle zoom effect
- [ ] Test on mobile viewport (single-column layout)