### PR TITLE
feat: commit UI — stage, unstage and commit without terminal (#302)

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -83,6 +83,15 @@ enum AccessibilityID {
     static let symbolResultsList = "symbolResultsList"
     static func symbolItem(_ name: String) -> String { "symbolItem_\(name)" }
 
+    // MARK: - Git Commit
+    static let commitSheet = "commitSheet"
+    static let commitFileList = "commitFileList"
+    static let commitMessageField = "commitMessageField"
+    static let commitButton = "commitButton"
+    static let commitCloseButton = "commitCloseButton"
+    static let commitDiffPreview = "commitDiffPreview"
+    static func commitFileEntry(_ path: String) -> String { "commitFileEntry_\(path)" }
+
     // MARK: - Status bar
     static let statusBar = "statusBar"
     static let terminalToggleButton = "terminalToggleButton"

--- a/Pine/CommitView.swift
+++ b/Pine/CommitView.swift
@@ -1,0 +1,423 @@
+//
+//  CommitView.swift
+//  Pine
+//
+//  Git commit UI — stage files and create commits without terminal.
+//
+
+import SwiftUI
+
+// MARK: - Data Model
+
+/// Represents a file entry in the commit view.
+struct CommitFileEntry: Identifiable, Equatable {
+    let id: String // relative path
+    let path: String
+    let status: GitFileStatus
+    let isStaged: Bool
+
+    var statusLabel: String {
+        switch status {
+        case .added: return "A"
+        case .modified, .staged: return "M"
+        case .deleted: return "D"
+        case .untracked: return "?"
+        case .conflict: return "C"
+        case .mixed: return "M"
+        }
+    }
+}
+
+// MARK: - CommitView
+
+struct CommitView: View {
+    var gitProvider: GitStatusProvider
+    @Binding var isPresented: Bool
+
+    @State private var commitMessage = ""
+    @State private var stagedFiles: [String: GitFileStatus] = [:]
+    @State private var unstagedFiles: [String: GitFileStatus] = [:]
+    @State private var selectedFilePath: String?
+    @State private var diffText = ""
+    @State private var errorMessage = ""
+    @State private var isCommitting = false
+    @State private var showEmptyMessageAlert = false
+
+    private var stagedEntries: [CommitFileEntry] {
+        stagedFiles.map { CommitFileEntry(id: "staged-\($0.key)", path: $0.key, status: $0.value, isStaged: true) }
+            .sorted { $0.path < $1.path }
+    }
+
+    private var unstagedEntries: [CommitFileEntry] {
+        unstagedFiles.map { CommitFileEntry(id: "unstaged-\($0.key)", path: $0.key, status: $0.value, isStaged: false) }
+            .sorted { $0.path < $1.path }
+    }
+
+    private var hasChanges: Bool {
+        !stagedFiles.isEmpty || !unstagedFiles.isEmpty
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text(Strings.commitTitle)
+                    .font(.headline)
+                Spacer()
+                Button {
+                    isPresented = false
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier(AccessibilityID.commitCloseButton)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            if !hasChanges {
+                emptyStateView
+            } else {
+                HSplitView {
+                    fileListView
+                        .frame(minWidth: 200, idealWidth: 280)
+
+                    diffPreviewView
+                        .frame(minWidth: 200, idealWidth: 320)
+                }
+                .frame(maxHeight: .infinity)
+            }
+
+            Divider()
+
+            commitBarView
+                .padding(8)
+
+            if !errorMessage.isEmpty {
+                Divider()
+                Text(errorMessage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 8)
+                    .transition(PineAnimation.fadeTransition)
+            }
+        }
+        .frame(width: 640, height: 480)
+        .animation(PineAnimation.quick, value: errorMessage.isEmpty)
+        .accessibilityIdentifier(AccessibilityID.commitSheet)
+        .task {
+            await refreshFileList()
+        }
+        .alert(Strings.commitEmptyMessageTitle, isPresented: $showEmptyMessageAlert) {
+            Button(Strings.commitEmptyMessageCancel, role: .cancel) { }
+            Button(Strings.commitEmptyMessageConfirm) {
+                performCommit()
+            }
+        } message: {
+            Text(Strings.commitEmptyMessageBody)
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var emptyStateView: some View {
+        VStack(spacing: 8) {
+            Spacer()
+            Image(systemName: "checkmark.circle")
+                .font(.system(size: 32))
+                .foregroundStyle(.secondary)
+            Text(Strings.commitNoChanges)
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var fileListView: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                if !stagedEntries.isEmpty {
+                    sectionHeader(Strings.commitStagedSection, count: stagedEntries.count) {
+                        unstageAll()
+                    }
+
+                    ForEach(stagedEntries) { entry in
+                        fileRow(entry: entry)
+                    }
+                }
+
+                if !unstagedEntries.isEmpty {
+                    sectionHeader(Strings.commitUnstagedSection, count: unstagedEntries.count) {
+                        stageAll()
+                    }
+
+                    ForEach(unstagedEntries) { entry in
+                        fileRow(entry: entry)
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier(AccessibilityID.commitFileList)
+    }
+
+    private func sectionHeader(
+        _ title: LocalizedStringKey,
+        count: Int,
+        action: @escaping () -> Void
+    ) -> some View {
+        HStack {
+            Text(title)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+            Text("(\(count))")
+                .font(.system(size: 11))
+                .foregroundStyle(.tertiary)
+            Spacer()
+            Button {
+                action()
+            } label: {
+                Image(systemName: title == Strings.commitStagedSection
+                      ? "minus.circle" : "plus.circle")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help(title == Strings.commitStagedSection
+                  ? String(localized: "commit.unstageAll")
+                  : String(localized: "commit.stageAll"))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .background(.quaternary.opacity(0.5))
+    }
+
+    private func fileRow(entry: CommitFileEntry) -> some View {
+        Button {
+            selectFile(entry)
+        } label: {
+            HStack(spacing: 6) {
+                // Stage/unstage checkbox
+                Button {
+                    toggleStaging(entry)
+                } label: {
+                    Image(systemName: entry.isStaged
+                          ? "checkmark.square.fill" : "square")
+                        .font(.system(size: 12))
+                        .foregroundStyle(entry.isStaged ? .green : .secondary)
+                }
+                .buttonStyle(.plain)
+
+                // Status indicator
+                Text(entry.statusLabel)
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundStyle(entry.status.color)
+                    .frame(width: 14)
+
+                // File name
+                Text(entry.path)
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundStyle(selectedFilePath == entry.path ? .white : .primary)
+
+                Spacer()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
+            .background(selectedFilePath == entry.path
+                        ? Color.accentColor.opacity(0.3)
+                        : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(AccessibilityID.commitFileEntry(entry.path))
+    }
+
+    private var diffPreviewView: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let path = selectedFilePath {
+                HStack {
+                    Text(path)
+                        .font(.system(size: 11, weight: .medium))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer()
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(.quaternary.opacity(0.5))
+
+                ScrollView([.horizontal, .vertical]) {
+                    Text(diffText.isEmpty ? String(localized: "commit.noDiff") : diffText)
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(diffText.isEmpty ? .secondary : .primary)
+                        .textSelection(.enabled)
+                        .padding(8)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .accessibilityIdentifier(AccessibilityID.commitDiffPreview)
+            } else {
+                VStack {
+                    Spacer()
+                    Text(Strings.commitSelectFile)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    private var commitBarView: some View {
+        HStack(spacing: 8) {
+            TextField(Strings.commitMessagePlaceholder, text: $commitMessage, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .lineLimit(1...3)
+                .accessibilityIdentifier(AccessibilityID.commitMessageField)
+
+            Button {
+                if commitMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    showEmptyMessageAlert = true
+                } else {
+                    performCommit()
+                }
+            } label: {
+                Label(Strings.commitButton, systemImage: MenuIcons.commit)
+            }
+            .keyboardShortcut(.return, modifiers: .command)
+            .disabled(stagedFiles.isEmpty || isCommitting)
+            .accessibilityIdentifier(AccessibilityID.commitButton)
+        }
+    }
+
+    // MARK: - Actions
+
+    private func refreshFileList() async {
+        guard let url = gitProvider.repositoryURL else { return }
+        let result = await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let files = GitStatusProvider.fetchStagedAndUnstaged(at: url)
+                continuation.resume(returning: files)
+            }
+        }
+        stagedFiles = result.staged
+        unstagedFiles = result.unstaged
+    }
+
+    private func selectFile(_ entry: CommitFileEntry) {
+        selectedFilePath = entry.path
+        loadDiff(for: entry)
+    }
+
+    private func loadDiff(for entry: CommitFileEntry) {
+        guard let url = gitProvider.repositoryURL else { return }
+        let path = entry.path
+        let isStaged = entry.isStaged
+        Task {
+            let diff = await withCheckedContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    let result = isStaged
+                        ? GitStatusProvider.diffForStagedFile(path, at: url)
+                        : GitStatusProvider.diffForCommitFile(path, at: url)
+                    continuation.resume(returning: result)
+                }
+            }
+            diffText = diff
+        }
+    }
+
+    private func toggleStaging(_ entry: CommitFileEntry) {
+        guard let url = gitProvider.repositoryURL else { return }
+        Task {
+            let result: (success: Bool, error: String)
+            if entry.isStaged {
+                result = await withCheckedContinuation { continuation in
+                    DispatchQueue.global(qos: .userInitiated).async {
+                        continuation.resume(returning: GitStatusProvider.unstageFile(entry.path, at: url))
+                    }
+                }
+            } else {
+                result = await withCheckedContinuation { continuation in
+                    DispatchQueue.global(qos: .userInitiated).async {
+                        continuation.resume(returning: GitStatusProvider.stageFile(entry.path, at: url))
+                    }
+                }
+            }
+            if result.success {
+                await refreshFileList()
+            } else {
+                errorMessage = result.error
+            }
+        }
+    }
+
+    private func stageAll() {
+        guard let url = gitProvider.repositoryURL else { return }
+        let paths = Array(unstagedFiles.keys)
+        Task {
+            let result = await withCheckedContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    continuation.resume(returning: GitStatusProvider.stageFiles(paths, at: url))
+                }
+            }
+            if result.success {
+                await refreshFileList()
+            } else {
+                errorMessage = result.error
+            }
+        }
+    }
+
+    private func unstageAll() {
+        guard let url = gitProvider.repositoryURL else { return }
+        let paths = Array(stagedFiles.keys)
+        Task {
+            let result = await withCheckedContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    continuation.resume(returning: GitStatusProvider.unstageFiles(paths, at: url))
+                }
+            }
+            if result.success {
+                await refreshFileList()
+            } else {
+                errorMessage = result.error
+            }
+        }
+    }
+
+    private func performCommit() {
+        guard let url = gitProvider.repositoryURL else { return }
+        guard !stagedFiles.isEmpty else { return }
+
+        isCommitting = true
+        let message = commitMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        let effectiveMessage = message.isEmpty ? "No message" : message
+
+        Task {
+            let result = await withCheckedContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    continuation.resume(returning: GitStatusProvider.commit(message: effectiveMessage, at: url))
+                }
+            }
+
+            isCommitting = false
+
+            if result.success {
+                errorMessage = ""
+                commitMessage = ""
+                await gitProvider.refreshAsync()
+                NotificationCenter.default.post(name: .refreshLineDiffs, object: nil)
+                isPresented = false
+            } else {
+                errorMessage = result.error
+            }
+        }
+    }
+}

--- a/Pine/CommitView.swift
+++ b/Pine/CommitView.swift
@@ -142,7 +142,7 @@ struct CommitView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
                 if !stagedEntries.isEmpty {
-                    sectionHeader(Strings.commitStagedSection, count: stagedEntries.count) {
+                    sectionHeader(Strings.commitStagedSection, count: stagedEntries.count, isStaged: true) {
                         unstageAll()
                     }
 
@@ -152,7 +152,7 @@ struct CommitView: View {
                 }
 
                 if !unstagedEntries.isEmpty {
-                    sectionHeader(Strings.commitUnstagedSection, count: unstagedEntries.count) {
+                    sectionHeader(Strings.commitUnstagedSection, count: unstagedEntries.count, isStaged: false) {
                         stageAll()
                     }
 
@@ -168,6 +168,7 @@ struct CommitView: View {
     private func sectionHeader(
         _ title: LocalizedStringKey,
         count: Int,
+        isStaged: Bool,
         action: @escaping () -> Void
     ) -> some View {
         HStack {
@@ -182,13 +183,12 @@ struct CommitView: View {
             Button {
                 action()
             } label: {
-                Image(systemName: title == Strings.commitStagedSection
-                      ? "minus.circle" : "plus.circle")
+                Image(systemName: isStaged ? "minus.circle" : "plus.circle")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }
             .buttonStyle(.plain)
-            .help(title == Strings.commitStagedSection
+            .help(isStaged
                   ? String(localized: "commit.unstageAll")
                   : String(localized: "commit.stageAll"))
         }
@@ -393,6 +393,7 @@ struct CommitView: View {
     }
 
     private func performCommit() {
+        guard !isCommitting else { return }
         guard let url = gitProvider.repositoryURL else { return }
         guard !stagedFiles.isEmpty else { return }
 

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -35,6 +35,7 @@ struct ContentView: View {
     @State var isQuickOpenPresented = false
     @State var isSymbolNavigatorPresented = false
     @State var showGoToLine = false
+    @State var showCommitView = false
     @AppStorage("minimapVisible") var isMinimapVisible = true
     @AppStorage(BlameConstants.storageKey) var isBlameVisible = true
     @AppStorage("wordWrapEnabled") var isWordWrapEnabled = true
@@ -146,6 +147,16 @@ struct ContentView: View {
                     )
                 }
             )
+        }
+        .sheet(isPresented: $showCommitView) {
+            CommitView(
+                gitProvider: workspace.gitProvider,
+                isPresented: $showCommitView
+            )
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .showCommitView)) { _ in
+            guard workspace.gitProvider.isGitRepository else { return }
+            showCommitView = true
         }
         .onChange(of: selectedNode) { _, newNode in
             guard let node = newNode, !node.isDirectory else { return }

--- a/Pine/GitStatusProvider.swift
+++ b/Pine/GitStatusProvider.swift
@@ -423,7 +423,7 @@ final class GitStatusProvider {
 
     /// Creates a commit with the given message. Files must be staged before calling.
     nonisolated static func commit(message: String, at repoURL: URL) -> (success: Bool, error: String) {
-        let result = runGit(["commit", "-m", message], at: repoURL)
+        let result = runGit(["commit", "-m", "--", message], at: repoURL)
         if result.exitCode == 0 {
             return (true, "")
         }

--- a/Pine/GitStatusProvider.swift
+++ b/Pine/GitStatusProvider.swift
@@ -378,6 +378,123 @@ final class GitStatusProvider {
         }
     }
 
+    // MARK: - Staging Operations
+
+    /// Stages a file for commit.
+    nonisolated static func stageFile(_ path: String, at repoURL: URL) -> (success: Bool, error: String) {
+        let result = runGit(["add", "--", path], at: repoURL)
+        if result.exitCode == 0 {
+            return (true, "")
+        }
+        return (false, result.errorOutput.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    /// Unstages a file (resets to HEAD).
+    nonisolated static func unstageFile(_ path: String, at repoURL: URL) -> (success: Bool, error: String) {
+        // For untracked files, use rm --cached; for others, use reset HEAD
+        let result = runGit(["reset", "HEAD", "--", path], at: repoURL)
+        if result.exitCode == 0 {
+            return (true, "")
+        }
+        return (false, result.errorOutput.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    /// Stages multiple files at once.
+    nonisolated static func stageFiles(_ paths: [String], at repoURL: URL) -> (success: Bool, error: String) {
+        let args = ["add", "--"] + paths
+        let result = runGit(args, at: repoURL)
+        if result.exitCode == 0 {
+            return (true, "")
+        }
+        return (false, result.errorOutput.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    /// Unstages multiple files at once.
+    nonisolated static func unstageFiles(_ paths: [String], at repoURL: URL) -> (success: Bool, error: String) {
+        let args = ["reset", "HEAD", "--"] + paths
+        let result = runGit(args, at: repoURL)
+        if result.exitCode == 0 {
+            return (true, "")
+        }
+        return (false, result.errorOutput.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    // MARK: - Commit Operations
+
+    /// Creates a commit with the given message. Files must be staged before calling.
+    nonisolated static func commit(message: String, at repoURL: URL) -> (success: Bool, error: String) {
+        let result = runGit(["commit", "-m", message], at: repoURL)
+        if result.exitCode == 0 {
+            return (true, "")
+        }
+        return (false, result.errorOutput.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    /// Returns the diff output for a specific file (unstaged changes).
+    nonisolated static func diffForCommitFile(_ path: String, at repoURL: URL) -> String {
+        let result = runGit(["diff", "--", path], at: repoURL)
+        if result.exitCode == 0 { return result.output }
+        return ""
+    }
+
+    /// Returns the diff output for a staged file.
+    nonisolated static func diffForStagedFile(_ path: String, at repoURL: URL) -> String {
+        let result = runGit(["diff", "--cached", "--", path], at: repoURL)
+        if result.exitCode == 0 { return result.output }
+        return ""
+    }
+
+    /// Returns staged and unstaged file lists separately by parsing porcelain output.
+    nonisolated static func parseStagedAndUnstaged(
+        _ output: String
+    ) -> (staged: [String: GitFileStatus], unstaged: [String: GitFileStatus]) {
+        var staged: [String: GitFileStatus] = [:]
+        var unstaged: [String: GitFileStatus] = [:]
+
+        for line in output.components(separatedBy: "\n") {
+            guard line.count >= 3 else { continue }
+            guard !line.hasPrefix("!!") else { continue }
+            let indexChar = line[line.startIndex]
+            let workTreeChar = line[line.index(after: line.startIndex)]
+            var path = String(line.dropFirst(3))
+            path = Self.unquoteGitPath(path)
+
+            if path.contains(" -> ") {
+                let parts = path.components(separatedBy: " -> ")
+                if parts.count == 2 { path = parts[1] }
+            }
+
+            // Staged changes (index column)
+            switch indexChar {
+            case "A": staged[path] = .added
+            case "M": staged[path] = .staged
+            case "D": staged[path] = .deleted
+            case "R": staged[path] = .staged
+            default: break
+            }
+
+            // Unstaged changes (worktree column)
+            switch workTreeChar {
+            case "M": unstaged[path] = .modified
+            case "D": unstaged[path] = .deleted
+            case "?":
+                if indexChar == "?" { unstaged[path] = .untracked }
+            default: break
+            }
+        }
+
+        return (staged, unstaged)
+    }
+
+    /// Fetches staged and unstaged file lists from the repository.
+    nonisolated static func fetchStagedAndUnstaged(
+        at url: URL
+    ) -> (staged: [String: GitFileStatus], unstaged: [String: GitFileStatus]) {
+        let result = runGit(["--no-optional-locks", "status", "--porcelain"], at: url)
+        guard result.exitCode == 0 else { return ([:], [:]) }
+        return parseStagedAndUnstaged(result.output)
+    }
+
     // MARK: - Branch Operations
 
     func checkoutBranch(_ branch: String) -> (success: Bool, error: String) {

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -483,6 +483,846 @@
         }
       }
     },
+    "commit.button" : {
+      "comment" : "Button label for creating a commit.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commit"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commit"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valider"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コミット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커밋"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commit"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Коммит"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提交"
+          }
+        }
+      }
+    },
+    "commit.emptyMessage.body" : {
+      "comment" : "Alert body when commit message is empty.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Möchten Sie ohne Nachricht committen?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Do you want to commit without a message?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Desea confirmar sin mensaje?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous valider sans message ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メッセージなしでコミットしますか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메시지 없이 커밋하시겠습니까?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deseja fazer commit sem mensagem?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать коммит без сообщения?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "是否不填写消息直接提交？"
+          }
+        }
+      }
+    },
+    "commit.emptyMessage.cancel" : {
+      "comment" : "Cancel button in empty commit message alert.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbrechen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "취소"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отмена"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        }
+      }
+    },
+    "commit.emptyMessage.confirm" : {
+      "comment" : "Confirm button in empty commit message alert.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trotzdem committen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commit Anyway"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmar de todos modos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valider quand même"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "そのままコミット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "그래도 커밋"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fazer commit mesmo assim"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Всё равно коммит"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仍然提交"
+          }
+        }
+      }
+    },
+    "commit.emptyMessage.title" : {
+      "comment" : "Alert title when commit message is empty.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leere Commit-Nachricht"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empty Commit Message"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mensaje de confirmación vacío"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Message de commit vide"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コミットメッセージが空です"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "빈 커밋 메시지"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mensagem de commit vazia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пустое сообщение коммита"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提交消息为空"
+          }
+        }
+      }
+    },
+    "commit.messagePlaceholder" : {
+      "comment" : "Placeholder text in commit message field.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commit-Nachricht..."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commit message..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mensaje de confirmación..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Message de commit..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コミットメッセージ..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커밋 메시지..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mensagem de commit..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сообщение коммита..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提交消息..."
+          }
+        }
+      }
+    },
+    "commit.noDiff" : {
+      "comment" : "Shown when selected file has no diff to display.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein Diff verfügbar"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No diff available"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay diferencias disponibles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune différence disponible"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "差分がありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "변경 사항 없음"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhuma diferença disponível"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет изменений для отображения"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有可用的差异"
+          }
+        }
+      }
+    },
+    "commit.noChanges" : {
+      "comment" : "Shown when there are no changes to commit.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Änderungen zum Committen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No changes to commit"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay cambios para confirmar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune modification à valider"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コミットする変更がありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커밋할 변경 사항 없음"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhuma alteração para commit"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет изменений для коммита"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有可提交的更改"
+          }
+        }
+      }
+    },
+    "commit.selectFile" : {
+      "comment" : "Prompt to select a file to view its diff.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datei auswählen, um Diff anzuzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select a file to view diff"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccione un archivo para ver diferencias"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionnez un fichier pour voir les différences"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "差分を表示するファイルを選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "변경 사항을 보려면 파일을 선택하세요"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecione um arquivo para ver as diferenças"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите файл для просмотра изменений"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择文件查看差异"
+          }
+        }
+      }
+    },
+    "commit.staged" : {
+      "comment" : "Section header for staged files in commit view.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bereitgestellt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Staged"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparados"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indexés"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ステージ済み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스테이지됨"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparados"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовлены"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已暂存"
+          }
+        }
+      }
+    },
+    "commit.stageAll" : {
+      "comment" : "Tooltip: stage all changed files.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle bereitstellen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stage All"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparar todo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout indexer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてステージ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모두 스테이지"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparar tudo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовить все"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部暂存"
+          }
+        }
+      }
+    },
+    "commit.title" : {
+      "comment" : "Title of the commit sheet.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commit"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commit"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commit"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コミット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커밋"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commit"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Коммит"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提交"
+          }
+        }
+      }
+    },
+    "commit.unstaged" : {
+      "comment" : "Section header for unstaged files in commit view.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nicht bereitgestellt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unstaged"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No preparados"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non indexés"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未ステージ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스테이지 안됨"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não preparados"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не подготовлены"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未暂存"
+          }
+        }
+      }
+    },
+    "commit.unstageAll" : {
+      "comment" : "Tooltip: unstage all staged files.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle zurücksetzen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unstage All"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quitar todos del área de preparación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout désindexer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてアンステージ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모두 스테이지 취소"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remover tudo da preparação"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Убрать все из подготовки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部取消暂存"
+          }
+        }
+      }
+    },
     "conflict.externalModify.keep" : {
       "comment" : "Button: keep local unsaved changes instead of reloading from disk.",
       "extractionState" : "manual",
@@ -2999,6 +3839,66 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消固定标签页"
+          }
+        }
+      }
+    },
+    "menu.commit" : {
+      "comment" : "Menu item for Git Commit (⌘⇧K).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commit…"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commit…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmar…"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commit…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コミット…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커밋…"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commit…"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Коммит…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提交…"
           }
         }
       }

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -46,6 +46,10 @@ enum MenuIcons {
     // MARK: - Terminal menu
     static let newTerminalTab = "plus"
 
+    // MARK: - Git menu
+    static let switchBranch = "arrow.triangle.branch"
+    static let commit = "checkmark.message"
+
     // MARK: - Context menu
     static let newFile = "doc.badge.plus"
     static let newFolder = "folder.badge.plus"

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -186,6 +186,26 @@ struct PineApp: App {
                 }
                 .disabled(focusedProject?.terminal.isTerminalVisible != true)
             }
+            // Git menu: Switch Branch, Commit
+            CommandMenu(Strings.menuGit) {
+                Button {
+                    NotificationCenter.default.post(name: .switchBranch, object: nil)
+                } label: {
+                    Label(Strings.menuSwitchBranch, systemImage: MenuIcons.switchBranch)
+                }
+                .keyboardShortcut("b", modifiers: [.command, .shift])
+                .disabled(focusedProject?.workspace.gitProvider.isGitRepository != true)
+
+                Divider()
+
+                Button {
+                    NotificationCenter.default.post(name: .showCommitView, object: nil)
+                } label: {
+                    Label(Strings.menuCommit, systemImage: MenuIcons.commit)
+                }
+                .keyboardShortcut("k", modifiers: [.command, .shift])
+                .disabled(focusedProject?.workspace.gitProvider.isGitRepository != true)
+            }
             // Edit menu: Toggle Comment, Find & Replace, Find in Project
             CommandGroup(after: .pasteboard) {
                 Button {
@@ -1195,4 +1215,6 @@ extension Notification.Name {
     // Symbol Navigation (issue #306)
     static let showSymbolNavigator = Notification.Name("showSymbolNavigator")
     static let symbolNavigate = Notification.Name("symbolNavigate")
+    // Git Commit UI (issue #302)
+    static let showCommitView = Notification.Name("showCommitView")
 }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -376,6 +376,33 @@ enum Strings {
         String(localized: "terminal.tabCloseWarning.close")
     }
 
+    // MARK: - Git Commit UI
+
+    static let menuCommit: LocalizedStringKey = "menu.commit"
+    static let commitTitle: LocalizedStringKey = "commit.title"
+    static let commitButton: LocalizedStringKey = "commit.button"
+    static let commitNoChanges: LocalizedStringKey = "commit.noChanges"
+    static let commitStagedSection: LocalizedStringKey = "commit.staged"
+    static let commitUnstagedSection: LocalizedStringKey = "commit.unstaged"
+    static let commitMessagePlaceholder: LocalizedStringKey = "commit.messagePlaceholder"
+    static let commitSelectFile: LocalizedStringKey = "commit.selectFile"
+
+    static var commitEmptyMessageTitle: String {
+        String(localized: "commit.emptyMessage.title")
+    }
+
+    static var commitEmptyMessageBody: String {
+        String(localized: "commit.emptyMessage.body")
+    }
+
+    static var commitEmptyMessageConfirm: String {
+        String(localized: "commit.emptyMessage.confirm")
+    }
+
+    static var commitEmptyMessageCancel: String {
+        String(localized: "commit.emptyMessage.cancel")
+    }
+
     // MARK: - Progress Indicators
 
     static var progressLoadingProject: String {

--- a/PineTests/GitCommitTests.swift
+++ b/PineTests/GitCommitTests.swift
@@ -1,0 +1,428 @@
+//
+//  GitCommitTests.swift
+//  PineTests
+//
+//  Tests for git staging, unstaging, commit operations, and CommitFileEntry model.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Git Commit Operations")
+struct GitCommitTests {
+
+    // MARK: - Helpers
+
+    private func makeGitRepo() throws -> URL {
+        let rawDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-commit-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: rawDir, withIntermediateDirectories: true)
+        let dir = try resolveURL(rawDir)
+
+        try runShell("git init", at: dir)
+        try runShell("git config user.email 'test@test.com'", at: dir)
+        try runShell("git config user.name 'Test'", at: dir)
+
+        try "initial".write(
+            to: dir.appendingPathComponent("README.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try runShell("git add .", at: dir)
+        try runShell("git commit -m 'initial'", at: dir)
+
+        return dir
+    }
+
+    private func resolveURL(_ url: URL) throws -> URL {
+        guard let resolved = realpath(url.path, nil) else { throw CocoaError(.fileNoSuchFile) }
+        defer { free(resolved) }
+        return URL(fileURLWithPath: String(cString: resolved))
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    @discardableResult
+    private func runShell(_ command: String, at dir: URL) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        process.currentDirectoryURL = dir
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+        try process.run()
+        process.waitUntilExit()
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0 else {
+            let stderr = String(data: errData, encoding: .utf8) ?? ""
+            throw NSError(
+                domain: "ShellError",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: "'\(command)' failed: \(stderr)"]
+            )
+        }
+        return String(data: outData, encoding: .utf8) ?? ""
+    }
+
+    // MARK: - parseStagedAndUnstaged
+
+    @Test("parseStagedAndUnstaged parses staged added file")
+    func parseStagedAdded() {
+        let output = "A  newfile.swift\n"
+        let result = GitStatusProvider.parseStagedAndUnstaged(output)
+        #expect(result.staged["newfile.swift"] == .added)
+        #expect(result.unstaged.isEmpty)
+    }
+
+    @Test("parseStagedAndUnstaged parses staged modified file")
+    func parseStagedModified() {
+        let output = "M  changed.swift\n"
+        let result = GitStatusProvider.parseStagedAndUnstaged(output)
+        #expect(result.staged["changed.swift"] == .staged)
+        #expect(result.unstaged.isEmpty)
+    }
+
+    @Test("parseStagedAndUnstaged parses unstaged modified file")
+    func parseUnstagedModified() {
+        let output = " M changed.swift\n"
+        let result = GitStatusProvider.parseStagedAndUnstaged(output)
+        #expect(result.unstaged["changed.swift"] == .modified)
+        #expect(result.staged.isEmpty)
+    }
+
+    @Test("parseStagedAndUnstaged parses untracked file")
+    func parseUntracked() {
+        let output = "?? newfile.swift\n"
+        let result = GitStatusProvider.parseStagedAndUnstaged(output)
+        #expect(result.unstaged["newfile.swift"] == .untracked)
+        #expect(result.staged.isEmpty)
+    }
+
+    @Test("parseStagedAndUnstaged parses both staged and unstaged changes")
+    func parseMixed() {
+        let output = "MM both.swift\n"
+        let result = GitStatusProvider.parseStagedAndUnstaged(output)
+        #expect(result.staged["both.swift"] == .staged)
+        #expect(result.unstaged["both.swift"] == .modified)
+    }
+
+    @Test("parseStagedAndUnstaged parses staged deleted file")
+    func parseStagedDeleted() {
+        let output = "D  removed.swift\n"
+        let result = GitStatusProvider.parseStagedAndUnstaged(output)
+        #expect(result.staged["removed.swift"] == .deleted)
+    }
+
+    @Test("parseStagedAndUnstaged parses unstaged deleted file")
+    func parseUnstagedDeleted() {
+        let output = " D removed.swift\n"
+        let result = GitStatusProvider.parseStagedAndUnstaged(output)
+        #expect(result.unstaged["removed.swift"] == .deleted)
+    }
+
+    @Test("parseStagedAndUnstaged handles renamed files")
+    func parseRenamed() {
+        let output = "R  old.swift -> new.swift\n"
+        let result = GitStatusProvider.parseStagedAndUnstaged(output)
+        #expect(result.staged["new.swift"] == .staged)
+    }
+
+    @Test("parseStagedAndUnstaged ignores ignored entries")
+    func parseIgnored() {
+        let output = "!! ignored.swift\n"
+        let result = GitStatusProvider.parseStagedAndUnstaged(output)
+        #expect(result.staged.isEmpty)
+        #expect(result.unstaged.isEmpty)
+    }
+
+    @Test("parseStagedAndUnstaged handles empty output")
+    func parseEmpty() {
+        let result = GitStatusProvider.parseStagedAndUnstaged("")
+        #expect(result.staged.isEmpty)
+        #expect(result.unstaged.isEmpty)
+    }
+
+    @Test("parseStagedAndUnstaged handles multiple files")
+    func parseMultiple() {
+        let output = """
+        A  new.swift
+         M modified.swift
+        ?? untracked.txt
+        D  deleted.swift
+        """
+        let result = GitStatusProvider.parseStagedAndUnstaged(output)
+        #expect(result.staged.count == 2) // new.swift (added) + deleted.swift (deleted)
+        #expect(result.unstaged.count == 2) // modified.swift + untracked.txt
+    }
+
+    @Test("parseStagedAndUnstaged handles quoted paths")
+    func parseQuotedPaths() {
+        let output = "A  \"path with spaces/file.swift\"\n"
+        let result = GitStatusProvider.parseStagedAndUnstaged(output)
+        #expect(result.staged["path with spaces/file.swift"] == .added)
+    }
+
+    // MARK: - Integration: stageFile / unstageFile
+
+    @Test("stageFile stages a modified file")
+    func stageFileIntegration() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        try "modified".write(
+            to: dir.appendingPathComponent("README.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let result = GitStatusProvider.stageFile("README.md", at: dir)
+        #expect(result.success)
+
+        let files = GitStatusProvider.fetchStagedAndUnstaged(at: dir)
+        #expect(files.staged["README.md"] == .staged)
+    }
+
+    @Test("unstageFile unstages a staged file")
+    func unstageFileIntegration() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        try "modified".write(
+            to: dir.appendingPathComponent("README.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        _ = GitStatusProvider.stageFile("README.md", at: dir)
+        let result = GitStatusProvider.unstageFile("README.md", at: dir)
+        #expect(result.success)
+
+        let files = GitStatusProvider.fetchStagedAndUnstaged(at: dir)
+        #expect(files.staged["README.md"] == nil)
+        #expect(files.unstaged["README.md"] == .modified)
+    }
+
+    @Test("stageFiles stages multiple files at once")
+    func stageMultipleFiles() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        try "a".write(to: dir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "b".write(to: dir.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+
+        let result = GitStatusProvider.stageFiles(["a.txt", "b.txt"], at: dir)
+        #expect(result.success)
+
+        let files = GitStatusProvider.fetchStagedAndUnstaged(at: dir)
+        #expect(files.staged["a.txt"] == .added)
+        #expect(files.staged["b.txt"] == .added)
+    }
+
+    @Test("unstageFiles unstages multiple files at once")
+    func unstageMultipleFiles() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        try "a".write(to: dir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+        try "b".write(to: dir.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+        _ = GitStatusProvider.stageFiles(["a.txt", "b.txt"], at: dir)
+
+        let result = GitStatusProvider.unstageFiles(["a.txt", "b.txt"], at: dir)
+        #expect(result.success)
+
+        let files = GitStatusProvider.fetchStagedAndUnstaged(at: dir)
+        #expect(files.staged["a.txt"] == nil)
+        #expect(files.staged["b.txt"] == nil)
+    }
+
+    // MARK: - Integration: commit
+
+    @Test("commit creates a commit with staged files")
+    func commitIntegration() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        try "new content".write(
+            to: dir.appendingPathComponent("README.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        _ = GitStatusProvider.stageFile("README.md", at: dir)
+
+        let result = GitStatusProvider.commit(message: "test commit", at: dir)
+        #expect(result.success)
+
+        // Verify no staged files after commit
+        let files = GitStatusProvider.fetchStagedAndUnstaged(at: dir)
+        #expect(files.staged.isEmpty)
+        #expect(files.unstaged.isEmpty)
+
+        // Verify commit message in log
+        let log = try runShell("git log --oneline -1", at: dir)
+        #expect(log.contains("test commit"))
+    }
+
+    @Test("commit fails with no staged files")
+    func commitNoStagedFiles() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        let result = GitStatusProvider.commit(message: "empty commit", at: dir)
+        #expect(!result.success)
+    }
+
+    @Test("commit with multiline message")
+    func commitMultilineMessage() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        try "updated".write(
+            to: dir.appendingPathComponent("README.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        _ = GitStatusProvider.stageFile("README.md", at: dir)
+
+        let message = "feat: add feature\n\nThis is the body of the commit message."
+        let result = GitStatusProvider.commit(message: message, at: dir)
+        #expect(result.success)
+    }
+
+    // MARK: - Integration: diff methods
+
+    @Test("diffForCommitFile returns diff for unstaged changes")
+    func diffForUnstagedFile() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        try "changed content".write(
+            to: dir.appendingPathComponent("README.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let diff = GitStatusProvider.diffForCommitFile("README.md", at: dir)
+        #expect(diff.contains("changed content"))
+    }
+
+    @Test("diffForStagedFile returns diff for staged changes")
+    func diffForStagedFileTest() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        try "staged content".write(
+            to: dir.appendingPathComponent("README.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        _ = GitStatusProvider.stageFile("README.md", at: dir)
+
+        let diff = GitStatusProvider.diffForStagedFile("README.md", at: dir)
+        #expect(diff.contains("staged content"))
+    }
+
+    @Test("diffForCommitFile returns empty for clean file")
+    func diffForCleanFile() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        let diff = GitStatusProvider.diffForCommitFile("README.md", at: dir)
+        #expect(diff.isEmpty)
+    }
+
+    // MARK: - CommitFileEntry model
+
+    @Test("CommitFileEntry statusLabel for added")
+    func statusLabelAdded() {
+        let entry = CommitFileEntry(id: "test", path: "file.swift", status: .added, isStaged: true)
+        #expect(entry.statusLabel == "A")
+    }
+
+    @Test("CommitFileEntry statusLabel for modified")
+    func statusLabelModified() {
+        let entry = CommitFileEntry(id: "test", path: "file.swift", status: .modified, isStaged: false)
+        #expect(entry.statusLabel == "M")
+    }
+
+    @Test("CommitFileEntry statusLabel for deleted")
+    func statusLabelDeleted() {
+        let entry = CommitFileEntry(id: "test", path: "file.swift", status: .deleted, isStaged: true)
+        #expect(entry.statusLabel == "D")
+    }
+
+    @Test("CommitFileEntry statusLabel for untracked")
+    func statusLabelUntracked() {
+        let entry = CommitFileEntry(id: "test", path: "file.swift", status: .untracked, isStaged: false)
+        #expect(entry.statusLabel == "?")
+    }
+
+    @Test("CommitFileEntry statusLabel for conflict")
+    func statusLabelConflict() {
+        let entry = CommitFileEntry(id: "test", path: "file.swift", status: .conflict, isStaged: false)
+        #expect(entry.statusLabel == "C")
+    }
+
+    @Test("CommitFileEntry statusLabel for staged")
+    func statusLabelStaged() {
+        let entry = CommitFileEntry(id: "test", path: "file.swift", status: .staged, isStaged: true)
+        #expect(entry.statusLabel == "M")
+    }
+
+    @Test("CommitFileEntry statusLabel for mixed")
+    func statusLabelMixed() {
+        let entry = CommitFileEntry(id: "test", path: "file.swift", status: .mixed, isStaged: false)
+        #expect(entry.statusLabel == "M")
+    }
+
+    @Test("CommitFileEntry equality")
+    func entryEquality() {
+        let entry1 = CommitFileEntry(id: "a", path: "file.swift", status: .added, isStaged: true)
+        let entry2 = CommitFileEntry(id: "a", path: "file.swift", status: .added, isStaged: true)
+        let entry3 = CommitFileEntry(id: "b", path: "file.swift", status: .modified, isStaged: false)
+        #expect(entry1 == entry2)
+        #expect(entry1 != entry3)
+    }
+
+    // MARK: - fetchStagedAndUnstaged integration
+
+    @Test("fetchStagedAndUnstaged returns correct file lists")
+    func fetchStagedAndUnstagedIntegration() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        // Create modified file
+        try "modified".write(
+            to: dir.appendingPathComponent("README.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Create new file and stage it
+        try "new".write(
+            to: dir.appendingPathComponent("new.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try runShell("git add new.txt", at: dir)
+
+        let files = GitStatusProvider.fetchStagedAndUnstaged(at: dir)
+        #expect(files.staged["new.txt"] == .added)
+        #expect(files.unstaged["README.md"] == .modified)
+    }
+
+    @Test("fetchStagedAndUnstaged returns empty for clean repo")
+    func fetchCleanRepo() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        let files = GitStatusProvider.fetchStagedAndUnstaged(at: dir)
+        #expect(files.staged.isEmpty)
+        #expect(files.unstaged.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- CommitView — SwiftUI sheet with staged/unstaged file lists, diff preview, commit message
- Stage/Unstage individual files or all at once
- Cmd+Shift+K shortcut, Git menu integration
- 32 unit tests, localized to 9 languages

Closes #302

## Test plan

- [x] 32 unit tests pass
- [x] SwiftLint clean
- [ ] Manual: stage files, view diff, commit with message