### PR TITLE
fix: allow docs-only PRs to pass required CI checks (#656)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,32 +6,53 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "*.md"
-      - "docs/**"
-      - "assets/**"
-      - "LICENSE"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".release-please-manifest.json"
-      - "release-please-config.json"
   push:
     branches: [main]
-    paths-ignore:
-      - "*.md"
-      - "docs/**"
-      - "assets/**"
-      - "LICENSE"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".release-please-manifest.json"
-      - "release-please-config.json"
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
+  # Detect whether the PR/push touches only docs/config files.
+  # When only non-code files change, downstream jobs are skipped —
+  # GitHub treats skipped required checks as passed (strict policy is off).
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for code changes
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+
+          # List changed files, exclude docs/config-only paths
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep -cvE '^(.*\.md|docs/|assets/|LICENSE|\.github/ISSUE_TEMPLATE/|\.release-please-manifest\.json|release-please-config\.json)$' || true)
+
+          if [ "$CHANGED" -gt 0 ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "Code changes detected ($CHANGED files)"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "Docs-only changes, skipping CI jobs"
+          fi
+
   lint:
     name: SwiftLint
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     env:
       SWIFTLINT_VERSION: "0.58.2"
@@ -52,6 +73,8 @@ jobs:
 
   build:
     name: Build for Testing
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -381,6 +404,8 @@ jobs:
   # Fails CI if someone adds a new test class and forgets to shard it.
   verify-ui-shards:
     name: Verify UI Test Shards
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -510,7 +535,7 @@ jobs:
     name: Flaky Test Summary
     runs-on: ubuntu-latest
     needs: ui-tests
-    if: always() && needs.ui-tests.result != 'cancelled'
+    if: always() && needs.ui-tests.result != 'cancelled' && needs.ui-tests.result != 'skipped'
     steps:
       - name: Download Flaky Reports
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ permissions:
 jobs:
   # Detect whether the PR/push touches only docs/config files.
   # When only non-code files change, downstream jobs are skipped —
-  # GitHub treats skipped required checks as passed (strict policy is off).
+  # GitHub treats skipped required checks as passed because
+  # strict_required_status_checks_policy is OFF in branch protection.
+  # If strict policy is ever enabled, skipped jobs will BLOCK merges.
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
@@ -25,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       - name: Check for code changes
         id: filter
@@ -38,8 +40,13 @@ jobs:
             HEAD="${{ github.sha }}"
           fi
 
+          # On branch creation, github.event.before is the null SHA — fall back to parent
+          if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            BASE="HEAD~1"
+          fi
+
           # List changed files, exclude docs/config-only paths
-          CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep -cvE '^(.*\.md|docs/|assets/|LICENSE|\.github/ISSUE_TEMPLATE/|\.release-please-manifest\.json|release-please-config\.json)$' || true)
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep -cvE '^(.*\.md|docs/.*|assets/.*|LICENSE|\.github/ISSUE_TEMPLATE/.*|\.release-please-manifest\.json|release-please-config\.json)$' || true)
 
           if [ "$CHANGED" -gt 0 ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Removes paths-ignore from CI workflow triggers so the workflow always runs
- Adds a lightweight Detect Changes job that checks whether code files were modified
- When only docs/config files change, all downstream jobs (lint, build, tests) are skipped
- GitHub treats skipped required checks as passed (strict status policy is off in our ruleset)

Closes #656

## Test plan
- [ ] Create a PR that only changes a .md file and verify all CI jobs show as skipped
- [ ] Create a PR that changes a .swift file and verify all CI jobs run normally
- [ ] Create a PR that changes both .md and .swift files and verify all CI jobs run