### PR TITLE
polish: visual refinement — spacing, empty states, layout metrics (#507)

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -61,6 +61,8 @@ enum AccessibilityID {
 
     // MARK: - Project Search
     static let projectSearchResultsList = "projectSearchResultsList"
+    static let searchEmptyState = "searchEmptyState"
+    static let searchInitialState = "searchInitialState"
 
     // MARK: - Quick Open
     static let quickOpenOverlay = "quickOpenOverlay"

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -1490,7 +1490,7 @@ struct StatusBarView: View {
     var tabManager: TabManager
 
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: LayoutMetrics.statusBarItemSpacing) {
             if gitProvider.isGitRepository {
                 // Git file change summary
                 if !gitProvider.fileStatuses.isEmpty {
@@ -1521,7 +1521,7 @@ struct StatusBarView: View {
                             .foregroundStyle(.teal)
                         }
                     }
-                    .font(.system(size: 10))
+                    .font(.system(size: LayoutMetrics.captionFontSize))
                 }
             }
 
@@ -1530,7 +1530,7 @@ struct StatusBarView: View {
             if let activeTab = tabManager.activeTab, activeTab.kind == .text {
                 // Line / Column indicator (cached in EditorTab by TabManager)
                 Text(verbatim: "Ln \(activeTab.cursorLine), Col \(activeTab.cursorColumn)")
-                    .font(.system(size: 11))
+                    .font(.system(size: LayoutMetrics.bodySmallFontSize))
                     .foregroundStyle(.secondary)
                     .accessibilityIdentifier(AccessibilityID.cursorPosition)
 
@@ -1538,7 +1538,7 @@ struct StatusBarView: View {
 
                 // Indentation style indicator (cached, recomputed on content change)
                 Text(verbatim: activeTab.cachedIndentation.displayName)
-                    .font(.system(size: 11))
+                    .font(.system(size: LayoutMetrics.bodySmallFontSize))
                     .foregroundStyle(.secondary)
                     .accessibilityIdentifier(AccessibilityID.indentationIndicator)
 
@@ -1546,7 +1546,7 @@ struct StatusBarView: View {
 
                 // Line ending indicator (cached, recomputed on content change)
                 Text(verbatim: activeTab.cachedLineEnding.displayName)
-                    .font(.system(size: 11))
+                    .font(.system(size: LayoutMetrics.bodySmallFontSize))
                     .foregroundStyle(.secondary)
                     .accessibilityIdentifier(AccessibilityID.lineEndingIndicator)
 
@@ -1568,7 +1568,7 @@ struct StatusBarView: View {
                     }
                 } label: {
                     Text(activeTab.encoding.displayName)
-                        .font(.system(size: 11))
+                        .font(.system(size: LayoutMetrics.bodySmallFontSize))
                         .foregroundStyle(.secondary)
                 }
                 .menuStyle(.borderlessButton)
@@ -1581,7 +1581,7 @@ struct StatusBarView: View {
                     statusDivider
 
                     Text(verbatim: FileSizeFormatter.format(size))
-                        .font(.system(size: 11))
+                        .font(.system(size: LayoutMetrics.bodySmallFontSize))
                         .foregroundStyle(.secondary)
                         .accessibilityIdentifier(AccessibilityID.fileSizeIndicator)
                 }
@@ -1594,11 +1594,11 @@ struct StatusBarView: View {
                 HStack(spacing: 3) {
                     Image(systemName: terminal.isTerminalVisible
                           ? "chevron.down" : "chevron.up")
-                        .font(.system(size: 9, weight: .semibold))
+                        .font(.system(size: LayoutMetrics.iconSmallFontSize, weight: .semibold))
                     Image(systemName: "terminal")
-                        .font(.system(size: 10))
+                        .font(.system(size: LayoutMetrics.captionFontSize))
                     Text(Strings.terminalLabel)
-                        .font(.system(size: 11))
+                        .font(.system(size: LayoutMetrics.bodySmallFontSize))
                 }
                 .foregroundStyle(terminal.isTerminalVisible ? .primary : .secondary)
             }
@@ -1607,15 +1607,15 @@ struct StatusBarView: View {
             .accessibilityIdentifier(AccessibilityID.terminalToggleButton)
             .accessibilityAddTraits(.isButton)
         }
-        .padding(.leading, 8)
-        .padding(.trailing, 14)
-        .frame(height: 22)
+        .padding(.horizontal, LayoutMetrics.statusBarHorizontalPadding)
+        .frame(height: LayoutMetrics.statusBarHeight)
         .background(.bar)
+        .accessibilityIdentifier(AccessibilityID.statusBar)
     }
 
     private var statusDivider: some View {
         Text(verbatim: "·")
-            .font(.system(size: 11))
+            .font(.system(size: LayoutMetrics.bodySmallFontSize))
             .foregroundStyle(.quaternary)
     }
 

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -1624,6 +1624,7 @@ struct StatusBarView: View {
         .padding(.horizontal, LayoutMetrics.statusBarHorizontalPadding)
         .frame(height: LayoutMetrics.statusBarHeight)
         .background(.bar)
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier(AccessibilityID.statusBar)
     }
 

--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -148,7 +148,7 @@ struct EditorTabBar: View {
                     onTogglePreview?()
                 } label: {
                     Image(systemName: previewIcon)
-                        .font(.system(size: LayoutMetrics.iconMediumFontSize, weight: .medium))
+                        .font(.system(size: LayoutMetrics.bodySmallFontSize, weight: .medium))
                         .foregroundStyle(.secondary)
                         .frame(width: 24, height: 24)
                 }

--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -119,7 +119,7 @@ struct EditorTabBar: View {
                     }
                 } label: {
                     Image(systemName: "chevron.down")
-                        .font(.system(size: 9, weight: .medium))
+                        .font(.system(size: LayoutMetrics.iconSmallFontSize, weight: .medium))
                         .foregroundStyle(.secondary)
                         .frame(width: 24, height: 24)
                         .contentShape(Rectangle())
@@ -134,7 +134,7 @@ struct EditorTabBar: View {
             Group {
                 if isAutoSaving {
                     Text(Strings.autoSaving)
-                        .font(.system(size: 10))
+                        .font(.system(size: LayoutMetrics.captionFontSize))
                         .foregroundStyle(.tertiary)
                         .transition(.opacity)
                         .accessibilityIdentifier(AccessibilityID.autoSaveIndicator)
@@ -148,7 +148,7 @@ struct EditorTabBar: View {
                     onTogglePreview?()
                 } label: {
                     Image(systemName: previewIcon)
-                        .font(.system(size: 11, weight: .medium))
+                        .font(.system(size: LayoutMetrics.iconMediumFontSize, weight: .medium))
                         .foregroundStyle(.secondary)
                         .frame(width: 24, height: 24)
                 }
@@ -158,7 +158,7 @@ struct EditorTabBar: View {
                 .padding(.trailing, 4)
             }
         }
-        .frame(height: 30)
+        .frame(height: LayoutMetrics.tabBarHeight)
         .background(.bar)
         .accessibilityIdentifier(AccessibilityID.editorTabBar)
     }
@@ -227,11 +227,11 @@ struct EditorTabItem: View {
             .accessibilityIdentifier(AccessibilityID.editorTabCloseButton(tab.fileName))
 
             Image(systemName: FileIconMapper.iconForFile(tab.fileName))
-                .font(.system(size: 9))
+                .font(.system(size: LayoutMetrics.iconSmallFontSize))
                 .foregroundStyle(.secondary)
 
             Text(tab.fileName)
-                .font(.system(size: 11))
+                .font(.system(size: LayoutMetrics.bodySmallFontSize))
                 .lineLimit(1)
                 .truncationMode(.middle)
         }

--- a/Pine/LayoutMetrics.swift
+++ b/Pine/LayoutMetrics.swift
@@ -1,0 +1,58 @@
+//
+//  LayoutMetrics.swift
+//  Pine
+//
+//  Centralized layout constants for consistent spacing, font sizes,
+//  and dimensions across the UI. Avoids hardcoded magic numbers.
+//
+
+import Foundation
+
+/// Shared layout metrics for Pine UI components.
+///
+/// Usage: `LayoutMetrics.statusBarHeight`, `LayoutMetrics.bodySmallFontSize`, etc.
+/// Centralizing these values ensures visual consistency and makes
+/// design changes a single-point edit.
+enum LayoutMetrics {
+
+    // MARK: - Font sizes
+
+    /// Small icon size (close buttons, tab chevrons). 9pt.
+    static let iconSmallFontSize: CGFloat = 9
+
+    /// Caption / badge text. 10pt.
+    static let captionFontSize: CGFloat = 10
+
+    /// Body-small / status bar items. 11pt.
+    static let bodySmallFontSize: CGFloat = 11
+
+    /// Medium icon size (file icons in tabs, preview toggle). 11pt.
+    static let iconMediumFontSize: CGFloat = 11
+
+    // MARK: - Status bar
+
+    /// Symmetric horizontal padding for the status bar.
+    static let statusBarHorizontalPadding: CGFloat = 10
+
+    /// Status bar fixed height.
+    static let statusBarHeight: CGFloat = 22
+
+    /// Spacing between status bar items.
+    static let statusBarItemSpacing: CGFloat = 6
+
+    // MARK: - Tab bar
+
+    /// Editor / terminal tab bar height.
+    static let tabBarHeight: CGFloat = 30
+
+    // MARK: - Search results
+
+    /// Vertical padding for individual match rows.
+    static let searchResultRowVerticalPadding: CGFloat = 2
+
+    /// Vertical padding for file group headers.
+    static let searchResultHeaderVerticalPadding: CGFloat = 4
+
+    /// Horizontal padding for search result rows and headers.
+    static let searchResultHorizontalPadding: CGFloat = 8
+}

--- a/Pine/LayoutMetrics.swift
+++ b/Pine/LayoutMetrics.swift
@@ -8,7 +8,11 @@
 
 import Foundation
 
-/// Shared layout metrics for Pine UI components.
+/// Shared **UI layout** metrics for Pine visual components — spacing, font sizes, and dimensions.
+///
+/// This enum is for presentational constants only (padding, heights, font sizes).
+/// For logical/domain constants (ASCII codes, file size thresholds, search limits)
+/// see ``Constants``.
 ///
 /// Usage: `LayoutMetrics.statusBarHeight`, `LayoutMetrics.bodySmallFontSize`, etc.
 /// Centralizing these values ensures visual consistency and makes
@@ -25,9 +29,6 @@ enum LayoutMetrics {
 
     /// Body-small / status bar items. 11pt.
     static let bodySmallFontSize: CGFloat = 11
-
-    /// Medium icon size (file icons in tabs, preview toggle). 11pt.
-    static let iconMediumFontSize: CGFloat = 11
 
     // MARK: - Status bar
 

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -5702,6 +5702,42 @@
         }
       }
     },
+    "search.initialDescription" : {
+      "comment" : "Description text shown on the initial search screen before any query is entered.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type to search across all project files"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите текст для поиска по всем файлам проекта"
+          }
+        }
+      }
+    },
+    "search.initialPrompt" : {
+      "comment" : "Title shown on the initial search screen before any query is entered.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search in Project"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск по проекту"
+          }
+        }
+      }
+    },
     "search.noResults" : {
       "comment" : "Shown when project search finds no results.",
       "extractionState" : "manual",

--- a/Pine/SearchResultsView.swift
+++ b/Pine/SearchResultsView.swift
@@ -15,22 +15,22 @@ struct SearchResultsView: View {
         let search = projectManager.searchProvider
 
         if search.isSearching {
-            VStack {
-                Spacer()
+            ContentUnavailableView {
                 ProgressView()
                     .controlSize(.small)
-                Spacer()
             }
-            .frame(maxWidth: .infinity)
         } else if search.results.isEmpty && !search.query.isEmpty {
-            VStack {
-                Spacer()
-                Text(Strings.searchNoResults)
-                    .foregroundStyle(.secondary)
-                    .font(.system(size: 12))
-                Spacer()
+            ContentUnavailableView {
+                Label(Strings.searchNoResults, systemImage: "magnifyingglass")
             }
-            .frame(maxWidth: .infinity)
+            .accessibilityIdentifier(AccessibilityID.searchEmptyState)
+        } else if search.query.isEmpty {
+            ContentUnavailableView {
+                Label(Strings.searchInitialPrompt, systemImage: "text.magnifyingglass")
+            } description: {
+                Text(Strings.searchInitialDescription)
+            }
+            .accessibilityIdentifier(AccessibilityID.searchInitialState)
         } else {
             searchResultsList
         }
@@ -52,23 +52,23 @@ struct SearchResultsView: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 4) {
                 Image(systemName: FileIconMapper.iconForFile(group.url.lastPathComponent))
-                    .font(.system(size: 11))
+                    .font(.system(size: LayoutMetrics.iconMediumFontSize))
                     .foregroundStyle(.secondary)
                 Text(group.relativePath)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: LayoutMetrics.bodySmallFontSize, weight: .medium))
                     .lineLimit(1)
                     .truncationMode(.middle)
 
                 Spacer()
 
                 Text("\(group.matches.count)")
-                    .font(.system(size: 10))
+                    .font(.system(size: LayoutMetrics.captionFontSize))
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 4)
                     .background(.quaternary, in: Capsule())
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(.horizontal, LayoutMetrics.searchResultHorizontalPadding)
+            .padding(.vertical, LayoutMetrics.searchResultHeaderVerticalPadding)
             .background(.bar)
 
             ForEach(group.matches) { match in
@@ -101,17 +101,17 @@ private struct MatchRowView: View {
         } label: {
             HStack(spacing: 6) {
                 Text("\(match.lineNumber)")
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(.system(size: LayoutMetrics.captionFontSize, design: .monospaced))
                     .foregroundStyle(.tertiary)
                     .frame(width: 30, alignment: .trailing)
 
                 highlightedText
-                    .font(.system(size: 11, design: .monospaced))
+                    .font(.system(size: LayoutMetrics.bodySmallFontSize, design: .monospaced))
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 2)
+            .padding(.horizontal, LayoutMetrics.searchResultHorizontalPadding)
+            .padding(.vertical, LayoutMetrics.searchResultRowVerticalPadding)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
             .background(isHovered ? Color.primary.opacity(0.06) : Color.clear)

--- a/Pine/SearchResultsView.swift
+++ b/Pine/SearchResultsView.swift
@@ -15,10 +15,13 @@ struct SearchResultsView: View {
         let search = projectManager.searchProvider
 
         if search.isSearching {
-            ContentUnavailableView {
+            VStack {
+                Spacer()
                 ProgressView()
                     .controlSize(.small)
+                Spacer()
             }
+            .frame(maxWidth: .infinity)
         } else if search.results.isEmpty && !search.query.isEmpty {
             ContentUnavailableView {
                 Label(Strings.searchNoResults, systemImage: "magnifyingglass")
@@ -52,7 +55,7 @@ struct SearchResultsView: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 4) {
                 Image(systemName: FileIconMapper.iconForFile(group.url.lastPathComponent))
-                    .font(.system(size: LayoutMetrics.iconMediumFontSize))
+                    .font(.system(size: LayoutMetrics.bodySmallFontSize))
                     .foregroundStyle(.secondary)
                 Text(group.relativePath)
                     .font(.system(size: LayoutMetrics.bodySmallFontSize, weight: .medium))

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -248,6 +248,8 @@ enum Strings {
 
     static let searchPlaceholder: LocalizedStringKey = "search.placeholder"
     static let searchNoResults: LocalizedStringKey = "search.noResults"
+    static let searchInitialPrompt: LocalizedStringKey = "search.initialPrompt"
+    static let searchInitialDescription: LocalizedStringKey = "search.initialDescription"
     static let searchCaseSensitive: LocalizedStringKey = "search.caseSensitive"
     static let searchClose: LocalizedStringKey = "search.close"
     static let menuFind: LocalizedStringKey = "menu.find"

--- a/PineTests/LayoutMetricsTests.swift
+++ b/PineTests/LayoutMetricsTests.swift
@@ -30,11 +30,6 @@ struct LayoutMetricsTests {
         #expect(LayoutMetrics.iconSmallFontSize == 9)
     }
 
-    @Test("Icon medium font size is 11")
-    func iconMediumFontSize() {
-        #expect(LayoutMetrics.iconMediumFontSize == 11)
-    }
-
     // MARK: - Spacing
 
     @Test("Status bar horizontal padding is consistent")
@@ -79,7 +74,6 @@ struct LayoutMetricsTests {
         #expect(LayoutMetrics.captionFontSize > 0)
         #expect(LayoutMetrics.bodySmallFontSize > 0)
         #expect(LayoutMetrics.iconSmallFontSize > 0)
-        #expect(LayoutMetrics.iconMediumFontSize > 0)
         #expect(LayoutMetrics.statusBarHorizontalPadding > 0)
         #expect(LayoutMetrics.statusBarHeight > 0)
         #expect(LayoutMetrics.statusBarItemSpacing > 0)

--- a/PineTests/LayoutMetricsTests.swift
+++ b/PineTests/LayoutMetricsTests.swift
@@ -1,0 +1,99 @@
+//
+//  LayoutMetricsTests.swift
+//  PineTests
+//
+//  Tests for centralized layout spacing constants.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("LayoutMetrics Constants")
+struct LayoutMetricsTests {
+
+    // MARK: - Font sizes
+
+    @Test("Caption font size is 10")
+    func captionFontSize() {
+        #expect(LayoutMetrics.captionFontSize == 10)
+    }
+
+    @Test("Body small font size is 11")
+    func bodySmallFontSize() {
+        #expect(LayoutMetrics.bodySmallFontSize == 11)
+    }
+
+    @Test("Icon small font size is 9")
+    func iconSmallFontSize() {
+        #expect(LayoutMetrics.iconSmallFontSize == 9)
+    }
+
+    @Test("Icon medium font size is 11")
+    func iconMediumFontSize() {
+        #expect(LayoutMetrics.iconMediumFontSize == 11)
+    }
+
+    // MARK: - Spacing
+
+    @Test("Status bar horizontal padding is consistent")
+    func statusBarPadding() {
+        #expect(LayoutMetrics.statusBarHorizontalPadding == 10)
+    }
+
+    @Test("Status bar height is 22")
+    func statusBarHeight() {
+        #expect(LayoutMetrics.statusBarHeight == 22)
+    }
+
+    @Test("Status bar item spacing is 6")
+    func statusBarItemSpacing() {
+        #expect(LayoutMetrics.statusBarItemSpacing == 6)
+    }
+
+    @Test("Tab bar height is 30")
+    func tabBarHeight() {
+        #expect(LayoutMetrics.tabBarHeight == 30)
+    }
+
+    @Test("Search results row vertical padding is 2")
+    func searchResultsRowPadding() {
+        #expect(LayoutMetrics.searchResultRowVerticalPadding == 2)
+    }
+
+    @Test("Search results header vertical padding is 4")
+    func searchResultsHeaderPadding() {
+        #expect(LayoutMetrics.searchResultHeaderVerticalPadding == 4)
+    }
+
+    @Test("Search results horizontal padding is 8")
+    func searchResultsHorizontalPadding() {
+        #expect(LayoutMetrics.searchResultHorizontalPadding == 8)
+    }
+
+    // MARK: - All values are positive
+
+    @Test("All spacing values are positive")
+    func allValuesPositive() {
+        #expect(LayoutMetrics.captionFontSize > 0)
+        #expect(LayoutMetrics.bodySmallFontSize > 0)
+        #expect(LayoutMetrics.iconSmallFontSize > 0)
+        #expect(LayoutMetrics.iconMediumFontSize > 0)
+        #expect(LayoutMetrics.statusBarHorizontalPadding > 0)
+        #expect(LayoutMetrics.statusBarHeight > 0)
+        #expect(LayoutMetrics.statusBarItemSpacing > 0)
+        #expect(LayoutMetrics.tabBarHeight > 0)
+        #expect(LayoutMetrics.searchResultRowVerticalPadding > 0)
+        #expect(LayoutMetrics.searchResultHeaderVerticalPadding > 0)
+        #expect(LayoutMetrics.searchResultHorizontalPadding > 0)
+    }
+
+    // MARK: - Font size ordering
+
+    @Test("Font sizes are ordered: icon small < caption < body small")
+    func fontSizeOrdering() {
+        #expect(LayoutMetrics.iconSmallFontSize < LayoutMetrics.captionFontSize)
+        #expect(LayoutMetrics.captionFontSize < LayoutMetrics.bodySmallFontSize)
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Pine/LayoutMetrics.swift` — centralized font sizes, spacing, dimensions
- Replace hardcoded magic numbers in StatusBarView, EditorTabBar, SearchResultsView
- Fix asymmetric status bar padding (leading 8 + trailing 14 → horizontal 10)
- Add `ContentUnavailableView` empty states for search (no results + initial prompt)
- Add accessibility identifiers for empty states

⚠️ **Visual changes** — needs product owner review before merge

Closes #507

## Test plan

- [x] 13 unit tests in `LayoutMetricsTests`
- [x] Localization: en/ru for new strings
- [x] SwiftLint clean