### PR TITLE
fix: reserve layout space for inline diff phantom block (#697, #698)

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -50,8 +50,17 @@ final class GutterTextView: NSTextView {
     var diffHunksForHighlight: [DiffHunk] = []
 
     /// The ID of the currently expanded hunk (shows inline diff). Nil = all collapsed.
+    /// Setting this triggers a layout invalidation so that the layout manager
+    /// reserves space for the phantom block on the anchor line (#697, #698).
     var expandedHunkID: UUID? {
-        didSet { needsDisplay = true }
+        didSet {
+            guard oldValue != expandedHunkID else { return }
+            if let layoutManager = layoutManager {
+                let fullRange = NSRange(location: 0, length: (string as NSString).length)
+                layoutManager.invalidateLayout(forCharacterRange: fullRange, actualCharacterRange: nil)
+            }
+            needsDisplay = true
+        }
     }
 
     /// Subtle green tint for added lines.
@@ -235,7 +244,7 @@ final class GutterTextView: NSTextView {
 
         layoutManager.enumerateLineFragments(
             forGlyphRange: visibleGlyphRange
-        ) { [self] lineRect, _, _, glyphRange, _ in
+        ) { [self] _, usedRect, _, glyphRange, _ in
             let charIndex = layoutManager.characterIndexForGlyph(at: glyphRange.location)
 
             // Determine if this is a new logical line
@@ -251,30 +260,32 @@ final class GutterTextView: NSTextView {
             }
 
             if isNewLogicalLine {
-                let y = lineRect.origin.y + originY - visibleRect.origin.y
+                // usedRect tracks the actual glyph row; on the anchor line of an
+                // expanded phantom block, the layout manager delegate has shifted
+                // usedRect down inside an inflated lineRect — so the area from
+                // lineRect.origin.y up to usedRect.origin.y is the reserved
+                // phantom space (#697, #698).
+                let glyphRowY = usedRect.origin.y + originY - visibleRect.origin.y
+                let glyphRowHeight = usedRect.height
 
-                // Draw deleted phantom blocks above this line if it's an anchor
+                // Draw deleted phantom blocks in the reserved area above the glyph row.
                 if deletedAnchorSet.contains(lineNumber), let blocks = deletedAnchorMap[lineNumber] {
-                    var currentY = y
+                    var drawTop = glyphRowY - CGFloat(blocks.reduce(0) { $0 + $1.lines.count }) * glyphRowHeight
                     for block in blocks {
-                        let blockHeight = CGFloat(block.lines.count) * lineRect.height
-                        currentY -= blockHeight
-                    }
-                    // Draw blocks top-down so they stack correctly
-                    var drawY = currentY
-                    for block in blocks {
-                        let blockHeight = CGFloat(block.lines.count) * lineRect.height
-                        self.drawDeletedPhantomBlock(block, at: drawY + blockHeight, lineHeight: lineRect.height)
-                        drawY += blockHeight
+                        let blockHeight = CGFloat(block.lines.count) * glyphRowHeight
+                        self.drawDeletedPhantomBlock(block, at: drawTop + blockHeight, lineHeight: glyphRowHeight)
+                        drawTop += blockHeight
                     }
                 }
 
                 // Draw green background on added lines (only for expanded hunk)
                 if hunkAddedLines.contains(lineNumber) {
-                    var highlightRect = lineRect
-                    highlightRect.origin.x = 0
-                    highlightRect.size.width = self.bounds.width
-                    highlightRect.origin.y = y
+                    let highlightRect = NSRect(
+                        x: 0,
+                        y: glyphRowY,
+                        width: self.bounds.width,
+                        height: glyphRowHeight
+                    )
                     Self.addedLineColor.setFill()
                     highlightRect.fill()
                 }
@@ -1806,6 +1817,8 @@ struct CodeEditorView: NSViewRepresentable {
             let newID: UUID? = (gutterView.expandedHunkID == hunk.id) ? nil : hunk.id
             gutterView.expandedHunkID = newID
             lineNumberView?.expandedHunkID = newID
+            // expandedHunkID didSet invalidates layout so the phantom block
+            // anchor line is re-inflated by the layout manager delegate.
         }
 
         /// Handles fold code notifications from menu/keyboard shortcuts.
@@ -1949,22 +1962,57 @@ struct CodeEditorView: NSViewRepresentable {
             in textContainer: NSTextContainer,
             forGlyphRange glyphRange: NSRange
         ) -> Bool {
-            guard !parent.foldState.foldedRanges.isEmpty else { return false }
-            let charRange = layoutManager.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
+            // We use this hook for two things:
+            //  1. Code folding — collapse hidden lines to zero height.
+            //  2. Inline diff phantom block — inflate the anchor line of the
+            //     expanded hunk so the deleted-lines block has real layout space
+            //     (#697, #698). Without this the phantom is drawn over real text
+            //     and line numbers desync.
+            let hasFolds = !parent.foldState.foldedRanges.isEmpty
+            let phantomHunks = expandedPhantomHunks
+            let expandedID = expandedPhantomHunkID
+            guard hasFolds || (expandedID != nil && !phantomHunks.isEmpty) else { return false }
 
-            // Use cached line starts for O(log n) lookup
             guard let cache = lineStartsCache else { return false }
+            let charRange = layoutManager.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
             let line = cache.lineNumber(at: charRange.location)
 
             // If this line is hidden (inside a folded region), collapse it to zero height
-            if parent.foldState.isLineHidden(line) {
+            if hasFolds && parent.foldState.isLineHidden(line) {
                 lineFragmentRect.pointee.size.height = 0
                 lineFragmentUsedRect.pointee.size.height = 0
                 baselineOffset.pointee = 0
                 return true
             }
 
+            // Inflate the anchor line of the expanded hunk to reserve space for phantoms.
+            let phantomCount = InlineDiffProvider.phantomLineCount(
+                forLine: line,
+                in: phantomHunks,
+                expandedHunkID: expandedID
+            )
+            if phantomCount > 0 {
+                let baseHeight = lineFragmentRect.pointee.size.height
+                let extra = baseHeight * CGFloat(phantomCount)
+                lineFragmentRect.pointee.size.height = baseHeight + extra
+                // Push the glyph row to the bottom of the inflated fragment so the
+                // top portion is the reserved phantom area.
+                lineFragmentUsedRect.pointee.origin.y += extra
+                baselineOffset.pointee += extra
+                return true
+            }
+
             return false
+        }
+
+        /// Diff hunks driving phantom expansion (mirrors gutterView state).
+        var expandedPhantomHunks: [DiffHunk] {
+            (scrollView?.documentView as? GutterTextView)?.diffHunksForHighlight ?? []
+        }
+
+        /// ID of the currently expanded hunk, if any.
+        var expandedPhantomHunkID: UUID? {
+            (scrollView?.documentView as? GutterTextView)?.expandedHunkID
         }
 
         private func reportStateChange() {

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -55,12 +55,22 @@ final class GutterTextView: NSTextView {
     var expandedHunkID: UUID? {
         didSet {
             guard oldValue != expandedHunkID else { return }
-            if let layoutManager = layoutManager {
-                let fullRange = NSRange(location: 0, length: (string as NSString).length)
-                layoutManager.invalidateLayout(forCharacterRange: fullRange, actualCharacterRange: nil)
-            }
+            // Notify the layout manager delegate (Coordinator) so it can refresh
+            // its cached phantom state and run a targeted layout invalidation
+            // around the affected anchor lines (#697, #698).
+            (layoutManager?.delegate as? CodeEditorView.Coordinator)?
+                .phantomStateDidChange(previousAnchorLine: phantomAnchorLine(forHunkID: oldValue))
             needsDisplay = true
         }
+    }
+
+    /// Resolves the anchor (1-based) line for a given hunk ID, or nil if it's
+    /// not a pure deletion hunk currently in `diffHunksForHighlight`.
+    fileprivate func phantomAnchorLine(forHunkID hunkID: UUID?) -> Int? {
+        InlineDiffProvider.phantomAnchorLine(
+            in: diffHunksForHighlight,
+            expandedHunkID: hunkID
+        )
     }
 
     /// Subtle green tint for added lines.
@@ -762,6 +772,10 @@ struct CodeEditorView: NSViewRepresentable {
 
         // ── NSLayoutManager delegate for code folding ──
         layoutManager.delegate = context.coordinator
+        // Seed cached phantom state so the layout manager delegate doesn't
+        // hop to the document view on every line fragment (#723 review).
+        context.coordinator.cachedPhantomHunks = diffHunks
+        context.coordinator.cachedExpandedHunkID = nil
 
         // ── Номера строк — поверх scroll view, как отдельный сиблинг ──
         let lineNumberView = LineNumberView(textView: textView, clipView: scrollView.contentView)
@@ -981,6 +995,9 @@ struct CodeEditorView: NSViewRepresentable {
                     gutterView.expandedHunkID = nil
                     context.coordinator.lineNumberView?.expandedHunkID = nil
                 }
+                // Refresh cached phantom state used by the layout manager
+                // delegate (#723 review).
+                context.coordinator.phantomStateDidChange(previousAnchorLine: nil)
                 gutterView.needsDisplay = true
             }
         }
@@ -1969,8 +1986,8 @@ struct CodeEditorView: NSViewRepresentable {
             //     (#697, #698). Without this the phantom is drawn over real text
             //     and line numbers desync.
             let hasFolds = !parent.foldState.foldedRanges.isEmpty
-            let phantomHunks = expandedPhantomHunks
-            let expandedID = expandedPhantomHunkID
+            let phantomHunks = cachedPhantomHunks
+            let expandedID = cachedExpandedHunkID
             guard hasFolds || (expandedID != nil && !phantomHunks.isEmpty) else { return false }
 
             guard let cache = lineStartsCache else { return false }
@@ -2005,14 +2022,61 @@ struct CodeEditorView: NSViewRepresentable {
             return false
         }
 
-        /// Diff hunks driving phantom expansion (mirrors gutterView state).
-        var expandedPhantomHunks: [DiffHunk] {
-            (scrollView?.documentView as? GutterTextView)?.diffHunksForHighlight ?? []
-        }
+        /// Cached diff hunks driving phantom expansion (refreshed via
+        /// `phantomStateDidChange` instead of hopping to the document view on
+        /// every layout-fragment callback — see #723 review).
+        var cachedPhantomHunks: [DiffHunk] = []
 
-        /// ID of the currently expanded hunk, if any.
-        var expandedPhantomHunkID: UUID? {
-            (scrollView?.documentView as? GutterTextView)?.expandedHunkID
+        /// Cached expanded hunk ID — kept in sync with GutterTextView.
+        var cachedExpandedHunkID: UUID?
+
+        /// Called by GutterTextView when expandedHunkID or diffHunksForHighlight
+        /// changes. Refreshes cached phantom state and runs a targeted layout
+        /// invalidation around the affected anchor lines (#697, #698, #723).
+        func phantomStateDidChange(previousAnchorLine: Int?) {
+            guard let gutterView = scrollView?.documentView as? GutterTextView,
+                  let layoutManager = gutterView.layoutManager else {
+                cachedPhantomHunks = []
+                cachedExpandedHunkID = nil
+                return
+            }
+            cachedPhantomHunks = gutterView.diffHunksForHighlight
+            cachedExpandedHunkID = gutterView.expandedHunkID
+
+            let newAnchorLine = InlineDiffProvider.phantomAnchorLine(
+                in: cachedPhantomHunks,
+                expandedHunkID: cachedExpandedHunkID
+            )
+
+            // Build a sorted, deduplicated list of anchor lines whose layout
+            // must be invalidated (current and previous, if any).
+            var anchors: [Int] = []
+            if let prev = previousAnchorLine { anchors.append(prev) }
+            if let cur = newAnchorLine, cur != previousAnchorLine { anchors.append(cur) }
+
+            let textStorageLength = gutterView.textStorage?.length ?? 0
+            if anchors.isEmpty {
+                // Nothing to invalidate locally — fall back to full-document
+                // invalidation only when we actually have no anchor info at all.
+                let fullRange = NSRange(location: 0, length: textStorageLength)
+                layoutManager.invalidateLayout(forCharacterRange: fullRange, actualCharacterRange: nil)
+                return
+            }
+
+            for anchor in anchors {
+                guard let cache = lineStartsCache,
+                      let start = cache.charIndexForLineStart(anchor) else {
+                    // Cache miss — invalidate everything as a safety net.
+                    let fullRange = NSRange(location: 0, length: textStorageLength)
+                    layoutManager.invalidateLayout(forCharacterRange: fullRange, actualCharacterRange: nil)
+                    return
+                }
+                // End of the anchor line: start of the next line, or end of doc.
+                let end = cache.charIndexForLineStart(anchor + 1) ?? textStorageLength
+                let length = max(0, min(end, textStorageLength) - start)
+                let range = NSRange(location: start, length: length)
+                layoutManager.invalidateLayout(forCharacterRange: range, actualCharacterRange: nil)
+            }
         }
 
         private func reportStateChange() {

--- a/Pine/InlineDiffProvider.swift
+++ b/Pine/InlineDiffProvider.swift
@@ -277,6 +277,45 @@ enum InlineDiffProvider {
         return blocks
     }
 
+    // MARK: - Phantom layout reservation (#697, #698)
+
+    /// Returns the number of deleted phantom lines that should be reserved
+    /// above the given editor line, when the given hunk is expanded.
+    ///
+    /// Used by the layout manager delegate to inflate the line fragment rect
+    /// of the anchor line so that subsequent code lines shift down — the phantom
+    /// block then has real layout space and does not overlap real text.
+    /// Returns 0 for non-anchor lines, modified hunks, unexpanded hunks, or empty input.
+    static func phantomLineCount(
+        forLine line: Int,
+        in hunks: [DiffHunk],
+        expandedHunkID: UUID?
+    ) -> Int {
+        guard let expandedID = expandedHunkID,
+              let hunk = hunks.first(where: { $0.id == expandedID }) else {
+            return 0
+        }
+        guard !isModifiedHunk(hunk) else { return 0 }
+        let deleted = hunk.deletedLines
+        guard !deleted.isEmpty else { return 0 }
+        guard hunk.newStart == line else { return 0 }
+        return deleted.count
+    }
+
+    /// Returns the anchor (1-based) line of the expanded hunk's phantom block, or nil.
+    static func phantomAnchorLine(
+        in hunks: [DiffHunk],
+        expandedHunkID: UUID?
+    ) -> Int? {
+        guard let expandedID = expandedHunkID,
+              let hunk = hunks.first(where: { $0.id == expandedID }),
+              !isModifiedHunk(hunk),
+              !hunk.deletedLines.isEmpty else {
+            return nil
+        }
+        return hunk.newStart
+    }
+
     // MARK: - Fetch hunks for file
 
     /// Fetches diff hunks for a file asynchronously.

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -412,7 +412,11 @@ final class LineNumberView: NSView {
 
         layoutManager.enumerateLineFragments(
             forGlyphRange: visibleGlyphRange
-        ) { lineRect, _, _, glyphRange, _ in
+        ) { lineRect, usedRect, _, glyphRange, _ in
+            // usedRect tracks the actual glyph row position. When the inline diff
+            // phantom block reserves space above the anchor line, lineRect is
+            // inflated but usedRect stays at the glyph row — so line numbers
+            // must follow usedRect to stay aligned with the code (#697, #698).
             let charIndex = layoutManager.characterIndexForGlyph(at: glyphRange.location)
 
             // Определяем: новая логическая строка или soft-wrap (перенос длинной строки)?
@@ -437,8 +441,9 @@ final class LineNumberView: NSView {
                     return
                 }
 
-                // Y: позиция фрагмента в textContainer + сдвиг контейнера − скролл
-                let y = lineRect.origin.y + originY - visibleRect.origin.y
+                // Y: glyph row position (usedRect) — matches code text vertically.
+                let y = usedRect.origin.y + originY - visibleRect.origin.y
+                let rowHeight = usedRect.height > 0 ? usedRect.height : lineRect.height
 
                 let numStr = "\(lineNumber)" as NSString
                 let size = numStr.size(withAttributes: attrs)
@@ -450,7 +455,7 @@ final class LineNumberView: NSView {
                     if let foldable = self.foldStartMap[lineNumber] {
                         let isFolded = self.foldState.isFolded(foldable)
                         self.drawFoldIndicator(
-                            at: y, lineHeight: lineRect.height,
+                            at: y, lineHeight: rowHeight,
                             isFolded: isFolded
                         )
                     }
@@ -483,7 +488,7 @@ final class LineNumberView: NSView {
                             x: self.gutterWidth - diffBarWidth,
                             y: y,
                             width: diffBarWidth,
-                            height: lineRect.height
+                            height: rowHeight
                         )
                         markerColor.setFill()
                         barRect.fill()
@@ -493,7 +498,7 @@ final class LineNumberView: NSView {
                 // ── Validation diagnostic icon ──
                 if let diag = self.diagnosticMap[lineNumber] {
                     self.drawDiagnosticIcon(
-                        at: y, lineHeight: lineRect.height,
+                        at: y, lineHeight: rowHeight,
                         severity: diag.severity
                     )
                 }

--- a/Pine/LineStartsCache.swift
+++ b/Pine/LineStartsCache.swift
@@ -50,6 +50,14 @@ struct LineStartsCache {
         lineIndex(containing: charIndex) + 1
     }
 
+    /// Возвращает UTF-16 смещение начала строки (1-based номер).
+    /// Возвращает nil, если строка вне диапазона.
+    func charIndexForLineStart(_ line: Int) -> Int? {
+        let idx = line - 1
+        guard idx >= 0 && idx < lineStarts.count else { return nil }
+        return lineStarts[idx]
+    }
+
     /// Инкрементально обновляет кэш после редактирования текста.
     /// - Parameters:
     ///   - editedRange: Диапазон в новом тексте, покрывающий вставленный/изменённый контент.

--- a/PineTests/InlineDiffPhantomLayoutTests.swift
+++ b/PineTests/InlineDiffPhantomLayoutTests.swift
@@ -13,6 +13,7 @@
 
 import Testing
 import AppKit
+import SwiftUI
 @testable import Pine
 
 @Suite("Inline Diff Phantom Layout Tests")
@@ -140,5 +141,175 @@ struct InlineDiffPhantomLayoutTests {
         #expect(InlineDiffProvider.phantomAnchorLine(
             in: [hunk], expandedHunkID: hunk.id
         ) == nil)
+    }
+
+    // MARK: - Integration tests against the real layout manager
+    //
+    // These tests assemble the same Storage → LayoutManager → Container →
+    // GutterTextView stack used by CodeEditorView.makeNSView, attach the
+    // Coordinator as the layout manager delegate, then call ensureLayout
+    // and inspect lineFragmentRect / lineFragmentUsedRect for the anchor
+    // line. This verifies the *behavior* (real fragment height, real glyph
+    // row offset) — not just the pure helpers.
+
+    /// Builds a minimal CodeEditorView + Coordinator wired to a real
+    /// GutterTextView text stack. Returns the pieces a test needs.
+    private func makeIntegrationStack(
+        text: String,
+        diffHunks: [DiffHunk]
+    ) -> (
+        coordinator: CodeEditorView.Coordinator,
+        gutterView: GutterTextView,
+        layoutManager: NSLayoutManager
+    ) {
+        let textStorage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 600, height: CGFloat.greatestFiniteMagnitude)
+        )
+        textContainer.lineFragmentPadding = 5
+        layoutManager.addTextContainer(textContainer)
+
+        let gutterView = GutterTextView(
+            frame: NSRect(x: 0, y: 0, width: 600, height: 800),
+            textContainer: textContainer
+        )
+        gutterView.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        gutterView.diffHunksForHighlight = diffHunks
+
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 600, height: 800))
+        scrollView.documentView = gutterView
+
+        let editorView = CodeEditorView(
+            text: .constant(text),
+            language: "swift",
+            fileName: "test.swift",
+            diffHunks: diffHunks,
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: editorView)
+        coordinator.scrollView = scrollView
+        coordinator.lineStartsCache = LineStartsCache(text: text)
+        layoutManager.delegate = coordinator
+        // Seed cached state (mirrors makeNSView).
+        coordinator.cachedPhantomHunks = diffHunks
+        coordinator.cachedExpandedHunkID = nil
+
+        return (coordinator, gutterView, layoutManager)
+    }
+
+    /// Returns the height of the line fragment for the given 1-based line.
+    private func lineFragmentHeight(
+        forLine line: Int,
+        layoutManager: NSLayoutManager,
+        textStorage: NSTextStorage
+    ) -> (rectHeight: CGFloat, usedHeight: CGFloat, usedY: CGFloat) {
+        // Force layout for the entire document.
+        layoutManager.ensureLayout(for: layoutManager.textContainers[0])
+
+        let nsString = textStorage.string as NSString
+        // Find character index of the start of the requested line.
+        var currentLine = 1
+        var charIndex = 0
+        let length = nsString.length
+        while currentLine < line && charIndex < length {
+            let lineRange = nsString.lineRange(for: NSRange(location: charIndex, length: 0))
+            charIndex = NSMaxRange(lineRange)
+            currentLine += 1
+        }
+        let glyphIndex = layoutManager.glyphIndexForCharacter(at: charIndex)
+        var effectiveRange = NSRange(location: 0, length: 0)
+        let rect = layoutManager.lineFragmentRect(
+            forGlyphAt: glyphIndex,
+            effectiveRange: &effectiveRange
+        )
+        let used = layoutManager.lineFragmentUsedRect(
+            forGlyphAt: glyphIndex,
+            effectiveRange: nil
+        )
+        return (rect.size.height, used.size.height, used.origin.y - rect.origin.y)
+    }
+
+    @Test func anchorLineFragmentTallerWhenHunkExpanded() {
+        // Document with 6 lines; the deletion hunk's anchor is line 3 with
+        // 2 phantom lines.
+        let text = "line1\nline2\nline3\nline4\nline5\nline6\n"
+        let hunk = deletionHunk(newStart: 3, deletedLines: ["old_a", "old_b"])
+        let stack = makeIntegrationStack(text: text, diffHunks: [hunk])
+
+        guard let textStorage = stack.layoutManager.textStorage else {
+            Issue.record("layoutManager has no textStorage")
+            return
+        }
+
+        // Baseline (collapsed): anchor line fragment should be a normal
+        // single-line height, glyph row aligned with the fragment top.
+        let baseline = lineFragmentHeight(
+            forLine: 3,
+            layoutManager: stack.layoutManager,
+            textStorage: textStorage
+        )
+        #expect(baseline.rectHeight > 0)
+        #expect(baseline.usedY == 0)
+
+        // Expand the hunk. The didSet on GutterTextView should fire and the
+        // Coordinator should re-cache + invalidate, so the next ensureLayout
+        // returns an inflated fragment.
+        stack.gutterView.expandedHunkID = hunk.id
+
+        let expanded = lineFragmentHeight(
+            forLine: 3,
+            layoutManager: stack.layoutManager,
+            textStorage: textStorage
+        )
+
+        // Inflated fragment height = baseline * (1 + phantomCount) where
+        // phantomCount == 2.
+        let expectedHeight = baseline.rectHeight * 3
+        #expect(abs(expanded.rectHeight - expectedHeight) < 0.5,
+                "expected anchor fragment to be ~\(expectedHeight), got \(expanded.rectHeight)")
+        // Glyph row should be pushed to the bottom by phantomCount * baseHeight.
+        let expectedShift = baseline.rectHeight * 2
+        #expect(abs(expanded.usedY - expectedShift) < 0.5,
+                "expected glyph row Y shift ~\(expectedShift), got \(expanded.usedY)")
+    }
+
+    @Test func anchorLineFragmentReturnsToNormalWhenCollapsed() {
+        let text = "alpha\nbeta\ngamma\ndelta\nepsilon\n"
+        let hunk = deletionHunk(newStart: 4, deletedLines: ["old1", "old2", "old3"])
+        let stack = makeIntegrationStack(text: text, diffHunks: [hunk])
+        guard let textStorage = stack.layoutManager.textStorage else {
+            Issue.record("layoutManager has no textStorage")
+            return
+        }
+
+        // Capture baseline FIRST.
+        let baseline = lineFragmentHeight(
+            forLine: 4,
+            layoutManager: stack.layoutManager,
+            textStorage: textStorage
+        )
+
+        // Expand → verify it inflated.
+        stack.gutterView.expandedHunkID = hunk.id
+        let expanded = lineFragmentHeight(
+            forLine: 4,
+            layoutManager: stack.layoutManager,
+            textStorage: textStorage
+        )
+        #expect(expanded.rectHeight > baseline.rectHeight + 0.5)
+
+        // Collapse → verify the anchor fragment returned to normal.
+        stack.gutterView.expandedHunkID = nil
+        let collapsed = lineFragmentHeight(
+            forLine: 4,
+            layoutManager: stack.layoutManager,
+            textStorage: textStorage
+        )
+        #expect(abs(collapsed.rectHeight - baseline.rectHeight) < 0.5,
+                "expected fragment to return to baseline \(baseline.rectHeight), got \(collapsed.rectHeight)")
+        #expect(collapsed.usedY == 0,
+                "expected glyph row Y to return to 0, got \(collapsed.usedY)")
     }
 }

--- a/PineTests/InlineDiffPhantomLayoutTests.swift
+++ b/PineTests/InlineDiffPhantomLayoutTests.swift
@@ -1,0 +1,144 @@
+//
+//  InlineDiffPhantomLayoutTests.swift
+//  PineTests
+//
+//  Tests for layout-aware phantom block reservation (#697, #698).
+//
+//  When an inline diff hunk is expanded, the phantom block of deleted lines
+//  must reserve real layout space so that:
+//  - Subsequent code lines shift down (no overlap)
+//  - LineNumberView draws line numbers in the correct slots
+//  - The gutter does not overlap the code area
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+@Suite("Inline Diff Phantom Layout Tests")
+@MainActor
+struct InlineDiffPhantomLayoutTests {
+
+    // MARK: - Helpers
+
+    private func deletionHunk(
+        newStart: Int = 3,
+        deletedLines: [String] = ["old1", "old2", "old3"]
+    ) -> DiffHunk {
+        let raw = "@@ -\(newStart),\(deletedLines.count) +\(newStart),0 @@\n"
+            + deletedLines.map { "-\($0)" }.joined(separator: "\n")
+        return DiffHunk(
+            newStart: newStart,
+            newCount: 0,
+            oldStart: newStart,
+            oldCount: deletedLines.count,
+            rawText: raw
+        )
+    }
+
+    private func modifiedHunk(newStart: Int = 3) -> DiffHunk {
+        // Modified hunks are excluded from phantom rendering (#681).
+        DiffHunk(
+            newStart: newStart, newCount: 1,
+            oldStart: newStart, oldCount: 1,
+            rawText: "@@ -\(newStart),1 +\(newStart),1 @@\n-old\n+new\n"
+        )
+    }
+
+    // MARK: - phantomLineCount
+
+    @Test func phantomLineCountReturnsZeroWhenNoExpandedHunk() {
+        let hunk = deletionHunk(newStart: 5, deletedLines: ["a", "b"])
+        let count = InlineDiffProvider.phantomLineCount(
+            forLine: 5,
+            in: [hunk],
+            expandedHunkID: nil
+        )
+        #expect(count == 0)
+    }
+
+    @Test func phantomLineCountReturnsZeroForUnexpandedHunk() {
+        let hunk = deletionHunk(newStart: 5, deletedLines: ["a", "b"])
+        let other = UUID()
+        let count = InlineDiffProvider.phantomLineCount(
+            forLine: 5,
+            in: [hunk],
+            expandedHunkID: other
+        )
+        #expect(count == 0)
+    }
+
+    @Test func phantomLineCountReturnsDeletedLinesAtAnchor() {
+        let hunk = deletionHunk(newStart: 5, deletedLines: ["a", "b", "c"])
+        let count = InlineDiffProvider.phantomLineCount(
+            forLine: 5,
+            in: [hunk],
+            expandedHunkID: hunk.id
+        )
+        #expect(count == 3)
+    }
+
+    @Test func phantomLineCountReturnsZeroForNonAnchorLine() {
+        let hunk = deletionHunk(newStart: 5, deletedLines: ["a", "b"])
+        #expect(InlineDiffProvider.phantomLineCount(
+            forLine: 4, in: [hunk], expandedHunkID: hunk.id
+        ) == 0)
+        #expect(InlineDiffProvider.phantomLineCount(
+            forLine: 6, in: [hunk], expandedHunkID: hunk.id
+        ) == 0)
+    }
+
+    @Test func phantomLineCountIgnoresModifiedHunks() {
+        // Modified hunks (delete+add) do not render phantom overlay (#681).
+        let hunk = modifiedHunk(newStart: 5)
+        let count = InlineDiffProvider.phantomLineCount(
+            forLine: 5,
+            in: [hunk],
+            expandedHunkID: hunk.id
+        )
+        #expect(count == 0)
+    }
+
+    @Test func phantomLineCountSelectsOnlyExpandedHunkAmongMany() {
+        let h1 = deletionHunk(newStart: 5, deletedLines: ["a"])
+        let h2 = deletionHunk(newStart: 10, deletedLines: ["b", "c"])
+        // Expand h2 — h1's anchor must return 0
+        #expect(InlineDiffProvider.phantomLineCount(
+            forLine: 5, in: [h1, h2], expandedHunkID: h2.id
+        ) == 0)
+        #expect(InlineDiffProvider.phantomLineCount(
+            forLine: 10, in: [h1, h2], expandedHunkID: h2.id
+        ) == 2)
+    }
+
+    @Test func phantomLineCountWithEmptyHunksIsZero() {
+        #expect(InlineDiffProvider.phantomLineCount(
+            forLine: 1, in: [], expandedHunkID: UUID()
+        ) == 0)
+    }
+
+    // MARK: - phantomAnchorLine
+
+    @Test func phantomAnchorLineForExpandedHunk() {
+        let hunk = deletionHunk(newStart: 7, deletedLines: ["a", "b"])
+        let anchor = InlineDiffProvider.phantomAnchorLine(
+            in: [hunk],
+            expandedHunkID: hunk.id
+        )
+        #expect(anchor == 7)
+    }
+
+    @Test func phantomAnchorLineNilWhenNoExpansion() {
+        let hunk = deletionHunk(newStart: 7)
+        #expect(InlineDiffProvider.phantomAnchorLine(
+            in: [hunk], expandedHunkID: nil
+        ) == nil)
+    }
+
+    @Test func phantomAnchorLineNilForModifiedHunk() {
+        let hunk = modifiedHunk(newStart: 7)
+        #expect(InlineDiffProvider.phantomAnchorLine(
+            in: [hunk], expandedHunkID: hunk.id
+        ) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #697, closes #698.

The expanded inline diff phantom block (deleted lines shown above the anchor) was drawn purely in GutterTextView.drawBackground without participating in NSLayoutManager layout. As a result:
- Real code lines never shifted, so the phantom block was painted on top of real text — the gutter-overlaps-code visual in #698.
- LineNumberView had no idea phantom space existed, so it rendered numbers in their original glyph slots — but the editor was painting other glyphs there, producing the "87" over "37" line-number corruption in #697.

## Fix (the Apple way)

Hook into the NSLayoutManagerDelegate we already use for code folding and let layout reserve the phantom space.

- shouldSetLineFragmentRect now inflates the anchor-line fragment by N * lineHeight (N = number of deleted phantom lines) and shifts usedRect.origin.y and baselineOffset down by the same amount. The top portion of the inflated fragment becomes the reserved phantom area; the actual glyphs render at the bottom — subsequent lines naturally shift down.
- GutterTextView.expandedHunkID.didSet notifies the Coordinator, which refreshes its cached phantom state and runs a **targeted** invalidateLayout around just the affected anchor lines (previous + new) — no full-document invalidation on hot path.
- The Coordinator caches `cachedPhantomHunks` / `cachedExpandedHunkID` so the layout-fragment delegate does not hop to `scrollView.documentView` on every line fragment.
- LineNumberView.draw and drawInlineDiffHighlights now anchor vertical positioning to usedRect.origin.y (the actual glyph row) instead of lineRect.origin.y (the inflated fragment), so line numbers and the green added-line background stay in sync with the real text.
- Phantom block drawing anchors to the top of the inflated fragment, filling the reserved area instead of drawing over code.

## New API

- `InlineDiffProvider.phantomLineCount(forLine:in:expandedHunkID:)` and `phantomAnchorLine(in:expandedHunkID:)` — pure helpers covered by 10 unit tests.
- `LineStartsCache.charIndexForLineStart(_:)` — used by the Coordinator to compute the targeted invalidation range.
- 2 new **integration tests** in `InlineDiffPhantomLayoutTests` build the real Storage → LayoutManager → GutterTextView stack, attach the Coordinator as the layout delegate, call `ensureLayout`, and assert the anchor line's `lineFragmentRect` actually grew by `phantomCount * lineHeight` (and that `lineFragmentUsedRect.origin.y` shifted down by the same amount). Verified to fail without the inflation hook.

Modified hunks (delete + add) are excluded per #681.

## Test plan

- [x] swiftlint --strict clean
- [x] xcodebuild build succeeds
- [x] New InlineDiffPhantomLayoutTests (12 tests, including 2 integration) pass
- [x] Full PineTests suite passes (no regressions in fold / diff / gutter / line-number tests)
- [x] Manual visual check: open a file with a pure-deletion hunk, click the diff marker — phantom block above the anchor, lines below shift down, line numbers correct, no gutter/code overlap. Esc restores.
