### PR TITLE
perf: lazy syntax highlighting for visible viewport only

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -427,7 +427,8 @@ struct CodeEditorView: NSViewRepresentable {
     var indentStyle: IndentationStyle = .spaces(4)
 
     /// Порог (в символах) для переключения на viewport-based подсветку.
-    static let viewportHighlightThreshold = 100_000
+    /// Lowered from 100KB to 50KB to be more aggressive about lazy highlighting (#637).
+    static let viewportHighlightThreshold = 50_000
 
     /// Файл достаточно большой для viewport-based подсветки?
     private var useViewportHighlighting: Bool {

--- a/Pine/SyntaxHighlighter.swift
+++ b/Pine/SyntaxHighlighter.swift
@@ -346,11 +346,11 @@ final class SyntaxHighlighter: @unchecked Sendable {
     }
 
     /// Количество строк контекста для viewport-based подсветки (больше, чем для edit).
-    private let viewportContextLines = 100
+    private let viewportContextLines = 50
     /// Extra context lines for multiline rules (block comments, multiline strings).
-    /// 500 lines in each direction is enough to catch most multiline constructs
+    /// 200 lines in each direction is enough to catch most multiline constructs
     /// without scanning the entire file.
-    private let multilineContextLines = 500
+    private let multilineContextLines = 200
 
     /// Подсветка только видимой области + буфер.
     /// Используется для больших файлов вместо полного `highlight()`.

--- a/PinePerformanceTests/SyntaxHighlighterPerformanceTests.swift
+++ b/PinePerformanceTests/SyntaxHighlighterPerformanceTests.swift
@@ -153,6 +153,90 @@ final class SyntaxHighlighterPerformanceTests: XCTestCase {
         }
     }
 
+    // MARK: - Viewport Highlight (lazy, ±50 line buffer)
+
+    func testViewportHighlight5000Lines() {
+        let code = generateSwiftCode(lines: 5000)
+        let textStorage = NSTextStorage(string: code)
+        let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+        let source = code as NSString
+
+        // Find char offset of line 2500 (middle of file)
+        var lineCount = 0
+        var midOffset = 0
+        for i in 0..<source.length {
+            if lineCount >= 2500 { midOffset = i; break }
+            if source.character(at: i) == 0x0A { lineCount += 1 }
+        }
+        // Visible range: ~20 lines in the middle
+        var endOffset = midOffset
+        var linesFound = 0
+        while endOffset < source.length && linesFound < 20 {
+            if source.character(at: endOffset) == 0x0A { linesFound += 1 }
+            endOffset += 1
+        }
+        let visibleRange = NSRange(location: midOffset, length: endOffset - midOffset)
+
+        measure {
+            highlighter.highlightVisibleRange(
+                textStorage: textStorage,
+                visibleCharRange: visibleRange,
+                language: "perfswift",
+                font: font
+            )
+        }
+    }
+
+    func testViewportHighlightVsFullHighlight5000Lines() {
+        let code = generateSwiftCode(lines: 5000)
+        let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+        let source = code as NSString
+
+        // Find char offset of line 2500
+        var lineCount = 0
+        var midOffset = 0
+        for i in 0..<source.length {
+            if lineCount >= 2500 { midOffset = i; break }
+            if source.character(at: i) == 0x0A { lineCount += 1 }
+        }
+        var endOffset = midOffset
+        var linesFound = 0
+        while endOffset < source.length && linesFound < 20 {
+            if source.character(at: endOffset) == 0x0A { linesFound += 1 }
+            endOffset += 1
+        }
+        let visibleRange = NSRange(location: midOffset, length: endOffset - midOffset)
+
+        // Viewport highlight should be significantly faster than full highlight
+        let viewportStorage = NSTextStorage(string: code)
+        let fullStorage = NSTextStorage(string: code)
+
+        let viewportStart = CFAbsoluteTimeGetCurrent()
+        for _ in 0..<10 {
+            highlighter.highlightVisibleRange(
+                textStorage: viewportStorage,
+                visibleCharRange: visibleRange,
+                language: "perfswift",
+                font: font
+            )
+        }
+        let viewportTime = CFAbsoluteTimeGetCurrent() - viewportStart
+
+        let fullStart = CFAbsoluteTimeGetCurrent()
+        for _ in 0..<10 {
+            highlighter.highlight(
+                textStorage: fullStorage,
+                language: "perfswift",
+                font: font
+            )
+        }
+        let fullTime = CFAbsoluteTimeGetCurrent() - fullStart
+
+        // Viewport highlighting should be at least 2x faster than full
+        XCTAssertLessThan(viewportTime, fullTime,
+                          "Viewport highlight (\(viewportTime)s) should be faster than full (\(fullTime)s)")
+    }
+
     // MARK: - Comment and String Ranges
 
     func testCommentAndStringRanges() {

--- a/PineTests/ScrollPerformanceTests.swift
+++ b/PineTests/ScrollPerformanceTests.swift
@@ -107,10 +107,10 @@ struct ScrollPerformanceTests {
 
     // MARK: - Viewport highlighting threshold
 
-    @Test("Viewport highlight threshold is 100_000 characters")
+    @Test("Viewport highlight threshold is 50_000 characters")
     @MainActor func viewportHighlightThresholdCheck() {
         // Verify threshold constant value
-        #expect(CodeEditorView.viewportHighlightThreshold == 100_000)
+        #expect(CodeEditorView.viewportHighlightThreshold == 50_000)
     }
 
     // MARK: - Gutter font equality (#440)

--- a/PineTests/SyntaxHighlighterTests.swift
+++ b/PineTests/SyntaxHighlighterTests.swift
@@ -296,10 +296,10 @@ struct SyntaxHighlighterTests {
         #expect(foregroundColor(in: storage, at: line305Offset) == keywordColor,
                 "Line 305 (within visible range) should have keyword color")
 
-        // Line 0 should NOT have keyword color (outside visible range + 100-line buffer)
+        // Line 0 should NOT have keyword color (outside visible range + 50-line buffer)
         let line0Color = foregroundColor(in: storage, at: 0)
         #expect(line0Color != keywordColor,
-                "Line 0 (outside visible range + buffer) should not have keyword color")
+                "Line 0 (outside visible range + 50-line buffer) should not have keyword color")
     }
 
     // MARK: - 7. highlightVisibleRange detects multiline tokens
@@ -605,5 +605,130 @@ struct SyntaxHighlighterTests {
                 "`#` must become comment in langB")
         #expect(foregroundColor(in: textStorage, at: funcPos) != keywordColor,
                 "`func` must lose keyword color in langB")
+    }
+
+    // MARK: - 12. Viewport buffer is 50 lines (#637)
+
+    @Test func viewportBufferIs50Lines() {
+        register(langA)
+
+        // 300 lines of "func lineN()"
+        let lines = (0..<300).map { "func line\($0)()" }
+        let text = lines.joined(separator: "\n")
+        let storage = NSTextStorage(string: text)
+        let hl = SyntaxHighlighter.shared
+        let keywordColor = hl.theme.color(for: "keyword")
+
+        // Highlight only lines 150-160 (middle of file)
+        let rangeStart = lineOffset(150, in: text)
+        let rangeEnd = lineOffset(161, in: text)
+        let visibleRange = NSRange(location: rangeStart, length: rangeEnd - rangeStart)
+
+        hl.highlightVisibleRange(
+            textStorage: storage,
+            visibleCharRange: visibleRange,
+            language: "langa",
+            font: font
+        )
+
+        // Line 155 (within visible range) should have keyword color
+        let line155Offset = lineOffset(155, in: text)
+        #expect(foregroundColor(in: storage, at: line155Offset) == keywordColor,
+                "Line 155 (within visible range) should have keyword color")
+
+        // Line 110 (within 50-line buffer: 150 - 50 = 100) should have keyword color
+        let line110Offset = lineOffset(110, in: text)
+        #expect(foregroundColor(in: storage, at: line110Offset) == keywordColor,
+                "Line 110 (within 50-line buffer) should have keyword color")
+
+        // Line 0 (far outside 50-line buffer) should NOT have keyword color
+        let line0Color = foregroundColor(in: storage, at: 0)
+        #expect(line0Color != keywordColor,
+                "Line 0 (outside 50-line buffer) should not have keyword color")
+
+        // Line 299 (far outside 50-line buffer) should NOT have keyword color
+        let line299Offset = lineOffset(299, in: text)
+        let line299Color = foregroundColor(in: storage, at: line299Offset)
+        #expect(line299Color != keywordColor,
+                "Line 299 (outside 50-line buffer) should not have keyword color")
+    }
+
+    // MARK: - 13. viewportHighlightThreshold is 50KB (#637)
+
+    @Test func viewportHighlightThresholdIs50KB() {
+        #expect(CodeEditorView.viewportHighlightThreshold == 50_000,
+                "viewportHighlightThreshold should be 50KB for aggressive viewport highlighting")
+    }
+
+    // MARK: - 14. Viewport highlighting leaves untouched regions with default color
+
+    @Test func viewportHighlightingLeavesUntouchedRegionsDefault() {
+        register(langA)
+
+        // 400 lines of "func lineN()"
+        let lines = (0..<400).map { "func line\($0)()" }
+        let text = lines.joined(separator: "\n")
+        let storage = NSTextStorage(string: text)
+        let hl = SyntaxHighlighter.shared
+        let keywordColor = hl.theme.color(for: "keyword")
+
+        // Set a custom color on line 0 before any highlighting
+        storage.addAttribute(.foregroundColor, value: NSColor.orange,
+                             range: NSRange(location: 0, length: 4))
+
+        // Highlight only lines 200-210
+        let rangeStart = lineOffset(200, in: text)
+        let rangeEnd = lineOffset(211, in: text)
+        let visibleRange = NSRange(location: rangeStart, length: rangeEnd - rangeStart)
+
+        hl.highlightVisibleRange(
+            textStorage: storage,
+            visibleCharRange: visibleRange,
+            language: "langa",
+            font: font
+        )
+
+        // Line 0 should still have orange color (untouched by viewport highlighting)
+        let line0Color = foregroundColor(in: storage, at: 0)
+        #expect(line0Color == NSColor.orange,
+                "Line 0 (far outside viewport) should retain its pre-existing color")
+
+        // Line 205 should have keyword color (within viewport)
+        let line205Offset = lineOffset(205, in: text)
+        #expect(foregroundColor(in: storage, at: line205Offset) == keywordColor,
+                "Line 205 (within viewport) should have keyword color")
+    }
+
+    // MARK: - 15. Multiline context is 200 lines (#637)
+
+    @Test func multilineContextDetectsCommentWithin200Lines() {
+        register(langA)
+
+        // Block comment starting at line 0, spanning 180 lines,
+        // then some code. Ask to highlight lines 190-200.
+        // The multiline context (200 lines) should reach back to line 0
+        // and detect the block comment.
+        let text = makeLongComment(prefixLines: 0, commentLines: 180)
+        let storage = NSTextStorage(string: text)
+        let hl = SyntaxHighlighter.shared
+        let commentColor = hl.theme.color(for: "comment")
+
+        // Highlight lines near the end of the comment
+        let rangeStart = lineOffset(170, in: text)
+        let rangeEnd = lineOffset(178, in: text)
+        let visibleRange = NSRange(location: rangeStart, length: rangeEnd - rangeStart)
+
+        hl.highlightVisibleRange(
+            textStorage: storage,
+            visibleCharRange: visibleRange,
+            language: "langa",
+            font: font
+        )
+
+        // Line 175 should be comment-colored (multiline context of 200 lines
+        // should detect the block comment opening at line 0)
+        let line175Offset = lineOffset(175, in: text) + 3
+        #expect(foregroundColor(in: storage, at: line175Offset) == commentColor,
+                "Line 175 inside block comment should be detected within 200-line multiline context")
     }
 }


### PR DESCRIPTION
## Summary
- Lowered `viewportHighlightThreshold` from 100KB to 50KB — files 50KB+ now use viewport-based highlighting instead of full-document scan
- Reduced viewport buffer from ±100 to ±50 lines around the visible area, cutting the highlighted region roughly in half
- Reduced multiline context scan from ±500 to ±200 lines — still catches block comments and multiline strings without scanning the entire file

Closes #637

## Test plan
- [x] 4 new unit tests: buffer size validation, threshold value, untouched region preservation, multiline context detection within 200 lines
- [x] 2 new performance benchmarks: viewport highlight on 5000-line file, viewport vs full highlight comparison
- [x] All 18 existing SyntaxHighlighterTests pass
- [x] SwiftLint clean