### PR TITLE
fix: editor tab bar overflows without scroll or collapse when many tabs open

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -27,6 +27,7 @@ enum AccessibilityID {
     static let lineNumberGutter = "lineNumberGutter"
     static let minimap = "minimap"
     static let autoSaveIndicator = "autoSaveIndicator"
+    static let editorTabOverflowMenu = "editorTabOverflowMenu"
     static let quickLookPreview = "quickLookPreview"
 
     // MARK: - Terminal

--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -43,7 +43,7 @@ struct EditorTabBar: View {
     /// Computes tab widths: active tab stays at full width, inactive tabs share the rest.
     static func inactiveTabWidth(availableWidth: CGFloat, tabCount: Int) -> CGFloat {
         guard tabCount > 1 else { return maxTabWidth }
-        let totalPadding: CGFloat = 8 // 4pt padding on each side of HStack
+        let totalPadding: CGFloat = 12 // 4pt leading + 8pt trailing
         let totalSpacing = CGFloat(max(tabCount - 1, 0)) * 2 // 2pt spacing between tabs
         let usable = availableWidth - totalPadding - totalSpacing - maxTabWidth // reserve space for active tab
         let inactiveCount = CGFloat(tabCount - 1)

--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -27,6 +27,11 @@ struct EditorTabBar: View {
 
     @State private var draggingTabID: UUID?
 
+    /// Minimum tab width before scrolling kicks in.
+    static let minTabWidth: CGFloat = 80
+    /// Maximum tab width when there is plenty of space.
+    static let maxTabWidth: CGFloat = 180
+
     private var previewIcon: String {
         switch previewMode {
         case .source: "doc.plaintext"
@@ -35,33 +40,96 @@ struct EditorTabBar: View {
         }
     }
 
+    /// Computes tab widths: active tab stays at full width, inactive tabs share the rest.
+    static func inactiveTabWidth(availableWidth: CGFloat, tabCount: Int) -> CGFloat {
+        guard tabCount > 1 else { return maxTabWidth }
+        let totalPadding: CGFloat = 8 // 4pt padding on each side of HStack
+        let totalSpacing = CGFloat(max(tabCount - 1, 0)) * 2 // 2pt spacing between tabs
+        let usable = availableWidth - totalPadding - totalSpacing - maxTabWidth // reserve space for active tab
+        let inactiveCount = CGFloat(tabCount - 1)
+        let perTab = usable / inactiveCount
+        return min(max(perTab, minTabWidth), maxTabWidth)
+    }
+
     var body: some View {
-        HStack(spacing: 0) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 2) {
-                    ForEach(tabManager.tabs) { tab in
-                        EditorTabItem(
-                            tab: tab,
-                            isActive: tab.id == tabManager.activeTabID,
-                            onSelect: { tabManager.activeTabID = tab.id },
-                            onClose: { onCloseTab(tab) }
-                        )
-                        .onDrag {
-                            draggingTabID = tab.id
-                            return NSItemProvider(object: tab.id.uuidString as NSString)
+        HStack(alignment: .center, spacing: 0) {
+            GeometryReader { geometry in
+                ScrollViewReader { proxy in
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 2) {
+                            let inactiveWidth = Self.inactiveTabWidth(
+                                availableWidth: geometry.size.width,
+                                tabCount: tabManager.tabs.count
+                            )
+                            ForEach(tabManager.tabs) { tab in
+                                let isActive = tab.id == tabManager.activeTabID
+                                EditorTabItem(
+                                    tab: tab,
+                                    isActive: isActive,
+                                    onSelect: { tabManager.activeTabID = tab.id },
+                                    onClose: { onCloseTab(tab) }
+                                )
+                                .frame(maxWidth: isActive ? Self.maxTabWidth : inactiveWidth)
+                                .id(tab.id)
+                                .onDrag {
+                                    draggingTabID = tab.id
+                                    return NSItemProvider(object: tab.id.uuidString as NSString)
+                                }
+                                .onDrop(of: [.text], delegate: TabDropDelegate(
+                                    tabManager: tabManager,
+                                    targetTabID: tab.id,
+                                    draggingTabID: $draggingTabID,
+                                    onReorder: onReorder
+                                ))
+                            }
                         }
-                        .onDrop(of: [.text], delegate: TabDropDelegate(
-                            tabManager: tabManager,
-                            targetTabID: tab.id,
-                            draggingTabID: $draggingTabID,
-                            onReorder: onReorder
-                        ))
+                        .padding(.leading, 4)
+                        .padding(.trailing, 8)
+                    }
+                    .frame(maxHeight: .infinity, alignment: .center)
+                    .onAppear {
+                        if let activeID = tabManager.activeTabID {
+                            proxy.scrollTo(activeID, anchor: .center)
+                        }
+                    }
+                    .onChange(of: tabManager.activeTabID) {
+                        guard let activeID = tabManager.activeTabID else { return }
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            proxy.scrollTo(activeID, anchor: .center)
+                        }
                     }
                 }
-                .padding(.horizontal, 4)
             }
 
-            Spacer()
+            // Overflow menu — quick access to all open tabs
+            if tabManager.tabs.count > 1 {
+                Menu {
+                    ForEach(tabManager.tabs) { tab in
+                        Button {
+                            tabManager.activeTabID = tab.id
+                        } label: {
+                            Label {
+                                Text(tab.fileName)
+                                    + Text(tab.isDirty ? " ●" : "")
+                            } icon: {
+                                Image(systemName: FileIconMapper.iconForFile(tab.fileName))
+                            }
+                        }
+                        .disabled(tab.id == tabManager.activeTabID)
+                    }
+                } label: {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 24, height: 24)
+                        .contentShape(Rectangle())
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .frame(width: 24, height: 30)
+                .accessibilityIdentifier(AccessibilityID.editorTabOverflowMenu)
+            }
 
             Group {
                 if isAutoSaving {
@@ -165,6 +233,7 @@ struct EditorTabItem: View {
             Text(tab.fileName)
                 .font(.system(size: 11))
                 .lineLimit(1)
+                .truncationMode(.middle)
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 4)

--- a/PineTests/EditorTabBarTests.swift
+++ b/PineTests/EditorTabBarTests.swift
@@ -1,0 +1,86 @@
+//
+//  EditorTabBarTests.swift
+//  PineTests
+//
+//  Tests for EditorTabBar tab width calculation and overflow behavior.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("EditorTabBar Tab Width Tests")
+struct EditorTabBarTests {
+
+    // MARK: - inactiveTabWidth calculation
+
+    @Test("Returns maxTabWidth when plenty of space for few tabs")
+    func maxWidthWhenPlentyOfSpace() {
+        let width = EditorTabBar.inactiveTabWidth(availableWidth: 1000, tabCount: 3)
+        #expect(width == EditorTabBar.maxTabWidth)
+    }
+
+    @Test("Returns minTabWidth when extremely narrow")
+    func minWidthWhenVeryNarrow() {
+        let width = EditorTabBar.inactiveTabWidth(availableWidth: 200, tabCount: 10)
+        #expect(width == EditorTabBar.minTabWidth)
+    }
+
+    @Test("Returns maxTabWidth for single tab (no inactive tabs)")
+    func maxWidthForSingleTab() {
+        let width = EditorTabBar.inactiveTabWidth(availableWidth: 500, tabCount: 1)
+        #expect(width == EditorTabBar.maxTabWidth)
+    }
+
+    @Test("Inactive tabs shrink as tab count increases")
+    func tabsShrinkWithCount() {
+        let width3 = EditorTabBar.inactiveTabWidth(availableWidth: 800, tabCount: 3)
+        let width10 = EditorTabBar.inactiveTabWidth(availableWidth: 800, tabCount: 10)
+        #expect(width3 > width10)
+    }
+
+    @Test("Inactive tab width never exceeds maxTabWidth")
+    func neverExceedsMax() {
+        let width = EditorTabBar.inactiveTabWidth(availableWidth: 10000, tabCount: 2)
+        #expect(width <= EditorTabBar.maxTabWidth)
+    }
+
+    @Test("Inactive tab width never goes below minTabWidth")
+    func neverBelowMin() {
+        let width = EditorTabBar.inactiveTabWidth(availableWidth: 50, tabCount: 100)
+        #expect(width >= EditorTabBar.minTabWidth)
+    }
+
+    @Test("Active tab space is reserved from available width")
+    func activeTabSpaceReserved() {
+        // 3 tabs in 600px: usable = 600 - 8(padding) - 4(spacing) - 180(active) = 408, perTab = 204 → clamped to 180
+        let width = EditorTabBar.inactiveTabWidth(availableWidth: 600, tabCount: 3)
+        #expect(width == EditorTabBar.maxTabWidth)
+
+        // 6 tabs in 600px: usable = 600 - 8 - 10 - 180 = 402, perTab = 80.4
+        let width6 = EditorTabBar.inactiveTabWidth(availableWidth: 600, tabCount: 6)
+        #expect(width6 > EditorTabBar.minTabWidth)
+        #expect(width6 < EditorTabBar.maxTabWidth)
+    }
+
+    @Test("Two tabs both get maxTabWidth in wide space")
+    func twoTabsWideSpace() {
+        // 2 tabs in 500px: usable = 500 - 8 - 2 - 180 = 310, perTab = 310 → clamped to 180
+        let width = EditorTabBar.inactiveTabWidth(availableWidth: 500, tabCount: 2)
+        #expect(width == EditorTabBar.maxTabWidth)
+    }
+
+    @Test("Inactive tabs get intermediate width between min and max")
+    func intermediateWidth() {
+        // 10 tabs in 900px: usable = 900 - 8 - 18 - 180 = 694, perTab = 77.1 → clamped to 80
+        let width = EditorTabBar.inactiveTabWidth(availableWidth: 1000, tabCount: 10)
+        #expect(width >= EditorTabBar.minTabWidth)
+    }
+
+    @Test("Many tabs in narrow space all clamp to minTabWidth")
+    func manyTabsNarrowSpace() {
+        let width = EditorTabBar.inactiveTabWidth(availableWidth: 400, tabCount: 20)
+        #expect(width == EditorTabBar.minTabWidth)
+    }
+}

--- a/PineTests/EditorTabBarTests.swift
+++ b/PineTests/EditorTabBarTests.swift
@@ -54,12 +54,12 @@ struct EditorTabBarTests {
 
     @Test("Active tab space is reserved from available width")
     func activeTabSpaceReserved() {
-        // 3 tabs in 600px: usable = 600 - 8(padding) - 4(spacing) - 180(active) = 408, perTab = 204 → clamped to 180
+        // 3 tabs in 600px: usable = 600 - 12(padding) - 4(spacing) - 180(active) = 404, perTab = 202 → clamped to 180
         let width = EditorTabBar.inactiveTabWidth(availableWidth: 600, tabCount: 3)
         #expect(width == EditorTabBar.maxTabWidth)
 
-        // 6 tabs in 600px: usable = 600 - 8 - 10 - 180 = 402, perTab = 80.4
-        let width6 = EditorTabBar.inactiveTabWidth(availableWidth: 600, tabCount: 6)
+        // 6 tabs in 700px: usable = 700 - 12 - 10 - 180 = 498, perTab = 99.6
+        let width6 = EditorTabBar.inactiveTabWidth(availableWidth: 700, tabCount: 6)
         #expect(width6 > EditorTabBar.minTabWidth)
         #expect(width6 < EditorTabBar.maxTabWidth)
     }


### PR DESCRIPTION
## Summary

- **Tab shrinking**: inactive tabs shrink proportionally (180pt → 80pt min) while the active tab stays at full width for readability
- **Horizontal scroll**: trackpad/scroll wheel navigates overflowing tabs
- **Auto-scroll**: tab bar scrolls to the active tab on switch (Cmd+P, sidebar click, `.onAppear` for restored sessions)
- **Overflow menu**: chevron dropdown at the right edge lists all open tabs with file icons and dirty indicators (●)
- **Truncation**: long filenames use middle ellipsis (`Foo…bar.swift`)

## Test plan

- [x] Unit tests for `inactiveTabWidth()` — 10 tests covering boundaries, clamping, proportional shrinking
- [x] Open 8+ files — tabs shrink, active tab stays full width
- [x] Switch tabs via Cmd+P / sidebar — tab bar auto-scrolls to active tab
- [x] Click chevron (▾) — dropdown shows all tabs, active tab is dimmed
- [x] Restore a session with many tabs — active tab is visible on launch
- [x] Drag-to-reorder still works with shrunken tabs
- [x] Markdown preview toggle and auto-save indicator still visible

Closes #452