### PR TITLE
fix: reserve layout space for inline diff phantom block (#697, #698)

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -47,11 +47,70 @@ final class GutterTextView: NSTextView {
     var deletedLineBlocks: [DeletedLinesBlock] = []
 
     /// The diff hunks for the current file — used to filter highlights to the expanded hunk only.
-    var diffHunksForHighlight: [DiffHunk] = []
+    var diffHunksForHighlight: [DiffHunk] = [] {
+        didSet { recomputePhantomBlockHeights() }
+    }
 
     /// The ID of the currently expanded hunk (shows inline diff). Nil = all collapsed.
     var expandedHunkID: UUID? {
-        didSet { needsDisplay = true }
+        didSet {
+            recomputePhantomBlockHeights()
+            needsDisplay = true
+        }
+    }
+
+    /// Map of anchor line number → reserved vertical space (in points) for the
+    /// phantom deleted-lines block above that line. Used by the layout manager
+    /// delegate (`paragraphSpacingBeforeGlyphAt`) to reserve real layout space
+    /// so the phantom block does not overlap real code (#697 / #698).
+    private(set) var phantomBlockHeights: [Int: CGFloat] = [:]
+
+    /// Estimated line height for phantom block height calculation.
+    /// Uses the editor's font; falls back to 16pt if no font is set.
+    private var estimatedLineHeight: CGFloat {
+        guard let font = font else { return 16 }
+        // Approximate single-line height (NSLayoutManager line spacing is ~font.ascender + |descender| + leading).
+        return ceil(font.ascender + abs(font.descender) + font.leading)
+    }
+
+    /// Rebuilds `phantomBlockHeights` from the currently expanded hunk and
+    /// invalidates layout for affected character ranges so the layout manager
+    /// re-asks the delegate for `paragraphSpacingBeforeGlyphAt`.
+    private func recomputePhantomBlockHeights() {
+        let oldHeights = phantomBlockHeights
+        var newHeights: [Int: CGFloat] = [:]
+        if let expandedID = expandedHunkID,
+           let hunk = diffHunksForHighlight.first(where: { $0.id == expandedID }) {
+            let blocks = InlineDiffProvider.deletedLineBlocks(from: [hunk])
+            let lh = estimatedLineHeight
+            for block in blocks where !block.lines.isEmpty {
+                newHeights[block.anchorLine, default: 0] += CGFloat(block.lines.count) * lh
+            }
+        }
+        guard newHeights != oldHeights else { return }
+        phantomBlockHeights = newHeights
+        invalidateLayoutForPhantomChange()
+    }
+
+    /// Invalidates layout for the entire document so the layout manager
+    /// re-queries `paragraphSpacingBeforeGlyphAt` for affected lines.
+    /// We invalidate the whole document because the set of affected anchor
+    /// lines is small and full invalidation is simple and reliable.
+    private func invalidateLayoutForPhantomChange() {
+        guard let layoutManager = layoutManager else { return }
+        let length = (string as NSString).length
+        guard length > 0 else { return }
+        layoutManager.invalidateLayout(
+            forCharacterRange: NSRange(location: 0, length: length),
+            actualCharacterRange: nil
+        )
+        needsDisplay = true
+    }
+
+    /// Returns the phantom block height (in points) reserved before the given
+    /// 1-based line number, or 0 if none.
+    func phantomBlockHeight(forLine line: Int) -> CGFloat {
+        phantomBlockHeights[line] ?? 0
     }
 
     /// Subtle green tint for added lines.
@@ -235,7 +294,7 @@ final class GutterTextView: NSTextView {
 
         layoutManager.enumerateLineFragments(
             forGlyphRange: visibleGlyphRange
-        ) { [self] lineRect, _, _, glyphRange, _ in
+        ) { [self] lineRect, usedRect, _, glyphRange, _ in
             let charIndex = layoutManager.characterIndexForGlyph(at: glyphRange.location)
 
             // Determine if this is a new logical line
@@ -251,30 +310,37 @@ final class GutterTextView: NSTextView {
             }
 
             if isNewLogicalLine {
-                let y = lineRect.origin.y + originY - visibleRect.origin.y
+                // Phantom space reserved by the layout manager delegate
+                // (`paragraphSpacingBeforeGlyphAt`) sits in the top portion of
+                // lineRect: between lineRect.minY and usedRect.minY.
+                let phantomTopY = lineRect.origin.y + originY - visibleRect.origin.y
+                let usedY = usedRect.origin.y + originY - visibleRect.origin.y
+                let lineGlyphLineHeight = usedRect.height > 0 ? usedRect.height : lineRect.height
 
-                // Draw deleted phantom blocks above this line if it's an anchor
+                // Draw deleted phantom blocks in the reserved space above this line
                 if deletedAnchorSet.contains(lineNumber), let blocks = deletedAnchorMap[lineNumber] {
-                    var currentY = y
+                    var drawY = phantomTopY
                     for block in blocks {
-                        let blockHeight = CGFloat(block.lines.count) * lineRect.height
-                        currentY -= blockHeight
-                    }
-                    // Draw blocks top-down so they stack correctly
-                    var drawY = currentY
-                    for block in blocks {
-                        let blockHeight = CGFloat(block.lines.count) * lineRect.height
-                        self.drawDeletedPhantomBlock(block, at: drawY + blockHeight, lineHeight: lineRect.height)
+                        let blockHeight = CGFloat(block.lines.count) * lineGlyphLineHeight
+                        self.drawDeletedPhantomBlock(
+                            block,
+                            at: drawY + blockHeight,
+                            lineHeight: lineGlyphLineHeight
+                        )
                         drawY += blockHeight
                     }
                 }
 
                 // Draw green background on added lines (only for expanded hunk)
+                // Constrained to text area (after the gutter) so it does not overlap the gutter (#698).
                 if hunkAddedLines.contains(lineNumber) {
-                    var highlightRect = lineRect
-                    highlightRect.origin.x = 0
-                    highlightRect.size.width = self.bounds.width
-                    highlightRect.origin.y = y
+                    let textX = self.textContainerOrigin.x
+                    let highlightRect = NSRect(
+                        x: textX,
+                        y: usedY,
+                        width: max(0, self.bounds.width - textX),
+                        height: lineGlyphLineHeight
+                    )
                     Self.addedLineColor.setFill()
                     highlightRect.fill()
                 }
@@ -298,8 +364,16 @@ final class GutterTextView: NSTextView {
         let blockHeight = lineCount * lineHeight
         let blockY = anchorY - blockHeight
 
-        // Draw background for the entire deleted block
-        let bgRect = NSRect(x: 0, y: blockY, width: bounds.width, height: blockHeight)
+        // Draw background for the entire deleted block.
+        // Constrained to the text area (right of the gutter) so the phantom
+        // background does not overlap the gutter / line numbers (#698).
+        let textX = textContainerOrigin.x
+        let bgRect = NSRect(
+            x: textX,
+            y: blockY,
+            width: max(0, bounds.width - textX),
+            height: blockHeight
+        )
         bgColor.setFill()
         bgRect.fill()
 
@@ -319,7 +393,7 @@ final class GutterTextView: NSTextView {
         // Draw a subtle separator line between deleted block and editor content
         let separatorY = anchorY
         let separatorPath = NSBezierPath()
-        separatorPath.move(to: NSPoint(x: 0, y: separatorY))
+        separatorPath.move(to: NSPoint(x: textX, y: separatorY))
         separatorPath.line(to: NSPoint(x: bounds.width, y: separatorY))
         separatorPath.lineWidth = 0.5
         Self.deletedSeparatorColor.setStroke()
@@ -1965,6 +2039,49 @@ struct CodeEditorView: NSViewRepresentable {
             }
 
             return false
+        }
+
+        /// Reserves vertical space above the anchor line of an expanded inline
+        /// diff hunk so the phantom deleted-lines block can render without
+        /// overlapping real code or the gutter (#697 / #698).
+        ///
+        /// The space is requested only for the FIRST glyph of the anchor
+        /// line — `paragraphSpacingBeforeGlyphAt` is queried for every glyph,
+        /// but only the first one in a paragraph contributes to the layout
+        /// (subsequent glyphs in the same paragraph must return 0).
+        func layoutManager(
+            _ layoutManager: NSLayoutManager,
+            paragraphSpacingBeforeGlyphAt glyphIndex: Int,
+            withProposedLineFragmentRect rect: NSRect
+        ) -> CGFloat {
+            guard let sv = scrollView,
+                  let textView = sv.documentView as? GutterTextView,
+                  !textView.phantomBlockHeights.isEmpty else { return 0 }
+
+            let charIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
+            let source = textView.string as NSString
+            guard charIndex <= source.length else { return 0 }
+
+            // Only the first glyph of a logical line should contribute spacing.
+            // The first glyph of a line is at charIndex 0 or directly after a newline.
+            if charIndex > 0 {
+                let prev = source.character(at: charIndex - 1)
+                guard prev == ASCII.newline else { return 0 }
+            }
+
+            // Compute 1-based line number.
+            let line: Int
+            if let cache = lineStartsCache {
+                line = cache.lineNumber(at: charIndex)
+            } else {
+                var count = 1
+                for i in 0..<charIndex where source.character(at: i) == ASCII.newline {
+                    count += 1
+                }
+                line = count
+            }
+
+            return textView.phantomBlockHeight(forLine: line)
         }
 
         private func reportStateChange() {

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -412,7 +412,12 @@ final class LineNumberView: NSView {
 
         layoutManager.enumerateLineFragments(
             forGlyphRange: visibleGlyphRange
-        ) { lineRect, _, _, glyphRange, _ in
+        ) { lineRect, usedRect, _, glyphRange, _ in
+            // Use usedRect for line-number Y so paragraph spacing reserved for
+            // inline-diff phantom blocks (#697 / #698) does not push the line
+            // number up into the phantom area.
+            let textY = usedRect.height > 0 ? usedRect.origin.y : lineRect.origin.y
+            let textHeight = usedRect.height > 0 ? usedRect.height : lineRect.height
             let charIndex = layoutManager.characterIndexForGlyph(at: glyphRange.location)
 
             // Определяем: новая логическая строка или soft-wrap (перенос длинной строки)?
@@ -437,8 +442,11 @@ final class LineNumberView: NSView {
                     return
                 }
 
-                // Y: позиция фрагмента в textContainer + сдвиг контейнера − скролл
-                let y = lineRect.origin.y + originY - visibleRect.origin.y
+                // Y: позиция текста (usedRect) + сдвиг контейнера − скролл.
+                // Используем usedRect, чтобы paragraph spacing, зарезервированный
+                // для phantom-блока inline diff (#697 / #698), не сдвигал номер
+                // строки в верх phantom area.
+                let y = textY + originY - visibleRect.origin.y
 
                 let numStr = "\(lineNumber)" as NSString
                 let size = numStr.size(withAttributes: attrs)
@@ -450,7 +458,7 @@ final class LineNumberView: NSView {
                     if let foldable = self.foldStartMap[lineNumber] {
                         let isFolded = self.foldState.isFolded(foldable)
                         self.drawFoldIndicator(
-                            at: y, lineHeight: lineRect.height,
+                            at: y, lineHeight: textHeight,
                             isFolded: isFolded
                         )
                     }
@@ -483,7 +491,7 @@ final class LineNumberView: NSView {
                             x: self.gutterWidth - diffBarWidth,
                             y: y,
                             width: diffBarWidth,
-                            height: lineRect.height
+                            height: textHeight
                         )
                         markerColor.setFill()
                         barRect.fill()
@@ -493,7 +501,7 @@ final class LineNumberView: NSView {
                 // ── Validation diagnostic icon ──
                 if let diag = self.diagnosticMap[lineNumber] {
                     self.drawDiagnosticIcon(
-                        at: y, lineHeight: lineRect.height,
+                        at: y, lineHeight: textHeight,
                         severity: diag.severity
                     )
                 }

--- a/PineTests/InlineDiffPhantomLayoutTests.swift
+++ b/PineTests/InlineDiffPhantomLayoutTests.swift
@@ -1,0 +1,280 @@
+//
+//  InlineDiffPhantomLayoutTests.swift
+//  PineTests
+//
+//  Tests for #697 (gutter line number corruption when hunk expanded) and
+//  #698 (gutter overlaps code when hunk expanded).
+//
+//  Both bugs share a single root cause: the inline-diff phantom block was
+//  drawn in `drawBackground` without reserving any layout space, so it
+//  overlapped real text and the gutter. The fix uses NSLayoutManagerDelegate
+//  `paragraphSpacingBeforeGlyphAt` to reserve real vertical space above the
+//  anchor line, so the layout manager itself shifts subsequent content.
+//
+
+import Testing
+import AppKit
+import SwiftUI
+@testable import Pine
+
+@Suite("Inline Diff Phantom Layout Tests")
+@MainActor
+struct InlineDiffPhantomLayoutTests {
+
+    // MARK: - Helpers
+
+    private func makeTextView(text: String = "line1\nline2\nline3\nline4\nline5\n") -> GutterTextView {
+        let textStorage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        )
+        layoutManager.addTextContainer(textContainer)
+        let tv = GutterTextView(
+            frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+            textContainer: textContainer
+        )
+        tv.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        return tv
+    }
+
+    private func deletionHunk(newStart: Int = 3, deletedLines: [String] = ["old1", "old2"]) -> DiffHunk {
+        // Pure deletion hunk: phantom overlay shows the deleted lines.
+        let raw = "@@ -\(newStart),\(deletedLines.count) +\(newStart),0 @@\n"
+            + deletedLines.map { "-\($0)" }.joined(separator: "\n")
+        return DiffHunk(
+            newStart: newStart,
+            newCount: 0,
+            oldStart: newStart,
+            oldCount: deletedLines.count,
+            rawText: raw
+        )
+    }
+
+    // MARK: - phantomBlockHeights basics
+
+    @Test func phantomHeightsEmptyByDefault() {
+        let tv = makeTextView()
+        #expect(tv.phantomBlockHeights.isEmpty)
+        #expect(tv.phantomBlockHeight(forLine: 1) == 0)
+    }
+
+    @Test func phantomHeightsZeroWhenNoExpandedHunk() {
+        let tv = makeTextView()
+        let hunk = deletionHunk()
+        tv.diffHunksForHighlight = [hunk]
+        // Not expanded yet — no reserved space.
+        #expect(tv.phantomBlockHeights.isEmpty)
+    }
+
+    @Test func phantomHeightsPopulatedWhenHunkExpanded() {
+        let tv = makeTextView()
+        let hunk = deletionHunk(newStart: 3, deletedLines: ["old1", "old2"])
+        tv.diffHunksForHighlight = [hunk]
+        tv.expandedHunkID = hunk.id
+
+        // Anchor line of a pure-deletion hunk is `newStart` (3 here).
+        let height = tv.phantomBlockHeight(forLine: 3)
+        #expect(height > 0, "Phantom block must reserve non-zero height for the anchor line")
+        // 2 deleted lines → height ≈ 2 × line height. Sanity-check it scales.
+        let oneLine = tv.phantomBlockHeight(forLine: 999) // unrelated
+        #expect(oneLine == 0)
+    }
+
+    @Test func phantomHeightsScaleWithDeletedLineCount() {
+        let tv = makeTextView()
+        let h1 = deletionHunk(newStart: 3, deletedLines: ["a"])
+        tv.diffHunksForHighlight = [h1]
+        tv.expandedHunkID = h1.id
+        let single = tv.phantomBlockHeight(forLine: 3)
+
+        let h3 = deletionHunk(newStart: 3, deletedLines: ["a", "b", "c"])
+        tv.diffHunksForHighlight = [h3]
+        tv.expandedHunkID = h3.id
+        let triple = tv.phantomBlockHeight(forLine: 3)
+
+        #expect(triple > single)
+        // Should be roughly 3× — allow rounding slack.
+        #expect(triple >= single * 2.5)
+    }
+
+    @Test func phantomHeightsClearedWhenCollapsed() {
+        let tv = makeTextView()
+        let hunk = deletionHunk()
+        tv.diffHunksForHighlight = [hunk]
+        tv.expandedHunkID = hunk.id
+        #expect(!tv.phantomBlockHeights.isEmpty)
+        tv.expandedHunkID = nil
+        #expect(tv.phantomBlockHeights.isEmpty)
+    }
+
+    @Test func phantomHeightsClearedWhenHunksReplaced() {
+        let tv = makeTextView()
+        let hunk = deletionHunk()
+        tv.diffHunksForHighlight = [hunk]
+        tv.expandedHunkID = hunk.id
+        #expect(!tv.phantomBlockHeights.isEmpty)
+        // Replace hunks — stale expandedHunkID no longer matches anything.
+        tv.diffHunksForHighlight = []
+        #expect(tv.phantomBlockHeights.isEmpty,
+                "Phantom heights must be cleared when expanded hunk no longer exists")
+    }
+
+    @Test func modifiedHunksDoNotReservePhantomSpace() {
+        // Modified hunks (both - and + lines) intentionally skip the phantom
+        // overlay (#681). Phantom heights must reflect that.
+        let tv = makeTextView()
+        let modified = DiffHunk(
+            newStart: 3, newCount: 1, oldStart: 3, oldCount: 1,
+            rawText: "@@ -3,1 +3,1 @@\n-old\n+new"
+        )
+        tv.diffHunksForHighlight = [modified]
+        tv.expandedHunkID = modified.id
+        #expect(tv.phantomBlockHeights.isEmpty,
+                "Modified hunks must not reserve phantom space")
+    }
+
+    // MARK: - Layout integration
+
+    @Test func anchorLineFragmentTallerWhenHunkExpanded() {
+        // The defining property of the fix: the layout manager actually
+        // reserves vertical space above the anchor line. We verify by
+        // measuring the lineFragmentRect height for the anchor line glyph
+        // before and after expanding the hunk.
+        let text = "line1\nline2\nline3\nline4\nline5\n"
+        let tv = makeTextView(text: text)
+        // Wire the coordinator as layout manager delegate so that
+        // paragraphSpacingBeforeGlyphAt is queried.
+        let parent = CodeEditorView(
+            text: .constant(text), language: "swift", foldState: .constant(FoldState())
+        )
+        let coordinator = parent.makeCoordinator()
+        // Coordinator needs a scrollView reference so it can find the GutterTextView.
+        let scrollView = NSScrollView(frame: tv.frame)
+        scrollView.documentView = tv
+        coordinator.scrollView = scrollView
+        tv.layoutManager?.delegate = coordinator
+
+        // Force layout once with no expansion.
+        tv.layoutManager?.ensureLayout(for: tv.textContainer!) // swiftlint:disable:this force_unwrapping
+
+        // Anchor line 3 in pure-deletion hunk → glyph index for char index of line 3.
+        // Char index of line 3 = length of "line1\nline2\n" = 12.
+        let anchorChar = 12
+        let glyphIdx = tv.layoutManager!.glyphIndexForCharacter(at: anchorChar) // swiftlint:disable:this force_unwrapping
+        let baseRect = tv.layoutManager!.lineFragmentRect( // swiftlint:disable:this force_unwrapping
+            forGlyphAt: glyphIdx, effectiveRange: nil
+        )
+
+        // Now expand a deletion hunk anchored at line 3.
+        let hunk = deletionHunk(newStart: 3, deletedLines: ["old1", "old2"])
+        tv.diffHunksForHighlight = [hunk]
+        tv.expandedHunkID = hunk.id
+        tv.layoutManager?.ensureLayout(for: tv.textContainer!) // swiftlint:disable:this force_unwrapping
+
+        let glyphIdx2 = tv.layoutManager!.glyphIndexForCharacter(at: anchorChar) // swiftlint:disable:this force_unwrapping
+        let expandedRect = tv.layoutManager!.lineFragmentRect( // swiftlint:disable:this force_unwrapping
+            forGlyphAt: glyphIdx2, effectiveRange: nil
+        )
+
+        // The fragment rect must be taller AND its used rect should sit
+        // lower (top of the rect now contains reserved phantom space).
+        #expect(
+            expandedRect.height > baseRect.height,
+            "Anchor lineFragmentRect must grow when hunk is expanded (got base=\(baseRect.height), expanded=\(expandedRect.height))"
+        )
+    }
+
+    @Test func anchorLineFragmentReturnsToNormalWhenCollapsed() {
+        let text = "line1\nline2\nline3\nline4\nline5\n"
+        let tv = makeTextView(text: text)
+        let parent = CodeEditorView(
+            text: .constant(text), language: "swift", foldState: .constant(FoldState())
+        )
+        let coordinator = parent.makeCoordinator()
+        let scrollView = NSScrollView(frame: tv.frame)
+        scrollView.documentView = tv
+        coordinator.scrollView = scrollView
+        tv.layoutManager?.delegate = coordinator
+
+        tv.layoutManager?.ensureLayout(for: tv.textContainer!) // swiftlint:disable:this force_unwrapping
+        let anchorChar = 12
+        let baseHeight = tv.layoutManager!.lineFragmentRect( // swiftlint:disable:this force_unwrapping
+            forGlyphAt: tv.layoutManager!.glyphIndexForCharacter(at: anchorChar), // swiftlint:disable:this force_unwrapping
+            effectiveRange: nil
+        ).height
+
+        let hunk = deletionHunk(newStart: 3, deletedLines: ["a", "b"])
+        tv.diffHunksForHighlight = [hunk]
+        tv.expandedHunkID = hunk.id
+        tv.layoutManager?.ensureLayout(for: tv.textContainer!) // swiftlint:disable:this force_unwrapping
+
+        tv.expandedHunkID = nil
+        tv.layoutManager?.ensureLayout(for: tv.textContainer!) // swiftlint:disable:this force_unwrapping
+        let collapsedHeight = tv.layoutManager!.lineFragmentRect( // swiftlint:disable:this force_unwrapping
+            forGlyphAt: tv.layoutManager!.glyphIndexForCharacter(at: anchorChar), // swiftlint:disable:this force_unwrapping
+            effectiveRange: nil
+        ).height
+
+        #expect(abs(collapsedHeight - baseHeight) < 0.5,
+                "Anchor fragment must return to baseline height after collapse")
+    }
+
+    @Test func paragraphSpacingNonZeroOnlyForFirstGlyphOfAnchorLine() {
+        // The delegate must return spacing only for the FIRST glyph of the
+        // anchor line — never for glyphs mid-line, otherwise the spacing
+        // contribution would multiply with line length.
+        let text = "abc\ndef\nghi\n"
+        let tv = makeTextView(text: text)
+        let parent = CodeEditorView(
+            text: .constant(text), language: "swift", foldState: .constant(FoldState())
+        )
+        let coordinator = parent.makeCoordinator()
+        let scrollView = NSScrollView(frame: tv.frame)
+        scrollView.documentView = tv
+        coordinator.scrollView = scrollView
+        tv.layoutManager?.delegate = coordinator
+
+        // Pure deletion anchored at line 2 (char index 4 = 'd').
+        let hunk = deletionHunk(newStart: 2, deletedLines: ["old"])
+        tv.diffHunksForHighlight = [hunk]
+        tv.expandedHunkID = hunk.id
+
+        let lm = tv.layoutManager! // swiftlint:disable:this force_unwrapping
+        let glyphFirst = lm.glyphIndexForCharacter(at: 4) // 'd' — first glyph of line 2
+        let glyphMid = lm.glyphIndexForCharacter(at: 5)   // 'e' — mid-line
+
+        let proposed = NSRect(x: 0, y: 0, width: 100, height: 16)
+        let firstSpacing = coordinator.layoutManager(
+            lm,
+            paragraphSpacingBeforeGlyphAt: glyphFirst,
+            withProposedLineFragmentRect: proposed
+        )
+        let midSpacing = coordinator.layoutManager(
+            lm,
+            paragraphSpacingBeforeGlyphAt: glyphMid,
+            withProposedLineFragmentRect: proposed
+        )
+
+        #expect(firstSpacing > 0, "First glyph of anchor line must contribute spacing")
+        #expect(midSpacing == 0, "Mid-line glyphs must NOT contribute spacing")
+    }
+
+    // MARK: - Phantom drawing constraint
+
+    @Test func phantomBlockBackgroundDoesNotOverlapGutter() {
+        // Regression for #698: the phantom block background previously
+        // started at x=0 (under the gutter). It must now start at the text
+        // container origin (right of the gutter).
+        //
+        // We verify the invariant indirectly: the GutterTextView's
+        // `textContainerOrigin.x` equals `gutterInset`, and the phantom
+        // drawing code uses `textContainerOrigin.x` as its left edge. This
+        // test documents the invariant by asserting `gutterInset > 0`.
+        let tv = makeTextView()
+        tv.gutterInset = 44
+        #expect(tv.textContainerOrigin.x == tv.gutterInset)
+        #expect(tv.gutterInset > 0)
+    }
+}


### PR DESCRIPTION
Fixes #697 and #698 - both share one root cause.

The inline-diff phantom block was drawn in drawBackground without reserving any layout space, so it overlapped real lines (#697 - line numbers stacked) and its background extended from x=0 painting over the gutter (#698).

## Fix - Apple way via NSLayoutManager

- GutterTextView computes phantomBlockHeights[anchorLine] from the expanded hunk and invalidates layout when it changes.
- Coordinator implements layoutManager(_:paragraphSpacingBeforeGlyphAt:withProposedLineFragmentRect:), returning the reserved height for the first glyph of the anchor line. The layout manager grows the anchor lineFragmentRect, so subsequent text genuinely shifts down - no overlap.
- LineNumberView draws line numbers using usedRect.origin.y so numbers stay aligned with their text baseline (not pushed into the reserved phantom space).
- drawDeletedPhantomBlock and the added-line highlight clip backgrounds to [textContainerOrigin.x, bounds.width] so the gutter is never overpainted.

When the hunk is collapsed, phantomBlockHeights is cleared and layout re-invalidated.

## Tests

Adds PineTests/InlineDiffPhantomLayoutTests.swift (11 tests):
- phantomBlockHeights state machine (empty / expand / collapse / hunk replacement / modified-hunk skip)
- Real layout integration: anchor lineFragmentRect.height grows on expand and shrinks back on collapse via ensureLayout
- Delegate invariant: paragraphSpacingBeforeGlyphAt returns non-zero only for the first glyph of the anchor line
- Gutter-clip invariant

InlineDiffExpandTests, InlineDiffRenderingTests, LineNumberViewTests, LineNumberBaselineTests all still pass.

## Test plan
- [x] Build succeeds
- [x] Unit tests pass (11 new + 67 existing related tests)
- [ ] Visual check by Fedor

Closes #697
Closes #698
