### PR TITLE
fix: sync line endings menu checkmark after conversion

### DIFF
--- a/Pine/StatusBarView.swift
+++ b/Pine/StatusBarView.swift
@@ -103,6 +103,7 @@ struct StatusBarView: View {
                 }
                 .menuStyle(.borderlessButton)
                 .fixedSize()
+                .id(activeTab.cachedLineEnding)
                 .accessibilityIdentifier(AccessibilityID.lineEndingIndicator)
 
                 statusDivider

--- a/PineTests/StatusBarInfoTests.swift
+++ b/PineTests/StatusBarInfoTests.swift
@@ -190,6 +190,30 @@ struct StatusBarInfoTests {
         #expect(manager.activeTab?.isDirty == true)
     }
 
+    @Test("TabManager cachedLineEnding updates after round-trip conversion")
+    func tabManagerCachedLineEndingRoundTrip() {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("test.swift")
+        try? "line1\nline2\n".write(to: url, atomically: true, encoding: .utf8)
+
+        let manager = TabManager()
+        manager.openTab(url: url)
+        #expect(manager.activeTab?.cachedLineEnding == .lf)
+
+        // LF → CRLF
+        manager.convertActiveTabLineEndings(to: .crlf)
+        #expect(manager.activeTab?.cachedLineEnding == .crlf)
+
+        // CRLF → LF
+        manager.convertActiveTabLineEndings(to: .lf)
+        #expect(manager.activeTab?.cachedLineEnding == .lf)
+
+        // LF → CRLF again
+        manager.convertActiveTabLineEndings(to: .crlf)
+        #expect(manager.activeTab?.cachedLineEnding == .crlf)
+    }
+
     @Test("TabManager convert line endings same format is no-op")
     func tabManagerConvertSameLineEndings() {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)


### PR DESCRIPTION
## Summary

- Fix stale checkmark in line endings menu after LF/CRLF conversion
- Add `.id(activeTab.cachedLineEnding)` to force SwiftUI `Menu` rebuild when line ending changes
- Add round-trip conversion test (LF→CRLF→LF→CRLF) verifying `cachedLineEnding` stays in sync

Closes #616

## Root cause

SwiftUI `Menu` content is lazily evaluated — it does not re-evaluate when observed data changes. After `convertActiveTabLineEndings`, the model (`cachedLineEnding`) updates correctly, but the Menu body still renders the old checkmark position.

## Fix

`.id(activeTab.cachedLineEnding)` forces SwiftUI to destroy and recreate the `Menu` view whenever `cachedLineEnding` changes, ensuring the checkmark reflects the current state.

## Test plan

- [x] New unit test: `tabManagerCachedLineEndingRoundTrip` — verifies cachedLineEnding updates correctly through multiple conversions
- [x] All 39 StatusBarInfoTests pass
- [ ] Manual: open LF file → convert to CRLF → click menu again → checkmark on CRLF