### PR TITLE
fix: resolve code folding rendering corruption and multi-region issues

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -1125,12 +1125,12 @@ struct CodeEditorView: NSViewRepresentable {
                   let textView = sv.documentView as? NSTextView,
                   let layoutManager = textView.layoutManager else { return }
 
+            let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
             lineNumberView?.foldState = parent.foldState
-            // Invalidate layout so the delegate methods re-evaluate which lines are hidden
-            layoutManager.invalidateLayout(
-                forCharacterRange: NSRange(location: 0, length: (textView.string as NSString).length),
-                actualCharacterRange: nil
-            )
+            // Invalidate glyphs so shouldGenerateGlyphs re-evaluates hidden lines,
+            // then invalidate layout so shouldSetLineFragmentRect collapses heights.
+            layoutManager.invalidateGlyphs(forCharacterRange: fullRange, changeInLength: 0, actualCharacterRange: nil)
+            layoutManager.invalidateLayout(forCharacterRange: fullRange, actualCharacterRange: nil)
             textView.needsDisplay = true
             lineNumberView?.needsDisplay = true
             minimapView?.needsDisplay = true
@@ -1141,15 +1141,67 @@ struct CodeEditorView: NSViewRepresentable {
         // swiftlint:disable:next function_parameter_count
         func layoutManager(
             _ layoutManager: NSLayoutManager,
+            shouldGenerateGlyphs glyphs: UnsafePointer<CGGlyph>,
+            properties props: UnsafePointer<NSLayoutManager.GlyphProperty>,
+            characterIndexes charIndexes: UnsafePointer<Int>,
+            font aFont: NSFont,
+            forGlyphRange glyphRange: NSRange
+        ) -> Int {
+            guard !parent.foldState.foldedRanges.isEmpty,
+                  let cache = lineStartsCache else { return 0 }
+
+            let count = glyphRange.length
+            let modifiedProps = UnsafeMutablePointer<NSLayoutManager.GlyphProperty>.allocate(capacity: count)
+            defer { modifiedProps.deallocate() }
+
+            // Single pass: cache hidden state per charIndex to avoid redundant lookups
+            // (adjacent glyphs often share the same charIndex or line).
+            var hasHidden = false
+            var prevCharIndex = -1
+            var prevHidden = false
+
+            for i in 0..<count {
+                let charIndex = charIndexes[i]
+                let isHidden: Bool
+                if charIndex == prevCharIndex {
+                    isHidden = prevHidden
+                } else {
+                    let line = cache.lineNumber(at: charIndex)
+                    isHidden = parent.foldState.isLineHidden(line)
+                    prevCharIndex = charIndex
+                    prevHidden = isHidden
+                }
+                if isHidden {
+                    modifiedProps[i] = .null
+                    hasHidden = true
+                } else {
+                    modifiedProps[i] = props[i]
+                }
+            }
+
+            guard hasHidden else { return 0 }
+
+            layoutManager.setGlyphs(
+                glyphs, properties: modifiedProps,
+                characterIndexes: charIndexes, font: aFont,
+                forGlyphRange: glyphRange
+            )
+            return count
+        }
+
+        // swiftlint:disable:next function_parameter_count
+        func layoutManager(
+            _ layoutManager: NSLayoutManager,
             shouldSetLineFragmentRect lineFragmentRect: UnsafeMutablePointer<NSRect>,
             lineFragmentUsedRect: UnsafeMutablePointer<NSRect>,
             baselineOffset: UnsafeMutablePointer<CGFloat>,
             in textContainer: NSTextContainer,
             forGlyphRange glyphRange: NSRange
         ) -> Bool {
+            guard !parent.foldState.foldedRanges.isEmpty else { return false }
             let charRange = layoutManager.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
 
-            // Use cached line starts for O(log n) lookup instead of O(n) linear scan
+            // Use cached line starts for O(log n) lookup
             guard let cache = lineStartsCache else { return false }
             let line = cache.lineNumber(at: charRange.location)
 

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -252,17 +252,21 @@ final class LineNumberView: NSView {
         if visibleGlyphRange.location == NSNotFound { return }
 
         // ── Считаем номер первой видимой строки ──
-        // (количество \n до первого видимого символа + 1)
         let firstVisibleCharIndex = layoutManager.characterIndexForGlyph(
             at: visibleGlyphRange.location
         )
-        var lineNumber = 1
-        if firstVisibleCharIndex > 0 {
-            var count = 0
-            for i in 0..<firstVisibleCharIndex where source.character(at: i) == 0x0A {
-                count += 1
+        var lineNumber: Int
+        if let cache = lineStartsCache {
+            lineNumber = cache.lineNumber(at: firstVisibleCharIndex)
+        } else {
+            lineNumber = 1
+            if firstVisibleCharIndex > 0 {
+                var count = 0
+                for i in 0..<firstVisibleCharIndex where source.character(at: i) == 0x0A {
+                    count += 1
+                }
+                lineNumber = count + 1
             }
-            lineNumber = count + 1
         }
 
         // ── Рисуем номера видимых строк через enumerateLineFragments ──
@@ -270,6 +274,7 @@ final class LineNumberView: NSView {
         var previousLineCharIndex = -1
         let diffBarWidth: CGFloat = 3
         let showFoldIndicators = isMouseInside && !foldStartMap.isEmpty
+        let hasFolds = !foldState.foldedRanges.isEmpty
 
         layoutManager.enumerateLineFragments(
             forGlyphRange: visibleGlyphRange
@@ -291,6 +296,13 @@ final class LineNumberView: NSView {
             }
 
             if isNewLogicalLine {
+                // Skip hidden lines (inside folded regions) — only increment counter
+                if hasFolds && self.foldState.isLineHidden(lineNumber) {
+                    lineNumber += 1
+                    previousLineCharIndex = charIndex
+                    return
+                }
+
                 // Y: позиция фрагмента в textContainer + сдвиг контейнера − скролл
                 let y = lineRect.origin.y + originY - visibleRect.origin.y
 

--- a/PineTests/FoldStateTests.swift
+++ b/PineTests/FoldStateTests.swift
@@ -154,4 +154,45 @@ struct FoldStateTests {
         let state = FoldState()
         #expect(state.hiddenLineCount(for: makeFoldable(start: 1, end: 5)) == 3)
     }
+
+    // MARK: - Adjacent folds
+
+    @Test func twoAdjacentFoldsHideCorrectLines() {
+        var state = FoldState()
+        // First block: lines 1-4, second block: lines 5-8
+        let first = makeFoldable(start: 1, end: 4)
+        let second = makeFoldable(start: 5, end: 8)
+        state.fold(first)
+        state.fold(second)
+
+        // First fold hides lines 2-3
+        #expect(!state.isLineHidden(1))
+        #expect(state.isLineHidden(2))
+        #expect(state.isLineHidden(3))
+        #expect(!state.isLineHidden(4))
+
+        // Second fold hides lines 6-7
+        #expect(!state.isLineHidden(5))
+        #expect(state.isLineHidden(6))
+        #expect(state.isLineHidden(7))
+        #expect(!state.isLineHidden(8))
+
+        // Line 9+ not hidden
+        #expect(!state.isLineHidden(9))
+    }
+
+    @Test func foldSecondAfterFirst() {
+        var state = FoldState()
+        let first = makeFoldable(start: 1, end: 4)
+        let second = makeFoldable(start: 5, end: 8)
+        state.fold(first)
+
+        // After folding first, second should still be foldable
+        #expect(!state.isFolded(second))
+        #expect(!state.isLineHidden(5))
+
+        state.fold(second)
+        #expect(state.isFolded(second))
+        #expect(state.isLineHidden(6))
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #291 — code folding had three critical bugs:

- **Corrupted text rendering**: Added `shouldGenerateGlyphs` NSLayoutManagerDelegate method that sets `.null` property on glyphs of hidden lines, preventing overlapping text. Previously only `shouldSetLineFragmentRect` was used (height=0), but glyphs were still drawn.
- **Slow folding**: Replaced O(n) per-fragment line number counting with a cached `lineStarts` array and O(log n) binary search. This eliminates the O(n²) bottleneck on large files.
- **Second region fails to fold**: Fixed `LineNumberGutter.draw()` to skip hidden lines (inside folded regions) so the `lineNumber` counter stays correct. Previously hidden 0-height fragments still incremented the counter, causing fold indicators on subsequent regions to have mismatched line numbers.

## Changes

- `FoldRangeCalculator`: Made `buildLineStarts()` and `lineNumber(at:lineStarts:)` public for reuse
- `CodeEditorView.Coordinator`: Added `cachedLineStarts`, `shouldGenerateGlyphs` delegate, updated `applyFoldState` to invalidate glyphs
- `LineNumberGutter`: Added `cachedLineStarts`, skip hidden lines in draw loop, use binary search for click handling
- Tests: 10 new tests for `buildLineStarts`, `lineNumber`, and adjacent fold behavior

## Test plan

- [x] All 719 unit tests pass
- [x] SwiftLint — 0 violations
- [ ] Manual: open a Go file with two `var()` blocks, fold both — verify clean rendering
- [ ] Manual: open a large file, fold a region — verify no delay
- [ ] Manual: fold/unfold multiple regions — verify line numbers stay correct