### PR TITLE
fix: prevent minimap viewport jump on Enter at EOF

### DIFF
--- a/Pine/MinimapView.swift
+++ b/Pine/MinimapView.swift
@@ -60,11 +60,15 @@ final class MinimapView: NSView {
     private let charWidth: CGFloat = MinimapConstants.charWidth
 
     /// Total document height including top origin offset and bottom inset.
+    /// Ensures layout is up-to-date before measuring to prevent stale values
+    /// when text changes (e.g., pressing Enter at end of file) trigger a redraw
+    /// before the layout manager has recalculated.
     private func documentHeight(
         layoutManager: NSLayoutManager,
         textContainer: NSTextContainer,
         textView: NSTextView
     ) -> CGFloat {
+        layoutManager.ensureLayout(for: textContainer)
         let usedRect = layoutManager.usedRect(for: textContainer)
         return usedRect.height + textView.textContainerOrigin.y + textView.textContainerInset.height
     }
@@ -227,7 +231,9 @@ final class MinimapView: NSView {
         // minimap is scrolled to show the bottom of the document.
         let visibleRect = scrollView.contentView.bounds
         let maxEditorScroll = max(1, docHeight - visibleRect.height)
-        let currentScroll = visibleRect.origin.y
+        // Clamp scroll position to prevent jump when scroll offset exceeds
+        // document height during layout recalculation
+        let currentScroll = min(visibleRect.origin.y, max(0, maxEditorScroll))
         let scrollFraction = min(max(currentScroll / maxEditorScroll, 0), 1)
 
         let maxMinimapOffset = scaledDocHeight - panelHeight
@@ -374,7 +380,10 @@ final class MinimapView: NSView {
         let (offset, _) = minimapOffset()
         let visibleRect = scrollView.contentView.bounds
 
-        let y = visibleRect.origin.y * scale - offset
+        // Clamp scroll position to document height to prevent viewport jump
+        // when layout manager hasn't fully recalculated after text changes
+        let clampedScrollY = min(visibleRect.origin.y, max(0, docHeight - visibleRect.height))
+        let y = clampedScrollY * scale - offset
         let height = visibleRect.height * scale
 
         let clampedY = max(0, y)

--- a/PineTests/MinimapViewTests.swift
+++ b/PineTests/MinimapViewTests.swift
@@ -137,6 +137,76 @@ struct MinimapViewTests {
         #expect(minimap.lineDiffs.isEmpty)
     }
 
+    // MARK: - Viewport clamping (issue #586)
+
+    @Test("Viewport rect is valid for empty document")
+    func viewportRectEmptyDocument() {
+        let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 500, height: 400))
+        textView.string = ""
+
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 500, height: 400))
+        scrollView.documentView = textView
+
+        let minimap = MinimapView(textView: textView)
+        minimap.frame = NSRect(x: 0, y: 0, width: 80, height: 400)
+
+        // Empty document — viewport should either be nil or have non-negative origin
+        let rect = minimap.computeViewportRect()
+        if let rect {
+            #expect(rect.origin.y >= 0)
+        }
+    }
+
+    @Test("Viewport rect stays clamped when scroll exceeds document height")
+    func viewportRectClampedOnOverscroll() {
+        let textStorage = NSTextStorage(string: String(repeating: "Line\n", count: 50))
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        )
+        textContainer.widthTracksTextView = true
+        layoutManager.addTextContainer(textContainer)
+
+        let textView = NSTextView(
+            frame: NSRect(x: 0, y: 0, width: 500, height: 400),
+            textContainer: textContainer
+        )
+
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 500, height: 400))
+        scrollView.documentView = textView
+
+        let minimap = MinimapView(textView: textView)
+        minimap.frame = NSRect(x: 0, y: 0, width: 80, height: 400)
+
+        layoutManager.ensureLayout(for: textContainer)
+
+        // Simulate scroll beyond document bounds (as happens on Enter at EOF)
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 99_999))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+
+        let rect = minimap.computeViewportRect()
+        if let rect {
+            #expect(rect.origin.y >= 0)
+            #expect(rect.origin.y + rect.height <= minimap.bounds.height + 1)
+        }
+    }
+
+    @Test("scrollToPosition does not crash with empty document")
+    func scrollToPositionEmptyDocument() {
+        let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 500, height: 400))
+        textView.string = ""
+
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 500, height: 400))
+        scrollView.documentView = textView
+
+        let minimap = MinimapView(textView: textView)
+        minimap.frame = NSRect(x: 0, y: 0, width: 80, height: 400)
+
+        // Should not crash
+        minimap.scrollToPosition(minimapY: 50)
+    }
+
     @Test("MinimapView does not crash drawing with diff markers")
     func drawWithDiffMarkers() {
         let textStorage = NSTextStorage(string: "Hello\nWorld\nFoo\n")


### PR DESCRIPTION
## Summary
- Fixes minimap viewport indicator jumping when pressing Enter at the end of a file (#586)
- Root cause: minimap redraws before `NSLayoutManager` recalculates document height after text changes, causing scroll position to exceed document bounds
- Added `ensureLayout(for:)` call in `documentHeight()` to guarantee fresh layout metrics
- Clamped scroll position in `minimapOffset()` and `computeViewportRect()` so viewport stays within valid bounds even during transient layout states

## Test plan
- [x] Added 3 unit tests in `MinimapViewTests`: empty document viewport, overscroll clamping, scrollToPosition with empty doc
- [x] All 13 minimap tests pass
- [x] SwiftLint clean

Closes #586