### PR TITLE
feat(editor): add SmartListContinuation pure logic

### DIFF
--- a/Pine/SmartListContinuation.swift
+++ b/Pine/SmartListContinuation.swift
@@ -1,0 +1,187 @@
+//
+//  SmartListContinuation.swift
+//  Pine
+//
+
+import Foundation
+
+/// Pure, side-effect-free logic for "smart list continuation" — the editor behaviour
+/// where pressing Return inside a Markdown list automatically starts the next bullet
+/// (or terminates the list when the current item is empty).
+///
+/// Why a standalone type? The integration point lives inside `GutterTextView`'s
+/// `insertNewline(_:)` override, which is being refactored in #797. Keeping the core
+/// logic in a pure function gives us:
+///
+/// 1. Full unit-test coverage without an NSTextView harness.
+/// 2. An easy drop-in for the wiring PR that follows #797.
+/// 3. No risk of regressing editor behaviour while #797 is still in flight — this file
+///    is referenced by nothing until wiring lands.
+///
+/// ## Supported list styles
+/// - Unordered bullets: `-`, `*`, `+`
+/// - Ordered bullets:   `1.`, `42)` (any positive integer followed by `.` or `)`)
+/// - GitHub task lists: `- [ ]`, `- [x]`, `* [X]` — the checkbox is reset to `[ ]` on
+///   continuation so the new task starts unchecked.
+/// - Blockquote prefix: `>` preceding any of the above (common in Markdown)
+///
+/// ## Termination rule
+/// Pressing Return on an "empty" list item (only the bullet, optional checkbox, and
+/// whitespace) exits the list: the current line is cleared and a plain newline is
+/// inserted. This matches VS Code, iA Writer, and Obsidian.
+enum SmartListContinuation {
+
+    /// Result of processing a Return keypress on a line that begins with a list marker.
+    enum Outcome: Equatable {
+        /// Replace the current line with `replacement` (usually an empty string, to erase
+        /// the stray bullet) and then insert a plain newline. Emitted when the user hits
+        /// Return on an otherwise-empty list item — signals "exit the list".
+        case terminate(replacement: String)
+
+        /// Insert `"\n" + continuation` at the cursor. `continuation` is the indent +
+        /// next bullet (ordered lists auto-increment their counter).
+        case `continue`(continuation: String)
+    }
+
+    /// Attempts to compute a smart-list outcome for a Return keypress.
+    ///
+    /// - Parameter currentLine: The full text of the line the cursor currently sits on,
+    ///   **excluding** the newline character. Trailing whitespace may be present.
+    /// - Returns: An `Outcome` describing what the editor should do, or `nil` when the
+    ///   line is not a recognised list item (the editor should fall back to its default
+    ///   newline behaviour, e.g. auto-indent).
+    static func handleReturn(currentLine: String) -> Outcome? {
+        guard let item = parse(line: currentLine) else { return nil }
+
+        // Empty-body rule: when the only content after the bullet (and optional
+        // checkbox) is whitespace, exit the list by clearing the line.
+        if item.body.trimmingCharacters(in: .whitespaces).isEmpty {
+            return .terminate(replacement: "")
+        }
+
+        // Otherwise continue the list with the incremented counter (if any).
+        return .continue(continuation: item.nextPrefix())
+    }
+
+    // MARK: - Parsing
+
+    /// Internal representation of a parsed list item. Made visible to tests via
+    /// `@testable import`.
+    struct ParsedItem: Equatable {
+        /// Leading indentation (spaces and tabs) before any list marker.
+        let indent: String
+        /// Optional `> ` blockquote prefix (including its trailing space, if any).
+        let blockquote: String
+        /// The bullet marker itself.
+        let marker: Marker
+        /// Optional GitHub task-list checkbox, including its trailing space.
+        /// e.g. `"[ ] "` or `"[x] "`. Empty string when absent.
+        let checkbox: String
+        /// Everything after the marker (and optional checkbox) on the current line.
+        let body: String
+
+        /// The prefix to insert on the next line to continue this list item.
+        /// Ordered markers auto-increment; unordered markers are copied verbatim.
+        /// Task-list checkboxes are reset to the unchecked state.
+        func nextPrefix() -> String {
+            let bulletText: String
+            switch marker {
+            case .unordered(let char):
+                bulletText = "\(char) "
+            case .ordered(let number, let delimiter):
+                bulletText = "\(number + 1)\(delimiter) "
+            }
+            let checkboxText = checkbox.isEmpty ? "" : "[ ] "
+            return indent + blockquote + bulletText + checkboxText
+        }
+    }
+
+    enum Marker: Equatable {
+        case unordered(Character)          // '-', '*', '+'
+        case ordered(Int, Character)       // number + '.' or ')'
+    }
+
+    /// Parses a line into a `ParsedItem`, or returns `nil` when the line is not a
+    /// recognised list item. This is deliberately permissive: it accepts any of the
+    /// CommonMark bullet characters and any positive integer counter.
+    static func parse(line: String) -> ParsedItem? {
+        var scanner = line.startIndex
+
+        // 1. Leading indentation (spaces / tabs).
+        let indentStart = scanner
+        while scanner < line.endIndex, line[scanner] == " " || line[scanner] == "\t" {
+            scanner = line.index(after: scanner)
+        }
+        let indent = String(line[indentStart..<scanner])
+
+        // 2. Optional blockquote prefix: one or more ">" each optionally followed by a
+        //    single space. CommonMark allows `>` or `> ` but not leading spaces inside
+        //    the prefix, so we match conservatively.
+        let blockquoteStart = scanner
+        while scanner < line.endIndex, line[scanner] == ">" {
+            scanner = line.index(after: scanner)
+            if scanner < line.endIndex, line[scanner] == " " {
+                scanner = line.index(after: scanner)
+            }
+        }
+        let blockquote = String(line[blockquoteStart..<scanner])
+
+        // 3. Bullet marker (unordered or ordered). Must be followed by at least one space.
+        guard scanner < line.endIndex else { return nil }
+        let marker: Marker
+        let afterMarkerIndex: String.Index
+
+        let firstChar = line[scanner]
+        if firstChar == "-" || firstChar == "*" || firstChar == "+" {
+            let next = line.index(after: scanner)
+            guard next < line.endIndex, line[next] == " " else { return nil }
+            marker = .unordered(firstChar)
+            afterMarkerIndex = line.index(after: next)
+        } else if firstChar.isASCII, firstChar.isNumber {
+            var digitEnd = scanner
+            while digitEnd < line.endIndex, line[digitEnd].isNumber {
+                digitEnd = line.index(after: digitEnd)
+            }
+            guard digitEnd < line.endIndex else { return nil }
+            let delim = line[digitEnd]
+            guard delim == "." || delim == ")" else { return nil }
+            let afterDelim = line.index(after: digitEnd)
+            guard afterDelim < line.endIndex, line[afterDelim] == " " else { return nil }
+            guard let number = Int(line[scanner..<digitEnd]) else { return nil }
+            marker = .ordered(number, delim)
+            afterMarkerIndex = line.index(after: afterDelim)
+        } else {
+            return nil
+        }
+
+        // 4. Optional task-list checkbox: `[ ]`, `[x]`, `[X]` followed by a space.
+        var checkbox = ""
+        var bodyStart = afterMarkerIndex
+        if afterMarkerIndex < line.endIndex, line[afterMarkerIndex] == "[" {
+            let b1 = line.index(after: afterMarkerIndex)
+            if b1 < line.endIndex {
+                let state = line[b1]
+                if state == " " || state == "x" || state == "X" {
+                    let b2 = line.index(after: b1)
+                    if b2 < line.endIndex, line[b2] == "]" {
+                        let b3 = line.index(after: b2)
+                        if b3 < line.endIndex, line[b3] == " " {
+                            // Include the trailing space so nextPrefix() can copy verbatim.
+                            checkbox = String(line[afterMarkerIndex...b3])
+                            bodyStart = line.index(after: b3)
+                        }
+                    }
+                }
+            }
+        }
+
+        let body = String(line[bodyStart..<line.endIndex])
+        return ParsedItem(
+            indent: indent,
+            blockquote: blockquote,
+            marker: marker,
+            checkbox: checkbox,
+            body: body
+        )
+    }
+}

--- a/PineTests/SmartListContinuationTests.swift
+++ b/PineTests/SmartListContinuationTests.swift
@@ -1,0 +1,242 @@
+//
+//  SmartListContinuationTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("SmartListContinuation.parse")
+@MainActor
+struct SmartListContinuationParseTests {
+
+    @Test("Parses simple dash bullet")
+    func simpleDash() {
+        let item = SmartListContinuation.parse(line: "- hello")
+        #expect(item?.indent == "")
+        #expect(item?.blockquote == "")
+        #expect(item?.marker == .unordered("-"))
+        #expect(item?.checkbox == "")
+        #expect(item?.body == "hello")
+    }
+
+    @Test("Parses asterisk and plus bullets")
+    func otherUnorderedMarkers() {
+        #expect(SmartListContinuation.parse(line: "* x")?.marker == .unordered("*"))
+        #expect(SmartListContinuation.parse(line: "+ x")?.marker == .unordered("+"))
+    }
+
+    @Test("Parses ordered list with period")
+    func orderedPeriod() {
+        let item = SmartListContinuation.parse(line: "1. first")
+        #expect(item?.marker == .ordered(1, "."))
+        #expect(item?.body == "first")
+    }
+
+    @Test("Parses ordered list with parenthesis")
+    func orderedParen() {
+        let item = SmartListContinuation.parse(line: "42) item")
+        #expect(item?.marker == .ordered(42, ")"))
+        #expect(item?.body == "item")
+    }
+
+    @Test("Parses indented bullet")
+    func indentedBullet() {
+        let item = SmartListContinuation.parse(line: "    - nested")
+        #expect(item?.indent == "    ")
+        #expect(item?.marker == .unordered("-"))
+    }
+
+    @Test("Parses tab-indented bullet")
+    func tabIndentedBullet() {
+        let item = SmartListContinuation.parse(line: "\t- nested")
+        #expect(item?.indent == "\t")
+    }
+
+    @Test("Parses blockquote prefix")
+    func blockquote() {
+        let item = SmartListContinuation.parse(line: "> - quoted")
+        #expect(item?.blockquote == "> ")
+        #expect(item?.marker == .unordered("-"))
+        #expect(item?.body == "quoted")
+    }
+
+    @Test("Parses nested blockquote prefix")
+    func nestedBlockquote() {
+        let item = SmartListContinuation.parse(line: "> > - deep")
+        #expect(item?.blockquote == "> > ")
+        #expect(item?.body == "deep")
+    }
+
+    @Test("Parses unchecked task list")
+    func uncheckedTask() {
+        let item = SmartListContinuation.parse(line: "- [ ] todo")
+        #expect(item?.checkbox == "[ ] ")
+        #expect(item?.body == "todo")
+    }
+
+    @Test("Parses checked task list (lowercase)")
+    func checkedTaskLower() {
+        let item = SmartListContinuation.parse(line: "- [x] done")
+        #expect(item?.checkbox == "[x] ")
+    }
+
+    @Test("Parses checked task list (uppercase)")
+    func checkedTaskUpper() {
+        let item = SmartListContinuation.parse(line: "* [X] done")
+        #expect(item?.checkbox == "[X] ")
+        #expect(item?.marker == .unordered("*"))
+    }
+
+    @Test("Returns nil for plain text")
+    func plainText() {
+        #expect(SmartListContinuation.parse(line: "not a list") == nil)
+    }
+
+    @Test("Returns nil for empty line")
+    func emptyLine() {
+        #expect(SmartListContinuation.parse(line: "") == nil)
+    }
+
+    @Test("Returns nil for bare dash with no space")
+    func bareDash() {
+        #expect(SmartListContinuation.parse(line: "-") == nil)
+    }
+
+    @Test("Returns nil for marker with no body and no trailing space")
+    func markerOnly() {
+        #expect(SmartListContinuation.parse(line: "1.") == nil)
+    }
+
+    @Test("Accepts marker with trailing space and empty body")
+    func markerWithEmptyBody() {
+        let item = SmartListContinuation.parse(line: "- ")
+        #expect(item != nil)
+        #expect(item?.body == "")
+    }
+
+    @Test("Returns nil for number without delimiter")
+    func numberOnly() {
+        #expect(SmartListContinuation.parse(line: "1 hello") == nil)
+    }
+
+    @Test("Handles multi-digit ordered markers")
+    func multiDigitOrdered() {
+        let item = SmartListContinuation.parse(line: "100. hundred")
+        #expect(item?.marker == .ordered(100, "."))
+    }
+}
+
+@Suite("SmartListContinuation.handleReturn")
+@MainActor
+struct SmartListContinuationReturnTests {
+
+    @Test("Continues an unordered list")
+    func continuesUnordered() {
+        let result = SmartListContinuation.handleReturn(currentLine: "- first")
+        #expect(result == .continue(continuation: "- "))
+    }
+
+    @Test("Continues an ordered list, incrementing the counter")
+    func continuesOrderedIncrement() {
+        let result = SmartListContinuation.handleReturn(currentLine: "3. third")
+        #expect(result == .continue(continuation: "4. "))
+    }
+
+    @Test("Continues ordered parenthesis style")
+    func continuesOrderedParen() {
+        let result = SmartListContinuation.handleReturn(currentLine: "9) nine")
+        #expect(result == .continue(continuation: "10) "))
+    }
+
+    @Test("Preserves indentation when continuing")
+    func preservesIndent() {
+        let result = SmartListContinuation.handleReturn(currentLine: "    - nested")
+        #expect(result == .continue(continuation: "    - "))
+    }
+
+    @Test("Preserves blockquote prefix when continuing")
+    func preservesBlockquote() {
+        let result = SmartListContinuation.handleReturn(currentLine: "> - quoted")
+        #expect(result == .continue(continuation: "> - "))
+    }
+
+    @Test("Terminates when body is empty")
+    func terminatesOnEmptyBody() {
+        let result = SmartListContinuation.handleReturn(currentLine: "- ")
+        #expect(result == .terminate(replacement: ""))
+    }
+
+    @Test("Terminates when body is only whitespace")
+    func terminatesOnWhitespaceBody() {
+        let result = SmartListContinuation.handleReturn(currentLine: "-    ")
+        #expect(result == .terminate(replacement: ""))
+    }
+
+    @Test("Terminates empty ordered item")
+    func terminatesEmptyOrdered() {
+        let result = SmartListContinuation.handleReturn(currentLine: "1. ")
+        #expect(result == .terminate(replacement: ""))
+    }
+
+    @Test("Terminates empty task-list item")
+    func terminatesEmptyTask() {
+        let result = SmartListContinuation.handleReturn(currentLine: "- [ ] ")
+        #expect(result == .terminate(replacement: ""))
+    }
+
+    @Test("Continues a checked task: new task starts unchecked")
+    func taskResetsCheckbox() {
+        let result = SmartListContinuation.handleReturn(currentLine: "- [x] done")
+        #expect(result == .continue(continuation: "- [ ] "))
+    }
+
+    @Test("Continues an unchecked task")
+    func taskContinuesUnchecked() {
+        let result = SmartListContinuation.handleReturn(currentLine: "- [ ] todo")
+        #expect(result == .continue(continuation: "- [ ] "))
+    }
+
+    @Test("Returns nil for non-list plain text")
+    func nilForPlain() {
+        #expect(SmartListContinuation.handleReturn(currentLine: "hello world") == nil)
+    }
+
+    @Test("Returns nil for empty line")
+    func nilForEmpty() {
+        #expect(SmartListContinuation.handleReturn(currentLine: "") == nil)
+    }
+
+    @Test("Handles ordered list body that starts with digits")
+    func orderedBodyWithDigits() {
+        let result = SmartListContinuation.handleReturn(currentLine: "1. 2 apples")
+        #expect(result == .continue(continuation: "2. "))
+    }
+
+    @Test("Handles deep indentation (tabs + spaces)")
+    func deepIndent() {
+        let result = SmartListContinuation.handleReturn(currentLine: "\t    - mix")
+        #expect(result == .continue(continuation: "\t    - "))
+    }
+
+    @Test("Handles blockquote empty item: terminates (but preserves quote prefix is not the point — the list dies)")
+    func blockquoteEmptyTerminates() {
+        let result = SmartListContinuation.handleReturn(currentLine: "> - ")
+        #expect(result == .terminate(replacement: ""))
+    }
+
+    @Test("Idempotence check: parsing the continuation line produces a parseable empty item")
+    func continuationIsParseable() {
+        guard let outcome = SmartListContinuation.handleReturn(currentLine: "- a"),
+              case .continue(let cont) = outcome else {
+            Issue.record("expected continue")
+            return
+        }
+        // The continuation should itself be a parseable list line.
+        let parsed = SmartListContinuation.parse(line: cont)
+        #expect(parsed != nil)
+        #expect(parsed?.body == "")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SmartListContinuation`, a pure, side-effect-free enum that computes what should happen when the user presses Return inside a Markdown list line.
- Ships 35 unit tests covering parse, continue, terminate, and round-trip behaviour.
- **No editor wiring.** The integration point lives inside `GutterTextView.insertNewline(_:)`, which is currently being refactored in #797 (CodeEditorView split). Wiring will land as a tiny follow-up once #797 merges, to avoid touching a locked file.

## Behaviour
Pressing Return on a recognised list line produces one of two outcomes:

- `.continue(continuation:)` — insert a newline followed by the computed prefix (indent + blockquote + next bullet, with ordered counters auto-incremented and task-list checkboxes reset to `[ ]`).
- `.terminate(replacement:)` — clear the current line and insert a plain newline, because the user hit Return on an otherwise-empty bullet (VS Code / Obsidian convention for "exit the list").

Supported markers:
- Unordered: `-`, `*`, `+`
- Ordered: `1.`, `42)` (any positive integer followed by `.` or `)`)
- GitHub task lists: `- [ ]`, `- [x]`, `* [X]` — continuation resets the checkbox
- Leading tabs and spaces preserved
- Single- or multi-level blockquote prefixes (`>`, `> >`, etc.) preserved

Plain text and unrecognised lines return `nil` so the editor can fall through to its default newline handling.

## Why a standalone type?
Keeping the logic in a pure enum gives us:
1. Full unit-test coverage without an NSTextView harness.
2. A drop-in wiring PR after #797 lands.
3. Zero risk of regressing the editor while #797 is in flight — this file is referenced by nothing until wiring.

## Test plan
- [x] 17 `SmartListContinuationParseTests` — every marker variant, indent, blockquote, checkbox, multi-digit ordered, plain text, empty line, bare dash, marker-only, number-only.
- [x] 18 `SmartListContinuationReturnTests` — continue unordered/ordered (with increment), paren style, preserved indent, blockquote continuation, terminate on empty body / whitespace body / empty ordered / empty task, checked task reset, unchecked task continue, plain text nil, empty nil, body starting with digits, deep tab+space indent, empty blockquote item, continuation round-trip parseability.
- [x] `swiftlint --strict` clean.
- [x] `xcodebuild build` clean.

Part of #787