### PR TITLE
fix: scope NotificationCenter observers to specific scroll views

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -502,7 +502,7 @@ struct CodeEditorView: NSViewRepresentable {
         layoutManager.delegate = context.coordinator
 
         // ── Номера строк — поверх scroll view, как отдельный сиблинг ──
-        let lineNumberView = LineNumberView(textView: textView)
+        let lineNumberView = LineNumberView(textView: textView, clipView: scrollView.contentView)
         lineNumberView.gutterWidth = gutterWidth
         lineNumberView.gutterFont = gutterFont
         lineNumberView.editorFont = editorFont
@@ -514,7 +514,7 @@ struct CodeEditorView: NSViewRepresentable {
         container.addSubview(lineNumberView)
 
         // ── Minimap — справа от scroll view ──
-        let minimapView = MinimapView(textView: textView)
+        let minimapView = MinimapView(textView: textView, clipView: scrollView.contentView)
         minimapView.isHidden = !isMinimapVisible
         container.addSubview(minimapView)
 

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -67,8 +67,10 @@ final class LineNumberView: NSView {
         foldStartMap = Dictionary(foldableRanges.map { ($0.startLine, $0) }, uniquingKeysWith: { _, last in last })
     }
 
-    /// Counter for bounds-change notifications received — internal for testability.
+    #if DEBUG
+    /// Counter for bounds-change notifications received — debug-only, for testability.
     var boundsChangeCount = 0
+    #endif
 
     /// Cached total line count — updated on text change, not on every draw.
     private var cachedTotalLines = 1
@@ -116,7 +118,7 @@ final class LineNumberView: NSView {
 
         #if DEBUG
         if resolvedClipView == nil {
-            print("⚠️ LineNumberView: clipView is nil at init — scroll observer will not fire. Pass clipView explicitly.")
+            print("LineNumberView: clipView is nil at init — scroll observer will not fire. Pass clipView explicitly.")
         }
         #endif
     }
@@ -212,7 +214,11 @@ final class LineNumberView: NSView {
     }
 
     @objc private func handleBoundsChange(_ notification: Notification) {
+        // Safety: if clipView was nil at init, subscription is unscoped — filter here
+        guard observedClipView == nil || notification.object as AnyObject? === observedClipView else { return }
+        #if DEBUG
         boundsChangeCount += 1
+        #endif
         needsDisplay = true
     }
 

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -11,6 +11,9 @@ import AppKit
 /// Добавляется как subview NSScrollView и остаётся на месте при скролле.
 final class LineNumberView: NSView {
     weak var textView: NSTextView?
+    /// The clip view this gutter observes for scroll notifications.
+    /// Stored explicitly to avoid relying on enclosingScrollView at notification time.
+    private weak var observedClipView: NSClipView?
 
     var gutterFont = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
     var editorFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
@@ -64,6 +67,9 @@ final class LineNumberView: NSView {
         foldStartMap = Dictionary(foldableRanges.map { ($0.startLine, $0) }, uniquingKeysWith: { _, last in last })
     }
 
+    /// Counter for bounds-change notifications received — internal for testability.
+    var boundsChangeCount = 0
+
     /// Cached total line count — updated on text change, not on every draw.
     private var cachedTotalLines = 1
 
@@ -82,17 +88,19 @@ final class LineNumberView: NSView {
 
     override var isFlipped: Bool { true }
 
-    init(textView: NSTextView) {
+    init(textView: NSTextView, clipView: NSClipView? = nil) {
         self.textView = textView
+        let resolvedClipView = clipView ?? textView.enclosingScrollView?.contentView
+        self.observedClipView = resolvedClipView
         super.init(frame: .zero)
         setAccessibilityElement(true)
         setAccessibilityIdentifier(AccessibilityID.lineNumberGutter)
 
-        // Скролл — подписываемся без object, чтобы не зависеть от конкретного clipView
+        // Скролл — подписываемся на конкретный clipView (#465)
         NotificationCenter.default.addObserver(
             self, selector: #selector(handleBoundsChange(_:)),
             name: NSView.boundsDidChangeNotification,
-            object: nil
+            object: resolvedClipView
         )
         // Изменение текста/фрейма
         NotificationCenter.default.addObserver(
@@ -105,6 +113,12 @@ final class LineNumberView: NSView {
             name: NSView.frameDidChangeNotification,
             object: textView
         )
+
+        #if DEBUG
+        if resolvedClipView == nil {
+            print("⚠️ LineNumberView: clipView is nil at init — scroll observer will not fire. Pass clipView explicitly.")
+        }
+        #endif
     }
 
     override func viewDidMoveToWindow() {
@@ -198,9 +212,7 @@ final class LineNumberView: NSView {
     }
 
     @objc private func handleBoundsChange(_ notification: Notification) {
-        // Реагируем только на скролл нашего scroll view
-        guard let clipView = notification.object as? NSClipView,
-              clipView == textView?.enclosingScrollView?.contentView else { return }
+        boundsChangeCount += 1
         needsDisplay = true
     }
 

--- a/Pine/MinimapView.swift
+++ b/Pine/MinimapView.swift
@@ -37,6 +37,8 @@ enum MinimapSettings {
 /// the currently visible region. Supports click-to-scroll and drag-to-scroll.
 final class MinimapView: NSView {
     weak var textView: NSTextView?
+    /// The clip view this minimap observes for scroll notifications.
+    private weak var observedClipView: NSClipView?
 
     /// Git diff data — when set, colored markers appear on the right edge.
     var lineDiffs: [GitLineDiff] = [] {
@@ -93,13 +95,18 @@ final class MinimapView: NSView {
         }
     }
 
+    /// Counter for scroll-change notifications received — internal for testability.
+    var scrollChangeCount = 0
+
     /// Whether user is currently dragging in the minimap.
     private var isDragging = false
 
     override var isFlipped: Bool { true }
 
-    init(textView: NSTextView) {
+    init(textView: NSTextView, clipView: NSClipView? = nil) {
         self.textView = textView
+        let resolvedClipView = clipView ?? textView.enclosingScrollView?.contentView
+        self.observedClipView = resolvedClipView
         super.init(frame: .zero)
         wantsLayer = true
         setAccessibilityIdentifier(AccessibilityID.minimap)
@@ -118,11 +125,18 @@ final class MinimapView: NSView {
             name: NSView.frameDidChangeNotification,
             object: textView
         )
+        // Скролл — подписываемся на конкретный clipView (#465)
         NotificationCenter.default.addObserver(
             self, selector: #selector(scrollDidChange(_:)),
             name: NSView.boundsDidChangeNotification,
-            object: nil
+            object: resolvedClipView
         )
+
+        #if DEBUG
+        if resolvedClipView == nil {
+            print("⚠️ MinimapView: clipView is nil at init — scroll observer will not fire. Pass clipView explicitly.")
+        }
+        #endif
     }
 
     @available(*, unavailable)
@@ -157,9 +171,7 @@ final class MinimapView: NSView {
     }
 
     @objc private func scrollDidChange(_ notification: Notification) {
-        guard let clipView = notification.object as? NSClipView,
-              clipView == textView?.enclosingScrollView?.contentView else { return }
-
+        scrollChangeCount += 1
         let now = CACurrentMediaTime()
         if now - lastScrollRedrawTime >= Self.scrollThrottleInterval {
             lastScrollRedrawTime = now

--- a/Pine/MinimapView.swift
+++ b/Pine/MinimapView.swift
@@ -95,8 +95,10 @@ final class MinimapView: NSView {
         }
     }
 
-    /// Counter for scroll-change notifications received — internal for testability.
+    #if DEBUG
+    /// Counter for scroll-change notifications received — debug-only, for testability.
     var scrollChangeCount = 0
+    #endif
 
     /// Whether user is currently dragging in the minimap.
     private var isDragging = false
@@ -134,7 +136,7 @@ final class MinimapView: NSView {
 
         #if DEBUG
         if resolvedClipView == nil {
-            print("⚠️ MinimapView: clipView is nil at init — scroll observer will not fire. Pass clipView explicitly.")
+            print("MinimapView: clipView is nil at init — scroll observer will not fire. Pass clipView explicitly.")
         }
         #endif
     }
@@ -171,7 +173,11 @@ final class MinimapView: NSView {
     }
 
     @objc private func scrollDidChange(_ notification: Notification) {
+        // Safety: if clipView was nil at init, subscription is unscoped — filter here
+        guard observedClipView == nil || notification.object as AnyObject? === observedClipView else { return }
+        #if DEBUG
         scrollChangeCount += 1
+        #endif
         let now = CACurrentMediaTime()
         if now - lastScrollRedrawTime >= Self.scrollThrottleInterval {
             lastScrollRedrawTime = now

--- a/PineTests/NotificationObserverScopingTests.swift
+++ b/PineTests/NotificationObserverScopingTests.swift
@@ -1,0 +1,278 @@
+//
+//  NotificationObserverScopingTests.swift
+//  PineTests
+//
+//  Tests for issue #465: NotificationCenter observers must be scoped
+//  to specific scroll views, not object: nil.
+//
+
+import Testing
+import AppKit
+import SwiftUI
+@testable import Pine
+
+@Suite("NotificationCenter Observer Scoping")
+struct NotificationObserverScopingTests {
+
+    // MARK: - Helpers
+
+    /// Creates a full text stack: NSTextStorage → NSLayoutManager → NSTextContainer → NSTextView → NSScrollView.
+    private func makeTextStack(text: String = "line1\nline2\nline3") -> (NSScrollView, NSTextView) {
+        let textStorage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        )
+        layoutManager.addTextContainer(textContainer)
+        let textView = NSTextView(
+            frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+            textContainer: textContainer
+        )
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 500, height: 500))
+        scrollView.documentView = textView
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        return (scrollView, textView)
+    }
+
+    // MARK: - LineNumberView observer scoping
+
+    @Test("LineNumberView ignores boundsDidChange from unrelated clipView")
+    func lineNumberViewIgnoresUnrelatedClipView() {
+        let (scrollView, textView) = makeTextStack()
+        let lineNumberView = LineNumberView(textView: textView, clipView: scrollView.contentView)
+
+        let initialCount = lineNumberView.boundsChangeCount
+
+        // Create a completely unrelated scroll view
+        let foreignScrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 200, height: 200))
+        foreignScrollView.documentView = NSTextView()
+
+        // Post boundsDidChange from the foreign clipView
+        NotificationCenter.default.post(
+            name: NSView.boundsDidChangeNotification,
+            object: foreignScrollView.contentView
+        )
+
+        #expect(lineNumberView.boundsChangeCount == initialCount,
+                "LineNumberView must not react to notifications from unrelated scroll views")
+    }
+
+    @Test("LineNumberView reacts to boundsDidChange from its own clipView")
+    func lineNumberViewReactsToOwnClipView() {
+        let (scrollView, textView) = makeTextStack()
+        let lineNumberView = LineNumberView(textView: textView, clipView: scrollView.contentView)
+
+        let initialCount = lineNumberView.boundsChangeCount
+
+        // Post boundsDidChange from the correct clipView
+        NotificationCenter.default.post(
+            name: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView
+        )
+
+        #expect(lineNumberView.boundsChangeCount == initialCount + 1,
+                "LineNumberView must react when its own scroll view scrolls")
+    }
+
+    // MARK: - MinimapView observer scoping
+
+    @Test("MinimapView ignores boundsDidChange from unrelated clipView")
+    func minimapViewIgnoresUnrelatedClipView() {
+        let (scrollView, textView) = makeTextStack()
+        let minimapView = MinimapView(textView: textView, clipView: scrollView.contentView)
+
+        let initialCount = minimapView.scrollChangeCount
+
+        // Create a foreign scroll view
+        let foreignScrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 200, height: 200))
+        foreignScrollView.documentView = NSTextView()
+
+        // Post from foreign clipView
+        NotificationCenter.default.post(
+            name: NSView.boundsDidChangeNotification,
+            object: foreignScrollView.contentView
+        )
+
+        #expect(minimapView.scrollChangeCount == initialCount,
+                "MinimapView must not react to notifications from unrelated scroll views")
+    }
+
+    @Test("MinimapView reacts to boundsDidChange from its own clipView")
+    func minimapViewReactsToOwnClipView() {
+        let (scrollView, textView) = makeTextStack()
+        let minimapView = MinimapView(textView: textView, clipView: scrollView.contentView)
+
+        let initialCount = minimapView.scrollChangeCount
+
+        NotificationCenter.default.post(
+            name: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView
+        )
+
+        #expect(minimapView.scrollChangeCount == initialCount + 1,
+                "MinimapView must react when its own scroll view scrolls")
+    }
+
+    // MARK: - Deinit / retain cycle tests
+
+    @Test("LineNumberView deinit is called — no retain cycles")
+    func lineNumberViewDeinitCalled() {
+        weak var weakView: LineNumberView?
+        autoreleasepool {
+            let (scrollView, textView) = makeTextStack()
+            let view = LineNumberView(textView: textView, clipView: scrollView.contentView)
+            weakView = view
+        }
+
+        #expect(weakView == nil,
+                "LineNumberView must be deallocated — no retain cycles from NotificationCenter observers")
+    }
+
+    @Test("MinimapView deinit is called — no retain cycles")
+    func minimapViewDeinitCalled() {
+        weak var weakView: MinimapView?
+        autoreleasepool {
+            let (scrollView, textView) = makeTextStack()
+            let view = MinimapView(textView: textView, clipView: scrollView.contentView)
+            weakView = view
+            _ = view
+        }
+
+        #expect(weakView == nil,
+                "MinimapView must be deallocated — no retain cycles from NotificationCenter observers")
+    }
+
+    @Test("CodeEditorView.Coordinator deinit is called — no retain cycles")
+    func coordinatorDeinitCalled() {
+        weak var weakCoordinator: CodeEditorView.Coordinator?
+        autoreleasepool {
+            let editorView = CodeEditorView(
+                text: .constant("hello"),
+                contentVersion: 0,
+                language: "txt",
+                fileName: "test.txt",
+                foldState: .constant(FoldState())
+            )
+            let coordinator = CodeEditorView.Coordinator(parent: editorView)
+            weakCoordinator = coordinator
+            _ = coordinator
+        }
+
+        #expect(weakCoordinator == nil,
+                "Coordinator must be deallocated — no retain cycles")
+    }
+
+    // MARK: - Coordinator command notification scoping
+
+    @Test("Coordinator handleToggleComment only fires for key window")
+    func coordinatorToggleCommentKeyWindowGuard() {
+        let (scrollView, _) = makeTextStack(text: "// hello")
+        let editorView = CodeEditorView(
+            text: .constant("// hello"),
+            contentVersion: 0,
+            language: "swift",
+            fileName: "test.swift",
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: editorView)
+        coordinator.scrollView = scrollView
+
+        // Without a window (or non-key window), handleToggleComment should be a no-op
+        coordinator.handleToggleComment()
+
+        let textView = scrollView.documentView as? NSTextView
+        #expect(textView?.string == "// hello",
+                "Toggle comment must not fire without a key window")
+    }
+
+    @Test("Coordinator find actions only fire for key window")
+    func coordinatorFindActionsKeyWindowGuard() {
+        let (scrollView, _) = makeTextStack(text: "hello world")
+        let editorView = CodeEditorView(
+            text: .constant("hello world"),
+            contentVersion: 0,
+            language: "txt",
+            fileName: "test.txt",
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: editorView)
+        coordinator.scrollView = scrollView
+
+        // These should all be no-ops without a key window — no crash
+        coordinator.handleFindInFile()
+        coordinator.handleFindAndReplace()
+        coordinator.handleFindNext()
+        coordinator.handleFindPrevious()
+        coordinator.handleUseSelectionForFind()
+    }
+
+    @Test("Coordinator fold code only fires for key window")
+    func coordinatorFoldCodeKeyWindowGuard() {
+        let (scrollView, _) = makeTextStack(text: "func foo() {\n    bar()\n}")
+        let editorView = CodeEditorView(
+            text: .constant("func foo() {\n    bar()\n}"),
+            contentVersion: 0,
+            language: "swift",
+            fileName: "test.swift",
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: editorView)
+        coordinator.scrollView = scrollView
+
+        let notification = Notification(
+            name: .foldCode,
+            object: nil,
+            userInfo: ["action": "fold"]
+        )
+        coordinator.handleFoldCode(notification)
+    }
+
+    // MARK: - Multiple observers isolation
+
+    @Test("Two LineNumberViews do not interfere with each other's scroll notifications")
+    func twoLineNumberViewsIsolated() {
+        let (scrollView1, textView1) = makeTextStack(text: "file1\nline2")
+        let (scrollView2, textView2) = makeTextStack(text: "file2\nline2")
+
+        let lineNum1 = LineNumberView(textView: textView1, clipView: scrollView1.contentView)
+        let lineNum2 = LineNumberView(textView: textView2, clipView: scrollView2.contentView)
+
+        let count1Before = lineNum1.boundsChangeCount
+        let count2Before = lineNum2.boundsChangeCount
+
+        // Scroll only scrollView1
+        NotificationCenter.default.post(
+            name: NSView.boundsDidChangeNotification,
+            object: scrollView1.contentView
+        )
+
+        #expect(lineNum1.boundsChangeCount == count1Before + 1,
+                "LineNumberView 1 must react to its own scroll")
+        #expect(lineNum2.boundsChangeCount == count2Before,
+                "LineNumberView 2 must NOT react to scrollView1's scroll")
+    }
+
+    @Test("Two MinimapViews do not interfere with each other's scroll notifications")
+    func twoMinimapViewsIsolated() {
+        let (scrollView1, textView1) = makeTextStack(text: "file1\nline2")
+        let (scrollView2, textView2) = makeTextStack(text: "file2\nline2")
+
+        let minimap1 = MinimapView(textView: textView1, clipView: scrollView1.contentView)
+        let minimap2 = MinimapView(textView: textView2, clipView: scrollView2.contentView)
+
+        let count1Before = minimap1.scrollChangeCount
+        let count2Before = minimap2.scrollChangeCount
+
+        // Scroll only scrollView1
+        NotificationCenter.default.post(
+            name: NSView.boundsDidChangeNotification,
+            object: scrollView1.contentView
+        )
+
+        #expect(minimap1.scrollChangeCount == count1Before + 1,
+                "MinimapView 1 must react to its own scroll")
+        #expect(minimap2.scrollChangeCount == count2Before,
+                "MinimapView 2 must NOT react to scrollView1's scroll")
+    }
+}


### PR DESCRIPTION
## Summary
- **LineNumberView** and **MinimapView** subscribed to `NSView.boundsDidChangeNotification` with `object: nil`, receiving notifications from ALL scroll views in the app. With multiple editor windows, this caused unnecessary handler invocations and redraws
- Changed both views to accept an explicit `clipView` parameter and subscribe only to their own scroll view's `NSClipView`
- Removed redundant guard clauses in notification handlers (no longer needed since subscriptions are scoped)
- Added debug warnings when `clipView` is nil at init (graceful degradation instead of hard assert)

Closes #465

## Changes
- `LineNumberGutter.swift`: Added `clipView` param to init, subscribe to specific `NSClipView`
- `MinimapView.swift`: Same pattern — scoped `boundsDidChangeNotification` observer
- `CodeEditorView.swift`: Pass `scrollView.contentView` explicitly when creating `LineNumberView` and `MinimapView`
- `NotificationObserverScopingTests.swift`: 12 new tests covering observer isolation, deinit/retain cycles, and command notification guards

## Test plan
- [x] 12 new unit tests pass (observer scoping, isolation between views, deinit verification, coordinator guards)
- [x] 37 existing related tests pass (LineNumberView, MinimapView, CodeEditorCoordinator, LineNumberBaseline)
- [x] SwiftLint clean
- [ ] Manual: open two editor windows, scroll one — verify the other's gutter/minimap don't redraw