### PR TITLE
test: add unit tests for blame lookup and auto-indent logic

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -46,9 +46,9 @@ final class GutterTextView: NSTextView {
     }
 
     /// Blame lookup: line number → GitBlameLine (O(1) access).
-    private var blameLookup: [Int: GitBlameLine] = [:]
+    private(set) var blameLookup: [Int: GitBlameLine] = [:]
     /// Previous blame data count — avoids rebuilding the dictionary on every updateNSView.
-    private var blameLineCount: Int = -1
+    private(set) var blameLineCount: Int = -1
     var isBlameVisible: Bool = false
 
     /// Sets blame data and rebuilds O(1) lookup dictionary.

--- a/PineTests/AutoIndentTests.swift
+++ b/PineTests/AutoIndentTests.swift
@@ -1,0 +1,166 @@
+//
+//  AutoIndentTests.swift
+//  PineTests
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+/// Tests for GutterTextView auto-indent logic (insertNewline override).
+struct AutoIndentTests {
+
+    private func makeGutterTextView(text: String) -> GutterTextView {
+        let textStorage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        )
+        layoutManager.addTextContainer(textContainer)
+        return GutterTextView(
+            frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+            textContainer: textContainer
+        )
+    }
+
+    /// Simulates pressing Enter at the given cursor position.
+    private func insertNewline(in view: GutterTextView, at position: Int) {
+        view.setSelectedRange(NSRange(location: position, length: 0))
+        view.insertNewline(nil)
+    }
+
+    // MARK: - Basic indent preservation
+
+    @Test func insertNewline_preservesLeadingSpaces() {
+        let view = makeGutterTextView(text: "    hello")
+        insertNewline(in: view, at: 9) // end of "    hello"
+
+        #expect(view.string == "    hello\n    ")
+    }
+
+    @Test func insertNewline_preservesLeadingTabs() {
+        let view = makeGutterTextView(text: "\t\thello")
+        insertNewline(in: view, at: 7) // end of "\t\thello"
+
+        #expect(view.string == "\t\thello\n\t\t")
+    }
+
+    @Test func insertNewline_preservesMixedTabsAndSpaces() {
+        let view = makeGutterTextView(text: "\t  hello")
+        insertNewline(in: view, at: 8) // end of "\t  hello"
+
+        #expect(view.string == "\t  hello\n\t  ")
+    }
+
+    @Test func insertNewline_noIndent_whenLineHasNoLeading() {
+        let view = makeGutterTextView(text: "hello")
+        insertNewline(in: view, at: 5)
+
+        #expect(view.string == "hello\n")
+    }
+
+    // MARK: - Indent increase after openers
+
+    @Test func insertNewline_afterOpenBrace_increasesIndent() {
+        let view = makeGutterTextView(text: "func foo() {")
+        insertNewline(in: view, at: 12) // after "{"
+
+        #expect(view.string == "func foo() {\n    ")
+    }
+
+    @Test func insertNewline_afterOpenParen_increasesIndent() {
+        let view = makeGutterTextView(text: "call(")
+        insertNewline(in: view, at: 5) // after "("
+
+        #expect(view.string == "call(\n    ")
+    }
+
+    @Test func insertNewline_afterColon_increasesIndent() {
+        let view = makeGutterTextView(text: "case .foo:")
+        insertNewline(in: view, at: 10) // after ":"
+
+        #expect(view.string == "case .foo:\n    ")
+    }
+
+    @Test func insertNewline_afterOpener_withExistingIndent() {
+        let view = makeGutterTextView(text: "    if true {")
+        insertNewline(in: view, at: 13) // after "{"
+
+        #expect(view.string == "    if true {\n        ")
+    }
+
+    // MARK: - Bracket pair expansion (cursor between { and })
+
+    @Test func insertNewline_betweenBraces_expandsToThreeLines() {
+        let view = makeGutterTextView(text: "{}")
+        insertNewline(in: view, at: 1) // between { and }
+
+        #expect(view.string == "{\n    \n}")
+    }
+
+    @Test func insertNewline_betweenParens_expandsToThreeLines() {
+        let view = makeGutterTextView(text: "()")
+        insertNewline(in: view, at: 1) // between ( and )
+
+        #expect(view.string == "(\n    \n)")
+    }
+
+    @Test func insertNewline_betweenBraces_withIndent() {
+        let view = makeGutterTextView(text: "    {}")
+        insertNewline(in: view, at: 5) // between { and }
+
+        #expect(view.string == "    {\n        \n    }")
+    }
+
+    @Test func insertNewline_betweenBraces_cursorOnMiddleLine() {
+        let view = makeGutterTextView(text: "{}")
+        insertNewline(in: view, at: 1) // between { and }
+
+        // Cursor should be on the middle (indented) line
+        let cursor = view.selectedRange().location
+        let expectedPos = 1 + 1 + 4 // after "{" + "\n" + "    "
+        #expect(cursor == expectedPos)
+    }
+
+    // MARK: - Empty and whitespace-only lines
+
+    @Test func insertNewline_emptyLine() {
+        let view = makeGutterTextView(text: "line1\n\nline3")
+        insertNewline(in: view, at: 6) // on the empty line
+
+        #expect(view.string == "line1\n\n\nline3")
+    }
+
+    @Test func insertNewline_whitespaceOnlyLine() {
+        let view = makeGutterTextView(text: "    ")
+        insertNewline(in: view, at: 4) // end of whitespace-only line
+
+        #expect(view.string == "    \n    ")
+    }
+
+    // MARK: - Cursor mid-line
+
+    @Test func insertNewline_midLine_preservesIndent() {
+        let view = makeGutterTextView(text: "    hello world")
+        insertNewline(in: view, at: 9) // after "    hello"
+
+        #expect(view.string == "    hello\n     world")
+    }
+
+    // MARK: - No indent increase for non-openers
+
+    @Test func insertNewline_afterCloseBrace_noExtraIndent() {
+        let view = makeGutterTextView(text: "    }")
+        insertNewline(in: view, at: 5) // after "}"
+
+        #expect(view.string == "    }\n    ")
+    }
+
+    @Test func insertNewline_afterRegularChar_noExtraIndent() {
+        let view = makeGutterTextView(text: "    return x")
+        insertNewline(in: view, at: 12) // after "x"
+
+        #expect(view.string == "    return x\n    ")
+    }
+}

--- a/PineTests/AutoIndentTests.swift
+++ b/PineTests/AutoIndentTests.swift
@@ -145,6 +145,7 @@ struct AutoIndentTests {
         let view = makeGutterTextView(text: "    hello world")
         insertNewline(in: view, at: 9) // after "    hello"
 
+        // 5 spaces before "world": 4 from indent + 1 original space before "world"
         #expect(view.string == "    hello\n     world")
     }
 

--- a/PineTests/BlameLookupTests.swift
+++ b/PineTests/BlameLookupTests.swift
@@ -99,20 +99,19 @@ struct BlameLookupTests {
 
     // MARK: - Cache guard (skip rebuild when data unchanged)
 
-    @Test func setBlameLines_sameData_skipsRebuild() {
+    @Test func setBlameLines_sameData_doesNotTriggerDisplay() {
         let view = makeGutterTextView()
+        view.isBlameVisible = true
         let lines = [makeBlameLine(line: 1), makeBlameLine(line: 2)]
 
         view.setBlameLines(lines)
-        let firstLookup = view.blameLookup
-
-        // Call again with same data — should not rebuild
-        view.setBlameLines(lines)
-        let secondLookup = view.blameLookup
-
-        // Same keys and values means cache guard worked
-        #expect(firstLookup.keys.sorted() == secondLookup.keys.sorted())
         #expect(view.blameLineCount == 2)
+
+        // Mark needsDisplay false, then call again with same data.
+        // If cache guard works, display() is NOT called, so needsDisplay stays false.
+        view.needsDisplay = false
+        view.setBlameLines(lines)
+        #expect(!view.needsDisplay, "Cache guard should skip display() for identical data")
     }
 
     @Test func setBlameLines_differentCount_rebuilds() {

--- a/PineTests/BlameLookupTests.swift
+++ b/PineTests/BlameLookupTests.swift
@@ -1,0 +1,179 @@
+//
+//  BlameLookupTests.swift
+//  PineTests
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+/// Tests for GutterTextView.setBlameLines — blame lookup dictionary rebuild.
+struct BlameLookupTests {
+
+    private func makeGutterTextView() -> GutterTextView {
+        let textStorage = NSTextStorage(string: "line1\nline2\nline3")
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        )
+        layoutManager.addTextContainer(textContainer)
+        return GutterTextView(
+            frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+            textContainer: textContainer
+        )
+    }
+
+    private func makeBlameLine(
+        hash: String = "abc123",
+        author: String = "Author",
+        line: Int,
+        summary: String = "commit message"
+    ) -> GitBlameLine {
+        GitBlameLine(
+            hash: hash,
+            author: author,
+            authorTime: Date(timeIntervalSince1970: 1_700_000_000),
+            summary: summary,
+            finalLine: line
+        )
+    }
+
+    // MARK: - Lookup rebuild
+
+    @Test func setBlameLines_buildsLookupDictionary() {
+        let view = makeGutterTextView()
+        let lines = [
+            makeBlameLine(line: 1),
+            makeBlameLine(line: 2),
+            makeBlameLine(line: 3)
+        ]
+
+        view.setBlameLines(lines)
+
+        #expect(view.blameLookup.count == 3)
+        #expect(view.blameLookup[1]?.finalLine == 1)
+        #expect(view.blameLookup[2]?.finalLine == 2)
+        #expect(view.blameLookup[3]?.finalLine == 3)
+    }
+
+    @Test func setBlameLines_updatesLineCount() {
+        let view = makeGutterTextView()
+        let lines = [makeBlameLine(line: 1), makeBlameLine(line: 2)]
+
+        view.setBlameLines(lines)
+
+        #expect(view.blameLineCount == 2)
+    }
+
+    // MARK: - Empty data
+
+    @Test func setBlameLines_emptyArray_clearsLookup() {
+        let view = makeGutterTextView()
+        // First set some data
+        view.setBlameLines([makeBlameLine(line: 1)])
+        #expect(view.blameLookup.count == 1)
+
+        // Then clear
+        view.setBlameLines([])
+
+        #expect(view.blameLookup.isEmpty)
+        #expect(view.blameLineCount == 0)
+    }
+
+    // MARK: - Duplicate line numbers
+
+    @Test func setBlameLines_duplicateLineNumbers_keepsLast() {
+        let view = makeGutterTextView()
+        let lines = [
+            makeBlameLine(hash: "first", line: 1, summary: "first commit"),
+            makeBlameLine(hash: "second", line: 1, summary: "second commit")
+        ]
+
+        view.setBlameLines(lines)
+
+        #expect(view.blameLookup.count == 1)
+        #expect(view.blameLookup[1]?.hash == "second")
+        #expect(view.blameLookup[1]?.summary == "second commit")
+    }
+
+    // MARK: - Cache guard (skip rebuild when data unchanged)
+
+    @Test func setBlameLines_sameData_skipsRebuild() {
+        let view = makeGutterTextView()
+        let lines = [makeBlameLine(line: 1), makeBlameLine(line: 2)]
+
+        view.setBlameLines(lines)
+        let firstLookup = view.blameLookup
+
+        // Call again with same data — should not rebuild
+        view.setBlameLines(lines)
+        let secondLookup = view.blameLookup
+
+        // Same keys and values means cache guard worked
+        #expect(firstLookup.keys.sorted() == secondLookup.keys.sorted())
+        #expect(view.blameLineCount == 2)
+    }
+
+    @Test func setBlameLines_differentCount_rebuilds() {
+        let view = makeGutterTextView()
+        view.setBlameLines([makeBlameLine(line: 1)])
+        #expect(view.blameLineCount == 1)
+
+        view.setBlameLines([makeBlameLine(line: 1), makeBlameLine(line: 2)])
+        #expect(view.blameLineCount == 2)
+        #expect(view.blameLookup.count == 2)
+    }
+
+    @Test func setBlameLines_sameCountDifferentFirstLine_rebuilds() {
+        let view = makeGutterTextView()
+        view.setBlameLines([makeBlameLine(hash: "aaa", line: 1)])
+        #expect(view.blameLookup[1]?.hash == "aaa")
+
+        // Same count but different first element
+        view.setBlameLines([makeBlameLine(hash: "bbb", line: 1)])
+        #expect(view.blameLookup[1]?.hash == "bbb")
+    }
+
+    // MARK: - Update after content change
+
+    @Test func setBlameLines_updateAfterFileEdit() {
+        let view = makeGutterTextView()
+        // Initial blame for 3 lines
+        view.setBlameLines([
+            makeBlameLine(line: 1),
+            makeBlameLine(line: 2),
+            makeBlameLine(line: 3)
+        ])
+        #expect(view.blameLookup.count == 3)
+
+        // After edit, blame has 4 lines
+        view.setBlameLines([
+            makeBlameLine(line: 1),
+            makeBlameLine(hash: "0000000000000000000000000000000000000000", line: 2, summary: "uncommitted"),
+            makeBlameLine(line: 3),
+            makeBlameLine(line: 4)
+        ])
+        #expect(view.blameLookup.count == 4)
+        #expect(view.blameLookup[2]?.isUncommitted == true)
+    }
+
+    // MARK: - Non-contiguous line numbers
+
+    @Test func setBlameLines_nonContiguousLines() {
+        let view = makeGutterTextView()
+        let lines = [
+            makeBlameLine(line: 5),
+            makeBlameLine(line: 10),
+            makeBlameLine(line: 15)
+        ]
+
+        view.setBlameLines(lines)
+
+        #expect(view.blameLookup[5] != nil)
+        #expect(view.blameLookup[10] != nil)
+        #expect(view.blameLookup[15] != nil)
+        #expect(view.blameLookup[1] == nil)
+        #expect(view.blameLookup[6] == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- **BlameLookupTests** (9 tests): covers `GutterTextView.setBlameLines` — lookup dictionary rebuild, empty data, duplicate line numbers, cache guard optimization, data update after file edit, non-contiguous line numbers
- **AutoIndentTests** (17 tests): covers `GutterTextView.insertNewline` — indent preservation (spaces, tabs, mixed), indent increase after `{`/`(`/`:`, bracket pair expansion (`{}` → 3 lines), empty lines, whitespace-only lines, mid-line cursor
- Changed `blameLookup`/`blameLineCount` from `private` to `private(set)` for testability via `@testable import`

Closes #331

## Test plan

- [x] All 9 BlameLookupTests pass
- [x] All 17 AutoIndentTests pass
- [x] SwiftLint: 0 violations
- [x] Existing tests unaffected