### PR TITLE
fix: prune empty editor leaf when surrounded by terminals

### DIFF
--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -70,6 +70,10 @@ extension ContentView {
                 tabManager.activeTabID = tab.id
             }
 
+            // Collapse any restored editor leaves that ended up with no tabs
+            // (e.g., persisted empty placeholders next to terminal panes).
+            paneManager.pruneEmptyEditorLeaves()
+
             didRestoreTabs = !projectManager.allTabs.isEmpty
         }
 

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -195,10 +195,9 @@ extension ContentView {
     }
 
     func handleFileSelection(_ node: FileNode) {
-        // Use the active editor pane's TabManager so files open in the
-        // visible editor pane, even when focus is on a terminal pane.
-        let tm = paneManager.activeEditorTabManager ?? tabManager
-        tm.openTab(url: node.url)
+        // Open into the active editor pane, creating one on demand if the
+        // user has pruned all editor panes (e.g. terminals-only layout).
+        paneManager.ensureEditorPane().openTab(url: node.url)
     }
 
     /// Syncs sidebar selection to match the active editor tab.

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -251,7 +251,7 @@ struct ContentView: View {
         .environment(projectManager)
         .environment(projectManager.workspace)
         .environment(projectManager.terminal)
-        .environment(projectManager.tabManager)
+        .environment(projectManager.primaryTabManager)
         .environment(projectManager.paneManager)
         .environment(projectManager.toastManager)
         .environment(registry)

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -317,9 +317,6 @@ struct PaneLeafView: View {
         if tabManager.tabs.isEmpty {
             paneManager.removePane(paneID)
         }
-        // Defensive: also collapse any other now-empty editor leaves so the
-        // layout doesn't keep stale placeholders around.
-        paneManager.pruneEmptyEditorLeaves()
     }
 
     private func closeOtherTabsWithConfirmation(keeping tabID: UUID, tabManager: TabManager) {
@@ -333,6 +330,5 @@ struct PaneLeafView: View {
     private func closeAllTabsWithConfirmation(tabManager: TabManager) {
         TabCloseHelper.closeAllTabs(in: tabManager, gitProvider: workspace.gitProvider)
         paneManager.removePane(paneID)
-        paneManager.pruneEmptyEditorLeaves()
     }
 }

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -317,6 +317,9 @@ struct PaneLeafView: View {
         if tabManager.tabs.isEmpty {
             paneManager.removePane(paneID)
         }
+        // Defensive: also collapse any other now-empty editor leaves so the
+        // layout doesn't keep stale placeholders around.
+        paneManager.pruneEmptyEditorLeaves()
     }
 
     private func closeOtherTabsWithConfirmation(keeping tabID: UUID, tabManager: TabManager) {
@@ -330,5 +333,6 @@ struct PaneLeafView: View {
     private func closeAllTabsWithConfirmation(tabManager: TabManager) {
         TabCloseHelper.closeAllTabs(in: tabManager, gitProvider: workspace.gitProvider)
         paneManager.removePane(paneID)
+        paneManager.pruneEmptyEditorLeaves()
     }
 }

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -358,14 +358,26 @@ final class PaneManager {
         return fresh
     }
 
-    /// Removes a pane and promotes its sibling. The single root leaf cannot
-    /// be removed (valid empty-state). When the last editor pane is removed,
-    /// callers can use ``ensureEditorPane()`` to recreate one on demand.
+    /// Removes a pane and promotes its sibling. When the very last leaf in
+    /// the tree is removed, a fresh empty editor leaf is created in its
+    /// place so the window never ends up with no content at all.
     func removePane(_ paneID: PaneID) {
         // If the pane being removed is the maximized pane, restore first
         // so the saved layout is available for removal.
         if maximizedPaneID == paneID {
             restoreFromMaximize()
+        }
+
+        // Special case: removing the only leaf in the tree → replace it with
+        // a fresh empty editor leaf so the user always has a destination.
+        if root.leafCount == 1, root.firstLeafID == paneID {
+            tabManagers[paneID] = nil
+            terminalStates[paneID] = nil
+            let newID = PaneID()
+            tabManagers[newID] = TabManager()
+            root = .leaf(newID, .editor)
+            activePaneID = newID
+            return
         }
 
         guard root.leafCount > 1,

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -279,9 +279,52 @@ final class PaneManager {
         moveTab(url: tabURL, from: srcTM, to: dstTM)
         activePaneID = targetID
 
-        // Clean up empty panes
-        if srcTM.tabs.isEmpty {
-            removePane(sourceID)
+        // Clean up empty editor panes (centralized hook).
+        pruneEmptyEditorLeaves()
+    }
+
+    // MARK: - Empty editor leaf pruning
+
+    /// Removes editor leaves whose TabManager has no tabs, as long as the
+    /// resulting tree still contains at least one editor leaf. This collapses
+    /// the empty "No File Selected" placeholder when the user has another
+    /// editor pane to work with — fixing the UX issue where a stale editor
+    /// leaf would dominate the layout next to other panes.
+    ///
+    /// Invariants:
+    ///   - The tree must always contain at least one editor leaf so that
+    ///     opening files from the sidebar always has a destination, and so
+    ///     `ProjectManager.tabManager` (primary) keeps a stable home.
+    ///   - The single root leaf is never removed (valid empty-state).
+    ///   - A maximized pane is never removed; restore first if needed.
+    ///
+    /// Idempotent and safe to call after any structural mutation.
+    func pruneEmptyEditorLeaves() {
+        // Iterate until no more removals happen. Each pass collects victims
+        // up-front to keep iteration independent of mutations.
+        while true {
+            let editorLeafCount = root.leafCount(ofType: .editor)
+            // Need at least 2 editor leaves to be allowed to remove one.
+            guard editorLeafCount > 1 else { return }
+            // Cannot prune the only leaf in the tree.
+            guard root.leafCount > 1 else { return }
+
+            let victim = root.leafIDs.first { id in
+                guard root.content(for: id) == .editor else { return false }
+                guard id != maximizedPaneID else { return false }
+                guard let tm = tabManagers[id] else { return false }
+                return tm.tabs.isEmpty
+            }
+            guard let paneID = victim else { return }
+            guard let newRoot = root.removing(paneID) else { return }
+
+            tabManagers[paneID] = nil
+            terminalStates[paneID] = nil
+            root = newRoot
+
+            if activePaneID == paneID {
+                activePaneID = root.firstLeafID ?? activePaneID
+            }
         }
     }
 

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -285,27 +285,21 @@ final class PaneManager {
 
     // MARK: - Empty editor leaf pruning
 
-    /// Removes editor leaves whose TabManager has no tabs, as long as the
-    /// resulting tree still contains at least one editor leaf. This collapses
-    /// the empty "No File Selected" placeholder when the user has another
-    /// editor pane to work with — fixing the UX issue where a stale editor
-    /// leaf would dominate the layout next to other panes.
+    /// Removes any editor leaf whose TabManager has no tabs, collapsing the
+    /// empty "No File Selected" placeholder so it never occupies layout space
+    /// when the user has other panes to work with. Pruning is unconditional
+    /// when other content (editor or terminal) remains in the tree; if a file
+    /// is later opened from the sidebar / Quick Open / Recent, callers use
+    /// ``ensureEditorPane()`` to recreate an editor leaf on demand.
     ///
     /// Invariants:
-    ///   - The tree must always contain at least one editor leaf so that
-    ///     opening files from the sidebar always has a destination, and so
-    ///     `ProjectManager.tabManager` (primary) keeps a stable home.
-    ///   - The single root leaf is never removed (valid empty-state).
+    ///   - The single root leaf is never removed (valid empty-state on a
+    ///     freshly opened project).
     ///   - A maximized pane is never removed; restore first if needed.
     ///
     /// Idempotent and safe to call after any structural mutation.
     func pruneEmptyEditorLeaves() {
-        // Iterate until no more removals happen. Each pass collects victims
-        // up-front to keep iteration independent of mutations.
         while true {
-            let editorLeafCount = root.leafCount(ofType: .editor)
-            // Need at least 2 editor leaves to be allowed to remove one.
-            guard editorLeafCount > 1 else { return }
             // Cannot prune the only leaf in the tree.
             guard root.leafCount > 1 else { return }
 
@@ -328,9 +322,45 @@ final class PaneManager {
         }
     }
 
-    /// Removes a pane and promotes its sibling.
-    /// If removing this pane would leave zero editor panes, the pane is kept
-    /// but its tabs are closed instead — ensuring the editor area is always available.
+    /// Returns the TabManager of an editor leaf suitable for receiving a
+    /// newly opened file. If an editor leaf already exists, returns its
+    /// TabManager (preferring the active one). Otherwise creates a new
+    /// editor leaf next to the first terminal pane, splitting it vertically
+    /// so the new editor sits above the terminal — matching the behavior
+    /// users expect when opening files into a terminals-only layout.
+    ///
+    /// Always returns non-nil; the only failure mode (entire tree gone) is
+    /// guarded by re-using the existing root leaf as a last resort.
+    @discardableResult
+    func ensureEditorPane() -> TabManager {
+        if let tm = activeEditorTabManager { return tm }
+
+        // No editor leaf exists — create one by splitting the first terminal
+        // pane (insertBefore = true puts the new editor above the terminal).
+        if let terminalLeafID = root.leafIDs.first(where: { root.content(for: $0) == .terminal }),
+           let newID = splitPane(terminalLeafID, axis: .vertical, insertBefore: true),
+           let tm = tabManagers[newID] {
+            activePaneID = newID
+            return tm
+        }
+
+        // Theoretical fallback: tree contains neither editor nor terminal
+        // leaves (impossible in practice). Fall back to whatever TabManager
+        // we still have, or create a fresh one bound to the existing root.
+        if let firstID = root.firstLeafID, let tm = tabManagers[firstID] {
+            return tm
+        }
+        let fresh = TabManager()
+        let newID = PaneID()
+        tabManagers[newID] = fresh
+        root = .leaf(newID, .editor)
+        activePaneID = newID
+        return fresh
+    }
+
+    /// Removes a pane and promotes its sibling. The single root leaf cannot
+    /// be removed (valid empty-state). When the last editor pane is removed,
+    /// callers can use ``ensureEditorPane()`` to recreate one on demand.
     func removePane(_ paneID: PaneID) {
         // If the pane being removed is the maximized pane, restore first
         // so the saved layout is available for removal.
@@ -340,15 +370,6 @@ final class PaneManager {
 
         guard root.leafCount > 1,
               let newRoot = root.removing(paneID) else { return }
-
-        // Prevent removing the last editor pane — clear its tabs instead.
-        if root.content(for: paneID) == .editor,
-           root.leafCount(ofType: .editor) <= 1 {
-            if let tm = tabManagers[paneID] {
-                tm.closeAllTabs(force: true)
-            }
-            return
-        }
 
         tabManagers[paneID] = nil
         terminalStates[paneID] = nil

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -546,7 +546,7 @@ private struct ProjectWindowView: View {
                     .environment(pm)
                     .environment(pm.workspace)
                     .environment(pm.terminal)
-                    .environment(pm.tabManager)
+                    .environment(pm.primaryTabManager)
                     .environment(pm.paneManager)
                     .environment(pm.toastManager)
                     .environment(registry)

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -14,20 +14,21 @@ import SwiftUI
 final class ProjectManager {
     let workspace = WorkspaceManager()
     let terminal = TerminalManager()
-    /// The primary TabManager (first pane). For the *focused* pane's TabManager,
-    /// use ``activeTabManager`` which delegates to ``PaneManager/activeTabManager``.
-    let tabManager = TabManager()
+    /// The primary TabManager (root editor pane). Owns the recovery wiring and
+    /// editor-context subscription. For the *focused* pane's TabManager, use
+    /// ``activeTabManager`` which delegates to ``PaneManager/activeEditorTabManager``.
+    let primaryTabManager = TabManager()
     let searchProvider = ProjectSearchProvider()
     let quickOpenProvider = QuickOpenProvider()
     let progress = ProgressTracker()
     let contextFileWriter = ContextFileWriter()
     @ObservationIgnored
-    private(set) lazy var paneManager = PaneManager(existingTabManager: tabManager)
+    private(set) lazy var paneManager = PaneManager(existingTabManager: primaryTabManager)
 
     /// Returns the TabManager for the currently focused pane.
-    /// Falls back to the primary ``tabManager`` when paneManager has a single pane.
+    /// Falls back to the primary ``primaryTabManager`` when no editor pane is active.
     var activeTabManager: TabManager {
-        paneManager.activeEditorTabManager ?? tabManager
+        paneManager.activeEditorTabManager ?? primaryTabManager
     }
 
     /// Collects all tabs from every pane (for session save, dirty-tab checks, etc.).
@@ -66,7 +67,7 @@ final class ProjectManager {
         }
         workspace.progressTracker = progress
         workspace.gitProvider.progressTracker = progress
-        tabManager.onEditorContextChanged = { [weak self] in
+        primaryTabManager.onEditorContextChanged = { [weak self] in
             self?.updateEditorContext()
         }
         // Wire TerminalManager to PaneManager (lazy wiring)
@@ -90,7 +91,7 @@ final class ProjectManager {
         manager.tabsProvider = { [weak self] in
             self?.allTabs ?? []
         }
-        tabManager.recoveryManager = manager
+        primaryTabManager.recoveryManager = manager
         manager.startPeriodicSnapshots()
         recoveryManager = manager
     }

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -17,6 +17,16 @@ final class ProjectManager {
     /// The primary TabManager (root editor pane). Owns the recovery wiring and
     /// editor-context subscription. For the *focused* pane's TabManager, use
     /// ``activeTabManager`` which delegates to ``PaneManager/activeEditorTabManager``.
+    ///
+    /// Note: this instance can become an *orphan* — i.e. no pane in the
+    /// `PaneManager` tree references it — after `pruneEmptyEditorLeaves`
+    /// removes the root editor pane (terminals-only layout) or after a
+    /// session restore that does not bind it to any leaf. In that state it
+    /// is harmless: it holds no tabs, contributes nothing to `allTabs`, and
+    /// is recreated as a leaf-bound TabManager via `ensureEditorPane()`
+    /// when the user opens a file again. The reference is kept solely so
+    /// the recovery wiring and editor-context subscription survive across
+    /// such transitions.
     let primaryTabManager = TabManager()
     let searchProvider = ProjectSearchProvider()
     let quickOpenProvider = QuickOpenProvider()

--- a/Pine/QuickOpenView.swift
+++ b/Pine/QuickOpenView.swift
@@ -154,7 +154,7 @@ struct QuickOpenView: View {
 
     private func openFile(_ url: URL) {
         provider.recordOpened(url: url)
-        projectManager.primaryTabManager.openTab(url: url)
+        projectManager.paneManager.ensureEditorPane().openTab(url: url)
         isPresented = false
     }
 }

--- a/Pine/QuickOpenView.swift
+++ b/Pine/QuickOpenView.swift
@@ -154,7 +154,7 @@ struct QuickOpenView: View {
 
     private func openFile(_ url: URL) {
         provider.recordOpened(url: url)
-        projectManager.tabManager.openTab(url: url)
+        projectManager.primaryTabManager.openTab(url: url)
         isPresented = false
     }
 }

--- a/Pine/SymbolNavigatorView.swift
+++ b/Pine/SymbolNavigatorView.swift
@@ -120,7 +120,7 @@ struct SymbolNavigatorView: View {
     // MARK: - Actions
 
     private func loadSymbols() {
-        guard let tab = projectManager.primaryTabManager.activeTab else { return }
+        guard let tab = projectManager.activeTabManager.activeTab else { return }
         let ext = tab.url.pathExtension
         allSymbols = SymbolParser.parse(content: tab.content, fileExtension: ext)
         filteredSymbols = allSymbols
@@ -147,7 +147,7 @@ struct SymbolNavigatorView: View {
     }
 
     private func navigateToSymbol(_ symbol: PineSymbol) {
-        guard let tab = projectManager.primaryTabManager.activeTab else { return }
+        guard let tab = projectManager.activeTabManager.activeTab else { return }
         let offset = ContentView.cursorOffset(forLine: symbol.line, in: tab.content)
         NotificationCenter.default.post(
             name: .symbolNavigate,

--- a/Pine/SymbolNavigatorView.swift
+++ b/Pine/SymbolNavigatorView.swift
@@ -120,7 +120,7 @@ struct SymbolNavigatorView: View {
     // MARK: - Actions
 
     private func loadSymbols() {
-        guard let tab = projectManager.tabManager.activeTab else { return }
+        guard let tab = projectManager.primaryTabManager.activeTab else { return }
         let ext = tab.url.pathExtension
         allSymbols = SymbolParser.parse(content: tab.content, fileExtension: ext)
         filteredSymbols = allSymbols
@@ -147,7 +147,7 @@ struct SymbolNavigatorView: View {
     }
 
     private func navigateToSymbol(_ symbol: PineSymbol) {
-        guard let tab = projectManager.tabManager.activeTab else { return }
+        guard let tab = projectManager.primaryTabManager.activeTab else { return }
         let offset = ContentView.cursorOffset(forLine: symbol.line, in: tab.content)
         NotificationCenter.default.post(
             name: .symbolNavigate,

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -26,6 +26,10 @@ final class TerminalManager {
 
         if let tpID = lastActiveTerminalPaneID,
            pm.terminalState(for: tpID) != nil {
+            // Adding a tab to an existing terminal pane is not a structural
+            // mutation — the layout already includes a terminal, so any
+            // adjacent empty editor was already pruned (or kept on purpose).
+            // No prune needed here.
             pm.terminalState(for: tpID)?.addTab(workingDirectory: workingDirectory)
             pm.activePaneID = tpID
         } else {

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -32,6 +32,10 @@ final class TerminalManager {
             // Create terminal pane spanning full width at bottom
             let newID = pm.createTerminalPaneAtBottom(workingDirectory: workingDirectory)
             lastActiveTerminalPaneID = newID
+            // Collapse any empty editor placeholder that was sitting next to
+            // the new terminal — the user clearly wants the screen real estate
+            // for terminals, not for "No File Selected".
+            pm.pruneEmptyEditorLeaves()
         }
     }
 

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -240,7 +240,7 @@ struct WelcomeView: View {
                         // Give the project window time to initialize, then open the file
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                             let canonical = projectDir.resolvingSymlinksInPath()
-                            registry.openProjects[canonical]?.tabManager.openTab(url: file)
+                            registry.openProjects[canonical]?.primaryTabManager.openTab(url: file)
                         }
                     }
                 }

--- a/PineTests/CloseDelegateTests.swift
+++ b/PineTests/CloseDelegateTests.swift
@@ -66,9 +66,9 @@ struct CloseDelegateTests {
         defer { cleanup(dir) }
         let (delegate, pm, _) = makeCloseDelegate(projectURL: dir)
 
-        #expect(pm.tabManager.tabs.isEmpty)
+        #expect(pm.primaryTabManager.tabs.isEmpty)
         delegate.closeActiveTab()
-        #expect(pm.tabManager.tabs.isEmpty)
+        #expect(pm.primaryTabManager.tabs.isEmpty)
     }
 
     @Test func closeActiveTabClosesCleanTab() throws {
@@ -78,11 +78,11 @@ struct CloseDelegateTests {
 
         let fileURL = dir.appendingPathComponent("clean.swift")
         try "clean content".write(to: fileURL, atomically: true, encoding: .utf8)
-        pm.tabManager.openTab(url: fileURL)
+        pm.primaryTabManager.openTab(url: fileURL)
 
-        #expect(pm.tabManager.tabs.count == 1)
+        #expect(pm.primaryTabManager.tabs.count == 1)
         delegate.closeActiveTab()
-        #expect(pm.tabManager.tabs.isEmpty)
+        #expect(pm.primaryTabManager.tabs.isEmpty)
     }
 
     // MARK: - windowWillClose idempotency

--- a/PineTests/MultiPaneIntegrationTests.swift
+++ b/PineTests/MultiPaneIntegrationTests.swift
@@ -40,7 +40,7 @@ struct MultiPaneIntegrationTests {
 
     @Test func activeTabManager_singlePane_returnsPrimaryTabManager() {
         let pm = ProjectManager()
-        #expect(pm.activeTabManager === pm.tabManager)
+        #expect(pm.activeTabManager === pm.primaryTabManager)
     }
 
     @Test func activeTabManager_switchesBetweenPanes() {
@@ -62,6 +62,24 @@ struct MultiPaneIntegrationTests {
         #expect(pm.activeTabManager === firstTM)
     }
 
+    @Test func activeTabManager_returnsPrimary_whenFocusIsOnTerminalPane() {
+        let pm = ProjectManager()
+        let editorPaneID = pm.paneManager.activePaneID
+
+        // Create a terminal pane and focus it
+        guard let terminalPaneID = pm.paneManager.createTerminalPane(
+            relativeTo: editorPaneID, axis: .vertical, workingDirectory: nil
+        ) else {
+            Issue.record("Terminal split failed")
+            return
+        }
+        pm.paneManager.activePaneID = terminalPaneID
+
+        // With only one editor leaf, the nearest-editor lookup must resolve
+        // to the primary TabManager — never nil, never the terminal pane.
+        #expect(pm.activeTabManager === pm.primaryTabManager)
+    }
+
     // MARK: - allTabs collects from all panes
 
     @Test func allTabs_collectsFromAllPanes() {
@@ -70,7 +88,7 @@ struct MultiPaneIntegrationTests {
         let url2 = URL(fileURLWithPath: "/tmp/test-all-tabs-2.swift")
 
         let firstPaneID = pm.paneManager.activePaneID
-        pm.tabManager.openTab(url: url1)
+        pm.primaryTabManager.openTab(url: url1)
 
         guard let secondPaneID = pm.paneManager.splitPane(firstPaneID, axis: .horizontal) else {
             Issue.record("Split failed")
@@ -92,7 +110,7 @@ struct MultiPaneIntegrationTests {
 
         let pm = ProjectManager()
         let firstPaneID = pm.paneManager.activePaneID
-        pm.tabManager.openTab(url: files[0])
+        pm.primaryTabManager.openTab(url: files[0])
 
         guard let secondPaneID = pm.paneManager.splitPane(firstPaneID, axis: .horizontal) else {
             Issue.record("Split failed")
@@ -115,7 +133,7 @@ struct MultiPaneIntegrationTests {
         defer { cleanup(dir) }
 
         let pm = ProjectManager()
-        pm.tabManager.openTab(url: files[0])
+        pm.primaryTabManager.openTab(url: files[0])
 
         #expect(pm.hasUnsavedChanges == false)
         #expect(pm.allDirtyTabs.isEmpty)
@@ -129,8 +147,8 @@ struct MultiPaneIntegrationTests {
 
         let pm = ProjectManager()
         let firstPaneID = pm.paneManager.activePaneID
-        pm.tabManager.openTab(url: files[0])
-        pm.tabManager.updateContent("// modified a.swift")
+        pm.primaryTabManager.openTab(url: files[0])
+        pm.primaryTabManager.updateContent("// modified a.swift")
 
         guard let secondPaneID = pm.paneManager.splitPane(firstPaneID, axis: .horizontal) else {
             Issue.record("Split failed")
@@ -169,7 +187,7 @@ struct MultiPaneIntegrationTests {
         pm.workspace.loadDirectory(url: dir)
 
         let firstPaneID = pm.paneManager.activePaneID
-        pm.tabManager.openTab(url: files[0])
+        pm.primaryTabManager.openTab(url: files[0])
 
         guard let secondPaneID = pm.paneManager.splitPane(firstPaneID, axis: .horizontal) else {
             Issue.record("Split failed")
@@ -243,6 +261,6 @@ struct MultiPaneIntegrationTests {
         pm.paneManager.removePane(secondPaneID)
 
         // Should fall back to first pane
-        #expect(pm.activeTabManager === pm.tabManager)
+        #expect(pm.activeTabManager === pm.primaryTabManager)
     }
 }

--- a/PineTests/PaneManagerPruneEmptyEditorTests.swift
+++ b/PineTests/PaneManagerPruneEmptyEditorTests.swift
@@ -1,0 +1,228 @@
+//
+//  PaneManagerPruneEmptyEditorTests.swift
+//  PineTests
+//
+//  Tests for `PaneManager.pruneEmptyEditorLeaves()`, which collapses
+//  editor leaves whose TabManager has no tabs whenever the tree still
+//  contains another editor leaf. Fixes the UX bug where an empty
+//  "No File Selected" placeholder dominated the layout next to other panes.
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+@Suite("PaneManager prune empty editor leaves")
+@MainActor
+struct PaneManagerPruneEmptyEditorTests {
+
+    private func makeURL(_ name: String) -> URL {
+        URL(fileURLWithPath: "/tmp/pine-prune-tests/\(name)")
+    }
+
+    private func openDummyTab(in tm: TabManager, name: String) {
+        // Use openTab variant that does not hit disk: simulate a tab append
+        // by reusing TabManager's internal append via a tiny shim. To avoid
+        // touching disk, we directly mutate `tabs` (TabManager exposes it).
+        let url = makeURL(name)
+        let tab = EditorTab(url: url, content: "", savedContent: "")
+        tm.tabs.append(tab)
+        tm.activeTabID = tab.id
+    }
+
+    // MARK: - Single pane (root) is never pruned
+
+    @Test func singleEmptyEditorRoot_isNotPruned() {
+        let manager = PaneManager()
+        manager.pruneEmptyEditorLeaves()
+        #expect(manager.root.leafCount == 1)
+        #expect(manager.tabManagers.count == 1)
+    }
+
+    // MARK: - Two editor leaves: empty one collapses next to non-empty
+
+    @Test func emptyEditor_collapsesNextToEditorWithTabs() {
+        let manager = PaneManager()
+        let original = manager.activePaneID
+        // Original editor is empty. Split → new editor pane (also empty).
+        guard let newID = manager.splitPane(original, axis: .horizontal) else {
+            Issue.record("split failed"); return
+        }
+        // Give the NEW pane a tab so the original empty one is the victim.
+        guard let newTM = manager.tabManager(for: newID) else {
+            Issue.record("missing TM"); return
+        }
+        openDummyTab(in: newTM, name: "a.swift")
+
+        manager.pruneEmptyEditorLeaves()
+
+        #expect(manager.root.leafCount == 1)
+        #expect(manager.tabManagers[original] == nil)
+        #expect(manager.tabManagers[newID] != nil)
+        // Active pane should now be the surviving leaf.
+        #expect(manager.activePaneID == newID)
+    }
+
+    // MARK: - Empty editor next to terminal: NOT pruned (invariant)
+
+    @Test func emptyEditorNextToTerminal_isPreserved_invariantOneEditor() {
+        let manager = PaneManager()
+        let editorID = manager.activePaneID
+        _ = manager.createTerminalPane(
+            relativeTo: editorID, axis: .horizontal, workingDirectory: nil
+        )
+        #expect(manager.root.leafCount == 2)
+
+        manager.pruneEmptyEditorLeaves()
+
+        // Editor must remain — invariant: the tree must always contain
+        // at least one editor leaf so the sidebar always has a destination.
+        #expect(manager.root.leafCount == 2)
+        #expect(manager.root.leafCount(ofType: .editor) == 1)
+        #expect(manager.tabManagers[editorID] != nil)
+    }
+
+    // MARK: - DnD: moving last tab away collapses empty source
+
+    @Test func moveTabBetweenPanes_collapsesEmptySourceEditor() {
+        let manager = PaneManager()
+        let sourceID = manager.activePaneID
+        guard let sourceTM = manager.tabManager(for: sourceID) else {
+            Issue.record("missing TM"); return
+        }
+        openDummyTab(in: sourceTM, name: "moved.swift")
+
+        guard let destID = manager.splitPane(sourceID, axis: .horizontal) else {
+            Issue.record("split failed"); return
+        }
+        // Give dest its own tab so it survives prune.
+        guard let destTM = manager.tabManager(for: destID) else {
+            Issue.record("missing dest TM"); return
+        }
+        openDummyTab(in: destTM, name: "keep.swift")
+
+        manager.moveTabBetweenPanes(
+            tabURL: makeURL("moved.swift"),
+            from: sourceID,
+            to: destID
+        )
+
+        #expect(manager.root.leafCount == 1)
+        #expect(manager.tabManagers[sourceID] == nil)
+        #expect(manager.tabManagers[destID] != nil)
+        #expect(manager.activePaneID == destID)
+    }
+
+    // MARK: - Deeply nested tree: middle empty editor pruned, parent splits collapse
+
+    @Test func deeplyNestedEmptyEditor_isPrunedAndParentCollapses() {
+        let manager = PaneManager()
+        let rootID = manager.activePaneID
+        // Build: split root horizontally → A | B; split B vertically → A | (B / C)
+        guard let bID = manager.splitPane(rootID, axis: .horizontal) else {
+            Issue.record("split B failed"); return
+        }
+        guard let cID = manager.splitPane(bID, axis: .vertical) else {
+            Issue.record("split C failed"); return
+        }
+        // Give A and C tabs; B remains empty.
+        if let tmA = manager.tabManager(for: rootID) {
+            openDummyTab(in: tmA, name: "a.swift")
+        }
+        if let tmC = manager.tabManager(for: cID) {
+            openDummyTab(in: tmC, name: "c.swift")
+        }
+        #expect(manager.root.leafCount == 3)
+
+        manager.pruneEmptyEditorLeaves()
+
+        #expect(manager.root.leafCount == 2)
+        #expect(manager.tabManagers[bID] == nil)
+        // Both surviving leaves still present.
+        let ids = Set(manager.root.leafIDs)
+        #expect(ids.contains(rootID))
+        #expect(ids.contains(cID))
+    }
+
+    // MARK: - Multiple empty editors: all pruned except one (invariant)
+
+    @Test func multipleEmptyEditors_keepsAtLeastOne() {
+        let manager = PaneManager()
+        let firstID = manager.activePaneID
+        guard let secondID = manager.splitPane(firstID, axis: .horizontal) else {
+            Issue.record("split failed"); return
+        }
+        guard let thirdID = manager.splitPane(secondID, axis: .horizontal) else {
+            Issue.record("split failed"); return
+        }
+        _ = thirdID
+        // All three editors are empty.
+        manager.pruneEmptyEditorLeaves()
+
+        // Exactly one editor must survive.
+        #expect(manager.root.leafCount(ofType: .editor) == 1)
+        #expect(manager.root.leafCount == 1)
+    }
+
+    // MARK: - Maximized empty editor is not pruned
+
+    @Test func maximizedEmptyEditor_isNotPruned() {
+        let manager = PaneManager()
+        let firstID = manager.activePaneID
+        guard let secondID = manager.splitPane(firstID, axis: .horizontal) else {
+            Issue.record("split failed"); return
+        }
+        if let tm2 = manager.tabManager(for: secondID) {
+            openDummyTab(in: tm2, name: "x.swift")
+        }
+        // Maximize the empty pane.
+        manager.maximize(paneID: firstID)
+        #expect(manager.maximizedPaneID == firstID)
+
+        manager.pruneEmptyEditorLeaves()
+
+        // Maximized pane must remain intact.
+        #expect(manager.maximizedPaneID == firstID)
+        #expect(manager.tabManagers[firstID] != nil)
+    }
+
+    // MARK: - Idempotence
+
+    @Test func pruneIsIdempotent() {
+        let manager = PaneManager()
+        let firstID = manager.activePaneID
+        guard let secondID = manager.splitPane(firstID, axis: .horizontal) else {
+            Issue.record("split failed"); return
+        }
+        if let tm2 = manager.tabManager(for: secondID) {
+            openDummyTab(in: tm2, name: "x.swift")
+        }
+        manager.pruneEmptyEditorLeaves()
+        let snapshotLeaves = manager.root.leafCount
+        let snapshotIDs = manager.root.leafIDs
+        manager.pruneEmptyEditorLeaves()
+        manager.pruneEmptyEditorLeaves()
+        #expect(manager.root.leafCount == snapshotLeaves)
+        #expect(manager.root.leafIDs == snapshotIDs)
+    }
+
+    // MARK: - Active pane reassignment when victim was active
+
+    @Test func activePaneReassignedWhenVictimWasActive() {
+        let manager = PaneManager()
+        let firstID = manager.activePaneID
+        guard let secondID = manager.splitPane(firstID, axis: .horizontal) else {
+            Issue.record("split failed"); return
+        }
+        if let tm2 = manager.tabManager(for: secondID) {
+            openDummyTab(in: tm2, name: "x.swift")
+        }
+        // Make the empty pane active explicitly.
+        manager.activePaneID = firstID
+
+        manager.pruneEmptyEditorLeaves()
+
+        #expect(manager.activePaneID == secondID)
+        #expect(manager.tabManagers[firstID] == nil)
+    }
+}

--- a/PineTests/PaneManagerPruneEmptyEditorTests.swift
+++ b/PineTests/PaneManagerPruneEmptyEditorTests.swift
@@ -16,18 +16,19 @@ import Foundation
 @MainActor
 struct PaneManagerPruneEmptyEditorTests {
 
-    private func makeURL(_ name: String) -> URL {
-        URL(fileURLWithPath: "/tmp/pine-prune-tests/\(name)")
-    }
-
-    private func openDummyTab(in tm: TabManager, name: String) {
-        // Use openTab variant that does not hit disk: simulate a tab append
-        // by reusing TabManager's internal append via a tiny shim. To avoid
-        // touching disk, we directly mutate `tabs` (TabManager exposes it).
-        let url = makeURL(name)
-        let tab = EditorTab(url: url, content: "", savedContent: "")
-        tm.tabs.append(tab)
-        tm.activeTabID = tab.id
+    /// Creates a real file in a unique temp directory and opens it via
+    /// `TabManager.openTab(url:)` so all tab invariants (highlight cache,
+    /// dirty tracking, observers) are exercised exactly like in production.
+    /// Returns the file URL so callers can reference it later (e.g. DnD).
+    @discardableResult
+    private func openDummyTab(in tm: TabManager, name: String) -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-prune-tests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(name)
+        try? "// \(name)".write(to: url, atomically: true, encoding: .utf8)
+        tm.openTab(url: url)
+        return url
     }
 
     // MARK: - Single pane (root) is never pruned
@@ -114,6 +115,33 @@ struct PaneManagerPruneEmptyEditorTests {
         #expect(manager.root.leafCount(ofType: .editor) == 1)
     }
 
+    /// Quick Open path: simulates `QuickOpenView.openFile` against a
+    /// terminals-only layout — must transparently recreate an editor leaf
+    /// and open the file in it. Mirrors the production code path
+    /// `paneManager.ensureEditorPane().openTab(url:)`.
+    @Test func quickOpen_inTerminalsOnlyLayout_recreatesEditorAndOpensFile() {
+        let manager = PaneManager()
+        let editorID = manager.activePaneID
+        _ = manager.createTerminalPane(
+            relativeTo: editorID, axis: .horizontal, workingDirectory: nil
+        )
+        manager.pruneEmptyEditorLeaves()
+        #expect(manager.root.leafCount(ofType: .editor) == 0)
+
+        // Simulate Quick Open's openFile flow.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-quick-open-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("opened-via-quick-open.swift")
+        try? "// quick open".write(to: url, atomically: true, encoding: .utf8)
+        manager.ensureEditorPane().openTab(url: url)
+
+        #expect(manager.root.leafCount(ofType: .editor) == 1)
+        let activeTM = manager.tabManagers[manager.activePaneID]
+        #expect(activeTM?.tabs.count == 1)
+        #expect(activeTM?.tabs.first?.url == url)
+    }
+
     @Test func ensureEditorPane_thenOpenFile_endToEnd() {
         let manager = PaneManager()
         let editorID = manager.activePaneID
@@ -141,7 +169,7 @@ struct PaneManagerPruneEmptyEditorTests {
         guard let sourceTM = manager.tabManager(for: sourceID) else {
             Issue.record("missing TM"); return
         }
-        openDummyTab(in: sourceTM, name: "moved.swift")
+        let movedURL = openDummyTab(in: sourceTM, name: "moved.swift")
 
         guard let destID = manager.splitPane(sourceID, axis: .horizontal) else {
             Issue.record("split failed"); return
@@ -153,7 +181,7 @@ struct PaneManagerPruneEmptyEditorTests {
         openDummyTab(in: destTM, name: "keep.swift")
 
         manager.moveTabBetweenPanes(
-            tabURL: makeURL("moved.swift"),
+            tabURL: movedURL,
             from: sourceID,
             to: destID
         )

--- a/PineTests/PaneManagerPruneEmptyEditorTests.swift
+++ b/PineTests/PaneManagerPruneEmptyEditorTests.swift
@@ -63,23 +63,74 @@ struct PaneManagerPruneEmptyEditorTests {
         #expect(manager.activePaneID == newID)
     }
 
-    // MARK: - Empty editor next to terminal: NOT pruned (invariant)
+    // MARK: - Empty editor next to terminal: pruned (no inhabitant invariant)
 
-    @Test func emptyEditorNextToTerminal_isPreserved_invariantOneEditor() {
+    @Test func emptyEditorNextToTerminal_isPruned() {
         let manager = PaneManager()
         let editorID = manager.activePaneID
-        _ = manager.createTerminalPane(
+        let terminalID = manager.createTerminalPane(
             relativeTo: editorID, axis: .horizontal, workingDirectory: nil
         )
         #expect(manager.root.leafCount == 2)
 
         manager.pruneEmptyEditorLeaves()
 
-        // Editor must remain — invariant: the tree must always contain
-        // at least one editor leaf so the sidebar always has a destination.
-        #expect(manager.root.leafCount == 2)
+        // Editor must be removed — terminals-only layout is now valid.
+        #expect(manager.root.leafCount == 1)
+        #expect(manager.root.leafCount(ofType: .editor) == 0)
+        #expect(manager.tabManagers[editorID] == nil)
+        #expect(manager.root.firstLeafID == terminalID)
+    }
+
+    // MARK: - ensureEditorPane: re-creates editor when only terminals remain
+
+    @Test func ensureEditorPane_createsNewEditorWhenOnlyTerminalsExist() {
+        let manager = PaneManager()
+        let editorID = manager.activePaneID
+        _ = manager.createTerminalPane(
+            relativeTo: editorID, axis: .horizontal, workingDirectory: nil
+        )
+        manager.pruneEmptyEditorLeaves()
+        #expect(manager.root.leafCount(ofType: .editor) == 0)
+
+        let tm = manager.ensureEditorPane()
+
+        // A fresh editor leaf is created and active.
         #expect(manager.root.leafCount(ofType: .editor) == 1)
-        #expect(manager.tabManagers[editorID] != nil)
+        #expect(manager.root.leafCount == 2)
+        #expect(tm.tabs.isEmpty)
+        // The newly-created editor pane is now the active pane.
+        #expect(manager.tabManagers[manager.activePaneID] === tm)
+    }
+
+    @Test func ensureEditorPane_returnsExistingEditorWhenOneAlreadyExists() {
+        let manager = PaneManager()
+        let editorID = manager.activePaneID
+        let originalTM = manager.tabManager(for: editorID)
+
+        let tm = manager.ensureEditorPane()
+
+        #expect(tm === originalTM)
+        #expect(manager.root.leafCount(ofType: .editor) == 1)
+    }
+
+    @Test func ensureEditorPane_thenOpenFile_endToEnd() {
+        let manager = PaneManager()
+        let editorID = manager.activePaneID
+        _ = manager.createTerminalPane(
+            relativeTo: editorID, axis: .horizontal, workingDirectory: nil
+        )
+        manager.pruneEmptyEditorLeaves()
+        #expect(manager.root.leafCount(ofType: .editor) == 0)
+
+        // Simulate opening a file from the sidebar after pruning.
+        let url = URL(fileURLWithPath: "/tmp/ensure-end-to-end.swift")
+        manager.ensureEditorPane().openTab(url: url)
+
+        #expect(manager.root.leafCount(ofType: .editor) == 1)
+        let activeTM = manager.tabManagers[manager.activePaneID]
+        #expect(activeTM?.tabs.count == 1)
+        #expect(activeTM?.tabs.first?.url == url)
     }
 
     // MARK: - DnD: moving last tab away collapses empty source

--- a/PineTests/PaneManagerTests.swift
+++ b/PineTests/PaneManagerTests.swift
@@ -670,7 +670,7 @@ struct PaneManagerTests {
 
     // MARK: - Last editor pane protection
 
-    @Test func removePane_lastEditorPane_clearsTabsInsteadOfRemoving() {
+    @Test func removePane_lastEditorPane_isRemovedLeavingTerminalsOnly() {
         let manager = PaneManager()
         let editorPane = manager.activePaneID
         let testURL = URL(fileURLWithPath: "/tmp/test.swift")
@@ -685,15 +685,15 @@ struct PaneManagerTests {
         }
         #expect(manager.root.leafCount == 2)
 
-        // Try to remove the only editor pane — should NOT remove it
+        // Removing the only editor pane is now allowed: layout becomes
+        // terminals-only and a new editor can be created on demand via
+        // `ensureEditorPane()` when the user opens a file again.
         manager.removePane(editorPane)
 
-        // Editor pane still exists, but its tabs are cleared
-        #expect(manager.root.leafCount == 2)
-        #expect(manager.root.content(for: editorPane) == .editor)
-        #expect(manager.tabManager(for: editorPane)?.tabs.isEmpty == true)
-        // Terminal pane still exists
-        #expect(manager.root.content(for: terminalPane) == .terminal)
+        #expect(manager.root.leafCount == 1)
+        #expect(manager.root.leafCount(ofType: .editor) == 0)
+        #expect(manager.tabManagers[editorPane] == nil)
+        #expect(manager.root.firstLeafID == terminalPane)
     }
 
     @Test func removePane_nonLastEditorPane_removesNormally() {
@@ -776,7 +776,7 @@ struct PaneManagerTests {
         #expect(manager.root.leafCount(ofType: .terminal) == 1)
     }
 
-    @Test func removePane_lastEditorWithMultipleTerminals_keepsEditor() {
+    @Test func removePane_lastEditorWithMultipleTerminals_isRemoved() {
         let manager = PaneManager()
         let editorPane = manager.activePaneID
 
@@ -795,9 +795,12 @@ struct PaneManagerTests {
         #expect(manager.root.leafCount(ofType: .editor) == 1)
         #expect(manager.root.leafCount(ofType: .terminal) == 2)
 
-        // Try to remove the only editor pane — should be prevented
+        // Removing the only editor pane is now allowed; the layout becomes
+        // terminals-only.
         manager.removePane(editorPane)
-        #expect(manager.root.leafCount(ofType: .editor) == 1)
-        #expect(manager.root.content(for: editorPane) == .editor)
+        #expect(manager.root.leafCount == 2)
+        #expect(manager.root.leafCount(ofType: .editor) == 0)
+        #expect(manager.root.leafCount(ofType: .terminal) == 2)
+        #expect(manager.tabManagers[editorPane] == nil)
     }
 }

--- a/PineTests/PaneManagerTests.swift
+++ b/PineTests/PaneManagerTests.swift
@@ -365,8 +365,13 @@ struct PaneManagerTests {
         }
 
         manager.moveTabBetweenPanes(tabURL: ghostURL, from: firstPane, to: secondPane)
+        // Source pane retains its tab — ghost URL was a no-op move.
         #expect(manager.tabManager(for: firstPane)?.tabs.count == 1)
-        #expect(manager.tabManager(for: secondPane)?.tabs.isEmpty == true)
+        // The empty destination pane is now collapsed by `pruneEmptyEditorLeaves`,
+        // since `firstPane` still holds a tab and the invariant (≥1 editor leaf
+        // in the tree) is preserved.
+        #expect(manager.tabManager(for: secondPane) == nil)
+        #expect(manager.root.leafCount == 1)
     }
 
     @Test func moveTabBetweenPanes_preservesAllTabState() {

--- a/PineTests/ProjectManagerSessionTests.swift
+++ b/PineTests/ProjectManagerSessionTests.swift
@@ -39,8 +39,8 @@ struct ProjectManagerSessionTests {
         let pm = ProjectManager()
         pm.workspace.loadDirectory(url: dir)
 
-        pm.tabManager.openTab(url: files[0])
-        pm.tabManager.openTab(url: files[1])
+        pm.primaryTabManager.openTab(url: files[0])
+        pm.primaryTabManager.openTab(url: files[1])
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
@@ -58,8 +58,8 @@ struct ProjectManagerSessionTests {
         let pm = ProjectManager()
         pm.workspace.loadDirectory(url: dir)
 
-        pm.tabManager.openTab(url: files[0])
-        pm.tabManager.openTab(url: files[1])
+        pm.primaryTabManager.openTab(url: files[0])
+        pm.primaryTabManager.openTab(url: files[1])
         // files[1] is active (last opened)
         pm.saveSession()
 
@@ -83,8 +83,8 @@ struct ProjectManagerSessionTests {
         let pm = ProjectManager()
         pm.workspace.loadDirectory(url: dir)
 
-        pm.tabManager.openTab(url: files[0])
-        pm.tabManager.openTab(url: outsideFile)
+        pm.primaryTabManager.openTab(url: files[0])
+        pm.primaryTabManager.openTab(url: outsideFile)
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
@@ -99,7 +99,7 @@ struct ProjectManagerSessionTests {
 
         let pm = ProjectManager()
         // Do NOT call loadDirectory — rootURL stays nil
-        pm.tabManager.openTab(url: files[0])
+        pm.primaryTabManager.openTab(url: files[0])
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
@@ -115,12 +115,12 @@ struct ProjectManagerSessionTests {
         pm.workspace.loadDirectory(url: dir)
 
         // First save with 2 tabs
-        pm.tabManager.openTab(url: files[0])
-        pm.tabManager.openTab(url: files[1])
+        pm.primaryTabManager.openTab(url: files[0])
+        pm.primaryTabManager.openTab(url: files[1])
         pm.saveSession()
 
         // Open a third tab and save again
-        pm.tabManager.openTab(url: files[2])
+        pm.primaryTabManager.openTab(url: files[2])
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
@@ -137,12 +137,12 @@ struct ProjectManagerSessionTests {
         // Phase 1: open tabs and save
         let pm1 = ProjectManager()
         pm1.workspace.loadDirectory(url: dir)
-        pm1.tabManager.openTab(url: files[0])
-        pm1.tabManager.openTab(url: files[1])
-        pm1.tabManager.openTab(url: files[2])
+        pm1.primaryTabManager.openTab(url: files[0])
+        pm1.primaryTabManager.openTab(url: files[1])
+        pm1.primaryTabManager.openTab(url: files[2])
         // Switch active to middle tab
-        if let middleTab = pm1.tabManager.tab(for: files[1]) {
-            pm1.tabManager.activeTabID = middleTab.id
+        if let middleTab = pm1.primaryTabManager.tab(for: files[1]) {
+            pm1.primaryTabManager.activeTabID = middleTab.id
         }
         pm1.saveSession()
 
@@ -154,17 +154,17 @@ struct ProjectManagerSessionTests {
         let session = try #require(SessionState.load(for: canonical))
 
         for url in session.existingFileURLs {
-            pm2.tabManager.openTab(url: url)
+            pm2.primaryTabManager.openTab(url: url)
         }
         if let activeURL = session.activeFileURL,
-           let tab = pm2.tabManager.tab(for: activeURL) {
-            pm2.tabManager.activeTabID = tab.id
+           let tab = pm2.primaryTabManager.tab(for: activeURL) {
+            pm2.primaryTabManager.activeTabID = tab.id
         }
 
         // Verify restoration
-        #expect(pm2.tabManager.tabs.count == 3)
-        #expect(pm2.tabManager.activeTab?.url == files[1])
-        #expect(pm2.tabManager.tabs.map(\.url) == files)
+        #expect(pm2.primaryTabManager.tabs.count == 3)
+        #expect(pm2.primaryTabManager.activeTab?.url == files[1])
+        #expect(pm2.primaryTabManager.tabs.map(\.url) == files)
     }
 
     // MARK: - Outside-root filtering (issue #170)
@@ -183,8 +183,8 @@ struct ProjectManagerSessionTests {
         let pm = ProjectManager()
         pm.workspace.loadDirectory(url: dir)
 
-        pm.tabManager.openTab(url: files[0])
-        pm.tabManager.openTab(url: outsideFile)
+        pm.primaryTabManager.openTab(url: files[0])
+        pm.primaryTabManager.openTab(url: outsideFile)
         // outsideFile is now active (last opened)
         pm.saveSession()
 
@@ -211,11 +211,11 @@ struct ProjectManagerSessionTests {
         let pm = ProjectManager()
         pm.workspace.loadDirectory(url: dir)
 
-        pm.tabManager.openTab(url: insideMd)
-        pm.tabManager.openTab(url: outsideMd)
+        pm.primaryTabManager.openTab(url: insideMd)
+        pm.primaryTabManager.openTab(url: outsideMd)
         // Set non-default preview mode on both
-        for index in pm.tabManager.tabs.indices where pm.tabManager.tabs[index].isMarkdownFile {
-            pm.tabManager.tabs[index].previewMode = .split
+        for index in pm.primaryTabManager.tabs.indices where pm.primaryTabManager.tabs[index].isMarkdownFile {
+            pm.primaryTabManager.tabs[index].previewMode = .split
         }
         pm.saveSession()
 
@@ -241,11 +241,11 @@ struct ProjectManagerSessionTests {
         let pm = ProjectManager()
         pm.workspace.loadDirectory(url: dir)
 
-        pm.tabManager.openTab(url: files[0])
-        pm.tabManager.openTab(url: outsideFile)
+        pm.primaryTabManager.openTab(url: files[0])
+        pm.primaryTabManager.openTab(url: outsideFile)
         // Disable highlighting on both
-        pm.tabManager.tabs[0].syntaxHighlightingDisabled = true
-        pm.tabManager.tabs[1].syntaxHighlightingDisabled = true
+        pm.primaryTabManager.tabs[0].syntaxHighlightingDisabled = true
+        pm.primaryTabManager.tabs[1].syntaxHighlightingDisabled = true
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
@@ -262,10 +262,10 @@ struct ProjectManagerSessionTests {
         let pm = ProjectManager()
         pm.workspace.loadDirectory(url: dir)
 
-        pm.tabManager.openTab(url: files[0])
-        pm.tabManager.openTab(url: files[1])
+        pm.primaryTabManager.openTab(url: files[0])
+        pm.primaryTabManager.openTab(url: files[1])
         // Simulate opening files[1] without highlighting (large file)
-        pm.tabManager.tabs[1].syntaxHighlightingDisabled = true
+        pm.primaryTabManager.tabs[1].syntaxHighlightingDisabled = true
         pm.saveSession()
 
         let canonical = dir.resolvingSymlinksInPath()
@@ -279,11 +279,11 @@ struct ProjectManagerSessionTests {
         pm2.workspace.loadDirectory(url: dir)
         let disabledSet = Set(session.highlightingDisabledPaths ?? [])
         for url in session.existingFileURLs {
-            pm2.tabManager.openTab(url: url, syntaxHighlightingDisabled: disabledSet.contains(url.path))
+            pm2.primaryTabManager.openTab(url: url, syntaxHighlightingDisabled: disabledSet.contains(url.path))
         }
 
-        #expect(pm2.tabManager.tabs[0].syntaxHighlightingDisabled == false)
-        #expect(pm2.tabManager.tabs[1].syntaxHighlightingDisabled == true)
+        #expect(pm2.primaryTabManager.tabs[0].syntaxHighlightingDisabled == false)
+        #expect(pm2.primaryTabManager.tabs[1].syntaxHighlightingDisabled == true)
     }
 
     @Test func sessionSurvivedWindowClose() throws {
@@ -293,8 +293,8 @@ struct ProjectManagerSessionTests {
         let registry = ProjectRegistry()
         let pm = try #require(registry.projectManager(for: dir))
 
-        pm.tabManager.openTab(url: files[0])
-        pm.tabManager.openTab(url: files[1])
+        pm.primaryTabManager.openTab(url: files[0])
+        pm.primaryTabManager.openTab(url: files[1])
 
         // Simulate PR #98 onDisappear behavior: save THEN close
         let canonical = dir.resolvingSymlinksInPath()
@@ -310,8 +310,8 @@ struct ProjectManagerSessionTests {
         let pm2 = try #require(registry.projectManager(for: dir))
         let restoredSession = try #require(SessionState.load(for: canonical))
         for url in restoredSession.existingFileURLs {
-            pm2.tabManager.openTab(url: url)
+            pm2.primaryTabManager.openTab(url: url)
         }
-        #expect(pm2.tabManager.tabs.count == 2)
+        #expect(pm2.primaryTabManager.tabs.count == 2)
     }
 }

--- a/PineTests/ProjectManagerSessionTests.swift
+++ b/PineTests/ProjectManagerSessionTests.swift
@@ -314,4 +314,49 @@ struct ProjectManagerSessionTests {
         }
         #expect(pm2.primaryTabManager.tabs.count == 2)
     }
+
+    // MARK: - Empty editor + terminal layout round-trip
+
+    /// Persist a layout where the editor pane sits empty next to a terminal
+    /// pane, then reload it: after restore, `pruneEmptyEditorLeaves` must
+    /// collapse the empty editor so the user does not face the same UX bug
+    /// twice across app launches.
+    @Test func roundTrip_emptyEditorNextToTerminal_isPrunedAfterRestore() throws {
+        let (dir, _) = try makeTempProject()
+        defer { cleanup(dir) }
+
+        // Phase 1: build "empty editor + terminal" layout and save the session.
+        let pm1 = ProjectManager()
+        pm1.workspace.loadDirectory(url: dir)
+        let editorPaneID = pm1.paneManager.activePaneID
+        _ = pm1.paneManager.createTerminalPane(
+            relativeTo: editorPaneID, axis: .vertical, workingDirectory: dir
+        )
+        // Editor pane is intentionally left empty.
+        #expect(pm1.paneManager.root.leafCount(ofType: .editor) == 1)
+        #expect(pm1.paneManager.root.leafCount(ofType: .terminal) == 1)
+        pm1.saveSession()
+
+        // Phase 2: reload session into a fresh ProjectManager and apply the
+        // same restore steps that ContentView+Helpers.restoreSessionIfNeeded
+        // performs (restoreLayout → populate → pruneEmptyEditorLeaves).
+        let pm2 = ProjectManager()
+        pm2.workspace.loadDirectory(url: dir)
+
+        let canonical = dir.resolvingSymlinksInPath()
+        let session = try #require(SessionState.load(for: canonical))
+        let layoutData = try #require(session.paneLayoutData)
+        let restoredNode = try #require(try? JSONDecoder().decode(PaneNode.self, from: layoutData))
+        pm2.paneManager.restoreLayout(
+            from: restoredNode,
+            activePaneUUID: session.activePaneID.flatMap { UUID(uuidString: $0) }
+        )
+        // No tabs to populate — the editor leaf was empty when persisted.
+        pm2.paneManager.pruneEmptyEditorLeaves()
+
+        // After prune the empty editor must be gone — only the terminal remains.
+        #expect(pm2.paneManager.root.leafCount == 1)
+        #expect(pm2.paneManager.root.leafCount(ofType: .editor) == 0)
+        #expect(pm2.paneManager.root.leafCount(ofType: .terminal) == 1)
+    }
 }

--- a/PineTests/SessionRestoreHighlightTests.swift
+++ b/PineTests/SessionRestoreHighlightTests.swift
@@ -44,9 +44,9 @@ struct SessionRestoreHighlightTests {
         // Phase 1: save session with 3 tabs, middle one active
         let pm1 = ProjectManager()
         pm1.workspace.loadDirectory(url: dir)
-        for file in files { pm1.tabManager.openTab(url: file) }
-        if let middleTab = pm1.tabManager.tab(for: files[1]) {
-            pm1.tabManager.activeTabID = middleTab.id
+        for file in files { pm1.primaryTabManager.openTab(url: file) }
+        if let middleTab = pm1.primaryTabManager.tab(for: files[1]) {
+            pm1.primaryTabManager.activeTabID = middleTab.id
         }
         pm1.saveSession()
 
@@ -58,18 +58,18 @@ struct SessionRestoreHighlightTests {
 
         let disabledSet = Set(session.existingHighlightingDisabledPaths ?? [])
         for url in session.existingFileURLs {
-            pm2.tabManager.openTab(url: url, syntaxHighlightingDisabled: disabledSet.contains(url.path))
+            pm2.primaryTabManager.openTab(url: url, syntaxHighlightingDisabled: disabledSet.contains(url.path))
         }
         if let activeURL = session.activeFileURL,
-           let tab = pm2.tabManager.tab(for: activeURL) {
-            pm2.tabManager.activeTabID = tab.id
+           let tab = pm2.primaryTabManager.tab(for: activeURL) {
+            pm2.primaryTabManager.activeTabID = tab.id
         }
 
         // The active tab must exist and match the saved one
-        #expect(pm2.tabManager.activeTab != nil)
-        #expect(pm2.tabManager.activeTab?.url == files[1])
+        #expect(pm2.primaryTabManager.activeTab != nil)
+        #expect(pm2.primaryTabManager.activeTab?.url == files[1])
         // Verify content was loaded (precondition for syntax highlighting)
-        #expect(pm2.tabManager.activeTab?.content.isEmpty == false)
+        #expect(pm2.primaryTabManager.activeTab?.content.isEmpty == false)
     }
 
     @Test func restoredSingleTabIsActive() throws {
@@ -79,7 +79,7 @@ struct SessionRestoreHighlightTests {
         // Save with one tab
         let pm1 = ProjectManager()
         pm1.workspace.loadDirectory(url: dir)
-        pm1.tabManager.openTab(url: files[0])
+        pm1.primaryTabManager.openTab(url: files[0])
         pm1.saveSession()
 
         // Restore
@@ -89,17 +89,17 @@ struct SessionRestoreHighlightTests {
         let session = try #require(SessionState.load(for: canonical))
 
         for url in session.existingFileURLs {
-            pm2.tabManager.openTab(url: url)
+            pm2.primaryTabManager.openTab(url: url)
         }
         if let activeURL = session.activeFileURL,
-           let tab = pm2.tabManager.tab(for: activeURL) {
-            pm2.tabManager.activeTabID = tab.id
+           let tab = pm2.primaryTabManager.tab(for: activeURL) {
+            pm2.primaryTabManager.activeTabID = tab.id
         }
 
         // Single tab must be active — this is the case where onChange(activeTabID)
         // might not fire if the value was already set by openTab.
-        #expect(pm2.tabManager.activeTab != nil)
-        #expect(pm2.tabManager.activeTab?.url == files[0])
+        #expect(pm2.primaryTabManager.activeTab != nil)
+        #expect(pm2.primaryTabManager.activeTab?.url == files[0])
     }
 
     @Test func restoredLastTabAsActiveDoesNotChangeID() throws {
@@ -109,7 +109,7 @@ struct SessionRestoreHighlightTests {
         // Save with last tab active (which is the default after opening)
         let pm1 = ProjectManager()
         pm1.workspace.loadDirectory(url: dir)
-        for file in files { pm1.tabManager.openTab(url: file) }
+        for file in files { pm1.primaryTabManager.openTab(url: file) }
         // Last tab (files[2]) is already active — don't explicitly set it
         pm1.saveSession()
 
@@ -120,22 +120,22 @@ struct SessionRestoreHighlightTests {
         let session = try #require(SessionState.load(for: canonical))
 
         for url in session.existingFileURLs {
-            pm2.tabManager.openTab(url: url)
+            pm2.primaryTabManager.openTab(url: url)
         }
 
         // Track the activeTabID before the explicit set
-        let idBeforeExplicitSet = pm2.tabManager.activeTabID
+        let idBeforeExplicitSet = pm2.primaryTabManager.activeTabID
 
         if let activeURL = session.activeFileURL,
-           let tab = pm2.tabManager.tab(for: activeURL) {
-            pm2.tabManager.activeTabID = tab.id
+           let tab = pm2.primaryTabManager.tab(for: activeURL) {
+            pm2.primaryTabManager.activeTabID = tab.id
         }
 
         // The explicit set should be a no-op because last tab was already active.
         // This is the edge case where onChange(activeTabID) would NOT fire,
         // so the caller must explicitly trigger refreshLineDiffs.
-        #expect(pm2.tabManager.activeTabID == idBeforeExplicitSet)
-        #expect(pm2.tabManager.activeTab?.url == files[2])
+        #expect(pm2.primaryTabManager.activeTabID == idBeforeExplicitSet)
+        #expect(pm2.primaryTabManager.activeTab?.url == files[2])
     }
 
     @Test func restoredTabsHaveContentForHighlighting() throws {
@@ -150,7 +150,7 @@ struct SessionRestoreHighlightTests {
         // Save and restore
         let pm1 = ProjectManager()
         pm1.workspace.loadDirectory(url: dir)
-        for file in files { pm1.tabManager.openTab(url: file) }
+        for file in files { pm1.primaryTabManager.openTab(url: file) }
         pm1.saveSession()
 
         let pm2 = ProjectManager()
@@ -160,11 +160,11 @@ struct SessionRestoreHighlightTests {
 
         let disabledSet = Set(session.existingHighlightingDisabledPaths ?? [])
         for url in session.existingFileURLs {
-            pm2.tabManager.openTab(url: url, syntaxHighlightingDisabled: disabledSet.contains(url.path))
+            pm2.primaryTabManager.openTab(url: url, syntaxHighlightingDisabled: disabledSet.contains(url.path))
         }
 
         // All tabs must have content loaded from disk
-        for (i, tab) in pm2.tabManager.tabs.enumerated() {
+        for (i, tab) in pm2.primaryTabManager.tabs.enumerated() {
             #expect(!tab.content.isEmpty, "Tab \(i) (\(tab.fileName)) has empty content")
             #expect(tab.content.contains("example\(i)"),
                     "Tab \(i) content should match file content")
@@ -188,7 +188,7 @@ struct SessionRestoreHighlightTests {
         pm.workspace.loadDirectory(url: dir)
 
         for url in [swiftFile, jsFile, pyFile] {
-            pm.tabManager.openTab(url: url)
+            pm.primaryTabManager.openTab(url: url)
         }
         pm.saveSession()
 
@@ -199,11 +199,11 @@ struct SessionRestoreHighlightTests {
         let session = try #require(SessionState.load(for: canonical))
 
         for url in session.existingFileURLs {
-            pm2.tabManager.openTab(url: url)
+            pm2.primaryTabManager.openTab(url: url)
         }
 
         // Language extension must be preserved for syntax highlighting grammar selection
-        let languages = pm2.tabManager.tabs.map(\.language)
+        let languages = pm2.primaryTabManager.tabs.map(\.language)
         #expect(languages.contains("swift"))
         #expect(languages.contains("js"))
         #expect(languages.contains("py"))
@@ -215,7 +215,7 @@ struct SessionRestoreHighlightTests {
 
         let pm = ProjectManager()
         pm.workspace.loadDirectory(url: dir)
-        for file in files { pm.tabManager.openTab(url: file) }
+        for file in files { pm.primaryTabManager.openTab(url: file) }
         pm.saveSession()
 
         // Restore
@@ -226,11 +226,11 @@ struct SessionRestoreHighlightTests {
 
         let disabledSet = Set(session.existingHighlightingDisabledPaths ?? [])
         for url in session.existingFileURLs {
-            pm2.tabManager.openTab(url: url, syntaxHighlightingDisabled: disabledSet.contains(url.path))
+            pm2.primaryTabManager.openTab(url: url, syntaxHighlightingDisabled: disabledSet.contains(url.path))
         }
 
         // No tabs should have highlighting disabled for normal-sized files
-        for tab in pm2.tabManager.tabs {
+        for tab in pm2.primaryTabManager.tabs {
             #expect(tab.syntaxHighlightingDisabled == false,
                     "\(tab.fileName) should not have highlighting disabled")
         }
@@ -243,8 +243,8 @@ struct SessionRestoreHighlightTests {
         // Save with one tab having highlighting disabled
         let pm = ProjectManager()
         pm.workspace.loadDirectory(url: dir)
-        for file in files { pm.tabManager.openTab(url: file) }
-        pm.tabManager.tabs[1].syntaxHighlightingDisabled = true
+        for file in files { pm.primaryTabManager.openTab(url: file) }
+        pm.primaryTabManager.tabs[1].syntaxHighlightingDisabled = true
         pm.saveSession()
 
         // Restore
@@ -255,12 +255,12 @@ struct SessionRestoreHighlightTests {
 
         let disabledSet = Set(session.existingHighlightingDisabledPaths ?? [])
         for url in session.existingFileURLs {
-            pm2.tabManager.openTab(url: url, syntaxHighlightingDisabled: disabledSet.contains(url.path))
+            pm2.primaryTabManager.openTab(url: url, syntaxHighlightingDisabled: disabledSet.contains(url.path))
         }
 
-        #expect(pm2.tabManager.tabs[0].syntaxHighlightingDisabled == false)
-        #expect(pm2.tabManager.tabs[1].syntaxHighlightingDisabled == true)
-        #expect(pm2.tabManager.tabs[2].syntaxHighlightingDisabled == false)
+        #expect(pm2.primaryTabManager.tabs[0].syntaxHighlightingDisabled == false)
+        #expect(pm2.primaryTabManager.tabs[1].syntaxHighlightingDisabled == true)
+        #expect(pm2.primaryTabManager.tabs[2].syntaxHighlightingDisabled == false)
     }
 
     @Test func restoreEmptySessionDoesNotSetActiveTab() throws {
@@ -281,13 +281,13 @@ struct SessionRestoreHighlightTests {
         // Session exists but has no files
         if let session {
             for url in session.existingFileURLs {
-                pm2.tabManager.openTab(url: url)
+                pm2.primaryTabManager.openTab(url: url)
             }
         }
 
         // No tabs, no active tab — refreshLineDiffs should be a no-op
-        #expect(pm2.tabManager.tabs.isEmpty)
-        #expect(pm2.tabManager.activeTabID == nil)
+        #expect(pm2.primaryTabManager.tabs.isEmpty)
+        #expect(pm2.primaryTabManager.activeTabID == nil)
     }
 
     @Test func deletedFilesSkippedDuringRestore() throws {
@@ -297,9 +297,9 @@ struct SessionRestoreHighlightTests {
         // Save session
         let pm = ProjectManager()
         pm.workspace.loadDirectory(url: dir)
-        for file in files { pm.tabManager.openTab(url: file) }
-        if let middleTab = pm.tabManager.tab(for: files[1]) {
-            pm.tabManager.activeTabID = middleTab.id
+        for file in files { pm.primaryTabManager.openTab(url: file) }
+        if let middleTab = pm.primaryTabManager.tab(for: files[1]) {
+            pm.primaryTabManager.activeTabID = middleTab.id
         }
         pm.saveSession()
 
@@ -314,17 +314,17 @@ struct SessionRestoreHighlightTests {
 
         let disabledSet = Set(session.existingHighlightingDisabledPaths ?? [])
         for url in session.existingFileURLs {
-            pm2.tabManager.openTab(url: url, syntaxHighlightingDisabled: disabledSet.contains(url.path))
+            pm2.primaryTabManager.openTab(url: url, syntaxHighlightingDisabled: disabledSet.contains(url.path))
         }
         // Active file was deleted, so activeFileURL returns nil
         if let activeURL = session.activeFileURL,
-           let tab = pm2.tabManager.tab(for: activeURL) {
-            pm2.tabManager.activeTabID = tab.id
+           let tab = pm2.primaryTabManager.tab(for: activeURL) {
+            pm2.primaryTabManager.activeTabID = tab.id
         }
 
         // Only 2 tabs restored (deleted file skipped by existingFileURLs)
-        #expect(pm2.tabManager.tabs.count == 2)
+        #expect(pm2.primaryTabManager.tabs.count == 2)
         // activeTab should still be set (fallback to last opened)
-        #expect(pm2.tabManager.activeTab != nil)
+        #expect(pm2.primaryTabManager.activeTab != nil)
     }
 }

--- a/PineTests/TerminalManagerTests.swift
+++ b/PineTests/TerminalManagerTests.swift
@@ -119,12 +119,20 @@ struct TerminalManagerTests {
         manager.paneManager = pm
 
         let editorPaneID = pm.activePaneID
+        // Open a tab so the editor leaf survives the auto-prune that runs
+        // when a terminal pane is created next to an empty editor.
+        pm.tabManager(for: editorPaneID)?.openTab(
+            url: URL(fileURLWithPath: "/tmp/all-term-tabs.swift")
+        )
         manager.createTerminalTab(relativeTo: editorPaneID, workingDirectory: nil)
 
         // Force creating a second terminal pane by clearing lastActiveTerminalPaneID
         manager.lastActiveTerminalPaneID = nil
         // Split the editor pane first to get a second editor pane
         if let newEditorID = pm.splitPane(editorPaneID, axis: .horizontal) {
+            pm.tabManager(for: newEditorID)?.openTab(
+                url: URL(fileURLWithPath: "/tmp/all-term-tabs-2.swift")
+            )
             manager.createTerminalTab(relativeTo: newEditorID, workingDirectory: nil)
         }
 

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -85,7 +85,7 @@ struct WindowLifecycleTests {
 
         let registry = ProjectRegistry()
         let pm = try #require(registry.projectManager(for: dir))
-        pm.tabManager.openTab(url: file)
+        pm.primaryTabManager.openTab(url: file)
 
         let delegate = AppDelegate()
         delegate.openNamedWindow = { _ in }
@@ -115,8 +115,8 @@ struct WindowLifecycleTests {
         let registry = ProjectRegistry()
         let pm1 = try #require(registry.projectManager(for: dir1))
         let pm2 = try #require(registry.projectManager(for: dir2))
-        pm1.tabManager.openTab(url: file1)
-        pm2.tabManager.openTab(url: file2)
+        pm1.primaryTabManager.openTab(url: file1)
+        pm2.primaryTabManager.openTab(url: file2)
 
         let delegate = AppDelegate()
         delegate.registry = registry
@@ -161,7 +161,7 @@ struct WindowLifecycleTests {
 
         let registry = ProjectRegistry()
         let pm = try #require(registry.projectManager(for: dir))
-        pm.tabManager.openTab(url: file)
+        pm.primaryTabManager.openTab(url: file)
 
         let delegate = AppDelegate()
         let window = NSWindow()
@@ -177,7 +177,7 @@ struct WindowLifecycleTests {
         // Clean tabs — window should close (not close tab one by one)
         #expect(closeDelegate.windowShouldClose(window))
         // Tabs should NOT have been closed individually
-        #expect(pm.tabManager.tabs.count == 1)
+        #expect(pm.primaryTabManager.tabs.count == 1)
     }
 
     @Test func windowShouldCloseDoesNotCloseIndividualCleanTab() throws {
@@ -188,8 +188,8 @@ struct WindowLifecycleTests {
 
         let registry = ProjectRegistry()
         let pm = try #require(registry.projectManager(for: dir))
-        pm.tabManager.openTab(url: file1)
-        pm.tabManager.openTab(url: file2)
+        pm.primaryTabManager.openTab(url: file1)
+        pm.primaryTabManager.openTab(url: file2)
 
         let delegate = AppDelegate()
         let window = NSWindow()
@@ -205,7 +205,7 @@ struct WindowLifecycleTests {
         // With multiple clean tabs, should close window (return true)
         // and NOT close tabs one by one
         #expect(closeDelegate.windowShouldClose(window))
-        #expect(pm.tabManager.tabs.count == 2)
+        #expect(pm.primaryTabManager.tabs.count == 2)
     }
 
     // MARK: - showWelcome

--- a/PineUITests/TerminalTests.swift
+++ b/PineUITests/TerminalTests.swift
@@ -68,6 +68,19 @@ final class TerminalTests: PineUITestCase {
         app.menuItems["New Tab"].click()
     }
 
+    /// Opens main.swift from the sidebar so the editor leaf has a tab and
+    /// won't be auto-pruned when a terminal pane is created next to it.
+    private func openMainSwiftFromSidebar() {
+        let mainFile = app.staticTexts["fileNode_main.swift"]
+        XCTAssertTrue(
+            waitForExistence(mainFile, timeout: 10),
+            "main.swift should appear in the sidebar"
+        )
+        mainFile.click()
+        let tab = app.descendants(matching: .any)["editorTab_main.swift"].firstMatch
+        XCTAssertTrue(waitForExistence(tab, timeout: 5), "main.swift tab should appear")
+    }
+
     private func launchAndWaitForLoad() {
         launchWithProject(projectURL)
         guard waitForExistence(terminalToggle, timeout: 10) else {
@@ -123,6 +136,8 @@ final class TerminalTests: PineUITestCase {
     /// After creating a terminal, a pane divider appears indicating split layout.
     func testTerminalPaneAppearsInSplitLayout() throws {
         launchAndWaitForLoad()
+        // Open a file so the editor pane has content and won't be auto-pruned.
+        openMainSwiftFromSidebar()
 
         // No divider before terminal
         XCTAssertEqual(paneDividers.count, 0, "No pane divider should exist initially")
@@ -201,6 +216,7 @@ final class TerminalTests: PineUITestCase {
     /// Maximize then restore brings back both panes.
     func testRestoreFromMaximize() throws {
         launchAndWaitForLoad()
+        openMainSwiftFromSidebar()
 
         createTerminalViaMenu()
         XCTAssertTrue(
@@ -232,10 +248,13 @@ final class TerminalTests: PineUITestCase {
             terminalTab("Terminal 1").exists,
             "Terminal tab should be visible after restore"
         )
-        // Both terminal and editor should be visible after restore
+        // After restore the editor pane comes back; the previously-opened
+        // main.swift tab should be visible again. Re-query freshly because
+        // SwiftUI tears down and recreates the editor view on restore.
+        let restoredTab = app.descendants(matching: .any)["editorTab_main.swift"].firstMatch
         XCTAssertTrue(
-            editorPlaceholder.exists || editorTabBar.exists,
-            "Editor area should be visible after restore"
+            waitForExistence(restoredTab, timeout: 5),
+            "Editor area (with main.swift tab) should be visible after restore"
         )
     }
 
@@ -314,6 +333,7 @@ final class TerminalTests: PineUITestCase {
     /// Closing the only terminal tab removes the entire terminal pane.
     func testCloseLastTabRemovesPane() throws {
         launchAndWaitForLoad()
+        openMainSwiftFromSidebar()
 
         createTerminalViaMenu()
         let tab1 = terminalTab("Terminal 1")
@@ -375,6 +395,7 @@ final class TerminalTests: PineUITestCase {
     /// Create terminal, close it, create another — verify it works correctly.
     func testMultipleTerminalPanesViaMenu() throws {
         launchAndWaitForLoad()
+        openMainSwiftFromSidebar()
 
         // Create first terminal
         createTerminalViaMenu()
@@ -437,6 +458,7 @@ final class TerminalTests: PineUITestCase {
     /// Terminal pane persists after interacting with the editor area.
     func testTerminalPersistsAfterEditorInteraction() throws {
         launchAndWaitForLoad()
+        openMainSwiftFromSidebar()
 
         createTerminalViaMenu()
         let tab1 = terminalTab("Terminal 1")
@@ -500,6 +522,7 @@ final class TerminalTests: PineUITestCase {
     /// Terminal toggle in status bar can show and hide the terminal pane.
     func testTerminalToggleViaStatusBarButton() throws {
         launchAndWaitForLoad()
+        openMainSwiftFromSidebar()
 
         // Click toggle to show terminal
         terminalToggle.click()
@@ -580,6 +603,7 @@ final class TerminalTests: PineUITestCase {
 
     func testMaximizeThenHide() throws {
         launchAndWaitForLoad()
+        openMainSwiftFromSidebar()
 
         createTerminalViaMenu()
         XCTAssertTrue(
@@ -602,15 +626,76 @@ final class TerminalTests: PineUITestCase {
         }
         XCTAssertFalse(tab1.exists, "Terminal should be removed after hide while maximized")
 
-        // Editor should be back
-        let placeholderOrEditor = editorPlaceholder.exists || editorTabBar.exists
-        // Give editor a moment to appear
-        if !placeholderOrEditor {
-            Thread.sleep(forTimeInterval: 1)
-        }
+        // After hiding the (maximized) terminal, the editor pane is the only
+        // remaining content; main.swift opened earlier should still be there.
+        let restoredTab = app.descendants(matching: .any)["editorTab_main.swift"].firstMatch
         XCTAssertTrue(
-            editorPlaceholder.exists || editorTabBar.exists,
-            "Editor area should be restored after hiding maximized terminal"
+            waitForExistence(restoredTab, timeout: 5),
+            "Editor area (with main.swift tab) should be restored after hiding maximized terminal"
+        )
+    }
+
+    // MARK: - Empty editor leaf pruning (issue: empty "No File Selected" next to terminals)
+
+    /// Reproduces the user's reported scenario: open a project, never select
+    /// a file, create a terminal pane — the empty "No File Selected"
+    /// placeholder must disappear so terminals get the full layout. Clicking
+    /// a file in the sidebar afterwards must transparently recreate an
+    /// editor pane on demand and open the file in it.
+    func testEmptyEditorPrunedNextToTerminal_andRecreatedOnFileClick() throws {
+        launchAndWaitForLoad()
+
+        // Initially the editor pane shows the placeholder.
+        XCTAssertTrue(
+            waitForExistence(editorPlaceholder, timeout: 5),
+            "Editor placeholder should be visible on a freshly opened project"
+        )
+
+        // Create a terminal — the empty editor pane should be auto-pruned.
+        createTerminalViaMenu()
+        XCTAssertTrue(
+            waitForExistence(terminalTab("Terminal 1"), timeout: 10),
+            "Terminal 1 tab should appear after Terminal -> New Tab"
+        )
+
+        // The placeholder must be gone — terminals own the full screen now.
+        let disappearDeadline = Date().addingTimeInterval(5)
+        while editorPlaceholder.exists && Date() < disappearDeadline {
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        XCTAssertFalse(
+            editorPlaceholder.exists,
+            "Empty 'No File Selected' placeholder should be pruned next to a terminal"
+        )
+        XCTAssertEqual(
+            paneDividers.count, 0,
+            "No pane divider should remain when only the terminal pane exists"
+        )
+
+        // Click a file in the sidebar — a new editor pane should be created
+        // on demand above the terminal and open the file inside it.
+        let mainFile = app.staticTexts["fileNode_main.swift"]
+        XCTAssertTrue(
+            waitForExistence(mainFile, timeout: 10),
+            "main.swift should be visible in the sidebar"
+        )
+        mainFile.click()
+
+        let editorTab = app.descendants(matching: .any)["editorTab_main.swift"].firstMatch
+        XCTAssertTrue(
+            waitForExistence(editorTab, timeout: 5),
+            "Editor pane should be recreated and main.swift opened after sidebar click"
+        )
+        // Both editor and terminal coexist — divider must reappear.
+        let divider = app.descendants(matching: .any)["paneDivider"].firstMatch
+        XCTAssertTrue(
+            waitForExistence(divider, timeout: 5),
+            "Pane divider should reappear once an editor pane is recreated"
+        )
+        // Terminal must still be there.
+        XCTAssertTrue(
+            terminalTab("Terminal 1").exists,
+            "Terminal pane must persist when a new editor pane is created next to it"
         )
     }
 }

--- a/PineUITests/TerminalTests.swift
+++ b/PineUITests/TerminalTests.swift
@@ -697,5 +697,15 @@ final class TerminalTests: PineUITestCase {
             terminalTab("Terminal 1").exists,
             "Terminal pane must persist when a new editor pane is created next to it"
         )
+
+        // The recreated editor must sit ABOVE the terminal (vertical split,
+        // editor on top) — verify by comparing y-coordinates of the two
+        // tab bars. The editor tab's frame must start above the terminal tab.
+        let editorTabFrame = editorTab.frame
+        let terminalTabFrame = terminalTab("Terminal 1").frame
+        XCTAssertLessThan(
+            editorTabFrame.minY, terminalTabFrame.minY,
+            "Recreated editor pane must be positioned above the terminal pane"
+        )
     }
 }


### PR DESCRIPTION
## Summary

Fixes the user-reported UX issue where the empty "No File Selected" editor placeholder dominates layout space when the user has only terminal panes around it (see screenshot in issue context).

- **Auto-prune** empty editor leaves whenever another leaf (editor or terminal) remains in the tree.
- **On-demand recreation:** opening a file from the sidebar / Quick Open in a terminals-only layout transparently creates a new editor leaf above the first terminal pane via the new \`PaneManager.ensureEditorPane()\`.
- **Fallback safety:** \`removePane\` replaces the very last leaf with a fresh empty editor leaf so the window can never end up with no content.
- Renames \`ProjectManager.tabManager\` → \`primaryTabManager\` to make the role of the stored TabManager explicit (preparing the architecture for the prune).

## Commits

1. \`a0daec4\` fix: collapse empty editor leaves next to other panes (initial pruneEmptyEditorLeaves with conservative invariant)
2. \`f4976c2\` refactor: rename ProjectManager.tabManager to primaryTabManager
3. \`7d4c8d7\` feat: prune empty editor leaves and recreate on demand (drop the invariant, add ensureEditorPane)
4. \`d90d2c1\` feat: prune empty editor on terminal create + recreate on hide (TerminalManager hook + last-leaf fallback + UI test)

## Test plan

- [x] swiftlint — 0 violations across 269 files
- [x] xcodebuild build — SUCCEEDED
- [x] PineTests — 2846 tests, all green (38.9s)
- [x] PineUITests/TerminalTests — 18/18 green, including new \`testEmptyEditorPrunedNextToTerminal_andRecreatedOnFileClick\` reproducing the exact reported scenario

## New tests

- \`emptyEditorNextToTerminal_isPruned\`
- \`ensureEditorPane_createsNewEditorWhenOnlyTerminalsExist\`
- \`ensureEditorPane_returnsExistingEditorWhenOneAlreadyExists\`
- \`ensureEditorPane_thenOpenFile_endToEnd\`
- \`activeTabManager_returnsPrimary_whenFocusIsOnTerminalPane\`
- \`testEmptyEditorPrunedNextToTerminal_andRecreatedOnFileClick\` (UI)
- Plus 9 prune tests carried over from the initial \`a0daec4\` commit

## Out of scope (follow-ups)

- \`SymbolNavigatorView\` and \`@FocusedValue\`-driven menu commands still read \`primaryTabManager\` instead of the active editor; this is a pre-existing multi-pane bug not caused by this PR.
- \`.environment(pm.primaryTabManager)\` injects the primary TabManager into the SwiftUI environment; switching it to the active editor needs reactive plumbing and deserves its own PR.