### PR TITLE
chore(release): remove Homebrew tap update from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,24 +237,6 @@ jobs:
               --generate-notes
           fi
 
-      - name: Update Homebrew Tap
-        env:
-          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
-        run: |
-          VERSION=${{ steps.version.outputs.VERSION }}
-          SHA256=$(shasum -a 256 "$RUNNER_TEMP/Pine-${VERSION}.dmg" | awk '{print $1}')
-
-          git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/batonogov/homebrew-tap.git $RUNNER_TEMP/homebrew-tap
-          cd $RUNNER_TEMP/homebrew-tap
-          sed -i '' "s/version \".*\"/version \"$VERSION\"/" Casks/pine-editor.rb
-          sed -i '' "s/sha256 \".*\"/sha256 \"$SHA256\"/" Casks/pine-editor.rb
-          sed -i '' "s|Pine.dmg|Pine-#{version}.dmg|" Casks/pine-editor.rb
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Casks/pine-editor.rb
-          git commit -m "Update Pine to $VERSION"
-          git push
-
       - name: Cleanup keychain
         if: always()
         run: security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,9 +167,8 @@ Pine uses GCD for background work, bridged to async/await via `withCheckedContin
   - Config: `release-please-config.json`, manifest: `.release-please-manifest.json`
   - Requires `RELEASE_PLEASE_TOKEN` secret (PAT with `contents: write` + `pull-requests: write`) — default `GITHUB_TOKEN` won't trigger downstream workflows
 - **Build workflow** (`.github/workflows/release.yml`) triggers on `v*` tags
-- Pipeline: build → code sign → notarize → create DMG → GitHub Release → update Homebrew Tap
-- Secrets: `CERTIFICATE_P12`, `CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID`, `TAP_GITHUB_TOKEN`, `RELEASE_PLEASE_TOKEN`
-- Homebrew: `brew tap batonogov/tap && brew install --cask pine-editor`
+- Pipeline: build → code sign → notarize → create DMG → GitHub Release
+- Secrets: `CERTIFICATE_P12`, `CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID`, `RELEASE_PLEASE_TOKEN`
 - **CI pipeline** (`.github/workflows/ci.yml`): Lint → Build → Unit Tests (with code coverage) + 6 UI Test shards (parallel) + Flaky Test Summary. All UI tests always run (no conditional skip). Coverage threshold: 70% logic-only (SwiftUI view files excluded). Flaky tests auto-retry once and are reported separately. UI test shards must be balanced (±3 tests); verify script checks all test classes are assigned to a shard
 - **Branch protection**: requires all checks to pass + branch up-to-date with main. This means sequential merge queue — after merging one PR, others need Update Branch + re-run CI (~5.5 min each)
 - **Action pinning** — all third-party GitHub Actions are pinned by full commit SHA (not mutable tags) for supply-chain safety. To update: find the new version's commit SHA on GitHub (Tags → verify the commit), replace the SHA in the workflow file, and keep the `# vX` comment in sync

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,7 @@ Pine uses GCD for background work, bridged to async/await via `withCheckedContin
 - **Build workflow** (`.github/workflows/release.yml`) triggers on `v*` tags
 - Pipeline: build → code sign → notarize → create DMG → GitHub Release
 - Secrets: `CERTIFICATE_P12`, `CERTIFICATE_PASSWORD`, `APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID`, `RELEASE_PLEASE_TOKEN`
+- Homebrew: `brew tap batonogov/tap && brew install --cask pine-editor` (tap is not auto-updated on release — version is pinned)
 - **CI pipeline** (`.github/workflows/ci.yml`): Lint → Build → Unit Tests (with code coverage) + 6 UI Test shards (parallel) + Flaky Test Summary. All UI tests always run (no conditional skip). Coverage threshold: 70% logic-only (SwiftUI view files excluded). Flaky tests auto-retry once and are reported separately. UI test shards must be balanced (±3 tests); verify script checks all test classes are assigned to a shard
 - **Branch protection**: requires all checks to pass + branch up-to-date with main. This means sequential merge queue — after merging one PR, others need Update Branch + re-run CI (~5.5 min each)
 - **Action pinning** — all third-party GitHub Actions are pinned by full commit SHA (not mutable tags) for supply-chain safety. To update: find the new version's commit SHA on GitHub (Tags → verify the commit), replace the SHA in the workflow file, and keep the `# vX` comment in sync


### PR DESCRIPTION
## Summary

- Remove «Update Homebrew Tap» step from `.github/workflows/release.yml`
- Remove `TAP_GITHUB_TOKEN` from CLAUDE.md secrets list
- Remove Homebrew install instructions from CLAUDE.md

Closes #826

## Test plan

- [ ] Release workflow still builds, signs, notarizes, and publishes DMG to GitHub Releases
- [ ] No references to Homebrew tap remain in CI/CD