### PR TITLE
feat: add LSP foundation with JSON-RPC protocol layer

### DIFF
--- a/Pine/LSPClient.swift
+++ b/Pine/LSPClient.swift
@@ -10,6 +10,9 @@ import os
 ///
 /// Manages the server process lifecycle, sends requests/notifications, and routes responses.
 /// Thread-safe: all state mutations are serialized on an internal queue.
+/// Marked `@unchecked Sendable` because all mutable state is protected by `queue`
+/// (a serial DispatchQueue). The compiler cannot verify GCD-based synchronization,
+/// so we use `@unchecked` and maintain the invariant manually.
 final class LSPClient: @unchecked Sendable {
 
     // MARK: - Types
@@ -28,11 +31,22 @@ final class LSPClient: @unchecked Sendable {
         case shutdown
     }
 
-    typealias ResponseHandler = (Result<AnyCodable?, LSPClientError>) -> Void
+    typealias ResponseHandler = (Result<JSONValue?, LSPClientError>) -> Void
+
+    // MARK: - Constants
+
+    /// Timeout interval for pending requests (30 seconds).
+    static let requestTimeoutInterval: TimeInterval = 30
 
     // MARK: - Properties
 
-    private(set) var state: State = .idle
+    /// Thread-safe state accessor. Reads are synchronized via `queue`.
+    var state: State {
+        queue.sync { _state }
+    }
+
+    // All mutable state below is only accessed on `queue`.
+    private var _state: State = .idle
     private var process: Process?
     private var stdinPipe: Pipe?
     private var stdoutPipe: Pipe?
@@ -40,6 +54,7 @@ final class LSPClient: @unchecked Sendable {
 
     private var nextRequestId = 1
     private var pendingRequests: [Int: ResponseHandler] = [:]
+    private var requestTimeoutTimers: [Int: DispatchWorkItem] = [:]
     private var readBuffer = Data()
 
     private let queue = DispatchQueue(label: "com.pine.lsp-client", qos: .userInitiated)
@@ -48,7 +63,7 @@ final class LSPClient: @unchecked Sendable {
     private let environment: [String: String]?
 
     /// Called on the main queue when the server sends a notification.
-    var onNotification: ((String, AnyCodable?) -> Void)?
+    var onNotification: ((String, JSONValue?) -> Void)?
 
     // MARK: - Init
 
@@ -69,11 +84,86 @@ final class LSPClient: @unchecked Sendable {
 
     // MARK: - Lifecycle
 
-    /// Starts the language server process.
+    /// Starts the language server process asynchronously.
+    /// - Parameter completion: Called on the internal queue when start completes or fails.
+    func start(completion: @escaping (Result<Void, any Error>) -> Void) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            guard self._state == .idle else {
+                completion(.success(()))
+                return
+            }
+            self._state = .starting
+
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: self.serverPath)
+            proc.arguments = self.serverArguments
+
+            if let env = self.environment {
+                var processEnv = ProcessInfo.processInfo.environment
+                for (key, val) in env {
+                    processEnv[key] = val
+                }
+                proc.environment = processEnv
+            }
+
+            let stdin = Pipe()
+            let stdout = Pipe()
+            let stderr = Pipe()
+
+            proc.standardInput = stdin
+            proc.standardOutput = stdout
+            proc.standardError = stderr
+
+            self.stdinPipe = stdin
+            self.stdoutPipe = stdout
+            self.stderrPipe = stderr
+            self.process = proc
+
+            stdout.fileHandleForReading.readabilityHandler = { [weak self] handle in
+                let data = handle.availableData
+                guard !data.isEmpty else { return }
+                self?.queue.async {
+                    self?.handleStdoutData(data)
+                }
+            }
+
+            stderr.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                if let text = String(data: data, encoding: .utf8), !text.isEmpty {
+                    Logger.lsp.debug("LSP stderr: \(text)")
+                }
+            }
+
+            proc.terminationHandler = { [weak self] _ in
+                self?.queue.async {
+                    self?.handleTermination()
+                }
+            }
+
+            do {
+                try proc.run()
+                self._state = .running
+                Logger.lsp.info("LSP server started: \(self.serverPath)")
+                completion(.success(()))
+            } catch {
+                self._state = .idle
+                self.process = nil
+                self.stdinPipe = nil
+                self.stdoutPipe = nil
+                self.stderrPipe = nil
+                Logger.lsp.error("Failed to start LSP server: \(error)")
+                completion(.failure(error))
+            }
+        }
+    }
+
+    /// Synchronous start for backward compatibility (used in tests).
+    /// Throws if the server cannot be started.
     func start() throws {
         try queue.sync {
-            guard state == .idle else { return }
-            state = .starting
+            guard _state == .idle else { return }
+            _state = .starting
 
             let proc = Process()
             proc.executableURL = URL(fileURLWithPath: serverPath)
@@ -122,19 +212,19 @@ final class LSPClient: @unchecked Sendable {
             }
 
             try proc.run()
-            state = .running
+            _state = .running
             Logger.lsp.info("LSP server started: \(self.serverPath)")
         }
     }
 
     /// Sends the initialize request and waits for the response.
-    func initialize(rootUri: String?, completion: @escaping (Result<AnyCodable?, LSPClientError>) -> Void) {
+    func initialize(rootUri: String?, completion: @escaping (Result<JSONValue?, LSPClientError>) -> Void) {
         let params = InitializeParams(rootUri: rootUri)
-        sendRequest(method: "initialize", params: encodableToAnyCodable(params), completion: { result in
+        sendRequest(method: "initialize", params: encodableToJSONValue(params), completion: { result in
             switch result {
             case .success:
                 // Send initialized notification after successful init response
-                self.sendNotification(method: "initialized", params: AnyCodable([:] as [String: Any]))
+                self.sendNotification(method: "initialized", params: .object([:]))
             case .failure:
                 break
             }
@@ -157,33 +247,35 @@ final class LSPClient: @unchecked Sendable {
 
     /// Notifies the server that a document was opened.
     func didOpenDocument(uri: String, languageId: String, version: Int, text: String) {
-        let item = TextDocumentItem(uri: uri, languageId: languageId, version: version, text: text)
-        let params: [String: Any] = [
-            "textDocument": [
-                "uri": item.uri,
-                "languageId": item.languageId,
-                "version": item.version,
-                "text": item.text
-            ]
-        ]
-        sendNotification(method: "textDocument/didOpen", params: AnyCodable(params))
+        let params: JSONValue = .object([
+            "textDocument": .object([
+                "uri": .string(uri),
+                "languageId": .string(languageId),
+                "version": .int(version),
+                "text": .string(text)
+            ])
+        ])
+        sendNotification(method: "textDocument/didOpen", params: params)
     }
 
     /// Notifies the server that a document was closed.
     func didCloseDocument(uri: String) {
-        let params: [String: Any] = [
-            "textDocument": ["uri": uri]
-        ]
-        sendNotification(method: "textDocument/didClose", params: AnyCodable(params))
+        let params: JSONValue = .object([
+            "textDocument": .object(["uri": .string(uri)])
+        ])
+        sendNotification(method: "textDocument/didClose", params: params)
     }
 
     /// Notifies the server that a document changed (full sync).
     func didChangeDocument(uri: String, version: Int, text: String) {
-        let params: [String: Any] = [
-            "textDocument": ["uri": uri, "version": version],
-            "contentChanges": [["text": text]]
-        ]
-        sendNotification(method: "textDocument/didChange", params: AnyCodable(params))
+        let params: JSONValue = .object([
+            "textDocument": .object([
+                "uri": .string(uri),
+                "version": .int(version)
+            ]),
+            "contentChanges": .array([.object(["text": .string(text)])])
+        ])
+        sendNotification(method: "textDocument/didChange", params: params)
     }
 
     // MARK: - Completion
@@ -195,11 +287,11 @@ final class LSPClient: @unchecked Sendable {
         character: Int,
         completion: @escaping (Result<[CompletionItem], LSPClientError>) -> Void
     ) {
-        let params: [String: Any] = [
-            "textDocument": ["uri": uri],
-            "position": ["line": line, "character": character]
-        ]
-        sendRequest(method: "textDocument/completion", params: AnyCodable(params)) { result in
+        let params: JSONValue = .object([
+            "textDocument": .object(["uri": .string(uri)]),
+            "position": .object(["line": .int(line), "character": .int(character)])
+        ])
+        sendRequest(method: "textDocument/completion", params: params) { result in
             switch result {
             case .success(let value):
                 let items = Self.parseCompletionItems(from: value)
@@ -213,9 +305,10 @@ final class LSPClient: @unchecked Sendable {
     // MARK: - JSON-RPC Transport
 
     /// Sends a JSON-RPC request and registers a response handler.
-    func sendRequest(method: String, params: AnyCodable?, completion: @escaping ResponseHandler) {
+    /// Automatically times out after `requestTimeoutInterval` seconds.
+    func sendRequest(method: String, params: JSONValue?, completion: @escaping ResponseHandler) {
         queue.async { [weak self] in
-            guard let self, self.state == .running else {
+            guard let self, self._state == .running else {
                 completion(.failure(.serverNotRunning))
                 return
             }
@@ -233,13 +326,16 @@ final class LSPClient: @unchecked Sendable {
 
             self.stdinPipe?.fileHandleForWriting.write(data)
             Logger.lsp.debug("LSP request [\(id)] \(method)")
+
+            // Schedule timeout cleanup
+            self.scheduleTimeout(for: id)
         }
     }
 
     /// Sends a JSON-RPC notification (no response expected).
-    func sendNotification(method: String, params: AnyCodable?) {
+    func sendNotification(method: String, params: JSONValue?) {
         queue.async { [weak self] in
-            guard let self, self.state == .running else { return }
+            guard let self, self._state == .running else { return }
 
             let notification = JSONRPCNotification(method: method, params: params)
             guard let data = try? LSPMessageCodec.encode(notification) else { return }
@@ -249,47 +345,71 @@ final class LSPClient: @unchecked Sendable {
         }
     }
 
+    // MARK: - Timeout Management
+
+    /// Schedules a timeout for a pending request. Must be called on `queue`.
+    private func scheduleTimeout(for requestId: Int) {
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            // Already on self.queue
+            if let handler = self.pendingRequests.removeValue(forKey: requestId) {
+                self.requestTimeoutTimers.removeValue(forKey: requestId)
+                Logger.lsp.warning("LSP request [\(requestId)] timed out")
+                handler(.failure(.requestTimeout))
+            }
+        }
+        requestTimeoutTimers[requestId] = workItem
+        queue.asyncAfter(
+            deadline: .now() + Self.requestTimeoutInterval,
+            execute: workItem
+        )
+    }
+
+    /// Cancels the timeout timer for a completed request. Must be called on `queue`.
+    private func cancelTimeout(for requestId: Int) {
+        if let timer = requestTimeoutTimers.removeValue(forKey: requestId) {
+            timer.cancel()
+        }
+    }
+
     // MARK: - Response Handling
 
     private func handleStdoutData(_ data: Data) {
         readBuffer.append(data)
 
-        while let (response, consumed) = LSPMessageCodec.decode(from: readBuffer) {
+        while let (message, consumed) = LSPMessageCodec.decodeMessage(from: readBuffer) {
             readBuffer = Data(readBuffer.dropFirst(consumed))
 
-            if let id = response.id {
+            if message.isResponse, let id = message.id {
                 // It's a response to a request
+                cancelTimeout(for: id)
                 if let handler = pendingRequests.removeValue(forKey: id) {
-                    if let error = response.error {
+                    if let error = message.error {
                         handler(.failure(.serverError(code: error.code, message: error.message)))
                     } else {
-                        handler(.success(response.result))
+                        handler(.success(message.result))
                     }
                 }
-            } else {
-                // It's a server notification — parse method from raw JSON
-                // JSONRPCResponse doesn't have method, so we re-decode
-                if let notif = decodeNotification(from: readBuffer, consumed: consumed, originalData: data) {
-                    DispatchQueue.main.async { [weak self] in
-                        self?.onNotification?(notif.method, notif.params)
-                    }
+            } else if message.isNotification, let method = message.method {
+                // Server-initiated notification (e.g., diagnostics, log messages)
+                let params = message.params
+                Logger.lsp.debug("LSP server notification: \(method)")
+                DispatchQueue.main.async { [weak self] in
+                    self?.onNotification?(method, params)
                 }
             }
         }
     }
 
-    /// Attempts to decode a server-initiated notification from the raw body.
-    /// This is needed because JSONRPCResponse doesn't carry a method field.
-    private func decodeNotification(from buffer: Data, consumed: Int, originalData: Data) -> JSONRPCNotification? {
-        // Re-parse from the original buffer to get the method field
-        // This is a simplified approach — in production we'd use a unified message type
-        nil
-    }
-
     private func handleTermination() {
-        state = .shutdown
+        _state = .shutdown
         let pending = pendingRequests
         pendingRequests.removeAll()
+        // Cancel all timeout timers
+        for (_, timer) in requestTimeoutTimers {
+            timer.cancel()
+        }
+        requestTimeoutTimers.removeAll()
         for (_, handler) in pending {
             handler(.failure(.serverNotRunning))
         }
@@ -304,41 +424,49 @@ final class LSPClient: @unchecked Sendable {
         stdinPipe = nil
         stdoutPipe = nil
         stderrPipe = nil
-        state = .shutdown
+        // Cancel all timeout timers
+        for (_, timer) in requestTimeoutTimers {
+            timer.cancel()
+        }
+        requestTimeoutTimers.removeAll()
+        _state = .shutdown
     }
 
     // MARK: - Helpers
 
-    /// Converts an Encodable value to AnyCodable via JSON round-trip.
-    private func encodableToAnyCodable<T: Encodable>(_ value: T) -> AnyCodable? {
+    /// Converts an Encodable value to JSONValue via JSON round-trip.
+    private func encodableToJSONValue<T: Encodable>(_ value: T) -> JSONValue? {
         guard let data = try? JSONEncoder().encode(value),
-              let dict = try? JSONSerialization.jsonObject(with: data) else {
+              let obj = try? JSONDecoder().decode(JSONValue.self, from: data) else {
             return nil
         }
-        return AnyCodable(dict)
+        return obj
     }
 
     /// Parses completion items from the server response.
-    static func parseCompletionItems(from value: AnyCodable?) -> [CompletionItem] {
+    static func parseCompletionItems(from value: JSONValue?) -> [CompletionItem] {
         guard let value else { return [] }
 
         // Response can be either [CompletionItem] or CompletionList { items: [CompletionItem] }
-        if let dict = value.value as? [String: Any],
-           let itemsArray = dict["items"] as? [[String: Any]] {
+        if case .object(let dict) = value,
+           case .array(let itemsArray) = dict["items"] {
             return itemsArray.compactMap { parseOneCompletionItem($0) }
-        } else if let array = value.value as? [[String: Any]] {
+        } else if case .array(let array) = value {
             return array.compactMap { parseOneCompletionItem($0) }
         }
         return []
     }
 
-    private static func parseOneCompletionItem(_ dict: [String: Any]) -> CompletionItem? {
-        guard let label = dict["label"] as? String else { return nil }
+    private static func parseOneCompletionItem(_ value: JSONValue) -> CompletionItem? {
+        guard case .object(let dict) = value,
+              case .string(let label) = dict["label"] else {
+            return nil
+        }
         return CompletionItem(
             label: label,
-            kind: dict["kind"] as? Int,
-            detail: dict["detail"] as? String,
-            insertText: dict["insertText"] as? String
+            kind: dict["kind"]?.intValue,
+            detail: dict["detail"]?.stringValue,
+            insertText: dict["insertText"]?.stringValue
         )
     }
 }

--- a/Pine/LSPClient.swift
+++ b/Pine/LSPClient.swift
@@ -1,0 +1,344 @@
+//
+//  LSPClient.swift
+//  Pine
+//
+
+import Foundation
+import os
+
+/// LSP client that communicates with a language server via JSON-RPC over stdin/stdout.
+///
+/// Manages the server process lifecycle, sends requests/notifications, and routes responses.
+/// Thread-safe: all state mutations are serialized on an internal queue.
+final class LSPClient: @unchecked Sendable {
+
+    // MARK: - Types
+
+    enum LSPClientError: Error, Equatable {
+        case serverNotRunning
+        case encodingFailed
+        case requestTimeout
+        case serverError(code: Int, message: String)
+    }
+
+    enum State: Equatable {
+        case idle
+        case starting
+        case running
+        case shutdown
+    }
+
+    typealias ResponseHandler = (Result<AnyCodable?, LSPClientError>) -> Void
+
+    // MARK: - Properties
+
+    private(set) var state: State = .idle
+    private var process: Process?
+    private var stdinPipe: Pipe?
+    private var stdoutPipe: Pipe?
+    private var stderrPipe: Pipe?
+
+    private var nextRequestId = 1
+    private var pendingRequests: [Int: ResponseHandler] = [:]
+    private var readBuffer = Data()
+
+    private let queue = DispatchQueue(label: "com.pine.lsp-client", qos: .userInitiated)
+    private let serverPath: String
+    private let serverArguments: [String]
+    private let environment: [String: String]?
+
+    /// Called on the main queue when the server sends a notification.
+    var onNotification: ((String, AnyCodable?) -> Void)?
+
+    // MARK: - Init
+
+    /// Creates an LSP client for the given language server executable.
+    /// - Parameters:
+    ///   - serverPath: Path to the language server binary.
+    ///   - arguments: Command-line arguments for the server.
+    ///   - environment: Optional environment variables for the server process.
+    init(serverPath: String, arguments: [String] = [], environment: [String: String]? = nil) {
+        self.serverPath = serverPath
+        self.serverArguments = arguments
+        self.environment = environment
+    }
+
+    deinit {
+        stopProcess()
+    }
+
+    // MARK: - Lifecycle
+
+    /// Starts the language server process.
+    func start() throws {
+        try queue.sync {
+            guard state == .idle else { return }
+            state = .starting
+
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: serverPath)
+            proc.arguments = serverArguments
+
+            if let env = environment {
+                var processEnv = ProcessInfo.processInfo.environment
+                for (key, val) in env {
+                    processEnv[key] = val
+                }
+                proc.environment = processEnv
+            }
+
+            let stdin = Pipe()
+            let stdout = Pipe()
+            let stderr = Pipe()
+
+            proc.standardInput = stdin
+            proc.standardOutput = stdout
+            proc.standardError = stderr
+
+            self.stdinPipe = stdin
+            self.stdoutPipe = stdout
+            self.stderrPipe = stderr
+            self.process = proc
+
+            stdout.fileHandleForReading.readabilityHandler = { [weak self] handle in
+                let data = handle.availableData
+                guard !data.isEmpty else { return }
+                self?.queue.async {
+                    self?.handleStdoutData(data)
+                }
+            }
+
+            stderr.fileHandleForReading.readabilityHandler = { handle in
+                let data = handle.availableData
+                if let text = String(data: data, encoding: .utf8), !text.isEmpty {
+                    Logger.lsp.debug("LSP stderr: \(text)")
+                }
+            }
+
+            proc.terminationHandler = { [weak self] _ in
+                self?.queue.async {
+                    self?.handleTermination()
+                }
+            }
+
+            try proc.run()
+            state = .running
+            Logger.lsp.info("LSP server started: \(self.serverPath)")
+        }
+    }
+
+    /// Sends the initialize request and waits for the response.
+    func initialize(rootUri: String?, completion: @escaping (Result<AnyCodable?, LSPClientError>) -> Void) {
+        let params = InitializeParams(rootUri: rootUri)
+        sendRequest(method: "initialize", params: encodableToAnyCodable(params), completion: { result in
+            switch result {
+            case .success:
+                // Send initialized notification after successful init response
+                self.sendNotification(method: "initialized", params: AnyCodable([:] as [String: Any]))
+            case .failure:
+                break
+            }
+            completion(result)
+        })
+    }
+
+    /// Sends a shutdown request followed by exit notification.
+    func shutdown(completion: @escaping () -> Void) {
+        sendRequest(method: "shutdown", params: nil) { [weak self] _ in
+            self?.sendNotification(method: "exit", params: nil)
+            self?.queue.async {
+                self?.stopProcess()
+                completion()
+            }
+        }
+    }
+
+    // MARK: - Document Sync
+
+    /// Notifies the server that a document was opened.
+    func didOpenDocument(uri: String, languageId: String, version: Int, text: String) {
+        let item = TextDocumentItem(uri: uri, languageId: languageId, version: version, text: text)
+        let params: [String: Any] = [
+            "textDocument": [
+                "uri": item.uri,
+                "languageId": item.languageId,
+                "version": item.version,
+                "text": item.text
+            ]
+        ]
+        sendNotification(method: "textDocument/didOpen", params: AnyCodable(params))
+    }
+
+    /// Notifies the server that a document was closed.
+    func didCloseDocument(uri: String) {
+        let params: [String: Any] = [
+            "textDocument": ["uri": uri]
+        ]
+        sendNotification(method: "textDocument/didClose", params: AnyCodable(params))
+    }
+
+    /// Notifies the server that a document changed (full sync).
+    func didChangeDocument(uri: String, version: Int, text: String) {
+        let params: [String: Any] = [
+            "textDocument": ["uri": uri, "version": version],
+            "contentChanges": [["text": text]]
+        ]
+        sendNotification(method: "textDocument/didChange", params: AnyCodable(params))
+    }
+
+    // MARK: - Completion
+
+    /// Requests completions at the given position.
+    func requestCompletion(
+        uri: String,
+        line: Int,
+        character: Int,
+        completion: @escaping (Result<[CompletionItem], LSPClientError>) -> Void
+    ) {
+        let params: [String: Any] = [
+            "textDocument": ["uri": uri],
+            "position": ["line": line, "character": character]
+        ]
+        sendRequest(method: "textDocument/completion", params: AnyCodable(params)) { result in
+            switch result {
+            case .success(let value):
+                let items = Self.parseCompletionItems(from: value)
+                completion(.success(items))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    // MARK: - JSON-RPC Transport
+
+    /// Sends a JSON-RPC request and registers a response handler.
+    func sendRequest(method: String, params: AnyCodable?, completion: @escaping ResponseHandler) {
+        queue.async { [weak self] in
+            guard let self, self.state == .running else {
+                completion(.failure(.serverNotRunning))
+                return
+            }
+
+            let id = self.nextRequestId
+            self.nextRequestId += 1
+            self.pendingRequests[id] = completion
+
+            let request = JSONRPCRequest(id: id, method: method, params: params)
+            guard let data = try? LSPMessageCodec.encode(request) else {
+                self.pendingRequests.removeValue(forKey: id)
+                completion(.failure(.encodingFailed))
+                return
+            }
+
+            self.stdinPipe?.fileHandleForWriting.write(data)
+            Logger.lsp.debug("LSP request [\(id)] \(method)")
+        }
+    }
+
+    /// Sends a JSON-RPC notification (no response expected).
+    func sendNotification(method: String, params: AnyCodable?) {
+        queue.async { [weak self] in
+            guard let self, self.state == .running else { return }
+
+            let notification = JSONRPCNotification(method: method, params: params)
+            guard let data = try? LSPMessageCodec.encode(notification) else { return }
+
+            self.stdinPipe?.fileHandleForWriting.write(data)
+            Logger.lsp.debug("LSP notification: \(method)")
+        }
+    }
+
+    // MARK: - Response Handling
+
+    private func handleStdoutData(_ data: Data) {
+        readBuffer.append(data)
+
+        while let (response, consumed) = LSPMessageCodec.decode(from: readBuffer) {
+            readBuffer = Data(readBuffer.dropFirst(consumed))
+
+            if let id = response.id {
+                // It's a response to a request
+                if let handler = pendingRequests.removeValue(forKey: id) {
+                    if let error = response.error {
+                        handler(.failure(.serverError(code: error.code, message: error.message)))
+                    } else {
+                        handler(.success(response.result))
+                    }
+                }
+            } else {
+                // It's a server notification — parse method from raw JSON
+                // JSONRPCResponse doesn't have method, so we re-decode
+                if let notif = decodeNotification(from: readBuffer, consumed: consumed, originalData: data) {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.onNotification?(notif.method, notif.params)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Attempts to decode a server-initiated notification from the raw body.
+    /// This is needed because JSONRPCResponse doesn't carry a method field.
+    private func decodeNotification(from buffer: Data, consumed: Int, originalData: Data) -> JSONRPCNotification? {
+        // Re-parse from the original buffer to get the method field
+        // This is a simplified approach — in production we'd use a unified message type
+        nil
+    }
+
+    private func handleTermination() {
+        state = .shutdown
+        let pending = pendingRequests
+        pendingRequests.removeAll()
+        for (_, handler) in pending {
+            handler(.failure(.serverNotRunning))
+        }
+        Logger.lsp.info("LSP server terminated")
+    }
+
+    private func stopProcess() {
+        process?.terminate()
+        stdoutPipe?.fileHandleForReading.readabilityHandler = nil
+        stderrPipe?.fileHandleForReading.readabilityHandler = nil
+        process = nil
+        stdinPipe = nil
+        stdoutPipe = nil
+        stderrPipe = nil
+        state = .shutdown
+    }
+
+    // MARK: - Helpers
+
+    /// Converts an Encodable value to AnyCodable via JSON round-trip.
+    private func encodableToAnyCodable<T: Encodable>(_ value: T) -> AnyCodable? {
+        guard let data = try? JSONEncoder().encode(value),
+              let dict = try? JSONSerialization.jsonObject(with: data) else {
+            return nil
+        }
+        return AnyCodable(dict)
+    }
+
+    /// Parses completion items from the server response.
+    static func parseCompletionItems(from value: AnyCodable?) -> [CompletionItem] {
+        guard let value else { return [] }
+
+        // Response can be either [CompletionItem] or CompletionList { items: [CompletionItem] }
+        if let dict = value.value as? [String: Any],
+           let itemsArray = dict["items"] as? [[String: Any]] {
+            return itemsArray.compactMap { parseOneCompletionItem($0) }
+        } else if let array = value.value as? [[String: Any]] {
+            return array.compactMap { parseOneCompletionItem($0) }
+        }
+        return []
+    }
+
+    private static func parseOneCompletionItem(_ dict: [String: Any]) -> CompletionItem? {
+        guard let label = dict["label"] as? String else { return nil }
+        return CompletionItem(
+            label: label,
+            kind: dict["kind"] as? Int,
+            detail: dict["detail"] as? String,
+            insertText: dict["insertText"] as? String
+        )
+    }
+}

--- a/Pine/LSPManager.swift
+++ b/Pine/LSPManager.swift
@@ -10,6 +10,9 @@ import os
 ///
 /// Determines the appropriate language server based on file extension,
 /// starts/stops servers as needed, and routes document events.
+/// Marked `@unchecked Sendable` because all mutable state is protected by `queue`
+/// (a serial DispatchQueue). The compiler cannot verify GCD-based synchronization,
+/// so we use `@unchecked` and maintain the invariant manually.
 final class LSPManager: @unchecked Sendable {
 
     // MARK: - Types
@@ -36,7 +39,33 @@ final class LSPManager: @unchecked Sendable {
     private var configs: [ServerConfig]
     private var rootUri: String?
 
+    /// Common search paths for language server binaries.
+    /// Includes both Intel (`/usr/local/bin`) and Apple Silicon (`/opt/homebrew/bin`) Homebrew paths.
+    static let serverSearchPaths: [String] = [
+        "/usr/local/bin",
+        "/opt/homebrew/bin",
+        "/usr/bin"
+    ]
+
+    /// Resolves the first existing executable path for a binary name across known search paths.
+    /// Returns the full path if found, or the original path if it's already absolute.
+    static func resolveServerPath(_ name: String) -> String? {
+        // If already an absolute path, return as-is if executable
+        if name.hasPrefix("/") {
+            return FileManager.default.isExecutableFile(atPath: name) ? name : nil
+        }
+        // Search common paths
+        for dir in serverSearchPaths {
+            let fullPath = "\(dir)/\(name)"
+            if FileManager.default.isExecutableFile(atPath: fullPath) {
+                return fullPath
+            }
+        }
+        return nil
+    }
+
     /// Known server configurations.
+    /// Server paths use `resolveServerPath` at lookup time to support both Intel and Apple Silicon Macs.
     static let defaultConfigs: [ServerConfig] = [
         ServerConfig(
             languageId: "swift",
@@ -46,31 +75,31 @@ final class LSPManager: @unchecked Sendable {
         ),
         ServerConfig(
             languageId: "typescript",
-            serverPath: "/usr/local/bin/typescript-language-server",
+            serverPath: "typescript-language-server",
             arguments: ["--stdio"],
             extensions: ["ts", "tsx"]
         ),
         ServerConfig(
             languageId: "javascript",
-            serverPath: "/usr/local/bin/typescript-language-server",
+            serverPath: "typescript-language-server",
             arguments: ["--stdio"],
             extensions: ["js", "jsx"]
         ),
         ServerConfig(
             languageId: "python",
-            serverPath: "/usr/local/bin/pylsp",
+            serverPath: "pylsp",
             arguments: [],
             extensions: ["py"]
         ),
         ServerConfig(
             languageId: "go",
-            serverPath: "/usr/local/bin/gopls",
+            serverPath: "gopls",
             arguments: ["serve"],
             extensions: ["go"]
         ),
         ServerConfig(
             languageId: "rust",
-            serverPath: "/usr/local/bin/rust-analyzer",
+            serverPath: "rust-analyzer",
             arguments: [],
             extensions: ["rs"]
         ),
@@ -138,34 +167,38 @@ final class LSPManager: @unchecked Sendable {
                 return
             }
 
-            // Verify server exists
-            guard FileManager.default.isExecutableFile(atPath: config.serverPath) else {
-                Logger.lsp.warning("Server not found at: \(config.serverPath)")
+            // Resolve server path (supports both Intel and Apple Silicon)
+            guard let resolvedPath = Self.resolveServerPath(config.serverPath) else {
+                Logger.lsp.warning(
+                    "Server not found for \(languageId). Searched: \(config.serverPath) in \(Self.serverSearchPaths)"
+                )
                 completion(.failure(.serverNotRunning))
                 return
             }
 
-            let client = LSPClient(serverPath: config.serverPath, arguments: config.arguments)
+            let client = LSPClient(serverPath: resolvedPath, arguments: config.arguments)
             self.clients[languageId] = client
 
-            do {
-                try client.start()
-            } catch {
-                Logger.lsp.error("Failed to start LSP server for \(languageId): \(error)")
-                self.clients.removeValue(forKey: languageId)
-                completion(.failure(.serverNotRunning))
-                return
-            }
-
-            let rootUri = self.rootUri
-            client.initialize(rootUri: rootUri) { result in
+            client.start { [weak self] result in
                 switch result {
                 case .success:
-                    Logger.lsp.info("LSP initialized for \(languageId)")
-                    completion(.success(client))
+                    let rootUri = self?.queue.sync { self?.rootUri }
+                    client.initialize(rootUri: rootUri ?? nil) { initResult in
+                        switch initResult {
+                        case .success:
+                            Logger.lsp.info("LSP initialized for \(languageId)")
+                            completion(.success(client))
+                        case .failure(let error):
+                            Logger.lsp.error("LSP initialize failed for \(languageId): \(error)")
+                            completion(.failure(error))
+                        }
+                    }
                 case .failure(let error):
-                    Logger.lsp.error("LSP initialize failed for \(languageId): \(error)")
-                    completion(.failure(error))
+                    Logger.lsp.error("Failed to start LSP server for \(languageId): \(error)")
+                    self?.queue.async {
+                        self?.clients.removeValue(forKey: languageId)
+                    }
+                    completion(.failure(.serverNotRunning))
                 }
             }
         }

--- a/Pine/LSPManager.swift
+++ b/Pine/LSPManager.swift
@@ -1,0 +1,208 @@
+//
+//  LSPManager.swift
+//  Pine
+//
+
+import Foundation
+import os
+
+/// Manages LSP clients for different languages.
+///
+/// Determines the appropriate language server based on file extension,
+/// starts/stops servers as needed, and routes document events.
+final class LSPManager: @unchecked Sendable {
+
+    // MARK: - Types
+
+    /// Configuration for a language server.
+    struct ServerConfig: Equatable, Sendable {
+        let languageId: String
+        let serverPath: String
+        let arguments: [String]
+        let extensions: Set<String>
+
+        init(languageId: String, serverPath: String, arguments: [String] = [], extensions: Set<String>) {
+            self.languageId = languageId
+            self.serverPath = serverPath
+            self.arguments = arguments
+            self.extensions = extensions
+        }
+    }
+
+    // MARK: - Properties
+
+    private let queue = DispatchQueue(label: "com.pine.lsp-manager", qos: .userInitiated)
+    private var clients: [String: LSPClient] = [:] // keyed by languageId
+    private var configs: [ServerConfig]
+    private var rootUri: String?
+
+    /// Known server configurations.
+    static let defaultConfigs: [ServerConfig] = [
+        ServerConfig(
+            languageId: "swift",
+            serverPath: "/usr/bin/xcrun",
+            arguments: ["sourcekit-lsp"],
+            extensions: ["swift"]
+        ),
+        ServerConfig(
+            languageId: "typescript",
+            serverPath: "/usr/local/bin/typescript-language-server",
+            arguments: ["--stdio"],
+            extensions: ["ts", "tsx"]
+        ),
+        ServerConfig(
+            languageId: "javascript",
+            serverPath: "/usr/local/bin/typescript-language-server",
+            arguments: ["--stdio"],
+            extensions: ["js", "jsx"]
+        ),
+        ServerConfig(
+            languageId: "python",
+            serverPath: "/usr/local/bin/pylsp",
+            arguments: [],
+            extensions: ["py"]
+        ),
+        ServerConfig(
+            languageId: "go",
+            serverPath: "/usr/local/bin/gopls",
+            arguments: ["serve"],
+            extensions: ["go"]
+        ),
+        ServerConfig(
+            languageId: "rust",
+            serverPath: "/usr/local/bin/rust-analyzer",
+            arguments: [],
+            extensions: ["rs"]
+        ),
+        ServerConfig(
+            languageId: "c",
+            serverPath: "/usr/bin/clangd",
+            arguments: [],
+            extensions: ["c", "h"]
+        ),
+        ServerConfig(
+            languageId: "cpp",
+            serverPath: "/usr/bin/clangd",
+            arguments: [],
+            extensions: ["cpp", "cc", "cxx", "hpp", "hxx"]
+        )
+    ]
+
+    // MARK: - Init
+
+    init(configs: [ServerConfig]? = nil) {
+        self.configs = configs ?? Self.defaultConfigs
+    }
+
+    // MARK: - Public API
+
+    /// Sets the workspace root URI for initialize requests.
+    func setRootUri(_ uri: String?) {
+        queue.sync {
+            self.rootUri = uri
+        }
+    }
+
+    /// Finds the server config for a file extension.
+    func configForExtension(_ ext: String) -> ServerConfig? {
+        let lower = ext.lowercased()
+        return configs.first { $0.extensions.contains(lower) }
+    }
+
+    /// Returns the language ID for a file extension, if supported.
+    func languageIdForExtension(_ ext: String) -> String? {
+        configForExtension(ext)?.languageId
+    }
+
+    /// Returns the existing client for a language, if running.
+    func clientForLanguage(_ languageId: String) -> LSPClient? {
+        queue.sync { clients[languageId] }
+    }
+
+    /// Gets or creates a client for the given language, starts it, and runs initialize handshake.
+    func ensureClient(
+        for languageId: String,
+        completion: @escaping (Result<LSPClient, LSPClient.LSPClientError>) -> Void
+    ) {
+        queue.async { [weak self] in
+            guard let self else { return }
+
+            if let existing = self.clients[languageId], existing.state == .running {
+                completion(.success(existing))
+                return
+            }
+
+            guard let config = self.configs.first(where: { $0.languageId == languageId }) else {
+                Logger.lsp.error("No server config for language: \(languageId)")
+                completion(.failure(.serverNotRunning))
+                return
+            }
+
+            // Verify server exists
+            guard FileManager.default.isExecutableFile(atPath: config.serverPath) else {
+                Logger.lsp.warning("Server not found at: \(config.serverPath)")
+                completion(.failure(.serverNotRunning))
+                return
+            }
+
+            let client = LSPClient(serverPath: config.serverPath, arguments: config.arguments)
+            self.clients[languageId] = client
+
+            do {
+                try client.start()
+            } catch {
+                Logger.lsp.error("Failed to start LSP server for \(languageId): \(error)")
+                self.clients.removeValue(forKey: languageId)
+                completion(.failure(.serverNotRunning))
+                return
+            }
+
+            let rootUri = self.rootUri
+            client.initialize(rootUri: rootUri) { result in
+                switch result {
+                case .success:
+                    Logger.lsp.info("LSP initialized for \(languageId)")
+                    completion(.success(client))
+                case .failure(let error):
+                    Logger.lsp.error("LSP initialize failed for \(languageId): \(error)")
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+
+    /// Shuts down all running language servers.
+    func shutdownAll(completion: @escaping () -> Void) {
+        queue.async { [weak self] in
+            guard let self else {
+                completion()
+                return
+            }
+
+            let allClients = self.clients
+            self.clients.removeAll()
+
+            guard !allClients.isEmpty else {
+                completion()
+                return
+            }
+
+            let group = DispatchGroup()
+            for (_, client) in allClients {
+                group.enter()
+                client.shutdown { group.leave() }
+            }
+            group.notify(queue: .main) { completion() }
+        }
+    }
+
+    /// Converts a file URL to an LSP document URI string.
+    static func documentUri(for fileURL: URL) -> String {
+        fileURL.absoluteString
+    }
+
+    /// Converts a directory URL to an LSP root URI string.
+    static func rootUri(for directoryURL: URL) -> String {
+        directoryURL.absoluteString
+    }
+}

--- a/Pine/LSPMessage.swift
+++ b/Pine/LSPMessage.swift
@@ -1,0 +1,351 @@
+//
+//  LSPMessage.swift
+//  Pine
+//
+
+import Foundation
+
+// MARK: - JSON-RPC Base Types
+
+/// JSON-RPC 2.0 request message for LSP communication.
+struct JSONRPCRequest: Codable {
+    let jsonrpc: String
+    let id: Int
+    let method: String
+    let params: AnyCodable?
+
+    init(id: Int, method: String, params: AnyCodable? = nil) {
+        self.jsonrpc = "2.0"
+        self.id = id
+        self.method = method
+        self.params = params
+    }
+}
+
+/// JSON-RPC 2.0 notification (no id, no response expected).
+struct JSONRPCNotification: Codable {
+    let jsonrpc: String
+    let method: String
+    let params: AnyCodable?
+
+    init(method: String, params: AnyCodable? = nil) {
+        self.jsonrpc = "2.0"
+        self.method = method
+        self.params = params
+    }
+}
+
+/// JSON-RPC 2.0 response message.
+struct JSONRPCResponse: Codable {
+    let jsonrpc: String
+    let id: Int?
+    let result: AnyCodable?
+    let error: JSONRPCError?
+}
+
+/// JSON-RPC error object.
+struct JSONRPCError: Codable {
+    let code: Int
+    let message: String
+    let data: AnyCodable?
+}
+
+// MARK: - Type-erased Codable wrapper
+
+/// A type-erased Codable value for flexible JSON-RPC params/results.
+struct AnyCodable: Codable, Equatable, @unchecked Sendable {
+    let value: Any
+
+    init(_ value: Any) {
+        self.value = value
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            value = NSNull()
+        } else if let bool = try? container.decode(Bool.self) {
+            value = bool
+        } else if let int = try? container.decode(Int.self) {
+            value = int
+        } else if let double = try? container.decode(Double.self) {
+            value = double
+        } else if let string = try? container.decode(String.self) {
+            value = string
+        } else if let array = try? container.decode([AnyCodable].self) {
+            value = array.map(\.value)
+        } else if let dict = try? container.decode([String: AnyCodable].self) {
+            value = dict.mapValues(\.value)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported JSON value")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch value {
+        case is NSNull:
+            try container.encodeNil()
+        case let bool as Bool:
+            try container.encode(bool)
+        case let int as Int:
+            try container.encode(int)
+        case let double as Double:
+            try container.encode(double)
+        case let string as String:
+            try container.encode(string)
+        case let array as [Any]:
+            try container.encode(array.map { AnyCodable($0) })
+        case let dict as [String: Any]:
+            try container.encode(dict.mapValues { AnyCodable($0) })
+        default:
+            throw EncodingError.invalidValue(value, .init(codingPath: encoder.codingPath, debugDescription: "Unsupported type"))
+        }
+    }
+
+    static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
+        // Compare JSON serialized form for equality
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        guard let lhsData = try? encoder.encode(lhs),
+              let rhsData = try? encoder.encode(rhs) else {
+            return false
+        }
+        return lhsData == rhsData
+    }
+}
+
+// MARK: - LSP Message Encoding/Decoding
+
+/// Handles LSP message framing (Content-Length header + JSON body).
+enum LSPMessageCodec {
+
+    /// Encodes a JSON-RPC request into LSP wire format with Content-Length header.
+    static func encode(_ request: JSONRPCRequest) throws -> Data {
+        let body = try JSONEncoder().encode(request)
+        return frame(body)
+    }
+
+    /// Encodes a JSON-RPC notification into LSP wire format.
+    static func encode(_ notification: JSONRPCNotification) throws -> Data {
+        let body = try JSONEncoder().encode(notification)
+        return frame(body)
+    }
+
+    /// Wraps JSON body with Content-Length header per LSP spec.
+    static func frame(_ body: Data) -> Data {
+        let header = "Content-Length: \(body.count)\r\n\r\n"
+        var result = Data(header.utf8)
+        result.append(body)
+        return result
+    }
+
+    /// Parses one LSP message from a data buffer.
+    /// Returns (response, bytesConsumed) or nil if buffer is incomplete.
+    static func decode(from buffer: Data) -> (JSONRPCResponse, Int)? {
+        guard let headerEnd = findHeaderEnd(in: buffer) else { return nil }
+
+        let headerData = buffer[buffer.startIndex..<headerEnd]
+        guard let headerString = String(data: headerData, encoding: .utf8),
+              let contentLength = parseContentLength(from: headerString) else {
+            return nil
+        }
+
+        let bodyStart = headerEnd + 4 // skip \r\n\r\n
+        let bodyEnd = bodyStart + contentLength
+
+        guard buffer.count >= bodyEnd else { return nil }
+
+        let bodyData = buffer[bodyStart..<bodyEnd]
+        guard let response = try? JSONDecoder().decode(JSONRPCResponse.self, from: bodyData) else {
+            return nil
+        }
+
+        return (response, bodyEnd)
+    }
+
+    /// Finds the end of HTTP headers (position of first \r\n in \r\n\r\n).
+    private static func findHeaderEnd(in data: Data) -> Int? {
+        let separator: [UInt8] = [0x0D, 0x0A, 0x0D, 0x0A] // \r\n\r\n
+        guard data.count >= 4 else { return nil }
+        for i in data.startIndex...(data.count - 4) {
+            if data[i] == separator[0] && data[i + 1] == separator[1]
+                && data[i + 2] == separator[2] && data[i + 3] == separator[3] {
+                return i
+            }
+        }
+        return nil
+    }
+
+    /// Extracts Content-Length value from header string.
+    static func parseContentLength(from header: String) -> Int? {
+        for line in header.components(separatedBy: "\r\n") {
+            let parts = line.split(separator: ":", maxSplits: 1)
+            if parts.count == 2,
+               parts[0].trimmingCharacters(in: .whitespaces).lowercased() == "content-length",
+               let length = Int(parts[1].trimmingCharacters(in: .whitespaces)) {
+                return length
+            }
+        }
+        return nil
+    }
+}
+
+// MARK: - LSP Initialize Types
+
+/// Client capabilities sent during initialize handshake.
+struct LSPClientCapabilities: Codable {
+    let textDocument: TextDocumentClientCapabilities?
+
+    init(textDocument: TextDocumentClientCapabilities? = TextDocumentClientCapabilities()) {
+        self.textDocument = textDocument
+    }
+}
+
+struct TextDocumentClientCapabilities: Codable {
+    let completion: CompletionClientCapabilities?
+    let synchronization: TextDocumentSyncClientCapabilities?
+
+    init(
+        completion: CompletionClientCapabilities? = CompletionClientCapabilities(),
+        synchronization: TextDocumentSyncClientCapabilities? = TextDocumentSyncClientCapabilities()
+    ) {
+        self.completion = completion
+        self.synchronization = synchronization
+    }
+}
+
+struct CompletionClientCapabilities: Codable {
+    let completionItem: CompletionItemCapabilities?
+
+    init(completionItem: CompletionItemCapabilities? = CompletionItemCapabilities()) {
+        self.completionItem = completionItem
+    }
+}
+
+struct CompletionItemCapabilities: Codable {
+    let snippetSupport: Bool
+
+    init(snippetSupport: Bool = false) {
+        self.snippetSupport = snippetSupport
+    }
+}
+
+struct TextDocumentSyncClientCapabilities: Codable {
+    let didSave: Bool
+    let willSave: Bool
+
+    init(didSave: Bool = true, willSave: Bool = false) {
+        self.didSave = didSave
+        self.willSave = willSave
+    }
+}
+
+/// Parameters for the initialize request.
+struct InitializeParams: Codable {
+    let processId: Int
+    let rootUri: String?
+    let capabilities: LSPClientCapabilities
+
+    init(rootUri: String?, capabilities: LSPClientCapabilities = LSPClientCapabilities()) {
+        self.processId = Int(ProcessInfo.processInfo.processIdentifier)
+        self.rootUri = rootUri
+        self.capabilities = capabilities
+    }
+}
+
+// MARK: - LSP TextDocument Types
+
+/// Identifies a text document by its URI.
+struct TextDocumentIdentifier: Codable {
+    let uri: String
+}
+
+/// Full document info sent on didOpen.
+struct TextDocumentItem: Codable {
+    let uri: String
+    let languageId: String
+    let version: Int
+    let text: String
+}
+
+/// Versioned document identifier for didChange.
+struct VersionedTextDocumentIdentifier: Codable {
+    let uri: String
+    let version: Int
+}
+
+/// A content change event (full document sync).
+struct TextDocumentContentChangeEvent: Codable {
+    let text: String
+}
+
+/// Position in a text document (0-based line and character).
+struct LSPPosition: Codable, Equatable {
+    let line: Int
+    let character: Int
+}
+
+/// A range in a text document.
+struct LSPRange: Codable, Equatable {
+    let start: LSPPosition
+    let end: LSPPosition
+}
+
+// MARK: - Completion Types
+
+/// Parameters for textDocument/completion.
+struct CompletionParams: Codable {
+    let textDocument: TextDocumentIdentifier
+    let position: LSPPosition
+}
+
+/// A single completion item returned by the server.
+struct CompletionItem: Codable, Equatable {
+    let label: String
+    let kind: Int?
+    let detail: String?
+    let insertText: String?
+
+    init(label: String, kind: Int? = nil, detail: String? = nil, insertText: String? = nil) {
+        self.label = label
+        self.kind = kind
+        self.detail = detail
+        self.insertText = insertText
+    }
+}
+
+/// Completion result — either an array or a CompletionList.
+struct CompletionList: Codable {
+    let isIncomplete: Bool
+    let items: [CompletionItem]
+}
+
+/// Standard CompletionItemKind values from LSP spec.
+enum CompletionItemKind: Int, Codable, Sendable {
+    case text = 1
+    case method = 2
+    case function = 3
+    case constructor = 4
+    case field = 5
+    case variable = 6
+    case classKind = 7
+    case interface = 8
+    case module = 9
+    case property = 10
+    case unit = 11
+    case value = 12
+    case enumKind = 13
+    case keyword = 14
+    case snippet = 15
+    case color = 16
+    case file = 17
+    case reference = 18
+    case folder = 19
+    case enumMember = 20
+    case constant = 21
+    case structKind = 22
+    case event = 23
+    case `operator` = 24
+    case typeParameter = 25
+}

--- a/Pine/LSPMessage.swift
+++ b/Pine/LSPMessage.swift
@@ -5,6 +5,191 @@
 
 import Foundation
 
+// MARK: - Type-safe JSON Value
+
+/// A type-safe, Sendable replacement for type-erased JSON values in LSP communication.
+///
+/// Unlike a type-erased `Any` wrapper, `JSONValue` is a proper enum that:
+/// - Is fully `Sendable` without `@unchecked` — safe to pass across concurrency domains
+/// - Provides exhaustive pattern matching — the compiler catches unhandled cases
+/// - Preserves value semantics — no hidden reference types or `Any` boxing
+///
+/// Trade-off: callers must pattern-match to extract values (e.g., `case .string(let s)`)
+/// instead of casting from `Any`. This is intentional — it makes JSON handling explicit
+/// and prevents runtime type mismatches.
+enum JSONValue: Codable, Equatable, Sendable, Hashable {
+    case null
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self = .int(int)
+        } else if let double = try? container.decode(Double.self) {
+            self = .double(double)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else if let array = try? container.decode([JSONValue].self) {
+            self = .array(array)
+        } else if let dict = try? container.decode([String: JSONValue].self) {
+            self = .object(dict)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container, debugDescription: "Unsupported JSON value"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null:
+            try container.encodeNil()
+        case .bool(let val):
+            try container.encode(val)
+        case .int(let val):
+            try container.encode(val)
+        case .double(let val):
+            try container.encode(val)
+        case .string(let val):
+            try container.encode(val)
+        case .array(let val):
+            try container.encode(val)
+        case .object(let val):
+            try container.encode(val)
+        }
+    }
+
+    // MARK: - Convenience Initializers
+
+    /// Creates a JSONValue from an untyped `Any` value (e.g., from JSONSerialization).
+    /// Returns `.null` for unsupported types.
+    init(_ value: Any) {
+        switch value {
+        case is NSNull:
+            self = .null
+        case let bool as Bool:
+            self = .bool(bool)
+        case let int as Int:
+            self = .int(int)
+        case let double as Double where !(value is Bool):
+            self = .double(double)
+        case let string as String:
+            self = .string(string)
+        case let array as [Any]:
+            self = .array(array.map { JSONValue($0) })
+        case let dict as [String: Any]:
+            self = .object(dict.mapValues { JSONValue($0) })
+        default:
+            self = .null
+        }
+    }
+
+    /// Converts to untyped `Any` for interop (e.g., building JSON-RPC params from dictionaries).
+    var anyValue: Any {
+        switch self {
+        case .null: return NSNull()
+        case .bool(let val): return val
+        case .int(let val): return val
+        case .double(let val): return val
+        case .string(let val): return val
+        case .array(let val): return val.map(\.anyValue)
+        case .object(let val): return val.mapValues(\.anyValue)
+        }
+    }
+
+    // MARK: - Subscript Access
+
+    /// Dictionary subscript for `.object` values.
+    subscript(key: String) -> JSONValue? {
+        if case .object(let dict) = self {
+            return dict[key]
+        }
+        return nil
+    }
+
+    /// Array subscript for `.array` values.
+    subscript(index: Int) -> JSONValue? {
+        if case .array(let arr) = self, arr.indices.contains(index) {
+            return arr[index]
+        }
+        return nil
+    }
+
+    // MARK: - ExpressibleBy Literals
+
+    /// String value extraction.
+    var stringValue: String? {
+        if case .string(let val) = self { return val }
+        return nil
+    }
+
+    /// Int value extraction.
+    var intValue: Int? {
+        if case .int(let val) = self { return val }
+        return nil
+    }
+
+    /// Bool value extraction.
+    var boolValue: Bool? {
+        if case .bool(let val) = self { return val }
+        return nil
+    }
+
+    /// Array value extraction.
+    var arrayValue: [JSONValue]? {
+        if case .array(let val) = self { return val }
+        return nil
+    }
+
+    /// Dictionary value extraction.
+    var objectValue: [String: JSONValue]? {
+        if case .object(let val) = self { return val }
+        return nil
+    }
+}
+
+// MARK: - JSONValue Literal Conformances
+
+extension JSONValue: ExpressibleByStringLiteral {
+    init(stringLiteral value: String) { self = .string(value) }
+}
+
+extension JSONValue: ExpressibleByIntegerLiteral {
+    init(integerLiteral value: Int) { self = .int(value) }
+}
+
+extension JSONValue: ExpressibleByBooleanLiteral {
+    init(booleanLiteral value: Bool) { self = .bool(value) }
+}
+
+extension JSONValue: ExpressibleByFloatLiteral {
+    init(floatLiteral value: Double) { self = .double(value) }
+}
+
+extension JSONValue: ExpressibleByNilLiteral {
+    init(nilLiteral: ()) { self = .null }
+}
+
+extension JSONValue: ExpressibleByArrayLiteral {
+    init(arrayLiteral elements: JSONValue...) { self = .array(elements) }
+}
+
+extension JSONValue: ExpressibleByDictionaryLiteral {
+    init(dictionaryLiteral elements: (String, JSONValue)...) {
+        self = .object(Dictionary(uniqueKeysWithValues: elements))
+    }
+}
+
 // MARK: - JSON-RPC Base Types
 
 /// JSON-RPC 2.0 request message for LSP communication.
@@ -12,9 +197,9 @@ struct JSONRPCRequest: Codable {
     let jsonrpc: String
     let id: Int
     let method: String
-    let params: AnyCodable?
+    let params: JSONValue?
 
-    init(id: Int, method: String, params: AnyCodable? = nil) {
+    init(id: Int, method: String, params: JSONValue? = nil) {
         self.jsonrpc = "2.0"
         self.id = id
         self.method = method
@@ -26,9 +211,9 @@ struct JSONRPCRequest: Codable {
 struct JSONRPCNotification: Codable {
     let jsonrpc: String
     let method: String
-    let params: AnyCodable?
+    let params: JSONValue?
 
-    init(method: String, params: AnyCodable? = nil) {
+    init(method: String, params: JSONValue? = nil) {
         self.jsonrpc = "2.0"
         self.method = method
         self.params = params
@@ -39,7 +224,7 @@ struct JSONRPCNotification: Codable {
 struct JSONRPCResponse: Codable {
     let jsonrpc: String
     let id: Int?
-    let result: AnyCodable?
+    let result: JSONValue?
     let error: JSONRPCError?
 }
 
@@ -47,71 +232,29 @@ struct JSONRPCResponse: Codable {
 struct JSONRPCError: Codable {
     let code: Int
     let message: String
-    let data: AnyCodable?
+    let data: JSONValue?
 }
 
-// MARK: - Type-erased Codable wrapper
+// MARK: - Unified JSON-RPC Message
 
-/// A type-erased Codable value for flexible JSON-RPC params/results.
-struct AnyCodable: Codable, Equatable, @unchecked Sendable {
-    let value: Any
+/// A unified JSON-RPC message type that can represent requests, responses, and notifications.
+/// Used for decoding incoming messages where the type is not known in advance.
+struct JSONRPCMessage: Codable {
+    let jsonrpc: String
+    let id: Int?
+    let method: String?
+    let params: JSONValue?
+    let result: JSONValue?
+    let error: JSONRPCError?
 
-    init(_ value: Any) {
-        self.value = value
+    /// Whether this message is a server-initiated notification (has method, no id).
+    var isNotification: Bool {
+        method != nil && id == nil
     }
 
-    init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        if container.decodeNil() {
-            value = NSNull()
-        } else if let bool = try? container.decode(Bool.self) {
-            value = bool
-        } else if let int = try? container.decode(Int.self) {
-            value = int
-        } else if let double = try? container.decode(Double.self) {
-            value = double
-        } else if let string = try? container.decode(String.self) {
-            value = string
-        } else if let array = try? container.decode([AnyCodable].self) {
-            value = array.map(\.value)
-        } else if let dict = try? container.decode([String: AnyCodable].self) {
-            value = dict.mapValues(\.value)
-        } else {
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported JSON value")
-        }
-    }
-
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        switch value {
-        case is NSNull:
-            try container.encodeNil()
-        case let bool as Bool:
-            try container.encode(bool)
-        case let int as Int:
-            try container.encode(int)
-        case let double as Double:
-            try container.encode(double)
-        case let string as String:
-            try container.encode(string)
-        case let array as [Any]:
-            try container.encode(array.map { AnyCodable($0) })
-        case let dict as [String: Any]:
-            try container.encode(dict.mapValues { AnyCodable($0) })
-        default:
-            throw EncodingError.invalidValue(value, .init(codingPath: encoder.codingPath, debugDescription: "Unsupported type"))
-        }
-    }
-
-    static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
-        // Compare JSON serialized form for equality
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .sortedKeys
-        guard let lhsData = try? encoder.encode(lhs),
-              let rhsData = try? encoder.encode(rhs) else {
-            return false
-        }
-        return lhsData == rhsData
+    /// Whether this message is a response to a request (has id, no method).
+    var isResponse: Bool {
+        id != nil
     }
 }
 
@@ -140,7 +283,31 @@ enum LSPMessageCodec {
         return result
     }
 
-    /// Parses one LSP message from a data buffer.
+    /// Parses one LSP message from a data buffer using the unified message type.
+    /// Returns (message, bytesConsumed) or nil if buffer is incomplete.
+    static func decodeMessage(from buffer: Data) -> (JSONRPCMessage, Int)? {
+        guard let headerEnd = findHeaderEnd(in: buffer) else { return nil }
+
+        let headerData = buffer[buffer.startIndex..<headerEnd]
+        guard let headerString = String(data: headerData, encoding: .utf8),
+              let contentLength = parseContentLength(from: headerString) else {
+            return nil
+        }
+
+        let bodyStart = headerEnd + 4 // skip \r\n\r\n
+        let bodyEnd = bodyStart + contentLength
+
+        guard buffer.count >= bodyEnd else { return nil }
+
+        let bodyData = buffer[bodyStart..<bodyEnd]
+        guard let message = try? JSONDecoder().decode(JSONRPCMessage.self, from: bodyData) else {
+            return nil
+        }
+
+        return (message, bodyEnd)
+    }
+
+    /// Parses one LSP message from a data buffer as a response.
     /// Returns (response, bytesConsumed) or nil if buffer is incomplete.
     static func decode(from buffer: Data) -> (JSONRPCResponse, Int)? {
         guard let headerEnd = findHeaderEnd(in: buffer) else { return nil }
@@ -168,10 +335,10 @@ enum LSPMessageCodec {
     private static func findHeaderEnd(in data: Data) -> Int? {
         let separator: [UInt8] = [0x0D, 0x0A, 0x0D, 0x0A] // \r\n\r\n
         guard data.count >= 4 else { return nil }
-        for i in data.startIndex...(data.count - 4) {
-            if data[i] == separator[0] && data[i + 1] == separator[1]
-                && data[i + 2] == separator[2] && data[i + 3] == separator[3] {
-                return i
+        for idx in data.startIndex...(data.count - 4) {
+            if data[idx] == separator[0] && data[idx + 1] == separator[1]
+                && data[idx + 2] == separator[2] && data[idx + 3] == separator[3] {
+                return idx
             }
         }
         return nil
@@ -348,4 +515,43 @@ enum CompletionItemKind: Int, Codable, Sendable {
     case event = 23
     case `operator` = 24
     case typeParameter = 25
+}
+
+// MARK: - LSP Diagnostic Types
+
+/// A diagnostic message from the language server (e.g., errors, warnings).
+struct LSPDiagnostic: Codable, Equatable {
+    let range: LSPRange
+    let severity: Int?
+    let code: JSONValue?
+    let source: String?
+    let message: String
+
+    /// Standard severity values from LSP spec.
+    enum Severity: Int {
+        case error = 1
+        case warning = 2
+        case information = 3
+        case hint = 4
+    }
+}
+
+/// Parameters for textDocument/publishDiagnostics notification.
+struct PublishDiagnosticsParams: Codable, Equatable {
+    let uri: String
+    let diagnostics: [LSPDiagnostic]
+}
+
+/// Parameters for window/logMessage and window/showMessage notifications.
+struct LogMessageParams: Codable, Equatable {
+    let type: Int
+    let message: String
+
+    /// Standard message types from LSP spec.
+    enum MessageType: Int {
+        case error = 1
+        case warning = 2
+        case info = 3
+        case log = 4
+    }
 }

--- a/Pine/Logging.swift
+++ b/Pine/Logging.swift
@@ -18,6 +18,7 @@ nonisolated enum LogCategory: String, CaseIterable {
     case editor
     case app
     case migration
+    case lsp
 
     /// Subsystem для всех логгеров Pine.
     static let subsystem = Bundle.main.bundleIdentifier ?? "io.github.batonogov.pine"
@@ -48,4 +49,7 @@ nonisolated extension Logger {
 
     /// Миграции данных.
     static let migration = Logger(subsystem: LogCategory.subsystem, category: LogCategory.migration.rawValue)
+
+    /// LSP: языковые серверы, JSON-RPC, autocomplete.
+    static let lsp = Logger(subsystem: LogCategory.subsystem, category: LogCategory.lsp.rawValue)
 }

--- a/PineTests/LSPClientTests.swift
+++ b/PineTests/LSPClientTests.swift
@@ -1,0 +1,128 @@
+//
+//  LSPClientTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+struct LSPClientTests {
+
+    // MARK: - Parse Completion Items
+
+    @Test func parseCompletionItemsFromArray() {
+        let items: [[String: Any]] = [
+            ["label": "print", "kind": 3, "detail": "func print()"],
+            ["label": "String", "kind": 7]
+        ]
+        let result = LSPClient.parseCompletionItems(from: AnyCodable(items))
+        #expect(result.count == 2)
+        #expect(result[0].label == "print")
+        #expect(result[0].kind == 3)
+        #expect(result[0].detail == "func print()")
+        #expect(result[1].label == "String")
+        #expect(result[1].kind == 7)
+    }
+
+    @Test func parseCompletionItemsFromCompletionList() {
+        let list: [String: Any] = [
+            "isIncomplete": false,
+            "items": [
+                ["label": "forEach", "kind": 2, "insertText": "forEach { $1 }"],
+                ["label": "map", "kind": 2]
+            ]
+        ]
+        let result = LSPClient.parseCompletionItems(from: AnyCodable(list))
+        #expect(result.count == 2)
+        #expect(result[0].label == "forEach")
+        #expect(result[0].insertText == "forEach { $1 }")
+        #expect(result[1].label == "map")
+    }
+
+    @Test func parseCompletionItemsFromNil() {
+        let result = LSPClient.parseCompletionItems(from: nil)
+        #expect(result.isEmpty)
+    }
+
+    @Test func parseCompletionItemsFromEmptyArray() {
+        let result = LSPClient.parseCompletionItems(from: AnyCodable([] as [Any]))
+        #expect(result.isEmpty)
+    }
+
+    @Test func parseCompletionItemsFromEmptyList() {
+        let list: [String: Any] = ["isIncomplete": true, "items": [] as [Any]]
+        let result = LSPClient.parseCompletionItems(from: AnyCodable(list))
+        #expect(result.isEmpty)
+    }
+
+    @Test func parseCompletionItemsSkipsInvalidEntries() {
+        // Items without "label" should be skipped
+        let items: [[String: Any]] = [
+            ["label": "valid", "kind": 1],
+            ["kind": 3], // no label — should be skipped
+            ["label": "also_valid"]
+        ]
+        let result = LSPClient.parseCompletionItems(from: AnyCodable(items))
+        #expect(result.count == 2)
+        #expect(result[0].label == "valid")
+        #expect(result[1].label == "also_valid")
+    }
+
+    @Test func parseCompletionItemsFromScalarReturnsEmpty() {
+        let result = LSPClient.parseCompletionItems(from: AnyCodable("not an array"))
+        #expect(result.isEmpty)
+    }
+
+    @Test func parseCompletionItemsFromIntReturnsEmpty() {
+        let result = LSPClient.parseCompletionItems(from: AnyCodable(42))
+        #expect(result.isEmpty)
+    }
+
+    // MARK: - LSPClient State
+
+    @Test func initialStateIsIdle() {
+        let client = LSPClient(serverPath: "/nonexistent")
+        #expect(client.state == .idle)
+    }
+
+    @Test func startFailsForNonexistentServer() {
+        let client = LSPClient(serverPath: "/nonexistent/server")
+        #expect(throws: (any Error).self) {
+            try client.start()
+        }
+    }
+
+    // MARK: - LSPClientError
+
+    @Test func errorEquality() {
+        let a = LSPClient.LSPClientError.serverNotRunning
+        let b = LSPClient.LSPClientError.serverNotRunning
+        #expect(a == b)
+
+        let c = LSPClient.LSPClientError.encodingFailed
+        #expect(a != c)
+
+        let d = LSPClient.LSPClientError.serverError(code: -32600, message: "Invalid")
+        let e = LSPClient.LSPClientError.serverError(code: -32600, message: "Invalid")
+        #expect(d == e)
+
+        let f = LSPClient.LSPClientError.serverError(code: -32601, message: "Not found")
+        #expect(d != f)
+    }
+
+    @Test func requestTimeoutError() {
+        let error = LSPClient.LSPClientError.requestTimeout
+        #expect(error == .requestTimeout)
+        #expect(error != .serverNotRunning)
+    }
+
+    // MARK: - State Equality
+
+    @Test func stateEquality() {
+        #expect(LSPClient.State.idle == .idle)
+        #expect(LSPClient.State.running == .running)
+        #expect(LSPClient.State.idle != .running)
+        #expect(LSPClient.State.starting != .shutdown)
+    }
+}

--- a/PineTests/LSPClientTests.swift
+++ b/PineTests/LSPClientTests.swift
@@ -12,11 +12,11 @@ struct LSPClientTests {
     // MARK: - Parse Completion Items
 
     @Test func parseCompletionItemsFromArray() {
-        let items: [[String: Any]] = [
-            ["label": "print", "kind": 3, "detail": "func print()"],
-            ["label": "String", "kind": 7]
-        ]
-        let result = LSPClient.parseCompletionItems(from: AnyCodable(items))
+        let items: JSONValue = .array([
+            .object(["label": .string("print"), "kind": .int(3), "detail": .string("func print()")]),
+            .object(["label": .string("String"), "kind": .int(7)])
+        ])
+        let result = LSPClient.parseCompletionItems(from: items)
         #expect(result.count == 2)
         #expect(result[0].label == "print")
         #expect(result[0].kind == 3)
@@ -26,14 +26,18 @@ struct LSPClientTests {
     }
 
     @Test func parseCompletionItemsFromCompletionList() {
-        let list: [String: Any] = [
-            "isIncomplete": false,
-            "items": [
-                ["label": "forEach", "kind": 2, "insertText": "forEach { $1 }"],
-                ["label": "map", "kind": 2]
-            ]
-        ]
-        let result = LSPClient.parseCompletionItems(from: AnyCodable(list))
+        let list: JSONValue = .object([
+            "isIncomplete": .bool(false),
+            "items": .array([
+                .object([
+                    "label": .string("forEach"),
+                    "kind": .int(2),
+                    "insertText": .string("forEach { $1 }")
+                ]),
+                .object(["label": .string("map"), "kind": .int(2)])
+            ])
+        ])
+        let result = LSPClient.parseCompletionItems(from: list)
         #expect(result.count == 2)
         #expect(result[0].label == "forEach")
         #expect(result[0].insertText == "forEach { $1 }")
@@ -46,36 +50,36 @@ struct LSPClientTests {
     }
 
     @Test func parseCompletionItemsFromEmptyArray() {
-        let result = LSPClient.parseCompletionItems(from: AnyCodable([] as [Any]))
+        let result = LSPClient.parseCompletionItems(from: .array([]))
         #expect(result.isEmpty)
     }
 
     @Test func parseCompletionItemsFromEmptyList() {
-        let list: [String: Any] = ["isIncomplete": true, "items": [] as [Any]]
-        let result = LSPClient.parseCompletionItems(from: AnyCodable(list))
+        let list: JSONValue = .object(["isIncomplete": .bool(true), "items": .array([])])
+        let result = LSPClient.parseCompletionItems(from: list)
         #expect(result.isEmpty)
     }
 
     @Test func parseCompletionItemsSkipsInvalidEntries() {
         // Items without "label" should be skipped
-        let items: [[String: Any]] = [
-            ["label": "valid", "kind": 1],
-            ["kind": 3], // no label — should be skipped
-            ["label": "also_valid"]
-        ]
-        let result = LSPClient.parseCompletionItems(from: AnyCodable(items))
+        let items: JSONValue = .array([
+            .object(["label": .string("valid"), "kind": .int(1)]),
+            .object(["kind": .int(3)]), // no label — should be skipped
+            .object(["label": .string("also_valid")])
+        ])
+        let result = LSPClient.parseCompletionItems(from: items)
         #expect(result.count == 2)
         #expect(result[0].label == "valid")
         #expect(result[1].label == "also_valid")
     }
 
     @Test func parseCompletionItemsFromScalarReturnsEmpty() {
-        let result = LSPClient.parseCompletionItems(from: AnyCodable("not an array"))
+        let result = LSPClient.parseCompletionItems(from: .string("not an array"))
         #expect(result.isEmpty)
     }
 
     @Test func parseCompletionItemsFromIntReturnsEmpty() {
-        let result = LSPClient.parseCompletionItems(from: AnyCodable(42))
+        let result = LSPClient.parseCompletionItems(from: .int(42))
         #expect(result.isEmpty)
     }
 
@@ -93,22 +97,38 @@ struct LSPClientTests {
         }
     }
 
+    @Test func asyncStartCallsCompletion() async {
+        let client = LSPClient(serverPath: "/nonexistent/server")
+        let result: Result<Void, any Error> = await withCheckedContinuation { continuation in
+            client.start { result in
+                continuation.resume(returning: result)
+            }
+        }
+        // Should fail since the server doesn't exist
+        switch result {
+        case .success:
+            Issue.record("Expected failure for nonexistent server")
+        case .failure:
+            #expect(client.state == .idle)
+        }
+    }
+
     // MARK: - LSPClientError
 
     @Test func errorEquality() {
-        let a = LSPClient.LSPClientError.serverNotRunning
-        let b = LSPClient.LSPClientError.serverNotRunning
-        #expect(a == b)
+        let errA = LSPClient.LSPClientError.serverNotRunning
+        let errB = LSPClient.LSPClientError.serverNotRunning
+        #expect(errA == errB)
 
-        let c = LSPClient.LSPClientError.encodingFailed
-        #expect(a != c)
+        let errC = LSPClient.LSPClientError.encodingFailed
+        #expect(errA != errC)
 
-        let d = LSPClient.LSPClientError.serverError(code: -32600, message: "Invalid")
-        let e = LSPClient.LSPClientError.serverError(code: -32600, message: "Invalid")
-        #expect(d == e)
+        let errD = LSPClient.LSPClientError.serverError(code: -32600, message: "Invalid")
+        let errE = LSPClient.LSPClientError.serverError(code: -32600, message: "Invalid")
+        #expect(errD == errE)
 
-        let f = LSPClient.LSPClientError.serverError(code: -32601, message: "Not found")
-        #expect(d != f)
+        let errF = LSPClient.LSPClientError.serverError(code: -32601, message: "Not found")
+        #expect(errD != errF)
     }
 
     @Test func requestTimeoutError() {
@@ -124,5 +144,29 @@ struct LSPClientTests {
         #expect(LSPClient.State.running == .running)
         #expect(LSPClient.State.idle != .running)
         #expect(LSPClient.State.starting != .shutdown)
+    }
+
+    // MARK: - Timeout Configuration
+
+    @Test func requestTimeoutIntervalIs30Seconds() {
+        #expect(LSPClient.requestTimeoutInterval == 30)
+    }
+
+    // MARK: - Thread-safe State Access
+
+    @Test func stateIsThreadSafe() async {
+        let client = LSPClient(serverPath: "/nonexistent")
+
+        // Access state from multiple concurrent tasks
+        await withTaskGroup(of: LSPClient.State.self) { group in
+            for _ in 0..<10 {
+                group.addTask {
+                    client.state
+                }
+            }
+            for await state in group {
+                #expect(state == .idle)
+            }
+        }
     }
 }

--- a/PineTests/LSPManagerTests.swift
+++ b/PineTests/LSPManagerTests.swift
@@ -1,0 +1,214 @@
+//
+//  LSPManagerTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+struct LSPManagerTests {
+
+    // MARK: - Language Detection
+
+    @Test func swiftExtensionMapsToSwift() {
+        let manager = LSPManager()
+        let langId = manager.languageIdForExtension("swift")
+        #expect(langId == "swift")
+    }
+
+    @Test func tsExtensionMapsToTypeScript() {
+        let manager = LSPManager()
+        #expect(manager.languageIdForExtension("ts") == "typescript")
+        #expect(manager.languageIdForExtension("tsx") == "typescript")
+    }
+
+    @Test func jsExtensionMapsToJavaScript() {
+        let manager = LSPManager()
+        #expect(manager.languageIdForExtension("js") == "javascript")
+        #expect(manager.languageIdForExtension("jsx") == "javascript")
+    }
+
+    @Test func pythonExtensionMapsToPython() {
+        let manager = LSPManager()
+        #expect(manager.languageIdForExtension("py") == "python")
+    }
+
+    @Test func goExtensionMapsToGo() {
+        let manager = LSPManager()
+        #expect(manager.languageIdForExtension("go") == "go")
+    }
+
+    @Test func rustExtensionMapsToRust() {
+        let manager = LSPManager()
+        #expect(manager.languageIdForExtension("rs") == "rust")
+    }
+
+    @Test func cExtensionMapsToC() {
+        let manager = LSPManager()
+        #expect(manager.languageIdForExtension("c") == "c")
+        #expect(manager.languageIdForExtension("h") == "c")
+    }
+
+    @Test func cppExtensionMapsToCpp() {
+        let manager = LSPManager()
+        #expect(manager.languageIdForExtension("cpp") == "cpp")
+        #expect(manager.languageIdForExtension("cc") == "cpp")
+        #expect(manager.languageIdForExtension("cxx") == "cpp")
+        #expect(manager.languageIdForExtension("hpp") == "cpp")
+        #expect(manager.languageIdForExtension("hxx") == "cpp")
+    }
+
+    @Test func unknownExtensionReturnsNil() {
+        let manager = LSPManager()
+        #expect(manager.languageIdForExtension("txt") == nil)
+        #expect(manager.languageIdForExtension("md") == nil)
+        #expect(manager.languageIdForExtension("json") == nil)
+        #expect(manager.languageIdForExtension("xml") == nil)
+    }
+
+    @Test func extensionLookupIsCaseInsensitive() {
+        let manager = LSPManager()
+        #expect(manager.languageIdForExtension("Swift") == "swift")
+        #expect(manager.languageIdForExtension("SWIFT") == "swift")
+        #expect(manager.languageIdForExtension("PY") == "python")
+        #expect(manager.languageIdForExtension("Rs") == "rust")
+    }
+
+    // MARK: - Config Lookup
+
+    @Test func configForSwiftExtension() {
+        let manager = LSPManager()
+        let config = manager.configForExtension("swift")
+        #expect(config?.languageId == "swift")
+        #expect(config?.serverPath == "/usr/bin/xcrun")
+        #expect(config?.arguments == ["sourcekit-lsp"])
+    }
+
+    @Test func configForUnknownExtensionIsNil() {
+        let manager = LSPManager()
+        let config = manager.configForExtension("unknown")
+        #expect(config == nil)
+    }
+
+    // MARK: - Custom Configs
+
+    @Test func customConfigsOverrideDefaults() {
+        let custom = LSPManager.ServerConfig(
+            languageId: "ruby",
+            serverPath: "/usr/local/bin/solargraph",
+            arguments: ["stdio"],
+            extensions: ["rb"]
+        )
+        let manager = LSPManager(configs: [custom])
+        #expect(manager.languageIdForExtension("rb") == "ruby")
+        #expect(manager.languageIdForExtension("swift") == nil)
+    }
+
+    @Test func emptyConfigsMeansNoLanguageSupport() {
+        let manager = LSPManager(configs: [])
+        #expect(manager.languageIdForExtension("swift") == nil)
+        #expect(manager.languageIdForExtension("py") == nil)
+    }
+
+    // MARK: - Client Lookup
+
+    @Test func clientForUnstartedLanguageIsNil() {
+        let manager = LSPManager()
+        #expect(manager.clientForLanguage("swift") == nil)
+    }
+
+    // MARK: - Document URI
+
+    @Test func documentUriFromFileURL() {
+        let url = URL(fileURLWithPath: "/Users/test/project/main.swift")
+        let uri = LSPManager.documentUri(for: url)
+        #expect(uri == "file:///Users/test/project/main.swift")
+    }
+
+    @Test func rootUriFromDirectoryURL() {
+        let url = URL(fileURLWithPath: "/Users/test/project/")
+        let uri = LSPManager.rootUri(for: url)
+        #expect(uri.hasPrefix("file:///Users/test/project"))
+    }
+
+    @Test func documentUriHandlesSpaces() {
+        let url = URL(fileURLWithPath: "/Users/test/my project/file.swift")
+        let uri = LSPManager.documentUri(for: url)
+        #expect(uri.contains("my%20project"))
+    }
+
+    // MARK: - Root URI
+
+    @Test func setRootUri() {
+        let manager = LSPManager()
+        // Should not crash — this is a basic setter test
+        manager.setRootUri("file:///test")
+        manager.setRootUri(nil)
+    }
+
+    // MARK: - Default Configs Validation
+
+    @Test func defaultConfigsHaveValidStructure() {
+        let configs = LSPManager.defaultConfigs
+        #expect(!configs.isEmpty)
+        for config in configs {
+            #expect(!config.languageId.isEmpty)
+            #expect(!config.serverPath.isEmpty)
+            #expect(!config.extensions.isEmpty)
+        }
+    }
+
+    @Test func defaultConfigsHaveUniqueLanguageIds() {
+        let configs = LSPManager.defaultConfigs
+        let ids = configs.map(\.languageId)
+        let uniqueIds = Set(ids)
+        #expect(ids.count == uniqueIds.count)
+    }
+
+    @Test func defaultConfigsExtensionsDontOverlap() {
+        let configs = LSPManager.defaultConfigs
+        var seen = Set<String>()
+        for config in configs {
+            for ext in config.extensions {
+                #expect(!seen.contains(ext), "Duplicate extension: \(ext)")
+                seen.insert(ext)
+            }
+        }
+    }
+
+    // MARK: - ServerConfig Equatable
+
+    @Test func serverConfigEquality() {
+        let a = LSPManager.ServerConfig(
+            languageId: "swift",
+            serverPath: "/usr/bin/xcrun",
+            arguments: ["sourcekit-lsp"],
+            extensions: ["swift"]
+        )
+        let b = LSPManager.ServerConfig(
+            languageId: "swift",
+            serverPath: "/usr/bin/xcrun",
+            arguments: ["sourcekit-lsp"],
+            extensions: ["swift"]
+        )
+        let c = LSPManager.ServerConfig(
+            languageId: "python",
+            serverPath: "/usr/local/bin/pylsp",
+            extensions: ["py"]
+        )
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    // MARK: - Shutdown
+
+    @Test func shutdownAllWithNoClientsCompletes() async {
+        let manager = LSPManager()
+        await withCheckedContinuation { continuation in
+            manager.shutdownAll {
+                continuation.resume()
+            }
+        }
+    }
+}

--- a/PineTests/LSPManagerTests.swift
+++ b/PineTests/LSPManagerTests.swift
@@ -180,25 +180,25 @@ struct LSPManagerTests {
     // MARK: - ServerConfig Equatable
 
     @Test func serverConfigEquality() {
-        let a = LSPManager.ServerConfig(
+        let cfgA = LSPManager.ServerConfig(
             languageId: "swift",
             serverPath: "/usr/bin/xcrun",
             arguments: ["sourcekit-lsp"],
             extensions: ["swift"]
         )
-        let b = LSPManager.ServerConfig(
+        let cfgB = LSPManager.ServerConfig(
             languageId: "swift",
             serverPath: "/usr/bin/xcrun",
             arguments: ["sourcekit-lsp"],
             extensions: ["swift"]
         )
-        let c = LSPManager.ServerConfig(
+        let cfgC = LSPManager.ServerConfig(
             languageId: "python",
             serverPath: "/usr/local/bin/pylsp",
             extensions: ["py"]
         )
-        #expect(a == b)
-        #expect(a != c)
+        #expect(cfgA == cfgB)
+        #expect(cfgA != cfgC)
     }
 
     // MARK: - Shutdown
@@ -209,6 +209,62 @@ struct LSPManagerTests {
             manager.shutdownAll {
                 continuation.resume()
             }
+        }
+    }
+
+    // MARK: - Server Path Resolution
+
+    @Test func resolveAbsolutePathThatExists() {
+        // /usr/bin/xcrun should exist on macOS
+        let resolved = LSPManager.resolveServerPath("/usr/bin/xcrun")
+        #expect(resolved == "/usr/bin/xcrun")
+    }
+
+    @Test func resolveAbsolutePathThatDoesNotExist() {
+        let resolved = LSPManager.resolveServerPath("/nonexistent/binary")
+        #expect(resolved == nil)
+    }
+
+    @Test func resolveRelativeNameFindsInSearchPaths() {
+        // "xcrun" should be found at /usr/bin/xcrun
+        let resolved = LSPManager.resolveServerPath("xcrun")
+        #expect(resolved != nil)
+        #expect(resolved?.hasSuffix("xcrun") == true)
+    }
+
+    @Test func resolveRelativeNameReturnsNilForUnknown() {
+        let resolved = LSPManager.resolveServerPath("totally_nonexistent_binary_xyz")
+        #expect(resolved == nil)
+    }
+
+    @Test func serverSearchPathsIncludeHomebrewPaths() {
+        let paths = LSPManager.serverSearchPaths
+        #expect(paths.contains("/opt/homebrew/bin"))
+        #expect(paths.contains("/usr/local/bin"))
+        #expect(paths.contains("/usr/bin"))
+    }
+
+    // MARK: - ensureClient with Missing Server
+
+    @Test func ensureClientFailsForMissingServer() async {
+        let custom = LSPManager.ServerConfig(
+            languageId: "fakeLang",
+            serverPath: "totally_nonexistent_server_abc",
+            extensions: ["fake"]
+        )
+        let manager = LSPManager(configs: [custom])
+
+        let result: Result<LSPClient, LSPClient.LSPClientError> = await withCheckedContinuation { continuation in
+            manager.ensureClient(for: "fakeLang") { result in
+                continuation.resume(returning: result)
+            }
+        }
+
+        switch result {
+        case .success:
+            Issue.record("Expected failure for nonexistent server")
+        case .failure(let error):
+            #expect(error == .serverNotRunning)
         }
     }
 }

--- a/PineTests/LSPMessageTests.swift
+++ b/PineTests/LSPMessageTests.swift
@@ -1,0 +1,437 @@
+//
+//  LSPMessageTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+struct LSPMessageTests {
+
+    // MARK: - AnyCodable
+
+    @Test func anyCodableEncodesString() throws {
+        let value = AnyCodable("hello")
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
+        #expect(decoded.value as? String == "hello")
+    }
+
+    @Test func anyCodableEncodesInt() throws {
+        let value = AnyCodable(42)
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
+        #expect(decoded.value as? Int == 42)
+    }
+
+    @Test func anyCodableEncodesBool() throws {
+        let value = AnyCodable(true)
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
+        #expect(decoded.value as? Bool == true)
+    }
+
+    @Test func anyCodableEncodesDouble() throws {
+        let value = AnyCodable(3.14)
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
+        #expect(decoded.value as? Double == 3.14)
+    }
+
+    @Test func anyCodableEncodesNull() throws {
+        let value = AnyCodable(NSNull())
+        let data = try JSONEncoder().encode(value)
+        let json = String(data: data, encoding: .utf8)
+        #expect(json == "null")
+    }
+
+    @Test func anyCodableEncodesArray() throws {
+        let value = AnyCodable([1, 2, 3])
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
+        let array = decoded.value as? [Any]
+        #expect(array?.count == 3)
+    }
+
+    @Test func anyCodableEncodesDictionary() throws {
+        let value = AnyCodable(["key": "value"])
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
+        let dict = decoded.value as? [String: Any]
+        #expect(dict?["key"] as? String == "value")
+    }
+
+    @Test func anyCodableEquality() {
+        let a = AnyCodable(42)
+        let b = AnyCodable(42)
+        let c = AnyCodable("42")
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    @Test func anyCodableNestedStructure() throws {
+        let nested: [String: Any] = [
+            "name": "test",
+            "items": [1, 2, 3],
+            "meta": ["active": true]
+        ]
+        let value = AnyCodable(nested)
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
+        let dict = decoded.value as? [String: Any]
+        #expect(dict?["name"] as? String == "test")
+    }
+
+    // MARK: - JSONRPCRequest Encoding
+
+    @Test func requestEncodesCorrectly() throws {
+        let request = JSONRPCRequest(id: 1, method: "initialize", params: AnyCodable(["rootUri": "/test"]))
+        let data = try JSONEncoder().encode(request)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["jsonrpc"] as? String == "2.0")
+        #expect(json?["id"] as? Int == 1)
+        #expect(json?["method"] as? String == "initialize")
+    }
+
+    @Test func requestWithNilParams() throws {
+        let request = JSONRPCRequest(id: 5, method: "shutdown")
+        let data = try JSONEncoder().encode(request)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["method"] as? String == "shutdown")
+        #expect(json?["id"] as? Int == 5)
+    }
+
+    @Test func requestRoundTrips() throws {
+        let original = JSONRPCRequest(id: 3, method: "textDocument/completion", params: AnyCodable(["line": 10]))
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(JSONRPCRequest.self, from: data)
+        #expect(decoded.jsonrpc == "2.0")
+        #expect(decoded.id == 3)
+        #expect(decoded.method == "textDocument/completion")
+    }
+
+    // MARK: - JSONRPCNotification Encoding
+
+    @Test func notificationEncodesCorrectly() throws {
+        let notif = JSONRPCNotification(method: "initialized", params: AnyCodable([:] as [String: Any]))
+        let data = try JSONEncoder().encode(notif)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["jsonrpc"] as? String == "2.0")
+        #expect(json?["method"] as? String == "initialized")
+        #expect(json?["id"] == nil) // notifications have no id
+    }
+
+    @Test func notificationWithoutParams() throws {
+        let notif = JSONRPCNotification(method: "exit")
+        let data = try JSONEncoder().encode(notif)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["method"] as? String == "exit")
+    }
+
+    // MARK: - JSONRPCResponse Decoding
+
+    @Test func responseDecodesSuccess() throws {
+        let json = """
+        {"jsonrpc":"2.0","id":1,"result":{"capabilities":{}}}
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(JSONRPCResponse.self, from: data)
+        #expect(response.id == 1)
+        #expect(response.error == nil)
+        #expect(response.result != nil)
+    }
+
+    @Test func responseDecodesError() throws {
+        let json = """
+        {"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"Invalid request"}}
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(JSONRPCResponse.self, from: data)
+        #expect(response.id == 2)
+        #expect(response.error?.code == -32600)
+        #expect(response.error?.message == "Invalid request")
+        #expect(response.result == nil)
+    }
+
+    @Test func responseDecodesNullResult() throws {
+        let json = """
+        {"jsonrpc":"2.0","id":3,"result":null}
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(JSONRPCResponse.self, from: data)
+        #expect(response.id == 3)
+        #expect(response.error == nil)
+    }
+
+    // MARK: - LSP Message Framing
+
+    @Test func encodeRequestWithContentLengthHeader() throws {
+        let request = JSONRPCRequest(id: 1, method: "initialize")
+        let framed = try LSPMessageCodec.encode(request)
+        let text = String(data: framed, encoding: .utf8) ?? ""
+        #expect(text.hasPrefix("Content-Length: "))
+        #expect(text.contains("\r\n\r\n"))
+    }
+
+    @Test func encodeNotificationWithContentLengthHeader() throws {
+        let notif = JSONRPCNotification(method: "exit")
+        let framed = try LSPMessageCodec.encode(notif)
+        let text = String(data: framed, encoding: .utf8) ?? ""
+        #expect(text.hasPrefix("Content-Length: "))
+    }
+
+    @Test func frameContentLengthMatchesBody() {
+        let body = Data("{\"test\":true}".utf8)
+        let framed = LSPMessageCodec.frame(body)
+        let text = String(data: framed, encoding: .utf8) ?? ""
+        // Header should say Content-Length: 13 (the body size)
+        #expect(text.contains("Content-Length: \(body.count)"))
+    }
+
+    @Test func decodeResponseFromFramedData() throws {
+        let json = """
+        {"jsonrpc":"2.0","id":1,"result":{"capabilities":{"completionProvider":{}}}}
+        """
+        let body = Data(json.utf8)
+        let framed = LSPMessageCodec.frame(body)
+
+        let result = LSPMessageCodec.decode(from: framed)
+        #expect(result != nil)
+        #expect(result?.0.id == 1)
+        #expect(result?.1 == framed.count)
+    }
+
+    @Test func decodeReturnsNilForIncompleteHeader() {
+        let partial = Data("Content-Len".utf8)
+        let result = LSPMessageCodec.decode(from: partial)
+        #expect(result == nil)
+    }
+
+    @Test func decodeReturnsNilForIncompleteBody() {
+        let header = "Content-Length: 100\r\n\r\n"
+        let data = Data(header.utf8) + Data("{}".utf8) // only 2 bytes, not 100
+        let result = LSPMessageCodec.decode(from: data)
+        #expect(result == nil)
+    }
+
+    @Test func decodeMultipleMessagesFromBuffer() throws {
+        let json1 = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":null}"
+        let json2 = "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":42}"
+
+        var buffer = LSPMessageCodec.frame(Data(json1.utf8))
+        buffer.append(LSPMessageCodec.frame(Data(json2.utf8)))
+
+        // Decode first
+        let first = LSPMessageCodec.decode(from: buffer)
+        #expect(first != nil)
+        #expect(first?.0.id == 1)
+
+        // Advance buffer
+        let consumed = try #require(first).1
+        let remaining = Data(buffer.dropFirst(consumed))
+        let second = LSPMessageCodec.decode(from: remaining)
+        #expect(second != nil)
+        #expect(second?.0.id == 2)
+    }
+
+    @Test func decodeErrorResponse() throws {
+        let json = """
+        {"jsonrpc":"2.0","id":5,"error":{"code":-32601,"message":"Method not found"}}
+        """
+        let framed = LSPMessageCodec.frame(Data(json.utf8))
+        let result = LSPMessageCodec.decode(from: framed)
+        #expect(result?.0.error?.code == -32601)
+        #expect(result?.0.error?.message == "Method not found")
+    }
+
+    // MARK: - Content-Length Parsing
+
+    @Test func parseContentLengthFromHeader() {
+        let header = "Content-Length: 42\r\nContent-Type: application/json"
+        let length = LSPMessageCodec.parseContentLength(from: header)
+        #expect(length == 42)
+    }
+
+    @Test func parseContentLengthCaseInsensitive() {
+        let header = "content-length: 100"
+        let length = LSPMessageCodec.parseContentLength(from: header)
+        #expect(length == 100)
+    }
+
+    @Test func parseContentLengthReturnsNilForMissing() {
+        let header = "Content-Type: application/json"
+        let length = LSPMessageCodec.parseContentLength(from: header)
+        #expect(length == nil)
+    }
+
+    @Test func parseContentLengthWithExtraSpaces() {
+        let header = "Content-Length:   256  "
+        let length = LSPMessageCodec.parseContentLength(from: header)
+        #expect(length == 256)
+    }
+
+    // MARK: - LSP Position/Range
+
+    @Test func positionEquality() {
+        let a = LSPPosition(line: 5, character: 10)
+        let b = LSPPosition(line: 5, character: 10)
+        let c = LSPPosition(line: 5, character: 11)
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    @Test func rangeEquality() {
+        let range1 = LSPRange(
+            start: LSPPosition(line: 0, character: 0),
+            end: LSPPosition(line: 10, character: 5)
+        )
+        let range2 = LSPRange(
+            start: LSPPosition(line: 0, character: 0),
+            end: LSPPosition(line: 10, character: 5)
+        )
+        #expect(range1 == range2)
+    }
+
+    // MARK: - LSP Types Encoding
+
+    @Test func initializeParamsEncodes() throws {
+        let params = InitializeParams(rootUri: "file:///test")
+        let data = try JSONEncoder().encode(params)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["rootUri"] as? String == "file:///test")
+        #expect(json?["processId"] as? Int == Int(ProcessInfo.processInfo.processIdentifier))
+    }
+
+    @Test func initializeParamsWithNilRoot() throws {
+        let params = InitializeParams(rootUri: nil)
+        let data = try JSONEncoder().encode(params)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        // JSONEncoder encodes nil Optional as null, JSONSerialization reads it as NSNull
+        // But rootUri may be omitted entirely — either case is valid for LSP
+        let hasNullRoot = json?["rootUri"] is NSNull
+        let missingRoot = json?["rootUri"] == nil
+        #expect(hasNullRoot || missingRoot)
+    }
+
+    @Test func textDocumentItemEncodes() throws {
+        let item = TextDocumentItem(uri: "file:///test.swift", languageId: "swift", version: 1, text: "import Foundation")
+        let data = try JSONEncoder().encode(item)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["uri"] as? String == "file:///test.swift")
+        #expect(json?["languageId"] as? String == "swift")
+        #expect(json?["version"] as? Int == 1)
+        #expect(json?["text"] as? String == "import Foundation")
+    }
+
+    @Test func completionParamsEncodes() throws {
+        let params = CompletionParams(
+            textDocument: TextDocumentIdentifier(uri: "file:///test.swift"),
+            position: LSPPosition(line: 5, character: 10)
+        )
+        let data = try JSONEncoder().encode(params)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let textDoc = json?["textDocument"] as? [String: Any]
+        let position = json?["position"] as? [String: Any]
+        #expect(textDoc?["uri"] as? String == "file:///test.swift")
+        #expect(position?["line"] as? Int == 5)
+        #expect(position?["character"] as? Int == 10)
+    }
+
+    @Test func completionItemDecodes() throws {
+        let json = """
+        {"label":"print","kind":3,"detail":"func print(_ items: Any...)","insertText":"print($1)"}
+        """
+        let data = Data(json.utf8)
+        let item = try JSONDecoder().decode(CompletionItem.self, from: data)
+        #expect(item.label == "print")
+        #expect(item.kind == 3)
+        #expect(item.detail == "func print(_ items: Any...)")
+        #expect(item.insertText == "print($1)")
+    }
+
+    @Test func completionItemWithMinimalFields() throws {
+        let json = """
+        {"label":"myFunction"}
+        """
+        let data = Data(json.utf8)
+        let item = try JSONDecoder().decode(CompletionItem.self, from: data)
+        #expect(item.label == "myFunction")
+        #expect(item.kind == nil)
+        #expect(item.detail == nil)
+        #expect(item.insertText == nil)
+    }
+
+    @Test func completionItemEquality() {
+        let a = CompletionItem(label: "test", kind: 3, detail: "detail")
+        let b = CompletionItem(label: "test", kind: 3, detail: "detail")
+        let c = CompletionItem(label: "other")
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    @Test func completionListDecodes() throws {
+        let json = """
+        {"isIncomplete":false,"items":[{"label":"foo"},{"label":"bar","kind":6}]}
+        """
+        let data = Data(json.utf8)
+        let list = try JSONDecoder().decode(CompletionList.self, from: data)
+        #expect(list.isIncomplete == false)
+        #expect(list.items.count == 2)
+        #expect(list.items[0].label == "foo")
+        #expect(list.items[1].label == "bar")
+        #expect(list.items[1].kind == 6)
+    }
+
+    // MARK: - CompletionItemKind
+
+    @Test func completionItemKindRawValues() {
+        #expect(CompletionItemKind.text.rawValue == 1)
+        #expect(CompletionItemKind.method.rawValue == 2)
+        #expect(CompletionItemKind.function.rawValue == 3)
+        #expect(CompletionItemKind.keyword.rawValue == 14)
+        #expect(CompletionItemKind.snippet.rawValue == 15)
+        #expect(CompletionItemKind.typeParameter.rawValue == 25)
+    }
+
+    // MARK: - Content Change Event
+
+    @Test func contentChangeEventEncodes() throws {
+        let change = TextDocumentContentChangeEvent(text: "new content")
+        let data = try JSONEncoder().encode(change)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["text"] as? String == "new content")
+    }
+
+    // MARK: - Versioned Document Identifier
+
+    @Test func versionedDocIdentifierEncodes() throws {
+        let doc = VersionedTextDocumentIdentifier(uri: "file:///test.swift", version: 5)
+        let data = try JSONEncoder().encode(doc)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(json?["uri"] as? String == "file:///test.swift")
+        #expect(json?["version"] as? Int == 5)
+    }
+
+    // MARK: - Client Capabilities
+
+    @Test func clientCapabilitiesEncodes() throws {
+        let caps = LSPClientCapabilities()
+        let data = try JSONEncoder().encode(caps)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let textDoc = json?["textDocument"] as? [String: Any]
+        #expect(textDoc != nil)
+        let completion = textDoc?["completion"] as? [String: Any]
+        #expect(completion != nil)
+    }
+
+    @Test func clientCapabilitiesSnippetSupportDefault() throws {
+        let caps = LSPClientCapabilities()
+        let data = try JSONEncoder().encode(caps)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let textDoc = json?["textDocument"] as? [String: Any]
+        let completion = textDoc?["completion"] as? [String: Any]
+        let completionItem = completion?["completionItem"] as? [String: Any]
+        #expect(completionItem?["snippetSupport"] as? Bool == false)
+    }
+}

--- a/PineTests/LSPMessageTests.swift
+++ b/PineTests/LSPMessageTests.swift
@@ -9,84 +9,143 @@ import Foundation
 
 struct LSPMessageTests {
 
-    // MARK: - AnyCodable
+    // MARK: - JSONValue
 
-    @Test func anyCodableEncodesString() throws {
-        let value = AnyCodable("hello")
+    @Test func jsonValueEncodesString() throws {
+        let value: JSONValue = .string("hello")
         let data = try JSONEncoder().encode(value)
-        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
-        #expect(decoded.value as? String == "hello")
+        let decoded = try JSONDecoder().decode(JSONValue.self, from: data)
+        #expect(decoded == .string("hello"))
     }
 
-    @Test func anyCodableEncodesInt() throws {
-        let value = AnyCodable(42)
+    @Test func jsonValueEncodesInt() throws {
+        let value: JSONValue = .int(42)
         let data = try JSONEncoder().encode(value)
-        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
-        #expect(decoded.value as? Int == 42)
+        let decoded = try JSONDecoder().decode(JSONValue.self, from: data)
+        #expect(decoded == .int(42))
     }
 
-    @Test func anyCodableEncodesBool() throws {
-        let value = AnyCodable(true)
+    @Test func jsonValueEncodesBool() throws {
+        let value: JSONValue = .bool(true)
         let data = try JSONEncoder().encode(value)
-        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
-        #expect(decoded.value as? Bool == true)
+        let decoded = try JSONDecoder().decode(JSONValue.self, from: data)
+        #expect(decoded == .bool(true))
     }
 
-    @Test func anyCodableEncodesDouble() throws {
-        let value = AnyCodable(3.14)
+    @Test func jsonValueEncodesDouble() throws {
+        let value: JSONValue = .double(3.14)
         let data = try JSONEncoder().encode(value)
-        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
-        #expect(decoded.value as? Double == 3.14)
+        let decoded = try JSONDecoder().decode(JSONValue.self, from: data)
+        #expect(decoded == .double(3.14))
     }
 
-    @Test func anyCodableEncodesNull() throws {
-        let value = AnyCodable(NSNull())
+    @Test func jsonValueEncodesNull() throws {
+        let value: JSONValue = .null
         let data = try JSONEncoder().encode(value)
         let json = String(data: data, encoding: .utf8)
         #expect(json == "null")
     }
 
-    @Test func anyCodableEncodesArray() throws {
-        let value = AnyCodable([1, 2, 3])
+    @Test func jsonValueEncodesArray() throws {
+        let value: JSONValue = .array([.int(1), .int(2), .int(3)])
         let data = try JSONEncoder().encode(value)
-        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
-        let array = decoded.value as? [Any]
-        #expect(array?.count == 3)
+        let decoded = try JSONDecoder().decode(JSONValue.self, from: data)
+        #expect(decoded.arrayValue?.count == 3)
     }
 
-    @Test func anyCodableEncodesDictionary() throws {
-        let value = AnyCodable(["key": "value"])
+    @Test func jsonValueEncodesDictionary() throws {
+        let value: JSONValue = .object(["key": .string("value")])
         let data = try JSONEncoder().encode(value)
-        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
-        let dict = decoded.value as? [String: Any]
-        #expect(dict?["key"] as? String == "value")
+        let decoded = try JSONDecoder().decode(JSONValue.self, from: data)
+        #expect(decoded["key"] == .string("value"))
     }
 
-    @Test func anyCodableEquality() {
-        let a = AnyCodable(42)
-        let b = AnyCodable(42)
-        let c = AnyCodable("42")
-        #expect(a == b)
-        #expect(a != c)
+    @Test func jsonValueEquality() {
+        let intA: JSONValue = .int(42)
+        let intB: JSONValue = .int(42)
+        let str: JSONValue = .string("42")
+        #expect(intA == intB)
+        #expect(intA != str)
     }
 
-    @Test func anyCodableNestedStructure() throws {
-        let nested: [String: Any] = [
-            "name": "test",
-            "items": [1, 2, 3],
-            "meta": ["active": true]
-        ]
-        let value = AnyCodable(nested)
-        let data = try JSONEncoder().encode(value)
-        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
-        let dict = decoded.value as? [String: Any]
-        #expect(dict?["name"] as? String == "test")
+    @Test func jsonValueNestedStructure() throws {
+        let nested: JSONValue = .object([
+            "name": .string("test"),
+            "items": .array([.int(1), .int(2), .int(3)]),
+            "meta": .object(["active": .bool(true)])
+        ])
+        let data = try JSONEncoder().encode(nested)
+        let decoded = try JSONDecoder().decode(JSONValue.self, from: data)
+        #expect(decoded["name"] == .string("test"))
+        #expect(decoded["meta"]?["active"] == .bool(true))
+    }
+
+    @Test func jsonValueSubscripts() {
+        let obj: JSONValue = .object(["key": .string("val")])
+        #expect(obj["key"]?.stringValue == "val")
+        #expect(obj["missing"] == nil)
+
+        let arr: JSONValue = .array([.int(10), .int(20)])
+        #expect(arr[0]?.intValue == 10)
+        #expect(arr[5] == nil)
+    }
+
+    @Test func jsonValueAccessors() {
+        #expect(JSONValue.string("hi").stringValue == "hi")
+        #expect(JSONValue.int(5).intValue == 5)
+        #expect(JSONValue.bool(true).boolValue == true)
+        #expect(JSONValue.array([]).arrayValue != nil)
+        #expect(JSONValue.object([:]).objectValue != nil)
+        // Wrong type returns nil
+        #expect(JSONValue.string("hi").intValue == nil)
+        #expect(JSONValue.int(5).stringValue == nil)
+    }
+
+    @Test func jsonValueFromAny() {
+        let fromString = JSONValue("hello" as Any)
+        #expect(fromString == .string("hello"))
+
+        let fromInt = JSONValue(42 as Any)
+        #expect(fromInt == .int(42))
+
+        let fromDict = JSONValue(["key": "value"] as Any)
+        #expect(fromDict["key"] == .string("value"))
+
+        let fromArray = JSONValue([1, 2, 3] as Any)
+        #expect(fromArray.arrayValue?.count == 3)
+    }
+
+    @Test func jsonValueLiterals() {
+        let str: JSONValue = "hello"
+        #expect(str == .string("hello"))
+
+        let num: JSONValue = 42
+        #expect(num == .int(42))
+
+        let flag: JSONValue = true
+        #expect(flag == .bool(true))
+
+        let nothing: JSONValue = nil
+        #expect(nothing == .null)
+
+        let arr: JSONValue = [1, 2, 3]
+        #expect(arr.arrayValue?.count == 3)
+
+        let dict: JSONValue = ["key": "value"]
+        #expect(dict["key"] == .string("value"))
+    }
+
+    @Test func jsonValueHashable() {
+        let set: Set<JSONValue> = [.int(1), .int(2), .int(1)]
+        #expect(set.count == 2)
     }
 
     // MARK: - JSONRPCRequest Encoding
 
     @Test func requestEncodesCorrectly() throws {
-        let request = JSONRPCRequest(id: 1, method: "initialize", params: AnyCodable(["rootUri": "/test"]))
+        let request = JSONRPCRequest(
+            id: 1, method: "initialize", params: .object(["rootUri": .string("/test")])
+        )
         let data = try JSONEncoder().encode(request)
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         #expect(json?["jsonrpc"] as? String == "2.0")
@@ -103,7 +162,9 @@ struct LSPMessageTests {
     }
 
     @Test func requestRoundTrips() throws {
-        let original = JSONRPCRequest(id: 3, method: "textDocument/completion", params: AnyCodable(["line": 10]))
+        let original = JSONRPCRequest(
+            id: 3, method: "textDocument/completion", params: .object(["line": .int(10)])
+        )
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(JSONRPCRequest.self, from: data)
         #expect(decoded.jsonrpc == "2.0")
@@ -114,7 +175,7 @@ struct LSPMessageTests {
     // MARK: - JSONRPCNotification Encoding
 
     @Test func notificationEncodesCorrectly() throws {
-        let notif = JSONRPCNotification(method: "initialized", params: AnyCodable([:] as [String: Any]))
+        let notif = JSONRPCNotification(method: "initialized", params: .object([:]))
         let data = try JSONEncoder().encode(notif)
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         #expect(json?["jsonrpc"] as? String == "2.0")
@@ -162,6 +223,42 @@ struct LSPMessageTests {
         let response = try JSONDecoder().decode(JSONRPCResponse.self, from: data)
         #expect(response.id == 3)
         #expect(response.error == nil)
+    }
+
+    // MARK: - JSONRPCMessage (Unified)
+
+    @Test func unifiedMessageDecodesNotification() throws {
+        let json = """
+        {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file:///test.swift","diagnostics":[]}}
+        """
+        let data = Data(json.utf8)
+        let message = try JSONDecoder().decode(JSONRPCMessage.self, from: data)
+        #expect(message.isNotification)
+        #expect(!message.isResponse)
+        #expect(message.method == "textDocument/publishDiagnostics")
+    }
+
+    @Test func unifiedMessageDecodesResponse() throws {
+        let json = """
+        {"jsonrpc":"2.0","id":1,"result":{"capabilities":{}}}
+        """
+        let data = Data(json.utf8)
+        let message = try JSONDecoder().decode(JSONRPCMessage.self, from: data)
+        #expect(message.isResponse)
+        #expect(!message.isNotification)
+        #expect(message.id == 1)
+    }
+
+    @Test func unifiedMessageDecodesLogMessage() throws {
+        let json = """
+        {"jsonrpc":"2.0","method":"window/logMessage","params":{"type":3,"message":"Server ready"}}
+        """
+        let data = Data(json.utf8)
+        let message = try JSONDecoder().decode(JSONRPCMessage.self, from: data)
+        #expect(message.isNotification)
+        #expect(message.method == "window/logMessage")
+        #expect(message.params?["type"] == .int(3))
+        #expect(message.params?["message"] == .string("Server ready"))
     }
 
     // MARK: - LSP Message Framing
@@ -245,6 +342,17 @@ struct LSPMessageTests {
         #expect(result?.0.error?.message == "Method not found")
     }
 
+    @Test func decodeMessageFromFramedNotification() throws {
+        let json = """
+        {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file:///test","diagnostics":[]}}
+        """
+        let framed = LSPMessageCodec.frame(Data(json.utf8))
+        let result = LSPMessageCodec.decodeMessage(from: framed)
+        #expect(result != nil)
+        #expect(result?.0.isNotification == true)
+        #expect(result?.0.method == "textDocument/publishDiagnostics")
+    }
+
     // MARK: - Content-Length Parsing
 
     @Test func parseContentLengthFromHeader() {
@@ -274,11 +382,11 @@ struct LSPMessageTests {
     // MARK: - LSP Position/Range
 
     @Test func positionEquality() {
-        let a = LSPPosition(line: 5, character: 10)
-        let b = LSPPosition(line: 5, character: 10)
-        let c = LSPPosition(line: 5, character: 11)
-        #expect(a == b)
-        #expect(a != c)
+        let posA = LSPPosition(line: 5, character: 10)
+        let posB = LSPPosition(line: 5, character: 10)
+        let posC = LSPPosition(line: 5, character: 11)
+        #expect(posA == posB)
+        #expect(posA != posC)
     }
 
     @Test func rangeEquality() {
@@ -315,7 +423,9 @@ struct LSPMessageTests {
     }
 
     @Test func textDocumentItemEncodes() throws {
-        let item = TextDocumentItem(uri: "file:///test.swift", languageId: "swift", version: 1, text: "import Foundation")
+        let item = TextDocumentItem(
+            uri: "file:///test.swift", languageId: "swift", version: 1, text: "import Foundation"
+        )
         let data = try JSONEncoder().encode(item)
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         #expect(json?["uri"] as? String == "file:///test.swift")
@@ -363,11 +473,11 @@ struct LSPMessageTests {
     }
 
     @Test func completionItemEquality() {
-        let a = CompletionItem(label: "test", kind: 3, detail: "detail")
-        let b = CompletionItem(label: "test", kind: 3, detail: "detail")
-        let c = CompletionItem(label: "other")
-        #expect(a == b)
-        #expect(a != c)
+        let itemA = CompletionItem(label: "test", kind: 3, detail: "detail")
+        let itemB = CompletionItem(label: "test", kind: 3, detail: "detail")
+        let itemC = CompletionItem(label: "other")
+        #expect(itemA == itemB)
+        #expect(itemA != itemC)
     }
 
     @Test func completionListDecodes() throws {
@@ -433,5 +543,66 @@ struct LSPMessageTests {
         let completion = textDoc?["completion"] as? [String: Any]
         let completionItem = completion?["completionItem"] as? [String: Any]
         #expect(completionItem?["snippetSupport"] as? Bool == false)
+    }
+
+    // MARK: - LSP Diagnostic Types
+
+    @Test func diagnosticDecodes() throws {
+        let json = """
+        {
+            "range": {"start": {"line": 5, "character": 0}, "end": {"line": 5, "character": 10}},
+            "severity": 1,
+            "message": "Use of undeclared type 'Foo'"
+        }
+        """
+        let data = Data(json.utf8)
+        let diag = try JSONDecoder().decode(LSPDiagnostic.self, from: data)
+        #expect(diag.range.start.line == 5)
+        #expect(diag.severity == LSPDiagnostic.Severity.error.rawValue)
+        #expect(diag.message == "Use of undeclared type 'Foo'")
+    }
+
+    @Test func publishDiagnosticsParamsDecodes() throws {
+        let json = """
+        {
+            "uri": "file:///test.swift",
+            "diagnostics": [
+                {
+                    "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 5}},
+                    "severity": 2,
+                    "message": "Unused variable"
+                }
+            ]
+        }
+        """
+        let data = Data(json.utf8)
+        let params = try JSONDecoder().decode(PublishDiagnosticsParams.self, from: data)
+        #expect(params.uri == "file:///test.swift")
+        #expect(params.diagnostics.count == 1)
+        #expect(params.diagnostics[0].severity == LSPDiagnostic.Severity.warning.rawValue)
+    }
+
+    @Test func logMessageParamsDecodes() throws {
+        let json = """
+        {"type": 3, "message": "Server initialized successfully"}
+        """
+        let data = Data(json.utf8)
+        let params = try JSONDecoder().decode(LogMessageParams.self, from: data)
+        #expect(params.type == LogMessageParams.MessageType.info.rawValue)
+        #expect(params.message == "Server initialized successfully")
+    }
+
+    @Test func diagnosticSeverityValues() {
+        #expect(LSPDiagnostic.Severity.error.rawValue == 1)
+        #expect(LSPDiagnostic.Severity.warning.rawValue == 2)
+        #expect(LSPDiagnostic.Severity.information.rawValue == 3)
+        #expect(LSPDiagnostic.Severity.hint.rawValue == 4)
+    }
+
+    @Test func logMessageTypeValues() {
+        #expect(LogMessageParams.MessageType.error.rawValue == 1)
+        #expect(LogMessageParams.MessageType.warning.rawValue == 2)
+        #expect(LogMessageParams.MessageType.info.rawValue == 3)
+        #expect(LogMessageParams.MessageType.log.rawValue == 4)
     }
 }


### PR DESCRIPTION
## Summary

Closes #281 (foundation layer only)

- **LSPMessage.swift** — JSON-RPC 2.0 types (request, notification, response, error), `AnyCodable` type-erased wrapper, LSP message framing codec (`Content-Length` headers), and LSP protocol types (initialize, text document sync, completion)
- **LSPClient.swift** — manages language server process lifecycle via stdin/stdout, sends requests/notifications, routes responses via pending request handlers, handles server termination
- **LSPManager.swift** — coordinates multiple LSP clients per language, maps file extensions to server configs (sourcekit-lsp for Swift, typescript-language-server for TS/JS, pylsp for Python, gopls for Go, rust-analyzer for Rust, clangd for C/C++)
- **Logging.swift** — added `lsp` logging category

No UI changes in this PR — protocol layer only.

## Test plan

- [x] 80+ unit tests: JSON-RPC encoding/decoding, message framing, Content-Length parsing, LSP type serialization, completion item parsing, language extension detection, server config validation, error handling
- [x] SwiftLint clean
- [ ] CI passes