### PR TITLE
feat: git diff panel with split view (Cmd+Shift+C)

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -56,6 +56,18 @@ enum AccessibilityID {
     // MARK: - Project Search
     static let projectSearchResultsList = "projectSearchResultsList"
 
+    // MARK: - Diff Panel
+    static let diffPanel = "diffPanel"
+    static let diffPanelStagedSection = "diffPanelStagedSection"
+    static let diffPanelUnstagedSection = "diffPanelUnstagedSection"
+    static func diffPanelFile(_ name: String) -> String { "diffPanelFile_\(name)" }
+    static func diffPanelHunk(_ index: Int) -> String { "diffPanelHunk_\(index)" }
+    static let diffPanelStageHunkButton = "diffPanelStageHunkButton"
+    static let diffPanelUnstageHunkButton = "diffPanelUnstageHunkButton"
+    static let diffPanelDiscardHunkButton = "diffPanelDiscardHunkButton"
+    static let diffDetailView = "diffDetailView"
+    static let diffDetailPlaceholder = "diffDetailPlaceholder"
+
     // MARK: - Status bar
     static let statusBar = "statusBar"
     static let terminalToggleButton = "terminalToggleButton"

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -29,6 +29,7 @@ struct ContentView: View {
     @State private var goToLineOffset: GoToRequest?
     @State private var recoveryEntries: [(UUID, RecoveryEntry)] = []
     @State private var showRecoveryDialog = false
+    @State private var isDiffPanelVisible = false
     @AppStorage("minimapVisible") private var isMinimapVisible = true
     @AppStorage(BlameConstants.storageKey) private var isBlameVisible = true
 
@@ -42,7 +43,8 @@ struct ContentView: View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             SidebarSearchableContent(
                 selectedNode: $selectedNode,
-                workspace: workspace
+                workspace: workspace,
+                isDiffPanelVisible: isDiffPanelVisible
             )
             .accessibilityIdentifier(AccessibilityID.sidebar)
             .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 400)
@@ -147,6 +149,7 @@ struct ContentView: View {
             lineDiffs: $lineDiffs,
             columnVisibility: $columnVisibility,
             isSearchPresented: $isSearchPresented,
+            isDiffPanelVisible: $isDiffPanelVisible,
             onRefreshLineDiffs: { refreshLineDiffs() },
             onRefreshBlame: { refreshBlame() },
             onCloseTab: { closeTabWithConfirmation($0) },
@@ -493,9 +496,21 @@ struct ContentView: View {
     // MARK: - Область редактора
 
     @ViewBuilder
+    private var diffDetailContent: some View {
+        if let entry = projectManager.diffPanel.selectedEntry {
+            DiffDetailView(
+                entry: entry,
+                gitProvider: projectManager.gitProvider,
+                diffPanel: projectManager.diffPanel
+            )
+        } else {
+            DiffPlaceholderView()
+        }
+    }
+
     private var editorArea: some View {
         VStack(spacing: 0) {
-            if !tabManager.tabs.isEmpty {
+            if !isDiffPanelVisible && !tabManager.tabs.isEmpty {
                 EditorTabBar(
                     tabManager: tabManager,
                     onCloseTab: { tab in closeTabWithConfirmation(tab) },
@@ -507,7 +522,9 @@ struct ContentView: View {
                 )
             }
 
-            if let tab = activeTab {
+            if isDiffPanelVisible {
+                diffDetailContent
+            } else if let tab = activeTab {
                 Group {
                     if tab.kind == .preview {
                         QuickLookPreviewView(url: tab.url)
@@ -668,10 +685,13 @@ private struct ProjectSearchModifier: ViewModifier {
 private struct SidebarSearchableContent: View {
     @Binding var selectedNode: FileNode?
     var workspace: WorkspaceManager
+    var isDiffPanelVisible: Bool
     @Environment(ProjectManager.self) var projectManager
 
     var body: some View {
-        if !projectManager.searchProvider.query.isEmpty {
+        if isDiffPanelVisible {
+            DiffPanelView()
+        } else if !projectManager.searchProvider.query.isEmpty {
             SearchResultsView()
         } else {
             SidebarView(workspace: workspace, selectedFile: $selectedNode)
@@ -720,6 +740,7 @@ private struct GitAndNotificationObserver: ViewModifier {
     @Binding var lineDiffs: [GitLineDiff]
     @Binding var columnVisibility: NavigationSplitViewVisibility
     @Binding var isSearchPresented: Bool
+    @Binding var isDiffPanelVisible: Bool
     var onRefreshLineDiffs: () -> Void
     var onRefreshBlame: () -> Void
     var onCloseTab: (EditorTab) -> Void
@@ -743,6 +764,11 @@ private struct GitAndNotificationObserver: ViewModifier {
             }
             .onChange(of: workspace.gitProvider.fileStatuses) { _, _ in
                 onRefreshLineDiffs()
+                if isDiffPanelVisible {
+                    Task {
+                        await projectManager.diffPanel.refresh(gitProvider: projectManager.gitProvider)
+                    }
+                }
             }
             .onReceive(NotificationCenter.default.publisher(for: .refreshLineDiffs)) { _ in
                 guard controlActiveState == .key else { return }
@@ -775,7 +801,22 @@ private struct GitAndNotificationObserver: ViewModifier {
             }
             .onReceive(NotificationCenter.default.publisher(for: .showProjectSearch)) { _ in
                 columnVisibility = .all
+                isDiffPanelVisible = false
                 isSearchPresented = true
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .showDiffPanel)) { _ in
+                guard controlActiveState == .key else { return }
+                isDiffPanelVisible.toggle()
+                if isDiffPanelVisible {
+                    isSearchPresented = false
+                    projectManager.searchProvider.query = ""
+                    columnVisibility = .all
+                    Task {
+                        await projectManager.diffPanel.refresh(gitProvider: projectManager.gitProvider)
+                    }
+                } else {
+                    projectManager.diffPanel.selectedFilePath = nil
+                }
             }
             .onReceive(NotificationCenter.default.publisher(for: .navigateChange)) { notification in
                 guard controlActiveState == .key,

--- a/Pine/DiffDetailView.swift
+++ b/Pine/DiffDetailView.swift
@@ -1,0 +1,239 @@
+//
+//  DiffDetailView.swift
+//  Pine
+//
+//  Full diff view for the editor area showing hunks of a selected file.
+//
+
+import SwiftUI
+
+// MARK: - Detail View (editor area)
+
+struct DiffDetailView: View {
+    let entry: DiffFileEntry
+    let gitProvider: GitStatusProvider
+    let diffPanel: DiffPanelProvider
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                fileHeader
+                if entry.hunks.isEmpty {
+                    noHunksPlaceholder
+                } else {
+                    ForEach(Array(entry.hunks.enumerated()), id: \.element.id) { index, hunk in
+                        DiffHunkDetailView(
+                            hunk: hunk,
+                            hunkIndex: index,
+                            filePath: entry.relativePath,
+                            isStaged: entry.isStaged,
+                            gitProvider: gitProvider,
+                            diffPanel: diffPanel
+                        )
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier(AccessibilityID.diffDetailView)
+    }
+
+    private var fileHeader: some View {
+        HStack(spacing: 8) {
+            Image(systemName: FileIconMapper.iconForFile(
+                (entry.relativePath as NSString).lastPathComponent
+            ))
+            .font(.system(size: 14))
+            .foregroundStyle(.secondary)
+
+            Text(entry.relativePath)
+                .font(.system(size: 13, weight: .medium))
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Text(statusLetter)
+                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                .foregroundStyle(entry.status.color)
+
+            Spacer()
+
+            fileActions
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.bar)
+    }
+
+    private var statusLetter: String {
+        switch entry.status {
+        case .modified: "M"
+        case .added:    "A"
+        case .deleted:  "D"
+        case .untracked: "U"
+        case .staged:   "S"
+        case .conflict: "C"
+        case .mixed:    "M"
+        }
+    }
+
+    @ViewBuilder
+    private var fileActions: some View {
+        if entry.isStaged {
+            Button {
+                Task { await diffPanel.unstageFile(entry.relativePath, gitProvider: gitProvider) }
+            } label: {
+                Label(Strings.diffPanelUnstageFile, systemImage: "minus.circle")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.plain)
+        } else {
+            Button {
+                Task { await diffPanel.stageFile(entry.relativePath, gitProvider: gitProvider) }
+            } label: {
+                Label(Strings.diffPanelStageFile, systemImage: "plus.circle")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var noHunksPlaceholder: some View {
+        VStack {
+            Spacer().frame(height: 40)
+            Text(entry.status == .untracked
+                 ? Strings.diffDetailUntrackedFile
+                 : Strings.diffDetailNoHunks)
+                .foregroundStyle(.secondary)
+                .font(.system(size: 12))
+                .frame(maxWidth: .infinity)
+        }
+    }
+}
+
+// MARK: - Placeholder (no file selected)
+
+struct DiffPlaceholderView: View {
+    var body: some View {
+        ContentUnavailableView {
+            Label(Strings.diffDetailSelectFile, systemImage: "doc.text.magnifyingglass")
+        } description: {
+            Text(Strings.diffDetailSelectFileDescription)
+        }
+        .accessibilityIdentifier(AccessibilityID.diffDetailPlaceholder)
+    }
+}
+
+// MARK: - Hunk Detail View
+
+struct DiffHunkDetailView: View {
+    let hunk: DiffHunk
+    let hunkIndex: Int
+    let filePath: String
+    let isStaged: Bool
+    let gitProvider: GitStatusProvider
+    let diffPanel: DiffPanelProvider
+
+    @State private var showDiscardConfirm = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            hunkHeader
+            hunkLines
+        }
+        .accessibilityIdentifier(AccessibilityID.diffPanelHunk(hunkIndex))
+        .alert(Strings.diffPanelDiscardConfirmTitle, isPresented: $showDiscardConfirm) {
+            Button(Strings.diffPanelDiscardButton, role: .destructive) {
+                Task { await diffPanel.discardHunk(hunk, filePath: filePath, gitProvider: gitProvider) }
+            }
+            Button(Strings.diffPanelCancelButton, role: .cancel) { }
+        } message: {
+            Text(Strings.diffPanelDiscardConfirmMessage)
+        }
+    }
+
+    private var hunkHeader: some View {
+        HStack(spacing: 6) {
+            Text(hunkSummary)
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            Spacer()
+
+            if isStaged {
+                Button {
+                    Task { await diffPanel.unstageHunk(hunk, filePath: filePath, gitProvider: gitProvider) }
+                } label: {
+                    Image(systemName: "minus.circle").font(.system(size: 12))
+                }
+                .buttonStyle(.plain)
+                .help(Strings.diffPanelUnstageHunk)
+                .accessibilityIdentifier(AccessibilityID.diffPanelUnstageHunkButton)
+            } else {
+                Button {
+                    Task { await diffPanel.stageHunk(hunk, filePath: filePath, gitProvider: gitProvider) }
+                } label: {
+                    Image(systemName: "plus.circle").font(.system(size: 12))
+                }
+                .buttonStyle(.plain)
+                .help(Strings.diffPanelStageHunk)
+                .accessibilityIdentifier(AccessibilityID.diffPanelStageHunkButton)
+
+                Button { showDiscardConfirm = true } label: {
+                    Image(systemName: "trash").font(.system(size: 12))
+                }
+                .buttonStyle(.plain)
+                .help(Strings.diffPanelDiscardHunk)
+                .accessibilityIdentifier(AccessibilityID.diffPanelDiscardHunkButton)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .background(Color.primary.opacity(0.04))
+    }
+
+    private var hunkSummary: String {
+        let header = hunk.header
+        guard let endRange = header.range(
+            of: "@@", options: .backwards,
+            range: header.index(header.startIndex, offsetBy: 2)..<header.endIndex
+        ) else { return header }
+        return String(header[...endRange.upperBound]).trimmingCharacters(in: .whitespaces)
+    }
+
+    private var hunkLines: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(hunk.lines) { line in
+                HStack(spacing: 0) {
+                    Text(linePrefix(line.kind))
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 18, alignment: .center)
+                    Text(line.content)
+                        .font(.system(size: 12, design: .monospaced))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 1)
+                .background(lineBackground(line.kind))
+            }
+        }
+    }
+
+    private func linePrefix(_ kind: DiffLine.Kind) -> String {
+        switch kind {
+        case .context: " "
+        case .added:   "+"
+        case .removed: "-"
+        }
+    }
+
+    private func lineBackground(_ kind: DiffLine.Kind) -> Color {
+        switch kind {
+        case .context: .clear
+        case .added:   Color.green.opacity(0.12)
+        case .removed: Color.red.opacity(0.12)
+        }
+    }
+}

--- a/Pine/DiffHunk.swift
+++ b/Pine/DiffHunk.swift
@@ -1,0 +1,337 @@
+//
+//  DiffHunk.swift
+//  Pine
+//
+//  Models for full git diff output with hunk-level granularity.
+//
+
+import Foundation
+
+// MARK: - Diff Line
+
+struct DiffLine: Identifiable, Equatable, Sendable {
+    enum Kind: Equatable, Sendable {
+        case context
+        case added
+        case removed
+    }
+
+    let id = UUID()
+    let kind: Kind
+    let content: String
+
+    static func == (lhs: DiffLine, rhs: DiffLine) -> Bool {
+        lhs.kind == rhs.kind && lhs.content == rhs.content
+    }
+}
+
+// MARK: - Diff Hunk
+
+struct DiffHunk: Identifiable, Equatable, Sendable {
+    let id = UUID()
+    let oldStart: Int
+    let oldCount: Int
+    let newStart: Int
+    let newCount: Int
+    let header: String
+    let lines: [DiffLine]
+
+    static func == (lhs: DiffHunk, rhs: DiffHunk) -> Bool {
+        lhs.oldStart == rhs.oldStart
+            && lhs.oldCount == rhs.oldCount
+            && lhs.newStart == rhs.newStart
+            && lhs.newCount == rhs.newCount
+            && lhs.header == rhs.header
+            && lhs.lines == rhs.lines
+    }
+}
+
+// MARK: - Diff File Entry
+
+struct DiffFileEntry: Identifiable, Equatable, Sendable {
+    let id = UUID()
+    let relativePath: String
+    let status: GitFileStatus
+    let hunks: [DiffHunk]
+    let isStaged: Bool
+
+    static func == (lhs: DiffFileEntry, rhs: DiffFileEntry) -> Bool {
+        lhs.relativePath == rhs.relativePath
+            && lhs.status == rhs.status
+            && lhs.hunks == rhs.hunks
+            && lhs.isStaged == rhs.isStaged
+    }
+}
+
+// MARK: - Full Diff Parser
+
+extension GitStatusProvider {
+
+    nonisolated static func parseFullDiff(_ output: String) -> [String: [DiffHunk]] {
+        guard !output.isEmpty else { return [:] }
+
+        var result: [String: [DiffHunk]] = [:]
+        let lines = output.components(separatedBy: "\n")
+        var i = 0
+        var currentFile: String?
+
+        while i < lines.count {
+            let line = lines[i]
+
+            if line.hasPrefix("diff --git ") {
+                currentFile = parseFilePath(from: line)
+                i += 1
+                while i < lines.count
+                    && !lines[i].hasPrefix("@@")
+                    && !lines[i].hasPrefix("diff --git ") {
+                    i += 1
+                }
+                continue
+            }
+
+            if line.hasPrefix("@@"), let currentFile {
+                if let hunk = parseHunk(lines: lines, from: &i) {
+                    result[currentFile, default: []].append(hunk)
+                }
+                continue
+            }
+
+            i += 1
+        }
+
+        return result
+    }
+
+    nonisolated static func parseFilePath(from diffHeader: String) -> String? {
+        guard diffHeader.hasPrefix("diff --git ") else { return nil }
+        let content = String(diffHeader.dropFirst("diff --git ".count))
+
+        if content.contains("\"") {
+            if let range = content.range(of: " b/", options: .backwards) {
+                let bPath = String(content[range.upperBound...])
+                return unquoteGitPath(bPath)
+            }
+            let parts = content.components(separatedBy: "\" \"")
+            if parts.count == 2 {
+                let bPart = parts[1].hasSuffix("\"") ? String(parts[1].dropLast()) : parts[1]
+                return unquoteGitPath(bPart.hasPrefix("b/") ? String(bPart.dropFirst(2)) : bPart)
+            }
+        }
+
+        guard let range = content.range(of: " b/", options: .backwards) else { return nil }
+        return String(content[range.upperBound...])
+    }
+
+    nonisolated private static func parseHunk(lines: [String], from i: inout Int) -> DiffHunk? {
+        let headerLine = lines[i]
+        guard let parsed = parseHunkHeader(headerLine) else {
+            i += 1
+            return nil
+        }
+
+        let (oldStart, oldCount, newStart, newCount) = parsed
+        i += 1
+
+        var diffLines: [DiffLine] = []
+
+        while i < lines.count {
+            let line = lines[i]
+            if line.hasPrefix("@@") || line.hasPrefix("diff --git ") { break }
+
+            if line.hasPrefix("+") {
+                diffLines.append(DiffLine(kind: .added, content: String(line.dropFirst())))
+            } else if line.hasPrefix("-") {
+                diffLines.append(DiffLine(kind: .removed, content: String(line.dropFirst())))
+            } else if line.hasPrefix(" ") {
+                diffLines.append(DiffLine(kind: .context, content: String(line.dropFirst())))
+            } else if line.hasPrefix("\\") {
+                // "\ No newline at end of file" — skip
+            } else if line.isEmpty && i == lines.count - 1 {
+                // Trailing empty line
+            } else {
+                break
+            }
+            i += 1
+        }
+
+        return DiffHunk(
+            oldStart: oldStart, oldCount: oldCount,
+            newStart: newStart, newCount: newCount,
+            header: headerLine, lines: diffLines
+        )
+    }
+
+    nonisolated static func parseHunkHeader(_ header: String) -> (Int, Int, Int, Int)? {
+        guard header.hasPrefix("@@") else { return nil }
+
+        let scanner = Scanner(string: header)
+        _ = scanner.scanString("@@")
+        _ = scanner.scanString("-")
+
+        guard let oldStart = scanner.scanInt() else { return nil }
+        var oldCount = 1
+        if scanner.scanString(",") != nil {
+            if let count = scanner.scanInt() { oldCount = count }
+        }
+
+        _ = scanner.scanString("+")
+        guard let newStart = scanner.scanInt() else { return nil }
+        var newCount = 1
+        if scanner.scanString(",") != nil {
+            if let count = scanner.scanInt() { newCount = count }
+        }
+
+        return (oldStart, oldCount, newStart, newCount)
+    }
+
+    nonisolated static func patchForHunk(_ hunk: DiffHunk, filePath: String) -> String {
+        var patch = "--- a/\(filePath)\n"
+        patch += "+++ b/\(filePath)\n"
+        patch += "\(hunk.header)\n"
+        for line in hunk.lines {
+            switch line.kind {
+            case .context:  patch += " \(line.content)\n"
+            case .added:    patch += "+\(line.content)\n"
+            case .removed:  patch += "-\(line.content)\n"
+            }
+        }
+        return patch
+    }
+
+    // MARK: - Staged/Unstaged Diff
+
+    func stagedDiff() -> [String: [DiffHunk]] {
+        guard isGitRepository, let url = repositoryURL else { return [:] }
+        let headCheck = Self.runGit(["rev-parse", "HEAD"], at: url)
+        let args: [String]
+        if headCheck.exitCode == 0 {
+            args = ["diff", "--cached"]
+        } else {
+            args = ["diff", "--cached", "--diff-filter=A"]
+        }
+        let result = Self.runGit(args, at: url)
+        guard result.exitCode == 0 else { return [:] }
+        return Self.parseFullDiff(result.output)
+    }
+
+    func unstagedDiff() -> [String: [DiffHunk]] {
+        guard isGitRepository, let url = repositoryURL else { return [:] }
+        let result = Self.runGit(["diff"], at: url)
+        guard result.exitCode == 0 else { return [:] }
+        return Self.parseFullDiff(result.output)
+    }
+
+    // MARK: - Staging Operations
+
+    func stageHunk(_ hunk: DiffHunk, filePath: String) -> Bool {
+        guard let url = repositoryURL else { return false }
+        let patch = Self.patchForHunk(hunk, filePath: filePath)
+        return applyPatch(patch, arguments: ["apply", "--cached"], at: url)
+    }
+
+    func unstageHunk(_ hunk: DiffHunk, filePath: String) -> Bool {
+        guard let url = repositoryURL else { return false }
+        let patch = Self.patchForHunk(hunk, filePath: filePath)
+        return applyPatch(patch, arguments: ["apply", "--cached", "--reverse"], at: url)
+    }
+
+    func discardHunk(_ hunk: DiffHunk, filePath: String) -> Bool {
+        guard let url = repositoryURL else { return false }
+        let patch = Self.patchForHunk(hunk, filePath: filePath)
+        return applyPatch(patch, arguments: ["apply", "--reverse"], at: url)
+    }
+
+    func stageFile(_ relativePath: String) -> Bool {
+        guard let url = repositoryURL else { return false }
+        let result = Self.runGit(["add", "--", relativePath], at: url)
+        return result.exitCode == 0
+    }
+
+    func unstageFile(_ relativePath: String) -> Bool {
+        guard let url = repositoryURL else { return false }
+        let result = Self.runGit(["reset", "HEAD", "--", relativePath], at: url)
+        return result.exitCode == 0
+    }
+
+    func discardFile(_ relativePath: String) -> Bool {
+        guard let url = repositoryURL else { return false }
+        let result = Self.runGit(["checkout", "--", relativePath], at: url)
+        return result.exitCode == 0
+    }
+
+    func splitStatuses() -> (staged: [String: GitFileStatus], unstaged: [String: GitFileStatus]) {
+        guard isGitRepository, let url = repositoryURL else { return ([:], [:]) }
+        let result = Self.runGit(["--no-optional-locks", "status", "--porcelain"], at: url)
+        guard result.exitCode == 0 else { return ([:], [:]) }
+
+        var staged: [String: GitFileStatus] = [:]
+        var unstaged: [String: GitFileStatus] = [:]
+
+        for line in result.output.components(separatedBy: "\n") {
+            guard line.count >= 3 else { continue }
+            let indexChar = line[line.startIndex]
+            let workTreeChar = line[line.index(after: line.startIndex)]
+            var path = String(line.dropFirst(3))
+            path = Self.unquoteGitPath(path)
+
+            if path.contains(" -> ") {
+                let parts = path.components(separatedBy: " -> ")
+                if parts.count == 2 { path = parts[1] }
+            }
+
+            switch indexChar {
+            case "M": staged[path] = .modified
+            case "A": staged[path] = .added
+            case "D": staged[path] = .deleted
+            case "R": staged[path] = .staged
+            default: break
+            }
+
+            switch workTreeChar {
+            case "M": unstaged[path] = .modified
+            case "D": unstaged[path] = .deleted
+            case "?":
+                if indexChar == "?" { unstaged[path] = .untracked }
+            default: break
+            }
+        }
+
+        return (staged, unstaged)
+    }
+
+    // MARK: - Private Helpers
+
+    private func applyPatch(_ patch: String, arguments: [String], at directory: URL) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = arguments
+        process.currentDirectoryURL = directory
+
+        let inPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardInput = inPipe
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = errPipe
+
+        do {
+            try process.run()
+
+            let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+            timer.schedule(deadline: .now() + Self.defaultGitTimeout)
+            timer.setEventHandler {
+                if process.isRunning { process.terminate() }
+            }
+            timer.resume()
+
+            if let data = patch.data(using: .utf8) {
+                inPipe.fileHandleForWriting.write(data)
+            }
+            inPipe.fileHandleForWriting.closeFile()
+            process.waitUntilExit()
+            timer.cancel()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
+}

--- a/Pine/DiffPanelProvider.swift
+++ b/Pine/DiffPanelProvider.swift
@@ -1,0 +1,179 @@
+//
+//  DiffPanelProvider.swift
+//  Pine
+//
+//  Manages the state of the git diff panel: file lists, staging operations.
+//
+
+import Foundation
+
+@Observable
+final class DiffPanelProvider {
+    private(set) var stagedEntries: [DiffFileEntry] = []
+    private(set) var unstagedEntries: [DiffFileEntry] = []
+    private(set) var isLoading = false
+
+    /// Currently selected file path shown in the detail view.
+    var selectedFilePath: String?
+
+    /// Returns the selected DiffFileEntry from staged or unstaged entries.
+    var selectedEntry: DiffFileEntry? {
+        guard let path = selectedFilePath else { return nil }
+        return stagedEntries.first { $0.relativePath == path }
+            ?? unstagedEntries.first { $0.relativePath == path }
+    }
+
+    func refresh(gitProvider: GitStatusProvider) async {
+        await MainActor.run { isLoading = true }
+
+        let (stagedResult, unstagedResult, splitResult) = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let staged = gitProvider.stagedDiff()
+                let unstaged = gitProvider.unstagedDiff()
+                let split = gitProvider.splitStatuses()
+                continuation.resume(returning: (staged, unstaged, split))
+            }
+        }
+
+        guard !Task.isCancelled else { return }
+
+        let stagedFiles = buildEntries(diffs: stagedResult, statuses: splitResult.staged, isStaged: true)
+        let unstagedFiles = buildEntries(diffs: unstagedResult, statuses: splitResult.unstaged, isStaged: false)
+
+        await MainActor.run {
+            self.stagedEntries = stagedFiles
+            self.unstagedEntries = unstagedFiles
+            self.isLoading = false
+
+            if let path = selectedFilePath,
+               !stagedFiles.contains(where: { $0.relativePath == path }),
+               !unstagedFiles.contains(where: { $0.relativePath == path }) {
+                selectedFilePath = nil
+            }
+        }
+    }
+
+    func stageHunk(_ hunk: DiffHunk, filePath: String, gitProvider: GitStatusProvider) async {
+        let success = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: gitProvider.stageHunk(hunk, filePath: filePath))
+            }
+        }
+        if success {
+            await gitProvider.refreshAsync()
+            await refresh(gitProvider: gitProvider)
+        }
+    }
+
+    func unstageHunk(_ hunk: DiffHunk, filePath: String, gitProvider: GitStatusProvider) async {
+        let success = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: gitProvider.unstageHunk(hunk, filePath: filePath))
+            }
+        }
+        if success {
+            await gitProvider.refreshAsync()
+            await refresh(gitProvider: gitProvider)
+        }
+    }
+
+    func discardHunk(_ hunk: DiffHunk, filePath: String, gitProvider: GitStatusProvider) async {
+        let success = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: gitProvider.discardHunk(hunk, filePath: filePath))
+            }
+        }
+        if success {
+            await gitProvider.refreshAsync()
+            await refresh(gitProvider: gitProvider)
+            NotificationCenter.default.post(name: .refreshLineDiffs, object: nil)
+        }
+    }
+
+    func stageFile(_ relativePath: String, gitProvider: GitStatusProvider) async {
+        let success = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: gitProvider.stageFile(relativePath))
+            }
+        }
+        if success {
+            await gitProvider.refreshAsync()
+            await refresh(gitProvider: gitProvider)
+        }
+    }
+
+    func unstageFile(_ relativePath: String, gitProvider: GitStatusProvider) async {
+        let success = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: gitProvider.unstageFile(relativePath))
+            }
+        }
+        if success {
+            await gitProvider.refreshAsync()
+            await refresh(gitProvider: gitProvider)
+        }
+    }
+
+    func discardFile(_ relativePath: String, gitProvider: GitStatusProvider) async {
+        let success = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: gitProvider.discardFile(relativePath))
+            }
+        }
+        if success {
+            if selectedFilePath == relativePath { selectedFilePath = nil }
+            await gitProvider.refreshAsync()
+            await refresh(gitProvider: gitProvider)
+            NotificationCenter.default.post(name: .refreshLineDiffs, object: nil)
+        }
+    }
+
+    func stageAll(gitProvider: GitStatusProvider) async {
+        guard let url = gitProvider.repositoryURL else { return }
+        let success = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let result = GitStatusProvider.runGit(["add", "-A"], at: url)
+                continuation.resume(returning: result.exitCode == 0)
+            }
+        }
+        if success {
+            await gitProvider.refreshAsync()
+            await refresh(gitProvider: gitProvider)
+        }
+    }
+
+    func unstageAll(gitProvider: GitStatusProvider) async {
+        guard let url = gitProvider.repositoryURL else { return }
+        let success = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let result = GitStatusProvider.runGit(["reset", "HEAD"], at: url)
+                continuation.resume(returning: result.exitCode == 0)
+            }
+        }
+        if success {
+            await gitProvider.refreshAsync()
+            await refresh(gitProvider: gitProvider)
+        }
+    }
+
+    // MARK: - Private
+
+    private func buildEntries(
+        diffs: [String: [DiffHunk]],
+        statuses: [String: GitFileStatus],
+        isStaged: Bool
+    ) -> [DiffFileEntry] {
+        var entries: [DiffFileEntry] = []
+
+        for (path, hunks) in diffs.sorted(by: { $0.key < $1.key }) {
+            let status = statuses[path] ?? .modified
+            entries.append(DiffFileEntry(relativePath: path, status: status, hunks: hunks, isStaged: isStaged))
+        }
+
+        for (path, status) in statuses.sorted(by: { $0.key < $1.key }) where diffs[path] == nil {
+            entries.append(DiffFileEntry(relativePath: path, status: status, hunks: [], isStaged: isStaged))
+        }
+
+        return entries
+    }
+}

--- a/Pine/DiffPanelView.swift
+++ b/Pine/DiffPanelView.swift
@@ -1,0 +1,193 @@
+//
+//  DiffPanelView.swift
+//  Pine
+//
+//  Sidebar file list for the git diff panel. Selecting a file shows its diff in the editor area.
+//
+
+import SwiftUI
+
+struct DiffPanelView: View {
+    @Environment(ProjectManager.self) var projectManager
+
+    var body: some View {
+        let diffPanel = projectManager.diffPanel
+
+        if diffPanel.isLoading {
+            VStack {
+                Spacer()
+                ProgressView()
+                    .controlSize(.small)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+        } else if diffPanel.stagedEntries.isEmpty && diffPanel.unstagedEntries.isEmpty {
+            VStack {
+                Spacer()
+                Text(Strings.diffPanelNoChanges)
+                    .foregroundStyle(.secondary)
+                    .font(.system(size: 12))
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+        } else {
+            diffList
+        }
+    }
+
+    private var diffList: some View {
+        let diffPanel = projectManager.diffPanel
+        let gitProvider = projectManager.gitProvider
+
+        return ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                if !diffPanel.stagedEntries.isEmpty {
+                    sectionHeader(
+                        title: Strings.diffPanelStagedChanges,
+                        count: diffPanel.stagedEntries.count,
+                        action: { Task { await diffPanel.unstageAll(gitProvider: gitProvider) } },
+                        actionIcon: "minus.circle",
+                        actionTooltip: Strings.diffPanelUnstageAll
+                    )
+                    .accessibilityIdentifier(AccessibilityID.diffPanelStagedSection)
+
+                    ForEach(diffPanel.stagedEntries) { entry in
+                        DiffFileRowView(
+                            entry: entry,
+                            isSelected: diffPanel.selectedFilePath == entry.relativePath,
+                            gitProvider: gitProvider,
+                            diffPanel: diffPanel
+                        )
+                    }
+                }
+
+                if !diffPanel.unstagedEntries.isEmpty {
+                    sectionHeader(
+                        title: Strings.diffPanelUnstagedChanges,
+                        count: diffPanel.unstagedEntries.count,
+                        action: { Task { await diffPanel.stageAll(gitProvider: gitProvider) } },
+                        actionIcon: "plus.circle",
+                        actionTooltip: Strings.diffPanelStageAll
+                    )
+                    .accessibilityIdentifier(AccessibilityID.diffPanelUnstagedSection)
+
+                    ForEach(diffPanel.unstagedEntries) { entry in
+                        DiffFileRowView(
+                            entry: entry,
+                            isSelected: diffPanel.selectedFilePath == entry.relativePath,
+                            gitProvider: gitProvider,
+                            diffPanel: diffPanel
+                        )
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier(AccessibilityID.diffPanel)
+    }
+
+    private func sectionHeader(
+        title: LocalizedStringKey,
+        count: Int,
+        action: @escaping () -> Void,
+        actionIcon: String,
+        actionTooltip: LocalizedStringKey
+    ) -> some View {
+        HStack {
+            Text(title)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+            Spacer()
+            Text("\(count)")
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 4)
+                .background(.quaternary, in: Capsule())
+            Button(action: action) {
+                Image(systemName: actionIcon)
+                    .font(.system(size: 11))
+            }
+            .buttonStyle(.plain)
+            .help(actionTooltip)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(.bar)
+    }
+}
+
+// MARK: - File Row
+
+private struct DiffFileRowView: View {
+    let entry: DiffFileEntry
+    let isSelected: Bool
+    let gitProvider: GitStatusProvider
+    let diffPanel: DiffPanelProvider
+
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: FileIconMapper.iconForFile(
+                (entry.relativePath as NSString).lastPathComponent
+            ))
+            .font(.system(size: 11))
+            .foregroundStyle(.secondary)
+
+            Text(entry.relativePath)
+                .font(.system(size: 11))
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Spacer()
+
+            Text(statusLetter)
+                .font(.system(size: 9, weight: .bold, design: .monospaced))
+                .foregroundStyle(entry.status.color)
+
+            if isHovered {
+                fileActions
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
+        .background(isSelected ? Color.accentColor.opacity(0.15) : isHovered ? Color.primary.opacity(0.06) : .clear)
+        .onTapGesture { diffPanel.selectedFilePath = entry.relativePath }
+        .onHover { isHovered = $0 }
+        .accessibilityIdentifier(AccessibilityID.diffPanelFile(entry.relativePath))
+    }
+
+    private var statusLetter: String {
+        switch entry.status {
+        case .modified: "M"
+        case .added:    "A"
+        case .deleted:  "D"
+        case .untracked: "U"
+        case .staged:   "S"
+        case .conflict: "C"
+        case .mixed:    "M"
+        }
+    }
+
+    @ViewBuilder
+    private var fileActions: some View {
+        if entry.isStaged {
+            Button {
+                Task { await diffPanel.unstageFile(entry.relativePath, gitProvider: gitProvider) }
+            } label: {
+                Image(systemName: "minus.circle").font(.system(size: 11))
+            }
+            .buttonStyle(.plain)
+            .help(Strings.diffPanelUnstageFile)
+        } else {
+            Button {
+                Task { await diffPanel.stageFile(entry.relativePath, gitProvider: gitProvider) }
+            } label: {
+                Image(systemName: "plus.circle").font(.system(size: 11))
+            }
+            .buttonStyle(.plain)
+            .help(Strings.diffPanelStageFile)
+        }
+    }
+}

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -1811,6 +1811,139 @@
         }
       }
     },
+    "diffDetail.noHunks" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No displayable changes" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Нет отображаемых изменений" } }
+      }
+    },
+    "diffDetail.selectFile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Select a File" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Выберите файл" } }
+      }
+    },
+    "diffDetail.selectFileDescription" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Select a file from the sidebar to view its changes" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Выберите файл в боковой панели для просмотра изменений" } }
+      }
+    },
+    "diffDetail.untrackedFile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Untracked file — stage to see diff" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Неотслеживаемый файл — добавьте для просмотра diff" } }
+      }
+    },
+    "diffPanel.discardConfirm.cancel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Cancel" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Отмена" } }
+      }
+    },
+    "diffPanel.discardConfirm.discard" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Discard" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Отменить изменения" } }
+      }
+    },
+    "diffPanel.discardConfirm.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "This change will be permanently lost." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Это изменение будет безвозвратно потеряно." } }
+      }
+    },
+    "diffPanel.discardConfirm.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Discard this change?" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Отменить это изменение?" } }
+      }
+    },
+    "diffPanel.discardHunk" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Discard Hunk" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Отменить фрагмент" } }
+      }
+    },
+    "diffPanel.noChanges" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No Changes" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Нет изменений" } }
+      }
+    },
+    "diffPanel.stageAll" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Stage All" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Добавить всё" } }
+      }
+    },
+    "diffPanel.stageFile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Stage File" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Добавить файл" } }
+      }
+    },
+    "diffPanel.stageHunk" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Stage Hunk" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Добавить фрагмент" } }
+      }
+    },
+    "diffPanel.stagedChanges" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Staged Changes" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Подготовленные изменения" } }
+      }
+    },
+    "diffPanel.unstageAll" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Unstage All" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Убрать всё" } }
+      }
+    },
+    "diffPanel.unstageFile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Unstage File" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Убрать файл" } }
+      }
+    },
+    "diffPanel.unstageHunk" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Unstage Hunk" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Убрать фрагмент" } }
+      }
+    },
+    "diffPanel.unstagedChanges" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Unstaged Changes" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Неподготовленные изменения" } }
+      }
+    },
+    "menu.toggleDiffPanel" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Toggle Changes" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Переключить панель изменений" } }
+      }
+    },
     "editor.noFileSelected" : {
       "comment" : "Placeholder title shown in the editor area when no file is open.",
       "extractionState" : "manual",

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -40,6 +40,9 @@ enum MenuIcons {
     // MARK: - Terminal menu
     static let newTerminalTab = "plus"
 
+    // MARK: - Git menu
+    static let diffPanel = "arrow.triangle.branch"
+
     // MARK: - Context menu
     static let newFile = "doc.badge.plus"
     static let newFolder = "folder.badge.plus"

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -99,6 +99,13 @@ struct PineApp: App {
                 }
                 .keyboardShortcut("b", modifiers: [.command, .control])
 
+                Button {
+                    NotificationCenter.default.post(name: .showDiffPanel, object: nil)
+                } label: {
+                    Label(Strings.menuToggleDiffPanel, systemImage: MenuIcons.diffPanel)
+                }
+                .keyboardShortcut("c", modifiers: [.command, .shift])
+
                 Divider()
 
                 Button {
@@ -1036,4 +1043,5 @@ extension Notification.Name {
     static let useSelectionForFind = Notification.Name("useSelectionForFind")
     // Find in Terminal (issue #308)
     static let findInTerminal = Notification.Name("findInTerminal")
+    static let showDiffPanel = Notification.Name("showDiffPanel")
 }

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -15,6 +15,7 @@ final class ProjectManager {
     let terminal = TerminalManager()
     let tabManager = TabManager()
     let searchProvider = ProjectSearchProvider()
+    let diffPanel = DiffPanelProvider()
     private(set) var recoveryManager: RecoveryManager?
 
     deinit {

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -254,6 +254,41 @@ enum Strings {
     static let sidebarFiles: LocalizedStringKey = "sidebar.files"
     static let sidebarSearch: LocalizedStringKey = "sidebar.search"
 
+    // MARK: - Diff Panel
+
+    static let menuToggleDiffPanel: LocalizedStringKey = "menu.toggleDiffPanel"
+    static let diffPanelStagedChanges: LocalizedStringKey = "diffPanel.stagedChanges"
+    static let diffPanelUnstagedChanges: LocalizedStringKey = "diffPanel.unstagedChanges"
+    static let diffPanelNoChanges: LocalizedStringKey = "diffPanel.noChanges"
+    static let diffPanelStageHunk: LocalizedStringKey = "diffPanel.stageHunk"
+    static let diffPanelUnstageHunk: LocalizedStringKey = "diffPanel.unstageHunk"
+    static let diffPanelDiscardHunk: LocalizedStringKey = "diffPanel.discardHunk"
+    static let diffPanelStageAll: LocalizedStringKey = "diffPanel.stageAll"
+    static let diffPanelUnstageAll: LocalizedStringKey = "diffPanel.unstageAll"
+    static let diffPanelStageFile: LocalizedStringKey = "diffPanel.stageFile"
+    static let diffPanelUnstageFile: LocalizedStringKey = "diffPanel.unstageFile"
+
+    static var diffPanelDiscardConfirmTitle: String {
+        String(localized: "diffPanel.discardConfirm.title")
+    }
+
+    static var diffPanelDiscardConfirmMessage: String {
+        String(localized: "diffPanel.discardConfirm.message")
+    }
+
+    static var diffPanelDiscardButton: String {
+        String(localized: "diffPanel.discardConfirm.discard")
+    }
+
+    static var diffPanelCancelButton: String {
+        String(localized: "diffPanel.discardConfirm.cancel")
+    }
+
+    static let diffDetailSelectFile: LocalizedStringKey = "diffDetail.selectFile"
+    static let diffDetailSelectFileDescription: LocalizedStringKey = "diffDetail.selectFileDescription"
+    static let diffDetailUntrackedFile: LocalizedStringKey = "diffDetail.untrackedFile"
+    static let diffDetailNoHunks: LocalizedStringKey = "diffDetail.noHunks"
+
     // MARK: - Terminal Search
 
     static let terminalSearchPlaceholder: LocalizedStringKey = "terminal.search.placeholder"

--- a/PineTests/DiffHunkParserTests.swift
+++ b/PineTests/DiffHunkParserTests.swift
@@ -1,0 +1,217 @@
+//
+//  DiffHunkParserTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+@testable import Pine
+
+struct DiffHunkParserTests {
+
+    // MARK: - parseHunkHeader
+
+    @Test func parsesStandardHunkHeader() throws {
+        let result = try #require(GitStatusProvider.parseHunkHeader("@@ -10,5 +10,7 @@ func foo()"))
+        let (oldStart, oldCount, newStart, newCount) = result
+        #expect(oldStart == 10)
+        #expect(oldCount == 5)
+        #expect(newStart == 10)
+        #expect(newCount == 7)
+    }
+
+    @Test func parsesHunkHeaderWithoutCount() throws {
+        let result = try #require(GitStatusProvider.parseHunkHeader("@@ -1 +1 @@"))
+        let (oldStart, oldCount, newStart, newCount) = result
+        #expect(oldStart == 1)
+        #expect(oldCount == 1)
+        #expect(newStart == 1)
+        #expect(newCount == 1)
+    }
+
+    @Test func parsesHunkHeaderMixedCounts() throws {
+        let result = try #require(GitStatusProvider.parseHunkHeader("@@ -5,3 +5 @@"))
+        let (_, oldCount, _, newCount) = result
+        #expect(oldCount == 3)
+        #expect(newCount == 1)
+    }
+
+    @Test func parsesHunkHeaderZeroCount() throws {
+        let result = try #require(GitStatusProvider.parseHunkHeader("@@ -0,0 +1,3 @@"))
+        let (oldStart, oldCount, newStart, newCount) = result
+        #expect(oldStart == 0)
+        #expect(oldCount == 0)
+        #expect(newStart == 1)
+        #expect(newCount == 3)
+    }
+
+    @Test func returnsNilForInvalidHeader() {
+        #expect(GitStatusProvider.parseHunkHeader("not a hunk") == nil)
+        #expect(GitStatusProvider.parseHunkHeader("") == nil)
+    }
+
+    // MARK: - parseFilePath
+
+    @Test func parsesSimpleFilePath() {
+        let path = GitStatusProvider.parseFilePath(from: "diff --git a/Pine/Foo.swift b/Pine/Foo.swift")
+        #expect(path == "Pine/Foo.swift")
+    }
+
+    @Test func parsesFilePathWithSpaces() {
+        let path = GitStatusProvider.parseFilePath(from: "diff --git a/dir/my file.txt b/dir/my file.txt")
+        #expect(path == "dir/my file.txt")
+    }
+
+    @Test func returnsNilForNonDiffLine() {
+        #expect(GitStatusProvider.parseFilePath(from: "not a diff header") == nil)
+    }
+
+    // MARK: - parseFullDiff
+
+    @Test func parsesEmptyOutput() {
+        let result = GitStatusProvider.parseFullDiff("")
+        #expect(result.isEmpty)
+    }
+
+    @Test func parsesSingleFileWithOneHunk() throws {
+        let diff = """
+        diff --git a/file.swift b/file.swift
+        index abc1234..def5678 100644
+        --- a/file.swift
+        +++ b/file.swift
+        @@ -1,3 +1,4 @@
+         line1
+        +added line
+         line2
+         line3
+        """
+        let result = GitStatusProvider.parseFullDiff(diff)
+        #expect(result.count == 1)
+
+        let hunks = try #require(result["file.swift"])
+        let hunk = hunks[0]
+        #expect(hunk.oldStart == 1)
+        #expect(hunk.oldCount == 3)
+        #expect(hunk.newStart == 1)
+        #expect(hunk.newCount == 4)
+        #expect(hunk.lines.count == 4)
+        #expect(hunk.lines[0].kind == .context)
+        #expect(hunk.lines[1].kind == .added)
+        #expect(hunk.lines[1].content == "added line")
+    }
+
+    @Test func parsesMultipleHunksInOneFile() throws {
+        let diff = """
+        diff --git a/file.swift b/file.swift
+        index abc1234..def5678 100644
+        --- a/file.swift
+        +++ b/file.swift
+        @@ -1,3 +1,4 @@
+         line1
+        +added line
+         line2
+         line3
+        @@ -10,3 +11,2 @@
+         line10
+        -removed line
+         line12
+        """
+        let result = GitStatusProvider.parseFullDiff(diff)
+        let hunks = try #require(result["file.swift"])
+        #expect(hunks.count == 2)
+        #expect(hunks[0].lines.filter { $0.kind == .added }.count == 1)
+        #expect(hunks[1].lines.filter { $0.kind == .removed }.count == 1)
+    }
+
+    @Test func parsesMultipleFiles() {
+        let diff = """
+        diff --git a/foo.swift b/foo.swift
+        index abc..def 100644
+        --- a/foo.swift
+        +++ b/foo.swift
+        @@ -1,2 +1,3 @@
+         line1
+        +new
+         line2
+        diff --git a/bar.swift b/bar.swift
+        index abc..def 100644
+        --- a/bar.swift
+        +++ b/bar.swift
+        @@ -5,3 +5,2 @@
+         old
+        -deleted
+         remaining
+        """
+        let result = GitStatusProvider.parseFullDiff(diff)
+        #expect(result.count == 2)
+        #expect(result["foo.swift"]?.count == 1)
+        #expect(result["bar.swift"]?.count == 1)
+    }
+
+    @Test func parsesAddedAndRemovedLines() throws {
+        let diff = """
+        diff --git a/test.txt b/test.txt
+        index abc..def 100644
+        --- a/test.txt
+        +++ b/test.txt
+        @@ -1,3 +1,3 @@
+         keep
+        -old line
+        +new line
+         keep
+        """
+        let hunks = try #require(GitStatusProvider.parseFullDiff(diff)["test.txt"])
+        let hunk = hunks[0]
+        #expect(hunk.lines.count == 4)
+        #expect(hunk.lines[1].kind == .removed)
+        #expect(hunk.lines[1].content == "old line")
+        #expect(hunk.lines[2].kind == .added)
+        #expect(hunk.lines[2].content == "new line")
+    }
+
+    @Test func handlesNoNewlineAtEndOfFile() throws {
+        let diff = """
+        diff --git a/test.txt b/test.txt
+        index abc..def 100644
+        --- a/test.txt
+        +++ b/test.txt
+        @@ -1,2 +1,2 @@
+         line1
+        -old
+        \\ No newline at end of file
+        +new
+        \\ No newline at end of file
+        """
+        let hunks = try #require(GitStatusProvider.parseFullDiff(diff)["test.txt"])
+        let contentLines = hunks[0].lines.filter { $0.kind != .context || !$0.content.isEmpty }
+        #expect(contentLines.count >= 3)
+    }
+
+    // MARK: - patchForHunk
+
+    @Test func generatesPatchForHunk() {
+        let hunk = DiffHunk(
+            oldStart: 1, oldCount: 3, newStart: 1, newCount: 4,
+            header: "@@ -1,3 +1,4 @@",
+            lines: [
+                DiffLine(kind: .context, content: "line1"),
+                DiffLine(kind: .added, content: "new line"),
+                DiffLine(kind: .context, content: "line2"),
+                DiffLine(kind: .context, content: "line3")
+            ]
+        )
+        let patch = GitStatusProvider.patchForHunk(hunk, filePath: "test.swift")
+        #expect(patch.contains("--- a/test.swift"))
+        #expect(patch.contains("+++ b/test.swift"))
+        #expect(patch.contains("+new line"))
+        #expect(patch.contains(" line1"))
+    }
+
+    // MARK: - selectedEntry
+
+    @Test func selectedEntryFindsInStaged() {
+        let provider = DiffPanelProvider()
+        // Verify computed property returns nil when no selection
+        #expect(provider.selectedEntry == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Git diff panel (Cmd+Shift+C) with split view: sidebar shows file list, editor area shows full diff
- Hunk-level stage, unstage, and discard actions with confirmation dialog
- File-level and bulk stage/unstage operations
- Auto-refresh when git status changes
- 16 unit tests for diff parser

## New Files
- `DiffHunk.swift` — models + full diff parser + git staging operations
- `DiffPanelProvider.swift` — @Observable state manager
- `DiffPanelView.swift` — compact sidebar file list
- `DiffDetailView.swift` — full diff view in editor area
- `DiffHunkParserTests.swift` — 16 unit tests

## Modified Files
- `PineApp.swift` — Cmd+Shift+C menu item + notification
- `ContentView.swift` — sidebar + editor area integration
- `ProjectManager.swift` — added `diffPanel` property
- `Strings.swift`, `MenuIcons.swift`, `AccessibilityIdentifiers.swift`, `Localizable.xcstrings`

Closes #374
Closes #303

## Test plan
- [x] Unit tests pass (16 new)
- [ ] Cmd+Shift+C toggles diff panel
- [ ] Sidebar shows staged/unstaged file list
- [ ] Clicking file shows full diff in editor area
- [ ] Stage/unstage hunks via +/- buttons
- [ ] Discard hunk with confirmation dialog
- [ ] Panel auto-refreshes on file save