### PR TITLE
fix: Cmd+Z after creating a file undoes both create and rename (#527)

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -1547,9 +1547,11 @@ struct FileNodeRow: View {
         // Name unchanged — accept as-is
         if newURL == oldURL {
             editState.clear()
-            // For newly created items, register a single undo that deletes the file (#527)
+            // For newly created items, register a grouped undo that deletes the file (#527)
             if wasNewlyCreated, let undoManager {
-                try? FileOperationUndoManager.registerCreateUndo(at: oldURL, undoManager: undoManager)
+                try? FileOperationUndoManager.finalizeNewItem(
+                    from: oldURL, to: oldURL, undoManager: undoManager
+                )
             }
             if wasNewlyCreated && !node.isDirectory {
                 tabManager.openTab(url: oldURL)
@@ -1559,12 +1561,11 @@ struct FileNodeRow: View {
 
         do {
             if wasNewlyCreated {
-                // For newly created items: rename without undo registration, then register
-                // a single undo that deletes the final file — so Cmd+Z removes it entirely (#527).
-                try FileManager.default.moveItem(at: oldURL, to: newURL)
-                if let undoManager {
-                    try? FileOperationUndoManager.registerCreateUndo(at: newURL, undoManager: undoManager)
-                }
+                // For newly created items: rename + register a grouped undo so that
+                // a single Cmd+Z removes the file entirely (#527).
+                try FileOperationUndoManager.finalizeNewItem(
+                    from: oldURL, to: newURL, undoManager: undoManager ?? UndoManager()
+                )
             } else if let undoManager {
                 try FileOperationUndoManager.renameItem(from: oldURL, to: newURL, undoManager: undoManager)
             } else {

--- a/Pine/FileOperationUndoManager.swift
+++ b/Pine/FileOperationUndoManager.swift
@@ -54,22 +54,33 @@ enum FileOperationUndoManager {
         undoManager.setActionName(Strings.undoRename)
     }
 
-    // MARK: - Register Create Undo (without creating)
+    // MARK: - Finalize New Item (grouped create + rename undo, #527)
 
-    /// Registers an undo action that trashes the item at `url`, without creating it.
+    /// Optionally renames a newly created item and registers a **grouped** undo action
+    /// so that a single Cmd+Z removes the item entirely.
     ///
-    /// Used when create + rename are performed as separate steps but should undo as one action (#527).
-    /// The caller has already created (and optionally renamed) the item; this method only registers
-    /// the undo so that a single Cmd+Z deletes the final file.
-    static func registerCreateUndo(at url: URL, undoManager: UndoManager) throws {
+    /// When `originalURL == finalURL` (user accepted the default name), no rename is performed.
+    /// Uses `beginUndoGrouping()` / `endUndoGrouping()` to guarantee the operation
+    /// is atomic from the undo stack perspective.
+    static func finalizeNewItem(
+        from originalURL: URL,
+        to finalURL: URL,
+        undoManager: UndoManager
+    ) throws {
+        if finalURL != originalURL {
+            try FileManager.default.moveItem(at: originalURL, to: finalURL)
+        }
+
+        undoManager.beginUndoGrouping()
         undoManager.registerUndo(withTarget: undoManager) { (undoMgr: UndoManager) in
             do {
-                try FileOperationUndoManager.deleteItem(at: url, undoManager: undoMgr)
+                try FileOperationUndoManager.deleteItem(at: finalURL, undoManager: undoMgr)
             } catch {
                 Logger.fileTree.error("Undo create failed: \(error)")
             }
         }
         undoManager.setActionName(Strings.undoCreate)
+        undoManager.endUndoGrouping()
     }
 
     // MARK: - Create

--- a/PineTests/FileOperationUndoManagerTests.swift
+++ b/PineTests/FileOperationUndoManagerTests.swift
@@ -218,45 +218,25 @@ struct FileOperationUndoManagerTests {
 
     // MARK: - Grouped create+rename undo (#527)
 
-    @Test func registerCreateUndoDeletesFileOnUndo() throws {
+    @Test func finalizeNewItemRenamesAndDeletesOnUndo() throws {
         let dir = try makeTempDir()
         defer { cleanup(dir) }
 
-        // Simulate create + rename flow: file already exists at final URL
-        let finalURL = dir.appendingPathComponent("myFile.swift")
-        try "code".write(to: finalURL, atomically: true, encoding: .utf8)
-
-        let undoManager = UndoManager()
-
-        try FileOperationUndoManager.registerCreateUndo(at: finalURL, undoManager: undoManager)
-
-        // File still exists before undo
-        #expect(FileManager.default.fileExists(atPath: finalURL.path))
-
-        // Single undo should delete the file
-        undoManager.undo()
-
-        #expect(!FileManager.default.fileExists(atPath: finalURL.path))
-    }
-
-    @Test func registerCreateUndoSingleUndoRemovesRenamedFile() throws {
-        let dir = try makeTempDir()
-        defer { cleanup(dir) }
-
-        // Simulate the full create+rename flow:
-        // 1. Create "untitled"
+        // Simulate: create "untitled", then finalize with rename to "hello.swift"
         let untitledURL = dir.appendingPathComponent("untitled")
         FileManager.default.createFile(atPath: untitledURL.path, contents: nil)
-
-        // 2. Rename to "hello.swift"
         let finalURL = dir.appendingPathComponent("hello.swift")
-        try FileManager.default.moveItem(at: untitledURL, to: finalURL)
 
-        // 3. Register single undo for the final URL
         let undoManager = UndoManager()
-        try FileOperationUndoManager.registerCreateUndo(at: finalURL, undoManager: undoManager)
+        try FileOperationUndoManager.finalizeNewItem(
+            from: untitledURL, to: finalURL, undoManager: undoManager
+        )
 
-        // One Cmd+Z should delete the file entirely
+        // File should be at final URL after finalize
+        #expect(FileManager.default.fileExists(atPath: finalURL.path))
+        #expect(!FileManager.default.fileExists(atPath: untitledURL.path))
+
+        // Single undo should remove the file entirely
         #expect(undoManager.canUndo)
         undoManager.undo()
 
@@ -264,24 +244,108 @@ struct FileOperationUndoManagerTests {
         #expect(!FileManager.default.fileExists(atPath: untitledURL.path))
     }
 
-    @Test func registerCreateUndoRedoRestoresFile() throws {
+    @Test func finalizeNewItemWithoutRenameDeletesOnUndo() throws {
         let dir = try makeTempDir()
         defer { cleanup(dir) }
 
-        let fileURL = dir.appendingPathComponent("recreate.txt")
-        try "content".write(to: fileURL, atomically: true, encoding: .utf8)
+        // User accepted the default "untitled" name (no rename)
+        let fileURL = dir.appendingPathComponent("untitled")
+        try "code".write(to: fileURL, atomically: true, encoding: .utf8)
 
         let undoManager = UndoManager()
-        try FileOperationUndoManager.registerCreateUndo(at: fileURL, undoManager: undoManager)
+        try FileOperationUndoManager.finalizeNewItem(
+            from: fileURL, to: fileURL, undoManager: undoManager
+        )
+
+        #expect(FileManager.default.fileExists(atPath: fileURL.path))
+
+        undoManager.undo()
+
+        #expect(!FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
+    @Test func finalizeNewItemRedoRestoresFile() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let untitledURL = dir.appendingPathComponent("untitled")
+        try "content".write(to: untitledURL, atomically: true, encoding: .utf8)
+        let finalURL = dir.appendingPathComponent("myFile.swift")
+
+        let undoManager = UndoManager()
+        try FileOperationUndoManager.finalizeNewItem(
+            from: untitledURL, to: finalURL, undoManager: undoManager
+        )
 
         // Undo (delete)
         undoManager.undo()
-        #expect(!FileManager.default.fileExists(atPath: fileURL.path))
+        #expect(!FileManager.default.fileExists(atPath: finalURL.path))
 
         // Redo (restore from trash)
         undoManager.redo()
-        #expect(FileManager.default.fileExists(atPath: fileURL.path))
+        #expect(FileManager.default.fileExists(atPath: finalURL.path))
     }
+
+    @Test func finalizeNewItemRenameToNonexistentOriginalThrows() {
+        let undoManager = UndoManager()
+        let fakeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nonexistent-\(UUID().uuidString)")
+        let destURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dest-\(UUID().uuidString)")
+
+        #expect(throws: (any Error).self) {
+            try FileOperationUndoManager.finalizeNewItem(
+                from: fakeURL, to: destURL, undoManager: undoManager
+            )
+        }
+    }
+
+    @Test func finalizeNewItemIsOneUndoStep() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let untitledURL = dir.appendingPathComponent("untitled")
+        FileManager.default.createFile(atPath: untitledURL.path, contents: nil)
+        let finalURL = dir.appendingPathComponent("test.txt")
+
+        let undoManager = UndoManager()
+        undoManager.groupsByEvent = false
+
+        try FileOperationUndoManager.finalizeNewItem(
+            from: untitledURL, to: finalURL, undoManager: undoManager
+        )
+
+        // Only one undo step should be registered (grouped)
+        #expect(undoManager.canUndo)
+        undoManager.undo()
+        #expect(!undoManager.canUndo)
+        #expect(!FileManager.default.fileExists(atPath: finalURL.path))
+    }
+
+    @Test func finalizeNewItemDirectoryRenamesAndDeletesOnUndo() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let untitledDir = dir.appendingPathComponent("untitled folder")
+        try FileManager.default.createDirectory(at: untitledDir, withIntermediateDirectories: false)
+        let finalDir = dir.appendingPathComponent("Sources")
+
+        let undoManager = UndoManager()
+        try FileOperationUndoManager.finalizeNewItem(
+            from: untitledDir, to: finalDir, undoManager: undoManager
+        )
+
+        var isDir: ObjCBool = false
+        #expect(FileManager.default.fileExists(atPath: finalDir.path, isDirectory: &isDir))
+        #expect(isDir.boolValue)
+
+        undoManager.undo()
+
+        #expect(!FileManager.default.fileExists(atPath: finalDir.path))
+        #expect(!FileManager.default.fileExists(atPath: untitledDir.path))
+    }
+
+    // MARK: - Error cases
 
     @Test func renameNonexistentFileThrows() {
         let undoManager = UndoManager()


### PR DESCRIPTION
Closes #527