### PR TITLE
feat: stage action on inline diff hunk toolbar (#687)

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -676,6 +676,9 @@ struct CodeEditorView: NSViewRepresentable {
     /// Called when the user clicks Restore on the inline diff toolbar (#689).
     /// The receiver is expected to perform `git apply --reverse` and reload the buffer.
     var onRestoreHunk: ((DiffHunk) -> Void)?
+    /// Called when the user clicks Stage on the inline diff toolbar (#687).
+    /// The receiver is expected to perform `git apply --cached` and refresh diff data.
+    var onStageHunk: ((DiffHunk) -> Void)?
 
     private var editorFont: NSFont {
         NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
@@ -1863,6 +1866,13 @@ struct CodeEditorView: NSViewRepresentable {
                 self?.parent.onRestoreHunk?(hunk)
                 // The buffer reload will refresh diffHunks and updateNSView will
                 // collapse the expanded hunk; we also dismiss eagerly.
+                self?.dismissInlineDiffToolbar()
+            }
+            toolbar.onStage = { [weak self] in
+                self?.parent.onStageHunk?(hunk)
+                // After staging, the diff data refresh causes updateNSView to
+                // collapse the expanded hunk; dismiss the toolbar eagerly so the
+                // UI feels responsive while git runs.
                 self?.dismissInlineDiffToolbar()
             }
             toolbar.onNext = { [weak self] in

--- a/Pine/InlineDiffToolbarView.swift
+++ b/Pine/InlineDiffToolbarView.swift
@@ -15,6 +15,8 @@ final class InlineDiffToolbarView: NSView {
 
     // MARK: - Callbacks
 
+    /// Invoked when the user clicks the Stage button (#687).
+    var onStage: (() -> Void)?
     /// Invoked when the user clicks the Restore button.
     var onRestore: (() -> Void)?
     /// Invoked when the user clicks the next-hunk button.
@@ -26,6 +28,7 @@ final class InlineDiffToolbarView: NSView {
 
     // MARK: - Buttons
 
+    let stageButton: NSButton
     let restoreButton: NSButton
     let nextButton: NSButton
     let previousButton: NSButton
@@ -40,6 +43,11 @@ final class InlineDiffToolbarView: NSView {
     // MARK: - Init
 
     init() {
+        self.stageButton = Self.makeTextButton(
+            title: NSLocalizedString("Stage", comment: "Inline diff Stage button"),
+            symbol: "plus.square",
+            id: AccessibilityID.inlineDiffStageButton
+        )
         self.restoreButton = Self.makeTextButton(
             title: NSLocalizedString("Restore", comment: "Inline diff Restore button"),
             symbol: "arrow.uturn.backward",
@@ -70,6 +78,8 @@ final class InlineDiffToolbarView: NSView {
 
         setAccessibilityIdentifier(AccessibilityID.inlineDiffToolbar)
 
+        stageButton.target = self
+        stageButton.action = #selector(stageClicked(_:))
         restoreButton.target = self
         restoreButton.action = #selector(restoreClicked(_:))
         nextButton.target = self
@@ -79,6 +89,7 @@ final class InlineDiffToolbarView: NSView {
 
         addSubview(previousButton)
         addSubview(nextButton)
+        addSubview(stageButton)
         addSubview(restoreButton)
 
         layoutButtons()
@@ -102,8 +113,8 @@ final class InlineDiffToolbarView: NSView {
     }
 
     private func layoutButtons() {
-        // Order (left → right): Previous, Next, Restore
-        let buttons: [NSButton] = [previousButton, nextButton, restoreButton]
+        // Order (left → right): Previous, Next, Stage, Restore
+        let buttons: [NSButton] = [previousButton, nextButton, stageButton, restoreButton]
         var x = Self.horizontalPadding
         let y = Self.verticalPadding
         for btn in buttons {
@@ -130,6 +141,10 @@ final class InlineDiffToolbarView: NSView {
     }
 
     // MARK: - Actions
+
+    @objc private func stageClicked(_ sender: Any?) {
+        onStage?()
+    }
 
     @objc private func restoreClicked(_ sender: Any?) {
         onRestore?()

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -205,6 +205,9 @@ struct PaneLeafView: View {
             fontSize: FontSizeSettings.shared.fontSize,
             onRestoreHunk: { hunk in
                 handleGutterRevert(hunk, tabManager: tabManager)
+            },
+            onStageHunk: { hunk in
+                handleGutterAccept(hunk, tabManager: tabManager)
             }
         )
         .id(tab.id)

--- a/PineTests/InlineDiffStageTests.swift
+++ b/PineTests/InlineDiffStageTests.swift
@@ -1,0 +1,123 @@
+//
+//  InlineDiffStageTests.swift
+//  PineTests
+//
+//  Tests for the Stage action on the inline diff toolbar (#687):
+//  - Stage button exists on the toolbar
+//  - Stage callback fires on click
+//  - Stage button has correct accessibility identifier
+//  - Stage button sits to the left of Restore (UX order)
+//  - acceptHunk wiring path exists in CodeEditorView via onStageHunk
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+@Suite("Inline Diff Stage Tests")
+@MainActor
+struct InlineDiffStageTests {
+
+    private func makeHunk() -> DiffHunk {
+        DiffHunk(
+            newStart: 2, newCount: 1, oldStart: 2, oldCount: 1,
+            rawText: "@@ -2,1 +2,1 @@\n-old\n+new\n"
+        )
+    }
+
+    @Test func toolbarHasStageButton() {
+        let toolbar = InlineDiffToolbarView()
+        let mirror = Mirror(reflecting: toolbar)
+        let labels = mirror.children.compactMap { $0.label }
+        #expect(labels.contains("stageButton"),
+                "Stage button should exist after #687")
+    }
+
+    @Test func stageButtonHasAccessibilityIdentifier() {
+        let toolbar = InlineDiffToolbarView()
+        #expect(toolbar.stageButton.identifier?.rawValue == AccessibilityID.inlineDiffStageButton)
+    }
+
+    @Test func stageCallbackInvokedOnClick() {
+        let toolbar = InlineDiffToolbarView()
+        var called = false
+        toolbar.onStage = { called = true }
+        toolbar.stageButton.performClick(nil)
+        #expect(called)
+    }
+
+    @Test func stageCallbackNilByDefault() {
+        let toolbar = InlineDiffToolbarView()
+        #expect(toolbar.onStage == nil)
+        // Clicking with no callback should not crash
+        toolbar.stageButton.performClick(nil)
+    }
+
+    @Test func stageButtonIsEnabledByDefault() {
+        let toolbar = InlineDiffToolbarView()
+        #expect(toolbar.stageButton.isEnabled)
+    }
+
+    @Test func stageButtonIsLeftOfRestore() {
+        // UX requirement: Stage sits to the LEFT of Restore in the toolbar.
+        let toolbar = InlineDiffToolbarView()
+        // Force the toolbar to lay out so frames are populated.
+        toolbar.layoutSubtreeIfNeeded()
+        #expect(toolbar.stageButton.frame.origin.x < toolbar.restoreButton.frame.origin.x,
+                "Stage should appear before Restore (left → right)")
+    }
+
+    @Test func stageButtonHasNonZeroSize() {
+        let toolbar = InlineDiffToolbarView()
+        toolbar.layoutSubtreeIfNeeded()
+        #expect(toolbar.stageButton.frame.width > 0)
+        #expect(toolbar.stageButton.frame.height > 0)
+    }
+
+    @Test func toolbarIntrinsicSizeAccountsForStageButton() {
+        // Toolbar with Stage should be wider than a hypothetical 3-button layout.
+        // We just sanity-check the width is reasonable for 4 controls.
+        let toolbar = InlineDiffToolbarView()
+        let size = toolbar.intrinsicContentSize
+        #expect(size.width > 100)
+    }
+
+    @Test func stageDismissCallbackPathExists() {
+        // After clicking Stage, the toolbar callback chain in CodeEditorView
+        // is expected to dismiss the toolbar via dismissInlineDiffToolbar().
+        // We verify the callback wiring shape here — actual reload happens in
+        // PaneLeafView.handleGutterAccept.
+        let toolbar = InlineDiffToolbarView()
+        var stageCalled = false
+        var dismissCalled = false
+        toolbar.onStage = { stageCalled = true }
+        toolbar.onDismiss = { dismissCalled = true }
+        toolbar.stageButton.performClick(nil)
+        toolbar.requestDismiss()
+        #expect(stageCalled)
+        #expect(dismissCalled)
+    }
+
+    // MARK: - acceptHunk wiring (regression: action available)
+
+    @Test func acceptHunkAPIIsCallableForStaging() {
+        // Sanity-check that the acceptHunk API used by the Stage path still
+        // exists and accepts the expected parameter shape.
+        let hunk = makeHunk()
+        let tmpDir = FileManager.default.temporaryDirectory
+        let fakeFile = tmpDir.appendingPathComponent("nonexistent.txt")
+        // We don't actually run git here — we just verify the function signature.
+        Task {
+            _ = await InlineDiffProvider.acceptHunk(hunk, fileURL: fakeFile, repoURL: tmpDir)
+        }
+    }
+
+    // MARK: - Updated PR1 invariant
+
+    @Test func toolbarStillExposesRestoreAndNavAfterPR2() {
+        let toolbar = InlineDiffToolbarView()
+        #expect(toolbar.restoreButton.identifier?.rawValue == AccessibilityID.inlineDiffRestoreButton)
+        #expect(toolbar.nextButton.identifier?.rawValue == AccessibilityID.inlineDiffNextButton)
+        #expect(toolbar.previousButton.identifier?.rawValue == AccessibilityID.inlineDiffPreviousButton)
+    }
+}

--- a/PineTests/InlineDiffToolbarTests.swift
+++ b/PineTests/InlineDiffToolbarTests.swift
@@ -165,16 +165,7 @@ struct InlineDiffToolbarTests {
         #expect(toolbar.previousButton.identifier?.rawValue == AccessibilityID.inlineDiffPreviousButton)
     }
 
-    @Test func toolbarDoesNotHaveStageButtonInPR1() {
-        // PR1 (#689) ships without Stage. Stage is added in PR2 (#687).
-        let toolbar = InlineDiffToolbarView()
-        let mirror = Mirror(reflecting: toolbar)
-        let labels = mirror.children.compactMap { $0.label }
-        #expect(!labels.contains("stageButton"),
-                "Stage button should not exist in PR1 (#689)")
-    }
-
-    @Test func restoreCallbackIsInvokedOnButtonClick() {
+@Test func restoreCallbackIsInvokedOnButtonClick() {
         let toolbar = InlineDiffToolbarView()
         var called = false
         toolbar.onRestore = { called = true }


### PR DESCRIPTION
## Summary

Adds the **Stage** action to the floating inline diff toolbar introduced in #689 (PR #722).

Closes #687.

- New **Stage** button on the toolbar — runs `git apply --cached` for the hunk
- After staging, `git status` refresh makes the marker disappear, the hunk goes away, and the toolbar dismisses
- Button order (left → right): Previous, Next, **Stage**, Restore

## Depends on

This PR is stacked on top of #722 (#689). Please merge #722 first.

## Implementation

- `InlineDiffToolbarView` gains a `stageButton` (`plus.square` SF Symbol) and an `onStage` callback
- `CodeEditorView.onStageHunk` parameter is wired by `Coordinator.presentInlineDiffToolbar` to dismiss the toolbar after the click and forward to the host
- `PaneLeafView` connects `onStageHunk` to the existing `handleGutterAccept` path (`InlineDiffProvider.acceptHunk` + `git status` refresh + `refreshLineDiffs`)
- A11y identifier: `inlineDiffStageButton` (was reserved during #689)

## Test plan

- [x] 10 new unit tests in `InlineDiffStageTests` — Stage button existence, accessibility id, callback wiring, default-nil callback, button order (left of Restore), enabled state, intrinsic size, dismiss path, and `acceptHunk` API surface
- [x] All `InlineDiffToolbarTests` / `InlineDiffExpandTests` still pass — 62 tests in the inline diff suites
- [x] `swiftlint --strict` clean (0 violations across 272 files)
- [x] Pine builds and runs; manual visual check OK
