### PR TITLE
ci(release): download Metal Toolchain before archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
           sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
           xcodebuild -version
 
+      - name: Download Metal Toolchain
+        run: xcodebuild -downloadComponent MetalToolchain
+
       - name: Install certificate
         env:
           CERTIFICATE_P12: ${{ secrets.CERTIFICATE_P12 }}


### PR DESCRIPTION
## Summary
Release build run [24209761976](https://github.com/batonogov/pine/actions/runs/24209761976/job/70715919755) failed:

\`\`\`
error: cannot execute tool 'metal' due to missing Metal Toolchain; use: xcodebuild -downloadComponent MetalToolchain
The following build commands failed:
    CompileMetalFile .../SwiftTerm/Sources/SwiftTerm/Apple/Metal/Shaders.metal
    Archiving project Pine with scheme Pine
\`\`\`

The macos-26 runner image no longer ships the Metal Toolchain pre-installed. SwiftTerm's \`Shaders.metal\` needs it during \`xcodebuild archive\`.

## Fix
Add the same \`xcodebuild -downloadComponent MetalToolchain\` step that \`ci.yml\` already uses, right after Xcode selection in \`release.yml\`.

## Test plan
- [ ] Re-tag and re-run the release workflow once merged, verify the archive step completes.