### PR TITLE
ci: expand paths-ignore to skip CI on non-code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
       - "docs/**"
       - "assets/**"
       - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".release-please-manifest.json"
+      - "release-please-config.json"
   push:
     branches: [main]
     paths-ignore:
@@ -18,6 +21,9 @@ on:
       - "docs/**"
       - "assets/**"
       - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".release-please-manifest.json"
+      - "release-please-config.json"
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #247

## Summary

- Expand `paths-ignore` in CI workflow to skip runs on non-code changes
- Added: `.github/ISSUE_TEMPLATE/**`, `.release-please-manifest.json`, `release-please-config.json`
- `.github/workflows/**` is intentionally **not** ignored — workflow changes still trigger CI

## Test plan

- [ ] Verify CI triggers on code changes (`.swift`, `.xcodeproj`, etc.)
- [ ] Verify CI triggers on workflow changes (`.github/workflows/*.yml`)
- [ ] Verify CI does **not** trigger on ignored paths (issue templates, release-please configs)