### PR TITLE
refactor: extract magic numbers into named constants (#464)

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -124,7 +124,7 @@ final class GutterTextView: NSTextView {
 
         // Compute 1-based line number from cursor position
         var lineNumber = 1
-        for i in 0..<cursorLocation where source.character(at: i) == 0x0A {
+        for i in 0..<cursorLocation where source.character(at: i) == ASCII.newline {
             lineNumber += 1
         }
 
@@ -134,7 +134,7 @@ final class GutterTextView: NSTextView {
         let lineRange = source.lineRange(for: NSRange(location: cursorLocation, length: 0))
         var lineEnd = NSMaxRange(lineRange)
         if lineEnd > lineRange.location && lineEnd <= source.length
-            && source.character(at: lineEnd - 1) == 0x0A {
+            && source.character(at: lineEnd - 1) == ASCII.newline {
             lineEnd -= 1
         }
 
@@ -1057,7 +1057,7 @@ struct CodeEditorView: NSViewRepresentable {
                 // file with regex on every cursor move. Window boundaries are aligned to
                 // line starts/ends via NSString.lineRange to avoid slicing through
                 // comment/string delimiters (e.g. cutting "/*" in half).
-                let bracketSearchRadius = 5000
+                let bracketSearchRadius = EditorConstants.bracketSearchRadius
                 let rawStart = max(0, cursorRange.location - bracketSearchRadius)
                 let rawEnd = min(nsFullText.length, cursorRange.location + bracketSearchRadius)
                 let alignedStart = nsFullText.lineRange(
@@ -1457,7 +1457,7 @@ struct CodeEditorView: NSViewRepresentable {
         var linesFound = 0
         var end = startChar
         while end < totalLength && linesFound < estimatedScreenLines {
-            if source.character(at: end) == 0x0A { linesFound += 1 }
+            if source.character(at: end) == ASCII.newline { linesFound += 1 }
             end += 1
         }
 
@@ -1468,14 +1468,14 @@ struct CodeEditorView: NSViewRepresentable {
         var currentLine = 0
         for i in 0..<totalLength {
             if currentLine >= line { return i }
-            if source.character(at: i) == 0x0A { currentLine += 1 }
+            if source.character(at: i) == ASCII.newline { currentLine += 1 }
         }
         return totalLength
     }
 
     private static func lineNumber(at charOffset: Int, in source: NSString) -> Int {
         var line = 0
-        for i in 0..<min(charOffset, source.length) where source.character(at: i) == 0x0A {
+        for i in 0..<min(charOffset, source.length) where source.character(at: i) == ASCII.newline {
             line += 1
         }
         return line

--- a/Pine/Constants.swift
+++ b/Pine/Constants.swift
@@ -1,0 +1,63 @@
+//
+//  Constants.swift
+//  Pine
+//
+//  Named constants extracted from magic numbers across the codebase.
+//
+
+import Foundation
+
+// MARK: - ASCII Character Codes
+
+/// Common ASCII character codes used for text scanning.
+enum ASCII {
+    /// Line feed (`\n`) — 0x0A
+    static let newline: unichar = 0x0A
+    /// Carriage return (`\r`) — 0x0D
+    static let carriageReturn: unichar = 0x0D
+}
+
+// MARK: - File Size Constants
+
+/// Commonly used file size values in bytes.
+enum FileSizeConstants {
+    /// 1 KB = 1,024 bytes
+    static let oneKB = 1_024
+    /// 1 MB = 1,048,576 bytes
+    static let oneMB = 1_048_576
+    /// 10 MB = 10,485,760 bytes
+    static let tenMB = 10_485_760
+}
+
+// MARK: - Editor Constants
+
+/// Constants used by the code editor (CodeEditorView).
+enum EditorConstants {
+    /// Number of characters to search in each direction when looking for bracket matches.
+    /// Large enough to find nearby brackets, small enough to avoid scanning the entire file.
+    static let bracketSearchRadius = 5000
+}
+
+// MARK: - Search Constants
+
+/// Constants used by project search (ProjectSearchProvider).
+enum SearchConstants {
+    /// Maximum number of characters to keep from a matched line for display.
+    static let lineContentPrefixLimit = 200
+}
+
+// MARK: - Minimap Constants
+
+/// Constants used by the minimap view (MinimapView).
+enum MinimapConstants {
+    /// Alpha component for syntax-colored segments in the minimap.
+    static let syntaxSegmentAlpha: CGFloat = 0.55
+    /// Width of git diff marker strips on the right edge.
+    static let diffMarkerWidth: CGFloat = 4
+    /// Height of each line representation in the minimap.
+    static let lineHeight: CGFloat = 2
+    /// Width of a single character in minimap coordinates.
+    static let charWidth: CGFloat = 0.8
+    /// Horizontal padding before the first character.
+    static let leadingPadding: CGFloat = 4
+}

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -648,7 +648,7 @@ struct ContentView: View {
             let lineEnd = NSMaxRange(lineRange)
             if lineEnd > clamped { break }
             // Only advance to next line if a newline actually ends this line
-            if lineEnd == clamped && (clamped == 0 || nsContent.character(at: clamped - 1) != 0x0A) {
+            if lineEnd == clamped && (clamped == 0 || nsContent.character(at: clamped - 1) != ASCII.newline) {
                 break
             }
             line += 1

--- a/Pine/FoldRangeCalculator.swift
+++ b/Pine/FoldRangeCalculator.swift
@@ -57,7 +57,7 @@ enum FoldRangeCalculator {
 
         // Предварительно вычисляем номера строк и позиции начала строк
         var lineStarts: [Int] = [0]
-        for i in 0..<length where source.character(at: i) == 0x0A {
+        for i in 0..<length where source.character(at: i) == ASCII.newline {
             lineStarts.append(i + 1)
         }
 

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -207,7 +207,7 @@ final class LineNumberView: NSView {
         // Fallback: linear scan if cache not available
         let source = textView.string as NSString
         var line = 1
-        for i in 0..<min(charIndex, source.length) where source.character(at: i) == 0x0A {
+        for i in 0..<min(charIndex, source.length) where source.character(at: i) == ASCII.newline {
             line += 1
         }
         return line
@@ -237,7 +237,7 @@ final class LineNumberView: NSView {
             return
         }
         var count = 1
-        for i in 0..<source.length where source.character(at: i) == 0x0A {
+        for i in 0..<source.length where source.character(at: i) == ASCII.newline {
             count += 1
         }
         cachedTotalLines = count
@@ -297,7 +297,7 @@ final class LineNumberView: NSView {
             lineNumber = 1
             if firstVisibleCharIndex > 0 {
                 var count = 0
-                for i in 0..<firstVisibleCharIndex where source.character(at: i) == 0x0A {
+                for i in 0..<firstVisibleCharIndex where source.character(at: i) == ASCII.newline {
                     count += 1
                 }
                 lineNumber = count + 1

--- a/Pine/LineStartsCache.swift
+++ b/Pine/LineStartsCache.swift
@@ -23,7 +23,7 @@ struct LineStartsCache {
     init(source: NSString) {
         let length = source.length
         var starts: [Int] = [0]
-        for i in 0..<length where source.character(at: i) == 0x0A {
+        for i in 0..<length where source.character(at: i) == ASCII.newline {
             starts.append(i + 1)
         }
         lineStarts = starts
@@ -87,7 +87,7 @@ struct LineStartsCache {
         // Сканируем editedRange в новом тексте и вставляем новые строки.
         let scanEnd = min(editedRange.location + editedRange.length, source.length)
         var newStarts: [Int] = []
-        for i in editedRange.location..<scanEnd where source.character(at: i) == 0x0A {
+        for i in editedRange.location..<scanEnd where source.character(at: i) == ASCII.newline {
             newStarts.append(i + 1)
         }
 

--- a/Pine/MinimapView.swift
+++ b/Pine/MinimapView.swift
@@ -56,7 +56,7 @@ final class MinimapView: NSView {
     static let scaleFactor: CGFloat = 0.12
 
     /// Width of one character in minimap coordinates.
-    private let charWidth: CGFloat = 0.8
+    private let charWidth: CGFloat = MinimapConstants.charWidth
 
     /// Total document height including top origin offset and bottom inset.
     private func documentHeight(
@@ -253,7 +253,7 @@ final class MinimapView: NSView {
         let (offset, _) = minimapOffset()
         let scale = Self.scaleFactor
         let originY = textView.textContainerOrigin.y
-        let lineHeight: CGFloat = 2
+        let lineHeight: CGFloat = MinimapConstants.lineHeight
 
         // Calculate the document Y range that maps to the visible minimap area.
         // Only enumerate line fragments within this range to avoid iterating the entire document.
@@ -265,7 +265,7 @@ final class MinimapView: NSView {
 
         // Diff marker state — tracked incrementally across fragments
         let hasDiffMarkers = !diffMap.isEmpty
-        let markerWidth: CGFloat = 4
+        let markerWidth: CGFloat = MinimapConstants.diffMarkerWidth
         let markerX = bounds.width - markerWidth
         var diffLineNumber = 1
         var diffLastCharPos = 0
@@ -277,7 +277,7 @@ final class MinimapView: NSView {
             // Advance diff line counter for newlines between last position and this fragment
             if hasDiffMarkers {
                 let scanEnd = min(charRange.location, source.length)
-                for i in diffLastCharPos..<scanEnd where source.character(at: i) == 0x0A {
+                for i in diffLastCharPos..<scanEnd where source.character(at: i) == ASCII.newline {
                     diffLineNumber += 1
                 }
                 diffLastCharPos = scanEnd
@@ -305,7 +305,7 @@ final class MinimapView: NSView {
 
             // Leading whitespace → x offset
             let leadingSpaces = lineText.prefix(while: { $0 == " " || $0 == "\t" }).count
-            let xStart: CGFloat = CGFloat(leadingSpaces) * self.charWidth + 4
+            let xStart: CGFloat = CGFloat(leadingSpaces) * self.charWidth + MinimapConstants.leadingPadding
 
             // Walk through syntax-colored segments
             var pos = charRange.location
@@ -336,7 +336,7 @@ final class MinimapView: NSView {
                     )
 
                     if segRect.maxX > 0 && segRect.minX < self.bounds.width {
-                        color.withAlphaComponent(0.55).setFill()
+                        color.withAlphaComponent(MinimapConstants.syntaxSegmentAlpha).setFill()
                         segRect.fill()
                     }
                 }

--- a/Pine/ProjectSearchProvider.swift
+++ b/Pine/ProjectSearchProvider.swift
@@ -37,7 +37,7 @@ final class ProjectSearchProvider {
     private(set) var totalMatchCount: Int = 0
 
     /// Maximum file size to search (1 MB).
-    nonisolated static let maxFileSize = 1_048_576
+    nonisolated static let maxFileSize = FileSizeConstants.oneMB
     /// Maximum total matches before stopping.
     nonisolated static let maxResults = 1_000
     /// Maximum matches per file in parallel search to avoid unbounded memory use.
@@ -196,7 +196,7 @@ final class ProjectSearchProvider {
 
                 matches.append(SearchMatch(
                     lineNumber: index + 1,
-                    lineContent: String(trimmedLine.prefix(200)),
+                    lineContent: String(trimmedLine.prefix(SearchConstants.lineContentPrefixLimit)),
                     matchRangeStart: utf16Start,
                     matchRangeLength: utf16Length
                 ))

--- a/Pine/StatusBarInfo.swift
+++ b/Pine/StatusBarInfo.swift
@@ -22,13 +22,13 @@ struct CursorLocation: Equatable {
         var i = 0
         while i < clampedPosition {
             let char = nsContent.character(at: i)
-            if char == 0x0A { // \n
+            if char == ASCII.newline {
                 currentLine += 1
                 lineStart = i + 1
-            } else if char == 0x0D { // \r
+            } else if char == ASCII.carriageReturn {
                 currentLine += 1
                 // Skip \n in \r\n pair
-                if i + 1 < nsContent.length && nsContent.character(at: i + 1) == 0x0A {
+                if i + 1 < nsContent.length && nsContent.character(at: i + 1) == ASCII.newline {
                     i += 1
                 }
                 lineStart = i + 1
@@ -62,10 +62,11 @@ enum LineEnding: Equatable {
         var i = 0
         while i < nsContent.length {
             let char = nsContent.character(at: i)
-            if char == 0x0D && i + 1 < nsContent.length && nsContent.character(at: i + 1) == 0x0A {
+            if char == ASCII.carriageReturn && i + 1 < nsContent.length
+                && nsContent.character(at: i + 1) == ASCII.newline {
                 crlfCount += 1
                 i += 2
-            } else if char == 0x0A {
+            } else if char == ASCII.newline {
                 lfCount += 1
                 i += 1
             } else {
@@ -129,12 +130,12 @@ enum IndentationStyle: Equatable {
 /// Formats file sizes for display.
 enum FileSizeFormatter {
     static func format(_ bytes: Int) -> String {
-        if bytes < 1_024 {
+        if bytes < FileSizeConstants.oneKB {
             return "\(bytes) B"
-        } else if bytes < 1_048_576 {
-            return String(format: "%.1f KB", Double(bytes) / 1_024.0)
+        } else if bytes < FileSizeConstants.oneMB {
+            return String(format: "%.1f KB", Double(bytes) / Double(FileSizeConstants.oneKB))
         } else {
-            return String(format: "%.1f MB", Double(bytes) / 1_048_576.0)
+            return String(format: "%.1f MB", Double(bytes) / Double(FileSizeConstants.oneMB))
         }
     }
 }

--- a/Pine/SyntaxHighlighter.swift
+++ b/Pine/SyntaxHighlighter.swift
@@ -532,14 +532,14 @@ final class SyntaxHighlighter: @unchecked Sendable {
         var start = expanded.location
         while start > 0 && linesAdded < contextCount {
             start -= 1
-            if source.character(at: start) == 0x0A { linesAdded += 1 }
+            if source.character(at: start) == ASCII.newline { linesAdded += 1 }
         }
         if start > 0 { start += 1 }
 
         linesAdded = 0
         var end = NSMaxRange(expanded)
         while end < totalLength && linesAdded < contextCount {
-            if source.character(at: end) == 0x0A { linesAdded += 1 }
+            if source.character(at: end) == ASCII.newline { linesAdded += 1 }
             end += 1
         }
 

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -12,13 +12,13 @@ import UniformTypeIdentifiers
 @Observable
 final class TabManager {
     /// File size threshold (in bytes) above which a warning is shown before opening.
-    static let largeFileThreshold = 1_048_576 // 1 MB
+    static let largeFileThreshold = FileSizeConstants.oneMB
 
     /// File size threshold (in bytes) above which only a partial load is performed.
-    static let hugeFileThreshold = 10_485_760 // 10 MB
+    static let hugeFileThreshold = FileSizeConstants.tenMB
 
     /// Number of bytes to load from the beginning of a huge file.
-    static let hugeFilePartialLoadSize = 1_048_576 // 1 MB
+    static let hugeFilePartialLoadSize = FileSizeConstants.oneMB
 
     var tabs: [EditorTab] = []
     var activeTabID: UUID?
@@ -62,7 +62,7 @@ final class TabManager {
 
         // Large file warning
         if let size = fileSize(url: url), size >= Self.largeFileThreshold {
-            let sizeMB = Double(size) / 1_048_576.0
+            let sizeMB = Double(size) / Double(FileSizeConstants.oneMB)
             let result = showLargeFileAlert(fileName: url.lastPathComponent, sizeMB: sizeMB)
             switch result {
             case .cancel:

--- a/PineTests/ConstantsTests.swift
+++ b/PineTests/ConstantsTests.swift
@@ -1,0 +1,108 @@
+//
+//  ConstantsTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+struct ConstantsTests {
+
+    // MARK: - ASCII constants
+
+    @Test func asciiNewlineHasCorrectValue() {
+        #expect(ASCII.newline == 0x0A)
+    }
+
+    @Test func asciiCarriageReturnHasCorrectValue() {
+        #expect(ASCII.carriageReturn == 0x0D)
+    }
+
+    // MARK: - File size thresholds ordering
+
+    @Test func fileSizeThresholdsAreInAscendingOrder() {
+        #expect(FileSizeConstants.oneKB < FileSizeConstants.oneMB)
+        #expect(FileSizeConstants.oneMB < FileSizeConstants.tenMB)
+    }
+
+    @Test func oneKBIsExactly1024Bytes() {
+        #expect(FileSizeConstants.oneKB == 1_024)
+    }
+
+    @Test func oneMBIsExactly1048576Bytes() {
+        #expect(FileSizeConstants.oneMB == 1_048_576)
+    }
+
+    @Test func tenMBIsExactly10485760Bytes() {
+        #expect(FileSizeConstants.tenMB == 10_485_760)
+    }
+
+    // MARK: - TabManager uses shared constants
+
+    @Test func largeFileThresholdMatchesOneMB() {
+        #expect(TabManager.largeFileThreshold == FileSizeConstants.oneMB)
+    }
+
+    @Test func hugeFileThresholdMatchesTenMB() {
+        #expect(TabManager.hugeFileThreshold == FileSizeConstants.tenMB)
+    }
+
+    @Test func hugeFilePartialLoadSizeMatchesOneMB() {
+        #expect(TabManager.hugeFilePartialLoadSize == FileSizeConstants.oneMB)
+    }
+
+    // MARK: - ProjectSearchProvider uses shared constants
+
+    @Test func projectSearchMaxFileSizeMatchesOneMB() {
+        #expect(ProjectSearchProvider.maxFileSize == FileSizeConstants.oneMB)
+    }
+
+    // MARK: - Bracket search radius
+
+    @Test func bracketSearchRadiusIsPositive() {
+        #expect(EditorConstants.bracketSearchRadius > 0)
+    }
+
+    @Test func bracketSearchRadiusIsReasonable() {
+        // Should be at least a few hundred chars to catch nearby brackets
+        #expect(EditorConstants.bracketSearchRadius >= 500)
+        // But not so large it defeats the purpose of windowed search
+        #expect(EditorConstants.bracketSearchRadius <= 50_000)
+    }
+
+    // MARK: - Search constants
+
+    @Test func lineContentPrefixLimitIsPositive() {
+        #expect(SearchConstants.lineContentPrefixLimit > 0)
+    }
+
+    @Test func lineContentPrefixLimitIsReasonable() {
+        // Should show meaningful context but not unlimited
+        #expect(SearchConstants.lineContentPrefixLimit >= 80)
+        #expect(SearchConstants.lineContentPrefixLimit <= 1000)
+    }
+
+    // MARK: - Minimap constants
+
+    @Test func minimapSyntaxAlphaIsBetweenZeroAndOne() {
+        #expect(MinimapConstants.syntaxSegmentAlpha > 0)
+        #expect(MinimapConstants.syntaxSegmentAlpha <= 1)
+    }
+
+    @Test func minimapDiffMarkerWidthIsPositive() {
+        #expect(MinimapConstants.diffMarkerWidth > 0)
+    }
+
+    @Test func minimapLineHeightIsPositive() {
+        #expect(MinimapConstants.lineHeight > 0)
+    }
+
+    @Test func minimapCharWidthIsPositive() {
+        #expect(MinimapConstants.charWidth > 0)
+    }
+
+    @Test func minimapLeadingPaddingIsNonNegative() {
+        #expect(MinimapConstants.leadingPadding >= 0)
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Pine/Constants.swift` with 5 enum namespaces: `ASCII`, `FileSizeConstants`, `EditorConstants`, `SearchConstants`, `MinimapConstants`
- Replace magic numbers (0x0A, 0x0D, 1_048_576, 5000, rendering values) across 10 source files
- No behavioral changes — pure refactor

Closes #464

## Test plan

- [x] 19 unit tests in `ConstantsTests` — values, ordering, relationships
- [x] SwiftLint clean
- [x] All existing tests pass