### PR TITLE
ci: optimize pipeline speed (target 6-7 min)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,16 @@ jobs:
   lint:
     name: SwiftLint
     runs-on: ubuntu-latest
+    env:
+      SWIFTLINT_VERSION: "0.58.2"
+      SWIFTLINT_SHA256: "f1e4cb061609bea53ac442a0db0a07422822c34080d4a9ac9780f53e98602b77"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install SwiftLint
         run: |
-          curl -sL "https://github.com/realm/SwiftLint/releases/download/0.58.2/swiftlint_linux.zip" -o swiftlint.zip
+          curl -sL "https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/swiftlint_linux.zip" -o swiftlint.zip
+          echo "${SWIFTLINT_SHA256}  swiftlint.zip" | sha256sum -c -
           unzip -o swiftlint.zip
           chmod +x swiftlint
           sudo mv swiftlint /usr/local/bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,16 @@ jobs:
 
   lint:
     name: SwiftLint
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install SwiftLint
-        run: brew install swiftlint
+        run: |
+          curl -sL "https://github.com/realm/SwiftLint/releases/download/0.58.2/swiftlint_linux.zip" -o swiftlint.zip
+          unzip -o swiftlint.zip
+          chmod +x swiftlint
+          sudo mv swiftlint /usr/local/bin/
 
       - name: Run SwiftLint
         run: swiftlint --strict
@@ -67,7 +71,7 @@ jobs:
   build:
     name: Build for Testing
     runs-on: macos-26
-    needs: lint
+    needs: changes
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -77,6 +81,14 @@ jobs:
           echo "Using Xcode at: $XCODE_PATH"
           sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
           xcodebuild -version
+
+      - name: Cache SPM Dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: DerivedData/SourcePackages
+          key: spm-${{ runner.os }}-${{ hashFiles('Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
 
       - name: Build App
         run: |
@@ -340,7 +352,7 @@ jobs:
   verify-ui-shards:
     name: Verify UI Test Shards
     runs-on: ubuntu-latest
-    needs: [lint, changes]
+    needs: changes
     if: ${{ needs.changes.outputs.ui == 'true' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -367,7 +379,7 @@ jobs:
           fi
           echo "All $(echo "$ACTUAL" | wc -l | tr -d ' ') UI test classes are sharded."
 
-  # UI test shards — 4 parallel jobs, ~21 tests each.
+  # UI test shards — 6 parallel jobs, ~14-15 tests each.
   # To rebalance: count tests per class, redistribute so shards stay within ±3 tests.
   # List classes with: grep -r "func test" PineUITests/ | sed 's/:.*//' | sort | uniq -c | sort -rn
   ui-tests:
@@ -379,35 +391,41 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Shard 1 — Window & Welcome (21 tests)
-          - shard-name: "Window & Welcome"
+          # Shard 1 — Welcome (14 tests)
+          - shard-name: "Welcome"
             test-classes: >-
               -only-testing:PineUITests/WelcomeWindowTests
-              -only-testing:PineUITests/SidebarSearchTests
-          # Shard 2 — Editor Core (21 tests)
-          - shard-name: "Editor Core"
+          # Shard 2 — Editor & Gutter (15 tests)
+          - shard-name: "Editor & Gutter"
             test-classes: >-
               -only-testing:PineUITests/EditorWindowTests
-              -only-testing:PineUITests/FontSizeTests
-              -only-testing:PineUITests/DiffNavigationUITests
               -only-testing:PineUITests/LineNumberGutterUITests
-          # Shard 3 — File Operations (20 tests)
-          - shard-name: "File Operations"
+          # Shard 3 — Files & Branch (15 tests)
+          - shard-name: "Files & Branch"
             test-classes: >-
               -only-testing:PineUITests/DeleteTests
+              -only-testing:PineUITests/BranchSwitcherTests
+              -only-testing:PineUITests/DiffNavigationUITests
+          # Shard 4 — Search & Duplicate (15 tests)
+          - shard-name: "Search & Duplicate"
+            test-classes: >-
+              -only-testing:PineUITests/SidebarSearchTests
               -only-testing:PineUITests/DuplicateTests
-              -only-testing:PineUITests/MultiWindowTests
               -only-testing:PineUITests/MinimapTests
-          # Shard 4 — Git, Terminal & Misc (21 tests)
-          - shard-name: "Git, Terminal & Misc"
+              -only-testing:PineUITests/BlameViewTests
+          # Shard 5 — Security & Terminal (15 tests)
+          - shard-name: "Security & Terminal"
             test-classes: >-
               -only-testing:PineUITests/SymlinkSecurityUITests
-              -only-testing:PineUITests/BranchSwitcherTests
-              -only-testing:PineUITests/GitignoreFilterTests
+              -only-testing:PineUITests/MultiWindowTests
               -only-testing:PineUITests/TerminalTests
-              -only-testing:PineUITests/CheckForUpdatesTests
-              -only-testing:PineUITests/BlameViewTests
               -only-testing:PineUITests/ToggleCommentTests
+          # Shard 6 — Git & Font (14 tests)
+          - shard-name: "Git & Font"
+            test-classes: >-
+              -only-testing:PineUITests/GitignoreFilterTests
+              -only-testing:PineUITests/FontSizeTests
+              -only-testing:PineUITests/CheckForUpdatesTests
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install SwiftLint
         run: |
-          curl -sL "https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/swiftlint_linux.zip" -o swiftlint.zip
+          curl -fSL "https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/swiftlint_linux.zip" -o swiftlint.zip
           echo "${SWIFTLINT_SHA256}  swiftlint.zip" | sha256sum -c -
           unzip -o swiftlint.zip
           chmod +x swiftlint


### PR DESCRIPTION
## Summary

- **SwiftLint on Linux** — moved from `macos-26` to `ubuntu-latest`, downloads pre-built binary from GitHub releases. Frees a macOS runner slot for tests
- **Build parallel with Lint** — removed `needs: lint` from build job, both now run concurrently after `changes`
- **6 UI shards** — rebalanced from 4 shards (~21 tests) to 6 shards (~14-15 tests each), reducing longest stage from ~5 min to ~3 min
- **SPM cache** — added `actions/cache` for SwiftTerm package resolution (`DerivedData/SourcePackages`), saves ~10-20s per build
- **Faster verify-ui-shards** — removed unnecessary `lint` dependency

## Expected critical path

```
Lint (15s, Ubuntu) ──────────────┐
                                 ├── (all must pass)
Build (2 min, macOS) ────────────┤
  ├── Unit Tests (1.5 min)       │
  ├── UI Shard 1 (3 min)        │
  ├── UI Shard 2 (3 min)        │
  ├── UI Shard 3 (3 min)        │
  ├── UI Shard 4 (3 min)        │
  ├── UI Shard 5 (3 min)        │
  └── UI Shard 6 (3 min)        │
Verify Shards (3s, Ubuntu) ──────┘
```

**Target: ~6 min** (down from ~10-12 min)

## UI shard distribution (88 tests total)

| Shard | Classes | Tests |
|-------|---------|-------|
| Welcome | WelcomeWindowTests | 14 |
| Editor & Gutter | EditorWindowTests, LineNumberGutterUITests | 15 |
| Files & Branch | DeleteTests, BranchSwitcherTests, DiffNavigationUITests | 15 |
| Search & Duplicate | SidebarSearchTests, DuplicateTests, MinimapTests, BlameViewTests | 15 |
| Security & Terminal | SymlinkSecurityUITests, MultiWindowTests, TerminalTests, ToggleCommentTests | 15 |
| Git & Font | GitignoreFilterTests, FontSizeTests, CheckForUpdatesTests | 14 |

## Test plan

- [ ] CI pipeline runs successfully on this PR
- [ ] SwiftLint passes on Ubuntu runner
- [ ] All 6 UI shards complete
- [ ] SPM cache hits on subsequent runs
- [ ] verify-ui-shards detects all 17 test classes

Closes #407