### PR TITLE
fix: align line number baseline with editor text baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,7 @@ jobs:
               -only-testing:PineUITests/EditorWindowTests
               -only-testing:PineUITests/FontSizeTests
               -only-testing:PineUITests/DiffNavigationUITests
+              -only-testing:PineUITests/LineNumberGutterUITests
           # Shard 3 — File Operations (20 tests)
           - shard-name: "File Operations"
             test-classes: >-

--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -24,6 +24,7 @@ enum AccessibilityID {
     static func editorTabCloseButton(_ name: String) -> String { "editorTabClose_\(name)" }
     static let editorPlaceholder = "editorPlaceholder"
     static let codeEditor = "codeEditor"
+    static let lineNumberGutter = "lineNumberGutter"
     static let minimap = "minimap"
     static let autoSaveIndicator = "autoSaveIndicator"
     static let quickLookPreview = "quickLookPreview"

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -503,7 +503,6 @@ struct CodeEditorView: NSViewRepresentable {
 
         // ── Номера строк — поверх scroll view, как отдельный сиблинг ──
         let lineNumberView = LineNumberView(textView: textView)
-        lineNumberView.setAccessibilityIdentifier(AccessibilityID.lineNumberGutter)
         lineNumberView.gutterWidth = gutterWidth
         lineNumberView.gutterFont = gutterFont
         lineNumberView.editorFont = editorFont

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -503,6 +503,7 @@ struct CodeEditorView: NSViewRepresentable {
 
         // ── Номера строк — поверх scroll view, как отдельный сиблинг ──
         let lineNumberView = LineNumberView(textView: textView)
+        lineNumberView.setAccessibilityIdentifier(AccessibilityID.lineNumberGutter)
         lineNumberView.gutterWidth = gutterWidth
         lineNumberView.gutterFont = gutterFont
         lineNumberView.editorFont = editorFont

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -505,6 +505,7 @@ struct CodeEditorView: NSViewRepresentable {
         let lineNumberView = LineNumberView(textView: textView)
         lineNumberView.gutterWidth = gutterWidth
         lineNumberView.gutterFont = gutterFont
+        lineNumberView.editorFont = editorFont
         lineNumberView.foldState = foldState
         let coordinator = context.coordinator
         lineNumberView.onFoldToggle = { [weak coordinator] foldable in
@@ -856,6 +857,7 @@ struct CodeEditorView: NSViewRepresentable {
 
             // Update gutter font
             lineNumberView?.gutterFont = gutterFont
+            lineNumberView?.editorFont = font
             lineNumberView?.needsDisplay = true
         }
 

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -81,6 +81,7 @@ final class LineNumberView: NSView {
         self.textView = textView
         super.init(frame: .zero)
         setAccessibilityElement(true)
+        setAccessibilityIdentifier(AccessibilityID.lineNumberGutter)
 
         // Скролл — подписываемся без object, чтобы не зависеть от конкретного clipView
         NotificationCenter.default.addObserver(

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -13,6 +13,12 @@ final class LineNumberView: NSView {
     weak var textView: NSTextView?
 
     var gutterFont = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+    var editorFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+
+    /// Vertical offset to align gutter number baseline with editor text baseline.
+    var baselineOffset: CGFloat {
+        editorFont.ascender - gutterFont.ascender
+    }
     private let gutterTextColor = NSColor.secondaryLabelColor
     private let gutterBgColor = NSColor.controlBackgroundColor
     private let separatorColor = NSColor.separatorColor
@@ -245,7 +251,7 @@ final class LineNumberView: NSView {
             let numStr = "1" as NSString
             let size = numStr.size(withAttributes: attrs)
             let x = gutterWidth - size.width - 8
-            numStr.draw(at: NSPoint(x: x, y: originY), withAttributes: attrs)
+            numStr.draw(at: NSPoint(x: x, y: originY + baselineOffset), withAttributes: attrs)
             return
         }
 
@@ -313,7 +319,7 @@ final class LineNumberView: NSView {
                 let numStr = "\(lineNumber)" as NSString
                 let size = numStr.size(withAttributes: attrs)
                 let x = self.gutterWidth - size.width - 8
-                numStr.draw(at: NSPoint(x: x, y: y), withAttributes: attrs)
+                numStr.draw(at: NSPoint(x: x, y: y + self.baselineOffset), withAttributes: attrs)
 
                 // ── Fold disclosure triangle ──
                 if showFoldIndicators || self.foldState.foldedRanges.contains(where: { $0.startLine == lineNumber }) {
@@ -374,7 +380,7 @@ final class LineNumberView: NSView {
                 let numStr = "\(lineNumber)" as NSString
                 let size = numStr.size(withAttributes: attrs)
                 let x = gutterWidth - size.width - 8
-                numStr.draw(at: NSPoint(x: x, y: y), withAttributes: attrs)
+                numStr.draw(at: NSPoint(x: x, y: y + baselineOffset), withAttributes: attrs)
             }
         }
 

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -80,6 +80,7 @@ final class LineNumberView: NSView {
     init(textView: NSTextView) {
         self.textView = textView
         super.init(frame: .zero)
+        setAccessibilityElement(true)
 
         // Скролл — подписываемся без object, чтобы не зависеть от конкретного clipView
         NotificationCenter.default.addObserver(

--- a/PineTests/LineNumberBaselineTests.swift
+++ b/PineTests/LineNumberBaselineTests.swift
@@ -1,0 +1,64 @@
+//
+//  LineNumberBaselineTests.swift
+//  PineTests
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+/// Tests that line number baseline aligns with editor text baseline.
+struct LineNumberBaselineTests {
+
+    private func makeView() -> LineNumberView {
+        let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 500, height: 500))
+        return LineNumberView(textView: textView)
+    }
+
+    /// When editor font is larger than gutter font, baselineOffset should compensate.
+    @Test func baselineOffsetCompensatesForSmallerGutterFont() {
+        let editorFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        let gutterFont = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+
+        let view = makeView()
+        view.gutterFont = gutterFont
+        view.editorFont = editorFont
+
+        let expectedOffset = editorFont.ascender - gutterFont.ascender
+        #expect(expectedOffset > 0, "Editor font ascender should be larger")
+        #expect(view.baselineOffset == expectedOffset)
+    }
+
+    /// When editor and gutter fonts have the same size, baselineOffset should be 0.
+    @Test func baselineOffsetZeroWhenFontsMatch() {
+        let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+
+        let view = makeView()
+        view.gutterFont = font
+        view.editorFont = font
+
+        #expect(view.baselineOffset == 0)
+    }
+
+    /// baselineOffset updates when fonts change and reflects ascender difference.
+    @Test func baselineOffsetUpdatesWithFonts() {
+        let view = makeView()
+
+        let editor1 = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        let gutter1 = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        view.editorFont = editor1
+        view.gutterFont = gutter1
+        let offset1 = view.baselineOffset
+
+        // Change to different size — offset should match new ascender difference
+        let editor2 = NSFont.monospacedSystemFont(ofSize: 20, weight: .regular)
+        let gutter2 = NSFont.monospacedSystemFont(ofSize: 14, weight: .regular)
+        view.editorFont = editor2
+        view.gutterFont = gutter2
+        let offset2 = view.baselineOffset
+
+        let expected2 = editor2.ascender - gutter2.ascender
+        #expect(offset2 == expected2)
+        #expect(offset1 != offset2, "Offset should change when fonts change")
+    }
+}

--- a/PineTests/LineNumberBaselineTests.swift
+++ b/PineTests/LineNumberBaselineTests.swift
@@ -40,6 +40,72 @@ struct LineNumberBaselineTests {
         #expect(view.baselineOffset == 0)
     }
 
+    /// At minimum font size (8pt), both fonts are equal — offset should be 0.
+    @Test func baselineOffsetZeroAtMinimumFontSize() {
+        let minSize = FontSizeSettings.minSize
+        let editorFont = NSFont.monospacedSystemFont(ofSize: minSize, weight: .regular)
+        let gutterFont = NSFont.monospacedSystemFont(
+            ofSize: max(minSize - 2, minSize), weight: .regular
+        )
+
+        let view = makeView()
+        view.editorFont = editorFont
+        view.gutterFont = gutterFont
+
+        #expect(view.baselineOffset == 0, "At min size both fonts are equal, offset should be 0")
+    }
+
+    /// At maximum font size (32pt), offset should still be correct.
+    @Test func baselineOffsetCorrectAtMaximumFontSize() {
+        let maxSize = FontSizeSettings.maxSize
+        let editorFont = NSFont.monospacedSystemFont(ofSize: maxSize, weight: .regular)
+        let gutterFont = NSFont.monospacedSystemFont(ofSize: maxSize - 2, weight: .regular)
+
+        let view = makeView()
+        view.editorFont = editorFont
+        view.gutterFont = gutterFont
+
+        let expected = editorFont.ascender - gutterFont.ascender
+        #expect(view.baselineOffset == expected)
+        #expect(view.baselineOffset > 0)
+    }
+
+    /// When gutter font is clamped to minSize (e.g. fontSize=9, gutterFont=8 not 7).
+    @Test func baselineOffsetWithClampedGutterFont() {
+        let minSize = FontSizeSettings.minSize
+        let editorSize: CGFloat = minSize + 1 // 9pt
+        let editorFont = NSFont.monospacedSystemFont(ofSize: editorSize, weight: .regular)
+        let gutterFont = NSFont.monospacedSystemFont(
+            ofSize: max(editorSize - 2, minSize), weight: .regular
+        )
+
+        let view = makeView()
+        view.editorFont = editorFont
+        view.gutterFont = gutterFont
+
+        // gutterFont clamped to 8pt (not 7pt), so difference is 9-8=1pt
+        #expect(gutterFont.pointSize == minSize)
+        let expected = editorFont.ascender - gutterFont.ascender
+        #expect(view.baselineOffset == expected)
+        #expect(view.baselineOffset > 0)
+    }
+
+    /// baselineOffset is never negative in normal usage (editor >= gutter).
+    @Test func baselineOffsetNonNegativeForAllValidSizes() {
+        let view = makeView()
+
+        for size in stride(from: FontSizeSettings.minSize, through: FontSizeSettings.maxSize, by: 1) {
+            let editorFont = NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
+            let gutterFont = NSFont.monospacedSystemFont(
+                ofSize: max(size - 2, FontSizeSettings.minSize), weight: .regular
+            )
+            view.editorFont = editorFont
+            view.gutterFont = gutterFont
+
+            #expect(view.baselineOffset >= 0, "Offset should be non-negative at size \(size)")
+        }
+    }
+
     /// baselineOffset updates when fonts change and reflects ascender difference.
     @Test func baselineOffsetUpdatesWithFonts() {
         let view = makeView()

--- a/PineUITests/LineNumberGutterUITests.swift
+++ b/PineUITests/LineNumberGutterUITests.swift
@@ -25,37 +25,17 @@ final class LineNumberGutterUITests: PineUITestCase {
         try super.tearDownWithError()
     }
 
-    // MARK: - Tests
+    // MARK: - Helpers
 
-    /// Line number gutter should appear when a file is opened in the editor.
-    func testGutterAppearsWhenFileOpened() throws {
-        launchWithProject(projectURL)
-
-        let sidebar = app.outlines["sidebar"]
-        XCTAssertTrue(waitForExistence(sidebar, timeout: 10), "Sidebar should appear")
-
-        let fileRow = app.staticTexts["fileNode_main.swift"]
-        guard waitForExistence(fileRow, timeout: 5) else {
-            XCTFail("main.swift should appear in the sidebar")
-            return
-        }
-        fileRow.click()
-
-        let editor = app.textViews["codeEditor"].firstMatch
-        XCTAssertTrue(waitForExistence(editor, timeout: 5), "Code editor should appear")
-
-        let gutter = app.descendants(matching: .any)["lineNumberGutter"].firstMatch
-        XCTAssertTrue(waitForExistence(gutter, timeout: 5), "Line number gutter should appear")
-    }
-
-    /// Line number gutter should be positioned to the left of the code editor.
-    func testGutterIsLeftOfEditor() throws {
+    /// Opens main.swift and returns the editor and gutter elements.
+    private func openFileAndGetElements() throws -> (editor: XCUIElement, gutter: XCUIElement) {
         launchWithProject(projectURL)
 
         let fileRow = app.staticTexts["fileNode_main.swift"]
         guard waitForExistence(fileRow, timeout: 10) else {
             XCTFail("main.swift should appear in the sidebar")
-            return
+            return (app.textViews["codeEditor"].firstMatch,
+                    app.descendants(matching: .any)["lineNumberGutter"].firstMatch)
         }
         fileRow.click()
 
@@ -65,7 +45,20 @@ final class LineNumberGutterUITests: PineUITestCase {
         let gutter = app.descendants(matching: .any)["lineNumberGutter"].firstMatch
         XCTAssertTrue(waitForExistence(gutter, timeout: 5), "Line number gutter should appear")
 
-        // Gutter's left edge should be at or before editor's left edge
+        return (editor, gutter)
+    }
+
+    // MARK: - Tests
+
+    /// Line number gutter should appear when a file is opened in the editor.
+    func testGutterAppearsWhenFileOpened() throws {
+        _ = try openFileAndGetElements()
+    }
+
+    /// Line number gutter should be positioned to the left of the code editor.
+    func testGutterIsLeftOfEditor() throws {
+        let (editor, gutter) = try openFileAndGetElements()
+
         XCTAssertLessThanOrEqual(
             gutter.frame.minX, editor.frame.minX,
             "Gutter should be positioned at or to the left of the editor"
@@ -74,22 +67,8 @@ final class LineNumberGutterUITests: PineUITestCase {
 
     /// Line number gutter should have the same vertical position as the code editor.
     func testGutterVerticallyAlignedWithEditor() throws {
-        launchWithProject(projectURL)
+        let (editor, gutter) = try openFileAndGetElements()
 
-        let fileRow = app.staticTexts["fileNode_main.swift"]
-        guard waitForExistence(fileRow, timeout: 10) else {
-            XCTFail("main.swift should appear in the sidebar")
-            return
-        }
-        fileRow.click()
-
-        let editor = app.textViews["codeEditor"].firstMatch
-        XCTAssertTrue(waitForExistence(editor, timeout: 5), "Code editor should appear")
-
-        let gutter = app.descendants(matching: .any)["lineNumberGutter"].firstMatch
-        XCTAssertTrue(waitForExistence(gutter, timeout: 5), "Line number gutter should appear")
-
-        // Gutter and editor should share the same top Y position (within tolerance)
         XCTAssertEqual(
             gutter.frame.minY, editor.frame.minY,
             accuracy: 2,

--- a/PineUITests/LineNumberGutterUITests.swift
+++ b/PineUITests/LineNumberGutterUITests.swift
@@ -1,0 +1,99 @@
+//
+//  LineNumberGutterUITests.swift
+//  PineUITests
+//
+//  Tests that the line number gutter appears alongside the code editor.
+//
+
+import XCTest
+
+final class LineNumberGutterUITests: PineUITestCase {
+
+    private var projectURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        projectURL = try createTempProject(files: [
+            "main.swift": "let a = 1\nlet b = 2\nlet c = 3\n"
+        ])
+    }
+
+    override func tearDownWithError() throws {
+        if let url = projectURL {
+            cleanupProject(url)
+        }
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Tests
+
+    /// Line number gutter should appear when a file is opened in the editor.
+    func testGutterAppearsWhenFileOpened() throws {
+        launchWithProject(projectURL)
+
+        let sidebar = app.outlines["sidebar"]
+        XCTAssertTrue(waitForExistence(sidebar, timeout: 10), "Sidebar should appear")
+
+        let fileRow = app.staticTexts["fileNode_main.swift"]
+        guard waitForExistence(fileRow, timeout: 5) else {
+            XCTFail("main.swift should appear in the sidebar")
+            return
+        }
+        fileRow.click()
+
+        let editor = app.textViews["codeEditor"].firstMatch
+        XCTAssertTrue(waitForExistence(editor, timeout: 5), "Code editor should appear")
+
+        let gutter = app.descendants(matching: .any)["lineNumberGutter"].firstMatch
+        XCTAssertTrue(waitForExistence(gutter, timeout: 5), "Line number gutter should appear")
+    }
+
+    /// Line number gutter should be positioned to the left of the code editor.
+    func testGutterIsLeftOfEditor() throws {
+        launchWithProject(projectURL)
+
+        let fileRow = app.staticTexts["fileNode_main.swift"]
+        guard waitForExistence(fileRow, timeout: 10) else {
+            XCTFail("main.swift should appear in the sidebar")
+            return
+        }
+        fileRow.click()
+
+        let editor = app.textViews["codeEditor"].firstMatch
+        XCTAssertTrue(waitForExistence(editor, timeout: 5), "Code editor should appear")
+
+        let gutter = app.descendants(matching: .any)["lineNumberGutter"].firstMatch
+        XCTAssertTrue(waitForExistence(gutter, timeout: 5), "Line number gutter should appear")
+
+        // Gutter's left edge should be at or before editor's left edge
+        XCTAssertLessThanOrEqual(
+            gutter.frame.minX, editor.frame.minX,
+            "Gutter should be positioned at or to the left of the editor"
+        )
+    }
+
+    /// Line number gutter should have the same vertical position as the code editor.
+    func testGutterVerticallyAlignedWithEditor() throws {
+        launchWithProject(projectURL)
+
+        let fileRow = app.staticTexts["fileNode_main.swift"]
+        guard waitForExistence(fileRow, timeout: 10) else {
+            XCTFail("main.swift should appear in the sidebar")
+            return
+        }
+        fileRow.click()
+
+        let editor = app.textViews["codeEditor"].firstMatch
+        XCTAssertTrue(waitForExistence(editor, timeout: 5), "Code editor should appear")
+
+        let gutter = app.descendants(matching: .any)["lineNumberGutter"].firstMatch
+        XCTAssertTrue(waitForExistence(gutter, timeout: 5), "Line number gutter should appear")
+
+        // Gutter and editor should share the same top Y position (within tolerance)
+        XCTAssertEqual(
+            gutter.frame.minY, editor.frame.minY,
+            accuracy: 2,
+            "Gutter should be vertically aligned with the editor"
+        )
+    }
+}


### PR DESCRIPTION
Closes #388

## Summary
- Line numbers use a font 2pt smaller than editor text but were drawn from the same Y origin, causing vertical misalignment
- Added `editorFont` property and computed `baselineOffset` (`editorFont.ascender - gutterFont.ascender`) to `LineNumberView`
- Applied baseline offset to all three `numStr.draw()` call sites (empty file, main loop, trailing empty line)

## Test plan
- [x] Added `LineNumberBaselineTests` (3 tests): offset compensation, zero offset when fonts match, offset updates on font change
- [x] All tests pass
- [x] SwiftLint clean