### PR TITLE
feat: add Go to Line dialog (Cmd+L)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,11 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Targets 
 - Type-check a single file (no sudo needed): `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -typecheck -target arm64-apple-macos26.0 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk <file.swift>`
 - **Dependency:** SwiftTerm added via Xcode SPM (File > Add Package Dependencies > `https://github.com/migueldeicaza/SwiftTerm.git`)
 - No other third-party dependencies
+- **Xcode project format:** Uses `PBXFileSystemSynchronizedRootGroup` (objectVersion 77) — new `.swift` files placed in `Pine/`, `PineTests/`, or `PineUITests/` are automatically picked up by Xcode. No manual `project.pbxproj` edits needed
 - **Git hooks:** Run once after cloning: `git config core.hooksPath .githooks && git config merge.ours.driver true`. Enables pre-commit hook that auto-unstages cosmetic-only changes to `Localizable.xcstrings` (Xcode build artifacts) and `ours` merge driver for xcstrings conflicts
 - **SwiftLint:** `brew install swiftlint` — runs as a build phase; config in `.swiftlint.yml`. Run `swiftlint` before every commit and fix all warnings/errors. If `swiftlint` crashes with `sourcekitdInProc` error, prefix with `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer`
 - **Unit Tests:** `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineTests`
+- Run a single test class: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineTests/GoToLineTests`
 - Unit test target: `PineTests` (Swift Testing framework) — covers git parsing, grammar models, file tree, syntax highlighting, find & replace, code folding, minimap, status bar, project search, and more (46+ test files)
 - **UI Tests:** `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineUITests`
 - UI test target: `PineUITests` (XCTest/XCUITest) — end-to-end tests for Welcome window, editor tabs, terminal, multi-window, minimap, git blame, branch switcher, and more (17+ test files)
@@ -51,6 +53,8 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Targets 
 **Minimap:** `MinimapView` renders a scaled-down (12%) document overview on the right edge of the editor showing syntax colors and git diff markers. Click or drag to scroll the editor proportionally. A viewport indicator rectangle shows the visible region. Toggle visibility via menu.
 
 **Code folding:** `FoldRangeCalculator` identifies foldable ranges by scanning matched bracket pairs (`{}`, `[]`, `()`). `FoldState` tracks which ranges are folded for the active tab using a sorted set for O(1) hidden-line lookups. Fold/unfold/toggle operations are available via menu and gutter clicks.
+
+**Adding menu commands:** Menu items are defined in `PineApp.swift` inside `CommandGroup`. They post notifications via `NotificationCenter.default.post(name:)`. Notification names are defined as static properties in `extension Notification.Name` (bottom of `PineApp.swift`). `ContentView` listens via `.onReceive()` inside `GitAndNotificationObserver` ViewModifier. Strings go in `Strings.swift`, icons in `MenuIcons.swift`, localization in `Localizable.xcstrings` (targeted text insertion, not json.dump).
 
 **Find & Replace:** Uses NSTextView's native find bar (`usesFindBar = true`) triggered via NotificationCenter. Notifications: `findInFile` (Cmd+F), `findAndReplace` (Cmd+Option+F), `findNext` (Cmd+G), `findPrevious` (Cmd+Shift+G), `useSelectionForFind` (Cmd+E). The find bar is presented by `GutterTextView`'s coordinator in response to menu commands.
 
@@ -87,6 +91,8 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Targets 
 - `FoldState.swift` — Tracks folded code regions for the active tab; O(1) hidden-line lookups via sorted set
 - `FoldRangeCalculator.swift` — Identifies foldable ranges from matched bracket pairs `{}`, `[]`, `()` using binary search for line number resolution
 - `GitBlameInfo.swift` — Data structures for git blame output (GitBlameLine: hash, author, timestamp, summary; BlameConstants for storage key)
+- `GoToLineParser.swift` — Parses "line" and "line:column" input for Go to Line navigation (Cmd+L)
+- `GoToLineView.swift` — Compact sheet dialog for Go to Line with validation and auto-focus
 - `BracketMatcher.swift` — Finds matching bracket pairs while skipping comment and string ranges
 - `CommentToggler.swift` — Toggles line and block comments for the active selection
 - `ProjectSearchProvider.swift` — Async full-project text search with debounce, .gitignore support, binary file detection, and 1 MB per-file limit
@@ -121,7 +127,7 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Targets 
 - Uses `@Observable` macro (Swift 5.9+), not ObservableObject/Published
 - Models are either structs (EditorTab) or @Observable classes (FileNode, TerminalTab) depending on identity semantics
 - Grammar files are JSON in `Pine/Grammars/` — add new languages by adding a new JSON file following the existing format
-- Keyboard shortcuts: Save (Cmd+S), Save All (Cmd+Option+S), Save As (Cmd+Shift+S), Duplicate (Cmd+Shift+D), Open Folder (Cmd+Shift+O), Close Tab (Cmd+W), Toggle Terminal (Cmd+`), New Terminal Tab (Cmd+T), Switch Branch (Cmd+Shift+B), Next Change (Ctrl+Opt+↓), Previous Change (Ctrl+Opt+↑), Find (Cmd+F), Find & Replace (Cmd+Option+F), Find Next (Cmd+G), Find Previous (Cmd+Shift+G), Use Selection for Find (Cmd+E). Menu commands flow through `@FocusedValue(\.projectManager)` to `TabManager`. Cmd+W is intercepted via `NSEvent.addLocalMonitorForEvents` in AppDelegate (not a SwiftUI menu command) to close the active tab; the window close button goes through `CloseDelegate.windowShouldClose` to close the entire window
+- Keyboard shortcuts: Save (Cmd+S), Save All (Cmd+Option+S), Save As (Cmd+Shift+S), Duplicate (Cmd+Shift+D), Open Folder (Cmd+Shift+O), Close Tab (Cmd+W), Toggle Terminal (Cmd+`), New Terminal Tab (Cmd+T), Switch Branch (Cmd+Shift+B), Go to Line (Cmd+L), Next Change (Ctrl+Opt+↓), Previous Change (Ctrl+Opt+↑), Find (Cmd+F), Find & Replace (Cmd+Option+F), Find Next (Cmd+G), Find Previous (Cmd+Shift+G), Use Selection for Find (Cmd+E). Menu commands flow through `@FocusedValue(\.projectManager)` to `TabManager`. Cmd+W is intercepted via `NSEvent.addLocalMonitorForEvents` in AppDelegate (not a SwiftUI menu command) to close the active tab; the window close button goes through `CloseDelegate.windowShouldClose` to close the entire window
 - UI uses semantic system colors (migrated from hardcoded dark theme values)
 - macOS 26 SDK renamed `NSColor(sRGBRed:)` → `NSColor(srgbRed:)` (lowercase)
 - Editor features: auto-indent on newline, current line highlight, git diff gutter markers, minimap, code folding, git blame, find & replace, status bar (line/col, indentation, encoding, line endings, file size), auto-save, async syntax highlighting, bracket matching, comment toggling, markdown preview

--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -49,6 +49,10 @@ enum AccessibilityID {
     static let markdownPreviewToggle = "markdownPreviewToggle"
     static let markdownPreviewView = "markdownPreviewView"
 
+    // MARK: - Go to Line
+    static let goToLineSheet = "goToLineSheet"
+    static let goToLineField = "goToLineField"
+
     // MARK: - Branch switcher
     static let branchSwitcherButton = "branchSwitcherButton"
     static let branchSearchField = "branchSearchField"

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -591,7 +591,14 @@ struct ContentView: View {
 
     private var totalLineCount: Int {
         guard let content = activeTab?.content else { return 1 }
-        return max(1, (content as NSString).components(separatedBy: .newlines).count)
+        let ns = content as NSString
+        var count = 1
+        var pos = 0
+        while pos < ns.length {
+            pos = NSMaxRange(ns.lineRange(for: NSRange(location: pos, length: 0)))
+            count += 1
+        }
+        return max(1, count - 1)
     }
 
     /// Converts a 1-based line number to a UTF-16 cursor offset within content.

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -29,6 +29,7 @@ struct ContentView: View {
     @State private var goToLineOffset: GoToRequest?
     @State private var recoveryEntries: [(UUID, RecoveryEntry)] = []
     @State private var showRecoveryDialog = false
+    @State private var showGoToLine = false
     @AppStorage("minimapVisible") private var isMinimapVisible = true
     @AppStorage(BlameConstants.storageKey) private var isBlameVisible = true
 
@@ -113,6 +114,18 @@ struct ContentView: View {
                 onDiscard: { discardRecovery() }
             )
         }
+        .sheet(isPresented: $showGoToLine) {
+            GoToLineView(
+                totalLines: totalLineCount,
+                isPresented: $showGoToLine,
+                onGoTo: { line, column in
+                    guard let tab = tabManager.activeTab else { return }
+                    goToLineOffset = GoToRequest(
+                        offset: Self.cursorOffset(forLine: line, column: column, in: tab.content)
+                    )
+                }
+            )
+        }
         .onChange(of: selectedNode) { _, newNode in
             guard let node = newNode, !node.isDirectory else { return }
             handleFileSelection(node)
@@ -147,6 +160,7 @@ struct ContentView: View {
             lineDiffs: $lineDiffs,
             columnVisibility: $columnVisibility,
             isSearchPresented: $isSearchPresented,
+            showGoToLine: $showGoToLine,
             onRefreshLineDiffs: { refreshLineDiffs() },
             onRefreshBlame: { refreshBlame() },
             onCloseTab: { closeTabWithConfirmation($0) },
@@ -575,6 +589,11 @@ struct ContentView: View {
         .onAppear { goToLineOffset = nil }
     }
 
+    private var totalLineCount: Int {
+        guard let content = activeTab?.content else { return 1 }
+        return max(1, (content as NSString).components(separatedBy: .newlines).count)
+    }
+
     /// Converts a 1-based line number to a UTF-16 cursor offset within content.
     static func cursorOffset(forLine line: Int, in content: String) -> Int {
         let nsContent = content as NSString
@@ -586,6 +605,19 @@ struct ContentView: View {
             currentLine += 1
         }
         return min(offset, nsContent.length)
+    }
+
+    /// Converts a 1-based line and optional column to a UTF-16 cursor offset.
+    static func cursorOffset(forLine line: Int, column: Int?, in content: String) -> Int {
+        let lineOffset = cursorOffset(forLine: line, in: content)
+        guard let column, column > 1 else { return lineOffset }
+        let nsContent = content as NSString
+        let lineRange = nsContent.lineRange(for: NSRange(location: lineOffset, length: 0))
+        // lineRange.length includes the newline; limit column to actual content length
+        let lineText = nsContent.substring(with: lineRange)
+        let lineContentLength = lineText.hasSuffix("\n") ? lineRange.length - 1 : lineRange.length
+        let colOffset = min(column - 1, lineContentLength)
+        return min(lineOffset + colOffset, nsContent.length)
     }
 
     /// Converts a UTF-16 cursor offset to a 1-based line number.
@@ -720,6 +752,7 @@ private struct GitAndNotificationObserver: ViewModifier {
     @Binding var lineDiffs: [GitLineDiff]
     @Binding var columnVisibility: NavigationSplitViewVisibility
     @Binding var isSearchPresented: Bool
+    @Binding var showGoToLine: Bool
     var onRefreshLineDiffs: () -> Void
     var onRefreshBlame: () -> Void
     var onCloseTab: (EditorTab) -> Void
@@ -776,6 +809,11 @@ private struct GitAndNotificationObserver: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .showProjectSearch)) { _ in
                 columnVisibility = .all
                 isSearchPresented = true
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .goToLine)) { _ in
+                guard controlActiveState == .key,
+                      tabManager.activeTab != nil else { return }
+                showGoToLine = true
             }
             .onReceive(NotificationCenter.default.publisher(for: .navigateChange)) { notification in
                 guard controlActiveState == .key,

--- a/Pine/GoToLineParser.swift
+++ b/Pine/GoToLineParser.swift
@@ -1,0 +1,30 @@
+//
+//  GoToLineParser.swift
+//  Pine
+//
+
+import Foundation
+
+/// Parses user input for Go to Line navigation.
+/// Accepts formats: "42" (line only) or "42:10" (line:column), both 1-based.
+struct GoToLineParser {
+    struct Result {
+        let line: Int
+        let column: Int?
+    }
+
+    static func parse(_ input: String) -> Result? {
+        let trimmed = input.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+        let parts = trimmed.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
+        guard parts.count <= 2,
+              let first = parts.first,
+              let line = Int(first),
+              line >= 1 else { return nil }
+        if parts.count == 2 {
+            guard let col = Int(parts[1]), col >= 1 else { return nil }
+            return Result(line: line, column: col)
+        }
+        return Result(line: line, column: nil)
+    }
+}

--- a/Pine/GoToLineView.swift
+++ b/Pine/GoToLineView.swift
@@ -17,7 +17,7 @@ struct GoToLineView: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            TextField(Strings.goToLinePlaceholder, text: $inputText)
+            TextField("42 or 42:10", text: $inputText)
                 .textFieldStyle(.roundedBorder)
                 .focused($isFieldFocused)
                 .accessibilityIdentifier(AccessibilityID.goToLineField)

--- a/Pine/GoToLineView.swift
+++ b/Pine/GoToLineView.swift
@@ -17,7 +17,7 @@ struct GoToLineView: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            TextField("Line[:Column]", text: $inputText)
+            TextField(Strings.goToLinePlaceholder, text: $inputText)
                 .textFieldStyle(.roundedBorder)
                 .focused($isFieldFocused)
                 .accessibilityIdentifier(AccessibilityID.goToLineField)
@@ -26,6 +26,7 @@ struct GoToLineView: View {
                         .stroke(isInvalid ? Color.red : Color.clear, lineWidth: 1)
                 )
                 .onSubmit { submit() }
+                .onChange(of: inputText) { _, _ in isInvalid = false }
 
             Text("1–\(totalLines)")
                 .font(.caption)

--- a/Pine/GoToLineView.swift
+++ b/Pine/GoToLineView.swift
@@ -1,0 +1,50 @@
+//
+//  GoToLineView.swift
+//  Pine
+//
+
+import SwiftUI
+
+/// Compact dialog for Go to Line navigation (Cmd+L).
+struct GoToLineView: View {
+    let totalLines: Int
+    @Binding var isPresented: Bool
+    var onGoTo: (Int, Int?) -> Void
+
+    @State private var inputText = ""
+    @State private var isInvalid = false
+    @FocusState private var isFieldFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 8) {
+            TextField("Line[:Column]", text: $inputText)
+                .textFieldStyle(.roundedBorder)
+                .focused($isFieldFocused)
+                .accessibilityIdentifier(AccessibilityID.goToLineField)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(isInvalid ? Color.red : Color.clear, lineWidth: 1)
+                )
+                .onSubmit { submit() }
+
+            Text("1–\(totalLines)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(width: 220)
+        .accessibilityIdentifier(AccessibilityID.goToLineSheet)
+        .onAppear { isFieldFocused = true }
+        .onExitCommand { isPresented = false }
+    }
+
+    private func submit() {
+        guard let result = GoToLineParser.parse(inputText),
+              result.line <= totalLines else {
+            isInvalid = true
+            return
+        }
+        onGoTo(result.line, result.column)
+        isPresented = false
+    }
+}

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -2939,66 +2939,6 @@
         }
       }
     },
-    "goToLine.placeholder" : {
-      "comment" : "Placeholder for Go to Line text field.",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeile[:Spalte]"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Line[:Column]"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Línea[:Columna]"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ligne[:Colonne]"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "行[:列]"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "줄[:열]"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Linha[:Coluna]"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Строка[:Столбец]"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "行[:列]"
-          }
-        }
-      }
-    },
     "menu.goToLine" : {
       "comment" : "Menu item for Go to Line (⌘L).",
       "extractionState" : "manual",

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -2939,6 +2939,66 @@
         }
       }
     },
+    "menu.goToLine" : {
+      "comment" : "Menu item for Go to Line (⌘L).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gehe zu Zeile"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go to Line"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ir a la línea"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aller à la ligne"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行へ移動"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "줄로 이동"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ir para a linha"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перейти к строке"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳转到行"
+          }
+        }
+      }
+    },
     "menu.findInTerminal" : {
       "comment" : "Menu item for Find in Terminal — opens the terminal search bar.",
       "extractionState" : "manual",

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -2939,6 +2939,66 @@
         }
       }
     },
+    "goToLine.placeholder" : {
+      "comment" : "Placeholder for Go to Line text field.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeile[:Spalte]"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Line[:Column]"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Línea[:Columna]"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ligne[:Colonne]"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行[:列]"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "줄[:열]"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linha[:Coluna]"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Строка[:Столбец]"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行[:列]"
+          }
+        }
+      }
+    },
     "menu.goToLine" : {
       "comment" : "Menu item for Go to Line (⌘L).",
       "extractionState" : "manual",

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -19,6 +19,7 @@ enum MenuIcons {
     static let find = "magnifyingglass"
     static let findAndReplace = "arrow.left.arrow.right"
     static let findInProject = "magnifyingglass"
+    static let goToLine = "number"
     static let nextChange = "chevron.down"
     static let previousChange = "chevron.up"
     static let foldCode = "chevron.down.square"

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -205,6 +205,16 @@ struct PineApp: App {
                 Divider()
 
                 Button {
+                    NotificationCenter.default.post(name: .goToLine, object: nil)
+                } label: {
+                    Label(Strings.menuGoToLine, systemImage: MenuIcons.goToLine)
+                }
+                .keyboardShortcut("l", modifiers: .command)
+                .disabled(focusedProject?.tabManager.activeTab == nil)
+
+                Divider()
+
+                Button {
                     NotificationCenter.default.post(
                         name: .navigateChange, object: nil,
                         userInfo: ["direction": "next"]
@@ -1036,4 +1046,6 @@ extension Notification.Name {
     static let useSelectionForFind = Notification.Name("useSelectionForFind")
     // Find in Terminal (issue #308)
     static let findInTerminal = Notification.Name("findInTerminal")
+    // Go to Line (issue #418)
+    static let goToLine = Notification.Name("goToLine")
 }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -246,6 +246,7 @@ enum Strings {
     static let menuUseSelectionForFind: LocalizedStringKey = "menu.useSelectionForFind"
     static let menuFindInProject: LocalizedStringKey = "menu.findInProject"
     static let menuGoToLine: LocalizedStringKey = "menu.goToLine"
+    static let goToLinePlaceholder: LocalizedStringKey = "goToLine.placeholder"
     static let menuNextChange: LocalizedStringKey = "menu.nextChange"
     static let menuPreviousChange: LocalizedStringKey = "menu.previousChange"
     static let menuFoldCode: LocalizedStringKey = "menu.foldCode"

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -246,7 +246,6 @@ enum Strings {
     static let menuUseSelectionForFind: LocalizedStringKey = "menu.useSelectionForFind"
     static let menuFindInProject: LocalizedStringKey = "menu.findInProject"
     static let menuGoToLine: LocalizedStringKey = "menu.goToLine"
-    static let goToLinePlaceholder: LocalizedStringKey = "goToLine.placeholder"
     static let menuNextChange: LocalizedStringKey = "menu.nextChange"
     static let menuPreviousChange: LocalizedStringKey = "menu.previousChange"
     static let menuFoldCode: LocalizedStringKey = "menu.foldCode"

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -245,6 +245,7 @@ enum Strings {
     static let menuFindPrevious: LocalizedStringKey = "menu.findPrevious"
     static let menuUseSelectionForFind: LocalizedStringKey = "menu.useSelectionForFind"
     static let menuFindInProject: LocalizedStringKey = "menu.findInProject"
+    static let menuGoToLine: LocalizedStringKey = "menu.goToLine"
     static let menuNextChange: LocalizedStringKey = "menu.nextChange"
     static let menuPreviousChange: LocalizedStringKey = "menu.previousChange"
     static let menuFoldCode: LocalizedStringKey = "menu.foldCode"

--- a/PineTests/GoToLineTests.swift
+++ b/PineTests/GoToLineTests.swift
@@ -105,6 +105,40 @@ struct GoToLineTests {
         )
     }
 
+    // MARK: - totalLineCount consistency
+
+    @Test func totalLineCount_matchesCursorOffsetLineEnumeration() {
+        // Ensure the line counting algorithm matches cursorOffset's line enumeration
+        let content = "first\nsecond\nthird"
+        let ns = content as NSString
+        var count = 1
+        var pos = 0
+        while pos < ns.length {
+            pos = NSMaxRange(ns.lineRange(for: NSRange(location: pos, length: 0)))
+            count += 1
+        }
+        let totalLines = max(1, count - 1)
+        #expect(totalLines == 3)
+
+        // Line 3 should be navigable
+        let offset = ContentView.cursorOffset(forLine: 3, in: content)
+        #expect(offset == 13)
+    }
+
+    @Test func totalLineCount_trailingNewline() {
+        let content = "first\nsecond\n"
+        let ns = content as NSString
+        var count = 1
+        var pos = 0
+        while pos < ns.length {
+            pos = NSMaxRange(ns.lineRange(for: NSRange(location: pos, length: 0)))
+            count += 1
+        }
+        let totalLines = max(1, count - 1)
+        // "first\nsecond\n" has 2 lines of content, trailing newline doesn't add a navigable line
+        #expect(totalLines == 2)
+    }
+
     // MARK: - cursorOffset with column
 
     @Test func cursorOffset_lineOnly() {

--- a/PineTests/GoToLineTests.swift
+++ b/PineTests/GoToLineTests.swift
@@ -1,0 +1,146 @@
+//
+//  GoToLineTests.swift
+//  PineTests
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+struct GoToLineTests {
+
+    // MARK: - Parser: valid inputs
+
+    @Test func parse_lineOnly() {
+        let result = GoToLineParser.parse("42")
+        #expect(result?.line == 42)
+        #expect(result?.column == nil)
+    }
+
+    @Test func parse_lineAndColumn() {
+        let result = GoToLineParser.parse("42:10")
+        #expect(result?.line == 42)
+        #expect(result?.column == 10)
+    }
+
+    @Test func parse_trims_whitespace() {
+        let result = GoToLineParser.parse("  42  ")
+        #expect(result?.line == 42)
+        #expect(result?.column == nil)
+    }
+
+    @Test func parse_lineOne() {
+        let result = GoToLineParser.parse("1")
+        #expect(result?.line == 1)
+    }
+
+    @Test func parse_lineAndColumnOne() {
+        let result = GoToLineParser.parse("1:1")
+        #expect(result?.line == 1)
+        #expect(result?.column == 1)
+    }
+
+    // MARK: - Parser: invalid inputs
+
+    @Test func parse_emptyString_returnsNil() {
+        #expect(GoToLineParser.parse("") == nil)
+    }
+
+    @Test func parse_whitespaceOnly_returnsNil() {
+        #expect(GoToLineParser.parse("   ") == nil)
+    }
+
+    @Test func parse_nonNumeric_returnsNil() {
+        #expect(GoToLineParser.parse("abc") == nil)
+    }
+
+    @Test func parse_zero_returnsNil() {
+        #expect(GoToLineParser.parse("0") == nil)
+    }
+
+    @Test func parse_negative_returnsNil() {
+        #expect(GoToLineParser.parse("-5") == nil)
+    }
+
+    @Test func parse_zeroColumn_returnsNil() {
+        #expect(GoToLineParser.parse("10:0") == nil)
+    }
+
+    @Test func parse_negativeColumn_returnsNil() {
+        #expect(GoToLineParser.parse("10:-3") == nil)
+    }
+
+    @Test func parse_tooManyParts_returnsNil() {
+        #expect(GoToLineParser.parse("1:2:3") == nil)
+    }
+
+    @Test func parse_nonNumericColumn_returnsNil() {
+        #expect(GoToLineParser.parse("10:abc") == nil)
+    }
+
+    @Test func parse_trailingColon_returnsNil() {
+        #expect(GoToLineParser.parse("10:") == nil)
+    }
+
+    @Test func parse_leadingColon_returnsNil() {
+        #expect(GoToLineParser.parse(":10") == nil)
+    }
+
+    @Test func parse_float_returnsNil() {
+        #expect(GoToLineParser.parse("10.5") == nil)
+    }
+
+    // MARK: - Notification name
+
+    @Test func goToLineNotificationName_isDefined() {
+        #expect(Notification.Name.goToLine.rawValue == "goToLine")
+    }
+
+    // MARK: - Menu icon
+
+    @Test func goToLineMenuIcon_existsAsSFSymbol() {
+        #expect(
+            NSImage(systemSymbolName: MenuIcons.goToLine, accessibilityDescription: nil) != nil,
+            "SF Symbol '\(MenuIcons.goToLine)' for Go to Line does not exist"
+        )
+    }
+
+    // MARK: - cursorOffset with column
+
+    @Test func cursorOffset_lineOnly() {
+        let content = "first\nsecond\nthird"
+        let offset = ContentView.cursorOffset(forLine: 2, in: content)
+        #expect(offset == 6) // "second" starts at index 6
+    }
+
+    @Test func cursorOffset_withColumn() {
+        let content = "first\nsecond\nthird"
+        let offset = ContentView.cursorOffset(forLine: 2, column: 4, in: content)
+        #expect(offset == 9) // index 6 + 3 (column 4 is 0-based offset 3)
+    }
+
+    @Test func cursorOffset_withColumn_one() {
+        let content = "first\nsecond\nthird"
+        let offset = ContentView.cursorOffset(forLine: 2, column: 1, in: content)
+        #expect(offset == 6) // column 1 = start of line
+    }
+
+    @Test func cursorOffset_withColumn_clampedToLineEnd() {
+        let content = "first\nsecond\nthird"
+        // "second" is 6 chars, column 100 should clamp
+        let offset = ContentView.cursorOffset(forLine: 2, column: 100, in: content)
+        #expect(offset == 12) // end of "second" (index 6 + 6)
+    }
+
+    @Test func cursorOffset_lastLine() {
+        let content = "first\nsecond\nthird"
+        let offset = ContentView.cursorOffset(forLine: 3, in: content)
+        #expect(offset == 13) // "third" starts at index 13
+    }
+
+    @Test func cursorOffset_beyondLastLine_clampsToEnd() {
+        let content = "first\nsecond\nthird"
+        let offset = ContentView.cursorOffset(forLine: 10, in: content)
+        #expect(offset == (content as NSString).length)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #418

- **GoToLineParser** — parses `"42"` (line) and `"42:10"` (line:column) formats with validation
- **GoToLineView** — compact sheet with text field, auto-focus, range hint, red border on invalid input
- **Menu item** — Edit → Go to Line (⌘L), disabled when no tab is open
- **Column support** — optional column navigation via `cursorOffset(forLine:column:in:)`
- **Localization** — all 9 languages (en, de, es, fr, ja, ko, pt-BR, ru, zh-Hans)

## Test plan

- [x] 25 unit tests: parser valid/invalid inputs, notification name, SF Symbol, cursor offset with column
- [ ] Manual: open file → Cmd+L → type line number → Enter → cursor jumps to line
- [ ] Manual: type `42:10` → cursor jumps to line 42, column 10
- [ ] Manual: type invalid input → red border, no navigation
- [ ] Manual: Escape dismisses the dialog
- [ ] Manual: menu item disabled when no file is open