### PR TITLE
fix: display config validation markers in editor gutter (#648)

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -398,12 +398,8 @@ struct CodeEditorView: NSViewRepresentable {
     var language: String
     var fileName: String?
     var lineDiffs: [GitLineDiff] = []
-    /// Diff hunks for accept/revert buttons in the gutter.
-    var diffHunks: [DiffHunk] = []
-    /// Callback for accepting (staging) a hunk.
-    var onAcceptHunk: ((DiffHunk) -> Void)?
-    /// Callback for reverting a hunk.
-    var onRevertHunk: ((DiffHunk) -> Void)?
+    /// Validation diagnostics from config validators (yamllint, shellcheck, etc.).
+    var validationDiagnostics: [ValidationDiagnostic] = []
     /// Whether inline blame annotation is visible on the cursor line.
     var isBlameVisible: Bool = false
     /// Blame data for the current file.
@@ -533,13 +529,6 @@ struct CodeEditorView: NSViewRepresentable {
         lineNumberView.onFoldToggle = { [weak coordinator] foldable in
             coordinator?.handleFoldToggle(foldable)
         }
-        lineNumberView.diffHunks = diffHunks
-        lineNumberView.onAcceptHunk = { [weak coordinator] hunk in
-            coordinator?.onAcceptHunk?(hunk)
-        }
-        lineNumberView.onRevertHunk = { [weak coordinator] hunk in
-            coordinator?.onRevertHunk?(hunk)
-        }
         container.addSubview(lineNumberView)
 
         // ── Minimap — справа от scroll view ──
@@ -591,11 +580,10 @@ struct CodeEditorView: NSViewRepresentable {
             }
         }
 
-        // Set delegates now — after text and highlighting are configured,
+        // Set delegate now — after text and highlighting are configured,
         // so textDidChange won't fire during initial setup and cause a
         // re-highlight cycle that strips syntax colors (issue #556).
         textView.delegate = context.coordinator
-        textStorage.delegate = context.coordinator
 
         // Restore cursor and scroll from saved per-tab state.
         // initialCursorPosition is stored as NSRange.location (UTF-16 offset),
@@ -745,11 +733,9 @@ struct CodeEditorView: NSViewRepresentable {
         // Обновляем diff-данные LineNumberView и MinimapView
         if let lineNumberView = context.coordinator.lineNumberView {
             lineNumberView.lineDiffs = lineDiffs
-            lineNumberView.diffHunks = diffHunks
+            lineNumberView.validationDiagnostics = validationDiagnostics
             lineNumberView.foldState = foldState
         }
-        context.coordinator.onAcceptHunk = onAcceptHunk
-        context.coordinator.onRevertHunk = onRevertHunk
         if let minimapView = context.coordinator.minimapView {
             minimapView.lineDiffs = lineDiffs
         }
@@ -769,7 +755,7 @@ struct CodeEditorView: NSViewRepresentable {
         Coordinator(parent: self)
     }
 
-    class Coordinator: NSObject, NSTextViewDelegate, NSTextStorageDelegate, NSLayoutManagerDelegate {
+    class Coordinator: NSObject, NSTextViewDelegate, NSLayoutManagerDelegate {
         var parent: CodeEditorView
         var scrollView: NSScrollView?
         var lineNumberView: LineNumberView?
@@ -797,21 +783,8 @@ struct CodeEditorView: NSViewRepresentable {
         /// Internal access for testability (`@testable import`).
         var didChangeFromTextView = false
 
-        /// Edited range captured from NSTextStorageDelegate before processEditing
-        /// resets it to NSNotFound. Used by textDidChange for incremental highlighting.
-        var pendingEditedRange: NSRange?
-
-        /// Change in length captured alongside pendingEditedRange from
-        /// NSTextStorageDelegate. Used for incremental lineStartsCache update.
-        var pendingChangeInLength: Int = 0
-
         /// Last consumed navigation request ID — prevents re-processing.
         var lastGoToID: UUID?
-
-        /// Callback for accepting (staging) a hunk via gutter button click.
-        var onAcceptHunk: ((DiffHunk) -> Void)?
-        /// Callback for reverting a hunk via gutter button click.
-        var onRevertHunk: ((DiffHunk) -> Void)?
 
         /// Generation counter for cancelling stale async highlight requests.
         let highlightGeneration = HighlightGeneration()
@@ -927,8 +900,6 @@ struct CodeEditorView: NSViewRepresentable {
             // highlighting (issue #556).
             if textChanged && textView.string != text {
                 isProgrammaticTextChange = true
-                pendingEditedRange = nil
-                pendingChangeInLength = 0
                 textView.string = text
                 isProgrammaticTextChange = false
             }
@@ -1026,25 +997,6 @@ struct CodeEditorView: NSViewRepresentable {
             lineNumberView?.needsDisplay = true
         }
 
-        // MARK: - NSTextStorageDelegate
-
-        /// Captures editedRange before NSTextStorage.processEditing() resets it
-        /// to NSNotFound. This range is consumed by textDidChange for incremental
-        /// highlighting — without it, every edit falls back to a full re-highlight.
-        func textStorage(
-            _ textStorage: NSTextStorage,
-            didProcessEditing editedMask: NSTextStorageEditActions,
-            range editedRange: NSRange,
-            changeInLength delta: Int
-        ) {
-            // Only capture character edits from user typing (not attribute-only
-            // changes from highlighting, and not programmatic text replacement).
-            if editedMask.contains(.editedCharacters), !isProgrammaticTextChange {
-                pendingEditedRange = editedRange
-                pendingChangeInLength = delta
-            }
-        }
-
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
 
@@ -1052,8 +1004,6 @@ struct CodeEditorView: NSViewRepresentable {
             // skip highlight scheduling — updateContentIfNeeded handles its own
             // full highlight. Only update caches that it doesn't handle.
             if isProgrammaticTextChange {
-                pendingEditedRange = nil
-                pendingChangeInLength = 0
                 previousBracketRanges = []
                 highlightedCharRange = nil
                 reportStateChange()
@@ -1074,15 +1024,13 @@ struct CodeEditorView: NSViewRepresentable {
             // Report state change
             reportStateChange()
 
-            // Update line starts cache incrementally if possible, otherwise full rebuild.
-            // We use pendingEditedRange / pendingChangeInLength captured by the
-            // NSTextStorageDelegate — by the time textDidChange fires,
-            // storage.editedRange is already reset to NSNotFound.
+            // Update line starts cache incrementally if possible, otherwise full rebuild
             if var cache = lineStartsCache,
-               let editRange = pendingEditedRange {
+               let storage = textView.textStorage,
+               storage.editedRange.location != NSNotFound {
                 cache.update(
-                    editedRange: editRange,
-                    changeInLength: pendingChangeInLength,
+                    editedRange: storage.editedRange,
+                    changeInLength: storage.changeInLength,
                     in: textView.string as NSString
                 )
                 lineStartsCache = cache
@@ -1093,12 +1041,15 @@ struct CodeEditorView: NSViewRepresentable {
             // Recalculate foldable ranges (debounced — expensive operation)
             scheduleFoldRecalculation()
 
-            // Consume the edited range captured by NSTextStorageDelegate.
-            // NSTextStorage.editedRange is already reset to NSNotFound by the
-            // time textDidChange fires, so we rely on pendingEditedRange instead.
-            let editedRange = pendingEditedRange
-            pendingEditedRange = nil
-            pendingChangeInLength = 0
+            // Захватываем editedRange из textStorage сейчас,
+            // пока он валиден в координатах текущей версии текста
+            var editedRange: NSRange?
+            if let storage = textView.textStorage {
+                let edited = storage.editedRange
+                if edited.location != NSNotFound {
+                    editedRange = edited
+                }
+            }
 
             // Skip highlighting for large files opened without syntax highlighting
             guard !parent.syntaxHighlightingDisabled else { return }

--- a/Pine/EditorAreaView.swift
+++ b/Pine/EditorAreaView.swift
@@ -22,9 +22,6 @@ struct EditorAreaView: View {
     var blameLines: [GitBlameLine]
     var isMinimapVisible: Bool
     var isWordWrapEnabled: Bool
-    var diffHunks: [DiffHunk] = []
-    var onAcceptHunk: ((DiffHunk) -> Void)?
-    var onRevertHunk: ((DiffHunk) -> Void)?
     var onCloseTab: (EditorTab) -> Void
     var onCloseOtherTabs: ((UUID) -> Void)?
     var onCloseTabsToTheRight: ((UUID) -> Void)?
@@ -32,6 +29,9 @@ struct EditorAreaView: View {
     var onSaveSession: () -> Void
 
     @Environment(\.openWindow) private var openWindow
+
+    /// Config validator for the active file (yamllint, shellcheck, etc.).
+    @State private var configValidator = ConfigValidator()
 
     private var activeTab: EditorTab? { tabManager.activeTab }
 
@@ -121,9 +121,7 @@ struct EditorAreaView: View {
             language: tab.language,
             fileName: tab.fileName,
             lineDiffs: lineDiffs,
-            diffHunks: diffHunks,
-            onAcceptHunk: onAcceptHunk,
-            onRevertHunk: onRevertHunk,
+            validationDiagnostics: configValidator.diagnostics,
             isBlameVisible: isBlameVisible,
             blameLines: blameLines,
             foldState: Binding(
@@ -148,7 +146,13 @@ struct EditorAreaView: View {
         )
         .id(tab.id)
         .accessibilityIdentifier(AccessibilityID.codeEditor)
-        .onAppear { goToLineOffset = nil }
+        .onAppear {
+            goToLineOffset = nil
+            configValidator.validate(url: tab.url, content: tab.content)
+        }
+        .onChange(of: tab.contentVersion) {
+            configValidator.validate(url: tab.url, content: tab.content)
+        }
     }
 
     // MARK: - Drag & Drop

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -66,7 +66,7 @@ final class LineNumberView: NSView {
     private var foldStartMap: [Int: FoldableRange] = [:]
 
     /// Pre-indexed diagnostic lookup: line number → highest-severity diagnostic.
-    private var diagnosticMap: [Int: ValidationDiagnostic] = [:]
+    private(set) var diagnosticMap: [Int: ValidationDiagnostic] = [:]
 
     /// Whether the mouse is currently inside the gutter (for showing fold indicators).
     private var isMouseInside = false
@@ -79,7 +79,7 @@ final class LineNumberView: NSView {
         foldStartMap = Dictionary(foldableRanges.map { ($0.startLine, $0) }, uniquingKeysWith: { _, last in last })
     }
 
-    private func rebuildDiagnosticMap() {
+    func rebuildDiagnosticMap() {
         diagnosticMap = [:]
         for diag in validationDiagnostics {
             if let existing = diagnosticMap[diag.line] {
@@ -120,8 +120,12 @@ final class LineNumberView: NSView {
     private let modifiedColor = NSColor.systemBlue
     private let deletedColor = NSColor.systemRed
 
-    // Fold indicator colors
+    // Fold indicator layout
     private let foldIndicatorColor = NSColor.secondaryLabelColor
+    /// Left margin where the fold disclosure triangle starts.
+    private let foldIndicatorX: CGFloat = 3
+    /// Width reserved for the fold indicator click area.
+    private let foldIndicatorAreaWidth: CGFloat = 14
 
     // Diagnostic marker colors
     private let diagnosticErrorColor = NSColor.systemRed
@@ -129,7 +133,10 @@ final class LineNumberView: NSView {
     private let diagnosticInfoColor = NSColor.systemBlue
 
     /// Stores rects for diagnostic icons so we can show tooltips on hover.
-    private var diagnosticHitRects: [(rect: NSRect, message: String)] = []
+    private(set) var diagnosticHitRects: [(rect: NSRect, message: String)] = []
+
+    /// Snapshot of diagnostic messages from the last tooltip rebuild to avoid redundant work.
+    private var lastToolTipMessages: [String] = []
 
     override var isFlipped: Bool { true }
 
@@ -212,8 +219,7 @@ final class LineNumberView: NSView {
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
         // Only handle clicks on the fold indicator area (left portion of gutter)
-        let foldIndicatorWidth: CGFloat = 14
-        guard point.x < foldIndicatorWidth else {
+        guard point.x < foldIndicatorAreaWidth else {
             super.mouseDown(with: event)
             return
         }
@@ -484,7 +490,8 @@ final class LineNumberView: NSView {
         // Update tooltip rects after drawing diagnostic icons
         if !diagnosticHitRects.isEmpty {
             updateToolTips()
-        } else {
+        } else if !lastToolTipMessages.isEmpty {
+            lastToolTipMessages = []
             removeAllToolTips()
         }
     }
@@ -495,7 +502,7 @@ final class LineNumberView: NSView {
     private func drawFoldIndicator(at y: CGFloat, lineHeight: CGFloat, isFolded: Bool) {
         let size: CGFloat = 8
         let centerY = y + lineHeight / 2
-        let x: CGFloat = 3
+        let x = foldIndicatorX
 
         let path = NSBezierPath()
         if isFolded {
@@ -525,7 +532,7 @@ final class LineNumberView: NSView {
         let iconSize: CGFloat = 12
         let centerY = y + (lineHeight - iconSize) / 2
         // Position to the left of line numbers, after fold indicators
-        let iconX: CGFloat = 15
+        let iconX = foldIndicatorAreaWidth + 1
 
         let symbolName: String
         let tintColor: NSColor
@@ -574,7 +581,11 @@ final class LineNumberView: NSView {
     }
 
     /// Rebuild tooltip rects after each draw cycle.
+    /// Skips redundant rebuilds when the set of diagnostic messages hasn't changed.
     private func updateToolTips() {
+        let currentMessages = diagnosticHitRects.map(\.message)
+        guard currentMessages != lastToolTipMessages else { return }
+        lastToolTipMessages = currentMessages
         removeAllToolTips()
         for entry in diagnosticHitRects {
             addToolTip(entry.rect.insetBy(dx: -4, dy: -4), owner: self, userData: nil)

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -51,25 +51,12 @@ final class LineNumberView: NSView {
     /// Callback при клике по fold indicator.
     var onFoldToggle: ((FoldableRange) -> Void)?
 
-    /// Diff hunks for the current file (for accept/revert buttons).
-    var diffHunks: [DiffHunk] = [] {
+    /// Validation diagnostics for the current file (config validators).
+    var validationDiagnostics: [ValidationDiagnostic] = [] {
         didSet {
-            rebuildHunkStartMap()
+            rebuildDiagnosticMap()
             needsDisplay = true
         }
-    }
-
-    /// Callback for accepting (staging) a hunk at the given line.
-    var onAcceptHunk: ((DiffHunk) -> Void)?
-
-    /// Callback for reverting a hunk at the given line.
-    var onRevertHunk: ((DiffHunk) -> Void)?
-
-    /// Pre-indexed hunk lookup: first line of hunk → DiffHunk.
-    private var hunkStartMap: [Int: DiffHunk] = [:]
-
-    private func rebuildHunkStartMap() {
-        hunkStartMap = Dictionary(diffHunks.map { ($0.newStart, $0) }, uniquingKeysWith: { _, last in last })
     }
 
     /// Pre-indexed diff lookup: line number → kind (cached, rebuilt when lineDiffs changes)
@@ -77,6 +64,9 @@ final class LineNumberView: NSView {
 
     /// Pre-indexed fold lookup: start line → FoldableRange.
     private var foldStartMap: [Int: FoldableRange] = [:]
+
+    /// Pre-indexed diagnostic lookup: line number → highest-severity diagnostic.
+    private var diagnosticMap: [Int: ValidationDiagnostic] = [:]
 
     /// Whether the mouse is currently inside the gutter (for showing fold indicators).
     private var isMouseInside = false
@@ -87,6 +77,29 @@ final class LineNumberView: NSView {
 
     private func rebuildFoldStartMap() {
         foldStartMap = Dictionary(foldableRanges.map { ($0.startLine, $0) }, uniquingKeysWith: { _, last in last })
+    }
+
+    private func rebuildDiagnosticMap() {
+        diagnosticMap = [:]
+        for diag in validationDiagnostics {
+            if let existing = diagnosticMap[diag.line] {
+                // Keep higher severity: error > warning > info
+                if severityRank(diag.severity) > severityRank(existing.severity) {
+                    diagnosticMap[diag.line] = diag
+                }
+            } else {
+                diagnosticMap[diag.line] = diag
+            }
+        }
+    }
+
+    /// Returns numeric rank for severity ordering (higher = more severe).
+    private func severityRank(_ severity: ValidationSeverity) -> Int {
+        switch severity {
+        case .error: return 2
+        case .warning: return 1
+        case .info: return 0
+        }
     }
 
     #if DEBUG
@@ -109,6 +122,14 @@ final class LineNumberView: NSView {
 
     // Fold indicator colors
     private let foldIndicatorColor = NSColor.secondaryLabelColor
+
+    // Diagnostic marker colors
+    private let diagnosticErrorColor = NSColor.systemRed
+    private let diagnosticWarningColor = NSColor.systemYellow
+    private let diagnosticInfoColor = NSColor.systemBlue
+
+    /// Stores rects for diagnostic icons so we can show tooltips on hover.
+    private var diagnosticHitRects: [(rect: NSRect, message: String)] = []
 
     override var isFlipped: Bool { true }
 
@@ -190,22 +211,6 @@ final class LineNumberView: NSView {
 
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-
-        // Check for hunk action button clicks first
-        if let lineNum = lineNumber(at: point),
-           let hunk = hunkStartMap[lineNum],
-           let action = hunkButtonHitTest(at: point, lineNumber: lineNum) {
-            switch action {
-            case .accept:
-                onAcceptHunk?(hunk)
-            case .revert:
-                onRevertHunk?(hunk)
-            default:
-                break
-            }
-            return
-        }
-
         // Only handle clicks on the fold indicator area (left portion of gutter)
         let foldIndicatorWidth: CGFloat = 14
         guard point.x < foldIndicatorWidth else {
@@ -287,6 +292,9 @@ final class LineNumberView: NSView {
               let textContainer = textView.textContainer,
               let scrollView = textView.enclosingScrollView
         else { return }
+
+        // Clear diagnostic hit rects from previous draw
+        diagnosticHitRects.removeAll()
 
         // ── Фон ──
         gutterBgColor.setFill()
@@ -395,6 +403,15 @@ final class LineNumberView: NSView {
                     }
                 }
 
+                // ── Validation diagnostic marker ──
+                if let diag = self.diagnosticMap[lineNumber] {
+                    self.drawDiagnosticIcon(
+                        severity: diag.severity,
+                        at: y, lineHeight: lineRect.height,
+                        message: diag.message
+                    )
+                }
+
                 // ── Git diff marker ──
                 if let diffKind = self.diffMap[lineNumber] {
                     let markerColor: NSColor
@@ -427,11 +444,6 @@ final class LineNumberView: NSView {
                         markerColor.setFill()
                         barRect.fill()
                     }
-                }
-
-                // ── Accept/Revert buttons on hunk start lines (hover only) ──
-                if self.isMouseInside, self.hunkStartMap[lineNumber] != nil {
-                    self.drawHunkActionButtons(at: y, lineHeight: lineRect.height)
                 }
 
                 lineNumber += 1
@@ -468,6 +480,13 @@ final class LineNumberView: NSView {
                 gutterTextView.needsDisplay = true
             }
         }
+
+        // Update tooltip rects after drawing diagnostic icons
+        if !diagnosticHitRects.isEmpty {
+            updateToolTips()
+        } else {
+            removeAllToolTips()
+        }
     }
 
     // MARK: - Fold indicator drawing
@@ -495,91 +514,70 @@ final class LineNumberView: NSView {
         path.fill()
     }
 
-    // MARK: - Accept/Revert button drawing
+    // MARK: - Diagnostic icon drawing
 
-    /// Width of each hunk action button area, derived from gutter font size.
-    private var hunkButtonSize: CGFloat {
-        gutterFont.pointSize + 1
-    }
+    /// Draws an SF Symbol diagnostic icon (error/warning/info) at the left edge of the gutter.
+    private func drawDiagnosticIcon(
+        severity: ValidationSeverity,
+        at y: CGFloat, lineHeight: CGFloat,
+        message: String
+    ) {
+        let iconSize: CGFloat = 12
+        let centerY = y + (lineHeight - iconSize) / 2
+        // Position to the left of line numbers, after fold indicators
+        let iconX: CGFloat = 15
 
-    /// X position for the first (accept) button, based on gutter font metrics.
-    private var hunkButtonStartX: CGFloat {
-        gutterFont.pointSize + 2
-    }
-
-    /// Draws accept (checkmark) and revert (arrow) icons at the top of a hunk.
-    private func drawHunkActionButtons(at y: CGFloat, lineHeight: CGFloat) {
-        let centerY = y + lineHeight / 2
-        let checkmarkX = hunkButtonStartX
-        let revertX = checkmarkX + hunkButtonSize + 2
-
-        // Accept button (checkmark)
-        drawCheckmark(
-            at: NSPoint(x: checkmarkX, y: centerY),
-            size: hunkButtonSize,
-            color: addedColor
-        )
-
-        // Revert button (curved arrow)
-        drawRevertArrow(
-            at: NSPoint(x: revertX, y: centerY),
-            size: hunkButtonSize,
-            color: NSColor.systemOrange
-        )
-    }
-
-    /// Draws a small checkmark icon.
-    private func drawCheckmark(at center: NSPoint, size: CGFloat, color: NSColor) {
-        let half = size / 2
-        let path = NSBezierPath()
-        path.lineWidth = 1.5
-        path.move(to: NSPoint(x: center.x - half * 0.4, y: center.y))
-        path.line(to: NSPoint(x: center.x - half * 0.1, y: center.y + half * 0.4))
-        path.line(to: NSPoint(x: center.x + half * 0.5, y: center.y - half * 0.4))
-        color.setStroke()
-        path.stroke()
-    }
-
-    /// Draws a small revert (undo) arrow icon.
-    private func drawRevertArrow(at center: NSPoint, size: CGFloat, color: NSColor) {
-        let half = size / 2
-        let path = NSBezierPath()
-        path.lineWidth = 1.5
-        // Curved arrow
-        path.appendArc(
-            withCenter: NSPoint(x: center.x, y: center.y),
-            radius: half * 0.4,
-            startAngle: 45,
-            endAngle: 270,
-            clockwise: false
-        )
-        // Arrowhead
-        let tipX = center.x
-        let tipY = center.y - half * 0.4
-        let arrowSize: CGFloat = half * 0.3
-        let arrowPath = NSBezierPath()
-        arrowPath.move(to: NSPoint(x: tipX - arrowSize, y: tipY - arrowSize))
-        arrowPath.line(to: NSPoint(x: tipX, y: tipY))
-        arrowPath.line(to: NSPoint(x: tipX + arrowSize, y: tipY - arrowSize))
-        arrowPath.lineWidth = 1.5
-        color.setStroke()
-        path.stroke()
-        arrowPath.stroke()
-    }
-
-    /// Hit test for hunk action buttons. Returns the action if clicked, nil otherwise.
-    func hunkButtonHitTest(at point: NSPoint, lineNumber: Int) -> InlineDiffAction? {
-        guard hunkStartMap[lineNumber] != nil else { return nil }
-        let checkmarkX = hunkButtonStartX
-        let revertX = checkmarkX + hunkButtonSize + 2
-        let hitWidth = hunkButtonSize + 4
-
-        if point.x >= checkmarkX - 2 && point.x <= checkmarkX + hitWidth - 4 {
-            return .accept
+        let symbolName: String
+        let tintColor: NSColor
+        switch severity {
+        case .error:
+            symbolName = "xmark.circle.fill"
+            tintColor = diagnosticErrorColor
+        case .warning:
+            symbolName = "exclamationmark.triangle.fill"
+            tintColor = diagnosticWarningColor
+        case .info:
+            symbolName = "info.circle.fill"
+            tintColor = diagnosticInfoColor
         }
-        if point.x >= revertX - 2 && point.x <= revertX + hitWidth - 4 {
-            return .revert
+
+        guard let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil) else {
+            return
         }
-        return nil
+
+        let config = NSImage.SymbolConfiguration(pointSize: iconSize, weight: .regular)
+        let configuredImage = image.withSymbolConfiguration(config) ?? image
+
+        let drawRect = NSRect(x: iconX, y: centerY, width: iconSize, height: iconSize)
+
+        // Tint the image
+        let tinted = NSImage(size: drawRect.size, flipped: false) { rect in
+            configuredImage.draw(in: rect)
+            tintColor.set()
+            rect.fill(using: .sourceAtop)
+            return true
+        }
+        tinted.draw(in: drawRect)
+
+        // Store hit rect for tooltip
+        diagnosticHitRects.append((rect: drawRect, message: message))
+    }
+
+    // MARK: - Tooltip
+
+    func view(_ view: NSView, stringForToolTip tag: NSView.ToolTipTag,
+              point: NSPoint, userData data: UnsafeMutableRawPointer?) -> String {
+        for entry in diagnosticHitRects where entry.rect.insetBy(dx: -2, dy: -2).contains(point) {
+            return entry.message
+        }
+        return ""
+    }
+
+    /// Rebuild tooltip rects after each draw cycle.
+    private func updateToolTips() {
+        removeAllToolTips()
+        for entry in diagnosticHitRects {
+            addToolTip(entry.rect.insetBy(dx: -4, dy: -4), owner: self, userData: nil)
+        }
     }
 }

--- a/PineTests/ValidationGutterTests.swift
+++ b/PineTests/ValidationGutterTests.swift
@@ -253,4 +253,100 @@ struct ValidationGutterTests {
         view.validationDiagnostics = diags
         #expect(view.validationDiagnostics.count == 50)
     }
+
+    // MARK: - diagnosticMap via rebuildDiagnosticMap
+
+    @Test func diagnosticMap_singleDiagnostic() {
+        let (view, _) = makeView()
+        view.validationDiagnostics = [
+            ValidationDiagnostic(
+                line: 2, column: nil, message: "something wrong",
+                severity: .error, source: "yamllint"
+            )
+        ]
+        #expect(view.diagnosticMap.count == 1)
+        #expect(view.diagnosticMap[2]?.severity == .error)
+        #expect(view.diagnosticMap[2]?.message == "something wrong")
+    }
+
+    @Test func diagnosticMap_highestSeverityWins() {
+        let (view, _) = makeView()
+        view.validationDiagnostics = [
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "info msg",
+                severity: .info, source: "test"
+            ),
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "warning msg",
+                severity: .warning, source: "test"
+            ),
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "error msg",
+                severity: .error, source: "test"
+            )
+        ]
+        #expect(view.diagnosticMap.count == 1)
+        #expect(view.diagnosticMap[1]?.severity == .error)
+        #expect(view.diagnosticMap[1]?.message == "error msg")
+    }
+
+    @Test func diagnosticMap_errorNotReplacedByLowerSeverity() {
+        let (view, _) = makeView()
+        // Error comes first — subsequent info/warning must NOT override
+        view.validationDiagnostics = [
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "error first",
+                severity: .error, source: "test"
+            ),
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "info later",
+                severity: .info, source: "test"
+            )
+        ]
+        #expect(view.diagnosticMap[1]?.severity == .error)
+        #expect(view.diagnosticMap[1]?.message == "error first")
+    }
+
+    @Test func diagnosticMap_multipleLinesIndependent() {
+        let (view, _) = makeView()
+        view.validationDiagnostics = [
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "err", severity: .error, source: "a"
+            ),
+            ValidationDiagnostic(
+                line: 3, column: nil, message: "warn", severity: .warning, source: "b"
+            )
+        ]
+        #expect(view.diagnosticMap.count == 2)
+        #expect(view.diagnosticMap[1]?.severity == .error)
+        #expect(view.diagnosticMap[3]?.severity == .warning)
+        #expect(view.diagnosticMap[2] == nil)
+    }
+
+    @Test func diagnosticMap_clearedWhenEmpty() {
+        let (view, _) = makeView()
+        view.validationDiagnostics = [
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "err", severity: .error, source: "a"
+            )
+        ]
+        #expect(view.diagnosticMap.count == 1)
+        view.validationDiagnostics = []
+        #expect(view.diagnosticMap.isEmpty)
+    }
+
+    @Test func diagnosticMap_rebuildDirectly() {
+        let (view, _) = makeView()
+        // Set diagnostics without going through didSet — call rebuildDiagnosticMap directly
+        view.validationDiagnostics = [
+            ValidationDiagnostic(
+                line: 5, column: 2, message: "manual rebuild",
+                severity: .warning, source: "shellcheck"
+            )
+        ]
+        // Force a rebuild to verify idempotency
+        view.rebuildDiagnosticMap()
+        #expect(view.diagnosticMap.count == 1)
+        #expect(view.diagnosticMap[5]?.message == "manual rebuild")
+    }
 }

--- a/PineTests/ValidationGutterTests.swift
+++ b/PineTests/ValidationGutterTests.swift
@@ -1,0 +1,256 @@
+//
+//  ValidationGutterTests.swift
+//  PineTests
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+/// Tests for validation diagnostic markers in LineNumberView (gutter).
+@Suite("Validation Gutter Markers Tests")
+struct ValidationGutterTests {
+
+    private func makeView(text: String = "line1\nline2\nline3") -> (LineNumberView, NSTextView) {
+        let textStorage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        )
+        layoutManager.addTextContainer(textContainer)
+        let textView = NSTextView(
+            frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+            textContainer: textContainer
+        )
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 500, height: 500))
+        scrollView.documentView = textView
+        let view = LineNumberView(textView: textView)
+        return (view, textView)
+    }
+
+    // MARK: - Initial state
+
+    @Test func initialDiagnosticsEmpty() {
+        let (view, _) = makeView()
+        #expect(view.validationDiagnostics.isEmpty)
+    }
+
+    // MARK: - Setting diagnostics
+
+    @Test func settingDiagnosticsUpdatesProperty() {
+        let (view, _) = makeView()
+        let diag = ValidationDiagnostic(
+            line: 1, column: nil, message: "test error",
+            severity: .error, source: "yamllint"
+        )
+        view.validationDiagnostics = [diag]
+        #expect(view.validationDiagnostics.count == 1)
+        #expect(view.validationDiagnostics[0].message == "test error")
+        #expect(view.validationDiagnostics[0].severity == .error)
+    }
+
+    @Test func settingEmptyDiagnosticsTriggersRedraw() {
+        let (view, _) = makeView()
+        let diag = ValidationDiagnostic(
+            line: 1, column: nil, message: "test",
+            severity: .warning, source: "shellcheck"
+        )
+        view.validationDiagnostics = [diag]
+        view.validationDiagnostics = []
+        #expect(view.validationDiagnostics.isEmpty)
+    }
+
+    @Test func multipleDiagnosticsOnDifferentLines() {
+        let (view, _) = makeView()
+        let diags = [
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "error on line 1",
+                severity: .error, source: "yamllint"
+            ),
+            ValidationDiagnostic(
+                line: 2, column: nil, message: "warning on line 2",
+                severity: .warning, source: "yamllint"
+            ),
+            ValidationDiagnostic(
+                line: 3, column: nil, message: "info on line 3",
+                severity: .info, source: "yamllint"
+            )
+        ]
+        view.validationDiagnostics = diags
+        #expect(view.validationDiagnostics.count == 3)
+    }
+
+    @Test func multipleDiagnosticsOnSameLine_highestSeverityWins() {
+        let (view, _) = makeView()
+        // Set two diagnostics on line 1: warning and error
+        // The diagnostic map should keep the error (higher severity)
+        let diags = [
+            ValidationDiagnostic(
+                line: 1, column: 1, message: "just a warning",
+                severity: .warning, source: "yamllint"
+            ),
+            ValidationDiagnostic(
+                line: 1, column: 5, message: "critical error",
+                severity: .error, source: "yamllint"
+            )
+        ]
+        view.validationDiagnostics = diags
+        // The view stores all diagnostics, but internal map picks highest severity
+        #expect(view.validationDiagnostics.count == 2)
+    }
+
+    @Test func diagnosticsReplacedOnNewSet() {
+        let (view, _) = makeView()
+        let first = [
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "first",
+                severity: .error, source: "yamllint"
+            )
+        ]
+        let second = [
+            ValidationDiagnostic(
+                line: 2, column: nil, message: "second",
+                severity: .warning, source: "shellcheck"
+            )
+        ]
+        view.validationDiagnostics = first
+        #expect(view.validationDiagnostics.count == 1)
+        #expect(view.validationDiagnostics[0].line == 1)
+
+        view.validationDiagnostics = second
+        #expect(view.validationDiagnostics.count == 1)
+        #expect(view.validationDiagnostics[0].line == 2)
+    }
+
+    @Test func diagnosticsWithAllSeverities() {
+        let (view, _) = makeView(text: "a\nb\nc\nd\ne")
+        let diags = [
+            ValidationDiagnostic(line: 1, column: nil, message: "err", severity: .error, source: "test"),
+            ValidationDiagnostic(line: 2, column: nil, message: "warn", severity: .warning, source: "test"),
+            ValidationDiagnostic(line: 3, column: nil, message: "info", severity: .info, source: "test")
+        ]
+        view.validationDiagnostics = diags
+        #expect(view.validationDiagnostics.count == 3)
+    }
+
+    // MARK: - Combined with lineDiffs
+
+    @Test func diagnosticsAndDiffsCoexist() {
+        let (view, _) = makeView()
+        view.lineDiffs = [GitLineDiff(line: 1, kind: .added)]
+        view.validationDiagnostics = [
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "error here",
+                severity: .error, source: "yamllint"
+            )
+        ]
+        // Both should be present independently
+        #expect(view.lineDiffs.count == 1)
+        #expect(view.validationDiagnostics.count == 1)
+    }
+
+    // MARK: - Combined with fold state
+
+    @Test func diagnosticsAndFoldsCoexist() {
+        let (view, _) = makeView()
+        let foldable = FoldableRange(startLine: 1, endLine: 3, startCharIndex: 0, endCharIndex: 20, kind: .braces)
+        view.foldableRanges = [foldable]
+        view.validationDiagnostics = [
+            ValidationDiagnostic(
+                line: 2, column: nil, message: "inside fold",
+                severity: .warning, source: "shellcheck"
+            )
+        ]
+        #expect(view.foldableRanges.count == 1)
+        #expect(view.validationDiagnostics.count == 1)
+    }
+
+    // MARK: - Severity ordering for same-line diagnostics
+
+    @Test func infoOverriddenByWarning() {
+        let (view, _) = makeView()
+        let diags = [
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "info",
+                severity: .info, source: "test"
+            ),
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "warning",
+                severity: .warning, source: "test"
+            )
+        ]
+        view.validationDiagnostics = diags
+        // The view stores all, but the internal map should have warning for line 1
+        #expect(view.validationDiagnostics.count == 2)
+    }
+
+    @Test func warningOverriddenByError() {
+        let (view, _) = makeView()
+        let diags = [
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "warning",
+                severity: .warning, source: "test"
+            ),
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "error",
+                severity: .error, source: "test"
+            )
+        ]
+        view.validationDiagnostics = diags
+        #expect(view.validationDiagnostics.count == 2)
+    }
+
+    @Test func errorNotOverriddenByInfo() {
+        let (view, _) = makeView()
+        // Error first, then info — error should remain
+        let diags = [
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "error",
+                severity: .error, source: "test"
+            ),
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "info",
+                severity: .info, source: "test"
+            )
+        ]
+        view.validationDiagnostics = diags
+        #expect(view.validationDiagnostics.count == 2)
+    }
+
+    // MARK: - Edge cases
+
+    @Test func diagnosticOnLineZeroIsAccepted() {
+        // Some tools may report line 0 for file-level issues
+        let (view, _) = makeView()
+        let diag = ValidationDiagnostic(
+            line: 0, column: nil, message: "file-level issue",
+            severity: .error, source: "terraform"
+        )
+        view.validationDiagnostics = [diag]
+        #expect(view.validationDiagnostics.count == 1)
+    }
+
+    @Test func diagnosticBeyondFileLength() {
+        let (view, _) = makeView(text: "a\nb")
+        let diag = ValidationDiagnostic(
+            line: 999, column: nil, message: "way beyond",
+            severity: .warning, source: "test"
+        )
+        view.validationDiagnostics = [diag]
+        // Should accept it — drawing will just skip it since the line is not visible
+        #expect(view.validationDiagnostics.count == 1)
+    }
+
+    @Test func largeDiagnosticSet() {
+        let (view, _) = makeView(text: (1...100).map { "line\($0)" }.joined(separator: "\n"))
+        let diags = (1...50).map {
+            ValidationDiagnostic(
+                line: $0, column: nil, message: "diag \($0)",
+                severity: $0 % 2 == 0 ? .warning : .error, source: "test"
+            )
+        }
+        view.validationDiagnostics = diags
+        #expect(view.validationDiagnostics.count == 50)
+    }
+}


### PR DESCRIPTION
## Summary

Connects ConfigValidator diagnostics to LineNumberGutter — shows error/warning/info SF Symbol icons at diagnostic line numbers with tooltip on hover.

Closes #648

## Test plan
- [x] 15 unit tests pass
- [x] SwiftLint clean
- [ ] Manual: open .yml with yamllint installed, add invalid YAML — see markers