### PR TITLE
ci: run full test suite on Release Please PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
               - 'PineUITests/**'
               - 'Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/**'
               - '.github/workflows/ci.yml'
+              - 'version.txt'
 
   lint:
     name: SwiftLint


### PR DESCRIPTION
## Summary

- Add `version.txt` to `dorny/paths-filter` `ui` filter in CI workflow
- Release Please PRs always bump `version.txt`, so this ensures UI tests and shard verification run on every release PR

Closes #385

## Test plan

- [ ] Verify CI runs full test suite (including UI tests) on the next Release Please PR