### PR TITLE
feat: add FPS counter overlay for performance monitoring

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -68,6 +68,9 @@ enum AccessibilityID {
     static let quickOpenResultsList = "quickOpenResultsList"
     static func quickOpenItem(_ name: String) -> String { "quickOpenItem_\(name)" }
 
+    // MARK: - FPS Overlay
+    static let fpsOverlay = "fpsOverlay"
+
     // MARK: - Status bar
     static let statusBar = "statusBar"
     static let terminalToggleButton = "terminalToggleButton"

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -33,6 +33,8 @@ struct ContentView: View {
     @State private var showGoToLine = false
     @AppStorage("minimapVisible") private var isMinimapVisible = true
     @AppStorage(BlameConstants.storageKey) private var isBlameVisible = true
+    @AppStorage(FPSCounterConstants.storageKey) private var isFPSCounterVisible = false
+    @State private var fpsCounter = FPSCounter()
 
     private var activeTab: EditorTab? { tabManager.activeTab }
 
@@ -563,6 +565,20 @@ struct ContentView: View {
                     Text(Strings.selectFilePrompt)
                 }
                 .accessibilityIdentifier(AccessibilityID.editorPlaceholder)
+            }
+        }
+        .overlay(alignment: .topTrailing) {
+            if isFPSCounterVisible {
+                FPSOverlayView(fpsCounter: fpsCounter)
+                    .padding(.top, 8)
+                    .padding(.trailing, 8)
+            }
+        }
+        .onChange(of: isFPSCounterVisible) { _, visible in
+            if visible {
+                fpsCounter.start()
+            } else {
+                fpsCounter.stop()
             }
         }
     }

--- a/Pine/FPSCounter.swift
+++ b/Pine/FPSCounter.swift
@@ -1,0 +1,98 @@
+//
+//  FPSCounter.swift
+//  Pine
+//
+//  Created by Claude on 23.03.2026.
+//
+
+import AppKit
+import QuartzCore
+
+/// Performance level based on measured frame rate.
+enum FPSLevel {
+    case excellent // ≥ 90 fps (ProMotion territory)
+    case good      // ≥ 50 fps
+    case fair      // ≥ 30 fps
+    case poor      // < 30 fps
+
+    init(fps: Int) {
+        switch fps {
+        case 90...: self = .excellent
+        case 50...: self = .good
+        case 30...: self = .fair
+        default:    self = .poor
+        }
+    }
+
+    var color: NSColor {
+        switch self {
+        case .excellent: .systemGreen
+        case .good:      .systemYellow
+        case .fair:      .systemOrange
+        case .poor:      .systemRed
+        }
+    }
+}
+
+/// UserDefaults key for FPS counter visibility.
+enum FPSCounterConstants {
+    static let storageKey = "showFPSCounter"
+}
+
+/// Monitors frame rate using CADisplayLink via NSScreen.
+///
+/// Shows real-time FPS to help diagnose scroll performance on ProMotion displays.
+/// Available in DEBUG builds via View menu, or in any build via:
+/// `defaults write com.batonogov.pine-editor showFPSCounter -bool YES`
+@Observable
+final class FPSCounter: NSObject {
+    private(set) var currentFPS: Int = 0
+
+    var level: FPSLevel { FPSLevel(fps: currentFPS) }
+
+    /// Formatted FPS string (e.g. "120 fps").
+    var fpsText: String { "\(currentFPS) fps" }
+
+    // MARK: - CADisplayLink
+
+    private var displayLink: CADisplayLink?
+    private var frameCount = 0
+    private var lastSampleTime: CFTimeInterval = 0
+
+    /// How often to update the displayed FPS value (in seconds).
+    private let sampleInterval: CFTimeInterval = 0.5
+
+    func start() {
+        guard displayLink == nil else { return }
+
+        frameCount = 0
+        lastSampleTime = CACurrentMediaTime()
+
+        guard let screen = NSScreen.main else { return }
+        let link = screen.displayLink(target: self, selector: #selector(handleFrame(_:)))
+        link.add(to: .main, forMode: .common)
+        displayLink = link
+    }
+
+    func stop() {
+        displayLink?.invalidate()
+        displayLink = nil
+        currentFPS = 0
+    }
+
+    @objc private func handleFrame(_ link: CADisplayLink) {
+        let now = CACurrentMediaTime()
+        frameCount += 1
+
+        let elapsed = now - lastSampleTime
+        if elapsed >= sampleInterval {
+            currentFPS = Int(round(Double(frameCount) / elapsed))
+            frameCount = 0
+            lastSampleTime = now
+        }
+    }
+
+    deinit {
+        stop()
+    }
+}

--- a/Pine/FPSOverlayView.swift
+++ b/Pine/FPSOverlayView.swift
@@ -1,0 +1,36 @@
+//
+//  FPSOverlayView.swift
+//  Pine
+//
+//  Created by Claude on 23.03.2026.
+//
+
+import SwiftUI
+
+/// A compact overlay that displays real-time FPS.
+///
+/// Color-coded by performance level:
+/// - Green: ≥ 90 fps (ProMotion)
+/// - Yellow: ≥ 50 fps
+/// - Orange: ≥ 30 fps
+/// - Red: < 30 fps
+struct FPSOverlayView: View {
+    var fpsCounter: FPSCounter
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(Color(nsColor: fpsCounter.level.color))
+                .frame(width: 6, height: 6)
+
+            Text(verbatim: fpsCounter.fpsText)
+                .monospacedDigit()
+        }
+        .font(.system(size: 10, weight: .medium, design: .monospaced))
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 6))
+        .accessibilityIdentifier(AccessibilityID.fpsOverlay)
+    }
+}

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -4743,6 +4743,66 @@
         }
       }
     },
+    "menu.toggleFPSCounter" : {
+      "comment" : "Menu command: toggle FPS counter overlay (DEBUG only).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FPS-Zähler umschalten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toggle FPS Counter"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alternar contador de FPS"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher/masquer le compteur FPS"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FPSカウンターを切り替え"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FPS 카운터 전환"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alternar contador de FPS"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переключить счётчик FPS"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换 FPS 计数器"
+          }
+        }
+      }
+    },
     "menu.togglePreview" : {
       "comment" : "Menu command: toggle markdown preview pane.",
       "extractionState" : "manual",

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -37,6 +37,7 @@ enum MenuIcons {
     static let togglePreview = "doc.richtext"
     static let toggleMinimap = "sidebar.right"
     static let toggleBlame = "person.text.rectangle"
+    static let toggleFPSCounter = "gauge.with.dots.needle.bottom.50percent"
     static let revealFileInFinder = "doc.viewfinder"
     static let revealProjectInFinder = "arrow.right.circle"
 

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -107,6 +107,15 @@ struct PineApp: App {
                 }
                 .keyboardShortcut("b", modifiers: [.command, .control])
 
+                #if DEBUG
+                Button {
+                    let key = FPSCounterConstants.storageKey
+                    UserDefaults.standard.set(!UserDefaults.standard.bool(forKey: key), forKey: key)
+                } label: {
+                    Label(Strings.menuToggleFPSCounter, systemImage: MenuIcons.toggleFPSCounter)
+                }
+                #endif
+
                 Divider()
 
                 Button {

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -143,6 +143,7 @@ enum Strings {
     static let menuToggleComment: LocalizedStringKey = "menu.toggleComment"
     static let menuToggleMinimap: LocalizedStringKey = "menu.toggleMinimap"
     static let menuToggleBlame: LocalizedStringKey = "menu.toggleBlame"
+    static let menuToggleFPSCounter: LocalizedStringKey = "menu.toggleFPSCounter"
 
     static var branchUncommittedChangesTitle: String {
         String(localized: "branch.uncommittedChanges.title")

--- a/PineTests/FPSCounterTests.swift
+++ b/PineTests/FPSCounterTests.swift
@@ -1,0 +1,162 @@
+//
+//  FPSCounterTests.swift
+//  PineTests
+//
+//  Created by Claude on 23.03.2026.
+//
+
+import AppKit
+import Testing
+
+@testable import Pine
+
+@Suite("FPSCounter Tests")
+struct FPSCounterTests {
+
+    // MARK: - FPSLevel from fps value
+
+    @Test("Excellent level for 120 fps")
+    func levelExcellentAt120() {
+        #expect(FPSLevel(fps: 120) == .excellent)
+    }
+
+    @Test("Excellent level for 90 fps")
+    func levelExcellentAt90() {
+        #expect(FPSLevel(fps: 90) == .excellent)
+    }
+
+    @Test("Good level for 60 fps")
+    func levelGoodAt60() {
+        #expect(FPSLevel(fps: 60) == .good)
+    }
+
+    @Test("Good level for 50 fps")
+    func levelGoodAt50() {
+        #expect(FPSLevel(fps: 50) == .good)
+    }
+
+    @Test("Fair level for 30 fps")
+    func levelFairAt30() {
+        #expect(FPSLevel(fps: 30) == .fair)
+    }
+
+    @Test("Fair level for 45 fps")
+    func levelFairAt45() {
+        #expect(FPSLevel(fps: 45) == .fair)
+    }
+
+    @Test("Poor level for 29 fps")
+    func levelPoorAt29() {
+        #expect(FPSLevel(fps: 29) == .poor)
+    }
+
+    @Test("Poor level for 0 fps")
+    func levelPoorAtZero() {
+        #expect(FPSLevel(fps: 0) == .poor)
+    }
+
+    // MARK: - FPSLevel colors
+
+    @Test("Excellent level is green")
+    func excellentColorGreen() {
+        #expect(FPSLevel.excellent.color == .systemGreen)
+    }
+
+    @Test("Good level is yellow")
+    func goodColorYellow() {
+        #expect(FPSLevel.good.color == .systemYellow)
+    }
+
+    @Test("Fair level is orange")
+    func fairColorOrange() {
+        #expect(FPSLevel.fair.color == .systemOrange)
+    }
+
+    @Test("Poor level is red")
+    func poorColorRed() {
+        #expect(FPSLevel.poor.color == .systemRed)
+    }
+
+    // MARK: - FPSCounter initial state
+
+    @Test("Initial FPS is zero")
+    func initialFPSIsZero() {
+        let counter = FPSCounter()
+        #expect(counter.currentFPS == 0)
+    }
+
+    @Test("Initial level is poor (0 fps)")
+    func initialLevelIsPoor() {
+        let counter = FPSCounter()
+        #expect(counter.level == .poor)
+    }
+
+    // MARK: - Text formatting
+
+    @Test("FPS text formats correctly")
+    func fpsTextFormatting() {
+        let counter = FPSCounter()
+        #expect(counter.fpsText == "0 fps")
+    }
+
+    // MARK: - FPSCounterConstants
+
+    @Test("Storage key is correct")
+    func storageKeyValue() {
+        #expect(FPSCounterConstants.storageKey == "showFPSCounter")
+    }
+
+    // MARK: - Start / Stop lifecycle
+
+    @Test("Start and stop do not crash")
+    func startStopLifecycle() {
+        let counter = FPSCounter()
+        counter.start()
+        counter.stop()
+        #expect(counter.currentFPS == 0)
+    }
+
+    @Test("Double start is safe")
+    func doubleStartIsSafe() {
+        let counter = FPSCounter()
+        counter.start()
+        counter.start()
+        counter.stop()
+    }
+
+    @Test("Double stop is safe")
+    func doubleStopIsSafe() {
+        let counter = FPSCounter()
+        counter.start()
+        counter.stop()
+        counter.stop()
+    }
+
+    @Test("Stop without start is safe")
+    func stopWithoutStartIsSafe() {
+        let counter = FPSCounter()
+        counter.stop()
+    }
+
+    // MARK: - FPSLevel boundary tests
+
+    @Test("Level at exact boundary 89 is good")
+    func levelAt89IsGood() {
+        #expect(FPSLevel(fps: 89) == .good)
+    }
+
+    @Test("Level at exact boundary 49 is fair")
+    func levelAt49IsFair() {
+        #expect(FPSLevel(fps: 49) == .fair)
+    }
+
+    @Test("Level at very high fps")
+    func levelAtVeryHighFPS() {
+        #expect(FPSLevel(fps: 240) == .excellent)
+    }
+
+    @Test("Level at negative fps defaults to poor")
+    func levelAtNegativeFPS() {
+        #expect(FPSLevel(fps: -1) == .poor)
+    }
+}


### PR DESCRIPTION
## Summary
- CADisplayLink-based FPS counter with color-coded overlay (green ≥90, yellow ≥50, orange ≥30, red <30 fps)
- Compact `.ultraThinMaterial` overlay in top-right corner of editor area
- Menu item (View → Toggle FPS Counter) visible in `#if DEBUG` builds only
- Release builds can enable via `defaults write io.github.batonogov.pine showFPSCounter -bool YES`
- 24 unit tests covering FPSLevel boundaries, colors, lifecycle, formatting

Closes #483

## Test plan
- [ ] Enable via View → Toggle FPS Counter in DEBUG build
- [ ] Verify overlay shows in top-right corner with green dot and fps value
- [ ] Scroll rapidly — verify FPS value updates smoothly every 0.5s
- [ ] Toggle off — verify overlay disappears and display link stops
- [ ] Verify menu item is hidden in Release build
- [ ] Verify `defaults write` enables overlay in Release build
- [ ] Run `PineTests/FPSCounterTests` — all 24 tests pass