### PR TITLE
fix: open files in active pane instead of primary (#695)

### DIFF
--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -191,10 +191,9 @@ extension ContentView {
     }
 
     func handleFileSelection(_ node: FileNode) {
-        // Use the active editor pane's TabManager so files open in the
-        // visible editor pane, even when focus is on a terminal pane.
-        let tm = paneManager.activeEditorTabManager ?? tabManager
-        tm.openTab(url: node.url)
+        // Route through ProjectManager so files always open in the
+        // currently focused pane (regression #695).
+        projectManager.openFileInActivePane(url: node.url)
     }
 
     /// Syncs sidebar selection to match the active editor tab.

--- a/Pine/FileNodeRow.swift
+++ b/Pine/FileNodeRow.swift
@@ -14,6 +14,7 @@ struct FileNodeRow: View {
     private static let logger = Logger.editor
     var node: FileNode
     @Environment(WorkspaceManager.self) var workspace
+    @Environment(ProjectManager.self) var projectManager
     @Environment(TabManager.self) var tabManager
     @Environment(PaneManager.self) var paneManager
     @Environment(SidebarEditState.self) var editState
@@ -176,7 +177,7 @@ struct FileNodeRow: View {
             at: node.url,
             isDirectory: node.isDirectory,
             workspace: workspace,
-            tabManager: tabManager
+            tabManager: projectManager.activeTabManager
         )
     }
 
@@ -209,7 +210,7 @@ struct FileNodeRow: View {
                 try? FileOperationUndoManager.finalizeNewItem(from: oldURL, to: oldURL, undoManager: undoManager)
             }
             if wasNewlyCreated && !node.isDirectory {
-                tabManager.openTab(url: oldURL)
+                projectManager.openFileInActivePane(url: oldURL)
             }
             return
         }
@@ -237,7 +238,7 @@ struct FileNodeRow: View {
             )
             // Auto-open newly created files in an editor tab
             if wasNewlyCreated && !node.isDirectory {
-                tabManager.openTab(url: newURL)
+                projectManager.openFileInActivePane(url: newURL)
             }
         } catch {
             // Keep editing so the user can try a different name

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -30,6 +30,28 @@ final class ProjectManager {
         paneManager.activeEditorTabManager ?? tabManager
     }
 
+    /// Opens a file URL in the currently focused editor pane.
+    ///
+    /// This is the canonical entry point for "open file" actions originating from
+    /// sidebar clicks, Quick Open, project search results, file rename auto-open,
+    /// drag-and-drop onto the window, and recent-file picks. It always routes
+    /// through ``activeTabManager`` so that with split panes the file lands in
+    /// the visible / focused pane instead of the primary tab manager. Regression
+    /// guard for #695.
+    ///
+    /// - Parameters:
+    ///   - url: File URL to open.
+    ///   - line: Optional 1-based line number to scroll to after opening
+    ///     (used by project search to jump to the match line).
+    func openFileInActivePane(url: URL, line: Int? = nil) {
+        let tm = activeTabManager
+        if let line {
+            tm.openTabAndGoToLine(url: url, line: line)
+        } else {
+            tm.openTab(url: url)
+        }
+    }
+
     /// Collects all tabs from every pane (for session save, dirty-tab checks, etc.).
     var allTabs: [EditorTab] {
         paneManager.tabManagers.values.flatMap(\.tabs)

--- a/Pine/QuickOpenView.swift
+++ b/Pine/QuickOpenView.swift
@@ -154,7 +154,7 @@ struct QuickOpenView: View {
 
     private func openFile(_ url: URL) {
         provider.recordOpened(url: url)
-        projectManager.tabManager.openTab(url: url)
+        projectManager.openFileInActivePane(url: url)
         isPresented = false
     }
 }

--- a/Pine/SearchResultsView.swift
+++ b/Pine/SearchResultsView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct SearchResultsView: View {
     @Environment(ProjectManager.self) var projectManager
-    @Environment(TabManager.self) var tabManager
 
     var body: some View {
         let search = projectManager.searchProvider
@@ -86,7 +85,7 @@ struct SearchResultsView: View {
                 MatchRowView(
                     match: match,
                     fileURL: group.url,
-                    tabManager: tabManager
+                    projectManager: projectManager
                 )
             }
         }
@@ -98,13 +97,13 @@ struct SearchResultsView: View {
 private struct MatchRowView: View {
     let match: SearchMatch
     let fileURL: URL
-    let tabManager: TabManager
+    let projectManager: ProjectManager
 
     @State private var isHovered = false
 
     var body: some View {
         Button {
-            tabManager.openTabAndGoToLine(url: fileURL, line: match.lineNumber)
+            projectManager.openFileInActivePane(url: fileURL, line: match.lineNumber)
         } label: {
             HStack(spacing: 6) {
                 Text("\(match.lineNumber)")

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -240,7 +240,7 @@ struct WelcomeView: View {
                         // Give the project window time to initialize, then open the file
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                             let canonical = projectDir.resolvingSymlinksInPath()
-                            registry.openProjects[canonical]?.tabManager.openTab(url: file)
+                            registry.openProjects[canonical]?.openFileInActivePane(url: file)
                         }
                     }
                 }

--- a/PineTests/OpenFileInActivePaneTests.swift
+++ b/PineTests/OpenFileInActivePaneTests.swift
@@ -78,18 +78,48 @@ struct OpenFileInActivePaneTests {
 
     @Test func openFile_terminalPaneActive_fallsBackToEditorPane() {
         let pm = ProjectManager()
-        let firstPaneID = pm.paneManager.activePaneID
+        let editorPaneID = pm.paneManager.activePaneID
+        let editorTM = pm.paneManager.tabManager(for: editorPaneID)
+        #expect(editorTM != nil)
 
         // Create a terminal pane and make it active.
-        pm.terminal.createTerminalTab(relativeTo: firstPaneID, workingDirectory: nil)
+        pm.terminal.createTerminalTab(relativeTo: editorPaneID, workingDirectory: nil)
+        // Sanity: active pane is now a terminal pane (no tabManager registered).
+        #expect(pm.paneManager.tabManager(for: pm.paneManager.activePaneID) == nil)
 
-        // Open a file — must land in an editor pane (not crash, not lost).
+        // Open a file — must fall back to the editor pane (not the terminal pane).
         let url = tmpFile("d.swift")
         pm.openFileInActivePane(url: url)
 
-        // Some editor TabManager somewhere has the tab.
-        let total = pm.allTabs.filter { $0.url == url }.count
-        #expect(total >= 1)
+        // The fallback should land in the editor pane's TabManager (which is also `pm.tabManager`,
+        // the only editor TabManager in this layout).
+        #expect(editorTM?.tabs.contains { $0.url == url } == true)
+        #expect(pm.tabManager.tabs.contains { $0.url == url })
+        // No duplicates across the project.
+        #expect(pm.allTabs.filter { $0.url == url }.count == 1)
+    }
+
+    // MARK: - Regression: single-pane behavior unchanged
+
+    @Test func openFile_singlePane_doesNotRegress() {
+        let pm = ProjectManager()
+        // In a single-pane layout, the active TabManager must be the primary one.
+        #expect(pm.activeTabManager === pm.tabManager)
+        // And there must be exactly one tabManager registered in the pane manager.
+        #expect(pm.paneManager.tabManagers.count == 1)
+
+        let urlA = tmpFile("regression-a.swift")
+        let urlB = tmpFile("regression-b.swift")
+        pm.openFileInActivePane(url: urlA)
+        pm.openFileInActivePane(url: urlB)
+
+        // Both files land in the primary TabManager.
+        #expect(pm.tabManager.tabs.contains { $0.url == urlA })
+        #expect(pm.tabManager.tabs.contains { $0.url == urlB })
+        // Active tab is the most recently opened one.
+        #expect(pm.tabManager.activeTab?.url == urlB)
+        // No extra TabManagers were spawned.
+        #expect(pm.paneManager.tabManagers.count == 1)
     }
 
     // MARK: - Open same file twice: no duplicate in active pane

--- a/PineTests/OpenFileInActivePaneTests.swift
+++ b/PineTests/OpenFileInActivePaneTests.swift
@@ -1,0 +1,107 @@
+//
+//  OpenFileInActivePaneTests.swift
+//  PineTests
+//
+//  Tests for ProjectManager.openFileInActivePane(url:) — verifies that
+//  files opened from sidebar / quick open / search results land in the
+//  currently focused pane, not the primary tabManager. Regression for #695.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Open File In Active Pane")
+@MainActor
+struct OpenFileInActivePaneTests {
+
+    private func tmpFile(_ name: String) -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(name)
+        try? "// \(name)".write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    // MARK: - Single pane: opens in primary
+
+    @Test func openFile_singlePane_opensInPrimary() {
+        let pm = ProjectManager()
+        let url = tmpFile("a.swift")
+
+        pm.openFileInActivePane(url: url)
+
+        #expect(pm.tabManager.tabs.contains { $0.url == url })
+        #expect(pm.activeTabManager.activeTab?.url == url)
+    }
+
+    // MARK: - Two panes: opens in active (second) pane, NOT primary
+
+    @Test func openFile_twoPanes_opensInActivePane() {
+        let pm = ProjectManager()
+        let firstPaneID = pm.paneManager.activePaneID
+        guard let secondPaneID = pm.paneManager.splitPane(firstPaneID, axis: .horizontal) else {
+            Issue.record("Split failed"); return
+        }
+        // After split, active pane is the new (second) pane.
+        #expect(pm.paneManager.activePaneID == secondPaneID)
+
+        let url = tmpFile("b.swift")
+        pm.openFileInActivePane(url: url)
+
+        let secondTM = pm.paneManager.tabManager(for: secondPaneID)
+        #expect(secondTM?.tabs.contains { $0.url == url } == true)
+        // Primary (first) pane must NOT receive the tab
+        #expect(pm.tabManager.tabs.contains { $0.url == url } == false)
+    }
+
+    // MARK: - Switching active pane back to first opens there
+
+    @Test func openFile_afterRefocusFirstPane_opensInFirst() {
+        let pm = ProjectManager()
+        let firstPaneID = pm.paneManager.activePaneID
+        guard let secondPaneID = pm.paneManager.splitPane(firstPaneID, axis: .horizontal) else {
+            Issue.record("Split failed"); return
+        }
+        pm.paneManager.activePaneID = firstPaneID
+
+        let url = tmpFile("c.swift")
+        pm.openFileInActivePane(url: url)
+
+        #expect(pm.tabManager.tabs.contains { $0.url == url })
+        #expect(pm.paneManager.tabManager(for: secondPaneID)?.tabs.contains { $0.url == url } == false)
+    }
+
+    // MARK: - Active pane is terminal: falls back to nearest editor pane
+
+    @Test func openFile_terminalPaneActive_fallsBackToEditorPane() {
+        let pm = ProjectManager()
+        let firstPaneID = pm.paneManager.activePaneID
+
+        // Create a terminal pane and make it active.
+        pm.terminal.createTerminalTab(relativeTo: firstPaneID, workingDirectory: nil)
+
+        // Open a file — must land in an editor pane (not crash, not lost).
+        let url = tmpFile("d.swift")
+        pm.openFileInActivePane(url: url)
+
+        // Some editor TabManager somewhere has the tab.
+        let total = pm.allTabs.filter { $0.url == url }.count
+        #expect(total >= 1)
+    }
+
+    // MARK: - Open same file twice: no duplicate in active pane
+
+    @Test func openFile_twiceInSameActivePane_noDuplicate() {
+        let pm = ProjectManager()
+        let url = tmpFile("e.swift")
+
+        pm.openFileInActivePane(url: url)
+        pm.openFileInActivePane(url: url)
+
+        let count = pm.activeTabManager.tabs.filter { $0.url == url }.count
+        #expect(count == 1)
+    }
+}


### PR DESCRIPTION
Closes #695.

## Summary

Sidebar clicks, Quick Open, project search results, file rename auto-open, drag-and-drop on the Welcome window, and the Welcome recent-file flow all opened files through the primary `tabManager`, ignoring which split pane was focused. With split panes, files always landed in the first pane regardless of focus.

## Solution

Introduced a single canonical entry point on `ProjectManager`:

```swift
func openFileInActivePane(url: URL, line: Int? = nil)
```

It routes through `activeTabManager` (which is `paneManager.activeEditorTabManager ?? tabManager`), so files always open in the focused editor pane. When the active pane is a terminal, it falls back to the nearest editor pane via the existing `activeEditorTabManager` logic.

All "open file" sites now go through this single method:

- `ContentView+Helpers.handleFileSelection` (sidebar click)
- `QuickOpenView.openFile`
- `SearchResultsView.MatchRowView` (now takes `ProjectManager` instead of `TabManager`)
- `FileNodeRow` rename auto-open (both new-item and post-rename branches)
- `FileNodeRow` duplicate (uses `projectManager.activeTabManager`)
- `WelcomeView` drop-handler (file-into-project)

## Design notes

- Centralizing the open path through one method means future open-file sites can't accidentally regress.
- `MatchRowView` now depends on `ProjectManager` instead of `TabManager`. This is correct because search results need to honor the *current* active pane at click time.
- Existing `@Environment(TabManager.self)` injection is preserved for backwards compatibility (still used by other call sites that operate on a specific pane's tabs).

## Test plan

- [x] New `OpenFileInActivePaneTests` (5 tests):
  - single pane → opens in primary
  - two panes → opens in active (second), NOT primary
  - refocus first pane → opens in first, not second
  - terminal pane active → falls back to nearest editor pane
  - same file twice → no duplicate tab
- [x] All tests pass
- [x] swiftlint --strict: 0 violations
