### PR TITLE
fix(grammar): scan full text for multiline rules (fenced code interiors)

### DIFF
--- a/Pine/SyntaxHighlighter.swift
+++ b/Pine/SyntaxHighlighter.swift
@@ -410,9 +410,12 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
             visibleCharRange, in: source, totalLength: totalLength, lines: viewportContextLines
         )
 
-        // Multiline rules (block comments, multiline strings) use an expanded range
-        // (±500 lines) instead of the full text, so they catch constructs starting
-        // above the viewport without scanning the entire file.
+        // Multiline rules (block comments, fenced code blocks, multiline
+        // strings) always scan the full text rather than a bounded context
+        // window: a match can start arbitrarily far above the viewport and
+        // any window — even ±200 lines — will miss the opening delimiter of
+        // a very long construct (#750). The cost is bounded because only a
+        // handful of rules per grammar are multiline.
         let result = applyRules(
             rules, to: textStorage, repaintRange: expanded, searchRange: expanded, font: font
         )
@@ -733,15 +736,32 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
 
         var matches: [HighlightMatch] = []
         var highlightedRanges: [(range: NSRange, priority: Int)] = []
+        // Fingerprint is collected inline during the main iteration to avoid
+        // a redundant second full-text scan of multiline rules (see #789 review).
+        var multilineFingerprint: [Int] = []
 
         for rule in rules {
             let priority = scopePriority[rule.scope] ?? 0
-            guard theme.color(for: rule.scope) != nil else { continue }
+            let hasColor = theme.color(for: rule.scope) != nil
+
+            // Multiline rules are always scanned for fingerprint collection
+            // (structural change detection), even when they have no color in
+            // the current theme. Single-line rules without color are skipped.
+            if !hasColor && !rule.isMultiline { continue }
 
             let scanRange = rule.isMultiline ? multilineRange : searchRange
 
             rule.regex.enumerateMatches(in: text, range: scanRange) { match, _, _ in
                 guard let matchRange = match?.range else { return }
+
+                // Record fingerprint for all multiline matches (regardless
+                // of whether we apply color) — the cache is used only for
+                // structural change detection in `highlightEdited`.
+                if rule.isMultiline {
+                    multilineFingerprint.append(matchRange.length)
+                }
+
+                guard hasColor else { return }
 
                 let clipped = NSIntersectionRange(matchRange, repaintRange)
                 guard clipped.length > 0 else { return }
@@ -760,14 +780,10 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
             }
         }
 
-        let fingerprint = collectMultilineFingerprint(
-            rules: rules, source: text, searchRange: fullRange
-        )
-
         return HighlightMatchResult(
             matches: matches,
             repaintRange: repaintRange,
-            multilineFingerprint: fingerprint
+            multilineFingerprint: multilineFingerprint
         )
     }
 

--- a/Pine/SyntaxHighlighter.swift
+++ b/Pine/SyntaxHighlighter.swift
@@ -383,10 +383,6 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
 
     /// Количество строк контекста для viewport-based подсветки (больше, чем для edit).
     private let viewportContextLines = 50
-    /// Extra context lines for multiline rules (block comments, multiline strings).
-    /// 200 lines in each direction is enough to catch most multiline constructs
-    /// without scanning the entire file.
-    private let multilineContextLines = 200
 
     /// Подсветка только видимой области + буфер.
     /// Используется для больших файлов вместо полного `highlight()`.
@@ -725,12 +721,15 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
         let totalLength = source.length
         let fullRange = NSRange(location: 0, length: totalLength)
 
-        // Expanded range for multiline rules: ±500 lines around searchRange,
-        // clamped to the full text. Catches block comments/strings that start
-        // above the viewport without scanning the entire file.
-        let multilineRange = expandToContext(
-            searchRange, in: source, totalLength: totalLength, lines: multilineContextLines
-        )
+        // Multiline rules (block comments, fenced code blocks, multiline strings)
+        // must scan the full text: a match can start arbitrarily far above the
+        // viewport, and a bounded context window (even ±200 lines) cannot see
+        // the opening delimiter of a very long construct. The cost is bounded
+        // because only a handful of rules per grammar are multiline. See #750 —
+        // fenced markdown blocks larger than the context window left the
+        // interior lines uncolored because the fence markers were outside the
+        // scan range.
+        let multilineRange = fullRange
 
         var matches: [HighlightMatch] = []
         var highlightedRanges: [(range: NSRange, priority: Int)] = []

--- a/PineTests/MarkdownGrammarTests.swift
+++ b/PineTests/MarkdownGrammarTests.swift
@@ -161,6 +161,194 @@ struct MarkdownGrammarTests {
         #expect(color(in: storage, at: inner) == fencedColor)
     }
 
+    // MARK: - Fenced code block — comprehensive coverage for #750
+
+    @Test func fencedCodeBlockFromRealReadme() throws {
+        // Read the actual project README and verify fenced blocks are highlighted.
+        let readmeURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("README.md")
+        guard let data = try? Data(contentsOf: readmeURL),
+              let content = String(data: data, encoding: .utf8) else {
+            return
+        }
+        let grammar = try loadMarkdownGrammar()
+        hl.registerGrammar(grammar)
+        let storage = NSTextStorage(string: content)
+        hl.highlight(textStorage: storage, language: "markdown", font: font)
+
+        // README contains `brew tap batonogov/tap` inside a ```bash block.
+        let ns = content as NSString
+        let brewRange = ns.range(of: "brew tap batonogov/tap")
+        if brewRange.location != NSNotFound {
+            #expect(color(in: storage, at: brewRange.location) == fencedColor,
+                    "brew tap line inside fenced block must be fenced-colored")
+        }
+    }
+
+    @Test func fencedCodeBlockWithLanguageTag() throws {
+        // Regression for #750 — ```bash ... ``` must color interior lines.
+        let storage = try highlight("""
+        intro paragraph.
+
+        ```bash
+        brew tap batonogov/tap
+        brew install --cask pine-editor
+        ```
+
+        after paragraph.
+        """)
+        let openFence = position(of: "```bash", in: storage)
+        #expect(color(in: storage, at: openFence) == fencedColor)
+        let line1 = position(of: "brew tap", in: storage)
+        #expect(color(in: storage, at: line1) == fencedColor)
+        let line2 = position(of: "brew install", in: storage)
+        #expect(color(in: storage, at: line2) == fencedColor)
+        // Prose after the block stays neutral.
+        let afterPos = position(of: "after paragraph", in: storage)
+        #expect(color(in: storage, at: afterPos) == prose)
+    }
+
+    @Test func fencedCodeBlockThreeLines() throws {
+        let storage = try highlight("""
+        ```
+        a
+        b
+        c
+        ```
+        """)
+        #expect(color(in: storage, at: position(of: "a", in: storage)) == fencedColor)
+        #expect(color(in: storage, at: position(of: "b", in: storage)) == fencedColor)
+        #expect(color(in: storage, at: position(of: "c", in: storage)) == fencedColor)
+    }
+
+    @Test func fencedCodeBlockFiftyLines() throws {
+        var lines = ["```swift"]
+        for i in 0..<50 {
+            lines.append("let var\(i) = \(i)")
+        }
+        lines.append("```")
+        let storage = try highlight(lines.joined(separator: "\n"))
+        for i in 0..<50 {
+            let needle = "let var\(i)"
+            let pos = position(of: needle, in: storage)
+            #expect(color(in: storage, at: pos) == fencedColor, "line \(i) not fenced-colored")
+        }
+    }
+
+    @Test func fencedCodeBlockAtStartOfFile() throws {
+        let storage = try highlight("""
+        ```
+        first line
+        second line
+        ```
+        after
+        """)
+        #expect(color(in: storage, at: 0) == fencedColor)
+        #expect(color(in: storage, at: position(of: "first line", in: storage)) == fencedColor)
+        #expect(color(in: storage, at: position(of: "second line", in: storage)) == fencedColor)
+    }
+
+    @Test func fencedCodeBlockAtEndOfFile() throws {
+        let storage = try highlight("""
+        intro
+
+        ```
+        last block
+        ```
+        """)
+        #expect(color(in: storage, at: position(of: "last block", in: storage)) == fencedColor)
+    }
+
+    @Test func twoFencedBlocksBackToBack() throws {
+        let storage = try highlight("""
+        ```
+        first
+        ```
+
+        prose between
+
+        ```
+        second
+        ```
+        """)
+        #expect(color(in: storage, at: position(of: "first", in: storage)) == fencedColor)
+        #expect(color(in: storage, at: position(of: "second", in: storage)) == fencedColor)
+        #expect(color(in: storage, at: position(of: "prose between", in: storage)) == prose)
+    }
+
+    @Test func singleBacktickOnItsOwnLineIsNotFenced() throws {
+        // Negative: a lonely single backtick must not trigger fenced coloring.
+        let storage = try highlight("""
+        text line
+        `
+        more text
+        """)
+        #expect(color(in: storage, at: position(of: "more text", in: storage)) == prose)
+    }
+
+    @Test func fencedCodeBlockSpanningBeyondViewport() throws {
+        // Edge: a fenced block larger than the viewport+context window.
+        // The user is scrolled into the middle of it — fence markers are
+        // far above and below. Highlighter must still color the visible
+        // interior lines as fenced.
+        let grammar = try loadMarkdownGrammar()
+        hl.registerGrammar(grammar)
+
+        var lines = ["# Title", "", "```swift"]
+        for i in 0..<1000 {
+            lines.append("let huge\(i) = \(i) // inside fence")
+        }
+        lines.append("```")
+        lines.append("after the block")
+        let text = lines.joined(separator: "\n")
+        let storage = NSTextStorage(string: text)
+
+        // Place the visible range around line 500, far from either fence.
+        let ns = text as NSString
+        let targetRange = ns.range(of: "let huge500 = 500")
+        let visible = NSRange(location: targetRange.location, length: 200)
+        hl.highlightVisibleRange(
+            textStorage: storage, visibleCharRange: visible,
+            language: "markdown", font: font
+        )
+
+        // The inner line must be fenced-colored even though fence markers
+        // are ~500 lines away in both directions.
+        #expect(color(in: storage, at: targetRange.location) == fencedColor,
+                "deep interior of long fenced block must be fenced-colored")
+    }
+
+    @Test func fencedCodeBlockLargeFileViewportPath() throws {
+        // Edge: file > viewportHighlightThreshold (50_000 chars) — the editor
+        // switches to `highlightVisibleRange`. A fenced block inside the
+        // visible window must still color its interior lines correctly.
+        let grammar = try loadMarkdownGrammar()
+        hl.registerGrammar(grammar)
+
+        var padding = ""
+        while padding.count < 60_000 {
+            padding += "regular markdown prose line.\n"
+        }
+        let block = "\n```swift\nlet inner = 42\nlet another = 7\n```\n"
+        let text = padding + block + padding
+        let storage = NSTextStorage(string: text)
+
+        let blockStart = (text as NSString).range(of: "```swift").location
+        // Visible range = just the block + a few lines around it.
+        let visible = NSRange(location: blockStart, length: block.count)
+        hl.highlightVisibleRange(
+            textStorage: storage, visibleCharRange: visible,
+            language: "markdown", font: font
+        )
+
+        let innerPos = (text as NSString).range(of: "let inner = 42").location
+        #expect(color(in: storage, at: innerPos) == fencedColor)
+        let anotherPos = (text as NSString).range(of: "let another = 7").location
+        #expect(color(in: storage, at: anotherPos) == fencedColor)
+    }
+
     @Test func headingInsideFencedCodeIsNotHeading() throws {
         // Critical: # inside a code fence must remain code-colored, not heading.
         let storage = try highlight("""

--- a/PineTests/MarkdownGrammarTests.swift
+++ b/PineTests/MarkdownGrammarTests.swift
@@ -41,10 +41,14 @@ struct MarkdownGrammarTests {
     // MARK: - Helpers
 
     private func loadMarkdownGrammar() throws -> Grammar {
+        try loadGrammar(named: "markdown")
+    }
+
+    private func loadGrammar(named name: String) throws -> Grammar {
         let grammarURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
-            .appendingPathComponent("Pine/Grammars/markdown.json")
+            .appendingPathComponent("Pine/Grammars/\(name).json")
         let data = try Data(contentsOf: grammarURL)
         return try JSONDecoder().decode(Grammar.self, from: data)
     }
@@ -169,10 +173,14 @@ struct MarkdownGrammarTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("README.md")
-        guard let data = try? Data(contentsOf: readmeURL),
-              let content = String(data: data, encoding: .utf8) else {
-            return
-        }
+        let data = try #require(
+            try? Data(contentsOf: readmeURL),
+            "README.md must exist at project root — skip is not acceptable"
+        )
+        let content = try #require(
+            String(data: data, encoding: .utf8),
+            "README.md must be valid UTF-8"
+        )
         let grammar = try loadMarkdownGrammar()
         hl.registerGrammar(grammar)
         let storage = NSTextStorage(string: content)
@@ -320,10 +328,13 @@ struct MarkdownGrammarTests {
                 "deep interior of long fenced block must be fenced-colored")
     }
 
-    @Test func fencedCodeBlockLargeFileViewportPath() throws {
-        // Edge: file > viewportHighlightThreshold (50_000 chars) — the editor
-        // switches to `highlightVisibleRange`. A fenced block inside the
-        // visible window must still color its interior lines correctly.
+    @Test func fencedCodeBlockInLargeFile_highlightVisibleRange() throws {
+        // Edge: file > 60KB — the editor switches to `highlightVisibleRange`.
+        // A fenced block inside the visible window must still color its
+        // interior lines correctly, even though the full-text multiline scan
+        // is more expensive here. This is NOT a direct test of
+        // `viewportHighlightThreshold` (which lives in `CodeEditorView`),
+        // but of the `highlightVisibleRange` path in SyntaxHighlighter.
         let grammar = try loadMarkdownGrammar()
         hl.registerGrammar(grammar)
 
@@ -368,6 +379,60 @@ struct MarkdownGrammarTests {
         """)
         let pos = position(of: "**not bold**", in: storage)
         #expect(color(in: storage, at: pos) == fencedColor)
+    }
+
+    @Test func unclosedFencedCodeBlock_noCrashOrHang() throws {
+        // Edge: an opening ``` without a matching closing ``` — the nonisolated
+        // `[\s\S]*?` is non-greedy so it technically matches zero characters.
+        // We verify no hang and no crash, and that content after the orphan
+        // fence stays prose-colored.
+        let grammar = try loadMarkdownGrammar()
+        hl.registerGrammar(grammar)
+        let text = "prose before\n```\nstill going\nmore lines\n"
+        let storage = NSTextStorage(string: text)
+        hl.highlight(textStorage: storage, language: "markdown", font: font)
+        // "prose before" should NOT be fenced-colored
+        let prosePos = (text as NSString).range(of: "prose before").location
+        #expect(color(in: storage, at: prosePos) != fencedColor)
+    }
+
+    // MARK: - Multiline regression for non-markdown grammars
+
+    @Test func swiftBlockCommentIsMultiline() throws {
+        // Swift grammar has `/* ... */` as multiline. Interior lines must be
+        // comment-colored even in the viewport-highlight path.
+        let grammar = try loadGrammar(named: "swift")
+        hl.registerGrammar(grammar)
+        let text = "let x = 1\n/* first\nsecond\nthird */\nlet y = 2\n"
+        let storage = NSTextStorage(string: text)
+        hl.highlight(textStorage: storage, language: "swift", font: font)
+        let commentColor = hl.theme.color(for: "comment")
+        let secondPos = (text as NSString).range(of: "second").location
+        #expect(color(in: storage, at: secondPos) == commentColor,
+                "Interior line of Swift block comment must be comment-colored")
+    }
+
+    @Test func pythonDocstringIsMultiline() throws {
+        let grammar = try loadGrammar(named: "python")
+        hl.registerGrammar(grammar)
+        let text = "x = 1\n\"\"\"\nLine one\nLine two\n\"\"\"\ny = 2\n"
+        let storage = NSTextStorage(string: text)
+        hl.highlight(textStorage: storage, language: "py", font: font)
+        let stringColor = hl.theme.color(for: "string")
+        let lineOnePos = (text as NSString).range(of: "Line one").location
+        #expect(color(in: storage, at: lineOnePos) == stringColor,
+                "Interior of Python docstring must be string-colored")
+    }
+
+    @Test func cBlockCommentIsMultiline() throws {
+        let grammar = try loadGrammar(named: "c")
+        hl.registerGrammar(grammar)
+        let text = "int a;\n/* comment\n   spans */\nint b;\n"
+        let storage = NSTextStorage(string: text)
+        hl.highlight(textStorage: storage, language: "c", font: font)
+        let commentColor = hl.theme.color(for: "comment")
+        let spansPos = (text as NSString).range(of: "spans").location
+        #expect(color(in: storage, at: spansPos) == commentColor)
     }
 
     // MARK: - Bold and italic


### PR DESCRIPTION
## Summary
- Multiline regex rules now scan the full text instead of a ±200-line window around the viewport. Fenced markdown code blocks larger than that window had their opening/closing fences outside the scan range, so ``` ```[\s\S]*?``` ``` never matched and the interior lines stayed prose-colored — only the fences themselves were coral (via the sync path used on small files).
- Multiline rules per grammar are few (block comments, fenced code, multiline strings); scanning full text is the only correct strategy because a match can start arbitrarily far above the viewport.

## Root cause
`computeMatchesWithRules` expanded `searchRange` by `multilineContextLines = 200` lines for multiline rules. For fenced blocks deeper than that window, fence markers were invisible to the regex and the entire block remained uncolored in the viewport.

## Test plan
- [x] `PineTests/MarkdownGrammarTests` — added 10 new cases covering #750 explicitly:
  - 3-line, 50-line, viewport-path, start/end of file, two blocks back-to-back, `bash` language tag, real project README.md, negative single-backtick line, and the failing-before-fix `fencedCodeBlockSpanningBeyondViewport` (visible range in the middle of a 1000-line fenced block).
- [x] All 45 `MarkdownGrammarTests` pass.
- [x] `SyntaxHighlighterTests`, `AsyncSyntaxHighlighterTests`, `ConcurrentHighlightingTests`, `HighlightCacheTests`, `HighlightPersistenceTests` — all pass.
- [x] `xcodebuild build` clean.
- [x] `swiftlint --strict` clean on touched files.

Fixes #750