### PR TITLE
feat: dim gitignored files in sidebar file tree

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -874,7 +874,8 @@ struct FileNodeRow: View {
                 inlineEditor
             } else {
                 Label(node.name, systemImage: iconName)
-                    .foregroundStyle(isGitIgnored ? .secondary : gitStatus?.color ?? .primary)
+                    .foregroundStyle(gitStatus?.color ?? .primary)
+                    .opacity(isGitIgnored ? 0.5 : 1.0)
             }
         }
         .tag(node)

--- a/Pine/GitStatusProvider.swift
+++ b/Pine/GitStatusProvider.swift
@@ -183,6 +183,8 @@ final class GitStatusProvider {
 
         for line in output.components(separatedBy: "\n") {
             guard line.count >= 3 else { continue }
+            // Skip ignored entries (!! prefix) from --ignored output
+            guard !line.hasPrefix("!!") else { continue }
             let indexChar = line[line.startIndex]
             let workTreeChar = line[line.index(after: line.startIndex)]
             var path = String(line.dropFirst(3))

--- a/PineTests/GitStatusParserTests.swift
+++ b/PineTests/GitStatusParserTests.swift
@@ -92,6 +92,19 @@ struct GitStatusParserTests {
         #expect(statuses.isEmpty)
     }
 
+    @Test func parseStatusOutputSkipsIgnoredEntries() {
+        let output = """
+         M src/main.swift
+        !! .claude/
+        !! default.profraw
+        """
+        let statuses = GitStatusProvider.parseStatusOutput(output)
+        #expect(statuses.count == 1)
+        #expect(statuses["src/main.swift"] == .modified)
+        #expect(statuses[".claude/"] == nil)
+        #expect(statuses["default.profraw"] == nil)
+    }
+
     // MARK: - statusForDirectory
 
     @Test func directoryStatusShowsConflictOverOthers() {


### PR DESCRIPTION
## Summary

- Gitignored files and directories now appear dimmed (secondary color + 60% opacity) in the sidebar file tree
- `GitStatusProvider` parses `git status --ignored --porcelain` to identify ignored paths
- Ignored status propagates to files inside ignored directories (e.g. files inside `node_modules/`)
- 7 new unit tests covering parsing and ignored status queries

Closes #200

## Test plan
- [ ] Open a project with a `.gitignore` file — ignored files/dirs should appear dimmed
- [ ] Verify tracked and modified files still show correct colors (orange, green, etc.)
- [ ] Verify files inside ignored directories (e.g. `build/output.o`) are also dimmed
- [ ] Run `PineTests/GitStatusParserTests` — all 24 tests pass