### PR TITLE
fix: remove contentMargins that clips first item in Welcome recent projects list

### DIFF
--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -94,7 +94,6 @@ struct WelcomeView: View {
                         .accessibilityIdentifier(AccessibilityID.welcomeRecentProject(url.lastPathComponent))
                     }
                     .listStyle(.plain)
-                    .contentMargins(.top, 0, for: .scrollContent)
                     .accessibilityIdentifier(AccessibilityID.welcomeRecentProjectsList)
                 }
             }

--- a/PineUITests/WelcomeWindowTests.swift
+++ b/PineUITests/WelcomeWindowTests.swift
@@ -196,6 +196,43 @@ final class WelcomeWindowTests: PineUITestCase {
         }
     }
 
+    // MARK: - First recent project is not obscured by header
+
+    func testFirstRecentProjectIsHittable() throws {
+        // Step 1: Launch with a project to create a recent entry
+        let url = try createTempProject(files: ["hello.swift": "// hi\n"])
+        projectURLs.append(url)
+        launchWithProject(url)
+
+        let sidebar = app.outlines["sidebar"]
+        XCTAssertTrue(waitForExistence(sidebar, timeout: 10), "Project should open")
+
+        // Step 2: Terminate and relaunch to see Welcome with recent projects
+        app.terminate()
+
+        app = XCUIApplication()
+        app.launchArguments += ["--reset-state"]
+        app.launch()
+        app.activate()
+
+        let welcomeWindow = app.windows["welcome"]
+        XCTAssertTrue(waitForExistence(welcomeWindow, timeout: 10), "Welcome should appear")
+
+        // Step 3: Verify the first recent project is fully visible and clickable
+        let projectName = url.lastPathComponent
+        let recentItem = app.descendants(matching: .any)[
+            "welcomeRecentProject_\(projectName)"
+        ].firstMatch
+        XCTAssertTrue(
+            waitForExistence(recentItem, timeout: 5),
+            "Recent project should appear in Welcome"
+        )
+        XCTAssertTrue(
+            recentItem.isHittable,
+            "First recent project should not be obscured by the header"
+        )
+    }
+
     // MARK: - P0: Close project → Welcome reappears
 
     func testWelcomeReappearsAfterClosingProjectWindow() throws {


### PR DESCRIPTION
## Summary

- Removed `.contentMargins(.top, 0, for: .scrollContent)` from the recent projects `List` in `WelcomeView` — this modifier caused the first item to be clipped behind the "Recent Projects" header on macOS 26 with Liquid Glass
- Added UI test `testFirstRecentProjectIsHittable` to verify the first recent project is fully visible and not obscured

## Test plan

- [x] UI test `testFirstRecentProjectIsHittable` passes
- [ ] Visual check: open Pine, verify the first recent project is fully visible in the Welcome window
- [ ] Existing Welcome window UI tests still pass

Closes #207