### PR TITLE
ci: add path filters to skip UI tests for non-UI changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
               - 'Pine/**/*.swift'
               - 'Pine.xcodeproj/**'
               - 'PineUITests/**'
+              - 'Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/**'
               - '.github/workflows/ci.yml'
 
   lint:


### PR DESCRIPTION
## Summary

- Adds `dorny/paths-filter` job to detect which files changed in a PR
- UI Tests job now runs only when UI-related code is modified: `Pine/**/*.swift`, `Pine.xcodeproj/**`, `PineUITests/**`, `.github/workflows/ci.yml`
- SwiftLint and Unit Tests continue to run on every PR (they're fast)
- Saves ~15min of macOS runner time on grammar-only, docs, or unit-test-only PRs

Closes #324

## Test plan

- [ ] PR with only grammar JSON changes → UI Tests should be skipped
- [ ] PR with Swift source changes → UI Tests should run
- [ ] PR with only unit test changes (`PineTests/`) → UI Tests should be skipped
- [ ] PR with CI workflow changes → UI Tests should run