### PR TITLE
fix: auto-scroll sidebar to newly created file (#528)

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -1087,6 +1087,8 @@ final class SidebarEditState {
     var renamingURL: URL?
     var editingText: String = ""
     var isNewlyCreated: Bool = false
+    /// URL of the newly created node to scroll to in the sidebar.
+    var scrollToNodeID: URL?
 
     func startRename(for node: FileNode) {
         renamingURL = node.url
@@ -1134,6 +1136,7 @@ final class SidebarEditState {
             }
             workspace.refreshFileTree()
             startNewItem(url: newURL)
+            scrollToNodeID = newURL
         } catch {
             Self.showFileError(error.localizedDescription)
         }
@@ -1161,6 +1164,7 @@ final class SidebarEditState {
             renamingURL = copyURL
             editingText = copyURL.lastPathComponent
             isNewlyCreated = false
+            scrollToNodeID = copyURL
             if !isDirectory {
                 tabManager.openTab(url: copyURL)
             }
@@ -1216,49 +1220,62 @@ struct SidebarView: View {
                 }
                 .navigationTitle(Strings.filesTitle)
             } else {
-                List(workspace.rootNodes, children: \.optionalChildren, selection: $selectedFile) { node in
-                    FileNodeRow(node: node)
-                }
-                .environment(editState)
-                .contextMenu {
-                    if let rootURL = workspace.rootURL {
-                        Button {
-                            editState.createNewItem(
-                                in: rootURL,
-                                isDirectory: false,
-                                workspace: workspace,
-                                undoManager: undoManager
-                            )
-                        } label: {
-                            Label(Strings.contextNewFile, systemImage: MenuIcons.newFile)
-                        }
+                ScrollViewReader { scrollProxy in
+                    List(workspace.rootNodes, children: \.optionalChildren, selection: $selectedFile) { node in
+                        FileNodeRow(node: node)
+                            .id(node.id)
+                    }
+                    .environment(editState)
+                    .contextMenu {
+                        if let rootURL = workspace.rootURL {
+                            Button {
+                                editState.createNewItem(
+                                    in: rootURL,
+                                    isDirectory: false,
+                                    workspace: workspace,
+                                    undoManager: undoManager
+                                )
+                            } label: {
+                                Label(Strings.contextNewFile, systemImage: MenuIcons.newFile)
+                            }
 
-                        Button {
-                            editState.createNewItem(
-                                in: rootURL,
-                                isDirectory: true,
-                                workspace: workspace,
-                                undoManager: undoManager
-                            )
-                        } label: {
-                            Label(Strings.contextNewFolder, systemImage: MenuIcons.newFolder)
-                        }
+                            Button {
+                                editState.createNewItem(
+                                    in: rootURL,
+                                    isDirectory: true,
+                                    workspace: workspace,
+                                    undoManager: undoManager
+                                )
+                            } label: {
+                                Label(Strings.contextNewFolder, systemImage: MenuIcons.newFolder)
+                            }
 
-                        Divider()
+                            Divider()
 
-                        Button {
-                            NSWorkspace.shared.activateFileViewerSelecting([rootURL])
-                        } label: {
-                            Label(Strings.contextRevealInFinder, systemImage: MenuIcons.revealInFinder)
+                            Button {
+                                NSWorkspace.shared.activateFileViewerSelecting([rootURL])
+                            } label: {
+                                Label(Strings.contextRevealInFinder, systemImage: MenuIcons.revealInFinder)
+                            }
                         }
                     }
-                }
-                .navigationTitle(workspace.projectName)
-                .onChange(of: editState.renamingURL) { _, newURL in
-                    if newURL != nil {
-                        // Defer to avoid modifying state during view update
+                    .navigationTitle(workspace.projectName)
+                    .onChange(of: editState.renamingURL) { _, newURL in
+                        if newURL != nil {
+                            // Defer to avoid modifying state during view update
+                            DispatchQueue.main.async {
+                                selectedFile = nil
+                            }
+                        }
+                    }
+                    .onChange(of: editState.scrollToNodeID) { _, targetID in
+                        guard let targetID else { return }
+                        // Defer scroll to next run loop so the file tree has time to update.
                         DispatchQueue.main.async {
-                            selectedFile = nil
+                            withAnimation {
+                                scrollProxy.scrollTo(targetID, anchor: .center)
+                            }
+                            editState.scrollToNodeID = nil
                         }
                     }
                 }

--- a/PineTests/SidebarEditStateTests.swift
+++ b/PineTests/SidebarEditStateTests.swift
@@ -1,0 +1,109 @@
+//
+//  SidebarEditStateTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("SidebarEditState Tests")
+struct SidebarEditStateTests {
+
+    private func makeTempDirectory() throws -> URL {
+        let rawDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-sidebar-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: rawDir, withIntermediateDirectories: true)
+        // Resolve firmlinks (/var -> /private/var) for consistent path comparison
+        guard let resolved = realpath(rawDir.path, nil) else { throw CocoaError(.fileNoSuchFile) }
+        defer { free(resolved) }
+        return URL(fileURLWithPath: String(cString: resolved))
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - scrollToNodeID
+
+    @Test("createNewItem sets scrollToNodeID for new file")
+    @MainActor
+    func createNewFileSetsScrollToNodeID() throws {
+        let tmpDir = try makeTempDirectory()
+        defer { cleanup(tmpDir) }
+
+        let workspace = WorkspaceManager()
+        workspace.loadDirectory(url: tmpDir)
+
+        let editState = SidebarEditState()
+        editState.createNewItem(in: tmpDir, isDirectory: false, workspace: workspace)
+
+        let scrollID = try #require(editState.scrollToNodeID)
+        #expect(scrollID == editState.renamingURL)
+        // Verify the file was actually created on disk
+        #expect(FileManager.default.fileExists(atPath: scrollID.path))
+    }
+
+    @Test("createNewItem sets scrollToNodeID for new folder")
+    @MainActor
+    func createNewFolderSetsScrollToNodeID() throws {
+        let tmpDir = try makeTempDirectory()
+        defer { cleanup(tmpDir) }
+
+        let workspace = WorkspaceManager()
+        workspace.loadDirectory(url: tmpDir)
+
+        let editState = SidebarEditState()
+        editState.createNewItem(in: tmpDir, isDirectory: true, workspace: workspace)
+
+        let scrollID = try #require(editState.scrollToNodeID)
+        #expect(scrollID == editState.renamingURL)
+        var isDir: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: scrollID.path, isDirectory: &isDir)
+        #expect(exists)
+        #expect(isDir.boolValue)
+    }
+
+    @Test("clear does not reset scrollToNodeID")
+    @MainActor
+    func clearDoesNotResetScrollToNodeID() {
+        let editState = SidebarEditState()
+        let testURL = URL(fileURLWithPath: "/tmp/test-node")
+        editState.scrollToNodeID = testURL
+
+        editState.clear()
+
+        // scrollToNodeID is managed separately from rename state — clear() should not touch it.
+        // The view's onChange handler resets it after scrolling.
+        #expect(editState.scrollToNodeID == testURL)
+    }
+
+    @Test("scrollToNodeID is nil initially")
+    func scrollToNodeIDNilInitially() {
+        let editState = SidebarEditState()
+        #expect(editState.scrollToNodeID == nil)
+    }
+
+    @Test("duplicateItem sets scrollToNodeID")
+    @MainActor
+    func duplicateItemSetsScrollToNodeID() throws {
+        let tmpDir = try makeTempDirectory()
+        defer { cleanup(tmpDir) }
+
+        let workspace = WorkspaceManager()
+        workspace.loadDirectory(url: tmpDir)
+
+        // Create a source file to duplicate
+        let sourceURL = tmpDir.appendingPathComponent("source.txt")
+        FileManager.default.createFile(atPath: sourceURL.path, contents: Data("hello".utf8))
+
+        let tabManager = TabManager()
+        let editState = SidebarEditState()
+        editState.duplicateItem(at: sourceURL, isDirectory: false, workspace: workspace, tabManager: tabManager)
+
+        let scrollID = try #require(editState.scrollToNodeID)
+        #expect(scrollID == editState.renamingURL)
+        #expect(FileManager.default.fileExists(atPath: scrollID.path))
+    }
+}


### PR DESCRIPTION
## Summary
- Auto-scroll sidebar to newly created file/folder using ScrollViewReader
- Matches Finder/Xcode behavior

Closes #528

## Test plan
- [x] SwiftLint clean
- [x] Unit tests pass