### PR TITLE
feat: add clickable line endings indicator with LF/CRLF conversion

### DIFF
--- a/Pine/StatusBarInfo.swift
+++ b/Pine/StatusBarInfo.swift
@@ -53,6 +53,27 @@ enum LineEnding: Equatable {
         }
     }
 
+    /// The other line ending style.
+    var opposite: LineEnding {
+        switch self {
+        case .lf: .crlf
+        case .crlf: .lf
+        }
+    }
+
+    /// Converts content to use this line ending style.
+    /// First normalizes all line endings to LF, then converts to the target.
+    func convert(_ content: String) -> String {
+        // Normalize: CRLF → LF first, then convert LF → target
+        let normalized = content.replacingOccurrences(of: "\r\n", with: "\n")
+        switch self {
+        case .lf:
+            return normalized
+        case .crlf:
+            return normalized.replacingOccurrences(of: "\n", with: "\r\n")
+        }
+    }
+
     /// Detects the predominant line ending style in content.
     /// If the majority of line endings are CRLF, returns `.crlf`; otherwise `.lf`.
     static func detect(in content: String) -> LineEnding {

--- a/Pine/StatusBarView.swift
+++ b/Pine/StatusBarView.swift
@@ -82,11 +82,28 @@ struct StatusBarView: View {
 
                 statusDivider
 
-                // Line ending indicator (cached, recomputed on content change)
-                Text(verbatim: activeTab.cachedLineEnding.displayName)
-                    .font(.system(size: LayoutMetrics.bodySmallFontSize))
-                    .foregroundStyle(.secondary)
-                    .accessibilityIdentifier(AccessibilityID.lineEndingIndicator)
+                // Line ending indicator with conversion menu
+                Menu {
+                    ForEach([LineEnding.lf, .crlf], id: \.self) { ending in
+                        Button {
+                            tabManager.convertActiveTabLineEndings(to: ending)
+                        } label: {
+                            HStack {
+                                Text(ending.displayName)
+                                if ending == activeTab.cachedLineEnding {
+                                    Image(systemName: "checkmark")
+                                }
+                            }
+                        }
+                    }
+                } label: {
+                    Text(verbatim: activeTab.cachedLineEnding.displayName)
+                        .font(.system(size: LayoutMetrics.bodySmallFontSize))
+                        .foregroundStyle(.secondary)
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .accessibilityIdentifier(AccessibilityID.lineEndingIndicator)
 
                 statusDivider
 

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -259,6 +259,23 @@ final class TabManager {
         onEditorContextChanged?()
     }
 
+    /// Converts the active tab's line endings to the specified style.
+    /// Marks the tab as dirty if content actually changed.
+    func convertActiveTabLineEndings(to target: LineEnding) {
+        guard let index = activeTabIndex else { return }
+        guard tabs[index].kind == .text else { return }
+        let converted = target.convert(tabs[index].content)
+        guard converted != tabs[index].content else { return }
+        tabs[index].content = converted
+        tabs[index].cachedHighlightResult = nil
+        tabs[index].recomputeContentCaches()
+
+        if isAutoSaveEnabled {
+            scheduleAutoSave()
+        }
+        recoveryManager?.scheduleSnapshot()
+    }
+
     /// Updates the fold state for the active tab.
     func updateFoldState(_ state: FoldState) {
         guard let index = activeTabIndex else { return }

--- a/PineTests/StatusBarInfoTests.swift
+++ b/PineTests/StatusBarInfoTests.swift
@@ -120,6 +120,92 @@ struct StatusBarInfoTests {
         #expect(LineEnding.crlf.displayName == "CRLF")
     }
 
+    // MARK: - Line ending conversion
+
+    @Test("Convert LF to CRLF")
+    func convertLFToCRLF() {
+        let result = LineEnding.crlf.convert("hello\nworld\n")
+        #expect(result == "hello\r\nworld\r\n")
+    }
+
+    @Test("Convert CRLF to LF")
+    func convertCRLFToLF() {
+        let result = LineEnding.lf.convert("hello\r\nworld\r\n")
+        #expect(result == "hello\nworld\n")
+    }
+
+    @Test("Convert already matching line endings is no-op")
+    func convertNoOp() {
+        let lfContent = "hello\nworld\n"
+        #expect(LineEnding.lf.convert(lfContent) == lfContent)
+
+        let crlfContent = "hello\r\nworld\r\n"
+        #expect(LineEnding.crlf.convert(crlfContent) == crlfContent)
+    }
+
+    @Test("Convert mixed line endings normalizes to target")
+    func convertMixed() {
+        let mixed = "line1\nline2\r\nline3\n"
+        let toLF = LineEnding.lf.convert(mixed)
+        #expect(toLF == "line1\nline2\nline3\n")
+
+        let toCRLF = LineEnding.crlf.convert(mixed)
+        #expect(toCRLF == "line1\r\nline2\r\nline3\r\n")
+    }
+
+    @Test("Convert empty string")
+    func convertEmpty() {
+        #expect(LineEnding.lf.convert("") == "")
+        #expect(LineEnding.crlf.convert("") == "")
+    }
+
+    @Test("Convert string with no line endings")
+    func convertNoLineEndings() {
+        #expect(LineEnding.lf.convert("hello") == "hello")
+        #expect(LineEnding.crlf.convert("hello") == "hello")
+    }
+
+    @Test("The opposite property returns the other line ending")
+    func lineEndingOpposite() {
+        #expect(LineEnding.lf.opposite == .crlf)
+        #expect(LineEnding.crlf.opposite == .lf)
+    }
+
+    // MARK: - TabManager line ending conversion
+
+    @Test("TabManager converts line endings and marks dirty")
+    func tabManagerConvertLineEndings() {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("test.swift")
+        try? "hello\nworld\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let manager = TabManager()
+        manager.openTab(url: url)
+        #expect(manager.activeTab?.cachedLineEnding == .lf)
+
+        manager.convertActiveTabLineEndings(to: .crlf)
+        #expect(manager.activeTab?.content == "hello\r\nworld\r\n")
+        #expect(manager.activeTab?.cachedLineEnding == .crlf)
+        #expect(manager.activeTab?.isDirty == true)
+    }
+
+    @Test("TabManager convert line endings same format is no-op")
+    func tabManagerConvertSameLineEndings() {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("test.swift")
+        try? "hello\nworld\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let manager = TabManager()
+        manager.openTab(url: url)
+        let originalContent = manager.activeTab?.content
+
+        manager.convertActiveTabLineEndings(to: .lf)
+        #expect(manager.activeTab?.content == originalContent)
+        #expect(manager.activeTab?.isDirty == false)
+    }
+
     // MARK: - Indentation detection
 
     @Test("Detect spaces indentation")


### PR DESCRIPTION
## Summary

- Add clickable line endings indicator (LF/CRLF) in the status bar with a dropdown menu to convert between formats
- `LineEnding.convert(_:)` normalizes all line endings to LF first, then converts to target — handles mixed endings correctly
- `TabManager.convertActiveTabLineEndings(to:)` applies conversion, marks tab dirty, invalidates highlight cache, triggers auto-save/recovery

Closes #277

## Test plan

- [x] Unit tests for `LineEnding.convert` — LF→CRLF, CRLF→LF, mixed, no-op, empty, no line endings
- [x] Unit tests for `LineEnding.opposite`
- [x] Unit tests for `TabManager.convertActiveTabLineEndings` — conversion marks dirty, same format is no-op
- [x] All 38 StatusBarInfoTests pass
- [ ] Manual: open file with LF endings, click indicator, select CRLF — verify content changes and tab shows unsaved dot
- [ ] Manual: verify CRLF file saves correctly with CRLF line endings preserved