### PR TITLE
feat: feature flags for runtime toggle of experimental features

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -83,6 +83,10 @@ enum AccessibilityID {
     static let symbolResultsList = "symbolResultsList"
     static func symbolItem(_ name: String) -> String { "symbolItem_\(name)" }
 
+    // MARK: - Feature Flags
+    static let featureFlagsResetButton = "featureFlagsResetButton"
+    static func featureFlagToggle(_ key: String) -> String { "featureFlag_\(key)" }
+
     // MARK: - Status bar
     static let statusBar = "statusBar"
     static let terminalToggleButton = "terminalToggleButton"

--- a/Pine/EditorAreaView.swift
+++ b/Pine/EditorAreaView.swift
@@ -15,6 +15,7 @@ struct EditorAreaView: View {
     @Environment(WorkspaceManager.self) private var workspace
     @Environment(ProjectManager.self) private var projectManager
     @Environment(ProjectRegistry.self) private var registry
+    @Environment(FeatureFlags.self) private var featureFlags
     @Binding var lineDiffs: [GitLineDiff]
     @Binding var isDragTargeted: Bool
     @Binding var goToLineOffset: GoToRequest?
@@ -117,9 +118,9 @@ struct EditorAreaView: View {
                 get: { tab.foldState },
                 set: { tabManager.updateFoldState($0) }
             ),
-            isMinimapVisible: isMinimapVisible,
+            isMinimapVisible: isMinimapVisible && featureFlags.isEnabled(.minimap),
             isWordWrapEnabled: isWordWrapEnabled,
-            syntaxHighlightingDisabled: tab.syntaxHighlightingDisabled,
+            syntaxHighlightingDisabled: tab.syntaxHighlightingDisabled || !featureFlags.isEnabled(.syntaxHighlighting),
             initialCursorPosition: goToLineOffset?.offset ?? tab.cursorPosition,
             initialScrollOffset: goToLineOffset != nil ? 0 : tab.scrollOffset,
             onStateChange: { cursor, scroll in

--- a/Pine/FeatureFlags.swift
+++ b/Pine/FeatureFlags.swift
@@ -1,0 +1,106 @@
+//
+//  FeatureFlags.swift
+//  Pine
+//
+//  Runtime feature flags backed by UserDefaults for toggling experimental features.
+//
+
+import Foundation
+
+/// Individual feature flag definition.
+enum Feature: String, CaseIterable, Identifiable {
+    case parallelSearch = "featureParallelSearch"
+    case quickOpen = "featureQuickOpen"
+    case minimap = "featureMinimap"
+    case autoSave = "featureAutoSave"
+    case syntaxHighlighting = "featureSyntaxHighlighting"
+
+    var id: String { rawValue }
+
+    /// Human-readable name for the settings UI.
+    var displayName: String {
+        switch self {
+        case .parallelSearch: String(localized: "featureFlags.parallelSearch")
+        case .quickOpen: String(localized: "featureFlags.quickOpen")
+        case .minimap: String(localized: "featureFlags.minimap")
+        case .autoSave: String(localized: "featureFlags.autoSave")
+        case .syntaxHighlighting: String(localized: "featureFlags.syntaxHighlighting")
+        }
+    }
+
+    /// Brief description of what this flag controls.
+    var explanation: String {
+        switch self {
+        case .parallelSearch: String(localized: "featureFlags.parallelSearch.description")
+        case .quickOpen: String(localized: "featureFlags.quickOpen.description")
+        case .minimap: String(localized: "featureFlags.minimap.description")
+        case .autoSave: String(localized: "featureFlags.autoSave.description")
+        case .syntaxHighlighting: String(localized: "featureFlags.syntaxHighlighting.description")
+        }
+    }
+
+    /// Default value when no UserDefaults entry exists. All features are enabled by default.
+    var defaultValue: Bool { true }
+}
+
+/// Centralized runtime feature flag manager.
+/// Read flags via `isEnabled(_:)`, toggle via `setEnabled(_:_:)`.
+/// All flags default to `true` — toggle off if issues are found.
+///
+/// Also usable from the command line:
+/// `defaults write com.batonogov.pine featureParallelSearch -bool NO`
+@Observable
+final class FeatureFlags {
+    static let shared = FeatureFlags()
+
+    private let defaults: UserDefaults
+
+    /// In-memory cache of flag values, synced with UserDefaults.
+    private var cache: [Feature: Bool] = [:]
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        // Populate cache from defaults (or use default values).
+        for feature in Feature.allCases {
+            let key = feature.rawValue
+            if defaults.object(forKey: key) != nil {
+                cache[feature] = defaults.bool(forKey: key)
+            } else {
+                cache[feature] = feature.defaultValue
+            }
+        }
+    }
+
+    /// Check whether a feature is currently enabled.
+    func isEnabled(_ feature: Feature) -> Bool {
+        cache[feature] ?? feature.defaultValue
+    }
+
+    /// Enable or disable a feature at runtime. Persists to UserDefaults.
+    func setEnabled(_ feature: Feature, _ enabled: Bool) {
+        cache[feature] = enabled
+        defaults.set(enabled, forKey: feature.rawValue)
+    }
+
+    /// Toggle a feature's state. Returns the new value.
+    @discardableResult
+    func toggle(_ feature: Feature) -> Bool {
+        let newValue = !isEnabled(feature)
+        setEnabled(feature, newValue)
+        return newValue
+    }
+
+    /// Reset all flags to their default values.
+    func resetAll() {
+        for feature in Feature.allCases {
+            cache[feature] = feature.defaultValue
+            defaults.removeObject(forKey: feature.rawValue)
+        }
+    }
+
+    /// Reset a single flag to its default value.
+    func reset(_ feature: Feature) {
+        cache[feature] = feature.defaultValue
+        defaults.removeObject(forKey: feature.rawValue)
+    }
+}

--- a/Pine/FeatureFlags.swift
+++ b/Pine/FeatureFlags.swift
@@ -49,7 +49,7 @@ enum Feature: String, CaseIterable, Identifiable {
 ///
 /// Also usable from the command line:
 /// `defaults write com.batonogov.pine featureParallelSearch -bool NO`
-@Observable
+@MainActor @Observable
 final class FeatureFlags {
     static let shared = FeatureFlags()
 

--- a/Pine/FeatureFlagsView.swift
+++ b/Pine/FeatureFlagsView.swift
@@ -1,0 +1,52 @@
+//
+//  FeatureFlagsView.swift
+//  Pine
+//
+//  Settings view for toggling feature flags at runtime.
+//
+
+import SwiftUI
+
+struct FeatureFlagsView: View {
+    private let featureFlags = FeatureFlags.shared
+
+    var body: some View {
+        Form {
+            Section {
+                ForEach(Feature.allCases) { feature in
+                    Toggle(isOn: binding(for: feature)) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(feature.displayName)
+                            Text(feature.explanation)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .accessibilityIdentifier(AccessibilityID.featureFlagToggle(feature.rawValue))
+                }
+            } header: {
+                Text(Strings.featureFlagsHeader)
+            } footer: {
+                Text(Strings.featureFlagsFooter)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                Button(Strings.featureFlagsResetAll) {
+                    featureFlags.resetAll()
+                }
+                .accessibilityIdentifier(AccessibilityID.featureFlagsResetButton)
+            }
+        }
+        .formStyle(.grouped)
+        .frame(minWidth: 450, minHeight: 300)
+    }
+
+    private func binding(for feature: Feature) -> Binding<Bool> {
+        Binding(
+            get: { featureFlags.isEnabled(feature) },
+            set: { featureFlags.setEnabled(feature, $0) }
+        )
+    }
+}

--- a/Pine/FeatureFlagsView.swift
+++ b/Pine/FeatureFlagsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct FeatureFlagsView: View {
-    private let featureFlags = FeatureFlags.shared
+    @Environment(FeatureFlags.self) private var featureFlags
 
     var body: some View {
         Form {

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -2103,6 +2103,786 @@
         }
       }
     },
+    "featureFlags.autoSave" : {
+      "comment" : "Feature flag display name for auto-save.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatisches Speichern"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-Save"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardado automático"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sauvegarde automatique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動保存"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 저장"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salvamento automático"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автосохранение"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动保存"
+          }
+        }
+      }
+    },
+    "featureFlags.autoSave.description" : {
+      "comment" : "Feature flag description for auto-save.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dateien automatisch nach Bearbeitung speichern"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatically save files after editing"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar archivos automáticamente después de editar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrer automatiquement les fichiers après modification"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編集後にファイルを自動保存"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "편집 후 파일 자동 저장"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salvar arquivos automaticamente após edição"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматически сохранять файлы после редактирования"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑后自动保存文件"
+          }
+        }
+      }
+    },
+    "featureFlags.footer" : {
+      "comment" : "Footer text in the feature flags settings section.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feature-Flags ermöglichen es, experimentelle Funktionen zur Laufzeit zu aktivieren oder zu deaktivieren. Änderungen werden sofort wirksam."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feature flags let you enable or disable experimental features at runtime. Changes take effect immediately."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los indicadores de funciones permiten activar o desactivar funciones experimentales en tiempo de ejecución. Los cambios se aplican de inmediato."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les drapeaux de fonctionnalités permettent d'activer ou de désactiver des fonctionnalités expérimentales à la volée. Les modifications prennent effet immédiatement."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機能フラグを使用すると、実験的な機能を実行時に有効または無効にできます。変更はすぐに反映されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기능 플래그를 사용하면 실험적 기능을 런타임에 활성화하거나 비활성화할 수 있습니다. 변경 사항은 즉시 적용됩니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Os sinalizadores de recursos permitem ativar ou desativar recursos experimentais em tempo de execução. As alterações entram em vigor imediatamente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Флаги функций позволяют включать и отключать экспериментальные функции во время работы. Изменения вступают в силу немедленно."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "功能标志可让您在运行时启用或禁用实验性功能。更改立即生效。"
+          }
+        }
+      }
+    },
+    "featureFlags.header" : {
+      "comment" : "Header text for the feature flags settings section.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feature-Flags"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feature Flags"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicadores de funciones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drapeaux de fonctionnalités"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "機能フラグ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기능 플래그"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sinalizadores de recursos"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Флаги функций"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "功能标志"
+          }
+        }
+      }
+    },
+    "featureFlags.minimap" : {
+      "comment" : "Feature flag display name for minimap.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimap"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimap"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimapa"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minicarte"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ミニマップ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미니맵"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimapa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Миникарта"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "迷你地图"
+          }
+        }
+      }
+    },
+    "featureFlags.minimap.description" : {
+      "comment" : "Feature flag description for minimap.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dokumentübersicht am rechten Rand des Editors anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show document overview on the right edge of the editor"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar vista general del documento en el borde derecho del editor"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher un aperçu du document sur le bord droit de l'éditeur"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エディタの右端にドキュメント概要を表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "편집기 오른쪽 가장자리에 문서 개요 표시"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar visão geral do documento na borda direita do editor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать обзор документа у правого края редактора"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在编辑器右侧显示文档概览"
+          }
+        }
+      }
+    },
+    "featureFlags.parallelSearch" : {
+      "comment" : "Feature flag display name for parallel search.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parallele Suche"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parallel Search"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Búsqueda paralela"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recherche parallèle"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "並列検索"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "병렬 검색"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesquisa paralela"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Параллельный поиск"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "并行搜索"
+          }
+        }
+      }
+    },
+    "featureFlags.parallelSearch.description" : {
+      "comment" : "Feature flag description for parallel search.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Projektweite Suche parallel in mehreren Dateien ausführen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Run project-wide search in parallel across multiple files"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ejecutar búsqueda de proyecto en paralelo en múltiples archivos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exécuter la recherche de projet en parallèle sur plusieurs fichiers"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複数ファイルでプロジェクト全体の検索を並列実行"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여러 파일에서 프로젝트 전체 검색을 병렬로 실행"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Executar pesquisa de projeto em paralelo em múltiplos arquivos"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выполнять поиск по проекту параллельно в нескольких файлах"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在多个文件中并行运行项目搜索"
+          }
+        }
+      }
+    },
+    "featureFlags.quickOpen" : {
+      "comment" : "Feature flag display name for quick open.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schnell öffnen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quick Open"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apertura rápida"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouverture rapide"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クイックオープン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "빠른 열기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abertura rápida"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Быстрое открытие"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速打开"
+          }
+        }
+      }
+    },
+    "featureFlags.quickOpen.description" : {
+      "comment" : "Feature flag description for quick open.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fuzzy-Suche zum schnellen Öffnen von Dateien im Projekt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fuzzy search to quickly open files in the project"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Búsqueda difusa para abrir archivos rápidamente en el proyecto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recherche floue pour ouvrir rapidement des fichiers dans le projet"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プロジェクト内のファイルをあいまい検索で素早く開く"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "프로젝트에서 파일을 빠르게 여는 퍼지 검색"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesquisa aproximada para abrir arquivos rapidamente no projeto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нечёткий поиск для быстрого открытия файлов в проекте"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模糊搜索快速打开项目中的文件"
+          }
+        }
+      }
+    },
+    "featureFlags.resetAll" : {
+      "comment" : "Button label to reset all feature flags to defaults.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle zurücksetzen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset All"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer todo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout réinitialiser"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてリセット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모두 재설정"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redefinir tudo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить все"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部重置"
+          }
+        }
+      }
+    },
+    "featureFlags.syntaxHighlighting" : {
+      "comment" : "Feature flag display name for syntax highlighting.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syntaxhervorhebung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syntax Highlighting"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resaltado de sintaxis"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coloration syntaxique"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シンタックスハイライト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "구문 강조"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destaque de sintaxe"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подсветка синтаксиса"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语法高亮"
+          }
+        }
+      }
+    },
+    "featureFlags.syntaxHighlighting.description" : {
+      "comment" : "Feature flag description for syntax highlighting.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syntaxhervorhebung für Programmiersprachen im Editor"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syntax highlighting for programming languages in the editor"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resaltado de sintaxis para lenguajes de programación en el editor"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coloration syntaxique pour les langages de programmation dans l'éditeur"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エディタ内のプログラミング言語のシンタックスハイライト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "편집기에서 프로그래밍 언어 구문 강조"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destaque de sintaxe para linguagens de programação no editor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подсветка синтаксиса для языков программирования в редакторе"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑器中编程语言的语法高亮"
+          }
+        }
+      }
+    },
     "fileOperation.createError %@" : {
       "comment" : "Error message when file creation fails. %@ is the file name.",
       "extractionState" : "manual",

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -413,6 +413,10 @@ struct PineApp: App {
         .defaultSize(width: 600, height: 400)
         .windowResizability(.contentSize)
         .defaultLaunchBehavior(.presented)
+
+        Settings {
+            FeatureFlagsView()
+        }
     }
 }
 

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -416,6 +416,7 @@ struct PineApp: App {
 
         Settings {
             FeatureFlagsView()
+                .environment(FeatureFlags.shared)
         }
     }
 }
@@ -500,6 +501,7 @@ private struct ProjectWindowView: View {
                     .environment(pm.terminal)
                     .environment(pm.tabManager)
                     .environment(registry)
+                    .environment(FeatureFlags.shared)
                     .focusedSceneValue(\.projectManager, pm)
                     .background {
                         WindowCloseInterceptor(

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -376,6 +376,12 @@ enum Strings {
         String(localized: "terminal.tabCloseWarning.close")
     }
 
+    // MARK: - Feature Flags
+
+    static let featureFlagsHeader: LocalizedStringKey = "featureFlags.header"
+    static let featureFlagsFooter: LocalizedStringKey = "featureFlags.footer"
+    static let featureFlagsResetAll: LocalizedStringKey = "featureFlags.resetAll"
+
     // MARK: - Progress Indicators
 
     static var progressLoadingProject: String {

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -26,6 +26,9 @@ final class TabManager {
     /// Number of bytes to load from the beginning of a huge file.
     static let hugeFilePartialLoadSize = FileSizeConstants.oneMB
 
+    /// Feature flags instance for gating features like auto-save.
+    var featureFlags: FeatureFlags = FeatureFlags.shared
+
     var tabs: [EditorTab] = []
     var activeTabID: UUID? {
         didSet {
@@ -241,7 +244,7 @@ final class TabManager {
         tabs[index].cachedHighlightResult = nil  // Invalidate stale highlight cache
         tabs[index].recomputeContentCaches()
 
-        if isAutoSaveEnabled {
+        if isAutoSaveEnabled && featureFlags.isEnabled(.autoSave) {
             scheduleAutoSave()
         }
 

--- a/PineTests/FeatureFlagsTests.swift
+++ b/PineTests/FeatureFlagsTests.swift
@@ -1,0 +1,226 @@
+//
+//  FeatureFlagsTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+@Suite("FeatureFlags Tests")
+struct FeatureFlagsTests {
+
+    private let suiteName = "PineTests.FeatureFlags.\(UUID().uuidString)"
+
+    private func makeDefaults() throws -> UserDefaults {
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        return defaults
+    }
+
+    private func cleanupDefaults(_ defaults: UserDefaults) {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    // MARK: - Default values
+
+    @Test func allFeaturesEnabledByDefault() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        for feature in Feature.allCases {
+            #expect(flags.isEnabled(feature), "Feature \(feature.rawValue) should be enabled by default")
+        }
+    }
+
+    @Test func defaultValuePropertyIsTrue() {
+        for feature in Feature.allCases {
+            #expect(feature.defaultValue == true)
+        }
+    }
+
+    // MARK: - Enable / Disable
+
+    @Test func disableFeature() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        flags.setEnabled(.parallelSearch, false)
+        #expect(flags.isEnabled(.parallelSearch) == false)
+    }
+
+    @Test func enableFeatureAfterDisable() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        flags.setEnabled(.minimap, false)
+        #expect(flags.isEnabled(.minimap) == false)
+
+        flags.setEnabled(.minimap, true)
+        #expect(flags.isEnabled(.minimap) == true)
+    }
+
+    @Test func toggleFeature() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        #expect(flags.isEnabled(.quickOpen) == true)
+
+        let newValue = flags.toggle(.quickOpen)
+        #expect(newValue == false)
+        #expect(flags.isEnabled(.quickOpen) == false)
+
+        let restored = flags.toggle(.quickOpen)
+        #expect(restored == true)
+        #expect(flags.isEnabled(.quickOpen) == true)
+    }
+
+    @Test func disablingOneDoesNotAffectOthers() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        flags.setEnabled(.autoSave, false)
+
+        for feature in Feature.allCases where feature != .autoSave {
+            #expect(flags.isEnabled(feature) == true,
+                    "Feature \(feature.rawValue) should still be enabled")
+        }
+    }
+
+    // MARK: - Persistence
+
+    @Test func flagPersistsToUserDefaults() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        flags.setEnabled(.syntaxHighlighting, false)
+
+        #expect(defaults.bool(forKey: Feature.syntaxHighlighting.rawValue) == false)
+    }
+
+    @Test func flagLoadsFromUserDefaults() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        defaults.set(false, forKey: Feature.parallelSearch.rawValue)
+
+        let flags = FeatureFlags(defaults: defaults)
+        #expect(flags.isEnabled(.parallelSearch) == false)
+    }
+
+    @Test func persistenceAcrossInstances() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags1 = FeatureFlags(defaults: defaults)
+        flags1.setEnabled(.minimap, false)
+        flags1.setEnabled(.autoSave, false)
+
+        let flags2 = FeatureFlags(defaults: defaults)
+        #expect(flags2.isEnabled(.minimap) == false)
+        #expect(flags2.isEnabled(.autoSave) == false)
+        #expect(flags2.isEnabled(.quickOpen) == true)
+    }
+
+    // MARK: - Reset
+
+    @Test func resetAllRestoresDefaults() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        for feature in Feature.allCases {
+            flags.setEnabled(feature, false)
+        }
+        for feature in Feature.allCases {
+            #expect(flags.isEnabled(feature) == false)
+        }
+
+        flags.resetAll()
+
+        for feature in Feature.allCases {
+            #expect(flags.isEnabled(feature) == true,
+                    "Feature \(feature.rawValue) should be restored to default")
+        }
+    }
+
+    @Test func resetAllClearsUserDefaults() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        flags.setEnabled(.parallelSearch, false)
+        flags.resetAll()
+
+        #expect(defaults.object(forKey: Feature.parallelSearch.rawValue) == nil)
+    }
+
+    @Test func resetSingleFeature() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        flags.setEnabled(.quickOpen, false)
+        flags.setEnabled(.minimap, false)
+
+        flags.reset(.quickOpen)
+
+        #expect(flags.isEnabled(.quickOpen) == true)
+        #expect(flags.isEnabled(.minimap) == false, "Other features should not be affected")
+    }
+
+    @Test func resetSingleClearsUserDefaultsKey() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        flags.setEnabled(.autoSave, false)
+        flags.reset(.autoSave)
+
+        #expect(defaults.object(forKey: Feature.autoSave.rawValue) == nil)
+    }
+
+    // MARK: - Feature enum
+
+    @Test func allCasesHaveDisplayName() {
+        for feature in Feature.allCases {
+            #expect(!feature.displayName.isEmpty)
+        }
+    }
+
+    @Test func allCasesHaveExplanation() {
+        for feature in Feature.allCases {
+            #expect(!feature.explanation.isEmpty)
+        }
+    }
+
+    @Test func featureIdsAreUnique() {
+        let ids = Feature.allCases.map(\.id)
+        #expect(Set(ids).count == ids.count, "Feature IDs must be unique")
+    }
+
+    @Test func featureRawValuesAreUserDefaultsKeys() {
+        // Verify convention: rawValue is used as UserDefaults key
+        for feature in Feature.allCases {
+            #expect(feature.rawValue.hasPrefix("feature"))
+        }
+    }
+
+    // MARK: - Command-line usage
+
+    @Test func commandLineDefaultsWriteSimulation() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        // Simulate: defaults write com.batonogov.pine featureParallelSearch -bool NO
+        defaults.set(false, forKey: "featureParallelSearch")
+
+        let flags = FeatureFlags(defaults: defaults)
+        #expect(flags.isEnabled(.parallelSearch) == false)
+    }
+}

--- a/PineTests/FeatureFlagsTests.swift
+++ b/PineTests/FeatureFlagsTests.swift
@@ -8,6 +8,7 @@ import Foundation
 @testable import Pine
 
 @Suite("FeatureFlags Tests")
+@MainActor
 struct FeatureFlagsTests {
 
     private let suiteName = "PineTests.FeatureFlags.\(UUID().uuidString)"
@@ -222,5 +223,99 @@ struct FeatureFlagsTests {
 
         let flags = FeatureFlags(defaults: defaults)
         #expect(flags.isEnabled(.parallelSearch) == false)
+    }
+
+    // MARK: - Auto-save integration
+
+    @Test func autoSaveRespectsFeatureFlag() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        let manager = TabManager()
+        manager.featureFlags = flags
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FeatureFlagsTests.\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let url = dir.appendingPathComponent("test.txt")
+        try "original".write(to: url, atomically: true, encoding: .utf8)
+
+        // Enable auto-save in UserDefaults
+        UserDefaults.standard.set(true, forKey: TabManager.autoSaveKey)
+        defer { UserDefaults.standard.removeObject(forKey: TabManager.autoSaveKey) }
+
+        manager.openTab(url: url)
+        manager.setAutoSaveDelay(0.05)
+
+        // Disable auto-save feature flag
+        flags.setEnabled(.autoSave, false)
+
+        // Update content — should NOT schedule auto-save
+        manager.updateContent("modified")
+        #expect(manager.hasScheduledAutoSave == false,
+                "Auto-save should not be scheduled when feature flag is disabled")
+    }
+
+    @Test func autoSaveWorksWhenFeatureFlagEnabled() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        let manager = TabManager()
+        manager.featureFlags = flags
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FeatureFlagsTests.\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let url = dir.appendingPathComponent("test.txt")
+        try "original".write(to: url, atomically: true, encoding: .utf8)
+
+        // Enable auto-save in UserDefaults
+        UserDefaults.standard.set(true, forKey: TabManager.autoSaveKey)
+        defer { UserDefaults.standard.removeObject(forKey: TabManager.autoSaveKey) }
+
+        manager.openTab(url: url)
+        manager.setAutoSaveDelay(0.05)
+
+        // Enable auto-save feature flag (default)
+        flags.setEnabled(.autoSave, true)
+
+        // Update content — SHOULD schedule auto-save
+        manager.updateContent("modified")
+        #expect(manager.hasScheduledAutoSave == true,
+                "Auto-save should be scheduled when feature flag is enabled")
+        manager.cancelAutoSave()
+    }
+
+    // MARK: - Feature flag integration properties
+
+    @Test func minimapFeatureFlagDefaultEnabled() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        #expect(flags.isEnabled(.minimap) == true)
+    }
+
+    @Test func syntaxHighlightingFeatureFlagDefaultEnabled() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        #expect(flags.isEnabled(.syntaxHighlighting) == true)
+    }
+
+    @Test func disablingMinimapDoesNotAffectSyntaxHighlighting() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let flags = FeatureFlags(defaults: defaults)
+        flags.setEnabled(.minimap, false)
+        #expect(flags.isEnabled(.syntaxHighlighting) == true)
     }
 }


### PR DESCRIPTION
## Summary

- Add `FeatureFlags` — `@Observable` class with `UserDefaults`-backed runtime feature flags
- Add `Feature` enum with 5 flags: `parallelSearch`, `quickOpen`, `minimap`, `autoSave`, `syntaxHighlighting`
- Add `FeatureFlagsView` in Settings scene (Cmd+,) with toggles and reset button
- All flags default to `true`, can be toggled off at runtime or via `defaults write`
- 18 unit tests covering enable/disable, persistence, reset, toggle, default values, and CLI usage

Closes #473

## Test plan

- [x] All 18 `FeatureFlagsTests` pass
- [ ] Open Settings (Cmd+,) — verify feature flags UI with toggles
- [ ] Toggle a flag off, relaunch, verify it persists
- [ ] Click "Reset All" — verify all flags return to enabled
- [ ] `defaults write com.batonogov.pine featureParallelSearch -bool NO` — verify flag reads as disabled