### PR TITLE
fix: clear stale pane drop-zone overlays after sidebar drag (#710)

### DIFF
--- a/Pine/PaneDropZone.swift
+++ b/Pine/PaneDropZone.swift
@@ -242,5 +242,6 @@ struct PaneSplitDropDelegate: DropDelegate {
 
     private func updateDropZone(info: DropInfo) {
         paneManager.dropZones[paneID] = PaneDropZone.zone(for: info.location, in: paneSize)
+        paneManager.startStaleDropPollingIfNeeded()
     }
 }

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -49,8 +49,22 @@ final class PaneManager {
     /// Active root-level drop zone — set by RootPaneSplitDropDelegate.
     var rootDropZone: RootDropZone?
 
-    /// NSEvent monitor for mouse-up cleanup of drop overlays.
+    /// NSEvent monitor for mouse-up cleanup of drop overlays (in-app).
     nonisolated(unsafe) private var mouseUpMonitor: Any?
+
+    /// NSEvent monitor for mouse-up cleanup that fires even when the cursor
+    /// is released outside the app window.
+    nonisolated(unsafe) private var globalMouseUpMonitor: Any?
+
+    /// Notification observers for window/app deactivation cleanup.
+    nonisolated(unsafe) private var deactivationObservers: [NSObjectProtocol] = []
+
+    /// Provider that returns `true` when the user is currently holding any
+    /// mouse button down (i.e. a drag is potentially in progress).
+    /// Defaults to `NSEvent.pressedMouseButtons`. Injectable for tests.
+    var isMouseButtonPressed: () -> Bool = {
+        NSEvent.pressedMouseButtons != 0
+    }
 
     /// Clears all drop zone overlays across all panes.
     func clearAllDropZones() {
@@ -61,6 +75,46 @@ final class PaneManager {
     /// Clears leaf-level drop zone overlays without touching rootDropZone.
     func clearLeafDropZones() {
         dropZones.removeAll()
+    }
+
+    /// Returns true if any drop zone overlay is currently visible.
+    var hasActiveDropZones: Bool {
+        !dropZones.isEmpty || rootDropZone != nil
+    }
+
+    /// Clears any visible drop zone overlays if the system reports that no
+    /// mouse button is pressed (i.e. there cannot be an active drag session).
+    /// This is a defensive cleanup hook used by polling and notification
+    /// observers in case SwiftUI's `DropDelegate` fails to call `dropExited`
+    /// or `performDrop` (issue #710).
+    func clearStaleDropZonesIfNoDragActive() {
+        guard hasActiveDropZones else { return }
+        if !isMouseButtonPressed() {
+            clearAllDropZones()
+        }
+    }
+
+    /// Polling timer that periodically checks whether stale overlays should
+    /// be cleared. Started lazily when an overlay first appears, stopped when
+    /// none remain. ~120ms cadence keeps overhead negligible.
+    nonisolated(unsafe) private var staleDropPollTimer: Timer?
+
+    /// Starts the stale-overlay polling timer if not already running.
+    /// Called by drop delegates whenever they set a drop zone.
+    func startStaleDropPollingIfNeeded() {
+        guard staleDropPollTimer == nil else { return }
+        let timer = Timer.scheduledTimer(withTimeInterval: 0.12, repeats: true) { [weak self] _ in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                if !self.hasActiveDropZones {
+                    self.staleDropPollTimer?.invalidate()
+                    self.staleDropPollTimer = nil
+                    return
+                }
+                self.clearStaleDropZonesIfNoDragActive()
+            }
+        }
+        staleDropPollTimer = timer
     }
 
     /// Creates a PaneManager with a single editor pane.
@@ -86,20 +140,62 @@ final class PaneManager {
         if let monitor = mouseUpMonitor {
             NSEvent.removeMonitor(monitor)
         }
+        if let monitor = globalMouseUpMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        for observer in deactivationObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        staleDropPollTimer?.invalidate()
     }
 
-    /// Installs a local NSEvent monitor that clears drop overlays on mouse-up.
-    /// SwiftUI DropDelegate does not reliably call dropExited/performDrop when
-    /// a drag is cancelled inside a pane, leaving stale overlays.
+    /// Installs an NSEvent monitor (local + global) and notification observers
+    /// that clear drop overlays whenever a drag could possibly have ended.
+    ///
+    /// SwiftUI's `DropDelegate` does not reliably call `dropExited` or
+    /// `performDrop` in all scenarios — e.g. when the drag is cancelled while
+    /// the cursor is inside a pane, when the cursor moves between panes very
+    /// quickly, or after the pane tree is mutated by `performDrop`.
+    /// See issue #710.
+    ///
+    /// We defend against stale overlays by combining several signals:
+    ///   1. Local mouse-up — drag released while the app is foreground
+    ///   2. Global mouse-up — drag released while another app is foreground
+    ///   3. Window/app deactivation — focus moved away mid-drag
     private func installMouseUpMonitor() {
-        mouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { [weak self] event in
-            if self?.dropZones.isEmpty == false {
-                // Small delay to let performDrop fire first (it also clears)
-                DispatchQueue.main.async {
-                    self?.clearAllDropZones()
+        let cleanup: @Sendable () -> Void = { [weak self] in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                if self.hasActiveDropZones {
+                    self.clearAllDropZones()
                 }
             }
+        }
+
+        mouseUpMonitor = NSEvent.addLocalMonitorForEvents(matching: .leftMouseUp) { event in
+            cleanup()
             return event
+        }
+
+        globalMouseUpMonitor = NSEvent.addGlobalMonitorForEvents(matching: .leftMouseUp) { _ in
+            cleanup()
+        }
+
+        let center = NotificationCenter.default
+        let names: [Notification.Name] = [
+            NSWindow.didResignKeyNotification,
+            NSApplication.didResignActiveNotification,
+            NSApplication.didHideNotification
+        ]
+        for name in names {
+            let observer = center.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.clearAllDropZones()
+            }
+            deactivationObservers.append(observer)
         }
     }
 

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -49,6 +49,10 @@ final class PaneManager {
     /// Active root-level drop zone — set by RootPaneSplitDropDelegate.
     var rootDropZone: RootDropZone?
 
+    // The four properties below are marked `nonisolated(unsafe)` solely so
+    // they can be touched from `deinit`, which is nonisolated even on a
+    // @MainActor class. All real reads/writes happen on the main thread.
+
     /// NSEvent monitor for mouse-up cleanup of drop overlays (in-app).
     nonisolated(unsafe) private var mouseUpMonitor: Any?
 
@@ -103,16 +107,17 @@ final class PaneManager {
     /// Called by drop delegates whenever they set a drop zone.
     func startStaleDropPollingIfNeeded() {
         guard staleDropPollTimer == nil else { return }
-        let timer = Timer.scheduledTimer(withTimeInterval: 0.12, repeats: true) { [weak self] _ in
-            DispatchQueue.main.async {
-                guard let self else { return }
-                if !self.hasActiveDropZones {
-                    self.staleDropPollTimer?.invalidate()
-                    self.staleDropPollTimer = nil
-                    return
-                }
-                self.clearStaleDropZonesIfNoDragActive()
+        // Timer scheduled on the main run loop fires on the main thread, and
+        // PaneManager is @MainActor, so no extra DispatchQueue.main.async hop
+        // is needed inside the callback.
+        let timer = Timer.scheduledTimer(withTimeInterval: 0.12, repeats: true) { [weak self] t in
+            guard let self else { t.invalidate(); return }
+            if !self.hasActiveDropZones {
+                t.invalidate()
+                self.staleDropPollTimer = nil
+                return
             }
+            self.clearStaleDropZonesIfNoDragActive()
         }
         staleDropPollTimer = timer
     }
@@ -163,7 +168,9 @@ final class PaneManager {
     ///   2. Global mouse-up — drag released while another app is foreground
     ///   3. Window/app deactivation — focus moved away mid-drag
     private func installMouseUpMonitor() {
-        let cleanup: @Sendable () -> Void = { [weak self] in
+        // Local closure invoked only from main-thread NSEvent monitor
+        // callbacks, so it does not need to be @Sendable.
+        let cleanup: () -> Void = { [weak self] in
             DispatchQueue.main.async {
                 guard let self else { return }
                 if self.hasActiveDropZones {
@@ -181,6 +188,11 @@ final class PaneManager {
             cleanup()
         }
 
+        // Note: `didResignKeyNotification` is intentionally aggressive — it
+        // fires whenever the window loses key status. This is acceptable
+        // because during an active drag session AppKit cannot present a sheet
+        // or popover that would steal key, so we will not clear an overlay
+        // out from under a real in-progress drag.
         let center = NotificationCenter.default
         let names: [Notification.Name] = [
             NSWindow.didResignKeyNotification,

--- a/Pine/RootDropZone.swift
+++ b/Pine/RootDropZone.swift
@@ -145,6 +145,7 @@ struct RootPaneSplitDropDelegate: DropDelegate {
 
     private func updateZone(info: DropInfo) {
         paneManager.rootDropZone = RootDropZone.detect(location: info.location, in: containerSize)
+        paneManager.startStaleDropPollingIfNeeded()
     }
 }
 

--- a/PineTests/PaneManagerStaleDropZoneTests.swift
+++ b/PineTests/PaneManagerStaleDropZoneTests.swift
@@ -104,6 +104,25 @@ struct PaneManagerStaleDropZoneTests {
         #expect(manager.hasActiveDropZones == true)
     }
 
+    /// Real timer-driven polling: schedules the timer, waits for it to fire,
+    /// and verifies the overlay is cleared once the mouse is no longer down.
+    /// Regression coverage for issue #710 — exercises the actual RunLoop tick
+    /// rather than just the synchronous helper.
+    @Test func startStaleDropPolling_clearsOverlayOnTimerTick() async {
+        let manager = PaneManager()
+        manager.dropZones[manager.activePaneID] = .center
+        manager.isMouseButtonPressed = { false }
+        #expect(manager.hasActiveDropZones == true)
+
+        manager.startStaleDropPollingIfNeeded()
+
+        // Timer cadence is 0.12s; wait ~250ms to allow at least one fire and
+        // the subsequent self-invalidation pass.
+        try? await Task.sleep(nanoseconds: 250_000_000)
+
+        #expect(manager.hasActiveDropZones == false)
+    }
+
     // MARK: - Edge cases
 
     @Test func clearStale_handlesMultipleLeafPanes() {

--- a/PineTests/PaneManagerStaleDropZoneTests.swift
+++ b/PineTests/PaneManagerStaleDropZoneTests.swift
@@ -1,0 +1,133 @@
+//
+//  PaneManagerStaleDropZoneTests.swift
+//  PineTests
+//
+//  Tests for the defensive cleanup of stale drop-zone overlays
+//  introduced for issue #710. SwiftUI's DropDelegate occasionally
+//  fails to call dropExited/performDrop, leaving the blue overlay
+//  visible after a sidebar file drag completes or is cancelled.
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+@Suite("PaneManager stale drop-zone cleanup (issue #710)")
+@MainActor
+struct PaneManagerStaleDropZoneTests {
+
+    // MARK: - hasActiveDropZones
+
+    @Test func hasActiveDropZones_falseByDefault() {
+        let manager = PaneManager()
+        #expect(manager.hasActiveDropZones == false)
+    }
+
+    @Test func hasActiveDropZones_trueWhenLeafZoneSet() {
+        let manager = PaneManager()
+        manager.dropZones[manager.activePaneID] = .center
+        #expect(manager.hasActiveDropZones == true)
+    }
+
+    @Test func hasActiveDropZones_trueWhenRootZoneSet() {
+        let manager = PaneManager()
+        manager.rootDropZone = .left
+        #expect(manager.hasActiveDropZones == true)
+    }
+
+    // MARK: - clearAllDropZones
+
+    @Test func clearAllDropZones_clearsLeafAndRoot() {
+        let manager = PaneManager()
+        manager.dropZones[manager.activePaneID] = .right
+        manager.rootDropZone = .top
+        manager.clearAllDropZones()
+        #expect(manager.dropZones.isEmpty)
+        #expect(manager.rootDropZone == nil)
+        #expect(manager.hasActiveDropZones == false)
+    }
+
+    @Test func clearLeafDropZones_keepsRootZone() {
+        let manager = PaneManager()
+        manager.dropZones[manager.activePaneID] = .right
+        manager.rootDropZone = .top
+        manager.clearLeafDropZones()
+        #expect(manager.dropZones.isEmpty)
+        #expect(manager.rootDropZone == .top)
+    }
+
+    // MARK: - clearStaleDropZonesIfNoDragActive
+
+    @Test func clearStale_noOpWhenNoOverlays() {
+        let manager = PaneManager()
+        manager.isMouseButtonPressed = { false }
+        manager.clearStaleDropZonesIfNoDragActive()
+        #expect(manager.hasActiveDropZones == false)
+    }
+
+    @Test func clearStale_clearsWhenMouseUp() {
+        let manager = PaneManager()
+        manager.dropZones[manager.activePaneID] = .center
+        manager.rootDropZone = .left
+        manager.isMouseButtonPressed = { false }
+
+        manager.clearStaleDropZonesIfNoDragActive()
+        #expect(manager.hasActiveDropZones == false)
+    }
+
+    @Test func clearStale_keepsZonesWhenMouseStillPressed() {
+        let manager = PaneManager()
+        manager.dropZones[manager.activePaneID] = .center
+        manager.isMouseButtonPressed = { true }
+
+        manager.clearStaleDropZonesIfNoDragActive()
+        #expect(manager.dropZones[manager.activePaneID] == .center)
+        #expect(manager.hasActiveDropZones == true)
+    }
+
+    @Test func clearStale_clearsRootOnlyWhenMouseUp() {
+        let manager = PaneManager()
+        manager.rootDropZone = .bottom
+        manager.isMouseButtonPressed = { false }
+        manager.clearStaleDropZonesIfNoDragActive()
+        #expect(manager.rootDropZone == nil)
+    }
+
+    // MARK: - Polling timer lifecycle
+
+    @Test func startStaleDropPolling_isIdempotent() {
+        let manager = PaneManager()
+        manager.dropZones[manager.activePaneID] = .center
+        manager.startStaleDropPollingIfNeeded()
+        manager.startStaleDropPollingIfNeeded()
+        // Should not crash; second call must be a no-op.
+        #expect(manager.hasActiveDropZones == true)
+    }
+
+    // MARK: - Edge cases
+
+    @Test func clearStale_handlesMultipleLeafPanes() {
+        let manager = PaneManager()
+        let firstID = manager.activePaneID
+        guard let secondID = manager.splitPane(firstID, axis: .horizontal) else {
+            Issue.record("Failed to split pane")
+            return
+        }
+        manager.dropZones[firstID] = .left
+        manager.dropZones[secondID] = .right
+        manager.isMouseButtonPressed = { false }
+
+        manager.clearStaleDropZonesIfNoDragActive()
+        #expect(manager.dropZones.isEmpty)
+    }
+
+    @Test func clearStale_repeatedCalls_areSafe() {
+        let manager = PaneManager()
+        manager.dropZones[manager.activePaneID] = .top
+        manager.isMouseButtonPressed = { false }
+        manager.clearStaleDropZonesIfNoDragActive()
+        manager.clearStaleDropZonesIfNoDragActive()
+        manager.clearStaleDropZonesIfNoDragActive()
+        #expect(manager.hasActiveDropZones == false)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #710 — drop zone overlay (blue tint) sometimes remained visible on editor panes after a sidebar file drag completed or was cancelled.

SwiftUI's `DropDelegate` does not reliably call `dropExited`/`performDrop` in all scenarios (cancelled drag inside a pane, fast cursor motion, post-mutation view invalidation). The previous local mouse-up monitor caught most cases but not 100%.

## Approach

Defend against stale overlays via three independent signals layered on top of the existing local monitor:

1. **Global mouse-up monitor** (`NSEvent.addGlobalMonitorForEvents`) — drag released while another app is foreground.
2. **Window/app deactivation observers** — `NSWindow.didResignKey`, `NSApplication.didResignActive`, `didHide` clear overlays if focus moves away mid-drag.
3. **~120ms polling timer** — runs only while overlays are visible; clears them as soon as `NSEvent.pressedMouseButtons == 0`. Self-stops when no overlays remain.

Drop activity is exposed via an injectable `isMouseButtonPressed` closure so cleanup logic is unit-testable without driving real NSEvents.

`PaneSplitDropDelegate.updateDropZone` and `RootPaneSplitDropDelegate.updateZone` now call `startStaleDropPollingIfNeeded()` so the watchdog spins up the moment any overlay appears.

## Test plan

- [x] 12 new unit tests in `PaneManagerStaleDropZoneTests` covering:
  - `hasActiveDropZones` for empty/leaf/root states
  - `clearAllDropZones` clears both leaf and root maps
  - `clearLeafDropZones` preserves the root zone
  - `clearStaleDropZonesIfNoDragActive` no-ops when no overlays
  - clears when mouse is up (leaf, root, both)
  - keeps overlays while mouse is still pressed
  - multi-pane layouts
  - idempotent polling startup
  - repeated cleanup calls are safe
- [x] Existing `PaneManagerTests` (40 tests) and `PaneManagerRootDropTests` (12 tests) still pass
- [x] `swiftlint --strict` clean (0 violations across 268 files)
- [ ] Manual: drag a sidebar file, release outside any pane → overlay disappears
- [ ] Manual: drag a sidebar file, switch app via Cmd+Tab → overlay disappears

Closes #710