### PR TITLE
fix: capture editedRange via NSTextStorageDelegate for incremental highlighting

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -578,10 +578,11 @@ struct CodeEditorView: NSViewRepresentable {
             }
         }
 
-        // Set delegate now — after text and highlighting are configured,
+        // Set delegates now — after text and highlighting are configured,
         // so textDidChange won't fire during initial setup and cause a
         // re-highlight cycle that strips syntax colors (issue #556).
         textView.delegate = context.coordinator
+        textStorage.delegate = context.coordinator
 
         // Restore cursor and scroll from saved per-tab state.
         // initialCursorPosition is stored as NSRange.location (UTF-16 offset),
@@ -752,7 +753,7 @@ struct CodeEditorView: NSViewRepresentable {
         Coordinator(parent: self)
     }
 
-    class Coordinator: NSObject, NSTextViewDelegate, NSLayoutManagerDelegate {
+    class Coordinator: NSObject, NSTextViewDelegate, NSTextStorageDelegate, NSLayoutManagerDelegate {
         var parent: CodeEditorView
         var scrollView: NSScrollView?
         var lineNumberView: LineNumberView?
@@ -779,6 +780,10 @@ struct CodeEditorView: NSViewRepresentable {
         /// (and resetting the cursor) on the SwiftUI re-render that follows.
         /// Internal access for testability (`@testable import`).
         var didChangeFromTextView = false
+
+        /// Edited range captured from NSTextStorageDelegate before processEditing
+        /// resets it to NSNotFound. Used by textDidChange for incremental highlighting.
+        var pendingEditedRange: NSRange?
 
         /// Last consumed navigation request ID — prevents re-processing.
         var lastGoToID: UUID?
@@ -897,6 +902,7 @@ struct CodeEditorView: NSViewRepresentable {
             // highlighting (issue #556).
             if textChanged && textView.string != text {
                 isProgrammaticTextChange = true
+                pendingEditedRange = nil
                 textView.string = text
                 isProgrammaticTextChange = false
             }
@@ -994,6 +1000,24 @@ struct CodeEditorView: NSViewRepresentable {
             lineNumberView?.needsDisplay = true
         }
 
+        // MARK: - NSTextStorageDelegate
+
+        /// Captures editedRange before NSTextStorage.processEditing() resets it
+        /// to NSNotFound. This range is consumed by textDidChange for incremental
+        /// highlighting — without it, every edit falls back to a full re-highlight.
+        func textStorage(
+            _ textStorage: NSTextStorage,
+            didProcessEditing editedMask: NSTextStorageEditActions,
+            range editedRange: NSRange,
+            changeInLength delta: Int
+        ) {
+            // Only capture character edits from user typing (not attribute-only
+            // changes from highlighting, and not programmatic text replacement).
+            if editedMask.contains(.editedCharacters), !isProgrammaticTextChange {
+                pendingEditedRange = editedRange
+            }
+        }
+
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
 
@@ -1001,6 +1025,7 @@ struct CodeEditorView: NSViewRepresentable {
             // skip highlight scheduling — updateContentIfNeeded handles its own
             // full highlight. Only update caches that it doesn't handle.
             if isProgrammaticTextChange {
+                pendingEditedRange = nil
                 previousBracketRanges = []
                 highlightedCharRange = nil
                 reportStateChange()
@@ -1038,15 +1063,11 @@ struct CodeEditorView: NSViewRepresentable {
             // Recalculate foldable ranges (debounced — expensive operation)
             scheduleFoldRecalculation()
 
-            // Захватываем editedRange из textStorage сейчас,
-            // пока он валиден в координатах текущей версии текста
-            var editedRange: NSRange?
-            if let storage = textView.textStorage {
-                let edited = storage.editedRange
-                if edited.location != NSNotFound {
-                    editedRange = edited
-                }
-            }
+            // Consume the edited range captured by NSTextStorageDelegate.
+            // NSTextStorage.editedRange is already reset to NSNotFound by the
+            // time textDidChange fires, so we rely on pendingEditedRange instead.
+            let editedRange = pendingEditedRange
+            pendingEditedRange = nil
 
             // Skip highlighting for large files opened without syntax highlighting
             guard !parent.syntaxHighlightingDisabled else { return }

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -785,6 +785,10 @@ struct CodeEditorView: NSViewRepresentable {
         /// resets it to NSNotFound. Used by textDidChange for incremental highlighting.
         var pendingEditedRange: NSRange?
 
+        /// Change in length captured alongside pendingEditedRange from
+        /// NSTextStorageDelegate. Used for incremental lineStartsCache update.
+        var pendingChangeInLength: Int = 0
+
         /// Last consumed navigation request ID — prevents re-processing.
         var lastGoToID: UUID?
 
@@ -903,6 +907,7 @@ struct CodeEditorView: NSViewRepresentable {
             if textChanged && textView.string != text {
                 isProgrammaticTextChange = true
                 pendingEditedRange = nil
+                pendingChangeInLength = 0
                 textView.string = text
                 isProgrammaticTextChange = false
             }
@@ -1015,6 +1020,7 @@ struct CodeEditorView: NSViewRepresentable {
             // changes from highlighting, and not programmatic text replacement).
             if editedMask.contains(.editedCharacters), !isProgrammaticTextChange {
                 pendingEditedRange = editedRange
+                pendingChangeInLength = delta
             }
         }
 
@@ -1026,6 +1032,7 @@ struct CodeEditorView: NSViewRepresentable {
             // full highlight. Only update caches that it doesn't handle.
             if isProgrammaticTextChange {
                 pendingEditedRange = nil
+                pendingChangeInLength = 0
                 previousBracketRanges = []
                 highlightedCharRange = nil
                 reportStateChange()
@@ -1046,13 +1053,15 @@ struct CodeEditorView: NSViewRepresentable {
             // Report state change
             reportStateChange()
 
-            // Update line starts cache incrementally if possible, otherwise full rebuild
+            // Update line starts cache incrementally if possible, otherwise full rebuild.
+            // We use pendingEditedRange / pendingChangeInLength captured by the
+            // NSTextStorageDelegate — by the time textDidChange fires,
+            // storage.editedRange is already reset to NSNotFound.
             if var cache = lineStartsCache,
-               let storage = textView.textStorage,
-               storage.editedRange.location != NSNotFound {
+               let editRange = pendingEditedRange {
                 cache.update(
-                    editedRange: storage.editedRange,
-                    changeInLength: storage.changeInLength,
+                    editedRange: editRange,
+                    changeInLength: pendingChangeInLength,
                     in: textView.string as NSString
                 )
                 lineStartsCache = cache
@@ -1068,6 +1077,7 @@ struct CodeEditorView: NSViewRepresentable {
             // time textDidChange fires, so we rely on pendingEditedRange instead.
             let editedRange = pendingEditedRange
             pendingEditedRange = nil
+            pendingChangeInLength = 0
 
             // Skip highlighting for large files opened without syntax highlighting
             guard !parent.syntaxHighlightingDisabled else { return }

--- a/PineTests/CodeEditorCoordinatorTests.swift
+++ b/PineTests/CodeEditorCoordinatorTests.swift
@@ -345,4 +345,156 @@ struct CodeEditorCoordinatorTests {
         #expect(textView.string == "")
         #expect(textView.selectedRange().location == 0)
     }
+
+    // MARK: - Issue #649: pendingEditedRange captured via NSTextStorageDelegate
+
+    @Test func pendingEditedRange_capturedByTextStorageDelegate() {
+        let text = "key: value"
+        let (scrollView, _) = makeTextStack(text: text)
+        guard let textView = scrollView.documentView as? NSTextView else {
+            Issue.record("Failed to get NSTextView from scroll view")
+            return
+        }
+
+        let editorView = CodeEditorView(
+            text: .constant(text),
+            contentVersion: 0,
+            language: "yaml",
+            fileName: "test.yaml",
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: editorView)
+        coordinator.scrollView = scrollView
+
+        // Wire up NSTextStorageDelegate
+        textView.textStorage?.delegate = coordinator
+
+        // Initially nil
+        #expect(coordinator.pendingEditedRange == nil)
+
+        // Simulate typing: insert a character
+        textView.textStorage?.beginEditing()
+        textView.textStorage?.replaceCharacters(
+            in: NSRange(location: 10, length: 0), with: "s"
+        )
+        textView.textStorage?.endEditing()
+
+        // pendingEditedRange should have been captured by the delegate
+        #expect(coordinator.pendingEditedRange != nil,
+                "NSTextStorageDelegate must capture editedRange before it resets")
+        #expect(coordinator.pendingEditedRange?.location == 10,
+                "Captured range must start at the insertion point")
+    }
+
+    @Test func pendingEditedRange_consumedByTextDidChange() {
+        let text = "name: test"
+        let (scrollView, _) = makeTextStack(text: text)
+        guard let textView = scrollView.documentView as? NSTextView else {
+            Issue.record("Failed to get NSTextView from scroll view")
+            return
+        }
+
+        let editorView = CodeEditorView(
+            text: .constant(text),
+            contentVersion: 0,
+            language: "yaml",
+            fileName: "test.yaml",
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: editorView)
+        coordinator.scrollView = scrollView
+        coordinator.syncContentVersion()
+
+        // Set up delegates
+        textView.delegate = coordinator
+        textView.textStorage?.delegate = coordinator
+
+        // Pre-set a pending range (simulating what the delegate would capture)
+        coordinator.pendingEditedRange = NSRange(location: 5, length: 1)
+
+        // Fire textDidChange — it should consume pendingEditedRange
+        NotificationCenter.default.post(
+            name: NSText.didChangeNotification, object: textView
+        )
+
+        #expect(coordinator.pendingEditedRange == nil,
+                "textDidChange must consume pendingEditedRange")
+    }
+
+    @Test func pendingEditedRange_clearedOnProgrammaticTextChange() {
+        let text = "hello"
+        let (scrollView, _) = makeTextStack(text: text)
+        guard let textView = scrollView.documentView as? NSTextView else {
+            Issue.record("Failed to get NSTextView from scroll view")
+            return
+        }
+
+        let editorView = CodeEditorView(
+            text: .constant(text),
+            contentVersion: 0,
+            language: "txt",
+            fileName: "test.txt",
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: editorView)
+        coordinator.scrollView = scrollView
+        coordinator.syncContentVersion()
+        textView.delegate = coordinator
+        textView.textStorage?.delegate = coordinator
+
+        // Set a pending range and mark as programmatic change
+        coordinator.pendingEditedRange = NSRange(location: 0, length: 5)
+
+        // Simulate programmatic text replacement (as in updateContentIfNeeded)
+        let updatedEditor = CodeEditorView(
+            text: .constant("world"),
+            contentVersion: 1,
+            language: "txt",
+            fileName: "test.txt",
+            foldState: .constant(FoldState())
+        )
+        coordinator.parent = updatedEditor
+
+        coordinator.updateContentIfNeeded(
+            text: "world", language: "txt", fileName: "test.txt", font: font
+        )
+
+        // After programmatic text change, pendingEditedRange should be cleared
+        // (the textDidChange handler clears it when isProgrammaticTextChange is true)
+        #expect(coordinator.pendingEditedRange == nil,
+                "pendingEditedRange must be cleared after programmatic text change")
+    }
+
+    @Test func pendingEditedRange_notSetForAttributeOnlyEdits() {
+        let text = "key: value"
+        let (scrollView, _) = makeTextStack(text: text)
+        guard let textView = scrollView.documentView as? NSTextView else {
+            Issue.record("Failed to get NSTextView from scroll view")
+            return
+        }
+
+        let editorView = CodeEditorView(
+            text: .constant(text),
+            contentVersion: 0,
+            language: "yaml",
+            fileName: "test.yaml",
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: editorView)
+        coordinator.scrollView = scrollView
+        textView.textStorage?.delegate = coordinator
+
+        // Attribute-only edit (like syntax highlighting applying colors)
+        textView.textStorage?.beginEditing()
+        textView.textStorage?.addAttribute(
+            .foregroundColor,
+            value: NSColor.red,
+            range: NSRange(location: 0, length: 3)
+        )
+        textView.textStorage?.endEditing()
+
+        // pendingEditedRange should NOT be set for attribute-only edits
+        #expect(coordinator.pendingEditedRange == nil,
+                "Attribute-only edits must not set pendingEditedRange")
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes #649 — syntax highlighting disappears when editing YAML (and other files)
- Root cause: `NSTextStorage.editedRange` resets to `NSNotFound` after `processEditing()`, but `textDidChange` fires *after* `processEditing`. So `editedRange` was always `nil`, forcing every keystroke to use full re-highlight instead of incremental `highlightEditedAsync`
- For files >50KB (viewport-based highlighting), this caused visible highlight disappearance during editing
- Fix: Coordinator now implements `NSTextStorageDelegate` and captures `editedRange` in `textStorage(_:didProcessEditing:range:changeInLength:)` before it resets. `textDidChange` consumes this `pendingEditedRange` for proper incremental highlighting

## Test plan
- [x] `pendingEditedRange_capturedByTextStorageDelegate` — verifies delegate captures range on character edits
- [x] `pendingEditedRange_consumedByTextDidChange` — verifies textDidChange consumes and clears the range
- [x] `pendingEditedRange_clearedOnProgrammaticTextChange` — verifies range is cleared during programmatic text replacement
- [x] `pendingEditedRange_notSetForAttributeOnlyEdits` — verifies attribute-only edits (highlighting) don't set the range
- [x] All existing CodeEditorCoordinatorTests pass
- [x] All HighlightPersistenceTests pass
- [x] SwiftLint clean