### PR TITLE
fix(editor): guard SyntaxHighlighter against nil attribute values and concurrent access

### DIFF
--- a/Pine/SyntaxHighlighter.swift
+++ b/Pine/SyntaxHighlighter.swift
@@ -714,7 +714,21 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
     }
 
     /// Core match computation — used by both `computeMatches` and `applyRules`.
-    /// Thread-safe: only reads immutable compiled rules and the provided text snapshot.
+    ///
+    /// **Thread safety.** Safe to call from any thread (including concurrent
+    /// callers on the background `highlightQueue`) as long as each invocation
+    /// passes its own `text` snapshot. This method:
+    /// - only reads immutable compiled rules via `rules` and the scope
+    ///   priority map (both immutable after registration),
+    /// - reads `theme.color(for:)` which is a pure dictionary lookup on an
+    ///   immutable `[String: NSColor]`,
+    /// - operates on local `matches`/`highlightedRanges` buffers that never
+    ///   escape this call,
+    /// - does NOT touch any `NSTextStorage` — that happens only in
+    ///   `applyMatches` on the main thread.
+    ///
+    /// Scopes without a registered theme color are skipped early so that no
+    /// nil color can later be written into an attribute dictionary.
     private func computeMatchesWithRules(
         _ rules: [CompiledRule],
         text: String,
@@ -772,7 +786,24 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
         )
     }
 
-    /// Applies pre-computed matches to NSTextStorage. Must be called on main thread.
+    /// Applies pre-computed matches to NSTextStorage.
+    ///
+    /// **Thread safety — MUST be called on the main thread.**
+    /// `NSTextStorage`/`NSMutableAttributedString` are not thread-safe. Calling
+    /// `addAttributes`/`addAttribute` from a background thread — or concurrently
+    /// with another thread (including the main thread via a synchronous
+    /// `highlightVisibleRange` call) — corrupts the internal
+    /// `NSMutableDictionary` backing store, surfacing as
+    /// `NSInvalidArgumentException: object cannot be nil` inside
+    /// `-[__NSDictionaryM setObject:forKey:]` even though every value passed in
+    /// is non-nil. See issue #790.
+    ///
+    /// Async entry points (`highlightAsync`, `highlightEditedAsync`,
+    /// `highlightVisibleRangeAsync`) hop to `@MainActor` before invoking this
+    /// method. Synchronous entry points (`highlightVisibleRange`,
+    /// `highlightEdited`) are documented main-thread-only and inherit the
+    /// caller's main-thread guarantee.
+    ///
     /// Validates that ranges are still valid — text may have changed between
     /// computation and application.
     /// Skips application if the undo manager is currently undoing/redoing to
@@ -814,6 +845,72 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
         textStorage.endEditing()
     }
 
+    /// Hops to the main thread (synchronously) to call `applyMatches`.
+    ///
+    /// Used by the async entry points. `NSTextStorage` and `NSFont` are not
+    /// `Sendable`, so we avoid `MainActor.run { }` (which requires Sendable
+    /// captures under strict concurrency) and instead route through
+    /// `DispatchQueue.main.sync` — classic Apple pattern for bridging
+    /// background GCD work to the main-thread UI. This also preserves ordering
+    /// with respect to the caller's `await`.
+    ///
+    /// Safe to call from any non-main thread; falls through directly when
+    /// already on main to avoid a redundant hop (and to prevent the deadlock
+    /// that `DispatchQueue.main.sync` causes when called from main).
+    nonisolated private func applyMatchesOnMain(
+        _ result: HighlightMatchResult,
+        to textStorage: NSTextStorage,
+        font: NSFont
+    ) {
+        let box = MainHopBox(textStorage: textStorage, font: font, highlighter: self)
+        if Thread.isMainThread {
+            box.highlighter.applyMatches(result, to: box.textStorage, font: box.font)
+        } else {
+            DispatchQueue.main.sync {
+                box.highlighter.applyMatches(result, to: box.textStorage, font: box.font)
+            }
+        }
+    }
+
+    /// Hops to the main thread (synchronously) to call `resetAttributes`.
+    /// See `applyMatchesOnMain` for rationale.
+    nonisolated private func resetAttributesOnMain(
+        textStorage: NSTextStorage,
+        range: NSRange,
+        font: NSFont
+    ) {
+        let box = MainHopBox(textStorage: textStorage, font: font, highlighter: self)
+        if Thread.isMainThread {
+            box.highlighter.resetAttributes(textStorage: box.textStorage, range: range, font: box.font)
+        } else {
+            DispatchQueue.main.sync {
+                box.highlighter.resetAttributes(
+                    textStorage: box.textStorage, range: range, font: box.font
+                )
+            }
+        }
+    }
+
+    /// `@unchecked Sendable` container for the non-Sendable captures needed to
+    /// hop `applyMatches`/`resetAttributes` to the main thread.
+    ///
+    /// `NSTextStorage` and `NSFont` are AppKit types without `Sendable`
+    /// conformance. Capturing them directly in a `DispatchQueue.main.sync {}`
+    /// closure trips Swift 6 strict concurrency. Safety invariants:
+    ///
+    /// - `textStorage` is exclusively mutated on the main thread (enforced by
+    ///   `applyMatches`/`resetAttributes` preconditions and the sync hop).
+    /// - `NSFont` is immutable.
+    /// - `SyntaxHighlighter` itself is already `@unchecked Sendable`.
+    /// - The box is stack-local: it never escapes beyond a single synchronous
+    ///   main-thread call, and the caller blocks on `sync` until the closure
+    ///   returns, so there is no cross-thread lifetime extension.
+    private struct MainHopBox: @unchecked Sendable {
+        let textStorage: NSTextStorage
+        let font: NSFont
+        let highlighter: SyntaxHighlighter
+    }
+
     /// Async full highlight: computes on background queue, applies on main thread.
     /// Returns the applied match result (for caching on tab switch), or nil if generation was stale.
     @discardableResult
@@ -849,16 +946,16 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
         // Check generation — if bumped, discard stale results
         if let generation, generation.current != gen { return nil }
 
+        // Mutating NSTextStorage attributes from a background thread races with
+        // any other highlight (sync or async) on the same storage and with
+        // main-thread consumers (layout manager, drawing). Hop to the main
+        // actor before calling applyMatches/resetAttributes — see #790.
         if let result {
-            applyMatches(result, to: textStorage, font: font)
+            self.applyMatchesOnMain(result, to: textStorage, font: font)
             updateMultilineCache(key: ObjectIdentifier(textStorage), fingerprint: result.multilineFingerprint)
             return result
         } else {
-            resetAttributes(
-                textStorage: textStorage,
-                range: fullRange,
-                font: font
-            )
+            self.resetAttributesOnMain(textStorage: textStorage, range: fullRange, font: font)
             return nil
         }
     }
@@ -920,11 +1017,12 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
         if let generation, generation.current != gen { return }
 
         let (result, _) = bgResult
+        // Hop to main before touching NSTextStorage — see #790.
         if let result {
-            applyMatches(result, to: textStorage, font: font)
+            self.applyMatchesOnMain(result, to: textStorage, font: font)
             updateMultilineCache(key: key, fingerprint: result.multilineFingerprint)
         } else {
-            resetAttributes(textStorage: textStorage, range: fullRange, font: font)
+            self.resetAttributesOnMain(textStorage: textStorage, range: fullRange, font: font)
         }
     }
 
@@ -965,15 +1063,12 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
 
         if let generation, generation.current != gen { return }
 
+        // Hop to main before touching NSTextStorage — see #790.
         if let result {
-            applyMatches(result, to: textStorage, font: font)
+            self.applyMatchesOnMain(result, to: textStorage, font: font)
             setMultilineCacheIfNil(key: key, fingerprint: result.multilineFingerprint)
         } else {
-            resetAttributes(
-                textStorage: textStorage,
-                range: visibleCharRange,
-                font: font
-            )
+            self.resetAttributesOnMain(textStorage: textStorage, range: visibleCharRange, font: font)
         }
     }
 }

--- a/PineTests/SyntaxHighlighterMainHopTests.swift
+++ b/PineTests/SyntaxHighlighterMainHopTests.swift
@@ -1,0 +1,281 @@
+//
+//  SyntaxHighlighterMainHopTests.swift
+//  PineTests
+//
+//  Regression tests for issue #790:
+//  `SyntaxHighlighter.applyMatches` crashed with
+//  `NSInvalidArgumentException: object cannot be nil` inside
+//  `-[__NSDictionaryM setObject:forKey:]` when multiple tabs highlighted
+//  concurrently and NSTextStorage was mutated from a background thread.
+//
+//  The fix routes `applyMatches`/`resetAttributes` through the main thread
+//  via `DispatchQueue.main.sync`. These tests exercise the hop from
+//  deliberately non-main contexts to verify no crash and correct colors.
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+/// Reference wrapper so we can mark it `@unchecked Sendable` and send it
+/// across task boundaries. Each instance is exclusively owned by one task at
+/// a time, so the lack of synchronization on its fields is safe.
+///
+/// We use a class (not a struct) because Swift 6 does not propagate
+/// `@unchecked Sendable` through a struct's non-Sendable stored properties:
+/// even if the wrapper type conforms, the compiler still refuses to send its
+/// individual `NSTextStorage`/`NSFont` fields across isolation boundaries.
+private final class StorageBox: @unchecked Sendable {
+    nonisolated(unsafe) let storage: NSTextStorage
+    nonisolated(unsafe) let font: NSFont
+    init(storage: NSTextStorage, font: NSFont) {
+        self.storage = storage
+        self.font = font
+    }
+}
+
+@Suite(.serialized)
+struct SyntaxHighlighterMainHopTests {
+
+    nonisolated(unsafe) private static let font =
+        NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+
+    private let swiftGrammar = Grammar(
+        name: "MainHopTestSwift",
+        extensions: ["mhtestswift"],
+        rules: [
+            GrammarRule(pattern: "/\\*[\\s\\S]*?\\*/", scope: "comment"),
+            GrammarRule(pattern: "\\bfunc\\b", scope: "keyword"),
+            GrammarRule(pattern: "\"[^\"]*\"", scope: "string")
+        ]
+    )
+
+    /// Grammar that emits a rule for a scope with NO theme color. This is
+    /// the code path that historically could have put a nil value into the
+    /// attribute dict — verifies the early guard in `computeMatchesWithRules`.
+    private let unknownScopeGrammar = Grammar(
+        name: "MainHopUnknownScope",
+        extensions: ["mhunknown"],
+        rules: [
+            GrammarRule(pattern: "\\bxyz\\b", scope: "totally.unregistered.scope"),
+            GrammarRule(pattern: "\\bfunc\\b", scope: "keyword")
+        ]
+    )
+
+    private func register() {
+        SyntaxHighlighter.shared.registerGrammar(swiftGrammar)
+        SyntaxHighlighter.shared.registerGrammar(unknownScopeGrammar)
+    }
+
+    private func foregroundColor(in storage: NSTextStorage, at position: Int) -> NSColor? {
+        guard position < storage.length else { return nil }
+        return storage.attribute(.foregroundColor, at: position, effectiveRange: nil) as? NSColor
+    }
+
+    // MARK: - 1. highlightAsync from a detached task (non-main executor)
+
+    /// Reproduces the #790 crash shape: `highlightAsync` invoked from outside
+    /// the main actor. Pre-fix, the continuation resumed on the generic
+    /// executor and mutated NSTextStorage off the main thread — that race is
+    /// what surfaced as "object cannot be nil".
+    @Test func highlightAsyncFromDetachedTaskDoesNotCrash() async {
+        register()
+        let hl = SyntaxHighlighter.shared
+        let keywordColor = hl.theme.color(for: "keyword")
+
+        let box = StorageBox(
+            storage: NSTextStorage(string: "func detached() { /* hi */ }"),
+            font: Self.font
+        )
+
+        await Task.detached {
+            await hl.highlightAsync(
+                textStorage: box.storage,
+                language: "mhtestswift",
+                font: box.font
+            )
+        }.value
+
+        #expect(foregroundColor(in: box.storage, at: 0) == keywordColor)
+    }
+
+    // MARK: - 2. Many detached concurrent highlights on independent storages
+
+    @Test func manyDetachedConcurrentHighlightsComplete() async {
+        register()
+        let hl = SyntaxHighlighter.shared
+        let keywordColor = hl.theme.color(for: "keyword")
+        let tabCount = 12
+
+        let boxes: [StorageBox] = (0..<tabCount).map { i in
+            StorageBox(
+                storage: NSTextStorage(string: "func tab\(i)() { /* c */ }"),
+                font: Self.font
+            )
+        }
+
+        await withTaskGroup(of: Void.self) { group in
+            for box in boxes {
+                group.addTask {
+                    await hl.highlightAsync(
+                        textStorage: box.storage,
+                        language: "mhtestswift",
+                        font: box.font
+                    )
+                }
+            }
+        }
+
+        for box in boxes {
+            #expect(foregroundColor(in: box.storage, at: 0) == keywordColor)
+        }
+    }
+
+    // MARK: - 3. Unknown scope never crashes / never writes nil
+
+    /// The early `guard theme.color(for: rule.scope) != nil else { continue }`
+    /// in `computeMatchesWithRules` must skip rules whose scope has no
+    /// registered theme color. Otherwise a nil could reach `addAttribute`.
+    @Test func unknownScopeDoesNotCrashAndDoesNotColorMatchedToken() async {
+        register()
+        let hl = SyntaxHighlighter.shared
+        let keywordColor = hl.theme.color(for: "keyword")
+
+        // `xyz` matches the unknown-scope rule; `func` matches keyword.
+        let box = StorageBox(
+            storage: NSTextStorage(string: "xyz func"),
+            font: Self.font
+        )
+        await hl.highlightAsync(
+            textStorage: box.storage,
+            language: "mhunknown",
+            font: box.font
+        )
+
+        // `func` must still be keyword-colored.
+        let funcPos = (box.storage.string as NSString).range(of: "func").location
+        #expect(foregroundColor(in: box.storage, at: funcPos) == keywordColor)
+
+        // `xyz` must NOT carry the keyword color and must not have crashed.
+        let xyzColor = foregroundColor(in: box.storage, at: 0)
+        #expect(xyzColor != keywordColor)
+    }
+
+    // MARK: - 4. Stale generation token discards result (from detached task)
+
+    @Test func staleGenerationIsDiscardedFromDetachedTask() async throws {
+        register()
+        let hl = SyntaxHighlighter.shared
+        let keywordColor = hl.theme.color(for: "keyword")
+
+        let lines = (0..<5_000).map { "func line\($0)()" }
+        let box = StorageBox(
+            storage: NSTextStorage(string: lines.joined(separator: "\n")),
+            font: Self.font
+        )
+
+        let gen = HighlightGeneration()
+        gen.increment()
+
+        let task = Task.detached {
+            await hl.highlightAsync(
+                textStorage: box.storage,
+                language: "mhtestswift",
+                font: box.font,
+                generation: gen
+            )
+        }
+
+        try await Task.sleep(for: .milliseconds(1))
+        gen.increment() // mark stale
+        _ = await task.value
+
+        let deep = box.storage.length - 10
+        #expect(foregroundColor(in: box.storage, at: deep) != keywordColor)
+    }
+
+    // MARK: - 5. Sync + async on independent storages — no crash
+
+    /// Mirrors the Thread-0-main vs Thread-10-background pattern in the
+    /// original crash dump: one storage processed synchronously on main,
+    /// another asynchronously off-main, interleaving main-thread work.
+    @Test func syncHighlightMixedWithDetachedAsyncHighlight() async {
+        register()
+        let hl = SyntaxHighlighter.shared
+        let keywordColor = hl.theme.color(for: "keyword")
+
+        let asyncBox = StorageBox(
+            storage: NSTextStorage(string: "func asyncTab() { /* a */ }"),
+            font: Self.font
+        )
+
+        let asyncTask = Task.detached {
+            for _ in 0..<20 {
+                await hl.highlightAsync(
+                    textStorage: asyncBox.storage,
+                    language: "mhtestswift",
+                    font: asyncBox.font
+                )
+            }
+        }
+
+        // On the current (test) task — which is on main — hammer the sync
+        // entry point on an independent storage. Pre-fix the combination
+        // crashed; post-fix both entry points serialize via main thread.
+        let syncStorage = NSTextStorage(string: "func syncTab() { /* s */ }")
+        for _ in 0..<20 {
+            hl.highlightVisibleRange(
+                textStorage: syncStorage,
+                visibleCharRange: NSRange(location: 0, length: syncStorage.length),
+                language: "mhtestswift",
+                font: Self.font
+            )
+        }
+        #expect(foregroundColor(in: syncStorage, at: 0) == keywordColor)
+
+        await asyncTask.value
+        #expect(foregroundColor(in: asyncBox.storage, at: 0) == keywordColor)
+    }
+
+    // MARK: - 6. highlightEditedAsync + highlightVisibleRangeAsync from detached
+
+    @Test func editedAndViewportAsyncFromDetachedTaskDoNotCrash() async {
+        register()
+        let hl = SyntaxHighlighter.shared
+        let keywordColor = hl.theme.color(for: "keyword")
+
+        let lines = (0..<100).map { "func line\($0)() { /* x */ }" }
+        let box = StorageBox(
+            storage: NSTextStorage(string: lines.joined(separator: "\n")),
+            font: Self.font
+        )
+
+        await Task.detached {
+            await hl.highlightAsync(
+                textStorage: box.storage,
+                language: "mhtestswift",
+                font: box.font
+            )
+        }.value
+
+        await Task.detached {
+            await hl.highlightEditedAsync(
+                textStorage: box.storage,
+                editedRange: NSRange(location: 0, length: 4),
+                language: "mhtestswift",
+                font: box.font
+            )
+        }.value
+
+        await Task.detached {
+            await hl.highlightVisibleRangeAsync(
+                textStorage: box.storage,
+                visibleCharRange: NSRange(location: 0, length: min(500, box.storage.length)),
+                language: "mhtestswift",
+                font: box.font
+            )
+        }.value
+
+        #expect(foregroundColor(in: box.storage, at: 0) == keywordColor)
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #790: `SyntaxHighlighter.applyMatches` crashed with `NSInvalidArgumentException: object cannot be nil` inside `-[__NSDictionaryM setObject:forKey:]` when multiple tabs highlighted concurrently on different languages.
- Root cause: the async entry points (`highlightAsync`, `highlightEditedAsync`, `highlightVisibleRangeAsync`) are `nonisolated`, and after `await withCheckedContinuation` resumed on a `highlightQueue` worker they continued on the generic executor — **not** the main actor — then called `applyMatches` / `resetAttributes`, which mutate `NSTextStorage` attributes. `NSTextStorage` is not thread-safe; off-main mutation racing with the sync `highlightVisibleRange` path (on main) corrupted the backing `NSMutableDictionary` and surfaced as a nil-value insertion even though every value passed in was non-nil.
- Fix: hop `applyMatches`/`resetAttributes` to the main thread through two new `nonisolated` helpers — `applyMatchesOnMain` / `resetAttributesOnMain` — using `DispatchQueue.main.sync` with a `Thread.isMainThread` short-circuit to avoid deadlock and redundant hops. A stack-local `MainHopBox` wrapper carries non-`Sendable` `NSTextStorage`/`NSFont` through strict-concurrency checks; its safety invariants are documented in-source.
- Documented thread-safety expectations on `applyMatches` and `computeMatchesWithRules`. The existing `guard theme.color(for: rule.scope) != nil` early-out in `computeMatchesWithRules` already prevented nil values from entering the attribute dict — new tests lock in that contract.

## Test plan
- [x] New `SyntaxHighlighterMainHopTests` (6 tests) covers:
  - highlightAsync from `Task.detached` (off main actor) does not crash and applies colors
  - 12 detached concurrent highlights on independent storages all complete
  - unknown theme scope — early guard prevents any nil attribute write
  - stale generation token discards result without touching main thread
  - sync `highlightVisibleRange` + async detached highlight interleaved on independent storages
  - `highlightEditedAsync` / `highlightVisibleRangeAsync` from detached tasks
- [x] `ConcurrentHighlightingTests` (7 tests) still pass, including `mixedLanguageTabsHighlightConcurrently`.
- [x] `SyntaxHighlighterTests` still pass, including `highlightVisibleRangeOverlappingCalls`.
- [x] 20 iterations of `ConcurrentHighlightingTests` + `SyntaxHighlighterMainHopTests` via `-test-iterations 20 -run-tests-until-failure` — all green.
- [x] Full `PineTests` suite: **3037/3037 passing**.
- [x] `swiftlint --strict` on entire project: 0 violations.
- [x] `xcodebuild build -scheme Pine`: clean build.

Fixes #790