### PR TITLE
feat: add code folding for collapsible regions

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -222,6 +222,8 @@ struct CodeEditorView: NSViewRepresentable {
     var language: String
     var fileName: String?
     var lineDiffs: [GitLineDiff] = []
+    /// Binding to the fold state for the active tab.
+    @Binding var foldState: FoldState
     /// Whether the minimap panel is visible.
     var isMinimapVisible: Bool = true
     /// Whether syntax highlighting is disabled for this tab (e.g. large files).
@@ -320,10 +322,18 @@ struct CodeEditorView: NSViewRepresentable {
 
         container.addSubview(scrollView)
 
+        // ── NSLayoutManager delegate for code folding ──
+        layoutManager.delegate = context.coordinator
+
         // ── Номера строк — поверх scroll view, как отдельный сиблинг ──
         let lineNumberView = LineNumberView(textView: textView)
         lineNumberView.gutterWidth = gutterWidth
         lineNumberView.gutterFont = gutterFont
+        lineNumberView.foldState = foldState
+        let coordinator = context.coordinator
+        lineNumberView.onFoldToggle = { [weak coordinator] foldable in
+            coordinator?.handleFoldToggle(foldable)
+        }
         container.addSubview(lineNumberView)
 
         // ── Minimap — справа от scroll view ──
@@ -395,6 +405,17 @@ struct CodeEditorView: NSViewRepresentable {
             object: nil
         )
 
+        // Observe fold code notifications (Cmd+Option+arrows)
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.handleFoldCode(_:)),
+            name: .foldCode,
+            object: nil
+        )
+
+        // Calculate initial foldable ranges
+        context.coordinator.recalculateFoldableRanges()
+
         return container
     }
 
@@ -431,6 +452,7 @@ struct CodeEditorView: NSViewRepresentable {
         // Обновляем diff-данные LineNumberView и MinimapView
         if let lineNumberView = context.coordinator.lineNumberView {
             lineNumberView.lineDiffs = lineDiffs
+            lineNumberView.foldState = foldState
         }
         if let minimapView = context.coordinator.minimapView {
             minimapView.lineDiffs = lineDiffs
@@ -451,11 +473,14 @@ struct CodeEditorView: NSViewRepresentable {
         Coordinator(parent: self)
     }
 
-    class Coordinator: NSObject, NSTextViewDelegate {
+    class Coordinator: NSObject, NSTextViewDelegate, NSLayoutManagerDelegate {
         var parent: CodeEditorView
         var scrollView: NSScrollView?
         var lineNumberView: LineNumberView?
         var minimapView: MinimapView?
+
+        /// Cached foldable ranges for the current text.
+        var foldableRanges: [FoldableRange] = []
 
         /// Последние язык/имя файла — для обнаружения смены грамматики
         /// при одинаковом содержимом файлов
@@ -622,6 +647,9 @@ struct CodeEditorView: NSViewRepresentable {
 
             // Report state change
             reportStateChange()
+
+            // Recalculate foldable ranges (debounced with highlighting)
+            recalculateFoldableRanges()
 
             // Захватываем editedRange из textStorage сейчас,
             // пока он валиден в координатах текущей версии текста
@@ -851,6 +879,144 @@ struct CodeEditorView: NSViewRepresentable {
                   let gutterView = sv.documentView as? GutterTextView,
                   gutterView.window?.isKeyWindow == true else { return }
             gutterView.toggleComment()
+        }
+
+        // MARK: - Code folding
+
+        /// Recalculates foldable ranges from the current text.
+        func recalculateFoldableRanges() {
+            guard let sv = scrollView,
+                  let textView = sv.documentView as? NSTextView else { return }
+            let text = textView.string
+            let skipRanges = SyntaxHighlighter.shared.commentAndStringRanges(
+                in: text,
+                language: parent.language,
+                fileName: parent.fileName
+            )
+            foldableRanges = FoldRangeCalculator.calculate(text: text, skipRanges: skipRanges)
+            lineNumberView?.foldableRanges = foldableRanges
+        }
+
+        /// Handles fold toggle from gutter click.
+        func handleFoldToggle(_ foldable: FoldableRange) {
+            parent.foldState.toggle(foldable)
+            applyFoldState()
+        }
+
+        /// Handles fold code notifications from menu/keyboard shortcuts.
+        @objc func handleFoldCode(_ notification: Notification) {
+            guard let sv = scrollView,
+                  let textView = sv.documentView as? GutterTextView,
+                  textView.window?.isKeyWindow == true,
+                  let action = notification.userInfo?["action"] as? String else { return }
+
+            switch action {
+            case "fold":
+                foldAtCursor()
+            case "unfold":
+                unfoldAtCursor()
+            case "foldAll":
+                parent.foldState.foldAll(foldableRanges)
+                applyFoldState()
+            case "unfoldAll":
+                parent.foldState.unfoldAll()
+                applyFoldState()
+            default:
+                break
+            }
+        }
+
+        /// Folds the innermost foldable range containing the cursor.
+        private func foldAtCursor() {
+            guard let sv = scrollView,
+                  let textView = sv.documentView as? NSTextView else { return }
+            let cursorLocation = textView.selectedRange().location
+            let source = textView.string as NSString
+
+            // Find cursor's line number
+            var cursorLine = 1
+            for i in 0..<min(cursorLocation, source.length) where source.character(at: i) == 0x0A {
+                cursorLine += 1
+            }
+
+            // Find innermost unfoldable range at cursor line
+            let candidates = foldableRanges.filter {
+                cursorLine >= $0.startLine && cursorLine <= $0.endLine
+                    && !parent.foldState.isFolded($0)
+            }
+            // Pick the innermost (smallest span)
+            if let best = candidates.min(by: { ($0.endLine - $0.startLine) < ($1.endLine - $1.startLine) }) {
+                parent.foldState.fold(best)
+                applyFoldState()
+            }
+        }
+
+        /// Unfolds the fold at the cursor position.
+        private func unfoldAtCursor() {
+            guard let sv = scrollView,
+                  let textView = sv.documentView as? NSTextView else { return }
+            let cursorLocation = textView.selectedRange().location
+            let source = textView.string as NSString
+
+            var cursorLine = 1
+            for i in 0..<min(cursorLocation, source.length) where source.character(at: i) == 0x0A {
+                cursorLine += 1
+            }
+
+            // Find folded range whose startLine matches cursor line
+            if let folded = parent.foldState.foldedRanges.first(where: { $0.startLine == cursorLine }) {
+                parent.foldState.unfold(folded)
+                applyFoldState()
+            }
+        }
+
+        /// Applies the current fold state to the layout manager and redraws.
+        private func applyFoldState() {
+            guard let sv = scrollView,
+                  let textView = sv.documentView as? NSTextView,
+                  let layoutManager = textView.layoutManager else { return }
+
+            lineNumberView?.foldState = parent.foldState
+            // Invalidate layout so the delegate methods re-evaluate which lines are hidden
+            layoutManager.invalidateLayout(
+                forCharacterRange: NSRange(location: 0, length: (textView.string as NSString).length),
+                actualCharacterRange: nil
+            )
+            textView.needsDisplay = true
+            lineNumberView?.needsDisplay = true
+            minimapView?.needsDisplay = true
+        }
+
+        // MARK: - NSLayoutManagerDelegate (code folding)
+
+        // swiftlint:disable:next function_parameter_count
+        func layoutManager(
+            _ layoutManager: NSLayoutManager,
+            shouldSetLineFragmentRect lineFragmentRect: UnsafeMutablePointer<NSRect>,
+            lineFragmentUsedRect: UnsafeMutablePointer<NSRect>,
+            baselineOffset: UnsafeMutablePointer<CGFloat>,
+            in textContainer: NSTextContainer,
+            forGlyphRange glyphRange: NSRange
+        ) -> Bool {
+            let charRange = layoutManager.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
+            guard let textStorage = layoutManager.textStorage else { return false }
+            let source = textStorage.string as NSString
+
+            // Find line number for the start of this glyph range
+            var line = 1
+            for i in 0..<min(charRange.location, source.length) where source.character(at: i) == 0x0A {
+                line += 1
+            }
+
+            // If this line is hidden (inside a folded region), collapse it to zero height
+            if parent.foldState.isLineHidden(line) {
+                lineFragmentRect.pointee.size.height = 0
+                lineFragmentUsedRect.pointee.size.height = 0
+                baselineOffset.pointee = 0
+                return true
+            }
+
+            return false
         }
 
         private func reportStateChange() {

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -515,6 +515,10 @@ struct ContentView: View {
             language: tab.language,
             fileName: tab.fileName,
             lineDiffs: lineDiffs,
+            foldState: Binding(
+                get: { tab.foldState },
+                set: { tabManager.updateFoldState($0) }
+            ),
             isMinimapVisible: isMinimapVisible,
             syntaxHighlightingDisabled: tab.syntaxHighlightingDisabled,
             initialCursorPosition: goToLineOffset?.offset ?? tab.cursorPosition,

--- a/Pine/EditorTab.swift
+++ b/Pine/EditorTab.swift
@@ -33,6 +33,9 @@ struct EditorTab: Identifiable, Hashable {
     /// Used to detect external changes by comparing with the current stat.
     var lastModDate: Date?
 
+    /// Состояние свёрнутых регионов кода.
+    var foldState: FoldState = FoldState()
+
     /// Markdown preview mode (source/preview/split). Only meaningful for markdown files.
     var previewMode: MarkdownPreviewMode = .source
 

--- a/Pine/FoldRangeCalculator.swift
+++ b/Pine/FoldRangeCalculator.swift
@@ -1,0 +1,124 @@
+//
+//  FoldRangeCalculator.swift
+//  Pine
+//
+
+import Foundation
+
+/// Описание складываемого региона кода.
+struct FoldableRange: Equatable {
+    /// 1-based номер строки с открывающей скобкой
+    let startLine: Int
+    /// 1-based номер строки с закрывающей скобкой
+    let endLine: Int
+    /// UTF-16 смещение открывающего символа
+    let startCharIndex: Int
+    /// UTF-16 смещение закрывающего символа
+    let endCharIndex: Int
+    /// Тип складываемого региона
+    let kind: FoldKind
+}
+
+/// Тип складываемого региона.
+enum FoldKind: Equatable {
+    case braces       // { }
+    case brackets     // [ ]
+    case parentheses  // ( )
+}
+
+/// Вычисляет складываемые регионы по парным скобкам.
+enum FoldRangeCalculator {
+
+    private static let openBrackets: [unichar: (close: unichar, kind: FoldKind)] = [
+        0x7B: (0x7D, .braces),       // { → }
+        0x5B: (0x5D, .brackets),     // [ → ]
+        0x28: (0x29, .parentheses)   // ( → )
+    ]
+
+    private static let closeBrackets: [unichar: unichar] = [
+        0x7D: 0x7B, // } → {
+        0x5D: 0x5B, // ] → [
+        0x29: 0x28  // ) → (
+    ]
+
+    /// Вычисляет все складываемые регионы в тексте.
+    ///
+    /// - Parameters:
+    ///   - text: исходный текст
+    ///   - skipRanges: диапазоны строк/комментариев, в которых скобки игнорируются
+    /// - Returns: массив складываемых регионов, отсортированный по startLine
+    static func calculate(
+        text: String,
+        skipRanges: [NSRange] = []
+    ) -> [FoldableRange] {
+        let source = text as NSString
+        let length = source.length
+        guard length > 0 else { return [] }
+
+        // Предварительно вычисляем номера строк и позиции начала строк
+        var lineStarts: [Int] = [0]
+        for i in 0..<length where source.character(at: i) == 0x0A {
+            lineStarts.append(i + 1)
+        }
+
+        // Стек: (charIndex, kind)
+        var stack: [(charIndex: Int, kind: FoldKind)] = []
+        var results: [FoldableRange] = []
+
+        for i in 0..<length {
+            if isInSkipRange(i, skipRanges: skipRanges) { continue }
+
+            let char = source.character(at: i)
+
+            if let info = openBrackets[char] {
+                stack.append((charIndex: i, kind: info.kind))
+            } else if let expectedOpen = closeBrackets[char] {
+                // Ищем matching opener в стеке
+                if let lastIdx = stack.lastIndex(where: {
+                    openBrackets[source.character(at: $0.charIndex)]?.close == char
+                        && source.character(at: $0.charIndex) == expectedOpen
+                }) {
+                    let opener = stack[lastIdx]
+                    stack.removeSubrange(lastIdx...)
+
+                    let startLine = lineNumber(at: opener.charIndex, lineStarts: lineStarts)
+                    let endLine = lineNumber(at: i, lineStarts: lineStarts)
+
+                    // Только многострочные регионы
+                    if endLine > startLine {
+                        results.append(FoldableRange(
+                            startLine: startLine,
+                            endLine: endLine,
+                            startCharIndex: opener.charIndex,
+                            endCharIndex: i,
+                            kind: opener.kind
+                        ))
+                    }
+                }
+            }
+        }
+
+        results.sort { $0.startLine < $1.startLine }
+        return results
+    }
+
+    /// Возвращает 1-based номер строки для символьного смещения.
+    private static func lineNumber(at charIndex: Int, lineStarts: [Int]) -> Int {
+        // Binary search для эффективности
+        var low = 0
+        var high = lineStarts.count - 1
+        while low < high {
+            let mid = (low + high + 1) / 2
+            if lineStarts[mid] <= charIndex {
+                low = mid
+            } else {
+                high = mid - 1
+            }
+        }
+        return low + 1 // 1-based
+    }
+
+    private static func isInSkipRange(_ position: Int, skipRanges: [NSRange]) -> Bool {
+        skipRanges.contains { NSLocationInRange(position, $0) }
+    }
+}

--- a/Pine/FoldState.swift
+++ b/Pine/FoldState.swift
@@ -1,0 +1,63 @@
+//
+//  FoldState.swift
+//  Pine
+//
+
+import Foundation
+
+/// Управляет состоянием свёрнутых регионов кода для одного таба.
+struct FoldState {
+    /// Текущие свёрнутые регионы.
+    private(set) var foldedRanges: [FoldableRange] = []
+
+    /// Сворачивает регион. Если уже свёрнут — ничего не делает.
+    mutating func fold(_ range: FoldableRange) {
+        guard !foldedRanges.contains(range) else { return }
+        foldedRanges.append(range)
+    }
+
+    /// Разворачивает регион.
+    mutating func unfold(_ range: FoldableRange) {
+        foldedRanges.removeAll { $0 == range }
+    }
+
+    /// Переключает fold/unfold для региона.
+    mutating func toggle(_ range: FoldableRange) {
+        if isFolded(range) {
+            unfold(range)
+        } else {
+            fold(range)
+        }
+    }
+
+    /// Сворачивает все указанные регионы.
+    mutating func foldAll(_ ranges: [FoldableRange]) {
+        for range in ranges {
+            fold(range)
+        }
+    }
+
+    /// Разворачивает все регионы.
+    mutating func unfoldAll() {
+        foldedRanges.removeAll()
+    }
+
+    /// Проверяет, свёрнут ли данный регион.
+    func isFolded(_ range: FoldableRange) -> Bool {
+        foldedRanges.contains(range)
+    }
+
+    /// Проверяет, скрыта ли строка (попадает ли она внутрь свёрнутого региона).
+    /// Строки startLine и endLine самого fold-а остаются видимыми.
+    func isLineHidden(_ line: Int) -> Bool {
+        foldedRanges.contains { range in
+            line > range.startLine && line < range.endLine
+        }
+    }
+
+    /// Количество скрытых строк при сворачивании региона.
+    /// Не зависит от текущего состояния fold — просто разница между start и end.
+    func hiddenLineCount(for range: FoldableRange) -> Int {
+        max(0, range.endLine - range.startLine - 1)
+    }
+}

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -25,11 +25,37 @@ final class LineNumberView: NSView {
         }
     }
 
+    /// Складываемые регионы для отрисовки disclosure triangles.
+    var foldableRanges: [FoldableRange] = [] {
+        didSet {
+            rebuildFoldStartMap()
+            needsDisplay = true
+        }
+    }
+
+    /// Текущее состояние свёрнутых регионов.
+    var foldState: FoldState = FoldState() {
+        didSet { needsDisplay = true }
+    }
+
+    /// Callback при клике по fold indicator.
+    var onFoldToggle: ((FoldableRange) -> Void)?
+
     /// Pre-indexed diff lookup: line number → kind (cached, rebuilt when lineDiffs changes)
     private var diffMap: [Int: GitLineDiff.Kind] = [:]
 
+    /// Pre-indexed fold lookup: start line → FoldableRange.
+    private var foldStartMap: [Int: FoldableRange] = [:]
+
+    /// Whether the mouse is currently inside the gutter (for showing fold indicators).
+    private var isMouseInside = false
+
     private func rebuildDiffMap() {
         diffMap = Dictionary(lineDiffs.map { ($0.line, $0.kind) }, uniquingKeysWith: { _, last in last })
+    }
+
+    private func rebuildFoldStartMap() {
+        foldStartMap = Dictionary(foldableRanges.map { ($0.startLine, $0) }, uniquingKeysWith: { _, last in last })
     }
 
     /// Cached total line count — updated on text change, not on every draw.
@@ -39,6 +65,9 @@ final class LineNumberView: NSView {
     private let addedColor = NSColor.systemGreen
     private let modifiedColor = NSColor.systemBlue
     private let deletedColor = NSColor.systemRed
+
+    // Fold indicator colors
+    private let foldIndicatorColor = NSColor.secondaryLabelColor
 
     override var isFlipped: Bool { true }
 
@@ -71,6 +100,8 @@ final class LineNumberView: NSView {
         textView?.enclosingScrollView?.contentView.postsBoundsChangedNotifications = true
         // Initialize cached line count from the current text
         recountTotalLines()
+        // Tracking area for hover — fold indicators appear on hover
+        updateTrackingAreas()
     }
 
     @available(*, unavailable)
@@ -78,6 +109,71 @@ final class LineNumberView: NSView {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: - Mouse tracking for fold indicators
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        for area in trackingAreas {
+            removeTrackingArea(area)
+        }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isMouseInside = true
+        needsDisplay = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isMouseInside = false
+        needsDisplay = true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        // Only handle clicks on the fold indicator area (left portion of gutter)
+        let foldIndicatorWidth: CGFloat = 14
+        guard point.x < foldIndicatorWidth else {
+            super.mouseDown(with: event)
+            return
+        }
+
+        // Find which line was clicked
+        if let lineNumber = lineNumber(at: point),
+           let foldable = foldStartMap[lineNumber] {
+            onFoldToggle?(foldable)
+        }
+    }
+
+    /// Returns the line number (1-based) at the given point in view coordinates.
+    private func lineNumber(at point: NSPoint) -> Int? {
+        guard let textView = textView,
+              let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer,
+              let scrollView = textView.enclosingScrollView else { return nil }
+
+        let visibleRect = scrollView.contentView.bounds
+        let originY = textView.textContainerOrigin.y
+
+        // Convert point to text container coordinates
+        let textY = point.y - originY + visibleRect.origin.y
+        let glyphIndex = layoutManager.glyphIndex(for: NSPoint(x: 0, y: textY), in: textContainer)
+        let charIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
+
+        let source = textView.string as NSString
+        var line = 1
+        for i in 0..<min(charIndex, source.length) where source.character(at: i) == 0x0A {
+            line += 1
+        }
+        return line
     }
 
     @objc private func handleBoundsChange(_ notification: Notification) {
@@ -165,6 +261,7 @@ final class LineNumberView: NSView {
         // Этот метод проходит только по видимым фрагментам строк — быстро.
         var previousLineCharIndex = -1
         let diffBarWidth: CGFloat = 3
+        let showFoldIndicators = isMouseInside && !foldStartMap.isEmpty
 
         layoutManager.enumerateLineFragments(
             forGlyphRange: visibleGlyphRange
@@ -193,6 +290,17 @@ final class LineNumberView: NSView {
                 let size = numStr.size(withAttributes: attrs)
                 let x = self.gutterWidth - size.width - 8
                 numStr.draw(at: NSPoint(x: x, y: y), withAttributes: attrs)
+
+                // ── Fold disclosure triangle ──
+                if showFoldIndicators || self.foldState.foldedRanges.contains(where: { $0.startLine == lineNumber }) {
+                    if let foldable = self.foldStartMap[lineNumber] {
+                        let isFolded = self.foldState.isFolded(foldable)
+                        self.drawFoldIndicator(
+                            at: y, lineHeight: lineRect.height,
+                            isFolded: isFolded
+                        )
+                    }
+                }
 
                 // ── Git diff marker ──
                 if let diffKind = self.diffMap[lineNumber] {
@@ -259,5 +367,30 @@ final class LineNumberView: NSView {
                 gutterTextView.needsDisplay = true
             }
         }
+    }
+
+    // MARK: - Fold indicator drawing
+
+    /// Draws a disclosure triangle for fold indicators.
+    private func drawFoldIndicator(at y: CGFloat, lineHeight: CGFloat, isFolded: Bool) {
+        let size: CGFloat = 8
+        let centerY = y + lineHeight / 2
+        let x: CGFloat = 3
+
+        let path = NSBezierPath()
+        if isFolded {
+            // ▶ (pointing right — folded)
+            path.move(to: NSPoint(x: x, y: centerY - size / 2))
+            path.line(to: NSPoint(x: x + size * 0.75, y: centerY))
+            path.line(to: NSPoint(x: x, y: centerY + size / 2))
+        } else {
+            // ▼ (pointing down — expanded)
+            path.move(to: NSPoint(x: x, y: centerY - size / 4))
+            path.line(to: NSPoint(x: x + size, y: centerY - size / 4))
+            path.line(to: NSPoint(x: x + size / 2, y: centerY + size / 2))
+        }
+        path.close()
+        foldIndicatorColor.setFill()
+        path.fill()
     }
 }

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -2842,6 +2842,78 @@
         }
       }
     },
+    "menu.foldCode" : {
+      "comment" : "Menu item for Fold Code (⌘⌥←).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fold"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Свернуть"
+          }
+        }
+      }
+    },
+    "menu.unfoldCode" : {
+      "comment" : "Menu item for Unfold Code (⌘⌥→).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unfold"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Развернуть"
+          }
+        }
+      }
+    },
+    "menu.foldAll" : {
+      "comment" : "Menu item for Fold All (⌘⌥⇧←).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fold All"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Свернуть все"
+          }
+        }
+      }
+    },
+    "menu.unfoldAll" : {
+      "comment" : "Menu item for Unfold All (⌘⌥⇧→).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unfold All"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Развернуть все"
+          }
+        }
+      }
+    },
     "menu.git" : {
       "comment" : "Top-level Git menu title in the menu bar.",
       "extractionState" : "manual",

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -18,6 +18,10 @@ enum MenuIcons {
     static let findInProject = "magnifyingglass"
     static let nextChange = "chevron.down"
     static let previousChange = "chevron.up"
+    static let foldCode = "chevron.down.square"
+    static let unfoldCode = "chevron.right.square"
+    static let foldAll = "rectangle.compress.vertical"
+    static let unfoldAll = "rectangle.expand.vertical"
 
     // MARK: - View menu
     static let increaseFontSize = "plus.magnifyingglass"

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -165,6 +165,52 @@ struct PineApp: App {
                 }
                 .keyboardShortcut(.upArrow, modifiers: [.control, .option])
                 .disabled(focusedProject?.tabManager.activeTab == nil)
+
+                Divider()
+
+                Button {
+                    NotificationCenter.default.post(
+                        name: .foldCode, object: nil,
+                        userInfo: ["action": "fold"]
+                    )
+                } label: {
+                    Label(Strings.menuFoldCode, systemImage: MenuIcons.foldCode)
+                }
+                .keyboardShortcut(.leftArrow, modifiers: [.command, .option])
+                .disabled(focusedProject?.tabManager.activeTab == nil)
+
+                Button {
+                    NotificationCenter.default.post(
+                        name: .foldCode, object: nil,
+                        userInfo: ["action": "unfold"]
+                    )
+                } label: {
+                    Label(Strings.menuUnfoldCode, systemImage: MenuIcons.unfoldCode)
+                }
+                .keyboardShortcut(.rightArrow, modifiers: [.command, .option])
+                .disabled(focusedProject?.tabManager.activeTab == nil)
+
+                Button {
+                    NotificationCenter.default.post(
+                        name: .foldCode, object: nil,
+                        userInfo: ["action": "foldAll"]
+                    )
+                } label: {
+                    Label(Strings.menuFoldAll, systemImage: MenuIcons.foldAll)
+                }
+                .keyboardShortcut(.leftArrow, modifiers: [.command, .option, .shift])
+                .disabled(focusedProject?.tabManager.activeTab == nil)
+
+                Button {
+                    NotificationCenter.default.post(
+                        name: .foldCode, object: nil,
+                        userInfo: ["action": "unfoldAll"]
+                    )
+                } label: {
+                    Label(Strings.menuUnfoldAll, systemImage: MenuIcons.unfoldAll)
+                }
+                .keyboardShortcut(.rightArrow, modifiers: [.command, .option, .shift])
+                .disabled(focusedProject?.tabManager.activeTab == nil)
             }
             // File menu: Save, Save All, Save As, Duplicate
             CommandGroup(replacing: .saveItem) {
@@ -887,4 +933,6 @@ extension Notification.Name {
     static let showProjectSearch = Notification.Name("showProjectSearch")
     /// userInfo: ["direction": "next" | "previous"]
     static let navigateChange = Notification.Name("navigateChange")
+    /// userInfo: ["action": "fold" | "unfold" | "foldAll" | "unfoldAll"]
+    static let foldCode = Notification.Name("foldCode")
 }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -239,6 +239,10 @@ enum Strings {
     static let menuFindInProject: LocalizedStringKey = "menu.findInProject"
     static let menuNextChange: LocalizedStringKey = "menu.nextChange"
     static let menuPreviousChange: LocalizedStringKey = "menu.previousChange"
+    static let menuFoldCode: LocalizedStringKey = "menu.foldCode"
+    static let menuUnfoldCode: LocalizedStringKey = "menu.unfoldCode"
+    static let menuFoldAll: LocalizedStringKey = "menu.foldAll"
+    static let menuUnfoldAll: LocalizedStringKey = "menu.unfoldAll"
     static let sidebarFiles: LocalizedStringKey = "sidebar.files"
     static let sidebarSearch: LocalizedStringKey = "sidebar.search"
 

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -169,6 +169,12 @@ final class TabManager {
         tabs[index].scrollOffset = scrollOffset
     }
 
+    /// Updates the fold state for the active tab.
+    func updateFoldState(_ state: FoldState) {
+        guard let index = activeTabIndex else { return }
+        tabs[index].foldState = state
+    }
+
     /// Saves the active tab to disk. Returns true on success.
     @discardableResult
     func saveActiveTab() -> Bool {

--- a/PineTests/CodeEditorCoordinatorTests.swift
+++ b/PineTests/CodeEditorCoordinatorTests.swift
@@ -44,7 +44,8 @@ struct CodeEditorCoordinatorTests {
             text: .constant(original),
             contentVersion: 0,
             language: "yaml",
-            fileName: "test.yaml"
+            fileName: "test.yaml",
+            foldState: .constant(FoldState())
         )
         let coordinator = CodeEditorView.Coordinator(parent: editorView)
         coordinator.scrollView = scrollView
@@ -66,7 +67,8 @@ struct CodeEditorCoordinatorTests {
             text: .constant(edited),
             contentVersion: 1,
             language: "yaml",
-            fileName: "test.yaml"
+            fileName: "test.yaml",
+            foldState: .constant(FoldState())
         )
         coordinator.parent = updatedEditorView
         coordinator.didChangeFromTextView = true
@@ -93,7 +95,8 @@ struct CodeEditorCoordinatorTests {
             text: .constant(original),
             contentVersion: 0,
             language: "txt",
-            fileName: "test.txt"
+            fileName: "test.txt",
+            foldState: .constant(FoldState())
         )
         let coordinator = CodeEditorView.Coordinator(parent: editorView)
         coordinator.scrollView = scrollView
@@ -109,7 +112,8 @@ struct CodeEditorCoordinatorTests {
             text: .constant(updated),
             contentVersion: 1,
             language: "txt",
-            fileName: "test.txt"
+            fileName: "test.txt",
+            foldState: .constant(FoldState())
         )
         coordinator.parent = updatedEditorView
         // didChangeFromTextView is NOT set — this is an external change
@@ -130,7 +134,8 @@ struct CodeEditorCoordinatorTests {
             text: .constant(text),
             contentVersion: 0,
             language: "swift",
-            fileName: "test.swift"
+            fileName: "test.swift",
+            foldState: .constant(FoldState())
         )
         let coordinator = CodeEditorView.Coordinator(parent: editorView)
         coordinator.scrollView = scrollView
@@ -146,7 +151,8 @@ struct CodeEditorCoordinatorTests {
             text: .constant(text),
             contentVersion: 1,
             language: "go",
-            fileName: "test.go"
+            fileName: "test.go",
+            foldState: .constant(FoldState())
         )
         coordinator.parent = updatedEditorView
         coordinator.didChangeFromTextView = true

--- a/PineTests/FoldRangeCalculatorTests.swift
+++ b/PineTests/FoldRangeCalculatorTests.swift
@@ -1,0 +1,148 @@
+//
+//  FoldRangeCalculatorTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+struct FoldRangeCalculatorTests {
+
+    // MARK: - Brace folding
+
+    @Test func simpleBracePair() {
+        let text = "func foo() {\n    bar()\n}"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.count == 1)
+        #expect(ranges[0].startLine == 1)
+        #expect(ranges[0].endLine == 3)
+        #expect(ranges[0].kind == .braces)
+    }
+
+    @Test func nestedBraces() {
+        let text = "func foo() {\n    if true {\n        bar()\n    }\n}"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.count == 2)
+        // Outer fold
+        let outer = ranges.first { $0.startLine == 1 }
+        #expect(outer != nil)
+        #expect(outer?.endLine == 5)
+        // Inner fold
+        let inner = ranges.first { $0.startLine == 2 }
+        #expect(inner != nil)
+        #expect(inner?.endLine == 4)
+    }
+
+    @Test func multipleBracePairsOnSameLevel() {
+        let text = "func a() {\n}\nfunc b() {\n}"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.count == 2)
+        #expect(ranges[0].startLine == 1)
+        #expect(ranges[0].endLine == 2)
+        #expect(ranges[1].startLine == 3)
+        #expect(ranges[1].endLine == 4)
+    }
+
+    @Test func singleLineBracesNotFoldable() {
+        // Braces on the same line should not produce a fold range
+        let text = "let x = { a }"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.isEmpty)
+    }
+
+    @Test func emptyTextReturnsNoRanges() {
+        let ranges = FoldRangeCalculator.calculate(text: "")
+        #expect(ranges.isEmpty)
+    }
+
+    @Test func textWithoutBracesReturnsNoRanges() {
+        let text = "let x = 1\nlet y = 2\nlet z = 3"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.isEmpty)
+    }
+
+    @Test func unbalancedOpeningBrace() {
+        let text = "func foo() {\n    bar()\n"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.isEmpty)
+    }
+
+    @Test func unbalancedClosingBrace() {
+        let text = "    bar()\n}"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.isEmpty)
+    }
+
+    @Test func squareBracketFolding() {
+        let text = "let arr = [\n    1,\n    2,\n    3\n]"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.count == 1)
+        #expect(ranges[0].startLine == 1)
+        #expect(ranges[0].endLine == 5)
+        #expect(ranges[0].kind == .brackets)
+    }
+
+    @Test func parenthesesFolding() {
+        let text = "foo(\n    arg1,\n    arg2\n)"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.count == 1)
+        #expect(ranges[0].startLine == 1)
+        #expect(ranges[0].endLine == 4)
+        #expect(ranges[0].kind == .parentheses)
+    }
+
+    @Test func bracesInStringSkipped() {
+        let text = "let s = \"{\"\nlet t = \"}\""
+        let ranges = FoldRangeCalculator.calculate(
+            text: text,
+            skipRanges: [NSRange(location: 9, length: 1), NSRange(location: 21, length: 1)]
+        )
+        #expect(ranges.isEmpty)
+    }
+
+    @Test func bracesInCommentSkipped() {
+        let text = "// {\n// }"
+        let ranges = FoldRangeCalculator.calculate(
+            text: text,
+            skipRanges: [NSRange(location: 3, length: 1), NSRange(location: 8, length: 1)]
+        )
+        #expect(ranges.isEmpty)
+    }
+
+    @Test func mixedBracketTypes() {
+        // { } on different lines + [ ] on same line — only braces produce fold
+        let text = "func foo() {\n    let arr = [1, 2]\n}"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.count == 1)
+        #expect(ranges[0].kind == .braces)
+    }
+
+    @Test func rangesAreSortedByStartLine() {
+        let text = "func a() {\n}\nfunc b() {\n    if true {\n    }\n}"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        let startLines = ranges.map(\.startLine)
+        #expect(startLines == startLines.sorted())
+    }
+
+    @Test func deeplyNestedBraces() {
+        let text = "a {\n  b {\n    c {\n      d()\n    }\n  }\n}"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.count == 3)
+        let outer = ranges.first { $0.startLine == 1 }
+        #expect(outer?.endLine == 7)
+        let middle = ranges.first { $0.startLine == 2 }
+        #expect(middle?.endLine == 6)
+        let inner = ranges.first { $0.startLine == 3 }
+        #expect(inner?.endLine == 5)
+    }
+
+    @Test func characterOffsetsAreCorrect() {
+        let text = "{\n  x\n}"
+        // { is at offset 0, } is at offset 6
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.count == 1)
+        #expect(ranges[0].startCharIndex == 0)
+        #expect(ranges[0].endCharIndex == 6)
+    }
+}

--- a/PineTests/FoldStateTests.swift
+++ b/PineTests/FoldStateTests.swift
@@ -1,0 +1,157 @@
+//
+//  FoldStateTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+struct FoldStateTests {
+
+    private func makeFoldable(start: Int, end: Int, startChar: Int = 0, endChar: Int = 0) -> FoldableRange {
+        FoldableRange(startLine: start, endLine: end, startCharIndex: startChar, endCharIndex: endChar, kind: .braces)
+    }
+
+    // MARK: - Fold / unfold
+
+    @Test func foldAddsToFoldedRanges() {
+        var state = FoldState()
+        let range = makeFoldable(start: 1, end: 5)
+        state.fold(range)
+        #expect(state.foldedRanges.count == 1)
+        #expect(state.foldedRanges[0] == range)
+    }
+
+    @Test func foldDuplicateIsIgnored() {
+        var state = FoldState()
+        let range = makeFoldable(start: 1, end: 5)
+        state.fold(range)
+        state.fold(range)
+        #expect(state.foldedRanges.count == 1)
+    }
+
+    @Test func unfoldRemovesRange() {
+        var state = FoldState()
+        let range = makeFoldable(start: 1, end: 5)
+        state.fold(range)
+        state.unfold(range)
+        #expect(state.foldedRanges.isEmpty)
+    }
+
+    @Test func unfoldNonexistentIsNoOp() {
+        var state = FoldState()
+        let range = makeFoldable(start: 1, end: 5)
+        state.unfold(range)
+        #expect(state.foldedRanges.isEmpty)
+    }
+
+    // MARK: - isFolded
+
+    @Test func isFoldedReturnsTrueForHiddenLines() {
+        var state = FoldState()
+        // Lines 1-5: start line stays visible, lines 2-4 are hidden, end line stays visible
+        state.fold(makeFoldable(start: 1, end: 5))
+        #expect(!state.isLineHidden(1)) // Start line visible
+        #expect(state.isLineHidden(2))
+        #expect(state.isLineHidden(3))
+        #expect(state.isLineHidden(4))
+        #expect(!state.isLineHidden(5)) // End line visible
+        #expect(!state.isLineHidden(6))
+    }
+
+    @Test func isLineHiddenWithNoFolds() {
+        let state = FoldState()
+        #expect(!state.isLineHidden(1))
+        #expect(!state.isLineHidden(100))
+    }
+
+    // MARK: - Fold all / unfold all
+
+    @Test func foldAll() {
+        var state = FoldState()
+        let ranges = [
+            makeFoldable(start: 1, end: 5),
+            makeFoldable(start: 10, end: 15)
+        ]
+        state.foldAll(ranges)
+        #expect(state.foldedRanges.count == 2)
+    }
+
+    @Test func unfoldAll() {
+        var state = FoldState()
+        state.fold(makeFoldable(start: 1, end: 5))
+        state.fold(makeFoldable(start: 10, end: 15))
+        state.unfoldAll()
+        #expect(state.foldedRanges.isEmpty)
+    }
+
+    // MARK: - Toggle
+
+    @Test func toggleFoldsWhenUnfolded() {
+        var state = FoldState()
+        let range = makeFoldable(start: 1, end: 5)
+        state.toggle(range)
+        #expect(state.foldedRanges.count == 1)
+    }
+
+    @Test func toggleUnfoldsWhenFolded() {
+        var state = FoldState()
+        let range = makeFoldable(start: 1, end: 5)
+        state.fold(range)
+        state.toggle(range)
+        #expect(state.foldedRanges.isEmpty)
+    }
+
+    // MARK: - isFolded for range
+
+    @Test func isFoldedForRange() {
+        var state = FoldState()
+        let range = makeFoldable(start: 1, end: 5)
+        #expect(!state.isFolded(range))
+        state.fold(range)
+        #expect(state.isFolded(range))
+    }
+
+    // MARK: - Nested folds
+
+    @Test func nestedFoldHiddenLines() {
+        var state = FoldState()
+        // Outer: 1-10, Inner: 3-7
+        state.fold(makeFoldable(start: 1, end: 10))
+        state.fold(makeFoldable(start: 3, end: 7))
+        // Lines 2-9 are hidden (from outer fold)
+        #expect(state.isLineHidden(2))
+        #expect(state.isLineHidden(5))
+        #expect(state.isLineHidden(9))
+        #expect(!state.isLineHidden(1))
+        #expect(!state.isLineHidden(10))
+    }
+
+    @Test func unfoldOuterKeepsInnerFolded() {
+        var state = FoldState()
+        let outer = makeFoldable(start: 1, end: 10)
+        let inner = makeFoldable(start: 3, end: 7)
+        state.fold(outer)
+        state.fold(inner)
+        state.unfold(outer)
+        // Inner fold should remain
+        #expect(state.foldedRanges.count == 1)
+        #expect(state.isLineHidden(4))
+        #expect(!state.isLineHidden(2))
+    }
+
+    // MARK: - Hidden line count
+
+    @Test func hiddenLineCount() {
+        var state = FoldState()
+        state.fold(makeFoldable(start: 1, end: 5))
+        // Lines 2,3,4 are hidden = 3 lines
+        #expect(state.hiddenLineCount(for: makeFoldable(start: 1, end: 5)) == 3)
+    }
+
+    @Test func hiddenLineCountForUnfolded() {
+        let state = FoldState()
+        #expect(state.hiddenLineCount(for: makeFoldable(start: 1, end: 5)) == 3)
+    }
+}

--- a/PineTests/SyntaxHighlighterTests.swift
+++ b/PineTests/SyntaxHighlighterTests.swift
@@ -559,7 +559,8 @@ struct SyntaxHighlighterTests {
         let editorView = CodeEditorView(
             text: .constant(text),
             language: "langa",
-            fileName: "test.langa"
+            fileName: "test.langa",
+            foldState: .constant(FoldState())
         )
         let coordinator = CodeEditorView.Coordinator(parent: editorView)
         coordinator.scrollView = scrollView


### PR DESCRIPTION
## Summary

Closes #276

- **FoldRangeCalculator** — detects foldable regions by matching `{}`, `[]`, `()` pairs across lines, respecting string/comment skip ranges
- **FoldState** — manages fold/unfold state per editor tab (persisted across tab switches)
- **Disclosure triangles** in line number gutter — appear on mouse hover (Xcode-style), click to fold/unfold; folded ranges show ▶, expanded show ▼
- **NSLayoutManager delegate** — hides folded lines by collapsing line fragments to zero height (text stays in storage, undo/find work correctly)
- **Keyboard shortcuts**: Cmd+Opt+← (fold), Cmd+Opt+→ (unfold), Cmd+Opt+Shift+← (fold all), Cmd+Opt+Shift+→ (unfold all)
- **Menu items** in Edit menu with en/ru localization
- **34 unit tests** covering FoldRangeCalculator (16 tests) and FoldState (15 tests), plus updated existing CodeEditorCoordinator tests (3 tests)

## Test plan

- [x] FoldRangeCalculator unit tests: simple braces, nested, multi-type, skip ranges, edge cases
- [x] FoldState unit tests: fold/unfold/toggle, nested folds, fold all/unfold all, hidden line detection
- [x] CodeEditorCoordinator tests updated for new foldState binding
- [x] SwiftLint: 0 violations
- [ ] Manual: open a Swift/JSON file, hover gutter to see fold indicators, click to fold/unfold
- [ ] Manual: verify Cmd+Opt+← folds at cursor, Cmd+Opt+→ unfolds
- [ ] Manual: verify fold all / unfold all via Cmd+Opt+Shift+←/→
- [ ] Manual: verify fold state persists across tab switches