### PR TITLE
feat: expandable inline diff toolbar with restore action (#689)

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -46,6 +46,13 @@ nonisolated enum AccessibilityID {
     static let editorTabOverflowMenu = "editorTabOverflowMenu"
     static let quickLookPreview = "quickLookPreview"
 
+    // MARK: - Inline diff toolbar (#689 / #687)
+    static let inlineDiffToolbar = "inlineDiffToolbar"
+    static let inlineDiffRestoreButton = "inlineDiffRestoreButton"
+    static let inlineDiffStageButton = "inlineDiffStageButton"
+    static let inlineDiffNextButton = "inlineDiffNextButton"
+    static let inlineDiffPreviousButton = "inlineDiffPreviousButton"
+
     // MARK: - Breadcrumb
     static let breadcrumbBar = "breadcrumbBar"
     static func breadcrumbSegment(_ name: String) -> String { "breadcrumbSegment_\(name)" }

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -503,6 +503,10 @@ final class GutterTextView: NSTextView {
 
     // MARK: - Escape key collapses expanded inline diff
 
+    /// Called when the inline diff should collapse (Escape, edit, click outside).
+    /// Wired by the Coordinator so it can also tear down the floating toolbar.
+    var onCollapseInlineDiff: (() -> Void)?
+
     override func keyDown(with event: NSEvent) {
         if event.keyCode == 53, expandedHunkID != nil {
             // Escape key (keyCode 53) collapses expanded inline diff
@@ -516,6 +520,7 @@ final class GutterTextView: NSTextView {
                     }
                 }
             }
+            onCollapseInlineDiff?()
             return
         }
         super.keyDown(with: event)
@@ -668,6 +673,9 @@ struct CodeEditorView: NSViewRepresentable {
     }
 
     var fontSize: CGFloat = FontSizeSettings.shared.fontSize
+    /// Called when the user clicks Restore on the inline diff toolbar (#689).
+    /// The receiver is expected to perform `git apply --reverse` and reload the buffer.
+    var onRestoreHunk: ((DiffHunk) -> Void)?
 
     private var editorFont: NSFont {
         NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
@@ -742,6 +750,9 @@ struct CodeEditorView: NSViewRepresentable {
         textView.addedLineNumbers = InlineDiffProvider.addedLineNumbers(from: diffHunks)
         textView.deletedLineBlocks = InlineDiffProvider.deletedLineBlocks(from: diffHunks)
         textView.diffHunksForHighlight = diffHunks
+        textView.onCollapseInlineDiff = { [weak coordinator = context.coordinator] in
+            coordinator?.dismissInlineDiffToolbar()
+        }
         // Delegate set AFTER text/highlight setup to prevent textDidChange from firing
         // during makeNSView and causing a spurious updateContent → cachedHighlightResult = nil
         // → contentVersion bump → updateNSView re-sets text → stripping highlight attributes.
@@ -969,6 +980,7 @@ struct CodeEditorView: NSViewRepresentable {
                 if gutterView.expandedHunkID != nil {
                     gutterView.expandedHunkID = nil
                     context.coordinator.lineNumberView?.expandedHunkID = nil
+                    context.coordinator.dismissInlineDiffToolbar()
                 }
                 gutterView.needsDisplay = true
             }
@@ -1320,6 +1332,15 @@ struct CodeEditorView: NSViewRepresentable {
             didChangeFromTextView = true
             parent.text = textView.string
 
+            // Any user edit dismisses the floating inline diff toolbar (#689) and
+            // collapses the expanded hunk — diff offsets become invalid as soon as
+            // the buffer changes.
+            if let gutterView = textView as? GutterTextView, gutterView.expandedHunkID != nil {
+                gutterView.expandedHunkID = nil
+                lineNumberView?.expandedHunkID = nil
+                dismissInlineDiffToolbar()
+            }
+
             // Подсветка синтаксиса сбросит backgroundColor —
             // считаем bracket highlight невалидным
             previousBracketRanges = []
@@ -1593,6 +1614,14 @@ struct CodeEditorView: NSViewRepresentable {
         @objc func scrollViewDidScroll(_ notification: Notification) {
             reportStateChange()
             highlightOnScrollIfNeeded()
+            // Track the expanded hunk so the toolbar follows it during scroll (#689)
+            if let toolbar = inlineDiffToolbar,
+               let textView = scrollView?.documentView as? GutterTextView,
+               let id = textView.expandedHunkID,
+               let hunk = parent.diffHunks.first(where: { $0.id == id }) {
+                _ = toolbar
+                repositionInlineDiffToolbar(for: hunk)
+            }
         }
 
         /// Подсвечивает видимую область при скролле (для больших файлов).
@@ -1806,6 +1835,148 @@ struct CodeEditorView: NSViewRepresentable {
             let newID: UUID? = (gutterView.expandedHunkID == hunk.id) ? nil : hunk.id
             gutterView.expandedHunkID = newID
             lineNumberView?.expandedHunkID = newID
+
+            if newID != nil {
+                presentInlineDiffToolbar(for: hunk)
+            } else {
+                dismissInlineDiffToolbar()
+            }
+        }
+
+        // MARK: - Inline diff toolbar (#689)
+
+        /// The currently displayed floating toolbar, if any.
+        var inlineDiffToolbar: InlineDiffToolbarView?
+
+        /// Presents the floating inline diff toolbar for the given hunk.
+        func presentInlineDiffToolbar(for hunk: DiffHunk) {
+            guard let sv = scrollView,
+                  let container = sv.superview else { return }
+
+            // Replace any existing toolbar — accordion behavior.
+            dismissInlineDiffToolbar()
+
+            let toolbar = InlineDiffToolbarView()
+            inlineDiffToolbar = toolbar
+
+            toolbar.onRestore = { [weak self] in
+                self?.parent.onRestoreHunk?(hunk)
+                // The buffer reload will refresh diffHunks and updateNSView will
+                // collapse the expanded hunk; we also dismiss eagerly.
+                self?.dismissInlineDiffToolbar()
+            }
+            toolbar.onNext = { [weak self] in
+                self?.navigateInlineDiff(direction: .next)
+            }
+            toolbar.onPrevious = { [weak self] in
+                self?.navigateInlineDiff(direction: .previous)
+            }
+            toolbar.onDismiss = { [weak self] in
+                self?.dismissInlineDiffToolbar()
+            }
+
+            container.addSubview(toolbar)
+            updateInlineDiffToolbarNavigationState(currentHunkID: hunk.id)
+            repositionInlineDiffToolbar(for: hunk)
+        }
+
+        /// Removes the toolbar from its superview.
+        func dismissInlineDiffToolbar() {
+            inlineDiffToolbar?.removeFromSuperview()
+            inlineDiffToolbar = nil
+        }
+
+        /// Updates next/previous button enabled state for the given hunk.
+        func updateInlineDiffToolbarNavigationState(currentHunkID: UUID?) {
+            guard let toolbar = inlineDiffToolbar else { return }
+            let hunks = parent.diffHunks
+            toolbar.updateNavigationState(
+                canGoNext: InlineDiffNavigator.canGoNext(from: currentHunkID, in: hunks),
+                canGoPrevious: InlineDiffNavigator.canGoPrevious(from: currentHunkID, in: hunks)
+            )
+        }
+
+        /// Computes the toolbar's screen position relative to the expanded hunk.
+        /// Anchors the toolbar to the right edge of the editor, just above the
+        /// hunk's first line.
+        func repositionInlineDiffToolbar(for hunk: DiffHunk) {
+            guard let toolbar = inlineDiffToolbar,
+                  let sv = scrollView,
+                  let textView = sv.documentView as? GutterTextView,
+                  let layoutManager = textView.layoutManager,
+                  let textContainer = textView.textContainer else { return }
+
+            let source = textView.string as NSString
+            // Resolve the character index of the hunk's first new-side line.
+            var charIndex = 0
+            var line = 1
+            while line < hunk.newStart && charIndex < source.length {
+                if source.character(at: charIndex) == ASCII.newline {
+                    line += 1
+                }
+                charIndex += 1
+            }
+            let glyphIndex = layoutManager.glyphIndexForCharacter(at: charIndex)
+            let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+
+            // Convert to scroll view content view coordinates.
+            let contentBounds = sv.contentView.bounds
+            let originY = textView.textContainerOrigin.y
+            let yInTextView = lineRect.origin.y + originY
+            let yInContent = yInTextView - contentBounds.origin.y
+
+            // Anchor: place above the hunk if there's room, otherwise below.
+            let toolbarSize = toolbar.intrinsicContentSize
+            let above = yInContent - toolbarSize.height - 4
+            let below = yInContent + lineRect.height + 4
+            let y = above >= 0 ? above : below
+
+            // Right-aligned with small inset (account for vertical scroller width).
+            let scrollerWidth: CGFloat = sv.verticalScroller?.frame.width ?? 0
+            let svFrame = sv.frame
+            let x = svFrame.origin.x + svFrame.width - toolbarSize.width - scrollerWidth - 8
+            let svOriginY = svFrame.origin.y
+
+            toolbar.frame = NSRect(
+                x: x,
+                y: svOriginY + y,
+                width: toolbarSize.width,
+                height: toolbarSize.height
+            )
+        }
+
+        /// Navigates to the next/previous hunk by the user pressing the toolbar arrows.
+        func navigateInlineDiff(direction: InlineDiffProvider.NavigationDirection) {
+            guard let sv = scrollView,
+                  let textView = sv.documentView as? GutterTextView else { return }
+            let hunks = parent.diffHunks
+            let currentID = textView.expandedHunkID
+            let target: DiffHunk?
+            switch direction {
+            case .next:
+                target = InlineDiffNavigator.nextHunk(after: currentID, in: hunks)
+            case .previous:
+                target = InlineDiffNavigator.previousHunk(before: currentID, in: hunks)
+            }
+            guard let next = target else { return }
+
+            textView.expandedHunkID = next.id
+            lineNumberView?.expandedHunkID = next.id
+
+            // Scroll the new hunk into view (1-based newStart → char index).
+            let source = textView.string as NSString
+            var charIndex = 0
+            var line = 1
+            while line < next.newStart && charIndex < source.length {
+                if source.character(at: charIndex) == ASCII.newline {
+                    line += 1
+                }
+                charIndex += 1
+            }
+            textView.scrollRangeToVisible(NSRange(location: charIndex, length: 0))
+
+            // Re-present toolbar so it tracks the new hunk position.
+            presentInlineDiffToolbar(for: next)
         }
 
         /// Handles fold code notifications from menu/keyboard shortcuts.

--- a/Pine/InlineDiffNavigator.swift
+++ b/Pine/InlineDiffNavigator.swift
@@ -1,0 +1,48 @@
+//
+//  InlineDiffNavigator.swift
+//  Pine
+//
+//  Pure navigation logic for jumping between diff hunks in the inline diff
+//  toolbar (#689). Navigation is bounded by the file — no wrap-around.
+//
+
+import Foundation
+
+enum InlineDiffNavigator {
+
+    /// Returns the hunk that follows the one identified by `currentID`.
+    /// If `currentID` is nil or unknown, returns the first hunk.
+    /// Returns `nil` when there is nothing after the current hunk (no wrap).
+    static func nextHunk(after currentID: UUID?, in hunks: [DiffHunk]) -> DiffHunk? {
+        guard !hunks.isEmpty else { return nil }
+        guard let currentID,
+              let idx = hunks.firstIndex(where: { $0.id == currentID }) else {
+            return hunks.first
+        }
+        let nextIdx = idx + 1
+        return nextIdx < hunks.count ? hunks[nextIdx] : nil
+    }
+
+    /// Returns the hunk that precedes the one identified by `currentID`.
+    /// If `currentID` is nil or unknown, returns the last hunk.
+    /// Returns `nil` when there is nothing before the current hunk (no wrap).
+    static func previousHunk(before currentID: UUID?, in hunks: [DiffHunk]) -> DiffHunk? {
+        guard !hunks.isEmpty else { return nil }
+        guard let currentID,
+              let idx = hunks.firstIndex(where: { $0.id == currentID }) else {
+            return hunks.last
+        }
+        let prevIdx = idx - 1
+        return prevIdx >= 0 ? hunks[prevIdx] : nil
+    }
+
+    /// Whether the next button should be enabled.
+    static func canGoNext(from currentID: UUID?, in hunks: [DiffHunk]) -> Bool {
+        nextHunk(after: currentID, in: hunks) != nil
+    }
+
+    /// Whether the previous button should be enabled.
+    static func canGoPrevious(from currentID: UUID?, in hunks: [DiffHunk]) -> Bool {
+        previousHunk(before: currentID, in: hunks) != nil
+    }
+}

--- a/Pine/InlineDiffToolbarView.swift
+++ b/Pine/InlineDiffToolbarView.swift
@@ -1,0 +1,174 @@
+//
+//  InlineDiffToolbarView.swift
+//  Pine
+//
+//  Floating action toolbar that appears alongside an expanded inline diff
+//  hunk (#689). Hosts Restore + navigation buttons. Stage is added later
+//  in #687 (PR2).
+//
+
+import AppKit
+
+/// A small floating NSView containing inline diff actions for the currently
+/// expanded hunk.
+final class InlineDiffToolbarView: NSView {
+
+    // MARK: - Callbacks
+
+    /// Invoked when the user clicks the Restore button.
+    var onRestore: (() -> Void)?
+    /// Invoked when the user clicks the next-hunk button.
+    var onNext: (() -> Void)?
+    /// Invoked when the user clicks the previous-hunk button.
+    var onPrevious: (() -> Void)?
+    /// Invoked when the toolbar requests dismissal (Escape, click outside, edit, etc.).
+    var onDismiss: (() -> Void)?
+
+    // MARK: - Buttons
+
+    let restoreButton: NSButton
+    let nextButton: NSButton
+    let previousButton: NSButton
+
+    // MARK: - Layout constants
+
+    private static let buttonHeight: CGFloat = 22
+    private static let horizontalPadding: CGFloat = 8
+    private static let verticalPadding: CGFloat = 4
+    private static let buttonSpacing: CGFloat = 6
+
+    // MARK: - Init
+
+    init() {
+        self.restoreButton = Self.makeTextButton(
+            title: NSLocalizedString("Restore", comment: "Inline diff Restore button"),
+            symbol: "arrow.uturn.backward",
+            id: AccessibilityID.inlineDiffRestoreButton
+        )
+        self.previousButton = Self.makeIconButton(
+            symbol: "chevron.up",
+            id: AccessibilityID.inlineDiffPreviousButton,
+            tooltip: NSLocalizedString("Previous Change", comment: "Inline diff prev button")
+        )
+        self.nextButton = Self.makeIconButton(
+            symbol: "chevron.down",
+            id: AccessibilityID.inlineDiffNextButton,
+            tooltip: NSLocalizedString("Next Change", comment: "Inline diff next button")
+        )
+
+        super.init(frame: .zero)
+
+        wantsLayer = true
+        layer?.cornerRadius = 6
+        layer?.borderWidth = 0.5
+        layer?.borderColor = NSColor.separatorColor.cgColor
+        layer?.backgroundColor = NSColor.controlBackgroundColor.withAlphaComponent(0.95).cgColor
+        layer?.shadowColor = NSColor.black.cgColor
+        layer?.shadowOpacity = 0.12
+        layer?.shadowRadius = 4
+        layer?.shadowOffset = NSSize(width: 0, height: -1)
+
+        setAccessibilityIdentifier(AccessibilityID.inlineDiffToolbar)
+
+        restoreButton.target = self
+        restoreButton.action = #selector(restoreClicked(_:))
+        nextButton.target = self
+        nextButton.action = #selector(nextClicked(_:))
+        previousButton.target = self
+        previousButton.action = #selector(previousClicked(_:))
+
+        addSubview(previousButton)
+        addSubview(nextButton)
+        addSubview(restoreButton)
+
+        layoutButtons()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Layout
+
+    override var intrinsicContentSize: NSSize {
+        let buttons: [NSButton] = subviews.compactMap { $0 as? NSButton }
+        let totalWidth = buttons.reduce(CGFloat(0)) { acc, btn in
+            acc + max(btn.intrinsicContentSize.width, Self.buttonHeight)
+        } + CGFloat(max(buttons.count - 1, 0)) * Self.buttonSpacing
+            + Self.horizontalPadding * 2
+        let height = Self.buttonHeight + Self.verticalPadding * 2
+        return NSSize(width: totalWidth, height: height)
+    }
+
+    private func layoutButtons() {
+        // Order (left → right): Previous, Next, Restore
+        let buttons: [NSButton] = [previousButton, nextButton, restoreButton]
+        var x = Self.horizontalPadding
+        let y = Self.verticalPadding
+        for btn in buttons {
+            let w = max(btn.intrinsicContentSize.width, Self.buttonHeight)
+            btn.frame = NSRect(x: x, y: y, width: w, height: Self.buttonHeight)
+            x += w + Self.buttonSpacing
+        }
+        let size = intrinsicContentSize
+        frame = NSRect(origin: frame.origin, size: size)
+    }
+
+    // MARK: - Public API
+
+    /// Updates enabled state of the navigation arrows.
+    func updateNavigationState(canGoNext: Bool, canGoPrevious: Bool) {
+        nextButton.isEnabled = canGoNext
+        previousButton.isEnabled = canGoPrevious
+    }
+
+    /// Forces a dismiss request (used by external triggers like Escape or
+    /// outside click) — exposed for unit-test invocation as well.
+    func requestDismiss() {
+        onDismiss?()
+    }
+
+    // MARK: - Actions
+
+    @objc private func restoreClicked(_ sender: Any?) {
+        onRestore?()
+    }
+
+    @objc private func nextClicked(_ sender: Any?) {
+        onNext?()
+    }
+
+    @objc private func previousClicked(_ sender: Any?) {
+        onPrevious?()
+    }
+
+    // MARK: - Button factories
+
+    private static func makeTextButton(title: String, symbol: String, id: String) -> NSButton {
+        let btn = NSButton()
+        btn.bezelStyle = .recessed
+        btn.title = title
+        btn.font = NSFont.systemFont(ofSize: 11, weight: .medium)
+        btn.image = NSImage(systemSymbolName: symbol, accessibilityDescription: title)
+        btn.imagePosition = .imageLeading
+        btn.imageScaling = .scaleProportionallyDown
+        btn.identifier = NSUserInterfaceItemIdentifier(id)
+        btn.setAccessibilityIdentifier(id)
+        btn.toolTip = title
+        return btn
+    }
+
+    private static func makeIconButton(symbol: String, id: String, tooltip: String) -> NSButton {
+        let btn = NSButton()
+        btn.bezelStyle = .recessed
+        btn.title = ""
+        btn.image = NSImage(systemSymbolName: symbol, accessibilityDescription: tooltip)
+        btn.imagePosition = .imageOnly
+        btn.imageScaling = .scaleProportionallyDown
+        btn.identifier = NSUserInterfaceItemIdentifier(id)
+        btn.setAccessibilityIdentifier(id)
+        btn.toolTip = tooltip
+        return btn
+    }
+}

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -202,7 +202,10 @@ struct PaneLeafView: View {
             cachedHighlightResult: tab.cachedHighlightResult,
             goToOffset: goToLineOffset,
             indentStyle: tab.cachedIndentation,
-            fontSize: FontSizeSettings.shared.fontSize
+            fontSize: FontSizeSettings.shared.fontSize,
+            onRestoreHunk: { hunk in
+                handleGutterRevert(hunk, tabManager: tabManager)
+            }
         )
         .id(tab.id)
         .accessibilityIdentifier(AccessibilityID.codeEditor)

--- a/PineTests/InlineDiffToolbarTests.swift
+++ b/PineTests/InlineDiffToolbarTests.swift
@@ -1,0 +1,240 @@
+//
+//  InlineDiffToolbarTests.swift
+//  PineTests
+//
+//  Tests for the floating inline diff toolbar (#689):
+//  - Hunk navigation without wrap-around (within file boundaries)
+//  - Restore callback wiring
+//  - Dismiss on edit / outside click
+//  - Edge cases for navigation (single hunk, multi hunk, boundaries)
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+@Suite("Inline Diff Toolbar Tests")
+@MainActor
+struct InlineDiffToolbarTests {
+
+    // MARK: - Helpers
+
+    private func makeHunk(
+        newStart: Int,
+        newCount: Int = 1,
+        oldStart: Int = 1,
+        oldCount: Int = 1,
+        rawText: String = "@@ -1,1 +1,1 @@\n-old\n+new\n"
+    ) -> DiffHunk {
+        DiffHunk(
+            newStart: newStart,
+            newCount: newCount,
+            oldStart: oldStart,
+            oldCount: oldCount,
+            rawText: rawText
+        )
+    }
+
+    // MARK: - Navigation: nextHunk (no wrap)
+
+    @Test func nextHunkReturnsNilWhenNoHunks() {
+        let result = InlineDiffNavigator.nextHunk(after: nil, in: [])
+        #expect(result == nil)
+    }
+
+    @Test func nextHunkFromNilReturnsFirst() {
+        let h1 = makeHunk(newStart: 2)
+        let h2 = makeHunk(newStart: 5)
+        let result = InlineDiffNavigator.nextHunk(after: nil, in: [h1, h2])
+        #expect(result?.id == h1.id)
+    }
+
+    @Test func nextHunkReturnsFollowingHunk() {
+        let h1 = makeHunk(newStart: 2)
+        let h2 = makeHunk(newStart: 5)
+        let h3 = makeHunk(newStart: 10)
+        let result = InlineDiffNavigator.nextHunk(after: h2.id, in: [h1, h2, h3])
+        #expect(result?.id == h3.id)
+    }
+
+    @Test func nextHunkOnLastReturnsNilNoWrap() {
+        let h1 = makeHunk(newStart: 2)
+        let h2 = makeHunk(newStart: 5)
+        let result = InlineDiffNavigator.nextHunk(after: h2.id, in: [h1, h2])
+        #expect(result == nil, "No wrap-around: next on last hunk returns nil")
+    }
+
+    @Test func nextHunkWithUnknownIDReturnsFirst() {
+        let h1 = makeHunk(newStart: 2)
+        let h2 = makeHunk(newStart: 5)
+        let result = InlineDiffNavigator.nextHunk(after: UUID(), in: [h1, h2])
+        #expect(result?.id == h1.id)
+    }
+
+    // MARK: - Navigation: previousHunk (no wrap)
+
+    @Test func previousHunkReturnsNilWhenNoHunks() {
+        let result = InlineDiffNavigator.previousHunk(before: nil, in: [])
+        #expect(result == nil)
+    }
+
+    @Test func previousHunkFromNilReturnsLast() {
+        let h1 = makeHunk(newStart: 2)
+        let h2 = makeHunk(newStart: 5)
+        let result = InlineDiffNavigator.previousHunk(before: nil, in: [h1, h2])
+        #expect(result?.id == h2.id)
+    }
+
+    @Test func previousHunkReturnsPrecedingHunk() {
+        let h1 = makeHunk(newStart: 2)
+        let h2 = makeHunk(newStart: 5)
+        let h3 = makeHunk(newStart: 10)
+        let result = InlineDiffNavigator.previousHunk(before: h3.id, in: [h1, h2, h3])
+        #expect(result?.id == h2.id)
+    }
+
+    @Test func previousHunkOnFirstReturnsNilNoWrap() {
+        let h1 = makeHunk(newStart: 2)
+        let h2 = makeHunk(newStart: 5)
+        let result = InlineDiffNavigator.previousHunk(before: h1.id, in: [h1, h2])
+        #expect(result == nil, "No wrap-around: previous on first hunk returns nil")
+    }
+
+    @Test func previousHunkWithSingleHunkReturnsNil() {
+        let h1 = makeHunk(newStart: 2)
+        let result = InlineDiffNavigator.previousHunk(before: h1.id, in: [h1])
+        #expect(result == nil)
+    }
+
+    @Test func nextHunkWithSingleHunkReturnsNil() {
+        let h1 = makeHunk(newStart: 2)
+        let result = InlineDiffNavigator.nextHunk(after: h1.id, in: [h1])
+        #expect(result == nil)
+    }
+
+    // MARK: - Boundary checks (canGoNext / canGoPrevious)
+
+    @Test func canGoNextFalseAtLastHunk() {
+        let h1 = makeHunk(newStart: 2)
+        let h2 = makeHunk(newStart: 5)
+        #expect(!InlineDiffNavigator.canGoNext(from: h2.id, in: [h1, h2]))
+    }
+
+    @Test func canGoNextTrueWhenMoreHunksFollow() {
+        let h1 = makeHunk(newStart: 2)
+        let h2 = makeHunk(newStart: 5)
+        #expect(InlineDiffNavigator.canGoNext(from: h1.id, in: [h1, h2]))
+    }
+
+    @Test func canGoPreviousFalseAtFirstHunk() {
+        let h1 = makeHunk(newStart: 2)
+        let h2 = makeHunk(newStart: 5)
+        #expect(!InlineDiffNavigator.canGoPrevious(from: h1.id, in: [h1, h2]))
+    }
+
+    @Test func canGoPreviousTrueWhenEarlierHunksExist() {
+        let h1 = makeHunk(newStart: 2)
+        let h2 = makeHunk(newStart: 5)
+        #expect(InlineDiffNavigator.canGoPrevious(from: h2.id, in: [h1, h2]))
+    }
+
+    @Test func canGoNextFalseWithSingleHunk() {
+        let h1 = makeHunk(newStart: 2)
+        #expect(!InlineDiffNavigator.canGoNext(from: h1.id, in: [h1]))
+    }
+
+    @Test func canGoPreviousFalseWithSingleHunk() {
+        let h1 = makeHunk(newStart: 2)
+        #expect(!InlineDiffNavigator.canGoPrevious(from: h1.id, in: [h1]))
+    }
+
+    @Test func canGoNextFalseWithEmptyHunks() {
+        #expect(!InlineDiffNavigator.canGoNext(from: nil, in: []))
+    }
+
+    @Test func canGoPreviousFalseWithEmptyHunks() {
+        #expect(!InlineDiffNavigator.canGoPrevious(from: nil, in: []))
+    }
+
+    // MARK: - InlineDiffToolbarView (PR1: Restore + nav, no Stage)
+
+    @Test func toolbarHasRestoreAndNavButtons() {
+        let toolbar = InlineDiffToolbarView()
+        #expect(toolbar.restoreButton.identifier?.rawValue == AccessibilityID.inlineDiffRestoreButton)
+        #expect(toolbar.nextButton.identifier?.rawValue == AccessibilityID.inlineDiffNextButton)
+        #expect(toolbar.previousButton.identifier?.rawValue == AccessibilityID.inlineDiffPreviousButton)
+    }
+
+    @Test func toolbarDoesNotHaveStageButtonInPR1() {
+        // PR1 (#689) ships without Stage. Stage is added in PR2 (#687).
+        let toolbar = InlineDiffToolbarView()
+        let mirror = Mirror(reflecting: toolbar)
+        let labels = mirror.children.compactMap { $0.label }
+        #expect(!labels.contains("stageButton"),
+                "Stage button should not exist in PR1 (#689)")
+    }
+
+    @Test func restoreCallbackIsInvokedOnButtonClick() {
+        let toolbar = InlineDiffToolbarView()
+        var called = false
+        toolbar.onRestore = { called = true }
+        toolbar.restoreButton.performClick(nil)
+        #expect(called)
+    }
+
+    @Test func nextCallbackIsInvokedOnButtonClick() {
+        let toolbar = InlineDiffToolbarView()
+        var called = false
+        toolbar.onNext = { called = true }
+        toolbar.nextButton.performClick(nil)
+        #expect(called)
+    }
+
+    @Test func previousCallbackIsInvokedOnButtonClick() {
+        let toolbar = InlineDiffToolbarView()
+        var called = false
+        toolbar.onPrevious = { called = true }
+        toolbar.previousButton.performClick(nil)
+        #expect(called)
+    }
+
+    @Test func dismissCallbackInvoked() {
+        let toolbar = InlineDiffToolbarView()
+        var called = false
+        toolbar.onDismiss = { called = true }
+        toolbar.requestDismiss()
+        #expect(called)
+    }
+
+    // MARK: - Button enabled state mirrors navigation availability
+
+    @Test func updateNavigationStateDisablesButtonsAtBoundaries() {
+        let toolbar = InlineDiffToolbarView()
+        toolbar.updateNavigationState(canGoNext: false, canGoPrevious: false)
+        #expect(!toolbar.nextButton.isEnabled)
+        #expect(!toolbar.previousButton.isEnabled)
+    }
+
+    @Test func updateNavigationStateEnablesButtons() {
+        let toolbar = InlineDiffToolbarView()
+        toolbar.updateNavigationState(canGoNext: true, canGoPrevious: true)
+        #expect(toolbar.nextButton.isEnabled)
+        #expect(toolbar.previousButton.isEnabled)
+    }
+
+    @Test func updateNavigationStateMixed() {
+        let toolbar = InlineDiffToolbarView()
+        toolbar.updateNavigationState(canGoNext: true, canGoPrevious: false)
+        #expect(toolbar.nextButton.isEnabled)
+        #expect(!toolbar.previousButton.isEnabled)
+    }
+
+    // MARK: - Toolbar sizing
+
+    @Test func toolbarHasNonZeroIntrinsicSize() {
+        let toolbar = InlineDiffToolbarView()
+        let size = toolbar.intrinsicContentSize
+        #expect(size.width > 0)
+        #expect(size.height > 0)
+    }
+}


### PR DESCRIPTION
## Summary

Implements step 2 of #687: a floating action toolbar that appears next to an expanded inline diff hunk in the editor gutter.

Closes #689.

- **Restore** button reverts the hunk via `git apply --reverse` and reloads the buffer
- **↑ / ↓** navigate between hunks within the file (bounded — no wrap-around)
- Dismiss via Escape, click outside, or any edit to the buffer
- Toolbar follows the hunk during scroll

Stage button is intentionally absent — it lands in the follow-up PR for #687.

## Implementation

- New `InlineDiffNavigator` (pure logic) — bounded next/previous hunk selection, with `canGoNext` / `canGoPrevious` for button enablement
- New `InlineDiffToolbarView: NSView` — Restore + ↑ + ↓ buttons with a11y identifiers, dismiss callback, intrinsic sizing
- `CodeEditorView.Coordinator` now presents/dismisses/repositions the toolbar in `handleDiffMarkerClick`, `textDidChange`, `scrollViewDidScroll`, and `updateNSView` (when diff data changes)
- `PaneLeafView` wires `onRestoreHunk` into the existing `handleGutterRevert` path
- A11y identifiers: `inlineDiffToolbar`, `inlineDiffRestoreButton`, `inlineDiffNextButton`, `inlineDiffPreviousButton` (Stage id reserved for #687)

## Test plan

- [x] 29 new unit tests in `InlineDiffToolbarTests` cover navigator boundaries, callback wiring, button enablement, and PR1's no-Stage invariant
- [x] All existing inline diff tests still pass (`InlineDiffExpandTests`, `InlineDiffProviderTests`, `InlineDiffRenderingTests`, `CleanGutterMarkersTests`) — 256 tests in 5 suites
- [x] `swiftlint --strict` clean (0 violations across 271 files)
- [x] Pine builds and runs; manual visual check OK
