### PR TITLE
fix: replace force cast with safe cast and add defer for FileHandle (#461)

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -1535,9 +1535,9 @@ struct CodeEditorView: NSViewRepresentable {
 
 // MARK: - NSImage tinting
 
-private extension NSImage {
+extension NSImage {
     func tinted(with color: NSColor) -> NSImage {
-        let image = copy() as! NSImage // swiftlint:disable:this force_cast
+        guard let image = copy() as? NSImage else { return self }
         image.lockFocus()
         color.set()
         NSRect(origin: .zero, size: size).fill(using: .sourceAtop)

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -137,8 +137,8 @@ final class TabManager {
         let content: String
         do {
             let handle = try FileHandle(forReadingFrom: url)
+            defer { handle.closeFile() }
             let partialData = handle.readData(ofLength: Self.hugeFilePartialLoadSize)
-            handle.closeFile()
             let (decoded, _) = String.Encoding.detect(from: partialData)
             let sizeString = ByteCountFormatter.string(
                 fromByteCount: Int64(totalSize), countStyle: .file

--- a/PineTests/NSImageTintingTests.swift
+++ b/PineTests/NSImageTintingTests.swift
@@ -1,0 +1,50 @@
+//
+//  NSImageTintingTests.swift
+//  PineTests
+//
+
+import AppKit
+import Testing
+
+@testable import Pine
+
+@Suite("NSImage Tinting Tests")
+struct NSImageTintingTests {
+
+    @Test("tinted(with:) returns an image of the same size")
+    func tintedReturnsSameSize() {
+        let original = NSImage(size: NSSize(width: 16, height: 16))
+        let tinted = original.tinted(with: .red)
+
+        #expect(tinted.size == original.size)
+    }
+
+    @Test("tinted(with:) returns a non-template image")
+    func tintedReturnsNonTemplate() {
+        let original = NSImage(size: NSSize(width: 16, height: 16))
+        original.isTemplate = true
+
+        let tinted = original.tinted(with: .blue)
+
+        #expect(tinted.isTemplate == false)
+    }
+
+    @Test("tinted(with:) returns a distinct copy, not the original")
+    func tintedReturnsDistinctCopy() {
+        let original = NSImage(size: NSSize(width: 16, height: 16))
+        let tinted = original.tinted(with: .green)
+
+        #expect(tinted !== original)
+    }
+
+    @Test("tinted(with:) safe cast does not crash on valid NSImage")
+    func tintedSafeCastSucceeds() {
+        // This test verifies the guard-let (as?) path works for normal images.
+        // Before the fix, this used force cast (as!) which could crash.
+        let original = NSImage(size: NSSize(width: 8, height: 8))
+        let tinted = original.tinted(with: .systemPink)
+
+        #expect(tinted.size.width == 8)
+        #expect(tinted.size.height == 8)
+    }
+}

--- a/PineTests/NSImageTintingTests.swift
+++ b/PineTests/NSImageTintingTests.swift
@@ -37,14 +37,11 @@ struct NSImageTintingTests {
         #expect(tinted !== original)
     }
 
-    @Test("tinted(with:) safe cast does not crash on valid NSImage")
-    func tintedSafeCastSucceeds() {
-        // This test verifies the guard-let (as?) path works for normal images.
-        // Before the fix, this used force cast (as!) which could crash.
+    @Test("tinted(with:) produces image with at least one representation")
+    func tintedHasRepresentations() {
         let original = NSImage(size: NSSize(width: 8, height: 8))
         let tinted = original.tinted(with: .systemPink)
 
-        #expect(tinted.size.width == 8)
-        #expect(tinted.size.height == 8)
+        #expect(!tinted.representations.isEmpty)
     }
 }

--- a/PineTests/TabManagerTests.swift
+++ b/PineTests/TabManagerTests.swift
@@ -1519,6 +1519,7 @@ struct TabManagerTests {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
         let url = dir.appendingPathComponent("huge.log")
 
         // Create a file at the huge threshold (10 MB)

--- a/PineTests/TabManagerTests.swift
+++ b/PineTests/TabManagerTests.swift
@@ -1510,4 +1510,30 @@ struct TabManagerTests {
         #expect(manager.activeTab?.content == "v2")
         #expect(manager.activeTab?.contentVersion ?? 0 > versionBefore)
     }
+
+    // MARK: - Huge file FileHandle safety (#461)
+
+    @Test("Opening huge file closes FileHandle via defer and produces truncated tab")
+    func openHugeFileClosesHandleSafely() throws {
+        let manager = TabManager()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("huge.log")
+
+        // Create a file at the huge threshold (10 MB)
+        let data = Data(count: TabManager.hugeFileThreshold)
+        try data.write(to: url)
+
+        manager.openTab(url: url)
+
+        let tab = manager.activeTab
+        #expect(tab != nil)
+        #expect(tab?.isTruncated == true)
+        #expect(tab?.syntaxHighlightingDisabled == true)
+        // File descriptor should be closed (defer ensures this).
+        // Verify we can still open the file — no leaked exclusive lock.
+        let handle = try FileHandle(forReadingFrom: url)
+        handle.closeFile()
+    }
 }


### PR DESCRIPTION
## Summary
- **CodeEditorView.swift:1540** — replaced `copy() as! NSImage` force cast with `as?` + `guard` to prevent crash if `copy()` returns an unexpected type
- **TabManager.swift:139** — wrapped `FileHandle.closeFile()` in `defer` block to prevent file descriptor leak if `readData(ofLength:)` throws before reaching `closeFile()`
- Changed `NSImage.tinted(with:)` visibility from `private` to `internal` for testability

## Test plan
- [x] Added `NSImageTintingTests` (4 tests): size preservation, non-template flag, distinct copy, safe cast success
- [x] Added `TabManagerTests/openHugeFileClosesHandleSafely`: verifies huge file opens as truncated tab and FileHandle is properly closed
- [x] All 5 new tests pass locally

Closes #461