### PR TITLE
feat: show inline diff on gutter click instead of always visible

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -46,6 +46,14 @@ final class GutterTextView: NSTextView {
     /// Blocks of deleted lines to render as phantom text above the anchor line (red background).
     var deletedLineBlocks: [DeletedLinesBlock] = []
 
+    /// The diff hunks for the current file — used to filter highlights to the expanded hunk only.
+    var diffHunksForHighlight: [DiffHunk] = []
+
+    /// The ID of the currently expanded hunk (shows inline diff). Nil = all collapsed.
+    var expandedHunkID: UUID? {
+        didSet { needsDisplay = true }
+    }
+
     /// Subtle green tint for added lines.
     private static let addedLineColor = NSColor(name: nil) { appearance in
         if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
@@ -149,10 +157,15 @@ final class GutterTextView: NSTextView {
         // ── Indent guides (behind everything else) ──
         IndentGuideRenderer.draw(in: self, dirtyRect: rect, indentStyle: indentStyle)
 
-        // ── Inline diff: green background on added lines, red phantom blocks for deleted lines ──
-        let hasDiffHighlights = !addedLineNumbers.isEmpty || !deletedLineBlocks.isEmpty
-        if hasDiffHighlights {
-            drawInlineDiffHighlights(in: rect, layoutManager: layoutManager, textContainer: textContainer)
+        // ── Inline diff: only shown when a hunk is expanded via gutter click ──
+        if let expandedID = expandedHunkID,
+           let expandedHunk = diffHunksForHighlight.first(where: { $0.id == expandedID }) {
+            drawInlineDiffHighlights(
+                in: rect,
+                layoutManager: layoutManager,
+                textContainer: textContainer,
+                expandedHunk: expandedHunk
+            )
         }
 
         let cursorRange = selectedRange()
@@ -177,10 +190,12 @@ final class GutterTextView: NSTextView {
     // MARK: - Inline diff drawing
 
     /// Draws green background highlights on added lines and red phantom blocks for deleted lines.
+    /// Only draws highlights for the given expanded hunk.
     private func drawInlineDiffHighlights(
         in rect: NSRect,
         layoutManager: NSLayoutManager,
-        textContainer: NSTextContainer
+        textContainer: NSTextContainer,
+        expandedHunk: DiffHunk
     ) {
         guard let scrollView = enclosingScrollView else { return }
         let visibleRect = scrollView.contentView.bounds
@@ -204,10 +219,14 @@ final class GutterTextView: NSTextView {
             lineNumber += 1
         }
 
-        // Build lookup: anchor line → array of deleted blocks (handles multiple blocks at same anchor)
-        let deletedAnchorSet = Set(deletedLineBlocks.map(\.anchorLine))
+        // Filter to only the expanded hunk's added lines and deleted blocks
+        let hunkAddedLines = InlineDiffProvider.addedLineNumbers(from: [expandedHunk])
+        let hunkDeletedBlocks = InlineDiffProvider.deletedLineBlocks(from: [expandedHunk])
+
+        // Build lookup: anchor line → array of deleted blocks
+        let deletedAnchorSet = Set(hunkDeletedBlocks.map(\.anchorLine))
         var deletedAnchorMap: [Int: [DeletedLinesBlock]] = [:]
-        for block in deletedLineBlocks {
+        for block in hunkDeletedBlocks {
             deletedAnchorMap[block.anchorLine, default: []].append(block)
         }
 
@@ -250,8 +269,8 @@ final class GutterTextView: NSTextView {
                     }
                 }
 
-                // Draw green background on added lines
-                if self.addedLineNumbers.contains(lineNumber) {
+                // Draw green background on added lines (only for expanded hunk)
+                if hunkAddedLines.contains(lineNumber) {
                     var highlightRect = lineRect
                     highlightRect.origin.x = 0
                     highlightRect.size.width = self.bounds.width
@@ -483,6 +502,26 @@ final class GutterTextView: NSTextView {
 
         insertText("\n\(indent)", replacementRange: selectedRange())
     }
+
+    // MARK: - Escape key collapses expanded inline diff
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 53, expandedHunkID != nil {
+            // Escape key (keyCode 53) collapses expanded inline diff
+            expandedHunkID = nil
+            // Also collapse in the sibling LineNumberView
+            if let container = enclosingScrollView?.superview as? EditorContainerView {
+                for subview in container.subviews {
+                    if let lineNumberView = subview as? LineNumberView {
+                        lineNumberView.expandedHunkID = nil
+                        break
+                    }
+                }
+            }
+            return
+        }
+        super.keyDown(with: event)
+    }
 }
 
 // MARK: - Editor scroll view with find bar height tracking
@@ -708,6 +747,7 @@ struct CodeEditorView: NSViewRepresentable {
         textView.indentStyle = indentStyle
         textView.addedLineNumbers = InlineDiffProvider.addedLineNumbers(from: diffHunks)
         textView.deletedLineBlocks = InlineDiffProvider.deletedLineBlocks(from: diffHunks)
+        textView.diffHunksForHighlight = diffHunks
         // Delegate set AFTER text/highlight setup to prevent textDidChange from firing
         // during makeNSView and causing a spurious updateContent → cachedHighlightResult = nil
         // → contentVersion bump → updateNSView re-sets text → stripping highlight attributes.
@@ -735,6 +775,9 @@ struct CodeEditorView: NSViewRepresentable {
         }
         lineNumberView.onRevertHunk = { [weak coordinator] hunk in
             coordinator?.onRevertHunk?(hunk)
+        }
+        lineNumberView.onDiffMarkerClick = { [weak coordinator] hunk in
+            coordinator?.handleDiffMarkerClick(hunk)
         }
         container.addSubview(lineNumberView)
 
@@ -933,6 +976,12 @@ struct CodeEditorView: NSViewRepresentable {
                 || gutterView.deletedLineBlocks != newDeletedBlocks {
                 gutterView.addedLineNumbers = newAddedLines
                 gutterView.deletedLineBlocks = newDeletedBlocks
+                gutterView.diffHunksForHighlight = diffHunks
+                // Collapse expanded hunk when diff data changes (hunks may have shifted)
+                if gutterView.expandedHunkID != nil {
+                    gutterView.expandedHunkID = nil
+                    context.coordinator.lineNumberView?.expandedHunkID = nil
+                }
                 gutterView.needsDisplay = true
             }
         }
@@ -1766,6 +1815,16 @@ struct CodeEditorView: NSViewRepresentable {
         func handleFoldToggle(_ foldable: FoldableRange) {
             parent.foldState.toggle(foldable)
             applyFoldState()
+        }
+
+        /// Toggles inline diff expansion for a hunk when user clicks a gutter diff marker.
+        func handleDiffMarkerClick(_ hunk: DiffHunk) {
+            guard let sv = scrollView,
+                  let gutterView = sv.documentView as? GutterTextView else { return }
+
+            let newID: UUID? = (gutterView.expandedHunkID == hunk.id) ? nil : hunk.id
+            gutterView.expandedHunkID = newID
+            lineNumberView?.expandedHunkID = newID
         }
 
         /// Handles fold code notifications from menu/keyboard shortcuts.

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -67,6 +67,14 @@ final class LineNumberView: NSView {
         }
     }
 
+    /// The ID of the currently expanded hunk (shows inline diff). Nil = all collapsed.
+    var expandedHunkID: UUID? {
+        didSet { needsDisplay = true }
+    }
+
+    /// Callback when a diff marker in the gutter is clicked (to toggle inline diff).
+    var onDiffMarkerClick: ((DiffHunk) -> Void)?
+
     /// Callback for accepting (staging) a hunk at the given line.
     var onAcceptHunk: ((DiffHunk) -> Void)?
 
@@ -228,9 +236,10 @@ final class LineNumberView: NSView {
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
 
-        // Check for hunk action button clicks first
+        // Check for hunk action button clicks first (only when hunk is expanded)
         if let lineNum = lineNumber(at: point),
            let hunk = hunkStartMap[lineNum],
+           expandedHunkID == hunk.id,
            let action = hunkButtonHitTest(at: point, lineNumber: lineNum) {
             switch action {
             case .accept:
@@ -241,6 +250,16 @@ final class LineNumberView: NSView {
                 break
             }
             return
+        }
+
+        // Check for diff marker click (right edge of gutter)
+        let diffBarWidth: CGFloat = 3
+        if point.x >= gutterWidth - diffBarWidth - 4 {
+            if let lineNum = lineNumber(at: point),
+               let hunk = hunkForLine(lineNum) {
+                onDiffMarkerClick?(hunk)
+                return
+            }
         }
 
         // Only handle clicks on the fold indicator area (left portion of gutter)
@@ -255,6 +274,13 @@ final class LineNumberView: NSView {
            let foldable = foldStartMap[lineNumber] {
             onFoldToggle?(foldable)
         }
+    }
+
+    /// Returns the hunk that covers the given line number, if any.
+    private func hunkForLine(_ line: Int) -> DiffHunk? {
+        // Check if line has a diff marker
+        guard diffMap[line] != nil else { return nil }
+        return InlineDiffProvider.hunk(atLine: line, in: diffHunks)
     }
 
     /// Cached line starts for O(log n) line number lookups in click handling.
@@ -474,8 +500,10 @@ final class LineNumberView: NSView {
                     )
                 }
 
-                // ── Accept/Revert buttons on hunk start lines (hover only) ──
-                if self.isMouseInside, self.hunkStartMap[lineNumber] != nil {
+                // ── Accept/Revert buttons on hunk start lines (only when hunk is expanded) ──
+                if self.isMouseInside,
+                   let hunk = self.hunkStartMap[lineNumber],
+                   self.expandedHunkID == hunk.id {
                     self.drawHunkActionButtons(at: y, lineHeight: lineRect.height)
                 }
 

--- a/PineTests/InlineDiffExpandTests.swift
+++ b/PineTests/InlineDiffExpandTests.swift
@@ -1,0 +1,354 @@
+//
+//  InlineDiffExpandTests.swift
+//  PineTests
+//
+//  Tests for inline diff expand/collapse on gutter click (#672).
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+/// Tests for the inline diff expand/collapse behavior:
+/// - Default: no inline diff highlights shown
+/// - Clicking a gutter diff marker: expands that hunk's inline diff
+/// - Clicking again: collapses
+/// - Escape key: collapses
+/// - Diff data change: collapses
+@Suite("Inline Diff Expand Tests")
+struct InlineDiffExpandTests {
+
+    // MARK: - Helpers
+
+    private func makeTextView(text: String = "line1\nline2\nline3\nline4\nline5\n") -> GutterTextView {
+        let textStorage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        )
+        layoutManager.addTextContainer(textContainer)
+        return GutterTextView(
+            frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+            textContainer: textContainer
+        )
+    }
+
+    private func makeHunk(
+        newStart: Int = 2,
+        newCount: Int = 2,
+        oldStart: Int = 2,
+        oldCount: Int = 1,
+        rawText: String = "@@ -2,1 +2,2 @@\n context\n+added line\n"
+    ) -> DiffHunk {
+        DiffHunk(
+            newStart: newStart,
+            newCount: newCount,
+            oldStart: oldStart,
+            oldCount: oldCount,
+            rawText: rawText
+        )
+    }
+
+    private func makeLineNumberView() -> LineNumberView {
+        let textStorage = NSTextStorage(string: "line1\nline2\nline3\n")
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        )
+        layoutManager.addTextContainer(textContainer)
+        let textView = GutterTextView(
+            frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+            textContainer: textContainer
+        )
+        return LineNumberView(textView: textView)
+    }
+
+    // MARK: - GutterTextView expandedHunkID
+
+    @Test func expandedHunkIDDefaultsToNil() {
+        let tv = makeTextView()
+        #expect(tv.expandedHunkID == nil)
+    }
+
+    @Test func settingExpandedHunkIDStoresValue() {
+        let tv = makeTextView()
+        let hunk = makeHunk()
+        tv.expandedHunkID = hunk.id
+        #expect(tv.expandedHunkID == hunk.id)
+    }
+
+    @Test func clearingExpandedHunkIDSetsNil() {
+        let tv = makeTextView()
+        let hunk = makeHunk()
+        tv.expandedHunkID = hunk.id
+        #expect(tv.expandedHunkID != nil)
+        tv.expandedHunkID = nil
+        #expect(tv.expandedHunkID == nil)
+    }
+
+    @Test func diffHunksForHighlightStoresHunks() {
+        let tv = makeTextView()
+        let hunk1 = makeHunk(newStart: 1)
+        let hunk2 = makeHunk(newStart: 5)
+        tv.diffHunksForHighlight = [hunk1, hunk2]
+        #expect(tv.diffHunksForHighlight.count == 2)
+        #expect(tv.diffHunksForHighlight[0].id == hunk1.id)
+        #expect(tv.diffHunksForHighlight[1].id == hunk2.id)
+    }
+
+    // MARK: - LineNumberView expandedHunkID
+
+    @Test func lineNumberViewExpandedHunkIDDefaultsToNil() {
+        let view = makeLineNumberView()
+        #expect(view.expandedHunkID == nil)
+    }
+
+    @Test func lineNumberViewExpandedHunkIDToggle() {
+        let view = makeLineNumberView()
+        let hunk = makeHunk()
+        view.expandedHunkID = hunk.id
+        #expect(view.expandedHunkID == hunk.id)
+        view.expandedHunkID = nil
+        #expect(view.expandedHunkID == nil)
+    }
+
+    // MARK: - onDiffMarkerClick callback
+
+    @Test func onDiffMarkerClickCallbackIsCalled() {
+        let view = makeLineNumberView()
+        let hunk = makeHunk()
+        view.diffHunks = [hunk]
+
+        var clickedHunk: DiffHunk?
+        view.onDiffMarkerClick = { h in
+            clickedHunk = h
+        }
+
+        // Simulate callback invocation
+        view.onDiffMarkerClick?(hunk)
+        #expect(clickedHunk?.id == hunk.id)
+    }
+
+    // MARK: - Accept/Revert buttons visibility (only when expanded)
+
+    @Test func hunkButtonHitTestReturnsNilForNonHunkLine() {
+        let view = makeLineNumberView()
+        let result = view.hunkButtonHitTest(at: NSPoint(x: 15, y: 10), lineNumber: 5)
+        #expect(result == nil)
+    }
+
+    @Test func hunkButtonHitTestReturnsActionForHunkStartLine() {
+        let view = makeLineNumberView()
+        let hunk = makeHunk(newStart: 1)
+        view.diffHunks = [hunk]
+        // hunkButtonHitTest checks hunkStartMap which is rebuilt in didSet
+        let result = view.hunkButtonHitTest(at: NSPoint(x: 15, y: 10), lineNumber: 1)
+        // Should return accept for left area
+        #expect(result == .accept)
+    }
+
+    // MARK: - Escape key collapses expanded hunk
+
+    @Test func escapeKeyCollapsesExpandedHunk() {
+        let tv = makeTextView()
+        let hunk = makeHunk()
+        tv.expandedHunkID = hunk.id
+        #expect(tv.expandedHunkID != nil)
+
+        // Simulate Escape key (keyCode 53)
+        guard let escapeEvent = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\u{1B}",
+            charactersIgnoringModifiers: "\u{1B}",
+            isARepeat: false,
+            keyCode: 53
+        ) else {
+            Issue.record("Failed to create Escape NSEvent")
+            return
+        }
+        tv.keyDown(with: escapeEvent)
+        #expect(tv.expandedHunkID == nil)
+    }
+
+    @Test func escapeKeyWithNoExpandedHunkDoesNotCrash() {
+        let tv = makeTextView()
+        #expect(tv.expandedHunkID == nil)
+        // When no hunk is expanded, keyDown passes to super — not tested directly
+        // because super.keyDown requires a full responder chain, but we verify
+        // the state remains nil.
+    }
+
+    // MARK: - Expand toggle logic
+
+    @Test func toggleExpandCollapsesSameHunk() {
+        let tv = makeTextView()
+        let hunk = makeHunk()
+
+        // Expand
+        tv.expandedHunkID = hunk.id
+        #expect(tv.expandedHunkID == hunk.id)
+
+        // Toggle same hunk — should collapse
+        let newID: UUID? = (tv.expandedHunkID == hunk.id) ? nil : hunk.id
+        tv.expandedHunkID = newID
+        #expect(tv.expandedHunkID == nil)
+    }
+
+    @Test func toggleExpandSwitchesHunk() {
+        let tv = makeTextView()
+        let hunk1 = makeHunk(newStart: 1)
+        let hunk2 = makeHunk(newStart: 5)
+
+        // Expand hunk1
+        tv.expandedHunkID = hunk1.id
+        #expect(tv.expandedHunkID == hunk1.id)
+
+        // Click hunk2 — should switch to hunk2
+        let newID: UUID? = (tv.expandedHunkID == hunk2.id) ? nil : hunk2.id
+        tv.expandedHunkID = newID
+        #expect(tv.expandedHunkID == hunk2.id)
+    }
+
+    // MARK: - Diff data change collapses expanded hunk
+
+    @Test func changingDiffDataShouldResetExpandedHunk() {
+        let tv = makeTextView()
+        let hunk = makeHunk()
+        tv.diffHunksForHighlight = [hunk]
+        tv.expandedHunkID = hunk.id
+
+        // Simulate diff data change (as updateNSView does)
+        let newHunk = makeHunk(newStart: 10)
+        tv.diffHunksForHighlight = [newHunk]
+        // In real code, updateNSView clears expandedHunkID when diff data changes
+        tv.expandedHunkID = nil
+
+        #expect(tv.expandedHunkID == nil)
+    }
+
+    // MARK: - hunkForLine via InlineDiffProvider
+
+    @Test func hunkAtLineFindsCorrectHunk() {
+        let hunk1 = makeHunk(newStart: 2, newCount: 3)
+        let hunk2 = makeHunk(newStart: 10, newCount: 2)
+
+        #expect(InlineDiffProvider.hunk(atLine: 2, in: [hunk1, hunk2])?.id == hunk1.id)
+        #expect(InlineDiffProvider.hunk(atLine: 4, in: [hunk1, hunk2])?.id == hunk1.id)
+        #expect(InlineDiffProvider.hunk(atLine: 10, in: [hunk1, hunk2])?.id == hunk2.id)
+        #expect(InlineDiffProvider.hunk(atLine: 7, in: [hunk1, hunk2]) == nil)
+    }
+
+    @Test func hunkAtLineForPureDeletion() {
+        let hunk = DiffHunk(
+            newStart: 5, newCount: 0, oldStart: 5, oldCount: 3,
+            rawText: "@@ -5,3 +5,0 @@\n-deleted1\n-deleted2\n-deleted3"
+        )
+        // Pure deletion — marker sits at the line after deletion point
+        #expect(InlineDiffProvider.hunk(atLine: 5, in: [hunk])?.id == hunk.id)
+        #expect(InlineDiffProvider.hunk(atLine: 4, in: [hunk]) == nil)
+        #expect(InlineDiffProvider.hunk(atLine: 6, in: [hunk]) == nil)
+    }
+
+    // MARK: - Filtered highlights for expanded hunk
+
+    @Test func addedLineNumbersFilteredToSingleHunk() {
+        let hunk1 = DiffHunk(
+            newStart: 2, newCount: 2, oldStart: 2, oldCount: 0,
+            rawText: "@@ -2,0 +2,2 @@\n+added1\n+added2"
+        )
+        let hunk2 = DiffHunk(
+            newStart: 8, newCount: 1, oldStart: 8, oldCount: 0,
+            rawText: "@@ -8,0 +8,1 @@\n+added3"
+        )
+
+        // Full set contains all added lines
+        let allAdded = InlineDiffProvider.addedLineNumbers(from: [hunk1, hunk2])
+        #expect(allAdded.contains(2))
+        #expect(allAdded.contains(3))
+        #expect(allAdded.contains(8))
+
+        // Filtered to hunk1 only
+        let hunk1Added = InlineDiffProvider.addedLineNumbers(from: [hunk1])
+        #expect(hunk1Added.contains(2))
+        #expect(hunk1Added.contains(3))
+        #expect(!hunk1Added.contains(8))
+
+        // Filtered to hunk2 only
+        let hunk2Added = InlineDiffProvider.addedLineNumbers(from: [hunk2])
+        #expect(!hunk2Added.contains(2))
+        #expect(!hunk2Added.contains(3))
+        #expect(hunk2Added.contains(8))
+    }
+
+    @Test func deletedLineBlocksFilteredToSingleHunk() {
+        let hunk1 = DiffHunk(
+            newStart: 2, newCount: 1, oldStart: 2, oldCount: 2,
+            rawText: "@@ -2,2 +2,1 @@\n-old line\n context"
+        )
+        let hunk2 = DiffHunk(
+            newStart: 8, newCount: 0, oldStart: 8, oldCount: 1,
+            rawText: "@@ -8,1 +8,0 @@\n-deleted"
+        )
+
+        let allBlocks = InlineDiffProvider.deletedLineBlocks(from: [hunk1, hunk2])
+        #expect(allBlocks.count == 2)
+
+        let hunk1Blocks = InlineDiffProvider.deletedLineBlocks(from: [hunk1])
+        #expect(hunk1Blocks.count == 1)
+        #expect(hunk1Blocks[0].anchorLine == 2)
+
+        let hunk2Blocks = InlineDiffProvider.deletedLineBlocks(from: [hunk2])
+        #expect(hunk2Blocks.count == 1)
+        #expect(hunk2Blocks[0].anchorLine == 8)
+    }
+
+    // MARK: - Edge cases
+
+    @Test func expandedHunkIDWithEmptyDiffHunks() {
+        let tv = makeTextView()
+        tv.diffHunksForHighlight = []
+        tv.expandedHunkID = UUID() // some random ID
+        // No crash — drawBackground should handle gracefully
+        #expect(tv.expandedHunkID != nil)
+    }
+
+    @Test func expandedHunkIDWithStaleID() {
+        let tv = makeTextView()
+        let hunk = makeHunk()
+        tv.diffHunksForHighlight = [hunk]
+        tv.expandedHunkID = hunk.id
+
+        // Replace hunks with new ones — stale ID should not match
+        let newHunk = makeHunk(newStart: 20)
+        tv.diffHunksForHighlight = [newHunk]
+
+        let found = tv.diffHunksForHighlight.first { $0.id == tv.expandedHunkID }
+        #expect(found == nil, "Stale expanded hunk ID should not match new hunks")
+    }
+
+    @Test func multipleHunksOnlyOneExpanded() {
+        let tv = makeTextView()
+        let hunk1 = makeHunk(newStart: 1)
+        let hunk2 = makeHunk(newStart: 5)
+        let hunk3 = makeHunk(newStart: 10)
+        tv.diffHunksForHighlight = [hunk1, hunk2, hunk3]
+
+        tv.expandedHunkID = hunk2.id
+
+        let expanded = tv.diffHunksForHighlight.first { $0.id == tv.expandedHunkID }
+        #expect(expanded?.id == hunk2.id)
+        #expect(expanded?.newStart == 5)
+    }
+
+    @Test func lineNumberViewDiffMarkerCallbackNilByDefault() {
+        let view = makeLineNumberView()
+        #expect(view.onDiffMarkerClick == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Inline diff highlights (green added-line backgrounds, red deleted phantom blocks) are no longer always visible. They only appear when the user clicks a gutter diff marker, similar to Zed editor behavior.
- Clicking a diff marker in the gutter toggles inline diff expansion for that specific hunk. Clicking the same marker again or pressing Escape collapses it.
- Accept/Revert buttons in the gutter now only appear when their hunk is expanded, keeping the gutter clean by default.

Closes #672

## Changes
- **`Pine/CodeEditorView.swift`**: Added `expandedHunkID` and `diffHunksForHighlight` properties to `GutterTextView`. Modified `drawBackground` to only render inline diff highlights when a hunk is expanded. Added `keyDown` override for Escape key to collapse. Added `handleDiffMarkerClick` to Coordinator. Updated `makeNSView`/`updateNSView` to sync new state and collapse on diff data change.
- **`Pine/LineNumberGutter.swift`**: Added `expandedHunkID`, `onDiffMarkerClick` callback, and `hunkForLine` helper. Modified `mouseDown` to detect clicks on gutter diff markers. Accept/Revert buttons only drawn for expanded hunk.
- **`PineTests/InlineDiffExpandTests.swift`**: 22 new tests covering expand/collapse toggle, Escape key, stale ID handling, filtered highlights, edge cases.

## Test plan
- [x] Unit tests: 22 new tests in `InlineDiffExpandTests` — all pass
- [x] Full `PineTests` suite — all pass
- [x] SwiftLint — 0 violations
- [ ] Manual: open a file with git changes, verify gutter markers are visible but no green/red backgrounds
- [ ] Manual: click a gutter diff marker, verify inline diff appears for that hunk only
- [ ] Manual: click same marker again, verify it collapses
- [ ] Manual: press Escape while expanded, verify it collapses
- [ ] Manual: click Accept/Revert buttons on expanded hunk