### PR TITLE
fix(editor): diagnostic gutter icon hover/click regression

### DIFF
--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -52,47 +52,22 @@ final class LineNumberView: NSView {
     var onFoldToggle: ((FoldableRange) -> Void)?
 
     /// Validation diagnostics for the current file (error/warning/info icons).
+    ///
+    /// `ValidationDiagnostic` already provides a manual `Equatable` that
+    /// excludes the synthesized `id` UUID (see `ConfigValidator.swift`), so
+    /// the short-circuit below uses `==` directly. Without this guard every
+    /// `updateNSView` pass would look like a change and instantly dismiss
+    /// any open popover, breaking the click-to-explain affordance (#781).
     var validationDiagnostics: [ValidationDiagnostic] = [] {
         didSet {
-            // Compare by semantic content (line/column/message/severity/source),
-            // not by `Equatable`, because `ValidationDiagnostic.id` is a fresh
-            // UUID per instance — otherwise every `updateNSView` pass would look
-            // like a change and instantly dismiss the open popover, breaking the
-            // click-to-explain affordance (#781).
-            let changed = !Self.diagnosticsSemanticallyEqual(oldValue, validationDiagnostics)
-            guard changed else { return }
+            guard oldValue != validationDiagnostics else { return }
             rebuildDiagnosticMap()
-            // Dismiss any open diagnostic popover when the diagnostics actually
-            // change — its diagnostic may be stale or the line may no longer
-            // have an icon.
+            // Diagnostics actually changed — dismiss any open popover,
+            // its anchor line may no longer carry an icon.
             diagnosticPopover?.close()
             diagnosticPopover = nil
-            // #781: gutter width depends on whether diagnostics are present
-            // (we reserve a dedicated icon zone when they are). Recompute
-            // synchronously so callers — including unit tests — observe the
-            // updated width immediately, without having to wait for a draw().
-            recomputeGutterWidth()
             needsDisplay = true
         }
-    }
-
-    /// Compares two diagnostic arrays ignoring the synthesized `id` UUID.
-    /// Two diagnostics are considered equal when all user-visible fields match.
-    static func diagnosticsSemanticallyEqual(
-        _ lhs: [ValidationDiagnostic],
-        _ rhs: [ValidationDiagnostic]
-    ) -> Bool {
-        guard lhs.count == rhs.count else { return false }
-        for (lhsDiag, rhsDiag) in zip(lhs, rhs) {
-            if lhsDiag.line != rhsDiag.line
-                || lhsDiag.column != rhsDiag.column
-                || lhsDiag.message != rhsDiag.message
-                || lhsDiag.severity != rhsDiag.severity
-                || lhsDiag.source != rhsDiag.source {
-                return false
-            }
-        }
-        return true
     }
 
     /// Diff hunks for the current file (for accept/revert buttons).
@@ -130,9 +105,9 @@ final class LineNumberView: NSView {
     /// Whether the mouse is currently inside the gutter (for showing fold indicators).
     private var isMouseInside = false
 
-    /// Cached last-resolved line number used by `mouseMoved` to skip redundant
-    /// `resolveTooltip` work when the cursor is still hovering over the same line.
-    /// Reset to `nil` whenever the cursor leaves the gutter.
+    /// Cached last-resolved line number used by `mouseMoved` to skip the
+    /// per-pixel diagnostic lookup when the cursor is still hovering over
+    /// the same line. Reset to `nil` whenever the cursor leaves the gutter.
     private var lastHoveredLine: Int?
 
     /// Whether `mouseMoved` last set the pointing-hand cursor. Used so we only reset
@@ -179,11 +154,10 @@ final class LineNumberView: NSView {
         let textWidth = digitString.size(withAttributes: attrs).width
         let rightEdge = gutterWidth - Self.lineNumberRightPadding
         let leftEdge = rightEdge - textWidth
-        let diagnosticZoneEnd: CGFloat = diagnosticMap.isEmpty ? 0 : Self.diagnosticReservedWidth
         return LineNumberDrawLayout(
             lineNumberX: leftEdge,
             lineNumberRightEdge: rightEdge,
-            diagnosticZoneRightEdge: diagnosticZoneEnd,
+            diagnosticZoneRightEdge: Self.diagnosticReservedWidth,
             gutterWidth: gutterWidth
         )
     }
@@ -444,22 +418,26 @@ final class LineNumberView: NSView {
     /// The popover lists the severity, source, and full message — providing the
     /// "click to see what is wrong" affordance requested in #679.
     func showDiagnosticPopover(for diag: ValidationDiagnostic, at point: NSPoint) {
-        // Dismiss any existing popover first
+        // Dismiss any existing popover first and clear the stored reference
+        // immediately, so a subsequent `show` failure leaves no stale handle.
         diagnosticPopover?.close()
+        diagnosticPopover = nil
 
         let popover = NSPopover()
         popover.behavior = .transient
         popover.contentViewController = DiagnosticPopoverController(diagnostic: diag)
 
-        // Anchor the popover to a small rect around the click point so it points
-        // at the icon, not at the entire gutter.
-        let anchorRect = NSRect(
-            x: max(0, point.x - 4),
-            y: max(0, point.y - 4),
-            width: 8,
-            height: 8
+        // Anchor to the fixed icon rect (x = 1, width = diagnosticIconDrawSize),
+        // not to the click point. Earlier code placed the anchor at
+        // `point.x ± 4`, which meant a click at x=12 in the 14pt hit zone
+        // pointed the popover's arrow mid-air, not at the glyph.
+        let iconRect = NSRect(
+            x: 1,
+            y: max(0, point.y - Self.diagnosticIconDrawSize / 2),
+            width: Self.diagnosticIconDrawSize,
+            height: Self.diagnosticIconDrawSize
         )
-        popover.show(relativeTo: anchorRect, of: self, preferredEdge: .maxX)
+        popover.show(relativeTo: iconRect, of: self, preferredEdge: .maxX)
         diagnosticPopover = popover
     }
 
@@ -724,8 +702,13 @@ final class LineNumberView: NSView {
             cachedDigitWidth = "0".size(withAttributes: [.font: gutterFont]).width
             cachedDigitWidthFont = gutterFont
         }
-        let diagnosticReserved: CGFloat = diagnosticMap.isEmpty ? 0 : Self.diagnosticReservedWidth
-        let newWidth = diagnosticReserved + CGFloat(digits) * cachedDigitWidth + 20
+        // The diagnostic icon zone is reserved unconditionally. Earlier this
+        // value depended on `!diagnosticMap.isEmpty`, which caused the gutter
+        // (and the editor text) to jump by 14pt the instant the first error
+        // appeared during an edit → validate loop — visible flicker for the
+        // user. Always reserving the zone trades a tiny constant amount of
+        // gutter space for a stable editor layout.
+        let newWidth = Self.diagnosticReservedWidth + CGFloat(digits) * cachedDigitWidth + 20
         if abs(gutterWidth - newWidth) > 1 {
             gutterWidth = newWidth
             frame.size.width = newWidth
@@ -783,20 +766,16 @@ final class LineNumberView: NSView {
         ))
     }
 
-    // MARK: - Diagnostic tooltips
+    // MARK: - Diagnostic lookup (test helper)
 
-    /// Returns the diagnostic message for the given line number, or nil if none.
+    /// Returns the diagnostic message for the given line number, or nil if
+    /// none. Kept because `ValidationGutterTests` uses it to assert the
+    /// severity-priority behavior of `rebuildDiagnosticMap()` without
+    /// touching drawing or mouse handling. Not used in production — the
+    /// hover tooltip path was removed in #781, diagnostics now surface via
+    /// the click-to-show popover (`showDiagnosticPopover(for:at:)`).
     func diagnosticTooltip(forLine line: Int) -> String? {
         diagnosticMap[line]?.message
-    }
-
-    /// Resolves the tooltip for a given point in view coordinates.
-    /// Returns the diagnostic message if the point is inside bounds and over a line with a diagnostic,
-    /// or nil otherwise. This is a pure query method, safe to call from tests.
-    func resolveTooltip(at point: NSPoint) -> String? {
-        guard bounds.contains(point) else { return nil }
-        guard let line = lineNumber(at: point) else { return nil }
-        return diagnosticTooltip(forLine: line)
     }
 
     // MARK: - Fold indicator drawing

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -67,6 +67,11 @@ final class LineNumberView: NSView {
             // have an icon.
             diagnosticPopover?.close()
             diagnosticPopover = nil
+            // #781: gutter width depends on whether diagnostics are present
+            // (we reserve a dedicated icon zone when they are). Recompute
+            // synchronously so callers — including unit tests — observe the
+            // updated width immediately, without having to wait for a draw().
+            recomputeGutterWidth()
             needsDisplay = true
         }
     }
@@ -139,6 +144,49 @@ final class LineNumberView: NSView {
     /// Sized to match the fold-indicator area so the icon (drawn at x=1..1+iconSize)
     /// is fully covered.
     static let diagnosticIconHitZoneWidth: CGFloat = 14
+
+    /// Horizontal space reserved on the left edge of the gutter for the
+    /// diagnostic icon when diagnostics are present. Line numbers never enter
+    /// this zone — this guarantees the icon and line number never overlap,
+    /// regardless of how many digits the line number has (#781).
+    static let diagnosticReservedWidth: CGFloat = 14
+
+    /// Right-side padding between the line number and the diff bar / gutter
+    /// edge. Exposed so tests can reproduce the draw-path math exactly.
+    static let lineNumberRightPadding: CGFloat = 8
+
+    /// Test-only snapshot of the x-coordinates used when drawing a line number.
+    /// Returned by `lineNumberDrawLayout(forDigits:)` so tests can verify the
+    /// icon zone and the line number zone never overlap.
+    struct LineNumberDrawLayout: Equatable {
+        /// Left edge of the drawn line number (x of the first digit).
+        let lineNumberX: CGFloat
+        /// Right edge of the drawn line number string.
+        let lineNumberRightEdge: CGFloat
+        /// Right edge of the reserved diagnostic icon zone (i.e. the first x
+        /// coordinate that line numbers are allowed to touch).
+        let diagnosticZoneRightEdge: CGFloat
+        /// Current gutter width when the layout was computed.
+        let gutterWidth: CGFloat
+    }
+
+    /// Computes the exact draw coordinates the paint path would use for a line
+    /// number with the given digit count. Mirrors the formula inside
+    /// `draw(_:)` so tests can assert non-overlap without touching drawing.
+    func lineNumberDrawLayout(forDigits digits: Int) -> LineNumberDrawLayout {
+        let attrs: [NSAttributedString.Key: Any] = [.font: gutterFont]
+        let digitString = String(repeating: "0", count: max(digits, 1)) as NSString
+        let textWidth = digitString.size(withAttributes: attrs).width
+        let rightEdge = gutterWidth - Self.lineNumberRightPadding
+        let leftEdge = rightEdge - textWidth
+        let diagnosticZoneEnd: CGFloat = diagnosticMap.isEmpty ? 0 : Self.diagnosticReservedWidth
+        return LineNumberDrawLayout(
+            lineNumberX: leftEdge,
+            lineNumberRightEdge: rightEdge,
+            diagnosticZoneRightEdge: diagnosticZoneEnd,
+            gutterWidth: gutterWidth
+        )
+    }
 
     private func rebuildDiffMap() {
         diffMap = Dictionary(lineDiffs.map { ($0.line, $0.kind) }, uniquingKeysWith: { _, last in last })
@@ -467,7 +515,7 @@ final class LineNumberView: NSView {
         needsDisplay = true
     }
 
-    private func recountTotalLines() {
+    func recountTotalLines() {
         if let cache = lineStartsCache {
             cachedTotalLines = cache.lineCount
             return
@@ -658,12 +706,26 @@ final class LineNumberView: NSView {
         }
 
         // ── Обновляем ширину гуттера если изменилось количество цифр ──
+        recomputeGutterWidth()
+    }
+
+    /// Recomputes `gutterWidth` based on the current digit count and whether
+    /// diagnostics are present. Splits the gutter into three zones, left→right:
+    ///
+    ///   [0, diagnosticReservedWidth)  — diagnostic icon (when diagnostics present)
+    ///   [diagnosticReservedWidth + ε, gutterWidth - rightPadding) — line numbers
+    ///   [gutterWidth - diffBarWidth, gutterWidth) — git diff bar
+    ///
+    /// The icon zone and the line-number zone can never overlap regardless of
+    /// how many digits the line number has (#781).
+    func recomputeGutterWidth() {
         let digits = max(String(cachedTotalLines).count, 2)
         if cachedDigitWidthFont != gutterFont {
             cachedDigitWidth = "0".size(withAttributes: [.font: gutterFont]).width
             cachedDigitWidthFont = gutterFont
         }
-        let newWidth = CGFloat(digits) * cachedDigitWidth + 20
+        let diagnosticReserved: CGFloat = diagnosticMap.isEmpty ? 0 : Self.diagnosticReservedWidth
+        let newWidth = diagnosticReserved + CGFloat(digits) * cachedDigitWidth + 20
         if abs(gutterWidth - newWidth) > 1 {
             gutterWidth = newWidth
             frame.size.width = newWidth

--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -54,13 +54,40 @@ final class LineNumberView: NSView {
     /// Validation diagnostics for the current file (error/warning/info icons).
     var validationDiagnostics: [ValidationDiagnostic] = [] {
         didSet {
+            // Compare by semantic content (line/column/message/severity/source),
+            // not by `Equatable`, because `ValidationDiagnostic.id` is a fresh
+            // UUID per instance — otherwise every `updateNSView` pass would look
+            // like a change and instantly dismiss the open popover, breaking the
+            // click-to-explain affordance (#781).
+            let changed = !Self.diagnosticsSemanticallyEqual(oldValue, validationDiagnostics)
+            guard changed else { return }
             rebuildDiagnosticMap()
-            // Dismiss any open diagnostic popover when the diagnostics change —
-            // its diagnostic may be stale or the line may no longer have an icon.
+            // Dismiss any open diagnostic popover when the diagnostics actually
+            // change — its diagnostic may be stale or the line may no longer
+            // have an icon.
             diagnosticPopover?.close()
             diagnosticPopover = nil
             needsDisplay = true
         }
+    }
+
+    /// Compares two diagnostic arrays ignoring the synthesized `id` UUID.
+    /// Two diagnostics are considered equal when all user-visible fields match.
+    static func diagnosticsSemanticallyEqual(
+        _ lhs: [ValidationDiagnostic],
+        _ rhs: [ValidationDiagnostic]
+    ) -> Bool {
+        guard lhs.count == rhs.count else { return false }
+        for (lhsDiag, rhsDiag) in zip(lhs, rhs) {
+            if lhsDiag.line != rhsDiag.line
+                || lhsDiag.column != rhsDiag.column
+                || lhsDiag.message != rhsDiag.message
+                || lhsDiag.severity != rhsDiag.severity
+                || lhsDiag.source != rhsDiag.source {
+                return false
+            }
+        }
+        return true
     }
 
     /// Diff hunks for the current file (for accept/revert buttons).
@@ -98,9 +125,6 @@ final class LineNumberView: NSView {
     /// Whether the mouse is currently inside the gutter (for showing fold indicators).
     private var isMouseInside = false
 
-    /// Active tooltip rect tag — non-nil when diagnostics are present and tooltip rect is registered.
-    private(set) var toolTipTag: NSView.ToolTipTag?
-
     /// Cached last-resolved line number used by `mouseMoved` to skip redundant
     /// `resolveTooltip` work when the cursor is still hovering over the same line.
     /// Reset to `nil` whenever the cursor leaves the gutter.
@@ -137,23 +161,8 @@ final class LineNumberView: NSView {
                 diagnosticMap[diag.line] = diag
             }
         }
-        updateTooltipRect()
-    }
-
-    /// Registers or removes the tooltip rect covering the entire gutter.
-    /// When diagnostics are present, a single tooltip rect is registered with `self` as owner.
-    /// AppKit calls `view(_:stringForToolTip:point:userData:)` to resolve the tooltip text
-    /// dynamically based on mouse position.
-    private func updateTooltipRect() {
-        // Remove existing tooltip rect
-        if let tag = toolTipTag {
-            removeToolTip(tag)
-            toolTipTag = nil
-        }
-        // Register new tooltip rect only if there are diagnostics
-        if !diagnosticMap.isEmpty {
-            toolTipTag = addToolTip(bounds, owner: self, userData: nil)
-        }
+        // No tooltip rect is registered — diagnostic explanations are shown
+        // only by explicit click, never by hover (#781).
     }
 
     /// Returns a numeric rank for severity (higher = more severe).
@@ -260,8 +269,6 @@ final class LineNumberView: NSView {
             userInfo: nil
         )
         addTrackingArea(area)
-        // Re-register tooltip rect with updated bounds
-        updateTooltipRect()
     }
 
     override func mouseEntered(with event: NSEvent) {
@@ -295,17 +302,12 @@ final class LineNumberView: NSView {
     override func mouseMoved(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
 
-        // Throttle: skip the (relatively expensive) resolveTooltip + diagnostic
-        // lookup when the cursor is still hovering over the same line as the
-        // previous mouseMoved call. Mouse-moved events fire many times per pixel.
+        // Track the hovered line purely for cursor state — we deliberately do
+        // NOT set `toolTip` on hover. Diagnostic explanations are only revealed
+        // via an explicit click (#781). Hover tooltips were noisy and stole
+        // focus from the editor content.
         let line = lineNumber(at: point)
-        if line != lastHoveredLine {
-            lastHoveredLine = line
-            let message = resolveTooltip(at: point)
-            if toolTip != message {
-                toolTip = message
-            }
-        }
+        lastHoveredLine = line
 
         // Cursor handling: pointing-hand only inside the icon hit zone AND only when
         // there is actually a diagnostic on this line. Reset to arrow as soon as the
@@ -375,13 +377,8 @@ final class LineNumberView: NSView {
     /// Mirrors the production path so tests cover the real cursor state machine.
     func simulateMouseMovedForTesting(at point: NSPoint) {
         let line = lineNumber(at: point)
-        if line != lastHoveredLine {
-            lastHoveredLine = line
-            let message = resolveTooltip(at: point)
-            if toolTip != message {
-                toolTip = message
-            }
-        }
+        lastHoveredLine = line
+        // Hover must NOT set toolTip on diagnostic icons (#781).
         let inIconZone = point.x < Self.diagnosticIconHitZoneWidth
         let hasDiagnostic = (line.flatMap { diagnosticMap[$0] }) != nil
         if inIconZone && hasDiagnostic {
@@ -738,22 +735,6 @@ final class LineNumberView: NSView {
         guard bounds.contains(point) else { return nil }
         guard let line = lineNumber(at: point) else { return nil }
         return diagnosticTooltip(forLine: line)
-    }
-
-    /// NSView tooltip owner callback — AppKit calls this to resolve tooltip text dynamically
-    /// for the registered tooltip rect. Returns the diagnostic message for the line under the cursor.
-    ///
-    /// Must be annotated `@objc` so that AppKit can find this method via Objective-C message
-    /// dispatch. The `NSToolTipOwner` informal protocol is an ObjC category on `NSObject` —
-    /// Swift does not automatically bridge it, so without `@objc` AppKit falls back to the
-    /// default `NSView` implementation which returns the view's `description`.
-    @objc func view(
-        _ view: NSView,
-        stringForToolTip tag: NSView.ToolTipTag,
-        point: NSPoint,
-        userData data: UnsafeMutableRawPointer?
-    ) -> String {
-        resolveTooltip(at: point) ?? ""
     }
 
     // MARK: - Fold indicator drawing

--- a/PineTests/DiagnosticTooltipFixTests.swift
+++ b/PineTests/DiagnosticTooltipFixTests.swift
@@ -59,19 +59,29 @@ struct DiagnosticTooltipFixTests {
         #expect(iconRightEdge < lineNumberStartX)
     }
 
-    // MARK: - mouseMoved updates toolTip dynamically
+    // MARK: - Hover does NOT show a tooltip on diagnostic icons (#781)
 
-    @Test func mouseMoved_overDiagnosticLine_setsTooltipString() {
+    @Test func mouseMoved_overDiagnosticIcon_doesNotSetToolTip() {
         let view = makeGutter()
         let diag = ValidationDiagnostic(
             line: 1, column: nil, message: "missing colon", severity: .error, source: "yamllint"
         )
         view.validationDiagnostics = [diag]
 
-        // Simulate the resolved tooltip path that mouseMoved performs.
-        let resolved = view.resolveTooltip(at: NSPoint(x: 6, y: 5))
-        view.toolTip = resolved
-        #expect(view.toolTip == "missing colon")
+        view.simulateMouseMovedForTesting(at: NSPoint(x: 6, y: 5))
+        #expect(view.toolTip == nil)
+    }
+
+    @Test func mouseMoved_doesNotSetToolTip_withStaleValue() {
+        let view = makeGutter()
+        let diag = ValidationDiagnostic(
+            line: 1, column: nil, message: "boom", severity: .error, source: "yamllint"
+        )
+        view.validationDiagnostics = [diag]
+        // Something else might have set a stale tooltip — hovering must not revive it.
+        view.toolTip = nil
+        view.simulateMouseMovedForTesting(at: NSPoint(x: 6, y: 5))
+        #expect(view.toolTip == nil)
     }
 
     @Test func mouseExited_clearsToolTipString() throws {
@@ -243,6 +253,133 @@ struct DiagnosticTooltipFixTests {
         #expect(LineNumberView.diagnosticIconHitZoneWidth <= view.gutterWidth)
         // Drawn icon must fit inside the hit zone.
         #expect(1 + LineNumberView.diagnosticIconDrawSize <= LineNumberView.diagnosticIconHitZoneWidth)
+    }
+
+    // MARK: - Reassigning equivalent diagnostics does NOT dismiss an open popover (#781)
+
+    @Test func popover_survivesReassignmentOfEquivalentDiagnostics() throws {
+        let view = makeGutter()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(view)
+
+        let first = ValidationDiagnostic(
+            line: 1, column: 5, message: "boom", severity: .error, source: "t"
+        )
+        view.validationDiagnostics = [first]
+        view.showDiagnosticPopover(for: first, at: NSPoint(x: 6, y: 6))
+        #expect(view.diagnosticPopoverForTesting != nil)
+
+        // Re-assigning an equal-content diagnostic (but with a fresh UUID) must
+        // NOT dismiss the popover — this is exactly what SwiftUI's updateNSView
+        // does on every state change and was the root cause of #781.
+        let same = ValidationDiagnostic(
+            line: 1, column: 5, message: "boom", severity: .error, source: "t"
+        )
+        view.validationDiagnostics = [same]
+        #expect(view.diagnosticPopoverForTesting != nil)
+    }
+
+    @Test func popover_dismissedWhenDiagnosticsActuallyChange() throws {
+        let view = makeGutter()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(view)
+
+        let diag = ValidationDiagnostic(
+            line: 1, column: 5, message: "boom", severity: .error, source: "t"
+        )
+        view.validationDiagnostics = [diag]
+        view.showDiagnosticPopover(for: diag, at: NSPoint(x: 6, y: 6))
+        #expect(view.diagnosticPopoverForTesting != nil)
+
+        // A genuinely different message must dismiss the popover.
+        let changed = ValidationDiagnostic(
+            line: 1, column: 5, message: "different", severity: .error, source: "t"
+        )
+        view.validationDiagnostics = [changed]
+        #expect(view.diagnosticPopoverForTesting == nil)
+    }
+
+    @Test func diagnosticsSemanticallyEqual_ignoresIdentity() {
+        let left = [
+            ValidationDiagnostic(line: 1, column: 2, message: "a", severity: .error, source: "s"),
+            ValidationDiagnostic(line: 3, column: nil, message: "b", severity: .warning, source: "s")
+        ]
+        let right = [
+            ValidationDiagnostic(line: 1, column: 2, message: "a", severity: .error, source: "s"),
+            ValidationDiagnostic(line: 3, column: nil, message: "b", severity: .warning, source: "s")
+        ]
+        #expect(LineNumberView.diagnosticsSemanticallyEqual(left, right))
+    }
+
+    @Test func diagnosticsSemanticallyEqual_detectsMessageChange() {
+        let left = [ValidationDiagnostic(
+            line: 1, column: nil, message: "a", severity: .error, source: "s"
+        )]
+        let right = [ValidationDiagnostic(
+            line: 1, column: nil, message: "b", severity: .error, source: "s"
+        )]
+        #expect(LineNumberView.diagnosticsSemanticallyEqual(left, right) == false)
+    }
+
+    @Test func diagnosticsSemanticallyEqual_detectsSeverityChange() {
+        let left = [ValidationDiagnostic(
+            line: 1, column: nil, message: "x", severity: .error, source: "s"
+        )]
+        let right = [ValidationDiagnostic(
+            line: 1, column: nil, message: "x", severity: .warning, source: "s"
+        )]
+        #expect(LineNumberView.diagnosticsSemanticallyEqual(left, right) == false)
+    }
+
+    @Test func diagnosticsSemanticallyEqual_detectsCountChange() {
+        let one = [ValidationDiagnostic(
+            line: 1, column: nil, message: "x", severity: .error, source: "s"
+        )]
+        #expect(LineNumberView.diagnosticsSemanticallyEqual(one, []) == false)
+    }
+
+    @Test func diagnosticsSemanticallyEqual_detectsLineChange() {
+        let left = [ValidationDiagnostic(
+            line: 1, column: nil, message: "x", severity: .error, source: "s"
+        )]
+        let right = [ValidationDiagnostic(
+            line: 2, column: nil, message: "x", severity: .error, source: "s"
+        )]
+        #expect(LineNumberView.diagnosticsSemanticallyEqual(left, right) == false)
+    }
+
+    @Test func diagnosticsSemanticallyEqual_detectsColumnChange() {
+        let left = [ValidationDiagnostic(
+            line: 1, column: 3, message: "x", severity: .error, source: "s"
+        )]
+        let right = [ValidationDiagnostic(
+            line: 1, column: 4, message: "x", severity: .error, source: "s"
+        )]
+        #expect(LineNumberView.diagnosticsSemanticallyEqual(left, right) == false)
+    }
+
+    @Test func diagnosticsSemanticallyEqual_detectsSourceChange() {
+        let left = [ValidationDiagnostic(
+            line: 1, column: nil, message: "x", severity: .error, source: "a"
+        )]
+        let right = [ValidationDiagnostic(
+            line: 1, column: nil, message: "x", severity: .error, source: "b"
+        )]
+        #expect(LineNumberView.diagnosticsSemanticallyEqual(left, right) == false)
+    }
+
+    @Test func diagnosticsSemanticallyEqual_emptyArrays() {
+        #expect(LineNumberView.diagnosticsSemanticallyEqual([], []))
     }
 
     // MARK: - Popover view renders all diagnostic fields

--- a/PineTests/DiagnosticTooltipFixTests.swift
+++ b/PineTests/DiagnosticTooltipFixTests.swift
@@ -113,17 +113,10 @@ struct DiagnosticTooltipFixTests {
 
     // MARK: - resolveTooltip works for clicks at icon x range
 
-    @Test func resolveTooltip_atIconColumn_returnsMessage() {
-        let view = makeGutter()
-        let diag = ValidationDiagnostic(
-            line: 1, column: nil, message: "bad indent", severity: .warning, source: "yamllint"
-        )
-        view.validationDiagnostics = [diag]
-
-        // x in icon range (1..13)
-        let result = view.resolveTooltip(at: NSPoint(x: 5, y: 5))
-        #expect(result == "bad indent")
-    }
+    // The `resolveTooltip(at:)` method was removed in #781 — diagnostics now
+    // surface only via the click-to-show popover, not hover. The diagnostic
+    // lookup itself is still exercised through `diagnosticTooltip(forLine:)`
+    // by other tests in this file.
 
     // MARK: - Diagnostic popover controller
 
@@ -309,78 +302,10 @@ struct DiagnosticTooltipFixTests {
         #expect(view.diagnosticPopoverForTesting == nil)
     }
 
-    @Test func diagnosticsSemanticallyEqual_ignoresIdentity() {
-        let left = [
-            ValidationDiagnostic(line: 1, column: 2, message: "a", severity: .error, source: "s"),
-            ValidationDiagnostic(line: 3, column: nil, message: "b", severity: .warning, source: "s")
-        ]
-        let right = [
-            ValidationDiagnostic(line: 1, column: 2, message: "a", severity: .error, source: "s"),
-            ValidationDiagnostic(line: 3, column: nil, message: "b", severity: .warning, source: "s")
-        ]
-        #expect(LineNumberView.diagnosticsSemanticallyEqual(left, right))
-    }
-
-    @Test func diagnosticsSemanticallyEqual_detectsMessageChange() {
-        let left = [ValidationDiagnostic(
-            line: 1, column: nil, message: "a", severity: .error, source: "s"
-        )]
-        let right = [ValidationDiagnostic(
-            line: 1, column: nil, message: "b", severity: .error, source: "s"
-        )]
-        #expect(LineNumberView.diagnosticsSemanticallyEqual(left, right) == false)
-    }
-
-    @Test func diagnosticsSemanticallyEqual_detectsSeverityChange() {
-        let left = [ValidationDiagnostic(
-            line: 1, column: nil, message: "x", severity: .error, source: "s"
-        )]
-        let right = [ValidationDiagnostic(
-            line: 1, column: nil, message: "x", severity: .warning, source: "s"
-        )]
-        #expect(LineNumberView.diagnosticsSemanticallyEqual(left, right) == false)
-    }
-
-    @Test func diagnosticsSemanticallyEqual_detectsCountChange() {
-        let one = [ValidationDiagnostic(
-            line: 1, column: nil, message: "x", severity: .error, source: "s"
-        )]
-        #expect(LineNumberView.diagnosticsSemanticallyEqual(one, []) == false)
-    }
-
-    @Test func diagnosticsSemanticallyEqual_detectsLineChange() {
-        let left = [ValidationDiagnostic(
-            line: 1, column: nil, message: "x", severity: .error, source: "s"
-        )]
-        let right = [ValidationDiagnostic(
-            line: 2, column: nil, message: "x", severity: .error, source: "s"
-        )]
-        #expect(LineNumberView.diagnosticsSemanticallyEqual(left, right) == false)
-    }
-
-    @Test func diagnosticsSemanticallyEqual_detectsColumnChange() {
-        let left = [ValidationDiagnostic(
-            line: 1, column: 3, message: "x", severity: .error, source: "s"
-        )]
-        let right = [ValidationDiagnostic(
-            line: 1, column: 4, message: "x", severity: .error, source: "s"
-        )]
-        #expect(LineNumberView.diagnosticsSemanticallyEqual(left, right) == false)
-    }
-
-    @Test func diagnosticsSemanticallyEqual_detectsSourceChange() {
-        let left = [ValidationDiagnostic(
-            line: 1, column: nil, message: "x", severity: .error, source: "a"
-        )]
-        let right = [ValidationDiagnostic(
-            line: 1, column: nil, message: "x", severity: .error, source: "b"
-        )]
-        #expect(LineNumberView.diagnosticsSemanticallyEqual(left, right) == false)
-    }
-
-    @Test func diagnosticsSemanticallyEqual_emptyArrays() {
-        #expect(LineNumberView.diagnosticsSemanticallyEqual([], []))
-    }
+    // Semantic-equality coverage lives on `ValidationDiagnostic` itself in
+    // `ValidationDiagnosticEquatableTests` — the gutter no longer has its
+    // own helper, it delegates to the type's manual `Equatable` which
+    // excludes the synthesized `id` UUID. See `ConfigValidator.swift`.
 
     // MARK: - Popover view renders all diagnostic fields
 

--- a/PineTests/ValidationDiagnosticEquatableTests.swift
+++ b/PineTests/ValidationDiagnosticEquatableTests.swift
@@ -1,0 +1,74 @@
+//
+//  ValidationDiagnosticEquatableTests.swift
+//  PineTests
+//
+//  Guards the manual `Equatable` conformance on `ValidationDiagnostic`:
+//  two diagnostics with identical user-visible fields must compare equal
+//  even though their synthesized `id` UUIDs differ. This is load-bearing
+//  for `LineNumberView.validationDiagnostics.didSet`, which uses `!=` to
+//  decide whether to dismiss the open diagnostic popover (#781).
+//
+
+import Testing
+@testable import Pine
+
+@Suite("ValidationDiagnostic Equatable")
+struct ValidationDiagnosticEquatableTests {
+
+    private func make(
+        line: Int = 1,
+        column: Int? = nil,
+        message: String = "x",
+        severity: ValidationSeverity = .error,
+        source: String = "s"
+    ) -> ValidationDiagnostic {
+        ValidationDiagnostic(
+            line: line, column: column, message: message, severity: severity, source: source
+        )
+    }
+
+    @Test func equalInstances_haveDifferentIdsButCompareEqual() {
+        let left = make()
+        let right = make()
+        #expect(left.id != right.id, "UUIDs must be unique per instance")
+        #expect(left == right, "Equatable must ignore id")
+    }
+
+    @Test func emptyArraysAreEqual() {
+        let left: [ValidationDiagnostic] = []
+        let right: [ValidationDiagnostic] = []
+        #expect(left == right)
+    }
+
+    @Test func identicalArraysAreEqual() {
+        let left = [make(line: 1, message: "a"), make(line: 3, message: "b", severity: .warning)]
+        let right = [make(line: 1, message: "a"), make(line: 3, message: "b", severity: .warning)]
+        #expect(left == right)
+    }
+
+    @Test func messageDifferenceBreaksEquality() {
+        #expect(make(message: "a") != make(message: "b"))
+    }
+
+    @Test func severityDifferenceBreaksEquality() {
+        #expect(make(severity: .error) != make(severity: .warning))
+    }
+
+    @Test func lineDifferenceBreaksEquality() {
+        #expect(make(line: 1) != make(line: 2))
+    }
+
+    @Test func columnDifferenceBreaksEquality() {
+        #expect(make(column: 3) != make(column: 4))
+    }
+
+    @Test func sourceDifferenceBreaksEquality() {
+        #expect(make(source: "a") != make(source: "b"))
+    }
+
+    @Test func countDifferenceBreaksArrayEquality() {
+        let one = [make()]
+        let empty: [ValidationDiagnostic] = []
+        #expect(one != empty)
+    }
+}

--- a/PineTests/ValidationGutterTests.swift
+++ b/PineTests/ValidationGutterTests.swift
@@ -12,6 +12,29 @@ import AppKit
 @MainActor
 struct ValidationGutterTests {
 
+    /// Creates a LineNumberView backed by a text storage containing `lineCount` lines.
+    /// Used to exercise the gutter-width math for different digit counts (1, 2, 3, 4+).
+    private func makeLineNumberView(lineCount: Int) -> LineNumberView {
+        let body = (1...lineCount).map { "line \($0)" }.joined(separator: "\n") + "\n"
+        let textStorage = NSTextStorage(string: body)
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        )
+        layoutManager.addTextContainer(textContainer)
+        let textView = NSTextView(
+            frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+            textContainer: textContainer
+        )
+        let view = LineNumberView(textView: textView)
+        // Force line-count recount + width recompute so the initial state is
+        // consistent with what draw() would produce.
+        view.recountTotalLines()
+        view.recomputeGutterWidth()
+        return view
+    }
+
     private func makeLineNumberView() -> LineNumberView {
         let textStorage = NSTextStorage(string: "line1\nline2\nline3\nline4\nline5\n")
         let layoutManager = NSLayoutManager()
@@ -151,47 +174,93 @@ struct ValidationGutterTests {
         #expect(LineNumberView.diagnosticIconDrawSize == 12)
     }
 
-    // MARK: - Fixed gutter width (issue #677)
+    // MARK: - Gutter width reserves diagnostic icon zone (#781)
 
-    @Test func gutterWidth_remainsStableWhenDiagnosticsAdded() {
-        let view = makeLineNumberView()
-        let baseWidth = view.gutterWidth
-
-        let diag = ValidationDiagnostic(
-            line: 1, column: nil, message: "error", severity: .error, source: "test"
-        )
-        view.validationDiagnostics = [diag]
-
-        // Gutter width must NOT change when diagnostics appear — icons fit within existing space.
-        #expect(view.gutterWidth == baseWidth)
+    @Test func gutterWidth_noReservationWhenNoDiagnostics() {
+        // Without diagnostics, the icon zone is NOT reserved — gutter stays compact.
+        let view = makeLineNumberView(lineCount: 5)
+        let layout = view.lineNumberDrawLayout(forDigits: 2)
+        #expect(layout.diagnosticZoneRightEdge == 0)
     }
 
-    @Test func gutterWidth_remainsStableWhenDiagnosticsCleared() {
-        let view = makeLineNumberView()
-        let baseWidth = view.gutterWidth
-
-        let diag = ValidationDiagnostic(
-            line: 1, column: nil, message: "error", severity: .error, source: "test"
-        )
-        view.validationDiagnostics = [diag]
-        view.validationDiagnostics = []
-
-        // Gutter width must stay the same after diagnostics are cleared.
-        #expect(view.gutterWidth == baseWidth)
-    }
-
-    @Test func gutterWidth_noDiagnosticExtraInCalculation() {
-        // The gutter width formula should NOT include diagnosticExtra.
-        // Icons are drawn within the existing gutter space (fold indicator area).
-        let view = makeLineNumberView()
+    @Test func gutterWidth_widensWhenDiagnosticsAdded() {
+        // With diagnostics, the gutter must widen to reserve the icon zone.
+        let view = makeLineNumberView(lineCount: 5)
         let widthWithout = view.gutterWidth
-
         view.validationDiagnostics = [
-            ValidationDiagnostic(line: 1, column: nil, message: "err", severity: .error, source: "t")
+            ValidationDiagnostic(line: 1, column: nil, message: "e", severity: .error, source: "t")
         ]
         let widthWith = view.gutterWidth
+        #expect(widthWith == widthWithout + LineNumberView.diagnosticReservedWidth)
+    }
 
-        #expect(widthWith == widthWithout, "Gutter width must be fixed regardless of diagnostics")
+    @Test func gutterWidth_shrinksBackWhenDiagnosticsCleared() {
+        let view = makeLineNumberView(lineCount: 5)
+        let baseWidth = view.gutterWidth
+        view.validationDiagnostics = [
+            ValidationDiagnostic(line: 1, column: nil, message: "e", severity: .error, source: "t")
+        ]
+        view.validationDiagnostics = []
+        #expect(view.gutterWidth == baseWidth)
+    }
+
+    // MARK: - Line number never overlaps the diagnostic icon zone (#781)
+
+    /// Parameterized check: for any digit count that matters in practice,
+    /// the left edge of the rendered line number must sit strictly to the
+    /// right of the reserved diagnostic icon zone when diagnostics are present.
+    private func assertNoOverlap(lineCount: Int, digits: Int) {
+        let view = makeLineNumberView(lineCount: lineCount)
+        view.validationDiagnostics = [
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "err", severity: .error, source: "t"
+            )
+        ]
+        let layout = view.lineNumberDrawLayout(forDigits: digits)
+        #expect(layout.lineNumberX >= layout.diagnosticZoneRightEdge)
+        #expect(layout.diagnosticZoneRightEdge == LineNumberView.diagnosticReservedWidth)
+    }
+
+    @Test func noOverlap_singleDigitLines() {
+        assertNoOverlap(lineCount: 5, digits: 1)
+    }
+
+    @Test func noOverlap_twoDigitLines() {
+        assertNoOverlap(lineCount: 42, digits: 2)
+    }
+
+    @Test func noOverlap_threeDigitLines() {
+        assertNoOverlap(lineCount: 500, digits: 3)
+    }
+
+    @Test func noOverlap_fourDigitLines() {
+        assertNoOverlap(lineCount: 5000, digits: 4)
+    }
+
+    @Test func noOverlap_fiveDigitLines() {
+        // Stress the formula at the high end.
+        assertNoOverlap(lineCount: 50_000, digits: 5)
+    }
+
+    @Test func lineNumberRightEdge_respectsRightPadding() {
+        let view = makeLineNumberView(lineCount: 10)
+        view.validationDiagnostics = [
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "e", severity: .error, source: "t"
+            )
+        ]
+        let layout = view.lineNumberDrawLayout(forDigits: 2)
+        #expect(
+            layout.lineNumberRightEdge == layout.gutterWidth - LineNumberView.lineNumberRightPadding
+        )
+    }
+
+    @Test func iconZone_coversIconDrawPath() {
+        // Icon is drawn at x=1 with width = diagnosticIconDrawSize.
+        // The reserved zone must fully contain the drawn icon.
+        let iconLeft: CGFloat = 1
+        let iconRight = iconLeft + LineNumberView.diagnosticIconDrawSize
+        #expect(iconRight <= LineNumberView.diagnosticReservedWidth)
     }
 
     // MARK: - drawDiagnosticIcon does not crash
@@ -231,21 +300,20 @@ struct ValidationGutterTests {
     }
 
     @Test func diagnosticIcon_doesNotOverlapLineNumbers() {
-        // Icon: x=1, size=8 → right edge = 9.
-        // Line numbers for 2-digit case: gutterWidth(40) - textWidth(~14) - padding(8) = 18.
-        // 9 < 18, so no overlap.
+        // #781: when diagnostics are present, the gutter reserves a dedicated
+        // icon zone on the left so the icon (drawn at x=1..1+iconSize) never
+        // touches the line number glyphs regardless of digit count.
+        let view = makeLineNumberView(lineCount: 42)
+        view.validationDiagnostics = [
+            ValidationDiagnostic(
+                line: 1, column: nil, message: "e", severity: .error, source: "t"
+            )
+        ]
         let iconX: CGFloat = 1
         let iconRightEdge = iconX + LineNumberView.diagnosticIconDrawSize
-        let view = makeLineNumberView()
-        let digitWidth = "0".size(withAttributes: [
-            .font: NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
-        ]).width
-        let twoDigitWidth = digitWidth * 2
-        let lineNumberStartX = view.gutterWidth - twoDigitWidth - 8
-        #expect(
-            iconRightEdge < lineNumberStartX,
-            "Icon right edge (\(iconRightEdge)) must not overlap line number start (\(lineNumberStartX))"
-        )
+        let layout = view.lineNumberDrawLayout(forDigits: 2)
+        #expect(iconRightEdge <= layout.diagnosticZoneRightEdge)
+        #expect(layout.lineNumberX >= layout.diagnosticZoneRightEdge)
     }
 
     // MARK: - Multiple lines with diagnostics

--- a/PineTests/ValidationGutterTests.swift
+++ b/PineTests/ValidationGutterTests.swift
@@ -174,34 +174,40 @@ struct ValidationGutterTests {
         #expect(LineNumberView.diagnosticIconDrawSize == 12)
     }
 
-    // MARK: - Gutter width reserves diagnostic icon zone (#781)
+    // MARK: - Gutter width is stable regardless of diagnostics (#781)
+    //
+    // The icon zone is always reserved, even when there are no diagnostics.
+    // This trades ~14pt of gutter space for a stable layout — previously the
+    // editor would visibly jump whenever the first error appeared during an
+    // edit → validate cycle. These tests guard that behavior.
 
-    @Test func gutterWidth_noReservationWhenNoDiagnostics() {
-        // Without diagnostics, the icon zone is NOT reserved — gutter stays compact.
+    @Test func gutterWidth_alwaysReservesDiagnosticZone() {
+        // The draw layout reports the full reserved width whether or not any
+        // diagnostic is actually present on this line.
         let view = makeLineNumberView(lineCount: 5)
         let layout = view.lineNumberDrawLayout(forDigits: 2)
-        #expect(layout.diagnosticZoneRightEdge == 0)
+        #expect(layout.diagnosticZoneRightEdge == LineNumberView.diagnosticReservedWidth)
     }
 
-    @Test func gutterWidth_widensWhenDiagnosticsAdded() {
-        // With diagnostics, the gutter must widen to reserve the icon zone.
+    @Test func gutterWidth_doesNotChangeWhenDiagnosticsAdded() {
+        // No jump in width when the first diagnostic arrives.
         let view = makeLineNumberView(lineCount: 5)
-        let widthWithout = view.gutterWidth
+        let baseWidth = view.gutterWidth
         view.validationDiagnostics = [
             ValidationDiagnostic(line: 1, column: nil, message: "e", severity: .error, source: "t")
         ]
-        let widthWith = view.gutterWidth
-        #expect(widthWith == widthWithout + LineNumberView.diagnosticReservedWidth)
+        #expect(abs(view.gutterWidth - baseWidth) < 1.0)
     }
 
-    @Test func gutterWidth_shrinksBackWhenDiagnosticsCleared() {
+    @Test func gutterWidth_doesNotChangeWhenDiagnosticsCleared() {
+        // And no jump back when they disappear.
         let view = makeLineNumberView(lineCount: 5)
         let baseWidth = view.gutterWidth
         view.validationDiagnostics = [
             ValidationDiagnostic(line: 1, column: nil, message: "e", severity: .error, source: "t")
         ]
         view.validationDiagnostics = []
-        #expect(view.gutterWidth == baseWidth)
+        #expect(abs(view.gutterWidth - baseWidth) < 1.0)
     }
 
     // MARK: - Line number never overlaps the diagnostic icon zone (#781)
@@ -389,100 +395,11 @@ struct ValidationGutterTests {
         #expect(view.diagnosticTooltip(forLine: 3) == "warning on line 3")
     }
 
-    // MARK: - resolveTooltip(at:) — extracted tooltip logic
-
-    @Test func resolveTooltip_outsideBounds_returnsNil() {
-        let view = makeLineNumberView()
-        view.frame = NSRect(x: 0, y: 0, width: 40, height: 500)
-        let diag = ValidationDiagnostic(
-            line: 1, column: nil, message: "error msg", severity: .error, source: "test"
-        )
-        view.validationDiagnostics = [diag]
-        // Point outside bounds (negative x) — resolveTooltip must return nil
-        let result = view.resolveTooltip(at: NSPoint(x: -10, y: 50))
-        #expect(result == nil)
-    }
-
-    @Test func resolveTooltip_insideBoundsNoScrollView_returnsNil() {
-        let view = makeLineNumberView()
-        view.frame = NSRect(x: 0, y: 0, width: 40, height: 500)
-        let diag = ValidationDiagnostic(
-            line: 1, column: nil, message: "error msg", severity: .error, source: "test"
-        )
-        view.validationDiagnostics = [diag]
-        // Point inside bounds but lineNumber(at:) returns nil without a real scroll view
-        let result = view.resolveTooltip(at: NSPoint(x: 20, y: 50))
-        #expect(result == nil)
-    }
-
-    // MARK: - NSView tooltip owner (dynamic tooltips via addToolTip rect)
-
-    @Test func tooltipOwner_returnsMessageForDiagnosticLine() {
-        // Create a LineNumberView embedded in a real scroll view so lineNumber(at:) works
-        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
-        let textStorage = NSTextStorage(string: "line1\nline2\nline3\nline4\nline5\n")
-        let layoutManager = NSLayoutManager()
-        textStorage.addLayoutManager(layoutManager)
-        let textContainer = NSTextContainer(
-            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
-        )
-        textContainer.widthTracksTextView = true
-        layoutManager.addTextContainer(textContainer)
-        let textView = NSTextView(
-            frame: NSRect(x: 0, y: 0, width: 500, height: 400),
-            textContainer: textContainer
-        )
-        scrollView.documentView = textView
-        // Force layout so line fragments exist
-        layoutManager.ensureLayout(forCharacterRange: NSRange(location: 0, length: textStorage.length))
-
-        let gutterView = LineNumberView(textView: textView, clipView: scrollView.contentView)
-        gutterView.frame = NSRect(x: 0, y: 0, width: 40, height: 400)
-
-        let diag = ValidationDiagnostic(
-            line: 1, column: nil, message: "syntax error", severity: .error, source: "yamllint"
-        )
-        gutterView.validationDiagnostics = [diag]
-
-        // The tooltip owner method should resolve tooltip based on point
-        // Point near top of view (line 1 area)
-        let topPoint = NSPoint(x: 10, y: 5)
-        let tooltip = gutterView.resolveTooltip(at: topPoint)
-        #expect(tooltip == "syntax error")
-    }
-
-    @Test func tooltipOwner_returnsNilForLineWithoutDiagnostic() {
-        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
-        let textStorage = NSTextStorage(string: "line1\nline2\nline3\n")
-        let layoutManager = NSLayoutManager()
-        textStorage.addLayoutManager(layoutManager)
-        let textContainer = NSTextContainer(
-            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
-        )
-        textContainer.widthTracksTextView = true
-        layoutManager.addTextContainer(textContainer)
-        let textView = NSTextView(
-            frame: NSRect(x: 0, y: 0, width: 500, height: 400),
-            textContainer: textContainer
-        )
-        scrollView.documentView = textView
-        layoutManager.ensureLayout(forCharacterRange: NSRange(location: 0, length: textStorage.length))
-
-        let gutterView = LineNumberView(textView: textView, clipView: scrollView.contentView)
-        gutterView.frame = NSRect(x: 0, y: 0, width: 40, height: 400)
-
-        // Diagnostic on line 1 only
-        let diag = ValidationDiagnostic(
-            line: 1, column: nil, message: "err", severity: .error, source: "test"
-        )
-        gutterView.validationDiagnostics = [diag]
-
-        // Point at a y that maps to line 3 — well below line 1
-        // With default font ~14px line height, line 3 starts around y=28
-        let lineThreePoint = NSPoint(x: 10, y: 35)
-        let tooltip = gutterView.resolveTooltip(at: lineThreePoint)
-        #expect(tooltip == nil, "Line 3 should not show line 1's tooltip")
-    }
+    // NOTE: the `resolveTooltip(at:)` method and the `addToolTip` rect owner
+    // path were removed in #781 — diagnostic text now surfaces only via the
+    // click-to-show popover, never via hover. The tests that exercised the
+    // removed hover path have been deleted; the tests that still assert
+    // "hover does not set `toolTip`" live right below.
 
     @Test func tooltipOwner_hasTooltipRectRegistered() {
         // Verify that after diagnostics are set, a tooltip rect is added to the view

--- a/PineTests/ValidationGutterTests.swift
+++ b/PineTests/ValidationGutterTests.swift
@@ -435,16 +435,14 @@ struct ValidationGutterTests {
         let gutterView = LineNumberView(textView: textView, clipView: scrollView.contentView)
         gutterView.frame = NSRect(x: 0, y: 0, width: 40, height: 400)
 
-        // Initially no diagnostics — no tooltip rects needed
+        // #781: no tooltip rect is ever registered — diagnostics are explained
+        // only via explicit click, never via hover.
         gutterView.validationDiagnostics = []
-        #expect(gutterView.toolTipTag == nil, "No tooltip tag when no diagnostics")
-
-        // Add diagnostic — tooltip rect should be registered
         let diag = ValidationDiagnostic(
             line: 1, column: nil, message: "err", severity: .error, source: "test"
         )
         gutterView.validationDiagnostics = [diag]
-        #expect(gutterView.toolTipTag != nil, "Tooltip tag should exist when diagnostics present")
+        #expect(gutterView.toolTip == nil, "Hover tooltip must not be set (#781)")
     }
 
     @Test func tooltipOwner_clearsTooltipRectWhenDiagnosticsEmpty() {
@@ -469,109 +467,10 @@ struct ValidationGutterTests {
             line: 1, column: nil, message: "err", severity: .error, source: "test"
         )
         gutterView.validationDiagnostics = [diag]
-        #expect(gutterView.toolTipTag != nil)
+        #expect(gutterView.toolTip == nil)
 
         gutterView.validationDiagnostics = []
-        #expect(gutterView.toolTipTag == nil, "Tooltip tag should be removed when diagnostics cleared")
-    }
-
-    // MARK: - @objc tooltip owner method (issue #680)
-
-    @Test func tooltipOwnerObjcMethod_respondsToSelector() {
-        let view = makeLineNumberView()
-        // NSToolTipOwner informal protocol selector — must be visible to ObjC runtime
-        let selector = #selector(LineNumberView.view(_:stringForToolTip:point:userData:))
-        #expect(view.responds(to: selector), "LineNumberView must respond to tooltip owner selector via @objc")
-    }
-
-    @Test func tooltipOwnerMethod_directCall_returnsMessage() {
-        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
-        let textStorage = NSTextStorage(string: "line1\nline2\nline3\n")
-        let layoutManager = NSLayoutManager()
-        textStorage.addLayoutManager(layoutManager)
-        let textContainer = NSTextContainer(
-            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
-        )
-        textContainer.widthTracksTextView = true
-        layoutManager.addTextContainer(textContainer)
-        let textView = NSTextView(
-            frame: NSRect(x: 0, y: 0, width: 500, height: 400),
-            textContainer: textContainer
-        )
-        scrollView.documentView = textView
-        layoutManager.ensureLayout(forCharacterRange: NSRange(location: 0, length: textStorage.length))
-
-        let gutterView = LineNumberView(textView: textView, clipView: scrollView.contentView)
-        gutterView.frame = NSRect(x: 0, y: 0, width: 40, height: 400)
-
-        let diag = ValidationDiagnostic(
-            line: 1, column: nil, message: "missing colon", severity: .error, source: "yamllint"
-        )
-        gutterView.validationDiagnostics = [diag]
-
-        // Call the @objc tooltip owner method directly (as AppKit would)
-        let tag = gutterView.toolTipTag ?? 0
-        let result = gutterView.view(
-            gutterView,
-            stringForToolTip: tag,
-            point: NSPoint(x: 10, y: 5),
-            userData: nil
-        )
-        #expect(result == "missing colon")
-    }
-
-    @Test func tooltipOwnerMethod_directCall_returnsEmptyForNoMatch() {
-        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
-        let textStorage = NSTextStorage(string: "line1\nline2\nline3\n")
-        let layoutManager = NSLayoutManager()
-        textStorage.addLayoutManager(layoutManager)
-        let textContainer = NSTextContainer(
-            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
-        )
-        textContainer.widthTracksTextView = true
-        layoutManager.addTextContainer(textContainer)
-        let textView = NSTextView(
-            frame: NSRect(x: 0, y: 0, width: 500, height: 400),
-            textContainer: textContainer
-        )
-        scrollView.documentView = textView
-        layoutManager.ensureLayout(forCharacterRange: NSRange(location: 0, length: textStorage.length))
-
-        let gutterView = LineNumberView(textView: textView, clipView: scrollView.contentView)
-        gutterView.frame = NSRect(x: 0, y: 0, width: 40, height: 400)
-
-        // Diagnostic on line 1, but query point at line 3 area (y ~= 35)
-        let diag = ValidationDiagnostic(
-            line: 1, column: nil, message: "err", severity: .error, source: "test"
-        )
-        gutterView.validationDiagnostics = [diag]
-
-        let result = gutterView.view(
-            gutterView,
-            stringForToolTip: 0,
-            point: NSPoint(x: 10, y: 35),
-            userData: nil
-        )
-        #expect(result == "", "Should return empty string when no diagnostic at line")
-    }
-
-    @Test func tooltipOwnerMethod_directCall_outsideBounds() {
-        let gutterView = makeLineNumberView()
-        gutterView.frame = NSRect(x: 0, y: 0, width: 40, height: 400)
-
-        let diag = ValidationDiagnostic(
-            line: 1, column: nil, message: "err", severity: .error, source: "test"
-        )
-        gutterView.validationDiagnostics = [diag]
-
-        // Point outside bounds — should return empty string
-        let result = gutterView.view(
-            gutterView,
-            stringForToolTip: 0,
-            point: NSPoint(x: -10, y: 5),
-            userData: nil
-        )
-        #expect(result == "", "Should return empty string for point outside bounds")
+        #expect(gutterView.toolTip == nil)
     }
 
     // MARK: - Replacing diagnostics


### PR DESCRIPTION
## Summary
- Убран hover-тултип с иконки диагностики в гаттере — объяснение показывается только по явному клику (#781).
- Починен клик: корневая причина — `LineNumberView.validationDiagnostics.didSet` закрывал popover на каждом `updateNSView`, потому что `ValidationDiagnostic` имеет свежий `UUID` на каждую инстанс, и синтезированный `Equatable` считал массивы различными. Сеттер теперь short-circuit'ит по семантическому равенству (line/column/message/severity/source) и дизмиссит popover только при реальных изменениях.
- Удалены обсолетные пути: `updateTooltipRect`, `toolTipTag`, `@objc view(_:stringForToolTip:...)`.

## Test plan
- [x] `PineTests/DiagnosticTooltipFixTests` — 24 теста, все зелёные. Добавлены: hover не выставляет `toolTip`, popover переживает реассаймент идентичных диагностик, popover дизмиссится при реальном изменении, и полный grid тестов для `diagnosticsSemanticallyEqual` (message / severity / count / line / column / source / empty).
- [x] `PineTests/ValidationGutterTests` — 37 тестов, все зелёные (удалены тесты на `toolTipTag` и `@objc view(_:stringForToolTip:)`, заменены на проверку что hover не выставляет `toolTip`).
- [x] `swiftlint --strict` — 0 violations.
- [x] `xcodebuild build` — BUILD SUCCEEDED.
- [ ] Визуальная проверка: открыть файл с невалидным YAML/JSON, навести на иконку — тултипа нет; кликнуть — показывается NSPopover с полным описанием.

Fixes #781