### PR TITLE
feat: Preferences window with settings UI (#337)

### DIFF
--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -375,6 +375,10 @@ struct PineApp: App {
         .defaultSize(width: 600, height: 400)
         .windowResizability(.contentSize)
         .defaultLaunchBehavior(.presented)
+
+        Settings {
+            SettingsView()
+        }
     }
 }
 

--- a/Pine/SettingsManager.swift
+++ b/Pine/SettingsManager.swift
@@ -1,0 +1,123 @@
+//
+//  SettingsManager.swift
+//  Pine
+//
+
+import Foundation
+
+/// Central store for app preferences, backed by UserDefaults.
+/// Uses `pine.` prefix for all keys. Changes apply immediately.
+///
+/// Uses computed properties with direct UserDefaults access instead of
+/// stored properties with `didSet` to avoid infinite recursion with `@Observable`.
+@Observable
+final class SettingsManager {
+
+    // MARK: - Constants
+
+    static let defaultFontSize: CGFloat = 13
+    static let minFontSize: CGFloat = 8
+    static let maxFontSize: CGFloat = 32
+
+    static let defaultTabWidth = 4
+    static let minTabWidth = 1
+    static let maxTabWidth = 8
+
+    // MARK: - Keys
+
+    enum Keys {
+        static let autoSaveEnabled = "pine.autoSaveEnabled"
+        static let stripTrailingWhitespace = "pine.stripTrailingWhitespace"
+        static let fontSize = "pine.fontSize"
+        static let tabWidth = "pine.tabWidth"
+        static let showLineNumbers = "pine.showLineNumbers"
+        static let showMinimap = "pine.showMinimap"
+        static let theme = "pine.theme"
+    }
+
+    // MARK: - Storage
+
+    private let defaults: UserDefaults
+
+    // MARK: - Properties
+
+    var autoSaveEnabled: Bool {
+        get { defaults.bool(forKey: Keys.autoSaveEnabled) }
+        set { defaults.set(newValue, forKey: Keys.autoSaveEnabled) }
+    }
+
+    var stripTrailingWhitespace: Bool {
+        get {
+            if defaults.object(forKey: Keys.stripTrailingWhitespace) == nil {
+                return true
+            }
+            return defaults.bool(forKey: Keys.stripTrailingWhitespace)
+        }
+        set { defaults.set(newValue, forKey: Keys.stripTrailingWhitespace) }
+    }
+
+    var fontSize: CGFloat {
+        get {
+            let stored = defaults.double(forKey: Keys.fontSize)
+            if stored > 0 {
+                return min(max(CGFloat(stored), Self.minFontSize), Self.maxFontSize)
+            }
+            return Self.defaultFontSize
+        }
+        set {
+            let clamped = min(max(newValue, Self.minFontSize), Self.maxFontSize)
+            defaults.set(Double(clamped), forKey: Keys.fontSize)
+        }
+    }
+
+    var tabWidth: Int {
+        get {
+            let stored = defaults.integer(forKey: Keys.tabWidth)
+            if stored > 0 {
+                return min(max(stored, Self.minTabWidth), Self.maxTabWidth)
+            }
+            return Self.defaultTabWidth
+        }
+        set {
+            let clamped = min(max(newValue, Self.minTabWidth), Self.maxTabWidth)
+            defaults.set(clamped, forKey: Keys.tabWidth)
+        }
+    }
+
+    var showLineNumbers: Bool {
+        get {
+            if defaults.object(forKey: Keys.showLineNumbers) == nil {
+                return true
+            }
+            return defaults.bool(forKey: Keys.showLineNumbers)
+        }
+        set { defaults.set(newValue, forKey: Keys.showLineNumbers) }
+    }
+
+    var showMinimap: Bool {
+        get {
+            if defaults.object(forKey: Keys.showMinimap) == nil {
+                return true
+            }
+            return defaults.bool(forKey: Keys.showMinimap)
+        }
+        set { defaults.set(newValue, forKey: Keys.showMinimap) }
+    }
+
+    var theme: String {
+        get {
+            let stored = defaults.string(forKey: Keys.theme) ?? ""
+            return stored.isEmpty ? "default" : stored
+        }
+        set {
+            let value = newValue.isEmpty ? "default" : newValue
+            defaults.set(value, forKey: Keys.theme)
+        }
+    }
+
+    // MARK: - Init
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+}

--- a/Pine/SettingsView.swift
+++ b/Pine/SettingsView.swift
@@ -1,0 +1,93 @@
+//
+//  SettingsView.swift
+//  Pine
+//
+
+import SwiftUI
+
+/// Native macOS Preferences window with tabbed layout.
+/// Added as a `Settings` scene in PineApp — opens via Cmd+,.
+struct SettingsView: View {
+    @State private var settings = SettingsManager()
+
+    var body: some View {
+        TabView {
+            GeneralSettingsTab(settings: settings)
+                .tabItem {
+                    Label("General", systemImage: "gear")
+                }
+            EditorSettingsTab(settings: settings)
+                .tabItem {
+                    Label("Editor", systemImage: "text.cursor")
+                }
+            AppearanceSettingsTab(settings: settings)
+                .tabItem {
+                    Label("Appearance", systemImage: "paintpalette")
+                }
+        }
+        .frame(width: 450, height: 250)
+    }
+}
+
+// MARK: - General Tab
+
+struct GeneralSettingsTab: View {
+    @Bindable var settings: SettingsManager
+
+    var body: some View {
+        Form {
+            Toggle("Auto-save", isOn: $settings.autoSaveEnabled)
+            Toggle("Strip trailing whitespace on save", isOn: $settings.stripTrailingWhitespace)
+        }
+        .padding()
+    }
+}
+
+// MARK: - Editor Tab
+
+struct EditorSettingsTab: View {
+    @Bindable var settings: SettingsManager
+
+    var body: some View {
+        Form {
+            HStack {
+                Text("Font size:")
+                Stepper(
+                    value: $settings.fontSize,
+                    in: SettingsManager.minFontSize...SettingsManager.maxFontSize,
+                    step: 1
+                ) {
+                    Text("\(Int(settings.fontSize)) pt")
+                        .monospacedDigit()
+                }
+            }
+
+            Picker("Tab width:", selection: $settings.tabWidth) {
+                Text("2").tag(2)
+                Text("4").tag(4)
+                Text("8").tag(8)
+            }
+            .pickerStyle(.segmented)
+
+            Toggle("Show line numbers", isOn: $settings.showLineNumbers)
+        }
+        .padding()
+    }
+}
+
+// MARK: - Appearance Tab
+
+struct AppearanceSettingsTab: View {
+    @Bindable var settings: SettingsManager
+
+    var body: some View {
+        Form {
+            Picker("Theme:", selection: $settings.theme) {
+                Text("Default").tag("default")
+            }
+
+            Toggle("Show minimap", isOn: $settings.showMinimap)
+        }
+        .padding()
+    }
+}

--- a/PineTests/SettingsManagerTests.swift
+++ b/PineTests/SettingsManagerTests.swift
@@ -1,0 +1,299 @@
+//
+//  SettingsManagerTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+@Suite("SettingsManager Tests")
+struct SettingsManagerTests {
+
+    private let suiteName = "PineTests.Settings.\(UUID().uuidString)"
+
+    private func makeDefaults() throws -> UserDefaults {
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        return defaults
+    }
+
+    private func cleanupDefaults(_ defaults: UserDefaults) {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    // MARK: - Default values
+
+    @Test func defaultAutoSaveIsOff() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.autoSaveEnabled == false)
+    }
+
+    @Test func defaultStripTrailingWhitespaceIsOn() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.stripTrailingWhitespace == true)
+    }
+
+    @Test func defaultFontSizeIs13() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.fontSize == 13)
+    }
+
+    @Test func defaultTabWidthIs4() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.tabWidth == 4)
+    }
+
+    @Test func defaultShowLineNumbersIsOn() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.showLineNumbers == true)
+    }
+
+    @Test func defaultShowMinimapIsOn() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.showMinimap == true)
+    }
+
+    @Test func defaultThemeIsDefault() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.theme == "default")
+    }
+
+    // MARK: - Persistence (write)
+
+    @Test func autoSavePersistsToDefaults() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        settings.autoSaveEnabled = true
+        #expect(defaults.bool(forKey: SettingsManager.Keys.autoSaveEnabled) == true)
+    }
+
+    @Test func stripTrailingWhitespacePersists() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        settings.stripTrailingWhitespace = false
+        #expect(defaults.bool(forKey: SettingsManager.Keys.stripTrailingWhitespace) == false)
+    }
+
+    @Test func fontSizePersists() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        settings.fontSize = 18
+        #expect(defaults.double(forKey: SettingsManager.Keys.fontSize) == 18)
+    }
+
+    @Test func tabWidthPersists() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        settings.tabWidth = 2
+        #expect(defaults.integer(forKey: SettingsManager.Keys.tabWidth) == 2)
+    }
+
+    @Test func showLineNumbersPersists() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        settings.showLineNumbers = false
+        #expect(defaults.bool(forKey: SettingsManager.Keys.showLineNumbers) == false)
+    }
+
+    @Test func showMinimapPersists() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        settings.showMinimap = false
+        #expect(defaults.bool(forKey: SettingsManager.Keys.showMinimap) == false)
+    }
+
+    @Test func themePersists() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        settings.theme = "monokai"
+        #expect(defaults.string(forKey: SettingsManager.Keys.theme) == "monokai")
+    }
+
+    // MARK: - Persistence (read)
+
+    @Test func loadsAutoSaveFromDefaults() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        defaults.set(true, forKey: SettingsManager.Keys.autoSaveEnabled)
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.autoSaveEnabled == true)
+    }
+
+    @Test func loadsFontSizeFromDefaults() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        defaults.set(20.0, forKey: SettingsManager.Keys.fontSize)
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.fontSize == 20)
+    }
+
+    @Test func loadsTabWidthFromDefaults() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        defaults.set(8, forKey: SettingsManager.Keys.tabWidth)
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.tabWidth == 8)
+    }
+
+    @Test func loadsThemeFromDefaults() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        defaults.set("solarized", forKey: SettingsManager.Keys.theme)
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.theme == "solarized")
+    }
+
+    // MARK: - Edge cases / clamping
+
+    @Test func fontSizeClampedToMin() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        settings.fontSize = 2
+        #expect(settings.fontSize == SettingsManager.minFontSize)
+    }
+
+    @Test func fontSizeClampedToMax() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        settings.fontSize = 100
+        #expect(settings.fontSize == SettingsManager.maxFontSize)
+    }
+
+    @Test func tabWidthClampedToMin() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        settings.tabWidth = 0
+        #expect(settings.tabWidth == SettingsManager.minTabWidth)
+    }
+
+    @Test func tabWidthClampedToMax() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        settings.tabWidth = 20
+        #expect(settings.tabWidth == SettingsManager.maxTabWidth)
+    }
+
+    @Test func corruptedFontSizeInDefaultsFallsBackToDefault() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        // Negative value
+        defaults.set(-5.0, forKey: SettingsManager.Keys.fontSize)
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.fontSize == SettingsManager.defaultFontSize)
+    }
+
+    @Test func zeroFontSizeInDefaultsFallsBackToDefault() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        defaults.set(0.0, forKey: SettingsManager.Keys.fontSize)
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.fontSize == SettingsManager.defaultFontSize)
+    }
+
+    @Test func corruptedTabWidthInDefaultsFallsBackToDefault() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        // Zero value — integer(forKey:) returns 0 for missing key
+        defaults.set(0, forKey: SettingsManager.Keys.tabWidth)
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.tabWidth == SettingsManager.defaultTabWidth)
+    }
+
+    @Test func emptyThemeInDefaultsFallsBackToDefault() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        defaults.set("", forKey: SettingsManager.Keys.theme)
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.theme == "default")
+    }
+
+    // MARK: - Bool defaults for first launch
+
+    @Test func stripTrailingWhitespaceDefaultsTrueWhenKeyMissing() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        // Key is not set — object(forKey:) returns nil
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.stripTrailingWhitespace == true)
+    }
+
+    @Test func showLineNumbersDefaultsTrueWhenKeyMissing() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.showLineNumbers == true)
+    }
+
+    @Test func showMinimapDefaultsTrueWhenKeyMissing() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = SettingsManager(defaults: defaults)
+        #expect(settings.showMinimap == true)
+    }
+
+    // MARK: - Keys namespace
+
+    @Test func keysUsePinePrefix() {
+        #expect(SettingsManager.Keys.autoSaveEnabled == "pine.autoSaveEnabled")
+        #expect(SettingsManager.Keys.stripTrailingWhitespace == "pine.stripTrailingWhitespace")
+        #expect(SettingsManager.Keys.fontSize == "pine.fontSize")
+        #expect(SettingsManager.Keys.tabWidth == "pine.tabWidth")
+        #expect(SettingsManager.Keys.showLineNumbers == "pine.showLineNumbers")
+        #expect(SettingsManager.Keys.showMinimap == "pine.showMinimap")
+        #expect(SettingsManager.Keys.theme == "pine.theme")
+    }
+}


### PR DESCRIPTION
## Summary

- Add `SettingsManager` with computed properties backed by UserDefaults (no didSet to avoid @Observable infinite recursion)
- Add Settings scene with General, Editor, Appearance tabs
- Settings: auto-save, strip whitespace, font size, tab width, line numbers, minimap

⚠️ **Visual changes** — Preferences window, needs product owner review

Closes #337

## Test plan

- [x] 30 unit tests in `SettingsManagerTests`
- [x] No crash — computed properties prevent didSet recursion
- [x] SwiftLint clean