### PR TITLE
feat: add indent guides for code structure visualization

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -90,38 +90,56 @@ final class GutterTextView: NSTextView {
     /// Whether indent guides are visible (driven by @AppStorage in the view layer).
     var isIndentGuidesVisible: Bool = true
 
+    /// Cached indentation style from EditorTab — avoids re-detecting on every draw frame.
+    var cachedIndentStyle: IndentationStyle = .spaces(4)
+
+    /// Cached fold state reference for checking hidden lines during indent guide drawing.
+    var currentFoldState: FoldState = FoldState()
+
+    /// Cached character width for the current font — updated when font changes.
+    var cachedCharWidth: CGFloat = 0
+
+    /// Updates the cached character width from the current font.
+    func updateCachedCharWidth() {
+        let f = font ?? NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        cachedCharWidth = " ".size(withAttributes: [.font: f]).width
+    }
+
     override func drawBackground(in rect: NSRect) {
         super.drawBackground(in: rect)
 
         guard let layoutManager = layoutManager,
               textContainer != nil else { return }
 
-        // ── Indent guides (drawn behind everything, for all visible lines) ──
+        // ── Current line highlight (drawn first so guides render on top) ──
+        let cursorRange = selectedRange()
+        if cursorRange.length == 0 {
+            let glyphIndex = layoutManager.glyphIndexForCharacter(at: cursorRange.location)
+            var lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+
+            lineRect.origin.x = 0
+            lineRect.size.width = bounds.width
+            lineRect.origin.y += textContainerOrigin.y
+
+            currentLineColor.setFill()
+            lineRect.fill()
+
+            // ── Inline blame annotation ──
+            if isBlameVisible, !blameLookup.isEmpty {
+                drawInlineBlame(lineRect: lineRect, layoutManager: layoutManager)
+            }
+        }
+
+        // ── Indent guides (drawn AFTER current line highlight so they're visible) ──
         if isIndentGuidesVisible {
             drawIndentGuides(layoutManager: layoutManager)
         }
-
-        // ── Current line highlight ──
-        let cursorRange = selectedRange()
-        guard cursorRange.length == 0 else { return }
-
-        let glyphIndex = layoutManager.glyphIndexForCharacter(at: cursorRange.location)
-        var lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
-
-        lineRect.origin.x = 0
-        lineRect.size.width = bounds.width
-        lineRect.origin.y += textContainerOrigin.y
-
-        currentLineColor.setFill()
-        lineRect.fill()
-
-        // ── Inline blame annotation ──
-        if isBlameVisible, !blameLookup.isEmpty {
-            drawInlineBlame(lineRect: lineRect, layoutManager: layoutManager)
-        }
     }
 
-    /// Draws vertical indent guide lines for all visible lines.
+    /// Draws vertical indent guide lines for all visible lines using batched CGContext fills.
+    /// Uses cached indentation style (from EditorTab) instead of re-detecting on every frame.
+    /// Respects fold state by skipping hidden lines (height == 0).
+    /// Continues guides through blank lines using surrounding line context.
     private func drawIndentGuides(layoutManager: NSLayoutManager) {
         guard let textContainer = textContainer,
               let scrollView = enclosingScrollView else { return }
@@ -135,44 +153,66 @@ final class GutterTextView: NSTextView {
         )
         guard visibleGlyphRange.location != NSNotFound else { return }
 
-        // Detect indentation style from content
-        let style = IndentationStyle.detect(in: string)
+        // Use cached indentation style — no re-detection per frame (К2)
+        let style = cachedIndentStyle
         let indentUnit = IndentGuideRenderer.indentUnitWidth(from: style)
         let tabWidth = IndentGuideRenderer.effectiveTabWidth(from: style)
 
-        // Measure character width from the editor font
-        let editorFont = font ?? NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-        let charWidth = " ".size(withAttributes: [.font: editorFont]).width
+        // Use cached char width (С4)
+        let charWidth = cachedCharWidth > 0
+            ? cachedCharWidth
+            : " ".size(withAttributes: [.font: font ?? NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)]).width
 
         let originY = textContainerOrigin.y
         let textOriginX = textContainerOrigin.x + textContainer.lineFragmentPadding
+        let foldState = currentFoldState
+
+        // Pre-split visible text into lines for blank-line continuation (С2)
+        let allLines = source.components(separatedBy: .newlines)
+
+        // Collect all guide segments, then draw in one batch (К1)
+        var segments: [IndentGuideRenderer.GuideSegment] = []
 
         layoutManager.enumerateLineFragments(
             forGlyphRange: visibleGlyphRange
         ) { lineRect, _, _, glyphRange, _ in
+            // Skip folded lines with zero height (К3)
+            guard lineRect.height > 0 else { return }
+
             let charIndex = layoutManager.characterIndexForGlyph(at: glyphRange.location)
             let lineRange = source.lineRange(for: NSRange(location: charIndex, length: 0))
+
+            // Determine the line number for fold state check
+            let lineNumber = source.substring(to: charIndex).components(separatedBy: .newlines).count - 1
+            if foldState.isLineHidden(lineNumber) { return }
+
             let lineText = source.substring(with: lineRange)
+            let trimmed = lineText.trimmingCharacters(in: .whitespacesAndNewlines)
 
-            // For empty lines (just newline), skip — no guides
-            let trimmed = lineText.trimmingCharacters(in: .newlines)
-            guard !trimmed.isEmpty else { return }
+            let levels: Int
+            if trimmed.isEmpty {
+                // Blank line continuation (С2): use context from surrounding lines
+                levels = IndentGuideRenderer.effectiveLevels(
+                    forLineAt: lineNumber,
+                    lines: allLines,
+                    tabWidth: tabWidth,
+                    indentUnitWidth: indentUnit
+                )
+            } else {
+                let columns = IndentGuideRenderer.indentLevel(of: lineText, tabWidth: tabWidth)
+                levels = IndentGuideRenderer.guideLevels(columns: columns, indentUnitWidth: indentUnit)
+            }
 
-            let columns = IndentGuideRenderer.indentLevel(of: trimmed, tabWidth: tabWidth)
-            let levels = IndentGuideRenderer.guideLevels(
-                columns: columns, indentUnitWidth: indentUnit
-            )
+            guard levels > 0 else { return }
 
             let y = lineRect.origin.y + originY
-            IndentGuideRenderer.drawGuides(.init(
-                levels: levels,
-                indentUnitWidth: indentUnit,
-                charWidth: charWidth,
-                textOriginX: textOriginX,
-                lineY: y,
-                lineHeight: lineRect.height
-            ))
+            for level in 1...levels {
+                let x = textOriginX + CGFloat(level * indentUnit) * charWidth
+                segments.append(.init(x: x, y: y, height: lineRect.height))
+            }
         }
+
+        IndentGuideRenderer.drawBatched(segments)
     }
 
     /// Draws inline blame annotation after the line content on the cursor line.
@@ -467,6 +507,8 @@ struct CodeEditorView: NSViewRepresentable {
     var isWordWrapEnabled: Bool = true
     /// Whether indent guides are visible.
     var isIndentGuidesVisible: Bool = true
+    /// Cached indentation style from the active tab.
+    var cachedIndentation: IndentationStyle = .spaces(4)
     /// Whether syntax highlighting is disabled for this tab (e.g. large files).
     var syntaxHighlightingDisabled: Bool = false
     /// Cursor position to restore when the view is created (tab switch).
@@ -563,6 +605,9 @@ struct CodeEditorView: NSViewRepresentable {
         textView.setBlameLines(blameLines)
         textView.isBlameVisible = isBlameVisible
         textView.isIndentGuidesVisible = isIndentGuidesVisible
+        textView.cachedIndentStyle = cachedIndentation
+        textView.currentFoldState = foldState
+        textView.updateCachedCharWidth()
         // Delegate set AFTER text/highlight setup to prevent textDidChange from firing
         // during makeNSView and causing a spurious updateContent → cachedHighlightResult = nil
         // → contentVersion bump → updateNSView re-sets text → stripping highlight attributes.
@@ -765,6 +810,8 @@ struct CodeEditorView: NSViewRepresentable {
                 gutterView.isIndentGuidesVisible = isIndentGuidesVisible
                 gutterView.needsDisplay = true
             }
+            gutterView.cachedIndentStyle = cachedIndentation
+            gutterView.currentFoldState = foldState
         }
 
         context.coordinator.updateContentIfNeeded(
@@ -1036,10 +1083,11 @@ struct CodeEditorView: NSViewRepresentable {
                 }
             }
 
-            // Update gutter font
+            // Update gutter font and cached char width
             lineNumberView?.gutterFont = gutterFont
             lineNumberView?.editorFont = font
             lineNumberView?.needsDisplay = true
+            (textView as? GutterTextView)?.updateCachedCharWidth()
         }
 
         func textDidChange(_ notification: Notification) {

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -87,12 +87,21 @@ final class GutterTextView: NSTextView {
         return f
     }()
 
+    /// Whether indent guides are visible (driven by @AppStorage in the view layer).
+    var isIndentGuidesVisible: Bool = true
+
     override func drawBackground(in rect: NSRect) {
         super.drawBackground(in: rect)
 
         guard let layoutManager = layoutManager,
               textContainer != nil else { return }
 
+        // ── Indent guides (drawn behind everything, for all visible lines) ──
+        if isIndentGuidesVisible {
+            drawIndentGuides(layoutManager: layoutManager)
+        }
+
+        // ── Current line highlight ──
         let cursorRange = selectedRange()
         guard cursorRange.length == 0 else { return }
 
@@ -109,6 +118,60 @@ final class GutterTextView: NSTextView {
         // ── Inline blame annotation ──
         if isBlameVisible, !blameLookup.isEmpty {
             drawInlineBlame(lineRect: lineRect, layoutManager: layoutManager)
+        }
+    }
+
+    /// Draws vertical indent guide lines for all visible lines.
+    private func drawIndentGuides(layoutManager: NSLayoutManager) {
+        guard let textContainer = textContainer,
+              let scrollView = enclosingScrollView else { return }
+
+        let source = string as NSString
+        guard source.length > 0 else { return }
+
+        let visibleRect = scrollView.contentView.bounds
+        let visibleGlyphRange = layoutManager.glyphRange(
+            forBoundingRect: visibleRect, in: textContainer
+        )
+        guard visibleGlyphRange.location != NSNotFound else { return }
+
+        // Detect indentation style from content
+        let style = IndentationStyle.detect(in: string)
+        let indentUnit = IndentGuideRenderer.indentUnitWidth(from: style)
+        let tabWidth = IndentGuideRenderer.effectiveTabWidth(from: style)
+
+        // Measure character width from the editor font
+        let editorFont = font ?? NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        let charWidth = " ".size(withAttributes: [.font: editorFont]).width
+
+        let originY = textContainerOrigin.y
+        let textOriginX = textContainerOrigin.x + textContainer.lineFragmentPadding
+
+        layoutManager.enumerateLineFragments(
+            forGlyphRange: visibleGlyphRange
+        ) { lineRect, _, _, glyphRange, _ in
+            let charIndex = layoutManager.characterIndexForGlyph(at: glyphRange.location)
+            let lineRange = source.lineRange(for: NSRange(location: charIndex, length: 0))
+            let lineText = source.substring(with: lineRange)
+
+            // For empty lines (just newline), skip — no guides
+            let trimmed = lineText.trimmingCharacters(in: .newlines)
+            guard !trimmed.isEmpty else { return }
+
+            let columns = IndentGuideRenderer.indentLevel(of: trimmed, tabWidth: tabWidth)
+            let levels = IndentGuideRenderer.guideLevels(
+                columns: columns, indentUnitWidth: indentUnit
+            )
+
+            let y = lineRect.origin.y + originY
+            IndentGuideRenderer.drawGuides(.init(
+                levels: levels,
+                indentUnitWidth: indentUnit,
+                charWidth: charWidth,
+                textOriginX: textOriginX,
+                lineY: y,
+                lineHeight: lineRect.height
+            ))
         }
     }
 
@@ -402,6 +465,8 @@ struct CodeEditorView: NSViewRepresentable {
     var isMinimapVisible: Bool = true
     /// Whether word wrap is enabled (wrap at window edge vs. horizontal scroll).
     var isWordWrapEnabled: Bool = true
+    /// Whether indent guides are visible.
+    var isIndentGuidesVisible: Bool = true
     /// Whether syntax highlighting is disabled for this tab (e.g. large files).
     var syntaxHighlightingDisabled: Bool = false
     /// Cursor position to restore when the view is created (tab switch).
@@ -497,6 +562,7 @@ struct CodeEditorView: NSViewRepresentable {
         textView.exactFileName = fileName
         textView.setBlameLines(blameLines)
         textView.isBlameVisible = isBlameVisible
+        textView.isIndentGuidesVisible = isIndentGuidesVisible
         // Delegate set AFTER text/highlight setup to prevent textDidChange from firing
         // during makeNSView and causing a spurious updateContent → cachedHighlightResult = nil
         // → contentVersion bump → updateNSView re-sets text → stripping highlight attributes.
@@ -694,6 +760,10 @@ struct CodeEditorView: NSViewRepresentable {
             if gutterView.isBlameVisible != isBlameVisible {
                 gutterView.isBlameVisible = isBlameVisible
                 gutterView.display()
+            }
+            if gutterView.isIndentGuidesVisible != isIndentGuidesVisible {
+                gutterView.isIndentGuidesVisible = isIndentGuidesVisible
+                gutterView.needsDisplay = true
             }
         }
 

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -99,10 +99,20 @@ final class GutterTextView: NSTextView {
     /// Cached character width for the current font — updated when font changes.
     var cachedCharWidth: CGFloat = 0
 
-    /// Updates the cached character width from the current font.
+    /// Cached tab stop width as rendered by NSTextView — updated when font changes.
+    /// Used for correct indent guide positioning in tab-indented files (Go, Makefile).
+    var cachedTabStopWidth: CGFloat = 0
+
+    /// Updates the cached character width and tab stop width from the current font.
     func updateCachedCharWidth() {
         let f = font ?? NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
         cachedCharWidth = " ".size(withAttributes: [.font: f]).width
+
+        // Get the real tab stop width from the text view's paragraph style.
+        // NSTextView uses defaultParagraphStyle.defaultTabInterval for tab rendering.
+        let tabInterval = defaultParagraphStyle?.defaultTabInterval
+            ?? NSParagraphStyle.default.defaultTabInterval
+        cachedTabStopWidth = tabInterval > 0 ? tabInterval : cachedCharWidth * 4
     }
 
     override func drawBackground(in rect: NSRect) {
@@ -207,7 +217,13 @@ final class GutterTextView: NSTextView {
 
             let y = lineRect.origin.y + originY
             for level in 1...levels {
-                let x = textOriginX + CGFloat(level * indentUnit) * charWidth
+                let xOffset = IndentGuideRenderer.guideXOffset(
+                    level: level,
+                    style: style,
+                    charWidth: charWidth,
+                    tabStopWidth: self.cachedTabStopWidth
+                )
+                let x = textOriginX + xOffset
                 segments.append(.init(x: x, y: y, height: lineRect.height))
             }
         }

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -37,6 +37,7 @@ struct ContentView: View {
     @AppStorage("minimapVisible") var isMinimapVisible = true
     @AppStorage(BlameConstants.storageKey) var isBlameVisible = true
     @AppStorage("wordWrapEnabled") var isWordWrapEnabled = true
+    @AppStorage("indentGuidesVisible") var isIndentGuidesVisible = true
 
     var activeTab: EditorTab? { tabManager.activeTab }
 
@@ -181,6 +182,9 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .toggleWordWrap)) { _ in
             isWordWrapEnabled.toggle()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .toggleIndentGuides)) { _ in
+            isIndentGuidesVisible.toggle()
+        }
         .onChange(of: tabManager.pendingGoToLine) { _, newLine in
             guard let line = newLine, let tab = tabManager.activeTab else { return }
             tabManager.pendingGoToLine = nil
@@ -205,6 +209,7 @@ struct ContentView: View {
             blameLines: blameLines,
             isMinimapVisible: isMinimapVisible,
             isWordWrapEnabled: isWordWrapEnabled,
+            isIndentGuidesVisible: isIndentGuidesVisible,
             onCloseTab: { closeTabWithConfirmation($0) },
             onSaveSession: { projectManager.saveSession() }
         )

--- a/Pine/EditorAreaView.swift
+++ b/Pine/EditorAreaView.swift
@@ -22,6 +22,7 @@ struct EditorAreaView: View {
     var blameLines: [GitBlameLine]
     var isMinimapVisible: Bool
     var isWordWrapEnabled: Bool
+    var isIndentGuidesVisible: Bool
     var onCloseTab: (EditorTab) -> Void
     var onSaveSession: () -> Void
 
@@ -119,6 +120,7 @@ struct EditorAreaView: View {
             ),
             isMinimapVisible: isMinimapVisible,
             isWordWrapEnabled: isWordWrapEnabled,
+            isIndentGuidesVisible: isIndentGuidesVisible,
             syntaxHighlightingDisabled: tab.syntaxHighlightingDisabled,
             initialCursorPosition: goToLineOffset?.offset ?? tab.cursorPosition,
             initialScrollOffset: goToLineOffset != nil ? 0 : tab.scrollOffset,

--- a/Pine/EditorAreaView.swift
+++ b/Pine/EditorAreaView.swift
@@ -121,6 +121,7 @@ struct EditorAreaView: View {
             isMinimapVisible: isMinimapVisible,
             isWordWrapEnabled: isWordWrapEnabled,
             isIndentGuidesVisible: isIndentGuidesVisible,
+            cachedIndentation: tab.cachedIndentation,
             syntaxHighlightingDisabled: tab.syntaxHighlightingDisabled,
             initialCursorPosition: goToLineOffset?.offset ?? tab.cursorPosition,
             initialScrollOffset: goToLineOffset != nil ? 0 : tab.scrollOffset,

--- a/Pine/IndentGuideRenderer.swift
+++ b/Pine/IndentGuideRenderer.swift
@@ -141,4 +141,28 @@ enum IndentGuideRenderer {
         case .tabs: renderTabWidth
         }
     }
+
+    // MARK: - Guide X position
+
+    /// Computes the X offset (from text origin) for an indent guide at the given level.
+    ///
+    /// For **spaces**: `level * indentUnit * charWidth` — each level spans `indentUnit` space characters.
+    /// For **tabs**: `level * tabStopWidth` — each level spans one real tab stop as rendered by NSTextView.
+    ///
+    /// Using the real tab stop width fixes the bug where tab-indented files (Go, Makefile)
+    /// had all guides bunched up on the left because `charWidth` (width of a space) was used
+    /// instead of the actual tab stop interval.
+    static func guideXOffset(
+        level: Int,
+        style: IndentationStyle,
+        charWidth: CGFloat,
+        tabStopWidth: CGFloat
+    ) -> CGFloat {
+        switch style {
+        case .spaces(let count):
+            return CGFloat(level * count) * charWidth
+        case .tabs:
+            return CGFloat(level) * tabStopWidth
+        }
+    }
 }

--- a/Pine/IndentGuideRenderer.swift
+++ b/Pine/IndentGuideRenderer.swift
@@ -1,0 +1,107 @@
+//
+//  IndentGuideRenderer.swift
+//  Pine
+//
+//  Created by Claude on 25.03.2026.
+//
+
+import AppKit
+
+/// Calculates indent guide positions and draws vertical indent guide lines.
+///
+/// Indent guides are thin vertical lines at each indentation level, helping
+/// visualize code structure. The renderer works with visible lines only for
+/// performance and detects the indent unit (tabs or spaces) from the text.
+enum IndentGuideRenderer {
+
+    /// The color used for indent guide lines.
+    static let guideColor = NSColor.separatorColor.withAlphaComponent(0.3)
+
+    /// The width of each indent guide line in points.
+    static let guideLineWidth: CGFloat = 1
+
+    // MARK: - Indent level detection
+
+    /// Returns the number of leading whitespace columns in a line.
+    /// Tabs are expanded to `tabWidth` columns.
+    static func indentLevel(of line: String, tabWidth: Int) -> Int {
+        var columns = 0
+        for char in line {
+            if char == " " {
+                columns += 1
+            } else if char == "\t" {
+                columns += tabWidth
+            } else {
+                break
+            }
+        }
+        return columns
+    }
+
+    /// Returns the number of indent guide levels for a given column count and indent unit width.
+    /// For example, 8 columns with indent unit 4 gives 2 levels.
+    static func guideLevels(columns: Int, indentUnitWidth: Int) -> Int {
+        guard indentUnitWidth > 0 else { return 0 }
+        return columns / indentUnitWidth
+    }
+
+    /// Computes x-positions for indent guide lines given the indent unit width and character width.
+    /// Returns positions for levels 1, 2, 3, ... up to `maxLevel`.
+    static func guideXPositions(
+        maxLevel: Int,
+        indentUnitWidth: Int,
+        charWidth: CGFloat,
+        textOriginX: CGFloat
+    ) -> [CGFloat] {
+        guard maxLevel > 0, indentUnitWidth > 0 else { return [] }
+        return (1...maxLevel).map { level in
+            textOriginX + CGFloat(level * indentUnitWidth) * charWidth
+        }
+    }
+
+    // MARK: - Drawing
+
+    /// Parameters for drawing indent guides on a single line.
+    struct DrawContext {
+        let levels: Int
+        let indentUnitWidth: Int
+        let charWidth: CGFloat
+        let textOriginX: CGFloat
+        let lineY: CGFloat
+        let lineHeight: CGFloat
+    }
+
+    /// Draws indent guide lines for a single visible line.
+    static func drawGuides(_ context: DrawContext) {
+        guard context.levels > 0, context.indentUnitWidth > 0 else { return }
+
+        guideColor.setStroke()
+
+        for level in 1...context.levels {
+            let x = context.textOriginX + CGFloat(level * context.indentUnitWidth) * context.charWidth
+            let path = NSBezierPath()
+            path.move(to: NSPoint(x: x, y: context.lineY))
+            path.line(to: NSPoint(x: x, y: context.lineY + context.lineHeight))
+            path.lineWidth = guideLineWidth
+            path.stroke()
+        }
+    }
+
+    /// Detects indent unit width from an `IndentationStyle`.
+    static func indentUnitWidth(from style: IndentationStyle) -> Int {
+        switch style {
+        case .spaces(let count): count
+        case .tabs: 1  // tabs count as 1 tab-stop per indent level
+        }
+    }
+
+    /// Detects the effective tab width used for rendering.
+    /// For spaces, this equals the indent unit width.
+    /// For tabs, this is the standard tab width (typically 4).
+    static func effectiveTabWidth(from style: IndentationStyle) -> Int {
+        switch style {
+        case .spaces(let count): count
+        case .tabs: 4
+        }
+    }
+}

--- a/Pine/IndentGuideRenderer.swift
+++ b/Pine/IndentGuideRenderer.swift
@@ -2,7 +2,7 @@
 //  IndentGuideRenderer.swift
 //  Pine
 //
-//  Created by Claude on 25.03.2026.
+//  Created by Fedor Batonogov on 25.03.2026.
 //
 
 import AppKit
@@ -11,11 +11,17 @@ import AppKit
 ///
 /// Indent guides are thin vertical lines at each indentation level, helping
 /// visualize code structure. The renderer works with visible lines only for
-/// performance and detects the indent unit (tabs or spaces) from the text.
+/// performance and uses batched CGContext drawing to minimize allocations.
 enum IndentGuideRenderer {
 
-    /// The color used for indent guide lines.
-    static let guideColor = NSColor.separatorColor.withAlphaComponent(0.3)
+    /// Dynamic guide color that adapts to Light/Dark mode.
+    static let guideColor = NSColor(name: nil) { appearance in
+        if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
+            return NSColor.white.withAlphaComponent(0.12)
+        } else {
+            return NSColor.black.withAlphaComponent(0.10)
+        }
+    }
 
     /// The width of each indent guide line in points.
     static let guideLineWidth: CGFloat = 1
@@ -45,45 +51,76 @@ enum IndentGuideRenderer {
         return columns / indentUnitWidth
     }
 
-    /// Computes x-positions for indent guide lines given the indent unit width and character width.
-    /// Returns positions for levels 1, 2, 3, ... up to `maxLevel`.
-    static func guideXPositions(
-        maxLevel: Int,
-        indentUnitWidth: Int,
-        charWidth: CGFloat,
-        textOriginX: CGFloat
-    ) -> [CGFloat] {
-        guard maxLevel > 0, indentUnitWidth > 0 else { return [] }
-        return (1...maxLevel).map { level in
-            textOriginX + CGFloat(level * indentUnitWidth) * charWidth
+    /// Resolves the effective indent level for a line, handling blank lines
+    /// by looking at surrounding non-blank lines (continuation through blanks).
+    ///
+    /// For blank lines, the effective level is `min(previous non-blank, next non-blank)`.
+    /// This prevents indent guides from being interrupted by empty lines.
+    static func effectiveLevels(
+        forLineAt index: Int,
+        lines: [String],
+        tabWidth: Int,
+        indentUnitWidth: Int
+    ) -> Int {
+        guard indentUnitWidth > 0, index >= 0, index < lines.count else { return 0 }
+
+        let line = lines[index]
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !trimmed.isEmpty {
+            let columns = indentLevel(of: line, tabWidth: tabWidth)
+            return guideLevels(columns: columns, indentUnitWidth: indentUnitWidth)
         }
+
+        // Blank line: look at surrounding non-blank lines
+        var prevLevels = 0
+        for i in stride(from: index - 1, through: 0, by: -1) {
+            let prev = lines[i].trimmingCharacters(in: .whitespacesAndNewlines)
+            if !prev.isEmpty {
+                let cols = indentLevel(of: lines[i], tabWidth: tabWidth)
+                prevLevels = guideLevels(columns: cols, indentUnitWidth: indentUnitWidth)
+                break
+            }
+        }
+
+        var nextLevels = 0
+        for i in (index + 1)..<lines.count {
+            let next = lines[i].trimmingCharacters(in: .whitespacesAndNewlines)
+            if !next.isEmpty {
+                let cols = indentLevel(of: lines[i], tabWidth: tabWidth)
+                nextLevels = guideLevels(columns: cols, indentUnitWidth: indentUnitWidth)
+                break
+            }
+        }
+
+        return min(prevLevels, nextLevels)
     }
 
-    // MARK: - Drawing
+    // MARK: - Batched drawing
 
-    /// Parameters for drawing indent guides on a single line.
-    struct DrawContext {
-        let levels: Int
-        let indentUnitWidth: Int
-        let charWidth: CGFloat
-        let textOriginX: CGFloat
-        let lineY: CGFloat
-        let lineHeight: CGFloat
+    /// A single guide segment to be drawn.
+    struct GuideSegment {
+        let x: CGFloat
+        let y: CGFloat
+        let height: CGFloat
     }
 
-    /// Draws indent guide lines for a single visible line.
-    static func drawGuides(_ context: DrawContext) {
-        guard context.levels > 0, context.indentUnitWidth > 0 else { return }
+    /// Draws all indent guide segments in a single batched CGContext fill.
+    /// Much faster than individual NSBezierPath stroke() calls.
+    static func drawBatched(_ segments: [GuideSegment]) {
+        guard !segments.isEmpty,
+              let context = NSGraphicsContext.current?.cgContext else { return }
 
-        guideColor.setStroke()
+        guideColor.setFill()
 
-        for level in 1...context.levels {
-            let x = context.textOriginX + CGFloat(level * context.indentUnitWidth) * context.charWidth
-            let path = NSBezierPath()
-            path.move(to: NSPoint(x: x, y: context.lineY))
-            path.line(to: NSPoint(x: x, y: context.lineY + context.lineHeight))
-            path.lineWidth = guideLineWidth
-            path.stroke()
+        for segment in segments {
+            let rect = CGRect(
+                x: segment.x - guideLineWidth / 2,
+                y: segment.y,
+                width: guideLineWidth,
+                height: segment.height
+            )
+            context.fill(rect)
         }
     }
 
@@ -97,11 +134,11 @@ enum IndentGuideRenderer {
 
     /// Detects the effective tab width used for rendering.
     /// For spaces, this equals the indent unit width.
-    /// For tabs, this is the standard tab width (typically 4).
-    static func effectiveTabWidth(from style: IndentationStyle) -> Int {
+    /// For tabs, this uses the provided rendering tab width.
+    static func effectiveTabWidth(from style: IndentationStyle, renderTabWidth: Int = 4) -> Int {
         switch style {
         case .spaces(let count): count
-        case .tabs: 4
+        case .tabs: renderTabWidth
         }
     }
 }

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -4936,49 +4936,49 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Show Indent Guides"
+            "value" : "Toggle Indent Guides"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mostrar guías de sangría"
+            "value" : "Alternar guías de sangría"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Afficher les guides d'indentation"
+            "value" : "Basculer les guides d'indentation"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "インデントガイドを表示"
+            "value" : "インデントガイドの切替"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "들여쓰기 가이드 표시"
+            "value" : "들여쓰기 가이드 전환"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mostrar guias de recuo"
+            "value" : "Alternar guias de recuo"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Показать направляющие отступов"
+            "value" : "Направляющие отступов"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "显示缩进参考线"
+            "value" : "切换缩进参考线"
           }
         }
       }

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -4923,6 +4923,66 @@
         }
       }
     },
+    "menu.toggleIndentGuides" : {
+      "comment" : "Menu command: toggle indent guide lines in the editor.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einrückungslinien umschalten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Indent Guides"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar guías de sangría"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les guides d'indentation"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インデントガイドを表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "들여쓰기 가이드 표시"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar guias de recuo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показать направляющие отступов"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示缩进参考线"
+          }
+        }
+      }
+    },
     "menu.toggleWordWrap" : {
       "comment" : "Menu command: toggle word wrap in the editor (wrap at window edge vs. horizontal scroll).",
       "extractionState" : "manual",

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -39,6 +39,7 @@ enum MenuIcons {
     static let toggleMinimap = "sidebar.right"
     static let toggleBlame = "person.text.rectangle"
     static let toggleWordWrap = "text.word.spacing"
+    static let toggleIndentGuides = "line.3.horizontal"
     static let revealFileInFinder = "doc.viewfinder"
     static let revealProjectInFinder = "arrow.right.circle"
 

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -40,7 +40,7 @@ enum MenuIcons {
     static let toggleMinimap = "sidebar.right"
     static let toggleBlame = "person.text.rectangle"
     static let toggleWordWrap = "text.word.spacing"
-    static let toggleIndentGuides = "line.3.horizontal"
+    static let toggleIndentGuides = "increase.indent"
     static let revealFileInFinder = "doc.viewfinder"
     static let revealProjectInFinder = "arrow.right.circle"
 

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -135,6 +135,12 @@ struct PineApp: App {
                 }
                 .keyboardShortcut("z", modifiers: .option)
 
+                Button {
+                    NotificationCenter.default.post(name: .toggleIndentGuides, object: nil)
+                } label: {
+                    Label(Strings.menuToggleIndentGuides, systemImage: MenuIcons.toggleIndentGuides)
+                }
+
                 Divider()
 
                 Button {
@@ -1182,4 +1188,6 @@ extension Notification.Name {
     static let goToLine = Notification.Name("goToLine")
     // Word Wrap toggle (issue #416)
     static let toggleWordWrap = Notification.Name("toggleWordWrap")
+    // Indent Guides toggle (issue #165)
+    static let toggleIndentGuides = Notification.Name("toggleIndentGuides")
 }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -148,6 +148,7 @@ struct PineApp: App {
                 } label: {
                     Label(Strings.menuToggleIndentGuides, systemImage: MenuIcons.toggleIndentGuides)
                 }
+                .keyboardShortcut("i", modifiers: [.command, .control])
 
                 Divider()
 

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -156,6 +156,7 @@ enum Strings {
     static let menuToggleMinimap: LocalizedStringKey = "menu.toggleMinimap"
     static let menuToggleBlame: LocalizedStringKey = "menu.toggleBlame"
     static let menuToggleWordWrap: LocalizedStringKey = "menu.toggleWordWrap"
+    static let menuToggleIndentGuides: LocalizedStringKey = "menu.toggleIndentGuides"
 
     static var branchUncommittedChangesTitle: String {
         String(localized: "branch.uncommittedChanges.title")

--- a/PinePerformanceTests/IndentGuidePerformanceTests.swift
+++ b/PinePerformanceTests/IndentGuidePerformanceTests.swift
@@ -1,0 +1,130 @@
+//
+//  IndentGuidePerformanceTests.swift
+//  PinePerformanceTests
+//
+//  Created by Fedor Batonogov on 25.03.2026.
+//
+
+import XCTest
+@testable import Pine
+
+final class IndentGuidePerformanceTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Generates a realistic Swift-like file with nested indentation.
+    private func generateNestedCode(lines lineCount: Int) -> String {
+        var lines: [String] = []
+        var depth = 0
+        for i in 0..<lineCount {
+            if i % 10 == 0 && depth < 5 {
+                let indent = String(repeating: "    ", count: depth)
+                lines.append("\(indent)func method\(i)() {")
+                depth += 1
+            } else if i % 10 == 9 && depth > 0 {
+                depth -= 1
+                let indent = String(repeating: "    ", count: depth)
+                lines.append("\(indent)}")
+            } else if i % 7 == 0 {
+                // Blank line
+                lines.append("")
+            } else {
+                let indent = String(repeating: "    ", count: depth)
+                lines.append("\(indent)let x\(i) = \(i)")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Generates lines array for effectiveLevels testing.
+    private func generateLines(count: Int) -> [String] {
+        var lines: [String] = []
+        var depth = 0
+        for i in 0..<count {
+            if i % 10 == 0 && depth < 5 {
+                lines.append(String(repeating: "    ", count: depth) + "func f\(i)() {")
+                depth += 1
+            } else if i % 10 == 9 && depth > 0 {
+                depth -= 1
+                lines.append(String(repeating: "    ", count: depth) + "}")
+            } else if i % 7 == 0 {
+                lines.append("")
+            } else {
+                lines.append(String(repeating: "    ", count: depth) + "let x = \(i)")
+            }
+        }
+        return lines
+    }
+
+    // MARK: - Performance tests
+
+    func testIndentLevelDetection10KLines() {
+        let code = generateNestedCode(lines: 10_000)
+        let lines = code.components(separatedBy: "\n")
+
+        measure {
+            for line in lines {
+                _ = IndentGuideRenderer.indentLevel(of: line, tabWidth: 4)
+            }
+        }
+    }
+
+    func testGuideLevelsCalculation10KLines() {
+        let code = generateNestedCode(lines: 10_000)
+        let lines = code.components(separatedBy: "\n")
+        let columns = lines.map { IndentGuideRenderer.indentLevel(of: $0, tabWidth: 4) }
+
+        measure {
+            for col in columns {
+                _ = IndentGuideRenderer.guideLevels(columns: col, indentUnitWidth: 4)
+            }
+        }
+    }
+
+    func testEffectiveLevelsWithBlankLines10KLines() {
+        let lines = generateLines(count: 10_000)
+
+        measure {
+            for i in 0..<lines.count {
+                _ = IndentGuideRenderer.effectiveLevels(
+                    forLineAt: i,
+                    lines: lines,
+                    tabWidth: 4,
+                    indentUnitWidth: 4
+                )
+            }
+        }
+    }
+
+    func testSegmentCollection1KVisibleLines() {
+        // Simulates collecting guide segments for ~1000 visible lines
+        // (typical viewport is 40-80 lines, but test with more for stress)
+        let lines = generateLines(count: 1_000)
+
+        measure {
+            var segments: [IndentGuideRenderer.GuideSegment] = []
+            segments.reserveCapacity(lines.count * 3)
+            let charWidth: CGFloat = 7.8
+            let textOriginX: CGFloat = 44.0
+
+            for (i, line) in lines.enumerated() {
+                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                let levels: Int
+                if trimmed.isEmpty {
+                    levels = IndentGuideRenderer.effectiveLevels(
+                        forLineAt: i, lines: lines, tabWidth: 4, indentUnitWidth: 4
+                    )
+                } else {
+                    let cols = IndentGuideRenderer.indentLevel(of: line, tabWidth: 4)
+                    levels = IndentGuideRenderer.guideLevels(columns: cols, indentUnitWidth: 4)
+                }
+                guard levels > 0 else { continue }
+                let y = CGFloat(i) * 18.0
+                for level in 1...levels {
+                    let x = textOriginX + CGFloat(level * 4) * charWidth
+                    segments.append(.init(x: x, y: y, height: 18.0))
+                }
+            }
+        }
+    }
+}

--- a/PineTests/IndentGuideRendererTests.swift
+++ b/PineTests/IndentGuideRendererTests.swift
@@ -267,4 +267,119 @@ struct IndentGuideRendererTests {
         #expect(segment.y == 20.0)
         #expect(segment.height == 15.0)
     }
+
+    // MARK: - Guide X position (guideXOffset)
+
+    @Test("guideXOffset for spaces uses charWidth * level * indentUnit")
+    func guideXOffsetSpaces() {
+        let charWidth: CGFloat = 7.8
+        // .spaces(4): level 1 -> 1 * 4 * 7.8 = 31.2
+        let x1 = IndentGuideRenderer.guideXOffset(
+            level: 1, style: .spaces(4), charWidth: charWidth, tabStopWidth: 28
+        )
+        #expect(x1 == 31.2)
+
+        // .spaces(4): level 2 -> 2 * 4 * 7.8 = 62.4
+        let x2 = IndentGuideRenderer.guideXOffset(
+            level: 2, style: .spaces(4), charWidth: charWidth, tabStopWidth: 28
+        )
+        #expect(x2 == 62.4)
+    }
+
+    @Test("guideXOffset for spaces with indent unit 2")
+    func guideXOffsetSpacesUnit2() {
+        let charWidth: CGFloat = 8.0
+        // .spaces(2): level 1 -> 1 * 2 * 8.0 = 16.0
+        let offset = IndentGuideRenderer.guideXOffset(
+            level: 1, style: .spaces(2), charWidth: charWidth, tabStopWidth: 28
+        )
+        #expect(offset == 16.0)
+    }
+
+    @Test("guideXOffset for tabs uses tabStopWidth, not charWidth")
+    func guideXOffsetTabs() {
+        let charWidth: CGFloat = 7.8
+        let tabStopWidth: CGFloat = 28.0
+
+        // .tabs: level 1 -> 1 * 28.0 = 28.0 (not 1 * 1 * 7.8)
+        let x1 = IndentGuideRenderer.guideXOffset(
+            level: 1, style: .tabs, charWidth: charWidth, tabStopWidth: tabStopWidth
+        )
+        #expect(x1 == 28.0)
+
+        // .tabs: level 2 -> 2 * 28.0 = 56.0
+        let x2 = IndentGuideRenderer.guideXOffset(
+            level: 2, style: .tabs, charWidth: charWidth, tabStopWidth: tabStopWidth
+        )
+        #expect(x2 == 56.0)
+
+        // .tabs: level 3 -> 3 * 28.0 = 84.0
+        let x3 = IndentGuideRenderer.guideXOffset(
+            level: 3, style: .tabs, charWidth: charWidth, tabStopWidth: tabStopWidth
+        )
+        #expect(x3 == 84.0)
+    }
+
+    @Test("guideXOffset for tabs with custom tab stop width")
+    func guideXOffsetTabsCustomWidth() {
+        let offset = IndentGuideRenderer.guideXOffset(
+            level: 2, style: .tabs, charWidth: 7.8, tabStopWidth: 32.0
+        )
+        #expect(offset == 64.0)
+    }
+
+    @Test("guideXOffset tabs vs spaces produce different results for typical settings")
+    func guideXOffsetTabsVsSpaces() {
+        let charWidth: CGFloat = 7.8
+        let tabStopWidth: CGFloat = 28.0
+
+        let tabX = IndentGuideRenderer.guideXOffset(
+            level: 1, style: .tabs, charWidth: charWidth, tabStopWidth: tabStopWidth
+        )
+        let spaceX = IndentGuideRenderer.guideXOffset(
+            level: 1, style: .spaces(4), charWidth: charWidth, tabStopWidth: tabStopWidth
+        )
+        // Tab guide at 28pt, space guide at 31.2pt
+        #expect(tabX != spaceX)
+        #expect(tabX == 28.0)
+        #expect(spaceX == 31.2)
+    }
+
+    @Test("guideXOffset for Go-style tab indentation matches real tab stops")
+    func guideXOffsetGoStyle() {
+        // Go uses real tabs. NSTextView default tab interval = 28pt.
+        // Old buggy code would compute: level * 1 * 7.8 = 7.8pt (wrong)
+        // Fixed code computes: level * 28.0 = 28.0pt (correct)
+        let charWidth: CGFloat = 7.8
+        let tabStopWidth: CGFloat = 28.0
+
+        let guides = (1...3).map { level in
+            IndentGuideRenderer.guideXOffset(
+                level: level, style: .tabs, charWidth: charWidth, tabStopWidth: tabStopWidth
+            )
+        }
+        #expect(guides == [28.0, 56.0, 84.0])
+    }
+
+    @Test("guideXOffset evenly spaced for both styles")
+    func guideXOffsetEvenlySpaced() {
+        let charWidth: CGFloat = 8.0
+        let tabStopWidth: CGFloat = 32.0
+
+        // Tab file: guides at 32, 64, 96
+        let tabGuides = (1...3).map {
+            IndentGuideRenderer.guideXOffset(
+                level: $0, style: .tabs, charWidth: charWidth, tabStopWidth: tabStopWidth
+            )
+        }
+        #expect(tabGuides == [32.0, 64.0, 96.0])
+
+        // Space file (4-space indent, 8pt char): guides also at 32, 64, 96
+        let spaceGuides = (1...3).map {
+            IndentGuideRenderer.guideXOffset(
+                level: $0, style: .spaces(4), charWidth: charWidth, tabStopWidth: tabStopWidth
+            )
+        }
+        #expect(spaceGuides == [32.0, 64.0, 96.0])
+    }
 }

--- a/PineTests/IndentGuideRendererTests.swift
+++ b/PineTests/IndentGuideRendererTests.swift
@@ -1,0 +1,210 @@
+//
+//  IndentGuideRendererTests.swift
+//  PineTests
+//
+//  Created by Claude on 25.03.2026.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("IndentGuideRenderer Tests")
+struct IndentGuideRendererTests {
+
+    // MARK: - Indent level detection
+
+    @Test("Indent level for empty string")
+    func indentLevelEmpty() {
+        #expect(IndentGuideRenderer.indentLevel(of: "", tabWidth: 4) == 0)
+    }
+
+    @Test("Indent level for no indentation")
+    func indentLevelNone() {
+        #expect(IndentGuideRenderer.indentLevel(of: "hello", tabWidth: 4) == 0)
+    }
+
+    @Test("Indent level for 4 spaces")
+    func indentLevel4Spaces() {
+        #expect(IndentGuideRenderer.indentLevel(of: "    hello", tabWidth: 4) == 4)
+    }
+
+    @Test("Indent level for 8 spaces")
+    func indentLevel8Spaces() {
+        #expect(IndentGuideRenderer.indentLevel(of: "        hello", tabWidth: 4) == 8)
+    }
+
+    @Test("Indent level for single tab with tabWidth 4")
+    func indentLevelSingleTab() {
+        #expect(IndentGuideRenderer.indentLevel(of: "\thello", tabWidth: 4) == 4)
+    }
+
+    @Test("Indent level for two tabs with tabWidth 4")
+    func indentLevelTwoTabs() {
+        #expect(IndentGuideRenderer.indentLevel(of: "\t\thello", tabWidth: 4) == 8)
+    }
+
+    @Test("Indent level for mixed spaces and tabs")
+    func indentLevelMixed() {
+        // 2 spaces + 1 tab(4) = 6 columns
+        #expect(IndentGuideRenderer.indentLevel(of: "  \thello", tabWidth: 4) == 6)
+    }
+
+    @Test("Indent level for tab with tabWidth 2")
+    func indentLevelTabWidth2() {
+        #expect(IndentGuideRenderer.indentLevel(of: "\thello", tabWidth: 2) == 2)
+    }
+
+    @Test("Indent level for whitespace-only string")
+    func indentLevelWhitespaceOnly() {
+        #expect(IndentGuideRenderer.indentLevel(of: "    ", tabWidth: 4) == 4)
+    }
+
+    @Test("Indent level for 2 spaces")
+    func indentLevel2Spaces() {
+        #expect(IndentGuideRenderer.indentLevel(of: "  hello", tabWidth: 4) == 2)
+    }
+
+    // MARK: - Guide levels calculation
+
+    @Test("Guide levels for 0 columns")
+    func guideLevelsZero() {
+        #expect(IndentGuideRenderer.guideLevels(columns: 0, indentUnitWidth: 4) == 0)
+    }
+
+    @Test("Guide levels for 4 columns with unit 4")
+    func guideLevelsOne() {
+        #expect(IndentGuideRenderer.guideLevels(columns: 4, indentUnitWidth: 4) == 1)
+    }
+
+    @Test("Guide levels for 8 columns with unit 4")
+    func guideLevelsTwo() {
+        #expect(IndentGuideRenderer.guideLevels(columns: 8, indentUnitWidth: 4) == 2)
+    }
+
+    @Test("Guide levels for 6 columns with unit 4 (partial)")
+    func guideLevelsPartial() {
+        // 6 / 4 = 1 (integer division)
+        #expect(IndentGuideRenderer.guideLevels(columns: 6, indentUnitWidth: 4) == 1)
+    }
+
+    @Test("Guide levels for 2 columns with unit 2")
+    func guideLevelsUnit2() {
+        #expect(IndentGuideRenderer.guideLevels(columns: 2, indentUnitWidth: 2) == 1)
+    }
+
+    @Test("Guide levels for 8 columns with unit 2")
+    func guideLevelsUnit2Multiple() {
+        #expect(IndentGuideRenderer.guideLevels(columns: 8, indentUnitWidth: 2) == 4)
+    }
+
+    @Test("Guide levels with zero indent unit width")
+    func guideLevelsZeroUnit() {
+        #expect(IndentGuideRenderer.guideLevels(columns: 8, indentUnitWidth: 0) == 0)
+    }
+
+    // MARK: - Guide x-positions
+
+    @Test("Guide x-positions for 0 levels")
+    func xPositionsZeroLevels() {
+        let positions = IndentGuideRenderer.guideXPositions(
+            maxLevel: 0, indentUnitWidth: 4, charWidth: 8.0, textOriginX: 44.0
+        )
+        #expect(positions.isEmpty)
+    }
+
+    @Test("Guide x-positions for 1 level")
+    func xPositionsOneLevel() {
+        let positions = IndentGuideRenderer.guideXPositions(
+            maxLevel: 1, indentUnitWidth: 4, charWidth: 8.0, textOriginX: 44.0
+        )
+        #expect(positions.count == 1)
+        // 44 + 1*4*8 = 44 + 32 = 76
+        #expect(positions[0] == 76.0)
+    }
+
+    @Test("Guide x-positions for 3 levels")
+    func xPositionsThreeLevels() {
+        let positions = IndentGuideRenderer.guideXPositions(
+            maxLevel: 3, indentUnitWidth: 4, charWidth: 8.0, textOriginX: 44.0
+        )
+        #expect(positions.count == 3)
+        #expect(positions[0] == 76.0)   // 44 + 1*4*8
+        #expect(positions[1] == 108.0)  // 44 + 2*4*8
+        #expect(positions[2] == 140.0)  // 44 + 3*4*8
+    }
+
+    @Test("Guide x-positions with 2-space indent")
+    func xPositionsTwoSpaceIndent() {
+        let positions = IndentGuideRenderer.guideXPositions(
+            maxLevel: 2, indentUnitWidth: 2, charWidth: 7.5, textOriginX: 40.0
+        )
+        #expect(positions.count == 2)
+        // 40 + 1*2*7.5 = 55
+        #expect(positions[0] == 55.0)
+        // 40 + 2*2*7.5 = 70
+        #expect(positions[1] == 70.0)
+    }
+
+    @Test("Guide x-positions with zero indent unit width returns empty")
+    func xPositionsZeroIndentUnit() {
+        let positions = IndentGuideRenderer.guideXPositions(
+            maxLevel: 3, indentUnitWidth: 0, charWidth: 8.0, textOriginX: 44.0
+        )
+        #expect(positions.isEmpty)
+    }
+
+    // MARK: - Indent unit width from style
+
+    @Test("Indent unit width for spaces style")
+    func indentUnitWidthSpaces() {
+        #expect(IndentGuideRenderer.indentUnitWidth(from: .spaces(4)) == 4)
+        #expect(IndentGuideRenderer.indentUnitWidth(from: .spaces(2)) == 2)
+    }
+
+    @Test("Indent unit width for tabs style")
+    func indentUnitWidthTabs() {
+        #expect(IndentGuideRenderer.indentUnitWidth(from: .tabs) == 1)
+    }
+
+    // MARK: - Effective tab width
+
+    @Test("Effective tab width for spaces matches indent width")
+    func effectiveTabWidthSpaces() {
+        #expect(IndentGuideRenderer.effectiveTabWidth(from: .spaces(4)) == 4)
+        #expect(IndentGuideRenderer.effectiveTabWidth(from: .spaces(2)) == 2)
+    }
+
+    @Test("Effective tab width for tabs is 4")
+    func effectiveTabWidthTabs() {
+        #expect(IndentGuideRenderer.effectiveTabWidth(from: .tabs) == 4)
+    }
+
+    // MARK: - Edge cases
+
+    @Test("Indent level with only newline character")
+    func indentLevelNewline() {
+        #expect(IndentGuideRenderer.indentLevel(of: "\n", tabWidth: 4) == 0)
+    }
+
+    @Test("Indent level with spaces then newline")
+    func indentLevelSpacesNewline() {
+        #expect(IndentGuideRenderer.indentLevel(of: "    \n", tabWidth: 4) == 4)
+    }
+
+    @Test("Guide levels for very deep nesting")
+    func guideLevelsDeepNesting() {
+        // 40 columns with indent unit 4 = 10 levels
+        let columns = IndentGuideRenderer.indentLevel(
+            of: "                                        code", tabWidth: 4
+        )
+        #expect(columns == 40)
+        #expect(IndentGuideRenderer.guideLevels(columns: columns, indentUnitWidth: 4) == 10)
+    }
+
+    @Test("Indent level stops at first non-whitespace")
+    func indentLevelStopsAtContent() {
+        #expect(IndentGuideRenderer.indentLevel(of: "  hello  world", tabWidth: 4) == 2)
+    }
+}

--- a/PineTests/IndentGuideRendererTests.swift
+++ b/PineTests/IndentGuideRendererTests.swift
@@ -2,7 +2,7 @@
 //  IndentGuideRendererTests.swift
 //  PineTests
 //
-//  Created by Claude on 25.03.2026.
+//  Created by Fedor Batonogov on 25.03.2026.
 //
 
 import Foundation
@@ -104,57 +104,6 @@ struct IndentGuideRendererTests {
         #expect(IndentGuideRenderer.guideLevels(columns: 8, indentUnitWidth: 0) == 0)
     }
 
-    // MARK: - Guide x-positions
-
-    @Test("Guide x-positions for 0 levels")
-    func xPositionsZeroLevels() {
-        let positions = IndentGuideRenderer.guideXPositions(
-            maxLevel: 0, indentUnitWidth: 4, charWidth: 8.0, textOriginX: 44.0
-        )
-        #expect(positions.isEmpty)
-    }
-
-    @Test("Guide x-positions for 1 level")
-    func xPositionsOneLevel() {
-        let positions = IndentGuideRenderer.guideXPositions(
-            maxLevel: 1, indentUnitWidth: 4, charWidth: 8.0, textOriginX: 44.0
-        )
-        #expect(positions.count == 1)
-        // 44 + 1*4*8 = 44 + 32 = 76
-        #expect(positions[0] == 76.0)
-    }
-
-    @Test("Guide x-positions for 3 levels")
-    func xPositionsThreeLevels() {
-        let positions = IndentGuideRenderer.guideXPositions(
-            maxLevel: 3, indentUnitWidth: 4, charWidth: 8.0, textOriginX: 44.0
-        )
-        #expect(positions.count == 3)
-        #expect(positions[0] == 76.0)   // 44 + 1*4*8
-        #expect(positions[1] == 108.0)  // 44 + 2*4*8
-        #expect(positions[2] == 140.0)  // 44 + 3*4*8
-    }
-
-    @Test("Guide x-positions with 2-space indent")
-    func xPositionsTwoSpaceIndent() {
-        let positions = IndentGuideRenderer.guideXPositions(
-            maxLevel: 2, indentUnitWidth: 2, charWidth: 7.5, textOriginX: 40.0
-        )
-        #expect(positions.count == 2)
-        // 40 + 1*2*7.5 = 55
-        #expect(positions[0] == 55.0)
-        // 40 + 2*2*7.5 = 70
-        #expect(positions[1] == 70.0)
-    }
-
-    @Test("Guide x-positions with zero indent unit width returns empty")
-    func xPositionsZeroIndentUnit() {
-        let positions = IndentGuideRenderer.guideXPositions(
-            maxLevel: 3, indentUnitWidth: 0, charWidth: 8.0, textOriginX: 44.0
-        )
-        #expect(positions.isEmpty)
-    }
-
     // MARK: - Indent unit width from style
 
     @Test("Indent unit width for spaces style")
@@ -176,9 +125,103 @@ struct IndentGuideRendererTests {
         #expect(IndentGuideRenderer.effectiveTabWidth(from: .spaces(2)) == 2)
     }
 
-    @Test("Effective tab width for tabs is 4")
-    func effectiveTabWidthTabs() {
+    @Test("Effective tab width for tabs defaults to 4")
+    func effectiveTabWidthTabsDefault() {
         #expect(IndentGuideRenderer.effectiveTabWidth(from: .tabs) == 4)
+    }
+
+    @Test("Effective tab width for tabs with custom render width")
+    func effectiveTabWidthTabsCustom() {
+        #expect(IndentGuideRenderer.effectiveTabWidth(from: .tabs, renderTabWidth: 8) == 8)
+        #expect(IndentGuideRenderer.effectiveTabWidth(from: .tabs, renderTabWidth: 2) == 2)
+    }
+
+    // MARK: - Blank line continuation (effectiveLevels)
+
+    @Test("Effective levels for non-blank line returns actual levels")
+    func effectiveLevelsNonBlank() {
+        let lines = ["func foo() {", "    let x = 1", "}"]
+        let levels = IndentGuideRenderer.effectiveLevels(
+            forLineAt: 1, lines: lines, tabWidth: 4, indentUnitWidth: 4
+        )
+        #expect(levels == 1) // 4 columns / 4 unit = 1 level
+    }
+
+    @Test("Effective levels for blank line between indented lines")
+    func effectiveLevelsBlankBetween() {
+        let lines = ["    line1", "", "    line3"]
+        let levels = IndentGuideRenderer.effectiveLevels(
+            forLineAt: 1, lines: lines, tabWidth: 4, indentUnitWidth: 4
+        )
+        #expect(levels == 1) // min(1, 1) = 1
+    }
+
+    @Test("Effective levels for blank line with different surrounding indents")
+    func effectiveLevelsBlankDifferent() {
+        let lines = ["        deep", "", "    shallow"]
+        let levels = IndentGuideRenderer.effectiveLevels(
+            forLineAt: 1, lines: lines, tabWidth: 4, indentUnitWidth: 4
+        )
+        #expect(levels == 1) // min(2, 1) = 1
+    }
+
+    @Test("Effective levels for blank line at start of file")
+    func effectiveLevelsBlankAtStart() {
+        let lines = ["", "    code"]
+        let levels = IndentGuideRenderer.effectiveLevels(
+            forLineAt: 0, lines: lines, tabWidth: 4, indentUnitWidth: 4
+        )
+        #expect(levels == 0) // min(0, 1) = 0, no previous line
+    }
+
+    @Test("Effective levels for blank line at end of file")
+    func effectiveLevelsBlankAtEnd() {
+        let lines = ["    code", ""]
+        let levels = IndentGuideRenderer.effectiveLevels(
+            forLineAt: 1, lines: lines, tabWidth: 4, indentUnitWidth: 4
+        )
+        #expect(levels == 0) // min(1, 0) = 0, no next non-blank line
+    }
+
+    @Test("Effective levels for multiple consecutive blank lines")
+    func effectiveLevelsMultipleBlanks() {
+        let lines = ["        deep", "", "", "", "        deep"]
+        // All blank lines should get min(2, 2) = 2
+        for i in 1...3 {
+            let levels = IndentGuideRenderer.effectiveLevels(
+                forLineAt: i, lines: lines, tabWidth: 4, indentUnitWidth: 4
+            )
+            #expect(levels == 2)
+        }
+    }
+
+    @Test("Effective levels for blank line between unindented lines")
+    func effectiveLevelsBlankNoIndent() {
+        let lines = ["top", "", "bottom"]
+        let levels = IndentGuideRenderer.effectiveLevels(
+            forLineAt: 1, lines: lines, tabWidth: 4, indentUnitWidth: 4
+        )
+        #expect(levels == 0)
+    }
+
+    @Test("Effective levels with zero indent unit width returns 0")
+    func effectiveLevelsZeroUnit() {
+        let lines = ["    code"]
+        let levels = IndentGuideRenderer.effectiveLevels(
+            forLineAt: 0, lines: lines, tabWidth: 4, indentUnitWidth: 0
+        )
+        #expect(levels == 0)
+    }
+
+    @Test("Effective levels with out-of-bounds index returns 0")
+    func effectiveLevelsOutOfBounds() {
+        let lines = ["code"]
+        #expect(IndentGuideRenderer.effectiveLevels(
+            forLineAt: -1, lines: lines, tabWidth: 4, indentUnitWidth: 4
+        ) == 0)
+        #expect(IndentGuideRenderer.effectiveLevels(
+            forLineAt: 5, lines: lines, tabWidth: 4, indentUnitWidth: 4
+        ) == 0)
     }
 
     // MARK: - Edge cases
@@ -206,5 +249,22 @@ struct IndentGuideRendererTests {
     @Test("Indent level stops at first non-whitespace")
     func indentLevelStopsAtContent() {
         #expect(IndentGuideRenderer.indentLevel(of: "  hello  world", tabWidth: 4) == 2)
+    }
+
+    @Test("Effective levels for whitespace-only line treated as blank")
+    func effectiveLevelsWhitespaceOnly() {
+        let lines = ["    code", "   ", "    code"]
+        let levels = IndentGuideRenderer.effectiveLevels(
+            forLineAt: 1, lines: lines, tabWidth: 4, indentUnitWidth: 4
+        )
+        #expect(levels == 1) // whitespace-only treated as blank, min(1,1) = 1
+    }
+
+    @Test("Guide segment struct stores correct values")
+    func guideSegmentValues() {
+        let segment = IndentGuideRenderer.GuideSegment(x: 10.0, y: 20.0, height: 15.0)
+        #expect(segment.x == 10.0)
+        #expect(segment.y == 20.0)
+        #expect(segment.height == 15.0)
     }
 }


### PR DESCRIPTION
## Summary
- Adds vertical indentation guide lines to the code editor, drawn as thin 1pt lines at each indent level using `NSColor.separatorColor` with 0.3 alpha
- `IndentGuideRenderer` utility handles indent level detection (spaces/tabs), guide level calculation, and drawing with a `DrawContext` struct
- Menu toggle "Show Indent Guides" in View menu, persisted via `@AppStorage("indentGuidesVisible")`, enabled by default
- Only draws for visible lines (viewport-only rendering via `enumerateLineFragments`) for performance
- Auto-detects indent style (spaces width or tabs) from file content using existing `IndentationStyle.detect`

## Implementation
- **New file:** `Pine/IndentGuideRenderer.swift` — pure calculation + drawing logic, no AppKit view dependencies
- **Modified:** `Pine/CodeEditorView.swift` — added `isIndentGuidesVisible` property to `GutterTextView`, `drawIndentGuides()` method called from `drawBackground()`, property plumbed through `CodeEditorView` struct and `updateNSView`
- **Modified:** `Pine/EditorAreaView.swift`, `Pine/ContentView.swift` — pass `isIndentGuidesVisible` through the view hierarchy
- **Modified:** `Pine/PineApp.swift` — menu item + notification name `.toggleIndentGuides`
- **Modified:** `Pine/Strings.swift`, `Pine/MenuIcons.swift` — menu string + SF Symbol icon
- **Modified:** `Pine/Localizable.xcstrings` — translations for all 9 languages (en, de, es, fr, ja, ko, pt-BR, ru, zh-Hans)
- **New file:** `PineTests/IndentGuideRendererTests.swift` — 30 unit tests

## Test plan
- [x] Unit tests pass (30 tests in `IndentGuideRendererTests`)
- [ ] Open a file with indentation — verify vertical guide lines appear
- [ ] Toggle via View > Show Indent Guides — lines appear/disappear
- [ ] Close and reopen app — setting persists
- [ ] Test with spaces (2, 4, 8) and tabs indentation
- [ ] Verify performance on large files (guides only drawn for visible lines)

Closes #165