### PR TITLE
fix: auto-focus terminal on new tab creation and tab switch

### DIFF
--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -95,6 +95,9 @@ struct PineApp: App {
                 Button {
                     guard let pm = focusedProject else { return }
                     pm.terminal.isTerminalVisible.toggle()
+                    if pm.terminal.isTerminalVisible, let activeID = pm.terminal.activeTerminalID {
+                        pm.terminal.pendingFocusTabID = activeID
+                    }
                 } label: {
                     Label(Strings.toggleTerminal, systemImage: MenuIcons.toggleTerminal)
                 }

--- a/Pine/TerminalBarView.swift
+++ b/Pine/TerminalBarView.swift
@@ -36,7 +36,10 @@ struct TerminalNativeTabBar: View {
                             tab: tab,
                             isActive: tab.id == terminal.activeTerminalID,
                             canClose: terminal.terminalTabs.count > 1,
-                            onSelect: { terminal.activeTerminalID = tab.id },
+                            onSelect: {
+                                terminal.activeTerminalID = tab.id
+                                terminal.pendingFocusTabID = tab.id
+                            },
                             onClose: { closeTerminalTabWithConfirmation(tab) }
                         )
                     }

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -15,6 +15,12 @@ final class TerminalManager {
     var terminalTabs: [TerminalTab] = [TerminalTab(name: Strings.terminalDefaultName)]
     var activeTerminalID: UUID?
 
+    // MARK: - Focus
+
+    /// When non-nil, the terminal view for this tab should become first responder.
+    /// Set on new tab creation and tab switch; consumed by TerminalContainerView.
+    var pendingFocusTabID: UUID?
+
     // MARK: - Search state (Cmd+F in terminal)
 
     /// Whether the terminal search bar is currently visible.
@@ -44,6 +50,7 @@ final class TerminalManager {
         tab.configure(workingDirectory: workingDirectory)
         terminalTabs.append(tab)
         activeTerminalID = tab.id
+        pendingFocusTabID = tab.id
     }
 
     func closeTerminalTab(_ tab: TerminalTab) {

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -135,17 +135,36 @@ class TerminalContainerView: NSView {
             scrollInterceptor.terminalView = nil
             return
         }
-        // Если terminal view уже у нас и таб тот же — ничего не делаем
-        guard tab.id != currentTabID || tab.terminalView.superview !== self else { return }
-        subviews.forEach { $0.removeFromSuperview() }
-        currentTabID = tab.id
-        tab.terminalView.frame = bounds
-        addSubview(tab.terminalView)
+        let tabChanged = tab.id != currentTabID || tab.terminalView.superview !== self
+        if tabChanged {
+            subviews.forEach { $0.removeFromSuperview() }
+            currentTabID = tab.id
+            tab.terminalView.frame = bounds
+            addSubview(tab.terminalView)
 
-        // Place scroll interceptor on top of the terminal view
-        scrollInterceptor.frame = bounds
-        scrollInterceptor.terminalView = tab.terminalView
-        addSubview(scrollInterceptor)
+            // Place scroll interceptor on top of the terminal view
+            scrollInterceptor.frame = bounds
+            scrollInterceptor.terminalView = tab.terminalView
+            addSubview(scrollInterceptor)
+        }
+
+        // Focus the terminal view when requested by TerminalManager
+        if let pending = terminal?.pendingFocusTabID, pending == tab.id {
+            terminal?.pendingFocusTabID = nil
+            focusTerminalView(tab.terminalView)
+        }
+    }
+
+    /// Requests first responder on the terminal view.
+    /// If the view is not yet in a window, defers the call via async dispatch.
+    private func focusTerminalView(_ terminalView: LocalProcessTerminalView) {
+        if let win = window {
+            win.makeFirstResponder(terminalView)
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.window?.makeFirstResponder(terminalView)
+            }
+        }
     }
 
     override func layout() {

--- a/PineTests/TerminalManagerTests.swift
+++ b/PineTests/TerminalManagerTests.swift
@@ -650,4 +650,60 @@ struct TerminalManagerTests {
         #expect(tab.searchMatches.count == 1)
         #expect(tab.searchMatches[0].col == 4, "Match should account for leading spaces")
     }
+
+    // MARK: - Focus tests (issue #558)
+
+    @Test("pendingFocusTabID is nil initially")
+    func pendingFocusInitiallyNil() {
+        let manager = TerminalManager()
+        #expect(manager.pendingFocusTabID == nil)
+    }
+
+    @Test("addTerminalTab sets pendingFocusTabID to new tab")
+    func addTerminalTabSetsPendingFocus() throws {
+        let manager = TerminalManager()
+        manager.addTerminalTab(workingDirectory: nil)
+        let newTab = try #require(manager.terminalTabs.last)
+        #expect(manager.pendingFocusTabID == newTab.id)
+    }
+
+    @Test("pendingFocusTabID matches activeTerminalID after addTerminalTab")
+    func pendingFocusMatchesActiveAfterAdd() {
+        let manager = TerminalManager()
+        manager.addTerminalTab(workingDirectory: nil)
+        #expect(manager.pendingFocusTabID == manager.activeTerminalID)
+    }
+
+    @Test("pendingFocusTabID can be cleared externally")
+    func pendingFocusCanBeCleared() {
+        let manager = TerminalManager()
+        manager.addTerminalTab(workingDirectory: nil)
+        #expect(manager.pendingFocusTabID != nil)
+        manager.pendingFocusTabID = nil
+        #expect(manager.pendingFocusTabID == nil)
+    }
+
+    @Test("multiple addTerminalTab calls update pendingFocusTabID to latest")
+    func multiplePendingFocusUpdates() throws {
+        let manager = TerminalManager()
+        manager.addTerminalTab(workingDirectory: nil)
+        let firstNewID = manager.pendingFocusTabID
+
+        manager.addTerminalTab(workingDirectory: nil)
+        let secondNewTab = try #require(manager.terminalTabs.last)
+        #expect(manager.pendingFocusTabID == secondNewTab.id)
+        #expect(manager.pendingFocusTabID != firstNewID)
+    }
+
+    @Test("closeTerminalTab does not set pendingFocusTabID")
+    func closeDoesNotSetPendingFocus() throws {
+        let manager = TerminalManager()
+        manager.startTerminals(workingDirectory: nil)
+        manager.addTerminalTab(workingDirectory: nil)
+        manager.pendingFocusTabID = nil
+
+        let tabToClose = try #require(manager.terminalTabs.last)
+        manager.closeTerminalTab(tabToClose)
+        #expect(manager.pendingFocusTabID == nil)
+    }
 }


### PR DESCRIPTION
## Summary

Closes #558

- When creating a new terminal tab (Cmd+T, + button, or menu), keyboard focus now automatically moves to the terminal view
- When switching between terminal tabs by clicking, focus moves to the newly selected terminal
- When toggling terminal visibility (Cmd+`), focus moves to the active terminal tab

## Implementation

Added `pendingFocusTabID` to `TerminalManager` — a signal property that is set when a terminal tab should receive focus. `TerminalContainerView.showTab()` consumes this signal and calls `window.makeFirstResponder(terminalView)` on the `LocalProcessTerminalView`. If the view is not yet in a window hierarchy, the focus request is deferred via async dispatch.

## Test plan

- [x] 6 new unit tests for `pendingFocusTabID` behavior in `TerminalManagerTests`
- [x] All 56 existing TerminalManager tests pass
- [x] SwiftLint passes with no warnings
- [ ] Manual: Open project, Cmd+` to show terminal — cursor should blink in terminal
- [ ] Manual: Click + to add new terminal tab — new tab should be immediately focused
- [ ] Manual: Click between terminal tabs — clicked tab should receive keyboard focus