### PR TITLE
fix: re-highlight syntax after external file changes

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -876,6 +876,7 @@ struct CodeEditorView: NSViewRepresentable {
             // full highlight. Only update caches that it doesn't handle.
             if isProgrammaticTextChange {
                 previousBracketRanges = []
+                highlightedCharRange = nil
                 reportStateChange()
                 lineStartsCache = LineStartsCache(text: textView.string)
                 scheduleFoldRecalculation()

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -709,6 +709,11 @@ struct CodeEditorView: NSViewRepresentable {
         /// Задержка дебаунсинга
         private let highlightDelay: TimeInterval = 0.05
 
+        /// True while `updateContentIfNeeded` is replacing text programmatically.
+        /// Prevents `textDidChange` from scheduling a competing debounced highlight
+        /// that would invalidate the full highlight started by `updateContentIfNeeded`.
+        private var isProgrammaticTextChange = false
+
         /// Диапазон символов, уже подсвеченных viewport-based подсветкой.
         /// Internal access — записывается из `applyViewportHighlighting` и `highlightOnScrollIfNeeded`.
         var highlightedCharRange: NSRange?
@@ -789,7 +794,9 @@ struct CodeEditorView: NSViewRepresentable {
             }
 
             if textChanged {
+                isProgrammaticTextChange = true
                 textView.string = text
+                isProgrammaticTextChange = false
             }
 
             if !parent.syntaxHighlightingDisabled, let storage = textView.textStorage {
@@ -863,6 +870,18 @@ struct CodeEditorView: NSViewRepresentable {
 
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
+
+            // When text was replaced programmatically by updateContentIfNeeded,
+            // skip highlight scheduling — updateContentIfNeeded handles its own
+            // full highlight. Only update caches that it doesn't handle.
+            if isProgrammaticTextChange {
+                previousBracketRanges = []
+                reportStateChange()
+                lineStartsCache = LineStartsCache(text: textView.string)
+                scheduleFoldRecalculation()
+                return
+            }
+
             // Mark that this change originated from the user typing,
             // so the upcoming updateNSView won't overwrite the text and reset the cursor.
             didChangeFromTextView = true

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -813,6 +813,13 @@ private struct GitAndNotificationObserver: ViewModifier {
                 let conflicts = tabManager.checkExternalChanges()
                 onHandleExternalConflicts(conflicts)
             }
+            .onChange(of: controlActiveState) { _, newState in
+                // When the window becomes key, check for external changes that
+                // may have been missed while the window was inactive (issue #438).
+                guard newState == .key else { return }
+                let conflicts = tabManager.checkExternalChanges()
+                onHandleExternalConflicts(conflicts)
+            }
             .onReceive(NotificationCenter.default.publisher(for: .showProjectSearch)) { _ in
                 columnVisibility = .all
                 isSearchPresented = true

--- a/PineTests/TabManagerTests.swift
+++ b/PineTests/TabManagerTests.swift
@@ -1296,4 +1296,71 @@ struct TabManagerTests {
         #expect(manager.isAutoSaving == false)
         #expect(manager.activeTab?.isDirty == false)
     }
+
+    // MARK: - External change detection (issue #438)
+
+    @Test("checkExternalChanges silently reloads clean tab when file changes on disk")
+    func checkExternalChangesReloadsCleanTab() throws {
+        let manager = TabManager()
+        let url = tempFileURL(content: "original content")
+
+        manager.openTab(url: url)
+        #expect(manager.activeTab?.content == "original content")
+
+        let versionBefore = manager.activeTab?.contentVersion ?? 0
+
+        // Simulate external change: write new content and advance modification date
+        try "updated by external tool".write(to: url, atomically: true, encoding: .utf8)
+        // Ensure mod date is newer by touching with a future date
+        let futureDate = Date().addingTimeInterval(2)
+        try FileManager.default.setAttributes(
+            [.modificationDate: futureDate], ofItemAtPath: url.path
+        )
+
+        let conflicts = manager.checkExternalChanges()
+
+        #expect(conflicts.isEmpty)
+        #expect(manager.activeTab?.content == "updated by external tool")
+        #expect(manager.activeTab?.savedContent == "updated by external tool")
+        // contentVersion must increment so CodeEditorView picks up the change
+        #expect(manager.activeTab?.contentVersion ?? 0 > versionBefore)
+    }
+
+    @Test("checkExternalChanges returns conflict for dirty tab")
+    func checkExternalChangesConflictForDirtyTab() throws {
+        let manager = TabManager()
+        let url = tempFileURL(content: "original")
+
+        manager.openTab(url: url)
+        manager.updateContent("user edits")
+
+        // Simulate external change
+        try "external edit".write(to: url, atomically: true, encoding: .utf8)
+        let futureDate = Date().addingTimeInterval(2)
+        try FileManager.default.setAttributes(
+            [.modificationDate: futureDate], ofItemAtPath: url.path
+        )
+
+        let conflicts = manager.checkExternalChanges()
+
+        #expect(conflicts.count == 1)
+        #expect(conflicts.first?.kind == .modified)
+        // Content should NOT be overwritten — user has unsaved changes
+        #expect(manager.activeTab?.content == "user edits")
+    }
+
+    @Test("reloadTab updates content and increments contentVersion")
+    func reloadTabUpdatesContentVersion() throws {
+        let manager = TabManager()
+        let url = tempFileURL(content: "v1")
+
+        manager.openTab(url: url)
+        let versionBefore = manager.activeTab?.contentVersion ?? 0
+
+        try "v2".write(to: url, atomically: true, encoding: .utf8)
+        manager.reloadTab(url: url)
+
+        #expect(manager.activeTab?.content == "v2")
+        #expect(manager.activeTab?.contentVersion ?? 0 > versionBefore)
+    }
 }


### PR DESCRIPTION
Closes #438

## Summary
- **Race condition fix**: When `updateContentIfNeeded()` replaced text via `textView.string = text`, the synchronous `textDidChange()` callback scheduled a debounced highlight that incremented the generation token — causing the full highlight from `updateContentIfNeeded()` to discard its results. Added `isProgrammaticTextChange` flag so `textDidChange()` skips highlight scheduling for programmatic replacements.
- **Window activation fix**: `onChange(of: externalChangeToken)` returned early when the window was not key, but there was no re-check when the window became active again. Added `onChange(of: controlActiveState)` to run `checkExternalChanges()` when the window becomes key.
- **Tests**: Added 3 unit tests for external change detection in `TabManagerTests` (clean tab reload, dirty tab conflict, contentVersion increment on reload).

## Test plan
- [x] Unit tests: `PineTests/TabManagerTests` — 75 tests pass
- [ ] Manual: open a file in Pine, modify it externally (e.g. via terminal `echo "new" > file.swift`), verify syntax highlighting updates immediately
- [ ] Manual: switch to another app, modify the file externally, switch back to Pine — verify content and highlighting update on window focus