### PR TITLE
feat: search in recent projects list on Welcome screen (#300)

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -11,6 +11,7 @@ enum AccessibilityID {
     static let welcomeOpenFolderButton = "welcomeOpenFolderButton"
     static let welcomeRecentProjectsList = "welcomeRecentProjectsList"
     static let welcomeSearchField = "welcomeSearchField"
+    static let welcomeSearchToggle = "welcomeSearchToggle"
     static func welcomeRecentProject(_ name: String) -> String { "welcomeRecentProject_\(name)" }
 
     // MARK: - Main editor window

--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -10,6 +10,7 @@ enum AccessibilityID {
     static let welcomeWindow = "welcomeWindow"
     static let welcomeOpenFolderButton = "welcomeOpenFolderButton"
     static let welcomeRecentProjectsList = "welcomeRecentProjectsList"
+    static let welcomeSearchField = "welcomeSearchField"
     static func welcomeRecentProject(_ name: String) -> String { "welcomeRecentProject_\(name)" }
 
     // MARK: - Main editor window

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -7697,6 +7697,48 @@
             "state" : "translated",
             "value" : "Нет подходящих проектов"
           }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine passenden Projekte"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay proyectos coincidentes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun projet correspondant"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一致するプロジェクトはありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일치하는 프로젝트 없음"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhum projeto correspondente"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有匹配的项目"
+          }
         }
       }
     },
@@ -7774,6 +7816,48 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Фильтр проектов…"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Projekte filtern…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtrar proyectos…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtrer les projets…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プロジェクトを検索…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "프로젝트 검색…"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtrar projetos…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "筛选项目…"
           }
         }
       }

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -7682,6 +7682,24 @@
         }
       }
     },
+    "welcome.noSearchResults" : {
+      "comment" : "Placeholder when search filter matches no recent projects.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Matching Projects"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет подходящих проектов"
+          }
+        }
+      }
+    },
     "welcome.recentProjects" : {
       "comment" : "Header for recent projects list in the welcome window.",
       "extractionState" : "manual",
@@ -7738,6 +7756,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近的项目"
+          }
+        }
+      }
+    },
+    "welcome.searchPlaceholder" : {
+      "comment" : "Placeholder for the search field in the recent projects list.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter projects…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фильтр проектов…"
           }
         }
       }

--- a/Pine/RecentProjectsFilter.swift
+++ b/Pine/RecentProjectsFilter.swift
@@ -1,0 +1,21 @@
+//
+//  RecentProjectsFilter.swift
+//  Pine
+//
+
+import Foundation
+
+/// Filters recent project URLs by case-insensitive substring matching
+/// against the project name (last path component) and full path.
+enum RecentProjectsFilter {
+    /// Returns URLs that match the query. Empty/whitespace query returns all URLs.
+    static func filter(_ urls: [URL], query: String) -> [URL] {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return urls }
+        let lowered = trimmed.lowercased()
+        return urls.filter { url in
+            url.lastPathComponent.lowercased().contains(lowered)
+                || url.path.lowercased().contains(lowered)
+        }
+    }
+}

--- a/Pine/RecentProjectsFilter.swift
+++ b/Pine/RecentProjectsFilter.swift
@@ -10,7 +10,7 @@ import Foundation
 enum RecentProjectsFilter {
     /// Returns URLs that match the query. Empty/whitespace query returns all URLs.
     static func filter(_ urls: [URL], query: String) -> [URL] {
-        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return urls }
         let lowered = trimmed.lowercased()
         return urls.filter { url in

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -244,6 +244,9 @@ enum Strings {
     static let welcomeRecentProjects: LocalizedStringKey = "welcome.recentProjects"
     static let welcomeNoRecent: LocalizedStringKey = "welcome.noRecent"
     static let welcomeSearchPlaceholder: LocalizedStringKey = "welcome.searchPlaceholder"
+    static var welcomeSearchPlaceholderString: String {
+        String(localized: "welcome.searchPlaceholder")
+    }
     static let welcomeNoSearchResults: LocalizedStringKey = "welcome.noSearchResults"
 
     // MARK: - Project Search

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -243,6 +243,8 @@ enum Strings {
     static let welcomeSubtitle: LocalizedStringKey = "welcome.subtitle"
     static let welcomeRecentProjects: LocalizedStringKey = "welcome.recentProjects"
     static let welcomeNoRecent: LocalizedStringKey = "welcome.noRecent"
+    static let welcomeSearchPlaceholder: LocalizedStringKey = "welcome.searchPlaceholder"
+    static let welcomeNoSearchResults: LocalizedStringKey = "welcome.noSearchResults"
 
     // MARK: - Project Search
 

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -115,7 +115,7 @@ struct WelcomeView: View {
                     }
                     .frame(maxHeight: .infinity)
                 } else {
-                    if registry.recentProjects.count > 5 {
+                    if registry.recentProjects.count > 8 {
                         WelcomeSearchField(text: $searchText)
                             .frame(height: 22)
                             .padding(.horizontal)

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -26,6 +26,13 @@ struct WelcomeView: View {
     /// AppDelegate reference for checking pending project URL (UI testing).
     var appDelegate: AppDelegate?
 
+    @State private var searchText = ""
+
+    /// Recent projects filtered by the search query.
+    private var filteredProjects: [URL] {
+        RecentProjectsFilter.filter(registry.recentProjects, query: searchText)
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             // Left: logo and actions
@@ -71,26 +78,39 @@ struct WelcomeView: View {
                     }
                     .frame(maxHeight: .infinity)
                 } else {
-                    ScrollView {
-                        LazyVStack(spacing: 0) {
-                            ForEach(
-                                Array(registry.recentProjects.enumerated()),
-                                id: \.element
-                            ) { index, url in
-                                if index > 0 {
-                                    Divider()
-                                        .padding(.leading)
+                    TextField(Strings.welcomeSearchPlaceholder, text: $searchText)
+                        .textFieldStyle(.roundedBorder)
+                        .padding(.horizontal)
+                        .padding(.bottom, 8)
+                        .accessibilityIdentifier(AccessibilityID.welcomeSearchField)
+
+                    if filteredProjects.isEmpty {
+                        ContentUnavailableView {
+                            Label(Strings.welcomeNoSearchResults, systemImage: "magnifyingglass")
+                        }
+                        .frame(maxHeight: .infinity)
+                    } else {
+                        ScrollView {
+                            LazyVStack(spacing: 0) {
+                                ForEach(
+                                    Array(filteredProjects.enumerated()),
+                                    id: \.element
+                                ) { index, url in
+                                    if index > 0 {
+                                        Divider()
+                                            .padding(.leading)
+                                    }
+                                    RecentProjectRow(url: url) {
+                                        openProject(at: url)
+                                    }
+                                    .accessibilityIdentifier(
+                                        AccessibilityID.welcomeRecentProject(url.lastPathComponent)
+                                    )
                                 }
-                                RecentProjectRow(url: url) {
-                                    openProject(at: url)
-                                }
-                                .accessibilityIdentifier(
-                                    AccessibilityID.welcomeRecentProject(url.lastPathComponent)
-                                )
                             }
                         }
+                        .accessibilityIdentifier(AccessibilityID.welcomeRecentProjectsList)
                     }
-                    .accessibilityIdentifier(AccessibilityID.welcomeRecentProjectsList)
                 }
             }
             .frame(minWidth: 280)

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -14,7 +14,7 @@ struct WelcomeSearchField: NSViewRepresentable {
 
     func makeNSView(context: Context) -> NSSearchField {
         let searchField = NSSearchField()
-        searchField.placeholderString = Strings.welcomeSearchPlaceholder
+        searchField.placeholderString = String(localized: "welcome.searchPlaceholder")
         searchField.delegate = context.coordinator
         searchField.setAccessibilityIdentifier(AccessibilityID.welcomeSearchField)
         return searchField

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -14,7 +14,7 @@ struct WelcomeSearchField: NSViewRepresentable {
 
     func makeNSView(context: Context) -> NSSearchField {
         let searchField = NSSearchField()
-        searchField.placeholderString = String(localized: "welcome.searchPlaceholder")
+        searchField.placeholderString = Strings.welcomeSearchPlaceholderString
         searchField.delegate = context.coordinator
         searchField.setAccessibilityIdentifier(AccessibilityID.welcomeSearchField)
         return searchField
@@ -64,6 +64,7 @@ struct WelcomeView: View {
     var appDelegate: AppDelegate?
 
     @State private var searchText = ""
+    @State private var isSearchVisible = false
 
     /// Recent projects filtered by the search query.
     private var filteredProjects: [URL] {
@@ -103,11 +104,23 @@ struct WelcomeView: View {
 
             // Right: recent projects
             VStack(alignment: .leading, spacing: 0) {
-                Text(Strings.welcomeRecentProjects)
-                    .font(.headline)
-                    .padding(.horizontal)
-                    .padding(.top, 10)
-                    .padding(.bottom, 4)
+                HStack {
+                    Text(Strings.welcomeRecentProjects)
+                        .font(.headline)
+                    Spacer()
+                    if registry.recentProjects.count > 8 {
+                        Button {
+                            isSearchVisible.toggle()
+                        } label: {
+                            Image(systemName: "magnifyingglass")
+                        }
+                        .buttonStyle(.borderless)
+                        .accessibilityIdentifier(AccessibilityID.welcomeSearchToggle)
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.top, 10)
+                .padding(.bottom, 4)
 
                 if registry.recentProjects.isEmpty {
                     ContentUnavailableView {
@@ -115,7 +128,7 @@ struct WelcomeView: View {
                     }
                     .frame(maxHeight: .infinity)
                 } else {
-                    if registry.recentProjects.count > 8 {
+                    if isSearchVisible {
                         WelcomeSearchField(text: $searchText)
                             .frame(height: 22)
                             .padding(.horizontal)
@@ -154,6 +167,11 @@ struct WelcomeView: View {
             .frame(minWidth: 280)
         }
         .frame(width: 600, height: 400)
+        .onChange(of: isSearchVisible) { _, visible in
+            if !visible {
+                searchText = ""
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: .openFolder)) { _ in
             guard controlActiveState == .key else { return }
             openFolder()

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -5,7 +5,44 @@
 //  Created by Claude on 13.03.2026.
 //
 
+import AppKit
 import SwiftUI
+
+/// NSViewRepresentable wrapper for native NSSearchField (with magnifying glass and clear button).
+struct WelcomeSearchField: NSViewRepresentable {
+    @Binding var text: String
+
+    func makeNSView(context: Context) -> NSSearchField {
+        let searchField = NSSearchField()
+        searchField.placeholderString = Strings.welcomeSearchPlaceholder
+        searchField.delegate = context.coordinator
+        searchField.setAccessibilityIdentifier(AccessibilityID.welcomeSearchField)
+        return searchField
+    }
+
+    func updateNSView(_ nsView: NSSearchField, context: Context) {
+        if nsView.stringValue != text {
+            nsView.stringValue = text
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    final class Coordinator: NSObject, NSSearchFieldDelegate {
+        var text: Binding<String>
+
+        init(text: Binding<String>) {
+            self.text = text
+        }
+
+        func controlTextDidChange(_ obj: Notification) {
+            guard let field = obj.object as? NSSearchField else { return }
+            text.wrappedValue = field.stringValue
+        }
+    }
+}
 
 extension URL {
     /// Returns the path with the home directory replaced by `~`.
@@ -36,7 +73,7 @@ struct WelcomeView: View {
     var body: some View {
         HStack(spacing: 0) {
             // Left: logo and actions
-            VStack(spacing: 20) {
+            VStack(spacing: 14) {
                 Spacer()
 
                 Image(nsImage: NSApp.applicationIconImage)
@@ -69,8 +106,8 @@ struct WelcomeView: View {
                 Text(Strings.welcomeRecentProjects)
                     .font(.headline)
                     .padding(.horizontal)
-                    .padding(.top, 16)
-                    .padding(.bottom, 8)
+                    .padding(.top, 10)
+                    .padding(.bottom, 4)
 
                 if registry.recentProjects.isEmpty {
                     ContentUnavailableView {
@@ -78,11 +115,12 @@ struct WelcomeView: View {
                     }
                     .frame(maxHeight: .infinity)
                 } else {
-                    TextField(Strings.welcomeSearchPlaceholder, text: $searchText)
-                        .textFieldStyle(.roundedBorder)
-                        .padding(.horizontal)
-                        .padding(.bottom, 8)
-                        .accessibilityIdentifier(AccessibilityID.welcomeSearchField)
+                    if registry.recentProjects.count > 5 {
+                        WelcomeSearchField(text: $searchText)
+                            .frame(height: 22)
+                            .padding(.horizontal)
+                            .padding(.bottom, 4)
+                    }
 
                     if filteredProjects.isEmpty {
                         ContentUnavailableView {

--- a/PineTests/RecentProjectsFilterTests.swift
+++ b/PineTests/RecentProjectsFilterTests.swift
@@ -104,4 +104,19 @@ struct RecentProjectsFilterTests {
         #expect(result[0].lastPathComponent == "pine-editor")
         #expect(result[1].lastPathComponent == "pine-cli")
     }
+
+    // MARK: - Newline trimming
+
+    @Test func newlineOnlyQueryReturnsAll() {
+        let urls = makeURLs(["alpha", "beta"])
+        let result = RecentProjectsFilter.filter(urls, query: "\n\t  ")
+        #expect(result == urls)
+    }
+
+    @Test func queryWithLeadingNewlineTrimsCorrectly() {
+        let urls = makeURLs(["pine-editor", "vscode"])
+        let result = RecentProjectsFilter.filter(urls, query: "\npine\n")
+        #expect(result.count == 1)
+        #expect(result[0].lastPathComponent == "pine-editor")
+    }
 }

--- a/PineTests/RecentProjectsFilterTests.swift
+++ b/PineTests/RecentProjectsFilterTests.swift
@@ -1,0 +1,107 @@
+//
+//  RecentProjectsFilterTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+struct RecentProjectsFilterTests {
+
+    // MARK: - Helpers
+
+    private func makeURLs(_ names: [String]) -> [URL] {
+        names.map { URL(fileURLWithPath: "/Users/dev/\($0)") }
+    }
+
+    // MARK: - Empty query returns all
+
+    @Test func emptyQueryReturnsAll() {
+        let urls = makeURLs(["alpha", "beta", "gamma"])
+        let result = RecentProjectsFilter.filter(urls, query: "")
+        #expect(result == urls)
+    }
+
+    @Test func whitespaceOnlyQueryReturnsAll() {
+        let urls = makeURLs(["alpha", "beta"])
+        let result = RecentProjectsFilter.filter(urls, query: "   ")
+        #expect(result == urls)
+    }
+
+    // MARK: - Matches by project name
+
+    @Test func matchesByProjectName() {
+        let urls = makeURLs(["pine-editor", "vscode", "xcode"])
+        let result = RecentProjectsFilter.filter(urls, query: "pine")
+        #expect(result.count == 1)
+        #expect(result[0].lastPathComponent == "pine-editor")
+    }
+
+    // MARK: - Matches by path
+
+    @Test func matchesByPath() {
+        let urls = [
+            URL(fileURLWithPath: "/Users/dev/projects/alpha"),
+            URL(fileURLWithPath: "/Users/work/beta")
+        ]
+        let result = RecentProjectsFilter.filter(urls, query: "projects")
+        #expect(result.count == 1)
+        #expect(result[0].lastPathComponent == "alpha")
+    }
+
+    // MARK: - Case insensitive
+
+    @Test func caseInsensitiveMatch() {
+        let urls = makeURLs(["MyProject"])
+        let result = RecentProjectsFilter.filter(urls, query: "myproject")
+        #expect(result.count == 1)
+    }
+
+    @Test func caseInsensitiveMatchUpperQuery() {
+        let urls = makeURLs(["myproject"])
+        let result = RecentProjectsFilter.filter(urls, query: "MYPROJECT")
+        #expect(result.count == 1)
+    }
+
+    // MARK: - No matches
+
+    @Test func noMatchesReturnsEmpty() {
+        let urls = makeURLs(["alpha", "beta"])
+        let result = RecentProjectsFilter.filter(urls, query: "zzz")
+        #expect(result.isEmpty)
+    }
+
+    // MARK: - Preserves order
+
+    @Test func preservesOriginalOrder() {
+        let urls = makeURLs(["a-project", "b-project", "c-project"])
+        let result = RecentProjectsFilter.filter(urls, query: "project")
+        #expect(result == urls)
+    }
+
+    // MARK: - Empty list
+
+    @Test func emptyListReturnsEmpty() {
+        let result = RecentProjectsFilter.filter([], query: "anything")
+        #expect(result.isEmpty)
+    }
+
+    // MARK: - Substring match
+
+    @Test func substringMatchInMiddle() {
+        let urls = makeURLs(["my-awesome-app"])
+        let result = RecentProjectsFilter.filter(urls, query: "awesome")
+        #expect(result.count == 1)
+    }
+
+    // MARK: - Multiple matches
+
+    @Test func multipleMatches() {
+        let urls = makeURLs(["pine-editor", "pine-cli", "vscode"])
+        let result = RecentProjectsFilter.filter(urls, query: "pine")
+        #expect(result.count == 2)
+        #expect(result[0].lastPathComponent == "pine-editor")
+        #expect(result[1].lastPathComponent == "pine-cli")
+    }
+}


### PR DESCRIPTION
## Summary

- Add `RecentProjectsFilter` — case-insensitive substring match by project name and path
- Add search `TextField` above recent projects list in `WelcomeView`
- Show `ContentUnavailableView` when no matches found

⚠️ **Visual changes** — needs product owner review before merge

Closes #300

## Test plan

- [x] 11 unit tests in `RecentProjectsFilterTests`
- [x] Localization: en/ru
- [x] SwiftLint clean