### PR TITLE
ci: always run UI tests, remove conditional skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,28 +30,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  changes:
-    name: Detect Changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      ui: ${{ steps.filter.outputs.ui }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
-        id: filter
-        with:
-          filters: |
-            ui:
-              - 'Pine/**/*.swift'
-              - 'Pine.xcodeproj/**'
-              - 'PineUITests/**'
-              - 'Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/**'
-              - '.github/workflows/ci.yml'
-              - 'version.txt'
-
   lint:
     name: SwiftLint
     runs-on: ubuntu-latest
@@ -75,7 +53,6 @@ jobs:
   build:
     name: Build for Testing
     runs-on: macos-26
-    needs: changes
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -356,8 +333,6 @@ jobs:
   verify-ui-shards:
     name: Verify UI Test Shards
     runs-on: ubuntu-latest
-    needs: changes
-    if: ${{ needs.changes.outputs.ui == 'true' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -389,8 +364,7 @@ jobs:
   ui-tests:
     name: "UI Tests (${{ matrix.shard-name }})"
     runs-on: macos-26
-    needs: [build, changes]
-    if: ${{ needs.changes.outputs.ui == 'true' }}
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -480,8 +454,8 @@ jobs:
   flaky-summary:
     name: Flaky Test Summary
     runs-on: ubuntu-latest
-    needs: [ui-tests, changes]
-    if: always() && needs.changes.outputs.ui == 'true' && needs.ui-tests.result != 'cancelled'
+    needs: ui-tests
+    if: always() && needs.ui-tests.result != 'cancelled'
     steps:
       - name: Download Flaky Reports
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
## Summary

- Removed the `changes` job and `dorny/paths-filter` dependency
- UI tests (`ui-tests`, `verify-ui-shards`, `flaky-summary`) now run unconditionally on every PR
- Fixes branch protection deadlock when only non-UI files are modified (e.g. `Localizable.xcstrings`, docs)

## Test plan

- [ ] Verify CI runs all 6 UI test shards on this PR (even though only `ci.yml` changed)
- [ ] Verify branch protection checks all pass without `--admin` merge

Closes #436