### PR TITLE
fix: prevent .js and .ts files from being treated as binary (#479)

### DIFF
--- a/Pine/ProjectSearchProvider.swift
+++ b/Pine/ProjectSearchProvider.swift
@@ -263,7 +263,8 @@ final class ProjectSearchProvider {
     /// Extensions that UTType misclassifies as binary (e.g. .js → executable, .ts → MPEG-2 transport stream).
     nonisolated private static let textExtensionOverrides: Set<String> = [
         "js", "jsx", "mjs", "cjs",
-        "ts", "tsx", "mts", "cts"
+        "ts", "tsx", "mts", "cts",
+        "vue", "svelte", "astro"
     ]
 
     /// Returns true for known binary file types.

--- a/PineTests/ProjectSearchProviderTests.swift
+++ b/PineTests/ProjectSearchProviderTests.swift
@@ -341,6 +341,13 @@ struct ProjectSearchProviderTests {
         #expect(!ProjectSearchProvider.isBinaryFile(url: URL(fileURLWithPath: "/tmp/test.mts")))
     }
 
+    @Test("isBinaryFile treats .vue, .svelte, .astro as text, not binary")
+    func isBinaryAllowsWebFrameworkExtensions() {
+        #expect(!ProjectSearchProvider.isBinaryFile(url: URL(fileURLWithPath: "/tmp/App.vue")))
+        #expect(!ProjectSearchProvider.isBinaryFile(url: URL(fileURLWithPath: "/tmp/Component.svelte")))
+        #expect(!ProjectSearchProvider.isBinaryFile(url: URL(fileURLWithPath: "/tmp/page.astro")))
+    }
+
     @Test("isBinaryFile correctly detects real binary files")
     func isBinaryDetectsRealBinaries() {
         #expect(ProjectSearchProvider.isBinaryFile(url: URL(fileURLWithPath: "/tmp/test.png")))


### PR DESCRIPTION
## Summary

- Add `textExtensionOverrides` Set (js, jsx, mjs, cjs, ts, tsx, mts, cts) to `ProjectSearchProvider`
- These extensions are checked before UTType classification to bypass incorrect binary detection
- Root cause: `UTType(filenameExtension: "js")` returns `com.netscape.javascript-source` which conforms to `.executable`, and `.ts` maps to MPEG-2 transport stream conforming to `.audiovisualContent`

Closes #479

## Test plan

- [x] Tests that .js, .ts, .jsx, .tsx, .mjs, .mts are not treated as binary
- [x] Tests that real binary files (png, jpg, mp4, pdf, zip) are still filtered
- [x] Tests that `performSearch` finds results in .js and .ts files
- [x] Tests that `collectSearchableFiles` includes .js and .ts
- [x] All 46 ProjectSearchProvider tests pass
- [x] SwiftLint clean