### PR TITLE
feat: add word-based auto-completion from open files

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -229,6 +229,16 @@ final class GutterTextView: NSTextView {
         return filtered
     }
 
+    override func cancelOperation(_ sender: Any?) {
+        // Trigger word completion popup on Escape when there's a partial word
+        let range = rangeForUserCompletion
+        if range.length > 0 {
+            complete(nil)
+        } else {
+            super.cancelOperation(sender)
+        }
+    }
+
     func toggleComment() {
         guard let style = SyntaxHighlighter.shared.commentStyle(
             forExtension: fileExtension,

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -200,10 +200,19 @@ final class GutterTextView: NSTextView {
     /// File name for looking up the line comment prefix (e.g. "Dockerfile").
     var exactFileName: String?
 
-    /// Weak reference to TabManager for word-based auto-completion across open tabs.
-    weak var completionTabManager: TabManager?
+    /// Reference to TabManager for word-based auto-completion across open tabs.
+    /// Note: not `weak` because GutterTextView (class) holds the strong ref;
+    /// `CodeEditorView` (struct) just passes it through during updateNSView.
+    var completionTabManager: TabManager?
+
+    /// Project directory path used to isolate word completion cache per project.
+    var completionProjectID: String = ""
 
     // MARK: - Word completion
+
+    /// Tracks whether the completion popup is currently shown.
+    /// Used by `cancelOperation` to avoid the open→close→reopen loop.
+    private var isCompletionActive = false
 
     override func completions(
         forPartialWordRange charRange: NSRange,
@@ -215,9 +224,22 @@ final class GutterTextView: NSTextView {
         }
 
         let partial = (string as NSString).substring(with: charRange)
-        let allWords = WordCompletionProvider.collectWords(
-            from: tabManager.tabs,
-            excluding: partial
+
+        // Build lightweight snapshots of tabs to pass to the provider.
+        // The provider reads from cache (fast) and schedules background rescan if stale.
+        let snapshots = tabManager.tabs
+            .filter { $0.kind == .text }
+            .map { WordCompletionProvider.TabSnapshot(
+                id: $0.id,
+                content: $0.content,
+                contentVersion: $0.contentVersion,
+                kind: $0.kind
+            )}
+
+        let allWords = WordCompletionProvider.completionsFromCache(
+            tabSnapshots: snapshots,
+            excluding: partial,
+            projectID: completionProjectID
         )
         let filtered = WordCompletionProvider.completions(for: partial, in: allWords)
 
@@ -225,17 +247,25 @@ final class GutterTextView: NSTextView {
             return super.completions(forPartialWordRange: charRange, indexOfSelectedItem: index)
         }
 
+        // -1 means no item is pre-selected in the completion popup
         index.pointee = -1
+        isCompletionActive = true
         return filtered
     }
 
     override func cancelOperation(_ sender: Any?) {
-        // Trigger word completion popup on Escape when there's a partial word
-        let range = rangeForUserCompletion
-        if range.length > 0 {
-            complete(nil)
-        } else {
+        if isCompletionActive {
+            // Completion popup is showing — let NSTextView close it
+            isCompletionActive = false
             super.cancelOperation(sender)
+        } else {
+            // No completion popup — trigger one if there's a partial word
+            let range = rangeForUserCompletion
+            if range.length > 0 {
+                complete(nil)
+            } else {
+                super.cancelOperation(sender)
+            }
         }
     }
 
@@ -457,7 +487,11 @@ struct CodeEditorView: NSViewRepresentable {
     /// When non-nil, the editor scrolls to this offset. The `id` ensures each request is unique.
     var goToOffset: GoToRequest?
     /// TabManager reference for word-based auto-completion across open tabs.
-    weak var tabManager: TabManager?
+    /// Not `weak` — structs are value types, so `weak` has no effect here.
+    /// The reference is passed through to GutterTextView (class) during updateNSView.
+    var tabManager: TabManager?
+    /// Project directory path — isolates word completion cache per project.
+    var completionProjectID: String = ""
 
     /// Порог (в символах) для переключения на viewport-based подсветку.
     static let viewportHighlightThreshold = 100_000
@@ -537,6 +571,7 @@ struct CodeEditorView: NSViewRepresentable {
         textView.fileExtension = language
         textView.exactFileName = fileName
         textView.completionTabManager = tabManager
+        textView.completionProjectID = completionProjectID
         textView.setBlameLines(blameLines)
         textView.isBlameVisible = isBlameVisible
         // Delegate set AFTER text/highlight setup to prevent textDidChange from firing
@@ -733,6 +768,7 @@ struct CodeEditorView: NSViewRepresentable {
             gutterView.fileExtension = language
             gutterView.exactFileName = fileName
             gutterView.completionTabManager = tabManager
+            gutterView.completionProjectID = completionProjectID
             gutterView.setBlameLines(blameLines)
             if gutterView.isBlameVisible != isBlameVisible {
                 gutterView.isBlameVisible = isBlameVisible

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -200,6 +200,35 @@ final class GutterTextView: NSTextView {
     /// File name for looking up the line comment prefix (e.g. "Dockerfile").
     var exactFileName: String?
 
+    /// Weak reference to TabManager for word-based auto-completion across open tabs.
+    weak var completionTabManager: TabManager?
+
+    // MARK: - Word completion
+
+    override func completions(
+        forPartialWordRange charRange: NSRange,
+        indexOfSelectedItem index: UnsafeMutablePointer<Int>
+    ) -> [String]? {
+        guard charRange.length > 0,
+              let tabManager = completionTabManager else {
+            return super.completions(forPartialWordRange: charRange, indexOfSelectedItem: index)
+        }
+
+        let partial = (string as NSString).substring(with: charRange)
+        let allWords = WordCompletionProvider.collectWords(
+            from: tabManager.tabs,
+            excluding: partial
+        )
+        let filtered = WordCompletionProvider.completions(for: partial, in: allWords)
+
+        guard !filtered.isEmpty else {
+            return super.completions(forPartialWordRange: charRange, indexOfSelectedItem: index)
+        }
+
+        index.pointee = -1
+        return filtered
+    }
+
     func toggleComment() {
         guard let style = SyntaxHighlighter.shared.commentStyle(
             forExtension: fileExtension,
@@ -417,6 +446,8 @@ struct CodeEditorView: NSViewRepresentable {
     var cachedHighlightResult: HighlightMatchResult?
     /// When non-nil, the editor scrolls to this offset. The `id` ensures each request is unique.
     var goToOffset: GoToRequest?
+    /// TabManager reference for word-based auto-completion across open tabs.
+    weak var tabManager: TabManager?
 
     /// Порог (в символах) для переключения на viewport-based подсветку.
     static let viewportHighlightThreshold = 100_000
@@ -495,6 +526,7 @@ struct CodeEditorView: NSViewRepresentable {
 
         textView.fileExtension = language
         textView.exactFileName = fileName
+        textView.completionTabManager = tabManager
         textView.setBlameLines(blameLines)
         textView.isBlameVisible = isBlameVisible
         // Delegate set AFTER text/highlight setup to prevent textDidChange from firing
@@ -690,6 +722,7 @@ struct CodeEditorView: NSViewRepresentable {
            let gutterView = sv.documentView as? GutterTextView {
             gutterView.fileExtension = language
             gutterView.exactFileName = fileName
+            gutterView.completionTabManager = tabManager
             gutterView.setBlameLines(blameLines)
             if gutterView.isBlameVisible != isBlameVisible {
                 gutterView.isBlameVisible = isBlameVisible

--- a/Pine/EditorAreaView.swift
+++ b/Pine/EditorAreaView.swift
@@ -131,6 +131,7 @@ struct EditorAreaView: View {
             cachedHighlightResult: tab.cachedHighlightResult,
             goToOffset: goToLineOffset,
             tabManager: tabManager,
+            completionProjectID: projectManager.rootURL?.path ?? "",
             fontSize: FontSizeSettings.shared.fontSize
         )
         .id(tab.id)

--- a/Pine/EditorAreaView.swift
+++ b/Pine/EditorAreaView.swift
@@ -130,6 +130,7 @@ struct EditorAreaView: View {
             },
             cachedHighlightResult: tab.cachedHighlightResult,
             goToOffset: goToLineOffset,
+            tabManager: tabManager,
             fontSize: FontSizeSettings.shared.fontSize
         )
         .id(tab.id)

--- a/Pine/WordCompletionProvider.swift
+++ b/Pine/WordCompletionProvider.swift
@@ -10,13 +10,23 @@ import Foundation
 /// Provides word-based auto-completions by scanning text content from open editor tabs.
 /// Words are extracted using a Unicode-aware regex that matches identifiers (letters, digits, underscores)
 /// with a minimum length of 3 characters. Results are cached per-tab and invalidated by `contentVersion`.
+///
+/// Threading model: all regex scanning runs on a dedicated serial background queue (`scanQueue`).
+/// The `completions(forPartialWordRange:)` call on main thread reads only from the ready cache.
+/// If the cache is stale, a background rescan is triggered and current (possibly outdated) results are returned.
 enum WordCompletionProvider {
 
     /// Minimum word length to include in completions.
+    /// Set to 3 to filter out noise (operators, single-char vars). Two-letter identifiers like `id`, `ok`
+    /// are excluded because they generate too many false positives from partial matches in longer words.
     static let minWordLength = 3
 
     /// Maximum number of completions returned by `completions(for:in:)`.
     static let maxCompletions = 50
+
+    /// Maximum number of characters to scan per tab. Files beyond this limit are partially scanned
+    /// to keep indexing time bounded (avoids blocking on multi-MB files).
+    static let maxScanSize = 500_000  // ~500 KB
 
     /// Unicode-aware regex: matches identifiers starting with a letter or underscore,
     /// followed by letters, digits, or underscores. Supports Cyrillic, CJK, umlauts, etc.
@@ -34,24 +44,44 @@ enum WordCompletionProvider {
         let words: [String: Int]  // word → frequency
     }
 
-    /// Serial queue protecting the cache dictionary.
+    /// Serial queue protecting the cache dictionary and performing background scans.
     private static let cacheQueue = DispatchQueue(label: "com.pine.word-completion-cache")
 
-    /// Cache keyed by tab ID. Values store contentVersion for invalidation.
-    private static var tabCaches: [UUID: TabWordCache] = [:]
+    /// Background serial queue for regex scanning — never blocks main thread.
+    private static let scanQueue = DispatchQueue(label: "com.pine.word-completion-scan")
+
+    /// Cache keyed by composite key "projectID:tabID". Values store contentVersion for invalidation.
+    private static var tabCaches: [String: TabWordCache] = [:]
+
+    /// Last aggregated word list — returned immediately while background rescan runs.
+    private static var lastAggregatedWords: [String] = []
+
+    /// Project ID for the last aggregation — ensures we don't mix results across projects.
+    private static var lastProjectID: String?
+
+    // MARK: - Cache key helpers
+
+    /// Builds a cache key that includes the project ID to avoid cross-project word mixing.
+    private static func cacheKey(projectID: String, tabID: UUID) -> String {
+        "\(projectID):\(tabID.uuidString)"
+    }
 
     /// Extracts words from a single tab's content, returning word→frequency map.
     /// Uses cache when contentVersion matches; rescans only on change.
-    private static func wordsForTab(_ tab: EditorTab) -> [String: Int] {
-        // Check cache (lock-free read is fine — worst case we rescan once)
-        let cached: TabWordCache? = cacheQueue.sync { tabCaches[tab.id] }
+    /// **Must be called from `scanQueue` or `cacheQueue`** — NOT from main thread.
+    private static func wordsForTab(_ tab: EditorTab, projectID: String) -> [String: Int] {
+        let key = cacheKey(projectID: projectID, tabID: tab.id)
+
+        // Check cache
+        let cached: TabWordCache? = cacheQueue.sync { tabCaches[key] }
         if let cached, cached.contentVersion == tab.contentVersion {
             return cached.words
         }
 
-        // Scan the tab content
+        // Scan the tab content, respecting maxScanSize
         let text = tab.content as NSString
-        let range = NSRange(location: 0, length: text.length)
+        let scanLength = min(text.length, maxScanSize)
+        let range = NSRange(location: 0, length: scanLength)
         let matches = wordPattern.matches(in: tab.content, options: [], range: range)
 
         var frequency: [String: Int] = [:]
@@ -63,16 +93,20 @@ enum WordCompletionProvider {
 
         // Store in cache
         let entry = TabWordCache(tabID: tab.id, contentVersion: tab.contentVersion, words: frequency)
-        cacheQueue.sync { tabCaches[tab.id] = entry }
+        cacheQueue.sync { tabCaches[key] = entry }
 
         return frequency
     }
 
     /// Removes cached entries for tabs that are no longer open.
     /// Called lazily during `collectWords` to avoid unbounded cache growth.
-    private static func pruneCache(activeTabs: Set<UUID>) {
+    private static func pruneCache(projectID: String, activeTabs: Set<UUID>) {
+        let prefix = "\(projectID):"
         cacheQueue.sync {
-            tabCaches = tabCaches.filter { activeTabs.contains($0.key) }
+            tabCaches = tabCaches.filter { key, value in
+                guard key.hasPrefix(prefix) else { return true }  // keep other projects' caches
+                return activeTabs.contains(value.tabID)
+            }
         }
     }
 
@@ -81,17 +115,23 @@ enum WordCompletionProvider {
     /// - Parameters:
     ///   - tabs: The currently open editor tabs.
     ///   - currentWord: The word being typed — excluded from results to avoid self-completion.
+    ///   - projectID: Identifier for the current project (e.g. project directory path).
+    ///                Isolates caches between different open projects.
     /// - Returns: An array of unique words sorted by frequency (descending) then alphabetically.
-    static func collectWords(from tabs: [EditorTab], excluding currentWord: String) -> [String] {
+    static func collectWords(
+        from tabs: [EditorTab],
+        excluding currentWord: String,
+        projectID: String = ""
+    ) -> [String] {
         let textTabs = tabs.filter { $0.kind == .text }
         let activeIDs = Set(textTabs.map(\.id))
-        pruneCache(activeTabs: activeIDs)
+        pruneCache(projectID: projectID, activeTabs: activeIDs)
 
         var frequency: [String: Int] = [:]
         let excludeLower = currentWord.lowercased()
 
         for tab in textTabs {
-            let tabWords = wordsForTab(tab)
+            let tabWords = wordsForTab(tab, projectID: projectID)
             for (word, count) in tabWords {
                 guard word.lowercased() != excludeLower else { continue }
                 frequency[word, default: 0] += count
@@ -104,6 +144,129 @@ enum WordCompletionProvider {
             let freqR = frequency[rhs] ?? 0
             if freqL != freqR { return freqL > freqR }
             return lhs.localizedCaseInsensitiveCompare(rhs) == .orderedAscending
+        }
+    }
+
+    // MARK: - Async background indexing (K1)
+
+    /// Snapshot of tab data needed for background scanning — avoids capturing EditorTab from main thread.
+    struct TabSnapshot: Sendable {
+        let id: UUID
+        let content: String
+        let contentVersion: UInt64
+        let kind: EditorTab.TabKind
+    }
+
+    /// Triggers a background rescan of all tabs and returns the best available results immediately.
+    /// If the cache is fully up-to-date, returns fresh results. Otherwise returns the last aggregated
+    /// word list and schedules a background rescan. The next call will have updated data.
+    ///
+    /// This method is safe to call from the main thread — regex work happens on `scanQueue`.
+    static func completionsFromCache(
+        tabSnapshots: [TabSnapshot],
+        excluding currentWord: String,
+        projectID: String
+    ) -> [String] {
+        let textTabs = tabSnapshots.filter { $0.kind == .text }
+
+        // Check if all caches are valid (fast path — no scanning needed)
+        let allCachesFresh = cacheQueue.sync { () -> Bool in
+            for tab in textTabs {
+                let key = cacheKey(projectID: projectID, tabID: tab.id)
+                guard let cached = tabCaches[key],
+                      cached.contentVersion == tab.contentVersion else {
+                    return false
+                }
+            }
+            return true
+        }
+
+        if allCachesFresh {
+            // All caches valid — aggregate directly (reading from cache is fast)
+            let result = aggregateFromCache(
+                textTabs: textTabs,
+                excluding: currentWord,
+                projectID: projectID
+            )
+            cacheQueue.sync {
+                lastAggregatedWords = result
+                lastProjectID = projectID
+            }
+            return result
+        }
+
+        // Some caches are stale — return last known results + schedule background rescan
+        scheduleBackgroundScan(textTabs: textTabs, projectID: projectID)
+
+        return cacheQueue.sync {
+            guard lastProjectID == projectID else { return [] }
+            // Filter by current prefix from last aggregated results
+            return lastAggregatedWords
+        }
+    }
+
+    /// Aggregates words from cache (assumes all caches are valid).
+    private static func aggregateFromCache(
+        textTabs: [TabSnapshot],
+        excluding currentWord: String,
+        projectID: String
+    ) -> [String] {
+        let excludeLower = currentWord.lowercased()
+        var frequency: [String: Int] = [:]
+
+        cacheQueue.sync {
+            for tab in textTabs {
+                let key = cacheKey(projectID: projectID, tabID: tab.id)
+                guard let cached = tabCaches[key] else { continue }
+                for (word, count) in cached.words {
+                    guard word.lowercased() != excludeLower else { continue }
+                    frequency[word, default: 0] += count
+                }
+            }
+        }
+
+        return frequency.keys.sorted { lhs, rhs in
+            let freqL = frequency[lhs] ?? 0
+            let freqR = frequency[rhs] ?? 0
+            if freqL != freqR { return freqL > freqR }
+            return lhs.localizedCaseInsensitiveCompare(rhs) == .orderedAscending
+        }
+    }
+
+    /// Schedules a background scan for tabs with stale caches.
+    private static func scheduleBackgroundScan(
+        textTabs: [TabSnapshot],
+        projectID: String
+    ) {
+        scanQueue.async {
+            for tab in textTabs {
+                let key = cacheKey(projectID: projectID, tabID: tab.id)
+                let isCached = cacheQueue.sync { () -> Bool in
+                    guard let cached = tabCaches[key] else { return false }
+                    return cached.contentVersion == tab.contentVersion
+                }
+                guard !isCached else { continue }
+
+                // Scan tab content, respecting maxScanSize
+                let text = tab.content as NSString
+                let scanLength = min(text.length, maxScanSize)
+                let range = NSRange(location: 0, length: scanLength)
+                let matches = wordPattern.matches(in: tab.content, options: [], range: range)
+
+                var freq: [String: Int] = [:]
+                for match in matches {
+                    let word = text.substring(with: match.range)
+                    guard word.count >= minWordLength else { continue }
+                    freq[word, default: 0] += 1
+                }
+
+                let entry = TabWordCache(
+                    tabID: tab.id,
+                    contentVersion: tab.contentVersion,
+                    words: freq
+                )
+                cacheQueue.sync { tabCaches[key] = entry }
+            }
         }
     }
 
@@ -126,6 +289,10 @@ enum WordCompletionProvider {
 
     /// Clears the internal word cache. Intended for testing only.
     static func clearCache() {
-        cacheQueue.sync { tabCaches.removeAll() }
+        cacheQueue.sync {
+            tabCaches.removeAll()
+            lastAggregatedWords.removeAll()
+            lastProjectID = nil
+        }
     }
 }

--- a/Pine/WordCompletionProvider.swift
+++ b/Pine/WordCompletionProvider.swift
@@ -1,0 +1,64 @@
+//
+//  WordCompletionProvider.swift
+//  Pine
+//
+//  Word-based auto-completion provider that collects words from open editor tabs.
+//
+
+import Foundation
+
+/// Provides word-based auto-completions by scanning text content from open editor tabs.
+/// Words are extracted using a regex that matches identifiers (letters, digits, underscores)
+/// with a minimum length of 3 characters.
+enum WordCompletionProvider {
+
+    /// Minimum word length to include in completions.
+    static let minWordLength = 3
+
+    /// Regex pattern for extracting words: sequences of word characters (letters, digits, underscores).
+    private static let wordPattern = try! NSRegularExpression(  // swiftlint:disable:this force_try
+        pattern: "[a-zA-Z_][a-zA-Z0-9_]*",
+        options: []
+    )
+
+    /// Extracts unique words (3+ chars) from all open tabs' text content.
+    /// - Parameters:
+    ///   - tabs: The currently open editor tabs.
+    ///   - currentWord: The word being typed — excluded from results to avoid self-completion.
+    /// - Returns: An array of unique words sorted by frequency (descending) then alphabetically.
+    static func collectWords(from tabs: [EditorTab], excluding currentWord: String) -> [String] {
+        var frequency: [String: Int] = [:]
+        let excludeLower = currentWord.lowercased()
+
+        for tab in tabs where tab.kind == .text {
+            let text = tab.content as NSString
+            let range = NSRange(location: 0, length: text.length)
+            let matches = wordPattern.matches(in: tab.content, options: [], range: range)
+
+            for match in matches {
+                let word = text.substring(with: match.range)
+                guard word.count >= minWordLength else { continue }
+                guard word.lowercased() != excludeLower else { continue }
+                frequency[word, default: 0] += 1
+            }
+        }
+
+        // Sort by frequency (descending), then alphabetically for stable ordering
+        return frequency.keys.sorted { lhs, rhs in
+            let freqL = frequency[lhs] ?? 0
+            let freqR = frequency[rhs] ?? 0
+            if freqL != freqR { return freqL > freqR }
+            return lhs.localizedCaseInsensitiveCompare(rhs) == .orderedAscending
+        }
+    }
+
+    /// Filters words by case-insensitive prefix match.
+    /// - Parameters:
+    ///   - prefix: The partial word to match against.
+    ///   - words: The pool of candidate words (already sorted by frequency).
+    /// - Returns: Words matching the prefix, preserving the input sort order.
+    static func completions(for prefix: String, in words: [String]) -> [String] {
+        let prefixLower = prefix.lowercased()
+        return words.filter { $0.lowercased().hasPrefix(prefixLower) }
+    }
+}

--- a/Pine/WordCompletionProvider.swift
+++ b/Pine/WordCompletionProvider.swift
@@ -8,38 +8,93 @@
 import Foundation
 
 /// Provides word-based auto-completions by scanning text content from open editor tabs.
-/// Words are extracted using a regex that matches identifiers (letters, digits, underscores)
-/// with a minimum length of 3 characters.
+/// Words are extracted using a Unicode-aware regex that matches identifiers (letters, digits, underscores)
+/// with a minimum length of 3 characters. Results are cached per-tab and invalidated by `contentVersion`.
 enum WordCompletionProvider {
 
     /// Minimum word length to include in completions.
     static let minWordLength = 3
 
-    /// Regex pattern for extracting words: sequences of word characters (letters, digits, underscores).
+    /// Maximum number of completions returned by `completions(for:in:)`.
+    static let maxCompletions = 50
+
+    /// Unicode-aware regex: matches identifiers starting with a letter or underscore,
+    /// followed by letters, digits, or underscores. Supports Cyrillic, CJK, umlauts, etc.
     private static let wordPattern = try! NSRegularExpression(  // swiftlint:disable:this force_try
-        pattern: "[a-zA-Z_][a-zA-Z0-9_]*",
+        pattern: "[\\p{L}_][\\p{L}\\p{N}_]*",
         options: []
     )
 
+    // MARK: - Per-tab word cache
+
+    /// Cached word extraction result for a single tab.
+    private struct TabWordCache {
+        let tabID: UUID
+        let contentVersion: UInt64
+        let words: [String: Int]  // word → frequency
+    }
+
+    /// Serial queue protecting the cache dictionary.
+    private static let cacheQueue = DispatchQueue(label: "com.pine.word-completion-cache")
+
+    /// Cache keyed by tab ID. Values store contentVersion for invalidation.
+    private static var tabCaches: [UUID: TabWordCache] = [:]
+
+    /// Extracts words from a single tab's content, returning word→frequency map.
+    /// Uses cache when contentVersion matches; rescans only on change.
+    private static func wordsForTab(_ tab: EditorTab) -> [String: Int] {
+        // Check cache (lock-free read is fine — worst case we rescan once)
+        let cached: TabWordCache? = cacheQueue.sync { tabCaches[tab.id] }
+        if let cached, cached.contentVersion == tab.contentVersion {
+            return cached.words
+        }
+
+        // Scan the tab content
+        let text = tab.content as NSString
+        let range = NSRange(location: 0, length: text.length)
+        let matches = wordPattern.matches(in: tab.content, options: [], range: range)
+
+        var frequency: [String: Int] = [:]
+        for match in matches {
+            let word = text.substring(with: match.range)
+            guard word.count >= minWordLength else { continue }
+            frequency[word, default: 0] += 1
+        }
+
+        // Store in cache
+        let entry = TabWordCache(tabID: tab.id, contentVersion: tab.contentVersion, words: frequency)
+        cacheQueue.sync { tabCaches[tab.id] = entry }
+
+        return frequency
+    }
+
+    /// Removes cached entries for tabs that are no longer open.
+    /// Called lazily during `collectWords` to avoid unbounded cache growth.
+    private static func pruneCache(activeTabs: Set<UUID>) {
+        cacheQueue.sync {
+            tabCaches = tabCaches.filter { activeTabs.contains($0.key) }
+        }
+    }
+
     /// Extracts unique words (3+ chars) from all open tabs' text content.
+    /// Uses per-tab caching — only rescans tabs whose content has changed.
     /// - Parameters:
     ///   - tabs: The currently open editor tabs.
     ///   - currentWord: The word being typed — excluded from results to avoid self-completion.
     /// - Returns: An array of unique words sorted by frequency (descending) then alphabetically.
     static func collectWords(from tabs: [EditorTab], excluding currentWord: String) -> [String] {
+        let textTabs = tabs.filter { $0.kind == .text }
+        let activeIDs = Set(textTabs.map(\.id))
+        pruneCache(activeTabs: activeIDs)
+
         var frequency: [String: Int] = [:]
         let excludeLower = currentWord.lowercased()
 
-        for tab in tabs where tab.kind == .text {
-            let text = tab.content as NSString
-            let range = NSRange(location: 0, length: text.length)
-            let matches = wordPattern.matches(in: tab.content, options: [], range: range)
-
-            for match in matches {
-                let word = text.substring(with: match.range)
-                guard word.count >= minWordLength else { continue }
+        for tab in textTabs {
+            let tabWords = wordsForTab(tab)
+            for (word, count) in tabWords {
                 guard word.lowercased() != excludeLower else { continue }
-                frequency[word, default: 0] += 1
+                frequency[word, default: 0] += count
             }
         }
 
@@ -52,13 +107,25 @@ enum WordCompletionProvider {
         }
     }
 
-    /// Filters words by case-insensitive prefix match.
+    /// Filters words by case-insensitive prefix match, limited to `maxCompletions`.
     /// - Parameters:
     ///   - prefix: The partial word to match against.
     ///   - words: The pool of candidate words (already sorted by frequency).
-    /// - Returns: Words matching the prefix, preserving the input sort order.
+    /// - Returns: Words matching the prefix, preserving the input sort order, capped at `maxCompletions`.
     static func completions(for prefix: String, in words: [String]) -> [String] {
         let prefixLower = prefix.lowercased()
-        return words.filter { $0.lowercased().hasPrefix(prefixLower) }
+        var result: [String] = []
+        for word in words where word.lowercased().hasPrefix(prefixLower) {
+            result.append(word)
+            if result.count >= maxCompletions { break }
+        }
+        return result
+    }
+
+    // MARK: - Testing support
+
+    /// Clears the internal word cache. Intended for testing only.
+    static func clearCache() {
+        cacheQueue.sync { tabCaches.removeAll() }
     }
 }

--- a/PineTests/WordCompletionProviderTests.swift
+++ b/PineTests/WordCompletionProviderTests.swift
@@ -9,6 +9,11 @@ import Foundation
 
 struct WordCompletionProviderTests {
 
+    init() {
+        // Clear cache before each test for isolation
+        WordCompletionProvider.clearCache()
+    }
+
     // MARK: - collectWords
 
     @Test func emptyTabsReturnsEmpty() {
@@ -143,8 +148,8 @@ struct WordCompletionProviderTests {
     @Test func largeTextPerformance() {
         // Build a large text with many words
         var lines: [String] = []
-        for i in 0..<10_000 {
-            lines.append("func method_\(i)(param_\(i): Int) -> String")
+        for lineNum in 0..<10_000 {
+            lines.append("func method_\(lineNum)(param_\(lineNum): Int) -> String")
         }
         let tab = EditorTab(
             url: URL(fileURLWithPath: "/large.swift"),
@@ -157,6 +162,147 @@ struct WordCompletionProviderTests {
         #expect(words.contains("Int"))
         #expect(words.contains("String"))
         #expect(words.count > 100)
+    }
+
+    // MARK: - Unicode support
+
+    @Test func cyrillicWords() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: "let переменная = значение\nfunc вычислить() {}",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        #expect(words.contains("переменная"))
+        #expect(words.contains("значение"))
+        #expect(words.contains("вычислить"))
+    }
+
+    @Test func cjkWords() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: "let 変数名 = 値設定\nfunc 計算する() {}",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        #expect(words.contains("変数名"))
+        #expect(words.contains("値設定"))
+        #expect(words.contains("計算する"))
+    }
+
+    @Test func germanUmlauts() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: "let größe = überprüfung\nvar Ärger = Öffnung",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        #expect(words.contains("größe"))
+        #expect(words.contains("überprüfung"))
+        #expect(words.contains("Ärger"))
+        #expect(words.contains("Öffnung"))
+    }
+
+    @Test func mixedUnicodeAndAsciiIdentifiers() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: "let café_count = наш_проект123",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        #expect(words.contains("café_count"))
+        #expect(words.contains("наш_проект123"))
+    }
+
+    // MARK: - Edge cases
+
+    @Test func emptyFileReturnsEmpty() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/empty.swift"),
+            content: "",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        #expect(words.isEmpty)
+    }
+
+    @Test func whitespaceOnlyFileReturnsEmpty() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/whitespace.swift"),
+            content: "   \n\t\t\n   \n",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        #expect(words.isEmpty)
+    }
+
+    @Test func differentCasesOfSameWordPreserved() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: "myVar MyVar MYVAR myvar",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        // All case variants should be separate entries
+        #expect(words.contains("myVar"))
+        #expect(words.contains("MyVar"))
+        #expect(words.contains("MYVAR"))
+        #expect(words.contains("myvar"))
+        #expect(words.count == 4)
+    }
+
+    @Test func veryLongWord() {
+        let longWord = String(repeating: "a", count: 5000)
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: longWord,
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        #expect(words.count == 1)
+        #expect(words.first == longWord)
+    }
+
+    @Test func singleWordRepeatedManyTimes() {
+        let content = Array(repeating: "repeated", count: 1000).joined(separator: " ")
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: content,
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        // Should deduplicate — only one entry
+        #expect(words.count == 1)
+        #expect(words.first == "repeated")
+    }
+
+    // MARK: - Caching
+
+    @Test func cacheReturnsConsistentResults() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: "hello world test",
+            savedContent: ""
+        )
+        let words1 = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        let words2 = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        #expect(words1 == words2)
+    }
+
+    @Test func cacheInvalidatesOnContentChange() {
+        var tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: "hello world",
+            savedContent: ""
+        )
+        let words1 = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        #expect(words1.contains("hello"))
+        #expect(!words1.contains("newword"))
+
+        // Mutate content — contentVersion increments
+        tab.content = "hello newword"
+        let words2 = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        #expect(words2.contains("newword"))
     }
 
     // MARK: - completions (prefix matching)
@@ -177,7 +323,7 @@ struct WordCompletionProviderTests {
         #expect(!results.contains("world"))
     }
 
-    @Test func emptyPrefixReturnsAll() {
+    @Test func emptyPrefixReturnsAllUpToLimit() {
         let words = ["alpha", "beta", "gamma"]
         let results = WordCompletionProvider.completions(for: "", in: words)
         #expect(results.count == 3)
@@ -193,5 +339,23 @@ struct WordCompletionProviderTests {
         let words = ["zebra", "apple", "mango"]
         let results = WordCompletionProvider.completions(for: "", in: words)
         #expect(results == ["zebra", "apple", "mango"])
+    }
+
+    // MARK: - Completion limit
+
+    @Test func completionsLimitedToMax() {
+        // Create more words than maxCompletions, all matching prefix "word"
+        var words: [String] = []
+        for num in 0..<200 {
+            words.append("word\(num)")
+        }
+        let results = WordCompletionProvider.completions(for: "word", in: words)
+        #expect(results.count == WordCompletionProvider.maxCompletions)
+    }
+
+    @Test func completionsUnderLimitReturnsAll() {
+        let words = ["word1", "word2", "word3"]
+        let results = WordCompletionProvider.completions(for: "word", in: words)
+        #expect(results.count == 3)
     }
 }

--- a/PineTests/WordCompletionProviderTests.swift
+++ b/PineTests/WordCompletionProviderTests.swift
@@ -1,0 +1,197 @@
+//
+//  WordCompletionProviderTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+struct WordCompletionProviderTests {
+
+    // MARK: - collectWords
+
+    @Test func emptyTabsReturnsEmpty() {
+        let words = WordCompletionProvider.collectWords(from: [], excluding: "")
+        #expect(words.isEmpty)
+    }
+
+    @Test func singleTabReturnsUniqueWords() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: "let hello = world\nlet hello = swift",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        // "let" has 3 chars, "hello" appears twice, "world" once, "swift" once
+        #expect(words.contains("hello"))
+        #expect(words.contains("world"))
+        #expect(words.contains("swift"))
+        #expect(words.contains("let"))
+        // No duplicates
+        #expect(words.filter { $0 == "hello" }.count == 1)
+    }
+
+    @Test func multipleTabsCollectFromAll() {
+        let tab1 = EditorTab(
+            url: URL(fileURLWithPath: "/a.swift"),
+            content: "func alpha() {}",
+            savedContent: ""
+        )
+        let tab2 = EditorTab(
+            url: URL(fileURLWithPath: "/b.swift"),
+            content: "var beta = 42",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab1, tab2], excluding: "")
+        #expect(words.contains("func"))
+        #expect(words.contains("alpha"))
+        #expect(words.contains("var"))
+        #expect(words.contains("beta"))
+    }
+
+    @Test func wordsUnderThreeCharsExcluded() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: "a ab abc abcd",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        #expect(!words.contains("a"))
+        #expect(!words.contains("ab"))
+        #expect(words.contains("abc"))
+        #expect(words.contains("abcd"))
+    }
+
+    @Test func currentWordExcluded() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: "hello world",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "hello")
+        #expect(!words.contains("hello"))
+        #expect(words.contains("world"))
+    }
+
+    @Test func currentWordExclusionIsCaseInsensitive() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: "Hello world",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "hello")
+        #expect(!words.contains("Hello"))
+        #expect(words.contains("world"))
+    }
+
+    @Test func duplicatesAcrossTabsDeduplicated() {
+        let tab1 = EditorTab(
+            url: URL(fileURLWithPath: "/a.swift"),
+            content: "import Foundation",
+            savedContent: ""
+        )
+        let tab2 = EditorTab(
+            url: URL(fileURLWithPath: "/b.swift"),
+            content: "import Foundation",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab1, tab2], excluding: "")
+        #expect(words.filter { $0 == "import" }.count == 1)
+        #expect(words.filter { $0 == "Foundation" }.count == 1)
+    }
+
+    @Test func specialCharactersUnderscoresAndNumbers() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: "_privateVar my_func var123 __init__",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        #expect(words.contains("_privateVar"))
+        #expect(words.contains("my_func"))
+        #expect(words.contains("var123"))
+        #expect(words.contains("__init__"))
+    }
+
+    @Test func sortedByFrequencyDescending() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: "aaa bbb aaa ccc aaa bbb",
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        // aaa: 3, bbb: 2, ccc: 1
+        #expect(words.first == "aaa")
+        guard let bbbIdx = words.firstIndex(of: "bbb"),
+              let cccIdx = words.firstIndex(of: "ccc") else {
+            Issue.record("Expected bbb and ccc in words")
+            return
+        }
+        #expect(bbbIdx < cccIdx)
+    }
+
+    @Test func previewTabsSkipped() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/image.png"),
+            kind: .preview
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        #expect(words.isEmpty)
+    }
+
+    @Test func largeTextPerformance() {
+        // Build a large text with many words
+        var lines: [String] = []
+        for i in 0..<10_000 {
+            lines.append("func method_\(i)(param_\(i): Int) -> String")
+        }
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/large.swift"),
+            content: lines.joined(separator: "\n"),
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        // Should complete without issues and contain expected words
+        #expect(words.contains("func"))
+        #expect(words.contains("Int"))
+        #expect(words.contains("String"))
+        #expect(words.count > 100)
+    }
+
+    // MARK: - completions (prefix matching)
+
+    @Test func prefixMatchingWorks() {
+        let words = ["hello", "help", "world", "Heaven"]
+        let results = WordCompletionProvider.completions(for: "hel", in: words)
+        #expect(results.contains("hello"))
+        #expect(results.contains("help"))
+        #expect(!results.contains("world"))
+    }
+
+    @Test func prefixMatchingIsCaseInsensitive() {
+        let words = ["Hello", "HELP", "world"]
+        let results = WordCompletionProvider.completions(for: "hel", in: words)
+        #expect(results.contains("Hello"))
+        #expect(results.contains("HELP"))
+        #expect(!results.contains("world"))
+    }
+
+    @Test func emptyPrefixReturnsAll() {
+        let words = ["alpha", "beta", "gamma"]
+        let results = WordCompletionProvider.completions(for: "", in: words)
+        #expect(results.count == 3)
+    }
+
+    @Test func noMatchReturnsEmpty() {
+        let words = ["alpha", "beta"]
+        let results = WordCompletionProvider.completions(for: "xyz", in: words)
+        #expect(results.isEmpty)
+    }
+
+    @Test func preservesInputOrder() {
+        let words = ["zebra", "apple", "mango"]
+        let results = WordCompletionProvider.completions(for: "", in: words)
+        #expect(results == ["zebra", "apple", "mango"])
+    }
+}

--- a/PineTests/WordCompletionProviderTests.swift
+++ b/PineTests/WordCompletionProviderTests.swift
@@ -358,4 +358,171 @@ struct WordCompletionProviderTests {
         let results = WordCompletionProvider.completions(for: "word", in: words)
         #expect(results.count == 3)
     }
+
+    // MARK: - Project isolation (С3)
+
+    @Test func differentProjectIDsIsolateCache() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/shared.swift"),
+            content: "func sharedWord() {}",
+            savedContent: ""
+        )
+        // Collect for project A
+        let wordsA = WordCompletionProvider.collectWords(
+            from: [tab], excluding: "", projectID: "/projectA"
+        )
+        #expect(wordsA.contains("sharedWord"))
+
+        // Collect for project B with a different tab
+        let tabB = EditorTab(
+            url: URL(fileURLWithPath: "/other.swift"),
+            content: "var uniqueWord = true",
+            savedContent: ""
+        )
+        let wordsB = WordCompletionProvider.collectWords(
+            from: [tabB], excluding: "", projectID: "/projectB"
+        )
+        #expect(wordsB.contains("uniqueWord"))
+        #expect(!wordsB.contains("sharedWord"))
+    }
+
+    // MARK: - maxScanSize (С2)
+
+    @Test func largeFileScansOnlyMaxScanSize() {
+        // Create content larger than maxScanSize
+        // Each word "word_XXXX " is ~11 chars, so 500_000 / 11 ≈ 45_000 words fit in scan window
+        let wordBeforeCutoff = "beforeCutoff"
+        let wordAfterCutoff = "afterCutoff_unique_marker"
+        // Build: fill up to maxScanSize with repeated short words, then add unique word after
+        let filler = String(repeating: "fillerword ", count: WordCompletionProvider.maxScanSize / 11)
+        let content = filler + " " + wordAfterCutoff + " " + wordBeforeCutoff
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/huge.swift"),
+            content: content,
+            savedContent: ""
+        )
+        let words = WordCompletionProvider.collectWords(from: [tab], excluding: "")
+        // The filler word should be found
+        #expect(words.contains("fillerword"))
+        // Words beyond maxScanSize should be excluded
+        // (afterCutoff_unique_marker is placed after the scan window)
+        #expect(!words.contains(wordAfterCutoff))
+    }
+
+    // MARK: - Thread safety (С4)
+
+    @Test func concurrentCollectWordsDoesNotCrash() async {
+        // Create several tabs
+        let tabs = (0..<10).map { idx in
+            EditorTab(
+                url: URL(fileURLWithPath: "/file\(idx).swift"),
+                content: "func method\(idx)() { let value\(idx) = \(idx) }",
+                savedContent: ""
+            )
+        }
+
+        // Run collectWords concurrently from multiple threads
+        await withTaskGroup(of: [String].self) { group in
+            for iteration in 0..<20 {
+                group.addTask {
+                    WordCompletionProvider.collectWords(
+                        from: tabs,
+                        excluding: "method\(iteration % 10)",
+                        projectID: "/testProject"
+                    )
+                }
+            }
+            for await result in group {
+                // Just verify it returned without crashing and has some words
+                #expect(!result.isEmpty)
+            }
+        }
+    }
+
+    @Test func concurrentCacheAccessDoesNotCrash() async {
+        // Stress test: concurrent reads and writes to the cache
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/stress.swift"),
+            content: "alpha beta gamma delta epsilon",
+            savedContent: ""
+        )
+
+        await withTaskGroup(of: Void.self) { group in
+            // Concurrent collectors
+            for _ in 0..<10 {
+                group.addTask {
+                    _ = WordCompletionProvider.collectWords(
+                        from: [tab], excluding: "", projectID: "/stress"
+                    )
+                }
+            }
+            // Concurrent cache clears
+            for _ in 0..<5 {
+                group.addTask {
+                    WordCompletionProvider.clearCache()
+                }
+            }
+            // More concurrent collectors
+            for _ in 0..<10 {
+                group.addTask {
+                    _ = WordCompletionProvider.collectWords(
+                        from: [tab], excluding: "", projectID: "/stress"
+                    )
+                }
+            }
+        }
+        // If we got here without a crash, the test passes
+    }
+
+    // MARK: - completionsFromCache (async path)
+
+    @Test func completionsFromCacheReturnsCachedResults() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/test.swift"),
+            content: "func hello world test",
+            savedContent: ""
+        )
+        // Prime the cache via collectWords
+        _ = WordCompletionProvider.collectWords(from: [tab], excluding: "", projectID: "/test")
+
+        // Now use completionsFromCache — should return from cache immediately
+        let snapshot = WordCompletionProvider.TabSnapshot(
+            id: tab.id,
+            content: tab.content,
+            contentVersion: tab.contentVersion,
+            kind: tab.kind
+        )
+        let results = WordCompletionProvider.completionsFromCache(
+            tabSnapshots: [snapshot],
+            excluding: "",
+            projectID: "/test"
+        )
+        #expect(results.contains("hello"))
+        #expect(results.contains("world"))
+        #expect(results.contains("func"))
+        #expect(results.contains("test"))
+    }
+
+    @Test func completionsFromCacheReturnsEmptyOnFirstCallForNewProject() {
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/new.swift"),
+            content: "func brand_new_word() {}",
+            savedContent: ""
+        )
+        let snapshot = WordCompletionProvider.TabSnapshot(
+            id: tab.id,
+            content: tab.content,
+            contentVersion: tab.contentVersion,
+            kind: tab.kind
+        )
+        // First call with no cache — returns empty (or last known) and schedules background scan
+        let results = WordCompletionProvider.completionsFromCache(
+            tabSnapshots: [snapshot],
+            excluding: "",
+            projectID: "/brand_new_project"
+        )
+        // May be empty on first call since cache is cold
+        // This is expected behavior — next call will have results
+        #expect(results.isEmpty || results.contains("brand_new_word"))
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `WordCompletionProvider` that collects unique words (3+ chars) from all open editor tabs and provides prefix-filtered completions sorted by frequency
- Overrides `completions(forPartialWordRange:indexOfSelectedItem:)` in `GutterTextView` to hook into NSTextView's native completion popup (Escape / Cmd+.)
- Passes `TabManager` reference through `CodeEditorView` to `GutterTextView` via a weak property

Closes #307

## Test plan
- [x] 16 unit tests covering: empty tabs, single/multi tab collection, word length filtering, current word exclusion, case-insensitive exclusion, cross-tab deduplication, special characters (underscores/numbers), frequency-based sorting, preview tab skipping, large text, prefix matching (case-insensitive), empty/no-match prefix, order preservation
- [ ] Manual: open multiple files, type partial word, press Escape — verify completion popup shows words from other open tabs