### PR TITLE
fix(terminal): align SwiftTerm ANSI palette with macOS system colors

### DIFF
--- a/Pine/TerminalPalette.swift
+++ b/Pine/TerminalPalette.swift
@@ -1,0 +1,106 @@
+//
+//  TerminalPalette.swift
+//  Pine
+//
+//  Centralised ANSI 16-color palette for Pine's embedded SwiftTerm terminal.
+//
+//  Goal (issue #733): make Pine's terminal visually consistent with native
+//  macOS terminals (Terminal.app, Ghostty, iTerm2). Prompts coloured by
+//  oh-my-zsh / starship should look as muted as in those terminals, not
+//  noticeably brighter or more saturated.
+//
+//  Reference: Ghostty's built-in default 16-color palette
+//  (https://github.com/ghostty-org/ghostty, src/terminal/color.zig,
+//  `Name.default()`). This is the same Tomorrow-Night-derived set used by
+//  Ghostty out of the box on macOS, and it is what users see in
+//  Terminal.app's modern profiles, iTerm2's default and most "system"
+//  themes — visibly more muted than the highly-saturated Terminal.app
+//  "Basic" preset that SwiftTerm and Pine previously used.
+//
+//  ANSI 16 colors are fixed RGB values by convention — the standard does
+//  not vary with light/dark mode. Background / foreground / cursor remain
+//  semantic and follow the system appearance via NSColor.textColor /
+//  NSColor.textBackgroundColor (configured in TerminalTab).
+//
+
+import Foundation
+import SwiftTerm
+
+/// 8-bit RGB triple used to describe a single ANSI palette entry in
+/// human-readable form. Converted to SwiftTerm's 16-bit `Color` at install
+/// time. Public for unit-testing.
+struct TerminalPaletteEntry: Equatable {
+    let red: UInt8
+    let green: UInt8
+    let blue: UInt8
+
+    /// Promotes 8-bit components to SwiftTerm's 16-bit color space using the
+    /// standard `× 257` formula (so 0xFF → 0xFFFF, preserving full intensity).
+    func makeSwiftTermColor() -> SwiftTerm.Color {
+        SwiftTerm.Color(
+            red: UInt16(red) * 257,
+            green: UInt16(green) * 257,
+            blue: UInt16(blue) * 257
+        )
+    }
+}
+
+/// Pine's ANSI 16-color palette.
+///
+/// Order matches the SGR / xterm convention:
+/// `[black, red, green, yellow, blue, magenta, cyan, white,`
+/// ` brightBlack, brightRed, brightGreen, brightYellow,`
+/// ` brightBlue, brightMagenta, brightCyan, brightWhite]`.
+///
+/// The palette is a value type so tests can compare it without instantiating
+/// SwiftTerm views. The actual install into a `LocalProcessTerminalView`
+/// happens via `apply(to:)`.
+enum TerminalPalette {
+
+    /// Number of ANSI colors expected by SwiftTerm's `installColors`.
+    static let colorCount = 16
+
+    /// macOS-aligned 16-color ANSI palette (Ghostty default scheme).
+    /// See file header for rationale and provenance.
+    static let macOSAligned: [TerminalPaletteEntry] = [
+        .init(red: 0x1D, green: 0x1F, blue: 0x21), // 0  black
+        .init(red: 0xCC, green: 0x66, blue: 0x66), // 1  red
+        .init(red: 0xB5, green: 0xBD, blue: 0x68), // 2  green
+        .init(red: 0xF0, green: 0xC6, blue: 0x74), // 3  yellow
+        .init(red: 0x81, green: 0xA2, blue: 0xBE), // 4  blue
+        .init(red: 0xB2, green: 0x94, blue: 0xBB), // 5  magenta
+        .init(red: 0x8A, green: 0xBE, blue: 0xB7), // 6  cyan
+        .init(red: 0xC5, green: 0xC8, blue: 0xC6), // 7  white
+        .init(red: 0x66, green: 0x66, blue: 0x66), // 8  bright black (dim — autosuggestions)
+        .init(red: 0xD5, green: 0x4E, blue: 0x53), // 9  bright red
+        .init(red: 0xB9, green: 0xCA, blue: 0x4A), // 10 bright green
+        .init(red: 0xE7, green: 0xC5, blue: 0x47), // 11 bright yellow
+        .init(red: 0x7A, green: 0xA6, blue: 0xDA), // 12 bright blue
+        .init(red: 0xC3, green: 0x97, blue: 0xD8), // 13 bright magenta
+        .init(red: 0x70, green: 0xC0, blue: 0xB1), // 14 bright cyan
+        .init(red: 0xEA, green: 0xEA, blue: 0xEA), // 15 bright white
+    ]
+
+    /// Builds the SwiftTerm `Color` array for `installColors`.
+    /// Returns `nil` if the entry list does not contain exactly 16 entries —
+    /// the caller should then leave SwiftTerm on its built-in default rather
+    /// than installing a malformed palette.
+    static func swiftTermColors(
+        from entries: [TerminalPaletteEntry] = macOSAligned
+    ) -> [SwiftTerm.Color]? {
+        guard entries.count == colorCount else { return nil }
+        return entries.map { $0.makeSwiftTermColor() }
+    }
+
+    /// Installs the macOS-aligned palette on a `LocalProcessTerminalView`.
+    ///
+    /// Wrapped in a `guard` so that an unexpected SwiftTerm API change (the
+    /// palette failing to build) leaves the terminal usable on whatever
+    /// SwiftTerm provides by default — colors might look off, but the
+    /// terminal will not crash or render blank.
+    @MainActor
+    static func install(on terminalView: LocalProcessTerminalView) {
+        guard let colors = swiftTermColors() else { return }
+        terminalView.installColors(colors)
+    }
+}

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -321,29 +321,18 @@ final class TerminalTab: Identifiable, Hashable {
         terminalView.nativeForegroundColor = .textColor
         terminalView.nativeBackgroundColor = .textBackgroundColor
 
-        // Terminal.app color palette — color 8 (bright black) is a subdued gray
-        // so zsh-autosuggestions (fg=8) appear dimmed, not bright.
-        func c(_ r: UInt16, _ g: UInt16, _ b: UInt16) -> SwiftTerm.Color {
-            SwiftTerm.Color(red: r * 257, green: g * 257, blue: b * 257)
-        }
-        terminalView.installColors([
-            c(0, 0, 0),         // 0: black
-            c(194, 54, 33),     // 1: red
-            c(37, 188, 36),     // 2: green
-            c(173, 173, 39),    // 3: yellow
-            c(73, 46, 225),     // 4: blue
-            c(211, 56, 211),    // 5: magenta
-            c(51, 187, 200),    // 6: cyan
-            c(203, 204, 205),   // 7: white
-            c(80, 80, 80),       // 8: bright black (dim gray — for autosuggestions)
-            c(252, 57, 31),     // 9: bright red
-            c(49, 231, 34),     // 10: bright green
-            c(234, 236, 35),    // 11: bright yellow
-            c(88, 51, 255),     // 12: bright blue
-            c(249, 53, 248),    // 13: bright magenta
-            c(20, 240, 240),    // 14: bright cyan
-            c(233, 235, 235),   // 15: bright white
-        ])
+        // Match Ghostty / modern terminal behaviour: do NOT auto-promote bold
+        // text to the bright color variant. SwiftTerm's default of `true`
+        // doubles up the brightness of any bold ANSI segment, which was a
+        // major contributor to Pine's terminal looking visibly louder than
+        // native macOS terminals (issue #733).
+        terminalView.useBrightColors = false
+
+        // Apply Pine's macOS-aligned ANSI 16-color palette. Centralised in
+        // `TerminalPalette` so it can be unit-tested independently of the
+        // SwiftTerm view, and so the palette has a single source of truth.
+        // See `TerminalPalette.swift` for rationale (issue #733).
+        TerminalPalette.install(on: terminalView)
     }
 
     /// Сохраняет рабочую директорию для отложенного запуска

--- a/PineTests/TerminalPaletteTests.swift
+++ b/PineTests/TerminalPaletteTests.swift
@@ -1,0 +1,165 @@
+//
+//  TerminalPaletteTests.swift
+//  PineTests
+//
+//  Tests for `TerminalPalette` — Pine's centralised macOS-aligned ANSI
+//  16-color palette for the embedded SwiftTerm terminal (issue #733).
+//
+
+import Testing
+import AppKit
+import SwiftTerm
+@testable import Pine
+
+@Suite("TerminalPalette Tests")
+struct TerminalPaletteTests {
+
+    // MARK: - Shape
+
+    @Test func paletteHasExactly16Entries() {
+        #expect(TerminalPalette.macOSAligned.count == TerminalPalette.colorCount)
+        #expect(TerminalPalette.colorCount == 16)
+    }
+
+    @Test func paletteEntriesAreOrderedAndDistinct() {
+        let entries = TerminalPalette.macOSAligned
+        // No two slots are the exact same RGB — every ANSI color is unique.
+        let uniqueCount = Set(entries.map { "\($0.red),\($0.green),\($0.blue)" }).count
+        #expect(uniqueCount == entries.count)
+    }
+
+    // MARK: - Reference values (Ghostty default — exact RGB)
+
+    /// Locking the palette to its reference values prevents accidental
+    /// drift the next time someone "tweaks one color" without realising it
+    /// affects every Pine terminal.
+    @Test func paletteMatchesGhosttyDefault() {
+        let expected: [(UInt8, UInt8, UInt8)] = [
+            (0x1D, 0x1F, 0x21), // 0  black
+            (0xCC, 0x66, 0x66), // 1  red
+            (0xB5, 0xBD, 0x68), // 2  green
+            (0xF0, 0xC6, 0x74), // 3  yellow
+            (0x81, 0xA2, 0xBE), // 4  blue
+            (0xB2, 0x94, 0xBB), // 5  magenta
+            (0x8A, 0xBE, 0xB7), // 6  cyan
+            (0xC5, 0xC8, 0xC6), // 7  white
+            (0x66, 0x66, 0x66), // 8  bright black
+            (0xD5, 0x4E, 0x53), // 9  bright red
+            (0xB9, 0xCA, 0x4A), // 10 bright green
+            (0xE7, 0xC5, 0x47), // 11 bright yellow
+            (0x7A, 0xA6, 0xDA), // 12 bright blue
+            (0xC3, 0x97, 0xD8), // 13 bright magenta
+            (0x70, 0xC0, 0xB1), // 14 bright cyan
+            (0xEA, 0xEA, 0xEA), // 15 bright white
+        ]
+        let entries = TerminalPalette.macOSAligned
+        #expect(entries.count == expected.count)
+        for (index, exp) in expected.enumerated() {
+            let entry = entries[index]
+            #expect(entry.red == exp.0, "ANSI \(index) red mismatch")
+            #expect(entry.green == exp.1, "ANSI \(index) green mismatch")
+            #expect(entry.blue == exp.2, "ANSI \(index) blue mismatch")
+        }
+    }
+
+    // MARK: - 8-bit → 16-bit conversion
+
+    @Test func entryConvertsToSwiftTermColorWith257Multiplier() {
+        // 0x00 → 0x0000, 0xFF → 0xFFFF, 0x80 → 0x8080, 0x1D → 0x1D1D
+        let cases: [(UInt8, UInt16)] = [
+            (0x00, 0x0000),
+            (0xFF, 0xFFFF),
+            (0x80, 0x8080),
+            (0x1D, 0x1D1D),
+            (0xCC, 0xCCCC),
+        ]
+        for (eight, sixteen) in cases {
+            let entry = TerminalPaletteEntry(red: eight, green: eight, blue: eight)
+            let color = entry.makeSwiftTermColor()
+            #expect(color.red == sixteen)
+            #expect(color.green == sixteen)
+            #expect(color.blue == sixteen)
+        }
+    }
+
+    @Test func entryEdgeBoundariesDoNotOverflow() {
+        // Maximum value 255 must map cleanly to 0xFFFF without truncation /
+        // wrap-around. UInt8 cannot exceed 255 by construction, but verify the
+        // arithmetic stays inside UInt16.
+        let entry = TerminalPaletteEntry(red: 255, green: 255, blue: 255)
+        let color = entry.makeSwiftTermColor()
+        #expect(color.red == 0xFFFF)
+        #expect(color.green == 0xFFFF)
+        #expect(color.blue == 0xFFFF)
+
+        let zero = TerminalPaletteEntry(red: 0, green: 0, blue: 0)
+        let zc = zero.makeSwiftTermColor()
+        #expect(zc.red == 0)
+        #expect(zc.green == 0)
+        #expect(zc.blue == 0)
+    }
+
+    // MARK: - swiftTermColors() guard
+
+    @Test func swiftTermColorsReturnsSixteenColorsForDefaultPalette() {
+        let colors = TerminalPalette.swiftTermColors()
+        #expect(colors != nil)
+        #expect(colors?.count == 16)
+    }
+
+    @Test func swiftTermColorsRejectsTooFewEntries() {
+        let truncated = Array(TerminalPalette.macOSAligned.prefix(8))
+        #expect(TerminalPalette.swiftTermColors(from: truncated) == nil)
+    }
+
+    @Test func swiftTermColorsRejectsTooManyEntries() {
+        let extra = TerminalPalette.macOSAligned + [
+            TerminalPaletteEntry(red: 1, green: 2, blue: 3),
+        ]
+        #expect(TerminalPalette.swiftTermColors(from: extra) == nil)
+    }
+
+    @Test func swiftTermColorsRejectsEmptyPalette() {
+        #expect(TerminalPalette.swiftTermColors(from: []) == nil)
+    }
+
+    // MARK: - install(on:) integration
+
+    /// SwiftTerm's installed palette is internal — there is no public getter
+    /// to compare colors against. The best we can do at the integration
+    /// boundary is verify that `install(on:)` does not crash and that the
+    /// view remains usable. The exact RGB content is fully covered by the
+    /// pure-Swift tests above (`paletteMatchesGhosttyDefault`,
+    /// `entryConvertsToSwiftTermColorWith257Multiplier`).
+    @Test @MainActor func installDoesNotCrashOnFreshTerminalView() {
+        let view = LocalProcessTerminalView(frame: .init(x: 0, y: 0, width: 400, height: 200))
+        TerminalPalette.install(on: view)
+        // View must still expose its terminal after install.
+        _ = view.getTerminal()
+    }
+
+    @Test @MainActor func installIsIdempotent() {
+        // Installing twice must leave the terminal in a healthy state —
+        // no accumulation, no crash, palette helper still returns colors.
+        let view = LocalProcessTerminalView(frame: .init(x: 0, y: 0, width: 400, height: 200))
+        TerminalPalette.install(on: view)
+        TerminalPalette.install(on: view)
+        _ = view.getTerminal()
+        #expect(TerminalPalette.swiftTermColors()?.count == 16)
+    }
+
+    @Test @MainActor func newTerminalTabInstallsPaletteWithoutCrashing() {
+        // Smoke test: TerminalTab.init must call into TerminalPalette.install
+        // without throwing or producing a nil terminal. Exact RGB values are
+        // verified by the pure-Swift tests above.
+        let tab = TerminalTab(name: "palette-test")
+        _ = tab.terminalView.getTerminal()
+    }
+
+    @Test @MainActor func newTerminalTabDisablesUseBrightColors() {
+        // Bold-as-bright doubles brightness and was a major source of the
+        // visual mismatch with Ghostty / Terminal.app (issue #733).
+        let tab = TerminalTab(name: "test")
+        #expect(tab.terminalView.useBrightColors == false)
+    }
+}


### PR DESCRIPTION
## Summary
- Pine's embedded terminal looked visibly louder than Ghostty / Terminal.app / iTerm2 on the same machine — oh-my-zsh / starship prompts came out brighter and more saturated, making Pine stand out from native macOS terminals.
- Adopt Ghostty's built-in default 16-color ANSI palette (Tomorrow-Night-derived, the same muted set used by modern macOS terminal defaults) and disable SwiftTerm's bold-as-bright behaviour.
- Background / foreground / cursor stay semantic (`NSColor.textColor` / `NSColor.textBackgroundColor`) so light + dark mode keep working automatically.

## Changes
- New `Pine/TerminalPalette.swift` — single source of truth for the 16-color ANSI palette, with an 8-bit `TerminalPaletteEntry` value type, an explicit `swiftTermColors()` builder that guards against malformed input, and an `install(on:)` helper. The guard means a future SwiftTerm API change cannot make us install a malformed palette — the terminal falls back to SwiftTerm's built-in default instead of crashing.
- `Pine/TerminalSession.swift` — `TerminalTab.init` now sets `useBrightColors = false` and delegates the palette install to `TerminalPalette`. The previous inline 16-color list was removed.
- `PineTests/TerminalPaletteTests.swift` — 13 unit tests covering palette shape (count, uniqueness), exact RGB values vs the Ghostty reference, 8 to 16-bit conversion (boundary cases 0x00 / 0x80 / 0xFF / 0x1D / 0xCC), guard rejection of too-few / too-many / empty palettes, smoke tests that `install(on:)` is idempotent and that `TerminalTab.init` wires everything up without crashing, plus a regression test that `useBrightColors` stays `false`.

## Test plan
- [x] `xcodebuild test -only-testing:PineTests` — 2874 tests, all passing
- [x] `swiftlint` — 0 violations across 273 files
- [x] New `TerminalPaletteTests` suite — 13/13 passing
- [x] Verified `TerminalPalette.install(on:)` does not crash on a fresh `LocalProcessTerminalView`
- [x] Verified palette is idempotent under repeated install
- [x] Verified `TerminalTab` initialises with the new palette and `useBrightColors = false`
- [ ] Manual visual check side-by-side with Ghostty: open Pine, run `printf` with ANSI escapes / `vim` / `htop` / `ls --color`, confirm colours match Ghostty's muted defaults (recommended before merge — palette correctness is verified by tests, but the visual comparison is the actual user-facing acceptance criterion)

## Notes
- ANSI 16 colors are fixed RGB by convention — the standard does not change with light / dark mode. Theme adaptation happens via `nativeForegroundColor` / `nativeBackgroundColor`, which already use semantic `NSColor` and were not touched.
- 256-color and truecolor paths in SwiftTerm are unaffected — they do not go through `installColors`.
- Palette source: Ghostty `src/terminal/color.zig` → `Name.default()`.

Closes #733
