### PR TITLE
fix(sidebar): refresh tree promptly for changes from built-in terminal (#774)

### DIFF
--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -66,7 +66,11 @@ final class WorkspaceManager {
     /// 1s, which was long enough to swallow rapid terminal-driven changes
     /// following any sidebar edit.
     private var suppressWatcherUntil: Date?
-    private static let watcherSuppressWindow: TimeInterval = 0.15
+    /// Shared timing constant: used both as the `FileSystemWatcher` debounce
+    /// interval and as the watcher-echo suppression window after an in-app
+    /// `refreshFileTree()`. Keeping them equal guarantees that a refresh only
+    /// swallows its own immediate echo and never a subsequent external change.
+    static let watcherDebounce: TimeInterval = 0.15
 
     /// Schedules a debounced `onRootNodesChanged` notification.
     /// Cancels any pending notification so rapid updates coalesce into one.
@@ -137,7 +141,7 @@ final class WorkspaceManager {
         // (or any external process) appear in the sidebar almost immediately.
         // The previous default (500ms) combined with the watcher's own event
         // coalescing made the sidebar feel unresponsive to shell commands.
-        let watcher = FileSystemWatcher(debounceInterval: 0.15) { [weak self] in
+        let watcher = FileSystemWatcher(debounceInterval: Self.watcherDebounce) { [weak self] in
             // This closure runs on main (guaranteed by FileSystemWatcher).
             self?.externalChangeToken += 1
             self?.refreshFileTreeAsync()
@@ -310,13 +314,15 @@ final class WorkspaceManager {
         gitRefreshTask = Task { await gitProvider.refreshAsync() }
         // Suppress watcher echoes — we just refreshed, so any watcher event
         // within the next second is redundant and could break inline editing.
-        suppressWatcherUntil = Date().addingTimeInterval(Self.watcherSuppressWindow)
+        suppressWatcherUntil = Date().addingTimeInterval(Self.watcherDebounce)
     }
 
     /// Background variant called by the file watcher.
     /// Runs on main (watcher dispatches here) so loadGeneration
     /// access is safe; heavy I/O is dispatched to a background queue.
-    private func refreshFileTreeAsync() {
+    /// `internal` (not `private`) so tests can drive it directly and
+    /// verify suppression behaviour without depending on FSEvents timing.
+    func refreshFileTreeAsync() {
         if let until = suppressWatcherUntil, Date() < until {
             return
         }

--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -61,7 +61,12 @@ final class WorkspaceManager {
 
     /// After a synchronous refreshFileTree(), watcher events within this
     /// window are suppressed because they echo the action we just handled.
+    /// Kept short (150ms) so external changes (e.g. `mkdir` in the built-in
+    /// terminal) are not silently dropped — issue #774. Previously this was
+    /// 1s, which was long enough to swallow rapid terminal-driven changes
+    /// following any sidebar edit.
     private var suppressWatcherUntil: Date?
+    private static let watcherSuppressWindow: TimeInterval = 0.15
 
     /// Schedules a debounced `onRootNodesChanged` notification.
     /// Cancels any pending notification so rapid updates coalesce into one.
@@ -117,13 +122,22 @@ final class WorkspaceManager {
             gitProvider.applyEmptyState()
         }
 
-        loadDirectoryContentsAsync(url: url, generation: generation) { [weak self] in
-            self?.startWatching(url: url)
-        }
+        // Start watching *before* the async load begins so that any FS
+        // activity during the initial load (e.g. user opens Cmd+` and types
+        // `mkdir foo` immediately) is not lost. FSEvents buffers events so
+        // there is no race between watcher start and the first callback.
+        // Fixes issue #774.
+        startWatching(url: url)
+
+        loadDirectoryContentsAsync(url: url, generation: generation)
     }
 
     private func startWatching(url: URL) {
-        let watcher = FileSystemWatcher { [weak self] in
+        // Short debounce (150ms) so changes made in the built-in terminal
+        // (or any external process) appear in the sidebar almost immediately.
+        // The previous default (500ms) combined with the watcher's own event
+        // coalescing made the sidebar feel unresponsive to shell commands.
+        let watcher = FileSystemWatcher(debounceInterval: 0.15) { [weak self] in
             // This closure runs on main (guaranteed by FileSystemWatcher).
             self?.externalChangeToken += 1
             self?.refreshFileTreeAsync()
@@ -142,8 +156,7 @@ final class WorkspaceManager {
     /// then the full tree replaces it once ready.
     private func loadDirectoryContentsAsync(
         url: URL,
-        generation: Int,
-        completion: (@MainActor @Sendable () -> Void)? = nil
+        generation: Int
     ) {
         let progressID = progressTracker?.beginOperation(Strings.progressLoadingProject)
         // nonisolated-check:ignore — pre-existing pattern; tracked in #720
@@ -184,9 +197,6 @@ final class WorkspaceManager {
                 if !shallowResult.wasDepthLimited {
                     self.isLoading = false
                     if let progressID { self.progressTracker?.endOperation(progressID) }
-                    if let completion {
-                        MainActor.assumeIsolated { completion() }
-                    }
                 }
             }
 
@@ -210,9 +220,6 @@ final class WorkspaceManager {
                 self.notifyRootNodesChanged(fullChildren)
                 self.isLoading = false
                 if let progressID { self.progressTracker?.endOperation(progressID) }
-                if let completion {
-                    MainActor.assumeIsolated { completion() }
-                }
             }
         }
     }
@@ -303,7 +310,7 @@ final class WorkspaceManager {
         gitRefreshTask = Task { await gitProvider.refreshAsync() }
         // Suppress watcher echoes — we just refreshed, so any watcher event
         // within the next second is redundant and could break inline editing.
-        suppressWatcherUntil = Date().addingTimeInterval(1.0)
+        suppressWatcherUntil = Date().addingTimeInterval(Self.watcherSuppressWindow)
     }
 
     /// Background variant called by the file watcher.

--- a/PineTests/SidebarRefreshTests.swift
+++ b/PineTests/SidebarRefreshTests.swift
@@ -27,6 +27,22 @@ struct SidebarRefreshTests {
         try? FileManager.default.removeItem(at: url)
     }
 
+    /// Polls `condition` every 200ms up to `maxAttempts` times (default: 150,
+    /// ~30s total). FSEvents latency on CI runners has been observed at
+    /// 23-31s, so the generous ceiling is deliberate — it keeps these tests
+    /// reliable without meaningfully slowing the happy path, which returns
+    /// as soon as the condition flips to true.
+    @MainActor
+    private func waitFor(
+        _ condition: () -> Bool,
+        maxAttempts: Int = 150
+    ) async {
+        for _ in 0..<maxAttempts {
+            if condition() { return }
+            try? await Task.sleep(for: .milliseconds(200))
+        }
+    }
+
     // MARK: - FileSystemWatcher callback fires for new file
 
     @Test("FileSystemWatcher fires callback when a new file is created")
@@ -308,13 +324,7 @@ struct SidebarRefreshTests {
         // SwiftTerm's LocalProcessTerminalView executes shell commands.
         try runShell("mkdir silarc-dev-callserver", at: dir)
 
-        // FSEvents can be slow on CI — poll generously
-        for _ in 0..<100 {
-            try await Task.sleep(for: .milliseconds(200))
-            if manager.rootNodes.contains(where: { $0.name == "silarc-dev-callserver" }) {
-                break
-            }
-        }
+        await waitFor { manager.rootNodes.contains { $0.name == "silarc-dev-callserver" } }
 
         #expect(
             manager.rootNodes.contains { $0.name == "silarc-dev-callserver" },
@@ -334,10 +344,7 @@ struct SidebarRefreshTests {
 
         try runShell("touch bar.txt", at: dir)
 
-        for _ in 0..<100 {
-            try await Task.sleep(for: .milliseconds(200))
-            if manager.rootNodes.contains(where: { $0.name == "bar.txt" }) { break }
-        }
+        await waitFor { manager.rootNodes.contains { $0.name == "bar.txt" } }
 
         #expect(manager.rootNodes.contains { $0.name == "bar.txt" })
     }
@@ -354,18 +361,12 @@ struct SidebarRefreshTests {
         let manager = WorkspaceManager()
         manager.loadDirectory(url: dir)
 
-        for _ in 0..<100 {
-            try await Task.sleep(for: .milliseconds(200))
-            if manager.rootNodes.contains(where: { $0.name == "to_remove" }) { break }
-        }
+        await waitFor { manager.rootNodes.contains { $0.name == "to_remove" } }
         #expect(manager.rootNodes.contains { $0.name == "to_remove" })
 
         try runShell("rm -rf to_remove", at: dir)
 
-        for _ in 0..<100 {
-            try await Task.sleep(for: .milliseconds(200))
-            if !manager.rootNodes.contains(where: { $0.name == "to_remove" }) { break }
-        }
+        await waitFor { !manager.rootNodes.contains { $0.name == "to_remove" } }
 
         #expect(!manager.rootNodes.contains { $0.name == "to_remove" })
     }
@@ -385,21 +386,16 @@ struct SidebarRefreshTests {
         let manager = WorkspaceManager()
         manager.loadDirectory(url: dir)
 
-        for _ in 0..<100 {
-            try await Task.sleep(for: .milliseconds(200))
-            if manager.rootNodes.contains(where: { $0.name == "foo.txt" }) { break }
-        }
+        await waitFor { manager.rootNodes.contains { $0.name == "foo.txt" } }
 
         try runShell("mv foo.txt baz.txt", at: dir)
 
-        var sawBaz = false
-        var noFoo = false
-        for _ in 0..<100 {
-            try await Task.sleep(for: .milliseconds(200))
-            sawBaz = manager.rootNodes.contains { $0.name == "baz.txt" }
-            noFoo = !manager.rootNodes.contains { $0.name == "foo.txt" }
-            if sawBaz && noFoo { break }
+        await waitFor {
+            manager.rootNodes.contains { $0.name == "baz.txt" }
+                && !manager.rootNodes.contains { $0.name == "foo.txt" }
         }
+        let sawBaz = manager.rootNodes.contains { $0.name == "baz.txt" }
+        let noFoo = !manager.rootNodes.contains { $0.name == "foo.txt" }
 
         #expect(sawBaz, "baz.txt should appear after mv")
         #expect(noFoo, "foo.txt should disappear after mv")

--- a/PineTests/SidebarRefreshTests.swift
+++ b/PineTests/SidebarRefreshTests.swift
@@ -257,6 +257,154 @@ struct SidebarRefreshTests {
         )
     }
 
+    // MARK: - Issue #774: external shell processes (e.g. built-in terminal)
+
+    /// Runs a shell command as a child process, exactly like SwiftTerm's
+    /// `LocalProcessTerminalView` does when the user types in the built-in
+    /// terminal. This is the repro path for issue #774.
+    @discardableResult
+    private func runShell(_ command: String, at dir: URL) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        process.currentDirectoryURL = dir
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+        try process.run()
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            let stderr = String(
+                data: errPipe.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            ) ?? ""
+            throw NSError(
+                domain: "ShellError",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: "'\(command)' failed: \(stderr)"]
+            )
+        }
+        return String(
+            data: outPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+    }
+
+    @Test("Issue #774: mkdir via shell child process appears in sidebar")
+    @MainActor
+    func mkdirViaShellAppearsInSidebar() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        let manager = WorkspaceManager()
+        manager.loadDirectory(url: dir)
+
+        // Wait for initial load + watcher start
+        try await Task.sleep(for: .milliseconds(500))
+        #expect(manager.rootNodes.isEmpty)
+
+        // Reproduce the exact issue: run `mkdir` via /bin/sh, same as
+        // SwiftTerm's LocalProcessTerminalView executes shell commands.
+        try runShell("mkdir silarc-dev-callserver", at: dir)
+
+        // FSEvents can be slow on CI — poll generously
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(200))
+            if manager.rootNodes.contains(where: { $0.name == "silarc-dev-callserver" }) {
+                break
+            }
+        }
+
+        #expect(
+            manager.rootNodes.contains { $0.name == "silarc-dev-callserver" },
+            "Directory created via shell child process should appear in sidebar"
+        )
+    }
+
+    @Test("Issue #774: touch file via shell appears in sidebar")
+    @MainActor
+    func touchFileViaShellAppearsInSidebar() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        let manager = WorkspaceManager()
+        manager.loadDirectory(url: dir)
+        try await Task.sleep(for: .milliseconds(500))
+
+        try runShell("touch bar.txt", at: dir)
+
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(200))
+            if manager.rootNodes.contains(where: { $0.name == "bar.txt" }) { break }
+        }
+
+        #expect(manager.rootNodes.contains { $0.name == "bar.txt" })
+    }
+
+    @Test("Issue #774: rm -rf via shell removes from sidebar")
+    @MainActor
+    func rmViaShellRemovesFromSidebar() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        let subdir = dir.appendingPathComponent("to_remove")
+        try FileManager.default.createDirectory(at: subdir, withIntermediateDirectories: true)
+
+        let manager = WorkspaceManager()
+        manager.loadDirectory(url: dir)
+
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(200))
+            if manager.rootNodes.contains(where: { $0.name == "to_remove" }) { break }
+        }
+        #expect(manager.rootNodes.contains { $0.name == "to_remove" })
+
+        try runShell("rm -rf to_remove", at: dir)
+
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(200))
+            if !manager.rootNodes.contains(where: { $0.name == "to_remove" }) { break }
+        }
+
+        #expect(!manager.rootNodes.contains { $0.name == "to_remove" })
+    }
+
+    @Test("Issue #774: mv via shell updates sidebar")
+    @MainActor
+    func mvViaShellUpdatesSidebar() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        try "content".write(
+            to: dir.appendingPathComponent("foo.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let manager = WorkspaceManager()
+        manager.loadDirectory(url: dir)
+
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(200))
+            if manager.rootNodes.contains(where: { $0.name == "foo.txt" }) { break }
+        }
+
+        try runShell("mv foo.txt baz.txt", at: dir)
+
+        var sawBaz = false
+        var noFoo = false
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(200))
+            sawBaz = manager.rootNodes.contains { $0.name == "baz.txt" }
+            noFoo = !manager.rootNodes.contains { $0.name == "foo.txt" }
+            if sawBaz && noFoo { break }
+        }
+
+        #expect(sawBaz, "baz.txt should appear after mv")
+        #expect(noFoo, "foo.txt should disappear after mv")
+    }
+
     // MARK: - No double debounce in FileSystemWatcher
 
     // FSEvents latency is unpredictable on CI runners (23-31s observed vs <0.5s locally),

--- a/PineTests/WorkspaceManagerTests.swift
+++ b/PineTests/WorkspaceManagerTests.swift
@@ -340,38 +340,47 @@ struct WorkspaceManagerTests {
         #expect(aNode?.children?.first?.name == "b")
     }
 
-    @Test("refreshFileTree suppresses watcher echo events within suppression window")
+    @Test("refreshFileTree does not permanently block watcher events (issue #774)")
     @MainActor
-    func refreshFileTreeSuppressesEcho() async throws {
+    func refreshFileTreeDoesNotBlockLaterEvents() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
 
-        try "file".write(
-            to: dir.appendingPathComponent("test.txt"),
-            atomically: true,
-            encoding: .utf8
-        )
-
         let manager = WorkspaceManager()
         manager.loadDirectory(url: dir)
+
+        // Wait for initial load + watcher start
+        try await Task.sleep(for: .milliseconds(400))
+
+        // Simulate an in-app refresh (e.g. user created a file via sidebar).
+        // Previously this started a 1s watcher suppression window that swallowed
+        // genuine external changes (issue #774). The window is now ~150ms.
         manager.refreshFileTree()
 
-        // After refreshFileTree, echo watcher events within the
-        // suppression window (~1 second) should be suppressed.
         let tokenAfterRefresh = manager.externalChangeToken
 
-        // Modify a file — this triggers a watcher event
-        try "modified".write(
-            to: dir.appendingPathComponent("test.txt"),
+        // Wait out the (short) suppression window, then create a file externally.
+        try await Task.sleep(for: .milliseconds(250))
+        try "external".write(
+            to: dir.appendingPathComponent("external.txt"),
             atomically: true,
             encoding: .utf8
         )
 
-        // Wait longer than the watcher debounce (0.5s) but within
-        // the suppression window (1s) — the callback should be suppressed.
-        try await Task.sleep(for: .milliseconds(700))
+        // Watcher should still deliver this event and update rootNodes.
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(200))
+            if manager.rootNodes.contains(where: { $0.name == "external.txt" }) { break }
+        }
 
-        #expect(manager.externalChangeToken == tokenAfterRefresh)
+        #expect(
+            manager.externalChangeToken > tokenAfterRefresh,
+            "External changes after the suppression window must still trigger a refresh"
+        )
+        #expect(
+            manager.rootNodes.contains { $0.name == "external.txt" },
+            "External file must appear in sidebar"
+        )
     }
 
     @Test("loadDirectory stops file watcher from previous project")
@@ -394,11 +403,15 @@ struct WorkspaceManagerTests {
 
         let manager = WorkspaceManager()
         manager.loadDirectory(url: dir1)
-        manager.refreshFileTree()
+
+        // Let dir1's watcher fully settle before switching
+        try await Task.sleep(for: .milliseconds(400))
 
         // Switch to dir2 — should stop dir1's watcher
         manager.loadDirectory(url: dir2)
-        manager.refreshFileTree()
+
+        // Let dir2's initial watcher events settle before sampling the token
+        try await Task.sleep(for: .milliseconds(400))
 
         let tokenAfterSwitch = manager.externalChangeToken
 
@@ -411,7 +424,7 @@ struct WorkspaceManagerTests {
         )
 
         // Wait for any potential watcher event to fire
-        try await Task.sleep(for: .milliseconds(800))
+        try await Task.sleep(for: .milliseconds(500))
 
         // Token should not have changed from dir1 watcher events
         #expect(manager.externalChangeToken == tokenAfterSwitch)

--- a/PineTests/WorkspaceManagerTests.swift
+++ b/PineTests/WorkspaceManagerTests.swift
@@ -340,6 +340,51 @@ struct WorkspaceManagerTests {
         #expect(aNode?.children?.first?.name == "b")
     }
 
+    @Test("refreshFileTree suppresses watcher echoes within the suppression window")
+    @MainActor
+    func refreshFileTreeSuppressesEchoWithinWindow() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        let initialURL = dir.appendingPathComponent("initial.txt")
+        try "initial".write(to: initialURL, atomically: true, encoding: .utf8)
+
+        let manager = WorkspaceManager()
+        manager.loadDirectory(url: dir)
+
+        // Wait for initial load
+        for _ in 0..<150 {
+            try await Task.sleep(for: .milliseconds(200))
+            if manager.rootNodes.contains(where: { $0.name == "initial.txt" }) { break }
+        }
+        #expect(manager.rootNodes.contains { $0.name == "initial.txt" })
+
+        // Simulate an in-app refresh — this opens the suppression window
+        // (WorkspaceManager.watcherDebounce). Watcher callbacks that fire
+        // inside the window are redundant echoes of this refresh and must
+        // be dropped so rapid interactive edits don't fight the reload pipeline.
+        manager.refreshFileTree()
+
+        // Mutate the filesystem so that, IF `refreshFileTreeAsync()` were to
+        // actually run, we would observe a difference in `rootNodes`.
+        try FileManager.default.removeItem(at: initialURL)
+
+        // Drive the watcher code path directly (we cannot rely on FSEvents
+        // timing on CI). `refreshFileTreeAsync` is exposed as `internal`
+        // specifically so tests can exercise the suppression branch.
+        manager.refreshFileTreeAsync()
+
+        // Well inside the 150ms suppression window.
+        try await Task.sleep(for: .milliseconds(80))
+
+        // Suppression must have caused `refreshFileTreeAsync` to early-return,
+        // so the cached `rootNodes` still reflects the pre-removal snapshot.
+        #expect(
+            manager.rootNodes.contains { $0.name == "initial.txt" },
+            "Watcher echoes within the suppression window must not reload the tree"
+        )
+    }
+
     @Test("refreshFileTree does not permanently block watcher events (issue #774)")
     @MainActor
     func refreshFileTreeDoesNotBlockLaterEvents() async throws {


### PR DESCRIPTION
## Summary
- Start `FileSystemWatcher` synchronously in `loadDirectory()` instead of after the async load completes — prevents missing FS events during the initial project load.
- Drop the FSEvents debounce from 500 ms to 150 ms so the sidebar reacts quickly to `mkdir`/`touch`/`rm` in the built-in terminal.
- Shrink the post-refresh suppression window from 1 s to 150 ms so external changes that follow a sidebar edit are not silently swallowed.

## Root cause
Issue #774: creating files/directories via the built-in terminal did not update the sidebar. Two combined factors:
1. The watcher only started after the background tree load finished, so early terminal activity could happen before FSEvents was subscribed.
2. The 1 s post-refresh suppression window swallowed legitimate external changes that happened to follow any in-app edit.

## Test plan
- [x] New `Process()`-driven unit tests in `SidebarRefreshTests` that run `mkdir`, `touch`, `rm -rf`, `mv` via `/bin/sh` exactly like SwiftTerm does, asserting the sidebar picks them up.
- [x] New regression test `refreshFileTreeDoesNotBlockLaterEvents` verifying that external changes after the suppression window still trigger a refresh.
- [x] Existing `FileSystemWatcherTests`, `SidebarRefreshTests`, `WorkspaceManagerTests` all pass (38/38).
- [x] `swiftlint --strict` clean.
- [x] `xcodebuild build` succeeds.

## Acceptance (from issue #774)
- [x] `mkdir foo` in built-in terminal → `foo` appears in sidebar.
- [x] `touch bar.txt` → `bar.txt` appears.
- [x] `rm -rf foo` → `foo` disappears.
- [x] `mv foo baz` → `foo` disappears, `baz` appears.
- [x] Unit tests cover each scenario.

Fixes #774
