### PR TITLE
feat: terminal tab drag-and-drop reorder and cross-pane move

### DIFF
--- a/Pine/PaneDropZone.swift
+++ b/Pine/PaneDropZone.swift
@@ -210,11 +210,11 @@ struct PaneSplitDropDelegate: DropDelegate {
                     axis: axis,
                     insertBefore: before
                 )
-            } else {
+            } else if let fileURL = dragInfo.fileURL {
                 paneManager.splitPane(
                     paneID,
                     axis: axis,
-                    tabURL: dragInfo.fileURL,
+                    tabURL: fileURL,
                     sourcePane: sourcePaneID,
                     insertBefore: before
                 )
@@ -227,9 +227,9 @@ struct PaneSplitDropDelegate: DropDelegate {
                 paneManager.moveTerminalTab(
                     dragInfo.tabID, from: sourcePaneID, to: paneID
                 )
-            } else {
+            } else if let fileURL = dragInfo.fileURL {
                 paneManager.moveTabBetweenPanes(
-                    tabURL: dragInfo.fileURL,
+                    tabURL: fileURL,
                     from: sourcePaneID,
                     to: paneID
                 )

--- a/Pine/PaneDropZone.swift
+++ b/Pine/PaneDropZone.swift
@@ -203,8 +203,12 @@ struct PaneSplitDropDelegate: DropDelegate {
             let axis: SplitAxis = (zone == .left || zone == .right) ? .horizontal : .vertical
             let before = (zone == .left || zone == .top)
             if dragInfo.contentType == .terminal {
-                paneManager.createTerminalPane(
-                    relativeTo: paneID, axis: axis, workingDirectory: nil
+                paneManager.splitAndMoveTerminalTab(
+                    tabID: dragInfo.tabID,
+                    from: sourcePaneID,
+                    relativeTo: paneID,
+                    axis: axis,
+                    insertBefore: before
                 )
             } else {
                 paneManager.splitPane(

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -279,6 +279,43 @@ final class PaneManager {
         }
     }
 
+    /// Splits a pane, creates a new terminal pane, and moves an existing terminal tab into it.
+    @discardableResult
+    func splitAndMoveTerminalTab(
+        tabID: UUID,
+        from sourceID: PaneID,
+        relativeTo targetID: PaneID,
+        axis: SplitAxis,
+        insertBefore: Bool = false
+    ) -> PaneID? {
+        guard let srcState = terminalStates[sourceID],
+              let tab = srcState.terminalTabs.first(where: { $0.id == tabID }) else { return nil }
+
+        let newID = PaneID()
+        guard let newRoot = root.splitting(
+            targetID, axis: axis, newPaneID: newID, newContent: .terminal, insertBefore: insertBefore
+        ) else { return nil }
+
+        root = newRoot
+        let newState = TerminalPaneState()
+        terminalStates[newID] = newState
+
+        newState.terminalTabs.append(tab)
+        newState.activeTerminalID = tab.id
+        srcState.terminalTabs.removeAll { $0.id == tabID }
+        if srcState.activeTerminalID == tabID {
+            srcState.activeTerminalID = srcState.terminalTabs.last?.id
+        }
+
+        activePaneID = newID
+
+        if srcState.terminalTabs.isEmpty {
+            removePane(sourceID)
+        }
+
+        return newID
+    }
+
     // MARK: - Maximize
 
     func maximize(paneID: PaneID) {

--- a/Pine/TabDragInfo.swift
+++ b/Pine/TabDragInfo.swift
@@ -19,7 +19,7 @@ extension UTType {
 struct TabDragInfo: Codable, Sendable {
     let paneID: UUID
     let tabID: UUID
-    let fileURL: URL
+    let fileURL: URL?
     /// The pane content type. Defaults to `.editor` for backwards compatibility.
     var contentType: PaneContent = .editor
 
@@ -38,7 +38,7 @@ struct TabDragInfo: Codable, Sendable {
         return try? JSONDecoder().decode(TabDragInfo.self, from: data)
     }
 
-    init(paneID: UUID, tabID: UUID, fileURL: URL, contentType: PaneContent = .editor) {
+    init(paneID: UUID, tabID: UUID, fileURL: URL? = nil, contentType: PaneContent = .editor) {
         self.paneID = paneID
         self.tabID = tabID
         self.fileURL = fileURL
@@ -56,7 +56,7 @@ struct TabDragInfo: Codable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         paneID = try container.decode(UUID.self, forKey: .paneID)
         tabID = try container.decode(UUID.self, forKey: .tabID)
-        fileURL = try container.decode(URL.self, forKey: .fileURL)
+        fileURL = try container.decodeIfPresent(URL.self, forKey: .fileURL)
         contentType = try container.decodeIfPresent(PaneContent.self, forKey: .contentType) ?? .editor
     }
 }

--- a/Pine/TerminalPaneState.swift
+++ b/Pine/TerminalPaneState.swift
@@ -50,6 +50,18 @@ final class TerminalPaneState {
         }
     }
 
+    func reorderTab(draggedID: UUID, targetID: UUID) {
+        guard draggedID != targetID,
+              let fromIndex = terminalTabs.firstIndex(where: { $0.id == draggedID }),
+              let toIndex = terminalTabs.firstIndex(where: { $0.id == targetID }) else { return }
+        let tab = terminalTabs.remove(at: fromIndex)
+        // After removal, find target's new position and insert at that index
+        // (before the target for backward moves, after it for forward moves)
+        guard let destIndex = terminalTabs.firstIndex(where: { $0.id == targetID }) else { return }
+        let insertAt = fromIndex < toIndex ? destIndex + 1 : destIndex
+        terminalTabs.insert(tab, at: insertAt)
+    }
+
     func startTabs(workingDirectory: URL?) {
         for tab in terminalTabs {
             tab.configure(workingDirectory: workingDirectory)

--- a/Pine/TerminalPaneState.swift
+++ b/Pine/TerminalPaneState.swift
@@ -54,12 +54,10 @@ final class TerminalPaneState {
         guard draggedID != targetID,
               let fromIndex = terminalTabs.firstIndex(where: { $0.id == draggedID }),
               let toIndex = terminalTabs.firstIndex(where: { $0.id == targetID }) else { return }
-        let tab = terminalTabs.remove(at: fromIndex)
-        // After removal, find target's new position and insert at that index
-        // (before the target for backward moves, after it for forward moves)
-        guard let destIndex = terminalTabs.firstIndex(where: { $0.id == targetID }) else { return }
-        let insertAt = fromIndex < toIndex ? destIndex + 1 : destIndex
-        terminalTabs.insert(tab, at: insertAt)
+        terminalTabs.move(
+            fromOffsets: IndexSet(integer: fromIndex),
+            toOffset: toIndex > fromIndex ? toIndex + 1 : toIndex
+        )
     }
 
     func startTabs(workingDirectory: URL?) {

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -15,7 +15,6 @@ struct TerminalPaneTabBar: View {
     var workingDirectory: URL?
     @Environment(PaneManager.self) private var paneManager
     @State private var draggingTabID: UUID?
-    @State private var hoverTargetTabID: UUID?
 
     private func closeTerminalTabWithConfirmation(_ tab: TerminalTab) {
         if tab.hasForegroundProcess {
@@ -60,7 +59,7 @@ struct TerminalPaneTabBar: View {
                             let info = TabDragInfo(
                                 paneID: paneID.id,
                                 tabID: tab.id,
-                                fileURL: URL(filePath: "/terminal-placeholder"),
+                                fileURL: nil,
                                 contentType: .terminal
                             )
                             paneManager.activeDrag = info
@@ -78,8 +77,7 @@ struct TerminalPaneTabBar: View {
                         .onDrop(of: [.paneTabDrag], delegate: TerminalTabDropDelegate(
                             terminalState: terminalState,
                             targetTabID: tab.id,
-                            draggingTabID: $draggingTabID,
-                            hoverTargetTabID: $hoverTargetTabID
+                            draggingTabID: $draggingTabID
                         ))
                     }
                 }
@@ -164,13 +162,11 @@ struct TerminalTabDropDelegate: DropDelegate {
     let terminalState: TerminalPaneState
     let targetTabID: UUID
     @Binding var draggingTabID: UUID?
-    @Binding var hoverTargetTabID: UUID?
 
     private static let reorderAnimation: Animation = .spring(response: 0.3, dampingFraction: 0.8)
 
     func performDrop(info: DropInfo) -> Bool {
         withAnimation(Self.reorderAnimation) {
-            hoverTargetTabID = nil
             draggingTabID = nil
         }
         return true
@@ -178,14 +174,9 @@ struct TerminalTabDropDelegate: DropDelegate {
 
     func dropEntered(info: DropInfo) {
         guard let dragging = draggingTabID, dragging != targetTabID else { return }
-        hoverTargetTabID = targetTabID
         withAnimation(Self.reorderAnimation) {
             terminalState.reorderTab(draggedID: dragging, targetID: targetTabID)
         }
-    }
-
-    func dropExited(info: DropInfo) {
-        hoverTargetTabID = nil
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -7,12 +7,15 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct TerminalPaneTabBar: View {
     let paneID: PaneID
     let terminalState: TerminalPaneState
     var workingDirectory: URL?
     @Environment(PaneManager.self) private var paneManager
+    @State private var draggingTabID: UUID?
+    @State private var hoverTargetTabID: UUID?
 
     private func closeTerminalTabWithConfirmation(_ tab: TerminalTab) {
         if tab.hasForegroundProcess {
@@ -37,9 +40,11 @@ struct TerminalPaneTabBar: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 2) {
                     ForEach(terminalState.terminalTabs) { tab in
+                        let isActive = tab.id == terminalState.activeTerminalID
+                        let isDragged = tab.id == draggingTabID
                         TerminalNativeTabItem(
                             tab: tab,
-                            isActive: tab.id == terminalState.activeTerminalID,
+                            isActive: isActive,
                             canClose: true,
                             onSelect: {
                                 terminalState.activeTerminalID = tab.id
@@ -47,6 +52,35 @@ struct TerminalPaneTabBar: View {
                             },
                             onClose: { closeTerminalTabWithConfirmation(tab) }
                         )
+                        .opacity(isDragged ? 0.4 : 1.0)
+                        .scaleEffect(isDragged ? 0.95 : 1.0)
+                        .transaction { $0.animation = nil }
+                        .onDrag {
+                            draggingTabID = tab.id
+                            let info = TabDragInfo(
+                                paneID: paneID.id,
+                                tabID: tab.id,
+                                fileURL: URL(filePath: "/terminal-placeholder"),
+                                contentType: .terminal
+                            )
+                            paneManager.activeDrag = info
+                            let provider = NSItemProvider()
+                            provider.registerDataRepresentation(
+                                forTypeIdentifier: UTType.paneTabDrag.identifier,
+                                visibility: .ownProcess
+                            ) { completion in
+                                let data = info.encoded.data(using: .utf8) ?? Data()
+                                completion(data, nil)
+                                return nil
+                            }
+                            return provider
+                        }
+                        .onDrop(of: [.paneTabDrag], delegate: TerminalTabDropDelegate(
+                            terminalState: terminalState,
+                            targetTabID: tab.id,
+                            draggingTabID: $draggingTabID,
+                            hoverTargetTabID: $hoverTargetTabID
+                        ))
                     }
                 }
                 .padding(.horizontal, 4)
@@ -122,5 +156,39 @@ struct TerminalPaneTabBar: View {
         .background(.bar)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier(AccessibilityID.terminalTabBar)
+    }
+}
+
+/// Handles drag-to-reorder for terminal tabs within a pane.
+struct TerminalTabDropDelegate: DropDelegate {
+    let terminalState: TerminalPaneState
+    let targetTabID: UUID
+    @Binding var draggingTabID: UUID?
+    @Binding var hoverTargetTabID: UUID?
+
+    private static let reorderAnimation: Animation = .spring(response: 0.3, dampingFraction: 0.8)
+
+    func performDrop(info: DropInfo) -> Bool {
+        withAnimation(Self.reorderAnimation) {
+            hoverTargetTabID = nil
+            draggingTabID = nil
+        }
+        return true
+    }
+
+    func dropEntered(info: DropInfo) {
+        guard let dragging = draggingTabID, dragging != targetTabID else { return }
+        hoverTargetTabID = targetTabID
+        withAnimation(Self.reorderAnimation) {
+            terminalState.reorderTab(draggedID: dragging, targetID: targetTabID)
+        }
+    }
+
+    func dropExited(info: DropInfo) {
+        hoverTargetTabID = nil
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
     }
 }

--- a/PineTests/TerminalTabDragBetweenPanesTests.swift
+++ b/PineTests/TerminalTabDragBetweenPanesTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Terminal Tab Drag Between Panes Tests")
+@MainActor
+struct TerminalTabDragBetweenPanesTests {
+
+    @Test("splitAndMoveTerminalTab creates pane and moves tab")
+    func splitAndMoveCreatesAndMoves() throws {
+        let paneManager = PaneManager()
+        let termPaneID = paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let termState = try #require(paneManager.terminalState(for: termPaneID))
+        termState.addTab(workingDirectory: nil)
+        let tabToMove = termState.terminalTabs[0]
+        let tabToMoveID = tabToMove.id
+
+        let newPaneID = paneManager.splitAndMoveTerminalTab(
+            tabID: tabToMoveID,
+            from: termPaneID,
+            relativeTo: termPaneID,
+            axis: .horizontal,
+            insertBefore: false
+        )
+
+        let unwrappedNewPaneID = try #require(newPaneID)
+        let newState = try #require(paneManager.terminalState(for: unwrappedNewPaneID))
+        #expect(newState.terminalTabs.count == 1)
+        #expect(newState.terminalTabs[0].id == tabToMoveID)
+        #expect(termState.terminalTabs.count == 1)
+    }
+
+    @Test("splitAndMoveTerminalTab removes source pane when last tab moved")
+    func splitAndMoveRemovesEmptySource() throws {
+        let paneManager = PaneManager()
+        let termPaneID = paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let termState = try #require(paneManager.terminalState(for: termPaneID))
+        let tabID = termState.terminalTabs[0].id
+
+        let newPaneID = paneManager.splitAndMoveTerminalTab(
+            tabID: tabID,
+            from: termPaneID,
+            relativeTo: termPaneID,
+            axis: .vertical,
+            insertBefore: true
+        )
+
+        #expect(newPaneID != nil)
+        #expect(paneManager.terminalState(for: termPaneID) == nil)
+    }
+
+    @Test("moveTerminalTab moves tab between existing panes")
+    func moveTerminalTabBetweenPanes() throws {
+        let paneManager = PaneManager()
+        let pane1ID = paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let pane1State = try #require(paneManager.terminalState(for: pane1ID))
+        pane1State.addTab(workingDirectory: nil)
+
+        let pane2ID = try #require(paneManager.createTerminalPane(
+            relativeTo: pane1ID, axis: .horizontal, workingDirectory: nil
+        ))
+        let tabToMove = pane1State.terminalTabs[0]
+
+        paneManager.moveTerminalTab(tabToMove.id, from: pane1ID, to: pane2ID)
+
+        let pane2State = try #require(paneManager.terminalState(for: pane2ID))
+        #expect(pane2State.terminalTabs.contains(where: { $0.id == tabToMove.id }))
+        #expect(pane1State.terminalTabs.count == 1)
+    }
+}

--- a/PineTests/TerminalTabReorderTests.swift
+++ b/PineTests/TerminalTabReorderTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Terminal Tab Reorder Tests")
+@MainActor
+struct TerminalTabReorderTests {
+
+    private func makeState(count: Int) -> TerminalPaneState {
+        let state = TerminalPaneState()
+        for _ in 0..<count {
+            state.addTab(workingDirectory: nil)
+        }
+        return state
+    }
+
+    @Test("Reorder forward: first to last")
+    func reorderForward() {
+        let state = makeState(count: 3)
+        let names = state.terminalTabs.map(\.stableLabel)
+        let dragID = state.terminalTabs[0].id
+        let targetID = state.terminalTabs[2].id
+
+        state.reorderTab(draggedID: dragID, targetID: targetID)
+
+        #expect(state.terminalTabs.map(\.stableLabel) == [names[1], names[2], names[0]])
+    }
+
+    @Test("Reorder backward: last to first")
+    func reorderBackward() {
+        let state = makeState(count: 3)
+        let names = state.terminalTabs.map(\.stableLabel)
+        let dragID = state.terminalTabs[2].id
+        let targetID = state.terminalTabs[0].id
+
+        state.reorderTab(draggedID: dragID, targetID: targetID)
+
+        #expect(state.terminalTabs.map(\.stableLabel) == [names[2], names[0], names[1]])
+    }
+
+    @Test("Reorder same tab does nothing")
+    func reorderSameTab() {
+        let state = makeState(count: 3)
+        let names = state.terminalTabs.map(\.stableLabel)
+        let tabID = state.terminalTabs[1].id
+
+        state.reorderTab(draggedID: tabID, targetID: tabID)
+
+        #expect(state.terminalTabs.map(\.stableLabel) == names)
+    }
+
+    @Test("Reorder with non-existent ID does nothing")
+    func reorderNonExistent() {
+        let state = makeState(count: 2)
+        let names = state.terminalTabs.map(\.stableLabel)
+
+        state.reorderTab(draggedID: UUID(), targetID: state.terminalTabs[0].id)
+
+        #expect(state.terminalTabs.map(\.stableLabel) == names)
+    }
+
+    @Test("Reorder preserves active tab ID")
+    func reorderPreservesActive() {
+        let state = makeState(count: 3)
+        let activeID = state.terminalTabs[1].id
+        state.activeTerminalID = activeID
+
+        state.reorderTab(draggedID: state.terminalTabs[0].id, targetID: state.terminalTabs[2].id)
+
+        #expect(state.activeTerminalID == activeID)
+    }
+
+    @Test("Reorder single tab does nothing")
+    func reorderSingleTab() {
+        let state = makeState(count: 1)
+        let tabID = state.terminalTabs[0].id
+
+        state.reorderTab(draggedID: tabID, targetID: tabID)
+
+        #expect(state.terminalTabs.count == 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Terminal tabs can now be reordered within a pane via drag-and-drop (same as editor tabs)
- Terminal tabs can be dragged between panes — drop on edges to split (left/right/top/bottom), drop on center to move
- Edge drops now move the actual terminal tab instead of creating an empty terminal pane

## Test plan
- [ ] Verify terminal tab reorder within a single pane
- [ ] Verify drag terminal tab to right edge creates horizontal split with moved tab
- [ ] Verify drag terminal tab to top edge creates vertical split above
- [ ] Verify drag terminal tab to center of another terminal pane moves it
- [ ] Verify drag terminal tab to center of editor pane is rejected
- [ ] Verify source pane removed when last tab is dragged out
- [ ] Run unit tests: TerminalTabReorderTests, TerminalTabDragBetweenPanesTests