### PR TITLE
fix: eliminate syntax highlight flash on tab switch (#529)

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -408,6 +408,11 @@ struct CodeEditorView: NSViewRepresentable {
     var initialScrollOffset: CGFloat = 0
     /// Called when cursor position or scroll offset changes, so the caller can persist them.
     var onStateChange: ((Int, CGFloat) -> Void)?
+    /// Called when a new syntax highlight result is computed, so the caller can cache it in the tab.
+    var onHighlightCacheUpdate: ((HighlightMatchResult) -> Void)?
+    /// Cached highlight result from the previous session of this tab.
+    /// Applied synchronously on tab switch to eliminate the flash of unhighlighted text.
+    var cachedHighlightResult: HighlightMatchResult?
     /// When non-nil, the editor scrolls to this offset. The `id` ensures each request is unique.
     var goToOffset: GoToRequest?
 
@@ -545,8 +550,21 @@ struct CodeEditorView: NSViewRepresentable {
                 )
                 coordinator?.highlightedCharRange = initialRange
             })
+        } else if let cached = cachedHighlightResult {
+            // Apply cached highlights synchronously to avoid flash on tab switch.
+            SyntaxHighlighter.shared.applyMatches(cached, to: textStorage, font: editorFont)
         } else {
-            applyHighlightingAsync(to: textView, coordinator: context.coordinator)
+            // No cache — apply synchronous highlight for instant display on tab switch.
+            if !syntaxHighlightingDisabled {
+                if let result = SyntaxHighlighter.shared.highlight(
+                    textStorage: textStorage,
+                    language: language,
+                    fileName: fileName,
+                    font: editorFont
+                ) {
+                    onHighlightCacheUpdate?(result)
+                }
+            }
         }
 
         // Restore cursor and scroll from saved per-tab state.
@@ -819,21 +837,18 @@ struct CodeEditorView: NSViewRepresentable {
             if !parent.syntaxHighlightingDisabled, let storage = textView.textStorage {
                 if storage.length > CodeEditorView.viewportHighlightThreshold {
                     scheduleViewportHighlighting(textView: textView)
+                } else if let cached = parent.cachedHighlightResult {
+                    // Apply cached highlights synchronously to avoid flash on tab switch.
+                    SyntaxHighlighter.shared.applyMatches(cached, to: storage, font: font)
                 } else {
-                    highlightGeneration.increment()
-                    let gen = highlightGeneration
-                    let lang = language
-                    let name = fileName
-                    let editorFont = font
-                    highlightTask?.cancel()
-                    highlightTask = Task { @MainActor in
-                        await SyntaxHighlighter.shared.highlightAsync(
-                            textStorage: storage,
-                            language: lang,
-                            fileName: name,
-                            font: editorFont,
-                            generation: gen
-                        )
+                    // No cache — apply synchronous highlight for instant display.
+                    if let result = SyntaxHighlighter.shared.highlight(
+                        textStorage: storage,
+                        language: language,
+                        fileName: fileName,
+                        font: font
+                    ) {
+                        parent.onHighlightCacheUpdate?(result)
                     }
                 }
             }
@@ -889,14 +904,17 @@ struct CodeEditorView: NSViewRepresentable {
                     let lang = parent.language
                     let name = parent.fileName
                     highlightTask?.cancel()
-                    highlightTask = Task { @MainActor in
-                        await SyntaxHighlighter.shared.highlightAsync(
+                    highlightTask = Task { @MainActor [weak self] in
+                        let result = await SyntaxHighlighter.shared.highlightAsync(
                             textStorage: storage,
                             language: lang,
                             fileName: name,
                             font: font,
                             generation: gen
                         )
+                        if let result {
+                            self?.parent.onHighlightCacheUpdate?(result)
+                        }
                     }
                 }
             }
@@ -1002,14 +1020,17 @@ struct CodeEditorView: NSViewRepresentable {
                 } else if isLargeFile {
                     self.scheduleViewportHighlighting(textView: tv)
                 } else {
-                    self.highlightTask = Task { @MainActor in
-                        await SyntaxHighlighter.shared.highlightAsync(
+                    self.highlightTask = Task { @MainActor [weak self] in
+                        let result = await SyntaxHighlighter.shared.highlightAsync(
                             textStorage: storage,
                             language: lang,
                             fileName: name,
                             font: font,
                             generation: gen
                         )
+                        if let result {
+                            self?.parent.onHighlightCacheUpdate?(result)
+                        }
                     }
                 }
             }
@@ -1520,21 +1541,6 @@ struct CodeEditorView: NSViewRepresentable {
         )
     }
 
-    private func applyHighlightingAsync(to textView: NSTextView, coordinator: Coordinator) {
-        guard !syntaxHighlightingDisabled else { return }
-        guard let storage = textView.textStorage else { return }
-        let lang = language
-        let file = fileName
-        let font = editorFont
-        coordinator.setHighlightTask(Task { @MainActor in
-            await SyntaxHighlighter.shared.highlightAsync(
-                textStorage: storage,
-                language: lang,
-                fileName: file,
-                font: font
-            )
-        })
-    }
 }
 
 // MARK: - NSImage tinting

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -603,6 +603,10 @@ struct ContentView: View {
             onStateChange: { cursor, scroll in
                 tabManager.updateEditorState(cursorPosition: cursor, scrollOffset: scroll)
             },
+            onHighlightCacheUpdate: { result in
+                tabManager.updateHighlightCache(result)
+            },
+            cachedHighlightResult: tab.cachedHighlightResult,
             goToOffset: goToLineOffset,
             fontSize: FontSizeSettings.shared.fontSize
         )

--- a/Pine/EditorTab.swift
+++ b/Pine/EditorTab.swift
@@ -64,6 +64,11 @@ struct EditorTab: Identifiable, Hashable {
     /// Whether this tab's content was truncated on load (huge file partial load).
     var isTruncated: Bool = false
 
+    /// Cached syntax highlight matches — applied synchronously on tab switch
+    /// to eliminate the flash of unhighlighted text.
+    /// Not included in Hashable/Equatable (which use id only).
+    var cachedHighlightResult: HighlightMatchResult?
+
     /// The detected file encoding. Used for saving the file in its original encoding.
     var encoding: String.Encoding = .utf8
 

--- a/Pine/SyntaxHighlighter.swift
+++ b/Pine/SyntaxHighlighter.swift
@@ -322,17 +322,19 @@ final class SyntaxHighlighter: @unchecked Sendable {
     ]
 
     /// Применяет подсветку ко всему NSTextStorage и обновляет кэш многострочных матчей.
+    /// Returns the match result so callers can cache it for instant reapplication on tab switch.
+    @discardableResult
     func highlight(
         textStorage: NSTextStorage,
         language: String,
         fileName: String? = nil,
         font: NSFont
-    ) {
+    ) -> HighlightMatchResult? {
         guard let (_, rules) = resolveGrammar(language: language, fileName: fileName) else {
             resetAttributes(textStorage: textStorage,
                             range: NSRange(location: 0, length: textStorage.length),
                             font: font)
-            return
+            return nil
         }
 
         let fullRange = NSRange(location: 0, length: textStorage.length)
@@ -340,6 +342,7 @@ final class SyntaxHighlighter: @unchecked Sendable {
             rules, to: textStorage, repaintRange: fullRange, searchRange: fullRange, font: font
         )
         lock.withLock { multilineMatchCache[ObjectIdentifier(textStorage)] = result.multilineFingerprint }
+        return result
     }
 
     /// Количество строк контекста для viewport-based подсветки (больше, чем для edit).
@@ -760,18 +763,20 @@ final class SyntaxHighlighter: @unchecked Sendable {
     }
 
     /// Async full highlight: computes on background queue, applies on main thread.
+    /// Returns the applied match result (for caching on tab switch), or nil if generation was stale.
+    @discardableResult
     func highlightAsync(
         textStorage: NSTextStorage,
         language: String,
         fileName: String? = nil,
         font: NSFont,
         generation: HighlightGeneration? = nil
-    ) async {
+    ) async -> HighlightMatchResult? {
         // Explicit copy — NSTextStorage.string returns a reference to the internal
         // NSMutableString which may mutate while background work is in progress.
         let text = String(textStorage.string)
         let textLength = (text as NSString).length
-        guard textLength > 0 else { return }
+        guard textLength > 0 else { return nil }
 
         let fullRange = NSRange(location: 0, length: textLength)
         let gen = generation?.current ?? 0
@@ -790,17 +795,19 @@ final class SyntaxHighlighter: @unchecked Sendable {
         }
 
         // Check generation — if bumped, discard stale results
-        if let generation, generation.current != gen { return }
+        if let generation, generation.current != gen { return nil }
 
         if let result {
             applyMatches(result, to: textStorage, font: font)
             updateMultilineCache(key: ObjectIdentifier(textStorage), fingerprint: result.multilineFingerprint)
+            return result
         } else {
             resetAttributes(
                 textStorage: textStorage,
                 range: fullRange,
                 font: font
             )
+            return nil
         }
     }
 

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -225,6 +225,7 @@ final class TabManager {
         guard let index = activeTabIndex else { return }
         guard tabs[index].kind == .text else { return }
         tabs[index].content = newContent
+        tabs[index].cachedHighlightResult = nil  // Invalidate stale highlight cache
         tabs[index].recomputeContentCaches()
 
         if isAutoSaveEnabled {
@@ -248,6 +249,13 @@ final class TabManager {
     func updateFoldState(_ state: FoldState) {
         guard let index = activeTabIndex else { return }
         tabs[index].foldState = state
+    }
+
+    /// Updates the cached syntax highlight result for the active tab.
+    /// Used to apply highlights synchronously on tab switch, eliminating flash.
+    func updateHighlightCache(_ result: HighlightMatchResult) {
+        guard let index = activeTabIndex else { return }
+        tabs[index].cachedHighlightResult = result
     }
 
     /// Saves the active tab to disk. Returns true on success.

--- a/PineTests/ConcurrentHighlightingTests.swift
+++ b/PineTests/ConcurrentHighlightingTests.swift
@@ -102,12 +102,12 @@ struct ConcurrentHighlightingTests {
         let pythonStorage = NSTextStorage(string: pythonText)
 
         // Highlight both concurrently
-        async let swiftHighlight: Void = hl.highlightAsync(
+        async let swiftHighlight: HighlightMatchResult? = hl.highlightAsync(
             textStorage: swiftStorage,
             language: "conctestswift",
             font: font
         )
-        async let pythonHighlight: Void = hl.highlightAsync(
+        async let pythonHighlight: HighlightMatchResult? = hl.highlightAsync(
             textStorage: pythonStorage,
             language: "conctestpy",
             font: font
@@ -179,7 +179,7 @@ struct ConcurrentHighlightingTests {
         genA.increment() // 2
 
         // Tab A highlight should be discarded (stale), tab B should apply
-        async let highlightA: Void = hl.highlightAsync(
+        async let highlightA: HighlightMatchResult? = hl.highlightAsync(
             textStorage: storageA,
             language: "conctestswift",
             font: font,
@@ -189,7 +189,7 @@ struct ConcurrentHighlightingTests {
         genA.increment() // 3
 
         // Tab B uses its own generation — no bump, should apply
-        async let highlightB: Void = hl.highlightAsync(
+        async let highlightB: HighlightMatchResult? = hl.highlightAsync(
             textStorage: storageB,
             language: "conctestswift",
             font: font,

--- a/PineTests/HighlightCacheTests.swift
+++ b/PineTests/HighlightCacheTests.swift
@@ -1,0 +1,247 @@
+//
+//  HighlightCacheTests.swift
+//  PineTests
+//
+//  Tests for syntax highlight caching to eliminate flash on tab switch.
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+@Suite(.serialized)
+struct HighlightCacheTests {
+
+    private let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+
+    private let swiftGrammar = Grammar(
+        name: "TestSwift",
+        extensions: ["testswift"],
+        rules: [
+            GrammarRule(pattern: "\\bfunc\\b", scope: "keyword"),
+            GrammarRule(pattern: "\"[^\"]*\"", scope: "string"),
+            GrammarRule(pattern: "//.*$", scope: "comment", options: ["anchorsMatchLines"])
+        ]
+    )
+
+    private func register(_ grammars: Grammar...) {
+        for grammar in grammars {
+            SyntaxHighlighter.shared.registerGrammar(grammar)
+        }
+    }
+
+    // MARK: - EditorTab cache property
+
+    @Test("EditorTab cachedHighlightResult is nil by default")
+    func tabCacheNilByDefault() {
+        let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/test.swift"), content: "func test() {}")
+        #expect(tab.cachedHighlightResult == nil)
+    }
+
+    @Test("EditorTab cachedHighlightResult can be set and read")
+    func tabCacheSetAndRead() {
+        var tab = EditorTab(url: URL(fileURLWithPath: "/tmp/test.swift"), content: "func test() {}")
+        let result = HighlightMatchResult(
+            matches: [HighlightMatch(range: NSRange(location: 0, length: 4), scope: "keyword", priority: 0)],
+            repaintRange: NSRange(location: 0, length: 14),
+            multilineFingerprint: []
+        )
+        tab.cachedHighlightResult = result
+        #expect(tab.cachedHighlightResult != nil)
+        #expect(tab.cachedHighlightResult?.matches.count == 1)
+    }
+
+    // MARK: - Synchronous highlight returns result
+
+    @Test("SyntaxHighlighter.highlight returns match result for caching")
+    func highlightReturnsCacheableResult() throws {
+        register(swiftGrammar)
+        let storage = NSTextStorage(string: "func hello() {}")
+        let result = SyntaxHighlighter.shared.highlight(
+            textStorage: storage,
+            language: "testswift",
+            font: font
+        )
+        let unwrapped = try #require(result)
+        #expect(unwrapped.matches.isEmpty == false)
+        // "func" should be highlighted as keyword
+        let keywordMatch = unwrapped.matches.first { $0.scope == "keyword" }
+        #expect(keywordMatch != nil)
+        #expect(keywordMatch?.range == NSRange(location: 0, length: 4))
+    }
+
+    @Test("SyntaxHighlighter.highlight returns nil for unknown language")
+    func highlightReturnsNilForUnknownLanguage() {
+        let storage = NSTextStorage(string: "some text")
+        let result = SyntaxHighlighter.shared.highlight(
+            textStorage: storage,
+            language: "nonexistent_language_xyz",
+            font: font
+        )
+        #expect(result == nil)
+    }
+
+    // MARK: - Cache applied synchronously matches async result
+
+    @Test("Cached result applied synchronously produces same colors as fresh highlight")
+    func cachedResultMatchesFreshHighlight() throws {
+        register(swiftGrammar)
+
+        // First: highlight fresh and capture result
+        let text = "func foo() { // comment\n    \"string\"\n}"
+        let storage1 = NSTextStorage(string: text)
+        let result = SyntaxHighlighter.shared.highlight(
+            textStorage: storage1,
+            language: "testswift",
+            font: font
+        )
+        let unwrapped = try #require(result)
+
+        // Capture colors from fresh highlight
+        var freshColors: [Int: NSColor] = [:]
+        for i in 0..<storage1.length {
+            if let color = storage1.attribute(.foregroundColor, at: i, effectiveRange: nil) as? NSColor {
+                freshColors[i] = color
+            }
+        }
+
+        // Second: apply cached result to new storage with same text
+        let storage2 = NSTextStorage(string: text)
+        // Set default attributes first (simulating what makeNSView does)
+        storage2.addAttributes([
+            .foregroundColor: NSColor.textColor,
+            .font: font
+        ], range: NSRange(location: 0, length: storage2.length))
+
+        SyntaxHighlighter.shared.applyMatches(unwrapped, to: storage2, font: font)
+
+        // Colors should match
+        for i in 0..<storage2.length {
+            let cachedColor = storage2.attribute(.foregroundColor, at: i, effectiveRange: nil) as? NSColor
+            let freshColor = freshColors[i]
+            #expect(cachedColor == freshColor, "Color mismatch at position \(i)")
+        }
+    }
+
+    // MARK: - Cache invalidation on content change
+
+    @Test("TabManager.updateContent invalidates highlight cache")
+    func updateContentInvalidatesCache() {
+        let url = URL(fileURLWithPath: "/tmp/test.swift")
+        var tab = EditorTab(url: url, content: "func test() {}")
+        tab.cachedHighlightResult = HighlightMatchResult(
+            matches: [HighlightMatch(range: NSRange(location: 0, length: 4), scope: "keyword", priority: 0)],
+            repaintRange: NSRange(location: 0, length: 14),
+            multilineFingerprint: []
+        )
+        #expect(tab.cachedHighlightResult != nil)
+
+        // Simulate what updateContent does: set content and nil the cache
+        tab.content = "let x = 1"
+        tab.cachedHighlightResult = nil
+        #expect(tab.cachedHighlightResult == nil)
+    }
+
+    // MARK: - Cache survives tab switch roundtrip
+
+    @Test("Highlight cache persists across simulated tab switches")
+    func cachePersistsAcrossTabSwitch() throws {
+        register(swiftGrammar)
+
+        // Create two tabs
+        var tab1 = EditorTab(url: URL(fileURLWithPath: "/tmp/a.swift"), content: "func a() {}")
+        var tab2 = EditorTab(url: URL(fileURLWithPath: "/tmp/b.swift"), content: "func b() {}")
+
+        // Highlight tab1 and cache result
+        let storage1 = NSTextStorage(string: tab1.content)
+        let result1 = SyntaxHighlighter.shared.highlight(
+            textStorage: storage1, language: "testswift", font: font
+        )
+        tab1.cachedHighlightResult = result1
+
+        // Highlight tab2 and cache result
+        let storage2 = NSTextStorage(string: tab2.content)
+        let result2 = SyntaxHighlighter.shared.highlight(
+            textStorage: storage2, language: "testswift", font: font
+        )
+        tab2.cachedHighlightResult = result2
+
+        // Both caches should exist
+        let cached1 = try #require(tab1.cachedHighlightResult)
+        #expect(tab2.cachedHighlightResult != nil)
+
+        // Switch back to tab1 — apply cached result to fresh storage
+        let freshStorage = NSTextStorage(string: tab1.content)
+        freshStorage.addAttributes([
+            .foregroundColor: NSColor.textColor,
+            .font: font
+        ], range: NSRange(location: 0, length: freshStorage.length))
+
+        SyntaxHighlighter.shared.applyMatches(cached1, to: freshStorage, font: font)
+
+        // "func" should be highlighted
+        let funcColor = freshStorage.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        let bodyColor = freshStorage.attribute(.foregroundColor, at: 5, effectiveRange: nil) as? NSColor
+        #expect(funcColor != bodyColor, "Keyword 'func' should have different color from body text")
+    }
+
+    // MARK: - applyMatches validates range bounds
+
+    @Test("applyMatches discards result when text has changed (shorter)")
+    func applyMatchesDiscardsOutOfBoundsResult() throws {
+        register(swiftGrammar)
+
+        let longText = "func hello() { /* long content */ }"
+        let storage = NSTextStorage(string: longText)
+        let result = SyntaxHighlighter.shared.highlight(
+            textStorage: storage, language: "testswift", font: font
+        )
+        let unwrapped = try #require(result)
+
+        // Replace with shorter text
+        let shortStorage = NSTextStorage(string: "x")
+        shortStorage.addAttributes([
+            .foregroundColor: NSColor.textColor,
+            .font: font
+        ], range: NSRange(location: 0, length: shortStorage.length))
+
+        // Apply cached result from longer text — should be safely discarded
+        SyntaxHighlighter.shared.applyMatches(unwrapped, to: shortStorage, font: font)
+
+        // Should not crash, and text color should remain default
+        let color = shortStorage.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor
+        #expect(color == NSColor.textColor)
+    }
+
+    // MARK: - highlightAsync returns result
+
+    @Test("highlightAsync returns match result for caching")
+    func highlightAsyncReturnsCacheableResult() async {
+        register(swiftGrammar)
+        let storage = NSTextStorage(string: "func test() {}")
+        let result = await SyntaxHighlighter.shared.highlightAsync(
+            textStorage: storage,
+            language: "testswift",
+            font: font
+        )
+        #expect(result != nil)
+        let keywordMatch = result?.matches.first { $0.scope == "keyword" }
+        #expect(keywordMatch != nil)
+    }
+
+    @Test("highlightAsync returns non-nil when generation is current")
+    func highlightAsyncReturnsResultWhenGenerationCurrent() async {
+        register(swiftGrammar)
+        let storage = NSTextStorage(string: "func test() {}")
+        let generation = HighlightGeneration()
+
+        // Do not bump generation — result should be applied
+        let result = await SyntaxHighlighter.shared.highlightAsync(
+            textStorage: storage,
+            language: "testswift",
+            font: font,
+            generation: generation
+        )
+        #expect(result != nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Cache syntax highlight attributes per tab (`cachedHighlightResult` on `EditorTab`)
- Apply cached highlights synchronously on tab switch (in `makeNSView` and `updateContentIfNeeded`)
- Fall back to synchronous `SyntaxHighlighter.highlight()` when no cache exists (eliminates async delay)
- Invalidate cache on content edit (`TabManager.updateContent`)
- Update cache after each successful async highlight

Closes #529

## Test plan
- [x] SwiftLint clean (0 violations)
- [x] Unit tests pass (10 new tests in `HighlightCacheTests`)
- [x] Existing tests unaffected