### PR TITLE
fix: remove broken Unicode branch icon from toolbar subtitle

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -203,7 +203,16 @@ struct ContentView: View {
 
     /// Branch subtitle as a plain String to avoid generating a localization key.
     var branchSubtitle: String {
-        workspace.gitProvider.isGitRepository ? "⎇ \(workspace.gitProvider.currentBranch) ▾" : ""
+        Self.branchSubtitle(
+            isGitRepo: workspace.gitProvider.isGitRepository,
+            branchName: workspace.gitProvider.currentBranch
+        )
+    }
+
+    /// Builds the toolbar subtitle for the current git branch.
+    /// Kept as a static function for testability.
+    static func branchSubtitle(isGitRepo: Bool, branchName: String) -> String {
+        isGitRepo ? "\(branchName) ▾" : ""
     }
 
     // MARK: - Subview builders

--- a/PineTests/BranchSubtitleTests.swift
+++ b/PineTests/BranchSubtitleTests.swift
@@ -1,0 +1,99 @@
+//
+//  BranchSubtitleTests.swift
+//  PineTests
+//
+
+import Testing
+@testable import Pine
+
+struct BranchSubtitleTests {
+
+    // MARK: - Git repository cases
+
+    @Test func gitRepo_containsBranchNameAndDropdown() {
+        let result = ContentView.branchSubtitle(isGitRepo: true, branchName: "main")
+        #expect(result == "main ▾")
+    }
+
+    @Test func gitRepo_featureBranchWithSlash() {
+        let result = ContentView.branchSubtitle(isGitRepo: true, branchName: "feature/login")
+        #expect(result == "feature/login ▾")
+    }
+
+    @Test func gitRepo_deeplyNestedBranch() {
+        let result = ContentView.branchSubtitle(isGitRepo: true, branchName: "feature/team/sprint-3/JIRA-1234")
+        #expect(result == "feature/team/sprint-3/JIRA-1234 ▾")
+    }
+
+    @Test func gitRepo_longBranchName() {
+        let long = String(repeating: "a", count: 200)
+        let result = ContentView.branchSubtitle(isGitRepo: true, branchName: long)
+        #expect(result == "\(long) ▾")
+    }
+
+    @Test func gitRepo_branchWithSpecialCharacters() {
+        let result = ContentView.branchSubtitle(isGitRepo: true, branchName: "fix/emoji-🐛-bug")
+        #expect(result == "fix/emoji-🐛-bug ▾")
+    }
+
+    @Test func gitRepo_branchWithDots() {
+        let result = ContentView.branchSubtitle(isGitRepo: true, branchName: "release/v1.2.3")
+        #expect(result == "release/v1.2.3 ▾")
+    }
+
+    @Test func gitRepo_branchWithHyphensAndUnderscores() {
+        let result = ContentView.branchSubtitle(isGitRepo: true, branchName: "fix_some-thing_else")
+        #expect(result == "fix_some-thing_else ▾")
+    }
+
+    @Test func gitRepo_emptyBranchName() {
+        let result = ContentView.branchSubtitle(isGitRepo: true, branchName: "")
+        #expect(result == " ▾")
+    }
+
+    @Test func gitRepo_branchWithAtSign() {
+        let result = ContentView.branchSubtitle(isGitRepo: true, branchName: "user@feature")
+        #expect(result == "user@feature ▾")
+    }
+
+    @Test func gitRepo_detachedHead() {
+        let result = ContentView.branchSubtitle(isGitRepo: true, branchName: "HEAD detached at abc1234")
+        #expect(result == "HEAD detached at abc1234 ▾")
+    }
+
+    // MARK: - Non-git repository cases
+
+    @Test func notGitRepo_returnsEmptyString() {
+        let result = ContentView.branchSubtitle(isGitRepo: false, branchName: "main")
+        #expect(result.isEmpty)
+    }
+
+    @Test func notGitRepo_emptyBranchName_returnsEmpty() {
+        let result = ContentView.branchSubtitle(isGitRepo: false, branchName: "")
+        #expect(result.isEmpty)
+    }
+
+    // MARK: - Format invariants
+
+    @Test func subtitle_doesNotContainBrokenUnicodeSymbol() {
+        let result = ContentView.branchSubtitle(isGitRepo: true, branchName: "main")
+        #expect(!result.contains("⎇"))
+        #expect(!result.contains("√"))
+    }
+
+    @Test func subtitle_isPlainString_endsWithDropdownIndicator() {
+        let result = ContentView.branchSubtitle(isGitRepo: true, branchName: "develop")
+        #expect(result.hasSuffix("▾"))
+    }
+
+    @Test func subtitle_startsWithBranchName() {
+        let result = ContentView.branchSubtitle(isGitRepo: true, branchName: "develop")
+        #expect(result.hasPrefix("develop"))
+    }
+
+    @Test func subtitle_matchesExactFormat() {
+        // Verify the exact format so BranchSubtitleClickHandler can match window.subtitle
+        let result = ContentView.branchSubtitle(isGitRepo: true, branchName: "my-branch")
+        #expect(result == "my-branch ▾")
+    }
+}


### PR DESCRIPTION
## Summary

- Remove broken Unicode symbol `⎇` (U+2387) from toolbar subtitle — it rendered as "√" in macOS system fonts
- Subtitle now shows clean `"branchName ▾"` format without icon
- Extract `branchSubtitle(isGitRepo:branchName:)` as static function for testability
- `BranchSubtitleClickHandler` compatibility preserved — subtitle remains a plain `String`
- Add 16 unit tests covering branch names with slashes, dots, emoji, special chars, empty names, non-git repos, and format invariants

Closes #594

## Test plan
- [x] Open a git repo — subtitle shows "main ▾" (no broken symbol)
- [x] Open a non-git folder — no subtitle
- [x] Click subtitle — branch switcher popover still works
- [x] 16 unit tests pass