### PR TITLE
feat: terminal shell profile selection (bash/zsh/fish) (#422)

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -964,7 +964,7 @@ struct TerminalNativeTabBar: View {
                 .padding(.horizontal, 4)
             }
 
-            // Кнопка "+" — новый терминал
+            // Кнопка "+" — новый терминал (click = default shell, right-click = pick shell)
             Button {
                 terminal.addTerminalTab(workingDirectory: workingDirectory)
             } label: {
@@ -977,6 +977,16 @@ struct TerminalNativeTabBar: View {
             .help(Strings.newTerminal)
             .accessibilityIdentifier(AccessibilityID.newTerminalButton)
             .accessibilityAddTraits(.isButton)
+            .contextMenu {
+                ForEach(ShellSettings.shared.availableShells()) { shell in
+                    Button(shell.name) {
+                        terminal.addTerminalTab(
+                            workingDirectory: workingDirectory,
+                            shellOption: shell
+                        )
+                    }
+                }
+            }
 
             Spacer()
 

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -6854,6 +6854,42 @@
         }
       }
     },
+    "terminal.shell.default" : {
+      "comment" : "Label for the default shell option in terminal shell picker.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Default Shell"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Оболочка по умолчанию"
+          }
+        }
+      }
+    },
+    "terminal.shell.title" : {
+      "comment" : "Title for the shell selection section in terminal context menu.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Terminal With"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Новый терминал с"
+          }
+        }
+      }
+    },
     "terminal.numberedName %lld" : {
       "comment" : "Name for additional terminal tabs; %lld is the sequential tab number.",
       "extractionState" : "manual",

--- a/Pine/ShellSettings.swift
+++ b/Pine/ShellSettings.swift
@@ -80,4 +80,44 @@ final class ShellSettings {
         shellPath = Self.defaultShellPath
         shellArgs = Self.commonShells.first { $0.path == shellPath }?.defaultArgs ?? Self.defaultShellArgs
     }
+
+    /// Applies a shell option, updating both path and args.
+    func applyShellOption(_ option: ShellOption) {
+        shellPath = option.path
+        shellArgs = option.defaultArgs
+    }
+
+    /// Returns shells from `commonShells` that are actually installed (executable on disk),
+    /// plus any shells from `/etc/shells` that are executable but not in `commonShells`.
+    func availableShells() -> [ShellOption] {
+        var result: [ShellOption] = []
+        var seenPaths = Set<String>()
+
+        // First, add common shells that exist on this machine
+        for shell in Self.commonShells where fileManager.isExecutableFile(atPath: shell.path) {
+            result.append(shell)
+            seenPaths.insert(shell.path)
+        }
+
+        // Then, add any extra shells from /etc/shells
+        if let content = try? String(contentsOfFile: "/etc/shells", encoding: .utf8) {
+            for path in Self.parseEtcShells(content) where !seenPaths.contains(path) {
+                if fileManager.isExecutableFile(atPath: path) {
+                    let name = URL(fileURLWithPath: path).lastPathComponent
+                    result.append(ShellOption(name: name, path: path, defaultArgs: ["--login"]))
+                    seenPaths.insert(path)
+                }
+            }
+        }
+
+        return result
+    }
+
+    /// Parses `/etc/shells` content: filters comments and empty lines, returns shell paths.
+    static func parseEtcShells(_ content: String) -> [String] {
+        content
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+    }
 }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -109,6 +109,14 @@ enum Strings {
     static let showTerminalShortcut: LocalizedStringKey = "terminal.showShortcut"
     static let toggleTerminal: LocalizedStringKey = "terminal.toggle"
 
+    static var shellSelectionDefault: String {
+        String(localized: "terminal.shell.default")
+    }
+
+    static var shellSelectionTitle: String {
+        String(localized: "terminal.shell.title")
+    }
+
     // MARK: - Menu Commands
 
     static let menuIncreaseFontSize: LocalizedStringKey = "menu.increaseFontSize"

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -38,9 +38,17 @@ final class TerminalManager {
         }
     }
 
-    func addTerminalTab(workingDirectory: URL?) {
+    func addTerminalTab(workingDirectory: URL?, shellOption: ShellSettings.ShellOption? = nil) {
         let number = terminalTabs.count + 1
-        let tab = TerminalTab(name: Strings.terminalNumberedName(number))
+        let settings: ShellSettings
+        if let option = shellOption {
+            // Create a temporary ShellSettings for this specific tab
+            settings = ShellSettings()
+            settings.applyShellOption(option)
+        } else {
+            settings = .shared
+        }
+        let tab = TerminalTab(name: Strings.terminalNumberedName(number), shellSettings: settings)
         tab.configure(workingDirectory: workingDirectory)
         terminalTabs.append(tab)
         activeTerminalID = tab.id

--- a/PineTests/ShellSettingsTests.swift
+++ b/PineTests/ShellSettingsTests.swift
@@ -195,4 +195,121 @@ struct ShellSettingsTests {
         let expectedShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
         #expect(settings.shellPath == expectedShell)
     }
+
+    // MARK: - Available shells detection
+
+    @Test func availableShellsContainsZshAndBash() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = ShellSettings(defaults: defaults)
+        let available = settings.availableShells()
+
+        // /bin/zsh and /bin/bash exist on every macOS
+        #expect(available.contains { $0.path == "/bin/zsh" })
+        #expect(available.contains { $0.path == "/bin/bash" })
+    }
+
+    @Test func availableShellsOnlyContainsExecutableShells() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = ShellSettings(defaults: defaults)
+        let available = settings.availableShells()
+        let fm = FileManager.default
+
+        for shell in available {
+            #expect(fm.isExecutableFile(atPath: shell.path),
+                    "Shell \(shell.path) should be executable")
+        }
+    }
+
+    @Test func availableShellsHaveUniqueIDs() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = ShellSettings(defaults: defaults)
+        let available = settings.availableShells()
+        let ids = available.map(\.id)
+        let uniqueIDs = Set(ids)
+        #expect(ids.count == uniqueIDs.count)
+    }
+
+    @Test func availableShellsHaveNonEmptyNames() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = ShellSettings(defaults: defaults)
+        let available = settings.availableShells()
+
+        for shell in available {
+            #expect(!shell.name.isEmpty)
+            #expect(!shell.path.isEmpty)
+        }
+    }
+
+    // MARK: - Apply shell option
+
+    @Test func applyShellOptionSetsPathAndArgs() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = ShellSettings(defaults: defaults)
+        let option = ShellSettings.ShellOption(
+            name: "fish", path: "/usr/local/bin/fish", defaultArgs: ["-l"]
+        )
+        settings.applyShellOption(option)
+
+        #expect(settings.shellPath == "/usr/local/bin/fish")
+        #expect(settings.shellArgs == ["-l"])
+    }
+
+    @Test func applyShellOptionPersistsToDefaults() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = ShellSettings(defaults: defaults)
+        let option = ShellSettings.ShellOption(
+            name: "bash", path: "/bin/bash", defaultArgs: ["--login"]
+        )
+        settings.applyShellOption(option)
+
+        #expect(defaults.string(forKey: "terminalShellPath") == "/bin/bash")
+        #expect(defaults.stringArray(forKey: "terminalShellArgs") == ["--login"])
+    }
+
+    // MARK: - Parse /etc/shells
+
+    @Test func parseEtcShellsFiltersCommentsAndEmpty() {
+        let content = """
+        # List of acceptable shells
+        /bin/bash
+        /bin/zsh
+
+        # This is a comment
+        /usr/local/bin/fish
+        """
+        let paths = ShellSettings.parseEtcShells(content)
+        #expect(paths == ["/bin/bash", "/bin/zsh", "/usr/local/bin/fish"])
+    }
+
+    @Test func parseEtcShellsHandlesEmptyString() {
+        let paths = ShellSettings.parseEtcShells("")
+        #expect(paths.isEmpty)
+    }
+
+    @Test func parseEtcShellsHandlesOnlyComments() {
+        let content = """
+        # comment 1
+        # comment 2
+        """
+        let paths = ShellSettings.parseEtcShells(content)
+        #expect(paths.isEmpty)
+    }
+
+    @Test func parseEtcShellsTrimsWhitespace() {
+        let content = "  /bin/bash  \n\t/bin/zsh\t\n"
+        let paths = ShellSettings.parseEtcShells(content)
+        #expect(paths == ["/bin/bash", "/bin/zsh"])
+    }
 }


### PR DESCRIPTION
## Summary

- Add `ShellSettings` — detects available shells from common paths + `/etc/shells`
- Context menu on terminal "+" button to create tab with specific shell
- Persistence via UserDefaults

⚠️ **Visual/UX changes** — terminal context menu, needs product owner review

Closes #422

## Test plan

- [x] 8 unit tests in `ShellSettingsTests`
- [x] SwiftLint clean