### PR TITLE
feat: strip trailing whitespace on save

### DIFF
--- a/Pine/String+TrailingWhitespace.swift
+++ b/Pine/String+TrailingWhitespace.swift
@@ -1,0 +1,18 @@
+//
+//  String+TrailingWhitespace.swift
+//  Pine
+//
+
+import Foundation
+
+extension String {
+    /// Returns a copy with trailing whitespace (spaces and tabs) removed from every line.
+    /// Preserves line endings (LF, CRLF) and empty lines.
+    func trailingWhitespaceStripped() -> String {
+        replacingOccurrences(
+            of: "[ \\t]+(?=\\r?\\n|$)",
+            with: "",
+            options: .regularExpression
+        )
+    }
+}

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -216,8 +216,8 @@ final class TabManager {
         let tab = tabs[index]
         guard tab.kind == .text else { return false }
         let trimmed = tab.content.trailingWhitespaceStripped()
-        tabs[index].content = trimmed
         try trimmed.write(to: tab.url, atomically: true, encoding: tab.encoding)
+        tabs[index].content = trimmed
         tabs[index].savedContent = trimmed
         tabs[index].lastModDate = modDate(for: tab.url)
         tabs[index].fileSizeBytes = fileSize(url: tab.url)

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -215,8 +215,10 @@ final class TabManager {
     func trySaveTab(at index: Int) throws -> Bool {
         let tab = tabs[index]
         guard tab.kind == .text else { return false }
-        try tab.content.write(to: tab.url, atomically: true, encoding: tab.encoding)
-        tabs[index].savedContent = tab.content
+        let trimmed = tab.content.trailingWhitespaceStripped()
+        tabs[index].content = trimmed
+        try trimmed.write(to: tab.url, atomically: true, encoding: tab.encoding)
+        tabs[index].savedContent = trimmed
         tabs[index].lastModDate = modDate(for: tab.url)
         tabs[index].fileSizeBytes = fileSize(url: tab.url)
         recoveryManager?.deleteRecoveryFile(for: tab.id)

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -287,9 +287,11 @@ final class TabManager {
     func saveActiveTabAs(to newURL: URL) throws -> Bool {
         guard let index = activeTabIndex else { return false }
         let tab = tabs[index]
-        try tab.content.write(to: newURL, atomically: true, encoding: tab.encoding)
+        let trimmed = tab.content.trailingWhitespaceStripped()
+        try trimmed.write(to: newURL, atomically: true, encoding: tab.encoding)
+        tabs[index].content = trimmed
         tabs[index].url = newURL
-        tabs[index].savedContent = tab.content
+        tabs[index].savedContent = trimmed
         tabs[index].lastModDate = modDate(for: newURL)
         return true
     }
@@ -310,12 +312,13 @@ final class TabManager {
 
         guard let duplicateURL = finderCopyURL(for: originalURL) else { return false }
 
-        try tab.content.write(to: duplicateURL, atomically: true, encoding: tab.encoding)
+        let trimmed = tab.content.trailingWhitespaceStripped()
+        try trimmed.write(to: duplicateURL, atomically: true, encoding: tab.encoding)
 
         var newTab = EditorTab(
             url: duplicateURL,
-            content: tab.content,
-            savedContent: tab.content
+            content: trimmed,
+            savedContent: trimmed
         )
         newTab.lastModDate = modDate(for: duplicateURL)
         newTab.encoding = tab.encoding

--- a/PineTests/TabManagerTests.swift
+++ b/PineTests/TabManagerTests.swift
@@ -1164,6 +1164,100 @@ struct TabManagerTests {
         #expect(manager.activeTab?.isDirty == true)
     }
 
+    @Test("Save As strips trailing whitespace")
+    func saveAsStripsTrailingWhitespace() throws {
+        let manager = TabManager()
+        let url = tempFileURL(content: "hello")
+        let dir = url.deletingLastPathComponent()
+        let newURL = dir.appendingPathComponent("saved_as.swift")
+
+        manager.openTab(url: url)
+        manager.updateContent("code   \nmore\t\n")
+
+        try manager.saveActiveTabAs(to: newURL)
+
+        let onDisk = try String(contentsOf: newURL, encoding: .utf8)
+        #expect(onDisk == "code\nmore\n")
+        #expect(manager.activeTab?.content == "code\nmore\n")
+        #expect(manager.activeTab?.url == newURL)
+        #expect(manager.activeTab?.isDirty == false)
+    }
+
+    @Test("Duplicate tab strips trailing whitespace")
+    func duplicateStripsTrailingWhitespace() throws {
+        let manager = TabManager()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("file.swift")
+        try "hello".write(to: url, atomically: true, encoding: .utf8)
+
+        manager.openTab(url: url)
+        manager.updateContent("code   \nmore\t\n")
+        // Save original first so duplicate reads current content
+        manager.saveActiveTab()
+
+        // Re-add trailing whitespace
+        manager.updateContent("dup   \ntest\t\n")
+
+        let duplicated = manager.duplicateActiveTab()
+        #expect(duplicated == true)
+
+        // The duplicate tab (now active) should have trimmed content
+        guard let dupURL = manager.activeTab?.url else {
+            Issue.record("activeTab should not be nil after duplicate")
+            return
+        }
+        let onDisk = try String(contentsOf: dupURL, encoding: .utf8)
+        #expect(onDisk == "dup\ntest\n")
+        #expect(manager.activeTab?.content == "dup\ntest\n")
+    }
+
+    @Test("Strip trailing whitespace with mixed LF and CRLF")
+    func stripMixedLineEndings() {
+        let manager = TabManager()
+        let url = tempFileURL(content: "hello")
+
+        manager.openTab(url: url)
+        manager.updateContent("line1   \nline2\t\r\nline3  \n")
+
+        let success = manager.saveActiveTab()
+        #expect(success == true)
+
+        let onDisk = try? String(contentsOf: url, encoding: .utf8)
+        #expect(onDisk == "line1\nline2\r\nline3\n")
+    }
+
+    @Test("Save file with no trailing newline strips whitespace")
+    func saveNoTrailingNewline() {
+        let manager = TabManager()
+        let url = tempFileURL(content: "hello")
+
+        manager.openTab(url: url)
+        manager.updateContent("hello   ")
+
+        let success = manager.saveActiveTab()
+        #expect(success == true)
+
+        let onDisk = try? String(contentsOf: url, encoding: .utf8)
+        #expect(onDisk == "hello")
+    }
+
+    @Test("Save whitespace-only file produces empty lines")
+    func saveWhitespaceOnlyFile() {
+        let manager = TabManager()
+        let url = tempFileURL(content: "hello")
+
+        manager.openTab(url: url)
+        manager.updateContent("   \n\t\t\n")
+
+        let success = manager.saveActiveTab()
+        #expect(success == true)
+
+        let onDisk = try? String(contentsOf: url, encoding: .utf8)
+        #expect(onDisk == "\n\n")
+    }
+
     @Test("Auto-save strips trailing whitespace")
     func autoSaveStripsTrailingWhitespace() async throws {
         let manager = TabManager()

--- a/PineTests/TabManagerTests.swift
+++ b/PineTests/TabManagerTests.swift
@@ -1033,6 +1033,120 @@ struct TabManagerTests {
         #expect(manager.hasScheduledAutoSave == false)
     }
 
+    // MARK: - Strip trailing whitespace on save
+
+    @Test("Save strips trailing whitespace from all lines")
+    func saveStripsTrailingWhitespace() {
+        let manager = TabManager()
+        let url = tempFileURL(content: "hello")
+
+        manager.openTab(url: url)
+        manager.updateContent("hello   \nworld\t\t\nfoo  bar  \n")
+
+        let success = manager.saveActiveTab()
+        #expect(success == true)
+
+        let onDisk = try? String(contentsOf: url, encoding: .utf8)
+        #expect(onDisk == "hello\nworld\nfoo  bar\n")
+        #expect(manager.activeTab?.content == "hello\nworld\nfoo  bar\n")
+        #expect(manager.activeTab?.isDirty == false)
+    }
+
+    @Test("Save preserves content with no trailing whitespace")
+    func savePreservesCleanContent() {
+        let manager = TabManager()
+        let url = tempFileURL(content: "clean")
+
+        manager.openTab(url: url)
+        manager.updateContent("no trailing\nwhitespace here\n")
+
+        let success = manager.saveActiveTab()
+        #expect(success == true)
+
+        let onDisk = try? String(contentsOf: url, encoding: .utf8)
+        #expect(onDisk == "no trailing\nwhitespace here\n")
+    }
+
+    @Test("Save strips trailing whitespace but preserves empty lines")
+    func savePreservesEmptyLines() {
+        let manager = TabManager()
+        let url = tempFileURL(content: "hello")
+
+        manager.openTab(url: url)
+        manager.updateContent("line1  \n\nline3\t\n\n")
+
+        let success = manager.saveActiveTab()
+        #expect(success == true)
+
+        let onDisk = try? String(contentsOf: url, encoding: .utf8)
+        #expect(onDisk == "line1\n\nline3\n\n")
+    }
+
+    @Test("Save strips trailing whitespace with CRLF line endings")
+    func saveStripsCRLF() {
+        let manager = TabManager()
+        let url = tempFileURL(content: "hello")
+
+        manager.openTab(url: url)
+        manager.updateContent("hello   \r\nworld\t\r\n")
+
+        let success = manager.saveActiveTab()
+        #expect(success == true)
+
+        let onDisk = try? String(contentsOf: url, encoding: .utf8)
+        #expect(onDisk == "hello\r\nworld\r\n")
+    }
+
+    @Test("Save strips trailing whitespace — tabs and mixed spaces")
+    func saveStripsMixedWhitespace() {
+        let manager = TabManager()
+        let url = tempFileURL(content: "hello")
+
+        manager.openTab(url: url)
+        manager.updateContent("code \t \n\t  data  \t\n")
+
+        let success = manager.saveActiveTab()
+        #expect(success == true)
+
+        let onDisk = try? String(contentsOf: url, encoding: .utf8)
+        #expect(onDisk == "code\n\t  data\n")
+    }
+
+    @Test("trySaveTab also strips trailing whitespace")
+    func trySaveTabStripsWhitespace() throws {
+        let manager = TabManager()
+        let url = tempFileURL(content: "hello")
+
+        manager.openTab(url: url)
+        manager.updateContent("test   \n")
+
+        try manager.trySaveTab(at: 0)
+
+        let onDisk = try String(contentsOf: url, encoding: .utf8)
+        #expect(onDisk == "test\n")
+        #expect(manager.activeTab?.content == "test\n")
+    }
+
+    @Test("saveAllTabs strips trailing whitespace from all dirty tabs")
+    func saveAllTabsStripsWhitespace() {
+        let manager = TabManager()
+        let url1 = tempFileURL(name: "a.swift", content: "original1")
+        let url2 = tempFileURL(name: "b.swift", content: "original2")
+
+        manager.openTab(url: url1)
+        manager.updateContent("hello   \n")
+        manager.openTab(url: url2)
+        manager.updateContent("world\t\t\n")
+
+        let success = manager.saveAllTabs()
+        #expect(success == true)
+
+        let disk1 = try? String(contentsOf: url1, encoding: .utf8)
+        let disk2 = try? String(contentsOf: url2, encoding: .utf8)
+        #expect(disk1 == "hello\n")
+        #expect(disk2 == "world\n")
+    }
+
     @Test("isAutoSaving resets after auto-save completes")
     func isAutoSavingResetsAfterSave() async throws {
         let manager = TabManager()

--- a/PineTests/TabManagerTests.swift
+++ b/PineTests/TabManagerTests.swift
@@ -1147,6 +1147,43 @@ struct TabManagerTests {
         #expect(disk2 == "world\n")
     }
 
+    @Test("Failed save preserves original content with trailing whitespace")
+    func failedSavePreservesContent() {
+        let manager = TabManager()
+        let badURL = URL(fileURLWithPath: "/nonexistent_dir_\(UUID().uuidString)/file.txt")
+
+        let tab = EditorTab(url: badURL, content: "hello   \nworld\t\n", savedContent: "")
+        manager.tabs.append(tab)
+        manager.activeTabID = tab.id
+
+        #expect(throws: (any Error).self) {
+            try manager.trySaveTab(at: 0)
+        }
+        // Content must NOT be trimmed after failed write
+        #expect(manager.activeTab?.content == "hello   \nworld\t\n")
+        #expect(manager.activeTab?.isDirty == true)
+    }
+
+    @Test("Auto-save strips trailing whitespace")
+    func autoSaveStripsTrailingWhitespace() async throws {
+        let manager = TabManager()
+        manager.setAutoSaveDelay(0.1)
+        let url = tempFileURL(content: "original")
+
+        manager.openTab(url: url)
+        manager.updateContent("hello   \nworld\t\n")
+        #expect(manager.activeTab?.isDirty == true)
+
+        manager.scheduleAutoSave()
+
+        try await Task.sleep(for: .milliseconds(300))
+
+        #expect(manager.activeTab?.isDirty == false)
+        let onDisk = try String(contentsOf: url, encoding: .utf8)
+        #expect(onDisk == "hello\nworld\n")
+        #expect(manager.activeTab?.content == "hello\nworld\n")
+    }
+
     @Test("isAutoSaving resets after auto-save completes")
     func isAutoSavingResetsAfterSave() async throws {
         let manager = TabManager()

--- a/PineTests/TrailingWhitespaceTests.swift
+++ b/PineTests/TrailingWhitespaceTests.swift
@@ -1,0 +1,77 @@
+//
+//  TrailingWhitespaceTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("String trailing whitespace stripping")
+struct TrailingWhitespaceTests {
+
+    @Test("Strips trailing spaces from lines")
+    func stripsTrailingSpaces() {
+        let input = "hello   \nworld  \n"
+        #expect(input.trailingWhitespaceStripped() == "hello\nworld\n")
+    }
+
+    @Test("Strips trailing tabs from lines")
+    func stripsTrailingTabs() {
+        let input = "hello\t\t\nworld\t\n"
+        #expect(input.trailingWhitespaceStripped() == "hello\nworld\n")
+    }
+
+    @Test("Strips mixed trailing whitespace")
+    func stripsMixedWhitespace() {
+        let input = "hello \t \nworld\t  \n"
+        #expect(input.trailingWhitespaceStripped() == "hello\nworld\n")
+    }
+
+    @Test("Preserves empty lines")
+    func preservesEmptyLines() {
+        let input = "hello  \n\nworld\n\n"
+        #expect(input.trailingWhitespaceStripped() == "hello\n\nworld\n\n")
+    }
+
+    @Test("Preserves leading whitespace")
+    func preservesLeadingWhitespace() {
+        let input = "    hello  \n\tworld\t\n"
+        #expect(input.trailingWhitespaceStripped() == "    hello\n\tworld\n")
+    }
+
+    @Test("Handles CRLF line endings")
+    func handlesCRLF() {
+        let input = "hello   \r\nworld\t\r\n"
+        #expect(input.trailingWhitespaceStripped() == "hello\r\nworld\r\n")
+    }
+
+    @Test("No-op for clean string")
+    func noOpForCleanString() {
+        let input = "hello\nworld\n"
+        #expect(input.trailingWhitespaceStripped() == "hello\nworld\n")
+    }
+
+    @Test("Empty string returns empty")
+    func emptyString() {
+        #expect("".trailingWhitespaceStripped() == "")
+    }
+
+    @Test("Single line with trailing whitespace")
+    func singleLine() {
+        #expect("hello   ".trailingWhitespaceStripped() == "hello")
+    }
+
+    @Test("Only whitespace lines become empty")
+    func onlyWhitespace() {
+        let input = "   \n\t\t\n  \t  \n"
+        #expect(input.trailingWhitespaceStripped() == "\n\n\n")
+    }
+
+    @Test("Preserves internal whitespace")
+    func preservesInternalWhitespace() {
+        let input = "foo  bar  \nbaz\tqux\t\n"
+        #expect(input.trailingWhitespaceStripped() == "foo  bar\nbaz\tqux\n")
+    }
+}

--- a/PineTests/TrailingWhitespaceTests.swift
+++ b/PineTests/TrailingWhitespaceTests.swift
@@ -69,6 +69,22 @@ struct TrailingWhitespaceTests {
         #expect(input.trailingWhitespaceStripped() == "\n\n\n")
     }
 
+    @Test("Handles mixed LF and CRLF in same string")
+    func handlesMixedLineEndings() {
+        let input = "hello   \nworld\t\r\nfoo  \n"
+        #expect(input.trailingWhitespaceStripped() == "hello\nworld\r\nfoo\n")
+    }
+
+    @Test("String with no trailing newline")
+    func noTrailingNewline() {
+        #expect("hello   \nworld  ".trailingWhitespaceStripped() == "hello\nworld")
+    }
+
+    @Test("String of only newlines unchanged")
+    func onlyNewlines() {
+        #expect("\n\n\n".trailingWhitespaceStripped() == "\n\n\n")
+    }
+
     @Test("Preserves internal whitespace")
     func preservesInternalWhitespace() {
         let input = "foo  bar  \nbaz\tqux\t\n"


### PR DESCRIPTION
## Summary

- Automatically strips trailing whitespace (spaces/tabs) from all lines on save
- Applies to all save paths: manual save, save-all, save-as, and auto-save
- Preserves line endings (LF/CRLF), empty lines, leading whitespace, and internal whitespace

## Implementation

- `String.trailingWhitespaceStripped()` extension using regex to strip trailing spaces/tabs before line endings
- Hooked into `TabManager.trySaveTab()` — trims content before writing to disk and updates tab content to keep UI in sync

## Test plan

- [x] 11 unit tests for `String.trailingWhitespaceStripped()` (spaces, tabs, mixed, CRLF, empty lines, edge cases)
- [x] 7 integration tests in `TabManagerTests` (save, trySave, saveAll with trailing whitespace)
- [x] All existing TabManager tests pass (no regressions)

Closes #417