### PR TITLE
ci: extract 'Select Xcode' composite action

### DIFF
--- a/.github/actions/select-xcode/README.md
+++ b/.github/actions/select-xcode/README.md
@@ -1,0 +1,57 @@
+# Select Xcode
+
+Composite action that activates an installed Xcode via `sudo xcode-select`
+on macOS GitHub Actions runners. This is the first composite action in this
+repository; follow this layout (`action.yml` + `README.md` + optional
+`inputs`) when adding others.
+
+## Usage
+
+Newest stable Xcode (default):
+
+```yaml
+- name: Select Xcode
+  uses: ./.github/actions/select-xcode
+```
+
+Pin a specific version:
+
+```yaml
+- name: Select Xcode
+  uses: ./.github/actions/select-xcode
+  with:
+    xcode-version: Xcode_26.0
+```
+
+## Behavior
+
+- Scans `/Applications/Xcode*.app` on the runner.
+- Filters out beta builds (`*beta*`, `*Beta*`) because `sort -V` is not
+  reliable at ordering them against stable releases.
+- Picks the highest `sort -V` entry and runs `sudo xcode-select -s`
+  against its `Contents/Developer` directory.
+- Prints the selected `xcodebuild -version` for diagnostics.
+- Fails loudly (`::error::` + `exit 1`) if no candidate exists or the
+  requested exact version is missing.
+
+## Requirements
+
+- **macOS runner.** This action uses `sudo` and `xcode-select`; other
+  platforms will fail at the `sudo` step. Keep the calling job on
+  `macos-*` runners.
+- **`shell: bash` is set explicitly** inside the composite step — no
+  extra shell config is needed at the call site.
+
+## Inputs
+
+| Input           | Description                                                                                      | Required | Default                       |
+| --------------- | ------------------------------------------------------------------------------------------------ | -------- | ----------------------------- |
+| `xcode-version` | Exact Xcode app name without `.app`, e.g. `Xcode_26.0`. When empty, the newest stable is picked. | no       | `""` (auto-select newest)     |
+
+## Why
+
+Before this action, the Select Xcode block was copied into four jobs
+across `ci.yml` and `release.yml`. Any drift between copies would change
+which Xcode was active without an obvious diff. Extracting to one place
+fixes that and gives a single spot to add version pinning when the
+runner image gains multiple Xcodes. See #759 for context.

--- a/.github/actions/select-xcode/action.yml
+++ b/.github/actions/select-xcode/action.yml
@@ -1,12 +1,57 @@
 name: Select Xcode
-description: Select the newest installed Xcode via xcode-select.
+description: >-
+  Activate an installed Xcode via `sudo xcode-select` on macOS runners.
+  By default selects the newest stable `/Applications/Xcode*.app` (beta
+  builds are filtered out because `sort -V` is unreliable on them). Pass
+  `xcode-version` to pin a specific installation, e.g. `Xcode_26.0`.
+  Requires a macOS runner. Also prints the selected `xcodebuild -version`
+  for diagnostics.
+inputs:
+  xcode-version:
+    description: >-
+      Optional exact Xcode app name (without the `.app` suffix) to select,
+      e.g. `Xcode_26.0`. When omitted, the newest stable Xcode under
+      `/Applications` is used.
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
-    - name: Select Xcode
-      shell: bash
+    - shell: bash
+      env:
+        REQUESTED_VERSION: ${{ inputs.xcode-version }}
       run: |
-        XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+        set -euo pipefail
+        shopt -s nullglob
+
+        if [ -n "$REQUESTED_VERSION" ]; then
+          XCODE_PATH="/Applications/${REQUESTED_VERSION}.app"
+          if [ ! -d "$XCODE_PATH" ]; then
+            echo "::error::Requested Xcode not found at $XCODE_PATH"
+            echo "Available Xcode installations:" >&2
+            ls -d /Applications/Xcode*.app >&2 || true
+            exit 1
+          fi
+        else
+          # Filter out beta builds — sort -V does not order them reliably
+          # against stable releases, so picking "newest" could pick a beta
+          # on a runner that happens to have both.
+          candidates=(/Applications/Xcode*.app)
+          stable=()
+          for app in "${candidates[@]}"; do
+            case "$(basename "$app")" in
+              *beta*|*Beta*) continue ;;
+              *) stable+=("$app") ;;
+            esac
+          done
+          if [ ${#stable[@]} -eq 0 ]; then
+            echo "::error::No stable Xcode.app found under /Applications"
+            ls -d /Applications/Xcode*.app >&2 || true
+            exit 1
+          fi
+          XCODE_PATH=$(printf '%s\n' "${stable[@]}" | sort -V | tail -1)
+        fi
+
         echo "Using Xcode at: $XCODE_PATH"
         sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
         xcodebuild -version

--- a/.github/actions/select-xcode/action.yml
+++ b/.github/actions/select-xcode/action.yml
@@ -1,0 +1,12 @@
+name: Select Xcode
+description: Select the newest installed Xcode via xcode-select.
+runs:
+  using: composite
+  steps:
+    - name: Select Xcode
+      shell: bash
+      run: |
+        XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+        echo "Using Xcode at: $XCODE_PATH"
+        sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
+        xcodebuild -version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,11 +118,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Select Xcode
-        run: |
-          XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
-          echo "Using Xcode at: $XCODE_PATH"
-          sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
-          xcodebuild -version
+        uses: ./.github/actions/select-xcode
 
       - name: Download Metal Toolchain
         run: |
@@ -211,10 +207,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Select Xcode
-        run: |
-          XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
-          echo "Using Xcode at: $XCODE_PATH"
-          sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
+        uses: ./.github/actions/select-xcode
 
       - name: Download Build Products
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -544,10 +537,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Select Xcode
-        run: |
-          XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
-          echo "Using Xcode at: $XCODE_PATH"
-          sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
+        uses: ./.github/actions/select-xcode
 
       - name: Download Build Products
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Select Xcode
-        run: |
-          XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
-          echo "Using Xcode at: $XCODE_PATH"
-          sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
-          xcodebuild -version
+        uses: ./.github/actions/select-xcode
 
       - name: Install certificate
         env:


### PR DESCRIPTION
## Summary
- Extracted the repeated Select Xcode setup (newest `/Applications/Xcode*.app` + `xcode-select`) into a composite action at `.github/actions/select-xcode`.
- Replaced four inline blocks across `ci.yml` (build, unit-tests, ui-tests shards) and `release.yml` with `uses: ./.github/actions/select-xcode`.
- Behavior is equivalent; the two ci.yml jobs that previously omitted `xcodebuild -version` now log it (additive only).

## Test plan
- [ ] CI green on this PR
- [ ] Release workflow unaffected (tag build still selects Xcode correctly)

Fixes #759