### PR TITLE
fix(test): resolve flaky LayoutStabilityTests on CI

### DIFF
--- a/PineTests/LayoutStabilityTests.swift
+++ b/PineTests/LayoutStabilityTests.swift
@@ -69,9 +69,13 @@ struct LayoutStabilityTests {
 
         workspace.loadDirectory(url: tmpDir)
 
-        // Wait for async loading to complete — shallow load dispatches to
-        // a background queue then back to main, so allow generous time on CI.
-        let deadline = ContinuousClock.now + .seconds(5)
+        // The shallow load dispatches to a background GCD queue (which runs
+        // git setup + file tree scan), then sets isLoading = false via
+        // DispatchQueue.main.async. On CI runners the background work can be
+        // significantly slower than on local machines, so allow a generous
+        // 15-second timeout. Task.sleep on @MainActor yields the main
+        // executor, allowing GCD main-queue blocks to drain.
+        let deadline = ContinuousClock.now + .seconds(15)
         while workspace.isLoading, ContinuousClock.now < deadline {
             try? await Task.sleep(for: .milliseconds(50))
         }


### PR DESCRIPTION
## Summary
- Increases the polling timeout in `LayoutStabilityTests.isLoadingFalseAfterEmptyDir` from 5 seconds to 15 seconds
- The test verifies that `WorkspaceManager.isLoading` becomes `false` after loading an empty directory
- On CI runners, the background GCD work (git setup + file tree scan dispatched via `DispatchQueue.global`) takes longer than on local machines, causing the 5-second deadline to expire before the main-queue callback sets `isLoading = false`

## Root cause
The `loadDirectory` flow dispatches to a background GCD queue for git setup and file tree scanning, then dispatches back to `DispatchQueue.main.async` to set `isLoading = false`. The 5-second timeout was insufficient for slow CI runners where this round-trip consistently exceeded the deadline (failed 3/3 retries).

## Test plan
- [x] `LayoutStabilityTests` pass locally (all 10 tests)
- [ ] CI passes on this branch