### PR TITLE
fix: prevent blank terminal by deferring PTY start until non-zero size

### DIFF
--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -84,6 +84,11 @@ struct TerminalContentView: NSViewRepresentable {
 /// With internal editor tabs there is only one window,
 /// so no multi-window reclaim logic is needed.
 class TerminalContainerView: NSView {
+    /// Default frame used when the container has zero bounds (e.g. before the first
+    /// SwiftUI layout pass). Gives SwiftTerm a reasonable cols/rows so the terminal
+    /// is not blank when it first appears. The real size replaces this in `layout()`.
+    static let defaultTerminalFrame = NSRect(x: 0, y: 0, width: 800, height: 300)
+
     var terminal: TerminalManager?
     private var currentTabID: UUID?
     private let scrollInterceptor = TerminalScrollInterceptor()
@@ -102,7 +107,7 @@ class TerminalContainerView: NSView {
             subviews.forEach { $0.removeFromSuperview() }
             currentTabID = tab.id
             let effectiveBounds = bounds.size.width > 0 && bounds.size.height > 0
-                ? bounds : NSRect(x: 0, y: 0, width: 800, height: 300)
+                ? bounds : Self.defaultTerminalFrame
             tab.terminalView.frame = effectiveBounds
             addSubview(tab.terminalView)
 
@@ -233,6 +238,9 @@ class TerminalContainerView: NSView {
         // terminal which renders as a blank screen (issue #661).
         guard bounds.size.width > 0, bounds.size.height > 0 else { return }
         if tab.terminalView.superview === self {
+            // Terminal view is already in the hierarchy — just update its frame.
+            // Only set needsDisplay when the size actually changed to avoid
+            // redundant redraws on no-op layout passes.
             let sizeChanged = tab.terminalView.frame.size != bounds.size
             tab.terminalView.frame = bounds
             tab.terminalView.needsLayout = true
@@ -245,6 +253,9 @@ class TerminalContainerView: NSView {
             }
             tab.startIfNeeded()
         } else {
+            // Terminal view was removed (e.g. tab switch race) — re-add it.
+            // Always set needsDisplay here because showTab just inserted a fresh
+            // subview that has never been drawn at this container's size.
             showTab(tab)
             tab.terminalView.needsLayout = true
             tab.terminalView.needsDisplay = true
@@ -293,7 +304,7 @@ final class TerminalTab: Identifiable, Hashable {
     init(name: String, shellSettings: ShellSettings = .shared) {
         self.name = name
         self.shellSettings = shellSettings
-        self.terminalView = LocalProcessTerminalView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        self.terminalView = LocalProcessTerminalView(frame: TerminalContainerView.defaultTerminalFrame)
         self.delegate = TerminalTabDelegate()
         self.delegate.tab = self
         self.terminalView.processDelegate = self.delegate

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -101,11 +101,13 @@ class TerminalContainerView: NSView {
         if tabChanged {
             subviews.forEach { $0.removeFromSuperview() }
             currentTabID = tab.id
-            tab.terminalView.frame = bounds
+            let effectiveBounds = bounds.size.width > 0 && bounds.size.height > 0
+                ? bounds : NSRect(x: 0, y: 0, width: 800, height: 300)
+            tab.terminalView.frame = effectiveBounds
             addSubview(tab.terminalView)
 
             // Place click interceptor on top of the terminal view
-            scrollInterceptor.frame = bounds
+            scrollInterceptor.frame = effectiveBounds
             scrollInterceptor.terminalView = tab.terminalView
             addSubview(scrollInterceptor)
         }
@@ -226,14 +228,26 @@ class TerminalContainerView: NSView {
     override func layout() {
         super.layout()
         guard let terminal, let tab = terminal.activeTerminalTab else { return }
+        // Do not start the process or update frames until the container has a real size.
+        // SwiftTerm derives cols/rows from the frame; a zero-size frame produces a 0×0
+        // terminal which renders as a blank screen (issue #661).
+        guard bounds.size.width > 0, bounds.size.height > 0 else { return }
         if tab.terminalView.superview === self {
+            let sizeChanged = tab.terminalView.frame.size != bounds.size
             tab.terminalView.frame = bounds
             tab.terminalView.needsLayout = true
             scrollInterceptor.frame = bounds
+            if sizeChanged {
+                // Force SwiftTerm to recalculate cols/rows and re-render.
+                // This handles the transition from a placeholder frame to the
+                // real container size, ensuring the PTY gets the correct window size.
+                tab.terminalView.needsDisplay = true
+            }
             tab.startIfNeeded()
         } else {
             showTab(tab)
             tab.terminalView.needsLayout = true
+            tab.terminalView.needsDisplay = true
             tab.startIfNeeded()
         }
     }
@@ -347,9 +361,14 @@ final class TerminalTab: Identifiable, Hashable {
         workingDirectory?.path ?? (ProcessInfo.processInfo.environment["HOME"] ?? "/")
     }
 
-    /// Запускает процесс если ещё не запущен и view добавлен в иерархию
+    /// Запускает процесс если ещё не запущен и view добавлен в иерархию.
+    /// The terminal view must have a non-zero frame so SwiftTerm can calculate
+    /// the correct column/row count for the PTY. Starting with a zero frame
+    /// causes a blank terminal (issue #661).
     func startIfNeeded() {
         guard !processStarted else { return }
+        guard terminalView.frame.size.width > 0,
+              terminalView.frame.size.height > 0 else { return }
         processStarted = true
 
         let env = buildEnvironment()

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -464,4 +464,126 @@ struct TerminalTabTests {
         container.showTab(manager.activeTerminalTab)
         #expect(manager.pendingFocusTabID == nil)
     }
+
+    // MARK: - Blank terminal fix (issue #661)
+
+    @Test("startIfNeeded does not start with zero-size frame")
+    func startIfNeededGuardsZeroFrame() {
+        // Terminal created with default 800×300 frame
+        let tab = TerminalTab(name: "test")
+        // Override to zero to simulate the bug scenario
+        tab.terminalView.frame = .zero
+        tab.configure(workingDirectory: nil)
+        tab.startIfNeeded()
+        // Process should NOT have started because frame is zero
+        #expect(!tab.isProcessRunning)
+    }
+
+    @Test("startIfNeeded does not start with zero-width frame")
+    func startIfNeededGuardsZeroWidth() {
+        let tab = TerminalTab(name: "test")
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 0, height: 300)
+        tab.configure(workingDirectory: nil)
+        tab.startIfNeeded()
+        #expect(!tab.isProcessRunning)
+    }
+
+    @Test("startIfNeeded does not start with zero-height frame")
+    func startIfNeededGuardsZeroHeight() {
+        let tab = TerminalTab(name: "test")
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 800, height: 0)
+        tab.configure(workingDirectory: nil)
+        tab.startIfNeeded()
+        #expect(!tab.isProcessRunning)
+    }
+
+    @Test("startIfNeeded can be retried after frame becomes non-zero")
+    func startIfNeededRetriesAfterResize() {
+        let tab = TerminalTab(name: "test")
+        tab.terminalView.frame = .zero
+        tab.configure(workingDirectory: nil)
+        tab.startIfNeeded()
+        #expect(!tab.isProcessRunning)
+
+        // Now give it a real frame and try again
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        tab.startIfNeeded()
+        // Process should have started now
+        #expect(tab.isProcessRunning)
+    }
+
+    @Test("showTab uses fallback bounds when container has zero bounds")
+    func showTabFallbackBoundsOnZeroContainer() {
+        let container = TerminalContainerView(frame: .zero)
+        let tab = TerminalTab(name: "test")
+        container.showTab(tab)
+
+        // Terminal view should get a fallback frame (800×300), not zero
+        #expect(tab.terminalView.frame.size.width == 800)
+        #expect(tab.terminalView.frame.size.height == 300)
+    }
+
+    @Test("showTab uses container bounds when non-zero")
+    func showTabUsesRealBounds() {
+        let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 1024, height: 768))
+        let tab = TerminalTab(name: "test")
+        container.showTab(tab)
+
+        #expect(tab.terminalView.frame.size.width == 1024)
+        #expect(tab.terminalView.frame.size.height == 768)
+    }
+
+    @Test("layout with zero bounds does not start process")
+    func layoutZeroBoundsDoesNotStart() throws {
+        let manager = TerminalManager()
+        manager.startTerminals(workingDirectory: nil)
+        let tab = try #require(manager.activeTerminalTab)
+        // Give terminal view a zero frame to simulate the issue
+        tab.terminalView.frame = .zero
+
+        let container = TerminalContainerView(frame: .zero)
+        container.terminal = manager
+        container.showTab(tab)
+
+        // Trigger layout with zero bounds
+        container.layout()
+
+        // Process should NOT have started
+        #expect(!tab.isProcessRunning)
+    }
+
+    @Test("layout with non-zero bounds starts process")
+    func layoutNonZeroBoundsStartsProcess() throws {
+        let manager = TerminalManager()
+        manager.startTerminals(workingDirectory: nil)
+
+        let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        container.terminal = manager
+        container.showTab(manager.activeTerminalTab)
+
+        // Trigger layout with valid bounds
+        container.layout()
+
+        let tab = try #require(manager.activeTerminalTab)
+        #expect(tab.isProcessRunning)
+    }
+
+    @Test("layout updates terminal view frame to match container bounds")
+    func layoutUpdatesFrame() throws {
+        let manager = TerminalManager()
+        manager.startTerminals(workingDirectory: nil)
+
+        let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        container.terminal = manager
+        container.showTab(manager.activeTerminalTab)
+        container.layout()
+
+        // Now resize container
+        container.frame = NSRect(x: 0, y: 0, width: 1200, height: 600)
+        container.layout()
+
+        let tab = try #require(manager.activeTerminalTab)
+        #expect(tab.terminalView.frame.size.width == 1200)
+        #expect(tab.terminalView.frame.size.height == 600)
+    }
 }

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -14,7 +14,7 @@ struct TerminalTabTests {
 
     // MARK: - TerminalTab lifecycle
 
-    @Test func terminalTabInitialState() {
+    @Test @MainActor func terminalTabInitialState() {
         let tab = TerminalTab(name: "zsh")
         #expect(tab.name == "zsh")
         #expect(tab.isTerminated == false)
@@ -22,20 +22,20 @@ struct TerminalTabTests {
         #expect(tab.currentMatchIndex == -1)
     }
 
-    @Test func terminalTabsHaveUniqueIDs() {
+    @Test @MainActor func terminalTabsHaveUniqueIDs() {
         let tab1 = TerminalTab(name: "tab1")
         let tab2 = TerminalTab(name: "tab2")
         #expect(tab1.id != tab2.id)
         #expect(tab1 != tab2)
     }
 
-    @Test func terminalTabHashable() {
+    @Test @MainActor func terminalTabHashable() {
         let tab = TerminalTab(name: "test")
         var set: Set<TerminalTab> = [tab, tab]
         #expect(set.count == 1)
     }
 
-    @Test func stopSetsTerminatedIdempotently() {
+    @Test @MainActor func stopSetsTerminatedIdempotently() {
         let tab = TerminalTab(name: "test")
         tab.stop()
         #expect(tab.isTerminated == true)
@@ -45,19 +45,19 @@ struct TerminalTabTests {
 
     // MARK: - Search navigation with empty matches
 
-    @Test func nextMatchNoOpWithoutMatches() {
+    @Test @MainActor func nextMatchNoOpWithoutMatches() {
         let tab = TerminalTab(name: "test")
         tab.nextMatch()
         #expect(tab.currentMatchIndex == -1)
     }
 
-    @Test func previousMatchNoOpWithoutMatches() {
+    @Test @MainActor func previousMatchNoOpWithoutMatches() {
         let tab = TerminalTab(name: "test")
         tab.previousMatch()
         #expect(tab.currentMatchIndex == -1)
     }
 
-    @Test func clearSearchResetsState() {
+    @Test @MainActor func clearSearchResetsState() {
         let tab = TerminalTab(name: "test")
         tab.clearSearch()
         #expect(tab.searchMatches.isEmpty)
@@ -72,7 +72,7 @@ struct TerminalTabTests {
         #expect(container.subviews.isEmpty)
     }
 
-    @Test func showTabAddsTerminalView() {
+    @Test @MainActor func showTabAddsTerminalView() {
         let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
         let tab = TerminalTab(name: "test")
         container.showTab(tab)
@@ -81,7 +81,7 @@ struct TerminalTabTests {
         #expect(container.subviews.count == 2)
     }
 
-    @Test func showSameTabTwiceIsNoOp() {
+    @Test @MainActor func showSameTabTwiceIsNoOp() {
         let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
         let tab = TerminalTab(name: "test")
         container.showTab(tab)
@@ -90,7 +90,7 @@ struct TerminalTabTests {
         #expect(container.subviews.contains(tab.terminalView))
     }
 
-    @Test func switchTabsReplacesSubview() {
+    @Test @MainActor func switchTabsReplacesSubview() {
         let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
         let tab1 = TerminalTab(name: "tab1")
         let tab2 = TerminalTab(name: "tab2")
@@ -104,7 +104,7 @@ struct TerminalTabTests {
 
     // MARK: - TerminalContainerView scroll monitor lifecycle
 
-    @Test func showTabNilClearsScrollInterceptorTerminalView() {
+    @Test @MainActor func showTabNilClearsScrollInterceptorTerminalView() {
         let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
         let tab = TerminalTab(name: "test")
         container.showTab(tab)
@@ -113,7 +113,7 @@ struct TerminalTabTests {
         #expect(container.subviews.isEmpty)
     }
 
-    @Test func showTabSetsInterceptorFrameToContainerBounds() {
+    @Test @MainActor func showTabSetsInterceptorFrameToContainerBounds() {
         let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
         let tab = TerminalTab(name: "test")
         container.showTab(tab)
@@ -123,14 +123,14 @@ struct TerminalTabTests {
         #expect(interceptor?.frame == container.bounds)
     }
 
-    @Test func showTabSetsTerminalViewFrameToContainerBounds() {
+    @Test @MainActor func showTabSetsTerminalViewFrameToContainerBounds() {
         let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
         let tab = TerminalTab(name: "test")
         container.showTab(tab)
         #expect(tab.terminalView.frame == container.bounds)
     }
 
-    @Test func containerViewSubviewOrderIsTerminalThenInterceptor() {
+    @Test @MainActor func containerViewSubviewOrderIsTerminalThenInterceptor() {
         let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
         let tab = TerminalTab(name: "test")
         container.showTab(tab)
@@ -140,7 +140,7 @@ struct TerminalTabTests {
         #expect(container.subviews[1] is TerminalScrollInterceptor)
     }
 
-    @Test func removeFromSuperviewCleansUpContainer() {
+    @Test @MainActor func removeFromSuperviewCleansUpContainer() {
         let parent = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
         let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
         parent.addSubview(container)
@@ -153,7 +153,7 @@ struct TerminalTabTests {
         #expect(container.superview == nil)
     }
 
-    @Test func switchingTabsUpdatesInterceptorTerminalView() {
+    @Test @MainActor func switchingTabsUpdatesInterceptorTerminalView() {
         let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
         let tab1 = TerminalTab(name: "tab1")
         let tab2 = TerminalTab(name: "tab2")
@@ -221,7 +221,7 @@ struct TerminalTabTests {
 
     // MARK: - TerminalTabDelegate
 
-    @Test func delegateSetTerminalTitle() {
+    @Test @MainActor func delegateSetTerminalTitle() {
         let delegate = TerminalTabDelegate()
         let tab = TerminalTab(name: "original")
         delegate.tab = tab
@@ -230,7 +230,7 @@ struct TerminalTabTests {
         #expect(tab.name == "new title")
     }
 
-    @Test func delegateProcessTerminatedSetsFlag() {
+    @Test @MainActor func delegateProcessTerminatedSetsFlag() {
         let delegate = TerminalTabDelegate()
         let tab = TerminalTab(name: "test")
         delegate.tab = tab
@@ -239,7 +239,7 @@ struct TerminalTabTests {
         #expect(tab.isTerminated == true)
     }
 
-    @Test func delegateProcessTerminatedWithNonZeroExitCode() {
+    @Test @MainActor func delegateProcessTerminatedWithNonZeroExitCode() {
         let delegate = TerminalTabDelegate()
         let tab = TerminalTab(name: "test")
         delegate.tab = tab
@@ -285,9 +285,7 @@ struct TerminalTabTests {
         ))
     }
 
-    @Test("mouseDown on interceptor makes terminal view first responder")
-    @MainActor
-    func mouseDownOnInterceptorFocusesTerminalView() throws {
+    @Test @MainActor func mouseDownOnInterceptorFocusesTerminalView() throws {
         let interceptor = TerminalScrollInterceptor()
         interceptor.frame = NSRect(x: 0, y: 0, width: 800, height: 600)
         let terminalView = LocalProcessTerminalView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
@@ -304,9 +302,7 @@ struct TerminalTabTests {
         #expect(window.firstResponder === terminalView)
     }
 
-    @Test("mouseDown with nil terminalView does not crash")
-    @MainActor
-    func mouseDownWithNilTerminalViewSafe() throws {
+    @Test @MainActor func mouseDownWithNilTerminalViewSafe() throws {
         let interceptor = TerminalScrollInterceptor()
         interceptor.frame = NSRect(x: 0, y: 0, width: 800, height: 600)
         interceptor.terminalView = nil
@@ -322,9 +318,7 @@ struct TerminalTabTests {
         #expect(window.firstResponder !== interceptor)
     }
 
-    @Test("rightMouseDown on interceptor makes terminal view first responder")
-    @MainActor
-    func rightMouseDownOnInterceptorFocusesTerminalView() throws {
+    @Test @MainActor func rightMouseDownOnInterceptorFocusesTerminalView() throws {
         let interceptor = TerminalScrollInterceptor()
         interceptor.frame = NSRect(x: 0, y: 0, width: 800, height: 600)
         let terminalView = LocalProcessTerminalView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
@@ -351,9 +345,7 @@ struct TerminalTabTests {
         #expect(window.firstResponder === terminalView)
     }
 
-    @Test("click-to-focus works for first tab without pendingFocusTabID (the bug scenario)")
-    @MainActor
-    func clickToFocusFirstTab() throws {
+    @Test @MainActor func clickToFocusFirstTab() throws {
         let manager = TerminalManager()
         manager.startTerminals(workingDirectory: nil)
         // After startTerminals, pendingFocusTabID is nil — this is the bug scenario
@@ -378,9 +370,7 @@ struct TerminalTabTests {
         #expect(window.firstResponder === activeTab.terminalView)
     }
 
-    @Test("focus works after tab switch without pendingFocusTabID")
-    @MainActor
-    func focusAfterTabSwitchViaClick() throws {
+    @Test @MainActor func focusAfterTabSwitchViaClick() throws {
         let manager = TerminalManager()
         manager.startTerminals(workingDirectory: nil)
 
@@ -416,9 +406,7 @@ struct TerminalTabTests {
 
     // MARK: - pendingFocusTabID consumption
 
-    @Test("showTab consumes pendingFocusTabID for matching tab")
-    @MainActor
-    func showTabConsumesPendingFocus() throws {
+    @Test @MainActor func showTabConsumesPendingFocus() throws {
         let manager = TerminalManager()
         manager.startTerminals(workingDirectory: nil)
         manager.addTerminalTab(workingDirectory: nil)
@@ -432,9 +420,7 @@ struct TerminalTabTests {
         #expect(manager.pendingFocusTabID == nil)
     }
 
-    @Test("showTab does NOT consume pendingFocusTabID for wrong tab")
-    @MainActor
-    func showTabDoesNotConsumeMismatchedPendingFocus() throws {
+    @Test @MainActor func showTabDoesNotConsumeMismatchedPendingFocus() throws {
         let manager = TerminalManager()
         manager.startTerminals(workingDirectory: nil)
         manager.addTerminalTab(workingDirectory: nil)
@@ -451,9 +437,7 @@ struct TerminalTabTests {
         #expect(manager.pendingFocusTabID == newTab.id)
     }
 
-    @Test("showTab without pending focus does not crash")
-    @MainActor
-    func showTabWithoutPendingFocusNoCrash() {
+    @Test @MainActor func showTabWithoutPendingFocusNoCrash() {
         let manager = TerminalManager()
         manager.startTerminals(workingDirectory: nil)
         #expect(manager.pendingFocusTabID == nil)
@@ -467,8 +451,7 @@ struct TerminalTabTests {
 
     // MARK: - Blank terminal fix (issue #661)
 
-    @Test("startIfNeeded does not start with zero-size frame")
-    func startIfNeededGuardsZeroFrame() {
+    @Test @MainActor func startIfNeededGuardsZeroFrame() {
         // Terminal created with default 800×300 frame
         let tab = TerminalTab(name: "test")
         // Override to zero to simulate the bug scenario
@@ -479,8 +462,7 @@ struct TerminalTabTests {
         #expect(!tab.isProcessRunning)
     }
 
-    @Test("startIfNeeded does not start with zero-width frame")
-    func startIfNeededGuardsZeroWidth() {
+    @Test @MainActor func startIfNeededGuardsZeroWidth() {
         let tab = TerminalTab(name: "test")
         tab.terminalView.frame = NSRect(x: 0, y: 0, width: 0, height: 300)
         tab.configure(workingDirectory: nil)
@@ -488,8 +470,7 @@ struct TerminalTabTests {
         #expect(!tab.isProcessRunning)
     }
 
-    @Test("startIfNeeded does not start with zero-height frame")
-    func startIfNeededGuardsZeroHeight() {
+    @Test @MainActor func startIfNeededGuardsZeroHeight() {
         let tab = TerminalTab(name: "test")
         tab.terminalView.frame = NSRect(x: 0, y: 0, width: 800, height: 0)
         tab.configure(workingDirectory: nil)
@@ -497,8 +478,7 @@ struct TerminalTabTests {
         #expect(!tab.isProcessRunning)
     }
 
-    @Test("startIfNeeded can be retried after frame becomes non-zero")
-    func startIfNeededRetriesAfterResize() {
+    @Test @MainActor func startIfNeededRetriesAfterResize() {
         let tab = TerminalTab(name: "test")
         tab.terminalView.frame = .zero
         tab.configure(workingDirectory: nil)
@@ -512,19 +492,18 @@ struct TerminalTabTests {
         #expect(tab.isProcessRunning)
     }
 
-    @Test("showTab uses fallback bounds when container has zero bounds")
-    func showTabFallbackBoundsOnZeroContainer() {
+    @Test @MainActor func showTabFallbackBoundsOnZeroContainer() {
         let container = TerminalContainerView(frame: .zero)
         let tab = TerminalTab(name: "test")
         container.showTab(tab)
 
-        // Terminal view should get a fallback frame (800×300), not zero
-        #expect(tab.terminalView.frame.size.width == 800)
-        #expect(tab.terminalView.frame.size.height == 300)
+        // Terminal view should get the default fallback frame, not zero
+        let fallback = TerminalContainerView.defaultTerminalFrame
+        #expect(tab.terminalView.frame.size.width == fallback.size.width)
+        #expect(tab.terminalView.frame.size.height == fallback.size.height)
     }
 
-    @Test("showTab uses container bounds when non-zero")
-    func showTabUsesRealBounds() {
+    @Test @MainActor func showTabUsesRealBounds() {
         let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 1024, height: 768))
         let tab = TerminalTab(name: "test")
         container.showTab(tab)
@@ -533,8 +512,7 @@ struct TerminalTabTests {
         #expect(tab.terminalView.frame.size.height == 768)
     }
 
-    @Test("layout with zero bounds does not start process")
-    func layoutZeroBoundsDoesNotStart() throws {
+    @Test @MainActor func layoutZeroBoundsDoesNotStart() throws {
         let manager = TerminalManager()
         manager.startTerminals(workingDirectory: nil)
         let tab = try #require(manager.activeTerminalTab)
@@ -552,8 +530,7 @@ struct TerminalTabTests {
         #expect(!tab.isProcessRunning)
     }
 
-    @Test("layout with non-zero bounds starts process")
-    func layoutNonZeroBoundsStartsProcess() throws {
+    @Test @MainActor func layoutNonZeroBoundsStartsProcess() throws {
         let manager = TerminalManager()
         manager.startTerminals(workingDirectory: nil)
 
@@ -568,8 +545,7 @@ struct TerminalTabTests {
         #expect(tab.isProcessRunning)
     }
 
-    @Test("layout updates terminal view frame to match container bounds")
-    func layoutUpdatesFrame() throws {
+    @Test @MainActor func layoutUpdatesFrame() throws {
         let manager = TerminalManager()
         manager.startTerminals(workingDirectory: nil)
 
@@ -585,5 +561,35 @@ struct TerminalTabTests {
         let tab = try #require(manager.activeTerminalTab)
         #expect(tab.terminalView.frame.size.width == 1200)
         #expect(tab.terminalView.frame.size.height == 600)
+    }
+
+    @Test @MainActor func processStartsWithFallbackFrameAfterShowTabOnZeroContainer() throws {
+        // Integration test: showTab on a zero-bounds container uses the fallback
+        // frame, and a subsequent layout with real bounds starts the process.
+        let manager = TerminalManager()
+        manager.startTerminals(workingDirectory: nil)
+        let tab = try #require(manager.activeTerminalTab)
+
+        // Container starts with zero bounds (simulates first SwiftUI layout pass)
+        let container = TerminalContainerView(frame: .zero)
+        container.terminal = manager
+        container.showTab(tab)
+
+        // showTab should have used the fallback frame
+        let fallback = TerminalContainerView.defaultTerminalFrame
+        #expect(tab.terminalView.frame.size.width == fallback.size.width)
+        #expect(tab.terminalView.frame.size.height == fallback.size.height)
+
+        // Process should NOT be running yet (layout hasn't happened with real bounds)
+        #expect(!tab.isProcessRunning)
+
+        // Simulate the container getting a real size from SwiftUI
+        container.frame = NSRect(x: 0, y: 0, width: 1024, height: 768)
+        container.layout()
+
+        // Now the process should have started with the real frame
+        #expect(tab.isProcessRunning)
+        #expect(tab.terminalView.frame.size.width == 1024)
+        #expect(tab.terminalView.frame.size.height == 768)
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #661: Terminal tab intermittently renders completely blank (black screen)
- Root cause: race condition where shell process starts before `TerminalContainerView` gets a non-zero frame from SwiftUI layout, causing SwiftTerm to calculate 0 cols/rows for the PTY
- `startIfNeeded()` now guards against zero-width/height frames, deferring process start until the next `layout()` pass
- `showTab()` uses a fallback 800x300 frame when container bounds are zero
- `layout()` skips processing when bounds are zero and forces `needsDisplay` on size changes to ensure SwiftTerm recalculates cols/rows
- Adds 10 new unit tests covering all edge cases of the fix

## Test plan
- [x] All 2295 existing unit tests pass
- [x] 10 new tests for zero-size guards, fallback bounds, layout behavior, and retry-after-resize
- [x] SwiftLint: 0 violations
- [ ] Manual: open Pine, toggle terminal on/off rapidly, verify no blank screen
- [ ] Manual: open multiple terminal tabs in quick succession