### PR TITLE
fix: use static methods in FileOperationUndoManager to prevent use-after-free (#525)

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -1124,8 +1124,7 @@ final class SidebarEditState {
 
         do {
             if let undoManager {
-                let fileOps = FileOperationUndoManager()
-                try fileOps.createItem(at: newURL, isDirectory: isDirectory, undoManager: undoManager)
+                try FileOperationUndoManager.createItem(at: newURL, isDirectory: isDirectory, undoManager: undoManager)
             } else if isDirectory {
                 try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: false)
             } else if !FileManager.default.createFile(atPath: newURL.path, contents: nil) {
@@ -1303,8 +1302,6 @@ struct FileNodeRow: View {
     @Environment(\.undoManager) private var undoManager
     @FocusState private var isTextFieldFocused: Bool
 
-    private let fileOps = FileOperationUndoManager()
-
     private var isEditing: Bool {
         guard let renamingURL = editState.renamingURL else { return false }
         // Compare by path to ignore trailing-slash differences between
@@ -1471,7 +1468,7 @@ struct FileNodeRow: View {
 
         do {
             if let undoManager {
-                try fileOps.renameItem(from: oldURL, to: newURL, undoManager: undoManager)
+                try FileOperationUndoManager.renameItem(from: oldURL, to: newURL, undoManager: undoManager)
             } else {
                 try FileManager.default.moveItem(at: oldURL, to: newURL)
             }
@@ -1518,7 +1515,7 @@ struct FileNodeRow: View {
 
         do {
             if let undoManager {
-                try fileOps.deleteItem(at: deletedURL, undoManager: undoManager)
+                try FileOperationUndoManager.deleteItem(at: deletedURL, undoManager: undoManager)
             } else {
                 try FileManager.default.trashItem(at: deletedURL, resultingItemURL: nil)
             }

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -1107,6 +1107,10 @@ final class SidebarEditState {
     }
 
     /// Creates a file or folder with a unique "untitled" name, then starts inline rename.
+    ///
+    /// When creating a new item, undo registration is deferred to `commitRename` so that
+    /// the entire create+rename sequence is undone as a single Cmd+Z action (#527).
+    /// The `undoManager` is stored and used later by `commitRename`.
     func createNewItem(
         in parentURL: URL,
         isDirectory: Bool,
@@ -1123,9 +1127,9 @@ final class SidebarEditState {
         let newURL = parentURL.appendingPathComponent(name)
 
         do {
-            if let undoManager {
-                try FileOperationUndoManager.createItem(at: newURL, isDirectory: isDirectory, undoManager: undoManager)
-            } else if isDirectory {
+            // Do NOT register undo here — undo is deferred to commitRename so that
+            // create + rename are grouped as a single undo action (#527).
+            if isDirectory {
                 try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: false)
             } else if !FileManager.default.createFile(atPath: newURL.path, contents: nil) {
                 Self.showFileError(Strings.fileCreateError(name))
@@ -1460,6 +1464,10 @@ struct FileNodeRow: View {
         // Name unchanged — accept as-is
         if newURL == oldURL {
             editState.clear()
+            // For newly created items, register a single undo that deletes the file (#527)
+            if wasNewlyCreated, let undoManager {
+                try? FileOperationUndoManager.registerCreateUndo(at: oldURL, undoManager: undoManager)
+            }
             if wasNewlyCreated && !node.isDirectory {
                 tabManager.openTab(url: oldURL)
             }
@@ -1467,7 +1475,14 @@ struct FileNodeRow: View {
         }
 
         do {
-            if let undoManager {
+            if wasNewlyCreated {
+                // For newly created items: rename without undo registration, then register
+                // a single undo that deletes the final file — so Cmd+Z removes it entirely (#527).
+                try FileManager.default.moveItem(at: oldURL, to: newURL)
+                if let undoManager {
+                    try? FileOperationUndoManager.registerCreateUndo(at: newURL, undoManager: undoManager)
+                }
+            } else if let undoManager {
                 try FileOperationUndoManager.renameItem(from: oldURL, to: newURL, undoManager: undoManager)
             } else {
                 try FileManager.default.moveItem(at: oldURL, to: newURL)

--- a/Pine/FileOperationUndoManager.swift
+++ b/Pine/FileOperationUndoManager.swift
@@ -54,6 +54,24 @@ enum FileOperationUndoManager {
         undoManager.setActionName(Strings.undoRename)
     }
 
+    // MARK: - Register Create Undo (without creating)
+
+    /// Registers an undo action that trashes the item at `url`, without creating it.
+    ///
+    /// Used when create + rename are performed as separate steps but should undo as one action (#527).
+    /// The caller has already created (and optionally renamed) the item; this method only registers
+    /// the undo so that a single Cmd+Z deletes the final file.
+    static func registerCreateUndo(at url: URL, undoManager: UndoManager) throws {
+        undoManager.registerUndo(withTarget: undoManager) { (undoMgr: UndoManager) in
+            do {
+                try FileOperationUndoManager.deleteItem(at: url, undoManager: undoMgr)
+            } catch {
+                Logger.fileTree.error("Undo create failed: \(error)")
+            }
+        }
+        undoManager.setActionName(Strings.undoCreate)
+    }
+
     // MARK: - Create
 
     /// Creates a file or directory and registers an undo action that trashes it.

--- a/Pine/FileOperationUndoManager.swift
+++ b/Pine/FileOperationUndoManager.swift
@@ -10,23 +10,26 @@ import os
 ///
 /// Uses `FileManager.trashItem` for delete so that undo restores from Trash.
 /// Rename and create register inverse operations on the provided `UndoManager`.
-final class FileOperationUndoManager {
+///
+/// Implemented as an enum with static methods to avoid use-after-free crashes
+/// when SwiftUI recreates views that previously owned a class instance (#525).
+enum FileOperationUndoManager {
 
     // MARK: - Delete
 
     /// Moves the item to Trash and registers an undo action that restores it.
-    func deleteItem(at url: URL, undoManager: UndoManager) throws {
+    static func deleteItem(at url: URL, undoManager: UndoManager) throws {
         var trashURL: NSURL?
         try FileManager.default.trashItem(at: url, resultingItemURL: &trashURL)
 
         guard let restoredTrashURL = trashURL as URL? else { return }
 
-        undoManager.registerUndo(withTarget: self) { target in
+        undoManager.registerUndo(withTarget: undoManager) { (undoMgr: UndoManager) in
             do {
                 try FileManager.default.moveItem(at: restoredTrashURL, to: url)
                 // Register redo (delete again)
-                undoManager.registerUndo(withTarget: target) { target in
-                    try? target.deleteItem(at: url, undoManager: undoManager)
+                undoMgr.registerUndo(withTarget: undoMgr) { (redoMgr: UndoManager) in
+                    try? FileOperationUndoManager.deleteItem(at: url, undoManager: redoMgr)
                 }
             } catch {
                 Logger.fileTree.error("Undo delete failed: \(error)")
@@ -38,12 +41,12 @@ final class FileOperationUndoManager {
     // MARK: - Rename
 
     /// Renames (moves) an item and registers an undo action that reverts the rename.
-    func renameItem(from oldURL: URL, to newURL: URL, undoManager: UndoManager) throws {
+    static func renameItem(from oldURL: URL, to newURL: URL, undoManager: UndoManager) throws {
         try FileManager.default.moveItem(at: oldURL, to: newURL)
 
-        undoManager.registerUndo(withTarget: self) { target in
+        undoManager.registerUndo(withTarget: undoManager) { (undoMgr: UndoManager) in
             do {
-                try target.renameItem(from: newURL, to: oldURL, undoManager: undoManager)
+                try FileOperationUndoManager.renameItem(from: newURL, to: oldURL, undoManager: undoMgr)
             } catch {
                 Logger.fileTree.error("Undo rename failed: \(error)")
             }
@@ -54,7 +57,7 @@ final class FileOperationUndoManager {
     // MARK: - Create
 
     /// Creates a file or directory and registers an undo action that trashes it.
-    func createItem(at url: URL, isDirectory: Bool, undoManager: UndoManager) throws {
+    static func createItem(at url: URL, isDirectory: Bool, undoManager: UndoManager) throws {
         if isDirectory {
             try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
         } else {
@@ -63,9 +66,9 @@ final class FileOperationUndoManager {
             }
         }
 
-        undoManager.registerUndo(withTarget: self) { target in
+        undoManager.registerUndo(withTarget: undoManager) { (undoMgr: UndoManager) in
             do {
-                try target.deleteItem(at: url, undoManager: undoManager)
+                try FileOperationUndoManager.deleteItem(at: url, undoManager: undoMgr)
             } catch {
                 Logger.fileTree.error("Undo create failed: \(error)")
             }

--- a/PineTests/FileOperationUndoManagerTests.swift
+++ b/PineTests/FileOperationUndoManagerTests.swift
@@ -32,9 +32,8 @@ struct FileOperationUndoManagerTests {
         try "content".write(to: fileURL, atomically: true, encoding: .utf8)
 
         let undoManager = UndoManager()
-        let ops = FileOperationUndoManager()
 
-        try ops.deleteItem(at: fileURL, undoManager: undoManager)
+        try FileOperationUndoManager.deleteItem(at: fileURL, undoManager: undoManager)
 
         #expect(!FileManager.default.fileExists(atPath: fileURL.path))
 
@@ -55,9 +54,8 @@ struct FileOperationUndoManagerTests {
         try "inner".write(to: fileInside, atomically: true, encoding: .utf8)
 
         let undoManager = UndoManager()
-        let ops = FileOperationUndoManager()
 
-        try ops.deleteItem(at: subdir, undoManager: undoManager)
+        try FileOperationUndoManager.deleteItem(at: subdir, undoManager: undoManager)
 
         #expect(!FileManager.default.fileExists(atPath: subdir.path))
 
@@ -79,9 +77,8 @@ struct FileOperationUndoManagerTests {
         let newURL = dir.appendingPathComponent("new.txt")
 
         let undoManager = UndoManager()
-        let ops = FileOperationUndoManager()
 
-        try ops.renameItem(from: oldURL, to: newURL, undoManager: undoManager)
+        try FileOperationUndoManager.renameItem(from: oldURL, to: newURL, undoManager: undoManager)
 
         #expect(!FileManager.default.fileExists(atPath: oldURL.path))
         #expect(FileManager.default.fileExists(atPath: newURL.path))
@@ -104,9 +101,8 @@ struct FileOperationUndoManagerTests {
         let newURL = dir.appendingPathComponent("folderB")
 
         let undoManager = UndoManager()
-        let ops = FileOperationUndoManager()
 
-        try ops.renameItem(from: oldURL, to: newURL, undoManager: undoManager)
+        try FileOperationUndoManager.renameItem(from: oldURL, to: newURL, undoManager: undoManager)
 
         #expect(!FileManager.default.fileExists(atPath: oldURL.path))
         #expect(FileManager.default.fileExists(atPath: newURL.path))
@@ -126,9 +122,8 @@ struct FileOperationUndoManagerTests {
         let fileURL = dir.appendingPathComponent("created.txt")
 
         let undoManager = UndoManager()
-        let ops = FileOperationUndoManager()
 
-        try ops.createItem(at: fileURL, isDirectory: false, undoManager: undoManager)
+        try FileOperationUndoManager.createItem(at: fileURL, isDirectory: false, undoManager: undoManager)
 
         #expect(FileManager.default.fileExists(atPath: fileURL.path))
 
@@ -144,9 +139,8 @@ struct FileOperationUndoManagerTests {
         let folderURL = dir.appendingPathComponent("newFolder")
 
         let undoManager = UndoManager()
-        let ops = FileOperationUndoManager()
 
-        try ops.createItem(at: folderURL, isDirectory: true, undoManager: undoManager)
+        try FileOperationUndoManager.createItem(at: folderURL, isDirectory: true, undoManager: undoManager)
 
         var isDir: ObjCBool = false
         #expect(FileManager.default.fileExists(atPath: folderURL.path, isDirectory: &isDir))
@@ -167,9 +161,8 @@ struct FileOperationUndoManagerTests {
         try "redo".write(to: fileURL, atomically: true, encoding: .utf8)
 
         let undoManager = UndoManager()
-        let ops = FileOperationUndoManager()
 
-        try ops.deleteItem(at: fileURL, undoManager: undoManager)
+        try FileOperationUndoManager.deleteItem(at: fileURL, undoManager: undoManager)
         undoManager.undo()
         #expect(FileManager.default.fileExists(atPath: fileURL.path))
 
@@ -186,9 +179,8 @@ struct FileOperationUndoManagerTests {
         let newURL = dir.appendingPathComponent("b.txt")
 
         let undoManager = UndoManager()
-        let ops = FileOperationUndoManager()
 
-        try ops.renameItem(from: oldURL, to: newURL, undoManager: undoManager)
+        try FileOperationUndoManager.renameItem(from: oldURL, to: newURL, undoManager: undoManager)
         undoManager.undo()
         #expect(FileManager.default.fileExists(atPath: oldURL.path))
 
@@ -204,9 +196,8 @@ struct FileOperationUndoManagerTests {
         let fileURL = dir.appendingPathComponent("redocreate.txt")
 
         let undoManager = UndoManager()
-        let ops = FileOperationUndoManager()
 
-        try ops.createItem(at: fileURL, isDirectory: false, undoManager: undoManager)
+        try FileOperationUndoManager.createItem(at: fileURL, isDirectory: false, undoManager: undoManager)
         undoManager.undo()
         #expect(!FileManager.default.fileExists(atPath: fileURL.path))
 
@@ -217,23 +208,21 @@ struct FileOperationUndoManagerTests {
     // MARK: - Error cases
 
     @Test func deleteNonexistentFileThrows() {
-        let ops = FileOperationUndoManager()
         let undoManager = UndoManager()
         let fakeURL = FileManager.default.temporaryDirectory.appendingPathComponent("nonexistent-\(UUID().uuidString)")
 
         #expect(throws: (any Error).self) {
-            try ops.deleteItem(at: fakeURL, undoManager: undoManager)
+            try FileOperationUndoManager.deleteItem(at: fakeURL, undoManager: undoManager)
         }
     }
 
     @Test func renameNonexistentFileThrows() {
-        let ops = FileOperationUndoManager()
         let undoManager = UndoManager()
         let fakeURL = FileManager.default.temporaryDirectory.appendingPathComponent("nonexistent-\(UUID().uuidString)")
         let destURL = FileManager.default.temporaryDirectory.appendingPathComponent("dest-\(UUID().uuidString)")
 
         #expect(throws: (any Error).self) {
-            try ops.renameItem(from: fakeURL, to: destURL, undoManager: undoManager)
+            try FileOperationUndoManager.renameItem(from: fakeURL, to: destURL, undoManager: undoManager)
         }
     }
 }

--- a/PineTests/FileOperationUndoManagerTests.swift
+++ b/PineTests/FileOperationUndoManagerTests.swift
@@ -216,6 +216,73 @@ struct FileOperationUndoManagerTests {
         }
     }
 
+    // MARK: - Grouped create+rename undo (#527)
+
+    @Test func registerCreateUndoDeletesFileOnUndo() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        // Simulate create + rename flow: file already exists at final URL
+        let finalURL = dir.appendingPathComponent("myFile.swift")
+        try "code".write(to: finalURL, atomically: true, encoding: .utf8)
+
+        let undoManager = UndoManager()
+
+        try FileOperationUndoManager.registerCreateUndo(at: finalURL, undoManager: undoManager)
+
+        // File still exists before undo
+        #expect(FileManager.default.fileExists(atPath: finalURL.path))
+
+        // Single undo should delete the file
+        undoManager.undo()
+
+        #expect(!FileManager.default.fileExists(atPath: finalURL.path))
+    }
+
+    @Test func registerCreateUndoSingleUndoRemovesRenamedFile() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        // Simulate the full create+rename flow:
+        // 1. Create "untitled"
+        let untitledURL = dir.appendingPathComponent("untitled")
+        FileManager.default.createFile(atPath: untitledURL.path, contents: nil)
+
+        // 2. Rename to "hello.swift"
+        let finalURL = dir.appendingPathComponent("hello.swift")
+        try FileManager.default.moveItem(at: untitledURL, to: finalURL)
+
+        // 3. Register single undo for the final URL
+        let undoManager = UndoManager()
+        try FileOperationUndoManager.registerCreateUndo(at: finalURL, undoManager: undoManager)
+
+        // One Cmd+Z should delete the file entirely
+        #expect(undoManager.canUndo)
+        undoManager.undo()
+
+        #expect(!FileManager.default.fileExists(atPath: finalURL.path))
+        #expect(!FileManager.default.fileExists(atPath: untitledURL.path))
+    }
+
+    @Test func registerCreateUndoRedoRestoresFile() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let fileURL = dir.appendingPathComponent("recreate.txt")
+        try "content".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let undoManager = UndoManager()
+        try FileOperationUndoManager.registerCreateUndo(at: fileURL, undoManager: undoManager)
+
+        // Undo (delete)
+        undoManager.undo()
+        #expect(!FileManager.default.fileExists(atPath: fileURL.path))
+
+        // Redo (restore from trash)
+        undoManager.redo()
+        #expect(FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
     @Test func renameNonexistentFileThrows() {
         let undoManager = UndoManager()
         let fakeURL = FileManager.default.temporaryDirectory.appendingPathComponent("nonexistent-\(UUID().uuidString)")


### PR DESCRIPTION
## Summary

- Convert `FileOperationUndoManager` from `final class` to `enum` with static methods
- Use `undoManager` itself as `registerUndo(withTarget:)` target instead of `self`
- Remove `private let fileOps` from `FileNodeRow` — call static methods directly

Fixes crash: `EXC_BAD_ACCESS` when pressing Cmd+Z after file creation. The old class instance was deallocated by SwiftUI view recreation before undo fired.

Closes #525

## Test plan

- [x] Updated unit tests for static API
- [x] Manual test: create file → Cmd+Z → no crash
- [x] SwiftLint clean