### PR TITLE
fix: show correct file content when switching editor tabs

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -594,6 +594,7 @@ struct ContentView: View {
             goToOffset: goToLineOffset,
             fontSize: FontSizeSettings.shared.fontSize
         )
+        .id(tab.id)
         .accessibilityIdentifier(AccessibilityID.codeEditor)
         .onAppear { goToLineOffset = nil }
     }


### PR DESCRIPTION
## Summary
- Add `.id(tab.id)` to `CodeEditorView` so SwiftUI creates a fresh NSViewRepresentable for each tab switch instead of reusing the stale one

Closes #455

## Root cause
Without `.id()`, SwiftUI reused the same `CodeEditorView` instance across tab switches, calling `updateNSView()` on the old Coordinator. The Coordinator's NSTextView reference kept showing the previous file's content while tab title, status bar, and sidebar updated correctly.

## Test plan
- [x] Build succeeds (`xcodebuild build`)
- [x] SwiftLint: 0 violations
- [x] `CodeEditorCoordinatorTests` pass (7/7) — covers content update, cursor restoration, tab switching, empty files, and cursor clamping
- [x] Manual: open a project → open 3+ files in tabs → switch between tabs → verify each tab shows correct file content, minimap, and syntax highlighting