### PR TITLE
feat(terminal): opt-in ghost-text autosuggestions via bundled ZDOTDIR

### DIFF
--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -4899,6 +4899,24 @@
         }
       }
     },
+    "menu.shellAutosuggestions" : {
+      "comment" : "Menu toggle: enable ghost-text autosuggestions in the terminal via bundled ZDOTDIR (zsh only).",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shell Autosuggestions"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоподсказки shell"
+          }
+        }
+      }
+    },
     "menu.openFolder" : {
       "comment" : "Menu command: open a folder picker dialog (⌘⇧O).",
       "extractionState" : "manual",

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -50,6 +50,7 @@ nonisolated enum MenuIcons {
     // MARK: - Terminal menu
     static let newTerminalTab = "plus"
     static let sendToTerminal = "paperplane"
+    static let shellAutosuggestions = "text.insert"
 
     // MARK: - Validation
     static let toggleValidation = "checkmark.shield"

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -13,6 +13,7 @@ struct PineApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @FocusedValue(\.projectManager) private var focusedProject: ProjectManager?
     @AppStorage(TabManager.autoSaveKey) private var autoSaveEnabled = false
+    @AppStorage("terminalAutosuggestionsEnabled") private var shellAutosuggestionsEnabled = false
 
     private var registry: ProjectRegistry { appDelegate.registry }
 
@@ -195,6 +196,14 @@ struct PineApp: App {
                 }
                 .keyboardShortcut(.return, modifiers: [.command, .shift])
                 .disabled(focusedProject?.activeTabManager.activeTab == nil)
+
+                Divider()
+
+                // Opt-in ghost-text autosuggestions from shell history (#762).
+                // Only affects zsh — bash/fish/nushell users keep their setup.
+                Toggle(isOn: $shellAutosuggestionsEnabled) {
+                    Label(Strings.menuShellAutosuggestions, systemImage: MenuIcons.shellAutosuggestions)
+                }
             }
             // Edit menu: Toggle Comment, Find & Replace, Find in Project
             CommandGroup(after: .pasteboard) {

--- a/Pine/ShellAutosuggestions.swift
+++ b/Pine/ShellAutosuggestions.swift
@@ -1,0 +1,154 @@
+//
+//  ShellAutosuggestions.swift
+//  Pine
+//
+//  Provides opt-in ghost-text autosuggestions in the built-in terminal by
+//  installing a small bundled ZDOTDIR that sources the user's real `.zshrc`
+//  and then enables `zsh-autosuggestions` if it can be located on the host.
+//
+//  Design notes (Apple way — be a good guest on the user's machine):
+//  - Opt-in. Default is OFF. We never modify the user's real dotfiles.
+//  - Scoped to zsh. Bash/fish/nushell users keep their native setup.
+//  - We write a tiny bootstrap `.zshrc` under Application Support and point
+//    the child shell at it via `ZDOTDIR`. The bootstrap first sources the
+//    user's real `~/.zshrc` (so every alias, prompt, plugin keeps working —
+//    oh-my-zsh, starship, direnv, nvm, etc.) and only then adds
+//    `zsh-autosuggestions` from whichever standard location has it.
+//  - Bright-black slot (ghost-text color) was already fixed for palette
+//    parity in #765, so no palette changes are needed here.
+//  - TUI apps (vim, htop, k9s) are completely unaffected: `zsh-autosuggestions`
+//    is a line-editor widget, it only runs while zle is active at the prompt.
+//
+
+import Foundation
+
+/// Builds and manages a bundled ZDOTDIR used to enable ghost-text
+/// autosuggestions in Pine's terminal.
+///
+/// This type is intentionally `nonisolated` and side-effect-free except for
+/// its explicit filesystem calls, so it can be unit-tested without touching
+/// the real Application Support directory.
+struct ShellAutosuggestionsProvider {
+
+    // MARK: - Configuration
+
+    /// Directory where the bootstrap `.zshrc` will be written.
+    /// Typically `~/Library/Application Support/Pine/shell`.
+    let directory: URL
+
+    /// File manager used for all I/O (injectable for tests).
+    let fileManager: FileManager
+
+    /// Candidate locations of `zsh-autosuggestions.zsh` checked at shell
+    /// startup, in priority order. Kept as plain strings so the generated
+    /// `.zshrc` can iterate over them with a simple `for` loop.
+    ///
+    /// Covers:
+    /// - Homebrew on Apple Silicon and Intel
+    /// - MacPorts
+    /// - oh-my-zsh custom plugin directory
+    /// - System-wide `/usr/share` (some Linux-flavoured setups)
+    static let candidateAutosuggestionPaths: [String] = [
+        "/opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh",
+        "/usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh",
+        "/opt/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh",
+        "$HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh",
+        "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh",
+        "/usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh",
+    ]
+
+    // MARK: - Init
+
+    init(directory: URL, fileManager: FileManager = .default) {
+        self.directory = directory
+        self.fileManager = fileManager
+    }
+
+    /// Default provider rooted at `~/Library/Application Support/Pine/shell`.
+    static func defaultProvider(fileManager: FileManager = .default) -> ShellAutosuggestionsProvider {
+        let base = fileManager
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Pine", isDirectory: true)
+            .appendingPathComponent("shell", isDirectory: true)
+        return ShellAutosuggestionsProvider(directory: base, fileManager: fileManager)
+    }
+
+    // MARK: - API
+
+    /// Full path to the bootstrap `.zshrc` inside `directory`.
+    var zshrcURL: URL {
+        directory.appendingPathComponent(".zshrc", isDirectory: false)
+    }
+
+    /// Generates the bootstrap `.zshrc` contents.
+    ///
+    /// The script:
+    ///   1. Sources the user's real `~/.zshrc` if present, so everything the
+    ///      user already configured (prompt, plugins, functions) keeps working.
+    ///   2. Tries each candidate path for `zsh-autosuggestions.zsh` and sources
+    ///      the first one that exists.
+    ///   3. Tweaks the highlight style to use the bright-black ANSI slot so it
+    ///      inherits Pine's Terminal.app-matched palette from #765.
+    ///
+    /// Kept as `static` so tests can assert on the generated text without
+    /// touching the filesystem.
+    static func generateZshrc() -> String {
+        var lines: [String] = []
+        lines.append("# Pine — bootstrap ZDOTDIR for shell autosuggestions.")
+        lines.append("# Generated automatically. Do not edit — toggle from the Terminal menu.")
+        lines.append("")
+        lines.append("# 1. Source the user's real ~/.zshrc so their environment is preserved.")
+        lines.append("if [ -f \"$HOME/.zshrc\" ]; then")
+        lines.append("  ZDOTDIR=\"$HOME\" . \"$HOME/.zshrc\"")
+        lines.append("fi")
+        lines.append("")
+        lines.append("# 2. Enable zsh-autosuggestions from the first location that has it.")
+        lines.append("__pine_autosuggest_candidates=(")
+        for path in candidateAutosuggestionPaths {
+            lines.append("  \"\(path)\"")
+        }
+        lines.append(")")
+        lines.append("for __pine_candidate in \"${__pine_autosuggest_candidates[@]}\"; do")
+        lines.append("  __pine_expanded=\"${__pine_candidate/#\\$HOME/$HOME}\"")
+        lines.append("  if [ -f \"$__pine_expanded\" ]; then")
+        lines.append("    . \"$__pine_expanded\"")
+        lines.append("    break")
+        lines.append("  fi")
+        lines.append("done")
+        lines.append("unset __pine_autosuggest_candidates __pine_candidate __pine_expanded")
+        lines.append("")
+        lines.append("# 3. Use bright-black (ANSI slot 8) so the ghost text matches Pine's palette (#765).")
+        lines.append("ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'")
+        lines.append("")
+        return lines.joined(separator: "\n")
+    }
+
+    /// Writes (or rewrites) the bootstrap `.zshrc` on disk and returns the
+    /// directory path suitable for use as `ZDOTDIR`.
+    ///
+    /// Idempotent: safe to call on every terminal launch — it only rewrites
+    /// the file when the content differs, so we don't churn mtime for nothing.
+    @discardableResult
+    func install() throws -> URL {
+        try fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        let contents = Self.generateZshrc()
+        let target = zshrcURL
+        if let existing = try? String(contentsOf: target, encoding: .utf8), existing == contents {
+            return directory
+        }
+        try contents.write(to: target, atomically: true, encoding: .utf8)
+        return directory
+    }
+
+    /// Deletes the bootstrap directory (used when the user disables the feature
+    /// or for test cleanup). Never throws on a missing directory.
+    func uninstall() throws {
+        if fileManager.fileExists(atPath: directory.path) {
+            try fileManager.removeItem(at: directory)
+        }
+    }
+}

--- a/Pine/ShellSettings.swift
+++ b/Pine/ShellSettings.swift
@@ -29,6 +29,7 @@ final class ShellSettings {
 
     private static let shellPathKey = "terminalShellPath"
     private static let shellArgsKey = "terminalShellArgs"
+    private static let autosuggestionsEnabledKey = "terminalAutosuggestionsEnabled"
 
     /// Reads the user's login shell from the POSIX account database.
     /// Works reliably inside Xcode sandbox and App Sandbox where `$SHELL` may be absent or wrong.
@@ -64,6 +65,25 @@ final class ShellSettings {
         }
     }
 
+    /// Whether to enable opt-in ghost-text autosuggestions via a bundled
+    /// ZDOTDIR (see `ShellAutosuggestionsProvider`). Defaults to `false`
+    /// because Pine should never touch the user's shell environment without
+    /// explicit consent (Apple HIG: be a good guest on the user's machine).
+    ///
+    /// Only takes effect when the selected shell is zsh — bash/fish/nushell
+    /// users keep their native setup untouched.
+    var autosuggestionsEnabled: Bool {
+        didSet {
+            defaults.set(autosuggestionsEnabled, forKey: Self.autosuggestionsEnabledKey)
+        }
+    }
+
+    /// Whether the active shell is zsh (the only shell we inject ZDOTDIR for).
+    var isZshShell: Bool {
+        let name = (resolvedShellPath as NSString).lastPathComponent.lowercased()
+        return name == "zsh"
+    }
+
     /// Validated shell path — falls back to system shell (via `getpwuid`), then `$SHELL`, then `/bin/zsh`.
     var resolvedShellPath: String {
         if isExecutableFile(shellPath) { return shellPath }
@@ -97,10 +117,19 @@ final class ShellSettings {
         } else {
             self.shellArgs = Self.defaultShellArgs
         }
+
+        // Default OFF. `object(forKey:)` lets us distinguish "never set" from
+        // "explicitly set to false" in case we ever need to migrate.
+        if defaults.object(forKey: Self.autosuggestionsEnabledKey) != nil {
+            self.autosuggestionsEnabled = defaults.bool(forKey: Self.autosuggestionsEnabledKey)
+        } else {
+            self.autosuggestionsEnabled = false
+        }
     }
 
     func reset() {
         shellPath = Self.defaultShellPath
         shellArgs = Self.commonShells.first { $0.path == shellPath }?.defaultArgs ?? Self.defaultShellArgs
+        autosuggestionsEnabled = false
     }
 }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -140,6 +140,7 @@ enum Strings {
     static let menuResetFontSize: LocalizedStringKey = "menu.resetFontSize"
     static let menuTerminal: LocalizedStringKey = "menu.terminal"
     static let menuNewTerminalTab: LocalizedStringKey = "menu.newTerminalTab"
+    static let menuShellAutosuggestions: LocalizedStringKey = "menu.shellAutosuggestions"
     static let menuTogglePreview: LocalizedStringKey = "menu.togglePreview"
     static let menuView: LocalizedStringKey = "menu.view"
     static let menuGit: LocalizedStringKey = "menu.git"

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -355,6 +355,15 @@ final class TerminalTab: Identifiable, Hashable {
         var env = ProcessInfo.processInfo.environment
         env["PINE_TERMINAL"] = "1"
         env["TERM"] = "xterm-256color"
+        // Opt-in: inject bundled ZDOTDIR for zsh autosuggestions (#762).
+        // Only applies to zsh so we never surprise bash/fish/nushell users.
+        if shellSettings.autosuggestionsEnabled && shellSettings.isZshShell {
+            let provider = ShellAutosuggestionsProvider.defaultProvider()
+            if let zdotdir = try? provider.install() {
+                env["ZDOTDIR"] = zdotdir.path
+                env["PINE_SHELL_AUTOSUGGESTIONS"] = "1"
+            }
+        }
         if let wd = workingDirectory {
             env["PINE_PROJECT_ROOT"] = wd.path
             let hash = ContextFileWriter.hashedFileName(for: wd)

--- a/PineTests/ShellAutosuggestionsTests.swift
+++ b/PineTests/ShellAutosuggestionsTests.swift
@@ -1,0 +1,183 @@
+//
+//  ShellAutosuggestionsTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+@Suite("ShellAutosuggestions Tests")
+struct ShellAutosuggestionsTests {
+
+    // MARK: - Helpers
+
+    private func makeTempProvider() throws -> (ShellAutosuggestionsProvider, URL) {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-autosuggest-\(UUID().uuidString)", isDirectory: true)
+        let provider = ShellAutosuggestionsProvider(directory: tmp)
+        return (provider, tmp)
+    }
+
+    // MARK: - generateZshrc()
+
+    @Test func generatedZshrcContainsHeader() {
+        let script = ShellAutosuggestionsProvider.generateZshrc()
+        #expect(script.contains("# Pine"))
+        #expect(script.contains("Generated automatically"))
+    }
+
+    @Test func generatedZshrcSourcesUserRealZshrc() {
+        let script = ShellAutosuggestionsProvider.generateZshrc()
+        // Must source the user's real ~/.zshrc so everything (oh-my-zsh,
+        // starship, direnv, nvm, vim integration) keeps working.
+        #expect(script.contains("$HOME/.zshrc"))
+        #expect(script.contains("ZDOTDIR=\"$HOME\""))
+    }
+
+    @Test func generatedZshrcSourcesUserZshrcBeforePlugin() {
+        // Order matters: user config first, plugin second, so the plugin
+        // can observe whatever options the user's config set.
+        let script = ShellAutosuggestionsProvider.generateZshrc()
+        let userIdx = script.range(of: "$HOME/.zshrc")?.lowerBound
+        let pluginIdx = script.range(of: "zsh-autosuggestions.zsh")?.lowerBound
+        #expect(userIdx != nil && pluginIdx != nil)
+        if let u = userIdx, let p = pluginIdx {
+            #expect(u < p)
+        }
+    }
+
+    @Test func generatedZshrcIteratesAllCandidatePaths() {
+        let script = ShellAutosuggestionsProvider.generateZshrc()
+        for candidate in ShellAutosuggestionsProvider.candidateAutosuggestionPaths {
+            #expect(script.contains(candidate), "Candidate not referenced: \(candidate)")
+        }
+    }
+
+    @Test func generatedZshrcIncludesHomebrewArmAndIntelPaths() {
+        let paths = ShellAutosuggestionsProvider.candidateAutosuggestionPaths
+        #expect(paths.contains("/opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh"))
+        #expect(paths.contains("/usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh"))
+    }
+
+    @Test func generatedZshrcIncludesOhMyZshPath() {
+        let paths = ShellAutosuggestionsProvider.candidateAutosuggestionPaths
+        #expect(paths.contains { $0.contains(".oh-my-zsh") })
+    }
+
+    @Test func generatedZshrcUsesBrightBlackHighlightStyle() {
+        // Ghost text must use ANSI slot 8 to match Pine's Terminal.app palette
+        // fix in #765.
+        let script = ShellAutosuggestionsProvider.generateZshrc()
+        #expect(script.contains("ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE"))
+        #expect(script.contains("fg=8"))
+    }
+
+    @Test func generatedZshrcIsDeterministic() {
+        // Same input → same output, so install() can short-circuit on equality.
+        let a = ShellAutosuggestionsProvider.generateZshrc()
+        let b = ShellAutosuggestionsProvider.generateZshrc()
+        #expect(a == b)
+    }
+
+    @Test func generatedZshrcHasNoCRLFLineEndings() {
+        // A zshrc with \r\n breaks zsh on some systems.
+        let script = ShellAutosuggestionsProvider.generateZshrc()
+        #expect(!script.contains("\r"))
+    }
+
+    // MARK: - install() / uninstall()
+
+    @Test func installCreatesDirectoryAndZshrc() throws {
+        let (provider, tmp) = try makeTempProvider()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let result = try provider.install()
+        #expect(result == tmp)
+        #expect(FileManager.default.fileExists(atPath: tmp.path))
+        #expect(FileManager.default.fileExists(atPath: provider.zshrcURL.path))
+    }
+
+    @Test func installWritesCorrectContents() throws {
+        let (provider, tmp) = try makeTempProvider()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try provider.install()
+        let written = try String(contentsOf: provider.zshrcURL, encoding: .utf8)
+        #expect(written == ShellAutosuggestionsProvider.generateZshrc())
+    }
+
+    @Test func installIsIdempotent() throws {
+        let (provider, tmp) = try makeTempProvider()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try provider.install()
+        let mtime1 = try FileManager.default
+            .attributesOfItem(atPath: provider.zshrcURL.path)[.modificationDate] as? Date
+        // Sleep a beat to detect accidental rewrite.
+        Thread.sleep(forTimeInterval: 0.05)
+        try provider.install()
+        let mtime2 = try FileManager.default
+            .attributesOfItem(atPath: provider.zshrcURL.path)[.modificationDate] as? Date
+        #expect(mtime1 == mtime2, "install() must not rewrite file with identical content")
+    }
+
+    @Test func installRewritesWhenContentsDiffer() throws {
+        let (provider, tmp) = try makeTempProvider()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        try "stale content".write(to: provider.zshrcURL, atomically: true, encoding: .utf8)
+        try provider.install()
+        let written = try String(contentsOf: provider.zshrcURL, encoding: .utf8)
+        #expect(written == ShellAutosuggestionsProvider.generateZshrc())
+    }
+
+    @Test func installCreatesIntermediateDirectories() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-autosuggest-\(UUID().uuidString)")
+            .appendingPathComponent("nested")
+            .appendingPathComponent("shell", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(
+                at: tmp.deletingLastPathComponent().deletingLastPathComponent()
+            )
+        }
+        let provider = ShellAutosuggestionsProvider(directory: tmp)
+        _ = try provider.install()
+        #expect(FileManager.default.fileExists(atPath: provider.zshrcURL.path))
+    }
+
+    @Test func uninstallRemovesDirectory() throws {
+        let (provider, tmp) = try makeTempProvider()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try provider.install()
+        #expect(FileManager.default.fileExists(atPath: tmp.path))
+        try provider.uninstall()
+        #expect(!FileManager.default.fileExists(atPath: tmp.path))
+    }
+
+    @Test func uninstallOnMissingDirectoryDoesNotThrow() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-autosuggest-\(UUID().uuidString)")
+        let provider = ShellAutosuggestionsProvider(directory: tmp)
+        // Directory never created — must not throw.
+        try provider.uninstall()
+    }
+
+    // MARK: - defaultProvider()
+
+    @Test func defaultProviderPointsUnderApplicationSupportPine() {
+        let provider = ShellAutosuggestionsProvider.defaultProvider()
+        #expect(provider.directory.path.contains("Application Support"))
+        #expect(provider.directory.path.contains("Pine"))
+        #expect(provider.directory.lastPathComponent == "shell")
+    }
+
+    @Test func zshrcURLEndsWithDotZshrc() throws {
+        let (provider, tmp) = try makeTempProvider()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        #expect(provider.zshrcURL.lastPathComponent == ".zshrc")
+    }
+}

--- a/PineTests/ShellSettingsTests.swift
+++ b/PineTests/ShellSettingsTests.swift
@@ -312,6 +312,69 @@ struct ShellSettingsTests {
         }
     }
 
+    // MARK: - Autosuggestions flag (#762)
+
+    @Test func autosuggestionsDefaultIsOff() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+        let settings = ShellSettings(defaults: defaults)
+        #expect(settings.autosuggestionsEnabled == false,
+                "Default must be OFF — Pine never touches shell env without consent")
+    }
+
+    @Test func autosuggestionsEnabledPersists() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+        let s1 = ShellSettings(defaults: defaults)
+        s1.autosuggestionsEnabled = true
+        #expect(defaults.bool(forKey: "terminalAutosuggestionsEnabled") == true)
+        let s2 = ShellSettings(defaults: defaults)
+        #expect(s2.autosuggestionsEnabled == true)
+    }
+
+    @Test func autosuggestionsEnabledRoundTripsFalseExplicitly() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+        let s1 = ShellSettings(defaults: defaults)
+        s1.autosuggestionsEnabled = true
+        s1.autosuggestionsEnabled = false
+        let s2 = ShellSettings(defaults: defaults)
+        #expect(s2.autosuggestionsEnabled == false)
+    }
+
+    @Test func resetTurnsAutosuggestionsOff() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+        let settings = ShellSettings(defaults: defaults)
+        settings.autosuggestionsEnabled = true
+        settings.reset()
+        #expect(settings.autosuggestionsEnabled == false)
+    }
+
+    @Test func isZshShellTrueForBinZsh() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+        let settings = ShellSettings(defaults: defaults)
+        settings.shellPath = "/bin/zsh"
+        #expect(settings.isZshShell == true)
+    }
+
+    @Test func isZshShellFalseForBinBash() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+        let settings = ShellSettings(defaults: defaults)
+        settings.shellPath = "/bin/bash"
+        #expect(settings.isZshShell == false)
+    }
+
+    @Test func isZshShellFalseForShPath() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+        let settings = ShellSettings(defaults: defaults)
+        settings.shellPath = "/bin/sh"
+        #expect(settings.isZshShell == false)
+    }
+
     @Test func shellOptionHashableAndEquatable() {
         let opt1 = ShellSettings.ShellOption(name: "zsh", path: "/bin/zsh", defaultArgs: ["--login"])
         let opt2 = ShellSettings.ShellOption(name: "zsh", path: "/bin/zsh", defaultArgs: ["--login"])

--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ brew install --cask pine-editor
 
 **Direct download:** grab the latest `.dmg` from [Releases](https://github.com/batonogov/pine/releases/latest).
 
+### Shell autosuggestions (optional)
+
+Pine's built-in terminal can show inline ghost-text suggestions from your shell history — type `g`, and see `it pull` appear greyed-out for one-press completion. This is an opt-in feature because Pine never touches your shell environment without permission.
+
+1. Install [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) once:
+   ```bash
+   brew install zsh-autosuggestions
+   ```
+   (oh-my-zsh's `custom/plugins/zsh-autosuggestions` and MacPorts are also auto-detected.)
+2. In Pine, enable **Terminal → Shell Autosuggestions**.
+
+Under the hood, Pine writes a small bootstrap `.zshrc` under `~/Library/Application Support/Pine/shell/` and launches the terminal with `ZDOTDIR` pointing at it. The bootstrap sources your real `~/.zshrc` first (so your prompt, plugins, aliases and TUI setups like vim/htop keep working untouched) and only then loads zsh-autosuggestions. Only applies to zsh — bash, fish and nushell users are unaffected.
+
 ## Build from Source
 
 Requires macOS 26+ and Xcode 26+.


### PR DESCRIPTION
Closes #762.

## Summary
- New **Terminal → Shell Autosuggestions** menu toggle (default OFF).
- When enabled, Pine writes a tiny bootstrap `.zshrc` under `~/Library/Application Support/Pine/shell/` and launches the shell with `ZDOTDIR` pointing at it. The bootstrap sources the user's real `~/.zshrc` first and then loads `zsh-autosuggestions` from any standard location (Homebrew arm/intel, MacPorts, oh-my-zsh, `/usr/share`, `~/.zsh`).
- Ghost text uses ANSI slot 8 — matches the Terminal.app palette parity from #765 so the suggestion is readable.
- Only affects zsh. Bash, fish and nushell users keep their native setup untouched.
- README gets a short "Shell autosuggestions (optional)" section with the one-line `brew install zsh-autosuggestions` onboarding.

## Design rationale
The Apple-way path from the issue's recommendation: (1) documentation + (2) ZDOTDIR behind a toggle. We don't ship a vendored copy of `zsh-autosuggestions` — the user still installs the plugin themselves (brew/oh-my-zsh), and Pine just wires the `ZDOTDIR` bootstrap without mutating any user dotfile. Default OFF because Pine must never touch the user's shell environment without consent.

TUI apps (vim, htop, k9s, oh-my-zsh) are unaffected: `zsh-autosuggestions` is a zle widget that only runs at the interactive prompt, and our bootstrap sources `~/.zshrc` verbatim, so anything the user already configured keeps working.

## Changes
- `Pine/ShellAutosuggestions.swift` — new `ShellAutosuggestionsProvider` with deterministic `generateZshrc()`, idempotent `install()`/`uninstall()`, and a default provider under `Application Support/Pine/shell`.
- `Pine/ShellSettings.swift` — `autosuggestionsEnabled` flag persisted via `UserDefaults`, `isZshShell` helper, `reset()` clears the flag.
- `Pine/TerminalSession.swift` — `buildEnvironment()` injects `ZDOTDIR` + `PINE_SHELL_AUTOSUGGESTIONS=1` when the flag is on and the shell is zsh.
- `Pine/PineApp.swift` — Terminal menu toggle bound to `@AppStorage("terminalAutosuggestionsEnabled")`.
- `Pine/Strings.swift` + `Pine/Localizable.xcstrings` — new `menu.shellAutosuggestions` key (en + ru, targeted insert preserving the xcstrings format).
- `Pine/MenuIcons.swift` — `shellAutosuggestions = "text.insert"` SF Symbol.
- `README.md` — "Shell autosuggestions (optional)" section.

## Tests
- 18 new `ShellAutosuggestionsTests` (Swift Testing): script header, real-zshrc sourcing order, all candidate paths referenced, bright-black highlight style, determinism, no CRLF, install creates dir + file, idempotent on equal content, rewrites on different content, intermediate dirs, uninstall happy-path + missing-dir, default provider under `Application Support/Pine`.
- 6 new `ShellSettingsTests`: default OFF, persistence round-trip, explicit-false round-trip, `reset()` clears, `isZshShell` true for `/bin/zsh`, false for `/bin/bash`/`/bin/sh`.
- All 42 `ShellSettingsTests` + 18 `ShellAutosuggestionsTests` pass locally.
- `swiftlint --strict` clean (0 violations in 287 files).
- Full `xcodebuild build` SUCCEEDED.

## Test plan
- [ ] Install `zsh-autosuggestions` via `brew install zsh-autosuggestions` (or already present via oh-my-zsh).
- [ ] Open Pine, create a terminal pane, run `git pull`.
- [ ] Enable **Terminal → Shell Autosuggestions** (creates `~/Library/Application Support/Pine/shell/.zshrc` on next terminal).
- [ ] Open a **new** terminal tab, type `g` — expect `it pull` as grey ghost text; press → to accept.
- [ ] Toggle back off, open a new terminal — verify no ZDOTDIR-based behaviour remains.
- [ ] Launch `vim`, `htop`, switch git branches in oh-my-zsh prompt — nothing should regress.
- [ ] Switch shell to `/bin/bash` in a custom UserDefaults — verify toggle is a no-op.

## Visual changes
- New menu entry in the **Terminal** top-level menu:
  `Terminal → New Tab ⌘T / Find in Terminal / Send to Terminal ⇧⌘⏎ / ─── / Shell Autosuggestions ☑︎`
  (SF Symbol `text.insert`, Toggle-style checkmark when enabled.)
- README gains a short "Shell autosuggestions (optional)" block under Install.
- No other UI changes; no new windows, sheets, or toolbar items.
