### PR TITLE
fix(editor): restore git diff gutter updates in split panes

### DIFF
--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -88,9 +88,37 @@ struct PaneLeafView: View {
         if let tabManager {
             editorPaneContent(tabManager: tabManager)
                 .environment(tabManager)
+                .onAppear {
+                    // Initial load: refresh line diffs/blame for the active tab
+                    // even if `activeTabID` never changes (issue #780).
+                    refreshLineDiffs(tabManager: tabManager)
+                    refreshBlame(tabManager: tabManager)
+                }
                 .onChange(of: tabManager.activeTabID) { _, _ in
                     refreshLineDiffs(tabManager: tabManager)
                     refreshBlame(tabManager: tabManager)
+                }
+                .onChange(of: tabManager.activeTab?.contentVersion) { _, _ in
+                    // Re-compute diff markers as the user edits — otherwise gutter
+                    // markers become stale on every keystroke (issue #780).
+                    refreshLineDiffs(tabManager: tabManager)
+                }
+                .onChange(of: workspace.gitProvider.fileStatuses) { _, _ in
+                    // External git state changes (save, stash, checkout from CLI)
+                    // must refresh the gutter (issue #780).
+                    refreshLineDiffs(tabManager: tabManager)
+                }
+                .onChange(of: workspace.gitProvider.currentBranch) { _, _ in
+                    refreshLineDiffs(tabManager: tabManager)
+                    refreshBlame(tabManager: tabManager)
+                }
+                .onChange(of: workspace.gitProvider.isGitRepository) { _, isRepo in
+                    if isRepo {
+                        refreshLineDiffs(tabManager: tabManager)
+                    } else {
+                        lineDiffs = []
+                        diffHunks = []
+                    }
                 }
                 .modifier(BlameObserver(
                     isBlameVisible: isBlameVisible,

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -23,6 +23,9 @@ struct PaneLeafView: View {
     @State private var diffHunks: [DiffHunk] = []
     @State private var blameLines: [GitBlameLine] = []
     @State private var blameTask: Task<Void, Never>?
+    /// Handle for the most recently scheduled diff refresh so new triggers
+    /// can cancel a stale run (e.g. rapid typing or overlapping observers).
+    @State private var diffTask: Task<Void, Never>?
     @State private var configValidator = ConfigValidator()
     @State private var isDragTargeted = false
     @State private var goToLineOffset: GoToRequest?
@@ -99,9 +102,9 @@ struct PaneLeafView: View {
                     refreshBlame(tabManager: tabManager)
                 }
                 .onChange(of: tabManager.activeTab?.contentVersion) { _, _ in
-                    // Re-compute diff markers as the user edits — otherwise gutter
-                    // markers become stale on every keystroke (issue #780).
-                    refreshLineDiffs(tabManager: tabManager)
+                    // Re-compute diff markers as the user edits. Debounced so
+                    // `git diff` does not run on every keystroke (issue #780).
+                    refreshLineDiffs(tabManager: tabManager, debounce: true)
                 }
                 .onChange(of: workspace.gitProvider.fileStatuses) { _, _ in
                     // External git state changes (save, stash, checkout from CLI)
@@ -109,6 +112,9 @@ struct PaneLeafView: View {
                     refreshLineDiffs(tabManager: tabManager)
                 }
                 .onChange(of: workspace.gitProvider.currentBranch) { _, _ in
+                    // Branch switch: `fileStatuses` will also change around the
+                    // same time, but `diffTask` cancellation coalesces the two
+                    // observers into a single refresh.
                     refreshLineDiffs(tabManager: tabManager)
                     refreshBlame(tabManager: tabManager)
                 }
@@ -116,9 +122,20 @@ struct PaneLeafView: View {
                     if isRepo {
                         refreshLineDiffs(tabManager: tabManager)
                     } else {
+                        // Repo removed — clear every cached git-derived state,
+                        // including blame (previous fix only cleared diffs).
+                        diffTask?.cancel()
+                        diffTask = nil
+                        blameTask?.cancel()
+                        blameTask = nil
                         lineDiffs = []
                         diffHunks = []
+                        blameLines = []
                     }
+                }
+                .onDisappear {
+                    diffTask?.cancel()
+                    diffTask = nil
                 }
                 .modifier(BlameObserver(
                     isBlameVisible: isBlameVisible,
@@ -249,8 +266,21 @@ struct PaneLeafView: View {
 
     // MARK: - Git diff & blame
 
+    /// Debounce applied to content-edit triggered refreshes (keystrokes).
+    /// Matches the ~150ms used by other git-derived work in Pine.
+    private static let diffDebounce: Duration = .milliseconds(150)
+
     /// Refreshes cached line diffs and diff hunks for the active tab.
-    private func refreshLineDiffs(tabManager: TabManager) {
+    /// - Parameter debounce: when `true`, waits `diffDebounce` before running
+    ///   the diff so rapid typing coalesces into a single git invocation.
+    ///   Immediate (`false`) refreshes are used by tab switches, save,
+    ///   branch switch, and repo init — those already fire at human pace.
+    ///
+    /// The most recent invocation cancels any previously scheduled work
+    /// via `diffTask`, so overlapping observers (e.g. `fileStatuses` +
+    /// `currentBranch` firing in the same runloop tick) run only once.
+    private func refreshLineDiffs(tabManager: TabManager, debounce: Bool = false) {
+        diffTask?.cancel()
         guard let tab = tabManager.activeTab else {
             lineDiffs = []
             diffHunks = []
@@ -263,14 +293,18 @@ struct PaneLeafView: View {
             diffHunks = []
             return
         }
-        Task {
+        diffTask = Task { @MainActor in
+            if debounce {
+                try? await Task.sleep(for: Self.diffDebounce)
+                if Task.isCancelled { return }
+            }
             async let diffs = provider.diffForFileAsync(at: fileURL)
             async let hunks = InlineDiffProvider.fetchHunks(for: fileURL, repoURL: repoURL)
             let (resolvedDiffs, resolvedHunks) = await (diffs, hunks)
-            if tabManager.activeTab?.url == fileURL {
-                lineDiffs = resolvedDiffs
-                diffHunks = resolvedHunks
-            }
+            if Task.isCancelled { return }
+            guard tabManager.activeTab?.url == fileURL else { return }
+            lineDiffs = resolvedDiffs
+            diffHunks = resolvedHunks
         }
     }
 

--- a/PineTests/PaneLeafGitDiffRefreshTests.swift
+++ b/PineTests/PaneLeafGitDiffRefreshTests.swift
@@ -1,0 +1,312 @@
+//
+//  PaneLeafGitDiffRefreshTests.swift
+//  PineTests
+//
+//  Regression coverage for issue #780 — gutter git diff markers stopped
+//  updating after the split-panes refactor in PR #707 because the
+//  `refreshLineDiffs` call was only wired to `onChange(activeTabID)`.
+//  These tests verify the underlying signals that `PaneLeafView` now
+//  subscribes to (content edits, git-status changes, branch switches,
+//  repository transitions, initial load) actually fire and that
+//  `GitStatusProvider.diffForFileAsync` returns the expected diffs
+//  across the full save/edit/checkout lifecycle.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("PaneLeaf Git Diff Refresh Signals (#780)")
+@MainActor
+struct PaneLeafGitDiffRefreshTests {
+
+    // MARK: - Repo helpers
+
+    private func makeGitRepo() throws -> URL {
+        let rawDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-paneleaf-diff-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: rawDir, withIntermediateDirectories: true)
+        let dir = try resolveURL(rawDir)
+        try runShell("git init -b main", at: dir)
+        try runShell("git config user.email 'test@test.com'", at: dir)
+        try runShell("git config user.name 'Test'", at: dir)
+        try "line1\nline2\nline3\n".write(
+            to: dir.appendingPathComponent("file.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try runShell("git add .", at: dir)
+        try runShell("git commit -m 'initial'", at: dir)
+        return dir
+    }
+
+    private func resolveURL(_ url: URL) throws -> URL {
+        guard let resolved = realpath(url.path, nil) else { throw CocoaError(.fileNoSuchFile) }
+        defer { free(resolved) }
+        return URL(fileURLWithPath: String(cString: resolved))
+    }
+
+    private func cleanup(_ url: URL) { try? FileManager.default.removeItem(at: url) }
+
+    @discardableResult
+    private func runShell(_ command: String, at dir: URL) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        process.currentDirectoryURL = dir
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+        try process.run()
+        process.waitUntilExit()
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0 else {
+            let stderr = String(data: errData, encoding: .utf8) ?? ""
+            throw NSError(
+                domain: "ShellError",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: "'\(command)' failed: \(stderr)"]
+            )
+        }
+        return String(data: outData, encoding: .utf8) ?? ""
+    }
+
+    // MARK: - Signal 1: content edits (contentVersion increments)
+
+    /// `PaneLeafView` now subscribes to `tabManager.activeTab?.contentVersion`.
+    /// This test guards that the signal actually changes on every content edit,
+    /// so the SwiftUI `.onChange` hook fires and `refreshLineDiffs` runs.
+    @Test("EditorTab.contentVersion increments on every edit — drives onChange")
+    func contentVersionIncrementsOnEdit() {
+        let manager = TabManager()
+        let url = URL(fileURLWithPath: "/tmp/pine-test-\(UUID().uuidString).txt")
+        try? "hello".write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        manager.openTab(url: url)
+        guard let initialVersion = manager.activeTab?.contentVersion else {
+            Issue.record("No active tab after openTab")
+            return
+        }
+
+        manager.updateContent("hello world")
+        let afterEdit1 = manager.activeTab?.contentVersion ?? 0
+        #expect(afterEdit1 > initialVersion)
+
+        manager.updateContent("hello world!")
+        let afterEdit2 = manager.activeTab?.contentVersion ?? 0
+        #expect(afterEdit2 > afterEdit1)
+    }
+
+    /// Edge case: the same content re-applied MUST still register as an edit
+    /// (SwiftUI onChange semantics rely on Equatable; contentVersion bumps
+    /// regardless of whether the new string equals the old one).
+    @Test("contentVersion bumps even if new content equals old")
+    func contentVersionBumpsOnNoOpEdit() {
+        let manager = TabManager()
+        let url = URL(fileURLWithPath: "/tmp/pine-test-\(UUID().uuidString).txt")
+        try? "same".write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        manager.openTab(url: url)
+        let v0 = manager.activeTab?.contentVersion ?? 0
+        manager.updateContent("same")
+        let v1 = manager.activeTab?.contentVersion ?? 0
+        #expect(v1 > v0, "contentVersion must bump on every updateContent call")
+    }
+
+    // MARK: - Signal 2: git state changes (fileStatuses, currentBranch, isGitRepository)
+
+    @Test("GitStatusProvider.fileStatuses changes after a file is modified and refresh() runs")
+    func fileStatusesChangesOnModifyAndRefresh() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        let provider = GitStatusProvider()
+        provider.setup(repositoryURL: dir)
+        let initialStatuses = provider.fileStatuses
+        #expect(initialStatuses.isEmpty, "clean repo should have no modified files")
+
+        // Modify the tracked file
+        try "line1\nLINE-TWO\nline3\n".write(
+            to: dir.appendingPathComponent("file.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        provider.refresh()
+
+        #expect(provider.fileStatuses.isEmpty == false, "modified file should appear in fileStatuses")
+        #expect(initialStatuses != provider.fileStatuses,
+                "fileStatuses must differ after modification — drives onChange subscription")
+    }
+
+    @Test("GitStatusProvider.isGitRepository transitions false→true on setup")
+    func isGitRepositoryTransition() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        let provider = GitStatusProvider()
+        #expect(provider.isGitRepository == false)
+
+        provider.setup(repositoryURL: dir)
+        #expect(provider.isGitRepository == true,
+                "isGitRepository must flip true — drives PaneLeafView initial diff load")
+    }
+
+    @Test("GitStatusProvider.currentBranch updates on branch checkout")
+    func currentBranchUpdatesOnCheckout() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        let provider = GitStatusProvider()
+        provider.setup(repositoryURL: dir)
+        let initialBranch = provider.currentBranch
+        #expect(initialBranch.isEmpty == false)
+
+        try runShell("git checkout -b feature", at: dir)
+        provider.refresh()
+
+        #expect(provider.currentBranch == "feature")
+        #expect(provider.currentBranch != initialBranch,
+                "currentBranch must change — drives branch-switch onChange subscription")
+    }
+
+    // MARK: - Signal 3: data pipeline behind the subscription
+
+    /// Verifies `diffForFileAsync` returns diffs for an edited tracked file.
+    /// This is the exact method `PaneLeafView.refreshLineDiffs` calls when
+    /// subscriptions fire.
+    @Test("diffForFileAsync returns diffs for edited tracked file")
+    func diffForFileAsyncReturnsDiffsAfterEdit() async throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        let provider = GitStatusProvider()
+        provider.setup(repositoryURL: dir)
+
+        let fileURL = dir.appendingPathComponent("file.txt")
+
+        // Pre-edit: no diffs
+        let before = await provider.diffForFileAsync(at: fileURL)
+        #expect(before.isEmpty, "unmodified file should report no diffs")
+
+        // Modify the file on disk (simulates save)
+        try "line1\nMODIFIED\nline3\nline4-added\n".write(
+            to: fileURL,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let after = await provider.diffForFileAsync(at: fileURL)
+        #expect(after.isEmpty == false, "modified file should report diffs")
+    }
+
+    /// Edge case: diffForFileAsync on a non-git directory returns empty.
+    @Test("diffForFileAsync returns empty for non-git workspace")
+    func diffForFileAsyncEmptyForNonGit() async throws {
+        let rawDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-nogit-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: rawDir, withIntermediateDirectories: true)
+        let dir = try resolveURL(rawDir)
+        defer { cleanup(dir) }
+
+        try "hello\n".write(
+            to: dir.appendingPathComponent("file.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let provider = GitStatusProvider()
+        provider.setup(repositoryURL: dir)
+
+        let diffs = await provider.diffForFileAsync(at: dir.appendingPathComponent("file.txt"))
+        #expect(diffs.isEmpty)
+    }
+
+    // MARK: - Signal 4: split-pane scenario — two panes, independent refresh
+
+    /// Verifies that in a split-pane layout each pane's own `TabManager`
+    /// exposes its own `activeTab?.contentVersion`, so subscriptions in each
+    /// `PaneLeafView` are independent and do not interfere.
+    @Test("split panes have independent contentVersion streams per TabManager")
+    func splitPanesIndependentContentVersion() {
+        let manager = PaneManager()
+        let firstPane = manager.activePaneID
+        let urlA = URL(fileURLWithPath: "/tmp/pine-split-a-\(UUID().uuidString).txt")
+        let urlB = URL(fileURLWithPath: "/tmp/pine-split-b-\(UUID().uuidString).txt")
+        try? "A".write(to: urlA, atomically: true, encoding: .utf8)
+        try? "B".write(to: urlB, atomically: true, encoding: .utf8)
+        defer {
+            try? FileManager.default.removeItem(at: urlA)
+            try? FileManager.default.removeItem(at: urlB)
+        }
+
+        manager.tabManager(for: firstPane)?.openTab(url: urlA)
+        guard let secondPane = manager.splitPane(firstPane, axis: .horizontal) else {
+            Issue.record("Split failed")
+            return
+        }
+        manager.tabManager(for: secondPane)?.openTab(url: urlB)
+
+        guard let tmA = manager.tabManager(for: firstPane),
+              let tmB = manager.tabManager(for: secondPane) else {
+            Issue.record("TabManagers missing after split")
+            return
+        }
+
+        let v0A = tmA.activeTab?.contentVersion ?? 0
+        let v0B = tmB.activeTab?.contentVersion ?? 0
+
+        // Edit only pane A
+        tmA.updateContent("A edited")
+
+        let v1A = tmA.activeTab?.contentVersion ?? 0
+        let v1B = tmB.activeTab?.contentVersion ?? 0
+
+        #expect(v1A > v0A, "pane A contentVersion must bump")
+        #expect(v1B == v0B, "pane B contentVersion must NOT bump — independent subscriptions")
+    }
+
+    // MARK: - Signal 5: integration — full save flow updates diffs
+
+    /// End-to-end: simulates the user editing a file in an editor tab,
+    /// saving it, and verifies `diffForFileAsync` (the method called by
+    /// the subscription handler) reflects the modification. This is the
+    /// exact flow that issue #780 reported as broken.
+    @Test("full edit → save → refresh → diffForFileAsync flow")
+    func fullEditSaveRefreshFlow() async throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        let fileURL = dir.appendingPathComponent("file.txt")
+        let provider = GitStatusProvider()
+        provider.setup(repositoryURL: dir)
+
+        // Open the file in a TabManager
+        let tabManager = TabManager()
+        tabManager.openTab(url: fileURL)
+        #expect(tabManager.activeTab != nil)
+
+        // Edit in memory
+        tabManager.updateContent("line1\nEDITED\nline3\n")
+        #expect(tabManager.activeTab?.isDirty == true)
+
+        // Save to disk
+        let saved = tabManager.saveTab(at: 0)
+        #expect(saved == true)
+        #expect(tabManager.activeTab?.isDirty == false)
+
+        // Refresh git state (what the fileStatuses onChange subscription triggers)
+        provider.refresh()
+        #expect(provider.fileStatuses.isEmpty == false,
+                "after save, fileStatuses should show the modified file")
+
+        // Fetch diffs — what refreshLineDiffs() ultimately does
+        let diffs = await provider.diffForFileAsync(at: fileURL)
+        #expect(diffs.isEmpty == false,
+                "after save, diffForFileAsync must return diffs — the bug in #780 was that this was never called")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #780.

After #707 (split panes), `PaneLeafView.refreshLineDiffs` was only called on `onChange(of: tabManager.activeTabID)`. The subscriptions that previously lived in `ContentView` were lost in the move, so the gutter diff markers stopped updating on:

1. Content edits — markers froze during typing.
2. Save / external git ops — `fileStatuses` changed but no refresh fired.
3. Initial load — `activeTabID` does not change on first render.
4. Branch switches and repo init/removal.

## What changed

`Pine/PaneLeafView.swift` — `editorLeafBody` now also subscribes to:

- `.onAppear` (initial load)
- `onChange(of: tabManager.activeTab?.contentVersion)` (edits)
- `onChange(of: workspace.gitProvider.fileStatuses)` (save / external git)
- `onChange(of: workspace.gitProvider.currentBranch)` (branch switch)
- `onChange(of: workspace.gitProvider.isGitRepository)` (repo init/remove, clears markers when not a repo)

`EditorTab.contentVersion` is already bumped on every `content` mutation, so no model changes were needed. `GitStatusProvider` is already `@Observable`.

## Tests

New `PineTests/PaneLeafGitDiffRefreshTests.swift` (9 tests) covering each signal that the new subscriptions rely on, plus edge cases:

- `contentVersion` increments on every edit (including no-op edits).
- `GitStatusProvider.fileStatuses` changes after file modification + `refresh()`.
- `isGitRepository` transition false→true on `setup()`.
- `currentBranch` updates on CLI `git checkout -b feature`.
- `diffForFileAsync` returns diffs for edited tracked files and empty for non-git workspaces.
- Split panes: two panes have independent `contentVersion` streams (editing pane A does not bump pane B).
- Full integration: open tab → edit → save → refresh → `diffForFileAsync` returns diffs (the exact flow that was broken in #780).

All tests use real temporary git repositories via `Process()`.

## Test plan

- [x] `swiftlint --strict` clean
- [x] `xcodebuild build` succeeds
- [x] `-only-testing:PineTests/PaneLeafGitDiffRefreshTests` — 9/9 passing locally (2.5s)
- [ ] Manual check: open a git-tracked file, edit a line, observe gutter markers update live
- [ ] Manual check: save the file, observe markers stay in sync
- [ ] Manual check: switch branch via UI, observe markers recompute
- [ ] Manual check: split panes, edit in pane A, verify pane B markers unaffected