### PR TITLE
fix(tests): add isSelected accessibility trait to active editor tab

### DIFF
--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -181,6 +181,7 @@ struct EditorTabItem: View {
             HStack {
                 Button(tab.fileName, action: onSelect)
                     .accessibilityIdentifier(AccessibilityID.editorTab(tab.fileName))
+                    .accessibilityAddTraits(isActive ? .isSelected : [])
                 Button("Close", action: onClose)
                     .accessibilityIdentifier(AccessibilityID.editorTabCloseButton(tab.fileName))
             }

--- a/PineUITests/EditorWindowTests.swift
+++ b/PineUITests/EditorWindowTests.swift
@@ -98,7 +98,7 @@ final class EditorWindowTests: PineUITestCase {
         mainTab.click()
         let selectedPredicate = NSPredicate(format: "isSelected == true")
         expectation(for: selectedPredicate, evaluatedWith: mainTab)
-        waitForExpectations(timeout: 5)
+        waitForExpectations(timeout: 10)
 
         // main.swift tab should still exist (switching doesn't close tabs)
         XCTAssertTrue(mainTab.exists, "main.swift tab should still exist after clicking it")


### PR DESCRIPTION
## Summary

- Add `.accessibilityAddTraits(.isSelected)` to active editor tab button — without it `NSPredicate(format: "isSelected == true")` in `testClickingTabSwitchesActiveTab` never matches and the test times out
- Increase expectation timeout from 5s to 10s for CI reliability

## Context

Fixes the CI failure introduced by #370 where `testClickingTabSwitchesActiveTab` failed with:
```
Exceeded timeout of 5 seconds, with unfulfilled expectations:
"Expect predicate `isSelected == 1` for object "editorTab_main.swift" Button"
```

## Test plan

- [ ] `UI Tests (Editor Core)` CI shard passes
- [ ] VoiceOver correctly announces active tab as selected