### PR TITLE
feat: data migration system for UserDefaults schema changes (#471)

### DIFF
--- a/Pine/Logging.swift
+++ b/Pine/Logging.swift
@@ -17,6 +17,7 @@ enum LogCategory: String, CaseIterable {
     case terminal
     case editor
     case app
+    case migration
 
     /// Subsystem для всех логгеров Pine.
     static let subsystem = Bundle.main.bundleIdentifier ?? "io.github.batonogov.pine"
@@ -44,4 +45,7 @@ extension Logger {
 
     /// Приложение: запуск, окна, жизненный цикл.
     static let app = Logger(subsystem: LogCategory.subsystem, category: LogCategory.app.rawValue)
+
+    /// Миграции данных.
+    static let migration = Logger(subsystem: LogCategory.subsystem, category: LogCategory.migration.rawValue)
 }

--- a/Pine/MigrationManager.swift
+++ b/Pine/MigrationManager.swift
@@ -1,0 +1,142 @@
+//
+//  MigrationManager.swift
+//  Pine
+//
+//  Created by Claude on 24.03.2026.
+//
+
+import Foundation
+import os.log
+
+/// Manages sequential data migrations for UserDefaults schema changes.
+///
+/// On app launch, checks the stored schema version and applies any pending
+/// migrations in order. Each migration is a pure function that reads old
+/// format data and writes new format data.
+///
+/// Usage:
+/// ```
+/// var manager = MigrationManager()
+/// manager.registerMigration(from: 0, to: 1) { defaults in
+///     // transform data from v0 to v1
+/// }
+/// manager.runMigrations()
+/// ```
+struct MigrationManager {
+    /// UserDefaults key for the stored schema version.
+    static let schemaVersionKey = "pineSchemaVersion"
+
+    /// The latest schema version. Bump this when adding new migrations.
+    static let latestVersion = 1
+
+    /// Keys that indicate an existing (non-fresh) installation.
+    /// If none of these are present and no version key exists, treat as fresh install.
+    private static let existingInstallIndicators = [
+        "lastSessionState",         // Legacy session key
+        "recentProjectPaths",       // Recent projects
+        BlameConstants.storageKey   // Git blame preference
+    ]
+
+    private let defaults: UserDefaults
+    private var migrations: [(from: Int, to: Int, migrate: (UserDefaults) -> Void)] = []
+    private let logger = Logger(subsystem: "com.batonogov.Pine", category: "Migration")
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// Registers a migration step from one version to the next.
+    /// Migrations must be registered in ascending order (from: 0 → to: 1, from: 1 → to: 2, etc.).
+    mutating func registerMigration(from: Int, to: Int, migrate: @escaping (UserDefaults) -> Void) {
+        migrations.append((from: from, to: to, migrate: migrate))
+    }
+
+    /// Runs all pending migrations and updates the stored schema version.
+    ///
+    /// - Fresh install (no existing data, no version key): stamps latest version, skips migrations.
+    /// - Existing install without version key: treats as version 0 and runs all migrations.
+    /// - Existing install with version key: runs only migrations newer than the stored version.
+    func runMigrations() {
+        let hasVersionKey = defaults.object(forKey: Self.schemaVersionKey) != nil
+        let storedVersion = defaults.integer(forKey: Self.schemaVersionKey)
+
+        if storedVersion == Self.latestVersion {
+            logger.info("Schema already at version \(Self.latestVersion), no migrations needed")
+            return
+        }
+
+        if !hasVersionKey && !hasExistingData() {
+            // Fresh install — no data to migrate, just stamp latest version
+            logger.info("Fresh install detected, setting schema version to \(Self.latestVersion)")
+            defaults.set(Self.latestVersion, forKey: Self.schemaVersionKey)
+            return
+        }
+
+        // Run pending migrations
+        var currentVersion = storedVersion
+        let sortedMigrations = migrations.sorted { $0.from < $1.from }
+
+        for migration in sortedMigrations where migration.from >= currentVersion {
+            logger.info("Running migration v\(migration.from) → v\(migration.to)")
+            migration.migrate(defaults)
+            currentVersion = migration.to
+        }
+
+        defaults.set(Self.latestVersion, forKey: Self.schemaVersionKey)
+        logger.info("Migration complete, schema now at version \(Self.latestVersion)")
+    }
+
+    // MARK: - Private
+
+    private func storedSchemaVersion() -> Int {
+        defaults.integer(forKey: Self.schemaVersionKey)
+    }
+
+    /// Returns true if UserDefaults contains keys indicating an existing Pine installation.
+    private func hasExistingData() -> Bool {
+        for key in Self.existingInstallIndicators where defaults.object(forKey: key) != nil {
+            return true
+        }
+        // Check for per-project session keys
+        let allKeys = defaults.dictionaryRepresentation().keys
+        for key in allKeys where key.hasPrefix("sessionState:") {
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Default Migrations
+
+    /// Creates a MigrationManager with all built-in migrations registered.
+    static func withDefaultMigrations(defaults: UserDefaults = .standard) -> MigrationManager {
+        var manager = MigrationManager(defaults: defaults)
+
+        // Migration v0 → v1: Clean up stale recent projects that no longer exist on disk
+        manager.registerMigration(from: 0, to: 1) { defs in
+            if var paths = defs.stringArray(forKey: "recentProjectPaths") {
+                let before = paths.count
+                paths.removeAll { path in
+                    var isDir: ObjCBool = false
+                    return !FileManager.default.fileExists(atPath: path, isDirectory: &isDir)
+                        || !isDir.boolValue
+                }
+                if paths.count != before {
+                    defs.set(paths, forKey: "recentProjectPaths")
+                    Logger(subsystem: "com.batonogov.Pine", category: "Migration")
+                        .info("Cleaned \(before - paths.count) stale recent project(s)")
+                }
+            }
+
+            // Migrate legacy single-project session to per-project format
+            if let legacyData = defs.data(forKey: "lastSessionState") {
+                // Keep the legacy key for now — SessionState.load already handles fallback.
+                // Just log that we found it.
+                Logger(subsystem: "com.batonogov.Pine", category: "Migration")
+                    .info("Found legacy session key, will be migrated on next project open")
+                _ = legacyData // Suppress unused warning
+            }
+        }
+
+        return manager
+    }
+}

--- a/Pine/MigrationManager.swift
+++ b/Pine/MigrationManager.swift
@@ -98,10 +98,8 @@ struct MigrationManager {
             return true
         }
         // Check for prefixed keys (e.g. per-project session keys)
-        for prefix in Self.existingInstallPrefixedKeys {
-            if defaults.object(forKey: prefix) != nil {
-                return true
-            }
+        for prefix in Self.existingInstallPrefixedKeys where defaults.object(forKey: prefix) != nil {
+            return true
         }
         return false
     }

--- a/Pine/MigrationManager.swift
+++ b/Pine/MigrationManager.swift
@@ -34,12 +34,16 @@ struct MigrationManager {
     private static let existingInstallIndicators = [
         "lastSessionState",         // Legacy session key
         "recentProjectPaths",       // Recent projects
-        BlameConstants.storageKey   // Git blame preference
+        "blameVisible"              // Git blame preference
+    ]
+
+    /// Additional key prefixes to check for existing data.
+    private static let existingInstallPrefixedKeys = [
+        "sessionState:"             // Per-project session keys
     ]
 
     private let defaults: UserDefaults
     private var migrations: [(from: Int, to: Int, migrate: (UserDefaults) -> Void)] = []
-    private let logger = Logger(subsystem: "com.batonogov.Pine", category: "Migration")
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
@@ -61,13 +65,13 @@ struct MigrationManager {
         let storedVersion = defaults.integer(forKey: Self.schemaVersionKey)
 
         if storedVersion == Self.latestVersion {
-            logger.info("Schema already at version \(Self.latestVersion), no migrations needed")
+            Logger.migration.info("Schema already at version \(Self.latestVersion), no migrations needed")
             return
         }
 
         if !hasVersionKey && !hasExistingData() {
             // Fresh install — no data to migrate, just stamp latest version
-            logger.info("Fresh install detected, setting schema version to \(Self.latestVersion)")
+            Logger.migration.info("Fresh install detected, setting schema version to \(Self.latestVersion)")
             defaults.set(Self.latestVersion, forKey: Self.schemaVersionKey)
             return
         }
@@ -77,30 +81,27 @@ struct MigrationManager {
         let sortedMigrations = migrations.sorted { $0.from < $1.from }
 
         for migration in sortedMigrations where migration.from >= currentVersion {
-            logger.info("Running migration v\(migration.from) → v\(migration.to)")
+            Logger.migration.info("Running migration v\(migration.from) → v\(migration.to)")
             migration.migrate(defaults)
             currentVersion = migration.to
         }
 
         defaults.set(Self.latestVersion, forKey: Self.schemaVersionKey)
-        logger.info("Migration complete, schema now at version \(Self.latestVersion)")
+        Logger.migration.info("Migration complete, schema now at version \(Self.latestVersion)")
     }
 
     // MARK: - Private
-
-    private func storedSchemaVersion() -> Int {
-        defaults.integer(forKey: Self.schemaVersionKey)
-    }
 
     /// Returns true if UserDefaults contains keys indicating an existing Pine installation.
     private func hasExistingData() -> Bool {
         for key in Self.existingInstallIndicators where defaults.object(forKey: key) != nil {
             return true
         }
-        // Check for per-project session keys
-        let allKeys = defaults.dictionaryRepresentation().keys
-        for key in allKeys where key.hasPrefix("sessionState:") {
-            return true
+        // Check for prefixed keys (e.g. per-project session keys)
+        for prefix in Self.existingInstallPrefixedKeys {
+            if defaults.object(forKey: prefix) != nil {
+                return true
+            }
         }
         return false
     }
@@ -122,18 +123,9 @@ struct MigrationManager {
                 }
                 if paths.count != before {
                     defs.set(paths, forKey: "recentProjectPaths")
-                    Logger(subsystem: "com.batonogov.Pine", category: "Migration")
+                    Logger.migration
                         .info("Cleaned \(before - paths.count) stale recent project(s)")
                 }
-            }
-
-            // Migrate legacy single-project session to per-project format
-            if let legacyData = defs.data(forKey: "lastSessionState") {
-                // Keep the legacy key for now — SessionState.load already handles fallback.
-                // Just log that we found it.
-                Logger(subsystem: "com.batonogov.Pine", category: "Migration")
-                    .info("Found legacy session key, will be migrated on next project open")
-                _ = legacyData // Suppress unused warning
             }
         }
 

--- a/Pine/MigrationManager.swift
+++ b/Pine/MigrationManager.swift
@@ -2,11 +2,9 @@
 //  MigrationManager.swift
 //  Pine
 //
-//  Created by Claude on 24.03.2026.
-//
 
 import Foundation
-import os.log
+import os
 
 /// Manages sequential data migrations for UserDefaults schema changes.
 ///
@@ -97,8 +95,10 @@ struct MigrationManager {
         for key in Self.existingInstallIndicators where defaults.object(forKey: key) != nil {
             return true
         }
-        // Check for prefixed keys (e.g. per-project session keys)
-        for prefix in Self.existingInstallPrefixedKeys where defaults.object(forKey: prefix) != nil {
+        // Check for prefixed keys (e.g. per-project session keys like "sessionState:/path/...")
+        let allKeys = defaults.dictionaryRepresentation().keys
+        for prefix in Self.existingInstallPrefixedKeys
+            where allKeys.contains(where: { $0.hasPrefix(prefix) }) {
             return true
         }
         return false
@@ -125,6 +125,14 @@ struct MigrationManager {
                         .info("Cleaned \(before - paths.count) stale recent project(s)")
                 }
             }
+        }
+
+        // Validate that latestVersion matches the last registered migration
+        if let lastMigration = manager.migrations.max(by: { $0.to < $1.to }) {
+            assert(
+                latestVersion == lastMigration.to,
+                "latestVersion (\(latestVersion)) must equal the last migration's target (\(lastMigration.to))"
+            )
         }
 
         return manager

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -821,6 +821,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // Must be set before applicationDidFinishLaunching — the system runs
         // window restoration between willFinishLaunching and didFinishLaunching.
         UserDefaults.standard.set(false, forKey: "NSQuitAlwaysKeepsWindows")
+
+        // Run data migrations before any other UserDefaults access
+        MigrationManager.withDefaultMigrations().runMigrations()
+
         // Default blame to ON for first launch
         if UserDefaults.standard.object(forKey: BlameConstants.storageKey) == nil {
             UserDefaults.standard.set(true, forKey: BlameConstants.storageKey)

--- a/PineTests/LoggerTests.swift
+++ b/PineTests/LoggerTests.swift
@@ -68,11 +68,11 @@ struct LoggerTests {
     // MARK: - CaseIterable
 
     @Test func expectedCategoryCount() {
-        #expect(LogCategory.allCases.count == 7)
+        #expect(LogCategory.allCases.count == 8)
     }
 
     @Test func allCasesContainsAllCategories() {
-        let expected: Set<LogCategory> = [.syntax, .git, .fileTree, .search, .terminal, .editor, .app]
+        let expected: Set<LogCategory> = [.syntax, .git, .fileTree, .search, .terminal, .editor, .app, .migration]
         #expect(Set(LogCategory.allCases) == expected)
     }
 
@@ -86,6 +86,7 @@ struct LoggerTests {
         Logger.terminal.debug("test")
         Logger.editor.debug("test")
         Logger.app.debug("test")
+        Logger.migration.debug("test")
     }
 
     // MARK: - Logger creation from category

--- a/PineTests/MigrationManagerTests.swift
+++ b/PineTests/MigrationManagerTests.swift
@@ -1,0 +1,186 @@
+//
+//  MigrationManagerTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+struct MigrationManagerTests {
+
+    /// Creates a fresh in-memory UserDefaults suite for test isolation.
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "com.pine.test.\(UUID().uuidString)"
+        // swiftlint:disable:next force_unwrapping
+        let defaults = UserDefaults(suiteName: suiteName)!
+        return defaults
+    }
+
+    // MARK: - Fresh install starts at latest version
+
+    @Test func freshInstall_setsLatestVersion() {
+        let defaults = makeDefaults()
+
+        let manager = MigrationManager(defaults: defaults)
+        manager.runMigrations()
+
+        #expect(defaults.integer(forKey: MigrationManager.schemaVersionKey) == MigrationManager.latestVersion)
+    }
+
+    @Test func freshInstall_doesNotRunMigrations() {
+        let defaults = makeDefaults()
+        var migrationRan = false
+
+        var manager = MigrationManager(defaults: defaults)
+        manager.registerMigration(from: 0, to: 1) { _ in
+            migrationRan = true
+        }
+        manager.runMigrations()
+
+        #expect(!migrationRan)
+    }
+
+    // MARK: - Migration v0 → v1
+
+    @Test func migration_v0_to_v1_runs() {
+        let defaults = makeDefaults()
+        // Simulate a pre-migration installation (version 0 = no key set, but has data)
+        defaults.set("some-old-data", forKey: "legacyKey")
+        defaults.set(0, forKey: MigrationManager.schemaVersionKey)
+
+        var migrationRan = false
+
+        var manager = MigrationManager(defaults: defaults)
+        manager.registerMigration(from: 0, to: 1) { defs in
+            migrationRan = true
+            defs.removeObject(forKey: "legacyKey")
+        }
+        manager.runMigrations()
+
+        #expect(migrationRan)
+        #expect(defaults.object(forKey: "legacyKey") == nil)
+        #expect(defaults.integer(forKey: MigrationManager.schemaVersionKey) == MigrationManager.latestVersion)
+    }
+
+    // MARK: - Sequential migration chain
+
+    @Test func migration_chain_runs_in_order() {
+        let defaults = makeDefaults()
+        defaults.set(0, forKey: MigrationManager.schemaVersionKey)
+
+        var order: [Int] = []
+
+        var manager = MigrationManager(defaults: defaults)
+        manager.registerMigration(from: 0, to: 1) { _ in order.append(1) }
+        manager.registerMigration(from: 1, to: 2) { _ in order.append(2) }
+        manager.registerMigration(from: 2, to: 3) { _ in order.append(3) }
+        manager.runMigrations()
+
+        #expect(order == [1, 2, 3])
+        #expect(defaults.integer(forKey: MigrationManager.schemaVersionKey) == MigrationManager.latestVersion)
+    }
+
+    @Test func migration_skips_already_applied() {
+        let defaults = makeDefaults()
+        defaults.set(2, forKey: MigrationManager.schemaVersionKey)
+
+        var ranVersions: [Int] = []
+
+        var manager = MigrationManager(defaults: defaults)
+        manager.registerMigration(from: 0, to: 1) { _ in ranVersions.append(1) }
+        manager.registerMigration(from: 1, to: 2) { _ in ranVersions.append(2) }
+        manager.registerMigration(from: 2, to: 3) { _ in ranVersions.append(3) }
+        manager.runMigrations()
+
+        #expect(ranVersions == [3])
+    }
+
+    // MARK: - Idempotency
+
+    @Test func migration_idempotent_secondRunNoOp() {
+        let defaults = makeDefaults()
+        defaults.set(0, forKey: MigrationManager.schemaVersionKey)
+
+        var runCount = 0
+
+        var manager = MigrationManager(defaults: defaults)
+        manager.registerMigration(from: 0, to: 1) { _ in runCount += 1 }
+
+        manager.runMigrations()
+        #expect(runCount == 1)
+
+        // Second run should be a no-op — version is already at latest
+        manager.runMigrations()
+        #expect(runCount == 1)
+    }
+
+    // MARK: - Backward compatibility
+
+    @Test func existingData_withoutVersionKey_treatedAsVersion0() {
+        let defaults = makeDefaults()
+        // Simulate existing install that never had schema versioning
+        // (no schemaVersionKey set — defaults.integer returns 0)
+        defaults.set("existing-session", forKey: "sessionState:/some/path")
+
+        var migratedFromZero = false
+
+        var manager = MigrationManager(defaults: defaults)
+        manager.registerMigration(from: 0, to: 1) { _ in migratedFromZero = true }
+        manager.runMigrations()
+
+        #expect(migratedFromZero)
+        #expect(defaults.integer(forKey: MigrationManager.schemaVersionKey) == MigrationManager.latestVersion)
+    }
+
+    @Test func noExistingData_noVersionKey_freshInstall() {
+        let defaults = makeDefaults()
+        // Completely fresh — no data at all, no version key
+
+        var migrationRan = false
+
+        var manager = MigrationManager(defaults: defaults)
+        manager.registerMigration(from: 0, to: 1) { _ in migrationRan = true }
+        manager.runMigrations()
+
+        // Fresh install should NOT run migrations — just stamp latest version
+        #expect(!migrationRan)
+        #expect(defaults.integer(forKey: MigrationManager.schemaVersionKey) == MigrationManager.latestVersion)
+    }
+
+    // MARK: - Already at latest version
+
+    @Test func alreadyAtLatestVersion_noMigrationsRun() {
+        let defaults = makeDefaults()
+        defaults.set(MigrationManager.latestVersion, forKey: MigrationManager.schemaVersionKey)
+
+        var migrationRan = false
+
+        var manager = MigrationManager(defaults: defaults)
+        manager.registerMigration(from: 0, to: 1) { _ in migrationRan = true }
+        manager.runMigrations()
+
+        #expect(!migrationRan)
+    }
+
+    // MARK: - Migration mutates UserDefaults
+
+    @Test func migration_transformsData() {
+        let defaults = makeDefaults()
+        defaults.set(0, forKey: MigrationManager.schemaVersionKey)
+        defaults.set(["path1", "path2"], forKey: "recentProjectPaths")
+
+        var manager = MigrationManager(defaults: defaults)
+        manager.registerMigration(from: 0, to: 1) { defs in
+            // Simulate cleaning up stale recent projects
+            if var paths = defs.stringArray(forKey: "recentProjectPaths") {
+                paths.removeAll { $0 == "path1" }
+                defs.set(paths, forKey: "recentProjectPaths")
+            }
+        }
+        manager.runMigrations()
+
+        let remaining = defaults.stringArray(forKey: "recentProjectPaths")
+        #expect(remaining == ["path2"])
+    }
+}

--- a/PineTests/MigrationManagerTests.swift
+++ b/PineTests/MigrationManagerTests.swift
@@ -10,17 +10,19 @@ import Foundation
 struct MigrationManagerTests {
 
     /// Creates a fresh in-memory UserDefaults suite for test isolation.
-    private func makeDefaults() -> UserDefaults {
+    /// Returns both the defaults instance and the suite name for cleanup.
+    private func makeDefaults() -> (defaults: UserDefaults, suiteName: String) {
         let suiteName = "com.pine.test.\(UUID().uuidString)"
         // swiftlint:disable:next force_unwrapping
         let defaults = UserDefaults(suiteName: suiteName)!
-        return defaults
+        return (defaults, suiteName)
     }
 
     // MARK: - Fresh install starts at latest version
 
     @Test func freshInstall_setsLatestVersion() {
-        let defaults = makeDefaults()
+        let (defaults, suiteName) = makeDefaults()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
 
         let manager = MigrationManager(defaults: defaults)
         manager.runMigrations()
@@ -29,7 +31,9 @@ struct MigrationManagerTests {
     }
 
     @Test func freshInstall_doesNotRunMigrations() {
-        let defaults = makeDefaults()
+        let (defaults, suiteName) = makeDefaults()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
         var migrationRan = false
 
         var manager = MigrationManager(defaults: defaults)
@@ -44,7 +48,9 @@ struct MigrationManagerTests {
     // MARK: - Migration v0 → v1
 
     @Test func migration_v0_to_v1_runs() {
-        let defaults = makeDefaults()
+        let (defaults, suiteName) = makeDefaults()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
         // Simulate a pre-migration installation (version 0 = no key set, but has data)
         defaults.set("some-old-data", forKey: "legacyKey")
         defaults.set(0, forKey: MigrationManager.schemaVersionKey)
@@ -66,7 +72,9 @@ struct MigrationManagerTests {
     // MARK: - Sequential migration chain
 
     @Test func migration_chain_runs_in_order() {
-        let defaults = makeDefaults()
+        let (defaults, suiteName) = makeDefaults()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
         defaults.set(0, forKey: MigrationManager.schemaVersionKey)
 
         var order: [Int] = []
@@ -82,7 +90,9 @@ struct MigrationManagerTests {
     }
 
     @Test func migration_skips_already_applied() {
-        let defaults = makeDefaults()
+        let (defaults, suiteName) = makeDefaults()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
         defaults.set(2, forKey: MigrationManager.schemaVersionKey)
 
         var ranVersions: [Int] = []
@@ -99,7 +109,9 @@ struct MigrationManagerTests {
     // MARK: - Idempotency
 
     @Test func migration_idempotent_secondRunNoOp() {
-        let defaults = makeDefaults()
+        let (defaults, suiteName) = makeDefaults()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
         defaults.set(0, forKey: MigrationManager.schemaVersionKey)
 
         var runCount = 0
@@ -118,9 +130,11 @@ struct MigrationManagerTests {
     // MARK: - Backward compatibility
 
     @Test func existingData_withoutVersionKey_treatedAsVersion0() {
-        let defaults = makeDefaults()
+        let (defaults, suiteName) = makeDefaults()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
         // Simulate existing install that never had schema versioning
-        // (no schemaVersionKey set — defaults.integer returns 0)
+        // Uses a prefixed key like real per-project sessions ("sessionState:/some/path")
         defaults.set("existing-session", forKey: "sessionState:/some/path")
 
         var migratedFromZero = false
@@ -133,8 +147,26 @@ struct MigrationManagerTests {
         #expect(defaults.integer(forKey: MigrationManager.schemaVersionKey) == MigrationManager.latestVersion)
     }
 
+    @Test func existingData_exactIndicatorKey_treatedAsVersion0() {
+        let (defaults, suiteName) = makeDefaults()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
+        // Simulate existing install detected via exact key match
+        defaults.set(true, forKey: "blameVisible")
+
+        var migratedFromZero = false
+
+        var manager = MigrationManager(defaults: defaults)
+        manager.registerMigration(from: 0, to: 1) { _ in migratedFromZero = true }
+        manager.runMigrations()
+
+        #expect(migratedFromZero)
+    }
+
     @Test func noExistingData_noVersionKey_freshInstall() {
-        let defaults = makeDefaults()
+        let (defaults, suiteName) = makeDefaults()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
         // Completely fresh — no data at all, no version key
 
         var migrationRan = false
@@ -151,7 +183,9 @@ struct MigrationManagerTests {
     // MARK: - Already at latest version
 
     @Test func alreadyAtLatestVersion_noMigrationsRun() {
-        let defaults = makeDefaults()
+        let (defaults, suiteName) = makeDefaults()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
         defaults.set(MigrationManager.latestVersion, forKey: MigrationManager.schemaVersionKey)
 
         var migrationRan = false
@@ -166,7 +200,9 @@ struct MigrationManagerTests {
     // MARK: - Migration mutates UserDefaults
 
     @Test func migration_transformsData() {
-        let defaults = makeDefaults()
+        let (defaults, suiteName) = makeDefaults()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
         defaults.set(0, forKey: MigrationManager.schemaVersionKey)
         defaults.set(["path1", "path2"], forKey: "recentProjectPaths")
 
@@ -182,5 +218,25 @@ struct MigrationManagerTests {
 
         let remaining = defaults.stringArray(forKey: "recentProjectPaths")
         #expect(remaining == ["path2"])
+    }
+
+    // MARK: - withDefaultMigrations
+
+    @Test func withDefaultMigrations_cleansStaleRecentProjects() {
+        let (defaults, suiteName) = makeDefaults()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
+        // Simulate v0 install with stale recent projects (non-existent paths)
+        defaults.set(0, forKey: MigrationManager.schemaVersionKey)
+        let staleDir = "/tmp/pine-test-nonexistent-\(UUID().uuidString)"
+        let validDir = NSTemporaryDirectory()
+        defaults.set([staleDir, validDir], forKey: "recentProjectPaths")
+
+        let manager = MigrationManager.withDefaultMigrations(defaults: defaults)
+        manager.runMigrations()
+
+        let remaining = defaults.stringArray(forKey: "recentProjectPaths")
+        #expect(remaining == [validDir])
+        #expect(defaults.integer(forKey: MigrationManager.schemaVersionKey) == MigrationManager.latestVersion)
     }
 }


### PR DESCRIPTION
## Summary

- Add `MigrationManager` — sequential data migrations for UserDefaults schema changes
- Detects fresh install vs existing install, applies pending migrations in order
- First migration v0→v1: cleans stale recent projects that no longer exist on disk
- Runs in `applicationWillFinishLaunching` before any UserDefaults access
- Added `Logger.migration` category to Logging.swift

Closes #471

## Test plan

- [x] 10 unit tests in `MigrationManagerTests`
  - Fresh install, idempotency, chain migrations, backward compat, data transformation
- [x] SwiftLint clean