### PR TITLE
feat: drag files from sidebar to open in specific editor pane

### DIFF
--- a/Pine/FileNodeRow.swift
+++ b/Pine/FileNodeRow.swift
@@ -65,7 +65,9 @@ struct FileNodeRow: View {
                         .foregroundStyle(iconColor)
                 }
                 .opacity(isGitIgnored ? 0.5 : 1.0)
-                .draggable(sidebarDragPayload()) {
+                .onDrag {
+                    sidebarDragProvider()
+                } preview: {
                     sidebarDragPreview()
                 }
             }
@@ -77,14 +79,22 @@ struct FileNodeRow: View {
 
     // MARK: - Drag support
 
-    /// Returns the drag payload for `.draggable()`.
-    /// Directories use an empty placeholder so no meaningful drag starts.
-    private func sidebarDragPayload() -> SidebarFileDragInfo {
+    /// Creates an NSItemProvider for dragging this file node to an editor pane.
+    /// Directories return an empty provider (no-op drag).
+    private func sidebarDragProvider() -> NSItemProvider {
+        guard !node.isDirectory else { return NSItemProvider() }
         let info = SidebarFileDragInfo(fileURL: node.url)
-        if !node.isDirectory {
-            paneManager.activeSidebarDrag = info
+        paneManager.activeSidebarDrag = info
+        let provider = NSItemProvider()
+        provider.registerDataRepresentation(
+            forTypeIdentifier: UTType.sidebarFileDrag.identifier,
+            visibility: .ownProcess
+        ) { completion in
+            let data = info.encoded.data(using: .utf8) ?? Data()
+            completion(data, nil)
+            return nil
         }
-        return info
+        return provider
     }
 
     /// Drag preview label shown while dragging.

--- a/Pine/FileNodeRow.swift
+++ b/Pine/FileNodeRow.swift
@@ -65,16 +65,16 @@ struct FileNodeRow: View {
                         .foregroundStyle(iconColor)
                 }
                 .opacity(isGitIgnored ? 0.5 : 1.0)
-                .onDrag {
-                    sidebarDragProvider()
-                } preview: {
-                    sidebarDragPreview()
-                }
             }
         }
         .tag(node)
         .accessibilityIdentifier(AccessibilityID.fileNode(node.name))
         .contextMenu { fileNodeContextMenu }
+        .onDrag {
+            sidebarDragProvider()
+        } preview: {
+            sidebarDragPreview()
+        }
     }
 
     // MARK: - Drag support

--- a/Pine/FileNodeRow.swift
+++ b/Pine/FileNodeRow.swift
@@ -7,7 +7,6 @@
 
 import os
 import SwiftUI
-import UniformTypeIdentifiers
 
 // MARK: - File/folder row in the sidebar tree
 
@@ -70,32 +69,12 @@ struct FileNodeRow: View {
         .tag(node)
         .accessibilityIdentifier(AccessibilityID.fileNode(node.name))
         .contextMenu { fileNodeContextMenu }
-        .onDrag {
-            sidebarDragProvider()
-        } preview: {
+        .draggable(SidebarFileDragInfo(fileURL: node.url)) {
             sidebarDragPreview()
         }
     }
 
     // MARK: - Drag support
-
-    /// Creates an NSItemProvider for dragging this file node to an editor pane.
-    /// Directories return an empty provider (no-op drag).
-    private func sidebarDragProvider() -> NSItemProvider {
-        guard !node.isDirectory else { return NSItemProvider() }
-        let info = SidebarFileDragInfo(fileURL: node.url)
-        paneManager.activeSidebarDrag = info
-        let provider = NSItemProvider()
-        provider.registerDataRepresentation(
-            forTypeIdentifier: UTType.sidebarFileDrag.identifier,
-            visibility: .ownProcess
-        ) { completion in
-            let data = info.encoded.data(using: .utf8) ?? Data()
-            completion(data, nil)
-            return nil
-        }
-        return provider
-    }
 
     /// Drag preview label shown while dragging.
     @ViewBuilder

--- a/Pine/FileNodeRow.swift
+++ b/Pine/FileNodeRow.swift
@@ -7,6 +7,7 @@
 
 import os
 import SwiftUI
+import UniformTypeIdentifiers
 
 // MARK: - File/folder row in the sidebar tree
 
@@ -15,6 +16,7 @@ struct FileNodeRow: View {
     var node: FileNode
     @Environment(WorkspaceManager.self) var workspace
     @Environment(TabManager.self) var tabManager
+    @Environment(PaneManager.self) var paneManager
     @Environment(SidebarEditState.self) var editState
     @Environment(\.undoManager) private var undoManager
     @FocusState private var isTextFieldFocused: Bool
@@ -67,7 +69,30 @@ struct FileNodeRow: View {
         }
         .tag(node)
         .accessibilityIdentifier(AccessibilityID.fileNode(node.name))
+        .onDrag {
+            sidebarDragProvider()
+        }
         .contextMenu { fileNodeContextMenu }
+    }
+
+    // MARK: - Drag support
+
+    /// Creates an NSItemProvider for dragging this file node to an editor pane.
+    /// Directories return an empty provider (no-op drag).
+    private func sidebarDragProvider() -> NSItemProvider {
+        guard !node.isDirectory else { return NSItemProvider() }
+        let info = SidebarFileDragInfo(fileURL: node.url)
+        paneManager.activeSidebarDrag = info
+        let provider = NSItemProvider()
+        provider.registerDataRepresentation(
+            forTypeIdentifier: UTType.sidebarFileDrag.identifier,
+            visibility: .ownProcess
+        ) { completion in
+            let data = info.encoded.data(using: .utf8) ?? Data()
+            completion(data, nil)
+            return nil
+        }
+        return provider
     }
 
     // MARK: - Inline editor

--- a/Pine/FileNodeRow.swift
+++ b/Pine/FileNodeRow.swift
@@ -63,15 +63,15 @@ struct FileNodeRow: View {
                 } icon: {
                     Image(systemName: iconName)
                         .foregroundStyle(iconColor)
+                        .onDrag {
+                            sidebarDragProvider()
+                        }
                 }
                 .opacity(isGitIgnored ? 0.5 : 1.0)
             }
         }
         .tag(node)
         .accessibilityIdentifier(AccessibilityID.fileNode(node.name))
-        .onDrag {
-            sidebarDragProvider()
-        }
         .contextMenu { fileNodeContextMenu }
     }
 

--- a/Pine/FileNodeRow.swift
+++ b/Pine/FileNodeRow.swift
@@ -63,11 +63,11 @@ struct FileNodeRow: View {
                 } icon: {
                     Image(systemName: iconName)
                         .foregroundStyle(iconColor)
-                        .onDrag {
-                            sidebarDragProvider()
-                        }
                 }
                 .opacity(isGitIgnored ? 0.5 : 1.0)
+                .draggable(sidebarDragPayload()) {
+                    sidebarDragPreview()
+                }
             }
         }
         .tag(node)
@@ -77,22 +77,24 @@ struct FileNodeRow: View {
 
     // MARK: - Drag support
 
-    /// Creates an NSItemProvider for dragging this file node to an editor pane.
-    /// Directories return an empty provider (no-op drag).
-    private func sidebarDragProvider() -> NSItemProvider {
-        guard !node.isDirectory else { return NSItemProvider() }
+    /// Returns the drag payload for `.draggable()`.
+    /// Directories use an empty placeholder so no meaningful drag starts.
+    private func sidebarDragPayload() -> SidebarFileDragInfo {
         let info = SidebarFileDragInfo(fileURL: node.url)
-        paneManager.activeSidebarDrag = info
-        let provider = NSItemProvider()
-        provider.registerDataRepresentation(
-            forTypeIdentifier: UTType.sidebarFileDrag.identifier,
-            visibility: .ownProcess
-        ) { completion in
-            let data = info.encoded.data(using: .utf8) ?? Data()
-            completion(data, nil)
-            return nil
+        if !node.isDirectory {
+            paneManager.activeSidebarDrag = info
         }
-        return provider
+        return info
+    }
+
+    /// Drag preview label shown while dragging.
+    @ViewBuilder
+    private func sidebarDragPreview() -> some View {
+        Label(node.name, systemImage: iconName)
+            .font(.body)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
     }
 
     // MARK: - Inline editor

--- a/Pine/Info.plist
+++ b/Pine/Info.plist
@@ -704,6 +704,17 @@
 				<string>public.data</string>
 			</array>
 		</dict>
+		<!-- Sidebar file drag (internal DnD) -->
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.pine.sidebar-file-drag</string>
+			<key>UTTypeDescription</key>
+			<string>Pine Sidebar File Drag</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+		</dict>
 	</array>
 	<key>UTImportedTypeDeclarations</key>
 	<array>

--- a/Pine/PaneDropZone.swift
+++ b/Pine/PaneDropZone.swift
@@ -12,26 +12,41 @@ import UniformTypeIdentifiers
 
 /// Represents where a tab can be dropped relative to a pane.
 enum PaneDropZone: Equatable, Sendable {
+    case left
     case right
+    case top
     case bottom
     case center
 
-    /// Fraction of pane width/height that triggers edge drop zones (right/bottom).
-    static let edgeThreshold: CGFloat = 0.7
+    /// Fraction of pane width/height that triggers edge drop zones.
+    /// The outer 25% on each edge triggers a split.
+    static let edgeThreshold: CGFloat = 0.25
 
     /// Determines the drop zone based on cursor location within a container of the given size.
-    /// Uses percentage-based thresholds: right 30% = split right, bottom 30% = split down,
-    /// center = move to pane.
     static func zone(for location: CGPoint, in size: CGSize) -> PaneDropZone {
         let width = size.width
         let height = size.height
+        guard width > 0, height > 0 else { return .center }
 
-        let inRightZone = width > 0 && location.x > width * edgeThreshold
-        let inBottomZone = height > 0 && location.y > height * edgeThreshold
+        let relX = location.x / width
+        let relY = location.y / height
 
-        if inRightZone && (!inBottomZone || location.x / width > location.y / height) {
+        let inLeft = relX < edgeThreshold
+        let inRight = relX > (1 - edgeThreshold)
+        let inTop = relY < edgeThreshold
+        let inBottom = relY > (1 - edgeThreshold)
+
+        // If in a corner, pick the axis where the cursor is closer to the edge
+        let distToEdgeX = min(relX, 1 - relX)
+        let distToEdgeY = min(relY, 1 - relY)
+
+        if inLeft && (!inTop && !inBottom || distToEdgeX <= distToEdgeY) {
+            return .left
+        } else if inRight && (!inTop && !inBottom || distToEdgeX <= distToEdgeY) {
             return .right
-        } else if inBottomZone {
+        } else if inTop {
+            return .top
+        } else if inBottom {
             return .bottom
         } else {
             return .center
@@ -60,8 +75,12 @@ struct PaneDropOverlay: View {
 
     private func dropRect(zone: PaneDropZone, size: CGSize) -> CGRect {
         switch zone {
+        case .left:
+            return CGRect(x: 0, y: 0, width: size.width / 2, height: size.height)
         case .right:
             return CGRect(x: size.width / 2, y: 0, width: size.width / 2, height: size.height)
+        case .top:
+            return CGRect(x: 0, y: 0, width: size.width, height: size.height / 2)
         case .bottom:
             return CGRect(x: 0, y: size.height / 2, width: size.width, height: size.height / 2)
         case .center:
@@ -109,12 +128,11 @@ struct PaneSplitDropDelegate: DropDelegate {
 
     func dropExited(info: DropInfo) {
         dropZone = nil
-        // Clear stale drag state when drag leaves all valid drop targets
-        // (e.g., user cancels drag by dropping outside any pane).
-        paneManager.clearStaleDragState()
     }
 
     func performDrop(info: DropInfo) -> Bool {
+        defer { dropZone = nil }
+
         // Pane tab drag takes priority
         if info.hasItemsConforming(to: [.paneTabDrag]) {
             return handlePaneTabDrop()
@@ -127,7 +145,6 @@ struct PaneSplitDropDelegate: DropDelegate {
 
         // File drop from Finder — open as tab in this pane
         if info.hasItemsConforming(to: [.fileURL]) {
-            dropZone = nil
             handleFileDrop(providers: info.itemProviders(for: [.fileURL]))
             return true
         }
@@ -137,18 +154,18 @@ struct PaneSplitDropDelegate: DropDelegate {
 
     private func handleSidebarFileDrop() -> Bool {
         guard let zone = dropZone else { return false }
-        dropZone = nil
-
         guard let dragInfo = paneManager.activeSidebarDrag else { return false }
         paneManager.activeSidebarDrag = nil
 
         switch zone {
-        case .right, .bottom:
-            let axis: SplitAxis = zone == .right ? .horizontal : .vertical
+        case .left, .right, .top, .bottom:
+            let axis: SplitAxis = (zone == .left || zone == .right) ? .horizontal : .vertical
+            let before = (zone == .left || zone == .top)
             paneManager.splitAndOpenFile(
                 url: dragInfo.fileURL,
                 relativeTo: paneID,
-                axis: axis
+                axis: axis,
+                insertBefore: before
             )
         case .center:
             paneManager.openFileInPane(url: dragInfo.fileURL, paneID: paneID)
@@ -158,7 +175,6 @@ struct PaneSplitDropDelegate: DropDelegate {
 
     private func handlePaneTabDrop() -> Bool {
         guard let zone = dropZone else { return false }
-        dropZone = nil
 
         // Use synchronous shared drag state instead of async NSItemProvider
         guard let dragInfo = paneManager.activeDrag else { return false }
@@ -168,9 +184,10 @@ struct PaneSplitDropDelegate: DropDelegate {
         let targetContent = paneManager.root.content(for: paneID)
 
         switch zone {
-        case .right, .bottom:
+        case .left, .right, .top, .bottom:
             // Edge drop always creates a new pane of matching type
-            let axis: SplitAxis = zone == .right ? .horizontal : .vertical
+            let axis: SplitAxis = (zone == .left || zone == .right) ? .horizontal : .vertical
+            let before = (zone == .left || zone == .top)
             if dragInfo.contentType == .terminal {
                 paneManager.createTerminalPane(
                     relativeTo: paneID, axis: axis, workingDirectory: nil
@@ -180,7 +197,8 @@ struct PaneSplitDropDelegate: DropDelegate {
                     paneID,
                     axis: axis,
                     tabURL: dragInfo.fileURL,
-                    sourcePane: sourcePaneID
+                    sourcePane: sourcePaneID,
+                    insertBefore: before
                 )
             }
         case .center:

--- a/Pine/PaneDropZone.swift
+++ b/Pine/PaneDropZone.swift
@@ -139,9 +139,11 @@ struct PaneSplitDropDelegate: DropDelegate {
             return handlePaneTabDrop(zone: savedZone)
         }
 
-        // Sidebar file drag — uses synchronous shared state
+        // Sidebar file drag — decode from item providers async
         if info.hasItemsConforming(to: [.sidebarFileDrag]) {
-            return handleSidebarFileDrop(zone: savedZone)
+            let providers = info.itemProviders(for: [.sidebarFileDrag])
+            handleSidebarFileDrop(zone: savedZone, providers: providers)
+            return true
         }
 
         // File drop from Finder — open as tab in this pane
@@ -153,25 +155,36 @@ struct PaneSplitDropDelegate: DropDelegate {
         return false
     }
 
-    private func handleSidebarFileDrop(zone: PaneDropZone?) -> Bool {
-        guard let zone else { return false }
-        guard let dragInfo = paneManager.activeSidebarDrag else { return false }
-        paneManager.activeSidebarDrag = nil
+    private func handleSidebarFileDrop(zone: PaneDropZone?, providers: [NSItemProvider]) {
+        guard let zone else { return }
+        let capturedPaneID = paneID
+        let capturedPaneManager = paneManager
 
-        switch zone {
-        case .left, .right, .top, .bottom:
-            let axis: SplitAxis = (zone == .left || zone == .right) ? .horizontal : .vertical
-            let before = (zone == .left || zone == .top)
-            paneManager.splitAndOpenFile(
-                url: dragInfo.fileURL,
-                relativeTo: paneID,
-                axis: axis,
-                insertBefore: before
-            )
-        case .center:
-            paneManager.openFileInPane(url: dragInfo.fileURL, paneID: paneID)
+        Task {
+            guard let provider = providers.first,
+                  let data = try? await provider.loadItem(
+                      forTypeIdentifier: UTType.sidebarFileDrag.identifier
+                  ) as? Data,
+                  let dragInfo = try? JSONDecoder().decode(SidebarFileDragInfo.self, from: data) else {
+                return
+            }
+
+            await MainActor.run {
+                switch zone {
+                case .left, .right, .top, .bottom:
+                    let axis: SplitAxis = (zone == .left || zone == .right) ? .horizontal : .vertical
+                    let before = (zone == .left || zone == .top)
+                    capturedPaneManager.splitAndOpenFile(
+                        url: dragInfo.fileURL,
+                        relativeTo: capturedPaneID,
+                        axis: axis,
+                        insertBefore: before
+                    )
+                case .center:
+                    capturedPaneManager.openFileInPane(url: dragInfo.fileURL, paneID: capturedPaneID)
+                }
+            }
         }
-        return true
     }
 
     private func handlePaneTabDrop(zone: PaneDropZone?) -> Bool {

--- a/Pine/PaneDropZone.swift
+++ b/Pine/PaneDropZone.swift
@@ -91,7 +91,9 @@ struct PaneSplitDropDelegate: DropDelegate {
     @Binding var dropZone: PaneDropZone?
 
     func validateDrop(info: DropInfo) -> Bool {
-        info.hasItemsConforming(to: [.paneTabDrag]) || info.hasItemsConforming(to: [.fileURL])
+        info.hasItemsConforming(to: [.paneTabDrag])
+            || info.hasItemsConforming(to: [.sidebarFileDrag])
+            || info.hasItemsConforming(to: [.fileURL])
     }
 
     func dropEntered(info: DropInfo) {
@@ -100,7 +102,8 @@ struct PaneSplitDropDelegate: DropDelegate {
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
         updateDropZone(info: info)
-        let operation: DropOperation = info.hasItemsConforming(to: [.paneTabDrag]) ? .move : .copy
+        let operation: DropOperation = info.hasItemsConforming(to: [.paneTabDrag])
+            ? .move : .copy
         return DropProposal(operation: operation)
     }
 
@@ -114,6 +117,11 @@ struct PaneSplitDropDelegate: DropDelegate {
             return handlePaneTabDrop()
         }
 
+        // Sidebar file drag — uses synchronous shared state
+        if info.hasItemsConforming(to: [.sidebarFileDrag]) {
+            return handleSidebarFileDrop()
+        }
+
         // File drop from Finder — open as tab in this pane
         if info.hasItemsConforming(to: [.fileURL]) {
             dropZone = nil
@@ -122,6 +130,27 @@ struct PaneSplitDropDelegate: DropDelegate {
         }
 
         return false
+    }
+
+    private func handleSidebarFileDrop() -> Bool {
+        guard let zone = dropZone else { return false }
+        dropZone = nil
+
+        guard let dragInfo = paneManager.activeSidebarDrag else { return false }
+        paneManager.activeSidebarDrag = nil
+
+        switch zone {
+        case .right, .bottom:
+            let axis: SplitAxis = zone == .right ? .horizontal : .vertical
+            paneManager.splitAndOpenFile(
+                url: dragInfo.fileURL,
+                relativeTo: paneID,
+                axis: axis
+            )
+        case .center:
+            paneManager.openFileInPane(url: dragInfo.fileURL, paneID: paneID)
+        }
+        return true
     }
 
     private func handlePaneTabDrop() -> Bool {

--- a/Pine/PaneDropZone.swift
+++ b/Pine/PaneDropZone.swift
@@ -109,6 +109,9 @@ struct PaneSplitDropDelegate: DropDelegate {
 
     func dropExited(info: DropInfo) {
         dropZone = nil
+        // Clear stale drag state when drag leaves all valid drop targets
+        // (e.g., user cancels drag by dropping outside any pane).
+        paneManager.clearStaleDragState()
     }
 
     func performDrop(info: DropInfo) -> Bool {

--- a/Pine/PaneDropZone.swift
+++ b/Pine/PaneDropZone.swift
@@ -107,7 +107,6 @@ struct PaneSplitDropDelegate: DropDelegate {
     let paneManager: PaneManager
     /// Actual pane size from GeometryReader, used for percentage-based drop zone detection.
     let paneSize: CGSize
-    @Binding var dropZone: PaneDropZone?
 
     func validateDrop(info: DropInfo) -> Bool {
         info.hasItemsConforming(to: [.paneTabDrag])
@@ -127,20 +126,22 @@ struct PaneSplitDropDelegate: DropDelegate {
     }
 
     func dropExited(info: DropInfo) {
-        dropZone = nil
+        paneManager.dropZones[paneID] = nil
     }
 
     func performDrop(info: DropInfo) -> Bool {
-        defer { dropZone = nil }
+        // Snapshot zone and clear ALL overlays before tree mutations.
+        let savedZone = paneManager.dropZones[paneID]
+        paneManager.clearAllDropZones()
 
         // Pane tab drag takes priority
         if info.hasItemsConforming(to: [.paneTabDrag]) {
-            return handlePaneTabDrop()
+            return handlePaneTabDrop(zone: savedZone)
         }
 
         // Sidebar file drag — uses synchronous shared state
         if info.hasItemsConforming(to: [.sidebarFileDrag]) {
-            return handleSidebarFileDrop()
+            return handleSidebarFileDrop(zone: savedZone)
         }
 
         // File drop from Finder — open as tab in this pane
@@ -152,8 +153,8 @@ struct PaneSplitDropDelegate: DropDelegate {
         return false
     }
 
-    private func handleSidebarFileDrop() -> Bool {
-        guard let zone = dropZone else { return false }
+    private func handleSidebarFileDrop(zone: PaneDropZone?) -> Bool {
+        guard let zone else { return false }
         guard let dragInfo = paneManager.activeSidebarDrag else { return false }
         paneManager.activeSidebarDrag = nil
 
@@ -173,8 +174,8 @@ struct PaneSplitDropDelegate: DropDelegate {
         return true
     }
 
-    private func handlePaneTabDrop() -> Bool {
-        guard let zone = dropZone else { return false }
+    private func handlePaneTabDrop(zone: PaneDropZone?) -> Bool {
+        guard let zone else { return false }
 
         // Use synchronous shared drag state instead of async NSItemProvider
         guard let dragInfo = paneManager.activeDrag else { return false }
@@ -235,6 +236,6 @@ struct PaneSplitDropDelegate: DropDelegate {
     }
 
     private func updateDropZone(info: DropInfo) {
-        dropZone = PaneDropZone.zone(for: info.location, in: paneSize)
+        paneManager.dropZones[paneID] = PaneDropZone.zone(for: info.location, in: paneSize)
     }
 }

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -26,7 +26,6 @@ struct PaneLeafView: View {
     @State private var configValidator = ConfigValidator()
     @State private var isDragTargeted = false
     @State private var goToLineOffset: GoToRequest?
-    @State private var dropZone: PaneDropZone?
     @State private var paneSize: CGSize = .zero
 
     @AppStorage("minimapVisible") private var isMinimapVisible = true
@@ -57,13 +56,12 @@ struct PaneLeafView: View {
         }
         .onPreferenceChange(PaneSizePreferenceKey.self) { paneSize = $0 }
         .overlay {
-            PaneDropOverlay(dropZone: dropZone)
+            PaneDropOverlay(dropZone: paneManager.dropZones[paneID])
         }
         .onDrop(of: [.paneTabDrag, .sidebarFileDrag, .fileURL], delegate: PaneSplitDropDelegate(
             paneID: paneID,
             paneManager: paneManager,
-            paneSize: paneSize,
-            dropZone: $dropZone
+            paneSize: paneSize
         ))
         .border(
             isActive && paneManager.root.leafCount > 1

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -59,7 +59,7 @@ struct PaneLeafView: View {
         .overlay {
             PaneDropOverlay(dropZone: dropZone)
         }
-        .onDrop(of: [.paneTabDrag, .fileURL], delegate: PaneSplitDropDelegate(
+        .onDrop(of: [.paneTabDrag, .sidebarFileDrag, .fileURL], delegate: PaneSplitDropDelegate(
             paneID: paneID,
             paneManager: paneManager,
             paneSize: paneSize,

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -163,6 +163,7 @@ struct PaneLeafView: View {
                 } description: {
                     Text(Strings.selectFilePrompt)
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .accessibilityIdentifier(AccessibilityID.editorPlaceholder)
             }
 

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -94,19 +94,22 @@ final class PaneManager {
 
     /// Splits a pane by placing a new pane alongside it.
     /// The tab at the given URL is moved from the source pane to the new one.
+    /// If `insertBefore` is true, the new pane is placed before (left/top of) the target.
     @discardableResult
     func splitPane(
         _ targetID: PaneID,
         axis: SplitAxis,
         tabURL: URL? = nil,
-        sourcePane: PaneID? = nil
+        sourcePane: PaneID? = nil,
+        insertBefore: Bool = false
     ) -> PaneID? {
         let newID = PaneID()
         guard let newRoot = root.splitting(
             targetID,
             axis: axis,
             newPaneID: newID,
-            newContent: .editor
+            newContent: .editor,
+            insertBefore: insertBefore
         ) else { return nil }
 
         root = newRoot
@@ -325,9 +328,10 @@ final class PaneManager {
     func splitAndOpenFile(
         url: URL,
         relativeTo targetID: PaneID,
-        axis: SplitAxis
+        axis: SplitAxis,
+        insertBefore: Bool = false
     ) -> PaneID? {
-        guard let newPaneID = splitPane(targetID, axis: axis) else { return nil }
+        guard let newPaneID = splitPane(targetID, axis: axis, insertBefore: insertBefore) else { return nil }
         guard let newTabManager = tabManagers[newPaneID] else { return nil }
         newTabManager.openTab(url: url)
         return newPaneID

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -43,6 +43,10 @@ final class PaneManager {
     /// Using shared state avoids unreliable async NSItemProvider loading.
     var activeDrag: TabDragInfo?
 
+    /// Shared drag state for sidebar file drags.
+    /// Set by FileNodeRow.onDrag, read by PaneSplitDropDelegate.
+    var activeSidebarDrag: SidebarFileDragInfo?
+
     /// Creates a PaneManager with a single editor pane.
     init() {
         let initialID = PaneID()
@@ -296,6 +300,46 @@ final class PaneManager {
         } else if let firstLeaf = root.firstLeafID {
             activePaneID = firstLeaf
         }
+    }
+
+    // MARK: - Sidebar file drop operations
+
+    /// Opens a file as a new tab in the specified editor pane.
+    /// Does nothing if the pane has no TabManager (e.g., terminal pane)
+    /// or if the URL is a directory.
+    func openFileInPane(url: URL, paneID: PaneID) {
+        guard let tabManager = tabManagers[paneID] else { return }
+        // Skip directories — they should not open as editor tabs
+        var isDir: ObjCBool = false
+        if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue {
+            return
+        }
+        tabManager.openTab(url: url)
+        activePaneID = paneID
+    }
+
+    /// Splits a pane and opens a file in the new pane.
+    /// Returns the new pane's ID, or nil if the split failed.
+    @discardableResult
+    func splitAndOpenFile(
+        url: URL,
+        relativeTo targetID: PaneID,
+        axis: SplitAxis
+    ) -> PaneID? {
+        let newID = PaneID()
+        guard let newRoot = root.splitting(
+            targetID,
+            axis: axis,
+            newPaneID: newID,
+            newContent: .editor
+        ) else { return nil }
+
+        root = newRoot
+        let newTabManager = TabManager()
+        tabManagers[newID] = newTabManager
+        newTabManager.openTab(url: url)
+        activePaneID = newID
+        return newID
     }
 
     // MARK: - Private helpers

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -311,7 +311,8 @@ final class PaneManager {
         guard let tabManager = tabManagers[paneID] else { return }
         // Skip directories — they should not open as editor tabs
         var isDir: ObjCBool = false
-        if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue {
+        let filePath = url.path(percentEncoded: false)
+        if FileManager.default.fileExists(atPath: filePath, isDirectory: &isDir), isDir.boolValue {
             return
         }
         tabManager.openTab(url: url)
@@ -326,20 +327,17 @@ final class PaneManager {
         relativeTo targetID: PaneID,
         axis: SplitAxis
     ) -> PaneID? {
-        let newID = PaneID()
-        guard let newRoot = root.splitting(
-            targetID,
-            axis: axis,
-            newPaneID: newID,
-            newContent: .editor
-        ) else { return nil }
-
-        root = newRoot
-        let newTabManager = TabManager()
-        tabManagers[newID] = newTabManager
+        guard let newPaneID = splitPane(targetID, axis: axis) else { return nil }
+        guard let newTabManager = tabManagers[newPaneID] else { return nil }
         newTabManager.openTab(url: url)
-        activePaneID = newID
-        return newID
+        return newPaneID
+    }
+
+    /// Clears stale drag state for both tab drags and sidebar file drags.
+    /// Called when a drag exits all valid drop targets (e.g., user cancels drag).
+    func clearStaleDragState() {
+        activeDrag = nil
+        activeSidebarDrag = nil
     }
 
     // MARK: - Private helpers

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -47,6 +47,17 @@ final class PaneManager {
     /// Set by FileNodeRow.onDrag, read by PaneSplitDropDelegate.
     var activeSidebarDrag: SidebarFileDragInfo?
 
+    /// Active drop zone per pane — centralized to avoid stale @State/@Binding issues.
+    var dropZones: [PaneID: PaneDropZone] = [:]
+
+    /// NSEvent monitor for mouse-up cleanup of drop overlays.
+    nonisolated(unsafe) private var mouseUpMonitor: Any?
+
+    /// Clears all drop zone overlays across all panes.
+    func clearAllDropZones() {
+        dropZones.removeAll()
+    }
+
     /// Creates a PaneManager with a single editor pane.
     init() {
         let initialID = PaneID()
@@ -54,6 +65,7 @@ final class PaneManager {
         self.activePaneID = initialID
         let tm = TabManager()
         self.tabManagers[initialID] = tm
+        installMouseUpMonitor()
     }
 
     /// Creates a PaneManager with an existing TabManager (for migration from single-pane).
@@ -62,6 +74,28 @@ final class PaneManager {
         self.root = .leaf(initialID, .editor)
         self.activePaneID = initialID
         self.tabManagers[initialID] = existingTabManager
+        installMouseUpMonitor()
+    }
+
+    deinit {
+        if let monitor = mouseUpMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+    }
+
+    /// Installs a local NSEvent monitor that clears drop overlays on mouse-up.
+    /// SwiftUI DropDelegate does not reliably call dropExited/performDrop when
+    /// a drag is cancelled inside a pane, leaving stale overlays.
+    private func installMouseUpMonitor() {
+        mouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
+            if self?.dropZones.isEmpty == false {
+                // Small delay to let performDrop fire first (it also clears)
+                DispatchQueue.main.async {
+                    self?.clearAllDropZones()
+                }
+            }
+            return event
+        }
     }
 
     /// Returns the TabManager for a given pane.

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -43,10 +43,6 @@ final class PaneManager {
     /// Using shared state avoids unreliable async NSItemProvider loading.
     var activeDrag: TabDragInfo?
 
-    /// Shared drag state for sidebar file drags.
-    /// Set by FileNodeRow.onDrag, read by PaneSplitDropDelegate.
-    var activeSidebarDrag: SidebarFileDragInfo?
-
     /// Active drop zone per pane — centralized to avoid stale @State/@Binding issues.
     var dropZones: [PaneID: PaneDropZone] = [:]
 
@@ -375,7 +371,6 @@ final class PaneManager {
     /// Called when a drag exits all valid drop targets (e.g., user cancels drag).
     func clearStaleDragState() {
         activeDrag = nil
-        activeSidebarDrag = nil
     }
 
     // MARK: - Private helpers

--- a/Pine/PaneNode.swift
+++ b/Pine/PaneNode.swift
@@ -128,12 +128,14 @@ indirect enum PaneNode: Sendable {
     /// Replaces a leaf with a split, putting the original leaf and a new leaf side by side.
     /// Returns nil if `targetID` is not found, if `newPaneID` already exists in the tree,
     /// or if the resulting tree would exceed `paneMaxDepth`.
+    /// - Parameter insertBefore: If true, the new pane is placed before (left/top of) the target.
     func splitting(
         _ targetID: PaneID,
         axis: SplitAxis,
         newPaneID: PaneID,
         newContent: PaneContent,
-        ratio: CGFloat = 0.5
+        ratio: CGFloat = 0.5,
+        insertBefore: Bool = false
     ) -> PaneNode? {
         let clamped = min(max(ratio, 0.1), 0.9)
 
@@ -143,32 +145,37 @@ indirect enum PaneNode: Sendable {
         // Validate: resulting depth must not exceed maxDepth
         guard depth < paneMaxDepth else { return nil }
 
-        return splittingInternal(targetID, axis: axis, newPaneID: newPaneID, newContent: newContent, ratio: clamped)
+        return splittingInternal(targetID, params: SplitParams(
+            axis: axis, newPaneID: newPaneID,
+            newContent: newContent, ratio: clamped, insertBefore: insertBefore
+        ))
+    }
+
+    /// Parameters for an internal split operation, bundled to stay within the 5-parameter limit.
+    private struct SplitParams {
+        let axis: SplitAxis
+        let newPaneID: PaneID
+        let newContent: PaneContent
+        let ratio: CGFloat
+        let insertBefore: Bool
     }
 
     /// Internal recursive splitting without re-validating constraints.
-    private func splittingInternal(
-        _ targetID: PaneID,
-        axis: SplitAxis,
-        newPaneID: PaneID,
-        newContent: PaneContent,
-        ratio: CGFloat
-    ) -> PaneNode? {
+    private func splittingInternal(_ targetID: PaneID, params: SplitParams) -> PaneNode? {
         switch self {
         case .leaf(let id, let content):
             guard id == targetID else { return nil }
-            let newLeaf = PaneNode.leaf(newPaneID, newContent)
-            return .split(axis, first: .leaf(id, content), second: newLeaf, ratio: ratio)
+            let newLeaf = PaneNode.leaf(params.newPaneID, params.newContent)
+            if params.insertBefore {
+                return .split(params.axis, first: newLeaf, second: .leaf(id, content), ratio: params.ratio)
+            }
+            return .split(params.axis, first: .leaf(id, content), second: newLeaf, ratio: params.ratio)
 
         case .split(let ax, let first, let second, let currentRatio):
-            if let newFirst = first.splittingInternal(
-                targetID, axis: axis, newPaneID: newPaneID, newContent: newContent, ratio: ratio
-            ) {
+            if let newFirst = first.splittingInternal(targetID, params: params) {
                 return .split(ax, first: newFirst, second: second, ratio: currentRatio)
             }
-            if let newSecond = second.splittingInternal(
-                targetID, axis: axis, newPaneID: newPaneID, newContent: newContent, ratio: ratio
-            ) {
+            if let newSecond = second.splittingInternal(targetID, params: params) {
                 return .split(ax, first: first, second: newSecond, ratio: currentRatio)
             }
             return nil

--- a/Pine/SidebarFileDragInfo.swift
+++ b/Pine/SidebarFileDragInfo.swift
@@ -6,19 +6,26 @@
 //  Separate from TabDragInfo to distinguish sidebar file drags from tab drags.
 //
 
+import CoreTransferable
 import Foundation
 import UniformTypeIdentifiers
 
 /// Custom UTType for sidebar file drag operations.
 /// Distinct from `.paneTabDrag` so drop delegates can distinguish sidebar drags from tab reorders.
 extension UTType {
-    static let sidebarFileDrag = UTType(exportedAs: "com.pine.sidebar-file-drag")
+    nonisolated(unsafe) static let sidebarFileDrag = UTType(exportedAs: "com.pine.sidebar-file-drag")
 }
 
 /// Information about a file being dragged from the sidebar.
 /// JSON-encoded for NSItemProvider transport via custom UTType.
-struct SidebarFileDragInfo: Codable, Sendable {
+/// Conforms to Transferable so `.draggable()` can be used instead of `.onDrag`,
+/// which avoids tap gesture conflicts in List rows.
+struct SidebarFileDragInfo: Codable, Sendable, Transferable {
     let fileURL: URL
+
+    static var transferRepresentation: some TransferRepresentation {
+        CodableRepresentation(contentType: .sidebarFileDrag)
+    }
 
     /// JSON-encodes to a string for drag transfer.
     var encoded: String {

--- a/Pine/SidebarFileDragInfo.swift
+++ b/Pine/SidebarFileDragInfo.swift
@@ -1,0 +1,37 @@
+//
+//  SidebarFileDragInfo.swift
+//  Pine
+//
+//  Drag data for dragging files from the sidebar to editor panes.
+//  Separate from TabDragInfo to distinguish sidebar file drags from tab drags.
+//
+
+import Foundation
+import UniformTypeIdentifiers
+
+/// Custom UTType for sidebar file drag operations.
+/// Distinct from `.paneTabDrag` so drop delegates can distinguish sidebar drags from tab reorders.
+extension UTType {
+    static let sidebarFileDrag = UTType(exportedAs: "com.pine.sidebar-file-drag")
+}
+
+/// Information about a file being dragged from the sidebar.
+/// JSON-encoded for NSItemProvider transport via custom UTType.
+struct SidebarFileDragInfo: Codable, Sendable {
+    let fileURL: URL
+
+    /// JSON-encodes to a string for drag transfer.
+    var encoded: String {
+        guard let data = try? JSONEncoder().encode(self),
+              let string = String(data: data, encoding: .utf8) else {
+            return ""
+        }
+        return string
+    }
+
+    /// Decodes from a JSON string. Returns nil if format is invalid.
+    static func decode(from string: String) -> SidebarFileDragInfo? {
+        guard let data = string.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(SidebarFileDragInfo.self, from: data)
+    }
+}

--- a/Pine/SidebarFileDragInfo.swift
+++ b/Pine/SidebarFileDragInfo.swift
@@ -6,26 +6,19 @@
 //  Separate from TabDragInfo to distinguish sidebar file drags from tab drags.
 //
 
-import CoreTransferable
 import Foundation
 import UniformTypeIdentifiers
 
 /// Custom UTType for sidebar file drag operations.
 /// Distinct from `.paneTabDrag` so drop delegates can distinguish sidebar drags from tab reorders.
 extension UTType {
-    nonisolated(unsafe) static let sidebarFileDrag = UTType(exportedAs: "com.pine.sidebar-file-drag")
+    static let sidebarFileDrag = UTType(exportedAs: "com.pine.sidebar-file-drag")
 }
 
 /// Information about a file being dragged from the sidebar.
 /// JSON-encoded for NSItemProvider transport via custom UTType.
-/// Conforms to Transferable so `.draggable()` can be used instead of `.onDrag`,
-/// which avoids tap gesture conflicts in List rows.
-struct SidebarFileDragInfo: Codable, Sendable, Transferable {
+struct SidebarFileDragInfo: Codable, Sendable {
     let fileURL: URL
-
-    static var transferRepresentation: some TransferRepresentation {
-        CodableRepresentation(contentType: .sidebarFileDrag)
-    }
 
     /// JSON-encodes to a string for drag transfer.
     var encoded: String {

--- a/Pine/SidebarFileDragInfo.swift
+++ b/Pine/SidebarFileDragInfo.swift
@@ -6,19 +6,25 @@
 //  Separate from TabDragInfo to distinguish sidebar file drags from tab drags.
 //
 
+import CoreTransferable
 import Foundation
 import UniformTypeIdentifiers
 
 /// Custom UTType for sidebar file drag operations.
 /// Distinct from `.paneTabDrag` so drop delegates can distinguish sidebar drags from tab reorders.
-extension UTType {
+nonisolated extension UTType {
     static let sidebarFileDrag = UTType(exportedAs: "com.pine.sidebar-file-drag")
 }
 
 /// Information about a file being dragged from the sidebar.
-/// JSON-encoded for NSItemProvider transport via custom UTType.
-struct SidebarFileDragInfo: Codable, Sendable {
+/// Conforms to Transferable for use with `.draggable()` modifier,
+/// which works correctly with SwiftUI List selection (unlike `.onDrag`).
+struct SidebarFileDragInfo: Codable, Sendable, Transferable {
     let fileURL: URL
+
+    nonisolated static var transferRepresentation: some TransferRepresentation {
+        CodableRepresentation(contentType: .sidebarFileDrag)
+    }
 
     /// JSON-encodes to a string for drag transfer.
     var encoded: String {

--- a/PineTests/SidebarDragDropTests.swift
+++ b/PineTests/SidebarDragDropTests.swift
@@ -280,20 +280,40 @@ struct SidebarDragDropTests {
         #expect(zone == .center)
     }
 
+    @Test("PaneDropZone.zone returns left for left edge")
+    func dropZoneLeftForLeftEdge() {
+        let size = CGSize(width: 400, height: 300)
+        let location = CGPoint(x: 30, y: 150)
+
+        let zone = PaneDropZone.zone(for: location, in: size)
+
+        #expect(zone == .left)
+    }
+
     @Test("PaneDropZone.zone returns right for right edge")
     func dropZoneRightForRightEdge() {
         let size = CGSize(width: 400, height: 300)
-        let location = CGPoint(x: 350, y: 150)
+        let location = CGPoint(x: 370, y: 150)
 
         let zone = PaneDropZone.zone(for: location, in: size)
 
         #expect(zone == .right)
     }
 
+    @Test("PaneDropZone.zone returns top for top edge")
+    func dropZoneTopForTopEdge() {
+        let size = CGSize(width: 400, height: 300)
+        let location = CGPoint(x: 200, y: 20)
+
+        let zone = PaneDropZone.zone(for: location, in: size)
+
+        #expect(zone == .top)
+    }
+
     @Test("PaneDropZone.zone returns bottom for bottom edge")
     func dropZoneBottomForBottomEdge() {
         let size = CGSize(width: 400, height: 300)
-        let location = CGPoint(x: 150, y: 280)
+        let location = CGPoint(x: 200, y: 280)
 
         let zone = PaneDropZone.zone(for: location, in: size)
 

--- a/PineTests/SidebarDragDropTests.swift
+++ b/PineTests/SidebarDragDropTests.swift
@@ -359,6 +359,117 @@ struct SidebarDragDropTests {
         #expect(tm?.tabs.isEmpty == true)
     }
 
+    // MARK: - clearStaleDragState
+
+    @Test("clearStaleDragState clears activeSidebarDrag")
+    func clearStaleDragStateClearsSidebar() {
+        let pm = PaneManager()
+        pm.activeSidebarDrag = SidebarFileDragInfo(
+            fileURL: URL(fileURLWithPath: "/tmp/test.swift")
+        )
+
+        pm.clearStaleDragState()
+
+        #expect(pm.activeSidebarDrag == nil)
+    }
+
+    @Test("clearStaleDragState clears activeDrag")
+    func clearStaleDragStateClearsTab() {
+        let pm = PaneManager()
+        pm.activeDrag = TabDragInfo(
+            paneID: pm.activePaneID.id,
+            tabID: UUID(),
+            fileURL: URL(fileURLWithPath: "/tmp/test.swift")
+        )
+
+        pm.clearStaleDragState()
+
+        #expect(pm.activeDrag == nil)
+    }
+
+    @Test("clearStaleDragState clears both drag states simultaneously")
+    func clearStaleDragStateClearsBoth() {
+        let pm = PaneManager()
+        pm.activeSidebarDrag = SidebarFileDragInfo(
+            fileURL: URL(fileURLWithPath: "/tmp/sidebar.swift")
+        )
+        pm.activeDrag = TabDragInfo(
+            paneID: pm.activePaneID.id,
+            tabID: UUID(),
+            fileURL: URL(fileURLWithPath: "/tmp/tab.swift")
+        )
+
+        pm.clearStaleDragState()
+
+        #expect(pm.activeSidebarDrag == nil)
+        #expect(pm.activeDrag == nil)
+    }
+
+    @Test("clearStaleDragState is safe when both are already nil")
+    func clearStaleDragStateWhenAlreadyNil() {
+        let pm = PaneManager()
+
+        pm.clearStaleDragState()
+
+        #expect(pm.activeSidebarDrag == nil)
+        #expect(pm.activeDrag == nil)
+    }
+
+    // MARK: - openFileInPane with percent-encoded URLs
+
+    @Test("openFileInPane handles files with spaces in path")
+    func openFileWithSpacesInPath() {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("my project")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("my file.swift")
+        try? "let x = 1".write(to: file, atomically: true, encoding: .utf8)
+
+        let pm = PaneManager()
+        let paneID = pm.activePaneID
+
+        pm.openFileInPane(url: file, paneID: paneID)
+
+        let tm = pm.tabManager(for: paneID)
+        #expect(tm?.tabs.count == 1)
+        #expect(tm?.activeTab?.url == file)
+    }
+
+    @Test("openFileInPane skips directory with spaces in path")
+    func openDirectoryWithSpacesDoesNothing() {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("my directory")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let pm = PaneManager()
+        let paneID = pm.activePaneID
+
+        pm.openFileInPane(url: dir, paneID: paneID)
+
+        let tm = pm.tabManager(for: paneID)
+        #expect(tm?.tabs.isEmpty == true)
+    }
+
+    // MARK: - splitAndOpenFile reuses splitPane
+
+    @Test("splitAndOpenFile sets activePaneID to the new pane (via splitPane)")
+    func splitAndOpenFileActivePaneViaDelegate() throws {
+        let file = tempFile(name: "delegate.swift")
+        let pm = PaneManager()
+        let originalPaneID = pm.activePaneID
+
+        let newPaneID = pm.splitAndOpenFile(
+            url: file, relativeTo: originalPaneID, axis: .horizontal
+        )
+
+        let newID = try #require(newPaneID)
+        #expect(pm.activePaneID == newID)
+        // Verify the new pane has a registered TabManager (created by splitPane)
+        #expect(pm.tabManager(for: newID) != nil)
+    }
+
     // MARK: - Multiple files sequentially
 
     @Test("Opening multiple files in same pane creates multiple tabs")

--- a/PineTests/SidebarDragDropTests.swift
+++ b/PineTests/SidebarDragDropTests.swift
@@ -1,0 +1,397 @@
+//
+//  SidebarDragDropTests.swift
+//  PineTests
+//
+//  Tests for dragging files from the sidebar to open in specific editor panes.
+//
+
+import Foundation
+import Testing
+import UniformTypeIdentifiers
+
+@testable import Pine
+
+@Suite("Sidebar Drag & Drop Tests")
+@MainActor
+struct SidebarDragDropTests {
+
+    // MARK: - Helpers
+
+    /// Creates a temporary file for testing.
+    private func tempFile(name: String = "test.swift", content: String = "hello") -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(name)
+        try? content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    // MARK: - SidebarFileDragInfo encoding/decoding
+
+    @Test("SidebarFileDragInfo encodes and decodes round-trip")
+    func roundTrip() {
+        let url = URL(fileURLWithPath: "/tmp/test.swift")
+        let info = SidebarFileDragInfo(fileURL: url)
+        let encoded = info.encoded
+        let decoded = SidebarFileDragInfo.decode(from: encoded)
+
+        #expect(decoded != nil)
+        #expect(decoded?.fileURL == url)
+    }
+
+    @Test("SidebarFileDragInfo decode returns nil for invalid JSON")
+    func decodeInvalid() {
+        let result = SidebarFileDragInfo.decode(from: "not json")
+        #expect(result == nil)
+    }
+
+    @Test("SidebarFileDragInfo decode returns nil for empty string")
+    func decodeEmpty() {
+        let result = SidebarFileDragInfo.decode(from: "")
+        #expect(result == nil)
+    }
+
+    @Test("SidebarFileDragInfo preserves file URL with spaces")
+    func urlWithSpaces() {
+        let url = URL(fileURLWithPath: "/tmp/my project/file name.swift")
+        let info = SidebarFileDragInfo(fileURL: url)
+        let decoded = SidebarFileDragInfo.decode(from: info.encoded)
+
+        #expect(decoded?.fileURL.path == url.path)
+    }
+
+    @Test("SidebarFileDragInfo preserves deep nested path")
+    func deepNestedPath() {
+        let url = URL(fileURLWithPath: "/a/b/c/d/e/f/g.txt")
+        let info = SidebarFileDragInfo(fileURL: url)
+        let decoded = SidebarFileDragInfo.decode(from: info.encoded)
+
+        #expect(decoded?.fileURL == url)
+    }
+
+    // MARK: - UTType
+
+    @Test("sidebarFileDrag UTType is defined")
+    func utTypeDefined() {
+        let type = UTType.sidebarFileDrag
+        #expect(type.identifier == "com.pine.sidebar-file-drag")
+    }
+
+    @Test("sidebarFileDrag UTType is distinct from paneTabDrag")
+    func utTypeDistinct() {
+        #expect(UTType.sidebarFileDrag != UTType.paneTabDrag)
+    }
+
+    // MARK: - PaneManager.openFileInPane
+
+    @Test("openFileInPane opens file as tab in the specified pane")
+    func openFileInPane() {
+        let file = tempFile(name: "sidebar.swift", content: "let x = 1")
+        let pm = PaneManager()
+        let paneID = pm.activePaneID
+
+        pm.openFileInPane(url: file, paneID: paneID)
+
+        let tm = pm.tabManager(for: paneID)
+        #expect(tm?.tabs.count == 1)
+        #expect(tm?.activeTab?.url == file)
+    }
+
+    @Test("openFileInPane does nothing for nonexistent pane")
+    func openFileInNonexistentPane() {
+        let file = tempFile()
+        let pm = PaneManager()
+        let fakePaneID = PaneID()
+
+        pm.openFileInPane(url: file, paneID: fakePaneID)
+
+        // No crash, no tabs opened in active pane
+        let tm = pm.tabManager(for: pm.activePaneID)
+        #expect(tm?.tabs.isEmpty == true)
+    }
+
+    @Test("openFileInPane does not open duplicate tabs")
+    func openFileInPaneNoDuplicate() {
+        let file = tempFile(name: "dup.swift")
+        let pm = PaneManager()
+        let paneID = pm.activePaneID
+        pm.openFileInPane(url: file, paneID: paneID)
+
+        pm.openFileInPane(url: file, paneID: paneID)
+
+        let tm = pm.tabManager(for: paneID)
+        #expect(tm?.tabs.count == 1)
+    }
+
+    @Test("openFileInPane does nothing for terminal pane")
+    func openFileInTerminalPane() {
+        let file = tempFile()
+        let pm = PaneManager()
+        let termID = pm.createTerminalPaneAtBottom(workingDirectory: nil)
+
+        pm.openFileInPane(url: file, paneID: termID)
+
+        // Terminal panes have no tab manager — file should not open
+        let tm = pm.tabManager(for: termID)
+        #expect(tm == nil)
+    }
+
+    // MARK: - PaneManager.splitAndOpenFile
+
+    @Test("splitAndOpenFile creates horizontal split and opens file")
+    func splitAndOpenFileHorizontal() throws {
+        let file = tempFile(name: "split.swift", content: "let y = 2")
+        let pm = PaneManager()
+        let originalPaneID = pm.activePaneID
+
+        let newPaneID = pm.splitAndOpenFile(
+            url: file, relativeTo: originalPaneID, axis: .horizontal
+        )
+
+        let newID = try #require(newPaneID)
+        #expect(pm.root.leafCount == 2)
+        let tm = pm.tabManager(for: newID)
+        #expect(tm?.tabs.count == 1)
+        #expect(tm?.activeTab?.url == file)
+    }
+
+    @Test("splitAndOpenFile creates vertical split and opens file")
+    func splitAndOpenFileVertical() throws {
+        let file = tempFile(name: "split-v.swift")
+        let pm = PaneManager()
+        let originalPaneID = pm.activePaneID
+
+        let newPaneID = pm.splitAndOpenFile(
+            url: file, relativeTo: originalPaneID, axis: .vertical
+        )
+
+        let newID = try #require(newPaneID)
+        #expect(pm.root.leafCount == 2)
+        let tm = pm.tabManager(for: newID)
+        #expect(tm?.activeTab?.url == file)
+    }
+
+    @Test("splitAndOpenFile returns nil for nonexistent pane")
+    func splitAndOpenFileNonexistentPane() {
+        let file = tempFile()
+        let pm = PaneManager()
+        let fakePaneID = PaneID()
+
+        let result = pm.splitAndOpenFile(url: file, relativeTo: fakePaneID, axis: .horizontal)
+
+        #expect(result == nil)
+        #expect(pm.root.leafCount == 1)
+    }
+
+    @Test("splitAndOpenFile sets new pane as active")
+    func splitAndOpenFileSetsActive() {
+        let file = tempFile()
+        let pm = PaneManager()
+        let originalPaneID = pm.activePaneID
+
+        let newPaneID = pm.splitAndOpenFile(
+            url: file, relativeTo: originalPaneID, axis: .horizontal
+        )
+
+        #expect(pm.activePaneID == newPaneID)
+    }
+
+    @Test("splitAndOpenFile preserves existing pane tabs")
+    func splitAndOpenFilePreservesExistingTabs() {
+        let existingFile = tempFile(name: "existing.swift")
+        let newFile = tempFile(name: "new.swift")
+        let pm = PaneManager()
+        let originalPaneID = pm.activePaneID
+        pm.tabManager(for: originalPaneID)?.openTab(url: existingFile)
+
+        _ = pm.splitAndOpenFile(
+            url: newFile, relativeTo: originalPaneID, axis: .horizontal
+        )
+
+        let originalTM = pm.tabManager(for: originalPaneID)
+        #expect(originalTM?.tabs.count == 1)
+        #expect(originalTM?.activeTab?.url == existingFile)
+    }
+
+    @Test("splitAndOpenFile respects max depth")
+    func splitAndOpenFileMaxDepth() {
+        let pm = PaneManager()
+        var currentPaneID = pm.activePaneID
+
+        // Split until max depth
+        for i in 0..<(paneMaxDepth - 1) {
+            let file = tempFile(name: "deep\(i).swift")
+            if let newID = pm.splitAndOpenFile(
+                url: file, relativeTo: currentPaneID, axis: .horizontal
+            ) {
+                currentPaneID = newID
+            }
+        }
+
+        // Next split should fail
+        let oneMore = tempFile(name: "tooDeep.swift")
+        let result = pm.splitAndOpenFile(
+            url: oneMore, relativeTo: currentPaneID, axis: .horizontal
+        )
+        #expect(result == nil)
+    }
+
+    // MARK: - PaneManager.activeSidebarDrag
+
+    @Test("activeSidebarDrag is nil by default")
+    func activeSidebarDragDefault() {
+        let pm = PaneManager()
+        #expect(pm.activeSidebarDrag == nil)
+    }
+
+    @Test("activeSidebarDrag can be set and read")
+    func activeSidebarDragSetAndRead() {
+        let pm = PaneManager()
+        let url = URL(fileURLWithPath: "/tmp/test.swift")
+        let info = SidebarFileDragInfo(fileURL: url)
+
+        pm.activeSidebarDrag = info
+
+        #expect(pm.activeSidebarDrag?.fileURL == url)
+    }
+
+    @Test("activeSidebarDrag can be cleared")
+    func activeSidebarDragClear() {
+        let pm = PaneManager()
+        pm.activeSidebarDrag = SidebarFileDragInfo(
+            fileURL: URL(fileURLWithPath: "/tmp/test.swift")
+        )
+
+        pm.activeSidebarDrag = nil
+
+        #expect(pm.activeSidebarDrag == nil)
+    }
+
+    // MARK: - Drop zone + sidebar interaction
+
+    @Test("PaneDropZone.zone returns center for middle area")
+    func dropZoneCenterForMiddle() {
+        let size = CGSize(width: 400, height: 300)
+        let location = CGPoint(x: 200, y: 150)
+
+        let zone = PaneDropZone.zone(for: location, in: size)
+
+        #expect(zone == .center)
+    }
+
+    @Test("PaneDropZone.zone returns right for right edge")
+    func dropZoneRightForRightEdge() {
+        let size = CGSize(width: 400, height: 300)
+        let location = CGPoint(x: 350, y: 150)
+
+        let zone = PaneDropZone.zone(for: location, in: size)
+
+        #expect(zone == .right)
+    }
+
+    @Test("PaneDropZone.zone returns bottom for bottom edge")
+    func dropZoneBottomForBottomEdge() {
+        let size = CGSize(width: 400, height: 300)
+        let location = CGPoint(x: 150, y: 280)
+
+        let zone = PaneDropZone.zone(for: location, in: size)
+
+        #expect(zone == .bottom)
+    }
+
+    // MARK: - Integration: sidebar drag to center opens file in pane
+
+    @Test("Center drop from sidebar opens file as tab in target pane")
+    func centerDropOpensFile() {
+        let file = tempFile(name: "center.swift", content: "// center")
+        let pm = PaneManager()
+        let paneID = pm.activePaneID
+
+        // Simulate what PaneSplitDropDelegate does for center sidebar drop
+        pm.openFileInPane(url: file, paneID: paneID)
+
+        let tm = pm.tabManager(for: paneID)
+        #expect(tm?.tabs.count == 1)
+        #expect(tm?.activeTab?.url == file)
+    }
+
+    // MARK: - Integration: sidebar drag to edge creates split
+
+    @Test("Right edge drop from sidebar creates horizontal split with file")
+    func rightEdgeDropCreatesSplit() {
+        let file = tempFile(name: "right.swift", content: "// right")
+        let pm = PaneManager()
+        let paneID = pm.activePaneID
+
+        // Simulate what PaneSplitDropDelegate does for right edge sidebar drop
+        let newPaneID = pm.splitAndOpenFile(url: file, relativeTo: paneID, axis: .horizontal)
+
+        #expect(newPaneID != nil)
+        #expect(pm.root.leafCount == 2)
+    }
+
+    @Test("Bottom edge drop from sidebar creates vertical split with file")
+    func bottomEdgeDropCreatesSplit() {
+        let file = tempFile(name: "bottom.swift", content: "// bottom")
+        let pm = PaneManager()
+        let paneID = pm.activePaneID
+
+        let newPaneID = pm.splitAndOpenFile(url: file, relativeTo: paneID, axis: .vertical)
+
+        #expect(newPaneID != nil)
+        #expect(pm.root.leafCount == 2)
+    }
+
+    // MARK: - Edge: directories should not open as tabs
+
+    @Test("openFileInPane does not open directories")
+    func openDirectoryDoesNothing() {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let pm = PaneManager()
+        let paneID = pm.activePaneID
+
+        pm.openFileInPane(url: dir, paneID: paneID)
+
+        let tm = pm.tabManager(for: paneID)
+        #expect(tm?.tabs.isEmpty == true)
+    }
+
+    // MARK: - Multiple files sequentially
+
+    @Test("Opening multiple files in same pane creates multiple tabs")
+    func multipleFilesInSamePane() {
+        let file1 = tempFile(name: "a.swift")
+        let file2 = tempFile(name: "b.swift")
+        let file3 = tempFile(name: "c.swift")
+        let pm = PaneManager()
+        let paneID = pm.activePaneID
+
+        pm.openFileInPane(url: file1, paneID: paneID)
+        pm.openFileInPane(url: file2, paneID: paneID)
+        pm.openFileInPane(url: file3, paneID: paneID)
+
+        let tm = pm.tabManager(for: paneID)
+        #expect(tm?.tabs.count == 3)
+        #expect(tm?.activeTab?.url == file3)
+    }
+
+    // MARK: - Split then open in new pane
+
+    @Test("Split and open file leaves original pane unchanged")
+    func splitDoesNotModifyOriginal() {
+        let originalFile = tempFile(name: "original.swift")
+        let newFile = tempFile(name: "new.swift")
+        let pm = PaneManager()
+        let originalPaneID = pm.activePaneID
+        pm.tabManager(for: originalPaneID)?.openTab(url: originalFile)
+
+        _ = pm.splitAndOpenFile(url: newFile, relativeTo: originalPaneID, axis: .horizontal)
+
+        let originalTM = pm.tabManager(for: originalPaneID)
+        #expect(originalTM?.tabs.count == 1)
+        #expect(originalTM?.activeTab?.url == originalFile)
+    }
+}

--- a/PineTests/SidebarDragDropTests.swift
+++ b/PineTests/SidebarDragDropTests.swift
@@ -237,35 +237,15 @@ struct SidebarDragDropTests {
         #expect(result == nil)
     }
 
-    // MARK: - PaneManager.activeSidebarDrag
+    // MARK: - SidebarFileDragInfo Transferable
 
-    @Test("activeSidebarDrag is nil by default")
-    func activeSidebarDragDefault() {
-        let pm = PaneManager()
-        #expect(pm.activeSidebarDrag == nil)
-    }
-
-    @Test("activeSidebarDrag can be set and read")
-    func activeSidebarDragSetAndRead() {
-        let pm = PaneManager()
+    @Test("SidebarFileDragInfo conforms to Transferable via CodableRepresentation")
+    func sidebarDragInfoTransferable() {
         let url = URL(fileURLWithPath: "/tmp/test.swift")
         let info = SidebarFileDragInfo(fileURL: url)
-
-        pm.activeSidebarDrag = info
-
-        #expect(pm.activeSidebarDrag?.fileURL == url)
-    }
-
-    @Test("activeSidebarDrag can be cleared")
-    func activeSidebarDragClear() {
-        let pm = PaneManager()
-        pm.activeSidebarDrag = SidebarFileDragInfo(
-            fileURL: URL(fileURLWithPath: "/tmp/test.swift")
-        )
-
-        pm.activeSidebarDrag = nil
-
-        #expect(pm.activeSidebarDrag == nil)
+        let encoded = info.encoded
+        let decoded = SidebarFileDragInfo.decode(from: encoded)
+        #expect(decoded?.fileURL == url)
     }
 
     // MARK: - Drop zone + sidebar interaction
@@ -381,18 +361,6 @@ struct SidebarDragDropTests {
 
     // MARK: - clearStaleDragState
 
-    @Test("clearStaleDragState clears activeSidebarDrag")
-    func clearStaleDragStateClearsSidebar() {
-        let pm = PaneManager()
-        pm.activeSidebarDrag = SidebarFileDragInfo(
-            fileURL: URL(fileURLWithPath: "/tmp/test.swift")
-        )
-
-        pm.clearStaleDragState()
-
-        #expect(pm.activeSidebarDrag == nil)
-    }
-
     @Test("clearStaleDragState clears activeDrag")
     func clearStaleDragStateClearsTab() {
         let pm = PaneManager()
@@ -407,31 +375,12 @@ struct SidebarDragDropTests {
         #expect(pm.activeDrag == nil)
     }
 
-    @Test("clearStaleDragState clears both drag states simultaneously")
-    func clearStaleDragStateClearsBoth() {
-        let pm = PaneManager()
-        pm.activeSidebarDrag = SidebarFileDragInfo(
-            fileURL: URL(fileURLWithPath: "/tmp/sidebar.swift")
-        )
-        pm.activeDrag = TabDragInfo(
-            paneID: pm.activePaneID.id,
-            tabID: UUID(),
-            fileURL: URL(fileURLWithPath: "/tmp/tab.swift")
-        )
-
-        pm.clearStaleDragState()
-
-        #expect(pm.activeSidebarDrag == nil)
-        #expect(pm.activeDrag == nil)
-    }
-
-    @Test("clearStaleDragState is safe when both are already nil")
+    @Test("clearStaleDragState is safe when already nil")
     func clearStaleDragStateWhenAlreadyNil() {
         let pm = PaneManager()
 
         pm.clearStaleDragState()
 
-        #expect(pm.activeSidebarDrag == nil)
         #expect(pm.activeDrag == nil)
     }
 

--- a/PineTests/TabDragInfoTests.swift
+++ b/PineTests/TabDragInfoTests.swift
@@ -201,42 +201,107 @@ struct PaneDropZoneTests {
 struct PaneDropZoneZoneTests {
     private let size = CGSize(width: 1000, height: 800)
 
+    // MARK: - Threshold
+
+    @Test func edgeThreshold_isTwentyFivePercent() {
+        #expect(PaneDropZone.edgeThreshold == 0.25)
+    }
+
+    // MARK: - Center zone
+
     @Test func centerZone_inMiddleOfView() {
-        let location = CGPoint(x: 300, y: 300)
+        let location = CGPoint(x: 500, y: 400)
         #expect(PaneDropZone.zone(for: location, in: size) == .center)
     }
 
-    @Test func rightZone_inRightEdge() {
-        // x > 1000 * 0.7 = 700 → right zone
-        let location = CGPoint(x: 800, y: 200)
-        #expect(PaneDropZone.zone(for: location, in: size) == .right)
-    }
-
-    @Test func bottomZone_inBottomEdge() {
-        // y > 800 * 0.7 = 560 → bottom zone
-        let location = CGPoint(x: 200, y: 700)
-        #expect(PaneDropZone.zone(for: location, in: size) == .bottom)
-    }
-
-    @Test func rightZone_winsWhenBothEdges_rightDominant() {
-        // Both in right and bottom zone, but x/width > y/height → right wins
-        let location = CGPoint(x: 900, y: 600)
-        // 900/1000 = 0.9, 600/800 = 0.75 → right
-        #expect(PaneDropZone.zone(for: location, in: size) == .right)
-    }
-
-    @Test func bottomZone_winsWhenBothEdges_bottomDominant() {
-        // Both in right and bottom zone, but y/height > x/width → bottom wins
-        let location = CGPoint(x: 750, y: 780)
-        // 750/1000 = 0.75, 780/800 = 0.975 → bottom
-        #expect(PaneDropZone.zone(for: location, in: size) == .bottom)
-    }
-
-    @Test func centerZone_atExactThresholdBoundary() {
-        // x = 700 exactly (not > 700) → center
-        let location = CGPoint(x: 700, y: 400)
+    @Test func centerZone_justInsideAllEdges() {
+        // relX = 0.26, relY = 0.26 — inside all thresholds
+        let location = CGPoint(x: 260, y: 210)
         #expect(PaneDropZone.zone(for: location, in: size) == .center)
     }
+
+    // MARK: - Left zone
+
+    @Test func leftZone_leftEdge() {
+        // relX = 0.1 < 0.25, relY = 0.5 (center vertically) → left
+        let location = CGPoint(x: 100, y: 400)
+        #expect(PaneDropZone.zone(for: location, in: size) == .left)
+    }
+
+    @Test func leftZone_topLeftCorner_closerToLeft() {
+        // relX = 0.05, relY = 0.05 — both in left and top, distToEdgeX (0.05) <= distToEdgeY (0.05) → left
+        let location = CGPoint(x: 50, y: 40)
+        #expect(PaneDropZone.zone(for: location, in: size) == .left)
+    }
+
+    @Test func leftZone_atOrigin() {
+        // relX = 0, relY = 0 — both left and top, distToEdgeX (0) <= distToEdgeY (0) → left
+        let location = CGPoint(x: 0, y: 0)
+        #expect(PaneDropZone.zone(for: location, in: size) == .left)
+    }
+
+    // MARK: - Right zone
+
+    @Test func rightZone_rightEdge() {
+        // relX = 0.9 > 0.75, relY = 0.5 → right
+        let location = CGPoint(x: 900, y: 400)
+        #expect(PaneDropZone.zone(for: location, in: size) == .right)
+    }
+
+    @Test func rightZone_bottomRightCorner_closerToRight() {
+        // relX = 0.95, relY = 0.9 — both right and bottom
+        // distToEdgeX = 0.05, distToEdgeY = 0.1 → right wins (closer to edge)
+        let location = CGPoint(x: 950, y: 720)
+        #expect(PaneDropZone.zone(for: location, in: size) == .right)
+    }
+
+    // MARK: - Top zone
+
+    @Test func topZone_topEdge() {
+        // relX = 0.5, relY = 0.1 < 0.25 → top
+        let location = CGPoint(x: 500, y: 80)
+        #expect(PaneDropZone.zone(for: location, in: size) == .top)
+    }
+
+    @Test func topZone_topLeftCorner_closerToTop() {
+        // relX = 0.15, relY = 0.02 — both left and top
+        // distToEdgeX = 0.15, distToEdgeY = 0.02 → top wins (distToEdgeY < distToEdgeX)
+        let location = CGPoint(x: 150, y: 16)
+        #expect(PaneDropZone.zone(for: location, in: size) == .top)
+    }
+
+    // MARK: - Bottom zone
+
+    @Test func bottomZone_bottomEdge() {
+        // relX = 0.5, relY = 0.95 > 0.75 → bottom
+        let location = CGPoint(x: 500, y: 760)
+        #expect(PaneDropZone.zone(for: location, in: size) == .bottom)
+    }
+
+    @Test func bottomZone_bottomLeftCorner_closerToBottom() {
+        // relX = 0.15, relY = 0.98 — both left and bottom
+        // distToEdgeX = 0.15, distToEdgeY = 0.02 → bottom wins (distToEdgeY < distToEdgeX)
+        let location = CGPoint(x: 150, y: 784)
+        #expect(PaneDropZone.zone(for: location, in: size) == .bottom)
+    }
+
+    // MARK: - Corner disambiguation
+
+    @Test func rightZone_winsInCorner_whenCloserToRight() {
+        // relX = 0.95, relY = 0.9 — both right and bottom
+        // distToEdgeX = 0.05, distToEdgeY = 0.1 → right (distToEdgeX <= distToEdgeY)
+        let location = CGPoint(x: 950, y: 720)
+        #expect(PaneDropZone.zone(for: location, in: size) == .right)
+    }
+
+    @Test func bottomZone_winsInCorner_whenCloserToBottom() {
+        // relX = 0.8, relY = 0.98 — both right and bottom
+        // distToEdgeX = 0.2, distToEdgeY = 0.02 → bottom
+        let location = CGPoint(x: 800, y: 784)
+        #expect(PaneDropZone.zone(for: location, in: size) == .bottom)
+    }
+
+    // MARK: - Edge cases: zero/degenerate sizes
 
     @Test func centerZone_zeroSize() {
         let location = CGPoint(x: 100, y: 100)
@@ -249,38 +314,80 @@ struct PaneDropZoneZoneTests {
         #expect(PaneDropZone.zone(for: location, in: zeroWidthSize) == .center)
     }
 
-    @Test func bottomZone_zeroWidth_butYInBottom() {
-        let zeroWidthSize = CGSize(width: 0, height: 800)
-        let location = CGPoint(x: 0, y: 700)
-        #expect(PaneDropZone.zone(for: location, in: zeroWidthSize) == .bottom)
-    }
-
-    @Test func rightZone_zeroHeight_butXInRight() {
+    @Test func centerZone_zeroHeight() {
         let zeroHeightSize = CGSize(width: 1000, height: 0)
         let location = CGPoint(x: 800, y: 0)
-        #expect(PaneDropZone.zone(for: location, in: zeroHeightSize) == .right)
+        #expect(PaneDropZone.zone(for: location, in: zeroHeightSize) == .center)
     }
 
-    @Test func centerZone_topLeftCorner() {
-        let location = CGPoint(x: 0, y: 0)
+    @Test func centerZone_zeroWidth_evenIfYInBottom() {
+        // guard width > 0 fails → center
+        let zeroWidthSize = CGSize(width: 0, height: 800)
+        let location = CGPoint(x: 0, y: 700)
+        #expect(PaneDropZone.zone(for: location, in: zeroWidthSize) == .center)
+    }
+
+    @Test func centerZone_zeroHeight_evenIfXInRight() {
+        // guard height > 0 fails → center
+        let zeroHeightSize = CGSize(width: 1000, height: 0)
+        let location = CGPoint(x: 900, y: 0)
+        #expect(PaneDropZone.zone(for: location, in: zeroHeightSize) == .center)
+    }
+
+    // MARK: - Boundary: exactly at threshold
+
+    @Test func leftZone_atExactLeftThreshold() {
+        // relX = 0.249 < 0.25 → left
+        let location = CGPoint(x: 249, y: 400)
+        #expect(PaneDropZone.zone(for: location, in: size) == .left)
+    }
+
+    @Test func centerZone_justPastLeftThreshold() {
+        // relX = 0.25 (not < 0.25) → center
+        let location = CGPoint(x: 250, y: 400)
         #expect(PaneDropZone.zone(for: location, in: size) == .center)
     }
 
+    @Test func rightZone_justPastRightThreshold() {
+        // relX = 0.751 > 0.75 → right
+        let location = CGPoint(x: 751, y: 400)
+        #expect(PaneDropZone.zone(for: location, in: size) == .right)
+    }
+
+    @Test func centerZone_atExactRightThreshold() {
+        // relX = 0.75 (not > 0.75) → center
+        let location = CGPoint(x: 750, y: 400)
+        #expect(PaneDropZone.zone(for: location, in: size) == .center)
+    }
+
+    // MARK: - Small view
+
     @Test func rightZone_smallView() {
-        // Small view: 100x100, threshold at 70
+        // 100x100, threshold at 25. relX = 0.8 > 0.75 → right
         let smallSize = CGSize(width: 100, height: 100)
-        let location = CGPoint(x: 80, y: 30)
+        let location = CGPoint(x: 80, y: 50)
         #expect(PaneDropZone.zone(for: location, in: smallSize) == .right)
     }
 
     @Test func bottomZone_smallView() {
+        // 100x100, threshold at 25. relY = 0.8 > 0.75 → bottom
         let smallSize = CGSize(width: 100, height: 100)
-        let location = CGPoint(x: 30, y: 80)
+        let location = CGPoint(x: 50, y: 80)
         #expect(PaneDropZone.zone(for: location, in: smallSize) == .bottom)
     }
 
-    @Test func edgeThreshold_isSeventyPercent() {
-        #expect(PaneDropZone.edgeThreshold == 0.7)
+    @Test func leftZone_smallView() {
+        // 100x100, relX = 0.1 < 0.25 → left
+        let smallSize = CGSize(width: 100, height: 100)
+        let location = CGPoint(x: 10, y: 50)
+        #expect(PaneDropZone.zone(for: location, in: smallSize) == .left)
+    }
+
+    @Test func topZone_smallView() {
+        // 100x100, relY = 0.1 < 0.25 → top
+        let smallSize = CGSize(width: 100, height: 100)
+        let location = CGPoint(x: 50, y: 10)
+        #expect(PaneDropZone.zone(for: location, in: smallSize) == .top)
     }
 }
 


### PR DESCRIPTION
## Summary

- Add support for dragging files from the sidebar file tree directly into editor panes
- Drop on center of an existing editor pane opens the file as a new tab there
- Drop on right/bottom edge creates a new split pane with the dragged file
- Uses a dedicated `SidebarFileDragInfo` + `UTType.sidebarFileDrag` to reliably distinguish sidebar drags from tab reorder drags

Closes #705

## Test plan

- [x] 29 unit tests added covering all scenarios:
  - `SidebarFileDragInfo` encoding/decoding round-trip, invalid input, special characters
  - `UTType.sidebarFileDrag` is defined and distinct from `paneTabDrag`
  - `PaneManager.openFileInPane()` — opens file, deduplicates, skips directories, skips terminal panes, handles nonexistent panes
  - `PaneManager.splitAndOpenFile()` — horizontal/vertical split, preserves existing tabs, respects max depth, handles nonexistent panes
  - `activeSidebarDrag` shared state lifecycle
  - Integration scenarios: center drop opens tab, edge drop creates split
  - All existing 2766 tests still pass
- [ ] Manual: drag a `.swift` file from sidebar to center of editor pane — file opens as tab
- [ ] Manual: drag a file to right edge of pane — new horizontal split created
- [ ] Manual: drag a file to bottom edge — new vertical split created
- [ ] Manual: drag a folder — no drag operation starts (directories excluded)