### PR TITLE
fix(test): replace polling with CheckedContinuation in LayoutStabilityTests

### DIFF
--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -47,6 +47,9 @@ final class WorkspaceManager {
     /// Pending debounced notification work item.
     private var rootNodesChangedWorkItem: DispatchWorkItem?
 
+    /// Continuations waiting for `isLoading` to become `false`.
+    private var loadingContinuations: [CheckedContinuation<Void, Never>] = []
+
     /// Debounce interval for `onRootNodesChanged` notifications.
     private static let rootNodesChangedDebounce: TimeInterval = 0.2
 
@@ -88,6 +91,24 @@ final class WorkspaceManager {
 
     deinit {
         fileWatcher?.stop()
+    }
+
+    /// Suspends until the current load completes (`isLoading` becomes `false`).
+    /// Returns immediately if no load is in progress.
+    func waitForLoadingComplete() async {
+        guard isLoading else { return }
+        await withCheckedContinuation { continuation in
+            loadingContinuations.append(continuation)
+        }
+    }
+
+    /// Resumes all continuations waiting for load completion.
+    private func resumeLoadingContinuations() {
+        let continuations = loadingContinuations
+        loadingContinuations.removeAll()
+        for continuation in continuations {
+            continuation.resume()
+        }
     }
 
     func openFolder() {
@@ -200,6 +221,7 @@ final class WorkspaceManager {
                 // For shallow projects, loading is done — no Phase 2 needed.
                 if !shallowResult.wasDepthLimited {
                     self.isLoading = false
+                    self.resumeLoadingContinuations()
                     if let progressID { self.progressTracker?.endOperation(progressID) }
                 }
             }
@@ -223,6 +245,7 @@ final class WorkspaceManager {
                 self.rootNodes = fullChildren
                 self.notifyRootNodesChanged(fullChildren)
                 self.isLoading = false
+                self.resumeLoadingContinuations()
                 if let progressID { self.progressTracker?.endOperation(progressID) }
             }
         }

--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -95,10 +95,16 @@ final class WorkspaceManager {
 
     /// Suspends until the current load completes (`isLoading` becomes `false`).
     /// Returns immediately if no load is in progress.
+    /// The check is inside the continuation closure (which runs synchronously
+    /// before the suspend point) to avoid a race where `isLoading` flips
+    /// between the guard and the append.
     func waitForLoadingComplete() async {
-        guard isLoading else { return }
         await withCheckedContinuation { continuation in
-            loadingContinuations.append(continuation)
+            if isLoading {
+                loadingContinuations.append(continuation)
+            } else {
+                continuation.resume()
+            }
         }
     }
 
@@ -128,6 +134,11 @@ final class WorkspaceManager {
         // that would bump loadGeneration and race with the new load.
         fileWatcher?.stop()
         fileWatcher = nil
+
+        // Resume any continuations from a previous load so they don't
+        // hang forever when the old generation's guard-return skips
+        // resumeLoadingContinuations().
+        resumeLoadingContinuations()
 
         let isSameProject = (rootURL == url)
         rootURL = url

--- a/PineTests/LayoutStabilityTests.swift
+++ b/PineTests/LayoutStabilityTests.swift
@@ -69,18 +69,11 @@ struct LayoutStabilityTests {
 
         workspace.loadDirectory(url: tmpDir)
 
-        // The shallow load dispatches to a background GCD queue (which runs
-        // git setup + file tree scan), then sets isLoading = false via
-        // DispatchQueue.main.async. On CI runners the background work can be
-        // significantly slower than on local machines — git commands on a
-        // non-repo temp directory can take 25+ seconds when the runner is
-        // under load. Allow a 60-second timeout to avoid flaky failures.
-        // Task.sleep on @MainActor yields the main executor, allowing GCD
-        // main-queue blocks to drain.
-        let deadline = ContinuousClock.now + .seconds(60)
-        while workspace.isLoading, ContinuousClock.now < deadline {
-            try? await Task.sleep(for: .milliseconds(50))
-        }
+        // Uses CheckedContinuation-based waiting instead of polling with
+        // Task.sleep — eliminates flaky timeouts on CI runners where GCD
+        // main queue drain and Swift concurrency yields don't interleave
+        // reliably (see #823).
+        await workspace.waitForLoadingComplete()
         #expect(!workspace.isLoading)
     }
 


### PR DESCRIPTION
## Summary

- Add `waitForLoadingComplete() async` to `WorkspaceManager` using `CheckedContinuation` — resumes immediately when `isLoading` becomes `false`
- Replace polling loop (Task.sleep + 60s timeout) in `LayoutStabilityTests.isLoadingFalseAfterEmptyDir` with direct `await workspace.waitForLoadingComplete()`
- Test now completes in ~0.09s instead of flaking at 60s+ on CI

Closes #823

## Test plan

- [x] `LayoutStabilityTests` pass locally (0.087s)
- [ ] CI Unit Tests pass without timeout flakes