### PR TITLE
fix: align indent guides correctly for tab-indented files

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -17,6 +17,9 @@ final class GutterTextView: NSTextView {
     /// Ширина гуттера — задаётся извне.
     var gutterInset: CGFloat = 44
 
+    /// Indentation style for indent guide rendering.
+    var indentStyle: IndentationStyle = .spaces(4)
+
     /// Bottom padding so the last line is not clipped (issue #258).
     static let defaultBottomInset: CGFloat = 5
 
@@ -92,6 +95,9 @@ final class GutterTextView: NSTextView {
 
         guard let layoutManager = layoutManager,
               textContainer != nil else { return }
+
+        // ── Indent guides (behind everything else) ──
+        IndentGuideRenderer.draw(in: self, dirtyRect: rect, indentStyle: indentStyle)
 
         let cursorRange = selectedRange()
         guard cursorRange.length == 0 else { return }
@@ -417,6 +423,8 @@ struct CodeEditorView: NSViewRepresentable {
     var cachedHighlightResult: HighlightMatchResult?
     /// When non-nil, the editor scrolls to this offset. The `id` ensures each request is unique.
     var goToOffset: GoToRequest?
+    /// Indentation style detected for the current file, used for indent guide rendering.
+    var indentStyle: IndentationStyle = .spaces(4)
 
     /// Порог (в символах) для переключения на viewport-based подсветку.
     static let viewportHighlightThreshold = 100_000
@@ -497,6 +505,7 @@ struct CodeEditorView: NSViewRepresentable {
         textView.exactFileName = fileName
         textView.setBlameLines(blameLines)
         textView.isBlameVisible = isBlameVisible
+        textView.indentStyle = indentStyle
         // Delegate set AFTER text/highlight setup to prevent textDidChange from firing
         // during makeNSView and causing a spurious updateContent → cachedHighlightResult = nil
         // → contentVersion bump → updateNSView re-sets text → stripping highlight attributes.
@@ -690,6 +699,7 @@ struct CodeEditorView: NSViewRepresentable {
            let gutterView = sv.documentView as? GutterTextView {
             gutterView.fileExtension = language
             gutterView.exactFileName = fileName
+            gutterView.indentStyle = indentStyle
             gutterView.setBlameLines(blameLines)
             if gutterView.isBlameVisible != isBlameVisible {
                 gutterView.isBlameVisible = isBlameVisible

--- a/Pine/EditorAreaView.swift
+++ b/Pine/EditorAreaView.swift
@@ -130,6 +130,7 @@ struct EditorAreaView: View {
             },
             cachedHighlightResult: tab.cachedHighlightResult,
             goToOffset: goToLineOffset,
+            indentStyle: tab.cachedIndentation,
             fontSize: FontSizeSettings.shared.fontSize
         )
         .id(tab.id)

--- a/Pine/IndentGuideRenderer.swift
+++ b/Pine/IndentGuideRenderer.swift
@@ -1,0 +1,283 @@
+//
+//  IndentGuideRenderer.swift
+//  Pine
+//
+//  Created by Pine on 27.03.2026.
+//
+
+import AppKit
+
+// MARK: - Indent Guide Data Model
+
+/// Represents a single vertical indent guide to be drawn.
+struct IndentGuide: Equatable {
+    /// The indentation level (1-based). Level 1 is the first indent column.
+    let level: Int
+    /// The x-coordinate where the guide should be drawn (in text container coordinates).
+    let xPosition: CGFloat
+}
+
+// MARK: - Indent Guide Calculator (Pure Logic, Testable)
+
+/// Calculates indent guide positions for a given line of text.
+/// Handles tabs, spaces, and mixed indentation correctly.
+enum IndentGuideCalculator {
+
+    /// Computes the indentation level of a line based on its leading whitespace.
+    ///
+    /// For tab-based indentation, each tab counts as one indent level.
+    /// For space-based indentation, every `indentWidth` spaces count as one indent level.
+    /// Mixed indentation: tabs first (each = 1 level), then remaining spaces
+    /// contribute fractional levels (rounded down).
+    ///
+    /// - Parameters:
+    ///   - line: The text of the line.
+    ///   - indentWidth: Number of spaces per indent level (used for space-based indentation).
+    /// - Returns: The number of indent levels for this line.
+    static func indentLevel(of line: String, indentWidth: Int) -> Int {
+        guard indentWidth > 0 else { return 0 }
+
+        var tabs = 0
+        var spaces = 0
+
+        for char in line {
+            switch char {
+            case "\t":
+                tabs += 1
+            case " ":
+                spaces += 1
+            default:
+                break
+            }
+            if char != "\t" && char != " " { break }
+        }
+
+        // Each tab = 1 indent level, remaining spaces contribute based on indentWidth
+        return tabs + spaces / indentWidth
+    }
+
+    /// Computes the x-positions of indent guides for a given indentation level.
+    ///
+    /// For tab-based files, each guide is placed at the tab stop position.
+    /// For space-based files, each guide is placed at `level * indentWidth * charWidth`.
+    ///
+    /// - Parameters:
+    ///   - level: Number of indent levels.
+    ///   - charWidth: Width of a single space character in the current font.
+    ///   - tabStopWidth: Width of a tab stop in points (from NSTextView paragraph style).
+    ///   - usesTabs: Whether the file uses tab-based indentation.
+    ///   - indentWidth: Number of spaces per indent level (for space-based indentation).
+    /// - Returns: Array of `IndentGuide` values, one per level.
+    static func guides(
+        forLevel level: Int,
+        charWidth: CGFloat,
+        tabStopWidth: CGFloat,
+        usesTabs: Bool,
+        indentWidth: Int
+    ) -> [IndentGuide] {
+        guard level > 0, charWidth > 0 else { return [] }
+
+        return (1...level).map { lvl in
+            let xPos: CGFloat
+            if usesTabs {
+                // Tab-based: position at the tab stop boundary
+                xPos = CGFloat(lvl) * tabStopWidth
+            } else {
+                // Space-based: position at indentWidth * charWidth per level
+                xPos = CGFloat(lvl * indentWidth) * charWidth
+            }
+            return IndentGuide(level: lvl, xPosition: xPos)
+        }
+    }
+
+    /// Determines the effective indent level for blank/empty lines
+    /// by looking at surrounding non-blank lines.
+    ///
+    /// Blank lines inherit the minimum indent of the nearest
+    /// non-blank lines above and below them, so guides continue
+    /// through empty lines.
+    ///
+    /// - Parameters:
+    ///   - lineIndex: The 0-based index of the blank line.
+    ///   - lines: All lines in the document.
+    ///   - indentWidth: Number of spaces per indent level.
+    /// - Returns: The inherited indent level for the blank line.
+    static func inheritedIndentLevel(
+        forBlankLineAt lineIndex: Int,
+        in lines: [String],
+        indentWidth: Int
+    ) -> Int {
+        guard indentWidth > 0 else { return 0 }
+
+        // Search upward for nearest non-blank line
+        var above = 0
+        for i in stride(from: lineIndex - 1, through: 0, by: -1) {
+            let trimmed = lines[i].trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                above = indentLevel(of: lines[i], indentWidth: indentWidth)
+                break
+            }
+        }
+
+        // Search downward for nearest non-blank line
+        var below = 0
+        for i in (lineIndex + 1)..<lines.count {
+            let trimmed = lines[i].trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                below = indentLevel(of: lines[i], indentWidth: indentWidth)
+                break
+            }
+        }
+
+        return min(above, below)
+    }
+}
+
+// MARK: - Indent Guide Renderer (Drawing)
+
+/// Draws vertical indent guide lines in the editor.
+enum IndentGuideRenderer {
+
+    /// The color used for indent guide lines.
+    static let guideColor = NSColor(name: nil) { appearance in
+        if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
+            return NSColor.white.withAlphaComponent(0.08)
+        } else {
+            return NSColor.black.withAlphaComponent(0.08)
+        }
+    }
+
+    /// Width of the indent guide lines.
+    static let lineWidth: CGFloat = 1.0
+
+    /// Draws indent guides for all visible lines in the text view.
+    ///
+    /// - Parameters:
+    ///   - textView: The GutterTextView to draw in.
+    ///   - rect: The dirty rectangle to draw in.
+    ///   - indentStyle: The detected indentation style of the file.
+    static func draw(
+        in textView: NSTextView,
+        dirtyRect rect: NSRect,
+        indentStyle: IndentationStyle
+    ) {
+        guard let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer else { return }
+
+        let content = textView.string
+        guard !content.isEmpty else { return }
+
+        let usesTabs: Bool
+        let indentWidth: Int
+        switch indentStyle {
+        case .tabs:
+            usesTabs = true
+            indentWidth = 4 // Standard tab = 4 indent units
+        case .spaces(let width):
+            usesTabs = false
+            indentWidth = width
+        }
+
+        // Calculate character width using a space in the editor font
+        let font = textView.font ?? NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        let charWidth = " ".size(withAttributes: [.font: font]).width
+
+        // Get the actual tab stop width from the text view's paragraph style
+        let tabStopWidth: CGFloat
+        if let paragraphStyle = textView.defaultParagraphStyle,
+           let firstTab = paragraphStyle.tabStops.first {
+            tabStopWidth = firstTab.location
+        } else {
+            // Default NSTextView tab interval is 28pt
+            tabStopWidth = textView.defaultParagraphStyle?.defaultTabInterval
+                ?? NSParagraphStyle.default.defaultTabInterval
+        }
+
+        let origin = textView.textContainerOrigin
+        let nsContent = content as NSString
+        let lines = content.components(separatedBy: "\n")
+
+        // Find visible glyph range
+        let visibleRect = textView.visibleRect
+        let containerVisibleRect = NSRect(
+            x: visibleRect.origin.x - origin.x,
+            y: visibleRect.origin.y - origin.y,
+            width: visibleRect.width,
+            height: visibleRect.height
+        )
+        let visibleGlyphRange = layoutManager.glyphRange(
+            forBoundingRect: containerVisibleRect,
+            in: textContainer
+        )
+        let visibleCharRange = layoutManager.characterRange(
+            forGlyphRange: visibleGlyphRange, actualGlyphRange: nil
+        )
+
+        // Find which lines are visible
+        let firstVisibleLine = nsContent.lineRange(
+            for: NSRange(location: visibleCharRange.location, length: 0)
+        )
+        var lineStart = firstVisibleLine.location
+        var lineNumber = nsContent.substring(to: lineStart)
+            .components(separatedBy: "\n").count - 1
+
+        guideColor.setStroke()
+
+        let path = NSBezierPath()
+        path.lineWidth = lineWidth
+
+        while lineStart < nsContent.length && lineStart <= NSMaxRange(visibleCharRange) {
+            guard lineNumber < lines.count else { break }
+
+            let line = lines[lineNumber]
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            let level: Int
+            if trimmed.isEmpty {
+                level = IndentGuideCalculator.inheritedIndentLevel(
+                    forBlankLineAt: lineNumber, in: lines, indentWidth: indentWidth
+                )
+            } else {
+                level = IndentGuideCalculator.indentLevel(of: line, indentWidth: indentWidth)
+            }
+
+            if level > 0 {
+                // Get the line fragment rect for this line
+                let lineRange = nsContent.lineRange(for: NSRange(location: lineStart, length: 0))
+                let glyphRange = layoutManager.glyphRange(
+                    forCharacterRange: lineRange, actualCharacterRange: nil
+                )
+
+                if glyphRange.location != NSNotFound && glyphRange.length > 0 {
+                    let lineFragmentRect = layoutManager.lineFragmentRect(
+                        forGlyphAt: glyphRange.location, effectiveRange: nil
+                    )
+
+                    let guides = IndentGuideCalculator.guides(
+                        forLevel: level,
+                        charWidth: charWidth,
+                        tabStopWidth: tabStopWidth,
+                        usesTabs: usesTabs,
+                        indentWidth: indentWidth
+                    )
+
+                    for guide in guides {
+                        let x = guide.xPosition + origin.x
+                        let y = lineFragmentRect.origin.y + origin.y
+                        let height = lineFragmentRect.height
+
+                        path.move(to: NSPoint(x: x, y: y))
+                        path.line(to: NSPoint(x: x, y: y + height))
+                    }
+                }
+            }
+
+            // Advance to the next line
+            let lineRange = nsContent.lineRange(for: NSRange(location: lineStart, length: 0))
+            lineStart = NSMaxRange(lineRange)
+            lineNumber += 1
+        }
+
+        path.stroke()
+    }
+}

--- a/PineTests/IndentGuideCalculatorTests.swift
+++ b/PineTests/IndentGuideCalculatorTests.swift
@@ -1,0 +1,446 @@
+//
+//  IndentGuideCalculatorTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+/// Tests for IndentGuideCalculator — pure indent level and guide position logic.
+struct IndentGuideCalculatorTests {
+
+    // MARK: - indentLevel: Tab-only indentation
+
+    @Test func indentLevel_singleTab() {
+        let level = IndentGuideCalculator.indentLevel(of: "\tfoo", indentWidth: 4)
+        #expect(level == 1)
+    }
+
+    @Test func indentLevel_twoTabs() {
+        let level = IndentGuideCalculator.indentLevel(of: "\t\tbar", indentWidth: 4)
+        #expect(level == 2)
+    }
+
+    @Test func indentLevel_fiveTabs() {
+        let level = IndentGuideCalculator.indentLevel(of: "\t\t\t\t\tbaz", indentWidth: 4)
+        #expect(level == 5)
+    }
+
+    @Test func indentLevel_tabOnlyLine() {
+        // Line with only a tab and no content
+        let level = IndentGuideCalculator.indentLevel(of: "\t", indentWidth: 4)
+        #expect(level == 1)
+    }
+
+    @Test func indentLevel_multipleTabs_noContent() {
+        let level = IndentGuideCalculator.indentLevel(of: "\t\t\t", indentWidth: 4)
+        #expect(level == 3)
+    }
+
+    // MARK: - indentLevel: Space-only indentation
+
+    @Test func indentLevel_fourSpaces() {
+        let level = IndentGuideCalculator.indentLevel(of: "    code", indentWidth: 4)
+        #expect(level == 1)
+    }
+
+    @Test func indentLevel_eightSpaces() {
+        let level = IndentGuideCalculator.indentLevel(of: "        code", indentWidth: 4)
+        #expect(level == 2)
+    }
+
+    @Test func indentLevel_twoSpaces_indentWidth2() {
+        let level = IndentGuideCalculator.indentLevel(of: "  code", indentWidth: 2)
+        #expect(level == 1)
+    }
+
+    @Test func indentLevel_sixSpaces_indentWidth2() {
+        let level = IndentGuideCalculator.indentLevel(of: "      code", indentWidth: 2)
+        #expect(level == 3)
+    }
+
+    @Test func indentLevel_threeSpaces_indentWidth4_roundsDown() {
+        // 3 spaces with indentWidth 4 → 0 full levels
+        let level = IndentGuideCalculator.indentLevel(of: "   code", indentWidth: 4)
+        #expect(level == 0)
+    }
+
+    @Test func indentLevel_fiveSpaces_indentWidth4_roundsDown() {
+        // 5 spaces with indentWidth 4 → 1 full level (4 spaces = 1, 1 space remainder)
+        let level = IndentGuideCalculator.indentLevel(of: "     code", indentWidth: 4)
+        #expect(level == 1)
+    }
+
+    // MARK: - indentLevel: Mixed tabs + spaces
+
+    @Test func indentLevel_tabPlusSpaces() {
+        // 1 tab + 4 spaces = 1 (tab) + 1 (4 spaces / 4) = 2
+        let level = IndentGuideCalculator.indentLevel(of: "\t    code", indentWidth: 4)
+        #expect(level == 2)
+    }
+
+    @Test func indentLevel_tabPlusTwoSpaces_indentWidth4() {
+        // 1 tab + 2 spaces = 1 + 0 = 1 (2 spaces < 4)
+        let level = IndentGuideCalculator.indentLevel(of: "\t  code", indentWidth: 4)
+        #expect(level == 1)
+    }
+
+    @Test func indentLevel_twoTabsPlusTwoSpaces_indentWidth2() {
+        // 2 tabs + 2 spaces = 2 + 1 = 3
+        let level = IndentGuideCalculator.indentLevel(of: "\t\t  code", indentWidth: 2)
+        #expect(level == 3)
+    }
+
+    // MARK: - indentLevel: No indentation
+
+    @Test func indentLevel_noIndent() {
+        let level = IndentGuideCalculator.indentLevel(of: "code", indentWidth: 4)
+        #expect(level == 0)
+    }
+
+    @Test func indentLevel_emptyString() {
+        let level = IndentGuideCalculator.indentLevel(of: "", indentWidth: 4)
+        #expect(level == 0)
+    }
+
+    // MARK: - indentLevel: Edge cases
+
+    @Test func indentLevel_indentWidthZero_returnsZero() {
+        // Prevents division by zero
+        let level = IndentGuideCalculator.indentLevel(of: "    code", indentWidth: 0)
+        #expect(level == 0)
+    }
+
+    @Test func indentLevel_whitespaceOnlyLine() {
+        // All spaces, no actual content
+        let level = IndentGuideCalculator.indentLevel(of: "        ", indentWidth: 4)
+        #expect(level == 2)
+    }
+
+    @Test func indentLevel_tabsOnlyLine() {
+        let level = IndentGuideCalculator.indentLevel(of: "\t\t\t\t", indentWidth: 4)
+        #expect(level == 4)
+    }
+
+    @Test func indentLevel_indentWidth8() {
+        let level = IndentGuideCalculator.indentLevel(of: "        code", indentWidth: 8)
+        #expect(level == 1)
+    }
+
+    @Test func indentLevel_deepNesting_spaces() {
+        let line = String(repeating: "    ", count: 10) + "deeply_nested()"
+        let level = IndentGuideCalculator.indentLevel(of: line, indentWidth: 4)
+        #expect(level == 10)
+    }
+
+    @Test func indentLevel_deepNesting_tabs() {
+        let line = String(repeating: "\t", count: 10) + "deeply_nested()"
+        let level = IndentGuideCalculator.indentLevel(of: line, indentWidth: 4)
+        #expect(level == 10)
+    }
+
+    // MARK: - guides: Tab-based
+
+    @Test func guides_tabBased_level1() {
+        let guides = IndentGuideCalculator.guides(
+            forLevel: 1, charWidth: 7.0, tabStopWidth: 28.0,
+            usesTabs: true, indentWidth: 4
+        )
+        #expect(guides.count == 1)
+        #expect(guides[0].level == 1)
+        #expect(guides[0].xPosition == 28.0) // 1 * tabStopWidth
+    }
+
+    @Test func guides_tabBased_level3() {
+        let guides = IndentGuideCalculator.guides(
+            forLevel: 3, charWidth: 7.0, tabStopWidth: 28.0,
+            usesTabs: true, indentWidth: 4
+        )
+        #expect(guides.count == 3)
+        #expect(guides[0].xPosition == 28.0)
+        #expect(guides[1].xPosition == 56.0)
+        #expect(guides[2].xPosition == 84.0)
+    }
+
+    @Test func guides_tabBased_usesTabStopWidth_notCharWidth() {
+        // Key bug fix: tab guides must use tabStopWidth, not charWidth * indentWidth
+        let charWidth: CGFloat = 7.0
+        let tabStopWidth: CGFloat = 28.0
+        let guides = IndentGuideCalculator.guides(
+            forLevel: 2, charWidth: charWidth, tabStopWidth: tabStopWidth,
+            usesTabs: true, indentWidth: 4
+        )
+        // Must be 28 and 56, NOT 28 (7*4) and 56 (7*4*2) — same in this case, but
+        // the key point is that tabStopWidth is independent of charWidth * indentWidth
+        #expect(guides[0].xPosition == tabStopWidth)
+        #expect(guides[1].xPosition == tabStopWidth * 2)
+    }
+
+    @Test func guides_tabBased_customTabStop() {
+        // Tab stop at 32pt (not the standard 28pt)
+        let guides = IndentGuideCalculator.guides(
+            forLevel: 2, charWidth: 7.0, tabStopWidth: 32.0,
+            usesTabs: true, indentWidth: 4
+        )
+        #expect(guides[0].xPosition == 32.0)
+        #expect(guides[1].xPosition == 64.0)
+    }
+
+    // MARK: - guides: Space-based
+
+    @Test func guides_spaceBased_level1_indent4() {
+        let guides = IndentGuideCalculator.guides(
+            forLevel: 1, charWidth: 7.0, tabStopWidth: 28.0,
+            usesTabs: false, indentWidth: 4
+        )
+        #expect(guides.count == 1)
+        #expect(guides[0].xPosition == 28.0) // 1 * 4 * 7.0
+    }
+
+    @Test func guides_spaceBased_level2_indent2() {
+        let guides = IndentGuideCalculator.guides(
+            forLevel: 2, charWidth: 7.0, tabStopWidth: 28.0,
+            usesTabs: false, indentWidth: 2
+        )
+        #expect(guides.count == 2)
+        #expect(guides[0].xPosition == 14.0) // 1 * 2 * 7.0
+        #expect(guides[1].xPosition == 28.0) // 2 * 2 * 7.0
+    }
+
+    @Test func guides_spaceBased_differentCharWidth() {
+        // Larger font → wider charWidth
+        let guides = IndentGuideCalculator.guides(
+            forLevel: 1, charWidth: 9.5, tabStopWidth: 38.0,
+            usesTabs: false, indentWidth: 4
+        )
+        #expect(guides[0].xPosition == 38.0) // 1 * 4 * 9.5
+    }
+
+    // MARK: - guides: Edge cases
+
+    @Test func guides_levelZero_returnsEmpty() {
+        let guides = IndentGuideCalculator.guides(
+            forLevel: 0, charWidth: 7.0, tabStopWidth: 28.0,
+            usesTabs: true, indentWidth: 4
+        )
+        #expect(guides.isEmpty)
+    }
+
+    @Test func guides_charWidthZero_returnsEmpty() {
+        let guides = IndentGuideCalculator.guides(
+            forLevel: 2, charWidth: 0.0, tabStopWidth: 28.0,
+            usesTabs: false, indentWidth: 4
+        )
+        #expect(guides.isEmpty)
+    }
+
+    @Test func guides_negativeLevelReturnsEmpty() {
+        let guides = IndentGuideCalculator.guides(
+            forLevel: -1, charWidth: 7.0, tabStopWidth: 28.0,
+            usesTabs: true, indentWidth: 4
+        )
+        #expect(guides.isEmpty)
+    }
+
+    // MARK: - inheritedIndentLevel: Blank line inheritance
+
+    @Test func inheritedIndent_blankBetweenIndentedLines() {
+        let lines = [
+            "    func foo() {",
+            "",
+            "    }"
+        ]
+        let level = IndentGuideCalculator.inheritedIndentLevel(
+            forBlankLineAt: 1, in: lines, indentWidth: 4
+        )
+        #expect(level == 1) // min(1, 1) = 1
+    }
+
+    @Test func inheritedIndent_blankBetweenDifferentLevels() {
+        let lines = [
+            "        deep",
+            "",
+            "    shallow"
+        ]
+        let level = IndentGuideCalculator.inheritedIndentLevel(
+            forBlankLineAt: 1, in: lines, indentWidth: 4
+        )
+        #expect(level == 1) // min(2, 1) = 1
+    }
+
+    @Test func inheritedIndent_blankAtStart() {
+        let lines = [
+            "",
+            "    code"
+        ]
+        let level = IndentGuideCalculator.inheritedIndentLevel(
+            forBlankLineAt: 0, in: lines, indentWidth: 4
+        )
+        #expect(level == 0) // above = 0 (no lines above), below = 1 → min(0,1) = 0
+    }
+
+    @Test func inheritedIndent_blankAtEnd() {
+        let lines = [
+            "    code",
+            ""
+        ]
+        let level = IndentGuideCalculator.inheritedIndentLevel(
+            forBlankLineAt: 1, in: lines, indentWidth: 4
+        )
+        #expect(level == 0) // above = 1, below = 0 (no lines below) → min(1,0) = 0
+    }
+
+    @Test func inheritedIndent_multipleBlankLines() {
+        let lines = [
+            "        deep",
+            "",
+            "",
+            "",
+            "        deep"
+        ]
+        // Middle blank line
+        let level = IndentGuideCalculator.inheritedIndentLevel(
+            forBlankLineAt: 2, in: lines, indentWidth: 4
+        )
+        #expect(level == 2) // min(2, 2) = 2
+    }
+
+    @Test func inheritedIndent_blankSurroundedByNoIndent() {
+        let lines = [
+            "top",
+            "",
+            "bottom"
+        ]
+        let level = IndentGuideCalculator.inheritedIndentLevel(
+            forBlankLineAt: 1, in: lines, indentWidth: 4
+        )
+        #expect(level == 0) // min(0, 0) = 0
+    }
+
+    @Test func inheritedIndent_tabIndentedContext() {
+        let lines = [
+            "\t\tfunc body() {",
+            "",
+            "\t\t}"
+        ]
+        let level = IndentGuideCalculator.inheritedIndentLevel(
+            forBlankLineAt: 1, in: lines, indentWidth: 4
+        )
+        #expect(level == 2) // min(2, 2) = 2
+    }
+
+    @Test func inheritedIndent_whitespaceOnlyLineTreatedAsBlank() {
+        // A line with only spaces is treated as blank by trimmingCharacters
+        let lines = [
+            "        deep",
+            "   ",  // whitespace-only, treated as blank
+            "        deep"
+        ]
+        let level = IndentGuideCalculator.inheritedIndentLevel(
+            forBlankLineAt: 1, in: lines, indentWidth: 4
+        )
+        #expect(level == 2)
+    }
+
+    @Test func inheritedIndent_indentWidthZero_returnsZero() {
+        let lines = ["    code", "", "    code"]
+        let level = IndentGuideCalculator.inheritedIndentLevel(
+            forBlankLineAt: 1, in: lines, indentWidth: 0
+        )
+        #expect(level == 0)
+    }
+
+    @Test func inheritedIndent_allBlankLines() {
+        let lines = ["", "", ""]
+        let level = IndentGuideCalculator.inheritedIndentLevel(
+            forBlankLineAt: 1, in: lines, indentWidth: 4
+        )
+        #expect(level == 0)
+    }
+
+    // MARK: - IndentGuide struct
+
+    @Test func indentGuide_equatable() {
+        let a = IndentGuide(level: 1, xPosition: 28.0)
+        let b = IndentGuide(level: 1, xPosition: 28.0)
+        let c = IndentGuide(level: 2, xPosition: 56.0)
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    // MARK: - Real-world scenarios
+
+    @Test func goFile_tabIndented() {
+        // Typical Go file with tab indentation
+        let lines = [
+            "package main",           // level 0
+            "",                        // inherited: 0
+            "func main() {",          // level 0
+            "\tfmt.Println(\"hello\")", // level 1
+            "\tif true {",            // level 1
+            "\t\tfmt.Println(\"deep\")", // level 2
+            "\t}",                    // level 1
+            "}"                       // level 0
+        ]
+        #expect(IndentGuideCalculator.indentLevel(of: lines[0], indentWidth: 4) == 0)
+        #expect(IndentGuideCalculator.indentLevel(of: lines[3], indentWidth: 4) == 1)
+        #expect(IndentGuideCalculator.indentLevel(of: lines[4], indentWidth: 4) == 1)
+        #expect(IndentGuideCalculator.indentLevel(of: lines[5], indentWidth: 4) == 2)
+        #expect(IndentGuideCalculator.indentLevel(of: lines[6], indentWidth: 4) == 1)
+        #expect(IndentGuideCalculator.indentLevel(of: lines[7], indentWidth: 4) == 0)
+    }
+
+    @Test func makefile_tabIndented() {
+        // Makefile: recipes are indented with a single tab
+        let lines = [
+            "all: build",           // level 0
+            "\tgcc -o main main.c", // level 1
+            "",                      // inherited: min(1, 1) = 1
+            "clean:",               // level 0
+            "\trm -f main"          // level 1
+        ]
+        #expect(IndentGuideCalculator.indentLevel(of: lines[0], indentWidth: 4) == 0)
+        #expect(IndentGuideCalculator.indentLevel(of: lines[1], indentWidth: 4) == 1)
+        #expect(IndentGuideCalculator.indentLevel(of: lines[3], indentWidth: 4) == 0)
+        #expect(IndentGuideCalculator.indentLevel(of: lines[4], indentWidth: 4) == 1)
+
+        let inherited = IndentGuideCalculator.inheritedIndentLevel(
+            forBlankLineAt: 2, in: lines, indentWidth: 4
+        )
+        #expect(inherited == 0) // min(1, 0) = 0 because "clean:" has 0 indent
+    }
+
+    @Test func pythonFile_spaceIndented() {
+        let lines = [
+            "def foo():",                     // level 0
+            "    if True:",                   // level 1
+            "        print(\"nested\")",      // level 2
+            "    else:",                      // level 1
+            "        print(\"other\")"        // level 2
+        ]
+        #expect(IndentGuideCalculator.indentLevel(of: lines[0], indentWidth: 4) == 0)
+        #expect(IndentGuideCalculator.indentLevel(of: lines[1], indentWidth: 4) == 1)
+        #expect(IndentGuideCalculator.indentLevel(of: lines[2], indentWidth: 4) == 2)
+        #expect(IndentGuideCalculator.indentLevel(of: lines[3], indentWidth: 4) == 1)
+        #expect(IndentGuideCalculator.indentLevel(of: lines[4], indentWidth: 4) == 2)
+    }
+
+    @Test func guides_tabVsSpace_positionsAreDifferent() {
+        // With charWidth=7 and tabStopWidth=28:
+        // Tab-based level 1: x = 28 (tabStopWidth)
+        // Space-based level 1 with indent 4: x = 28 (4 * 7)
+        // Same in this case, but with different tabStopWidth they differ:
+        let tabGuides = IndentGuideCalculator.guides(
+            forLevel: 1, charWidth: 7.0, tabStopWidth: 35.0,
+            usesTabs: true, indentWidth: 4
+        )
+        let spaceGuides = IndentGuideCalculator.guides(
+            forLevel: 1, charWidth: 7.0, tabStopWidth: 35.0,
+            usesTabs: false, indentWidth: 4
+        )
+        #expect(tabGuides[0].xPosition == 35.0) // tabStopWidth
+        #expect(spaceGuides[0].xPosition == 28.0) // indentWidth * charWidth
+        #expect(tabGuides[0].xPosition != spaceGuides[0].xPosition)
+    }
+}


### PR DESCRIPTION
## Summary

- Fix indent guides misalignment for tab-based files (Go, Makefile) — guides were calculated using space charWidth instead of tab stop width
- New `IndentGuideRenderer.swift` with separated pure-logic `IndentGuideCalculator` (testable) and drawing `IndentGuideRenderer`
- Tab-based files: guide position = `level × tabStopWidth` (from NSTextView paragraph style)
- Space-based files: guide position = `level × indentWidth × charWidth`
- Blank lines inherit indent level from nearest non-blank lines above/below
- Viewport-only rendering for performance
- 47 unit tests: tabs, spaces, mixed, edge cases, blank line inheritance, Go/Makefile/Python scenarios

Closes #587

## Test plan
- [ ] Open a Go file with tab indentation — indent guides aligned correctly
- [ ] Open a Makefile — indent guides aligned to tab stops
- [ ] Open a Python file with spaces — guides unchanged
- [ ] Scroll through large file — no performance issues
- [x] 47 unit tests pass
- [x] SwiftLint clean