### PR TITLE
feat: add toast notifications for live file reload

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -83,6 +83,9 @@ nonisolated enum AccessibilityID {
     static let symbolResultsList = "symbolResultsList"
     static func symbolItem(_ name: String) -> String { "symbolItem_\(name)" }
 
+    // MARK: - Toast notifications
+    static let toastNotification = "toastNotification"
+
     // MARK: - Status bar
     static let statusBar = "statusBar"
     static let terminalToggleButton = "terminalToggleButton"

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -271,9 +271,14 @@ extension ContentView {
         }
     }
 
-    func handleExternalConflicts(_ conflicts: [TabManager.ExternalConflict]) {
-        let modified = conflicts.filter { $0.kind == .modified }
-        let deleted = conflicts.filter { $0.kind == .deleted }
+    func handleExternalChanges(_ result: TabManager.ExternalChangeResult) {
+        // Show toast for silently reloaded files
+        if !result.reloadedFileNames.isEmpty {
+            projectManager.toastManager.showFilesReloaded(result.reloadedFileNames)
+        }
+
+        let modified = result.conflicts.filter { $0.kind == .modified }
+        let deleted = result.conflicts.filter { $0.kind == .deleted }
 
         if !modified.isEmpty {
             let names = modified.map(\.url.lastPathComponent).joined(separator: ", ")

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -87,6 +87,9 @@ struct ContentView: View {
                 )
             }
         }
+        .overlay(alignment: .top) {
+            ToastOverlay()
+        }
         .modifier(ProjectSearchModifier(
             projectManager: projectManager,
             isSearchPresented: $isSearchPresented
@@ -188,7 +191,7 @@ struct ContentView: View {
             onCloseTab: { closeTabWithConfirmation($0) },
             onOpenNewProject: { openNewProject() },
             onHandleFileDeletion: { handleFileDeletion($0) },
-            onHandleExternalConflicts: { handleExternalConflicts($0) },
+            onHandleExternalChanges: { handleExternalChanges($0) },
             onNavigateToChange: { navigateToChange(direction: $0) }
         ))
         .onReceive(NotificationCenter.default.publisher(for: .toggleWordWrap)) { _ in
@@ -261,5 +264,6 @@ struct ContentView: View {
         .environment(projectManager.workspace)
         .environment(projectManager.terminal)
         .environment(projectManager.tabManager)
+        .environment(projectManager.toastManager)
         .environment(registry)
 }

--- a/Pine/GitAndNotificationObserver.swift
+++ b/Pine/GitAndNotificationObserver.swift
@@ -54,7 +54,7 @@ struct GitAndNotificationObserver: ViewModifier {
     var onCloseTab: (EditorTab) -> Void
     var onOpenNewProject: () -> Void
     var onHandleFileDeletion: (URL) -> Void
-    var onHandleExternalConflicts: ([TabManager.ExternalConflict]) -> Void
+    var onHandleExternalChanges: (TabManager.ExternalChangeResult) -> Void
     var onNavigateToChange: (ContentView.ChangeDirection) -> Void
 
     func body(content: Content) -> some View {
@@ -99,15 +99,15 @@ struct GitAndNotificationObserver: ViewModifier {
             }
             .onChange(of: workspace.externalChangeToken) { _, _ in
                 guard controlActiveState == .key else { return }
-                let conflicts = tabManager.checkExternalChanges()
-                onHandleExternalConflicts(conflicts)
+                let result = tabManager.checkExternalChanges()
+                onHandleExternalChanges(result)
             }
             .onChange(of: controlActiveState) { _, newState in
                 // When the window becomes key, check for external changes that
                 // may have been missed while the window was inactive (issue #438).
                 guard newState == .key else { return }
-                let conflicts = tabManager.checkExternalChanges()
-                onHandleExternalConflicts(conflicts)
+                let result = tabManager.checkExternalChanges()
+                onHandleExternalChanges(result)
             }
             .onReceive(NotificationCenter.default.publisher(for: .showProjectSearch)) { _ in
                 withAnimation(PineAnimation.quick) {

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -8570,6 +8570,186 @@
         }
       }
     },
+    "toast.fileReloaded %@" : {
+      "comment" : "Toast notification when a single file was reloaded from disk.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ wurde neu geladen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ reloaded"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ recargado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ rechargé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ を再読み込みしました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 다시 불러옴"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ recarregado"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ перезагружен"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已重新加载"
+          }
+        }
+      }
+    },
+    "toast.filesReloaded %lld %@" : {
+      "comment" : "Toast notification when multiple files were reloaded (count + names).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld Dateien neu geladen: %2$@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld files reloaded: %2$@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld archivos recargados: %2$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld fichiers rechargés : %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld 個のファイルを再読み込み: %2$@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld개 파일 다시 불러옴: %2$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld arquivos recarregados: %2$@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld файлов перезагружено: %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已重新加载 %1$lld 个文件：%2$@"
+          }
+        }
+      }
+    },
+    "toast.filesReloaded.more %lld %@ %lld" : {
+      "comment" : "Toast notification when many files were reloaded (shows first 3 names + remaining count).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld Dateien neu geladen: %2$@ und %3$lld weitere"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld files reloaded: %2$@ and %3$lld more"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld archivos recargados: %2$@ y %3$lld más"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld fichiers rechargés : %2$@ et %3$lld autres"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld 個のファイルを再読み込み: %2$@ 他%3$lld個"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld개 파일 다시 불러옴: %2$@ 외 %3$lld개"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld arquivos recarregados: %2$@ e mais %3$lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld файлов перезагружено: %2$@ и ещё %3$lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已重新加载 %1$lld 个文件：%2$@ 及另外 %3$lld 个"
+          }
+        }
+      }
+    },
     "undo.create" : {
       "comment" : "Undo action name for file/folder creation.",
       "extractionState" : "manual",

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -505,6 +505,7 @@ private struct ProjectWindowView: View {
                     .environment(pm.workspace)
                     .environment(pm.terminal)
                     .environment(pm.tabManager)
+                    .environment(pm.toastManager)
                     .environment(registry)
                     .focusedSceneValue(\.projectManager, pm)
                     .background {

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -19,6 +19,7 @@ final class ProjectManager {
     let quickOpenProvider = QuickOpenProvider()
     let progress = ProgressTracker()
     let contextFileWriter = ContextFileWriter()
+    let toastManager = ToastManager()
     // nonisolated(unsafe) allows deinit to call stopPeriodicSnapshots().
     // RecoveryManager is only mutated on @MainActor; deinit is the only
     // nonisolated access point, and it runs after the last reference is dropped.

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -397,6 +397,20 @@ enum Strings {
         String(localized: "validation.passed")
     }
 
+    // MARK: - Toast Notifications
+
+    static func toastFileReloaded(_ name: String) -> String {
+        String(localized: "toast.fileReloaded \(name)")
+    }
+
+    static func toastFilesReloaded(count: Int, names: String) -> String {
+        String(localized: "toast.filesReloaded \(count) \(names)")
+    }
+
+    static func toastFilesReloadedMore(count: Int, names: String, remaining: Int) -> String {
+        String(localized: "toast.filesReloaded.more \(count) \(names) \(remaining)")
+    }
+
     // MARK: - Progress Indicators
 
     static var progressLoadingProject: String {

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -658,12 +658,19 @@ final class TabManager {
         enum Kind: Equatable { case modified, deleted }
     }
 
+    /// Result of checking external changes — includes both conflicts and silently reloaded files.
+    struct ExternalChangeResult {
+        let conflicts: [ExternalConflict]
+        let reloadedFileNames: [String]
+    }
+
     /// Checks open tabs against disk state. Silently reloads clean tabs that were
     /// modified externally. Closes clean tabs for deleted files. Returns conflicts
-    /// for dirty tabs that need user resolution.
-    func checkExternalChanges() -> [ExternalConflict] {
+    /// for dirty tabs that need user resolution, plus names of silently reloaded files.
+    func checkExternalChanges() -> ExternalChangeResult {
         var conflicts: [ExternalConflict] = []
         var cleanDeletedIDs: [UUID] = []
+        var reloadedNames: [String] = []
 
         for index in tabs.indices {
             let tab = tabs[index]
@@ -694,6 +701,7 @@ final class TabManager {
                     tabs[index].content = content
                     tabs[index].savedContent = content
                     tabs[index].lastModDate = diskMod
+                    reloadedNames.append(tab.url.lastPathComponent)
                 } catch {
                     Self.logger.error("Failed to reload tab \(tab.url.lastPathComponent): \(error)")
                 }
@@ -704,7 +712,7 @@ final class TabManager {
             closeTab(id: id)
         }
 
-        return conflicts
+        return ExternalChangeResult(conflicts: conflicts, reloadedFileNames: reloadedNames)
     }
 
     /// Reloads a tab's content from disk (used after user chooses "reload" in conflict dialog).

--- a/Pine/ToastManager.swift
+++ b/Pine/ToastManager.swift
@@ -1,0 +1,113 @@
+//
+//  ToastManager.swift
+//  Pine
+//
+//  Manages a queue of non-blocking toast notifications.
+//  Toasts slide in from the top and auto-dismiss after a timeout.
+//
+
+import Foundation
+
+/// Represents a single toast notification.
+struct ToastItem: Identifiable, Equatable {
+    let id: UUID
+    let message: String
+    let kind: Kind
+
+    enum Kind: Equatable {
+        case filesReloaded
+        case info
+    }
+
+    init(message: String, kind: Kind = .info) {
+        self.id = UUID()
+        self.message = message
+        self.kind = kind
+    }
+}
+
+/// Manages a FIFO queue of toast notifications with auto-dismiss.
+@MainActor
+@Observable
+final class ToastManager {
+    /// Currently visible toast, if any.
+    private(set) var currentToast: ToastItem?
+
+    /// Queued toasts waiting to be shown.
+    private var queue: [ToastItem] = []
+
+    /// Auto-dismiss delay in seconds.
+    var dismissDelay: TimeInterval = 3.0
+
+    /// Pending auto-dismiss work item.
+    private var dismissWorkItem: DispatchWorkItem?
+
+    /// Shows a toast. If another toast is visible, queues this one.
+    func show(_ toast: ToastItem) {
+        if currentToast != nil {
+            queue.append(toast)
+        } else {
+            present(toast)
+        }
+    }
+
+    /// Convenience: show a toast for reloaded files.
+    func showFilesReloaded(_ fileNames: [String]) {
+        guard !fileNames.isEmpty else { return }
+        let message: String
+        if fileNames.count == 1 {
+            message = String(localized: "toast.fileReloaded \(fileNames[0])")
+        } else {
+            let names = fileNames.prefix(3).joined(separator: ", ")
+            let remaining = fileNames.count - 3
+            if remaining > 0 {
+                message = String(localized: "toast.filesReloaded.more \(fileNames.count) \(names) \(remaining)")
+            } else {
+                message = String(localized: "toast.filesReloaded \(fileNames.count) \(names)")
+            }
+        }
+        show(ToastItem(message: message, kind: .filesReloaded))
+    }
+
+    /// Dismisses the current toast and shows the next one in queue.
+    func dismiss() {
+        dismissWorkItem?.cancel()
+        dismissWorkItem = nil
+        currentToast = nil
+
+        if !queue.isEmpty {
+            let next = queue.removeFirst()
+            // Small delay between toasts for visual separation
+            let work = DispatchWorkItem { [weak self] in
+                self?.present(next)
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
+        }
+    }
+
+    /// Whether a toast is currently visible (for testing).
+    var isShowingToast: Bool {
+        currentToast != nil
+    }
+
+    /// Number of queued toasts (for testing).
+    var queueCount: Int {
+        queue.count
+    }
+
+    // MARK: - Private
+
+    private func present(_ toast: ToastItem) {
+        currentToast = toast
+        scheduleDismiss()
+    }
+
+    private func scheduleDismiss() {
+        dismissWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.dismiss()
+        }
+        dismissWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + dismissDelay, execute: work)
+    }
+}

--- a/Pine/ToastView.swift
+++ b/Pine/ToastView.swift
@@ -1,0 +1,79 @@
+//
+//  ToastView.swift
+//  Pine
+//
+//  Non-blocking toast notification overlay.
+//  Slides in from the top edge and auto-dismisses.
+//
+
+import SwiftUI
+
+/// Overlay that shows the current toast from ToastManager.
+struct ToastOverlay: View {
+    @Environment(ToastManager.self) private var toastManager
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            Color.clear
+            if let toast = toastManager.currentToast {
+                ToastView(item: toast) {
+                    withAnimation(PineAnimation.quick) {
+                        toastManager.dismiss()
+                    }
+                }
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .padding(.top, 8)
+                .accessibilityIdentifier(AccessibilityID.toastNotification)
+            }
+        }
+        .animation(PineAnimation.overlay, value: toastManager.currentToast?.id)
+        .allowsHitTesting(toastManager.currentToast != nil)
+    }
+}
+
+/// Individual toast notification view.
+struct ToastView: View {
+    let item: ToastItem
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: iconName)
+                .foregroundStyle(.secondary)
+                .font(.body)
+
+            Text(item.message)
+                .font(.callout)
+                .lineLimit(2)
+
+            Spacer(minLength: 4)
+
+            Button {
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(.regularMaterial)
+                .shadow(color: .black.opacity(0.15), radius: 8, y: 2)
+        }
+        .frame(maxWidth: 400)
+    }
+
+    private var iconName: String {
+        switch item.kind {
+        case .filesReloaded:
+            return "arrow.clockwise"
+        case .info:
+            return "info.circle"
+        }
+    }
+}

--- a/PineTests/TabManagerTests.swift
+++ b/PineTests/TabManagerTests.swift
@@ -1464,9 +1464,10 @@ struct TabManagerTests {
             [.modificationDate: futureDate], ofItemAtPath: url.path
         )
 
-        let conflicts = manager.checkExternalChanges()
+        let result = manager.checkExternalChanges()
 
-        #expect(conflicts.isEmpty)
+        #expect(result.conflicts.isEmpty)
+        #expect(result.reloadedFileNames.count == 1)
         #expect(manager.activeTab?.content == "updated by external tool")
         #expect(manager.activeTab?.savedContent == "updated by external tool")
         // contentVersion must increment so CodeEditorView picks up the change
@@ -1488,10 +1489,11 @@ struct TabManagerTests {
             [.modificationDate: futureDate], ofItemAtPath: url.path
         )
 
-        let conflicts = manager.checkExternalChanges()
+        let result = manager.checkExternalChanges()
 
-        #expect(conflicts.count == 1)
-        #expect(conflicts.first?.kind == .modified)
+        #expect(result.conflicts.count == 1)
+        #expect(result.conflicts.first?.kind == .modified)
+        #expect(result.reloadedFileNames.isEmpty)
         // Content should NOT be overwritten — user has unsaved changes
         #expect(manager.activeTab?.content == "user edits")
     }

--- a/PineTests/ToastManagerTests.swift
+++ b/PineTests/ToastManagerTests.swift
@@ -1,0 +1,138 @@
+//
+//  ToastManagerTests.swift
+//  PineTests
+//
+//  Tests for ToastManager: show, dismiss, queue, auto-dismiss.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("ToastManager Tests")
+@MainActor
+struct ToastManagerTests {
+
+    // MARK: - Basic show/dismiss
+
+    @Test("Show toast sets currentToast")
+    func showSetsCurrentToast() {
+        let manager = ToastManager()
+        let toast = ToastItem(message: "Hello", kind: .info)
+        manager.show(toast)
+        #expect(manager.currentToast == toast)
+    }
+
+    @Test("Dismiss clears currentToast")
+    func dismissClearsToast() {
+        let manager = ToastManager()
+        manager.show(ToastItem(message: "Hello"))
+        manager.dismiss()
+        #expect(manager.currentToast == nil)
+    }
+
+    @Test("isShowingToast reflects visibility")
+    func isShowingToast() {
+        let manager = ToastManager()
+        #expect(!manager.isShowingToast)
+        manager.show(ToastItem(message: "Test"))
+        #expect(manager.isShowingToast)
+        manager.dismiss()
+        #expect(!manager.isShowingToast)
+    }
+
+    // MARK: - Queue behavior
+
+    @Test("Second toast is queued when one is visible")
+    func secondToastQueued() {
+        let manager = ToastManager()
+        manager.show(ToastItem(message: "First"))
+        manager.show(ToastItem(message: "Second"))
+        #expect(manager.currentToast?.message == "First")
+        #expect(manager.queueCount == 1)
+    }
+
+    @Test("Third toast adds to queue")
+    func thirdToastQueued() {
+        let manager = ToastManager()
+        manager.show(ToastItem(message: "First"))
+        manager.show(ToastItem(message: "Second"))
+        manager.show(ToastItem(message: "Third"))
+        #expect(manager.queueCount == 2)
+    }
+
+    @Test("Dismiss shows next queued toast after delay")
+    func dismissShowsNext() async throws {
+        let manager = ToastManager()
+        manager.dismissDelay = 10 // Prevent auto-dismiss during test
+        manager.show(ToastItem(message: "First"))
+        manager.show(ToastItem(message: "Second"))
+        manager.dismiss()
+        // Next toast appears after 0.3s delay
+        try await Task.sleep(for: .milliseconds(500))
+        #expect(manager.currentToast?.message == "Second")
+        #expect(manager.queueCount == 0)
+    }
+
+    // MARK: - Auto-dismiss
+
+    @Test("Toast auto-dismisses after delay")
+    func autoDismiss() async throws {
+        let manager = ToastManager()
+        manager.dismissDelay = 0.2
+        manager.show(ToastItem(message: "Auto"))
+        #expect(manager.isShowingToast)
+        try await Task.sleep(for: .milliseconds(400))
+        #expect(!manager.isShowingToast)
+    }
+
+    // MARK: - showFilesReloaded convenience
+
+    @Test("showFilesReloaded with single file")
+    func showSingleFile() {
+        let manager = ToastManager()
+        manager.showFilesReloaded(["main.swift"])
+        #expect(manager.currentToast?.kind == .filesReloaded)
+        #expect(manager.isShowingToast)
+    }
+
+    @Test("showFilesReloaded with multiple files")
+    func showMultipleFiles() {
+        let manager = ToastManager()
+        manager.showFilesReloaded(["a.swift", "b.swift"])
+        #expect(manager.currentToast?.kind == .filesReloaded)
+    }
+
+    @Test("showFilesReloaded with more than 3 files truncates")
+    func showManyFiles() {
+        let manager = ToastManager()
+        manager.showFilesReloaded(["a.swift", "b.swift", "c.swift", "d.swift", "e.swift"])
+        #expect(manager.currentToast?.kind == .filesReloaded)
+        #expect(manager.isShowingToast)
+    }
+
+    @Test("showFilesReloaded with empty array does nothing")
+    func showEmptyFiles() {
+        let manager = ToastManager()
+        manager.showFilesReloaded([])
+        #expect(!manager.isShowingToast)
+    }
+
+    // MARK: - ToastItem
+
+    @Test("ToastItem equality is by id")
+    func toastItemEquality() {
+        let toast1 = ToastItem(message: "A")
+        let toast2 = ToastItem(message: "A")
+        #expect(toast1 != toast2)  // Different UUIDs
+        #expect(toast1 == toast1)
+    }
+
+    @Test("ToastItem kinds are equatable")
+    func toastItemKinds() {
+        #expect(ToastItem.Kind.filesReloaded == .filesReloaded)
+        #expect(ToastItem.Kind.info == .info)
+        #expect(ToastItem.Kind.filesReloaded != .info)
+    }
+}


### PR DESCRIPTION
## Summary
- **ToastManager** (`@Observable`) manages a FIFO queue of non-blocking toast notifications with auto-dismiss (3 seconds)
- **ToastView** slides from top edge with `.regularMaterial` background and dismiss button
- **TabManager.checkExternalChanges()** now returns `ExternalChangeResult` with both conflicts and silently reloaded file names
- Toast appears when clean files are reloaded from disk by external tools (Claude Code, Codex, etc.)
- Dirty files still get the existing conflict dialog (no behavior change)
- Localized in all 9 languages: de, en, es, fr, ja, ko, pt-BR, ru, zh-Hans

Closes #312

## Test plan
- [x] 13 unit tests for ToastManager (show, dismiss, queue, auto-dismiss, showFilesReloaded edge cases)
- [x] Existing TabManager tests updated and passing (85 tests)
- [x] FileEncoding tests passing
- [x] SwiftLint clean on all files