### PR TITLE
fix: reload editor content on external file change (#734)

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -625,6 +625,9 @@ struct CodeEditorView: NSViewRepresentable {
     var contentVersion: UInt64 = 0
     var language: String
     var fileName: String?
+    /// Full file URL — used by the coordinator to match notifications targeting
+    /// this specific tab (e.g., external file reloads).
+    var fileURL: URL?
     var lineDiffs: [GitLineDiff] = []
     /// Diff hunks for inline diff expansion in the gutter.
     var diffHunks: [DiffHunk] = []
@@ -1087,6 +1090,101 @@ struct CodeEditorView: NSViewRepresentable {
             // updateNSView call (issue #556).
             self.lastLanguage = parent.language
             self.lastFileName = parent.fileName
+            super.init()
+            // Listen for external file reload notifications. SwiftUI's
+            // @Observable + Binding pipeline does not always reliably
+            // re-render an NSViewRepresentable when an array element's
+            // inner property mutates (issue #734) — this notification is
+            // a robust fallback that directly forces the NSTextView to
+            // resync from disk.
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleTabReloadedFromDisk(_:)),
+                name: .tabReloadedFromDisk,
+                object: nil
+            )
+        }
+
+        /// Handles `.tabReloadedFromDisk` notification — if the URL matches
+        /// this editor's file, forcibly replaces the NSTextView contents with
+        /// the new text from disk and re-applies syntax highlighting.
+        ///
+        /// Cursor position and scroll offset are preserved on a best-effort
+        /// basis (clamped if the new content is shorter).
+        @objc func handleTabReloadedFromDisk(_ note: Notification) {
+            guard let url = note.userInfo?["url"] as? URL,
+                  let newText = note.userInfo?["text"] as? String,
+                  let parentURL = parent.fileURL,
+                  url == parentURL else { return }
+            applyExternalReload(text: newText)
+        }
+
+        /// Forcibly replaces NSTextView contents with externally-loaded text.
+        /// Preserves cursor and scroll offset (clamped to new bounds).
+        /// Re-runs syntax highlighting and fold recalculation.
+        func applyExternalReload(text newText: String) {
+            guard let sv = scrollView,
+                  let textView = sv.documentView as? NSTextView else { return }
+
+            // Skip if content already matches (idempotent against rapid reloads)
+            if textView.string == newText { return }
+
+            // Capture cursor and scroll for best-effort restore
+            let oldRange = textView.selectedRange()
+            let oldVisibleRect = sv.contentView.documentVisibleRect
+
+            cancelPendingHighlight()
+            if let storage = textView.textStorage {
+                SyntaxHighlighter.shared.invalidateCache(for: storage)
+            }
+            previousBracketRanges = []
+
+            isProgrammaticTextChange = true
+            pendingEditedRange = nil
+            pendingChangeInLength = 0
+            textView.string = newText
+            isProgrammaticTextChange = false
+
+            // Bump version counter so the next updateNSView from SwiftUI
+            // (which may carry a stale `text` value) does not re-trigger
+            // a redundant replacement.
+            lastContentVersion = parent.contentVersion
+
+            // Restore cursor (clamped) and scroll
+            let newLength = (newText as NSString).length
+            let clampedLoc = min(oldRange.location, newLength)
+            let clampedLen = min(oldRange.length, newLength - clampedLoc)
+            textView.setSelectedRange(NSRange(location: clampedLoc, length: clampedLen))
+            textView.scroll(oldVisibleRect.origin)
+
+            // Re-run syntax highlighting and fold calculation
+            if !parent.syntaxHighlightingDisabled, let storage = textView.textStorage {
+                if storage.length > CodeEditorView.viewportHighlightThreshold {
+                    scheduleViewportHighlightingPublic(textView: textView)
+                } else {
+                    let result = SyntaxHighlighter.shared.highlight(
+                        textStorage: storage,
+                        language: parent.language,
+                        fileName: parent.fileName,
+                        font: NSFont.monospacedSystemFont(
+                            ofSize: parent.fontSize, weight: .regular
+                        )
+                    )
+                    if let result {
+                        parent.onHighlightCacheUpdate?(result)
+                    }
+                }
+            }
+
+            lineStartsCache = LineStartsCache(text: newText)
+            scheduleFoldRecalculation()
+            reportStateChange()
+        }
+
+        /// Public wrapper around `scheduleViewportHighlighting` for use from
+        /// `applyExternalReload`. Internal access for testability.
+        func scheduleViewportHighlightingPublic(textView: NSTextView) {
+            scheduleViewportHighlighting(textView: textView)
         }
 
         deinit {

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -179,6 +179,7 @@ struct PaneLeafView: View {
             contentVersion: tab.contentVersion,
             language: tab.language,
             fileName: tab.fileName,
+            fileURL: tab.url,
             lineDiffs: lineDiffs,
             diffHunks: diffHunks,
             validationDiagnostics: configValidator.diagnostics,

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -1270,4 +1270,12 @@ extension Notification.Name {
     static let revealInSidebar = Notification.Name("revealInSidebar")
     /// userInfo: ["action": InlineDiffAction]
     static let inlineDiffAction = Notification.Name("inlineDiffAction")
+    /// Posted by `TabManager` after a tab's content was reloaded from disk
+    /// (e.g., file changed externally and was clean). The CodeEditorView
+    /// coordinator listens to forcibly resync NSTextView contents — this
+    /// guarantees the editor reflects disk state even if SwiftUI's
+    /// observation/binding chain fails to trigger `updateNSView` for the
+    /// inner property mutation (issue #734).
+    /// userInfo: ["url": URL, "text": String]
+    static let tabReloadedFromDisk = Notification.Name("tabReloadedFromDisk")
 }

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -763,7 +763,15 @@ final class TabManager {
                     tabs[index].content = content
                     tabs[index].savedContent = content
                     tabs[index].lastModDate = diskMod
+                    tabs[index].fileSizeBytes = fileSize(url: tab.url)
+                    tabs[index].cachedHighlightResult = nil
+                    tabs[index].recomputeContentCaches()
                     reloadedNames.append(tab.url.lastPathComponent)
+                    NotificationCenter.default.post(
+                        name: .tabReloadedFromDisk,
+                        object: nil,
+                        userInfo: ["url": tab.url, "text": content]
+                    )
                 } catch {
                     Self.logger.error("Failed to reload tab \(tab.url.lastPathComponent): \(error)")
                 }
@@ -778,6 +786,7 @@ final class TabManager {
     }
 
     /// Reloads a tab's content from disk (used after user chooses "reload" in conflict dialog).
+    /// Posts `.tabReloadedFromDisk` so the editor view can forcibly resync NSTextView.
     func reloadTab(url: URL) {
         guard let index = tabs.firstIndex(where: { $0.url == url }) else { return }
         do {
@@ -785,6 +794,14 @@ final class TabManager {
             tabs[index].content = content
             tabs[index].savedContent = content
             tabs[index].lastModDate = modDate(for: url)
+            tabs[index].fileSizeBytes = fileSize(url: url)
+            tabs[index].cachedHighlightResult = nil
+            tabs[index].recomputeContentCaches()
+            NotificationCenter.default.post(
+                name: .tabReloadedFromDisk,
+                object: nil,
+                userInfo: ["url": url, "text": content]
+            )
         } catch {
             Self.logger.error("Failed to reload tab from disk \(url.lastPathComponent): \(error)")
         }

--- a/PineTests/ExternalFileReloadTests.swift
+++ b/PineTests/ExternalFileReloadTests.swift
@@ -1,0 +1,389 @@
+//
+//  ExternalFileReloadTests.swift
+//  PineTests
+//
+//  Regression tests for issue #734: external file changes were detected
+//  and a toast was shown, but the editor's NSTextView did not actually
+//  resync from disk until the tab was closed and reopened.
+//
+//  These tests cover both the TabManager pipeline (data layer) and the
+//  CodeEditorView.Coordinator notification path (view layer) that
+//  guarantees the NSTextView reflects disk state.
+//
+
+import Testing
+import AppKit
+import Foundation
+import SwiftUI
+@testable import Pine
+
+@MainActor
+struct ExternalFileReloadTests {
+
+    nonisolated(unsafe) private let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+
+    private func tempFile(content: String) -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("file.txt")
+        try? content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func touch(_ url: URL, secondsInFuture: TimeInterval = 2) {
+        let date = Date().addingTimeInterval(secondsInFuture)
+        try? FileManager.default.setAttributes(
+            [.modificationDate: date], ofItemAtPath: url.path
+        )
+    }
+
+    /// Builds a minimal text system stack matching CodeEditorView.makeNSView.
+    private func makeTextStack(text: String) -> (NSScrollView, NSTextView) {
+        let textStorage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        )
+        layoutManager.addTextContainer(textContainer)
+        let textView = NSTextView(
+            frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+            textContainer: textContainer
+        )
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 500, height: 500))
+        scrollView.documentView = textView
+        return (scrollView, textView)
+    }
+
+    // MARK: - TabManager pipeline
+
+    @Test("checkExternalChanges posts .tabReloadedFromDisk for clean tab")
+    func postsNotificationForCleanReload() throws {
+        let url = tempFile(content: "v1")
+        let manager = TabManager()
+        manager.openTab(url: url)
+
+        var received: (URL, String)?
+        let token = NotificationCenter.default.addObserver(
+            forName: .tabReloadedFromDisk, object: nil, queue: .main
+        ) { note in
+            if let u = note.userInfo?["url"] as? URL,
+               let t = note.userInfo?["text"] as? String {
+                received = (u, t)
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        try "v2 from disk".write(to: url, atomically: true, encoding: .utf8)
+        touch(url)
+
+        let result = manager.checkExternalChanges()
+
+        #expect(result.reloadedFileNames.count == 1)
+        #expect(received?.0 == url)
+        #expect(received?.1 == "v2 from disk")
+        #expect(manager.activeTab?.content == "v2 from disk")
+    }
+
+    @Test("checkExternalChanges does NOT post for dirty tab — conflict instead")
+    func dirtyTabNoNotification() throws {
+        let url = tempFile(content: "v1")
+        let manager = TabManager()
+        manager.openTab(url: url)
+        manager.updateContent("user edits")
+
+        var fired = false
+        let token = NotificationCenter.default.addObserver(
+            forName: .tabReloadedFromDisk, object: nil, queue: .main
+        ) { _ in fired = true }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        try "external".write(to: url, atomically: true, encoding: .utf8)
+        touch(url)
+
+        let result = manager.checkExternalChanges()
+
+        #expect(result.conflicts.count == 1)
+        #expect(result.conflicts.first?.kind == .modified)
+        #expect(fired == false)
+        #expect(manager.activeTab?.content == "user edits")
+    }
+
+    @Test("reloadTab posts .tabReloadedFromDisk after dirty conflict resolution")
+    func reloadTabPostsNotification() throws {
+        let url = tempFile(content: "original")
+        let manager = TabManager()
+        manager.openTab(url: url)
+        manager.updateContent("dirty edit")
+
+        try "fresh from disk".write(to: url, atomically: true, encoding: .utf8)
+
+        var received: String?
+        let token = NotificationCenter.default.addObserver(
+            forName: .tabReloadedFromDisk, object: nil, queue: .main
+        ) { note in received = note.userInfo?["text"] as? String }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        manager.reloadTab(url: url)
+
+        #expect(received == "fresh from disk")
+        #expect(manager.activeTab?.content == "fresh from disk")
+        #expect(manager.activeTab?.isDirty == false)
+    }
+
+    @Test("checkExternalChanges recomputes content caches after reload")
+    func reloadRecomputesCaches() throws {
+        let url = tempFile(content: "    indented\n")
+        let manager = TabManager()
+        manager.openTab(url: url)
+
+        // Switch to tabs
+        try "\there\twith tabs\n".write(to: url, atomically: true, encoding: .utf8)
+        touch(url)
+
+        _ = manager.checkExternalChanges()
+
+        #expect(manager.activeTab?.cachedIndentation == .tabs)
+    }
+
+    @Test("Two rapid sequential reloads — last writer wins")
+    func raceLastWriterWins() throws {
+        let url = tempFile(content: "v0")
+        let manager = TabManager()
+        manager.openTab(url: url)
+
+        try "v1".write(to: url, atomically: true, encoding: .utf8)
+        touch(url, secondsInFuture: 1)
+        _ = manager.checkExternalChanges()
+        #expect(manager.activeTab?.content == "v1")
+
+        try "v2".write(to: url, atomically: true, encoding: .utf8)
+        touch(url, secondsInFuture: 5)
+        _ = manager.checkExternalChanges()
+        #expect(manager.activeTab?.content == "v2")
+    }
+
+    @Test("File deleted externally — clean tab is closed silently")
+    func deletedFileClosesCleanTab() throws {
+        let url = tempFile(content: "x")
+        let manager = TabManager()
+        manager.openTab(url: url)
+        try FileManager.default.removeItem(at: url)
+
+        let result = manager.checkExternalChanges()
+
+        #expect(result.conflicts.isEmpty)
+        #expect(manager.tabs.isEmpty)
+    }
+
+    @Test("File deleted externally — dirty tab returns conflict")
+    func deletedFileDirtyTabConflict() throws {
+        let url = tempFile(content: "x")
+        let manager = TabManager()
+        manager.openTab(url: url)
+        manager.updateContent("dirty")
+        try FileManager.default.removeItem(at: url)
+
+        let result = manager.checkExternalChanges()
+
+        #expect(result.conflicts.count == 1)
+        #expect(result.conflicts.first?.kind == .deleted)
+        #expect(manager.tabs.count == 1)
+    }
+
+    @Test("Reload with mismatched encoding fails gracefully — no crash")
+    func encodingMismatchSurvives() throws {
+        let url = tempFile(content: "ascii")
+        let manager = TabManager()
+        manager.openTab(url: url)
+        // Write UTF-16 BOM bytes — invalid as the original UTF-8 encoding
+        let invalidBytes = Data([0xFF, 0xFE, 0x00, 0xD8, 0x00, 0xDC])
+        try invalidBytes.write(to: url)
+        touch(url)
+        // Must not crash; the silent reload either succeeds with replacement
+        // chars or skips the tab.
+        _ = manager.checkExternalChanges()
+        #expect(manager.tabs.count == 1)
+    }
+
+    // MARK: - Coordinator notification path (#734 root cause)
+
+    @Test("Coordinator updates NSTextView on .tabReloadedFromDisk for matching URL")
+    func coordinatorAppliesNotification() {
+        let url = URL(fileURLWithPath: "/tmp/coordinator-test-\(UUID().uuidString).txt")
+        let (scrollView, textView) = makeTextStack(text: "old")
+
+        let view = CodeEditorView(
+            text: .constant("old"),
+            contentVersion: 0,
+            language: "txt",
+            fileName: "x.txt",
+            fileURL: url,
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: view)
+        coordinator.scrollView = scrollView
+        coordinator.syncContentVersion()
+
+        coordinator.applyExternalReload(text: "fresh content")
+
+        #expect(textView.string == "fresh content")
+    }
+
+    @Test("Coordinator ignores notification for a different URL")
+    func coordinatorIgnoresUnrelatedNotification() {
+        let myURL = URL(fileURLWithPath: "/tmp/me-\(UUID().uuidString).txt")
+        let otherURL = URL(fileURLWithPath: "/tmp/other-\(UUID().uuidString).txt")
+        let (scrollView, textView) = makeTextStack(text: "stable")
+
+        let view = CodeEditorView(
+            text: .constant("stable"),
+            contentVersion: 0,
+            language: "txt",
+            fileName: "me.txt",
+            fileURL: myURL,
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: view)
+        coordinator.scrollView = scrollView
+        coordinator.syncContentVersion()
+
+        NotificationCenter.default.post(
+            name: .tabReloadedFromDisk,
+            object: nil,
+            userInfo: ["url": otherURL, "text": "intruder"]
+        )
+
+        #expect(textView.string == "stable")
+    }
+
+    @Test("applyExternalReload is idempotent — same text is a no-op")
+    func idempotentReload() {
+        let url = URL(fileURLWithPath: "/tmp/idem-\(UUID().uuidString).txt")
+        let (scrollView, textView) = makeTextStack(text: "same")
+
+        let view = CodeEditorView(
+            text: .constant("same"),
+            contentVersion: 0,
+            language: "txt",
+            fileName: "x.txt",
+            fileURL: url,
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: view)
+        coordinator.scrollView = scrollView
+        coordinator.syncContentVersion()
+
+        // Place cursor mid-text
+        textView.setSelectedRange(NSRange(location: 2, length: 0))
+        coordinator.applyExternalReload(text: "same")
+
+        #expect(textView.string == "same")
+        #expect(textView.selectedRange().location == 2)
+    }
+
+    @Test("applyExternalReload preserves cursor when new content is longer")
+    func cursorPreservedLongerContent() {
+        let url = URL(fileURLWithPath: "/tmp/cur-\(UUID().uuidString).txt")
+        let (scrollView, textView) = makeTextStack(text: "hello")
+
+        let view = CodeEditorView(
+            text: .constant("hello"),
+            contentVersion: 0,
+            language: "txt",
+            fileName: "x.txt",
+            fileURL: url,
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: view)
+        coordinator.scrollView = scrollView
+        coordinator.syncContentVersion()
+
+        textView.setSelectedRange(NSRange(location: 3, length: 0))
+        coordinator.applyExternalReload(text: "hello, world!")
+
+        #expect(textView.string == "hello, world!")
+        #expect(textView.selectedRange().location == 3)
+    }
+
+    @Test("applyExternalReload clamps cursor when new content is shorter")
+    func cursorClampedShorterContent() {
+        let url = URL(fileURLWithPath: "/tmp/clamp-\(UUID().uuidString).txt")
+        let (scrollView, textView) = makeTextStack(text: "long string of text")
+
+        let view = CodeEditorView(
+            text: .constant("long string of text"),
+            contentVersion: 0,
+            language: "txt",
+            fileName: "x.txt",
+            fileURL: url,
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: view)
+        coordinator.scrollView = scrollView
+        coordinator.syncContentVersion()
+
+        textView.setSelectedRange(NSRange(location: 15, length: 0))
+        coordinator.applyExternalReload(text: "short")
+
+        #expect(textView.string == "short")
+        #expect(textView.selectedRange().location == 5)
+    }
+
+    @Test("End-to-end: TabManager.checkExternalChanges drives Coordinator via notification")
+    func endToEndPipeline() throws {
+        let url = tempFile(content: "before")
+        let manager = TabManager()
+        manager.openTab(url: url)
+
+        let (scrollView, textView) = makeTextStack(text: "before")
+        let view = CodeEditorView(
+            text: .constant("before"),
+            contentVersion: 0,
+            language: "txt",
+            fileName: url.lastPathComponent,
+            fileURL: url,
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: view)
+        coordinator.scrollView = scrollView
+        coordinator.syncContentVersion()
+
+        try "AFTER EXTERNAL CHANGE".write(to: url, atomically: true, encoding: .utf8)
+        touch(url)
+
+        let result = manager.checkExternalChanges()
+
+        #expect(result.reloadedFileNames.count == 1)
+        // The coordinator's NSNotification observer must have applied the
+        // new content to the NSTextView synchronously.
+        #expect(textView.string == "AFTER EXTERNAL CHANGE")
+    }
+
+    @Test("End-to-end: reloadTab via dirty conflict resolution drives Coordinator")
+    func endToEndDirtyResolve() throws {
+        let url = tempFile(content: "v1")
+        let manager = TabManager()
+        manager.openTab(url: url)
+        manager.updateContent("user edits")
+
+        let (scrollView, textView) = makeTextStack(text: "user edits")
+        let view = CodeEditorView(
+            text: .constant("user edits"),
+            contentVersion: 0,
+            language: "txt",
+            fileName: url.lastPathComponent,
+            fileURL: url,
+            foldState: .constant(FoldState())
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: view)
+        coordinator.scrollView = scrollView
+        coordinator.syncContentVersion()
+
+        try "fresh from disk".write(to: url, atomically: true, encoding: .utf8)
+        manager.reloadTab(url: url)
+
+        #expect(textView.string == "fresh from disk")
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #734: external file change toast fired but the editor kept showing stale content until the tab was closed and reopened.
- TabManager now posts `.tabReloadedFromDisk` after every silent reload and after `reloadTab(url:)`; the `CodeEditorView` coordinator listens and forcibly resyncs the `NSTextView`.
- Adds 15 unit tests covering the data layer, the coordinator notification path, and the full end-to-end pipeline.

## Root cause
`TabManager.checkExternalChanges` mutated `tabs[index].content` for clean tabs (correctly bumping `EditorTab.contentVersion`), but the SwiftUI `@Observable` + `Binding` chain through `PaneLeafView` -> `CodeEditorView` (`NSViewRepresentable`) did not reliably trigger `updateNSView` for the inner-property mutation. The data was correct, the toast was honest, but the AppKit text view never received the update — only a tab close/reopen rebuilt it via `makeNSView`.

## Changes
- `Pine/TabManager.swift`
  - `checkExternalChanges`: post `.tabReloadedFromDisk` `{url, text}` after silent reload, refresh `fileSizeBytes`, clear `cachedHighlightResult`, call `recomputeContentCaches()`.
  - `reloadTab(url:)`: same notification + cache refresh so the dirty-conflict resolution path also reaches the editor view.
- `Pine/CodeEditorView.swift`
  - New `fileURL: URL?` parameter on `CodeEditorView` for notification routing.
  - `Coordinator` registers an `NSNotificationCenter` observer in `init`. New `applyExternalReload(text:)` replaces `NSTextView` contents under `isProgrammaticTextChange`, preserves cursor (clamped to new bounds) and scroll offset, invalidates the highlight cache, re-runs syntax highlighting (synchronous for small files, viewport scheduling for large files), rebuilds `lineStartsCache`, and triggers fold recalculation + state report.
- `Pine/PaneLeafView.swift`: forwards `tab.url` as `fileURL` to `CodeEditorView`.
- `Pine/PineApp.swift`: declares `Notification.Name.tabReloadedFromDisk` with documentation referencing #734.
- `PineTests/ExternalFileReloadTests.swift`: 15 new tests.

## Test plan
- [x] `xcodebuild test ... -only-testing:PineTests/ExternalFileReloadTests` (15/15 pass)
- [x] `xcodebuild test ... -only-testing:PineTests` full suite (2876/2876 pass)
- [x] `swiftlint` (0 violations across 272 files)
- [x] Build green (`xcodebuild build`)

### Test coverage (ExternalFileReloadTests)
**TabManager pipeline**
- `checkExternalChanges` posts `.tabReloadedFromDisk` for a clean tab
- Dirty tab returns conflict and does NOT post the notification
- `reloadTab` posts the notification after dirty conflict resolution
- Reload recomputes content caches (indentation switches from spaces to tabs)
- Two rapid sequential reloads — last writer wins
- Externally deleted file closes a clean tab silently
- Externally deleted file with dirty tab returns `.deleted` conflict
- Reload with mismatched encoding fails gracefully without crash

**Coordinator notification path**
- Coordinator updates `NSTextView.string` on matching URL
- Coordinator ignores notifications for unrelated URLs
- `applyExternalReload` is idempotent (no-op when text unchanged, cursor preserved)
- Cursor preserved when new content is longer
- Cursor clamped when new content is shorter

**End-to-end**
- `TabManager.checkExternalChanges` -> notification -> `NSTextView` reflects disk content
- `reloadTab` (dirty conflict resolution path) -> `NSTextView` reflects disk content

Closes #734
