### PR TITLE
test: add performance test suite

### DIFF
--- a/Pine.xcodeproj/project.pbxproj
+++ b/Pine.xcodeproj/project.pbxproj
@@ -7,14 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3E3351B41A2D88029852BABE /* FoldRangeCalculatorPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151A121A4C586C4DA4D7F031 /* FoldRangeCalculatorPerformanceTests.swift */; };
-		8274CEE5D6290164B75F9B31 /* ProjectSearchPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E110CD7461A2DE6F65E8BC /* ProjectSearchPerformanceTests.swift */; };
 		9FA7317B2F61803400E91711 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 9FA7317A2F61803400E91711 /* SwiftTerm */; };
 		CF0000030000000000000003 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = CF0000030000000000000002 /* Markdown */; };
 		CF0000040000000000000003 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = CF0000040000000000000002 /* Sparkle */; };
 		CF0000050000000000000003 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = CF0000050000000000000002 /* Sparkle */; };
-		DF85B2177691A8BAC271AF19 /* SyntaxHighlighterPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503D24A3B58CB9046CCB71A1 /* SyntaxHighlighterPerformanceTests.swift */; };
-		E455779DF6077C6294CCA380 /* GitStatusParserPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2459BC63423821558EF2B76 /* GitStatusParserPerformanceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -42,35 +38,30 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		08E110CD7461A2DE6F65E8BC /* ProjectSearchPerformanceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProjectSearchPerformanceTests.swift; sourceTree = "<group>"; };
-		151A121A4C586C4DA4D7F031 /* FoldRangeCalculatorPerformanceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FoldRangeCalculatorPerformanceTests.swift; sourceTree = "<group>"; };
 		339161ED16D0B2E98319410B /* PinePerformanceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PinePerformanceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		503D24A3B58CB9046CCB71A1 /* SyntaxHighlighterPerformanceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyntaxHighlighterPerformanceTests.swift; sourceTree = "<group>"; };
 		9FA1A7282F5EFA8100BDDA8C /* Pine.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Pine.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF0000010000000000000005 /* PineTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PineTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF0000020000000000000005 /* PineUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PineUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D2459BC63423821558EF2B76 /* GitStatusParserPerformanceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GitStatusParserPerformanceTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		29D03576855FB7AAFC9C3E02 /* PinePerformanceTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = PinePerformanceTests;
+			sourceTree = "<group>";
+		};
 		9FA1A72A2F5EFA8100BDDA8C /* Pine */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = Pine;
 			sourceTree = "<group>";
 		};
 		CF0000010000000000000006 /* PineTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = PineTests;
 			sourceTree = "<group>";
 		};
 		CF0000020000000000000006 /* PineUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = PineUITests;
 			sourceTree = "<group>";
 		};
@@ -112,18 +103,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		29D03576855FB7AAFC9C3E02 /* PinePerformanceTests */ = {
-			isa = PBXGroup;
-			children = (
-				151A121A4C586C4DA4D7F031 /* FoldRangeCalculatorPerformanceTests.swift */,
-				D2459BC63423821558EF2B76 /* GitStatusParserPerformanceTests.swift */,
-				08E110CD7461A2DE6F65E8BC /* ProjectSearchPerformanceTests.swift */,
-				503D24A3B58CB9046CCB71A1 /* SyntaxHighlighterPerformanceTests.swift */,
-			);
-			name = PinePerformanceTests;
-			path = PinePerformanceTests;
-			sourceTree = "<group>";
-		};
 		9FA1A71F2F5EFA8100BDDA8C = {
 			isa = PBXGroup;
 			children = (
@@ -232,6 +211,9 @@
 			);
 			dependencies = (
 				81016B9894C276341B16A3B4 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				29D03576855FB7AAFC9C3E02 /* PinePerformanceTests */,
 			);
 			name = PinePerformanceTests;
 			productName = PinePerformanceTests;
@@ -354,10 +336,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3E3351B41A2D88029852BABE /* FoldRangeCalculatorPerformanceTests.swift in Sources */,
-				E455779DF6077C6294CCA380 /* GitStatusParserPerformanceTests.swift in Sources */,
-				8274CEE5D6290164B75F9B31 /* ProjectSearchPerformanceTests.swift in Sources */,
-				DF85B2177691A8BAC271AF19 /* SyntaxHighlighterPerformanceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pine.xcodeproj/project.pbxproj
+++ b/Pine.xcodeproj/project.pbxproj
@@ -7,13 +7,24 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3E3351B41A2D88029852BABE /* FoldRangeCalculatorPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151A121A4C586C4DA4D7F031 /* FoldRangeCalculatorPerformanceTests.swift */; };
+		8274CEE5D6290164B75F9B31 /* ProjectSearchPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E110CD7461A2DE6F65E8BC /* ProjectSearchPerformanceTests.swift */; };
 		9FA7317B2F61803400E91711 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 9FA7317A2F61803400E91711 /* SwiftTerm */; };
 		CF0000030000000000000003 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = CF0000030000000000000002 /* Markdown */; };
 		CF0000040000000000000003 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = CF0000040000000000000002 /* Sparkle */; };
 		CF0000050000000000000003 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = CF0000050000000000000002 /* Sparkle */; };
+		DF85B2177691A8BAC271AF19 /* SyntaxHighlighterPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503D24A3B58CB9046CCB71A1 /* SyntaxHighlighterPerformanceTests.swift */; };
+		E455779DF6077C6294CCA380 /* GitStatusParserPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2459BC63423821558EF2B76 /* GitStatusParserPerformanceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		76BB8940A08532DE75AC48AE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9FA1A7202F5EFA8100BDDA8C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9FA1A7272F5EFA8100BDDA8C;
+			remoteInfo = Pine;
+		};
 		CF000001000000000000000A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9FA1A7202F5EFA8100BDDA8C /* Project object */;
@@ -31,24 +42,35 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		08E110CD7461A2DE6F65E8BC /* ProjectSearchPerformanceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProjectSearchPerformanceTests.swift; sourceTree = "<group>"; };
+		151A121A4C586C4DA4D7F031 /* FoldRangeCalculatorPerformanceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FoldRangeCalculatorPerformanceTests.swift; sourceTree = "<group>"; };
+		339161ED16D0B2E98319410B /* PinePerformanceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PinePerformanceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		503D24A3B58CB9046CCB71A1 /* SyntaxHighlighterPerformanceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SyntaxHighlighterPerformanceTests.swift; sourceTree = "<group>"; };
 		9FA1A7282F5EFA8100BDDA8C /* Pine.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Pine.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF0000010000000000000005 /* PineTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PineTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF0000020000000000000005 /* PineUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PineUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2459BC63423821558EF2B76 /* GitStatusParserPerformanceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GitStatusParserPerformanceTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		9FA1A72A2F5EFA8100BDDA8C /* Pine */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = Pine;
 			sourceTree = "<group>";
 		};
 		CF0000010000000000000006 /* PineTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = PineTests;
 			sourceTree = "<group>";
 		};
 		CF0000020000000000000006 /* PineUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = PineUITests;
 			sourceTree = "<group>";
 		};
@@ -62,6 +84,13 @@
 				9FA7317B2F61803400E91711 /* SwiftTerm in Frameworks */,
 				CF0000030000000000000003 /* Markdown in Frameworks */,
 				CF0000040000000000000003 /* Sparkle in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CC3D4067C0EAA0DB99487981 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -83,6 +112,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		29D03576855FB7AAFC9C3E02 /* PinePerformanceTests */ = {
+			isa = PBXGroup;
+			children = (
+				151A121A4C586C4DA4D7F031 /* FoldRangeCalculatorPerformanceTests.swift */,
+				D2459BC63423821558EF2B76 /* GitStatusParserPerformanceTests.swift */,
+				08E110CD7461A2DE6F65E8BC /* ProjectSearchPerformanceTests.swift */,
+				503D24A3B58CB9046CCB71A1 /* SyntaxHighlighterPerformanceTests.swift */,
+			);
+			name = PinePerformanceTests;
+			path = PinePerformanceTests;
+			sourceTree = "<group>";
+		};
 		9FA1A71F2F5EFA8100BDDA8C = {
 			isa = PBXGroup;
 			children = (
@@ -90,6 +131,7 @@
 				CF0000010000000000000006 /* PineTests */,
 				CF0000020000000000000006 /* PineUITests */,
 				9FA1A7292F5EFA8100BDDA8C /* Products */,
+				29D03576855FB7AAFC9C3E02 /* PinePerformanceTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -99,6 +141,7 @@
 				9FA1A7282F5EFA8100BDDA8C /* Pine.app */,
 				CF0000010000000000000005 /* PineTests.xctest */,
 				CF0000020000000000000005 /* PineUITests.xctest */,
+				339161ED16D0B2E98319410B /* PinePerformanceTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -177,6 +220,24 @@
 			productReference = CF0000020000000000000005 /* PineUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		F1B3CEEE6D109B5E2447458C /* PinePerformanceTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DD2E9BC2E67EDA02FC58CF82 /* Build configuration list for PBXNativeTarget "PinePerformanceTests" */;
+			buildPhases = (
+				9C1E91B3F5A922A6616509B9 /* Sources */,
+				CC3D4067C0EAA0DB99487981 /* Frameworks */,
+				405E856F1384BB7EE6EB96F9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				81016B9894C276341B16A3B4 /* PBXTargetDependency */,
+			);
+			name = PinePerformanceTests;
+			productName = PinePerformanceTests;
+			productReference = 339161ED16D0B2E98319410B /* PinePerformanceTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -230,11 +291,19 @@
 				9FA1A7272F5EFA8100BDDA8C /* Pine */,
 				CF0000010000000000000001 /* PineTests */,
 				CF0000020000000000000001 /* PineUITests */,
+				F1B3CEEE6D109B5E2447458C /* PinePerformanceTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		405E856F1384BB7EE6EB96F9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9FA1A7262F5EFA8100BDDA8C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -281,6 +350,17 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		9C1E91B3F5A922A6616509B9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3E3351B41A2D88029852BABE /* FoldRangeCalculatorPerformanceTests.swift in Sources */,
+				E455779DF6077C6294CCA380 /* GitStatusParserPerformanceTests.swift in Sources */,
+				8274CEE5D6290164B75F9B31 /* ProjectSearchPerformanceTests.swift in Sources */,
+				DF85B2177691A8BAC271AF19 /* SyntaxHighlighterPerformanceTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9FA1A7242F5EFA8100BDDA8C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -305,6 +385,12 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		81016B9894C276341B16A3B4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Pine;
+			target = 9FA1A7272F5EFA8100BDDA8C /* Pine */;
+			targetProxy = 76BB8940A08532DE75AC48AE /* PBXContainerItemProxy */;
+		};
 		CF000001000000000000000B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = CF0000010000000000000001 /* PineTests */;
@@ -318,6 +404,40 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		0D4E1661ABDA8B538052F8F8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 69K34DW42R;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.batonogov.pine.performancetests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_STRICT_CONCURRENCY = minimal;
+				SWIFT_VERSION = 6.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Pine.app/Contents/MacOS/Pine";
+			};
+			name = Release;
+		};
+		6B6AEB96C07C725BAF65043E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 69K34DW42R;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.batonogov.pine.performancetests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_STRICT_CONCURRENCY = minimal;
+				SWIFT_VERSION = 6.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Pine.app/Contents/MacOS/Pine";
+			};
+			name = Debug;
+		};
 		9FA1A7312F5EFA8200BDDA8C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -627,6 +747,15 @@
 			buildConfigurations = (
 				CF0000020000000000000007 /* Debug */,
 				CF0000020000000000000008 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DD2E9BC2E67EDA02FC58CF82 /* Build configuration list for PBXNativeTarget "PinePerformanceTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0D4E1661ABDA8B538052F8F8 /* Release */,
+				6B6AEB96C07C725BAF65043E /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Pine.xcodeproj/xcshareddata/xcschemes/Pine.xcscheme
+++ b/Pine.xcodeproj/xcshareddata/xcschemes/Pine.xcscheme
@@ -50,6 +50,16 @@
                ReferencedContainer = "container:Pine.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F1B3CEEE6D109B5E2447458C"
+               BuildableName = "PinePerformanceTests.xctest"
+               BlueprintName = "PinePerformanceTests"
+               ReferencedContainer = "container:Pine.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/PinePerformanceTests/FoldRangeCalculatorPerformanceTests.swift
+++ b/PinePerformanceTests/FoldRangeCalculatorPerformanceTests.swift
@@ -1,0 +1,101 @@
+//
+//  FoldRangeCalculatorPerformanceTests.swift
+//  PinePerformanceTests
+//
+
+import XCTest
+@testable import Pine
+
+final class FoldRangeCalculatorPerformanceTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Generates deeply nested braces: `{ { { ... } } }`
+    private func generateDeeplyNestedBraces(depth: Int, linesPerLevel: Int = 2) -> String {
+        var lines: [String] = []
+        for i in 0..<depth {
+            let indent = String(repeating: "    ", count: i)
+            lines.append("\(indent)func level\(i)() {")
+            for j in 0..<linesPerLevel {
+                lines.append("\(indent)    let x\(j) = \(j)")
+            }
+        }
+        for i in stride(from: depth - 1, through: 0, by: -1) {
+            let indent = String(repeating: "    ", count: i)
+            lines.append("\(indent)}")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Generates a flat file with many independent brace blocks.
+    private func generateManyBlocks(count: Int, linesPerBlock: Int = 3) -> String {
+        var lines: [String] = []
+        for i in 0..<count {
+            lines.append("func block\(i)() {")
+            for j in 0..<linesPerBlock {
+                lines.append("    let x\(j) = \(j)")
+            }
+            lines.append("}")
+            lines.append("")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Generates a file with mixed bracket types: {}, [], ().
+    private func generateMixedBrackets(count: Int) -> String {
+        var lines: [String] = []
+        for i in 0..<count {
+            lines.append("let arr\(i) = [")
+            lines.append("    (key: \"a\", value: {")
+            lines.append("        return \(i)")
+            lines.append("    }),")
+            lines.append("    (key: \"b\", value: {")
+            lines.append("        return \(i + 1)")
+            lines.append("    })")
+            lines.append("]")
+            lines.append("")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Tests
+
+    func testDeeplyNestedBraces() {
+        let text = generateDeeplyNestedBraces(depth: 100)
+        measure {
+            _ = FoldRangeCalculator.calculate(text: text)
+        }
+    }
+
+    func testManyBlocks() {
+        let text = generateManyBlocks(count: 500)
+        measure {
+            _ = FoldRangeCalculator.calculate(text: text)
+        }
+    }
+
+    func testMixedBrackets() {
+        let text = generateMixedBrackets(count: 200)
+        measure {
+            _ = FoldRangeCalculator.calculate(text: text)
+        }
+    }
+
+    func testLargeFileWithSkipRanges() {
+        let text = generateManyBlocks(count: 300)
+        // Simulate comment/string ranges to skip
+        let skipRanges = stride(from: 0, to: text.count, by: 100).map {
+            NSRange(location: $0, length: min(20, text.count - $0))
+        }
+        measure {
+            _ = FoldRangeCalculator.calculate(text: text, skipRanges: skipRanges)
+        }
+    }
+
+    func testVeryLargeFile() {
+        let text = generateManyBlocks(count: 1000, linesPerBlock: 5)
+        measure {
+            _ = FoldRangeCalculator.calculate(text: text)
+        }
+    }
+}

--- a/PinePerformanceTests/GitStatusParserPerformanceTests.swift
+++ b/PinePerformanceTests/GitStatusParserPerformanceTests.swift
@@ -1,0 +1,176 @@
+//
+//  GitStatusParserPerformanceTests.swift
+//  PinePerformanceTests
+//
+
+import XCTest
+@testable import Pine
+
+final class GitStatusParserPerformanceTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Generates `git status --porcelain` output with many entries.
+    private func generateStatusOutput(count: Int) -> String {
+        var lines: [String] = []
+        for i in 0..<count {
+            let dir = "src/module\(i / 10)"
+            switch i % 6 {
+            case 0: lines.append("?? \(dir)/new_file\(i).swift")
+            case 1: lines.append(" M \(dir)/modified\(i).swift")
+            case 2: lines.append("M  \(dir)/staged\(i).swift")
+            case 3: lines.append("A  \(dir)/added\(i).swift")
+            case 4: lines.append(" D \(dir)/deleted\(i).swift")
+            case 5: lines.append("MM \(dir)/mixed\(i).swift")
+            default: break
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Generates `git status --porcelain --ignored` output.
+    private func generateIgnoredOutput(count: Int) -> String {
+        var lines: [String] = []
+        for i in 0..<count {
+            lines.append("!! build/output\(i)/")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Generates `git diff --unified=0` output with many hunks.
+    private func generateDiffOutput(hunkCount: Int) -> String {
+        var lines: [String] = [
+            "diff --git a/file.swift b/file.swift",
+            "index abc1234..def5678 100644",
+            "--- a/file.swift",
+            "+++ b/file.swift",
+        ]
+        var currentLine = 1
+        for _ in 0..<hunkCount {
+            let oldStart = currentLine
+            let newStart = currentLine
+            lines.append("@@ -\(oldStart),3 +\(newStart),5 @@ func example()")
+            lines.append("-    let old1 = 1")
+            lines.append("-    let old2 = 2")
+            lines.append("-    let old3 = 3")
+            lines.append("+    let new1 = 1")
+            lines.append("+    let new2 = 2")
+            lines.append("+    let new3 = 3")
+            lines.append("+    let new4 = 4")
+            lines.append("+    let new5 = 5")
+            currentLine += 10
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Generates `git blame --porcelain` output.
+    private func generateBlameOutput(lineCount: Int) -> String {
+        var lines: [String] = []
+        let hashes = (0..<10).map { String(format: "%040x", $0) }
+
+        for i in 0..<lineCount {
+            let hash = hashes[i % hashes.count]
+            let isFirst = i < hashes.count
+
+            lines.append("\(hash) \(i + 1) \(i + 1) 1")
+            if isFirst {
+                lines.append("author Developer\(i % 5)")
+                lines.append("author-time \(1700000000 + i * 3600)")
+                lines.append("summary Commit message \(i)")
+            }
+            lines.append("\tlet line\(i) = \(i)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Status Parsing
+
+    func testParseStatus500Entries() {
+        let output = generateStatusOutput(count: 500)
+        measure {
+            _ = GitStatusProvider.parseStatusOutput(output)
+        }
+    }
+
+    func testParseStatus2000Entries() {
+        let output = generateStatusOutput(count: 2000)
+        measure {
+            _ = GitStatusProvider.parseStatusOutput(output)
+        }
+    }
+
+    // MARK: - Ignored Parsing
+
+    func testParseIgnored500Entries() {
+        let output = generateIgnoredOutput(count: 500)
+        measure {
+            _ = GitStatusProvider.parseIgnoredOutput(output)
+        }
+    }
+
+    // MARK: - Diff Parsing
+
+    func testParseDiff100Hunks() {
+        let output = generateDiffOutput(hunkCount: 100)
+        measure {
+            _ = GitStatusProvider.parseDiff(output)
+        }
+    }
+
+    func testParseDiff500Hunks() {
+        let output = generateDiffOutput(hunkCount: 500)
+        measure {
+            _ = GitStatusProvider.parseDiff(output)
+        }
+    }
+
+    // MARK: - Blame Parsing
+
+    func testParseBlame500Lines() {
+        let output = generateBlameOutput(lineCount: 500)
+        measure {
+            _ = GitStatusProvider.parseBlame(output)
+        }
+    }
+
+    func testParseBlame2000Lines() {
+        let output = generateBlameOutput(lineCount: 2000)
+        measure {
+            _ = GitStatusProvider.parseBlame(output)
+        }
+    }
+
+    // MARK: - Change Region Starts
+
+    func testChangeRegionStarts() {
+        // Generate many diffs with contiguous and non-contiguous regions
+        var diffs: [GitLineDiff] = []
+        for region in 0..<100 {
+            let base = region * 20
+            for offset in 0..<5 {
+                diffs.append(GitLineDiff(line: base + offset, kind: .modified))
+            }
+        }
+
+        measure {
+            _ = GitLineDiff.changeRegionStarts(diffs)
+        }
+    }
+
+    func testNextChangeLine() {
+        var diffs: [GitLineDiff] = []
+        for region in 0..<200 {
+            let base = region * 15
+            for offset in 0..<3 {
+                diffs.append(GitLineDiff(line: base + offset, kind: .added))
+            }
+        }
+        let starts = GitLineDiff.changeRegionStarts(diffs)
+
+        measure {
+            for line in stride(from: 0, to: 3000, by: 10) {
+                _ = GitLineDiff.nextChangeLine(from: line, regionStarts: starts, diffs: diffs)
+            }
+        }
+    }
+}

--- a/PinePerformanceTests/ProjectSearchPerformanceTests.swift
+++ b/PinePerformanceTests/ProjectSearchPerformanceTests.swift
@@ -1,0 +1,121 @@
+//
+//  ProjectSearchPerformanceTests.swift
+//  PinePerformanceTests
+//
+
+import XCTest
+@testable import Pine
+
+final class ProjectSearchPerformanceTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PinePerformanceTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func createFiles(count: Int, linesPerFile: Int) {
+        for i in 0..<count {
+            let subdir = tempDir.appendingPathComponent("dir\(i / 50)")
+            try? FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+
+            var lines: [String] = []
+            for j in 0..<linesPerFile {
+                lines.append("let variable\(j) = \"value_\(i)_\(j)\" // line \(j)")
+            }
+            let content = lines.joined(separator: "\n")
+            let file = subdir.appendingPathComponent("file\(i).swift")
+            try? content.write(to: file, atomically: true, encoding: .utf8)
+        }
+    }
+
+    // MARK: - Single File Search
+
+    func testSearchSingleLargeFile() {
+        let lines = (0..<5000).map { "let value\($0) = compute(\($0)) // target marker" }
+        let content = lines.joined(separator: "\n")
+        let file = tempDir.appendingPathComponent("large.swift")
+        try? content.write(to: file, atomically: true, encoding: .utf8)
+
+        measure {
+            _ = ProjectSearchProvider.searchFile(at: file, query: "target", isCaseSensitive: false)
+        }
+    }
+
+    func testSearchSingleFileCaseSensitive() {
+        let lines = (0..<5000).map { "let Value\($0) = compute(\($0)) // Target marker" }
+        let content = lines.joined(separator: "\n")
+        let file = tempDir.appendingPathComponent("large_cs.swift")
+        try? content.write(to: file, atomically: true, encoding: .utf8)
+
+        measure {
+            _ = ProjectSearchProvider.searchFile(at: file, query: "Target", isCaseSensitive: true)
+        }
+    }
+
+    // MARK: - Multi-file Search (synchronous — searchFile across many files)
+
+    func testSearchAcross200Files() {
+        createFiles(count: 200, linesPerFile: 50)
+
+        let resolvedRoot = tempDir.resolvingSymlinksInPath().path + "/"
+        let files = ProjectSearchProvider.collectSearchableFiles(
+            rootURL: tempDir,
+            ignoredDirs: [],
+            resolvedRootPath: resolvedRoot
+        )
+
+        measure {
+            for (fileURL, _) in files {
+                _ = ProjectSearchProvider.searchFile(
+                    at: fileURL, query: "value", isCaseSensitive: false
+                )
+            }
+        }
+    }
+
+    func testSearchAcross500Files() {
+        createFiles(count: 500, linesPerFile: 30)
+
+        let resolvedRoot = tempDir.resolvingSymlinksInPath().path + "/"
+        let files = ProjectSearchProvider.collectSearchableFiles(
+            rootURL: tempDir,
+            ignoredDirs: [],
+            resolvedRootPath: resolvedRoot
+        )
+
+        measure {
+            for (fileURL, _) in files {
+                _ = ProjectSearchProvider.searchFile(
+                    at: fileURL, query: "variable", isCaseSensitive: false
+                )
+            }
+        }
+    }
+
+    // MARK: - File Collection
+
+    func testCollectSearchableFiles() {
+        createFiles(count: 500, linesPerFile: 10)
+
+        measure {
+            _ = ProjectSearchProvider.collectSearchableFiles(
+                rootURL: tempDir,
+                ignoredDirs: [],
+                resolvedRootPath: tempDir.resolvingSymlinksInPath().path + "/"
+            )
+        }
+    }
+}

--- a/PinePerformanceTests/SyntaxHighlighterPerformanceTests.swift
+++ b/PinePerformanceTests/SyntaxHighlighterPerformanceTests.swift
@@ -1,0 +1,165 @@
+//
+//  SyntaxHighlighterPerformanceTests.swift
+//  PinePerformanceTests
+//
+
+import XCTest
+import AppKit
+@testable import Pine
+
+@MainActor
+final class SyntaxHighlighterPerformanceTests: XCTestCase {
+
+    private var highlighter: SyntaxHighlighter!
+
+    override func setUp() {
+        super.setUp()
+        highlighter = SyntaxHighlighter.shared
+        // Register a Swift grammar for testing
+        let grammar = Grammar(
+            name: "PerfTestSwift",
+            extensions: ["perfswift"],
+            rules: [
+                GrammarRule(pattern: "//.*$", scope: "comment", options: ["anchorsMatchLines"]),
+                GrammarRule(pattern: #"/\*[\s\S]*?\*/"#, scope: "comment", options: ["dotMatchesLineSeparators"]),
+                GrammarRule(pattern: #""(?:[^"\\]|\\.)*""#, scope: "string"),
+                GrammarRule(
+                    pattern: #"\b(func|var|let|class|struct|enum|protocol|import|return"#
+                        + #"|if|else|guard|switch|case|for|while|do|try|catch|throw|throws|async|await)\b"#,
+                    scope: "keyword"
+                ),
+                GrammarRule(pattern: #"\b[A-Z][A-Za-z0-9_]*\b"#, scope: "type"),
+                GrammarRule(pattern: #"\b\d+(\.\d+)?\b"#, scope: "number"),
+                GrammarRule(pattern: #"\b[a-z][A-Za-z0-9_]*(?=\s*\()"#, scope: "function"),
+                GrammarRule(pattern: #"@\w+"#, scope: "attribute"),
+            ]
+        )
+        highlighter.registerGrammar(grammar)
+    }
+
+    // MARK: - Helpers
+
+    /// Generates realistic Swift-like code.
+    private func generateSwiftCode(lines: Int) -> String {
+        var result: [String] = [
+            "import Foundation",
+            "import AppKit",
+            "",
+        ]
+        var lineCount = 3
+        var classIndex = 0
+
+        while lineCount < lines {
+            result.append("/// A class for testing performance.")
+            result.append("class TestClass\(classIndex): NSObject {")
+            result.append("    var name: String = \"default\"")
+            result.append("    let id: Int = \(classIndex)")
+            result.append("")
+            lineCount += 5
+
+            for method in 0..<5 {
+                guard lineCount < lines else { break }
+                result.append("    func method\(method)(param: Int) -> String {")
+                result.append("        // Compute the result")
+                result.append("        let value = param * \(method + 1)")
+                result.append("        if value > 100 {")
+                result.append("            return \"large: \\(value)\"")
+                result.append("        } else {")
+                result.append("            return \"small: \\(value)\"")
+                result.append("        }")
+                result.append("    }")
+                result.append("")
+                lineCount += 10
+            }
+
+            result.append("}")
+            result.append("")
+            lineCount += 2
+            classIndex += 1
+        }
+
+        return result.joined(separator: "\n")
+    }
+
+    // MARK: - Full Highlight
+
+    func testFullHighlight500Lines() {
+        let code = generateSwiftCode(lines: 500)
+        let textStorage = NSTextStorage(string: code)
+        let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+        measure {
+            highlighter.highlight(textStorage: textStorage, language: "perfswift", font: font)
+        }
+    }
+
+    func testFullHighlight2000Lines() {
+        let code = generateSwiftCode(lines: 2000)
+        let textStorage = NSTextStorage(string: code)
+        let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+        measure {
+            highlighter.highlight(textStorage: textStorage, language: "perfswift", font: font)
+        }
+    }
+
+    func testFullHighlight5000Lines() {
+        let code = generateSwiftCode(lines: 5000)
+        let textStorage = NSTextStorage(string: code)
+        let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+        measure {
+            highlighter.highlight(textStorage: textStorage, language: "perfswift", font: font)
+        }
+    }
+
+    // MARK: - Incremental Highlight
+
+    func testIncrementalHighlight() {
+        let code = generateSwiftCode(lines: 2000)
+        let textStorage = NSTextStorage(string: code)
+        let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+        // First, do a full highlight to populate cache
+        highlighter.highlight(textStorage: textStorage, language: "perfswift", font: font)
+
+        // Simulate a small edit in the middle
+        let midpoint = code.count / 2
+        let editRange = NSRange(location: midpoint, length: 10)
+
+        measure {
+            highlighter.highlightEdited(
+                textStorage: textStorage,
+                editedRange: editRange,
+                language: "perfswift",
+                font: font
+            )
+        }
+    }
+
+    // MARK: - computeMatches (pure computation, no NSTextStorage mutation)
+
+    func testComputeMatches2000Lines() {
+        let code = generateSwiftCode(lines: 2000)
+        let fullRange = NSRange(location: 0, length: (code as NSString).length)
+
+        measure {
+            _ = highlighter.computeMatches(
+                text: code,
+                language: "perfswift",
+                repaintRange: fullRange,
+                searchRange: fullRange
+            )
+        }
+    }
+
+    // MARK: - Comment and String Ranges
+
+    func testCommentAndStringRanges() {
+        let code = generateSwiftCode(lines: 2000)
+
+        measure {
+            _ = highlighter.commentAndStringRanges(in: code, language: "perfswift")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PinePerformanceTests` target — 25 XCTest `measure {}` benchmarks for core operations
- **FoldRangeCalculator**: deeply nested (100 levels), many blocks (500+), mixed brackets, skip ranges, 1000+ blocks
- **SyntaxHighlighter**: full highlight 500/2000/5000 lines, incremental highlight, computeMatches, commentAndStringRanges
- **ProjectSearchProvider**: single file (5000 lines), multi-file (200/500 files), file collection (500 files)
- **GitStatusProvider**: status parsing 500/2000 entries, ignored parsing, diff parsing 100/500 hunks, blame parsing 500/2000 lines, change region navigation
- Target is `skipped` in scheme by default — run on demand via `-only-testing:PinePerformanceTests`

Closes #391

## Test plan

- [x] All 25 performance tests pass (`TEST SUCCEEDED`)
- [x] SwiftLint clean (0 violations)
- [x] Existing PineTests not affected
- [x] Target skipped in default CI test runs