### PR TITLE
fix(ci): grant write permissions to Claude CI workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- Change `pull-requests: read` → `write` in `claude-code-review.yml` so Claude can post review comments on PRs
- Change `pull-requests: read` → `write` and `issues: read` → `write` in `claude.yml` so Claude can respond to `@claude` mentions in PRs and issues

## Test plan
- [ ] Open a test PR after merge and verify Claude code review comment appears
- [ ] Comment `@claude` on an issue/PR and verify Claude responds