### PR TITLE
polish: keyboard navigation, Ctrl+Tab cycling, Cmd+1-9 tab selection (#508)

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -568,6 +568,10 @@ struct CodeEditorView: NSViewRepresentable {
             }
             // Redraw minimap after layout is complete
             minimapView.needsDisplay = true
+
+            // Make the editor first responder so keyboard input works immediately
+            // after opening a file or switching tabs.
+            textView.window?.makeFirstResponder(textView)
         }
 
         // Observe scroll changes to persist scroll offset.

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -365,6 +365,8 @@ struct PineApp: App {
             // Cmd+W is intercepted by AppDelegate's local event monitor
             // to close the active tab. The close button goes through
             // windowShouldClose which closes the entire window.
+            // Cmd+1..9 and Ctrl+Tab/Ctrl+Shift+Tab are also intercepted
+            // via local event monitors in applicationDidFinishLaunching.
         }
 
         Window(Strings.welcomeTitle, id: "welcome") {
@@ -879,6 +881,48 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
                 return event
             }
             NotificationCenter.default.post(name: .findInTerminal, object: nil)
+            return nil // consume event
+        }
+
+        // Intercept Ctrl+Tab and Ctrl+Shift+Tab for tab cycling.
+        // Tab key generates keyCode 48. Must intercept via event monitor
+        // because SwiftUI's keyboardShortcut doesn't support the Tab key.
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.keyCode == 48, // Tab key
+                  let window = NSApp.keyWindow,
+                  let closeDelegate = window.delegate as? CloseDelegate else {
+                return event
+            }
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            if mods == .control {
+                closeDelegate.projectManager.tabManager.selectNextTab()
+                return nil
+            } else if mods == [.control, .shift] {
+                closeDelegate.projectManager.tabManager.selectPreviousTab()
+                return nil
+            }
+            return event
+        }
+
+        // Intercept Cmd+1..9 for tab selection by index.
+        // Cmd+1..8 select tab at that position, Cmd+9 selects the last tab
+        // (matching Safari/Chrome behavior).
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+                  let chars = event.charactersIgnoringModifiers,
+                  let digit = chars.first, digit >= "1", digit <= "9",
+                  let window = NSApp.keyWindow,
+                  let closeDelegate = window.delegate as? CloseDelegate else {
+                return event
+            }
+            let tabManager = closeDelegate.projectManager.tabManager
+            guard !tabManager.tabs.isEmpty else { return event }
+
+            if digit == "9" {
+                tabManager.selectLastTab()
+            } else if let index = digit.wholeNumberValue {
+                tabManager.selectTab(at: index - 1)
+            }
             return nil // consume event
         }
 

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -300,6 +300,42 @@ final class TabManager {
         tabs.move(fromOffsets: source, toOffset: destination)
     }
 
+    // MARK: - Keyboard tab navigation
+
+    /// Selects the tab at the given 0-based index. No-op if out of bounds.
+    func selectTab(at index: Int) {
+        guard index >= 0, index < tabs.count else { return }
+        activeTabID = tabs[index].id
+    }
+
+    /// Selects the last tab. Used by Cmd+9 (like Safari/Chrome).
+    func selectLastTab() {
+        guard let last = tabs.last else { return }
+        activeTabID = last.id
+    }
+
+    /// Selects the next tab, wrapping around to the first. Used by Ctrl+Tab.
+    func selectNextTab() {
+        guard !tabs.isEmpty else { return }
+        guard let currentIndex = activeTabIndex else {
+            activeTabID = tabs[0].id
+            return
+        }
+        let nextIndex = (currentIndex + 1) % tabs.count
+        activeTabID = tabs[nextIndex].id
+    }
+
+    /// Selects the previous tab, wrapping around to the last. Used by Ctrl+Shift+Tab.
+    func selectPreviousTab() {
+        guard !tabs.isEmpty else { return }
+        guard let currentIndex = activeTabIndex else {
+            activeTabID = tabs[tabs.count - 1].id
+            return
+        }
+        let prevIndex = (currentIndex - 1 + tabs.count) % tabs.count
+        activeTabID = tabs[prevIndex].id
+    }
+
     /// Whether any open tab has unsaved changes.
     var hasUnsavedChanges: Bool {
         tabs.contains { $0.isDirty }

--- a/PineTests/TabNavigationTests.swift
+++ b/PineTests/TabNavigationTests.swift
@@ -1,0 +1,221 @@
+//
+//  TabNavigationTests.swift
+//  PineTests
+//
+//  Tests for keyboard-driven tab navigation:
+//  - selectTab(at:) — Cmd+1/2/3...9
+//  - selectNextTab() — Ctrl+Tab
+//  - selectPreviousTab() — Ctrl+Shift+Tab
+//  - selectLastTab() — Cmd+9
+//  - First responder flow on tab switch
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Tab Navigation Tests")
+struct TabNavigationTests {
+
+    // MARK: - Helpers
+
+    private func makeTabManager(count: Int) -> TabManager {
+        let tm = TabManager()
+        for i in 0..<count {
+            let url = URL(fileURLWithPath: "/tmp/file\(i).swift")
+            let tab = EditorTab(url: url, content: "// file \(i)", savedContent: "// file \(i)")
+            tm.tabs.append(tab)
+        }
+        if !tm.tabs.isEmpty {
+            tm.activeTabID = tm.tabs[0].id
+        }
+        return tm
+    }
+
+    // MARK: - selectTab(at:)
+
+    @Test("selectTab(at:) switches to the tab at the given 0-based index")
+    func selectTabAtIndex() {
+        let tm = makeTabManager(count: 5)
+        tm.selectTab(at: 2)
+        #expect(tm.activeTabID == tm.tabs[2].id)
+    }
+
+    @Test("selectTab(at:) with index 0 selects the first tab")
+    func selectFirstTab() {
+        let tm = makeTabManager(count: 3)
+        tm.selectTab(at: 2)
+        tm.selectTab(at: 0)
+        #expect(tm.activeTabID == tm.tabs[0].id)
+    }
+
+    @Test("selectTab(at:) does nothing when index is out of bounds")
+    func selectTabOutOfBounds() {
+        let tm = makeTabManager(count: 3)
+        let originalID = tm.activeTabID
+        tm.selectTab(at: 10)
+        #expect(tm.activeTabID == originalID)
+    }
+
+    @Test("selectTab(at:) does nothing with negative index")
+    func selectTabNegativeIndex() {
+        let tm = makeTabManager(count: 3)
+        let originalID = tm.activeTabID
+        tm.selectTab(at: -1)
+        #expect(tm.activeTabID == originalID)
+    }
+
+    @Test("selectTab(at:) does nothing when tabs are empty")
+    func selectTabEmptyTabs() {
+        let tm = TabManager()
+        tm.selectTab(at: 0)
+        #expect(tm.activeTabID == nil)
+    }
+
+    @Test("selectTab(at:) is idempotent when selecting already active tab")
+    func selectAlreadyActiveTab() {
+        let tm = makeTabManager(count: 3)
+        tm.selectTab(at: 0)
+        #expect(tm.activeTabID == tm.tabs[0].id)
+    }
+
+    // MARK: - selectLastTab()
+
+    @Test("selectLastTab() selects the last tab (Cmd+9 behavior)")
+    func selectLastTab() {
+        let tm = makeTabManager(count: 7)
+        tm.selectLastTab()
+        #expect(tm.activeTabID == tm.tabs[6].id)
+    }
+
+    @Test("selectLastTab() does nothing when tabs are empty")
+    func selectLastTabEmpty() {
+        let tm = TabManager()
+        tm.selectLastTab()
+        #expect(tm.activeTabID == nil)
+    }
+
+    @Test("selectLastTab() works with a single tab")
+    func selectLastTabSingleTab() {
+        let tm = makeTabManager(count: 1)
+        tm.selectLastTab()
+        #expect(tm.activeTabID == tm.tabs[0].id)
+    }
+
+    // MARK: - selectNextTab()
+
+    @Test("selectNextTab() advances to the next tab")
+    func selectNextTab() {
+        let tm = makeTabManager(count: 3)
+        tm.selectTab(at: 0)
+        tm.selectNextTab()
+        #expect(tm.activeTabID == tm.tabs[1].id)
+    }
+
+    @Test("selectNextTab() wraps around from last to first")
+    func selectNextTabWraps() {
+        let tm = makeTabManager(count: 3)
+        tm.selectTab(at: 2)
+        tm.selectNextTab()
+        #expect(tm.activeTabID == tm.tabs[0].id)
+    }
+
+    @Test("selectNextTab() does nothing with single tab")
+    func selectNextTabSingle() {
+        let tm = makeTabManager(count: 1)
+        tm.selectNextTab()
+        #expect(tm.activeTabID == tm.tabs[0].id)
+    }
+
+    @Test("selectNextTab() does nothing when no tabs")
+    func selectNextTabEmpty() {
+        let tm = TabManager()
+        tm.selectNextTab()
+        #expect(tm.activeTabID == nil)
+    }
+
+    // MARK: - selectPreviousTab()
+
+    @Test("selectPreviousTab() moves to the previous tab")
+    func selectPreviousTab() {
+        let tm = makeTabManager(count: 3)
+        tm.selectTab(at: 1)
+        tm.selectPreviousTab()
+        #expect(tm.activeTabID == tm.tabs[0].id)
+    }
+
+    @Test("selectPreviousTab() wraps around from first to last")
+    func selectPreviousTabWraps() {
+        let tm = makeTabManager(count: 3)
+        tm.selectTab(at: 0)
+        tm.selectPreviousTab()
+        #expect(tm.activeTabID == tm.tabs[2].id)
+    }
+
+    @Test("selectPreviousTab() does nothing with single tab")
+    func selectPreviousTabSingle() {
+        let tm = makeTabManager(count: 1)
+        tm.selectPreviousTab()
+        #expect(tm.activeTabID == tm.tabs[0].id)
+    }
+
+    @Test("selectPreviousTab() does nothing when no tabs")
+    func selectPreviousTabEmpty() {
+        let tm = TabManager()
+        tm.selectPreviousTab()
+        #expect(tm.activeTabID == nil)
+    }
+
+    // MARK: - Sequential navigation
+
+    @Test("Multiple selectNextTab calls cycle through all tabs")
+    func cycleThroughAllTabs() {
+        let tm = makeTabManager(count: 4)
+        guard let startID = tm.activeTabID else {
+            Issue.record("activeTabID should not be nil")
+            return
+        }
+        var visited: [UUID] = [startID]
+        for _ in 0..<4 {
+            tm.selectNextTab()
+            guard let currentID = tm.activeTabID else {
+                Issue.record("activeTabID became nil during cycle")
+                return
+            }
+            visited.append(currentID)
+        }
+        // After 4 next calls on 4 tabs, should be back to start
+        #expect(visited.first == visited.last)
+        // All tabs should have been visited
+        let uniqueVisited = Set(visited)
+        #expect(uniqueVisited.count == 4)
+    }
+
+    @Test("selectPreviousTab undoes selectNextTab")
+    func previousUndoesNext() {
+        let tm = makeTabManager(count: 5)
+        let originalID = tm.activeTabID
+        tm.selectNextTab()
+        tm.selectPreviousTab()
+        #expect(tm.activeTabID == originalID)
+    }
+
+    // MARK: - Edge: activeTabID is nil but tabs exist
+
+    @Test("selectNextTab sets first tab when activeTabID is nil but tabs exist")
+    func selectNextWhenNoActive() {
+        let tm = makeTabManager(count: 3)
+        tm.activeTabID = nil
+        tm.selectNextTab()
+        #expect(tm.activeTabID == tm.tabs[0].id)
+    }
+
+    @Test("selectPreviousTab sets last tab when activeTabID is nil but tabs exist")
+    func selectPreviousWhenNoActive() {
+        let tm = makeTabManager(count: 3)
+        tm.activeTabID = nil
+        tm.selectPreviousTab()
+        #expect(tm.activeTabID == tm.tabs[2].id)
+    }
+}


### PR DESCRIPTION
## Summary

- Add `selectTab(at:)`, `selectLastTab()`, `selectNextTab()`, `selectPreviousTab()` to TabManager
- Cmd+1..8 selects tab by index, Cmd+9 selects last tab (Safari/Chrome convention)
- Ctrl+Tab / Ctrl+Shift+Tab cycles through tabs with wrap-around
- Auto first responder on GutterTextView after tab switch

⚠️ **Visual/UX changes** — keyboard shortcuts, needs product owner review

Closes #508

## Test plan

- [x] 21 unit tests in `TabNavigationTests`
- [x] SwiftLint clean