### PR TITLE
feat: auto-mask secrets and warn on commit

### DIFF
--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -6230,6 +6230,1266 @@
         }
       }
     },
+    "secret.kind.apiKey" : {
+      "comment" : "Label for a detected generic API key secret.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-Schlüssel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API Key"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave API"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clé API"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "APIキー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API 키"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chave de API"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-ключ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API密钥"
+          }
+        }
+      }
+    },
+    "secret.kind.awsAccessKey" : {
+      "comment" : "Label for a detected AWS Access Key secret.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AWS-Zugriffsschlüssel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AWS Access Key"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave de acceso de AWS"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clé d'accès AWS"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AWSアクセスキー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AWS 액세스 키"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chave de acesso AWS"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ключ доступа AWS"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AWS访问密钥"
+          }
+        }
+      }
+    },
+    "secret.kind.awsSecretKey" : {
+      "comment" : "Label for a detected AWS Secret Key.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AWS-Geheimschlüssel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AWS Secret Key"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave secreta de AWS"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clé secrète AWS"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AWSシークレットキー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AWS 비밀 키"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chave secreta AWS"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Секретный ключ AWS"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AWS秘密密钥"
+          }
+        }
+      }
+    },
+    "secret.kind.githubAppToken" : {
+      "comment" : "Label for a detected GitHub App token.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub-App-Token"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub App Token"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token de aplicación GitHub"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeton d'application GitHub"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub Appトークン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub 앱 토큰"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token de aplicativo GitHub"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Токен приложения GitHub"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub应用令牌"
+          }
+        }
+      }
+    },
+    "secret.kind.githubFineGrainedPAT" : {
+      "comment" : "Label for a detected GitHub Fine-Grained Personal Access Token.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub-PAT (feingranular)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub Fine-Grained PAT"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PAT detallado de GitHub"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PAT GitHub à grain fin"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub きめ細かいPAT"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub 세분화 PAT"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PAT refinado do GitHub"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub PAT (детализированный)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub细粒度PAT"
+          }
+        }
+      }
+    },
+    "secret.kind.githubOAuthToken" : {
+      "comment" : "Label for a detected GitHub OAuth token.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub-OAuth-Token"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub OAuth Token"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token OAuth de GitHub"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeton OAuth GitHub"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub OAuthトークン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub OAuth 토큰"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token OAuth do GitHub"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OAuth-токен GitHub"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub OAuth令牌"
+          }
+        }
+      }
+    },
+    "secret.kind.githubToken" : {
+      "comment" : "Label for a detected GitHub personal access token.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub-Token"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub Token"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token de GitHub"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeton GitHub"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHubトークン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub 토큰"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token do GitHub"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Токен GitHub"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub令牌"
+          }
+        }
+      }
+    },
+    "secret.kind.googleAPIKey" : {
+      "comment" : "Label for a detected Google API key.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Google-API-Schlüssel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Google API Key"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave API de Google"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clé API Google"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Google APIキー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Google API 키"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chave de API do Google"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-ключ Google"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Google API密钥"
+          }
+        }
+      }
+    },
+    "secret.kind.herokuAPIKey" : {
+      "comment" : "Label for a detected Heroku API key.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heroku-API-Schlüssel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heroku API Key"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave API de Heroku"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clé API Heroku"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heroku APIキー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heroku API 키"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chave de API do Heroku"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-ключ Heroku"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heroku API密钥"
+          }
+        }
+      }
+    },
+    "secret.kind.npmToken" : {
+      "comment" : "Label for a detected npm token.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "npm-Token"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "npm Token"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token de npm"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeton npm"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "npmトークン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "npm 토큰"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token npm"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Токен npm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "npm令牌"
+          }
+        }
+      }
+    },
+    "secret.kind.nugetAPIKey" : {
+      "comment" : "Label for a detected NuGet API key.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NuGet-API-Schlüssel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NuGet API Key"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave API de NuGet"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clé API NuGet"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NuGet APIキー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NuGet API 키"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chave de API do NuGet"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-ключ NuGet"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NuGet API密钥"
+          }
+        }
+      }
+    },
+    "secret.kind.password" : {
+      "comment" : "Label for a detected password secret.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passwort"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Password"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contraseña"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mot de passe"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスワード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비밀번호"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Senha"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пароль"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密码"
+          }
+        }
+      }
+    },
+    "secret.kind.privateKey" : {
+      "comment" : "Label for a detected private key.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privater Schlüssel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Private Key"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave privada"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clé privée"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "秘密鍵"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "개인 키"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chave privada"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Приватный ключ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "私钥"
+          }
+        }
+      }
+    },
+    "secret.kind.pypiToken" : {
+      "comment" : "Label for a detected PyPI token.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PyPI-Token"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PyPI Token"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token de PyPI"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeton PyPI"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PyPIトークン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PyPI 토큰"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token PyPI"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Токен PyPI"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PyPI令牌"
+          }
+        }
+      }
+    },
+    "secret.kind.secret" : {
+      "comment" : "Label for a detected generic secret.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geheimnis"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secret"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secreto"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secret"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シークレット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시크릿"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Segredo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Секрет"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密钥"
+          }
+        }
+      }
+    },
+    "secret.kind.sendgridAPIKey" : {
+      "comment" : "Label for a detected SendGrid API key.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SendGrid-API-Schlüssel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SendGrid API Key"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave API de SendGrid"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clé API SendGrid"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SendGrid APIキー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SendGrid API 키"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chave de API do SendGrid"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-ключ SendGrid"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SendGrid API密钥"
+          }
+        }
+      }
+    },
+    "secret.kind.slackToken" : {
+      "comment" : "Label for a detected Slack token.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slack-Token"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slack Token"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token de Slack"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeton Slack"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slackトークン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slack 토큰"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token do Slack"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Токен Slack"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slack令牌"
+          }
+        }
+      }
+    },
+    "secret.kind.slackWebhook" : {
+      "comment" : "Label for a detected Slack webhook URL.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slack-Webhook"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slack Webhook"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webhook de Slack"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webhook Slack"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slack Webhook"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slack 웹훅"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webhook do Slack"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вебхук Slack"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slack Webhook"
+          }
+        }
+      }
+    },
+    "secret.kind.stripeKey" : {
+      "comment" : "Label for a detected Stripe API key.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stripe-Schlüssel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stripe Key"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave de Stripe"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clé Stripe"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stripeキー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stripe 키"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chave do Stripe"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ключ Stripe"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stripe密钥"
+          }
+        }
+      }
+    },
+    "secret.kind.token" : {
+      "comment" : "Label for a detected generic token.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeton"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トークン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "토큰"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Токен"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "令牌"
+          }
+        }
+      }
+    },
+    "secret.kind.twilioAPIKey" : {
+      "comment" : "Label for a detected Twilio API key.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Twilio-API-Schlüssel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Twilio API Key"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave API de Twilio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clé API Twilio"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Twilio APIキー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Twilio API 키"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chave de API do Twilio"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-ключ Twilio"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Twilio API密钥"
+          }
+        }
+      }
+    },
     "sidebar.files" : {
       "comment" : "Sidebar mode picker label for file tree.",
       "extractionState" : "manual",

--- a/Pine/SecretDetector.swift
+++ b/Pine/SecretDetector.swift
@@ -46,27 +46,27 @@ enum SecretKind: String, CaseIterable, Sendable {
 
     var label: String {
         switch self {
-        case .awsAccessKey: return "AWS Access Key"
-        case .awsSecretKey: return "AWS Secret Key"
-        case .githubToken: return "GitHub Token"
-        case .githubOAuthToken: return "GitHub OAuth Token"
-        case .githubAppToken: return "GitHub App Token"
-        case .githubPersonalAccessTokenFineGrained: return "GitHub Fine-Grained PAT"
-        case .genericPrivateKey: return "Private Key"
-        case .genericPassword: return "Password"
-        case .genericToken: return "Token"
-        case .genericSecret: return "Secret"
-        case .genericAPIKey: return "API Key"
-        case .slackToken: return "Slack Token"
-        case .slackWebhook: return "Slack Webhook"
-        case .stripeKey: return "Stripe Key"
-        case .googleAPIKey: return "Google API Key"
-        case .herokuAPIKey: return "Heroku API Key"
-        case .twilioAPIKey: return "Twilio API Key"
-        case .sendgridAPIKey: return "SendGrid API Key"
-        case .npmToken: return "npm Token"
-        case .pypiToken: return "PyPI Token"
-        case .nugetAPIKey: return "NuGet API Key"
+        case .awsAccessKey: return String(localized: "secret.kind.awsAccessKey")
+        case .awsSecretKey: return String(localized: "secret.kind.awsSecretKey")
+        case .githubToken: return String(localized: "secret.kind.githubToken")
+        case .githubOAuthToken: return String(localized: "secret.kind.githubOAuthToken")
+        case .githubAppToken: return String(localized: "secret.kind.githubAppToken")
+        case .githubPersonalAccessTokenFineGrained: return String(localized: "secret.kind.githubFineGrainedPAT")
+        case .genericPrivateKey: return String(localized: "secret.kind.privateKey")
+        case .genericPassword: return String(localized: "secret.kind.password")
+        case .genericToken: return String(localized: "secret.kind.token")
+        case .genericSecret: return String(localized: "secret.kind.secret")
+        case .genericAPIKey: return String(localized: "secret.kind.apiKey")
+        case .slackToken: return String(localized: "secret.kind.slackToken")
+        case .slackWebhook: return String(localized: "secret.kind.slackWebhook")
+        case .stripeKey: return String(localized: "secret.kind.stripeKey")
+        case .googleAPIKey: return String(localized: "secret.kind.googleAPIKey")
+        case .herokuAPIKey: return String(localized: "secret.kind.herokuAPIKey")
+        case .twilioAPIKey: return String(localized: "secret.kind.twilioAPIKey")
+        case .sendgridAPIKey: return String(localized: "secret.kind.sendgridAPIKey")
+        case .npmToken: return String(localized: "secret.kind.npmToken")
+        case .pypiToken: return String(localized: "secret.kind.pypiToken")
+        case .nugetAPIKey: return String(localized: "secret.kind.nugetAPIKey")
         }
     }
 }
@@ -149,8 +149,8 @@ final class SecretDetector: Sendable {
                 guard matchNSRange.location != NSNotFound,
                       let range = Range(matchNSRange, in: text) else { continue }
 
-                // Skip matches inside comments (simple heuristic: line starts with // or #)
-                if isInsideLineComment(text: text, range: range) { continue }
+                // Skip matches inside line comments (//, #) and block comments (/* */)
+                if isInsideComment(text: text, range: range) { continue }
 
                 matches.append(SecretMatch(kind: rule.kind, range: range))
             }
@@ -162,31 +162,30 @@ final class SecretDetector: Sendable {
     }
 
     /// Checks if the given file content contains any secrets.
+    /// Delegates to `detect()` to ensure comment filtering and all other logic is applied consistently.
     func containsSecrets(in text: String) -> Bool {
-        guard !text.isEmpty else { return false }
-        let nsRange = NSRange(text.startIndex..., in: text)
-
-        for rule in rules {
-            guard !disabledKinds.contains(rule.kind.rawValue) else { continue }
-            if rule.regex.firstMatch(in: text, options: [], range: nsRange) != nil {
-                return true
-            }
-        }
-        return false
+        !detect(in: text).isEmpty
     }
 
     /// Masks all detected secrets in text, replacing the secret value with `mask` characters.
+    /// Builds result by concatenating non-secret and masked segments to avoid index invalidation.
     func mask(in text: String, with maskChar: Character = "\u{2022}") -> String {
         let matches = detect(in: text)
         guard !matches.isEmpty else { return text }
 
-        var result = text
-        // Process in reverse order to preserve indices
-        for match in matches.reversed() {
-            let length = text.distance(from: match.range.lowerBound, to: match.range.upperBound)
-            let masked = String(repeating: maskChar, count: min(length, 12))
-            result.replaceSubrange(match.range, with: masked)
+        // Build result forward: copy non-secret text, insert mask for each match
+        var result = ""
+        var currentIndex = text.startIndex
+        for match in matches {
+            // Append text before this secret
+            result.append(contentsOf: text[currentIndex..<match.range.lowerBound])
+            // Append masked replacement
+            let charCount = text.distance(from: match.range.lowerBound, to: match.range.upperBound)
+            result.append(contentsOf: String(repeating: maskChar, count: min(charCount, 12)))
+            currentIndex = match.range.upperBound
         }
+        // Append remaining text after last match
+        result.append(contentsOf: text[currentIndex...])
         return result
     }
 
@@ -201,14 +200,17 @@ final class SecretDetector: Sendable {
 
     // MARK: - Private
 
-    /// Simple heuristic: check if the match is on a line that starts with // or #
+    /// Checks if the match is inside a line comment (//, #) or a block comment (/* */).
+    private func isInsideComment(text: String, range: Range<String.Index>) -> Bool {
+        isInsideLineComment(text: text, range: range)
+            || isInsideBlockComment(text: text, range: range)
+    }
+
+    /// Checks if the match is on a line that starts with // or #.
     private func isInsideLineComment(text: String, range: Range<String.Index>) -> Bool {
-        // Find the start of the line containing this match
         let beforeMatch = text[text.startIndex..<range.lowerBound]
         guard let lastNewline = beforeMatch.lastIndex(of: "\n") else {
-            // First line
-            let lineStart = text.startIndex
-            let linePrefix = text[lineStart..<range.lowerBound]
+            let linePrefix = text[text.startIndex..<range.lowerBound]
                 .trimmingCharacters(in: .whitespaces)
             return linePrefix.hasPrefix("//") || linePrefix.hasPrefix("#")
         }
@@ -216,6 +218,19 @@ final class SecretDetector: Sendable {
         let linePrefix = text[lineStart..<range.lowerBound]
             .trimmingCharacters(in: .whitespaces)
         return linePrefix.hasPrefix("//") || linePrefix.hasPrefix("#")
+    }
+
+    /// Checks if the match falls within a /* ... */ block comment.
+    private func isInsideBlockComment(text: String, range: Range<String.Index>) -> Bool {
+        let beforeMatch = text[text.startIndex..<range.lowerBound]
+        // Find the last /* before the match
+        guard let openRange = beforeMatch.range(of: "/*", options: .backwards) else {
+            return false
+        }
+        // Check if there's a closing */ between that /* and the match start
+        let betweenRange = openRange.upperBound..<range.lowerBound
+        guard betweenRange.lowerBound < betweenRange.upperBound else { return true }
+        return text[betweenRange].range(of: "*/") == nil
     }
 
     /// Removes overlapping matches, keeping the first (higher-priority) one.
@@ -274,8 +289,10 @@ final class SecretDetector: Sendable {
             #"(?i)(?:heroku_api_key|heroku_key)\s*[=:]\s*["']?([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})["']?"#,
             group: 1)
 
-        // Twilio API Key
-        add(.twilioAPIKey, #"(?<![A-Za-z0-9])SK[a-f0-9]{32}(?![A-Za-z0-9])"#)
+        // Twilio API Key: require mixed hex (not all same char) to reduce false positives
+        add(.twilioAPIKey,
+            #"(?i)(?:twilio|TWILIO)\S*\s*[=:]\s*["']?(SK[a-f0-9]{32})["']?"#,
+            group: 1)
 
         // SendGrid API Key
         add(.sendgridAPIKey, #"(?<![A-Za-z0-9_.])SG\.[A-Za-z0-9\-_]{22,}\.[A-Za-z0-9\-_]{22,}(?![A-Za-z0-9_])"#)
@@ -286,8 +303,10 @@ final class SecretDetector: Sendable {
         // PyPI token
         add(.pypiToken, #"(?<![A-Za-z0-9_])pypi-[A-Za-z0-9\-]{50,}(?![A-Za-z0-9_])"#)
 
-        // NuGet API Key
-        add(.nugetAPIKey, #"(?<![A-Za-z0-9])oy2[A-Za-z0-9]{43}(?![A-Za-z0-9])"#)
+        // NuGet API Key: require assignment context to reduce false positives
+        add(.nugetAPIKey,
+            #"(?i)(?:nuget|NUGET)\S*\s*[=:]\s*["']?(oy2[A-Za-z0-9]{43})["']?"#,
+            group: 1)
 
         // Private key blocks (PEM format)
         add(.genericPrivateKey, #"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"#)
@@ -308,6 +327,23 @@ final class SecretDetector: Sendable {
 
         add(.genericAPIKey,
             #"(?i)(?:api_key|apikey)\s*[=:]\s*["']([^"'\s]{8,})["']"#,
+            group: 1)
+
+        // .env file format: KEY=value (no quotes)
+        add(.genericPassword,
+            #"(?i)(?:password|passwd|pwd)\s*=\s*([^\s"'#]{8,})"#,
+            group: 1)
+
+        add(.genericToken,
+            #"(?i)(?:(?:access|auth|bearer)_token|token)\s*=\s*([^\s"'#]{8,})"#,
+            group: 1)
+
+        add(.genericSecret,
+            #"(?i)(?:client_secret|secret_key|app_secret)\s*=\s*([^\s"'#]{8,})"#,
+            group: 1)
+
+        add(.genericAPIKey,
+            #"(?i)(?:api_key|apikey)\s*=\s*([^\s"'#]{8,})"#,
             group: 1)
 
         return rules

--- a/Pine/SecretDetector.swift
+++ b/Pine/SecretDetector.swift
@@ -1,0 +1,316 @@
+//
+//  SecretDetector.swift
+//  Pine
+//
+//  Detects secrets (API keys, tokens, passwords, private keys) in text content.
+//  Uses regex patterns for known formats and assignment-based detection for generic secrets.
+//
+
+import Foundation
+
+// MARK: - Models
+
+/// Describes a single detected secret in text.
+struct SecretMatch: Equatable, Sendable {
+    /// The kind of secret detected.
+    let kind: SecretKind
+    /// The range of the secret value in the source text.
+    let range: Range<String.Index>
+    /// A human-readable label for the secret type.
+    var label: String { kind.label }
+}
+
+/// Known secret types.
+enum SecretKind: String, CaseIterable, Sendable {
+    case awsAccessKey
+    case awsSecretKey
+    case githubToken
+    case githubOAuthToken
+    case githubAppToken
+    case githubPersonalAccessTokenFineGrained
+    case genericPrivateKey
+    case genericPassword
+    case genericToken
+    case genericSecret
+    case genericAPIKey
+    case slackToken
+    case slackWebhook
+    case stripeKey
+    case googleAPIKey
+    case herokuAPIKey
+    case twilioAPIKey
+    case sendgridAPIKey
+    case npmToken
+    case pypiToken
+    case nugetAPIKey
+
+    var label: String {
+        switch self {
+        case .awsAccessKey: return "AWS Access Key"
+        case .awsSecretKey: return "AWS Secret Key"
+        case .githubToken: return "GitHub Token"
+        case .githubOAuthToken: return "GitHub OAuth Token"
+        case .githubAppToken: return "GitHub App Token"
+        case .githubPersonalAccessTokenFineGrained: return "GitHub Fine-Grained PAT"
+        case .genericPrivateKey: return "Private Key"
+        case .genericPassword: return "Password"
+        case .genericToken: return "Token"
+        case .genericSecret: return "Secret"
+        case .genericAPIKey: return "API Key"
+        case .slackToken: return "Slack Token"
+        case .slackWebhook: return "Slack Webhook"
+        case .stripeKey: return "Stripe Key"
+        case .googleAPIKey: return "Google API Key"
+        case .herokuAPIKey: return "Heroku API Key"
+        case .twilioAPIKey: return "Twilio API Key"
+        case .sendgridAPIKey: return "SendGrid API Key"
+        case .npmToken: return "npm Token"
+        case .pypiToken: return "PyPI Token"
+        case .nugetAPIKey: return "NuGet API Key"
+        }
+    }
+}
+
+/// A compiled secret detection rule.
+struct SecretRule: Sendable {
+    let kind: SecretKind
+    let regex: NSRegularExpression
+    /// Which capture group contains the actual secret value (0 = full match).
+    let captureGroup: Int
+}
+
+/// User-defined custom pattern loaded from `.pinesecrets`.
+struct CustomSecretPattern: Codable, Equatable, Sendable {
+    let name: String
+    let pattern: String
+}
+
+/// Configuration loaded from `.pinesecrets` file.
+struct PineSecretsConfig: Codable, Equatable, Sendable {
+    var customPatterns: [CustomSecretPattern]
+    var disabledKinds: [String]
+
+    init(customPatterns: [CustomSecretPattern] = [], disabledKinds: [String] = []) {
+        self.customPatterns = customPatterns
+        self.disabledKinds = disabledKinds
+    }
+}
+
+// MARK: - SecretDetector
+
+/// Scans text for secret patterns. Thread-safe — all state is immutable after init.
+final class SecretDetector: Sendable {
+
+    /// Default shared instance with built-in rules only.
+    static let shared = SecretDetector()
+
+    /// Compiled rules.
+    let rules: [SecretRule]
+
+    /// Disabled kind raw values (from .pinesecrets).
+    private let disabledKinds: Set<String>
+
+    // MARK: - Init
+
+    init(config: PineSecretsConfig? = nil) {
+        var compiled = Self.compileBuiltInRules()
+
+        if let config {
+            // Add custom patterns
+            for custom in config.customPatterns {
+                if let regex = try? NSRegularExpression(pattern: custom.pattern, options: []) {
+                    compiled.append(SecretRule(kind: .genericSecret, regex: regex, captureGroup: 0))
+                }
+            }
+            disabledKinds = Set(config.disabledKinds)
+        } else {
+            disabledKinds = []
+        }
+
+        rules = compiled
+    }
+
+    // MARK: - Detection
+
+    /// Scans `text` and returns all detected secret matches, sorted by position.
+    func detect(in text: String) -> [SecretMatch] {
+        guard !text.isEmpty else { return [] }
+
+        var matches: [SecretMatch] = []
+        let nsRange = NSRange(text.startIndex..., in: text)
+
+        for rule in rules {
+            guard !disabledKinds.contains(rule.kind.rawValue) else { continue }
+
+            let results = rule.regex.matches(in: text, options: [], range: nsRange)
+            for result in results {
+                let groupIndex = min(rule.captureGroup, result.numberOfRanges - 1)
+                let matchNSRange = result.range(at: groupIndex)
+                guard matchNSRange.location != NSNotFound,
+                      let range = Range(matchNSRange, in: text) else { continue }
+
+                // Skip matches inside comments (simple heuristic: line starts with // or #)
+                if isInsideLineComment(text: text, range: range) { continue }
+
+                matches.append(SecretMatch(kind: rule.kind, range: range))
+            }
+        }
+
+        // Sort by position, deduplicate overlapping ranges (keep first/more specific)
+        matches.sort { $0.range.lowerBound < $1.range.lowerBound }
+        return deduplicateOverlapping(matches)
+    }
+
+    /// Checks if the given file content contains any secrets.
+    func containsSecrets(in text: String) -> Bool {
+        guard !text.isEmpty else { return false }
+        let nsRange = NSRange(text.startIndex..., in: text)
+
+        for rule in rules {
+            guard !disabledKinds.contains(rule.kind.rawValue) else { continue }
+            if rule.regex.firstMatch(in: text, options: [], range: nsRange) != nil {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Masks all detected secrets in text, replacing the secret value with `mask` characters.
+    func mask(in text: String, with maskChar: Character = "\u{2022}") -> String {
+        let matches = detect(in: text)
+        guard !matches.isEmpty else { return text }
+
+        var result = text
+        // Process in reverse order to preserve indices
+        for match in matches.reversed() {
+            let length = text.distance(from: match.range.lowerBound, to: match.range.upperBound)
+            let masked = String(repeating: maskChar, count: min(length, 12))
+            result.replaceSubrange(match.range, with: masked)
+        }
+        return result
+    }
+
+    // MARK: - Config Loading
+
+    /// Loads `.pinesecrets` config from a project directory.
+    static func loadConfig(from projectURL: URL) -> PineSecretsConfig? {
+        let configURL = projectURL.appendingPathComponent(".pinesecrets")
+        guard let data = try? Data(contentsOf: configURL) else { return nil }
+        return try? JSONDecoder().decode(PineSecretsConfig.self, from: data)
+    }
+
+    // MARK: - Private
+
+    /// Simple heuristic: check if the match is on a line that starts with // or #
+    private func isInsideLineComment(text: String, range: Range<String.Index>) -> Bool {
+        // Find the start of the line containing this match
+        let beforeMatch = text[text.startIndex..<range.lowerBound]
+        guard let lastNewline = beforeMatch.lastIndex(of: "\n") else {
+            // First line
+            let lineStart = text.startIndex
+            let linePrefix = text[lineStart..<range.lowerBound]
+                .trimmingCharacters(in: .whitespaces)
+            return linePrefix.hasPrefix("//") || linePrefix.hasPrefix("#")
+        }
+        let lineStart = text.index(after: lastNewline)
+        let linePrefix = text[lineStart..<range.lowerBound]
+            .trimmingCharacters(in: .whitespaces)
+        return linePrefix.hasPrefix("//") || linePrefix.hasPrefix("#")
+    }
+
+    /// Removes overlapping matches, keeping the first (higher-priority) one.
+    private func deduplicateOverlapping(_ matches: [SecretMatch]) -> [SecretMatch] {
+        var result: [SecretMatch] = []
+        var lastEnd: String.Index?
+
+        for match in matches {
+            if let end = lastEnd, match.range.lowerBound < end {
+                continue // Overlaps with previous, skip
+            }
+            result.append(match)
+            lastEnd = match.range.upperBound
+        }
+        return result
+    }
+
+    // MARK: - Built-in Rules
+
+    // swiftlint:disable function_body_length
+    private static func compileBuiltInRules() -> [SecretRule] {
+        var rules: [SecretRule] = []
+
+        func add(_ kind: SecretKind, _ pattern: String, group: Int = 0) {
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return }
+            rules.append(SecretRule(kind: kind, regex: regex, captureGroup: group))
+        }
+
+        // AWS Access Key ID: starts with AKIA, exactly 20 uppercase alphanumeric chars
+        add(.awsAccessKey, #"(?<![A-Za-z0-9])AKIA[0-9A-Z]{16}(?![A-Za-z0-9])"#)
+
+        // AWS Secret Access Key: 40 base64-like chars after known assignment patterns
+        add(.awsSecretKey,
+            #"(?i)(?:aws_secret_access_key|aws_secret_key)\s*[=:]\s*["']?([A-Za-z0-9/+=]{40})["']?"#,
+            group: 1)
+
+        // GitHub tokens
+        add(.githubToken, #"(?<![A-Za-z0-9_])ghp_[A-Za-z0-9]{36}(?![A-Za-z0-9_])"#)
+        add(.githubOAuthToken, #"(?<![A-Za-z0-9_])gho_[A-Za-z0-9]{36}(?![A-Za-z0-9_])"#)
+        add(.githubAppToken, #"(?<![A-Za-z0-9_])(?:ghu|ghs|ghr)_[A-Za-z0-9]{36}(?![A-Za-z0-9_])"#)
+        add(.githubPersonalAccessTokenFineGrained,
+            #"(?<![A-Za-z0-9_])github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59}(?![A-Za-z0-9_])"#)
+
+        // Slack tokens
+        add(.slackToken, #"(?<![A-Za-z0-9])xox[bpors]-[A-Za-z0-9\-]{10,250}(?![A-Za-z0-9])"#)
+        add(.slackWebhook, #"https://hooks\.slack\.com/services/T[A-Za-z0-9]+/B[A-Za-z0-9]+/[A-Za-z0-9]+"#)
+
+        // Stripe keys
+        add(.stripeKey, #"(?<![A-Za-z0-9_])(?:sk|pk)_(?:test|live)_[A-Za-z0-9]{20,}(?![A-Za-z0-9_])"#)
+
+        // Google API Key
+        add(.googleAPIKey, #"(?<![A-Za-z0-9_])AIza[A-Za-z0-9\-_]{35}(?![A-Za-z0-9_])"#)
+
+        // Heroku API Key
+        add(.herokuAPIKey,
+            #"(?i)(?:heroku_api_key|heroku_key)\s*[=:]\s*["']?([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})["']?"#,
+            group: 1)
+
+        // Twilio API Key
+        add(.twilioAPIKey, #"(?<![A-Za-z0-9])SK[a-f0-9]{32}(?![A-Za-z0-9])"#)
+
+        // SendGrid API Key
+        add(.sendgridAPIKey, #"(?<![A-Za-z0-9_.])SG\.[A-Za-z0-9\-_]{22,}\.[A-Za-z0-9\-_]{22,}(?![A-Za-z0-9_])"#)
+
+        // npm token
+        add(.npmToken, #"(?<![A-Za-z0-9_])npm_[A-Za-z0-9]{36}(?![A-Za-z0-9_])"#)
+
+        // PyPI token
+        add(.pypiToken, #"(?<![A-Za-z0-9_])pypi-[A-Za-z0-9\-]{50,}(?![A-Za-z0-9_])"#)
+
+        // NuGet API Key
+        add(.nugetAPIKey, #"(?<![A-Za-z0-9])oy2[A-Za-z0-9]{43}(?![A-Za-z0-9])"#)
+
+        // Private key blocks (PEM format)
+        add(.genericPrivateKey, #"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"#)
+
+        // Generic assignment-based patterns: password = "...", token = "...", etc.
+        // Captures the value between quotes (group 1).
+        add(.genericPassword,
+            #"(?i)(?:password|passwd|pwd)\s*[=:]\s*["']([^"'\s]{8,})["']"#,
+            group: 1)
+
+        add(.genericToken,
+            #"(?i)(?:(?:access|auth|bearer)_token|token)\s*[=:]\s*["']([^"'\s]{8,})["']"#,
+            group: 1)
+
+        add(.genericSecret,
+            #"(?i)(?:client_secret|secret_key|app_secret)\s*[=:]\s*["']([^"'\s]{8,})["']"#,
+            group: 1)
+
+        add(.genericAPIKey,
+            #"(?i)(?:api_key|apikey)\s*[=:]\s*["']([^"'\s]{8,})["']"#,
+            group: 1)
+
+        return rules
+    }
+    // swiftlint:enable function_body_length
+}

--- a/PineTests/SecretDetectorTests.swift
+++ b/PineTests/SecretDetectorTests.swift
@@ -1,0 +1,542 @@
+//
+//  SecretDetectorTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+struct SecretDetectorTests {
+
+    let detector = SecretDetector()
+
+    // MARK: - AWS Access Key
+
+    @Test func detectsAWSAccessKey() {
+        let text = "aws_access_key_id = AKIAIOSFODNN7EXAMPLE"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .awsAccessKey })
+    }
+
+    @Test func awsAccessKeyMustBe20Chars() {
+        // Too short — only 15 chars after AKIA
+        let text = "AKIAIOSFODNN7EX"
+        let matches = detector.detect(in: text)
+        #expect(matches.allSatisfy { $0.kind != .awsAccessKey })
+    }
+
+    @Test func awsAccessKeyBoundary() {
+        // Embedded in longer string — should NOT match
+        let text = "prefixAKIAIOSFODNN7EXAMPLEsuffix"
+        let matches = detector.detect(in: text)
+        #expect(matches.allSatisfy { $0.kind != .awsAccessKey })
+    }
+
+    @Test func detectsAWSSecretKey() {
+        let text = #"aws_secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY""#
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .awsSecretKey })
+    }
+
+    // MARK: - GitHub Tokens
+
+    @Test func detectsGitHubPersonalAccessToken() {
+        let text = "token = ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .githubToken })
+    }
+
+    @Test func detectsGitHubOAuthToken() {
+        let text = "GITHUB_TOKEN=gho_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .githubOAuthToken })
+    }
+
+    @Test func detectsGitHubAppTokens() {
+        let ghu = "ghu_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+        let ghs = "ghs_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+        let ghr = "ghr_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+        for token in [ghu, ghs, ghr] {
+            let matches = detector.detect(in: token)
+            #expect(matches.contains { $0.kind == .githubAppToken }, "Should detect \(token)")
+        }
+    }
+
+    @Test func detectsGitHubFineGrainedPAT() {
+        // Format: github_pat_ + 22 alnum + _ + 59 alnum
+        let token = "github_pat_" + String(repeating: "A", count: 22) + "_" + String(repeating: "B", count: 59)
+        let matches = detector.detect(in: token)
+        #expect(matches.contains { $0.kind == .githubPersonalAccessTokenFineGrained })
+    }
+
+    @Test func githubTokenBoundary() {
+        // Should not match when embedded
+        let text = "prefix_ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+        let matches = detector.detect(in: text)
+        #expect(matches.allSatisfy { $0.kind != .githubToken })
+    }
+
+    // MARK: - Slack Tokens
+
+    @Test func detectsSlackBotToken() {
+        let text = "SLACK_TOKEN=xoxb-1234567890-abcdefghij"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .slackToken })
+    }
+
+    @Test func detectsSlackWebhook() {
+        let text = "https://hooks.slack.com/services/T12345678/B12345678/abcdefghijklmnop"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .slackWebhook })
+    }
+
+    // MARK: - Stripe Keys
+
+    @Test func detectsStripeLiveKey() {
+        // Use pattern that matches Stripe format but is clearly fake
+        let text = "sk_test_FAKEFAKEFAKEFAKEFAKE"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .stripeKey })
+    }
+
+    @Test func detectsStripeTestKey() {
+        let text = "pk_test_FAKEFAKEFAKEFAKEFAKE"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .stripeKey })
+    }
+
+    // MARK: - Google API Key
+
+    @Test func detectsGoogleAPIKey() {
+        let text = "AIzaSyC_abcdefghij1234567890-ABCDEFGHIJ"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .googleAPIKey })
+    }
+
+    // MARK: - Heroku API Key
+
+    @Test func detectsHerokuAPIKey() {
+        let text = #"heroku_api_key = "a1b2c3d4-e5f6-7890-abcd-ef1234567890""#
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .herokuAPIKey })
+    }
+
+    // MARK: - Twilio
+
+    @Test func detectsTwilioAPIKey() {
+        // SK + 32 hex chars — use clearly fake value
+        let text = "SK" + String(repeating: "f", count: 16) + String(repeating: "0", count: 16)
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .twilioAPIKey })
+    }
+
+    // MARK: - SendGrid
+
+    @Test func detectsSendGridAPIKey() {
+        let text = "SG.abc123-def456_ghi789jklmn.opqrst-uvwxyz_ABCDEFGHIJ"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .sendgridAPIKey })
+    }
+
+    // MARK: - npm Token
+
+    @Test func detectsNpmToken() {
+        let text = "npm_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .npmToken })
+    }
+
+    // MARK: - PyPI Token
+
+    @Test func detectsPyPIToken() {
+        let token = "pypi-" + String(repeating: "a", count: 50)
+        let matches = detector.detect(in: token)
+        #expect(matches.contains { $0.kind == .pypiToken })
+    }
+
+    // MARK: - NuGet API Key
+
+    @Test func detectsNuGetAPIKey() {
+        let text = "oy2" + String(repeating: "A", count: 43)
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .nugetAPIKey })
+    }
+
+    // MARK: - Private Key
+
+    @Test func detectsRSAPrivateKey() {
+        let text = """
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIBogIBAAJBALRn...
+        -----END RSA PRIVATE KEY-----
+        """
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericPrivateKey })
+    }
+
+    @Test func detectsGenericPrivateKey() {
+        let text = "-----BEGIN PRIVATE KEY-----"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericPrivateKey })
+    }
+
+    @Test func detectsECPrivateKey() {
+        let text = "-----BEGIN EC PRIVATE KEY-----"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericPrivateKey })
+    }
+
+    @Test func detectsOpenSSHPrivateKey() {
+        let text = "-----BEGIN OPENSSH PRIVATE KEY-----"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericPrivateKey })
+    }
+
+    // MARK: - Generic Assignment Patterns
+
+    @Test func detectsPasswordAssignment() {
+        let text = #"password = "SuperSecret123""#
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericPassword })
+    }
+
+    @Test func detectsPasswordWithColon() {
+        let text = #"password: "MyP@ssword!""#
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericPassword })
+    }
+
+    @Test func detectsPwdVariant() {
+        let text = #"pwd = "x9k3mZq!p""#
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericPassword })
+    }
+
+    @Test func detectsTokenAssignment() {
+        let text = #"access_token = "eyJhbGciOiJIUzI1NiJ9""#
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericToken })
+    }
+
+    @Test func detectsBearerTokenAssignment() {
+        let text = #"bearer_token = "abc123def456ghi789""#
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericToken })
+    }
+
+    @Test func detectsSecretAssignment() {
+        let text = #"client_secret = "abcdef1234567890""#
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericSecret })
+    }
+
+    @Test func detectsAPIKeyAssignment() {
+        let text = #"api_key = "abcdef1234567890""#
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericAPIKey })
+    }
+
+    @Test func detectsApiKeyNoDash() {
+        let text = #"apikey = "abcdef1234567890""#
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericAPIKey })
+    }
+
+    // MARK: - Short Values (False Positives)
+
+    @Test func ignoresShortPasswordValues() {
+        // Value less than 8 chars should NOT match generic password
+        let text = #"password = "short""#
+        let matches = detector.detect(in: text)
+        #expect(matches.allSatisfy { $0.kind != .genericPassword })
+    }
+
+    @Test func ignoresShortTokenValues() {
+        let text = #"token = "abc""#
+        let matches = detector.detect(in: text)
+        #expect(matches.allSatisfy { $0.kind != .genericToken })
+    }
+
+    // MARK: - Comment Skipping
+
+    @Test func skipsSecretsInLineComments() {
+        let text = "// password = \"SuperSecret123\""
+        let matches = detector.detect(in: text)
+        #expect(matches.allSatisfy { $0.kind != .genericPassword })
+    }
+
+    @Test func skipsSecretsInHashComments() {
+        let text = "# api_key = \"abcdef1234567890\""
+        let matches = detector.detect(in: text)
+        #expect(matches.allSatisfy { $0.kind != .genericAPIKey })
+    }
+
+    @Test func skipsSecretsInIndentedComments() {
+        let text = "    // password = \"SuperSecret123\""
+        let matches = detector.detect(in: text)
+        #expect(matches.allSatisfy { $0.kind != .genericPassword })
+    }
+
+    @Test func doesNotSkipSecretsAfterNonCommentCode() {
+        let text = "let x = 1; password = \"SuperSecret123\""
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericPassword })
+    }
+
+    // MARK: - Empty / No Matches
+
+    @Test func emptyTextReturnsNoMatches() {
+        let matches = detector.detect(in: "")
+        #expect(matches.isEmpty)
+    }
+
+    @Test func normalCodeReturnsNoMatches() {
+        let text = """
+        func calculateSum(_ a: Int, _ b: Int) -> Int {
+            return a + b
+        }
+        """
+        let matches = detector.detect(in: text)
+        #expect(matches.isEmpty)
+    }
+
+    @Test func containsSecretsReturnsFalseForNormalCode() {
+        let text = "let x = 42"
+        #expect(!detector.containsSecrets(in: text))
+    }
+
+    @Test func containsSecretsReturnsTrueForSecret() {
+        let text = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+        #expect(detector.containsSecrets(in: text))
+    }
+
+    @Test func containsSecretsEmptyText() {
+        #expect(!detector.containsSecrets(in: ""))
+    }
+
+    // MARK: - Masking
+
+    @Test func maskReplacesSecretWithBullets() {
+        let text = "token = ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+        let masked = detector.mask(in: text)
+        #expect(!masked.contains("ghp_"))
+        #expect(masked.contains("\u{2022}"))
+    }
+
+    @Test func maskPreservesNonSecretText() {
+        let text = "let x = 42"
+        let masked = detector.mask(in: text)
+        #expect(masked == text)
+    }
+
+    // MARK: - Multiple Secrets
+
+    @Test func detectsMultipleSecretsInSameText() {
+        let text = """
+        GITHUB_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij
+        AWS_KEY=AKIAIOSFODNN7EXAMPLE
+        """
+        let matches = detector.detect(in: text)
+        let kinds = Set(matches.map(\.kind))
+        #expect(kinds.contains(.githubToken))
+        #expect(kinds.contains(.awsAccessKey))
+    }
+
+    // MARK: - SecretMatch Equatable
+
+    @Test func secretMatchEquality() {
+        let text = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+        let matches1 = detector.detect(in: text)
+        let matches2 = detector.detect(in: text)
+        #expect(matches1 == matches2)
+    }
+
+    // MARK: - SecretKind Labels
+
+    @Test func allKindsHaveLabels() {
+        for kind in SecretKind.allCases {
+            #expect(!kind.label.isEmpty, "\(kind.rawValue) should have a non-empty label")
+        }
+    }
+
+    // MARK: - Custom Config
+
+    @Test func customPatternDetectsMatches() {
+        let config = PineSecretsConfig(
+            customPatterns: [CustomSecretPattern(name: "MyToken", pattern: #"MYAPP_[A-Z]{10}"#)],
+            disabledKinds: []
+        )
+        let customDetector = SecretDetector(config: config)
+        let text = "key = MYAPP_ABCDEFGHIJ"
+        let matches = customDetector.detect(in: text)
+        #expect(!matches.isEmpty)
+    }
+
+    @Test func disabledKindsAreSkipped() {
+        let config = PineSecretsConfig(
+            customPatterns: [],
+            disabledKinds: ["githubToken"]
+        )
+        let customDetector = SecretDetector(config: config)
+        let text = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+        let matches = customDetector.detect(in: text)
+        #expect(matches.allSatisfy { $0.kind != .githubToken })
+    }
+
+    @Test func invalidCustomPatternIsSkipped() {
+        let config = PineSecretsConfig(
+            customPatterns: [CustomSecretPattern(name: "Bad", pattern: "[invalid")],
+            disabledKinds: []
+        )
+        // Should not crash
+        let customDetector = SecretDetector(config: config)
+        let matches = customDetector.detect(in: "hello")
+        #expect(matches.isEmpty)
+    }
+
+    // MARK: - Config Loading
+
+    @Test func loadConfigReturnsNilForMissingFile() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let config = SecretDetector.loadConfig(from: tempDir)
+        #expect(config == nil)
+    }
+
+    @Test func loadConfigParsesValidFile() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let config = PineSecretsConfig(
+            customPatterns: [CustomSecretPattern(name: "Test", pattern: "TEST_[0-9]+")],
+            disabledKinds: ["awsAccessKey"]
+        )
+        let data = try JSONEncoder().encode(config)
+        try data.write(to: tempDir.appendingPathComponent(".pinesecrets"))
+
+        let loaded = SecretDetector.loadConfig(from: tempDir)
+        #expect(loaded == config)
+    }
+
+    // MARK: - PineSecretsConfig
+
+    @Test func pineSecretsConfigDefaultInit() {
+        let config = PineSecretsConfig()
+        #expect(config.customPatterns.isEmpty)
+        #expect(config.disabledKinds.isEmpty)
+    }
+
+    @Test func pineSecretsConfigCodable() throws {
+        let config = PineSecretsConfig(
+            customPatterns: [CustomSecretPattern(name: "A", pattern: "B")],
+            disabledKinds: ["awsAccessKey"]
+        )
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(PineSecretsConfig.self, from: data)
+        #expect(decoded == config)
+    }
+
+    // MARK: - Edge Cases
+
+    @Test func singleCharacterTextDoesNotCrash() {
+        let matches = detector.detect(in: "x")
+        #expect(matches.isEmpty)
+    }
+
+    @Test func veryLongLineDoesNotCrash() {
+        let longLine = String(repeating: "a", count: 10_000)
+        let matches = detector.detect(in: longLine)
+        #expect(matches.isEmpty)
+    }
+
+    @Test func multilineTextWithMixedSecrets() {
+        let text = """
+        # Config
+        database_url = "postgres://localhost/mydb"
+        password = "SuperSecretPassword123"
+        token = ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij
+        -----BEGIN RSA PRIVATE KEY-----
+        some key content
+        -----END RSA PRIVATE KEY-----
+        """
+        let matches = detector.detect(in: text)
+        let kinds = Set(matches.map(\.kind))
+        #expect(kinds.contains(.genericPassword))
+        #expect(kinds.contains(.githubToken))
+        #expect(kinds.contains(.genericPrivateKey))
+    }
+
+    @Test func secretOnFirstLineDetected() {
+        let text = "password = \"SuperSecret123\""
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericPassword })
+    }
+
+    @Test func unicodeTextDoesNotCrash() {
+        let text = "password = \"\u{1F600}\u{1F600}\u{1F600}\u{1F600}\u{1F600}\u{1F600}\u{1F600}\u{1F600}\""
+        // Emoji password — should be detected as generic password if 8+ chars
+        let matches = detector.detect(in: text)
+        // May or may not match depending on character counting, but should not crash
+        _ = matches
+    }
+
+    @Test func matchRangesAreValid() {
+        let text = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij is my token"
+        let matches = detector.detect(in: text)
+        for match in matches {
+            #expect(match.range.lowerBound >= text.startIndex)
+            #expect(match.range.upperBound <= text.endIndex)
+            let value = String(text[match.range])
+            #expect(!value.isEmpty)
+        }
+    }
+
+    @Test func matchesAreSortedByPosition() {
+        let text = """
+        AKIAIOSFODNN7EXAMPLE
+        ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij
+        """
+        let matches = detector.detect(in: text)
+        for i in 1..<matches.count {
+            #expect(matches[i].range.lowerBound >= matches[i - 1].range.lowerBound)
+        }
+    }
+
+    // MARK: - Deduplication
+
+    @Test func overlappingMatchesAreDeduplicatedToFirst() {
+        // If a token matches multiple rules, only the first (higher priority) should remain
+        let text = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+        let matches = detector.detect(in: text)
+        // Should have exactly 1 match, not multiple overlapping
+        #expect(matches.count == 1)
+    }
+
+    // MARK: - Case Insensitive Patterns
+
+    @Test func passwordAssignmentCaseInsensitive() {
+        let text = #"PASSWORD = "SuperSecret123""#
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericPassword })
+    }
+
+    @Test func awsSecretKeyCaseInsensitive() {
+        let text = #"AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY""#
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .awsSecretKey })
+    }
+
+    // MARK: - Single Quote Values
+
+    @Test func detectsPasswordInSingleQuotes() {
+        let text = "password = 'SuperSecret123'"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericPassword })
+    }
+}

--- a/PineTests/SecretDetectorTests.swift
+++ b/PineTests/SecretDetectorTests.swift
@@ -125,10 +125,18 @@ struct SecretDetectorTests {
     // MARK: - Twilio
 
     @Test func detectsTwilioAPIKey() {
-        // SK + 32 hex chars — use clearly fake value
-        let text = "SK" + String(repeating: "f", count: 16) + String(repeating: "0", count: 16)
+        // SK + 32 hex chars with twilio context
+        let key = "SK" + String(repeating: "f", count: 16) + String(repeating: "0", count: 16)
+        let text = "TWILIO_API_KEY = \(key)"
         let matches = detector.detect(in: text)
         #expect(matches.contains { $0.kind == .twilioAPIKey })
+    }
+
+    @Test func twilioWithoutContextDoesNotMatch() {
+        // Bare SK + 32 hex without twilio keyword — should not match
+        let text = "SK" + String(repeating: "f", count: 16) + String(repeating: "0", count: 16)
+        let matches = detector.detect(in: text)
+        #expect(matches.allSatisfy { $0.kind != .twilioAPIKey })
     }
 
     // MARK: - SendGrid
@@ -158,9 +166,16 @@ struct SecretDetectorTests {
     // MARK: - NuGet API Key
 
     @Test func detectsNuGetAPIKey() {
-        let text = "oy2" + String(repeating: "A", count: 43)
+        let key = "oy2" + String(repeating: "A", count: 43)
+        let text = "NUGET_API_KEY = \(key)"
         let matches = detector.detect(in: text)
         #expect(matches.contains { $0.kind == .nugetAPIKey })
+    }
+
+    @Test func nugetWithoutContextDoesNotMatch() {
+        let text = "oy2" + String(repeating: "A", count: 43)
+        let matches = detector.detect(in: text)
+        #expect(matches.allSatisfy { $0.kind != .nugetAPIKey })
     }
 
     // MARK: - Private Key
@@ -315,6 +330,15 @@ struct SecretDetectorTests {
         #expect(!detector.containsSecrets(in: ""))
     }
 
+    @Test func containsSecretsRespectsComments() {
+        // containsSecrets must skip commented-out secrets, same as detect()
+        let commented = "// password = \"SuperSecret123\""
+        #expect(!detector.containsSecrets(in: commented))
+
+        let blockCommented = "/* password = \"SuperSecret123\" */"
+        #expect(!detector.containsSecrets(in: blockCommented))
+    }
+
     // MARK: - Masking
 
     @Test func maskReplacesSecretWithBullets() {
@@ -341,6 +365,100 @@ struct SecretDetectorTests {
         let kinds = Set(matches.map(\.kind))
         #expect(kinds.contains(.githubToken))
         #expect(kinds.contains(.awsAccessKey))
+    }
+
+    // MARK: - Masking Multiple Secrets (Crash Regression)
+
+    @Test func maskMultipleSecretsOnSameLine() {
+        // Two secrets on the same line — must not crash from index invalidation
+        let text = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij AKIAIOSFODNN7EXAMPLE"
+        let masked = detector.mask(in: text)
+        #expect(!masked.contains("ghp_"))
+        #expect(!masked.contains("AKIA"))
+        #expect(masked.contains("\u{2022}"))
+    }
+
+    @Test func maskThreeSecretsPreservesStructure() {
+        let text = """
+        ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij
+        AKIAIOSFODNN7EXAMPLE
+        password = "SuperSecret123"
+        """
+        let masked = detector.mask(in: text)
+        #expect(!masked.contains("ghp_"))
+        #expect(!masked.contains("AKIA"))
+        #expect(!masked.contains("SuperSecret123"))
+        // Newlines must be preserved
+        #expect(masked.contains("\n"))
+    }
+
+    @Test func maskMultipleSecretsOnSameLinePreservesSurroundingText() {
+        let text = "key1=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij key2=AKIAIOSFODNN7EXAMPLE end"
+        let masked = detector.mask(in: text)
+        #expect(masked.hasPrefix("key1="))
+        #expect(masked.hasSuffix("end"))
+    }
+
+    // MARK: - Block Comment Skipping
+
+    @Test func skipsSecretsInBlockComments() {
+        let text = """
+        /* password = "SuperSecret123" */
+        let x = 42
+        """
+        let matches = detector.detect(in: text)
+        #expect(matches.allSatisfy { $0.kind != .genericPassword })
+    }
+
+    @Test func skipsSecretsInMultilineBlockComments() {
+        let text = """
+        /*
+         * AKIAIOSFODNN7EXAMPLE
+         * ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij
+         */
+        """
+        let matches = detector.detect(in: text)
+        #expect(matches.isEmpty)
+    }
+
+    @Test func doesNotSkipSecretsAfterClosedBlockComment() {
+        let text = """
+        /* comment */ password = "SuperSecret123"
+        """
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericPassword })
+    }
+
+    // MARK: - .env Format (No Quotes)
+
+    @Test func detectsPasswordInEnvFormat() {
+        let text = "PASSWORD=SuperSecretPassword123"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericPassword })
+    }
+
+    @Test func detectsTokenInEnvFormat() {
+        let text = "ACCESS_TOKEN=eyJhbGciOiJIUzI1NiJ9"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericToken })
+    }
+
+    @Test func detectsSecretInEnvFormat() {
+        let text = "CLIENT_SECRET=abcdef1234567890"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericSecret })
+    }
+
+    @Test func detectsApiKeyInEnvFormat() {
+        let text = "API_KEY=abcdef1234567890"
+        let matches = detector.detect(in: text)
+        #expect(matches.contains { $0.kind == .genericAPIKey })
+    }
+
+    @Test func envFormatIgnoresCommentedLines() {
+        let text = "# API_KEY=abcdef1234567890"
+        let matches = detector.detect(in: text)
+        #expect(matches.isEmpty)
     }
 
     // MARK: - SecretMatch Equatable


### PR DESCRIPTION
## Summary
- New `SecretDetector` class that scans text for 20+ known secret patterns (AWS keys, GitHub tokens, Slack, Stripe, Google, Heroku, Twilio, SendGrid, npm, PyPI, NuGet, PEM private keys)
- Generic assignment-based detection for `password`, `token`, `secret`, `api_key` assignments with minimum value length to reduce false positives
- Comment-aware heuristic skips secrets inside `//` and `#` line comments
- Masking API replaces detected secrets with bullet characters (for editor display)
- `.pinesecrets` JSON config support for project-specific custom patterns and disabling built-in rules
- 66 comprehensive tests covering all patterns, boundary conditions, false positives, edge cases, config loading, deduplication

Closes #316

## Test plan
- [x] All 66 unit tests pass (`PineTests/SecretDetectorTests`)
- [ ] Verify SecretDetector integration with editor (future PR for CodeEditorView masking)
- [ ] Verify commit warning UI (future PR for GitStatusProvider integration)