### PR TITLE
feat: drag & drop files and folders to open in Pine (#420)

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -31,6 +31,7 @@ struct ContentView: View {
     @State private var goToLineOffset: GoToRequest?
     @State private var recoveryEntries: [(UUID, RecoveryEntry)] = []
     @State private var showRecoveryDialog = false
+    @State private var isDragTargeted = false
     @State private var isQuickOpenPresented = false
     @State private var showGoToLine = false
     @AppStorage("minimapVisible") private var isMinimapVisible = true
@@ -325,14 +326,14 @@ struct ContentView: View {
     /// Files are opened as tabs; directories open as new project windows.
     private func handleFileDrop(providers: [NSItemProvider]) {
         for provider in providers {
-            provider.loadItem(forTypeIdentifier: "public.file-url", options: nil) { data, _ in
-                guard let data = data as? Data,
-                      let urlString = String(data: data, encoding: .utf8),
-                      let url = URL(string: urlString) else { return }
+            Task {
+                guard let url = try? await provider.loadItem(
+                    forTypeIdentifier: UTType.fileURL.identifier
+                ) as? URL else { return }
 
                 let classified = DropHandler.classifyURLs([url])
 
-                DispatchQueue.main.async {
+                await MainActor.run {
                     // Open directories as new project windows
                     for dir in classified.directories {
                         let canonical = dir.resolvingSymlinksInPath()
@@ -605,9 +606,16 @@ struct ContentView: View {
                 .accessibilityIdentifier(AccessibilityID.editorPlaceholder)
             }
         }
-        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+        .onDrop(of: [.fileURL], isTargeted: $isDragTargeted) { providers in
             handleFileDrop(providers: providers)
             return true
+        }
+        .overlay {
+            if isDragTargeted {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(.blue, lineWidth: 2)
+                    .allowsHitTesting(false)
+            }
         }
     }
 

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -7,6 +7,7 @@
 
 import os
 import SwiftUI
+import UniformTypeIdentifiers
 
 // MARK: - Главный ContentView
 
@@ -318,6 +319,33 @@ struct ContentView: View {
         openWindow(value: url)
     }
 
+    // MARK: - Drag & Drop
+
+    /// Handles file URLs dropped onto the editor area.
+    /// Files are opened as tabs; directories open as new project windows.
+    private func handleFileDrop(providers: [NSItemProvider]) {
+        for provider in providers {
+            provider.loadItem(forTypeIdentifier: "public.file-url", options: nil) { data, _ in
+                guard let data = data as? Data,
+                      let urlString = String(data: data, encoding: .utf8),
+                      let url = URL(string: urlString) else { return }
+
+                let classified = DropHandler.classifyURLs([url])
+
+                DispatchQueue.main.async {
+                    // Open directories as new project windows
+                    for dir in classified.directories {
+                        let canonical = dir.resolvingSymlinksInPath()
+                        guard registry.projectManager(for: canonical) != nil else { continue }
+                        openWindow(value: canonical)
+                    }
+                    // Open files as tabs in current project
+                    DropHandler.openFilesAsTabs(classified.files, in: tabManager)
+                }
+            }
+        }
+    }
+
     // MARK: - Управление файлами
 
     private func handleFileSelection(_ node: FileNode) {
@@ -576,6 +604,10 @@ struct ContentView: View {
                 }
                 .accessibilityIdentifier(AccessibilityID.editorPlaceholder)
             }
+        }
+        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            handleFileDrop(providers: providers)
+            return true
         }
     }
 

--- a/Pine/DropHandler.swift
+++ b/Pine/DropHandler.swift
@@ -1,0 +1,66 @@
+//
+//  DropHandler.swift
+//  Pine
+//
+//  Created by Claude on 24.03.2026.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+/// Pure-logic handler for drag & drop operations.
+/// Classifies dropped URLs into files and directories and performs the appropriate action.
+enum DropHandler {
+
+    /// Result of classifying a set of URLs into files and directories.
+    struct ClassifiedURLs {
+        let files: [URL]
+        let directories: [URL]
+    }
+
+    /// Classifies URLs into files and directories, ignoring nonexistent paths.
+    static func classifyURLs(_ urls: [URL]) -> ClassifiedURLs {
+        var files: [URL] = []
+        var directories: [URL] = []
+        let fm = FileManager.default
+
+        for url in urls {
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: url.path, isDirectory: &isDir) else { continue }
+            if isDir.boolValue {
+                directories.append(url)
+            } else {
+                files.append(url)
+            }
+        }
+
+        return ClassifiedURLs(files: files, directories: directories)
+    }
+
+    /// Extracts file URLs from string representations.
+    /// Accepts both `file://` URL strings and bare file paths.
+    static func extractFileURLs(from strings: [String]) -> [URL] {
+        strings.compactMap { string in
+            if let url = URL(string: string), url.isFileURL {
+                return url
+            }
+            // Try as a bare file path
+            let path = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard path.hasPrefix("/") else { return nil }
+            let url = URL(fileURLWithPath: path)
+            return FileManager.default.fileExists(atPath: url.path) ? url : nil
+        }
+    }
+
+    /// Returns true if the drop should open a new project window (i.e., contains directories).
+    static func shouldOpenAsProject(_ classified: ClassifiedURLs) -> Bool {
+        !classified.directories.isEmpty
+    }
+
+    /// Opens files as tabs in the given TabManager.
+    static func openFilesAsTabs(_ files: [URL], in tabManager: TabManager) {
+        for file in files {
+            tabManager.openTab(url: file)
+        }
+    }
+}

--- a/Pine/DropHandler.swift
+++ b/Pine/DropHandler.swift
@@ -37,21 +37,6 @@ enum DropHandler {
         return ClassifiedURLs(files: files, directories: directories)
     }
 
-    /// Extracts file URLs from string representations.
-    /// Accepts both `file://` URL strings and bare file paths.
-    static func extractFileURLs(from strings: [String]) -> [URL] {
-        strings.compactMap { string in
-            if let url = URL(string: string), url.isFileURL {
-                return url
-            }
-            // Try as a bare file path
-            let path = string.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard path.hasPrefix("/") else { return nil }
-            let url = URL(fileURLWithPath: path)
-            return FileManager.default.fileExists(atPath: url.path) ? url : nil
-        }
-    }
-
     /// Returns true if the drop should open a new project window (i.e., contains directories).
     static func shouldOpenAsProject(_ classified: ClassifiedURLs) -> Bool {
         !classified.directories.isEmpty

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -976,6 +976,46 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         false
     }
 
+    // MARK: - Open URLs (Dock icon drop, Finder "Open With")
+
+    /// Called when files/folders are dropped onto the Dock icon or opened via Finder.
+    func application(_ sender: NSApplication, open urls: [URL]) {
+        let classified = DropHandler.classifyURLs(urls)
+
+        // Open directories as projects
+        for dir in classified.directories {
+            let canonical = dir.resolvingSymlinksInPath()
+            guard registry.projectManager(for: canonical) != nil else { continue }
+            openProjectWindow?(canonical)
+            welcomeWindow?.orderOut(nil)
+        }
+
+        // Open files: if a project window is active, add as tabs; otherwise open parent as project
+        if !classified.files.isEmpty {
+            if let activeProject = activeProjectManager() {
+                DropHandler.openFilesAsTabs(classified.files, in: activeProject.tabManager)
+            } else if let firstFile = classified.files.first {
+                let projectDir = firstFile.deletingLastPathComponent().resolvingSymlinksInPath()
+                guard registry.projectManager(for: projectDir) != nil else { return }
+                openProjectWindow?(projectDir)
+                welcomeWindow?.orderOut(nil)
+                // Open files after project initializes
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                    guard let pm = self?.registry.openProjects[projectDir] else { return }
+                    DropHandler.openFilesAsTabs(classified.files, in: pm.tabManager)
+                }
+            }
+        }
+    }
+
+    /// Returns the ProjectManager for the currently active project window, if any.
+    private func activeProjectManager() -> ProjectManager? {
+        guard let window = NSApp.keyWindow,
+              let closeDelegate = window.delegate as? CloseDelegate else { return nil }
+        let canonical = closeDelegate.projectURL.resolvingSymlinksInPath()
+        return registry.openProjects[canonical]
+    }
+
     // MARK: - Dock Menu
 
     func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -7,6 +7,7 @@
 
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// NSViewRepresentable wrapper for native NSSearchField (with magnifying glass and clear button).
 struct WelcomeSearchField: NSViewRepresentable {
@@ -176,6 +177,10 @@ struct WelcomeView: View {
             guard controlActiveState == .key else { return }
             openFolder()
         }
+        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+            handleDrop(providers: providers)
+            return true
+        }
         .task {
             // Open pending project from PINE_OPEN_PROJECT env var.
             guard let url = appDelegate?.pendingProjectURL else { return }
@@ -183,6 +188,36 @@ struct WelcomeView: View {
             // Wait for initial SwiftUI layout to complete.
             try? await Task.sleep(for: .seconds(0.5))
             openProject(at: url)
+        }
+    }
+
+    /// Handles file URLs dropped onto the Welcome window.
+    /// Directories are opened as projects; files determine the project from their parent directory.
+    private func handleDrop(providers: [NSItemProvider]) {
+        for provider in providers {
+            provider.loadItem(forTypeIdentifier: "public.file-url", options: nil) { data, _ in
+                guard let data = data as? Data,
+                      let urlString = String(data: data, encoding: .utf8),
+                      let url = URL(string: urlString) else { return }
+
+                let classified = DropHandler.classifyURLs([url])
+
+                DispatchQueue.main.async {
+                    if let dir = classified.directories.first {
+                        // Open directory as project
+                        openProject(at: dir)
+                    } else if let file = classified.files.first {
+                        // Open file's parent directory as project, then open the file as a tab
+                        let projectDir = file.deletingLastPathComponent()
+                        openProject(at: projectDir)
+                        // Give the project window time to initialize, then open the file
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                            let canonical = projectDir.resolvingSymlinksInPath()
+                            registry.openProjects[canonical]?.tabManager.openTab(url: file)
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -66,6 +66,7 @@ struct WelcomeView: View {
 
     @State private var searchText = ""
     @State private var isSearchVisible = false
+    @State private var isDragTargeted = false
 
     /// Recent projects filtered by the search query.
     private var filteredProjects: [URL] {
@@ -177,9 +178,16 @@ struct WelcomeView: View {
             guard controlActiveState == .key else { return }
             openFolder()
         }
-        .onDrop(of: [.fileURL], isTargeted: nil) { providers in
+        .onDrop(of: [.fileURL], isTargeted: $isDragTargeted) { providers in
             handleDrop(providers: providers)
             return true
+        }
+        .overlay {
+            if isDragTargeted {
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(.blue, lineWidth: 2)
+                    .allowsHitTesting(false)
+            }
         }
         .task {
             // Open pending project from PINE_OPEN_PROJECT env var.
@@ -195,14 +203,14 @@ struct WelcomeView: View {
     /// Directories are opened as projects; files determine the project from their parent directory.
     private func handleDrop(providers: [NSItemProvider]) {
         for provider in providers {
-            provider.loadItem(forTypeIdentifier: "public.file-url", options: nil) { data, _ in
-                guard let data = data as? Data,
-                      let urlString = String(data: data, encoding: .utf8),
-                      let url = URL(string: urlString) else { return }
+            Task {
+                guard let url = try? await provider.loadItem(
+                    forTypeIdentifier: UTType.fileURL.identifier
+                ) as? URL else { return }
 
                 let classified = DropHandler.classifyURLs([url])
 
-                DispatchQueue.main.async {
+                await MainActor.run {
                     if let dir = classified.directories.first {
                         // Open directory as project
                         openProject(at: dir)

--- a/PineTests/DropHandlerTests.swift
+++ b/PineTests/DropHandlerTests.swift
@@ -1,0 +1,179 @@
+//
+//  DropHandlerTests.swift
+//  PineTests
+//
+//  Created by Claude on 24.03.2026.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("DropHandler Tests")
+struct DropHandlerTests {
+
+    /// Creates a temporary file for testing.
+    private func tempFile(name: String = "test.swift", content: String = "hello") -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(name)
+        try? content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    /// Creates a temporary directory for testing.
+    private func tempDirectory(name: String = "TestProject") -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent(name)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // MARK: - classifyURLs
+
+    @Test("classifyURLs separates files and directories")
+    func classifyURLsSeparatesFilesAndDirectories() {
+        let file1 = tempFile(name: "a.swift")
+        let file2 = tempFile(name: "b.txt", content: "world")
+        let dir = tempDirectory()
+
+        let result = DropHandler.classifyURLs([file1, dir, file2])
+
+        #expect(result.files.count == 2)
+        #expect(result.directories.count == 1)
+        #expect(result.files.contains(file1))
+        #expect(result.files.contains(file2))
+        #expect(result.directories.contains(dir))
+    }
+
+    @Test("classifyURLs returns empty for empty input")
+    func classifyURLsEmpty() {
+        let result = DropHandler.classifyURLs([])
+
+        #expect(result.files.isEmpty)
+        #expect(result.directories.isEmpty)
+    }
+
+    @Test("classifyURLs ignores nonexistent URLs")
+    func classifyURLsIgnoresNonexistent() {
+        let fake = URL(fileURLWithPath: "/nonexistent/\(UUID().uuidString)/file.txt")
+
+        let result = DropHandler.classifyURLs([fake])
+
+        #expect(result.files.isEmpty)
+        #expect(result.directories.isEmpty)
+    }
+
+    @Test("classifyURLs handles mixed valid and invalid URLs")
+    func classifyURLsMixed() {
+        let file = tempFile()
+        let fake = URL(fileURLWithPath: "/nonexistent/\(UUID().uuidString)")
+
+        let result = DropHandler.classifyURLs([file, fake])
+
+        #expect(result.files.count == 1)
+        #expect(result.directories.isEmpty)
+    }
+
+    // MARK: - extractFileURLs
+
+    @Test("extractFileURLs parses file URL strings")
+    func extractFileURLsFromStrings() {
+        let file = tempFile(name: "demo.swift")
+        let urlString = file.absoluteString
+
+        let result = DropHandler.extractFileURLs(from: [urlString])
+
+        #expect(result.count == 1)
+        #expect(result.first == file)
+    }
+
+    @Test("extractFileURLs skips invalid strings")
+    func extractFileURLsSkipsInvalid() {
+        let result = DropHandler.extractFileURLs(from: ["not-a-url", "https://example.com"])
+
+        #expect(result.isEmpty)
+    }
+
+    @Test("extractFileURLs handles file paths directly")
+    func extractFileURLsFromPaths() {
+        let file = tempFile(name: "path.txt")
+        // Pass the file path (not URL) — should still work
+        let result = DropHandler.extractFileURLs(from: [file.path])
+
+        #expect(result.count == 1)
+    }
+
+    // MARK: - shouldOpenAsProject
+
+    @Test("Single directory should open as project")
+    func singleDirectoryOpensAsProject() {
+        let dir = tempDirectory()
+        let classified = DropHandler.ClassifiedURLs(files: [], directories: [dir])
+
+        #expect(DropHandler.shouldOpenAsProject(classified))
+    }
+
+    @Test("Only files should not open as project")
+    func onlyFilesShouldNotOpenAsProject() {
+        let file = tempFile()
+        let classified = DropHandler.ClassifiedURLs(files: [file], directories: [])
+
+        #expect(!DropHandler.shouldOpenAsProject(classified))
+    }
+
+    @Test("Directory with files should open as project")
+    func directoryWithFilesShouldOpenAsProject() {
+        let file = tempFile()
+        let dir = tempDirectory()
+        let classified = DropHandler.ClassifiedURLs(files: [file], directories: [dir])
+
+        #expect(DropHandler.shouldOpenAsProject(classified))
+    }
+
+    @Test("Empty classified should not open as project")
+    func emptyClassifiedShouldNotOpenAsProject() {
+        let classified = DropHandler.ClassifiedURLs(files: [], directories: [])
+
+        #expect(!DropHandler.shouldOpenAsProject(classified))
+    }
+
+    // MARK: - openFilesAsTabs
+
+    @Test("openFilesAsTabs opens files in TabManager")
+    func openFilesAsTabs() {
+        let file1 = tempFile(name: "a.swift", content: "let a = 1")
+        let file2 = tempFile(name: "b.swift", content: "let b = 2")
+        let tabManager = TabManager()
+
+        DropHandler.openFilesAsTabs([file1, file2], in: tabManager)
+
+        #expect(tabManager.tabs.count == 2)
+        // Last file should be active
+        #expect(tabManager.activeTab?.url == file2)
+    }
+
+    @Test("openFilesAsTabs with empty array does nothing")
+    func openFilesAsTabsEmpty() {
+        let tabManager = TabManager()
+
+        DropHandler.openFilesAsTabs([], in: tabManager)
+
+        #expect(tabManager.tabs.isEmpty)
+    }
+
+    @Test("openFilesAsTabs deduplicates already open files")
+    func openFilesAsTabsDeduplicates() {
+        let file = tempFile(name: "dup.swift", content: "dup")
+        let tabManager = TabManager()
+        tabManager.openTab(url: file)
+        #expect(tabManager.tabs.count == 1)
+
+        DropHandler.openFilesAsTabs([file], in: tabManager)
+
+        #expect(tabManager.tabs.count == 1)
+    }
+}

--- a/PineTests/DropHandlerTests.swift
+++ b/PineTests/DropHandlerTests.swift
@@ -78,35 +78,6 @@ struct DropHandlerTests {
         #expect(result.directories.isEmpty)
     }
 
-    // MARK: - extractFileURLs
-
-    @Test("extractFileURLs parses file URL strings")
-    func extractFileURLsFromStrings() {
-        let file = tempFile(name: "demo.swift")
-        let urlString = file.absoluteString
-
-        let result = DropHandler.extractFileURLs(from: [urlString])
-
-        #expect(result.count == 1)
-        #expect(result.first == file)
-    }
-
-    @Test("extractFileURLs skips invalid strings")
-    func extractFileURLsSkipsInvalid() {
-        let result = DropHandler.extractFileURLs(from: ["not-a-url", "https://example.com"])
-
-        #expect(result.isEmpty)
-    }
-
-    @Test("extractFileURLs handles file paths directly")
-    func extractFileURLsFromPaths() {
-        let file = tempFile(name: "path.txt")
-        // Pass the file path (not URL) — should still work
-        let result = DropHandler.extractFileURLs(from: [file.path])
-
-        #expect(result.count == 1)
-    }
-
     // MARK: - shouldOpenAsProject
 
     @Test("Single directory should open as project")


### PR DESCRIPTION
## Summary

- Add `DropHandler` — classifies dropped URLs as files/folders, opens accordingly
- `.onDrop` on editor area — files open as tabs, folders as new projects
- `.onDrop` on Welcome window — folders as projects, files open parent dir
- `application(_:open:)` for Dock icon and Finder "Open With" support

⚠️ **Visual/UX changes** — drag & drop behavior, needs product owner review

Closes #420

## Test plan

- [x] 14 unit tests in `DropHandlerTests`
- [x] SwiftLint clean