### PR TITLE
feat: undo support for file operations (#469)

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -1095,7 +1095,12 @@ final class SidebarEditState {
     }
 
     /// Creates a file or folder with a unique "untitled" name, then starts inline rename.
-    func createNewItem(in parentURL: URL, isDirectory: Bool, workspace: WorkspaceManager) {
+    func createNewItem(
+        in parentURL: URL,
+        isDirectory: Bool,
+        workspace: WorkspaceManager,
+        undoManager: UndoManager? = nil
+    ) {
         if let root = workspace.rootURL, !FileNode.isWithinProjectRoot(parentURL, projectRoot: root) {
             Self.showFileError(Strings.operationOutsideProject)
             return
@@ -1106,7 +1111,10 @@ final class SidebarEditState {
         let newURL = parentURL.appendingPathComponent(name)
 
         do {
-            if isDirectory {
+            if let undoManager {
+                let fileOps = FileOperationUndoManager()
+                try fileOps.createItem(at: newURL, isDirectory: isDirectory, undoManager: undoManager)
+            } else if isDirectory {
                 try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: false)
             } else if !FileManager.default.createFile(atPath: newURL.path, contents: nil) {
                 Self.showFileError(Strings.fileCreateError(name))
@@ -1176,6 +1184,7 @@ struct SidebarView: View {
     @Binding var selectedFile: FileNode?
     @Environment(ProjectRegistry.self) var registry
     @Environment(\.openWindow) var openWindow
+    @Environment(\.undoManager) private var undoManager
     @State private var editState = SidebarEditState()
 
     var body: some View {
@@ -1202,13 +1211,23 @@ struct SidebarView: View {
                 .contextMenu {
                     if let rootURL = workspace.rootURL {
                         Button {
-                            editState.createNewItem(in: rootURL, isDirectory: false, workspace: workspace)
+                            editState.createNewItem(
+                                in: rootURL,
+                                isDirectory: false,
+                                workspace: workspace,
+                                undoManager: undoManager
+                            )
                         } label: {
                             Label(Strings.contextNewFile, systemImage: MenuIcons.newFile)
                         }
 
                         Button {
-                            editState.createNewItem(in: rootURL, isDirectory: true, workspace: workspace)
+                            editState.createNewItem(
+                                in: rootURL,
+                                isDirectory: true,
+                                workspace: workspace,
+                                undoManager: undoManager
+                            )
                         } label: {
                             Label(Strings.contextNewFolder, systemImage: MenuIcons.newFolder)
                         }
@@ -1268,7 +1287,10 @@ struct FileNodeRow: View {
     @Environment(WorkspaceManager.self) var workspace
     @Environment(TabManager.self) var tabManager
     @Environment(SidebarEditState.self) var editState
+    @Environment(\.undoManager) private var undoManager
     @FocusState private var isTextFieldFocused: Bool
+
+    private let fileOps = FileOperationUndoManager()
 
     private var isEditing: Bool {
         guard let renamingURL = editState.renamingURL else { return false }
@@ -1387,7 +1409,12 @@ struct FileNodeRow: View {
     // MARK: - File operations
 
     private func createNewItem(isDirectory: Bool) {
-        editState.createNewItem(in: node.url, isDirectory: isDirectory, workspace: workspace)
+        editState.createNewItem(
+            in: node.url,
+            isDirectory: isDirectory,
+            workspace: workspace,
+            undoManager: undoManager
+        )
     }
 
     private func duplicateItem() {
@@ -1430,7 +1457,11 @@ struct FileNodeRow: View {
         }
 
         do {
-            try FileManager.default.moveItem(at: oldURL, to: newURL)
+            if let undoManager {
+                try fileOps.renameItem(from: oldURL, to: newURL, undoManager: undoManager)
+            } else {
+                try FileManager.default.moveItem(at: oldURL, to: newURL)
+            }
             editState.clear()
             workspace.refreshFileTree()
             NotificationCenter.default.post(
@@ -1469,7 +1500,11 @@ struct FileNodeRow: View {
         }
 
         do {
-            try FileManager.default.trashItem(at: deletedURL, resultingItemURL: nil)
+            if let undoManager {
+                try fileOps.deleteItem(at: deletedURL, undoManager: undoManager)
+            } else {
+                try FileManager.default.trashItem(at: deletedURL, resultingItemURL: nil)
+            }
             workspace.refreshFileTree()
             NotificationCenter.default.post(
                 name: .fileDeleted,

--- a/Pine/FileOperationUndoManager.swift
+++ b/Pine/FileOperationUndoManager.swift
@@ -1,0 +1,82 @@
+//
+//  FileOperationUndoManager.swift
+//  Pine
+//
+
+import Foundation
+
+/// Manages file system operations (delete, rename, create) with undo/redo support.
+///
+/// Uses `FileManager.trashItem` for delete so that undo restores from Trash.
+/// Rename and create register inverse operations on the provided `UndoManager`.
+final class FileOperationUndoManager {
+
+    // MARK: - Delete
+
+    /// Moves the item to Trash and registers an undo action that restores it.
+    func deleteItem(at url: URL, undoManager: UndoManager) throws {
+        var trashURL: NSURL?
+        try FileManager.default.trashItem(at: url, resultingItemURL: &trashURL)
+
+        guard let restoredTrashURL = trashURL as URL? else { return }
+
+        undoManager.registerUndo(withTarget: self) { target in
+            do {
+                try FileManager.default.moveItem(at: restoredTrashURL, to: url)
+                // Register redo (delete again)
+                undoManager.registerUndo(withTarget: target) { target in
+                    try? target.deleteItem(at: url, undoManager: undoManager)
+                }
+            } catch {
+                Self.logError("Undo delete failed: \(error.localizedDescription)")
+            }
+        }
+        undoManager.setActionName(Strings.undoDelete)
+    }
+
+    // MARK: - Rename
+
+    /// Renames (moves) an item and registers an undo action that reverts the rename.
+    func renameItem(from oldURL: URL, to newURL: URL, undoManager: UndoManager) throws {
+        try FileManager.default.moveItem(at: oldURL, to: newURL)
+
+        undoManager.registerUndo(withTarget: self) { target in
+            do {
+                try target.renameItem(from: newURL, to: oldURL, undoManager: undoManager)
+            } catch {
+                Self.logError("Undo rename failed: \(error.localizedDescription)")
+            }
+        }
+        undoManager.setActionName(Strings.undoRename)
+    }
+
+    // MARK: - Create
+
+    /// Creates a file or directory and registers an undo action that trashes it.
+    func createItem(at url: URL, isDirectory: Bool, undoManager: UndoManager) throws {
+        if isDirectory {
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+        } else {
+            guard FileManager.default.createFile(atPath: url.path, contents: nil) else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+        }
+
+        undoManager.registerUndo(withTarget: self) { target in
+            do {
+                try target.deleteItem(at: url, undoManager: undoManager)
+            } catch {
+                Self.logError("Undo create failed: \(error.localizedDescription)")
+            }
+        }
+        undoManager.setActionName(Strings.undoCreate)
+    }
+
+    // MARK: - Private
+
+    private static func logError(_ message: String) {
+        #if DEBUG
+        print("[FileOperationUndoManager] \(message)")
+        #endif
+    }
+}

--- a/Pine/FileOperationUndoManager.swift
+++ b/Pine/FileOperationUndoManager.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import os
 
 /// Manages file system operations (delete, rename, create) with undo/redo support.
 ///
@@ -28,7 +29,7 @@ final class FileOperationUndoManager {
                     try? target.deleteItem(at: url, undoManager: undoManager)
                 }
             } catch {
-                Self.logError("Undo delete failed: \(error.localizedDescription)")
+                Logger.fileTree.error("Undo delete failed: \(error)")
             }
         }
         undoManager.setActionName(Strings.undoDelete)
@@ -44,7 +45,7 @@ final class FileOperationUndoManager {
             do {
                 try target.renameItem(from: newURL, to: oldURL, undoManager: undoManager)
             } catch {
-                Self.logError("Undo rename failed: \(error.localizedDescription)")
+                Logger.fileTree.error("Undo rename failed: \(error)")
             }
         }
         undoManager.setActionName(Strings.undoRename)
@@ -66,17 +67,10 @@ final class FileOperationUndoManager {
             do {
                 try target.deleteItem(at: url, undoManager: undoManager)
             } catch {
-                Self.logError("Undo create failed: \(error.localizedDescription)")
+                Logger.fileTree.error("Undo create failed: \(error)")
             }
         }
         undoManager.setActionName(Strings.undoCreate)
     }
 
-    // MARK: - Private
-
-    private static func logError(_ message: String) {
-        #if DEBUG
-        print("[FileOperationUndoManager] \(message)")
-        #endif
-    }
 }

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -7622,6 +7622,186 @@
         }
       }
     },
+    "undo.create" : {
+      "comment" : "Undo action name for file/folder creation.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erstellen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crear"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作成"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "생성"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создание"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建"
+          }
+        }
+      }
+    },
+    "undo.delete" : {
+      "comment" : "Undo action name for file/folder deletion.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Löschen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "삭제"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Excluir"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удаление"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除"
+          }
+        }
+      }
+    },
+    "undo.rename" : {
+      "comment" : "Undo action name for file/folder rename.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umbenennen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renombrar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renommer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名前変更"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이름 변경"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renomear"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переименование"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名"
+          }
+        }
+      }
+    },
     "welcome.noRecent" : {
       "comment" : "Placeholder when no recent projects exist.",
       "extractionState" : "manual",

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -64,6 +64,18 @@ enum Strings {
         String(localized: "fileOperation.createError \(name)")
     }
 
+    static var undoDelete: String {
+        String(localized: "undo.delete")
+    }
+
+    static var undoRename: String {
+        String(localized: "undo.rename")
+    }
+
+    static var undoCreate: String {
+        String(localized: "undo.create")
+    }
+
     static var operationOutsideProject: String {
         String(localized: "fileOperation.outsideProject")
     }

--- a/PineTests/FileOperationUndoManagerTests.swift
+++ b/PineTests/FileOperationUndoManagerTests.swift
@@ -1,0 +1,239 @@
+//
+//  FileOperationUndoManagerTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+struct FileOperationUndoManagerTests {
+
+    // MARK: - Helpers
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineUndoTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - Delete undo
+
+    @Test func deleteFileCanBeUndone() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let fileURL = dir.appendingPathComponent("hello.txt")
+        try "content".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let undoManager = UndoManager()
+        let ops = FileOperationUndoManager()
+
+        try ops.deleteItem(at: fileURL, undoManager: undoManager)
+
+        #expect(!FileManager.default.fileExists(atPath: fileURL.path))
+
+        undoManager.undo()
+
+        #expect(FileManager.default.fileExists(atPath: fileURL.path))
+        let restored = try String(contentsOf: fileURL, encoding: .utf8)
+        #expect(restored == "content")
+    }
+
+    @Test func deleteDirectoryCanBeUndone() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let subdir = dir.appendingPathComponent("myFolder")
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: false)
+        let fileInside = subdir.appendingPathComponent("inner.txt")
+        try "inner".write(to: fileInside, atomically: true, encoding: .utf8)
+
+        let undoManager = UndoManager()
+        let ops = FileOperationUndoManager()
+
+        try ops.deleteItem(at: subdir, undoManager: undoManager)
+
+        #expect(!FileManager.default.fileExists(atPath: subdir.path))
+
+        undoManager.undo()
+
+        #expect(FileManager.default.fileExists(atPath: subdir.path))
+        let restored = try String(contentsOf: fileInside, encoding: .utf8)
+        #expect(restored == "inner")
+    }
+
+    // MARK: - Rename undo
+
+    @Test func renameFileCanBeUndone() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let oldURL = dir.appendingPathComponent("old.txt")
+        try "data".write(to: oldURL, atomically: true, encoding: .utf8)
+        let newURL = dir.appendingPathComponent("new.txt")
+
+        let undoManager = UndoManager()
+        let ops = FileOperationUndoManager()
+
+        try ops.renameItem(from: oldURL, to: newURL, undoManager: undoManager)
+
+        #expect(!FileManager.default.fileExists(atPath: oldURL.path))
+        #expect(FileManager.default.fileExists(atPath: newURL.path))
+
+        undoManager.undo()
+
+        #expect(FileManager.default.fileExists(atPath: oldURL.path))
+        #expect(!FileManager.default.fileExists(atPath: newURL.path))
+        let content = try String(contentsOf: oldURL, encoding: .utf8)
+        #expect(content == "data")
+    }
+
+    @Test func renameDirectoryCanBeUndone() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let oldURL = dir.appendingPathComponent("folderA")
+        try FileManager.default.createDirectory(at: oldURL, withIntermediateDirectories: false)
+        try "x".write(to: oldURL.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        let newURL = dir.appendingPathComponent("folderB")
+
+        let undoManager = UndoManager()
+        let ops = FileOperationUndoManager()
+
+        try ops.renameItem(from: oldURL, to: newURL, undoManager: undoManager)
+
+        #expect(!FileManager.default.fileExists(atPath: oldURL.path))
+        #expect(FileManager.default.fileExists(atPath: newURL.path))
+
+        undoManager.undo()
+
+        #expect(FileManager.default.fileExists(atPath: oldURL.path))
+        #expect(!FileManager.default.fileExists(atPath: newURL.path))
+    }
+
+    // MARK: - Create undo
+
+    @Test func createFileCanBeUndone() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let fileURL = dir.appendingPathComponent("created.txt")
+
+        let undoManager = UndoManager()
+        let ops = FileOperationUndoManager()
+
+        try ops.createItem(at: fileURL, isDirectory: false, undoManager: undoManager)
+
+        #expect(FileManager.default.fileExists(atPath: fileURL.path))
+
+        undoManager.undo()
+
+        #expect(!FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
+    @Test func createDirectoryCanBeUndone() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let folderURL = dir.appendingPathComponent("newFolder")
+
+        let undoManager = UndoManager()
+        let ops = FileOperationUndoManager()
+
+        try ops.createItem(at: folderURL, isDirectory: true, undoManager: undoManager)
+
+        var isDir: ObjCBool = false
+        #expect(FileManager.default.fileExists(atPath: folderURL.path, isDirectory: &isDir))
+        #expect(isDir.boolValue)
+
+        undoManager.undo()
+
+        #expect(!FileManager.default.fileExists(atPath: folderURL.path))
+    }
+
+    // MARK: - Redo
+
+    @Test func deleteRedoDeletesAgain() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let fileURL = dir.appendingPathComponent("redo.txt")
+        try "redo".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let undoManager = UndoManager()
+        let ops = FileOperationUndoManager()
+
+        try ops.deleteItem(at: fileURL, undoManager: undoManager)
+        undoManager.undo()
+        #expect(FileManager.default.fileExists(atPath: fileURL.path))
+
+        undoManager.redo()
+        #expect(!FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
+    @Test func renameRedoRenamesAgain() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let oldURL = dir.appendingPathComponent("a.txt")
+        try "a".write(to: oldURL, atomically: true, encoding: .utf8)
+        let newURL = dir.appendingPathComponent("b.txt")
+
+        let undoManager = UndoManager()
+        let ops = FileOperationUndoManager()
+
+        try ops.renameItem(from: oldURL, to: newURL, undoManager: undoManager)
+        undoManager.undo()
+        #expect(FileManager.default.fileExists(atPath: oldURL.path))
+
+        undoManager.redo()
+        #expect(FileManager.default.fileExists(atPath: newURL.path))
+        #expect(!FileManager.default.fileExists(atPath: oldURL.path))
+    }
+
+    @Test func createRedoRecreates() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let fileURL = dir.appendingPathComponent("redocreate.txt")
+
+        let undoManager = UndoManager()
+        let ops = FileOperationUndoManager()
+
+        try ops.createItem(at: fileURL, isDirectory: false, undoManager: undoManager)
+        undoManager.undo()
+        #expect(!FileManager.default.fileExists(atPath: fileURL.path))
+
+        undoManager.redo()
+        #expect(FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
+    // MARK: - Error cases
+
+    @Test func deleteNonexistentFileThrows() {
+        let ops = FileOperationUndoManager()
+        let undoManager = UndoManager()
+        let fakeURL = FileManager.default.temporaryDirectory.appendingPathComponent("nonexistent-\(UUID().uuidString)")
+
+        #expect(throws: (any Error).self) {
+            try ops.deleteItem(at: fakeURL, undoManager: undoManager)
+        }
+    }
+
+    @Test func renameNonexistentFileThrows() {
+        let ops = FileOperationUndoManager()
+        let undoManager = UndoManager()
+        let fakeURL = FileManager.default.temporaryDirectory.appendingPathComponent("nonexistent-\(UUID().uuidString)")
+        let destURL = FileManager.default.temporaryDirectory.appendingPathComponent("dest-\(UUID().uuidString)")
+
+        #expect(throws: (any Error).self) {
+            try ops.renameItem(from: fakeURL, to: destURL, undoManager: undoManager)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add `FileOperationUndoManager` — wraps delete/rename/create with `UndoManager` support
- Delete uses `trashItem` (recoverable), rename registers inverse `moveItem`, create registers `trashItem`
- Integrated in `ContentView` sidebar via `@Environment(\.undoManager)`

Closes #469

## Test plan

- [x] 11 unit tests in `FileOperationUndoManagerTests`
- [x] Localization: en/ru
- [x] SwiftLint clean

## Review notes

- ⚠️ `logError` uses `print` instead of `Logger` — needs fix
- ⚠️ `error.localizedDescription` instead of `\(error)`