### PR TITLE
fix(test): increase LayoutStabilityTests timeout to 60s for CI

### DIFF
--- a/PineTests/LayoutStabilityTests.swift
+++ b/PineTests/LayoutStabilityTests.swift
@@ -72,10 +72,12 @@ struct LayoutStabilityTests {
         // The shallow load dispatches to a background GCD queue (which runs
         // git setup + file tree scan), then sets isLoading = false via
         // DispatchQueue.main.async. On CI runners the background work can be
-        // significantly slower than on local machines, so allow a generous
-        // 15-second timeout. Task.sleep on @MainActor yields the main
-        // executor, allowing GCD main-queue blocks to drain.
-        let deadline = ContinuousClock.now + .seconds(15)
+        // significantly slower than on local machines — git commands on a
+        // non-repo temp directory can take 25+ seconds when the runner is
+        // under load. Allow a 60-second timeout to avoid flaky failures.
+        // Task.sleep on @MainActor yields the main executor, allowing GCD
+        // main-queue blocks to drain.
+        let deadline = ContinuousClock.now + .seconds(60)
         while workspace.isLoading, ContinuousClock.now < deadline {
             try? await Task.sleep(for: .milliseconds(50))
         }


### PR DESCRIPTION
## Summary
- Increase `isLoading` polling timeout from 15s to 60s in `LayoutStabilityTests.isLoadingFalseAfterEmptyDir`
- Git commands on non-repo temp directories take 25+ seconds on slow CI runners, causing flaky failures

Fixes #821

## Test plan
- [x] `LayoutStabilityTests` pass locally
- [x] swiftlint clean
- [ ] CI passes on this PR