### PR TITLE
feat: show recent projects in Dock context menu

### DIFF
--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -644,7 +644,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         return menu
     }
 
-    @objc private func dockMenuOpenProject(_ sender: NSMenuItem) {
+    @objc func dockMenuOpenProject(_ sender: NSMenuItem) {
         guard let url = sender.representedObject as? URL else { return }
         let canonical = url.resolvingSymlinksInPath()
         // If the project is already open with a visible window, just bring it front

--- a/PineTests/DockMenuTests.swift
+++ b/PineTests/DockMenuTests.swift
@@ -23,9 +23,19 @@ struct DockMenuTests {
         try? FileManager.default.removeItem(at: url)
     }
 
-    @Test func dockMenuReturnsNilWhenNoRecentProjects() {
+    /// Creates a fresh AppDelegate with an isolated registry (no persisted recent projects).
+    private func makeDelegate() -> AppDelegate {
         let delegate = AppDelegate()
-        delegate.registry = ProjectRegistry()
+        let registry = ProjectRegistry()
+        registry.recentProjects = []
+        delegate.registry = registry
+        return delegate
+    }
+
+    // MARK: - Menu construction
+
+    @Test func dockMenuReturnsNilWhenNoRecentProjects() {
+        let delegate = makeDelegate()
         let menu = delegate.applicationDockMenu(NSApplication.shared)
         #expect(menu == nil)
     }
@@ -38,12 +48,9 @@ struct DockMenuTests {
             cleanup(dir2)
         }
 
-        let registry = ProjectRegistry()
-        _ = registry.projectManager(for: dir1)
-        _ = registry.projectManager(for: dir2)
-
-        let delegate = AppDelegate()
-        delegate.registry = registry
+        let delegate = makeDelegate()
+        _ = delegate.registry.projectManager(for: dir1)
+        _ = delegate.registry.projectManager(for: dir2)
 
         let menu = delegate.applicationDockMenu(NSApplication.shared)
         #expect(menu != nil)
@@ -61,15 +68,12 @@ struct DockMenuTests {
         var dirs: [URL] = []
         defer { dirs.forEach { cleanup($0) } }
 
-        let registry = ProjectRegistry()
+        let delegate = makeDelegate()
         for _ in 0..<12 {
             let dir = try makeTempDirectory()
             dirs.append(dir)
-            _ = registry.projectManager(for: dir)
+            _ = delegate.registry.projectManager(for: dir)
         }
-
-        let delegate = AppDelegate()
-        delegate.registry = registry
 
         let menu = delegate.applicationDockMenu(NSApplication.shared)
         guard let menu else { return }
@@ -80,11 +84,8 @@ struct DockMenuTests {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
 
-        let registry = ProjectRegistry()
-        _ = registry.projectManager(for: dir)
-
-        let delegate = AppDelegate()
-        delegate.registry = registry
+        let delegate = makeDelegate()
+        _ = delegate.registry.projectManager(for: dir)
 
         let menu = delegate.applicationDockMenu(NSApplication.shared)
         guard let menu else { return }
@@ -97,11 +98,8 @@ struct DockMenuTests {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
 
-        let registry = ProjectRegistry()
-        _ = registry.projectManager(for: dir)
-
-        let delegate = AppDelegate()
-        delegate.registry = registry
+        let delegate = makeDelegate()
+        _ = delegate.registry.projectManager(for: dir)
 
         let menu = delegate.applicationDockMenu(NSApplication.shared)
         guard let menu else { return }
@@ -109,5 +107,122 @@ struct DockMenuTests {
         let canonical = dir.resolvingSymlinksInPath()
         #expect(item.title.contains(canonical.lastPathComponent))
         #expect(item.title.contains("—"))
+    }
+
+    @Test func dockMenuOrderMatchesRecentProjectsOrder() throws {
+        let dir1 = try makeTempDirectory()
+        let dir2 = try makeTempDirectory()
+        let dir3 = try makeTempDirectory()
+        defer {
+            cleanup(dir1)
+            cleanup(dir2)
+            cleanup(dir3)
+        }
+
+        let delegate = makeDelegate()
+        _ = delegate.registry.projectManager(for: dir1)
+        _ = delegate.registry.projectManager(for: dir2)
+        _ = delegate.registry.projectManager(for: dir3)
+
+        let menu = delegate.applicationDockMenu(NSApplication.shared)
+        guard let menu else { return }
+        #expect(menu.items.count == 3)
+
+        // recentProjects order: dir3 (most recent), dir2, dir1
+        let canonical3 = dir3.resolvingSymlinksInPath()
+        let canonical2 = dir2.resolvingSymlinksInPath()
+        let canonical1 = dir1.resolvingSymlinksInPath()
+        #expect(menu.items[0].representedObject as? URL == canonical3)
+        #expect(menu.items[1].representedObject as? URL == canonical2)
+        #expect(menu.items[2].representedObject as? URL == canonical1)
+    }
+
+    // MARK: - Menu item action
+
+    @Test func dockMenuOpenProjectCallsOpenProjectWindow() throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        let delegate = makeDelegate()
+        var openedURL: URL?
+        delegate.openProjectWindow = { url in openedURL = url }
+
+        let canonical = dir.resolvingSymlinksInPath()
+        let item = NSMenuItem()
+        item.representedObject = canonical
+
+        delegate.dockMenuOpenProject(item)
+
+        #expect(openedURL == canonical)
+        #expect(delegate.registry.isProjectOpen(canonical))
+    }
+
+    @Test func dockMenuOpenProjectIgnoresInvalidRepresentedObject() {
+        let delegate = makeDelegate()
+        var openCalled = false
+        delegate.openProjectWindow = { _ in openCalled = true }
+
+        let item = NSMenuItem()
+        item.representedObject = "not a URL"
+
+        delegate.dockMenuOpenProject(item)
+        #expect(!openCalled)
+    }
+
+    @Test func dockMenuOpenProjectIgnoresNilRepresentedObject() {
+        let delegate = makeDelegate()
+        var openCalled = false
+        delegate.openProjectWindow = { _ in openCalled = true }
+
+        let item = NSMenuItem()
+        delegate.dockMenuOpenProject(item)
+        #expect(!openCalled)
+    }
+
+    @Test func dockMenuOpenProjectHandlesDeletedDirectory() throws {
+        let dir = try makeTempDirectory()
+        let canonical = dir.resolvingSymlinksInPath()
+
+        let delegate = makeDelegate()
+        _ = delegate.registry.projectManager(for: canonical)
+
+        // Delete the directory
+        cleanup(dir)
+
+        var openCalled = false
+        delegate.openProjectWindow = { _ in openCalled = true }
+
+        // Close to background so projectManager(for:) tries to recreate
+        delegate.registry.closeProject(canonical)
+
+        let item = NSMenuItem()
+        item.representedObject = canonical
+
+        delegate.dockMenuOpenProject(item)
+        // Should not open — directory doesn't exist
+        #expect(!openCalled)
+    }
+
+    @Test func dockMenuOpenProjectReopensBackgroundProject() throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        let canonical = dir.resolvingSymlinksInPath()
+        let delegate = makeDelegate()
+        _ = delegate.registry.projectManager(for: canonical)
+        // Move to background (simulates window close)
+        delegate.registry.closeProjectWindow(canonical)
+        #expect(delegate.registry.backgroundProjects.contains(canonical))
+
+        var openedURL: URL?
+        delegate.openProjectWindow = { url in openedURL = url }
+
+        let item = NSMenuItem()
+        item.representedObject = canonical
+
+        delegate.dockMenuOpenProject(item)
+
+        #expect(openedURL == canonical)
+        #expect(!delegate.registry.backgroundProjects.contains(canonical))
     }
 }


### PR DESCRIPTION
## Summary

- Implement `applicationDockMenu(_:)` in `AppDelegate` to show up to 10 recent projects when right-clicking the Dock icon
- Clicking a project opens it or focuses its existing window; Welcome window is hidden automatically
- Add 11 unit tests covering menu construction and action handler

Closes #195

## Test plan

- [x] Открыть 2-3 проекта, затем закрыть окна
- [x] Правый клик по иконке Pine в Dock — должен появиться список недавних проектов
- [x] Клик по проекту из Dock-меню — должно открыться окно с этим проектом
- [x] Клик по уже открытому проекту — должно сфокусироваться существующее окно (не дублировать)
- [x] Проверить что отображается не более 10 проектов (покрыто unit-тестом `dockMenuLimitsToTenProjects`)
- [x] Проверить формат: `ProjectName — ~/path/to/project`
- [x] Unit-тесты: `DockMenuTests` — все 11 тестов проходят