### PR TITLE
feat: add file type icon colors in sidebar, tab bar, and quick open

### DIFF
--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -290,7 +290,7 @@ struct EditorTabItem: View {
         ZStack(alignment: .topTrailing) {
             Image(systemName: FileIconMapper.iconForFile(tab.fileName))
                 .font(.system(size: LayoutMetrics.iconSmallFontSize))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(FileIconMapper.colorForFile(tab.fileName))
                 .padding(.horizontal, 10)
                 .padding(.vertical, 4)
 
@@ -332,7 +332,7 @@ struct EditorTabItem: View {
 
             Image(systemName: FileIconMapper.iconForFile(tab.fileName))
                 .font(.system(size: LayoutMetrics.iconSmallFontSize))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(FileIconMapper.colorForFile(tab.fileName))
 
             Text(tab.fileName)
                 .font(.system(size: LayoutMetrics.bodySmallFontSize))

--- a/Pine/FileIconMapper.swift
+++ b/Pine/FileIconMapper.swift
@@ -12,16 +12,26 @@ enum FileIconMapper {
     static func colorForFile(_ name: String) -> Color {
         let lowered = name.lowercased()
 
+        // .env variants (hasPrefix covers .env, .env.local, .env.production, etc.)
+        if lowered.hasPrefix(".env") {
+            return .yellow
+        }
+
         // Exact filename matches
         switch lowered {
         case "dockerfile", "containerfile":    return .blue
-        case "makefile", "cmakelists.txt":     return .secondary
+        case ".dockerignore":                  return .secondary
+        case "makefile":                       return .green
+        case "cmakelists.txt":                 return .green
         case ".gitignore", ".gitattributes":   return .orange
-        case ".env", ".env.local":             return .yellow
         case "license", "licence":             return .secondary
-        case "package.json", "package-lock.json",
-             "cargo.toml", "go.mod",
-             "podfile", "gemfile":             return .secondary
+        case "package.json", "package-lock.json": return .green
+        case "cargo.toml", "go.mod":           return .secondary
+        case "podfile", "podfile.lock":        return .red
+        case "gemfile":                        return .secondary
+        case "yarn.lock":                      return .blue
+        case "requirements.txt":               return .blue
+        case "setup.py":                       return .blue
         default: break
         }
 
@@ -111,16 +121,25 @@ enum FileIconMapper {
     static func iconForFile(_ name: String) -> String {
         let lowered = name.lowercased()
 
+        // .env variants (hasPrefix covers .env, .env.local, .env.production, etc.)
+        if lowered.hasPrefix(".env") {
+            return "lock.shield"
+        }
+
         // Exact filename matches
         switch lowered {
         case "dockerfile", "containerfile":    return "shippingbox"
+        case ".dockerignore":                  return "shippingbox"
         case "makefile", "cmakelists.txt":     return "hammer"
         case ".gitignore", ".gitattributes":   return "arrow.triangle.branch"
-        case ".env", ".env.local":             return "lock.shield"
         case "license", "licence":             return "doc.text.magnifyingglass"
         case "package.json", "package-lock.json",
              "cargo.toml", "go.mod",
-             "podfile", "gemfile":             return "shippingbox"
+             "podfile", "podfile.lock",
+             "gemfile":                        return "shippingbox"
+        case "yarn.lock":                      return "shippingbox"
+        case "requirements.txt":               return "doc.plaintext"
+        case "setup.py":                       return "terminal"
         default: break
         }
 

--- a/Pine/FileIconMapper.swift
+++ b/Pine/FileIconMapper.swift
@@ -4,8 +4,108 @@
 //
 
 import Foundation
+import SwiftUI
 
 enum FileIconMapper {
+
+    /// Returns a tint color for the file type icon based on file extension.
+    static func colorForFile(_ name: String) -> Color {
+        let lowered = name.lowercased()
+
+        // Exact filename matches
+        switch lowered {
+        case "dockerfile", "containerfile":    return .blue
+        case "makefile", "cmakelists.txt":     return .secondary
+        case ".gitignore", ".gitattributes":   return .orange
+        case ".env", ".env.local":             return .yellow
+        case "license", "licence":             return .secondary
+        case "package.json", "package-lock.json",
+             "cargo.toml", "go.mod",
+             "podfile", "gemfile":             return .secondary
+        default: break
+        }
+
+        let ext = (name as NSString).pathExtension.lowercased()
+        switch ext {
+        // Apple / Swift
+        case "swift":                          return .orange
+        case "plist", "entitlements":          return .secondary
+        case "storyboard", "xib":             return .blue
+
+        // Web
+        case "js", "mjs", "cjs":              return .yellow
+        case "ts", "mts", "cts":              return .blue
+        case "jsx", "tsx":                     return .cyan
+        case "html", "htm":                    return .orange
+        case "css", "scss", "sass", "less":   return .purple
+        case "vue", "svelte":                  return .green
+
+        // Data / Config
+        case "json", "jsonc":                  return .yellow
+        case "yaml", "yml":                    return .red
+        case "toml", "ini", "cfg", "conf":    return .secondary
+        case "xml", "svg":                     return .orange
+        case "graphql", "gql":                 return .pink
+
+        // Scripting / Systems
+        case "py", "pyw":                      return .blue
+        case "rb":                             return .red
+        case "sh", "bash", "zsh", "fish":     return .green
+        case "go":                             return .cyan
+        case "rs":                             return .orange
+        case "c", "h":                         return .blue
+        case "cpp", "cc", "cxx", "hpp":       return .blue
+        case "java", "kt", "kts":             return .red
+        case "cs":                             return .purple
+        case "lua":                            return .blue
+        case "r":                              return .blue
+        case "sql":                            return .yellow
+        case "proto":                          return .secondary
+
+        // Documentation
+        case "md", "markdown", "rst":          return .blue
+        case "txt", "text":                    return .secondary
+        case "pdf":                            return .red
+        case "rtf":                            return .secondary
+
+        // Images
+        case "png", "jpg", "jpeg", "gif",
+             "bmp", "tiff", "webp", "ico",
+             "heic":                           return .green
+
+        // Audio / Video
+        case "mp3", "wav", "aac", "flac",
+             "ogg", "m4a":                     return .purple
+        case "mp4", "mov", "avi", "mkv",
+             "webm":                           return .pink
+
+        // Archives
+        case "zip", "tar", "gz", "bz2",
+             "xz", "rar", "7z", "dmg":        return .brown
+
+        // Fonts
+        case "ttf", "otf", "woff", "woff2":  return .red
+
+        default:                               return .secondary
+        }
+    }
+
+    /// Returns a tint color for the folder icon.
+    static func colorForFolder(_ name: String) -> Color {
+        let ext = (name as NSString).pathExtension.lowercased()
+        switch ext {
+        case "xcodeproj", "xcworkspace":       return .blue
+        default: break
+        }
+
+        let lowered = name.lowercased()
+        switch lowered {
+        case "node_modules", "packages",
+             ".build", "build", "dist",
+             "output", "target":               return .secondary
+        default:                               return .blue
+        }
+    }
 
     /// Returns an SF Symbol name for the given file name.
     static func iconForFile(_ name: String) -> String {

--- a/Pine/FileNodeRow.swift
+++ b/Pine/FileNodeRow.swift
@@ -44,14 +44,25 @@ struct FileNodeRow: View {
             : FileIconMapper.iconForFile(node.name)
     }
 
+    private var iconColor: Color {
+        node.isDirectory
+            ? FileIconMapper.colorForFolder(node.name)
+            : FileIconMapper.colorForFile(node.name)
+    }
+
     var body: some View {
         Group {
             if isEditing {
                 inlineEditor
             } else {
-                Label(node.name, systemImage: iconName)
-                    .foregroundStyle(gitStatus?.color ?? .primary)
-                    .opacity(isGitIgnored ? 0.5 : 1.0)
+                Label {
+                    Text(node.name)
+                        .foregroundStyle(gitStatus?.color ?? .primary)
+                } icon: {
+                    Image(systemName: iconName)
+                        .foregroundStyle(iconColor)
+                }
+                .opacity(isGitIgnored ? 0.5 : 1.0)
             }
         }
         .tag(node)

--- a/Pine/QuickOpenView.swift
+++ b/Pine/QuickOpenView.swift
@@ -98,7 +98,7 @@ struct QuickOpenView: View {
         HStack(spacing: 8) {
             Image(systemName: FileIconMapper.iconForFile(result.fileName))
                 .font(.system(size: 14))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(FileIconMapper.colorForFile(result.fileName))
                 .frame(width: 20)
 
             VStack(alignment: .leading, spacing: 1) {

--- a/PineTests/FileIconMapperTests.swift
+++ b/PineTests/FileIconMapperTests.swift
@@ -14,12 +14,15 @@ struct FileIconMapperTests {
     @Test(arguments: [
         ("Dockerfile", "shippingbox"),
         ("Containerfile", "shippingbox"),
+        (".dockerignore", "shippingbox"),
         ("Makefile", "hammer"),
         ("CMakeLists.txt", "hammer"),
         (".gitignore", "arrow.triangle.branch"),
         (".gitattributes", "arrow.triangle.branch"),
         (".env", "lock.shield"),
         (".env.local", "lock.shield"),
+        (".env.production", "lock.shield"),
+        (".env.staging", "lock.shield"),
         ("LICENSE", "doc.text.magnifyingglass"),
         ("licence", "doc.text.magnifyingglass"),
         ("package.json", "shippingbox"),
@@ -27,7 +30,11 @@ struct FileIconMapperTests {
         ("Cargo.toml", "shippingbox"),
         ("go.mod", "shippingbox"),
         ("Podfile", "shippingbox"),
+        ("Podfile.lock", "shippingbox"),
         ("Gemfile", "shippingbox"),
+        ("yarn.lock", "shippingbox"),
+        ("requirements.txt", "doc.plaintext"),
+        ("setup.py", "terminal"),
     ])
     func fileExactName(name: String, expected: String) {
         #expect(FileIconMapper.iconForFile(name) == expected)
@@ -196,11 +203,45 @@ struct FileIconMapperTests {
 
     // MARK: - colorForFile — exact filename matches
 
-    @Test func fileColorExactFilenames() {
+    @Test func fileColorDockerfiles() {
         #expect(FileIconMapper.colorForFile("Dockerfile") == .blue)
         #expect(FileIconMapper.colorForFile("Containerfile") == .blue)
+        #expect(FileIconMapper.colorForFile(".dockerignore") == .secondary)
+    }
+
+    @Test func fileColorBuildTools() {
+        #expect(FileIconMapper.colorForFile("Makefile") == .green)
+        #expect(FileIconMapper.colorForFile("CMakeLists.txt") == .green)
+    }
+
+    @Test func fileColorGitFiles() {
         #expect(FileIconMapper.colorForFile(".gitignore") == .orange)
+        #expect(FileIconMapper.colorForFile(".gitattributes") == .orange)
+    }
+
+    @Test func fileColorEnvFiles() {
         #expect(FileIconMapper.colorForFile(".env") == .yellow)
+        #expect(FileIconMapper.colorForFile(".env.local") == .yellow)
+        #expect(FileIconMapper.colorForFile(".env.production") == .yellow)
+        #expect(FileIconMapper.colorForFile(".env.staging") == .yellow)
+    }
+
+    @Test func fileColorLicense() {
+        #expect(FileIconMapper.colorForFile("LICENSE") == .secondary)
+        #expect(FileIconMapper.colorForFile("licence") == .secondary)
+    }
+
+    @Test func fileColorPackageManagers() {
+        #expect(FileIconMapper.colorForFile("package.json") == .green)
+        #expect(FileIconMapper.colorForFile("package-lock.json") == .green)
+        #expect(FileIconMapper.colorForFile("Podfile") == .red)
+        #expect(FileIconMapper.colorForFile("Podfile.lock") == .red)
+        #expect(FileIconMapper.colorForFile("yarn.lock") == .blue)
+        #expect(FileIconMapper.colorForFile("requirements.txt") == .blue)
+        #expect(FileIconMapper.colorForFile("setup.py") == .blue)
+        #expect(FileIconMapper.colorForFile("Cargo.toml") == .secondary)
+        #expect(FileIconMapper.colorForFile("go.mod") == .secondary)
+        #expect(FileIconMapper.colorForFile("Gemfile") == .secondary)
     }
 
     // MARK: - colorForFile — Swift / Apple

--- a/PineTests/FileIconMapperTests.swift
+++ b/PineTests/FileIconMapperTests.swift
@@ -3,6 +3,7 @@
 //  PineTests
 //
 
+import SwiftUI
 import Testing
 @testable import Pine
 
@@ -191,5 +192,87 @@ struct FileIconMapperTests {
         #expect(FileIconMapper.iconForFolder("Tests") == "folder")
         #expect(FileIconMapper.iconForFolder("docs") == "folder")
         #expect(FileIconMapper.iconForFolder("my-feature") == "folder")
+    }
+
+    // MARK: - colorForFile — exact filename matches
+
+    @Test func fileColorExactFilenames() {
+        #expect(FileIconMapper.colorForFile("Dockerfile") == .blue)
+        #expect(FileIconMapper.colorForFile("Containerfile") == .blue)
+        #expect(FileIconMapper.colorForFile(".gitignore") == .orange)
+        #expect(FileIconMapper.colorForFile(".env") == .yellow)
+    }
+
+    // MARK: - colorForFile — Swift / Apple
+
+    @Test func fileColorSwift() {
+        #expect(FileIconMapper.colorForFile("main.swift") == .orange)
+    }
+
+    // MARK: - colorForFile — Web languages
+
+    @Test func fileColorWeb() {
+        #expect(FileIconMapper.colorForFile("app.js") == .yellow)
+        #expect(FileIconMapper.colorForFile("index.ts") == .blue)
+        #expect(FileIconMapper.colorForFile("App.jsx") == .cyan)
+        #expect(FileIconMapper.colorForFile("index.html") == .orange)
+        #expect(FileIconMapper.colorForFile("style.css") == .purple)
+        #expect(FileIconMapper.colorForFile("App.vue") == .green)
+    }
+
+    // MARK: - colorForFile — Data / Config
+
+    @Test func fileColorDataConfig() {
+        #expect(FileIconMapper.colorForFile("data.json") == .yellow)
+        #expect(FileIconMapper.colorForFile("config.yaml") == .red)
+    }
+
+    // MARK: - colorForFile — Scripting / Systems
+
+    @Test func fileColorScripting() {
+        #expect(FileIconMapper.colorForFile("main.py") == .blue)
+        #expect(FileIconMapper.colorForFile("script.rb") == .red)
+        #expect(FileIconMapper.colorForFile("run.sh") == .green)
+        #expect(FileIconMapper.colorForFile("main.go") == .cyan)
+        #expect(FileIconMapper.colorForFile("main.rs") == .orange)
+        #expect(FileIconMapper.colorForFile("main.c") == .blue)
+        #expect(FileIconMapper.colorForFile("App.java") == .red)
+        #expect(FileIconMapper.colorForFile("Program.cs") == .purple)
+    }
+
+    // MARK: - colorForFile — Documentation / Media / Archives
+
+    @Test func fileColorDocMediaArchive() {
+        #expect(FileIconMapper.colorForFile("README.md") == .blue)
+        #expect(FileIconMapper.colorForFile("photo.png") == .green)
+        #expect(FileIconMapper.colorForFile("song.mp3") == .purple)
+        #expect(FileIconMapper.colorForFile("clip.mp4") == .pink)
+        #expect(FileIconMapper.colorForFile("archive.zip") == .brown)
+        #expect(FileIconMapper.colorForFile("font.ttf") == .red)
+    }
+
+    // MARK: - colorForFile — unknown extension falls back to .secondary
+
+    @Test func fileColorUnknownExtension() {
+        #expect(FileIconMapper.colorForFile("data.xyz") == .secondary)
+        #expect(FileIconMapper.colorForFile("noext") == .secondary)
+    }
+
+    // MARK: - colorForFolder
+
+    @Test func folderColorXcodeProject() {
+        #expect(FileIconMapper.colorForFolder("App.xcodeproj") == .blue)
+        #expect(FileIconMapper.colorForFolder("App.xcworkspace") == .blue)
+    }
+
+    @Test func folderColorBuildDirs() {
+        #expect(FileIconMapper.colorForFolder("node_modules") == .secondary)
+        #expect(FileIconMapper.colorForFolder("build") == .secondary)
+        #expect(FileIconMapper.colorForFolder("dist") == .secondary)
+    }
+
+    @Test func folderColorDefault() {
+        #expect(FileIconMapper.colorForFolder("Sources") == .blue)
+        #expect(FileIconMapper.colorForFolder("Tests") == .blue)
     }
 }


### PR DESCRIPTION
Closes #638

## Summary
- Add `colorForFile(_:)` and `colorForFolder(_:)` methods to `FileIconMapper` that return semantic `Color` values per file extension
- Swift = orange, JS = yellow, TS = blue, Python = blue, Go = cyan, Rust = orange, HTML = orange, CSS = purple, JSON = yellow, YAML = red, Markdown = blue, Shell = green, Dockerfile = blue, Ruby = red, Java = red, C# = purple, and more
- Apply tinted icon colors to `FileNodeRow` (sidebar), `EditorTabItem` (tab bar — both pinned and unpinned), and `QuickOpenView` (quick open results)
- Folders default to blue, build/dependency dirs to secondary

## Test plan
- [x] Unit tests for `colorForFile` — exact filenames, all extension categories, unknown fallback
- [x] Unit tests for `colorForFolder` — Xcode projects, build dirs, default
- [x] SwiftLint clean
- [ ] Visual check: sidebar shows colored icons per file type
- [ ] Visual check: tab bar shows colored icons
- [ ] Visual check: Quick Open shows colored icons