### PR TITLE
fix: rename DocumentSymbol/SymbolKind to resolve type ambiguity with swift-markdown

### DIFF
--- a/Pine/SymbolNavigatorView.swift
+++ b/Pine/SymbolNavigatorView.swift
@@ -12,8 +12,8 @@ struct SymbolNavigatorView: View {
     @Binding var isPresented: Bool
     @State private var searchText = ""
     @State private var selectedIndex = 0
-    @State private var allSymbols: [DocumentSymbol] = []
-    @State private var filteredSymbols: [DocumentSymbol] = []
+    @State private var allSymbols: [PineSymbol] = []
+    @State private var filteredSymbols: [PineSymbol] = []
 
     var body: some View {
         VStack(spacing: 0) {
@@ -89,7 +89,7 @@ struct SymbolNavigatorView: View {
         .frame(maxWidth: .infinity)
     }
 
-    private func symbolRow(_ symbol: DocumentSymbol, isSelected: Bool) -> some View {
+    private func symbolRow(_ symbol: PineSymbol, isSelected: Bool) -> some View {
         HStack(spacing: 8) {
             Image(systemName: symbol.kind.iconName)
                 .font(.system(size: 14))
@@ -146,7 +146,7 @@ struct SymbolNavigatorView: View {
         navigateToSymbol(filteredSymbols[selectedIndex])
     }
 
-    private func navigateToSymbol(_ symbol: DocumentSymbol) {
+    private func navigateToSymbol(_ symbol: PineSymbol) {
         guard let tab = projectManager.tabManager.activeTab else { return }
         let offset = ContentView.cursorOffset(forLine: symbol.line, in: tab.content)
         NotificationCenter.default.post(
@@ -159,7 +159,7 @@ struct SymbolNavigatorView: View {
 
     // MARK: - Helpers
 
-    private func colorForKind(_ kind: SymbolKind) -> Color {
+    private func colorForKind(_ kind: PineSymbolKind) -> Color {
         switch kind {
         case .class: .purple
         case .struct: .blue

--- a/Pine/SymbolParser.swift
+++ b/Pine/SymbolParser.swift
@@ -8,20 +8,20 @@
 import Foundation
 
 /// A symbol extracted from source code.
-struct DocumentSymbol: Identifiable, Equatable {
+struct PineSymbol: Identifiable, Equatable {
     let id = UUID()
     let name: String
-    let kind: SymbolKind
+    let kind: PineSymbolKind
     /// 1-based line number where the symbol is defined.
     let line: Int
 
-    static func == (lhs: DocumentSymbol, rhs: DocumentSymbol) -> Bool {
+    static func == (lhs: PineSymbol, rhs: PineSymbol) -> Bool {
         lhs.name == rhs.name && lhs.kind == rhs.kind && lhs.line == rhs.line
     }
 }
 
 /// The kind of a document symbol.
-enum SymbolKind: String, CaseIterable, Comparable {
+enum PineSymbolKind: String, CaseIterable, Comparable {
     case `class`
     case `struct`
     case `enum`
@@ -55,7 +55,7 @@ enum SymbolKind: String, CaseIterable, Comparable {
     }
 
     /// Sort order for grouping symbols by kind.
-    static func < (lhs: SymbolKind, rhs: SymbolKind) -> Bool {
+    static func < (lhs: PineSymbolKind, rhs: PineSymbolKind) -> Bool {
         lhs.sortOrder < rhs.sortOrder
     }
 
@@ -83,12 +83,12 @@ enum SymbolParser {
     ///   - content: The source code text.
     ///   - fileExtension: The file extension (e.g. "swift", "py", "js").
     /// - Returns: An array of symbols sorted by line number.
-    static func parse(content: String, fileExtension: String) -> [DocumentSymbol] {
+    static func parse(content: String, fileExtension: String) -> [PineSymbol] {
         let rules = symbolRules(for: fileExtension.lowercased())
         guard !rules.isEmpty else { return [] }
 
         let excludedRanges = computeExcludedRanges(in: content, fileExtension: fileExtension)
-        var symbols: [DocumentSymbol] = []
+        var symbols: [PineSymbol] = []
 
         for rule in rules {
             let nsContent = content as NSString
@@ -110,7 +110,7 @@ enum SymbolParser {
                 let name = nsContent.substring(with: nameRange)
                 let line = lineNumber(at: nameRange.location, in: content)
 
-                symbols.append(DocumentSymbol(name: name, kind: rule.kind, line: line))
+                symbols.append(PineSymbol(name: name, kind: rule.kind, line: line))
             }
         }
 
@@ -119,7 +119,7 @@ enum SymbolParser {
     }
 
     /// Filters symbols using fuzzy subsequence matching (reuses QuickOpenProvider logic).
-    static func filter(_ symbols: [DocumentSymbol], query: String) -> [DocumentSymbol] {
+    static func filter(_ symbols: [PineSymbol], query: String) -> [PineSymbol] {
         guard !query.isEmpty else { return symbols }
         let queryLower = query.lowercased()
         return symbols.filter {
@@ -131,7 +131,7 @@ enum SymbolParser {
 
     private struct SymbolRule {
         let regex: NSRegularExpression
-        let kind: SymbolKind
+        let kind: PineSymbolKind
     }
 
     /// Returns compiled regex rules for the given file extension.

--- a/PineTests/SymbolParserTests.swift
+++ b/PineTests/SymbolParserTests.swift
@@ -264,8 +264,8 @@ struct SymbolParserTests {
     @Test("Fuzzy filter: exact match")
     func fuzzyExact() {
         let symbols = [
-            DocumentSymbol(name: "viewDidLoad", kind: .function, line: 1),
-            DocumentSymbol(name: "viewWillAppear", kind: .function, line: 5),
+            PineSymbol(name: "viewDidLoad", kind: .function, line: 1),
+            PineSymbol(name: "viewWillAppear", kind: .function, line: 5),
         ]
         let filtered = SymbolParser.filter(symbols, query: "viewDidLoad")
         #expect(filtered.count == 1)
@@ -275,9 +275,9 @@ struct SymbolParserTests {
     @Test("Fuzzy filter: subsequence match")
     func fuzzySubsequence() {
         let symbols = [
-            DocumentSymbol(name: "viewDidLoad", kind: .function, line: 1),
-            DocumentSymbol(name: "viewWillAppear", kind: .function, line: 5),
-            DocumentSymbol(name: "setupConstraints", kind: .function, line: 10),
+            PineSymbol(name: "viewDidLoad", kind: .function, line: 1),
+            PineSymbol(name: "viewWillAppear", kind: .function, line: 5),
+            PineSymbol(name: "setupConstraints", kind: .function, line: 10),
         ]
         let filtered = SymbolParser.filter(symbols, query: "vdl")
         #expect(filtered.count == 1)
@@ -287,8 +287,8 @@ struct SymbolParserTests {
     @Test("Fuzzy filter: empty query returns all")
     func fuzzyEmptyQuery() {
         let symbols = [
-            DocumentSymbol(name: "foo", kind: .function, line: 1),
-            DocumentSymbol(name: "bar", kind: .function, line: 2),
+            PineSymbol(name: "foo", kind: .function, line: 1),
+            PineSymbol(name: "bar", kind: .function, line: 2),
         ]
         let filtered = SymbolParser.filter(symbols, query: "")
         #expect(filtered.count == 2)
@@ -297,7 +297,7 @@ struct SymbolParserTests {
     @Test("Fuzzy filter: case insensitive")
     func fuzzyCaseInsensitive() {
         let symbols = [
-            DocumentSymbol(name: "MyClass", kind: .class, line: 1),
+            PineSymbol(name: "MyClass", kind: .class, line: 1),
         ]
         let filtered = SymbolParser.filter(symbols, query: "myclass")
         #expect(filtered.count == 1)
@@ -414,25 +414,25 @@ struct SymbolParserTests {
         #expect(symbols.contains { $0.name == "fmt" && $0.kind == .function })
     }
 
-    // MARK: - SymbolKind
+    // MARK: - PineSymbolKind
 
-    @Test("SymbolKind: sort order is stable")
+    @Test("PineSymbolKind: sort order is stable")
     func symbolKindSorting() {
-        let kinds: [SymbolKind] = [.function, .class, .enum, .struct, .protocol]
+        let kinds: [PineSymbolKind] = [.function, .class, .enum, .struct, .protocol]
         let sorted = kinds.sorted()
         #expect(sorted == [.class, .struct, .enum, .protocol, .function])
     }
 
-    @Test("SymbolKind: displayName is non-empty")
+    @Test("PineSymbolKind: displayName is non-empty")
     func symbolKindDisplayName() {
-        for kind in SymbolKind.allCases {
+        for kind in PineSymbolKind.allCases {
             #expect(!kind.displayName.isEmpty)
         }
     }
 
-    @Test("SymbolKind: iconName is non-empty")
+    @Test("PineSymbolKind: iconName is non-empty")
     func symbolKindIconName() {
-        for kind in SymbolKind.allCases {
+        for kind in PineSymbolKind.allCases {
             #expect(!kind.iconName.isEmpty)
         }
     }


### PR DESCRIPTION
## Summary
- Renames `DocumentSymbol` → `PineSymbol` and `SymbolKind` → `PineSymbolKind` to resolve type name conflicts with the swift-markdown SPM dependency
- Updates all references across `SymbolParser.swift`, `SymbolNavigatorView.swift`, and `SymbolParserTests.swift`

Closes #588

## Test plan
- [ ] Unit tests pass (`SymbolParserTests`)
- [ ] Symbol navigator (Cmd+Shift+R) works correctly in the editor
- [ ] Project builds without type ambiguity errors