### PR TITLE
feat: inline config validation (yamllint, terraform, shellcheck, hadolint)

### DIFF
--- a/Pine/ConfigValidator.swift
+++ b/Pine/ConfigValidator.swift
@@ -1,0 +1,518 @@
+//
+//  ConfigValidator.swift
+//  Pine
+//
+//  Created by Claude on 29.03.2026.
+//
+
+import Foundation
+
+// MARK: - Models
+
+/// Severity of a validation diagnostic.
+enum ValidationSeverity: Sendable, Equatable {
+    case error
+    case warning
+    case info
+}
+
+/// A single validation diagnostic tied to a line in the file.
+struct ValidationDiagnostic: Sendable, Equatable, Identifiable {
+    let id = UUID()
+    let line: Int
+    let column: Int?
+    let message: String
+    let severity: ValidationSeverity
+    /// The validator that produced this diagnostic (e.g. "yamllint", "shellcheck").
+    let source: String
+
+    static func == (lhs: ValidationDiagnostic, rhs: ValidationDiagnostic) -> Bool {
+        lhs.line == rhs.line
+            && lhs.column == rhs.column
+            && lhs.message == rhs.message
+            && lhs.severity == rhs.severity
+            && lhs.source == rhs.source
+    }
+}
+
+/// The type of config validator to use for a given file.
+enum ValidatorKind: Sendable, Equatable {
+    case yamllint
+    case terraform
+    case shellcheck
+    case hadolint
+
+    /// Display name for status bar / tooltips.
+    var displayName: String {
+        switch self {
+        case .yamllint: return "yamllint"
+        case .terraform: return "terraform"
+        case .shellcheck: return "shellcheck"
+        case .hadolint: return "hadolint"
+        }
+    }
+
+    /// The command-line tool name.
+    var toolName: String {
+        switch self {
+        case .yamllint: return "yamllint"
+        case .terraform: return "terraform"
+        case .shellcheck: return "shellcheck"
+        case .hadolint: return "hadolint"
+        }
+    }
+}
+
+// MARK: - Validator Detection
+
+/// Determines which validator to use based on file extension or name.
+enum ValidatorDetector {
+    static func detect(for url: URL) -> ValidatorKind? {
+        let ext = url.pathExtension.lowercased()
+        let name = url.lastPathComponent.lowercased()
+
+        switch ext {
+        case "yml", "yaml":
+            return .yamllint
+        case "tf", "tfvars":
+            return .terraform
+        case "sh", "bash", "zsh":
+            return .shellcheck
+        default:
+            break
+        }
+
+        // Dockerfile detection by name
+        if name == "dockerfile" || name.hasPrefix("dockerfile.") {
+            return .hadolint
+        }
+
+        return nil
+    }
+}
+
+// MARK: - Tool Availability
+
+/// Checks whether a command-line tool is available via `which`.
+enum ToolAvailability {
+    /// Cached availability results to avoid repeated `which` calls.
+    private static var cache: [String: String?] = [:]
+    private static let lock = NSLock()
+
+    /// Returns the full path to the tool if installed, nil otherwise.
+    static func path(for tool: String) -> String? {
+        lock.lock()
+        if let cached = cache[tool] {
+            lock.unlock()
+            return cached
+        }
+        lock.unlock()
+
+        let result = runWhich(tool)
+
+        lock.lock()
+        cache[tool] = result
+        lock.unlock()
+
+        return result
+    }
+
+    /// Clears cached results (useful for testing).
+    static func clearCache() {
+        lock.lock()
+        cache.removeAll()
+        lock.unlock()
+    }
+
+    private static func runWhich(_ tool: String) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        process.arguments = [tool]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+
+        // Add common tool paths
+        var env = ProcessInfo.processInfo.environment
+        let extraPaths = [
+            "/usr/local/bin",
+            "/opt/homebrew/bin",
+            "/usr/bin",
+            "\(NSHomeDirectory())/.local/bin"
+        ]
+        let currentPath = env["PATH"] ?? "/usr/bin:/bin"
+        env["PATH"] = (extraPaths + [currentPath]).joined(separator: ":")
+        process.environment = env
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            if process.terminationStatus == 0 {
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+                return path?.isEmpty == false ? path : nil
+            }
+        } catch {
+            // Tool not found
+        }
+        return nil
+    }
+}
+
+// MARK: - Output Parsers
+
+/// Parses output from various config validators into diagnostics.
+enum ValidatorOutputParser {
+
+    // MARK: - yamllint
+
+    /// Parses yamllint output in default format: `file.yml:3:1: [error] message`
+    static func parseYamllint(_ output: String) -> [ValidationDiagnostic] {
+        var diagnostics: [ValidationDiagnostic] = []
+        let lines = output.components(separatedBy: .newlines)
+
+        for line in lines {
+            guard let diagnostic = parseYamllintLine(line) else { continue }
+            diagnostics.append(diagnostic)
+        }
+        return diagnostics
+    }
+
+    /// Parses a single yamllint output line.
+    /// Format: `path:line:col: [level] message` or `path:line:col: [level] message (rule)`
+    static func parseYamllintLine(_ line: String) -> ValidationDiagnostic? {
+        // Pattern: anything:digits:digits: [error/warning] message
+        let pattern = #"^.*?:(\d+):(\d+): \[(error|warning)\] (.+)$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: line, range: NSRange(line.startIndex..., in: line)),
+              match.numberOfRanges >= 5 else {
+            return nil
+        }
+
+        guard let lineRange = Range(match.range(at: 1), in: line),
+              let colRange = Range(match.range(at: 2), in: line),
+              let levelRange = Range(match.range(at: 3), in: line),
+              let msgRange = Range(match.range(at: 4), in: line) else {
+            return nil
+        }
+
+        guard let lineNum = Int(line[lineRange]),
+              let colNum = Int(line[colRange]) else {
+            return nil
+        }
+
+        let level = String(line[levelRange])
+        let message = String(line[msgRange])
+        let severity: ValidationSeverity = level == "error" ? .error : .warning
+
+        return ValidationDiagnostic(
+            line: lineNum,
+            column: colNum,
+            message: message,
+            severity: severity,
+            source: "yamllint"
+        )
+    }
+
+    // MARK: - shellcheck
+
+    /// Parses shellcheck JSON output.
+    static func parseShellcheck(_ jsonOutput: String) -> [ValidationDiagnostic] {
+        guard let data = jsonOutput.data(using: .utf8) else { return [] }
+
+        struct ShellCheckItem: Decodable {
+            let line: Int
+            let column: Int
+            let level: String
+            let message: String
+            let code: Int
+        }
+
+        guard let items = try? JSONDecoder().decode([ShellCheckItem].self, from: data) else {
+            return []
+        }
+
+        return items.map { item in
+            let severity: ValidationSeverity
+            switch item.level {
+            case "error": severity = .error
+            case "warning": severity = .warning
+            default: severity = .info
+            }
+            return ValidationDiagnostic(
+                line: item.line,
+                column: item.column,
+                message: "SC\(item.code): \(item.message)",
+                severity: severity,
+                source: "shellcheck"
+            )
+        }
+    }
+
+    // MARK: - terraform validate
+
+    /// Parses `terraform validate -json` output.
+    static func parseTerraform(_ jsonOutput: String) -> [ValidationDiagnostic] {
+        guard let data = jsonOutput.data(using: .utf8) else { return [] }
+
+        struct TerraformOutput: Decodable {
+            let valid: Bool
+            let diagnostics: [TerraformDiag]?
+        }
+
+        struct TerraformDiag: Decodable {
+            let severity: String
+            let summary: String
+            let detail: String?
+            let range: TerraformRange?
+        }
+
+        struct TerraformRange: Decodable {
+            let start: TerraformPos
+        }
+
+        struct TerraformPos: Decodable {
+            let line: Int
+            let column: Int
+        }
+
+        guard let output = try? JSONDecoder().decode(TerraformOutput.self, from: data) else {
+            return []
+        }
+
+        return (output.diagnostics ?? []).map { diag in
+            let severity: ValidationSeverity = diag.severity == "error" ? .error : .warning
+            let message: String
+            if let detail = diag.detail, !detail.isEmpty {
+                message = "\(diag.summary): \(detail)"
+            } else {
+                message = diag.summary
+            }
+            return ValidationDiagnostic(
+                line: diag.range?.start.line ?? 1,
+                column: diag.range?.start.column ?? nil,
+                message: message,
+                severity: severity,
+                source: "terraform"
+            )
+        }
+    }
+
+    // MARK: - hadolint
+
+    /// Parses hadolint JSON output (--format json).
+    static func parseHadolint(_ jsonOutput: String) -> [ValidationDiagnostic] {
+        guard let data = jsonOutput.data(using: .utf8) else { return [] }
+
+        struct HadolintItem: Decodable {
+            let line: Int
+            let column: Int
+            let level: String
+            let message: String
+            let code: String
+        }
+
+        guard let items = try? JSONDecoder().decode([HadolintItem].self, from: data) else {
+            return []
+        }
+
+        return items.map { item in
+            let severity: ValidationSeverity
+            switch item.level {
+            case "error": severity = .error
+            case "warning": severity = .warning
+            default: severity = .info
+            }
+            return ValidationDiagnostic(
+                line: item.line,
+                column: item.column > 0 ? item.column : nil,
+                message: "\(item.code): \(item.message)",
+                severity: severity,
+                source: "hadolint"
+            )
+        }
+    }
+}
+
+// MARK: - ConfigValidator
+
+/// Runs external config validators and produces diagnostics.
+/// Designed to be called from a background queue with debouncing.
+@Observable
+final class ConfigValidator {
+
+    /// Current diagnostics for the active file.
+    private(set) var diagnostics: [ValidationDiagnostic] = []
+
+    /// Whether validation is currently running.
+    private(set) var isValidating = false
+
+    /// The validator kind for the current file, if any.
+    private(set) var activeValidator: ValidatorKind?
+
+    /// Whether the required tool is available.
+    private(set) var toolAvailable = false
+
+    /// Debounce interval in seconds.
+    static let debounceInterval: TimeInterval = 0.3
+
+    /// Serial queue for validation work.
+    private let queue = DispatchQueue(label: "com.pine.config-validation", qos: .utility)
+
+    /// Generation token to discard stale results.
+    private var generation: UInt64 = 0
+
+    /// Debounce work item.
+    private var debounceWorkItem: DispatchWorkItem?
+
+    /// Validates the given file content, debounced.
+    /// - Parameters:
+    ///   - url: The file URL (used for extension detection and temp file creation).
+    ///   - content: The current file content.
+    func validate(url: URL, content: String) {
+        debounceWorkItem?.cancel()
+
+        guard let kind = ValidatorDetector.detect(for: url) else {
+            DispatchQueue.main.async { [weak self] in
+                self?.diagnostics = []
+                self?.activeValidator = nil
+                self?.toolAvailable = false
+            }
+            return
+        }
+
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.runValidation(url: url, content: content, kind: kind)
+        }
+        debounceWorkItem = workItem
+        queue.asyncAfter(deadline: .now() + Self.debounceInterval, execute: workItem)
+    }
+
+    /// Clears all diagnostics (e.g. when switching tabs).
+    func clear() {
+        debounceWorkItem?.cancel()
+        generation &+= 1
+        DispatchQueue.main.async { [weak self] in
+            self?.diagnostics = []
+            self?.activeValidator = nil
+            self?.toolAvailable = false
+            self?.isValidating = false
+        }
+    }
+
+    // MARK: - Private
+
+    private func runValidation(url: URL, content: String, kind: ValidatorKind) {
+        let currentGen = generation &+ 1
+        generation = currentGen
+
+        DispatchQueue.main.async { [weak self] in
+            self?.isValidating = true
+            self?.activeValidator = kind
+        }
+
+        // Check tool availability
+        guard let toolPath = ToolAvailability.path(for: kind.toolName) else {
+            DispatchQueue.main.async { [weak self] in
+                guard self?.generation == currentGen else { return }
+                self?.diagnostics = []
+                self?.toolAvailable = false
+                self?.isValidating = false
+            }
+            return
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.toolAvailable = true
+        }
+
+        // Write content to temp file for validation
+        let tempDir = FileManager.default.temporaryDirectory
+        let tempFile = tempDir.appendingPathComponent(url.lastPathComponent)
+
+        do {
+            try content.write(to: tempFile, atomically: true, encoding: .utf8)
+        } catch {
+            DispatchQueue.main.async { [weak self] in
+                guard self?.generation == currentGen else { return }
+                self?.diagnostics = []
+                self?.isValidating = false
+            }
+            return
+        }
+
+        defer { try? FileManager.default.removeItem(at: tempFile) }
+
+        let result = runTool(toolPath: toolPath, kind: kind, filePath: tempFile.path)
+
+        guard generation == currentGen else { return }
+
+        let parsed: [ValidationDiagnostic]
+        switch kind {
+        case .yamllint:
+            parsed = ValidatorOutputParser.parseYamllint(result)
+        case .shellcheck:
+            parsed = ValidatorOutputParser.parseShellcheck(result)
+        case .terraform:
+            parsed = ValidatorOutputParser.parseTerraform(result)
+        case .hadolint:
+            parsed = ValidatorOutputParser.parseHadolint(result)
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard self?.generation == currentGen else { return }
+            self?.diagnostics = parsed
+            self?.isValidating = false
+        }
+    }
+
+    private func runTool(toolPath: String, kind: ValidatorKind, filePath: String) -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: toolPath)
+
+        switch kind {
+        case .yamllint:
+            process.arguments = ["-f", "parsable", filePath]
+        case .shellcheck:
+            process.arguments = ["-f", "json", filePath]
+        case .terraform:
+            // terraform validate needs to run in the file's directory
+            let dir = URL(fileURLWithPath: filePath).deletingLastPathComponent().path
+            process.currentDirectoryURL = URL(fileURLWithPath: dir)
+            process.arguments = ["validate", "-json"]
+        case .hadolint:
+            process.arguments = ["--format", "json", filePath]
+        }
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+
+        // Ensure common tool paths are available
+        var env = ProcessInfo.processInfo.environment
+        let extraPaths = ["/usr/local/bin", "/opt/homebrew/bin"]
+        let currentPath = env["PATH"] ?? "/usr/bin:/bin"
+        env["PATH"] = (extraPaths + [currentPath]).joined(separator: ":")
+        process.environment = env
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return ""
+        }
+
+        // yamllint outputs to stdout, shellcheck to stdout, terraform to stdout
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+
+        // Some tools output to stderr (yamllint parsable goes to stdout)
+        let output = String(data: outData, encoding: .utf8) ?? ""
+        let errOutput = String(data: errData, encoding: .utf8) ?? ""
+
+        // Return whichever has content
+        return output.isEmpty ? errOutput : output
+    }
+}

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -5043,6 +5043,306 @@
         }
       }
     },
+    "menu.toggleValidation" : {
+      "comment" : "Menu command: toggle inline config validation (yamllint, shellcheck, etc.).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validierung umschalten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toggle Validation"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alternar validación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer/désactiver la validation"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バリデーションを切り替え"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "유효성 검사 전환"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alternar validação"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переключить валидацию"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换验证"
+          }
+        }
+      }
+    },
+    "validation.errorCount %lld" : {
+      "comment" : "Status bar: number of validation errors found.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Fehler"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld errors"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld errores"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld erreurs"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld件のエラー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld개 오류"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld erros"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld ошибок"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld个错误"
+          }
+        }
+      }
+    },
+    "validation.warningCount %lld" : {
+      "comment" : "Status bar: number of validation warnings found.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Warnungen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld warnings"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld advertencias"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld avertissements"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld件の警告"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld개 경고"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld avisos"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld предупреждений"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld个警告"
+          }
+        }
+      }
+    },
+    "validation.toolNotInstalled %@" : {
+      "comment" : "Status bar tooltip: the validator tool is not installed.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ ist nicht installiert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is not installed"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ no está instalado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ n'est pas installé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@がインストールされていません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@가 설치되지 않았습니다"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ não está instalado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ не установлен"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@未安装"
+          }
+        }
+      }
+    },
+    "validation.passed" : {
+      "comment" : "Status bar: all validation checks passed with no issues.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validierung bestanden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validation passed"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validación exitosa"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validation réussie"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バリデーション合格"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "유효성 검사 통과"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validação aprovada"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Валидация пройдена"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "验证通过"
+          }
+        }
+      }
+    },
     "menu.togglePreview" : {
       "comment" : "Menu command: toggle markdown preview pane.",
       "extractionState" : "manual",

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -46,6 +46,9 @@ enum MenuIcons {
     // MARK: - Terminal menu
     static let newTerminalTab = "plus"
 
+    // MARK: - Validation
+    static let toggleValidation = "checkmark.shield"
+
     // MARK: - Context menu
     static let newFile = "doc.badge.plus"
     static let newFolder = "folder.badge.plus"

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -376,6 +376,26 @@ enum Strings {
         String(localized: "terminal.tabCloseWarning.close")
     }
 
+    // MARK: - Config Validation
+
+    static let menuToggleValidation: LocalizedStringKey = "menu.toggleValidation"
+
+    static var validationErrorCount: (Int) -> String = { count in
+        String(localized: "validation.errorCount \(count)")
+    }
+
+    static var validationWarningCount: (Int) -> String = { count in
+        String(localized: "validation.warningCount \(count)")
+    }
+
+    static var validationToolNotInstalled: (String) -> String = { tool in
+        String(localized: "validation.toolNotInstalled \(tool)")
+    }
+
+    static var validationPassed: String {
+        String(localized: "validation.passed")
+    }
+
     // MARK: - Progress Indicators
 
     static var progressLoadingProject: String {

--- a/PineTests/ConfigValidatorTests.swift
+++ b/PineTests/ConfigValidatorTests.swift
@@ -1,0 +1,464 @@
+//
+//  ConfigValidatorTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+@testable import Pine
+
+struct ConfigValidatorTests {
+
+    // MARK: - ValidatorDetector
+
+    @Test func detect_yaml() {
+        let url = URL(fileURLWithPath: "/tmp/config.yml")
+        #expect(ValidatorDetector.detect(for: url) == .yamllint)
+    }
+
+    @Test func detect_yamlExtension() {
+        let url = URL(fileURLWithPath: "/tmp/config.yaml")
+        #expect(ValidatorDetector.detect(for: url) == .yamllint)
+    }
+
+    @Test func detect_yamlCaseInsensitive() {
+        let url = URL(fileURLWithPath: "/tmp/config.YML")
+        #expect(ValidatorDetector.detect(for: url) == .yamllint)
+    }
+
+    @Test func detect_terraform_tf() {
+        let url = URL(fileURLWithPath: "/tmp/main.tf")
+        #expect(ValidatorDetector.detect(for: url) == .terraform)
+    }
+
+    @Test func detect_terraform_tfvars() {
+        let url = URL(fileURLWithPath: "/tmp/vars.tfvars")
+        #expect(ValidatorDetector.detect(for: url) == .terraform)
+    }
+
+    @Test func detect_shell_sh() {
+        let url = URL(fileURLWithPath: "/tmp/script.sh")
+        #expect(ValidatorDetector.detect(for: url) == .shellcheck)
+    }
+
+    @Test func detect_shell_bash() {
+        let url = URL(fileURLWithPath: "/tmp/deploy.bash")
+        #expect(ValidatorDetector.detect(for: url) == .shellcheck)
+    }
+
+    @Test func detect_shell_zsh() {
+        let url = URL(fileURLWithPath: "/tmp/init.zsh")
+        #expect(ValidatorDetector.detect(for: url) == .shellcheck)
+    }
+
+    @Test func detect_dockerfile() {
+        let url = URL(fileURLWithPath: "/tmp/Dockerfile")
+        #expect(ValidatorDetector.detect(for: url) == .hadolint)
+    }
+
+    @Test func detect_dockerfile_variant() {
+        let url = URL(fileURLWithPath: "/tmp/Dockerfile.prod")
+        #expect(ValidatorDetector.detect(for: url) == .hadolint)
+    }
+
+    @Test func detect_swift_returnsNil() {
+        let url = URL(fileURLWithPath: "/tmp/main.swift")
+        #expect(ValidatorDetector.detect(for: url) == nil)
+    }
+
+    @Test func detect_json_returnsNil() {
+        let url = URL(fileURLWithPath: "/tmp/config.json")
+        #expect(ValidatorDetector.detect(for: url) == nil)
+    }
+
+    @Test func detect_noExtension_notDockerfile_returnsNil() {
+        let url = URL(fileURLWithPath: "/tmp/Makefile")
+        #expect(ValidatorDetector.detect(for: url) == nil)
+    }
+
+    // MARK: - ValidatorKind properties
+
+    @Test func validatorKind_displayName() {
+        #expect(ValidatorKind.yamllint.displayName == "yamllint")
+        #expect(ValidatorKind.terraform.displayName == "terraform")
+        #expect(ValidatorKind.shellcheck.displayName == "shellcheck")
+        #expect(ValidatorKind.hadolint.displayName == "hadolint")
+    }
+
+    @Test func validatorKind_toolName() {
+        #expect(ValidatorKind.yamllint.toolName == "yamllint")
+        #expect(ValidatorKind.terraform.toolName == "terraform")
+        #expect(ValidatorKind.shellcheck.toolName == "shellcheck")
+        #expect(ValidatorKind.hadolint.toolName == "hadolint")
+    }
+
+    // MARK: - yamllint parser
+
+    @Test func parseYamllint_error() {
+        let output = "config.yml:3:1: [error] syntax error: mapping values are not allowed here"
+        let results = ValidatorOutputParser.parseYamllint(output)
+        #expect(results.count == 1)
+        #expect(results[0].line == 3)
+        #expect(results[0].column == 1)
+        #expect(results[0].severity == .error)
+        #expect(results[0].message == "syntax error: mapping values are not allowed here")
+        #expect(results[0].source == "yamllint")
+    }
+
+    @Test func parseYamllint_warning() {
+        let output = "config.yml:5:3: [warning] comment not indented like content (comments-indentation)"
+        let results = ValidatorOutputParser.parseYamllint(output)
+        #expect(results.count == 1)
+        #expect(results[0].line == 5)
+        #expect(results[0].column == 3)
+        #expect(results[0].severity == .warning)
+        #expect(results[0].message == "comment not indented like content (comments-indentation)")
+    }
+
+    @Test func parseYamllint_multipleLines() {
+        let output = """
+        file.yml:1:1: [warning] missing document start "---" (document-start)
+        file.yml:3:81: [error] line too long (89 > 80 characters) (line-length)
+        file.yml:10:1: [warning] too many blank lines (2 > 0) (empty-lines)
+        """
+        let results = ValidatorOutputParser.parseYamllint(output)
+        #expect(results.count == 3)
+        #expect(results[0].line == 1)
+        #expect(results[1].line == 3)
+        #expect(results[1].severity == .error)
+        #expect(results[2].line == 10)
+    }
+
+    @Test func parseYamllint_emptyOutput() {
+        let results = ValidatorOutputParser.parseYamllint("")
+        #expect(results.isEmpty)
+    }
+
+    @Test func parseYamllint_invalidLine_skipped() {
+        let output = "This is not a valid yamllint output line"
+        let results = ValidatorOutputParser.parseYamllint(output)
+        #expect(results.isEmpty)
+    }
+
+    @Test func parseYamllintLine_returnsNil_forGarbage() {
+        #expect(ValidatorOutputParser.parseYamllintLine("garbage") == nil)
+    }
+
+    @Test func parseYamllintLine_returnsNil_forEmpty() {
+        #expect(ValidatorOutputParser.parseYamllintLine("") == nil)
+    }
+
+    // MARK: - shellcheck parser
+
+    @Test func parseShellcheck_singleError() {
+        let json = """
+        [{"line":3,"column":5,"level":"error","message":"Expected \\"then\\"","code":1046}]
+        """
+        let results = ValidatorOutputParser.parseShellcheck(json)
+        #expect(results.count == 1)
+        #expect(results[0].line == 3)
+        #expect(results[0].column == 5)
+        #expect(results[0].severity == .error)
+        #expect(results[0].message == "SC1046: Expected \"then\"")
+        #expect(results[0].source == "shellcheck")
+    }
+
+    @Test func parseShellcheck_warningAndInfo() {
+        let json = """
+        [
+          {"line":1,"column":1,"level":"warning","message":"Use #!/usr/bin/env bash","code":2148},
+          {"line":5,"column":3,"level":"info","message":"Double quote to prevent globbing","code":2086}
+        ]
+        """
+        let results = ValidatorOutputParser.parseShellcheck(json)
+        #expect(results.count == 2)
+        #expect(results[0].severity == .warning)
+        #expect(results[1].severity == .info)
+        #expect(results[1].message.hasPrefix("SC2086:"))
+    }
+
+    @Test func parseShellcheck_emptyArray() {
+        let results = ValidatorOutputParser.parseShellcheck("[]")
+        #expect(results.isEmpty)
+    }
+
+    @Test func parseShellcheck_invalidJSON() {
+        let results = ValidatorOutputParser.parseShellcheck("not json")
+        #expect(results.isEmpty)
+    }
+
+    @Test func parseShellcheck_emptyString() {
+        let results = ValidatorOutputParser.parseShellcheck("")
+        #expect(results.isEmpty)
+    }
+
+    // MARK: - terraform parser
+
+    @Test func parseTerraform_valid() {
+        let json = """
+        {"valid":true,"diagnostics":[]}
+        """
+        let results = ValidatorOutputParser.parseTerraform(json)
+        #expect(results.isEmpty)
+    }
+
+    @Test func parseTerraform_withError() {
+        let json = """
+        {
+          "valid": false,
+          "diagnostics": [
+            {
+              "severity": "error",
+              "summary": "Invalid resource name",
+              "detail": "Names must start with a letter",
+              "range": {
+                "start": {"line": 5, "column": 10}
+              }
+            }
+          ]
+        }
+        """
+        let results = ValidatorOutputParser.parseTerraform(json)
+        #expect(results.count == 1)
+        #expect(results[0].line == 5)
+        #expect(results[0].column == 10)
+        #expect(results[0].severity == .error)
+        #expect(results[0].message == "Invalid resource name: Names must start with a letter")
+        #expect(results[0].source == "terraform")
+    }
+
+    @Test func parseTerraform_withWarning_noDetail() {
+        let json = """
+        {
+          "valid": true,
+          "diagnostics": [
+            {
+              "severity": "warning",
+              "summary": "Deprecated attribute",
+              "detail": "",
+              "range": {
+                "start": {"line": 2, "column": 1}
+              }
+            }
+          ]
+        }
+        """
+        let results = ValidatorOutputParser.parseTerraform(json)
+        #expect(results.count == 1)
+        #expect(results[0].severity == .warning)
+        #expect(results[0].message == "Deprecated attribute")
+    }
+
+    @Test func parseTerraform_noRange_defaultsToLine1() {
+        let json = """
+        {
+          "valid": false,
+          "diagnostics": [
+            {
+              "severity": "error",
+              "summary": "Module not found"
+            }
+          ]
+        }
+        """
+        let results = ValidatorOutputParser.parseTerraform(json)
+        #expect(results.count == 1)
+        #expect(results[0].line == 1)
+        #expect(results[0].column == nil)
+    }
+
+    @Test func parseTerraform_invalidJSON() {
+        let results = ValidatorOutputParser.parseTerraform("broken")
+        #expect(results.isEmpty)
+    }
+
+    @Test func parseTerraform_emptyString() {
+        let results = ValidatorOutputParser.parseTerraform("")
+        #expect(results.isEmpty)
+    }
+
+    @Test func parseTerraform_noDiagnosticsKey() {
+        let json = """
+        {"valid": true}
+        """
+        let results = ValidatorOutputParser.parseTerraform(json)
+        #expect(results.isEmpty)
+    }
+
+    // MARK: - hadolint parser
+
+    @Test func parseHadolint_singleWarning() {
+        let json = """
+        [{"line":3,"column":0,"level":"warning","message":"Use COPY instead of ADD","code":"DL3020"}]
+        """
+        let results = ValidatorOutputParser.parseHadolint(json)
+        #expect(results.count == 1)
+        #expect(results[0].line == 3)
+        #expect(results[0].column == nil) // column 0 → nil
+        #expect(results[0].severity == .warning)
+        #expect(results[0].message == "DL3020: Use COPY instead of ADD")
+        #expect(results[0].source == "hadolint")
+    }
+
+    @Test func parseHadolint_error() {
+        let json = """
+        [{"line":1,"column":1,"level":"error","message":"Invalid base image","code":"DL3006"}]
+        """
+        let results = ValidatorOutputParser.parseHadolint(json)
+        #expect(results.count == 1)
+        #expect(results[0].severity == .error)
+        #expect(results[0].column == 1)
+    }
+
+    @Test func parseHadolint_infoLevel() {
+        let json = """
+        [{"line":5,"column":0,"level":"info","message":"Pin versions","code":"DL3018"}]
+        """
+        let results = ValidatorOutputParser.parseHadolint(json)
+        #expect(results.count == 1)
+        #expect(results[0].severity == .info)
+    }
+
+    @Test func parseHadolint_emptyArray() {
+        let results = ValidatorOutputParser.parseHadolint("[]")
+        #expect(results.isEmpty)
+    }
+
+    @Test func parseHadolint_invalidJSON() {
+        let results = ValidatorOutputParser.parseHadolint("not json")
+        #expect(results.isEmpty)
+    }
+
+    // MARK: - ValidationDiagnostic equality
+
+    @Test func diagnostic_equality() {
+        let diag1 = ValidationDiagnostic(
+            line: 1, column: 2, message: "test", severity: .error, source: "yamllint"
+        )
+        let diag2 = ValidationDiagnostic(
+            line: 1, column: 2, message: "test", severity: .error, source: "yamllint"
+        )
+        #expect(diag1 == diag2)
+    }
+
+    @Test func diagnostic_inequality_differentLine() {
+        let diag1 = ValidationDiagnostic(
+            line: 1, column: 2, message: "test", severity: .error, source: "yamllint"
+        )
+        let diag2 = ValidationDiagnostic(
+            line: 2, column: 2, message: "test", severity: .error, source: "yamllint"
+        )
+        #expect(diag1 != diag2)
+    }
+
+    @Test func diagnostic_inequality_differentSeverity() {
+        let diag1 = ValidationDiagnostic(
+            line: 1, column: 2, message: "test", severity: .error, source: "yamllint"
+        )
+        let diag2 = ValidationDiagnostic(
+            line: 1, column: 2, message: "test", severity: .warning, source: "yamllint"
+        )
+        #expect(diag1 != diag2)
+    }
+
+    @Test func diagnostic_inequality_differentSource() {
+        let diag1 = ValidationDiagnostic(
+            line: 1, column: nil, message: "test", severity: .error, source: "yamllint"
+        )
+        let diag2 = ValidationDiagnostic(
+            line: 1, column: nil, message: "test", severity: .error, source: "shellcheck"
+        )
+        #expect(diag1 != diag2)
+    }
+
+    // MARK: - ValidationSeverity
+
+    @Test func severity_equatable() {
+        #expect(ValidationSeverity.error == ValidationSeverity.error)
+        #expect(ValidationSeverity.warning == ValidationSeverity.warning)
+        #expect(ValidationSeverity.info == ValidationSeverity.info)
+        #expect(ValidationSeverity.error != ValidationSeverity.warning)
+    }
+
+    // MARK: - ConfigValidator state
+
+    @Test func validator_initialState() {
+        let validator = ConfigValidator()
+        #expect(validator.diagnostics.isEmpty)
+        #expect(validator.isValidating == false)
+        #expect(validator.activeValidator == nil)
+        #expect(validator.toolAvailable == false)
+    }
+
+    @Test func validator_clear_resetsDiagnostics() {
+        let validator = ConfigValidator()
+        validator.clear()
+        #expect(validator.diagnostics.isEmpty)
+        #expect(validator.activeValidator == nil)
+        #expect(validator.toolAvailable == false)
+    }
+
+    // MARK: - ToolAvailability
+
+    @Test func toolAvailability_clearCache() {
+        // Just ensure clearCache doesn't crash
+        ToolAvailability.clearCache()
+    }
+
+    // MARK: - Edge cases: yamllint with path containing colons
+
+    @Test func parseYamllint_pathWithSpaces() {
+        let output = "/path/to my/config.yml:7:1: [error] duplication of key"
+        let results = ValidatorOutputParser.parseYamllint(output)
+        #expect(results.count == 1)
+        #expect(results[0].line == 7)
+        #expect(results[0].column == 1)
+    }
+
+    // MARK: - Multiple diagnostics mixed
+
+    @Test func parseShellcheck_multipleDiagnostics() {
+        let json = """
+        [
+          {"line":1,"column":1,"level":"error","message":"Missing shebang","code":2148},
+          {"line":3,"column":5,"level":"warning","message":"Quote variable","code":2086},
+          {"line":7,"column":1,"level":"info","message":"Use $() instead of backticks","code":2006}
+        ]
+        """
+        let results = ValidatorOutputParser.parseShellcheck(json)
+        #expect(results.count == 3)
+        #expect(results[0].severity == .error)
+        #expect(results[1].severity == .warning)
+        #expect(results[2].severity == .info)
+    }
+
+    // MARK: - Terraform multiple diagnostics
+
+    @Test func parseTerraform_multipleDiagnostics() {
+        let json = """
+        {
+          "valid": false,
+          "diagnostics": [
+            {
+              "severity": "error",
+              "summary": "First error",
+              "range": {"start": {"line": 1, "column": 1}}
+            },
+            {
+              "severity": "warning",
+              "summary": "A warning",
+              "detail": "More info",
+              "range": {"start": {"line": 10, "column": 5}}
+            }
+          ]
+        }
+        """
+        let results = ValidatorOutputParser.parseTerraform(json)
+        #expect(results.count == 2)
+        #expect(results[0].line == 1)
+        #expect(results[0].severity == .error)
+        #expect(results[1].line == 10)
+        #expect(results[1].severity == .warning)
+        #expect(results[1].message == "A warning: More info")
+    }
+}


### PR DESCRIPTION
Closes #314 - ConfigValidator runs external validators in background with 300ms debounce. ValidatorDetector maps file extensions. ValidatorOutputParser parses output. ToolAvailability caches lookups with graceful degradation. Localized for 9 languages. 50 unit tests.