### PR TITLE
ci: shard UI tests into 4 parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,16 @@ jobs:
           sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
           xcodebuild -version
 
+      - name: Build App
+        run: |
+          xcodebuild build \
+            -project Pine.xcodeproj \
+            -scheme Pine \
+            -destination "platform=macOS" \
+            -derivedDataPath DerivedData \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_ALLOWED=NO
+
       - name: Build for Testing
         run: |
           xcodebuild build-for-testing \


### PR DESCRIPTION
## Summary
- Build once with `build-for-testing`, upload DerivedData as artifact
- Run unit tests and 4 UI test shards in parallel via `test-without-building`
- `fail-fast: false` — one shard failure doesn't cancel others
- Expected pipeline time: ~17 min → ~5-7 min

## Shards
| Shard | Tests | Classes |
|-------|-------|---------|
| Window & Welcome | 21 | WelcomeWindowTests, SidebarSearchTests |
| Editor Core | 21 | EditorWindowTests, FontSizeTests, DiffNavigationUITests |
| File Operations | 20 | DeleteTests, DuplicateTests, MultiWindowTests, MinimapTests |
| Git, Terminal & Misc | 21 | SymlinkSecurityUITests, BranchSwitcherTests, GitignoreFilterTests, TerminalTests, CheckForUpdatesTests, BlameViewTests, ToggleCommentTests |

## Test plan
- [ ] CI pipeline runs successfully on this PR
- [ ] All 4 UI test shards pass
- [ ] Unit tests pass with shared build artifact
- [ ] Total pipeline time is reduced

Closes #323