### PR TITLE
fix: remove broken accept/revert buttons from gutter

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -626,14 +626,10 @@ struct CodeEditorView: NSViewRepresentable {
     var language: String
     var fileName: String?
     var lineDiffs: [GitLineDiff] = []
-    /// Diff hunks for accept/revert buttons in the gutter.
+    /// Diff hunks for inline diff expansion in the gutter.
     var diffHunks: [DiffHunk] = []
     /// Validation diagnostics for gutter icons (error/warning/info).
     var validationDiagnostics: [ValidationDiagnostic] = []
-    /// Callback for accepting (staging) a hunk.
-    var onAcceptHunk: ((DiffHunk) -> Void)?
-    /// Callback for reverting a hunk.
-    var onRevertHunk: ((DiffHunk) -> Void)?
     /// Whether inline blame annotation is visible on the cursor line.
     var isBlameVisible: Bool = false
     /// Blame data for the current file.
@@ -768,12 +764,6 @@ struct CodeEditorView: NSViewRepresentable {
         }
         lineNumberView.diffHunks = diffHunks
         lineNumberView.validationDiagnostics = validationDiagnostics
-        lineNumberView.onAcceptHunk = { [weak coordinator] hunk in
-            coordinator?.onAcceptHunk?(hunk)
-        }
-        lineNumberView.onRevertHunk = { [weak coordinator] hunk in
-            coordinator?.onRevertHunk?(hunk)
-        }
         lineNumberView.onDiffMarkerClick = { [weak coordinator] hunk in
             coordinator?.handleDiffMarkerClick(hunk)
         }
@@ -1001,8 +991,6 @@ struct CodeEditorView: NSViewRepresentable {
             lineNumberView.validationDiagnostics = validationDiagnostics
             lineNumberView.foldState = foldState
         }
-        context.coordinator.onAcceptHunk = onAcceptHunk
-        context.coordinator.onRevertHunk = onRevertHunk
         if let minimapView = context.coordinator.minimapView {
             minimapView.lineDiffs = lineDiffs
         }
@@ -1060,11 +1048,6 @@ struct CodeEditorView: NSViewRepresentable {
 
         /// Last consumed navigation request ID — prevents re-processing.
         var lastGoToID: UUID?
-
-        /// Callback for accepting (staging) a hunk via gutter button click.
-        var onAcceptHunk: ((DiffHunk) -> Void)?
-        /// Callback for reverting a hunk via gutter button click.
-        var onRevertHunk: ((DiffHunk) -> Void)?
 
         /// Generation counter for cancelling stale async highlight requests.
         let highlightGeneration = HighlightGeneration()

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -253,31 +253,6 @@ extension ContentView {
         }
     }
 
-    // MARK: - Gutter accept/revert buttons
-
-    func handleGutterAccept(_ hunk: DiffHunk) {
-        guard let tab = tabManager.activeTab,
-              let repoURL = workspace.rootURL else { return }
-        Task {
-            await InlineDiffProvider.acceptHunk(hunk, fileURL: tab.url, repoURL: repoURL)
-            await workspace.gitProvider.refreshAsync()
-            refreshLineDiffs()
-        }
-    }
-
-    func handleGutterRevert(_ hunk: DiffHunk) {
-        guard let tab = tabManager.activeTab,
-              let repoURL = workspace.rootURL else { return }
-        Task {
-            if let newContent = await InlineDiffProvider.revertHunk(hunk, fileURL: tab.url, repoURL: repoURL) {
-                tabManager.updateContent(newContent)
-                tabManager.reloadTab(url: tab.url)
-                await workspace.gitProvider.refreshAsync()
-                refreshLineDiffs()
-            }
-        }
-    }
-
     // MARK: - Inline diff actions (menu/keyboard)
 
     func handleInlineDiffAction(_ action: InlineDiffAction) {

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -252,8 +252,6 @@ struct ContentView: View {
             isMinimapVisible: isMinimapVisible,
             isWordWrapEnabled: isWordWrapEnabled,
             diffHunks: diffHunks,
-            onAcceptHunk: { hunk in handleGutterAccept(hunk) },
-            onRevertHunk: { hunk in handleGutterRevert(hunk) },
             onCloseTab: { closeTabWithConfirmation($0) },
             onCloseOtherTabs: { closeOtherTabsWithConfirmation(keeping: $0) },
             onCloseTabsToTheRight: { closeTabsToTheRightWithConfirmation(of: $0) },

--- a/Pine/EditorAreaView.swift
+++ b/Pine/EditorAreaView.swift
@@ -23,8 +23,6 @@ struct EditorAreaView: View {
     var isMinimapVisible: Bool
     var isWordWrapEnabled: Bool
     var diffHunks: [DiffHunk] = []
-    var onAcceptHunk: ((DiffHunk) -> Void)?
-    var onRevertHunk: ((DiffHunk) -> Void)?
     var onCloseTab: (EditorTab) -> Void
     var onCloseOtherTabs: ((UUID) -> Void)?
     var onCloseTabsToTheRight: ((UUID) -> Void)?
@@ -125,8 +123,6 @@ struct EditorAreaView: View {
             lineDiffs: lineDiffs,
             diffHunks: diffHunks,
             validationDiagnostics: configValidator.diagnostics,
-            onAcceptHunk: onAcceptHunk,
-            onRevertHunk: onRevertHunk,
             isBlameVisible: isBlameVisible,
             blameLines: blameLines,
             foldState: Binding(

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -75,12 +75,6 @@ final class LineNumberView: NSView {
     /// Callback when a diff marker in the gutter is clicked (to toggle inline diff).
     var onDiffMarkerClick: ((DiffHunk) -> Void)?
 
-    /// Callback for accepting (staging) a hunk at the given line.
-    var onAcceptHunk: ((DiffHunk) -> Void)?
-
-    /// Callback for reverting a hunk at the given line.
-    var onRevertHunk: ((DiffHunk) -> Void)?
-
     /// Pre-indexed hunk lookup: first line of hunk → DiffHunk.
     private var hunkStartMap: [Int: DiffHunk] = [:]
 
@@ -255,22 +249,6 @@ final class LineNumberView: NSView {
 
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-
-        // Check for hunk action button clicks first (only when hunk is expanded)
-        if let lineNum = lineNumber(at: point),
-           let hunk = hunkStartMap[lineNum],
-           expandedHunkID == hunk.id,
-           let action = hunkButtonHitTest(at: point, lineNumber: lineNum) {
-            switch action {
-            case .accept:
-                onAcceptHunk?(hunk)
-            case .revert:
-                onRevertHunk?(hunk)
-            default:
-                break
-            }
-            return
-        }
 
         // Check for diff marker click (right edge of gutter)
         let diffBarWidth: CGFloat = 3
@@ -520,12 +498,6 @@ final class LineNumberView: NSView {
                     )
                 }
 
-                // ── Accept/Revert buttons on hunk start lines (visible when hunk is expanded) ──
-                if let hunk = self.hunkStartMap[lineNumber],
-                   self.expandedHunkID == hunk.id {
-                    self.drawHunkActionButtons(at: y, lineHeight: lineRect.height)
-                }
-
                 lineNumber += 1
             }
 
@@ -665,91 +637,4 @@ final class LineNumberView: NSView {
         path.fill()
     }
 
-    // MARK: - Accept/Revert button drawing
-
-    /// Width of each hunk action button area, derived from gutter font size.
-    private var hunkButtonSize: CGFloat {
-        gutterFont.pointSize + 1
-    }
-
-    /// X position for the first (accept) button, based on gutter font metrics.
-    private var hunkButtonStartX: CGFloat {
-        gutterFont.pointSize + 2
-    }
-
-    /// Draws accept (checkmark) and revert (arrow) icons at the top of a hunk.
-    private func drawHunkActionButtons(at y: CGFloat, lineHeight: CGFloat) {
-        let centerY = y + lineHeight / 2
-        let checkmarkX = hunkButtonStartX
-        let revertX = checkmarkX + hunkButtonSize + 2
-
-        // Accept button (checkmark)
-        drawCheckmark(
-            at: NSPoint(x: checkmarkX, y: centerY),
-            size: hunkButtonSize,
-            color: addedColor
-        )
-
-        // Revert button (curved arrow)
-        drawRevertArrow(
-            at: NSPoint(x: revertX, y: centerY),
-            size: hunkButtonSize,
-            color: NSColor.systemOrange
-        )
-    }
-
-    /// Draws a small checkmark icon.
-    private func drawCheckmark(at center: NSPoint, size: CGFloat, color: NSColor) {
-        let half = size / 2
-        let path = NSBezierPath()
-        path.lineWidth = 1.5
-        path.move(to: NSPoint(x: center.x - half * 0.4, y: center.y))
-        path.line(to: NSPoint(x: center.x - half * 0.1, y: center.y + half * 0.4))
-        path.line(to: NSPoint(x: center.x + half * 0.5, y: center.y - half * 0.4))
-        color.setStroke()
-        path.stroke()
-    }
-
-    /// Draws a small revert (undo) arrow icon.
-    private func drawRevertArrow(at center: NSPoint, size: CGFloat, color: NSColor) {
-        let half = size / 2
-        let path = NSBezierPath()
-        path.lineWidth = 1.5
-        // Curved arrow
-        path.appendArc(
-            withCenter: NSPoint(x: center.x, y: center.y),
-            radius: half * 0.4,
-            startAngle: 45,
-            endAngle: 270,
-            clockwise: false
-        )
-        // Arrowhead
-        let tipX = center.x
-        let tipY = center.y - half * 0.4
-        let arrowSize: CGFloat = half * 0.3
-        let arrowPath = NSBezierPath()
-        arrowPath.move(to: NSPoint(x: tipX - arrowSize, y: tipY - arrowSize))
-        arrowPath.line(to: NSPoint(x: tipX, y: tipY))
-        arrowPath.line(to: NSPoint(x: tipX + arrowSize, y: tipY - arrowSize))
-        arrowPath.lineWidth = 1.5
-        color.setStroke()
-        path.stroke()
-        arrowPath.stroke()
-    }
-
-    /// Hit test for hunk action buttons. Returns the action if clicked, nil otherwise.
-    func hunkButtonHitTest(at point: NSPoint, lineNumber: Int) -> InlineDiffAction? {
-        guard hunkStartMap[lineNumber] != nil else { return nil }
-        let checkmarkX = hunkButtonStartX
-        let revertX = checkmarkX + hunkButtonSize + 2
-        let hitWidth = hunkButtonSize + 4
-
-        if point.x >= checkmarkX - 2 && point.x <= checkmarkX + hitWidth - 4 {
-            return .accept
-        }
-        if point.x >= revertX - 2 && point.x <= revertX + hitWidth - 4 {
-            return .revert
-        }
-        return nil
-    }
 }

--- a/PineTests/CleanGutterMarkersTests.swift
+++ b/PineTests/CleanGutterMarkersTests.swift
@@ -1,0 +1,165 @@
+//
+//  CleanGutterMarkersTests.swift
+//  PineTests
+//
+//  Tests for #688: gutter should show clean color markers only
+//  (green=added, yellow=modified, red=deleted) without accept/revert buttons
+//  that overlap line numbers.
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+@Suite("Clean Gutter Markers Tests")
+struct CleanGutterMarkersTests {
+
+    // MARK: - Helpers
+
+    private func makeLineNumberView() -> LineNumberView {
+        let textStorage = NSTextStorage(string: "line1\nline2\nline3\nline4\nline5\n")
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        )
+        layoutManager.addTextContainer(textContainer)
+        let textView = GutterTextView(
+            frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+            textContainer: textContainer
+        )
+        return LineNumberView(textView: textView)
+    }
+
+    private func makeHunk(
+        newStart: Int = 2,
+        newCount: Int = 2,
+        oldStart: Int = 2,
+        oldCount: Int = 1
+    ) -> DiffHunk {
+        DiffHunk(
+            newStart: newStart,
+            newCount: newCount,
+            oldStart: oldStart,
+            oldCount: oldCount,
+            rawText: "@@ -\(oldStart),\(oldCount) +\(newStart),\(newCount) @@\n context\n+added line\n"
+        )
+    }
+
+    // MARK: - Accept/Revert buttons removed from gutter
+
+    @Test func lineNumberViewHasNoAcceptHunkCallback() {
+        let view = makeLineNumberView()
+        // After #688, LineNumberView should not have onAcceptHunk/onRevertHunk properties.
+        // If compilation succeeds, these properties are gone. We verify the view has
+        // no accept/revert button drawing infrastructure by checking that
+        // hunkButtonHitTest is removed.
+        // This test validates that the gutter renders clean markers without button overlays.
+
+        // LineNumberView should still accept diffHunks for color markers
+        let hunk = makeHunk()
+        view.diffHunks = [hunk]
+        #expect(view.diffHunks.count == 1, "Diff hunks for color markers should still work")
+    }
+
+    @Test func lineNumberViewHasNoRevertHunkCallback() {
+        let view = makeLineNumberView()
+        // Verify no revert callback exists — the property should be removed.
+        // This is a compile-time check: if onRevertHunk still exists, the test below
+        // would need to reference it. Since we don't reference it, successful
+        // compilation proves the property is removed.
+
+        // Diff marker click callback should still exist (for expand/collapse)
+        var clicked = false
+        view.onDiffMarkerClick = { _ in clicked = true }
+        let hunk = makeHunk()
+        view.onDiffMarkerClick?(hunk)
+        #expect(clicked, "onDiffMarkerClick should still work for expand/collapse")
+    }
+
+    // MARK: - Diff color markers still render
+
+    @Test func addedDiffMarkersStillTracked() {
+        let view = makeLineNumberView()
+        view.lineDiffs = [
+            GitLineDiff(line: 1, kind: .added),
+            GitLineDiff(line: 2, kind: .added)
+        ]
+        #expect(view.lineDiffs.count == 2, "Added markers should be tracked")
+        #expect(view.lineDiffs[0].kind == .added)
+    }
+
+    @Test func modifiedDiffMarkersStillTracked() {
+        let view = makeLineNumberView()
+        view.lineDiffs = [GitLineDiff(line: 3, kind: .modified)]
+        #expect(view.lineDiffs.count == 1)
+        #expect(view.lineDiffs[0].kind == .modified)
+    }
+
+    @Test func deletedDiffMarkersStillTracked() {
+        let view = makeLineNumberView()
+        view.lineDiffs = [GitLineDiff(line: 5, kind: .deleted)]
+        #expect(view.lineDiffs.count == 1)
+        #expect(view.lineDiffs[0].kind == .deleted)
+    }
+
+    // MARK: - Expanded hunk still works (for inline diff highlighting)
+
+    @Test func expandedHunkIDStillWorks() {
+        let view = makeLineNumberView()
+        let hunk = makeHunk()
+        view.diffHunks = [hunk]
+        view.expandedHunkID = hunk.id
+        #expect(view.expandedHunkID == hunk.id, "Expanded hunk tracking should still work")
+
+        view.expandedHunkID = nil
+        #expect(view.expandedHunkID == nil, "Should be clearable")
+    }
+
+    // MARK: - Diff marker click still functional
+
+    @Test func diffMarkerClickCallbackStillFires() {
+        let view = makeLineNumberView()
+        let hunk = makeHunk(newStart: 1)
+        view.diffHunks = [hunk]
+
+        var receivedHunk: DiffHunk?
+        view.onDiffMarkerClick = { h in receivedHunk = h }
+        view.onDiffMarkerClick?(hunk)
+        #expect(receivedHunk?.id == hunk.id)
+    }
+
+    // MARK: - Menu accept/revert actions still exist (via NotificationCenter, not gutter)
+
+    @Test func inlineDiffActionEnumStillExists() {
+        // Menu commands (Accept Change, Revert Change, etc.) use InlineDiffAction
+        // and go through NotificationCenter, not through gutter buttons.
+        #expect(InlineDiffAction.accept.rawValue == "accept")
+        #expect(InlineDiffAction.revert.rawValue == "revert")
+        #expect(InlineDiffAction.acceptAll.rawValue == "acceptAll")
+        #expect(InlineDiffAction.revertAll.rawValue == "revertAll")
+    }
+
+    // MARK: - Multiple diff types coexist
+
+    @Test func multipleDiffTypesCoexist() {
+        let view = makeLineNumberView()
+        view.lineDiffs = [
+            GitLineDiff(line: 1, kind: .added),
+            GitLineDiff(line: 3, kind: .modified),
+            GitLineDiff(line: 5, kind: .deleted)
+        ]
+        #expect(view.lineDiffs.count == 3)
+    }
+
+    // MARK: - Empty diffs don't crash
+
+    @Test func emptyDiffsDoNotCrash() {
+        let view = makeLineNumberView()
+        view.lineDiffs = []
+        view.diffHunks = []
+        view.expandedHunkID = nil
+        #expect(view.lineDiffs.isEmpty)
+        #expect(view.diffHunks.isEmpty)
+    }
+}

--- a/PineTests/CleanGutterMarkersTests.swift
+++ b/PineTests/CleanGutterMarkersTests.swift
@@ -3,8 +3,8 @@
 //  PineTests
 //
 //  Tests for #688: gutter should show clean color markers only
-//  (green=added, yellow=modified, red=deleted) without accept/revert buttons
-//  that overlap line numbers.
+//  (green=added, yellow=modified, red=deleted) without accept/revert buttons.
+//  Validates behavioural changes: mouseDown routing, draw path, menu path.
 //
 
 import Testing
@@ -46,120 +46,395 @@ struct CleanGutterMarkersTests {
         )
     }
 
-    // MARK: - Accept/Revert buttons removed from gutter
+    // MARK: - Accept/Revert properties removed (Mirror reflection)
 
-    @Test func lineNumberViewHasNoAcceptHunkCallback() {
+    @Test func lineNumberViewHasNoAcceptHunkProperty() {
+        // After #688, onAcceptHunk was removed from LineNumberView.
+        // Use Mirror to verify the property does not exist at runtime.
         let view = makeLineNumberView()
-        // After #688, LineNumberView should not have onAcceptHunk/onRevertHunk properties.
-        // If compilation succeeds, these properties are gone. We verify the view has
-        // no accept/revert button drawing infrastructure by checking that
-        // hunkButtonHitTest is removed.
-        // This test validates that the gutter renders clean markers without button overlays.
-
-        // LineNumberView should still accept diffHunks for color markers
-        let hunk = makeHunk()
-        view.diffHunks = [hunk]
-        #expect(view.diffHunks.count == 1, "Diff hunks for color markers should still work")
+        let mirror = Mirror(reflecting: view)
+        let propertyNames = mirror.children.compactMap { $0.label }
+        #expect(!propertyNames.contains("onAcceptHunk"),
+                "onAcceptHunk property should be removed from LineNumberView")
     }
 
-    @Test func lineNumberViewHasNoRevertHunkCallback() {
+    @Test func lineNumberViewHasNoRevertHunkProperty() {
         let view = makeLineNumberView()
-        // Verify no revert callback exists — the property should be removed.
-        // This is a compile-time check: if onRevertHunk still exists, the test below
-        // would need to reference it. Since we don't reference it, successful
-        // compilation proves the property is removed.
-
-        // Diff marker click callback should still exist (for expand/collapse)
-        var clicked = false
-        view.onDiffMarkerClick = { _ in clicked = true }
-        let hunk = makeHunk()
-        view.onDiffMarkerClick?(hunk)
-        #expect(clicked, "onDiffMarkerClick should still work for expand/collapse")
+        let mirror = Mirror(reflecting: view)
+        let propertyNames = mirror.children.compactMap { $0.label }
+        #expect(!propertyNames.contains("onRevertHunk"),
+                "onRevertHunk property should be removed from LineNumberView")
     }
 
-    // MARK: - Diff color markers still render
+    @Test func lineNumberViewDoesNotRespondToHunkButtonHitTest() {
+        // hunkButtonHitTest method was removed — verify via ObjC runtime.
+        let view = makeLineNumberView()
+        let sel = NSSelectorFromString("hunkButtonHitTestAt:lineNumber:")
+        #expect(!view.responds(to: sel),
+                "hunkButtonHitTest should be removed from LineNumberView")
+    }
 
-    @Test func addedDiffMarkersStillTracked() {
+    // MARK: - Diff hunks didSet rebuilds hunkStartMap (behavioural)
+
+    @Test func settingDiffHunksRebuildsInternalState() {
+        // diffHunks didSet rebuilds hunkStartMap. Verify this by checking
+        // that the callback fires correctly for the new hunks.
+        let view = makeLineNumberView()
+        let hunk1 = makeHunk(newStart: 1)
+        let hunk2 = makeHunk(newStart: 5)
+
+        view.diffHunks = [hunk1]
+        // Now replace with different hunks
+        view.diffHunks = [hunk2]
+        // The InlineDiffProvider (which hunkForLine delegates to) should find hunk2
+        #expect(InlineDiffProvider.hunk(atLine: 5, in: view.diffHunks)?.id == hunk2.id)
+        #expect(InlineDiffProvider.hunk(atLine: 1, in: view.diffHunks) == nil,
+                "Old hunk should no longer be in diffHunks")
+    }
+
+    @Test func settingLineDiffsRebuildsInternalDiffMap() {
+        // lineDiffs didSet rebuilds diffMap. The internal diffMap is private,
+        // but we verify correctness by checking that lineDiffs is properly stored.
         let view = makeLineNumberView()
         view.lineDiffs = [
             GitLineDiff(line: 1, kind: .added),
-            GitLineDiff(line: 2, kind: .added)
+            GitLineDiff(line: 3, kind: .modified)
         ]
-        #expect(view.lineDiffs.count == 2, "Added markers should be tracked")
+        #expect(view.lineDiffs.count == 2)
+        #expect(view.lineDiffs[0].line == 1)
         #expect(view.lineDiffs[0].kind == .added)
-    }
+        #expect(view.lineDiffs[1].line == 3)
+        #expect(view.lineDiffs[1].kind == .modified)
 
-    @Test func modifiedDiffMarkersStillTracked() {
-        let view = makeLineNumberView()
-        view.lineDiffs = [GitLineDiff(line: 3, kind: .modified)]
-        #expect(view.lineDiffs.count == 1)
-        #expect(view.lineDiffs[0].kind == .modified)
-    }
-
-    @Test func deletedDiffMarkersStillTracked() {
-        let view = makeLineNumberView()
+        // Replace with new set
         view.lineDiffs = [GitLineDiff(line: 5, kind: .deleted)]
         #expect(view.lineDiffs.count == 1)
-        #expect(view.lineDiffs[0].kind == .deleted)
+        #expect(view.lineDiffs[0].line == 5)
     }
 
-    // MARK: - Expanded hunk still works (for inline diff highlighting)
-
-    @Test func expandedHunkIDStillWorks() {
+    @Test func expandedHunkIDTogglesCorrectly() {
         let view = makeLineNumberView()
         let hunk = makeHunk()
         view.diffHunks = [hunk]
-        view.expandedHunkID = hunk.id
-        #expect(view.expandedHunkID == hunk.id, "Expanded hunk tracking should still work")
 
-        view.expandedHunkID = nil
-        #expect(view.expandedHunkID == nil, "Should be clearable")
+        // Expand
+        view.expandedHunkID = hunk.id
+        #expect(view.expandedHunkID == hunk.id)
+
+        // Toggle (collapse)
+        let toggledID: UUID? = (view.expandedHunkID == hunk.id) ? nil : hunk.id
+        view.expandedHunkID = toggledID
+        #expect(view.expandedHunkID == nil)
+
+        // Toggle again (expand)
+        let toggledAgain: UUID? = (view.expandedHunkID == hunk.id) ? nil : hunk.id
+        view.expandedHunkID = toggledAgain
+        #expect(view.expandedHunkID == hunk.id)
     }
 
-    // MARK: - Diff marker click still functional
+    // MARK: - onDiffMarkerClick is the only click callback
 
-    @Test func diffMarkerClickCallbackStillFires() {
+    @Test func onDiffMarkerClickIsNilByDefault() {
         let view = makeLineNumberView()
-        let hunk = makeHunk(newStart: 1)
-        view.diffHunks = [hunk]
+        #expect(view.onDiffMarkerClick == nil,
+                "onDiffMarkerClick should be nil by default")
+    }
 
+    @Test func onDiffMarkerClickCallbackFires() {
+        let view = makeLineNumberView()
+        let hunk = makeHunk()
         var receivedHunk: DiffHunk?
         view.onDiffMarkerClick = { h in receivedHunk = h }
+        // Simulate callback invocation (as mouseDown would do)
         view.onDiffMarkerClick?(hunk)
         #expect(receivedHunk?.id == hunk.id)
     }
 
-    // MARK: - Menu accept/revert actions still exist (via NotificationCenter, not gutter)
+    @Test func onDiffMarkerClickReceivesCorrectHunkFromMultiple() {
+        let view = makeLineNumberView()
+        let hunk1 = makeHunk(newStart: 1)
+        let hunk2 = makeHunk(newStart: 5)
+        view.diffHunks = [hunk1, hunk2]
 
-    @Test func inlineDiffActionEnumStillExists() {
-        // Menu commands (Accept Change, Revert Change, etc.) use InlineDiffAction
-        // and go through NotificationCenter, not through gutter buttons.
-        #expect(InlineDiffAction.accept.rawValue == "accept")
-        #expect(InlineDiffAction.revert.rawValue == "revert")
-        #expect(InlineDiffAction.acceptAll.rawValue == "acceptAll")
-        #expect(InlineDiffAction.revertAll.rawValue == "revertAll")
+        var receivedHunks: [DiffHunk] = []
+        view.onDiffMarkerClick = { h in receivedHunks.append(h) }
+
+        view.onDiffMarkerClick?(hunk1)
+        view.onDiffMarkerClick?(hunk2)
+        #expect(receivedHunks.count == 2)
+        #expect(receivedHunks[0].id == hunk1.id)
+        #expect(receivedHunks[1].id == hunk2.id)
     }
 
-    // MARK: - Multiple diff types coexist
+    // MARK: - mouseDown routing: diff marker area delegates to onDiffMarkerClick only
 
-    @Test func multipleDiffTypesCoexist() {
+    @Test func mouseDownInDiffMarkerAreaWithNoDiffsDoesNotCrash() {
+        // mouseDown at the right edge (diff marker area) with no diffs set
+        // should not crash — lineNumber(at:) returns nil when no layout is available.
         let view = makeLineNumberView()
-        view.lineDiffs = [
-            GitLineDiff(line: 1, kind: .added),
-            GitLineDiff(line: 3, kind: .modified),
-            GitLineDiff(line: 5, kind: .deleted)
-        ]
-        #expect(view.lineDiffs.count == 3)
-    }
-
-    // MARK: - Empty diffs don't crash
-
-    @Test func emptyDiffsDoNotCrash() {
-        let view = makeLineNumberView()
-        view.lineDiffs = []
+        view.frame = NSRect(x: 0, y: 0, width: 50, height: 100)
+        view.gutterWidth = 50
         view.diffHunks = []
+
+        // This exercises the diff marker branch of mouseDown
+        // (point.x >= gutterWidth - diffBarWidth - 4 = 50 - 3 - 4 = 43)
+        // Without a real scroll view, lineNumber(at:) returns nil → no crash
+        let event = makeMouseEvent(at: NSPoint(x: 45, y: 10), in: view)
+        // Should not crash
+        view.mouseDown(with: event)
+    }
+
+    @Test func mouseDownInFoldAreaDoesNotTriggerDiffCallback() {
+        let view = makeLineNumberView()
+        view.frame = NSRect(x: 0, y: 0, width: 50, height: 100)
+        view.gutterWidth = 50
+        let hunk = makeHunk(newStart: 1)
+        view.diffHunks = [hunk]
+
+        var diffClicked = false
+        view.onDiffMarkerClick = { _ in diffClicked = true }
+
+        // Click in fold area (x < 14) — should NOT trigger diff callback
+        let event = makeMouseEvent(at: NSPoint(x: 5, y: 10), in: view)
+        view.mouseDown(with: event)
+        #expect(!diffClicked, "Click in fold area should not trigger diff marker callback")
+    }
+
+    @Test func mouseDownInMiddleAreaDoesNotTriggerDiffCallback() {
+        let view = makeLineNumberView()
+        view.frame = NSRect(x: 0, y: 0, width: 50, height: 100)
+        view.gutterWidth = 50
+        let hunk = makeHunk(newStart: 1)
+        view.diffHunks = [hunk]
+
+        var diffClicked = false
+        view.onDiffMarkerClick = { _ in diffClicked = true }
+
+        // Click in middle area (x >= 14 and x < gutterWidth - 7)
+        // This is the line number area — goes to super.mouseDown
+        let event = makeMouseEvent(at: NSPoint(x: 25, y: 10), in: view)
+        view.mouseDown(with: event)
+        #expect(!diffClicked, "Click in line number area should not trigger diff marker callback")
+    }
+
+    // MARK: - Expanded hunk without buttons: no side effects
+
+    @Test func expandingHunkDoesNotSetAcceptRevertCallbacks() {
+        // Expanding a hunk should only set expandedHunkID, not trigger any
+        // accept/revert callbacks (which no longer exist).
+        let view = makeLineNumberView()
+        let hunk = makeHunk()
+        view.diffHunks = [hunk]
+
+        // Verify no accept/revert properties via Mirror
+        let mirror = Mirror(reflecting: view)
+        let labels = mirror.children.compactMap { $0.label }
+        #expect(!labels.contains("onAcceptHunk"))
+        #expect(!labels.contains("onRevertHunk"))
+
+        view.expandedHunkID = hunk.id
+        #expect(view.expandedHunkID == hunk.id)
+    }
+
+    @Test func expandedHunkSwitchingDoesNotCrash() {
+        let view = makeLineNumberView()
+        let hunk1 = makeHunk(newStart: 1)
+        let hunk2 = makeHunk(newStart: 4)
+        view.diffHunks = [hunk1, hunk2]
+
+        view.expandedHunkID = hunk1.id
+        #expect(view.expandedHunkID == hunk1.id)
+
+        view.expandedHunkID = hunk2.id
+        #expect(view.expandedHunkID == hunk2.id)
+
         view.expandedHunkID = nil
-        #expect(view.lineDiffs.isEmpty)
+        #expect(view.expandedHunkID == nil)
+    }
+
+    // MARK: - Menu accept/revert via NotificationCenter still works
+
+    @Test func inlineDiffActionNotificationNameExists() {
+        // The notification path for menu-triggered accept/revert must still exist.
+        let name = Notification.Name.inlineDiffAction
+        #expect(name.rawValue == "inlineDiffAction",
+                "inlineDiffAction notification name must exist for menu commands")
+    }
+
+    @Test func inlineDiffActionNotificationDeliversPayload() {
+        var receivedAction: InlineDiffAction?
+        let observer = NotificationCenter.default.addObserver(
+            forName: .inlineDiffAction,
+            object: nil,
+            queue: .main
+        ) { notification in
+            receivedAction = notification.userInfo?["action"] as? InlineDiffAction
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        NotificationCenter.default.post(
+            name: .inlineDiffAction,
+            object: nil,
+            userInfo: ["action": InlineDiffAction.accept]
+        )
+        #expect(receivedAction == .accept,
+                "NotificationCenter should deliver accept action")
+    }
+
+    @Test func inlineDiffActionNotificationDeliversRevert() {
+        var receivedAction: InlineDiffAction?
+        let observer = NotificationCenter.default.addObserver(
+            forName: .inlineDiffAction,
+            object: nil,
+            queue: .main
+        ) { notification in
+            receivedAction = notification.userInfo?["action"] as? InlineDiffAction
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        NotificationCenter.default.post(
+            name: .inlineDiffAction,
+            object: nil,
+            userInfo: ["action": InlineDiffAction.revert]
+        )
+        #expect(receivedAction == .revert,
+                "NotificationCenter should deliver revert action")
+    }
+
+    @Test func inlineDiffActionNotificationDeliversAcceptAll() {
+        var receivedAction: InlineDiffAction?
+        let observer = NotificationCenter.default.addObserver(
+            forName: .inlineDiffAction,
+            object: nil,
+            queue: .main
+        ) { notification in
+            receivedAction = notification.userInfo?["action"] as? InlineDiffAction
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        NotificationCenter.default.post(
+            name: .inlineDiffAction,
+            object: nil,
+            userInfo: ["action": InlineDiffAction.acceptAll]
+        )
+        #expect(receivedAction == .acceptAll)
+    }
+
+    @Test func inlineDiffActionNotificationDeliversRevertAll() {
+        var receivedAction: InlineDiffAction?
+        let observer = NotificationCenter.default.addObserver(
+            forName: .inlineDiffAction,
+            object: nil,
+            queue: .main
+        ) { notification in
+            receivedAction = notification.userInfo?["action"] as? InlineDiffAction
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        NotificationCenter.default.post(
+            name: .inlineDiffAction,
+            object: nil,
+            userInfo: ["action": InlineDiffAction.revertAll]
+        )
+        #expect(receivedAction == .revertAll)
+    }
+
+    // MARK: - hunkForLine integration via InlineDiffProvider
+
+    @Test func hunkForLineRoutesToInlineDiffProvider() {
+        // LineNumberView.hunkForLine is private, but it delegates to
+        // InlineDiffProvider.hunk(atLine:in:). Verify the provider logic
+        // that the gutter relies on.
+        let hunk = makeHunk(newStart: 2, newCount: 3)
+        let hunks = [hunk]
+
+        // Lines within range [2, 4] should match
+        #expect(InlineDiffProvider.hunk(atLine: 2, in: hunks)?.id == hunk.id)
+        #expect(InlineDiffProvider.hunk(atLine: 3, in: hunks)?.id == hunk.id)
+        #expect(InlineDiffProvider.hunk(atLine: 4, in: hunks)?.id == hunk.id)
+
+        // Lines outside range should not match
+        #expect(InlineDiffProvider.hunk(atLine: 1, in: hunks) == nil)
+        #expect(InlineDiffProvider.hunk(atLine: 5, in: hunks) == nil)
+    }
+
+    @Test func hunkForLineRequiresDiffMapEntry() {
+        // hunkForLine guards on diffMap[line] != nil before calling InlineDiffProvider.
+        // Verify that InlineDiffProvider itself only matches lines within hunk range,
+        // so even without the diffMap guard, out-of-range lines return nil.
+        let hunk = makeHunk(newStart: 10, newCount: 1)
+        #expect(InlineDiffProvider.hunk(atLine: 9, in: [hunk]) == nil)
+        #expect(InlineDiffProvider.hunk(atLine: 10, in: [hunk])?.id == hunk.id)
+        #expect(InlineDiffProvider.hunk(atLine: 11, in: [hunk]) == nil)
+    }
+
+    @Test func hunkForLinePureDeletionMarker() {
+        // Pure deletion (newCount=0) puts marker at newStart
+        let hunk = DiffHunk(
+            newStart: 5, newCount: 0, oldStart: 5, oldCount: 3,
+            rawText: "@@ -5,3 +5,0 @@\n-del1\n-del2\n-del3"
+        )
+        #expect(InlineDiffProvider.hunk(atLine: 5, in: [hunk])?.id == hunk.id)
+        #expect(InlineDiffProvider.hunk(atLine: 4, in: [hunk]) == nil)
+        #expect(InlineDiffProvider.hunk(atLine: 6, in: [hunk]) == nil)
+    }
+
+    // MARK: - Empty and edge cases
+
+    @Test func emptyDiffHunksDoNotCrash() {
+        let view = makeLineNumberView()
+        view.diffHunks = []
+        view.lineDiffs = []
+        view.expandedHunkID = nil
+        // mouseDown with no diffs should not crash
+        let event = makeMouseEvent(at: NSPoint(x: 45, y: 10), in: view)
+        view.mouseDown(with: event)
+    }
+
+    @Test func replacingDiffHunksUpdatesState() {
+        let view = makeLineNumberView()
+        let hunk1 = makeHunk(newStart: 1)
+        let hunk2 = makeHunk(newStart: 5)
+
+        view.diffHunks = [hunk1]
+        #expect(view.diffHunks.count == 1)
+
+        view.diffHunks = [hunk1, hunk2]
+        #expect(view.diffHunks.count == 2)
+
+        view.diffHunks = []
         #expect(view.diffHunks.isEmpty)
+    }
+
+    @Test func expandedHunkIDWithStaleIDAfterDiffHunksChange() {
+        let view = makeLineNumberView()
+        let hunk = makeHunk()
+        view.diffHunks = [hunk]
+        view.expandedHunkID = hunk.id
+
+        // Replace hunks — stale ID remains but no longer matches any hunk
+        let newHunk = makeHunk(newStart: 10)
+        view.diffHunks = [newHunk]
+        let matchesOld = view.diffHunks.contains { $0.id == hunk.id }
+        #expect(!matchesOld, "Old hunk ID should not match new hunks")
+        #expect(view.expandedHunkID == hunk.id, "expandedHunkID is not auto-cleared")
+    }
+
+    // MARK: - Mouse event helper
+
+    private func makeMouseEvent(at point: NSPoint, in view: NSView) -> NSEvent {
+        // Convert view-local point to window coordinates for NSEvent
+        let windowPoint = view.convert(point, to: nil)
+        return NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: view.window?.windowNumber ?? 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1.0
+        )! // swiftlint:disable:this force_unwrapping
     }
 }

--- a/PineTests/InlineDiffExpandTests.swift
+++ b/PineTests/InlineDiffExpandTests.swift
@@ -131,15 +131,71 @@ struct InlineDiffExpandTests {
         #expect(clickedHunk?.id == hunk.id)
     }
 
-    // MARK: - Accept/Revert buttons removed (#688)
+    // MARK: - Accept/Revert buttons removed (#688) — mouseDown routing
 
-    @Test func gutterNoLongerHasAcceptRevertButtons() {
-        // After #688, accept/revert buttons were removed from the gutter.
-        // Diff markers still work for expand/collapse via onDiffMarkerClick.
+    @Test func mouseDownInOldButtonAreaDoesNotTriggerAcceptRevert() {
+        // After #688, clicking in the area where accept/revert buttons used to be
+        // (left-center of gutter, x ~15-30) no longer triggers any accept/revert action.
+        // It either hits the fold area (x < 14) or passes to super (14 <= x < gutterWidth - 7).
         let view = makeLineNumberView()
         let hunk = makeHunk(newStart: 1)
         view.diffHunks = [hunk]
-        #expect(view.diffHunks.count == 1, "Diff hunks still tracked")
+        view.expandedHunkID = hunk.id
+
+        // Verify no accept/revert properties exist
+        let mirror = Mirror(reflecting: view)
+        let labels = mirror.children.compactMap { $0.label }
+        #expect(!labels.contains("onAcceptHunk"),
+                "onAcceptHunk should be removed after #688")
+        #expect(!labels.contains("onRevertHunk"),
+                "onRevertHunk should be removed after #688")
+    }
+
+    @Test func expandedHunkClickOnlyTriggersMarkerCallback() {
+        // When a hunk is expanded, the only click action in the gutter is
+        // the diff marker click (right edge) for expand/collapse toggle.
+        let view = makeLineNumberView()
+        let hunk = makeHunk(newStart: 1)
+        view.diffHunks = [hunk]
+        view.expandedHunkID = hunk.id
+
+        var markerClicked = false
+        view.onDiffMarkerClick = { _ in markerClicked = true }
+
+        // Simulate callback as mouseDown would route it
+        view.onDiffMarkerClick?(hunk)
+        #expect(markerClicked, "Diff marker click should be the only click action")
+    }
+
+    @Test func mouseDownInMiddleGutterAreaWithExpandedHunkDoesNotCrash() {
+        // After removing accept/revert buttons, clicking in the middle of the
+        // gutter (where buttons used to be) should pass through to super.mouseDown.
+        let view = makeLineNumberView()
+        view.frame = NSRect(x: 0, y: 0, width: 50, height: 100)
+        view.gutterWidth = 50
+        let hunk = makeHunk(newStart: 1)
+        view.diffHunks = [hunk]
+        view.expandedHunkID = hunk.id
+
+        var diffClicked = false
+        view.onDiffMarkerClick = { _ in diffClicked = true }
+
+        // Click at x=20 — in the old button area, now line number area
+        // (x >= 14 and x < gutterWidth - 7 = 43)
+        let windowPoint = view.convert(NSPoint(x: 20, y: 10), to: nil)
+        let event = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1.0
+        )! // swiftlint:disable:this force_unwrapping
+        view.mouseDown(with: event)
+        #expect(!diffClicked, "Click in middle gutter area should not trigger diff callback")
     }
 
     // MARK: - Escape key collapses expanded hunk

--- a/PineTests/InlineDiffExpandTests.swift
+++ b/PineTests/InlineDiffExpandTests.swift
@@ -131,22 +131,15 @@ struct InlineDiffExpandTests {
         #expect(clickedHunk?.id == hunk.id)
     }
 
-    // MARK: - Accept/Revert buttons visibility (only when expanded)
+    // MARK: - Accept/Revert buttons removed (#688)
 
-    @Test func hunkButtonHitTestReturnsNilForNonHunkLine() {
-        let view = makeLineNumberView()
-        let result = view.hunkButtonHitTest(at: NSPoint(x: 15, y: 10), lineNumber: 5)
-        #expect(result == nil)
-    }
-
-    @Test func hunkButtonHitTestReturnsActionForHunkStartLine() {
+    @Test func gutterNoLongerHasAcceptRevertButtons() {
+        // After #688, accept/revert buttons were removed from the gutter.
+        // Diff markers still work for expand/collapse via onDiffMarkerClick.
         let view = makeLineNumberView()
         let hunk = makeHunk(newStart: 1)
         view.diffHunks = [hunk]
-        // hunkButtonHitTest checks hunkStartMap which is rebuilt in didSet
-        let result = view.hunkButtonHitTest(at: NSPoint(x: 15, y: 10), lineNumber: 1)
-        // Should return accept for left area
-        #expect(result == .accept)
+        #expect(view.diffHunks.count == 1, "Diff hunks still tracked")
     }
 
     // MARK: - Escape key collapses expanded hunk

--- a/PineTests/InlineDiffRenderingTests.swift
+++ b/PineTests/InlineDiffRenderingTests.swift
@@ -99,22 +99,75 @@ struct InlineDiffRenderingTests {
 
     // MARK: - Accept/Revert buttons removed (#688)
 
-    @Test func gutterHasNoAcceptRevertButtons() {
-        // After #688, accept/revert buttons were removed from the gutter.
-        // LineNumberView no longer has hunkButtonHitTest, onAcceptHunk, or onRevertHunk.
-        // Diff markers (colored bars) still render correctly.
+    @Test func expandedHunkDoesNotExposeAcceptRevertProperties() {
+        // After #688, expanding a hunk should NOT expose onAcceptHunk or
+        // onRevertHunk on LineNumberView. Verify via Mirror reflection.
         let view = makeLineNumberView()
         let hunk = makeHunk(newStart: 1)
         view.diffHunks = [hunk]
         view.expandedHunkID = hunk.id
 
-        // Verify diff hunks are still tracked for color markers
-        #expect(view.diffHunks.count == 1)
-        // onDiffMarkerClick still works for expand/collapse
-        var clicked = false
-        view.onDiffMarkerClick = { _ in clicked = true }
+        let mirror = Mirror(reflecting: view)
+        let labels = mirror.children.compactMap { $0.label }
+        #expect(!labels.contains("onAcceptHunk"),
+                "onAcceptHunk should not exist on LineNumberView")
+        #expect(!labels.contains("onRevertHunk"),
+                "onRevertHunk should not exist on LineNumberView")
+    }
+
+    @Test func expandedHunkDiffMarkerClickTogglesState() {
+        // Full integration: diff marker click toggles expand/collapse
+        // (the only click action remaining after button removal).
+        let view = makeLineNumberView()
+        let hunk = makeHunk(newStart: 1)
+        view.diffHunks = [hunk]
+
+        var clickedHunkIDs: [UUID] = []
+        view.onDiffMarkerClick = { h in clickedHunkIDs.append(h.id) }
+
+        // Expand
         view.onDiffMarkerClick?(hunk)
-        #expect(clicked)
+        view.expandedHunkID = hunk.id
+        #expect(view.expandedHunkID == hunk.id)
+        #expect(clickedHunkIDs.count == 1)
+
+        // Collapse (click same hunk again)
+        view.onDiffMarkerClick?(hunk)
+        view.expandedHunkID = nil
+        #expect(view.expandedHunkID == nil)
+        #expect(clickedHunkIDs.count == 2)
+        #expect(clickedHunkIDs[0] == clickedHunkIDs[1],
+                "Both clicks should target the same hunk")
+    }
+
+    @Test func mouseDownInOldButtonAreaPassesToSuperNotAcceptRevert() {
+        // Clicking where accept/revert buttons used to be drawn (x ~15-30)
+        // should pass through to super.mouseDown, not trigger any action.
+        let view = makeLineNumberView()
+        view.frame = NSRect(x: 0, y: 0, width: 50, height: 100)
+        view.gutterWidth = 50
+        let hunk = makeHunk(newStart: 1)
+        view.diffHunks = [hunk]
+        view.expandedHunkID = hunk.id
+
+        var diffClicked = false
+        view.onDiffMarkerClick = { _ in diffClicked = true }
+
+        // x=20 is in the old button area — now passes to super
+        let windowPoint = view.convert(NSPoint(x: 20, y: 10), to: nil)
+        let event = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1.0
+        )! // swiftlint:disable:this force_unwrapping
+        view.mouseDown(with: event)
+        #expect(!diffClicked, "Old button area click should not trigger diff callback")
     }
 
     // MARK: - Gutter diff marker click detects hunk across full range

--- a/PineTests/InlineDiffRenderingTests.swift
+++ b/PineTests/InlineDiffRenderingTests.swift
@@ -97,31 +97,24 @@ struct InlineDiffRenderingTests {
         #expect(blocks[0].lines[1] == "old line 2")
     }
 
-    // MARK: - Accept/Revert buttons visible when expanded (no hover required)
+    // MARK: - Accept/Revert buttons removed (#688)
 
-    @Test func hunkActionButtonsVisibleWhenExpanded() {
+    @Test func gutterHasNoAcceptRevertButtons() {
+        // After #688, accept/revert buttons were removed from the gutter.
+        // LineNumberView no longer has hunkButtonHitTest, onAcceptHunk, or onRevertHunk.
+        // Diff markers (colored bars) still render correctly.
         let view = makeLineNumberView()
         let hunk = makeHunk(newStart: 1)
         view.diffHunks = [hunk]
         view.expandedHunkID = hunk.id
 
-        // Buttons should be visible even without mouse hover (isMouseInside = false)
-        // The hunkStartMap should contain the hunk
-        let hitAccept = view.hunkButtonHitTest(at: NSPoint(x: 15, y: 10), lineNumber: 1)
-        #expect(hitAccept == .accept)
-    }
-
-    @Test func hitTestFindsButtonAreaRegardlessOfExpandState() {
-        let view = makeLineNumberView()
-        let hunk = makeHunk(newStart: 1)
-        view.diffHunks = [hunk]
-        view.expandedHunkID = nil
-
-        // hunkButtonHitTest only checks X coordinate and hunkStartMap presence —
-        // it does NOT check expandedHunkID (that guard lives in mouseDown).
-        // So hit test finds the button area even when collapsed.
-        let hitAccept = view.hunkButtonHitTest(at: NSPoint(x: 15, y: 10), lineNumber: 1)
-        #expect(hitAccept == .accept)
+        // Verify diff hunks are still tracked for color markers
+        #expect(view.diffHunks.count == 1)
+        // onDiffMarkerClick still works for expand/collapse
+        var clicked = false
+        view.onDiffMarkerClick = { _ in clicked = true }
+        view.onDiffMarkerClick?(hunk)
+        #expect(clicked)
     }
 
     // MARK: - Gutter diff marker click detects hunk across full range


### PR DESCRIPTION
## Summary
- Removed broken accept/revert buttons (checkmark + undo arrow) from the gutter that were rendering on top of line numbers, producing garbled text like "87℃" instead of "37"
- Gutter now shows only clean color markers: green (added), yellow (modified), red (deleted)
- Menu commands (Accept Change, Revert Change, Accept All, Revert All) still work via NotificationCenter — unaffected by this change

## Test plan
- [x] New `CleanGutterMarkersTests` (10 tests): verifies gutter has no accept/revert callbacks, color markers still work, expand/collapse still works, menu actions preserved
- [x] Updated `InlineDiffRenderingTests`: replaced button hit-test tests with verification that buttons are removed
- [x] Updated `InlineDiffExpandTests`: replaced button hit-test tests with verification that diff hunks are still tracked
- [x] All 53 tests pass
- [x] SwiftLint clean
- [x] Full build succeeds

Closes #688