### PR TITLE
feat(grammar): add setext headings, image links, nested emphasis to markdown

### DIFF
--- a/Pine/Grammars/markdown.json
+++ b/Pine/Grammars/markdown.json
@@ -8,8 +8,22 @@
             "scope": "markdown.code.fenced"
         },
         {
+            "pattern": "``[^`\\n]*(?:`[^`\\n]+)*``",
+            "scope": "markdown.code.double"
+        },
+        {
             "pattern": "`[^`\\n]+`",
             "scope": "markdown.code"
+        },
+        {
+            "pattern": "^[^\\n=#>\\-*+`][^\\n]*\\n=+[ \\t]*$",
+            "scope": "markdown.heading.1",
+            "options": ["anchorsMatchLines", "dotMatchesLineSeparators"]
+        },
+        {
+            "pattern": "^[^\\n=#>\\-*+`][^\\n]*\\n-+[ \\t]*$",
+            "scope": "markdown.heading.2",
+            "options": ["anchorsMatchLines", "dotMatchesLineSeparators"]
         },
         {
             "pattern": "^#\\s+.*$",
@@ -42,6 +56,10 @@
             "options": ["anchorsMatchLines"]
         },
         {
+            "pattern": "\\*\\*\\*[^*\\n]+\\*\\*\\*",
+            "scope": "markdown.bold"
+        },
+        {
             "pattern": "\\*\\*[^*\\n]+\\*\\*",
             "scope": "markdown.bold"
         },
@@ -58,6 +76,10 @@
             "pattern": "(?<=\\s|^)_[^_\\n]+_(?=\\s|$|[.,;:!?])",
             "scope": "markdown.italic",
             "options": ["anchorsMatchLines"]
+        },
+        {
+            "pattern": "!\\[[^\\]]*\\]\\([^)]+\\)",
+            "scope": "markdown.image"
         },
         {
             "pattern": "\\[[^\\]]+\\]\\([^)]+\\)",

--- a/Pine/SyntaxHighlighter.swift
+++ b/Pine/SyntaxHighlighter.swift
@@ -63,7 +63,14 @@ nonisolated struct Theme {
         "markdown.italic": dynamicColor(light: (0.52, 0.35, 0.70), dark: (0.78, 0.62, 0.92)),
         "markdown.code": dynamicColor(light: (0.76, 0.32, 0.18), dark: (0.95, 0.58, 0.40)),
         "markdown.code.fenced": dynamicColor(light: (0.58, 0.22, 0.10), dark: (0.99, 0.72, 0.52)),
+        // Double-backtick inline code — same hue as inline code so the visual
+        // matches user expectations, but a distinct scope lets the grammar
+        // prioritise it over single-backtick spans.
+        "markdown.code.double": dynamicColor(light: (0.76, 0.32, 0.18), dark: (0.95, 0.58, 0.40)),
         "markdown.link": dynamicColor(light: (0.10, 0.45, 0.78), dark: (0.36, 0.68, 0.98)),
+        // Image links — slightly teal-shifted from plain links so they read as
+        // "link carrying media".
+        "markdown.image": dynamicColor(light: (0.12, 0.56, 0.62), dark: (0.38, 0.82, 0.88)),
         "markdown.list": dynamicColor(light: (0.22, 0.55, 0.60), dark: (0.46, 0.82, 0.86)),
         "markdown.quote": dynamicColor(light: (0.40, 0.50, 0.42), dark: (0.58, 0.72, 0.60)),
         "markdown.rule": dynamicColor(light: (0.50, 0.50, 0.50), dark: (0.62, 0.62, 0.62)),
@@ -342,6 +349,9 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
         // Markdown: fenced/inline code must beat headings, headings beat emphasis,
         // emphasis beats links/lists/quotes so contained markup doesn't bleed through.
         "markdown.code.fenced": 95,
+        // Double-backtick span must beat single-backtick so the inner single
+        // backtick in ``foo`bar`` isn't re-coloured by the single-tick rule.
+        "markdown.code.double": 94,
         "markdown.code": 92,
         "markdown.heading.1": 80,
         "markdown.heading.2": 80,
@@ -351,6 +361,8 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
         "markdown.heading.6": 80,
         "markdown.bold": 60,
         "markdown.italic": 55,
+        // Image links above plain links so `![alt](url)` isn't taken by link.
+        "markdown.image": 52,
         "markdown.link": 50,
         "markdown.list": 40,
         "markdown.quote": 30,

--- a/PineTests/GrammarModelTests.swift
+++ b/PineTests/GrammarModelTests.swift
@@ -308,7 +308,11 @@ struct GrammarModelTests {
             "markdown.heading.1", "markdown.heading.2", "markdown.heading.3",
             "markdown.heading.4", "markdown.heading.5", "markdown.heading.6",
             "markdown.bold", "markdown.italic", "markdown.code", "markdown.code.fenced",
-            "markdown.link", "markdown.list", "markdown.quote", "markdown.rule"
+            // `markdown.code.double` is double-backtick inline code; distinct
+            // priority from single-backtick so nested backticks survive.
+            "markdown.code.double",
+            "markdown.link", "markdown.image", "markdown.list",
+            "markdown.quote", "markdown.rule"
         ]
 
         let grammarDir = URL(fileURLWithPath: #filePath)

--- a/PineTests/MarkdownGrammarTests.swift
+++ b/PineTests/MarkdownGrammarTests.swift
@@ -321,10 +321,143 @@ struct MarkdownGrammarTests {
         let scopes = [
             "markdown.bold", "markdown.italic", "markdown.code",
             "markdown.code.fenced", "markdown.link", "markdown.list",
-            "markdown.quote", "markdown.rule"
+            "markdown.quote", "markdown.rule",
+            "markdown.image", "markdown.code.double"
         ]
         for scope in scopes {
             #expect(hl.theme.color(for: scope) != nil, "Missing color for \(scope)")
         }
+    }
+
+    // MARK: - Setext headings (CommonMark)
+
+    // swiftlint:disable force_unwrapping
+    private var setextH1Color: NSColor { hl.theme.color(for: "markdown.heading.1")! }
+    private var setextH2Color: NSColor { hl.theme.color(for: "markdown.heading.2")! }
+    // swiftlint:enable force_unwrapping
+
+    @Test func setextHeading1IsHighlighted() throws {
+        let storage = try highlight("Title\n=====\n\nbody")
+        let pos = position(of: "Title", in: storage)
+        #expect(color(in: storage, at: pos) == setextH1Color)
+        let underline = position(of: "=====", in: storage)
+        #expect(color(in: storage, at: underline) == setextH1Color)
+    }
+
+    @Test func setextHeading2IsHighlighted() throws {
+        let storage = try highlight("Section\n-------\n\nbody")
+        let pos = position(of: "Section", in: storage)
+        #expect(color(in: storage, at: pos) == setextH2Color)
+    }
+
+    @Test func setextAtStartOfFile() throws {
+        let storage = try highlight("Top\n===\nrest")
+        #expect(color(in: storage, at: 0) == setextH1Color)
+    }
+
+    @Test func setextInMiddleOfFile() throws {
+        let storage = try highlight("intro paragraph.\n\nMiddle\n======\n\nmore text")
+        let pos = position(of: "Middle", in: storage)
+        #expect(color(in: storage, at: pos) == setextH1Color)
+    }
+
+    @Test func setextAtEndOfFile() throws {
+        let storage = try highlight("leading\n\nEnd\n---")
+        let pos = position(of: "End", in: storage)
+        #expect(color(in: storage, at: pos) == setextH2Color)
+    }
+
+    @Test func hrOfThreeDashesStillHighlighted() throws {
+        // A lone `---` without a text line above is still a horizontal rule.
+        let storage = try highlight("\n---\n")
+        let pos = position(of: "---", in: storage)
+        #expect(color(in: storage, at: pos) == ruleColor)
+    }
+
+    // MARK: - Image links
+
+    @Test func imageLinkIsHighlighted() throws {
+        let storage = try highlight("see ![logo](https://example.com/logo.png) here")
+        let pos = position(of: "![logo]", in: storage)
+        // swiftlint:disable:next force_unwrapping
+        #expect(color(in: storage, at: pos) == hl.theme.color(for: "markdown.image")!)
+    }
+
+    @Test func imageLinkWithEmptyAltText() throws {
+        let storage = try highlight("![](https://example.com/pic.png)")
+        // swiftlint:disable:next force_unwrapping
+        #expect(color(in: storage, at: 0) == hl.theme.color(for: "markdown.image")!)
+    }
+
+    @Test func imageLinkDoesNotCollideWithPlainLink() throws {
+        // `![alt](url)` must be coloured as image, not as plain link.
+        let storage = try highlight("![alt](url)")
+        let imageColor = hl.theme.color(for: "markdown.image")
+        #expect(color(in: storage, at: 0) == imageColor)
+        // Inner `[alt](url)` must NOT be re-coloured as a plain link on top.
+        let bracketPos = position(of: "[alt]", in: storage)
+        #expect(color(in: storage, at: bracketPos) == imageColor)
+    }
+
+    // MARK: - Nested emphasis
+
+    @Test func boldWithNestedItalicUnderscore() throws {
+        // `**bold _italic_**` — outer **...** must still highlight as bold.
+        let storage = try highlight("text **bold _italic_ end** tail")
+        let pos = position(of: "**bold", in: storage)
+        #expect(color(in: storage, at: pos) == boldColor)
+    }
+
+    @Test func tripleEmphasisIsHighlighted() throws {
+        // `***triple***` is bold+italic in CommonMark. We colour it as bold
+        // (priority chooses the stronger emphasis).
+        let storage = try highlight("a ***triple*** word")
+        let pos = position(of: "***triple***", in: storage)
+        // Must be SOME emphasis colour, not plain prose.
+        let col = color(in: storage, at: pos)
+        #expect(col == boldColor || col == italicColor)
+        #expect(col != prose)
+    }
+
+    @Test func nestedEmphasisDoesNotBreakSurroundingProse() throws {
+        let storage = try highlight("lead **a _b_ c** trail")
+        let leadPos = position(of: "lead", in: storage)
+        let trailPos = position(of: "trail", in: storage)
+        #expect(color(in: storage, at: leadPos) == prose)
+        #expect(color(in: storage, at: trailPos) == prose)
+    }
+
+    // MARK: - Double-backtick inline code
+
+    @Test func doubleBacktickInlineCodeIsHighlighted() throws {
+        let storage = try highlight("use ``foo`bar`` in code")
+        let pos = position(of: "``foo`bar``", in: storage)
+        // swiftlint:disable:next force_unwrapping
+        let dblColor = hl.theme.color(for: "markdown.code.double")!
+        #expect(color(in: storage, at: pos) == dblColor)
+    }
+
+    @Test func doubleBacktickBeatsSingleBacktick() throws {
+        // Middle backtick inside `` `` `` must NOT be re-coloured as single code.
+        let storage = try highlight("``x`y``")
+        let middleTick = position(of: "`y", in: storage)
+        // swiftlint:disable:next force_unwrapping
+        let dblColor = hl.theme.color(for: "markdown.code.double")!
+        #expect(color(in: storage, at: middleTick) == dblColor)
+    }
+
+    @Test func singleBacktickStillWorksAlongsideDouble() throws {
+        let storage = try highlight("inline `a` then ``b`c`` done")
+        let singlePos = position(of: "`a`", in: storage)
+        #expect(color(in: storage, at: singlePos) == codeColor)
+        let doublePos = position(of: "``b`c``", in: storage)
+        // swiftlint:disable:next force_unwrapping
+        #expect(color(in: storage, at: doublePos) == hl.theme.color(for: "markdown.code.double")!)
+    }
+
+    @Test func doubleBacktickEmptyIsIgnoredGracefully() throws {
+        // Degenerate `` `` `` `` `` (empty code span) must not crash.
+        let storage = try highlight("a ```` b")
+        #expect(storage.length > 0)
     }
 }


### PR DESCRIPTION
## Summary

Extends the markdown grammar with standard CommonMark patterns that were missing:

- **Setext headings** (`text\n====` / `text\n----`) mapped to H1/H2 scopes. First-char exclusion set prevents conflict with atx headings, horizontal rules, lists, quotes, and fenced code.
- **Image links** `![alt](url)` with a distinct `markdown.image` scope and priority above plain links so `![alt](url)` is never re-coloured by the inner `[alt](url)` match. Supports empty alt text.
- **Triple emphasis** `***text***` as a dedicated rule before the regular bold rule. Nested `**bold _italic_**` already worked (underscores allowed inside bold) and is now locked down by tests.
- **Double-backtick inline code** with a dedicated `markdown.code.double` scope and priority 94 (above single-backtick 92) so a literal backtick inside `` ``foo`bar`` `` isn't re-coloured by the single-backtick rule.

Fixes #749

## Test plan

- [x] 16 new unit tests in `MarkdownGrammarTests` covering:
  - Setext H1/H2 at start, middle, end of file
  - Lone `---` still highlighted as HR (no text above)
  - Image link with alt text, empty alt text, no collision with plain link
  - Nested emphasis `**bold _italic_**` and `***triple***`
  - Double-backtick with inner backtick, beats single-backtick, both coexist
  - Degenerate empty code span doesn't crash
- [x] All 51 `MarkdownGrammarTests` pass
- [x] `swiftlint --strict` clean (0 violations across 287 files)