### PR TITLE
ci: make coverage threshold a blocker instead of warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,9 +276,10 @@ jobs:
           THRESHOLD="${{ env.COVERAGE_THRESHOLD }}"
           echo "Coverage: ${COVERAGE}%, threshold: ${THRESHOLD}%"
           if python3 -c "exit(0 if float('$COVERAGE') >= float('$THRESHOLD') else 1)"; then
-            echo "Coverage is above threshold"
+            echo "✅ Coverage is above threshold"
           else
-            echo "::warning::Coverage ${COVERAGE}% is below ${THRESHOLD}% threshold"
+            echo "::error::Coverage ${COVERAGE}% is below ${THRESHOLD}% threshold"
+            exit 1
           fi
 
       - name: Comment Coverage on PR


### PR DESCRIPTION
## Summary

- Coverage below 70% now **fails the pipeline** (`exit 1`) instead of posting a `::warning`
- Changed warning emoji to error for clarity

Part of #563

## Test plan

- [ ] PR with coverage ≥70% passes the check
- [ ] PR with coverage <70% fails the check and blocks merge