### PR TITLE
feat: multiple cursors (Cmd+D, Option+Click, Cmd+Shift+L)

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -242,6 +242,11 @@ final class GutterTextView: NSTextView {
     private static let indentClosers: Set<Character> = ["}", ")"]
 
     override func insertNewline(_ sender: Any?) {
+        guard !hasMultipleCursors else {
+            multiCursorInsertNewline()
+            return
+        }
+
         let source = string as NSString
         let cursorLocation = selectedRange().location
 
@@ -285,6 +290,404 @@ final class GutterTextView: NSTextView {
         }
 
         insertText("\n\(indent)", replacementRange: selectedRange())
+    }
+
+    // MARK: - Multiple cursors
+
+    /// True when more than one cursor or selection is active.
+    var hasMultipleCursors: Bool { selectedRanges.count > 1 }
+
+    /// Adds a cursor at the next occurrence of the primary selection (Cmd+D).
+    /// If nothing is selected, selects the word under the cursor first.
+    func selectNextOccurrence() {
+        let allRanges = selectedRanges.map { $0.rangeValue }
+        let primaryRange = selectedRange()
+        let nsText = string as NSString
+
+        if primaryRange.length == 0 {
+            // No selection: select the word under the cursor
+            let wordRange = nsText.doubleClick(at: primaryRange.location)
+            if wordRange.length > 0 {
+                setSelectedRange(wordRange)
+            }
+            return
+        }
+
+        let searchText = nsText.substring(with: primaryRange)
+        // Search from just after the end of the last (rightmost) selection
+        let searchStart = allRanges.map { NSMaxRange($0) }.max() ?? NSMaxRange(primaryRange)
+
+        guard let found = MultiCursorLogic.findNextOccurrence(
+            of: searchText, in: nsText, after: searchStart
+        ) else { return }
+
+        // Skip if the occurrence is already selected
+        if allRanges.contains(where: { $0.location == found.location && $0.length == found.length }) {
+            return
+        }
+
+        let newRanges = (allRanges + [found])
+            .sorted { $0.location < $1.location }
+            .map { NSValue(range: $0) }
+        setSelectedRanges(newRanges, affinity: .downstream, stillSelecting: false)
+        scrollRangeToVisible(found)
+    }
+
+    /// Splits the primary selection into one cursor per line, at the end of each line's content (Cmd+Shift+L).
+    func splitIntoLineCursors() {
+        let primary = selectedRange()
+        guard primary.length > 0 else { return }
+        let nsText = string as NSString
+        let ranges = MultiCursorLogic.splitSelectionIntoLineRanges(selection: primary, in: nsText)
+        guard ranges.count > 1 else { return }
+        setSelectedRanges(ranges.map { NSValue(range: $0) }, affinity: .downstream, stillSelecting: false)
+    }
+
+    /// Collapses all cursors to the primary cursor position, removing extra cursors (Esc behavior).
+    func collapseToSingleCursor() {
+        guard hasMultipleCursors else { return }
+        let primary = selectedRange()
+        setSelectedRange(NSRange(location: primary.location, length: 0))
+    }
+
+    // MARK: - Keyboard overrides for multi-cursor
+
+    override func keyDown(with event: NSEvent) {
+        // keyCode 53 = Escape — collapse multiple cursors
+        if event.keyCode == 53 && hasMultipleCursors {
+            collapseToSingleCursor()
+            return
+        }
+        super.keyDown(with: event)
+    }
+
+    // MARK: - Option+Click: add cursor at click position
+
+    override func mouseDown(with event: NSEvent) {
+        guard event.modifierFlags.contains(.option) else {
+            super.mouseDown(with: event)
+            return
+        }
+        guard let lm = layoutManager, let tc = textContainer else {
+            super.mouseDown(with: event)
+            return
+        }
+
+        let pointInView = convert(event.locationInWindow, from: nil)
+        let origin = textContainerOrigin
+        let containerPoint = NSPoint(x: pointInView.x - origin.x, y: pointInView.y - origin.y)
+
+        var fraction: CGFloat = 0
+        let glyphIndex = lm.glyphIndex(for: containerPoint, in: tc, fractionOfDistanceThroughGlyph: &fraction)
+        let charIndex = lm.characterIndexForGlyph(at: glyphIndex)
+        let textLen = (string as NSString).length
+        let clampedIndex = min(charIndex, textLen)
+
+        let existing = selectedRanges.map { $0.rangeValue }
+        // Don't add a duplicate cursor at the same position
+        guard !existing.contains(where: { $0.location == clampedIndex && $0.length == 0 }) else { return }
+
+        let clickRange = NSRange(location: clampedIndex, length: 0)
+        let newRanges = (existing + [clickRange])
+            .sorted { $0.location < $1.location }
+            .map { NSValue(range: $0) }
+        setSelectedRanges(newRanges, affinity: .downstream, stillSelecting: false)
+    }
+
+    // MARK: - Multi-cursor text insertion
+
+    override func insertText(_ string: Any, replacementRange: NSRange) {
+        // Fall back to standard behavior for single cursor or during IME composition
+        guard hasMultipleCursors && !hasMarkedText() else {
+            super.insertText(string, replacementRange: replacementRange)
+            return
+        }
+
+        let str: String
+        if let plain = string as? String {
+            str = plain
+        } else if let attrStr = string as? NSAttributedString {
+            str = attrStr.string
+        } else {
+            super.insertText(string, replacementRange: replacementRange)
+            return
+        }
+
+        guard let storage = textStorage else {
+            super.insertText(string, replacementRange: replacementRange)
+            return
+        }
+
+        let allRanges = selectedRanges.map { $0.rangeValue }
+        let sortedRanges = allRanges.sorted { $0.location > $1.location }
+        let insertLen = (str as NSString).length
+
+        // Build edit descriptors in end-to-start order for position computation
+        let edits = sortedRanges.map { (range: $0, replacementLength: insertLen, cursorOffset: insertLen) }
+
+        undoManager?.beginUndoGrouping()
+        storage.beginEditing()
+        for range in sortedRanges {
+            storage.replaceCharacters(in: range, with: str)
+        }
+        storage.endEditing()
+        didChangeText()
+        undoManager?.endUndoGrouping()
+
+        let newPositions = MultiCursorLogic.newCursorPositions(edits: edits)
+        let newRanges = newPositions.map { NSValue(range: NSRange(location: $0, length: 0)) }
+        setSelectedRanges(newRanges, affinity: .downstream, stillSelecting: false)
+    }
+
+    // MARK: - Multi-cursor deletion
+
+    override func deleteBackward(_ sender: Any?) {
+        guard hasMultipleCursors else {
+            super.deleteBackward(sender)
+            return
+        }
+        guard let storage = textStorage else {
+            super.deleteBackward(sender)
+            return
+        }
+
+        let allRanges = selectedRanges.map { $0.rangeValue }
+        let sortedRanges = allRanges.sorted { $0.location > $1.location }
+
+        undoManager?.beginUndoGrouping()
+        storage.beginEditing()
+
+        var edits: [(range: NSRange, replacementLength: Int, cursorOffset: Int)] = []
+        for range in sortedRanges {
+            if range.length > 0 {
+                edits.append((range: range, replacementLength: 0, cursorOffset: 0))
+                storage.replaceCharacters(in: range, with: "")
+            } else if range.location > 0 {
+                let deleteRange = NSRange(location: range.location - 1, length: 1)
+                edits.append((range: deleteRange, replacementLength: 0, cursorOffset: 0))
+                storage.replaceCharacters(in: deleteRange, with: "")
+            } else {
+                // At start of document: no-op, cursor stays at 0
+                edits.append((range: NSRange(location: 0, length: 0), replacementLength: 0, cursorOffset: 0))
+            }
+        }
+
+        storage.endEditing()
+        didChangeText()
+        undoManager?.endUndoGrouping()
+
+        let newPositions = MultiCursorLogic.newCursorPositions(edits: edits)
+        // Deduplicate: adjacent cursors may produce the same position after deletion
+        let unique = Array(Set(newPositions)).sorted()
+        let newRanges = unique.map { NSValue(range: NSRange(location: max(0, $0), length: 0)) }
+        setSelectedRanges(newRanges.isEmpty ? [NSValue(range: NSRange(location: 0, length: 0))] : newRanges,
+                          affinity: .upstream, stillSelecting: false)
+    }
+
+    override func deleteForward(_ sender: Any?) {
+        guard hasMultipleCursors else {
+            super.deleteForward(sender)
+            return
+        }
+        guard let storage = textStorage else {
+            super.deleteForward(sender)
+            return
+        }
+
+        let allRanges = selectedRanges.map { $0.rangeValue }
+        let sortedRanges = allRanges.sorted { $0.location > $1.location }
+        let textLen = (string as NSString).length
+
+        undoManager?.beginUndoGrouping()
+        storage.beginEditing()
+
+        var edits: [(range: NSRange, replacementLength: Int, cursorOffset: Int)] = []
+        for range in sortedRanges {
+            if range.length > 0 {
+                edits.append((range: range, replacementLength: 0, cursorOffset: 0))
+                storage.replaceCharacters(in: range, with: "")
+            } else if range.location < textLen {
+                let deleteRange = NSRange(location: range.location, length: 1)
+                edits.append((range: deleteRange, replacementLength: 0, cursorOffset: 0))
+                storage.replaceCharacters(in: deleteRange, with: "")
+            } else {
+                // At end of document: no-op
+                edits.append((range: range, replacementLength: 0, cursorOffset: 0))
+            }
+        }
+
+        storage.endEditing()
+        didChangeText()
+        undoManager?.endUndoGrouping()
+
+        let newPositions = MultiCursorLogic.newCursorPositions(edits: edits)
+        let unique = Array(Set(newPositions)).sorted()
+        let newRanges = unique.map { NSValue(range: NSRange(location: max(0, $0), length: 0)) }
+        setSelectedRanges(newRanges.isEmpty ? [NSValue(range: NSRange(location: 0, length: 0))] : newRanges,
+                          affinity: .downstream, stillSelecting: false)
+    }
+
+    // MARK: - Multi-cursor movement
+
+    override func moveLeft(_ sender: Any?) {
+        guard hasMultipleCursors else {
+            super.moveLeft(sender)
+            return
+        }
+        let allRanges = selectedRanges.map { $0.rangeValue }
+        let moved = allRanges.map { range -> NSRange in
+            if range.length > 0 {
+                return NSRange(location: range.location, length: 0)
+            } else if range.location > 0 {
+                return NSRange(location: range.location - 1, length: 0)
+            }
+            return range
+        }
+        let merged = MultiCursorLogic.mergeOverlapping(moved)
+        setSelectedRanges(merged.map { NSValue(range: $0) }, affinity: .upstream, stillSelecting: false)
+    }
+
+    override func moveRight(_ sender: Any?) {
+        guard hasMultipleCursors else {
+            super.moveRight(sender)
+            return
+        }
+        let allRanges = selectedRanges.map { $0.rangeValue }
+        let textLen = (string as NSString).length
+        let moved = allRanges.map { range -> NSRange in
+            if range.length > 0 {
+                return NSRange(location: NSMaxRange(range), length: 0)
+            } else if range.location < textLen {
+                return NSRange(location: range.location + 1, length: 0)
+            }
+            return range
+        }
+        let merged = MultiCursorLogic.mergeOverlapping(moved)
+        setSelectedRanges(merged.map { NSValue(range: $0) }, affinity: .downstream, stillSelecting: false)
+    }
+
+    override func moveUp(_ sender: Any?) {
+        guard hasMultipleCursors, let lm = layoutManager, let tc = textContainer else {
+            super.moveUp(sender)
+            return
+        }
+        let allRanges = selectedRanges.map { $0.rangeValue }
+        let moved = allRanges.map { range -> NSRange in
+            let loc = range.location
+            if loc == 0 { return NSRange(location: 0, length: 0) }
+            let glyphIdx = lm.glyphIndexForCharacter(at: min(loc, max((string as NSString).length - 1, 0)))
+            let lineRect = lm.lineFragmentRect(forGlyphAt: glyphIdx, effectiveRange: nil)
+            let charLoc = lm.location(forGlyphAt: glyphIdx)
+            let xPos = lineRect.origin.x + charLoc.x
+            let targetY = lineRect.midY - lineRect.height
+            guard targetY >= 0 else { return NSRange(location: 0, length: 0) }
+            let targetPoint = NSPoint(x: xPos, y: targetY)
+            let newGlyph = lm.glyphIndex(for: targetPoint, in: tc, fractionOfDistanceThroughGlyph: nil)
+            let newChar = lm.characterIndexForGlyph(at: newGlyph)
+            return NSRange(location: newChar, length: 0)
+        }
+        let merged = MultiCursorLogic.mergeOverlapping(moved)
+        setSelectedRanges(merged.map { NSValue(range: $0) }, affinity: .upstream, stillSelecting: false)
+    }
+
+    override func moveDown(_ sender: Any?) {
+        guard hasMultipleCursors, let lm = layoutManager, let tc = textContainer else {
+            super.moveDown(sender)
+            return
+        }
+        let allRanges = selectedRanges.map { $0.rangeValue }
+        let textLen = (string as NSString).length
+        let moved = allRanges.map { range -> NSRange in
+            let loc = range.location
+            let safeLoc = min(loc, max(textLen - 1, 0))
+            let glyphIdx = lm.glyphIndexForCharacter(at: safeLoc)
+            let lineRect = lm.lineFragmentRect(forGlyphAt: glyphIdx, effectiveRange: nil)
+            let charLoc = lm.location(forGlyphAt: glyphIdx)
+            let xPos = lineRect.origin.x + charLoc.x
+            let targetPoint = NSPoint(x: xPos, y: lineRect.midY + lineRect.height)
+            let newGlyph = lm.glyphIndex(for: targetPoint, in: tc, fractionOfDistanceThroughGlyph: nil)
+            let newChar = lm.characterIndexForGlyph(at: newGlyph)
+            if newChar == loc { return NSRange(location: textLen, length: 0) }
+            return NSRange(location: newChar, length: 0)
+        }
+        let merged = MultiCursorLogic.mergeOverlapping(moved)
+        setSelectedRanges(merged.map { NSValue(range: $0) }, affinity: .downstream, stillSelecting: false)
+    }
+
+    // MARK: - Multi-cursor newline with per-cursor auto-indent
+
+    // swiftlint:disable:next function_body_length
+    private func multiCursorInsertNewline() {
+        guard let storage = textStorage else { return }
+
+        let source = string as NSString
+        let allRanges = selectedRanges.map { $0.rangeValue }
+        let sortedRanges = allRanges.sorted { $0.location > $1.location }
+
+        struct CursorInsert {
+            let range: NSRange
+            let text: String
+            let cursorOffset: Int
+        }
+
+        // Compute insert string for each cursor using the original text snapshot.
+        // Because we apply end-to-start, the text before each cursor is unchanged
+        // in the original snapshot at the time of computation.
+        var inserts: [CursorInsert] = []
+        for range in sortedRanges {
+            let cursorLocation = range.location
+            let lineRange = source.lineRange(for: NSRange(location: cursorLocation, length: 0))
+            let currentLine = source.substring(with: lineRange)
+            let leadingWhitespace = String(currentLine.prefix(while: { $0 == " " || $0 == "\t" }))
+
+            let textBeforeCursor = source.substring(with: NSRange(
+                location: lineRange.location,
+                length: cursorLocation - lineRange.location
+            ))
+            let lastNonSpace = textBeforeCursor.last(where: { !$0.isWhitespace })
+
+            let textAfterCursor = source.substring(with: NSRange(
+                location: cursorLocation,
+                length: NSMaxRange(lineRange) - cursorLocation
+            ))
+            let firstNonSpaceAfter = textAfterCursor.first(where: { !$0.isWhitespace && $0 != "\n" })
+
+            var indent = leadingWhitespace
+            if let last = lastNonSpace, Self.indentOpeners.contains(last) {
+                indent += "    "
+            }
+
+            let insertStr: String
+            let cursorOffset: Int
+            if let last = lastNonSpace, let first = firstNonSpaceAfter,
+               Self.indentOpeners.contains(last) && Self.indentClosers.contains(first) {
+                let closingIndent = leadingWhitespace
+                insertStr = "\n\(indent)\n\(closingIndent)"
+                cursorOffset = 1 + indent.count
+            } else {
+                insertStr = "\n\(indent)"
+                cursorOffset = (insertStr as NSString).length
+            }
+            inserts.append(CursorInsert(range: range, text: insertStr, cursorOffset: cursorOffset))
+        }
+
+        undoManager?.beginUndoGrouping()
+        storage.beginEditing()
+
+        var edits: [(range: NSRange, replacementLength: Int, cursorOffset: Int)] = []
+        for insert in inserts {
+            let repLen = (insert.text as NSString).length
+            edits.append((range: insert.range, replacementLength: repLen, cursorOffset: insert.cursorOffset))
+            storage.replaceCharacters(in: insert.range, with: insert.text)
+        }
+
+        storage.endEditing()
+        didChangeText()
+        undoManager?.endUndoGrouping()
+
+        let newPositions = MultiCursorLogic.newCursorPositions(edits: edits)
+        let newRanges = newPositions.map { NSValue(range: NSRange(location: $0, length: 0)) }
+        setSelectedRanges(newRanges, affinity: .downstream, stillSelecting: false)
     }
 }
 
@@ -589,6 +992,20 @@ struct CodeEditorView: NSViewRepresentable {
             context.coordinator,
             selector: #selector(Coordinator.handleFoldCode(_:)),
             name: .foldCode,
+            object: nil
+        )
+
+        // Observe multiple cursor notifications (Cmd+D, Cmd+Shift+L)
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.handleSelectNextOccurrence),
+            name: .selectNextOccurrence,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.handleSplitIntoLineCursors),
+            name: .splitIntoLineCursors,
             object: nil
         )
 
@@ -1352,6 +1769,22 @@ struct CodeEditorView: NSViewRepresentable {
             let cursor = textView.selectedRange().location
             let scroll = sv.contentView.bounds.origin.y
             parent.onStateChange?(cursor, scroll)
+        }
+
+        // MARK: - Multiple cursors
+
+        @objc func handleSelectNextOccurrence() {
+            guard let sv = scrollView,
+                  let gutterView = sv.documentView as? GutterTextView,
+                  gutterView.window?.isKeyWindow == true else { return }
+            gutterView.selectNextOccurrence()
+        }
+
+        @objc func handleSplitIntoLineCursors() {
+            guard let sv = scrollView,
+                  let gutterView = sv.documentView as? GutterTextView,
+                  gutterView.window?.isKeyWindow == true else { return }
+            gutterView.splitIntoLineCursors()
         }
     }
 

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -3959,6 +3959,30 @@
         }
       }
     },
+    "menu.selectNextOccurrence" : {
+      "comment" : "Menu command: add cursor at next occurrence of selection (⌘D).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Next Occurrence"
+          }
+        }
+      }
+    },
+    "menu.splitIntoLineCursors" : {
+      "comment" : "Menu command: split selection into one cursor per line (⌘⇧L).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Cursor to Line Ends"
+          }
+        }
+      }
+    },
     "menu.toggleMinimap" : {
       "comment" : "Menu command: toggle code minimap panel.",
       "extractionState" : "manual",

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -16,6 +16,8 @@ enum MenuIcons {
 
     // MARK: - Edit menu
     static let toggleComment = "slash.circle"
+    static let selectNextOccurrence = "text.cursor"
+    static let splitIntoLineCursors = "text.alignleft"
     static let find = "magnifyingglass"
     static let findAndReplace = "arrow.left.arrow.right"
     static let findInProject = "magnifyingglass"

--- a/Pine/MultiCursorLogic.swift
+++ b/Pine/MultiCursorLogic.swift
@@ -1,0 +1,123 @@
+//
+//  MultiCursorLogic.swift
+//  Pine
+//
+//  Pure, side-effect-free logic for multiple cursor operations.
+//  All functions are static to allow direct unit testing without a running NSTextView.
+//
+
+import AppKit
+
+/// Pure logic for multiple cursor operations in the editor.
+enum MultiCursorLogic {
+
+    // MARK: - Next occurrence
+
+    /// Finds the next occurrence of `text` in `fullText` starting at `searchStart`.
+    /// Wraps around to the beginning of the document if not found after `searchStart`.
+    /// Returns `nil` if `text` is empty or does not exist anywhere in `fullText`.
+    static func findNextOccurrence(of text: String, in fullText: NSString, after searchStart: Int) -> NSRange? {
+        guard !text.isEmpty else { return nil }
+        let totalLength = fullText.length
+        guard totalLength > 0 else { return nil }
+
+        // Search from searchStart to end of document
+        if searchStart < totalLength {
+            let tailRange = NSRange(location: searchStart, length: totalLength - searchStart)
+            let found = fullText.range(of: text, options: [], range: tailRange)
+            if found.location != NSNotFound { return found }
+        }
+
+        // Wrap around: search from beginning up to just before searchStart + text length
+        // (so we can match occurrences that start at 0 when searchStart > 0)
+        if searchStart > 0 {
+            let headLen = min(searchStart + (text as NSString).length - 1, totalLength)
+            if headLen > 0 {
+                let headRange = NSRange(location: 0, length: headLen)
+                let wrapped = fullText.range(of: text, options: [], range: headRange)
+                if wrapped.location != NSNotFound { return wrapped }
+            }
+        }
+
+        return nil
+    }
+
+    // MARK: - Merge overlapping ranges
+
+    /// Merges overlapping or adjacent `NSRange` values.
+    /// Returns a new array sorted ascending by location, with no overlapping ranges.
+    static func mergeOverlapping(_ ranges: [NSRange]) -> [NSRange] {
+        guard ranges.count > 1 else { return ranges }
+        let sorted = ranges.sorted { $0.location < $1.location }
+        var result = [sorted[0]]
+        for range in sorted.dropFirst() {
+            let last = result[result.count - 1]
+            if range.location <= NSMaxRange(last) {
+                let end = max(NSMaxRange(last), NSMaxRange(range))
+                result[result.count - 1] = NSRange(location: last.location, length: end - last.location)
+            } else {
+                result.append(range)
+            }
+        }
+        return result
+    }
+
+    // MARK: - Split selection into line cursors
+
+    /// Splits a selection spanning one or more lines into one zero-length cursor per line,
+    /// placed at the end of each line's content (before the line-ending newline character).
+    /// If the selection is empty, returns the original range unchanged.
+    static func splitSelectionIntoLineRanges(selection: NSRange, in fullText: NSString) -> [NSRange] {
+        guard selection.length > 0 else { return [selection] }
+        var ranges: [NSRange] = []
+        var location = selection.location
+        let end = NSMaxRange(selection)
+
+        while location < end {
+            let lineRange = fullText.lineRange(for: NSRange(location: location, length: 0))
+            // Place cursor at end of line content (before newline character)
+            var cursorPos = NSMaxRange(lineRange)
+            if cursorPos > lineRange.location &&
+               cursorPos <= fullText.length &&
+               fullText.character(at: cursorPos - 1) == 0x0A {
+                cursorPos -= 1
+            }
+            cursorPos = min(cursorPos, end)
+            ranges.append(NSRange(location: cursorPos, length: 0))
+            let nextLocation = NSMaxRange(lineRange)
+            guard nextLocation > location else { break } // safety guard against infinite loop
+            location = nextLocation
+        }
+
+        return ranges.isEmpty ? [selection] : ranges
+    }
+
+    // MARK: - New cursor positions after bulk edit
+
+    /// Computes final cursor positions after applying a batch of text substitutions.
+    ///
+    /// `edits` must be sorted **end-to-start** (largest location first). Each element
+    /// is `(replacementRange, replacementLength, cursorOffset)` where:
+    /// - `replacementRange` is the range being replaced in the *currently-being-modified* text
+    /// - `replacementLength` is the byte-length of the text being inserted (0 for deletion)
+    /// - `cursorOffset` is where the cursor lands inside the replacement (0 = start, replacementLength = end)
+    ///
+    /// Returns cursor positions sorted **ascending**.
+    static func newCursorPositions(edits: [(range: NSRange, replacementLength: Int, cursorOffset: Int)]) -> [Int] {
+        // Each edit is applied to a partially-modified text. Since edits are ordered end-to-start,
+        // each new edit is at a smaller location than all previously processed edits.
+        // All previously computed positions come AFTER the current insertion point,
+        // so they must be shifted by `delta = replacementLength - range.length`.
+        var positions: [Int] = []
+        for edit in edits {
+            let delta = edit.replacementLength - edit.range.length
+            for i in 0..<positions.count {
+                positions[i] += delta
+            }
+            // Insert at front so the smallest position ends up at index 0
+            positions.insert(edit.range.location + edit.cursorOffset, at: 0)
+        }
+        // positions is already sorted ascending (built from end to start, inserted at front)
+        return positions
+    }
+}

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -145,6 +145,24 @@ struct PineApp: App {
                 Divider()
 
                 Button {
+                    NotificationCenter.default.post(name: .selectNextOccurrence, object: nil)
+                } label: {
+                    Label(Strings.menuSelectNextOccurrence, systemImage: MenuIcons.selectNextOccurrence)
+                }
+                .keyboardShortcut("d", modifiers: .command)
+                .disabled(focusedProject?.tabManager.activeTab == nil)
+
+                Button {
+                    NotificationCenter.default.post(name: .splitIntoLineCursors, object: nil)
+                } label: {
+                    Label(Strings.menuSplitIntoLineCursors, systemImage: MenuIcons.splitIntoLineCursors)
+                }
+                .keyboardShortcut("l", modifiers: [.command, .shift])
+                .disabled(focusedProject?.tabManager.activeTab == nil)
+
+                Divider()
+
+                Button {
                     NotificationCenter.default.post(name: .findInFile, object: nil)
                 } label: {
                     Label(Strings.menuFind, systemImage: MenuIcons.find)
@@ -1002,4 +1020,7 @@ extension Notification.Name {
     static let findNext = Notification.Name("findNext")
     static let findPrevious = Notification.Name("findPrevious")
     static let useSelectionForFind = Notification.Name("useSelectionForFind")
+    // Multiple cursors (issue #333)
+    static let selectNextOccurrence = Notification.Name("selectNextOccurrence")
+    static let splitIntoLineCursors = Notification.Name("splitIntoLineCursors")
 }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -136,6 +136,8 @@ enum Strings {
     static let menuToggleComment: LocalizedStringKey = "menu.toggleComment"
     static let menuToggleMinimap: LocalizedStringKey = "menu.toggleMinimap"
     static let menuToggleBlame: LocalizedStringKey = "menu.toggleBlame"
+    static let menuSelectNextOccurrence: LocalizedStringKey = "menu.selectNextOccurrence"
+    static let menuSplitIntoLineCursors: LocalizedStringKey = "menu.splitIntoLineCursors"
 
     static var branchUncommittedChangesTitle: String {
         String(localized: "branch.uncommittedChanges.title")

--- a/PineTests/MultiCursorLogicTests.swift
+++ b/PineTests/MultiCursorLogicTests.swift
@@ -1,0 +1,440 @@
+//
+//  MultiCursorLogicTests.swift
+//  PineTests
+//
+//  Unit tests for MultiCursorLogic: findNextOccurrence, mergeOverlapping,
+//  splitSelectionIntoLineRanges, and newCursorPositions.
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+struct MultiCursorLogicTests {
+
+    // MARK: - findNextOccurrence
+
+    @Test func findNext_returnsFirstOccurrenceAfterOffset() {
+        let text = "foo bar foo baz" as NSString
+        let result = MultiCursorLogic.findNextOccurrence(of: "foo", in: text, after: 3)
+        #expect(result?.location == 8)
+        #expect(result?.length == 3)
+    }
+
+    @Test func findNext_wrapsAroundToBeginning() {
+        let text = "foo bar baz" as NSString
+        // searchStart is past the only occurrence
+        let result = MultiCursorLogic.findNextOccurrence(of: "foo", in: text, after: 3)
+        #expect(result?.location == 0)
+        #expect(result?.length == 3)
+    }
+
+    @Test func findNext_returnsNilForEmptySearchText() {
+        let text = "hello world" as NSString
+        let result = MultiCursorLogic.findNextOccurrence(of: "", in: text, after: 0)
+        #expect(result == nil)
+    }
+
+    @Test func findNext_returnsNilForEmptyDocument() {
+        let text = "" as NSString
+        let result = MultiCursorLogic.findNextOccurrence(of: "foo", in: text, after: 0)
+        #expect(result == nil)
+    }
+
+    @Test func findNext_returnsNilWhenTextNotPresent() {
+        let text = "hello world" as NSString
+        let result = MultiCursorLogic.findNextOccurrence(of: "xyz", in: text, after: 0)
+        #expect(result == nil)
+    }
+
+    @Test func findNext_findsSingleOccurrenceFromStart() {
+        let text = "hello world" as NSString
+        let result = MultiCursorLogic.findNextOccurrence(of: "world", in: text, after: 0)
+        #expect(result?.location == 6)
+        #expect(result?.length == 5)
+    }
+
+    @Test func findNext_handlesSearchStartAtEnd() {
+        let text = "abc" as NSString
+        // searchStart == length → wraps to find from beginning
+        let result = MultiCursorLogic.findNextOccurrence(of: "abc", in: text, after: 3)
+        #expect(result?.location == 0)
+    }
+
+    @Test func findNext_chainsThreeOccurrences() {
+        let text = "x x x" as NSString
+        let r1 = MultiCursorLogic.findNextOccurrence(of: "x", in: text, after: 0)
+        #expect(r1?.location == 0)
+
+        let after1 = r1.map { NSMaxRange($0) } ?? 1
+        let r2 = MultiCursorLogic.findNextOccurrence(of: "x", in: text, after: after1)
+        #expect(r2?.location == 2)
+
+        let after2 = r2.map { NSMaxRange($0) } ?? 3
+        let r3 = MultiCursorLogic.findNextOccurrence(of: "x", in: text, after: after2)
+        #expect(r3?.location == 4)
+
+        // Wrap around
+        let after3 = r3.map { NSMaxRange($0) } ?? 5
+        let r4 = MultiCursorLogic.findNextOccurrence(of: "x", in: text, after: after3)
+        #expect(r4?.location == 0)
+    }
+
+    @Test func findNext_isCaseSensitive() {
+        let text = "Foo foo FOO" as NSString
+        let result = MultiCursorLogic.findNextOccurrence(of: "foo", in: text, after: 0)
+        #expect(result?.location == 4)
+    }
+
+    // MARK: - mergeOverlapping
+
+    @Test func merge_singleRangeReturnsItself() {
+        let ranges = [NSRange(location: 5, length: 3)]
+        let result = MultiCursorLogic.mergeOverlapping(ranges)
+        #expect(result.count == 1)
+        #expect(result[0].location == 5 && result[0].length == 3)
+    }
+
+    @Test func merge_nonOverlappingRangesPreservedSorted() {
+        let ranges = [NSRange(location: 10, length: 2), NSRange(location: 0, length: 3)]
+        let result = MultiCursorLogic.mergeOverlapping(ranges)
+        #expect(result.count == 2)
+        #expect(result[0].location == 0)
+        #expect(result[1].location == 10)
+    }
+
+    @Test func merge_overlappingRangesMerged() {
+        let ranges = [NSRange(location: 0, length: 5), NSRange(location: 3, length: 5)]
+        let result = MultiCursorLogic.mergeOverlapping(ranges)
+        #expect(result.count == 1)
+        #expect(result[0].location == 0)
+        #expect(result[0].length == 8)
+    }
+
+    @Test func merge_adjacentRangesMerged() {
+        let ranges = [NSRange(location: 0, length: 3), NSRange(location: 3, length: 3)]
+        let result = MultiCursorLogic.mergeOverlapping(ranges)
+        #expect(result.count == 1)
+        #expect(result[0].location == 0)
+        #expect(result[0].length == 6)
+    }
+
+    @Test func merge_duplicateCursorsMerged() {
+        let ranges = [NSRange(location: 5, length: 0), NSRange(location: 5, length: 0)]
+        let result = MultiCursorLogic.mergeOverlapping(ranges)
+        #expect(result.count == 1)
+        #expect(result[0].location == 5 && result[0].length == 0)
+    }
+
+    @Test func merge_threeRangesPartiallyOverlapping() {
+        let ranges = [
+            NSRange(location: 0, length: 4),
+            NSRange(location: 2, length: 4),
+            NSRange(location: 10, length: 3)
+        ]
+        let result = MultiCursorLogic.mergeOverlapping(ranges)
+        #expect(result.count == 2)
+        #expect(result[0].location == 0 && result[0].length == 6)
+        #expect(result[1].location == 10 && result[1].length == 3)
+    }
+
+    @Test func merge_emptyInputReturnsEmpty() {
+        let result = MultiCursorLogic.mergeOverlapping([])
+        #expect(result.isEmpty)
+    }
+
+    // MARK: - splitSelectionIntoLineRanges
+
+    @Test func split_emptySelectionReturnsItself() {
+        let text = "hello\nworld" as NSString
+        let selection = NSRange(location: 3, length: 0)
+        let result = MultiCursorLogic.splitSelectionIntoLineRanges(selection: selection, in: text)
+        #expect(result.count == 1)
+        #expect(result[0].location == 3 && result[0].length == 0)
+    }
+
+    @Test func split_singleLineSelectionReturnsSingleCursor() {
+        let text = "hello\nworld" as NSString
+        let selection = NSRange(location: 0, length: 5)  // "hello"
+        let result = MultiCursorLogic.splitSelectionIntoLineRanges(selection: selection, in: text)
+        // Cursor at end of "hello" (before newline), which is position 5
+        #expect(result.count == 1)
+        #expect(result[0].location == 5 && result[0].length == 0)
+    }
+
+    @Test func split_twoLineSelectionReturnsTwoCursors() {
+        let text = "hello\nworld\n" as NSString
+        // Select "hello\nworld"
+        let selection = NSRange(location: 0, length: 11)
+        let result = MultiCursorLogic.splitSelectionIntoLineRanges(selection: selection, in: text)
+        #expect(result.count == 2)
+        // First cursor: end of "hello" (position 5)
+        #expect(result[0].location == 5 && result[0].length == 0)
+        // Second cursor: end of "world" (position 11)
+        #expect(result[1].location == 11 && result[1].length == 0)
+    }
+
+    @Test func split_threeLineSelection() {
+        let text = "abc\ndef\nghi\n" as NSString
+        let selection = NSRange(location: 0, length: 11)  // "abc\ndef\nghi"
+        let result = MultiCursorLogic.splitSelectionIntoLineRanges(selection: selection, in: text)
+        #expect(result.count == 3)
+        #expect(result[0].location == 3)  // end of "abc"
+        #expect(result[1].location == 7)  // end of "def"
+        #expect(result[2].location == 11) // end of "ghi"
+    }
+
+    @Test func split_selectionDoesNotIncludeNewline() {
+        let text = "line1\nline2" as NSString
+        // "line1\n" - selection includes the newline
+        let selection = NSRange(location: 0, length: 6)
+        let result = MultiCursorLogic.splitSelectionIntoLineRanges(selection: selection, in: text)
+        // Cursor should be at position 5 (before the newline), clamped to selection end (6)
+        #expect(result[0].location <= 6)
+    }
+
+    // MARK: - newCursorPositions
+
+    @Test func newCursorPositions_singleInsertionAtCursor() {
+        // Insert 1 char at position 5 (cursor, no selection)
+        let edits: [(range: NSRange, replacementLength: Int, cursorOffset: Int)] = [
+            (range: NSRange(location: 5, length: 0), replacementLength: 1, cursorOffset: 1)
+        ]
+        let result = MultiCursorLogic.newCursorPositions(edits: edits)
+        #expect(result == [6])
+    }
+
+    @Test func newCursorPositions_threeInsertionsEndToStart() {
+        // Three cursors at [5, 10, 15], insert 1 char each
+        // edits must be sorted end-to-start
+        let edits: [(range: NSRange, replacementLength: Int, cursorOffset: Int)] = [
+            (range: NSRange(location: 15, length: 0), replacementLength: 1, cursorOffset: 1),
+            (range: NSRange(location: 10, length: 0), replacementLength: 1, cursorOffset: 1),
+            (range: NSRange(location: 5, length: 0), replacementLength: 1, cursorOffset: 1)
+        ]
+        let result = MultiCursorLogic.newCursorPositions(edits: edits)
+        #expect(result == [6, 12, 18])
+    }
+
+    @Test func newCursorPositions_deleteBackward() {
+        // Two cursors at [5, 10], delete backward (each deletes char at loc-1)
+        // Ranges are (4,1) and (9,1), sorted end-to-start
+        let edits: [(range: NSRange, replacementLength: Int, cursorOffset: Int)] = [
+            (range: NSRange(location: 9, length: 1), replacementLength: 0, cursorOffset: 0),
+            (range: NSRange(location: 4, length: 1), replacementLength: 0, cursorOffset: 0)
+        ]
+        let result = MultiCursorLogic.newCursorPositions(edits: edits)
+        // After deleting at 9: cursor at 9. After deleting at 4: cursor at 4, adjust 9→8.
+        #expect(result == [4, 8])
+    }
+
+    @Test func newCursorPositions_replaceSelectionWithText() {
+        // Cursor with 3-char selection at [2,3], replaced by 1 char
+        // edits sorted end-to-start (only one edit)
+        let edits: [(range: NSRange, replacementLength: Int, cursorOffset: Int)] = [
+            (range: NSRange(location: 2, length: 3), replacementLength: 1, cursorOffset: 1)
+        ]
+        let result = MultiCursorLogic.newCursorPositions(edits: edits)
+        #expect(result == [3])
+    }
+
+    @Test func newCursorPositions_noOpAtDocumentStart() {
+        // Cursor at position 0, nothing to delete (no-op represented as (0,0) → 0 replacement)
+        let edits: [(range: NSRange, replacementLength: Int, cursorOffset: Int)] = [
+            (range: NSRange(location: 0, length: 0), replacementLength: 0, cursorOffset: 0)
+        ]
+        let result = MultiCursorLogic.newCursorPositions(edits: edits)
+        #expect(result == [0])
+    }
+
+    // MARK: - GutterTextView integration tests
+
+    /// Builds a minimal text stack with a GutterTextView for integration testing.
+    private func makeGutterTextView(text: String) -> GutterTextView {
+        let textStorage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        )
+        layoutManager.addTextContainer(textContainer)
+        let textView = GutterTextView(
+            frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+            textContainer: textContainer
+        )
+        return textView
+    }
+
+    @Test func gutterView_hasMultipleCursors_falseForSingle() {
+        let tv = makeGutterTextView(text: "hello world")
+        tv.setSelectedRange(NSRange(location: 0, length: 0))
+        #expect(!tv.hasMultipleCursors)
+    }
+
+    @Test func gutterView_hasMultipleCursors_trueForMultiple() {
+        let tv = makeGutterTextView(text: "hello world")
+        tv.setSelectedRanges([
+            NSValue(range: NSRange(location: 0, length: 0)),
+            NSValue(range: NSRange(location: 5, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+        #expect(tv.hasMultipleCursors)
+    }
+
+    @Test func gutterView_selectNextOccurrence_selectsWordWhenNoSelection() {
+        let tv = makeGutterTextView(text: "hello world")
+        tv.setSelectedRange(NSRange(location: 2, length: 0))
+        tv.selectNextOccurrence()
+        // "hello" should be selected
+        let range = tv.selectedRange()
+        #expect(range.length > 0)
+    }
+
+    @Test func gutterView_selectNextOccurrence_addsSecondCursor() {
+        let tv = makeGutterTextView(text: "foo bar foo")
+        // Select "foo" at position 0
+        tv.setSelectedRange(NSRange(location: 0, length: 3))
+        tv.selectNextOccurrence()
+        // Should have two selections
+        #expect(tv.selectedRanges.count == 2)
+        let ranges = tv.selectedRanges.map { $0.rangeValue }
+        #expect(ranges.contains { $0.location == 0 && $0.length == 3 })
+        #expect(ranges.contains { $0.location == 8 && $0.length == 3 })
+    }
+
+    @Test func gutterView_selectNextOccurrence_wrapsAround() {
+        let tv = makeGutterTextView(text: "foo bar foo baz foo")
+        // Select all occurrences, then next should wrap to first
+        tv.setSelectedRange(NSRange(location: 0, length: 3))
+        tv.selectNextOccurrence()  // adds (8, 3)
+        tv.selectNextOccurrence()  // adds (16, 3)
+        tv.selectNextOccurrence()  // wraps → should not add (0,3) again (already selected)
+        let count = tv.selectedRanges.count
+        #expect(count == 3)
+    }
+
+    @Test func gutterView_collapseToSingleCursor() {
+        let tv = makeGutterTextView(text: "hello world")
+        tv.setSelectedRanges([
+            NSValue(range: NSRange(location: 0, length: 0)),
+            NSValue(range: NSRange(location: 5, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+        #expect(tv.hasMultipleCursors)
+        tv.collapseToSingleCursor()
+        #expect(!tv.hasMultipleCursors)
+    }
+
+    @Test func gutterView_splitIntoLineCursors_noOpForEmptySelection() {
+        let tv = makeGutterTextView(text: "hello\nworld")
+        tv.setSelectedRange(NSRange(location: 2, length: 0))
+        tv.splitIntoLineCursors()
+        #expect(!tv.hasMultipleCursors)
+    }
+
+    @Test func gutterView_splitIntoLineCursors_twoLines() {
+        let tv = makeGutterTextView(text: "hello\nworld")
+        // Select both lines
+        tv.setSelectedRange(NSRange(location: 0, length: 11))
+        tv.splitIntoLineCursors()
+        #expect(tv.hasMultipleCursors)
+        #expect(tv.selectedRanges.count == 2)
+    }
+
+    @Test func gutterView_insertText_appliesAtAllCursors() {
+        let tv = makeGutterTextView(text: "abcde")
+        // Place cursors at positions 1 and 3
+        tv.setSelectedRanges([
+            NSValue(range: NSRange(location: 1, length: 0)),
+            NSValue(range: NSRange(location: 3, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+        tv.insertText("X", replacementRange: NSRange(location: NSNotFound, length: 0))
+        // "aXbcXde" → X inserted at 1 and 4 (3+1 shift from first insertion)
+        #expect(tv.string == "aXbcXde")
+    }
+
+    @Test func gutterView_deleteBackward_atAllCursors() {
+        let tv = makeGutterTextView(text: "abcde")
+        // Cursors after 'b' (position 2) and after 'd' (position 4)
+        tv.setSelectedRanges([
+            NSValue(range: NSRange(location: 2, length: 0)),
+            NSValue(range: NSRange(location: 4, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+        tv.deleteBackward(nil)
+        // Deletes 'b' and 'd': "ace"
+        #expect(tv.string == "ace")
+    }
+
+    @Test func gutterView_deleteForward_atAllCursors() {
+        let tv = makeGutterTextView(text: "abcde")
+        // Cursors before 'b' (position 1) and before 'd' (position 3)
+        tv.setSelectedRanges([
+            NSValue(range: NSRange(location: 1, length: 0)),
+            NSValue(range: NSRange(location: 3, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+        tv.deleteForward(nil)
+        // Deletes 'b' and 'd': "ace"
+        #expect(tv.string == "ace")
+    }
+
+    @Test func gutterView_moveLeft_collapsesSelectionsAndMovesCursors() {
+        let tv = makeGutterTextView(text: "abcde")
+        tv.setSelectedRanges([
+            NSValue(range: NSRange(location: 2, length: 0)),
+            NSValue(range: NSRange(location: 4, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+        tv.moveLeft(nil)
+        let ranges = tv.selectedRanges.map { $0.rangeValue }
+        #expect(ranges.count == 2)
+        #expect(ranges.contains { $0.location == 1 && $0.length == 0 })
+        #expect(ranges.contains { $0.location == 3 && $0.length == 0 })
+    }
+
+    @Test func gutterView_moveRight_movesCursorsRight() {
+        let tv = makeGutterTextView(text: "abcde")
+        tv.setSelectedRanges([
+            NSValue(range: NSRange(location: 1, length: 0)),
+            NSValue(range: NSRange(location: 3, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+        tv.moveRight(nil)
+        let ranges = tv.selectedRanges.map { $0.rangeValue }
+        #expect(ranges.count == 2)
+        #expect(ranges.contains { $0.location == 2 && $0.length == 0 })
+        #expect(ranges.contains { $0.location == 4 && $0.length == 0 })
+    }
+
+    @Test func gutterView_moveLeft_atDocumentStart_staysAtZero() {
+        let tv = makeGutterTextView(text: "abc")
+        tv.setSelectedRanges([
+            NSValue(range: NSRange(location: 0, length: 0)),
+            NSValue(range: NSRange(location: 2, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+        tv.moveLeft(nil)
+        let ranges = tv.selectedRanges.map { $0.rangeValue }
+        // Cursor at 0 stays at 0; cursor at 2 moves to 1
+        #expect(ranges.contains { $0.location == 0 })
+        #expect(ranges.contains { $0.location == 1 })
+    }
+
+    @Test func gutterView_insertText_mergesAdjacentCursorsAfterMovement() {
+        let tv = makeGutterTextView(text: "ab")
+        // Two cursors at position 1 (adjacent)
+        tv.setSelectedRanges([
+            NSValue(range: NSRange(location: 1, length: 0)),
+            NSValue(range: NSRange(location: 1, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+        // NSTextView may deduplicate these; verify it doesn't crash
+        tv.insertText("X", replacementRange: NSRange(location: NSNotFound, length: 0))
+        #expect(tv.string.contains("X"))
+    }
+
+    @Test func gutterView_collapseToSingleCursor_fromKeyboardAction() {
+        // Tests the collapseToSingleCursor() function (triggered by Esc in keyDown)
+        let tv = makeGutterTextView(text: "hello world")
+        tv.setSelectedRanges([
+            NSValue(range: NSRange(location: 0, length: 0)),
+            NSValue(range: NSRange(location: 6, length: 0))
+        ], affinity: .downstream, stillSelecting: false)
+        #expect(tv.hasMultipleCursors)
+        tv.collapseToSingleCursor()
+        #expect(!tv.hasMultipleCursors)
+    }
+}


### PR DESCRIPTION
Implements multiple cursor support for Pine's GutterTextView:

- Cmd+D: select next occurrence of current selection (or word under cursor)
- Option+Click: add cursor at click position
- Cmd+Shift+L: split selection into one cursor per line
- Esc: collapse all cursors to single cursor
- Simultaneous typing, deletion, movement at all cursors
- Per-cursor auto-indent on newline
- Undo groups all multi-cursor edits as one step
- Pure MultiCursorLogic functions with 25+ unit tests

Closes #333

Generated with [Claude Code](https://claude.ai/code)