### PR TITLE
fix: prevent QuickOpenProvider from indexing files outside project root via symlinks (#486)

### DIFF
--- a/Pine/QuickOpenProvider.swift
+++ b/Pine/QuickOpenProvider.swift
@@ -64,16 +64,24 @@ final class QuickOpenProvider {
     }
 
     private func collectFiles(from node: FileNode, into files: inout [URL], rootRealPath: String) {
-        if node.isDirectory {
+        if node.isSymlink {
+            // Resolve symlink target and check boundary for both files and directories
+            let resolvedPath = node.url.resolvingSymlinksInPath().path
+            let isInsideProject = resolvedPath == rootRealPath || resolvedPath.hasPrefix(rootRealPath + "/")
+            guard isInsideProject else { return }
+
+            if node.isDirectory {
+                guard let children = node.children else { return }
+                for child in children {
+                    collectFiles(from: child, into: &files, rootRealPath: rootRealPath)
+                }
+            } else {
+                files.append(node.url)
+            }
+        } else if node.isDirectory {
             guard let children = node.children else { return }
             for child in children {
                 collectFiles(from: child, into: &files, rootRealPath: rootRealPath)
-            }
-        } else if node.isSymlink {
-            // Skip symlinks pointing outside the project root
-            let resolvedPath = node.url.resolvingSymlinksInPath().path
-            if resolvedPath == rootRealPath || resolvedPath.hasPrefix(rootRealPath + "/") {
-                files.append(node.url)
             }
         } else {
             files.append(node.url)

--- a/PineTests/QuickOpenProviderTests.swift
+++ b/PineTests/QuickOpenProviderTests.swift
@@ -482,6 +482,74 @@ struct QuickOpenProviderTests {
         #expect(fileNames.contains("alias.swift"))
     }
 
+    @Test("symlink targeting directory outside project root is excluded from index")
+    func symlinkDirectoryOutsideProjectRootExcluded() throws {
+        let project = try createTestProject(files: ["real.swift": "// real"])
+        defer { cleanup(project) }
+
+        // Create a directory with files outside the project
+        let outside = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineOutsideDir-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: outside) }
+
+        let outsideFile = outside.appendingPathComponent("secret.swift")
+        try "// secret".write(to: outsideFile, atomically: true, encoding: .utf8)
+        let outsideFile2 = outside.appendingPathComponent("hidden.swift")
+        try "// hidden".write(to: outsideFile2, atomically: true, encoding: .utf8)
+
+        // Create symlink to directory inside project pointing outside
+        let symlinkURL = project.appendingPathComponent("linked_dir")
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: outside)
+
+        let provider = buildProvider(dir: project)
+        let fileNames = provider.fileIndex.map(\.lastPathComponent)
+        #expect(fileNames.contains("real.swift"))
+        #expect(!fileNames.contains("secret.swift"))
+        #expect(!fileNames.contains("hidden.swift"))
+    }
+
+    @Test("symlink targeting directory inside project root is included in index")
+    func symlinkDirectoryInsideProjectRootIncluded() throws {
+        // Create a project where the ONLY way to reach a subdirectory is through a symlink.
+        // This avoids FileNode's cycle detection (which skips symlinks pointing to
+        // already-visited real paths).
+        let project = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineSymlinkDirInside-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: project) }
+
+        // Create a hidden subdirectory (not normally indexed because we'll only
+        // reference it through the symlink).
+        let hiddenDir = project.appendingPathComponent(".hidden_src")
+        try FileManager.default.createDirectory(at: hiddenDir, withIntermediateDirectories: true)
+        try "// original".write(
+            to: hiddenDir.appendingPathComponent("original.swift"),
+            atomically: true, encoding: .utf8
+        )
+        try "// helper".write(
+            to: hiddenDir.appendingPathComponent("helper.swift"),
+            atomically: true, encoding: .utf8
+        )
+
+        // Create symlink pointing to .hidden_src (inside project)
+        let symlinkURL = project.appendingPathComponent("alias_dir")
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: hiddenDir)
+
+        // Also add a regular file
+        try "// main".write(
+            to: project.appendingPathComponent("main.swift"),
+            atomically: true, encoding: .utf8
+        )
+
+        let provider = buildProvider(dir: project)
+        let fileNames = provider.fileIndex.map(\.lastPathComponent)
+        #expect(fileNames.contains("main.swift"))
+        // Symlink directory inside project — its children should be indexed
+        #expect(fileNames.contains("original.swift"))
+        #expect(fileNames.contains("helper.swift"))
+    }
+
     @Test("regular files without symlinks are indexed normally")
     func regularFilesIndexedNormally() throws {
         let project = try createTestProject(files: [


### PR DESCRIPTION
## Summary

- Add symlink boundary check in `QuickOpenProvider.collectFiles`
- If a `FileNode` is a symlink, its resolved path is checked against `rootRealPath`
- Symlinks pointing outside the project root are skipped during indexing

Closes #486

## Test plan

- [x] Test that symlink outside project root is excluded from index
- [x] Test that symlink inside project root is included
- [x] Test that regular files are indexed normally
- [x] All 35 QuickOpenProvider tests pass
- [x] SwiftLint clean