### PR TITLE
fix: redesign screenshot tests with XCTAttachment and CI automation (#289)

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   screenshots:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,24 @@
+# NOTE: All third-party actions are pinned by full commit SHA for supply-chain safety.
+name: Update Screenshots
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  screenshots:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run screenshot tests and extract
+        run: bash scripts/update-screenshots.sh
+
+      - name: Commit screenshots
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git add assets/screenshot-*.png
+          git diff --staged --quiet || git commit -m "chore: update screenshots"
+          git push

--- a/PineUITests/ScreenshotTests.swift
+++ b/PineUITests/ScreenshotTests.swift
@@ -2,43 +2,22 @@
 //  ScreenshotTests.swift
 //  PineUITests
 //
-//  On-demand screenshot capture for assets/ directory.
-//  Skipped in CI — run locally: xcodebuild test ... -only-testing:PineUITests/ScreenshotTests
+//  On-demand screenshot capture using XCTAttachment (Apple Way).
+//  Run locally or in CI: xcodebuild test ... -only-testing:PineUITests/ScreenshotTests
+//  Screenshots are saved in the .xcresult bundle. Extract with:
+//    scripts/update-screenshots.sh
 //
 
 import XCTest
 
 final class ScreenshotTests: PineUITestCase {
 
-    /// Screenshots are on-demand only — skip in CI.
-    private func skipInCI() throws {
-        if ProcessInfo.processInfo.environment["CI"] != nil {
-            throw XCTSkip("Screenshot tests run on demand, not in CI")
-        }
-    }
-
-    /// Path to the assets/ directory at the repo root.
-    /// Uses PINE_REPO_ROOT env var (set by the caller) instead of #filePath,
-    /// which is unreliable in Xcode-managed build directories.
-    private var assetsDirectory: URL {
-        guard let root = ProcessInfo.processInfo.environment["PINE_REPO_ROOT"] else {
-            preconditionFailure("PINE_REPO_ROOT env var must be set to the repo root path")
-        }
-        return URL(fileURLWithPath: root).appendingPathComponent("assets", isDirectory: true)
-    }
-
-    /// Saves a screenshot to assets/ with the given filename and verifies the file was written.
-    private func saveScreenshot(_ screenshot: XCUIScreenshot, name: String) throws {
-        let fm = FileManager.default
-        if !fm.fileExists(atPath: assetsDirectory.path) {
-            try fm.createDirectory(at: assetsDirectory, withIntermediateDirectories: true)
-        }
-        let fileURL = assetsDirectory.appendingPathComponent(name)
-        try screenshot.pngRepresentation.write(to: fileURL)
-        XCTAssertTrue(
-            fm.fileExists(atPath: fileURL.path),
-            "Screenshot file should exist at \(fileURL.path)"
-        )
+    /// Attaches a screenshot to the test result with the given name.
+    private func attachScreenshot(_ screenshot: XCUIScreenshot, name: String) {
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
     }
 
     private var projectURL: URL?
@@ -51,8 +30,6 @@ final class ScreenshotTests: PineUITestCase {
     // MARK: - Welcome Window
 
     func testCaptureWelcomeWindow() throws {
-        try skipInCI()
-
         launchClean()
 
         let welcomeWindow = app.windows["welcome"]
@@ -65,14 +42,12 @@ final class ScreenshotTests: PineUITestCase {
         Thread.sleep(forTimeInterval: 1.0)
 
         let screenshot = app.windows["welcome"].screenshot()
-        try saveScreenshot(screenshot, name: "screenshot-welcome.png")
+        attachScreenshot(screenshot, name: "screenshot-welcome")
     }
 
     // MARK: - Editor with File
 
     func testCaptureEditorWithFile() throws {
-        try skipInCI()
-
         let swiftCode = """
         import Foundation
 
@@ -113,14 +88,12 @@ final class ScreenshotTests: PineUITestCase {
         Thread.sleep(forTimeInterval: 2.0)
 
         let screenshot = app.windows.firstMatch.screenshot()
-        try saveScreenshot(screenshot, name: "screenshot-editor.png")
+        attachScreenshot(screenshot, name: "screenshot-editor")
     }
 
     // MARK: - Terminal
 
     func testCaptureTerminal() throws {
-        try skipInCI()
-
         projectURL = try createTempProject(files: [
             "main.swift": "print(\"Hello, Pine!\")\n"
         ])
@@ -149,14 +122,12 @@ final class ScreenshotTests: PineUITestCase {
         Thread.sleep(forTimeInterval: 2.0)
 
         let screenshot = app.windows.firstMatch.screenshot()
-        try saveScreenshot(screenshot, name: "screenshot-terminal.png")
+        attachScreenshot(screenshot, name: "screenshot-terminal")
     }
 
     // MARK: - Sidebar (file tree)
 
     func testCaptureSidebar() throws {
-        try skipInCI()
-
         projectURL = try createTempProject(
             files: [
                 "Sources/App.swift": "// App entry point\n",
@@ -193,12 +164,10 @@ final class ScreenshotTests: PineUITestCase {
         Thread.sleep(forTimeInterval: 1.0)
 
         let screenshot = app.windows.firstMatch.screenshot()
-        try saveScreenshot(screenshot, name: "screenshot-sidebar.png")
+        attachScreenshot(screenshot, name: "screenshot-sidebar")
     }
 
     /// Tries to expand a folder row in the sidebar outline.
-    /// Uses multiple strategies because SwiftUI List disclosure behavior
-    /// is unreliable with XCUITest synthetic events on macOS 26.
     private func expandFolder(_ row: XCUIElement, in sidebar: XCUIElement) {
         // Strategy 1: double-click the row text
         row.doubleClick()
@@ -222,8 +191,6 @@ final class ScreenshotTests: PineUITestCase {
     // MARK: - Minimap
 
     func testCaptureMinimap() throws {
-        try skipInCI()
-
         // Create a file with enough content to make the minimap useful
         let lines = (1...80).map { "let line\($0) = \($0) * \($0)" }.joined(separator: "\n")
         let swiftCode = """
@@ -259,14 +226,12 @@ final class ScreenshotTests: PineUITestCase {
         Thread.sleep(forTimeInterval: 2.0)
 
         let screenshot = app.windows.firstMatch.screenshot()
-        try saveScreenshot(screenshot, name: "screenshot-minimap.png")
+        attachScreenshot(screenshot, name: "screenshot-minimap")
     }
 
     // MARK: - Markdown Preview
 
     func testCaptureMarkdownPreview() throws {
-        try skipInCI()
-
         let markdown = """
         # Pine Editor
 
@@ -314,6 +279,6 @@ final class ScreenshotTests: PineUITestCase {
         Thread.sleep(forTimeInterval: 2.0)
 
         let screenshot = app.windows.firstMatch.screenshot()
-        try saveScreenshot(screenshot, name: "screenshot-markdown.png")
+        attachScreenshot(screenshot, name: "screenshot-markdown")
     }
 }

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ xcodebuild -project Pine.xcodeproj -scheme Pine build
 
 SwiftTerm is resolved automatically via Swift Package Manager on first build.
 
+## Updating Screenshots
+
+Run `bash scripts/update-screenshots.sh` to capture fresh screenshots. The script runs UI tests, extracts screenshot attachments from the `.xcresult` bundle, and saves them to `assets/`.
+
 ## Built With
 
 - SwiftUI for app structure and native macOS UI

--- a/scripts/update-screenshots.sh
+++ b/scripts/update-screenshots.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+RESULT_PATH="$REPO_ROOT/build/screenshots.xcresult"
+
+# Clean previous result bundle
+rm -rf "$RESULT_PATH"
+
+echo "Running screenshot tests..."
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  xcodebuild test \
+  -project "$REPO_ROOT/Pine.xcodeproj" \
+  -scheme Pine \
+  -destination 'platform=macOS' \
+  -only-testing:PineUITests/ScreenshotTests \
+  -resultBundlePath "$RESULT_PATH" \
+  || true
+
+if [ ! -d "$RESULT_PATH" ]; then
+  echo "Error: xcresult bundle not found at $RESULT_PATH"
+  exit 1
+fi
+
+echo "Extracting screenshots..."
+
+# Get the test plan run summaries from xcresult
+GRAPH=$(xcrun xcresulttool get --path "$RESULT_PATH" --format json 2>/dev/null)
+
+# Extract all attachment IDs and names from the xcresult graph
+# Walk: actions -> actionResult -> testsRef -> summaries -> testableSummaries -> tests -> subtests -> ...
+TESTS_REF_ID=$(echo "$GRAPH" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+actions = data.get('actions', {}).get('_values', [])
+for action in actions:
+    result = action.get('actionResult', {})
+    tests_ref = result.get('testsRef', {})
+    ref_id = tests_ref.get('id', {}).get('_value', '')
+    if ref_id:
+        print(ref_id)
+        break
+")
+
+if [ -z "$TESTS_REF_ID" ]; then
+  echo "Error: could not find testsRef in xcresult"
+  exit 1
+fi
+
+# Get the test plan run summaries
+TESTS_SUMMARY=$(xcrun xcresulttool get --path "$RESULT_PATH" --format json --id "$TESTS_REF_ID" 2>/dev/null)
+
+# Extract attachment references (id + name) from test summaries
+ATTACHMENTS=$(echo "$TESTS_SUMMARY" | python3 -c "
+import json, sys
+
+def find_attachments(obj, results=None):
+    if results is None:
+        results = []
+    if isinstance(obj, dict):
+        if 'attachments' in obj:
+            atts = obj['attachments'].get('_values', [])
+            for att in atts:
+                name = att.get('name', {}).get('_value', '')
+                payload_ref = att.get('payloadRef', {})
+                att_id = payload_ref.get('id', {}).get('_value', '')
+                if name.startswith('screenshot-') and att_id:
+                    results.append(f'{att_id}|{name}')
+        for v in obj.values():
+            find_attachments(v, results)
+    elif isinstance(obj, list):
+        for item in obj:
+            find_attachments(item, results)
+    return results
+
+data = json.load(sys.stdin)
+for line in find_attachments(data):
+    print(line)
+")
+
+if [ -z "$ATTACHMENTS" ]; then
+  echo "Error: no screenshot attachments found in test results"
+  exit 1
+fi
+
+ASSETS_DIR="$REPO_ROOT/assets"
+mkdir -p "$ASSETS_DIR"
+
+COUNT=0
+while IFS='|' read -r ATT_ID ATT_NAME; do
+  OUTPUT_FILE="$ASSETS_DIR/${ATT_NAME}.png"
+  echo "  Extracting $ATT_NAME -> $OUTPUT_FILE"
+  xcrun xcresulttool export --path "$RESULT_PATH" --id "$ATT_ID" --output-path "$OUTPUT_FILE" --type file 2>/dev/null
+  COUNT=$((COUNT + 1))
+done <<< "$ATTACHMENTS"
+
+echo "Done! $COUNT screenshots saved to assets/"


### PR DESCRIPTION
## Summary

Complete redesign of screenshot automation:
- `XCTAttachment` instead of direct file writes (sandbox-safe, Apple Way)
- `scripts/update-screenshots.sh` — extract screenshots from xcresult
- `.github/workflows/screenshots.yml` — CI workflow on `workflow_dispatch` + release, `macos-26` runner
- Auto-commit screenshots to `assets/`

Replaces previous approach from #608 which crashed due to sandbox permissions.

## Test plan

- [x] Screenshot tests pass locally (5/6, markdown preview depends on #618)
- [x] XCTAttachment saves to xcresult
- [x] Script extracts screenshots
- [ ] CI workflow (needs merge to test)