### PR TITLE
feat: add tab context menu with close, copy path, reveal actions (#634)

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -25,6 +25,19 @@ nonisolated enum AccessibilityID {
     static func editorTab(_ name: String) -> String { "editorTab_\(name)" }
     static func editorTabCloseButton(_ name: String) -> String { "editorTabClose_\(name)" }
     static func editorTabPinToggle(_ name: String) -> String { "editorTabPinToggle_\(name)" }
+    static func editorTabCloseOthers(_ name: String) -> String { "editorTabCloseOthers_\(name)" }
+    static func editorTabCloseRight(_ name: String) -> String { "editorTabCloseRight_\(name)" }
+    static func editorTabCloseAll(_ name: String) -> String { "editorTabCloseAll_\(name)" }
+    static func editorTabCopyPath(_ name: String) -> String { "editorTabCopyPath_\(name)" }
+    static func editorTabCopyRelativePath(_ name: String) -> String {
+        "editorTabCopyRelativePath_\(name)"
+    }
+    static func editorTabRevealInSidebar(_ name: String) -> String {
+        "editorTabRevealInSidebar_\(name)"
+    }
+    static func editorTabRevealInFinder(_ name: String) -> String {
+        "editorTabRevealInFinder_\(name)"
+    }
     static let editorPlaceholder = "editorPlaceholder"
     static let codeEditor = "codeEditor"
     static let lineNumberGutter = "lineNumberGutter"

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -243,6 +243,59 @@ extension ContentView {
 
 extension ContentView {
 
+    /// Shows a confirmation dialog for bulk close operations when there are dirty tabs.
+    /// Returns `true` if the operation should proceed (user chose Save All or Don't Save),
+    /// `false` if cancelled. When the user chooses Save All, all dirty tabs are saved first.
+    private func confirmBulkClose(dirtyTabs: [EditorTab]) -> Bool {
+        guard !dirtyTabs.isEmpty else { return true }
+
+        let fileList = dirtyTabs.map { "  \u{2022} \($0.fileName)" }.joined(separator: "\n")
+        let alert = NSAlert()
+        alert.messageText = Strings.unsavedChangesTitle
+        alert.informativeText = Strings.unsavedChangesListMessage(fileList)
+        alert.addButton(withTitle: Strings.dialogSaveAll)
+        alert.addButton(withTitle: Strings.dialogDontSave)
+        alert.addButton(withTitle: Strings.dialogCancel)
+        alert.alertStyle = .warning
+
+        let response = alert.runModal()
+        switch response {
+        case .alertFirstButtonReturn:
+            // Save all dirty tabs; abort if any save fails
+            for tab in dirtyTabs {
+                guard let index = tabManager.tabs.firstIndex(where: { $0.id == tab.id }) else { continue }
+                guard tabManager.saveTab(at: index) else { return false }
+            }
+            Task { await workspace.gitProvider.refreshAsync() }
+            return true
+        case .alertSecondButtonReturn:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Closes all tabs except the one with the given ID, with unsaved-changes protection.
+    func closeOtherTabsWithConfirmation(keeping tabID: UUID) {
+        let dirty = tabManager.dirtyTabsForCloseOthers(keeping: tabID)
+        guard confirmBulkClose(dirtyTabs: dirty) else { return }
+        tabManager.closeOtherTabs(keeping: tabID, force: true)
+    }
+
+    /// Closes all tabs to the right of the given tab, with unsaved-changes protection.
+    func closeTabsToTheRightWithConfirmation(of tabID: UUID) {
+        let dirty = tabManager.dirtyTabsForCloseRight(of: tabID)
+        guard confirmBulkClose(dirtyTabs: dirty) else { return }
+        tabManager.closeTabsToTheRight(of: tabID, force: true)
+    }
+
+    /// Closes all tabs with unsaved-changes protection.
+    func closeAllTabsWithConfirmation() {
+        let dirty = tabManager.dirtyTabsForCloseAll()
+        guard confirmBulkClose(dirtyTabs: dirty) else { return }
+        tabManager.closeAllTabs(force: true)
+    }
+
     /// Closes a tab with unsaved-changes protection.
     func closeTabWithConfirmation(_ tab: EditorTab) {
         if tab.isDirty {

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -241,6 +241,9 @@ struct ContentView: View {
             isMinimapVisible: isMinimapVisible,
             isWordWrapEnabled: isWordWrapEnabled,
             onCloseTab: { closeTabWithConfirmation($0) },
+            onCloseOtherTabs: { closeOtherTabsWithConfirmation(keeping: $0) },
+            onCloseTabsToTheRight: { closeTabsToTheRightWithConfirmation(of: $0) },
+            onCloseAllTabs: { closeAllTabsWithConfirmation() },
             onSaveSession: { projectManager.saveSession() }
         )
     }

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -194,6 +194,13 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .toggleWordWrap)) { _ in
             isWordWrapEnabled.toggle()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .revealInSidebar)) { notification in
+            guard let url = notification.userInfo?["url"] as? URL else { return }
+            if let node = findNode(url: url, in: workspace.rootNodes) {
+                selectedNode = node
+                columnVisibility = .all
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: .sendTextToTerminal)) { notification in
             guard controlActiveState == .key,
                   let text = notification.userInfo?["text"] as? String,

--- a/Pine/EditorAreaView.swift
+++ b/Pine/EditorAreaView.swift
@@ -39,7 +39,8 @@ struct EditorAreaView: View {
                     isMarkdownFile: activeTab?.isMarkdownFile ?? false,
                     previewMode: activeTab?.previewMode ?? .source,
                     onTogglePreview: { tabManager.togglePreviewMode() },
-                    isAutoSaving: tabManager.isAutoSaving
+                    isAutoSaving: tabManager.isAutoSaving,
+                    projectRootURL: workspace.rootURL
                 )
             }
 

--- a/Pine/EditorAreaView.swift
+++ b/Pine/EditorAreaView.swift
@@ -23,6 +23,9 @@ struct EditorAreaView: View {
     var isMinimapVisible: Bool
     var isWordWrapEnabled: Bool
     var onCloseTab: (EditorTab) -> Void
+    var onCloseOtherTabs: ((UUID) -> Void)?
+    var onCloseTabsToTheRight: ((UUID) -> Void)?
+    var onCloseAllTabs: (() -> Void)?
     var onSaveSession: () -> Void
 
     @Environment(\.openWindow) private var openWindow
@@ -35,6 +38,9 @@ struct EditorAreaView: View {
                 EditorTabBar(
                     tabManager: tabManager,
                     onCloseTab: { tab in onCloseTab(tab) },
+                    onCloseOtherTabs: onCloseOtherTabs,
+                    onCloseTabsToTheRight: onCloseTabsToTheRight,
+                    onCloseAllTabs: onCloseAllTabs,
                     onReorder: { onSaveSession() },
                     isMarkdownFile: activeTab?.isMarkdownFile ?? false,
                     previewMode: activeTab?.previewMode ?? .source,

--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -24,6 +24,8 @@ struct EditorTabBar: View {
     var onTogglePreview: (() -> Void)?
     /// Whether an auto-save is in progress (shows a subtle indicator).
     var isAutoSaving: Bool = false
+    /// Project root URL for computing relative paths.
+    var projectRootURL: URL?
 
     @State private var draggingTabID: UUID?
     @State private var hoverTargetTabID: UUID?
@@ -79,6 +81,44 @@ struct EditorTabBar: View {
                                     onSelect: { tabManager.activeTabID = tab.id },
                                     onClose: { onCloseTab(tab) },
                                     onTogglePin: { tabManager.togglePin(id: tab.id) },
+                                    onCloseOtherTabs: {
+                                        tabManager.closeOtherTabs(keeping: tab.id)
+                                    },
+                                    onCloseTabsToTheRight: {
+                                        tabManager.closeTabsToTheRight(of: tab.id)
+                                    },
+                                    onCloseAllTabs: { tabManager.closeAllTabs() },
+                                    onCopyPath: {
+                                        NSPasteboard.general.clearContents()
+                                        NSPasteboard.general.setString(
+                                            tab.url.path, forType: .string
+                                        )
+                                    },
+                                    onCopyRelativePath: {
+                                        let relativePath = projectRootURL.flatMap { root in
+                                            tab.url.path.hasPrefix(root.path)
+                                                ? String(
+                                                    tab.url.path.dropFirst(root.path.count + 1)
+                                                )
+                                                : nil
+                                        } ?? tab.url.path
+                                        NSPasteboard.general.clearContents()
+                                        NSPasteboard.general.setString(
+                                            relativePath, forType: .string
+                                        )
+                                    },
+                                    onRevealInSidebar: {
+                                        NotificationCenter.default.post(
+                                            name: .revealInSidebar,
+                                            object: nil,
+                                            userInfo: ["url": tab.url]
+                                        )
+                                    },
+                                    onRevealInFinder: {
+                                        NSWorkspace.shared.activateFileViewerSelecting(
+                                            [tab.url]
+                                        )
+                                    },
                                     constrainedWidth: tab.isPinned
                                         ? Self.pinnedTabWidth
                                         : isActive ? Self.maxTabWidth : inactiveWidth
@@ -229,6 +269,13 @@ struct EditorTabItem: View {
     let onSelect: () -> Void
     let onClose: () -> Void
     var onTogglePin: (() -> Void)?
+    var onCloseOtherTabs: (() -> Void)?
+    var onCloseTabsToTheRight: (() -> Void)?
+    var onCloseAllTabs: (() -> Void)?
+    var onCopyPath: (() -> Void)?
+    var onCopyRelativePath: (() -> Void)?
+    var onRevealInSidebar: (() -> Void)?
+    var onRevealInFinder: (() -> Void)?
     var constrainedWidth: CGFloat?
 
     @State private var isHovering = false
@@ -271,6 +318,61 @@ struct EditorTabItem: View {
                     Label(Strings.menuCloseTab, systemImage: "xmark")
                 }
             }
+
+            Divider()
+
+            Button {
+                onCloseOtherTabs?()
+            } label: {
+                Label(Strings.tabCloseOtherTabs, systemImage: MenuIcons.closeOtherTabs)
+            }
+            .accessibilityIdentifier(AccessibilityID.editorTabCloseOthers(tab.fileName))
+
+            Button {
+                onCloseTabsToTheRight?()
+            } label: {
+                Label(Strings.tabCloseTabsToTheRight, systemImage: MenuIcons.closeTabsToTheRight)
+            }
+            .accessibilityIdentifier(AccessibilityID.editorTabCloseRight(tab.fileName))
+
+            Button(role: .destructive) {
+                onCloseAllTabs?()
+            } label: {
+                Label(Strings.tabCloseAllTabs, systemImage: MenuIcons.closeAllTabs)
+            }
+            .accessibilityIdentifier(AccessibilityID.editorTabCloseAll(tab.fileName))
+
+            Divider()
+
+            Button {
+                onCopyPath?()
+            } label: {
+                Label(Strings.tabCopyPath, systemImage: MenuIcons.copyPath)
+            }
+            .accessibilityIdentifier(AccessibilityID.editorTabCopyPath(tab.fileName))
+
+            Button {
+                onCopyRelativePath?()
+            } label: {
+                Label(Strings.tabCopyRelativePath, systemImage: MenuIcons.copyRelativePath)
+            }
+            .accessibilityIdentifier(AccessibilityID.editorTabCopyRelativePath(tab.fileName))
+
+            Divider()
+
+            Button {
+                onRevealInSidebar?()
+            } label: {
+                Label(Strings.tabRevealInSidebar, systemImage: MenuIcons.revealInSidebar)
+            }
+            .accessibilityIdentifier(AccessibilityID.editorTabRevealInSidebar(tab.fileName))
+
+            Button {
+                onRevealInFinder?()
+            } label: {
+                Label(Strings.tabRevealInFinder, systemImage: MenuIcons.revealInFinder)
+            }
+            .accessibilityIdentifier(AccessibilityID.editorTabRevealInFinder(tab.fileName))
         }
         .accessibilityRepresentation {
             HStack {

--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -14,6 +14,12 @@ struct EditorTabBar: View {
     /// Called when user clicks the close button on a tab.
     /// The caller is responsible for unsaved-changes protection.
     var onCloseTab: (EditorTab) -> Void
+    /// Called when user chooses "Close Other Tabs" from context menu.
+    var onCloseOtherTabs: ((UUID) -> Void)?
+    /// Called when user chooses "Close Tabs to the Right" from context menu.
+    var onCloseTabsToTheRight: ((UUID) -> Void)?
+    /// Called when user chooses "Close All Tabs" from context menu.
+    var onCloseAllTabs: (() -> Void)?
     /// Called after tabs are reordered via drag-and-drop.
     var onReorder: (() -> Void)?
     /// Whether the active tab is a Markdown file.
@@ -26,6 +32,21 @@ struct EditorTabBar: View {
     var isAutoSaving: Bool = false
     /// Project root URL for computing relative paths.
     var projectRootURL: URL?
+
+    /// Computes the relative path of a file URL relative to a project root URL.
+    /// Normalizes both paths via `standardizedFileURL` to handle trailing slashes
+    /// and symlinks consistently.
+    static func computeRelativePath(fileURL: URL, projectRootURL: URL?) -> String {
+        guard let root = projectRootURL else { return fileURL.path }
+        let normalizedFile = fileURL.standardizedFileURL.path
+        let normalizedRoot = root.standardizedFileURL.path
+        // Ensure root path ends with "/" for clean prefix stripping
+        let rootPrefix = normalizedRoot.hasSuffix("/") ? normalizedRoot : normalizedRoot + "/"
+        if normalizedFile.hasPrefix(rootPrefix) {
+            return String(normalizedFile.dropFirst(rootPrefix.count))
+        }
+        return fileURL.path
+    }
 
     @State private var draggingTabID: UUID?
     @State private var hoverTargetTabID: UUID?
@@ -82,12 +103,12 @@ struct EditorTabBar: View {
                                     onClose: { onCloseTab(tab) },
                                     onTogglePin: { tabManager.togglePin(id: tab.id) },
                                     onCloseOtherTabs: {
-                                        tabManager.closeOtherTabs(keeping: tab.id)
+                                        onCloseOtherTabs?(tab.id)
                                     },
                                     onCloseTabsToTheRight: {
-                                        tabManager.closeTabsToTheRight(of: tab.id)
+                                        onCloseTabsToTheRight?(tab.id)
                                     },
-                                    onCloseAllTabs: { tabManager.closeAllTabs() },
+                                    onCloseAllTabs: { onCloseAllTabs?() },
                                     onCopyPath: {
                                         NSPasteboard.general.clearContents()
                                         NSPasteboard.general.setString(
@@ -95,13 +116,10 @@ struct EditorTabBar: View {
                                         )
                                     },
                                     onCopyRelativePath: {
-                                        let relativePath = projectRootURL.flatMap { root in
-                                            tab.url.path.hasPrefix(root.path)
-                                                ? String(
-                                                    tab.url.path.dropFirst(root.path.count + 1)
-                                                )
-                                                : nil
-                                        } ?? tab.url.path
+                                        let relativePath = Self.computeRelativePath(
+                                            fileURL: tab.url,
+                                            projectRootURL: projectRootURL
+                                        )
                                         NSPasteboard.general.clearContents()
                                         NSPasteboard.general.setString(
                                             relativePath, forType: .string

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -3003,6 +3003,426 @@
         }
       }
     },
+    "tab.closeAllTabs" : {
+      "comment" : "Tab context menu: close all open tabs.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Tabs schließen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close All Tabs"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar todas las pestañas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer tous les onglets"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのタブを閉じる"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 탭 닫기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fechar todas as abas"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрыть все вкладки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭所有标签页"
+          }
+        }
+      }
+    },
+    "tab.closeOtherTabs" : {
+      "comment" : "Tab context menu: close all tabs except the right-clicked one.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Andere Tabs schließen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Other Tabs"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar otras pestañas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer les autres onglets"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "他のタブを閉じる"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다른 탭 닫기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fechar outras abas"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрыть другие вкладки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭其他标签页"
+          }
+        }
+      }
+    },
+    "tab.closeTabsToTheRight" : {
+      "comment" : "Tab context menu: close all tabs to the right of the current one.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechte Tabs schließen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Tabs to the Right"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar pestañas a la derecha"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer les onglets à droite"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "右側のタブを閉じる"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오른쪽 탭 닫기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fechar abas à direita"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрыть вкладки справа"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭右侧标签页"
+          }
+        }
+      }
+    },
+    "tab.copyPath" : {
+      "comment" : "Tab context menu: copy the full file path to clipboard.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pfad kopieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Path"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiar ruta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copier le chemin"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パスをコピー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "경로 복사"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiar caminho"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скопировать путь"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拷贝路径"
+          }
+        }
+      }
+    },
+    "tab.copyRelativePath" : {
+      "comment" : "Tab context menu: copy the file path relative to the project root.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Relativen Pfad kopieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Relative Path"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiar ruta relativa"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copier le chemin relatif"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "相対パスをコピー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상대 경로 복사"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiar caminho relativo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скопировать относительный путь"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拷贝相对路径"
+          }
+        }
+      }
+    },
+    "tab.revealInFinder" : {
+      "comment" : "Tab context menu: reveal the file in macOS Finder.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Im Finder anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reveal in Finder"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar en Finder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher dans le Finder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finderで表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finder에서 보기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revelar no Finder"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показать в Finder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在访达中显示"
+          }
+        }
+      }
+    },
+    "tab.revealInSidebar" : {
+      "comment" : "Tab context menu: reveal the file in the sidebar tree.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In Seitenleiste anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reveal in Sidebar"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar en la barra lateral"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher dans la barre latérale"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サイドバーで表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사이드바에서 보기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revelar na barra lateral"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показать в боковой панели"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在侧边栏中显示"
+          }
+        }
+      }
+    },
     "menu.decreaseFontSize" : {
       "comment" : "Menu command: decrease editor font size.",
       "extractionState" : "manual",

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -56,4 +56,12 @@ nonisolated enum MenuIcons {
     static let revealInFinder = "arrow.right.circle"
     static let rename = "pencil"
     static let delete = "trash"
+
+    // MARK: - Tab context menu
+    static let closeOtherTabs = "xmark.square"
+    static let closeTabsToTheRight = "xmark.rectangle"
+    static let closeAllTabs = "xmark.rectangle.fill"
+    static let copyPath = "doc.on.clipboard"
+    static let copyRelativePath = "link"
+    static let revealInSidebar = "sidebar.left"
 }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -1213,4 +1213,6 @@ extension Notification.Name {
     static let sendToTerminal = Notification.Name("sendToTerminal")
     /// userInfo: ["text": String]
     static let sendTextToTerminal = Notification.Name("sendTextToTerminal")
+    /// userInfo: ["url": URL] — reveals a file in the sidebar tree
+    static let revealInSidebar = Notification.Name("revealInSidebar")
 }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -189,6 +189,16 @@ enum Strings {
     static let tabPin: LocalizedStringKey = "tab.pin"
     static let tabUnpin: LocalizedStringKey = "tab.unpin"
 
+    // MARK: - Tab Context Menu
+
+    static let tabCloseOtherTabs: LocalizedStringKey = "tab.closeOtherTabs"
+    static let tabCloseTabsToTheRight: LocalizedStringKey = "tab.closeTabsToTheRight"
+    static let tabCloseAllTabs: LocalizedStringKey = "tab.closeAllTabs"
+    static let tabCopyPath: LocalizedStringKey = "tab.copyPath"
+    static let tabCopyRelativePath: LocalizedStringKey = "tab.copyRelativePath"
+    static let tabRevealInSidebar: LocalizedStringKey = "tab.revealInSidebar"
+    static let tabRevealInFinder: LocalizedStringKey = "tab.revealInFinder"
+
     // MARK: - Unsaved Changes Dialog (AppKit)
 
     static var unsavedChangesTitle: String {

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -400,6 +400,39 @@ final class TabManager {
         tabs = pinned + unpinned
     }
 
+    // MARK: - Context menu actions
+
+    /// Closes all tabs except the one with the given ID.
+    /// Pinned tabs are preserved unless they are the target tab.
+    func closeOtherTabs(keeping tabID: UUID) {
+        cancelAutoSave()
+        let idsToClose = tabs.filter { $0.id != tabID && !$0.isPinned }.map(\.id)
+        for id in idsToClose {
+            closeTab(id: id, force: true)
+        }
+        activeTabID = tabID
+    }
+
+    /// Closes all tabs to the right of the tab with the given ID.
+    /// Pinned tabs are not closed.
+    func closeTabsToTheRight(of tabID: UUID) {
+        guard let index = tabs.firstIndex(where: { $0.id == tabID }) else { return }
+        cancelAutoSave()
+        let rightTabs = tabs[(index + 1)...].filter { !$0.isPinned }
+        for tab in rightTabs.reversed() {
+            closeTab(id: tab.id, force: true)
+        }
+    }
+
+    /// Closes all tabs. Pinned tabs are force-closed.
+    func closeAllTabs() {
+        cancelAutoSave()
+        let allIDs = tabs.map(\.id)
+        for id in allIDs {
+            closeTab(id: id, force: true)
+        }
+    }
+
     // MARK: - Keyboard tab navigation
 
     /// Selects the tab at the given 0-based index. No-op if out of bounds.

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -402,33 +402,62 @@ final class TabManager {
 
     // MARK: - Context menu actions
 
+    /// Returns the dirty (unsaved) tabs that would be closed by `closeOtherTabs`.
+    /// Pinned tabs and the kept tab are excluded.
+    func dirtyTabsForCloseOthers(keeping tabID: UUID) -> [EditorTab] {
+        tabs.filter { $0.id != tabID && !$0.isPinned && $0.isDirty }
+    }
+
     /// Closes all tabs except the one with the given ID.
     /// Pinned tabs are preserved unless they are the target tab.
-    func closeOtherTabs(keeping tabID: UUID) {
+    /// When `force` is true, dirty tabs are closed without confirmation.
+    /// When `force` is false, dirty tabs are skipped (caller must handle them).
+    func closeOtherTabs(keeping tabID: UUID, force: Bool = false) {
         cancelAutoSave()
-        let idsToClose = tabs.filter { $0.id != tabID && !$0.isPinned }.map(\.id)
+        let idsToClose = tabs.filter { tab in
+            tab.id != tabID && !tab.isPinned && (force || !tab.isDirty)
+        }.map(\.id)
         for id in idsToClose {
             closeTab(id: id, force: true)
         }
         activeTabID = tabID
     }
 
+    /// Returns the dirty (unsaved) tabs that would be closed by `closeTabsToTheRight`.
+    func dirtyTabsForCloseRight(of tabID: UUID) -> [EditorTab] {
+        guard let index = tabs.firstIndex(where: { $0.id == tabID }) else { return [] }
+        return Array(tabs[(index + 1)...].filter { !$0.isPinned && $0.isDirty })
+    }
+
     /// Closes all tabs to the right of the tab with the given ID.
     /// Pinned tabs are not closed.
-    func closeTabsToTheRight(of tabID: UUID) {
+    /// When `force` is true, dirty tabs are closed without confirmation.
+    /// When `force` is false, dirty tabs are skipped.
+    func closeTabsToTheRight(of tabID: UUID, force: Bool = false) {
         guard let index = tabs.firstIndex(where: { $0.id == tabID }) else { return }
         cancelAutoSave()
-        let rightTabs = tabs[(index + 1)...].filter { !$0.isPinned }
+        let rightTabs = tabs[(index + 1)...].filter { tab in
+            !tab.isPinned && (force || !tab.isDirty)
+        }
         for tab in rightTabs.reversed() {
             closeTab(id: tab.id, force: true)
         }
     }
 
+    /// Returns the dirty (unsaved) tabs that would be closed by `closeAllTabs`.
+    func dirtyTabsForCloseAll() -> [EditorTab] {
+        tabs.filter(\.isDirty)
+    }
+
     /// Closes all tabs. Pinned tabs are force-closed.
-    func closeAllTabs() {
+    /// When `force` is true, dirty tabs are closed without confirmation.
+    /// When `force` is false, dirty tabs are skipped.
+    func closeAllTabs(force: Bool = false) {
         cancelAutoSave()
-        let allIDs = tabs.map(\.id)
-        for id in allIDs {
+        let idsToClose = tabs.filter { tab in
+            force || !tab.isDirty
+        }.map(\.id)
+        for id in idsToClose {
             closeTab(id: id, force: true)
         }
     }

--- a/PineTests/TabContextMenuTests.swift
+++ b/PineTests/TabContextMenuTests.swift
@@ -1,0 +1,177 @@
+//
+//  TabContextMenuTests.swift
+//  PineTests
+//
+//  Created by Claude on 29.03.2026.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Tab Context Menu Tests")
+struct TabContextMenuTests {
+
+    /// Creates a temporary file URL for testing.
+    private func tempFileURL(name: String = "test.swift", content: String = "hello") -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(name)
+        try? content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    /// Creates a TabManager with the given number of tabs.
+    private func managerWithTabs(_ count: Int) -> (TabManager, [URL]) {
+        let manager = TabManager()
+        var urls: [URL] = []
+        for index in 0..<count {
+            let url = tempFileURL(name: "file\(index).swift")
+            urls.append(url)
+            manager.openTab(url: url)
+        }
+        return (manager, urls)
+    }
+
+    // MARK: - Close Other Tabs
+
+    @Test("closeOtherTabs keeps only the specified tab")
+    func closeOtherTabsKeepsOne() {
+        let (manager, urls) = managerWithTabs(4)
+        let keepID = manager.tabs[1].id
+
+        manager.closeOtherTabs(keeping: keepID)
+
+        #expect(manager.tabs.count == 1)
+        #expect(manager.tabs[0].url == urls[1])
+        #expect(manager.activeTabID == keepID)
+    }
+
+    @Test("closeOtherTabs preserves pinned tabs")
+    func closeOtherTabsPreservesPinned() {
+        let (manager, urls) = managerWithTabs(4)
+        let keepID = manager.tabs[2].id
+        manager.togglePin(id: manager.tabs[0].id)
+
+        manager.closeOtherTabs(keeping: keepID)
+
+        #expect(manager.tabs.count == 2)
+        #expect(manager.tabs.contains { $0.url == urls[0] })
+        #expect(manager.tabs.contains { $0.url == urls[2] })
+    }
+
+    @Test("closeOtherTabs with single tab is a no-op")
+    func closeOtherTabsSingleTab() {
+        let (manager, _) = managerWithTabs(1)
+        let keepID = manager.tabs[0].id
+
+        manager.closeOtherTabs(keeping: keepID)
+
+        #expect(manager.tabs.count == 1)
+    }
+
+    // MARK: - Close Tabs to the Right
+
+    @Test("closeTabsToTheRight closes only right-side tabs")
+    func closeTabsToTheRight() {
+        let (manager, urls) = managerWithTabs(5)
+        let pivotID = manager.tabs[2].id
+
+        manager.closeTabsToTheRight(of: pivotID)
+
+        #expect(manager.tabs.count == 3)
+        #expect(manager.tabs[0].url == urls[0])
+        #expect(manager.tabs[1].url == urls[1])
+        #expect(manager.tabs[2].url == urls[2])
+    }
+
+    @Test("closeTabsToTheRight preserves pinned tabs on the right")
+    func closeTabsToTheRightPreservesPinned() {
+        let (manager, _) = managerWithTabs(4)
+        // Pin the last tab (it moves to the left)
+        let lastTabID = manager.tabs[3].id
+        manager.togglePin(id: lastTabID)
+        // Now pinned tab is at index 0, rest at 1-3
+        let pivotID = manager.tabs[1].id
+
+        manager.closeTabsToTheRight(of: pivotID)
+
+        // Pinned tab stays, pivot stays, right unpinned tabs closed
+        #expect(manager.tabs.count == 2)
+        #expect(manager.tabs[0].isPinned == true)
+    }
+
+    @Test("closeTabsToTheRight on last tab is a no-op")
+    func closeTabsToTheRightLastTab() {
+        let (manager, _) = managerWithTabs(3)
+        let lastID = manager.tabs[2].id
+
+        manager.closeTabsToTheRight(of: lastID)
+
+        #expect(manager.tabs.count == 3)
+    }
+
+    // MARK: - Close All Tabs
+
+    @Test("closeAllTabs removes all tabs including pinned")
+    func closeAllTabs() {
+        let (manager, _) = managerWithTabs(4)
+        manager.togglePin(id: manager.tabs[0].id)
+
+        manager.closeAllTabs()
+
+        #expect(manager.tabs.isEmpty)
+        #expect(manager.activeTabID == nil)
+    }
+
+    @Test("closeAllTabs on empty manager is a no-op")
+    func closeAllTabsEmpty() {
+        let manager = TabManager()
+
+        manager.closeAllTabs()
+
+        #expect(manager.tabs.isEmpty)
+    }
+
+    // MARK: - Close Other Tabs with active tab selection
+
+    @Test("closeOtherTabs sets active tab to the kept tab")
+    func closeOtherTabsSetsActive() {
+        let (manager, _) = managerWithTabs(3)
+        let keepID = manager.tabs[0].id
+        // Active tab is the last opened (tabs[2])
+        #expect(manager.activeTabID == manager.tabs[2].id)
+
+        manager.closeOtherTabs(keeping: keepID)
+
+        #expect(manager.activeTabID == keepID)
+    }
+
+    // MARK: - Close Tabs to the Right with invalid ID
+
+    @Test("closeTabsToTheRight with unknown ID is a no-op")
+    func closeTabsToTheRightUnknownID() {
+        let (manager, _) = managerWithTabs(3)
+        let unknownID = UUID()
+
+        manager.closeTabsToTheRight(of: unknownID)
+
+        #expect(manager.tabs.count == 3)
+    }
+
+    // MARK: - Combined scenarios
+
+    @Test("closeOtherTabs then closeAllTabs leaves empty state")
+    func closeOtherThenCloseAll() {
+        let (manager, _) = managerWithTabs(5)
+        let keepID = manager.tabs[2].id
+
+        manager.closeOtherTabs(keeping: keepID)
+        #expect(manager.tabs.count == 1)
+
+        manager.closeAllTabs()
+        #expect(manager.tabs.isEmpty)
+    }
+}

--- a/PineTests/TabContextMenuTests.swift
+++ b/PineTests/TabContextMenuTests.swift
@@ -37,12 +37,12 @@ struct TabContextMenuTests {
 
     // MARK: - Close Other Tabs
 
-    @Test("closeOtherTabs keeps only the specified tab")
+    @Test("closeOtherTabs with force keeps only the specified tab")
     func closeOtherTabsKeepsOne() {
         let (manager, urls) = managerWithTabs(4)
         let keepID = manager.tabs[1].id
 
-        manager.closeOtherTabs(keeping: keepID)
+        manager.closeOtherTabs(keeping: keepID, force: true)
 
         #expect(manager.tabs.count == 1)
         #expect(manager.tabs[0].url == urls[1])
@@ -55,7 +55,7 @@ struct TabContextMenuTests {
         let keepID = manager.tabs[2].id
         manager.togglePin(id: manager.tabs[0].id)
 
-        manager.closeOtherTabs(keeping: keepID)
+        manager.closeOtherTabs(keeping: keepID, force: true)
 
         #expect(manager.tabs.count == 2)
         #expect(manager.tabs.contains { $0.url == urls[0] })
@@ -67,7 +67,7 @@ struct TabContextMenuTests {
         let (manager, _) = managerWithTabs(1)
         let keepID = manager.tabs[0].id
 
-        manager.closeOtherTabs(keeping: keepID)
+        manager.closeOtherTabs(keeping: keepID, force: true)
 
         #expect(manager.tabs.count == 1)
     }
@@ -79,7 +79,7 @@ struct TabContextMenuTests {
         let (manager, urls) = managerWithTabs(5)
         let pivotID = manager.tabs[2].id
 
-        manager.closeTabsToTheRight(of: pivotID)
+        manager.closeTabsToTheRight(of: pivotID, force: true)
 
         #expect(manager.tabs.count == 3)
         #expect(manager.tabs[0].url == urls[0])
@@ -96,7 +96,7 @@ struct TabContextMenuTests {
         // Now pinned tab is at index 0, rest at 1-3
         let pivotID = manager.tabs[1].id
 
-        manager.closeTabsToTheRight(of: pivotID)
+        manager.closeTabsToTheRight(of: pivotID, force: true)
 
         // Pinned tab stays, pivot stays, right unpinned tabs closed
         #expect(manager.tabs.count == 2)
@@ -108,19 +108,19 @@ struct TabContextMenuTests {
         let (manager, _) = managerWithTabs(3)
         let lastID = manager.tabs[2].id
 
-        manager.closeTabsToTheRight(of: lastID)
+        manager.closeTabsToTheRight(of: lastID, force: true)
 
         #expect(manager.tabs.count == 3)
     }
 
     // MARK: - Close All Tabs
 
-    @Test("closeAllTabs removes all tabs including pinned")
+    @Test("closeAllTabs with force removes all tabs including pinned")
     func closeAllTabs() {
         let (manager, _) = managerWithTabs(4)
         manager.togglePin(id: manager.tabs[0].id)
 
-        manager.closeAllTabs()
+        manager.closeAllTabs(force: true)
 
         #expect(manager.tabs.isEmpty)
         #expect(manager.activeTabID == nil)
@@ -130,7 +130,7 @@ struct TabContextMenuTests {
     func closeAllTabsEmpty() {
         let manager = TabManager()
 
-        manager.closeAllTabs()
+        manager.closeAllTabs(force: true)
 
         #expect(manager.tabs.isEmpty)
     }
@@ -144,7 +144,7 @@ struct TabContextMenuTests {
         // Active tab is the last opened (tabs[2])
         #expect(manager.activeTabID == manager.tabs[2].id)
 
-        manager.closeOtherTabs(keeping: keepID)
+        manager.closeOtherTabs(keeping: keepID, force: true)
 
         #expect(manager.activeTabID == keepID)
     }
@@ -156,7 +156,7 @@ struct TabContextMenuTests {
         let (manager, _) = managerWithTabs(3)
         let unknownID = UUID()
 
-        manager.closeTabsToTheRight(of: unknownID)
+        manager.closeTabsToTheRight(of: unknownID, force: true)
 
         #expect(manager.tabs.count == 3)
     }
@@ -168,10 +168,197 @@ struct TabContextMenuTests {
         let (manager, _) = managerWithTabs(5)
         let keepID = manager.tabs[2].id
 
-        manager.closeOtherTabs(keeping: keepID)
+        manager.closeOtherTabs(keeping: keepID, force: true)
         #expect(manager.tabs.count == 1)
 
-        manager.closeAllTabs()
+        manager.closeAllTabs(force: true)
         #expect(manager.tabs.isEmpty)
+    }
+
+    // MARK: - Dirty tabs protection (no force)
+
+    @Test("closeOtherTabs without force skips dirty tabs")
+    func closeOtherTabsSkipsDirty() {
+        let (manager, urls) = managerWithTabs(4)
+        let keepID = manager.tabs[2].id
+        // Make tab at index 1 dirty
+        manager.activeTabID = manager.tabs[1].id
+        manager.updateContent("modified content")
+
+        manager.closeOtherTabs(keeping: keepID)
+
+        // Tab 0 (clean) closed, tab 1 (dirty) kept, tab 2 (kept), tab 3 (clean) closed
+        #expect(manager.tabs.count == 2)
+        #expect(manager.tabs.contains { $0.url == urls[1] })
+        #expect(manager.tabs.contains { $0.url == urls[2] })
+    }
+
+    @Test("closeTabsToTheRight without force skips dirty tabs")
+    func closeTabsToTheRightSkipsDirty() {
+        let (manager, urls) = managerWithTabs(4)
+        let pivotID = manager.tabs[1].id
+        // Make tab at index 3 dirty
+        manager.activeTabID = manager.tabs[3].id
+        manager.updateContent("modified content")
+
+        manager.closeTabsToTheRight(of: pivotID)
+
+        // Tab 2 (clean) closed, tab 3 (dirty) preserved
+        #expect(manager.tabs.count == 3)
+        #expect(manager.tabs.contains { $0.url == urls[0] })
+        #expect(manager.tabs.contains { $0.url == urls[1] })
+        #expect(manager.tabs.contains { $0.url == urls[3] })
+    }
+
+    @Test("closeAllTabs without force skips dirty tabs")
+    func closeAllTabsSkipsDirty() {
+        let (manager, urls) = managerWithTabs(3)
+        // Make tab at index 1 dirty
+        manager.activeTabID = manager.tabs[1].id
+        manager.updateContent("modified content")
+
+        manager.closeAllTabs()
+
+        // Only dirty tab remains
+        #expect(manager.tabs.count == 1)
+        #expect(manager.tabs[0].url == urls[1])
+    }
+
+    @Test("dirtyTabsForCloseOthers returns only dirty tabs that would be closed")
+    func dirtyTabsForCloseOthersReturnsCorrect() {
+        let (manager, urls) = managerWithTabs(4)
+        let keepID = manager.tabs[2].id
+        // Make tabs 0 and 3 dirty
+        manager.activeTabID = manager.tabs[0].id
+        manager.updateContent("dirty 0")
+        manager.activeTabID = manager.tabs[3].id
+        manager.updateContent("dirty 3")
+
+        let dirty = manager.dirtyTabsForCloseOthers(keeping: keepID)
+
+        #expect(dirty.count == 2)
+        #expect(dirty.contains { $0.url == urls[0] })
+        #expect(dirty.contains { $0.url == urls[3] })
+    }
+
+    @Test("dirtyTabsForCloseRight returns only dirty tabs to the right")
+    func dirtyTabsForCloseRightReturnsCorrect() {
+        let (manager, urls) = managerWithTabs(4)
+        let pivotID = manager.tabs[1].id
+        // Make tab 3 dirty
+        manager.activeTabID = manager.tabs[3].id
+        manager.updateContent("dirty 3")
+
+        let dirty = manager.dirtyTabsForCloseRight(of: pivotID)
+
+        #expect(dirty.count == 1)
+        #expect(dirty[0].url == urls[3])
+    }
+
+    @Test("dirtyTabsForCloseAll returns all dirty tabs")
+    func dirtyTabsForCloseAllReturnsCorrect() {
+        let (manager, urls) = managerWithTabs(3)
+        // Make tabs 0 and 2 dirty
+        manager.activeTabID = manager.tabs[0].id
+        manager.updateContent("dirty 0")
+        manager.activeTabID = manager.tabs[2].id
+        manager.updateContent("dirty 2")
+
+        let dirty = manager.dirtyTabsForCloseAll()
+
+        #expect(dirty.count == 2)
+        #expect(dirty.contains { $0.url == urls[0] })
+        #expect(dirty.contains { $0.url == urls[2] })
+    }
+
+    // MARK: - Copy Path (relative path computation)
+
+    @Test("computeRelativePath returns relative path for file inside project")
+    func computeRelativePathInsideProject() {
+        let root = URL(fileURLWithPath: "/Users/test/project")
+        let file = URL(fileURLWithPath: "/Users/test/project/Sources/main.swift")
+
+        let result = EditorTabBar.computeRelativePath(fileURL: file, projectRootURL: root)
+
+        #expect(result == "Sources/main.swift")
+    }
+
+    @Test("computeRelativePath handles trailing slash on root")
+    func computeRelativePathTrailingSlash() {
+        let root = URL(fileURLWithPath: "/Users/test/project/")
+        let file = URL(fileURLWithPath: "/Users/test/project/Sources/main.swift")
+
+        let result = EditorTabBar.computeRelativePath(fileURL: file, projectRootURL: root)
+
+        #expect(result == "Sources/main.swift")
+    }
+
+    @Test("computeRelativePath returns full path when file is outside project")
+    func computeRelativePathOutsideProject() {
+        let root = URL(fileURLWithPath: "/Users/test/project")
+        let file = URL(fileURLWithPath: "/Users/other/file.swift")
+
+        let result = EditorTabBar.computeRelativePath(fileURL: file, projectRootURL: root)
+
+        #expect(result == "/Users/other/file.swift")
+    }
+
+    @Test("computeRelativePath returns full path when projectRootURL is nil")
+    func computeRelativePathNilRoot() {
+        let file = URL(fileURLWithPath: "/Users/test/project/file.swift")
+
+        let result = EditorTabBar.computeRelativePath(fileURL: file, projectRootURL: nil)
+
+        #expect(result == "/Users/test/project/file.swift")
+    }
+
+    @Test("computeRelativePath handles root as file's direct parent")
+    func computeRelativePathDirectParent() {
+        let root = URL(fileURLWithPath: "/Users/test/project")
+        let file = URL(fileURLWithPath: "/Users/test/project/file.swift")
+
+        let result = EditorTabBar.computeRelativePath(fileURL: file, projectRootURL: root)
+
+        #expect(result == "file.swift")
+    }
+
+    @Test("computeRelativePath handles deeply nested files")
+    func computeRelativePathDeepNesting() {
+        let root = URL(fileURLWithPath: "/project")
+        let file = URL(fileURLWithPath: "/project/a/b/c/d/e.swift")
+
+        let result = EditorTabBar.computeRelativePath(fileURL: file, projectRootURL: root)
+
+        #expect(result == "a/b/c/d/e.swift")
+    }
+
+    // MARK: - Reveal in Sidebar (notification posting)
+
+    @Test("Reveal in Sidebar posts notification with correct URL")
+    func revealInSidebarPostsNotification() {
+        let expectedURL = URL(fileURLWithPath: "/test/file.swift")
+        var receivedURL: URL?
+
+        let observer = NotificationCenter.default.addObserver(
+            forName: .revealInSidebar,
+            object: nil,
+            queue: .main
+        ) { notification in
+            receivedURL = notification.userInfo?["url"] as? URL
+        }
+
+        NotificationCenter.default.post(
+            name: .revealInSidebar,
+            object: nil,
+            userInfo: ["url": expectedURL]
+        )
+
+        #expect(receivedURL == expectedURL)
+        NotificationCenter.default.removeObserver(observer)
+    }
+
+    @Test("Reveal in Sidebar notification has correct name")
+    func revealInSidebarNotificationName() {
+        #expect(Notification.Name.revealInSidebar.rawValue == "revealInSidebar")
     }
 }


### PR DESCRIPTION
## Summary

Right-click on editor tab shows context menu:
- Pin/Unpin Tab
- Close Tab, Close Other Tabs, Close Tabs to the Right, Close All
- Copy Path, Copy Relative Path
- Reveal in Sidebar, Reveal in Finder

11 unit tests, localized to 9 languages.

Closes #634

## Test plan
- [x] 11 unit tests pass
- [x] SwiftLint clean
- [ ] Manual: right-click tab, verify all actions