### PR TITLE
feat: add symbol navigator for quick jump to functions and classes

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -77,6 +77,12 @@ enum AccessibilityID {
     static let quickOpenResultsList = "quickOpenResultsList"
     static func quickOpenItem(_ name: String) -> String { "quickOpenItem_\(name)" }
 
+    // MARK: - Symbol Navigator
+    static let symbolNavigatorOverlay = "symbolNavigatorOverlay"
+    static let symbolSearchField = "symbolSearchField"
+    static let symbolResultsList = "symbolResultsList"
+    static func symbolItem(_ name: String) -> String { "symbolItem_\(name)" }
+
     // MARK: - Status bar
     static let statusBar = "statusBar"
     static let terminalToggleButton = "terminalToggleButton"

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -33,6 +33,7 @@ struct ContentView: View {
     @State var showRecoveryDialog = false
     @State var isDragTargeted = false
     @State var isQuickOpenPresented = false
+    @State var isSymbolNavigatorPresented = false
     @State var showGoToLine = false
     @AppStorage("minimapVisible") var isMinimapVisible = true
     @AppStorage(BlameConstants.storageKey) var isBlameVisible = true
@@ -121,6 +122,18 @@ struct ContentView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .showQuickOpen)) { _ in
             isQuickOpenPresented = true
+        }
+        .sheet(isPresented: $isSymbolNavigatorPresented) {
+            SymbolNavigatorView(isPresented: $isSymbolNavigatorPresented)
+                .environment(projectManager)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .showSymbolNavigator)) { _ in
+            guard tabManager.activeTab != nil else { return }
+            isSymbolNavigatorPresented = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .symbolNavigate)) { notification in
+            guard let offset = notification.userInfo?["offset"] as? Int else { return }
+            goToLineOffset = GoToRequest(offset: offset)
         }
         .sheet(isPresented: $showGoToLine) {
             GoToLineView(

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -23,6 +23,7 @@ enum MenuIcons {
     static let findAndReplace = "arrow.left.arrow.right"
     static let findInProject = "magnifyingglass"
     static let goToLine = "number"
+    static let symbolNavigator = "list.bullet.indent"
     static let nextChange = "chevron.down"
     static let previousChange = "chevron.up"
     static let foldCode = "chevron.down.square"

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -64,6 +64,14 @@ struct PineApp: App {
                 }
                 .keyboardShortcut("p", modifiers: .command)
                 .disabled(focusedProject?.workspace.rootURL == nil)
+
+                Button {
+                    NotificationCenter.default.post(name: .showSymbolNavigator, object: nil)
+                } label: {
+                    Label(Strings.menuSymbolNavigator, systemImage: MenuIcons.symbolNavigator)
+                }
+                .keyboardShortcut("r", modifiers: .command)
+                .disabled(focusedProject?.tabManager.activeTab == nil)
             }
             // View menu — add items to the existing system View menu
             CommandGroup(after: .toolbar) {
@@ -1182,4 +1190,7 @@ extension Notification.Name {
     static let goToLine = Notification.Name("goToLine")
     // Word Wrap toggle (issue #416)
     static let toggleWordWrap = Notification.Name("toggleWordWrap")
+    // Symbol Navigation (issue #306)
+    static let showSymbolNavigator = Notification.Name("showSymbolNavigator")
+    static let symbolNavigate = Notification.Name("symbolNavigate")
 }

--- a/Pine/QuickOpenView.swift
+++ b/Pine/QuickOpenView.swift
@@ -167,6 +167,7 @@ struct QuickOpenView: View {
 /// while redirecting navigation keys to the Quick Open list.
 struct QuickOpenSearchField: NSViewRepresentable {
     @Binding var text: String
+    var placeholder: String = String(localized: "quickOpen.placeholder")
     var onArrowUp: () -> Void
     var onArrowDown: () -> Void
     var onReturn: () -> Void
@@ -176,7 +177,7 @@ struct QuickOpenSearchField: NSViewRepresentable {
         let field = NSTextField()
         field.delegate = context.coordinator
         field.font = .systemFont(ofSize: 14)
-        field.placeholderString = String(localized: "quickOpen.placeholder")
+        field.placeholderString = placeholder
         field.bezelStyle = .roundedBezel
         field.focusRingType = .exterior
         field.cell?.sendsActionOnEndEditing = false

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -143,6 +143,13 @@ enum Strings {
     static let quickOpenNoResults: LocalizedStringKey = "quickOpen.noResults"
     static let quickOpenRecentEmpty: LocalizedStringKey = "quickOpen.recentEmpty"
 
+    // MARK: - Symbol Navigator
+
+    static let menuSymbolNavigator: LocalizedStringKey = "menu.symbolNavigator"
+    static let symbolNavigatorEmpty: LocalizedStringKey = "symbolNavigator.empty"
+    static let symbolNavigatorNoResults: LocalizedStringKey = "symbolNavigator.noResults"
+    static let symbolNavigatorPlaceholder: LocalizedStringKey = "symbolNavigator.placeholder"
+
     // MARK: - Branch Switcher
 
     static let branchFilterPlaceholder: LocalizedStringKey = "branch.filterPlaceholder"

--- a/Pine/SymbolNavigatorView.swift
+++ b/Pine/SymbolNavigatorView.swift
@@ -1,0 +1,172 @@
+//
+//  SymbolNavigatorView.swift
+//  Pine
+//
+//  Symbol navigation sheet for jumping to functions, classes, etc. (Cmd+Shift+R).
+//
+
+import SwiftUI
+
+struct SymbolNavigatorView: View {
+    @Environment(ProjectManager.self) var projectManager
+    @Binding var isPresented: Bool
+    @State private var searchText = ""
+    @State private var selectedIndex = 0
+    @State private var allSymbols: [DocumentSymbol] = []
+    @State private var filteredSymbols: [DocumentSymbol] = []
+
+    var body: some View {
+        VStack(spacing: 0) {
+            QuickOpenSearchField(
+                text: $searchText,
+                placeholder: String(localized: "symbolNavigator.placeholder"),
+                onArrowUp: { moveSelection(by: -1) },
+                onArrowDown: { moveSelection(by: 1) },
+                onReturn: { navigateToSelected() },
+                onEscape: { isPresented = false }
+            )
+            .accessibilityIdentifier(AccessibilityID.symbolSearchField)
+            .padding(10)
+
+            Divider()
+            resultsList
+        }
+        .frame(width: 500, height: 360)
+        .onAppear {
+            loadSymbols()
+        }
+        .onChange(of: searchText) { _, _ in
+            updateFilteredSymbols()
+        }
+        .accessibilityIdentifier(AccessibilityID.symbolNavigatorOverlay)
+    }
+
+    // MARK: - Results List
+
+    private var resultsList: some View {
+        Group {
+            if filteredSymbols.isEmpty {
+                emptyState
+                    .transition(PineAnimation.fadeTransition)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 0) {
+                            ForEach(Array(filteredSymbols.enumerated()), id: \.element.id) { index, symbol in
+                                symbolRow(symbol, isSelected: index == selectedIndex)
+                                    .id(index)
+                                    .onTapGesture {
+                                        selectedIndex = index
+                                        navigateToSymbol(symbol)
+                                    }
+                            }
+                        }
+                    }
+                    .onChange(of: selectedIndex) { _, newIndex in
+                        proxy.scrollTo(newIndex, anchor: .center)
+                    }
+                }
+            }
+        }
+        .animation(PineAnimation.content, value: filteredSymbols.isEmpty)
+        .accessibilityIdentifier(AccessibilityID.symbolResultsList)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Spacer()
+            if searchText.isEmpty {
+                Text(Strings.symbolNavigatorEmpty)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            } else {
+                Text(Strings.symbolNavigatorNoResults)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func symbolRow(_ symbol: DocumentSymbol, isSelected: Bool) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: symbol.kind.iconName)
+                .font(.system(size: 14))
+                .foregroundStyle(colorForKind(symbol.kind))
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(symbol.name)
+                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Text("\(symbol.kind.displayName) — line \(symbol.line)")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 5)
+        .background(isSelected ? Color.accentColor.opacity(0.2) : Color.clear)
+        .contentShape(Rectangle())
+        .accessibilityIdentifier(AccessibilityID.symbolItem(symbol.name))
+    }
+
+    // MARK: - Actions
+
+    private func loadSymbols() {
+        guard let tab = projectManager.tabManager.activeTab else { return }
+        let ext = tab.url.pathExtension
+        allSymbols = SymbolParser.parse(content: tab.content, fileExtension: ext)
+        filteredSymbols = allSymbols
+        selectedIndex = 0
+    }
+
+    private func updateFilteredSymbols() {
+        if searchText.isEmpty {
+            filteredSymbols = allSymbols
+        } else {
+            filteredSymbols = SymbolParser.filter(allSymbols, query: searchText)
+        }
+        selectedIndex = 0
+    }
+
+    private func moveSelection(by delta: Int) {
+        guard !filteredSymbols.isEmpty else { return }
+        selectedIndex = max(0, min(filteredSymbols.count - 1, selectedIndex + delta))
+    }
+
+    private func navigateToSelected() {
+        guard selectedIndex < filteredSymbols.count else { return }
+        navigateToSymbol(filteredSymbols[selectedIndex])
+    }
+
+    private func navigateToSymbol(_ symbol: DocumentSymbol) {
+        guard let tab = projectManager.tabManager.activeTab else { return }
+        let offset = ContentView.cursorOffset(forLine: symbol.line, in: tab.content)
+        NotificationCenter.default.post(
+            name: .symbolNavigate,
+            object: nil,
+            userInfo: ["offset": offset]
+        )
+        isPresented = false
+    }
+
+    // MARK: - Helpers
+
+    private func colorForKind(_ kind: SymbolKind) -> Color {
+        switch kind {
+        case .class: .purple
+        case .struct: .blue
+        case .enum: .orange
+        case .protocol, .interface: .green
+        case .function: .cyan
+        case .property: .secondary
+        }
+    }
+}

--- a/Pine/SymbolParser.swift
+++ b/Pine/SymbolParser.swift
@@ -1,0 +1,442 @@
+//
+//  SymbolParser.swift
+//  Pine
+//
+//  Regex-based symbol extraction for symbol navigation (Cmd+Shift+R).
+//
+
+import Foundation
+
+/// A symbol extracted from source code.
+struct DocumentSymbol: Identifiable, Equatable {
+    let id = UUID()
+    let name: String
+    let kind: SymbolKind
+    /// 1-based line number where the symbol is defined.
+    let line: Int
+
+    static func == (lhs: DocumentSymbol, rhs: DocumentSymbol) -> Bool {
+        lhs.name == rhs.name && lhs.kind == rhs.kind && lhs.line == rhs.line
+    }
+}
+
+/// The kind of a document symbol.
+enum SymbolKind: String, CaseIterable, Comparable {
+    case `class`
+    case `struct`
+    case `enum`
+    case `protocol`
+    case interface
+    case function
+    case property
+
+    var displayName: String {
+        switch self {
+        case .class: "Class"
+        case .struct: "Struct"
+        case .enum: "Enum"
+        case .protocol: "Protocol"
+        case .interface: "Interface"
+        case .function: "Function"
+        case .property: "Property"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .class: "c.square"
+        case .struct: "s.square"
+        case .enum: "e.square"
+        case .protocol: "p.square"
+        case .interface: "i.square"
+        case .function: "f.square"
+        case .property: "v.square"
+        }
+    }
+
+    /// Sort order for grouping symbols by kind.
+    static func < (lhs: SymbolKind, rhs: SymbolKind) -> Bool {
+        lhs.sortOrder < rhs.sortOrder
+    }
+
+    private var sortOrder: Int {
+        switch self {
+        case .class: 0
+        case .struct: 1
+        case .enum: 2
+        case .protocol: 3
+        case .interface: 4
+        case .function: 5
+        case .property: 6
+        }
+    }
+}
+
+/// Parses source code to extract symbols (functions, classes, structs, etc.).
+/// Uses regex-based extraction and skips symbols inside comments and strings.
+enum SymbolParser {
+
+    // MARK: - Public API
+
+    /// Extracts symbols from source code based on file extension.
+    /// - Parameters:
+    ///   - content: The source code text.
+    ///   - fileExtension: The file extension (e.g. "swift", "py", "js").
+    /// - Returns: An array of symbols sorted by line number.
+    static func parse(content: String, fileExtension: String) -> [DocumentSymbol] {
+        let rules = symbolRules(for: fileExtension.lowercased())
+        guard !rules.isEmpty else { return [] }
+
+        let excludedRanges = computeExcludedRanges(in: content, fileExtension: fileExtension)
+        var symbols: [DocumentSymbol] = []
+
+        for rule in rules {
+            let nsContent = content as NSString
+            let fullRange = NSRange(location: 0, length: nsContent.length)
+
+            rule.regex.enumerateMatches(in: content, range: fullRange) { match, _, _ in
+                guard let match else { return }
+
+                // Skip matches inside comments or strings
+                if isInsideExcludedRange(match.range, excludedRanges: excludedRanges) {
+                    return
+                }
+
+                // Extract the symbol name from capture group 1
+                guard match.numberOfRanges > 1,
+                      match.range(at: 1).location != NSNotFound else { return }
+
+                let nameRange = match.range(at: 1)
+                let name = nsContent.substring(with: nameRange)
+                let line = lineNumber(at: nameRange.location, in: content)
+
+                symbols.append(DocumentSymbol(name: name, kind: rule.kind, line: line))
+            }
+        }
+
+        symbols.sort { $0.line < $1.line }
+        return symbols
+    }
+
+    /// Filters symbols using fuzzy subsequence matching (reuses QuickOpenProvider logic).
+    static func filter(_ symbols: [DocumentSymbol], query: String) -> [DocumentSymbol] {
+        guard !query.isEmpty else { return symbols }
+        let queryLower = query.lowercased()
+        return symbols.filter {
+            QuickOpenProvider.isSubsequence(queryLower, of: $0.name.lowercased())
+        }
+    }
+
+    // MARK: - Symbol Rules
+
+    private struct SymbolRule {
+        let regex: NSRegularExpression
+        let kind: SymbolKind
+    }
+
+    /// Returns compiled regex rules for the given file extension.
+    private static func symbolRules(for ext: String) -> [SymbolRule] {
+        switch ext {
+        case "swift":
+            return swiftRules
+        case "py", "pyw":
+            return pythonRules
+        case "js", "jsx", "mjs":
+            return javascriptRules
+        case "ts", "tsx":
+            return typescriptRules
+        case "go":
+            return goRules
+        case "rb":
+            return rubyRules
+        case "rs":
+            return rustRules
+        case "java", "kt", "kts":
+            return javaKotlinRules
+        default:
+            return []
+        }
+    }
+
+    // MARK: - Language-specific rules
+
+    // swiftlint:disable force_try
+
+    private static let swiftRules: [SymbolRule] = [
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:(?:public|private|internal|fileprivate|open|final|static|override|@\w+)\s+)*class\s+(\w+)"#
+            ),
+            kind: .class
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:(?:public|private|internal|fileprivate|open|final|static)\s+)*struct\s+(\w+)"#
+            ),
+            kind: .struct
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:(?:public|private|internal|fileprivate|open)\s+)*enum\s+(\w+)"#
+            ),
+            kind: .enum
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:(?:public|private|internal|fileprivate|open)\s+)*protocol\s+(\w+)"#
+            ),
+            kind: .protocol
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:(?:public|private|internal|fileprivate|open|final|static|override|@\w+|mutating)\s+)*func\s+(\w+)"#
+            ),
+            kind: .function
+        ),
+    ]
+
+    private static let pythonRules: [SymbolRule] = [
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*class\s+(\w+)"#
+            ),
+            kind: .class
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:async\s+)?def\s+(\w+)"#
+            ),
+            kind: .function
+        ),
+    ]
+
+    private static let javascriptRules: [SymbolRule] = [
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*class\s+(\w+)"#
+            ),
+            kind: .class
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:async\s+)?function\s*\*?\s+(\w+)"#
+            ),
+            kind: .function
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?\([^)]*\)\s*=>"#
+            ),
+            kind: .function
+        ),
+    ]
+
+    private static let typescriptRules: [SymbolRule] = [
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:export\s+)?(?:abstract\s+)?class\s+(\w+)"#
+            ),
+            kind: .class
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:export\s+)?interface\s+(\w+)"#
+            ),
+            kind: .interface
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:export\s+)?enum\s+(\w+)"#
+            ),
+            kind: .enum
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:export\s+)?(?:async\s+)?function\s*\*?\s+(\w+)"#
+            ),
+            kind: .function
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?\([^)]*\)\s*=>"#
+            ),
+            kind: .function
+        ),
+    ]
+
+    private static let goRules: [SymbolRule] = [
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*type\s+(\w+)\s+struct\b"#
+            ),
+            kind: .struct
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*type\s+(\w+)\s+interface\b"#
+            ),
+            kind: .interface
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*func\s+(?:\([^)]*\)\s+)?(\w+)"#
+            ),
+            kind: .function
+        ),
+    ]
+
+    private static let rubyRules: [SymbolRule] = [
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*class\s+(\w+)"#
+            ),
+            kind: .class
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*module\s+(\w+)"#
+            ),
+            kind: .class
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*def\s+(?:self\.)?(\w+[?!]?)"#
+            ),
+            kind: .function
+        ),
+    ]
+
+    private static let rustRules: [SymbolRule] = [
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:pub(?:\([^)]*\))?\s+)?struct\s+(\w+)"#
+            ),
+            kind: .struct
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:pub(?:\([^)]*\))?\s+)?enum\s+(\w+)"#
+            ),
+            kind: .enum
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:pub(?:\([^)]*\))?\s+)?trait\s+(\w+)"#
+            ),
+            kind: .protocol
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+(\w+)"#
+            ),
+            kind: .function
+        ),
+    ]
+
+    private static let javaKotlinRules: [SymbolRule] = [
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:(?:public|private|protected|abstract|final|static)\s+)*class\s+(\w+)"#
+            ),
+            kind: .class
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:(?:public|private|protected)\s+)?interface\s+(\w+)"#
+            ),
+            kind: .interface
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:(?:public|private|protected)\s+)?enum\s+(\w+)"#
+            ),
+            kind: .enum
+        ),
+        SymbolRule(
+            regex: try! NSRegularExpression(
+                pattern: #"(?:^|\n)\s*(?:(?:public|private|protected|abstract|final|static|override|suspend)\s+)*fun\s+(\w+)"#
+            ),
+            kind: .function
+        ),
+    ]
+
+    // swiftlint:enable force_try
+
+    // MARK: - Comment/String Exclusion
+
+    /// Computes ranges that should be excluded (comments and strings).
+    private static func computeExcludedRanges(in content: String, fileExtension: String) -> [NSRange] {
+        var ranges: [NSRange] = []
+        let nsContent = content as NSString
+        let fullRange = NSRange(location: 0, length: nsContent.length)
+
+        // Determine comment patterns based on file extension
+        let patterns: [String]
+        switch fileExtension.lowercased() {
+        case "swift", "js", "jsx", "ts", "tsx", "java", "kt", "kts", "go", "rs":
+            patterns = [
+                #"//[^\n]*"#,                   // single-line comment
+                #"/\*[\s\S]*?\*/"#,             // block comment
+                #""(?:[^"\\]|\\.)*""#,          // double-quoted string
+                #"'(?:[^'\\]|\\.)*'"#,          // single-quoted string (JS/Java)
+            ]
+        case "py", "pyw":
+            patterns = [
+                #"#[^\n]*"#,                    // single-line comment
+                #"\"\"\"[\s\S]*?\"\"\""#,       // triple-double-quoted string
+                #"'''[\s\S]*?'''"#,             // triple-single-quoted string
+                #""(?:[^"\\]|\\.)*""#,          // double-quoted string
+                #"'(?:[^'\\]|\\.)*'"#,          // single-quoted string
+            ]
+        case "rb":
+            patterns = [
+                #"#[^\n]*"#,                    // single-line comment
+                #""(?:[^"\\]|\\.)*""#,          // double-quoted string
+                #"'(?:[^'\\]|\\.)*'"#,          // single-quoted string
+            ]
+        default:
+            patterns = [
+                #"//[^\n]*"#,
+                #"/\*[\s\S]*?\*/"#,
+                #""(?:[^"\\]|\\.)*""#,
+            ]
+        }
+
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            let matches = regex.matches(in: content, range: fullRange)
+            for match in matches {
+                ranges.append(match.range)
+            }
+        }
+
+        return ranges
+    }
+
+    /// Checks if a match range falls inside any excluded range.
+    private static func isInsideExcludedRange(_ range: NSRange, excludedRanges: [NSRange]) -> Bool {
+        let matchStart = range.location
+        for excluded in excludedRanges {
+            let exStart = excluded.location
+            let exEnd = exStart + excluded.length
+            if matchStart >= exStart && matchStart < exEnd {
+                return true
+            }
+        }
+        return false
+    }
+
+    // MARK: - Line Number Computation
+
+    /// Computes the 1-based line number for a character offset.
+    static func lineNumber(at offset: Int, in content: String) -> Int {
+        var line = 1
+        var currentOffset = 0
+        for char in content {
+            if currentOffset >= offset { break }
+            if char == "\n" { line += 1 }
+            currentOffset += char.utf16.count
+        }
+        return line
+    }
+}

--- a/PineTests/SymbolParserTests.swift
+++ b/PineTests/SymbolParserTests.swift
@@ -1,0 +1,459 @@
+//
+//  SymbolParserTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("SymbolParser Tests")
+struct SymbolParserTests {
+
+    // MARK: - Swift
+
+    @Test("Swift: parses functions")
+    func swiftFunctions() {
+        let code = """
+        func hello() {
+        }
+        public func world() {
+        }
+        private static func helper() {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "swift")
+        let funcs = symbols.filter { $0.kind == .function }
+        #expect(funcs.count == 3)
+        #expect(funcs[0].name == "hello")
+        #expect(funcs[1].name == "world")
+        #expect(funcs[2].name == "helper")
+    }
+
+    @Test("Swift: parses classes")
+    func swiftClasses() {
+        let code = """
+        class MyClass {
+        }
+        public final class AnotherClass {
+        }
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "swift")
+        let classes = symbols.filter { $0.kind == .class }
+        #expect(classes.count == 2)
+        #expect(classes[0].name == "MyClass")
+        #expect(classes[1].name == "AnotherClass")
+    }
+
+    @Test("Swift: parses structs")
+    func swiftStructs() {
+        let code = """
+        struct Point {
+            var x: Int
+            var y: Int
+        }
+        public struct Size {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "swift")
+        let structs = symbols.filter { $0.kind == .struct }
+        #expect(structs.count == 2)
+        #expect(structs[0].name == "Point")
+        #expect(structs[1].name == "Size")
+    }
+
+    @Test("Swift: parses enums")
+    func swiftEnums() {
+        let code = """
+        enum Direction {
+            case north, south
+        }
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "swift")
+        let enums = symbols.filter { $0.kind == .enum }
+        #expect(enums.count == 1)
+        #expect(enums[0].name == "Direction")
+    }
+
+    @Test("Swift: parses protocols")
+    func swiftProtocols() {
+        let code = """
+        protocol Drawable {
+            func draw()
+        }
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "swift")
+        let protocols = symbols.filter { $0.kind == .protocol }
+        #expect(protocols.count == 1)
+        #expect(protocols[0].name == "Drawable")
+        // Also check the nested function
+        let funcs = symbols.filter { $0.kind == .function }
+        #expect(funcs.count == 1)
+        #expect(funcs[0].name == "draw")
+    }
+
+    @Test("Swift: parses all symbol kinds together")
+    func swiftAllKinds() {
+        let code = """
+        class Foo {}
+        struct Bar {}
+        enum Baz {}
+        protocol Qux {}
+        func doStuff() {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "swift")
+        #expect(symbols.count == 5)
+        #expect(symbols[0].kind == .class)
+        #expect(symbols[1].kind == .struct)
+        #expect(symbols[2].kind == .enum)
+        #expect(symbols[3].kind == .protocol)
+        #expect(symbols[4].kind == .function)
+    }
+
+    // MARK: - Python
+
+    @Test("Python: parses classes and functions")
+    func pythonSymbols() {
+        let code = """
+        class MyClass:
+            def method(self):
+                pass
+
+        def standalone():
+            pass
+
+        async def async_func():
+            pass
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "py")
+        let classes = symbols.filter { $0.kind == .class }
+        let funcs = symbols.filter { $0.kind == .function }
+        #expect(classes.count == 1)
+        #expect(classes[0].name == "MyClass")
+        #expect(funcs.count == 3)
+        #expect(funcs[0].name == "method")
+        #expect(funcs[1].name == "standalone")
+        #expect(funcs[2].name == "async_func")
+    }
+
+    @Test("Python: nested function")
+    func pythonNestedFunction() {
+        let code = """
+        def outer():
+            def inner():
+                pass
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "py")
+        let funcs = symbols.filter { $0.kind == .function }
+        #expect(funcs.count == 2)
+        #expect(funcs[0].name == "outer")
+        #expect(funcs[1].name == "inner")
+    }
+
+    // MARK: - JavaScript
+
+    @Test("JavaScript: parses functions and classes")
+    func javascriptSymbols() {
+        let code = """
+        class App {
+        }
+
+        function render() {}
+
+        const handler = () => {}
+
+        export const fetchData = async (url) => {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "js")
+        let classes = symbols.filter { $0.kind == .class }
+        let funcs = symbols.filter { $0.kind == .function }
+        #expect(classes.count == 1)
+        #expect(classes[0].name == "App")
+        #expect(funcs.count == 3)
+        #expect(funcs[0].name == "render")
+        #expect(funcs[1].name == "handler")
+        #expect(funcs[2].name == "fetchData")
+    }
+
+    // MARK: - TypeScript
+
+    @Test("TypeScript: parses interfaces and enums")
+    func typescriptSymbols() {
+        let code = """
+        export interface User {
+            name: string;
+        }
+
+        export enum Status {
+            Active,
+            Inactive,
+        }
+
+        export class Service {}
+
+        export function init() {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "ts")
+        #expect(symbols.contains { $0.name == "User" && $0.kind == .interface })
+        #expect(symbols.contains { $0.name == "Status" && $0.kind == .enum })
+        #expect(symbols.contains { $0.name == "Service" && $0.kind == .class })
+        #expect(symbols.contains { $0.name == "init" && $0.kind == .function })
+    }
+
+    // MARK: - Comment Exclusion
+
+    @Test("Skips symbols inside single-line comments")
+    func skipsSingleLineComments() {
+        let code = """
+        // func commentedOut() {}
+        func realFunction() {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "swift")
+        #expect(symbols.count == 1)
+        #expect(symbols[0].name == "realFunction")
+    }
+
+    @Test("Skips symbols inside block comments")
+    func skipsBlockComments() {
+        let code = """
+        /* class CommentedClass {} */
+        class RealClass {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "swift")
+        let classes = symbols.filter { $0.kind == .class }
+        #expect(classes.count == 1)
+        #expect(classes[0].name == "RealClass")
+    }
+
+    @Test("Skips symbols inside Python comments")
+    func skipsPythonComments() {
+        let code = """
+        # def commented():
+        #     pass
+        def real():
+            pass
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "py")
+        #expect(symbols.count == 1)
+        #expect(symbols[0].name == "real")
+    }
+
+    // MARK: - String Exclusion
+
+    @Test("Skips symbols inside strings")
+    func skipsStrings() {
+        let code = """
+        let msg = "func fakeFunction() {}"
+        func realFunction() {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "swift")
+        let funcs = symbols.filter { $0.kind == .function }
+        #expect(funcs.count == 1)
+        #expect(funcs[0].name == "realFunction")
+    }
+
+    @Test("Skips symbols inside Python triple-quoted strings")
+    func skipsPythonTripleQuotedStrings() {
+        let code = "\"\"\"def fake():\n    pass\"\"\"\ndef real():\n    pass"
+        let symbols = SymbolParser.parse(content: code, fileExtension: "py")
+        #expect(symbols.count == 1)
+        #expect(symbols[0].name == "real")
+    }
+
+    // MARK: - Fuzzy Matching
+
+    @Test("Fuzzy filter: exact match")
+    func fuzzyExact() {
+        let symbols = [
+            DocumentSymbol(name: "viewDidLoad", kind: .function, line: 1),
+            DocumentSymbol(name: "viewWillAppear", kind: .function, line: 5),
+        ]
+        let filtered = SymbolParser.filter(symbols, query: "viewDidLoad")
+        #expect(filtered.count == 1)
+        #expect(filtered[0].name == "viewDidLoad")
+    }
+
+    @Test("Fuzzy filter: subsequence match")
+    func fuzzySubsequence() {
+        let symbols = [
+            DocumentSymbol(name: "viewDidLoad", kind: .function, line: 1),
+            DocumentSymbol(name: "viewWillAppear", kind: .function, line: 5),
+            DocumentSymbol(name: "setupConstraints", kind: .function, line: 10),
+        ]
+        let filtered = SymbolParser.filter(symbols, query: "vdl")
+        #expect(filtered.count == 1)
+        #expect(filtered[0].name == "viewDidLoad")
+    }
+
+    @Test("Fuzzy filter: empty query returns all")
+    func fuzzyEmptyQuery() {
+        let symbols = [
+            DocumentSymbol(name: "foo", kind: .function, line: 1),
+            DocumentSymbol(name: "bar", kind: .function, line: 2),
+        ]
+        let filtered = SymbolParser.filter(symbols, query: "")
+        #expect(filtered.count == 2)
+    }
+
+    @Test("Fuzzy filter: case insensitive")
+    func fuzzyCaseInsensitive() {
+        let symbols = [
+            DocumentSymbol(name: "MyClass", kind: .class, line: 1),
+        ]
+        let filtered = SymbolParser.filter(symbols, query: "myclass")
+        #expect(filtered.count == 1)
+    }
+
+    // MARK: - Empty File
+
+    @Test("Empty file returns no symbols")
+    func emptyFile() {
+        let symbols = SymbolParser.parse(content: "", fileExtension: "swift")
+        #expect(symbols.isEmpty)
+    }
+
+    @Test("Whitespace-only file returns no symbols")
+    func whitespaceOnlyFile() {
+        let symbols = SymbolParser.parse(content: "   \n\n   \n", fileExtension: "swift")
+        #expect(symbols.isEmpty)
+    }
+
+    // MARK: - Unsupported Extension
+
+    @Test("Unsupported extension returns no symbols")
+    func unsupportedExtension() {
+        let code = "func foo() {}"
+        let symbols = SymbolParser.parse(content: code, fileExtension: "txt")
+        #expect(symbols.isEmpty)
+    }
+
+    // MARK: - Nested Functions
+
+    @Test("Swift: nested functions are both extracted")
+    func swiftNestedFunctions() {
+        let code = """
+        func outer() {
+            func inner() {
+                func deeplyNested() {}
+            }
+        }
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "swift")
+        let funcs = symbols.filter { $0.kind == .function }
+        #expect(funcs.count == 3)
+        #expect(funcs[0].name == "outer")
+        #expect(funcs[1].name == "inner")
+        #expect(funcs[2].name == "deeplyNested")
+    }
+
+    // MARK: - Line Numbers
+
+    @Test("Line numbers are correct")
+    func lineNumbers() {
+        let code = """
+        class Foo {
+            func bar() {}
+        }
+
+        func baz() {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "swift")
+        #expect(symbols[0].line == 1) // class Foo
+        #expect(symbols[1].line == 2) // func bar
+        #expect(symbols[2].line == 5) // func baz
+    }
+
+    // MARK: - Go
+
+    @Test("Go: parses structs, interfaces, and functions")
+    func goSymbols() {
+        let code = """
+        type Server struct {
+            Port int
+        }
+
+        type Handler interface {
+            Handle()
+        }
+
+        func main() {}
+
+        func (s *Server) Start() {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "go")
+        #expect(symbols.contains { $0.name == "Server" && $0.kind == .struct })
+        #expect(symbols.contains { $0.name == "Handler" && $0.kind == .interface })
+        #expect(symbols.contains { $0.name == "main" && $0.kind == .function })
+        #expect(symbols.contains { $0.name == "Start" && $0.kind == .function })
+    }
+
+    // MARK: - Rust
+
+    @Test("Rust: parses structs, enums, traits, and functions")
+    func rustSymbols() {
+        let code = """
+        pub struct Config {
+            pub name: String,
+        }
+
+        enum Color {
+            Red,
+            Green,
+        }
+
+        pub trait Display {
+            fn fmt(&self);
+        }
+
+        pub async fn serve() {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "rs")
+        #expect(symbols.contains { $0.name == "Config" && $0.kind == .struct })
+        #expect(symbols.contains { $0.name == "Color" && $0.kind == .enum })
+        #expect(symbols.contains { $0.name == "Display" && $0.kind == .protocol })
+        #expect(symbols.contains { $0.name == "serve" && $0.kind == .function })
+        #expect(symbols.contains { $0.name == "fmt" && $0.kind == .function })
+    }
+
+    // MARK: - SymbolKind
+
+    @Test("SymbolKind: sort order is stable")
+    func symbolKindSorting() {
+        let kinds: [SymbolKind] = [.function, .class, .enum, .struct, .protocol]
+        let sorted = kinds.sorted()
+        #expect(sorted == [.class, .struct, .enum, .protocol, .function])
+    }
+
+    @Test("SymbolKind: displayName is non-empty")
+    func symbolKindDisplayName() {
+        for kind in SymbolKind.allCases {
+            #expect(!kind.displayName.isEmpty)
+        }
+    }
+
+    @Test("SymbolKind: iconName is non-empty")
+    func symbolKindIconName() {
+        for kind in SymbolKind.allCases {
+            #expect(!kind.iconName.isEmpty)
+        }
+    }
+
+    // MARK: - lineNumber helper
+
+    @Test("lineNumber: first character is line 1")
+    func lineNumberFirstChar() {
+        let content = "hello\nworld"
+        #expect(SymbolParser.lineNumber(at: 0, in: content) == 1)
+    }
+
+    @Test("lineNumber: second line")
+    func lineNumberSecondLine() {
+        let content = "hello\nworld"
+        // offset 6 = 'w' on line 2
+        #expect(SymbolParser.lineNumber(at: 6, in: content) == 2)
+    }
+
+    @Test("lineNumber: empty content")
+    func lineNumberEmptyContent() {
+        #expect(SymbolParser.lineNumber(at: 0, in: "") == 1)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #306

- Adds **Symbol Navigator** (Cmd+R) — a Quick Open–style sheet for jumping to functions, classes, structs, enums, protocols, and interfaces in the active file
- Regex-based `SymbolParser` with comment/string exclusion supports **8 languages**: Swift, Python, JavaScript, TypeScript, Go, Ruby, Rust, Java/Kotlin
- Fuzzy subsequence filtering (reuses `QuickOpenProvider.isSubsequence`), keyboard navigation (↑↓/Enter/Esc)
- Reuses `QuickOpenSearchField` with configurable placeholder

## Test plan

- [x] Unit tests: 30+ tests covering all 8 languages, comment/string exclusion, fuzzy filtering, line numbers, edge cases (empty file, unsupported extension, nested functions)
- [ ] Manual: open a Swift file → Cmd+R → verify symbols listed → type to filter → Enter to navigate → verify cursor jumps to correct line
- [ ] Manual: open files in other supported languages (Python, JS, TS, Go, Rust) and verify symbols are parsed correctly
- [ ] Manual: verify symbols inside comments and strings are excluded
- [ ] CI: all unit tests pass, SwiftLint clean