### PR TITLE
fix(ci): Detect Changes fail-safe on unreachable base SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,20 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 2
+          # Full history so the base SHA is always reachable. Shallow checkout
+          # used to silently break the diff when base wasn't in the shallow
+          # window, treating real code changes as docs-only and skipping every
+          # downstream job. See #751.
+          fetch-depth: 0
 
       - name: Check for code changes
         id: filter
+        # Strict mode: any failure here MUST surface, never silently fall
+        # through to "skip everything". See #751 for the postmortem.
+        shell: bash
         run: |
+          set -euo pipefail
+
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE="${{ github.event.pull_request.base.sha }}"
             HEAD="${{ github.event.pull_request.head.sha }}"
@@ -45,8 +54,23 @@ jobs:
             BASE="HEAD~1"
           fi
 
-          # List changed files, exclude docs/config-only paths
-          CHANGED=$(git diff --name-only "$BASE" "$HEAD" | grep -cvE '^(.*\.md|docs/.*|assets/.*|LICENSE|\.github/ISSUE_TEMPLATE/.*|\.release-please-manifest\.json|release-please-config\.json)$' || true)
+          # Sanity check: both SHAs MUST be reachable. If not (e.g. shallow
+          # clone window doesn't cover the base), we default to running all
+          # jobs rather than silently skipping them. "Fail safe", not "fail
+          # open" — better to waste a few CI minutes than to merge untested
+          # code on a green checkmark.
+          if ! git rev-parse --verify --quiet "$BASE^{commit}" >/dev/null \
+             || ! git rev-parse --verify --quiet "$HEAD^{commit}" >/dev/null; then
+            echo "::warning::Base or head SHA unreachable (BASE=$BASE HEAD=$HEAD); running all CI jobs as safety fallback"
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # List changed files, exclude docs/config-only paths.
+          # Note: no `|| true` — pipefail will catch git errors loudly.
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" \
+            | grep -cvE '^(.*\.md|docs/.*|assets/.*|LICENSE|\.github/ISSUE_TEMPLATE/.*|\.release-please-manifest\.json|release-please-config\.json)$' \
+            || CHANGED=0)
 
           if [ "$CHANGED" -gt 0 ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
Fixes #751 — `Detect Changes` job tихо проваливал ВСЕ CI-проверки на любом PR с stale/unreachable base SHA.

## Root cause
1. `actions/checkout` использовал `fetch-depth: 2`, поэтому base SHA из `pull_request.base.sha` мог не быть в shallow window.
2. `git diff --name-only "$BASE" "$HEAD" | grep ... || true` — `|| true` глотал ошибку git; результат был пустой → `CHANGED=0` → `code=false` → все downstream jobs SKIPPED.
3. PR показывал зелёную галочку (Detect Changes pass + claude-review pass), хотя ни Build, ни Test, ни Lint не запускались.

Свежий пример из реального мира: PR #747 run 24076627344 — `fatal: bad object ba544110...` → 6 SKIPPED + 2 SUCCESS, mergeable=true. Чистая бомба.

## Changes
- `fetch-depth: 0` чтобы base SHA всегда был reachable.
- `set -euo pipefail` в шаге Check for code changes — git ошибки теперь падают громко.
- Sanity check через `git rev-parse --verify` перед diff: если BASE или HEAD недоступны → `code=true` (fail-safe), warning в лог, job НЕ скипается.
- Убран `|| true` на git diff, заменён на явный `CHANGED=0` fallback.

## Test plan
- [x] YAML валиден.
- [ ] CI на этой ветке должен сам себя протестировать: после push'а Detect Changes должен сработать корректно и запустить все downstream jobs.
- [ ] Smoke на старом случае: можно временно симулировать unreachable BASE → ожидаем `code=true` warning, не silent skip.

Closes #751