### PR TITLE
feat: add multiple cursors (Cmd+D, Option+Click)

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -20,6 +20,9 @@ final class GutterTextView: NSTextView {
     /// Indentation style for indent guide rendering.
     var indentStyle: IndentationStyle = .spaces(4)
 
+    /// Multi-cursor state (issue #333).
+    var multiCursorState = MultiCursorState()
+
     /// Bottom padding so the last line is not clipped (issue #258).
     static let defaultBottomInset: CGFloat = 5
 
@@ -116,6 +119,12 @@ final class GutterTextView: NSTextView {
         if isBlameVisible, !blameLookup.isEmpty {
             drawInlineBlame(lineRect: lineRect, layoutManager: layoutManager)
         }
+
+        // ── Multi-cursor overlays (issue #333) ──
+        if multiCursorState.isMultiCursor {
+            drawMultiCursorLineHighlights()
+            drawMultiCursors(in: rect)
+        }
     }
 
     /// Draws inline blame annotation after the line content on the cursor line.
@@ -197,6 +206,367 @@ final class GutterTextView: NSTextView {
         if isBlameVisible { setNeedsDisplay(bounds) }
         super.setSelectedRanges(ranges, affinity: affinity, stillSelecting: stillSelecting)
         needsDisplay = true
+    }
+
+    // MARK: - Multi-cursor rendering (issue #333)
+
+    /// Color for extra cursor carets (secondary cursors).
+    private static let secondaryCursorColor = NSColor(name: nil) { appearance in
+        if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
+            return NSColor.white.withAlphaComponent(0.9)
+        } else {
+            return NSColor.black.withAlphaComponent(0.9)
+        }
+    }
+
+    /// Color for secondary selection highlights.
+    private static let secondarySelectionColor = NSColor(name: nil) { appearance in
+        if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
+            return NSColor.controlAccentColor.withAlphaComponent(0.25)
+        } else {
+            return NSColor.controlAccentColor.withAlphaComponent(0.2)
+        }
+    }
+
+    /// Draws secondary cursor carets and selection highlights.
+    private func drawMultiCursors(in rect: NSRect) {
+        guard multiCursorState.isMultiCursor,
+              let layoutManager = layoutManager,
+              let container = textContainer else { return }
+
+        let primaryRange = selectedRange()
+        let textLength = (string as NSString).length
+
+        for cursor in multiCursorState.cursors {
+            // Skip the primary cursor — NSTextView draws it natively
+            if cursor.range == primaryRange { continue }
+
+            guard cursor.range.location <= textLength else { continue }
+
+            if cursor.range.length > 0 {
+                // Draw selection highlight
+                let safeLength = min(cursor.range.length, textLength - cursor.range.location)
+                let safeRange = NSRange(location: cursor.range.location, length: safeLength)
+                let glyphRange = layoutManager.glyphRange(
+                    forCharacterRange: safeRange, actualCharacterRange: nil
+                )
+                Self.secondarySelectionColor.setFill()
+                layoutManager.enumerateEnclosingRects(
+                    forGlyphRange: glyphRange, withinSelectedGlyphRange: glyphRange,
+                    in: container
+                ) { selRect, _ in
+                    var adjustedRect = selRect
+                    adjustedRect.origin.x += self.textContainerOrigin.x
+                    adjustedRect.origin.y += self.textContainerOrigin.y
+                    adjustedRect.fill()
+                }
+            }
+
+            // Draw caret
+            let caretLocation = min(cursor.range.location + cursor.range.length, textLength)
+            let glyphIndex = layoutManager.glyphIndexForCharacter(at: min(caretLocation, max(textLength - 1, 0)))
+            let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+            let charPoint = layoutManager.location(forGlyphAt: glyphIndex)
+
+            var caretRect = NSRect(
+                x: lineRect.origin.x + charPoint.x + textContainerOrigin.x,
+                y: lineRect.origin.y + textContainerOrigin.y,
+                width: 1.5,
+                height: lineRect.height
+            )
+            // Ensure caret is within dirty rect for efficient drawing
+            guard caretRect.intersects(rect) else { continue }
+            caretRect = caretRect.intersection(rect)
+            Self.secondaryCursorColor.setFill()
+            caretRect.fill()
+        }
+    }
+
+    /// Highlight all lines that have a multi-cursor on them.
+    private func drawMultiCursorLineHighlights() {
+        guard multiCursorState.isMultiCursor,
+              let layoutManager = layoutManager else { return }
+
+        let textLength = (string as NSString).length
+
+        for cursor in multiCursorState.cursors {
+            // Skip primary — already drawn by drawBackground
+            if cursor.range == selectedRange() { continue }
+            guard cursor.range.location <= textLength else { continue }
+
+            let safeLoc = min(cursor.range.location, max(textLength - 1, 0))
+            let glyphIndex = layoutManager.glyphIndexForCharacter(at: safeLoc)
+            var lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+            lineRect.origin.x = 0
+            lineRect.size.width = bounds.width
+            lineRect.origin.y += textContainerOrigin.y
+
+            currentLineColor.setFill()
+            lineRect.fill()
+        }
+    }
+
+    // MARK: - Multi-cursor keyboard handling (Cmd+D, Escape)
+
+    override func keyDown(with event: NSEvent) {
+        // Escape — collapse to single cursor
+        if event.keyCode == 53 && multiCursorState.isMultiCursor { // 53 = Escape
+            multiCursorState.collapseToSingle()
+            clearSecondaryHighlights()
+            needsDisplay = true
+            return
+        }
+
+        super.keyDown(with: event)
+    }
+
+    /// Cmd+D handler: selects the next occurrence of the current word/selection.
+    func selectNextOccurrence() {
+        let source = string as NSString
+        guard source.length > 0 else { return }
+
+        let currentSelection = selectedRange()
+
+        // If no selection, first select the word under cursor
+        if currentSelection.length == 0 {
+            if let wordRange = MultiCursorState.wordAtCursor(in: source, cursorLocation: currentSelection.location) {
+                setSelectedRange(wordRange)
+                multiCursorState.setSingle(wordRange)
+                applySecondaryHighlights()
+                return
+            }
+            return
+        }
+
+        // Get the selected text
+        let selectedText = source.substring(with: currentSelection)
+
+        // Find next occurrence
+        let existingRanges = multiCursorState.cursors.map(\.range)
+        let lastCursor = multiCursorState.cursors.last ?? CursorSelection(range: currentSelection)
+        let searchFrom = NSMaxRange(lastCursor.range)
+
+        guard let nextRange = MultiCursorState.findNextOccurrence(
+            of: selectedText,
+            in: source,
+            searchFrom: searchFrom,
+            existingRanges: existingRanges
+        ) else { return }
+
+        // On first Cmd+D with existing selection but single cursor,
+        // ensure the current selection is tracked
+        if !multiCursorState.isMultiCursor {
+            multiCursorState.setSingle(currentSelection)
+        }
+
+        multiCursorState.addCursor(at: nextRange)
+        applySecondaryHighlights()
+
+        // Scroll to make the new cursor visible
+        scrollRangeToVisible(nextRange)
+        needsDisplay = true
+    }
+
+    // MARK: - Multi-cursor mouse handling (Option+Click)
+
+    override func mouseDown(with event: NSEvent) {
+        if event.modifierFlags.contains(.option) && !event.modifierFlags.contains(.shift) {
+            // Option+Click — add cursor at click position
+            let localPoint = convert(event.locationInWindow, from: nil)
+            let adjustedPoint = NSPoint(
+                x: localPoint.x - textContainerOrigin.x,
+                y: localPoint.y - textContainerOrigin.y
+            )
+
+            guard let container = textContainer,
+                  let layoutManager = layoutManager else {
+                super.mouseDown(with: event)
+                return
+            }
+
+            var fraction: CGFloat = 0
+            let glyphIndex = layoutManager.glyphIndex(for: adjustedPoint, in: container, fractionOfDistanceThroughGlyph: &fraction)
+            let charIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
+
+            if !multiCursorState.isMultiCursor {
+                // Start multi-cursor mode — add current cursor position first
+                multiCursorState.setSingle(selectedRange())
+            }
+
+            multiCursorState.addCursor(at: NSRange(location: charIndex, length: 0))
+            applySecondaryHighlights()
+            needsDisplay = true
+            return
+        }
+
+        // Normal click — reset to single cursor
+        if multiCursorState.isMultiCursor {
+            multiCursorState.collapseToSingle()
+            clearSecondaryHighlights()
+        }
+        super.mouseDown(with: event)
+    }
+
+    // MARK: - Multi-cursor text editing
+
+    override func insertText(_ string: Any, replacementRange: NSRange) {
+        guard multiCursorState.isMultiCursor else {
+            super.insertText(string, replacementRange: replacementRange)
+            return
+        }
+
+        let insertString: String
+        if let str = string as? String {
+            insertString = str
+        } else if let attrStr = string as? NSAttributedString {
+            insertString = attrStr.string
+        } else {
+            super.insertText(string, replacementRange: replacementRange)
+            return
+        }
+
+        let insertLength = (insertString as NSString).length
+
+        // Apply edits in reverse order so positions remain valid
+        let sortedCursors = multiCursorState.cursors.sorted(by: { $0.range.location > $1.range.location })
+
+        // Group undo
+        undoManager?.beginUndoGrouping()
+
+        for cursor in sortedCursors {
+            let source = self.string as NSString
+            let safeLoc = min(cursor.range.location, source.length)
+            let safeLen = min(cursor.range.length, source.length - safeLoc)
+            let safeRange = NSRange(location: safeLoc, length: safeLen)
+
+            if shouldChangeText(in: safeRange, replacementString: insertString) {
+                replaceCharacters(in: safeRange, with: insertString)
+                didChangeText()
+            }
+        }
+
+        undoManager?.endUndoGrouping()
+
+        // Update cursor positions after all edits
+        var newCursors: [CursorSelection] = []
+        var offset = 0
+        let originalSorted = multiCursorState.cursors.sorted()
+
+        for cursor in originalSorted {
+            let newLocation = cursor.range.location + offset + insertLength
+            newCursors.append(CursorSelection(range: NSRange(location: newLocation, length: 0)))
+            offset += insertLength - cursor.range.length
+        }
+
+        multiCursorState = MultiCursorState()
+        for cursor in newCursors {
+            multiCursorState.addCursor(at: cursor.range)
+        }
+
+        // Set primary selection to last cursor
+        if let last = newCursors.last {
+            setSelectedRange(last.range)
+        }
+
+        applySecondaryHighlights()
+        needsDisplay = true
+    }
+
+    override func deleteBackward(_ sender: Any?) {
+        guard multiCursorState.isMultiCursor else {
+            super.deleteBackward(sender)
+            return
+        }
+
+        let sortedCursors = multiCursorState.cursors.sorted(by: { $0.range.location > $1.range.location })
+
+        undoManager?.beginUndoGrouping()
+
+        for cursor in sortedCursors {
+            let source = self.string as NSString
+            let deleteRange: NSRange
+            if cursor.range.length > 0 {
+                let safeLoc = min(cursor.range.location, source.length)
+                let safeLen = min(cursor.range.length, source.length - safeLoc)
+                deleteRange = NSRange(location: safeLoc, length: safeLen)
+            } else {
+                guard cursor.range.location > 0 else { continue }
+                let safeLoc = min(cursor.range.location, source.length)
+                deleteRange = NSRange(location: safeLoc - 1, length: 1)
+            }
+
+            if shouldChangeText(in: deleteRange, replacementString: "") {
+                replaceCharacters(in: deleteRange, with: "")
+                didChangeText()
+            }
+        }
+
+        undoManager?.endUndoGrouping()
+
+        // Recalculate cursor positions
+        var newCursors: [CursorSelection] = []
+        var offset = 0
+        let originalSorted = multiCursorState.cursors.sorted()
+
+        for cursor in originalSorted {
+            let deleteLen = cursor.range.length > 0 ? cursor.range.length : (cursor.range.location > 0 ? 1 : 0)
+            let newLoc = max(0, cursor.range.location + offset - (cursor.range.length > 0 ? 0 : min(1, cursor.range.location)))
+            newCursors.append(CursorSelection(range: NSRange(location: newLoc, length: 0)))
+            offset -= deleteLen
+        }
+
+        multiCursorState = MultiCursorState()
+        for cursor in newCursors {
+            multiCursorState.addCursor(at: cursor.range)
+        }
+
+        if let first = newCursors.first {
+            setSelectedRange(first.range)
+        }
+
+        applySecondaryHighlights()
+        needsDisplay = true
+    }
+
+    // MARK: - Secondary cursor highlight management
+
+    /// Applies temporary highlight attributes for secondary cursors' selections.
+    private func applySecondaryHighlights() {
+        guard let layoutManager = layoutManager else { return }
+        let textLength = (string as NSString).length
+        let primaryRange = selectedRange()
+
+        // Clear previous secondary highlights
+        if textLength > 0 {
+            layoutManager.removeTemporaryAttribute(
+                .backgroundColor,
+                forCharacterRange: NSRange(location: 0, length: textLength)
+            )
+        }
+
+        // Apply highlights for all cursor selections (including primary for visual consistency)
+        for cursor in multiCursorState.cursors where cursor.range.length > 0 {
+            if cursor.range == primaryRange { continue } // NSTextView handles primary
+            let safeLoc = min(cursor.range.location, textLength)
+            let safeLen = min(cursor.range.length, textLength - safeLoc)
+            guard safeLen > 0 else { continue }
+            layoutManager.addTemporaryAttribute(
+                .backgroundColor,
+                value: Self.secondarySelectionColor,
+                forCharacterRange: NSRange(location: safeLoc, length: safeLen)
+            )
+        }
+    }
+
+    /// Removes all secondary cursor highlights.
+    private func clearSecondaryHighlights() {
+        guard let layoutManager = layoutManager else { return }
+        let textLength = (string as NSString).length
+        guard textLength > 0 else { return }
+        layoutManager.removeTemporaryAttribute(
+            .backgroundColor,
+            forCharacterRange: NSRange(location: 0, length: textLength)
+        )
     }
 
     // MARK: - Toggle comment
@@ -637,6 +1007,14 @@ struct CodeEditorView: NSViewRepresentable {
             context.coordinator,
             selector: #selector(Coordinator.handleToggleComment),
             name: .toggleComment,
+            object: nil
+        )
+
+        // Observe add next occurrence notification (Cmd+D, issue #333)
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.handleAddNextOccurrence),
+            name: .addNextOccurrence,
             object: nil
         )
 
@@ -1322,6 +1700,15 @@ struct CodeEditorView: NSViewRepresentable {
                   let gutterView = sv.documentView as? GutterTextView,
                   gutterView.window?.isKeyWindow == true else { return }
             gutterView.toggleComment()
+        }
+
+        // MARK: - Add Next Occurrence (issue #333)
+
+        @objc func handleAddNextOccurrence() {
+            guard let sv = scrollView,
+                  let gutterView = sv.documentView as? GutterTextView,
+                  gutterView.window?.isKeyWindow == true else { return }
+            gutterView.selectNextOccurrence()
         }
 
         // MARK: - Find & Replace (issue #275)

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -5523,6 +5523,66 @@
         }
       }
     },
+    "menu.addNextOccurrence" : {
+      "comment" : "Menu command: add next occurrence to multi-cursor selection (⌘D).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nächstes Vorkommen hinzufügen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Next Occurrence"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir siguiente coincidencia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter l'occurrence suivante"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次の出現箇所を追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음 일치 항목 추가"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adicionar próxima ocorrência"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить следующее вхождение"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加下一个匹配项"
+          }
+        }
+      }
+    },
     "menu.toggleComment" : {
       "comment" : "Menu command: toggle line comment (⌘/).",
       "extractionState" : "manual",

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -19,6 +19,7 @@ nonisolated enum MenuIcons {
 
     // MARK: - Edit menu
     static let toggleComment = "slash.circle"
+    static let addNextOccurrence = "text.cursor"
     static let find = "magnifyingglass"
     static let findAndReplace = "arrow.left.arrow.right"
     static let findInProject = "magnifyingglass"

--- a/Pine/MultiCursorState.swift
+++ b/Pine/MultiCursorState.swift
@@ -1,0 +1,202 @@
+//
+//  MultiCursorState.swift
+//  Pine
+//
+//  Tracks multiple insertion points / selections for multi-cursor editing.
+//  NSTextView only supports a single selection natively, so this model
+//  maintains extra cursors as an overlay and applies edits to all of them.
+//
+
+import AppKit
+
+/// A single cursor: either an insertion point (length == 0) or a selection.
+struct CursorSelection: Equatable, Comparable {
+    var range: NSRange
+
+    var location: Int { range.location }
+    var length: Int { range.length }
+
+    /// Sorts cursors by document position (earlier first).
+    static func < (lhs: CursorSelection, rhs: CursorSelection) -> Bool {
+        lhs.range.location < rhs.range.location
+    }
+}
+
+/// Manages multiple cursor positions for a GutterTextView.
+///
+/// When `cursors` has a single element, the text view behaves normally.
+/// With multiple elements, edits (insert, delete) are applied to all
+/// cursor positions from last to first (reverse order) so earlier
+/// positions remain valid while later ones are being modified.
+struct MultiCursorState {
+    /// All active cursors, always sorted by location ascending.
+    /// Invariant: never empty — at least one cursor always exists.
+    private(set) var cursors: [CursorSelection] = [CursorSelection(range: NSRange(location: 0, length: 0))]
+
+    /// True when there are multiple active cursors.
+    var isMultiCursor: Bool { cursors.count > 1 }
+
+    /// The primary cursor (first one or the one matching NSTextView's selection).
+    var primary: CursorSelection { cursors[0] }
+
+    // MARK: - Mutation
+
+    /// Replaces all cursors with a single one at the given range.
+    mutating func setSingle(_ range: NSRange) {
+        cursors = [CursorSelection(range: range)]
+    }
+
+    /// Adds a cursor at the given range if not already present.
+    /// Returns true if cursor was added.
+    @discardableResult
+    mutating func addCursor(at range: NSRange) -> Bool {
+        let newCursor = CursorSelection(range: range)
+        // Don't add duplicate
+        guard !cursors.contains(newCursor) else { return false }
+        cursors.append(newCursor)
+        cursors.sort()
+        mergeOverlapping()
+        return true
+    }
+
+    /// Removes all cursors except the first (primary).
+    mutating func collapseToSingle() {
+        guard cursors.count > 1 else { return }
+        cursors = [cursors[0]]
+    }
+
+    /// Adjusts all cursor positions after an edit operation.
+    /// `editLocation` is where the edit happened, `oldLength` is how many
+    /// characters were replaced, `newLength` is how many characters were inserted.
+    mutating func adjustAfterEdit(at editLocation: Int, oldLength: Int, newLength: Int) {
+        let delta = newLength - oldLength
+        for i in 0..<cursors.count {
+            let loc = cursors[i].range.location
+            if loc > editLocation {
+                cursors[i].range.location = max(editLocation, loc + delta)
+                // If cursor had a selection, adjust its length
+                if cursors[i].range.length > 0 && loc + delta < editLocation {
+                    cursors[i].range.length = max(0, cursors[i].range.length + delta)
+                }
+            } else if loc == editLocation && cursors[i].range.length > 0 {
+                // Selection starting at edit point — adjust length
+                cursors[i].range.length = max(0, cursors[i].range.length + delta)
+            }
+        }
+        mergeOverlapping()
+    }
+
+    /// Merges any overlapping or adjacent cursors.
+    mutating func mergeOverlapping() {
+        guard cursors.count > 1 else { return }
+        cursors.sort()
+        var merged: [CursorSelection] = [cursors[0]]
+        for i in 1..<cursors.count {
+            let last = merged[merged.count - 1]
+            let current = cursors[i]
+            let lastEnd = NSMaxRange(last.range)
+            if current.range.location <= lastEnd {
+                // Overlapping or adjacent — merge
+                let newEnd = max(lastEnd, NSMaxRange(current.range))
+                merged[merged.count - 1].range = NSRange(
+                    location: last.range.location,
+                    length: newEnd - last.range.location
+                )
+            } else {
+                merged.append(current)
+            }
+        }
+        cursors = merged
+    }
+
+    // MARK: - Cmd+D: Select Next Occurrence
+
+    /// Finds the next occurrence of `word` in `text` after `searchFrom` position.
+    /// If not found, wraps around from the beginning.
+    /// Returns the range of the match, or nil if `word` is not found.
+    static func findNextOccurrence(
+        of word: String,
+        in text: NSString,
+        searchFrom: Int,
+        existingRanges: [NSRange]
+    ) -> NSRange? {
+        let wordLength = (word as NSString).length
+        guard wordLength > 0 else { return nil }
+
+        // Search forward from searchFrom
+        let forwardRange = NSRange(location: searchFrom, length: text.length - searchFrom)
+        var result = text.range(of: word, options: [], range: forwardRange)
+
+        if result.location == NSNotFound {
+            // Wrap around — search from beginning
+            let wrapRange = NSRange(location: 0, length: searchFrom)
+            result = text.range(of: word, options: [], range: wrapRange)
+        }
+
+        guard result.location != NSNotFound else { return nil }
+
+        // Skip if already selected
+        if existingRanges.contains(where: { $0.location == result.location && $0.length == result.length }) {
+            // Try to find the next one after this match
+            let nextStart = result.location + 1
+            guard nextStart < text.length else { return nil }
+            let retryRange = NSRange(location: nextStart, length: text.length - nextStart)
+            let retry = text.range(of: word, options: [], range: retryRange)
+            if retry.location != NSNotFound
+                && !existingRanges.contains(where: { $0.location == retry.location && $0.length == retry.length }) {
+                return retry
+            }
+            // Also try wrapping
+            if nextStart > 0 {
+                let wrapRetry = NSRange(location: 0, length: nextStart)
+                let wrapResult = text.range(of: word, options: [], range: wrapRetry)
+                if wrapResult.location != NSNotFound
+                    && !existingRanges.contains(where: {
+                        $0.location == wrapResult.location && $0.length == wrapResult.length
+                    }) {
+                    return wrapResult
+                }
+            }
+            return nil
+        }
+
+        return result
+    }
+
+    /// Selects the word under the primary cursor's insertion point.
+    /// Returns the selected word, or nil if cursor is in whitespace.
+    static func wordAtCursor(in text: NSString, cursorLocation: Int) -> NSRange? {
+        guard cursorLocation <= text.length else { return nil }
+        guard text.length > 0 else { return nil }
+
+        // Use NSString's word boundary detection
+        let loc = min(cursorLocation, text.length - 1)
+        guard loc >= 0 else { return nil }
+
+        // Find word boundaries
+        var wordStart = loc
+        var wordEnd = loc
+
+        let isWordChar: (Int) -> Bool = { pos in
+            guard pos >= 0, pos < text.length else { return false }
+            let char = text.character(at: pos)
+            // Letters, digits, underscore
+            guard let scalar = Unicode.Scalar(char) else { return false }
+            return CharacterSet.alphanumerics.contains(scalar)
+                || char == 0x5F // underscore
+        }
+
+        guard isWordChar(loc) else { return nil }
+
+        while wordStart > 0 && isWordChar(wordStart - 1) {
+            wordStart -= 1
+        }
+        while wordEnd < text.length - 1 && isWordChar(wordEnd + 1) {
+            wordEnd += 1
+        }
+
+        let range = NSRange(location: wordStart, length: wordEnd - wordStart + 1)
+        guard range.length > 0 else { return nil }
+        return range
+    }
+}

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -205,6 +205,14 @@ struct PineApp: App {
                 }
                 .keyboardShortcut("/", modifiers: .command)
 
+                Button {
+                    NotificationCenter.default.post(name: .addNextOccurrence, object: nil)
+                } label: {
+                    Label(Strings.menuAddNextOccurrence, systemImage: MenuIcons.addNextOccurrence)
+                }
+                .keyboardShortcut("d", modifiers: .command)
+                .disabled(focusedProject?.tabManager.activeTab == nil)
+
                 Divider()
 
                 Button {
@@ -1260,4 +1268,6 @@ extension Notification.Name {
     static let revealInSidebar = Notification.Name("revealInSidebar")
     /// userInfo: ["action": InlineDiffAction]
     static let inlineDiffAction = Notification.Name("inlineDiffAction")
+    // Multiple cursors (issue #333)
+    static let addNextOccurrence = Notification.Name("addNextOccurrence")
 }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -160,6 +160,7 @@ enum Strings {
 
     static let menuCheckForUpdates: LocalizedStringKey = "menu.checkForUpdates"
     static let menuToggleComment: LocalizedStringKey = "menu.toggleComment"
+    static let menuAddNextOccurrence: LocalizedStringKey = "menu.addNextOccurrence"
     static let menuToggleMinimap: LocalizedStringKey = "menu.toggleMinimap"
     static let menuToggleBlame: LocalizedStringKey = "menu.toggleBlame"
     static let menuToggleWordWrap: LocalizedStringKey = "menu.toggleWordWrap"

--- a/PineTests/MultiCursorTests.swift
+++ b/PineTests/MultiCursorTests.swift
@@ -1,0 +1,370 @@
+//
+//  MultiCursorTests.swift
+//  PineTests
+//
+//  Tests for MultiCursorState — multiple cursor tracking and operations.
+//
+
+import Testing
+@testable import Pine
+import AppKit
+
+@Suite("MultiCursorState")
+struct MultiCursorTests {
+
+    // MARK: - CursorSelection
+
+    @Test("CursorSelection sorts by location")
+    func cursorSorting() {
+        let a = CursorSelection(range: NSRange(location: 10, length: 0))
+        let b = CursorSelection(range: NSRange(location: 5, length: 0))
+        let c = CursorSelection(range: NSRange(location: 20, length: 3))
+        var cursors = [a, b, c]
+        cursors.sort()
+        #expect(cursors[0].location == 5)
+        #expect(cursors[1].location == 10)
+        #expect(cursors[2].location == 20)
+    }
+
+    @Test("CursorSelection equality")
+    func cursorEquality() {
+        let a = CursorSelection(range: NSRange(location: 5, length: 3))
+        let b = CursorSelection(range: NSRange(location: 5, length: 3))
+        let c = CursorSelection(range: NSRange(location: 5, length: 0))
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    // MARK: - Basic state
+
+    @Test("Initial state has single cursor")
+    func initialState() {
+        let state = MultiCursorState()
+        #expect(state.cursors.count == 1)
+        #expect(!state.isMultiCursor)
+        #expect(state.primary.location == 0)
+    }
+
+    @Test("setSingle replaces all cursors")
+    func setSingle() {
+        var state = MultiCursorState()
+        state.addCursor(at: NSRange(location: 10, length: 0))
+        state.addCursor(at: NSRange(location: 20, length: 0))
+        #expect(state.cursors.count == 3)
+
+        state.setSingle(NSRange(location: 50, length: 5))
+        #expect(state.cursors.count == 1)
+        #expect(state.primary.location == 50)
+        #expect(state.primary.length == 5)
+    }
+
+    // MARK: - Adding cursors
+
+    @Test("addCursor adds new cursor")
+    func addCursor() {
+        var state = MultiCursorState()
+        state.setSingle(NSRange(location: 5, length: 0))
+        let added = state.addCursor(at: NSRange(location: 15, length: 0))
+        #expect(added)
+        #expect(state.isMultiCursor)
+        #expect(state.cursors.count == 2)
+    }
+
+    @Test("addCursor does not add duplicate")
+    func addCursorDuplicate() {
+        var state = MultiCursorState()
+        state.setSingle(NSRange(location: 5, length: 0))
+        let added = state.addCursor(at: NSRange(location: 5, length: 0))
+        #expect(!added)
+        #expect(state.cursors.count == 1)
+    }
+
+    @Test("addCursor keeps sorted order")
+    func addCursorSorted() {
+        var state = MultiCursorState()
+        state.setSingle(NSRange(location: 20, length: 0))
+        state.addCursor(at: NSRange(location: 5, length: 0))
+        state.addCursor(at: NSRange(location: 50, length: 0))
+        #expect(state.cursors[0].location == 5)
+        #expect(state.cursors[1].location == 20)
+        #expect(state.cursors[2].location == 50)
+    }
+
+    @Test("Overlapping cursors merge")
+    func mergeOverlapping() {
+        var state = MultiCursorState()
+        state.setSingle(NSRange(location: 5, length: 10)) // 5..15
+        state.addCursor(at: NSRange(location: 10, length: 10)) // 10..20
+        #expect(state.cursors.count == 1)
+        #expect(state.cursors[0].location == 5)
+        #expect(state.cursors[0].length == 15) // 5..20
+    }
+
+    @Test("Adjacent cursors merge")
+    func mergeAdjacent() {
+        var state = MultiCursorState()
+        state.setSingle(NSRange(location: 5, length: 5)) // 5..10
+        state.addCursor(at: NSRange(location: 10, length: 5)) // 10..15
+        #expect(state.cursors.count == 1)
+        #expect(state.cursors[0].location == 5)
+        #expect(state.cursors[0].length == 10) // 5..15
+    }
+
+    // MARK: - Collapse
+
+    @Test("collapseToSingle keeps first cursor")
+    func collapseToSingle() {
+        var state = MultiCursorState()
+        state.setSingle(NSRange(location: 5, length: 0))
+        state.addCursor(at: NSRange(location: 15, length: 0))
+        state.addCursor(at: NSRange(location: 25, length: 0))
+        state.collapseToSingle()
+        #expect(state.cursors.count == 1)
+        #expect(state.primary.location == 5)
+    }
+
+    @Test("collapseToSingle no-op for single cursor")
+    func collapseToSingleNoop() {
+        var state = MultiCursorState()
+        state.setSingle(NSRange(location: 10, length: 0))
+        state.collapseToSingle()
+        #expect(state.cursors.count == 1)
+    }
+
+    // MARK: - Find next occurrence
+
+    @Test("findNextOccurrence finds match after cursor")
+    func findNextOccurrenceBasic() {
+        let text = "hello world hello world" as NSString
+        let result = MultiCursorState.findNextOccurrence(
+            of: "hello",
+            in: text,
+            searchFrom: 5,
+            existingRanges: [NSRange(location: 0, length: 5)]
+        )
+        #expect(result != nil)
+        #expect(result?.location == 12)
+        #expect(result?.length == 5)
+    }
+
+    @Test("findNextOccurrence wraps around")
+    func findNextOccurrenceWrap() {
+        let text = "hello world" as NSString
+        let result = MultiCursorState.findNextOccurrence(
+            of: "hello",
+            in: text,
+            searchFrom: 10,
+            existingRanges: []
+        )
+        #expect(result != nil)
+        #expect(result?.location == 0)
+    }
+
+    @Test("findNextOccurrence returns nil when all occurrences selected")
+    func findNextOccurrenceAllSelected() {
+        let text = "ab ab" as NSString
+        let result = MultiCursorState.findNextOccurrence(
+            of: "ab",
+            in: text,
+            searchFrom: 5,
+            existingRanges: [
+                NSRange(location: 0, length: 2),
+                NSRange(location: 3, length: 2)
+            ]
+        )
+        #expect(result == nil)
+    }
+
+    @Test("findNextOccurrence returns nil for empty word")
+    func findNextOccurrenceEmptyWord() {
+        let text = "hello" as NSString
+        let result = MultiCursorState.findNextOccurrence(
+            of: "",
+            in: text,
+            searchFrom: 0,
+            existingRanges: []
+        )
+        #expect(result == nil)
+    }
+
+    @Test("findNextOccurrence returns nil when word not found")
+    func findNextOccurrenceNotFound() {
+        let text = "hello world" as NSString
+        let result = MultiCursorState.findNextOccurrence(
+            of: "xyz",
+            in: text,
+            searchFrom: 0,
+            existingRanges: []
+        )
+        #expect(result == nil)
+    }
+
+    @Test("findNextOccurrence skips already-selected match and finds next")
+    func findNextOccurrenceSkipsSelected() {
+        let text = "aa aa aa" as NSString
+        let result = MultiCursorState.findNextOccurrence(
+            of: "aa",
+            in: text,
+            searchFrom: 3,
+            existingRanges: [
+                NSRange(location: 0, length: 2),
+                NSRange(location: 3, length: 2)
+            ]
+        )
+        #expect(result != nil)
+        #expect(result?.location == 6)
+    }
+
+    // MARK: - Word at cursor
+
+    @Test("wordAtCursor selects word under cursor")
+    func wordAtCursorBasic() {
+        let text = "hello world" as NSString
+        let result = MultiCursorState.wordAtCursor(in: text, cursorLocation: 3)
+        #expect(result != nil)
+        #expect(result?.location == 0)
+        #expect(result?.length == 5) // "hello"
+    }
+
+    @Test("wordAtCursor returns nil on whitespace")
+    func wordAtCursorWhitespace() {
+        let text = "hello world" as NSString
+        let result = MultiCursorState.wordAtCursor(in: text, cursorLocation: 5)
+        #expect(result == nil)
+    }
+
+    @Test("wordAtCursor selects word with underscores")
+    func wordAtCursorUnderscore() throws {
+        let text = "my_var = 42" as NSString
+        let result = MultiCursorState.wordAtCursor(in: text, cursorLocation: 3)
+        let range = try #require(result)
+        #expect(text.substring(with: range) == "my_var")
+    }
+
+    @Test("wordAtCursor at beginning of text")
+    func wordAtCursorBeginning() {
+        let text = "hello" as NSString
+        let result = MultiCursorState.wordAtCursor(in: text, cursorLocation: 0)
+        #expect(result != nil)
+        #expect(result?.location == 0)
+        #expect(result?.length == 5)
+    }
+
+    @Test("wordAtCursor at end of text")
+    func wordAtCursorEnd() {
+        let text = "hello" as NSString
+        let result = MultiCursorState.wordAtCursor(in: text, cursorLocation: 4)
+        #expect(result != nil)
+        #expect(result?.location == 0)
+        #expect(result?.length == 5)
+    }
+
+    @Test("wordAtCursor empty text")
+    func wordAtCursorEmptyText() {
+        let text = "" as NSString
+        let result = MultiCursorState.wordAtCursor(in: text, cursorLocation: 0)
+        #expect(result == nil)
+    }
+
+    @Test("wordAtCursor beyond text length")
+    func wordAtCursorBeyondLength() {
+        let text = "hi" as NSString
+        let result = MultiCursorState.wordAtCursor(in: text, cursorLocation: 100)
+        #expect(result == nil)
+    }
+
+    // MARK: - Multiple Cmd+D chain
+
+    @Test("Multiple Cmd+D chains through occurrences")
+    func multipleSelectNextOccurrence() throws {
+        var state = MultiCursorState()
+        let text = "foo bar foo baz foo" as NSString
+
+        // First "selection" of foo at position 0
+        state.setSingle(NSRange(location: 0, length: 3))
+
+        // Second Cmd+D — find next foo
+        let second = MultiCursorState.findNextOccurrence(
+            of: "foo", in: text, searchFrom: 3,
+            existingRanges: state.cursors.map(\.range)
+        )
+        let secondRange = try #require(second)
+        #expect(secondRange.location == 8)
+        state.addCursor(at: secondRange)
+
+        // Third Cmd+D
+        let third = MultiCursorState.findNextOccurrence(
+            of: "foo", in: text, searchFrom: 11,
+            existingRanges: state.cursors.map(\.range)
+        )
+        let thirdRange = try #require(third)
+        #expect(thirdRange.location == 16)
+        state.addCursor(at: thirdRange)
+
+        #expect(state.cursors.count == 3)
+
+        // Fourth Cmd+D — wraps, all already selected
+        let fourth = MultiCursorState.findNextOccurrence(
+            of: "foo", in: text, searchFrom: 19,
+            existingRanges: state.cursors.map(\.range)
+        )
+        #expect(fourth == nil)
+    }
+
+    // MARK: - Edge cases
+
+    @Test("Cursor at beginning of file (BOF)")
+    func cursorAtBOF() {
+        var state = MultiCursorState()
+        state.setSingle(NSRange(location: 0, length: 0))
+        state.addCursor(at: NSRange(location: 5, length: 0))
+        #expect(state.cursors.count == 2)
+        #expect(state.cursors[0].location == 0)
+    }
+
+    @Test("Cursor at end of file (EOF)")
+    func cursorAtEOF() {
+        var state = MultiCursorState()
+        state.setSingle(NSRange(location: 100, length: 0))
+        state.addCursor(at: NSRange(location: 0, length: 0))
+        #expect(state.cursors.count == 2)
+        #expect(state.cursors[1].location == 100)
+    }
+
+    @Test("Many cursors (performance sanity)")
+    func manyCursors() {
+        var state = MultiCursorState()
+        state.setSingle(NSRange(location: 0, length: 0))
+        for i in 1..<100 {
+            state.addCursor(at: NSRange(location: i * 10, length: 0))
+        }
+        #expect(state.cursors.count == 100)
+        #expect(state.isMultiCursor)
+    }
+
+    @Test("adjustAfterEdit shifts cursors correctly")
+    func adjustAfterEdit() {
+        var state = MultiCursorState()
+        state.setSingle(NSRange(location: 5, length: 0))
+        state.addCursor(at: NSRange(location: 15, length: 0))
+        state.addCursor(at: NSRange(location: 25, length: 0))
+
+        // Insert 3 chars at position 10
+        state.adjustAfterEdit(at: 10, oldLength: 0, newLength: 3)
+        #expect(state.cursors[0].location == 5) // Before edit — unchanged
+        #expect(state.cursors[1].location == 18) // 15 + 3
+        #expect(state.cursors[2].location == 28) // 25 + 3
+    }
+
+    @Test("adjustAfterEdit with deletion shifts cursors back")
+    func adjustAfterEditDeletion() {
+        var state = MultiCursorState()
+        state.setSingle(NSRange(location: 5, length: 0))
+        state.addCursor(at: NSRange(location: 15, length: 0))
+
+        // Delete 3 chars at position 10
+        state.adjustAfterEdit(at: 10, oldLength: 3, newLength: 0)
+        #expect(state.cursors[0].location == 5) // Before edit — unchanged
+        #expect(state.cursors[1].location == 12) // 15 - 3
+    }
+}


### PR DESCRIPTION
Closes #333 - Add multi-cursor editing with Cmd+D (select next occurrence), Option+Click (add cursor), Escape (collapse). 30 unit tests, 9 languages.