### PR TITLE
fix(i18n): fix translation bugs in zh-Hans, de, and ru

### DIFF
--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -141,7 +141,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sie haben nicht commitete Änderungen. Das Wechseln zu \"%@\" kann diese überschreiben."
+            "value" : "Sie haben nicht festgeschriebene Änderungen. Das Wechseln zu \"%@\" kann diese überschreiben."
           }
         },
         "en" : {
@@ -261,7 +261,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nicht commitete Änderungen"
+            "value" : "Nicht festgeschriebene Änderungen"
           }
         },
         "en" : {
@@ -488,7 +488,7 @@
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Перезагрузить с диска"
+            "value" : "Обновить с диска"
           }
         },
         "zh-Hans" : {
@@ -3674,7 +3674,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sichern unter …"
+            "value" : "Sichern unter…"
           }
         },
         "en" : {
@@ -4505,7 +4505,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无結果"
+            "value" : "无结果"
           }
         }
       }


### PR DESCRIPTION
Fixes translation quality issues found during localization audit.

- zh-Hans: fix traditional character in `search.noResults` (結→结)
- de: replace anglicism "commitete" with native "festgeschriebene" in `branch.uncommittedChanges` keys
- de: remove space before ellipsis in `menu.saveAs` for consistency
- ru: replace misleading "Перезагрузить" (reboot) with "Обновить" (refresh) in `conflict.externalModify.reload`

Closes #328

Generated with [Claude Code](https://claude.ai/code)