### PR TITLE
feat: send selected code to terminal via Cmd+Shift+Enter

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -647,6 +647,14 @@ struct CodeEditorView: NSViewRepresentable {
             object: nil
         )
 
+        // Observe send to terminal notification (Cmd+Shift+Enter)
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.handleSendToTerminal),
+            name: .sendToTerminal,
+            object: nil
+        )
+
         // Calculate initial foldable ranges
         context.coordinator.recalculateFoldableRanges()
 
@@ -1312,6 +1320,84 @@ struct CodeEditorView: NSViewRepresentable {
         @objc func handleFindNext() { performFindAction(.nextMatch) }
         @objc func handleFindPrevious() { performFindAction(.previousMatch) }
         @objc func handleUseSelectionForFind() { performFindAction(.setSearchString) }
+
+        // MARK: - Send to Terminal (issue #311)
+
+        /// Extracts selected text (or current line if no selection) and posts
+        /// `.sendTextToTerminal` notification with the text in userInfo.
+        @objc func handleSendToTerminal() {
+            guard let sv = scrollView,
+                  let textView = sv.documentView as? GutterTextView,
+                  textView.window?.isKeyWindow == true else { return }
+
+            let text = extractTextForTerminal(from: textView)
+            guard !text.isEmpty else { return }
+
+            // Flash highlight the sent text range for visual feedback
+            flashSentTextHighlight(in: textView)
+
+            NotificationCenter.default.post(
+                name: .sendTextToTerminal,
+                object: nil,
+                userInfo: ["text": text]
+            )
+        }
+
+        /// Returns selected text or the current line if nothing is selected.
+        /// Internal access for testability.
+        func extractTextForTerminal(from textView: NSTextView) -> String {
+            let selectedRange = textView.selectedRange()
+            let source = textView.string as NSString
+
+            if selectedRange.length > 0 {
+                // Has selection — return selected text
+                guard selectedRange.location + selectedRange.length <= source.length else { return "" }
+                return source.substring(with: selectedRange)
+            } else {
+                // No selection — return current line
+                let lineRange = source.lineRange(for: NSRange(location: selectedRange.location, length: 0))
+                var lineText = source.substring(with: lineRange)
+                // Strip trailing newline
+                if lineText.hasSuffix("\n") {
+                    lineText = String(lineText.dropLast())
+                }
+                if lineText.hasSuffix("\r") {
+                    lineText = String(lineText.dropLast())
+                }
+                return lineText
+            }
+        }
+
+        /// Briefly highlights the sent text with a flash effect.
+        private func flashSentTextHighlight(in textView: NSTextView) {
+            let selectedRange = textView.selectedRange()
+            let source = textView.string as NSString
+            let rangeToFlash: NSRange
+
+            if selectedRange.length > 0 {
+                rangeToFlash = selectedRange
+            } else {
+                rangeToFlash = source.lineRange(
+                    for: NSRange(location: selectedRange.location, length: 0)
+                )
+            }
+
+            guard rangeToFlash.location + rangeToFlash.length <= source.length else { return }
+
+            let flashColor = NSColor.controlAccentColor.withAlphaComponent(0.3)
+            textView.layoutManager?.addTemporaryAttribute(
+                .backgroundColor,
+                value: flashColor,
+                forCharacterRange: rangeToFlash
+            )
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                textView.layoutManager?.removeTemporaryAttribute(
+                    .backgroundColor,
+                    forCharacterRange: rangeToFlash
+                )
+            }
+        }
 
         // MARK: - Code folding
 

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -398,4 +398,24 @@ extension ContentView {
         }
         return line
     }
+
+    // MARK: - Send to Terminal (issue #311)
+
+    /// Sends text to the active terminal tab.
+    /// If the terminal is hidden, shows it first. If no terminal tabs exist, creates one.
+    func sendTextToTerminal(_ text: String) {
+        // Ensure terminal is visible
+        if !terminal.isTerminalVisible {
+            terminal.isTerminalVisible = true
+        }
+
+        // Ensure there is an active terminal tab
+        if terminal.activeTerminalTab == nil {
+            projectManager.addTerminalTab()
+        }
+
+        // Send text followed by newline to execute
+        guard let activeTab = terminal.activeTerminalTab else { return }
+        activeTab.sendText(text + "\n")
+    }
 }

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -194,6 +194,12 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .toggleWordWrap)) { _ in
             isWordWrapEnabled.toggle()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .sendTextToTerminal)) { notification in
+            guard controlActiveState == .key,
+                  let text = notification.userInfo?["text"] as? String,
+                  !text.isEmpty else { return }
+            sendTextToTerminal(text)
+        }
         .onChange(of: tabManager.pendingGoToLine) { _, newLine in
             guard let line = newLine, let tab = tabManager.activeTab else { return }
             tabManager.pendingGoToLine = nil

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -3423,6 +3423,66 @@
         }
       }
     },
+    "menu.sendToTerminal" : {
+      "comment" : "Menu item to send selected code (or current line) to the active terminal tab.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An Terminal senden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Send to Terminal"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar al terminal"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyer au terminal"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ターミナルに送信"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "터미널로 보내기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar ao terminal"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отправить в терминал"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "发送到终端"
+          }
+        }
+      }
+    },
     "menu.findNext" : {
       "comment" : "Menu item for Find Next (⌘G).",
       "extractionState" : "manual",

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -45,6 +45,7 @@ enum MenuIcons {
 
     // MARK: - Terminal menu
     static let newTerminalTab = "plus"
+    static let sendToTerminal = "paperplane"
 
     // MARK: - Context menu
     static let newFile = "doc.badge.plus"

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -185,6 +185,16 @@ struct PineApp: App {
                     Label(Strings.menuFindInTerminal, systemImage: MenuIcons.find)
                 }
                 .disabled(focusedProject?.terminal.isTerminalVisible != true)
+
+                Divider()
+
+                Button {
+                    NotificationCenter.default.post(name: .sendToTerminal, object: nil)
+                } label: {
+                    Label(Strings.menuSendToTerminal, systemImage: MenuIcons.sendToTerminal)
+                }
+                .keyboardShortcut(.return, modifiers: [.command, .shift])
+                .disabled(focusedProject?.tabManager.activeTab == nil)
             }
             // Edit menu: Toggle Comment, Find & Replace, Find in Project
             CommandGroup(after: .pasteboard) {
@@ -1195,4 +1205,8 @@ extension Notification.Name {
     // Symbol Navigation (issue #306)
     static let showSymbolNavigator = Notification.Name("showSymbolNavigator")
     static let symbolNavigate = Notification.Name("symbolNavigate")
+    // Send to Terminal (issue #311)
+    static let sendToTerminal = Notification.Name("sendToTerminal")
+    /// userInfo: ["text": String]
+    static let sendTextToTerminal = Notification.Name("sendTextToTerminal")
 }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -304,6 +304,7 @@ enum Strings {
 
     static let terminalSearchPlaceholder: LocalizedStringKey = "terminal.search.placeholder"
     static let menuFindInTerminal: LocalizedStringKey = "menu.findInTerminal"
+    static let menuSendToTerminal: LocalizedStringKey = "menu.sendToTerminal"
 
     static var terminalSearchPreviousTooltip: String {
         String(localized: "terminal.search.previousTooltip")

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -484,6 +484,16 @@ final class TerminalTab: Identifiable, Hashable {
         terminalView.findNext(lastSearchQuery, options: lastSearchOptions)
     }
 
+    // MARK: - Send text to terminal
+
+    /// Sends the given text to the terminal process as keyboard input.
+    /// The text is written to the PTY as if the user typed it.
+    func sendText(_ text: String) {
+        guard isProcessRunning else { return }
+        let data = Array(text.utf8)
+        terminalView.process.send(data: data[...])
+    }
+
     static func == (lhs: TerminalTab, rhs: TerminalTab) -> Bool { lhs.id == rhs.id }
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
 }

--- a/PineTests/SendToTerminalTests.swift
+++ b/PineTests/SendToTerminalTests.swift
@@ -1,0 +1,167 @@
+//
+//  SendToTerminalTests.swift
+//  PineTests
+//
+
+import Testing
+import AppKit
+import SwiftUI
+@testable import Pine
+
+/// Tests for the "Send to Terminal" feature (issue #311).
+@Suite("Send to Terminal Tests")
+struct SendToTerminalTests {
+
+    // MARK: - Helpers
+
+    /// Builds a minimal text system stack for testing.
+    private func makeTextView(text: String) -> NSTextView {
+        let textStorage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        )
+        layoutManager.addTextContainer(textContainer)
+        let textView = NSTextView(
+            frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+            textContainer: textContainer
+        )
+        return textView
+    }
+
+    private func makeCoordinator() -> CodeEditorView.Coordinator {
+        let editorView = CodeEditorView(
+            text: .constant(""),
+            contentVersion: 0,
+            language: "swift",
+            fileName: "test.swift",
+            foldState: .constant(FoldState())
+        )
+        return CodeEditorView.Coordinator(parent: editorView)
+    }
+
+    // MARK: - extractTextForTerminal
+
+    @Test func extractsSelectedText() {
+        let text = "let x = 42\nlet y = 99\nlet z = 0"
+        let textView = makeTextView(text: text)
+        // Select "let x = 42" (10 characters)
+        textView.setSelectedRange(NSRange(location: 0, length: 10))
+
+        let coordinator = makeCoordinator()
+        let result = coordinator.extractTextForTerminal(from: textView)
+        #expect(result == "let x = 42")
+    }
+
+    @Test func extractsMultiLineSelection() {
+        let textView = makeTextView(text: "line1\nline2\nline3")
+        textView.setSelectedRange(NSRange(location: 0, length: 11)) // "line1\nline2"
+
+        let coordinator = makeCoordinator()
+        let result = coordinator.extractTextForTerminal(from: textView)
+        #expect(result == "line1\nline2")
+    }
+
+    @Test func extractsCurrentLineWhenNoSelection() {
+        let textView = makeTextView(text: "first line\nsecond line\nthird line")
+        // Cursor at position 15 — in "second line"
+        textView.setSelectedRange(NSRange(location: 15, length: 0))
+
+        let coordinator = makeCoordinator()
+        let result = coordinator.extractTextForTerminal(from: textView)
+        #expect(result == "second line")
+    }
+
+    @Test func extractsFirstLineWhenCursorAtStart() {
+        let textView = makeTextView(text: "hello world\nsecond")
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        let coordinator = makeCoordinator()
+        let result = coordinator.extractTextForTerminal(from: textView)
+        #expect(result == "hello world")
+    }
+
+    @Test func extractsLastLineWithoutTrailingNewline() {
+        let textView = makeTextView(text: "first\nlast")
+        // Cursor in "last"
+        textView.setSelectedRange(NSRange(location: 8, length: 0))
+
+        let coordinator = makeCoordinator()
+        let result = coordinator.extractTextForTerminal(from: textView)
+        #expect(result == "last")
+    }
+
+    @Test func extractsEmptyStringFromEmptyDocument() {
+        let textView = makeTextView(text: "")
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        let coordinator = makeCoordinator()
+        let result = coordinator.extractTextForTerminal(from: textView)
+        #expect(result == "")
+    }
+
+    @Test func extractsPartialSelection() {
+        let textView = makeTextView(text: "func hello() { return 42 }")
+        // Select "hello"
+        textView.setSelectedRange(NSRange(location: 5, length: 5))
+
+        let coordinator = makeCoordinator()
+        let result = coordinator.extractTextForTerminal(from: textView)
+        #expect(result == "hello")
+    }
+
+    @Test func extractsLineRegardlessOfLineEndings() {
+        // Test with plain \n line endings
+        let textView = makeTextView(text: "line1\nline2\nline3")
+        let content = textView.string
+        let line2Start = (content as NSString).range(of: "line2").location
+        textView.setSelectedRange(NSRange(location: line2Start, length: 0))
+
+        let coordinator = makeCoordinator()
+        let result = coordinator.extractTextForTerminal(from: textView)
+        #expect(result == "line2")
+    }
+
+    // MARK: - TerminalTab.sendText
+
+    @Test func sendTextDoesNotCrashOnStoppedTab() {
+        let tab = TerminalTab(name: "test")
+        tab.stop()
+        // Should not crash — just returns early
+        tab.sendText("hello")
+        #expect(tab.isTerminated == true)
+    }
+
+    @Test func sendTextDoesNotCrashOnUnstartedTab() {
+        let tab = TerminalTab(name: "test")
+        // Process not started, isProcessRunning is false — should return early
+        tab.sendText("hello")
+        #expect(tab.isTerminated == false)
+    }
+
+    // MARK: - Notification names
+
+    @Test func sendToTerminalNotificationNameExists() {
+        let name = Notification.Name.sendToTerminal
+        #expect(name.rawValue == "sendToTerminal")
+    }
+
+    @Test func sendTextToTerminalNotificationNameExists() {
+        let name = Notification.Name.sendTextToTerminal
+        #expect(name.rawValue == "sendTextToTerminal")
+    }
+
+    // MARK: - Menu strings and icons
+
+    @Test func menuStringExists() {
+        // Verify the string key is defined
+        let key = Strings.menuSendToTerminal
+        #expect(key != nil)
+    }
+
+    @Test func menuIconExists() {
+        let icon = MenuIcons.sendToTerminal
+        #expect(icon == "paperplane")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **Cmd+Shift+Enter** shortcut to send selected text (or current line) to the active terminal tab
- Text is written to the PTY followed by a newline for immediate execution
- Terminal auto-shows and creates a tab if needed
- Brief flash highlight on sent text for visual feedback

Closes #311

## Implementation
- `TerminalTab.sendText(_:)` — sends UTF-8 bytes to PTY via `process.send(data:)`
- `CodeEditorView.Coordinator.handleSendToTerminal()` — extracts text, posts `sendTextToTerminal` notification
- `ContentView` receives notification and routes text to active terminal
- Menu item in Terminal menu, localized in all 9 languages (de, en, es, fr, ja, ko, pt-BR, ru, zh-Hans)

## Test plan
- [x] 14 unit tests in `SendToTerminalTests.swift`
- [ ] Manual: select code, Cmd+Shift+Enter — verify text appears in terminal
- [ ] Manual: no selection, cursor on a line — verify current line is sent
- [ ] Manual: terminal hidden — verify it auto-shows
- [ ] Manual: verify flash highlight on sent text