### PR TITLE
test(coverage): audit and fill unit test gaps to 85% logic-only

### DIFF
--- a/Pine/SyntaxHighlighter.swift
+++ b/Pine/SyntaxHighlighter.swift
@@ -203,6 +203,7 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
         }
     }
 
+    #if DEBUG
     /// Removes a previously registered grammar (for test cleanup).
     func unregisterGrammar(_ grammar: Grammar) {
         lock.withLock {
@@ -218,6 +219,7 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
             compiledRules.removeValue(forKey: grammar.name)
         }
     }
+    #endif
 
     // MARK: - Загрузка грамматик
 

--- a/Pine/SyntaxHighlighter.swift
+++ b/Pine/SyntaxHighlighter.swift
@@ -203,6 +203,22 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
         }
     }
 
+    /// Removes a previously registered grammar (for test cleanup).
+    func unregisterGrammar(_ grammar: Grammar) {
+        lock.withLock {
+            for ext in grammar.extensions where grammarsByExtension[ext.lowercased()]?.name == grammar.name {
+                grammarsByExtension.removeValue(forKey: ext.lowercased())
+            }
+            if let fileNames = grammar.fileNames {
+                for name in fileNames where grammarsByFileName[name]?.name == grammar.name {
+                    grammarsByFileName.removeValue(forKey: name)
+                }
+            }
+            grammarsByFilePattern.removeAll { $0.grammar.name == grammar.name }
+            compiledRules.removeValue(forKey: grammar.name)
+        }
+    }
+
     // MARK: - Загрузка грамматик
 
     /// Ищет все .json файлы в папке Grammars/ внутри бандла и загружает их.

--- a/PineTests/ConfigValidatorEdgeTests.swift
+++ b/PineTests/ConfigValidatorEdgeTests.swift
@@ -7,6 +7,7 @@ import Foundation
 import Testing
 @testable import Pine
 
+@Suite("ConfigValidator Edge Case Tests")
 @MainActor
 struct ConfigValidatorEdgeTests {
 
@@ -52,6 +53,11 @@ struct ConfigValidatorEdgeTests {
 
     @Test func builtinYAML_emptyContent() {
         let diags = BuiltinValidator.validateYAML("")
+        #expect(diags.isEmpty)
+    }
+
+    @Test func builtinYAML_emptyLinesOnly() {
+        let diags = BuiltinValidator.validateYAML("\n\n\n")
         #expect(diags.isEmpty)
     }
 

--- a/PineTests/ConfigValidatorEdgeTests.swift
+++ b/PineTests/ConfigValidatorEdgeTests.swift
@@ -1,0 +1,398 @@
+//
+//  ConfigValidatorEdgeTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+@testable import Pine
+
+@MainActor
+struct ConfigValidatorEdgeTests {
+
+    // MARK: - BuiltinValidator YAML
+
+    @Test func builtinYAML_tabIndentation() {
+        let content = "\tkey: value"
+        let diags = BuiltinValidator.validateYAML(content)
+        #expect(diags.contains { $0.message.contains("tab") && $0.severity == .error })
+    }
+
+    @Test func builtinYAML_trailingWhitespace() {
+        let content = "key: value   "
+        let diags = BuiltinValidator.validateYAML(content)
+        #expect(diags.contains { $0.message.contains("Trailing whitespace") })
+    }
+
+    @Test func builtinYAML_unusualIndentation1Space() {
+        let content = " key: value"
+        let diags = BuiltinValidator.validateYAML(content)
+        #expect(diags.contains { $0.message.contains("Unusual indentation (1 spaces)") })
+    }
+
+    @Test func builtinYAML_unusualIndentation3Spaces() {
+        let content = "   key: value"
+        let diags = BuiltinValidator.validateYAML(content)
+        #expect(diags.contains { $0.message.contains("3 spaces") })
+    }
+
+    @Test func builtinYAML_normalIndentation2Spaces() {
+        let content = "  key: value"
+        let diags = BuiltinValidator.validateYAML(content)
+        let indentDiags = diags.filter { $0.message.contains("indentation") }
+        #expect(indentDiags.isEmpty)
+    }
+
+    @Test func builtinYAML_normalIndentation4Spaces() {
+        let content = "    key: value"
+        let diags = BuiltinValidator.validateYAML(content)
+        let indentDiags = diags.filter { $0.message.contains("indentation") }
+        #expect(indentDiags.isEmpty)
+    }
+
+    @Test func builtinYAML_emptyContent() {
+        let diags = BuiltinValidator.validateYAML("")
+        #expect(diags.isEmpty)
+    }
+
+    @Test func builtinYAML_commentsSkipped() {
+        let content = "# This is a comment"
+        let diags = BuiltinValidator.validateYAML(content)
+        #expect(diags.isEmpty)
+    }
+
+    @Test func builtinYAML_ambiguousMapping() {
+        let content = "key: value: extra: stuff"
+        let diags = BuiltinValidator.validateYAML(content)
+        #expect(diags.contains { $0.message.contains("Ambiguous mapping") })
+    }
+
+    @Test func builtinYAML_urlNotAmbiguous() {
+        // URL after colon should NOT trigger ambiguous mapping
+        let content = "url: https://example.com"
+        let diags = BuiltinValidator.validateYAML(content)
+        let ambig = diags.filter { $0.message.contains("Ambiguous") }
+        #expect(ambig.isEmpty)
+    }
+
+    @Test func builtinYAML_trailingTab() {
+        let content = "key: value\t"
+        let diags = BuiltinValidator.validateYAML(content)
+        #expect(diags.contains { $0.message.contains("Trailing whitespace") })
+    }
+
+    // MARK: - BuiltinValidator Dockerfile
+
+    @Test func builtinDockerfile_validFile() {
+        let content = "FROM ubuntu:20.04\nRUN apt-get update\nCMD [\"bash\"]"
+        let diags = BuiltinValidator.validateDockerfile(content)
+        #expect(diags.isEmpty)
+    }
+
+    @Test func builtinDockerfile_missingFROM() {
+        let content = "RUN apt-get update"
+        let diags = BuiltinValidator.validateDockerfile(content)
+        #expect(diags.contains { $0.message.contains("FROM") && $0.severity == .error })
+    }
+
+    @Test func builtinDockerfile_invalidInstruction() {
+        let content = "FROM ubuntu\nINVALIDCMD foo"
+        let diags = BuiltinValidator.validateDockerfile(content)
+        #expect(diags.contains { $0.message.contains("Invalid Dockerfile instruction") })
+    }
+
+    @Test func builtinDockerfile_deprecatedMAINTAINER() {
+        let content = "FROM ubuntu\nMAINTAINER test@test.com"
+        let diags = BuiltinValidator.validateDockerfile(content)
+        #expect(diags.contains { $0.message.contains("deprecated") })
+    }
+
+    @Test func builtinDockerfile_lowercaseInstruction() {
+        let content = "FROM ubuntu\nrun apt-get update"
+        let diags = BuiltinValidator.validateDockerfile(content)
+        #expect(diags.contains { $0.message.contains("should be uppercase") })
+    }
+
+    @Test func builtinDockerfile_continuationLines() {
+        let content = "FROM ubuntu\nRUN apt-get update && \\\n    apt-get install -y curl"
+        let diags = BuiltinValidator.validateDockerfile(content)
+        // No errors expected
+        let errors = diags.filter { $0.severity == .error }
+        #expect(errors.isEmpty)
+    }
+
+    @Test func builtinDockerfile_emptyFile() {
+        let diags = BuiltinValidator.validateDockerfile("")
+        // Empty file with only empty lines should NOT trigger missing FROM
+        #expect(diags.isEmpty)
+    }
+
+    @Test func builtinDockerfile_commentsOnly() {
+        let content = "# This is a comment\n# Another comment"
+        let diags = BuiltinValidator.validateDockerfile(content)
+        #expect(diags.isEmpty)
+    }
+
+    @Test func builtinDockerfile_allInstructions() {
+        // Verify all valid instructions are recognized
+        let instructions = BuiltinValidator.dockerfileInstructions
+        #expect(instructions.contains("FROM"))
+        #expect(instructions.contains("RUN"))
+        #expect(instructions.contains("CMD"))
+        #expect(instructions.contains("EXPOSE"))
+        #expect(instructions.contains("ENV"))
+        #expect(instructions.contains("COPY"))
+        #expect(instructions.contains("ENTRYPOINT"))
+        #expect(instructions.contains("WORKDIR"))
+        #expect(instructions.contains("ARG"))
+        #expect(instructions.contains("HEALTHCHECK"))
+    }
+
+    // MARK: - BuiltinValidator Shell
+
+    @Test func builtinShell_unquotedVariable() {
+        let content = "[ $var == \"value\" ]"
+        let diags = BuiltinValidator.validateShell(content)
+        #expect(diags.contains { $0.message.contains("Unquoted variable") })
+    }
+
+    @Test func builtinShell_backtickSubstitution() {
+        let content = "result=`date`"
+        let diags = BuiltinValidator.validateShell(content)
+        #expect(diags.contains { $0.message.contains("$(...) instead of backticks") })
+    }
+
+    @Test func builtinShell_backtickInSingleQuotes() {
+        // Backticks inside single quotes should NOT trigger warning
+        let content = "echo 'use `date` here'"
+        let diags = BuiltinValidator.validateShell(content)
+        let backtickDiags = diags.filter { $0.message.contains("backticks") }
+        #expect(backtickDiags.isEmpty)
+    }
+
+    @Test func builtinShell_emptyContent() {
+        let diags = BuiltinValidator.validateShell("")
+        #expect(diags.isEmpty)
+    }
+
+    @Test func builtinShell_commentsSkipped() {
+        let content = "# This is a comment with `backticks`"
+        let diags = BuiltinValidator.validateShell(content)
+        #expect(diags.isEmpty)
+    }
+
+    @Test func builtinShell_cleanScript() {
+        let content = "#!/bin/bash\necho \"Hello\"\nexit 0"
+        let diags = BuiltinValidator.validateShell(content)
+        #expect(diags.isEmpty)
+    }
+
+    // MARK: - ValidatorOutputParser shellcheck
+
+    @Test func parseShellcheck_validJSON() {
+        let json = """
+        [{"line":3,"column":5,"level":"warning","message":"Double quote","code":2086}]
+        """
+        let diags = ValidatorOutputParser.parseShellcheck(json)
+        #expect(diags.count == 1)
+        #expect(diags[0].line == 3)
+        #expect(diags[0].column == 5)
+        #expect(diags[0].severity == .warning)
+        #expect(diags[0].message.contains("SC2086"))
+        #expect(diags[0].source == "shellcheck")
+    }
+
+    @Test func parseShellcheck_errorLevel() {
+        let json = """
+        [{"line":1,"column":1,"level":"error","message":"Parse error","code":1000}]
+        """
+        let diags = ValidatorOutputParser.parseShellcheck(json)
+        #expect(diags[0].severity == .error)
+    }
+
+    @Test func parseShellcheck_infoLevel() {
+        let json = """
+        [{"line":1,"column":1,"level":"info","message":"Style suggestion","code":2000}]
+        """
+        let diags = ValidatorOutputParser.parseShellcheck(json)
+        #expect(diags[0].severity == .info)
+    }
+
+    @Test func parseShellcheck_invalidJSON() {
+        let diags = ValidatorOutputParser.parseShellcheck("not json")
+        #expect(diags.isEmpty)
+    }
+
+    @Test func parseShellcheck_emptyInput() {
+        let diags = ValidatorOutputParser.parseShellcheck("")
+        #expect(diags.isEmpty)
+    }
+
+    // MARK: - ValidatorOutputParser terraform
+
+    @Test func parseTerraform_validOutput() {
+        // swiftlint:disable:next line_length
+        let json = "{\"valid\":false,\"diagnostics\":[{\"severity\":\"error\",\"summary\":\"Missing resource\",\"detail\":\"Resource not found\",\"range\":{\"start\":{\"line\":5,\"column\":3}}}]}"
+        let diags = ValidatorOutputParser.parseTerraform(json)
+        #expect(diags.count == 1)
+        #expect(diags[0].line == 5)
+        #expect(diags[0].column == 3)
+        #expect(diags[0].severity == .error)
+        #expect(diags[0].message.contains("Missing resource"))
+        #expect(diags[0].message.contains("Resource not found"))
+        #expect(diags[0].source == "terraform")
+    }
+
+    @Test func parseTerraform_warningLevel() {
+        let json = """
+        {"valid":true,"diagnostics":[{"severity":"warning","summary":"Deprecated","detail":"","range":null}]}
+        """
+        let diags = ValidatorOutputParser.parseTerraform(json)
+        #expect(diags.count == 1)
+        #expect(diags[0].severity == .warning)
+        #expect(diags[0].line == 1) // Default when no range
+    }
+
+    @Test func parseTerraform_noDiagnostics() {
+        let json = """
+        {"valid":true,"diagnostics":null}
+        """
+        let diags = ValidatorOutputParser.parseTerraform(json)
+        #expect(diags.isEmpty)
+    }
+
+    @Test func parseTerraform_invalidJSON() {
+        let diags = ValidatorOutputParser.parseTerraform("invalid")
+        #expect(diags.isEmpty)
+    }
+
+    @Test func parseTerraform_noDetailField() {
+        let json = """
+        {"valid":false,"diagnostics":[{"severity":"error","summary":"Error msg"}]}
+        """
+        let diags = ValidatorOutputParser.parseTerraform(json)
+        #expect(diags.count == 1)
+        #expect(diags[0].message == "Error msg")
+    }
+
+    // MARK: - ValidatorOutputParser hadolint
+
+    @Test func parseHadolint_validOutput() {
+        let json = """
+        [{"line":1,"column":0,"level":"warning","message":"Pin versions","code":"DL3008"}]
+        """
+        let diags = ValidatorOutputParser.parseHadolint(json)
+        #expect(diags.count == 1)
+        #expect(diags[0].line == 1)
+        #expect(diags[0].column == nil) // column 0 → nil
+        #expect(diags[0].severity == .warning)
+        #expect(diags[0].message.contains("DL3008"))
+        #expect(diags[0].source == "hadolint")
+    }
+
+    @Test func parseHadolint_columnPositive() {
+        let json = """
+        [{"line":3,"column":5,"level":"error","message":"Bad","code":"DL3000"}]
+        """
+        let diags = ValidatorOutputParser.parseHadolint(json)
+        #expect(diags[0].column == 5)
+    }
+
+    @Test func parseHadolint_infoLevel() {
+        let json = """
+        [{"line":1,"column":0,"level":"style","message":"Style","code":"DL3000"}]
+        """
+        let diags = ValidatorOutputParser.parseHadolint(json)
+        #expect(diags[0].severity == .info) // default
+    }
+
+    @Test func parseHadolint_invalidJSON() {
+        let diags = ValidatorOutputParser.parseHadolint("not json")
+        #expect(diags.isEmpty)
+    }
+
+    // MARK: - ValidatorOutputParser yamllint
+
+    @Test func parseYamllintLine_validError() {
+        let line = "config.yml:10:5: [error] too many spaces"
+        let diag = ValidatorOutputParser.parseYamllintLine(line)
+        #expect(diag != nil)
+        #expect(diag?.line == 10)
+        #expect(diag?.column == 5)
+        #expect(diag?.severity == .error)
+        #expect(diag?.message == "too many spaces")
+    }
+
+    @Test func parseYamllintLine_validWarning() {
+        let line = "file.yaml:3:1: [warning] line too long"
+        let diag = ValidatorOutputParser.parseYamllintLine(line)
+        #expect(diag != nil)
+        #expect(diag?.severity == .warning)
+    }
+
+    @Test func parseYamllintLine_invalidLine() {
+        let diag = ValidatorOutputParser.parseYamllintLine("not a yamllint line")
+        #expect(diag == nil)
+    }
+
+    @Test func parseYamllint_multipleLines() {
+        let output = """
+        f.yml:1:1: [error] err1
+        f.yml:2:3: [warning] warn1
+
+        """
+        let diags = ValidatorOutputParser.parseYamllint(output)
+        #expect(diags.count == 2)
+    }
+
+    // MARK: - ValidationDiagnostic Equatable
+
+    @Test func validationDiagnostic_equalityByValue() {
+        let a = ValidationDiagnostic(line: 1, column: 2, message: "msg", severity: .error, source: "test")
+        let b = ValidationDiagnostic(line: 1, column: 2, message: "msg", severity: .error, source: "test")
+        #expect(a == b)
+    }
+
+    @Test func validationDiagnostic_inequalityByMessage() {
+        let a = ValidationDiagnostic(line: 1, column: nil, message: "msg1", severity: .error, source: "test")
+        let b = ValidationDiagnostic(line: 1, column: nil, message: "msg2", severity: .error, source: "test")
+        #expect(a != b)
+    }
+
+    // MARK: - ConfigValidator clear
+
+    @Test func configValidator_clear_resetsState() {
+        let validator = ConfigValidator()
+        validator.clear()
+        #expect(validator.diagnostics.isEmpty)
+        #expect(validator.activeValidator == nil)
+        #expect(validator.toolAvailable == false)
+        #expect(validator.isValidating == false)
+    }
+
+    // MARK: - ToolAvailability cache
+
+    @Test func toolAvailability_clearCache() {
+        // Should not crash
+        ToolAvailability.clearCache()
+    }
+
+    // MARK: - ValidatorDetector
+
+    @Test func validatorDetector_dockerfileDotVariant() {
+        let url = URL(fileURLWithPath: "/tmp/dockerfile.dev")
+        #expect(ValidatorDetector.detect(for: url) == .hadolint)
+    }
+
+    @Test func validatorDetector_upperCaseExtension() {
+        let url = URL(fileURLWithPath: "/tmp/config.YAML")
+        #expect(ValidatorDetector.detect(for: url) == .yamllint)
+    }
+
+    // MARK: - ValidationSeverity
+
+    @Test func validationSeverity_equatable() {
+        #expect(ValidationSeverity.error == .error)
+        #expect(ValidationSeverity.warning != .info)
+    }
+}

--- a/PineTests/ConfigValidatorEdgeTests.swift
+++ b/PineTests/ConfigValidatorEdgeTests.swift
@@ -397,8 +397,13 @@ struct ConfigValidatorEdgeTests {
 
     // MARK: - ValidationSeverity
 
-    @Test func validationSeverity_equatable() {
-        #expect(ValidationSeverity.error == .error)
-        #expect(ValidationSeverity.warning != .info)
+    @Test func validationSeverity_allCasesDistinct() {
+        let all: [ValidationSeverity] = [.error, .warning, .info]
+        // Each case is distinct from every other
+        for i in 0..<all.count {
+            for j in (i + 1)..<all.count {
+                #expect(all[i] != all[j])
+            }
+        }
     }
 }

--- a/PineTests/FoldRangeCalculatorEdgeTests.swift
+++ b/PineTests/FoldRangeCalculatorEdgeTests.swift
@@ -1,0 +1,114 @@
+//
+//  FoldRangeCalculatorEdgeTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+@MainActor
+struct FoldRangeCalculatorEdgeTests {
+
+    // MARK: - maxStackDepth
+
+    @Test func stackDepthCappedAtMax() {
+        // Build text with more nested braces than maxStackDepth
+        let depth = FoldRangeCalculator.maxStackDepth + 50
+        var text = ""
+        for _ in 0..<depth {
+            text += "{\n"
+        }
+        for _ in 0..<depth {
+            text += "}\n"
+        }
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        // Should not crash; results count bounded by maxStackDepth
+        #expect(ranges.count <= FoldRangeCalculator.maxStackDepth)
+    }
+
+    @Test func exactlyAtMaxStackDepth() {
+        let depth = FoldRangeCalculator.maxStackDepth
+        var text = ""
+        for _ in 0..<depth {
+            text += "{\n"
+        }
+        for _ in 0..<depth {
+            text += "}\n"
+        }
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        // At exactly max depth, all should be matched
+        #expect(ranges.count == depth)
+    }
+
+    // MARK: - All three bracket types in one text
+
+    @Test func allBracketTypesProduceFoldRanges() {
+        let text = "{\n  [\n    (\n      x\n    )\n  ]\n}"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.count == 3)
+        let kinds = Set(ranges.map(\.kind))
+        #expect(kinds.contains(.braces))
+        #expect(kinds.contains(.brackets))
+        #expect(kinds.contains(.parentheses))
+    }
+
+    // MARK: - Skip ranges edge cases
+
+    @Test func entireTextInSkipRangeProducesNoFolds() {
+        let text = "{\n  x\n}"
+        let fullRange = NSRange(location: 0, length: (text as NSString).length)
+        let ranges = FoldRangeCalculator.calculate(text: text, skipRanges: [fullRange])
+        #expect(ranges.isEmpty)
+    }
+
+    @Test func adjacentSkipRanges() {
+        // Skip ranges [0,1) and [1,2) — non-overlapping adjacent
+        let text = "{}\n(\n)"
+        let ranges = FoldRangeCalculator.calculate(
+            text: text,
+            skipRanges: [NSRange(location: 0, length: 1), NSRange(location: 1, length: 1)]
+        )
+        // Braces are skipped, parentheses should still work
+        #expect(ranges.count == 1)
+        #expect(ranges[0].kind == .parentheses)
+    }
+
+    // MARK: - Unicode text
+
+    @Test func unicodeBracketsWork() {
+        let text = "{\n  let emoji = \"🎉\"\n}"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.count == 1)
+        #expect(ranges[0].kind == .braces)
+    }
+
+    // MARK: - Only closing brackets
+
+    @Test func onlyClosingBracketsProduceNoRanges() {
+        let text = "}\n]\n)"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.isEmpty)
+    }
+
+    // MARK: - Single newline text
+
+    @Test func singleNewlineText() {
+        let ranges = FoldRangeCalculator.calculate(text: "\n")
+        #expect(ranges.isEmpty)
+    }
+
+    // MARK: - Interleaved types (not matching)
+
+    @Test func interleavedMismatchedBrackets() {
+        // { [ } ] — } doesn't match [ on top → skipped.
+        // ] matches [ on top → fold from line 2 to 4.
+        // { remains unmatched on stack.
+        let text = "{\n[\n}\n]"
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.count == 1)
+        #expect(ranges[0].startLine == 2)
+        #expect(ranges[0].endLine == 4)
+        #expect(ranges[0].kind == .brackets)
+    }
+}

--- a/PineTests/FoldRangeCalculatorEdgeTests.swift
+++ b/PineTests/FoldRangeCalculatorEdgeTests.swift
@@ -7,8 +7,27 @@ import Testing
 import Foundation
 @testable import Pine
 
+@Suite("FoldRangeCalculator Edge Case Tests")
 @MainActor
 struct FoldRangeCalculatorEdgeTests {
+
+    // MARK: - Empty and trivial inputs
+
+    @Test func emptyText_producesNoRanges() {
+        let ranges = FoldRangeCalculator.calculate(text: "")
+        #expect(ranges.isEmpty)
+    }
+
+    @Test func bracesOnSameLine_producesNoRange() {
+        let ranges = FoldRangeCalculator.calculate(text: "{ }")
+        #expect(ranges.isEmpty)
+    }
+
+    @Test func onlyOpeningBrackets_producesNoRanges() {
+        let text = "{\n[\n("
+        let ranges = FoldRangeCalculator.calculate(text: text)
+        #expect(ranges.isEmpty)
+    }
 
     // MARK: - maxStackDepth
 

--- a/PineTests/GitStatusProviderEdgeTests.swift
+++ b/PineTests/GitStatusProviderEdgeTests.swift
@@ -1,0 +1,503 @@
+//
+//  GitStatusProviderEdgeTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+@testable import Pine
+
+@Suite("GitStatusProvider Edge Case Tests")
+@MainActor
+struct GitStatusProviderEdgeTests {
+
+    // MARK: - unquoteGitPath
+
+    @Test func unquoteGitPath_plainPath() {
+        let result = GitStatusProvider.unquoteGitPath("simple/path.txt")
+        #expect(result == "simple/path.txt")
+    }
+
+    @Test func unquoteGitPath_quotedPathWithSpaces() {
+        let result = GitStatusProvider.unquoteGitPath("\"examples copy/file.txt\"")
+        #expect(result == "examples copy/file.txt")
+    }
+
+    @Test func unquoteGitPath_escapedBackslash() {
+        let result = GitStatusProvider.unquoteGitPath("\"path\\\\file.txt\"")
+        #expect(result == "path\\file.txt")
+    }
+
+    @Test func unquoteGitPath_escapedQuote() {
+        let result = GitStatusProvider.unquoteGitPath("\"he said \\\"hi\\\"\"")
+        #expect(result == "he said \"hi\"")
+    }
+
+    @Test func unquoteGitPath_escapedNewline() {
+        let result = GitStatusProvider.unquoteGitPath("\"line1\\nline2\"")
+        #expect(result == "line1\nline2")
+    }
+
+    @Test func unquoteGitPath_escapedTab() {
+        let result = GitStatusProvider.unquoteGitPath("\"col1\\tcol2\"")
+        #expect(result == "col1\tcol2")
+    }
+
+    @Test func unquoteGitPath_octalEscape() {
+        // \320\241 = Cyrillic С (U+0421)
+        let result = GitStatusProvider.unquoteGitPath("\"\\320\\241\"")
+        #expect(result == "С")
+    }
+
+    @Test func unquoteGitPath_emptyString() {
+        let result = GitStatusProvider.unquoteGitPath("")
+        #expect(result == "")
+    }
+
+    @Test func unquoteGitPath_singleQuoteNotTreated() {
+        // Single char is less than 2 chars for quoted check
+        let result = GitStatusProvider.unquoteGitPath("\"")
+        #expect(result == "\"")
+    }
+
+    @Test func unquoteGitPath_emptyQuotedString() {
+        let result = GitStatusProvider.unquoteGitPath("\"\"")
+        #expect(result == "")
+    }
+
+    @Test func unquoteGitPath_escapedBell() {
+        let result = GitStatusProvider.unquoteGitPath("\"\\a\"")
+        #expect(result == "\u{07}")
+    }
+
+    @Test func unquoteGitPath_escapedBackspace() {
+        let result = GitStatusProvider.unquoteGitPath("\"\\b\"")
+        #expect(result == "\u{08}")
+    }
+
+    @Test func unquoteGitPath_escapedFormFeed() {
+        let result = GitStatusProvider.unquoteGitPath("\"\\f\"")
+        #expect(result == "\u{0C}")
+    }
+
+    @Test func unquoteGitPath_escapedCarriageReturn() {
+        let result = GitStatusProvider.unquoteGitPath("\"\\r\"")
+        #expect(result == "\r")
+    }
+
+    @Test func unquoteGitPath_escapedVerticalTab() {
+        let result = GitStatusProvider.unquoteGitPath("\"\\v\"")
+        #expect(result == "\u{0B}")
+    }
+
+    @Test func unquoteGitPath_unknownEscapePreservesBackslash() {
+        let result = GitStatusProvider.unquoteGitPath("\"\\z\"")
+        #expect(result == "\\z")
+    }
+
+    @Test func unquoteGitPath_trailingBackslash() {
+        let result = GitStatusProvider.unquoteGitPath("\"foo\\\"")
+        #expect(result == "foo\\")
+    }
+
+    // MARK: - parseStatusOutput
+
+    @Test func parseStatusOutput_untrackedFile() {
+        let output = "?? newfile.txt\n"
+        let statuses = GitStatusProvider.parseStatusOutput(output)
+        #expect(statuses["newfile.txt"] == .untracked)
+    }
+
+    @Test func parseStatusOutput_modifiedFile() {
+        let output = " M modified.swift\n"
+        let statuses = GitStatusProvider.parseStatusOutput(output)
+        #expect(statuses["modified.swift"] == .modified)
+    }
+
+    @Test func parseStatusOutput_stagedFile() {
+        let output = "M  staged.swift\n"
+        let statuses = GitStatusProvider.parseStatusOutput(output)
+        #expect(statuses["staged.swift"] == .staged)
+    }
+
+    @Test func parseStatusOutput_addedFile() {
+        let output = "A  added.swift\n"
+        let statuses = GitStatusProvider.parseStatusOutput(output)
+        #expect(statuses["added.swift"] == .added)
+    }
+
+    @Test func parseStatusOutput_deletedFile() {
+        let output = "D  deleted.swift\n"
+        let statuses = GitStatusProvider.parseStatusOutput(output)
+        #expect(statuses["deleted.swift"] == .deleted)
+    }
+
+    @Test func parseStatusOutput_conflictUU() {
+        let output = "UU conflict.swift\n"
+        let statuses = GitStatusProvider.parseStatusOutput(output)
+        #expect(statuses["conflict.swift"] == .conflict)
+    }
+
+    @Test func parseStatusOutput_conflictAA() {
+        let output = "AA both-added.swift\n"
+        let statuses = GitStatusProvider.parseStatusOutput(output)
+        #expect(statuses["both-added.swift"] == .conflict)
+    }
+
+    @Test func parseStatusOutput_conflictDD() {
+        let output = "DD both-deleted.swift\n"
+        let statuses = GitStatusProvider.parseStatusOutput(output)
+        #expect(statuses["both-deleted.swift"] == .conflict)
+    }
+
+    @Test func parseStatusOutput_mixedFile() {
+        let output = "MM mixed.swift\n"
+        let statuses = GitStatusProvider.parseStatusOutput(output)
+        #expect(statuses["mixed.swift"] == .mixed)
+    }
+
+    @Test func parseStatusOutput_renamedFile() {
+        let output = "R  old.swift -> new.swift\n"
+        let statuses = GitStatusProvider.parseStatusOutput(output)
+        #expect(statuses["new.swift"] == .staged)
+    }
+
+    @Test func parseStatusOutput_ignoredFileSkipped() {
+        let output = "!! ignored_dir/\n"
+        let statuses = GitStatusProvider.parseStatusOutput(output)
+        #expect(statuses.isEmpty)
+    }
+
+    @Test func parseStatusOutput_shortLineIgnored() {
+        let output = "X\n"
+        let statuses = GitStatusProvider.parseStatusOutput(output)
+        #expect(statuses.isEmpty)
+    }
+
+    @Test func parseStatusOutput_emptyOutput() {
+        let statuses = GitStatusProvider.parseStatusOutput("")
+        #expect(statuses.isEmpty)
+    }
+
+    @Test func parseStatusOutput_workTreeDeleted() {
+        let output = " D deleted-worktree.swift\n"
+        let statuses = GitStatusProvider.parseStatusOutput(output)
+        #expect(statuses["deleted-worktree.swift"] == .deleted)
+    }
+
+    // MARK: - parseIgnoredOutput
+
+    @Test func parseIgnoredOutput_directoryIgnored() {
+        let output = "!! build/\n!! node_modules/\n"
+        let ignored = GitStatusProvider.parseIgnoredOutput(output)
+        #expect(ignored.contains("build"))
+        #expect(ignored.contains("node_modules"))
+    }
+
+    @Test func parseIgnoredOutput_fileIgnored() {
+        let output = "!! secret.env\n"
+        let ignored = GitStatusProvider.parseIgnoredOutput(output)
+        #expect(ignored.contains("secret.env"))
+    }
+
+    @Test func parseIgnoredOutput_nonIgnoredLinesSkipped() {
+        let output = " M modified.swift\n!! ignored/\n?? new.txt\n"
+        let ignored = GitStatusProvider.parseIgnoredOutput(output)
+        #expect(ignored.count == 1)
+        #expect(ignored.contains("ignored"))
+    }
+
+    @Test func parseIgnoredOutput_emptyOutput() {
+        let ignored = GitStatusProvider.parseIgnoredOutput("")
+        #expect(ignored.isEmpty)
+    }
+
+    // MARK: - parseHunkNewStart
+
+    @Test func parseHunkNewStart_simpleHunk() {
+        let result = GitStatusProvider.parseHunkNewStart("@@ -1,3 +5,7 @@")
+        #expect(result == 5)
+    }
+
+    @Test func parseHunkNewStart_noCountHunk() {
+        let result = GitStatusProvider.parseHunkNewStart("@@ -1 +3 @@")
+        #expect(result == 3)
+    }
+
+    @Test func parseHunkNewStart_invalidHeader() {
+        let result = GitStatusProvider.parseHunkNewStart("not a hunk")
+        #expect(result == nil)
+    }
+
+    @Test func parseHunkNewStart_noPlus() {
+        let result = GitStatusProvider.parseHunkNewStart("@@ -1,3 @@")
+        #expect(result == nil)
+    }
+
+    // MARK: - parseDiff
+
+    @Test func parseDiff_addedLines() {
+        let diff = """
+        diff --git a/file.txt b/file.txt
+        --- a/file.txt
+        +++ b/file.txt
+        @@ -1,3 +1,5 @@
+         context
+        +added line 1
+        +added line 2
+         more context
+        """
+        let diffs = GitStatusProvider.parseDiff(diff)
+        let added = diffs.filter { $0.kind == .added }
+        #expect(added.count == 2)
+    }
+
+    @Test func parseDiff_deletedLines() {
+        let diff = """
+        @@ -1,3 +1,1 @@
+        -deleted line 1
+        -deleted line 2
+         context
+        """
+        let diffs = GitStatusProvider.parseDiff(diff)
+        let deleted = diffs.filter { $0.kind == .deleted }
+        #expect(deleted.count == 1) // One delete marker
+    }
+
+    @Test func parseDiff_modifiedLines() {
+        let diff = """
+        @@ -1,1 +1,1 @@
+        -old line
+        +new line
+        """
+        let diffs = GitStatusProvider.parseDiff(diff)
+        let modified = diffs.filter { $0.kind == .modified }
+        #expect(modified.count == 1)
+    }
+
+    @Test func parseDiff_emptyOutput() {
+        let diffs = GitStatusProvider.parseDiff("")
+        #expect(diffs.isEmpty)
+    }
+
+    // MARK: - parseBlame
+
+    @Test func parseBlame_emptyOutput() {
+        let result = GitStatusProvider.parseBlame("")
+        #expect(result.isEmpty)
+    }
+
+    @Test func parseBlame_singleLine() {
+        let hash = String(repeating: "a", count: 40)
+        let output = """
+        \(hash) 1 1 1
+        author Test User
+        author-time 1700000000
+        summary Initial commit
+        \tline content
+        """
+        let result = GitStatusProvider.parseBlame(output)
+        #expect(result.count == 1)
+        #expect(result[0].hash == hash)
+        #expect(result[0].author == "Test User")
+        #expect(result[0].summary == "Initial commit")
+        #expect(result[0].finalLine == 1)
+    }
+
+    @Test func parseBlame_multipleLines_cachedCommit() {
+        let hash = String(repeating: "b", count: 40)
+        let output = """
+        \(hash) 1 1 2
+        author Author Name
+        author-time 1700000000
+        summary Some message
+        \tline 1
+        \(hash) 1 2
+        \tline 2
+        """
+        let result = GitStatusProvider.parseBlame(output)
+        #expect(result.count == 2)
+        #expect(result[0].author == "Author Name")
+        #expect(result[1].author == "Author Name") // Cached
+        #expect(result[1].finalLine == 2)
+    }
+
+    @Test func parseBlame_invalidHashSkipped() {
+        let output = "invalid line that is not a hash\n\tanother line\n"
+        let result = GitStatusProvider.parseBlame(output)
+        #expect(result.isEmpty)
+    }
+
+    // MARK: - GitLineDiff navigation
+
+    @Test func changeRegionStarts_emptyDiffs() {
+        let starts = GitLineDiff.changeRegionStarts([])
+        #expect(starts.isEmpty)
+    }
+
+    @Test func changeRegionStarts_singleDiff() {
+        let diffs = [GitLineDiff(line: 5, kind: .added)]
+        let starts = GitLineDiff.changeRegionStarts(diffs)
+        #expect(starts == [5])
+    }
+
+    @Test func changeRegionStarts_contiguousRegion() {
+        let diffs = [
+            GitLineDiff(line: 3, kind: .modified),
+            GitLineDiff(line: 4, kind: .modified),
+            GitLineDiff(line: 5, kind: .modified)
+        ]
+        let starts = GitLineDiff.changeRegionStarts(diffs)
+        #expect(starts == [3])
+    }
+
+    @Test func changeRegionStarts_multipleRegions() {
+        let diffs = [
+            GitLineDiff(line: 1, kind: .added),
+            GitLineDiff(line: 2, kind: .added),
+            GitLineDiff(line: 10, kind: .modified),
+            GitLineDiff(line: 20, kind: .deleted)
+        ]
+        let starts = GitLineDiff.changeRegionStarts(diffs)
+        #expect(starts == [1, 10, 20])
+    }
+
+    @Test func nextChangeLine_wrapsAround() {
+        let diffs = [
+            GitLineDiff(line: 5, kind: .added),
+            GitLineDiff(line: 15, kind: .modified)
+        ]
+        // From line 20 (after all), wraps to first
+        let next = GitLineDiff.nextChangeLine(from: 20, in: diffs)
+        #expect(next == 5)
+    }
+
+    @Test func nextChangeLine_fromInsideRegion() {
+        let diffs = [
+            GitLineDiff(line: 3, kind: .modified),
+            GitLineDiff(line: 4, kind: .modified),
+            GitLineDiff(line: 10, kind: .added)
+        ]
+        let next = GitLineDiff.nextChangeLine(from: 3, in: diffs)
+        #expect(next == 10)
+    }
+
+    @Test func nextChangeLine_emptyDiffs() {
+        let next = GitLineDiff.nextChangeLine(from: 1, in: [])
+        #expect(next == nil)
+    }
+
+    @Test func previousChangeLine_wrapsAround() {
+        let diffs = [
+            GitLineDiff(line: 5, kind: .added),
+            GitLineDiff(line: 15, kind: .modified)
+        ]
+        // From line 1 (before all), wraps to last
+        let prev = GitLineDiff.previousChangeLine(from: 1, in: diffs)
+        #expect(prev == 15)
+    }
+
+    @Test func previousChangeLine_emptyDiffs() {
+        let prev = GitLineDiff.previousChangeLine(from: 1, in: [])
+        #expect(prev == nil)
+    }
+
+    @Test func previousChangeLine_fromInsideRegion() {
+        let diffs = [
+            GitLineDiff(line: 3, kind: .modified),
+            GitLineDiff(line: 10, kind: .added),
+            GitLineDiff(line: 11, kind: .added)
+        ]
+        let prev = GitLineDiff.previousChangeLine(from: 10, in: diffs)
+        #expect(prev == 3)
+    }
+
+    // MARK: - GitFileStatus color coverage
+
+    @Test func gitFileStatus_allHaveColor() {
+        let statuses: [GitFileStatus] = [.untracked, .modified, .staged, .added, .deleted, .conflict, .mixed]
+        for status in statuses {
+            // Just verify we can get a color without crashing
+            _ = status.color
+        }
+    }
+
+    // MARK: - GitStatusProvider observable state
+
+    @Test func applyEmptyState_clearsAll() {
+        let provider = GitStatusProvider()
+        provider.currentBranch = "main"
+        provider.fileStatuses = ["a.swift": .modified]
+        provider.isGitRepository = true
+
+        provider.applyEmptyState()
+
+        #expect(provider.currentBranch == "")
+        #expect(provider.fileStatuses.isEmpty)
+        #expect(provider.isGitRepository == false)
+        #expect(provider.branches.isEmpty)
+    }
+
+    @Test func applyFetched_setsAll() {
+        let provider = GitStatusProvider()
+        provider.applyFetched(
+            branch: "develop",
+            statuses: ["f.swift": .staged],
+            ignored: ["build"],
+            branches: ["main", "develop"],
+            isRepository: true
+        )
+        #expect(provider.currentBranch == "develop")
+        #expect(provider.fileStatuses["f.swift"] == .staged)
+        #expect(provider.ignoredPaths.contains("build"))
+        #expect(provider.branches == ["main", "develop"])
+        #expect(provider.isGitRepository)
+    }
+
+    @Test func applyFetched_equalValues_noObservableUpdate() {
+        let provider = GitStatusProvider()
+        provider.applyFetched(
+            branch: "main",
+            statuses: ["a.swift": .modified],
+            ignored: [],
+            branches: ["main"],
+            isRepository: true
+        )
+        let count1 = provider.observableUpdateCount
+
+        // Apply same values again
+        provider.applyFetched(
+            branch: "main",
+            statuses: ["a.swift": .modified],
+            ignored: [],
+            branches: ["main"],
+            isRepository: true
+        )
+        let count2 = provider.observableUpdateCount
+        #expect(count2 == count1)
+    }
+
+    @Test func hasUncommittedChanges_trueWhenStatusesExist() {
+        let provider = GitStatusProvider()
+        provider.applyFetched(
+            branch: "main",
+            statuses: ["file.swift": .untracked],
+            ignored: [],
+            branches: [],
+            isRepository: true
+        )
+        #expect(provider.hasUncommittedChanges)
+    }
+
+    @Test func hasUncommittedChanges_falseWhenEmpty() {
+        let provider = GitStatusProvider()
+        provider.applyFetched(
+            branch: "main",
+            statuses: [:],
+            ignored: [],
+            branches: [],
+            isRepository: true
+        )
+        #expect(!provider.hasUncommittedChanges)
+    }
+}

--- a/PineTests/PaneManagerEdgeTests.swift
+++ b/PineTests/PaneManagerEdgeTests.swift
@@ -1,0 +1,326 @@
+//
+//  PaneManagerEdgeTests.swift
+//  PineTests
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+@Suite("PaneManager Edge Case Tests")
+@MainActor
+struct PaneManagerEdgeTests {
+
+    // MARK: - Maximize / Restore
+
+    @Test func maximize_setsMaximizedState() {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        manager.maximize(paneID: paneID)
+
+        #expect(manager.isMaximized)
+        #expect(manager.maximizedPaneID == paneID)
+        #expect(manager.savedRootBeforeMaximize != nil)
+    }
+
+    @Test func maximize_alreadyMaximized_noOp() {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        manager.maximize(paneID: paneID)
+
+        // Try to maximize again
+        let savedRoot = manager.savedRootBeforeMaximize
+        manager.maximize(paneID: paneID)
+        // Should not change
+        #expect(manager.savedRootBeforeMaximize?.leafCount == savedRoot?.leafCount)
+    }
+
+    @Test func restoreFromMaximize_restoresLayout() {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        _ = manager.splitPane(paneID, axis: .horizontal)
+
+        let leafCountBefore = manager.root.leafCount
+        manager.maximize(paneID: manager.activePaneID)
+        #expect(manager.root.leafCount == 1)
+
+        manager.restoreFromMaximize()
+        #expect(manager.root.leafCount == leafCountBefore)
+        #expect(manager.isMaximized == false)
+    }
+
+    @Test func restoreFromMaximize_noSaved_noOp() {
+        let manager = PaneManager()
+        manager.restoreFromMaximize()
+        #expect(manager.isMaximized == false)
+    }
+
+    @Test func persistableRoot_returnsFullLayoutWhenMaximized() {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        _ = manager.splitPane(paneID, axis: .horizontal)
+        let fullLeafCount = manager.root.leafCount
+
+        manager.maximize(paneID: manager.activePaneID)
+        #expect(manager.root.leafCount == 1) // maximized
+        #expect(manager.persistableRoot.leafCount == fullLeafCount) // returns full layout
+    }
+
+    // MARK: - Terminal pane operations
+
+    @Test func createTerminalPane_createsPane() {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        let termID = manager.createTerminalPane(
+            relativeTo: paneID, axis: .vertical, workingDirectory: nil
+        )
+        #expect(termID != nil)
+        #expect(manager.terminalPaneIDs.count == 1)
+    }
+
+    @Test func createTerminalPaneAtBottom_wrapsRoot() {
+        let manager = PaneManager()
+        let termID = manager.createTerminalPaneAtBottom(workingDirectory: nil)
+        #expect(manager.root.leafCount == 2)
+        #expect(manager.terminalPaneIDs.contains(termID))
+        #expect(manager.activePaneID == termID)
+    }
+
+    @Test func terminalState_forValidPaneID() {
+        let manager = PaneManager()
+        let termID = manager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let state = manager.terminalState(for: termID)
+        #expect(state != nil)
+        #expect(state?.terminalTabs.count == 1)
+    }
+
+    @Test func terminalState_forInvalidPaneID() {
+        let manager = PaneManager()
+        let state = manager.terminalState(for: PaneID())
+        #expect(state == nil)
+    }
+
+    @Test func allTerminalTabs_countsCorrectly() {
+        let manager = PaneManager()
+        _ = manager.createTerminalPaneAtBottom(workingDirectory: nil)
+        #expect(manager.allTerminalTabs.count == 1)
+    }
+
+    // MARK: - removePane
+
+    @Test func removePane_lastLeaf_createsNewEditor() {
+        let manager = PaneManager()
+        let onlyPane = manager.activePaneID
+        manager.removePane(onlyPane)
+
+        // Should create a new editor leaf
+        #expect(manager.root.leafCount == 1)
+        #expect(manager.activePaneID != onlyPane)
+        #expect(manager.tabManagers.count == 1)
+    }
+
+    @Test func removePane_switchesActivePaneIfRemoved() {
+        let manager = PaneManager()
+        let first = manager.activePaneID
+        guard let second = manager.splitPane(first, axis: .horizontal) else {
+            Issue.record("Split failed")
+            return
+        }
+        manager.activePaneID = first
+
+        manager.removePane(first)
+        #expect(manager.activePaneID == second)
+    }
+
+    @Test func removePane_maximizedPane_restoresFirst() {
+        let manager = PaneManager()
+        let first = manager.activePaneID
+        _ = manager.splitPane(first, axis: .horizontal)
+        manager.maximize(paneID: first)
+
+        manager.removePane(first)
+        #expect(!manager.isMaximized)
+    }
+
+    // MARK: - updateRatio
+
+    @Test func updateRatio_changesRatio() {
+        let manager = PaneManager()
+        let first = manager.activePaneID
+        _ = manager.splitPane(first, axis: .horizontal)
+
+        manager.updateRatio(for: first, ratio: 0.7)
+        if case .split(_, _, _, let ratio) = manager.root {
+            #expect(abs(ratio - 0.7) < 0.001 || abs(ratio - 0.3) < 0.001)
+        }
+    }
+
+    @Test func updateSplitRatio_changesRatio() {
+        let manager = PaneManager()
+        let first = manager.activePaneID
+        _ = manager.splitPane(first, axis: .horizontal)
+
+        manager.updateSplitRatio(containing: first, ratio: 0.8)
+        // Just verify it doesn't crash
+        #expect(manager.root.leafCount == 2)
+    }
+
+    // MARK: - Drop zone management
+
+    @Test func clearAllDropZones() {
+        let manager = PaneManager()
+        manager.dropZones[PaneID()] = .right
+        manager.rootDropZone = .bottom
+        manager.clearAllDropZones()
+        #expect(manager.dropZones.isEmpty)
+        #expect(manager.rootDropZone == nil)
+    }
+
+    @Test func clearLeafDropZones_preservesRoot() {
+        let manager = PaneManager()
+        manager.dropZones[PaneID()] = .right
+        manager.rootDropZone = .bottom
+        manager.clearLeafDropZones()
+        #expect(manager.dropZones.isEmpty)
+        #expect(manager.rootDropZone == .bottom)
+    }
+
+    @Test func hasActiveDropZones_trueWhenLeafDropZone() {
+        let manager = PaneManager()
+        manager.dropZones[PaneID()] = .right
+        #expect(manager.hasActiveDropZones)
+    }
+
+    @Test func hasActiveDropZones_trueWhenRootDropZone() {
+        let manager = PaneManager()
+        manager.rootDropZone = .top
+        #expect(manager.hasActiveDropZones)
+    }
+
+    @Test func hasActiveDropZones_falseWhenEmpty() {
+        let manager = PaneManager()
+        #expect(!manager.hasActiveDropZones)
+    }
+
+    @Test func clearStaleDropZonesIfNoDragActive_noDropZones_noOp() {
+        let manager = PaneManager()
+        manager.clearStaleDropZonesIfNoDragActive()
+        // No crash
+    }
+
+    @Test func clearStaleDropZonesIfNoDragActive_clearsWhenNoMouseDown() {
+        let manager = PaneManager()
+        manager.isMouseButtonPressed = { false }
+        manager.dropZones[PaneID()] = .right
+        manager.clearStaleDropZonesIfNoDragActive()
+        #expect(manager.dropZones.isEmpty)
+    }
+
+    @Test func clearStaleDropZonesIfNoDragActive_keepsWhenMouseDown() {
+        let manager = PaneManager()
+        manager.isMouseButtonPressed = { true }
+        let id = PaneID()
+        manager.dropZones[id] = .right
+        manager.clearStaleDropZonesIfNoDragActive()
+        #expect(!manager.dropZones.isEmpty)
+    }
+
+    // MARK: - ensureEditorPane
+
+    @Test func ensureEditorPane_returnsExistingEditorTM() {
+        let manager = PaneManager()
+        let tm = manager.ensureEditorPane()
+        #expect(tm === manager.activeTabManager)
+    }
+
+    // MARK: - allTabManagers
+
+    @Test func allTabManagers_returnsAll() {
+        let manager = PaneManager()
+        let first = manager.activePaneID
+        _ = manager.splitPane(first, axis: .horizontal)
+        #expect(manager.allTabManagers.count == 2)
+    }
+
+    // MARK: - activeEditorTabManager fallback
+
+    @Test func activeEditorTabManager_fallsBackWhenTerminalActive() {
+        let manager = PaneManager()
+        let editorPaneID = manager.activePaneID
+        let termID = manager.createTerminalPaneAtBottom(workingDirectory: nil)
+        manager.activePaneID = termID
+
+        let editorTM = manager.activeEditorTabManager
+        #expect(editorTM != nil)
+        #expect(editorTM === manager.tabManager(for: editorPaneID))
+    }
+
+    // MARK: - openFileInPane
+
+    @Test func openFileInPane_skipsDirectory() {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        let dir = FileManager.default.temporaryDirectory
+        manager.openFileInPane(url: dir, paneID: paneID)
+        #expect(manager.activeTabManager?.tabs.isEmpty == true)
+    }
+
+    @Test func openFileInPane_opensFile() {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("test.swift")
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try? "test".write(to: url, atomically: true, encoding: .utf8)
+
+        manager.openFileInPane(url: url, paneID: paneID)
+        #expect(manager.activeTabManager?.tabs.count == 1)
+    }
+
+    // MARK: - splitAndOpenFile
+
+    @Test func splitAndOpenFile_createsNewPaneWithFile() {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("test.swift")
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try? "test".write(to: url, atomically: true, encoding: .utf8)
+
+        let newID = manager.splitAndOpenFile(url: url, relativeTo: paneID, axis: .horizontal)
+        #expect(newID != nil)
+        if let newID {
+            #expect(manager.tabManager(for: newID)?.tabs.count == 1)
+        }
+    }
+
+    // MARK: - clearStaleDragState
+
+    @Test func clearStaleDragState_clearsActiveDrag() {
+        let manager = PaneManager()
+        manager.activeDrag = TabDragInfo(
+            paneID: UUID(),
+            tabID: UUID(),
+            fileURL: nil,
+            contentType: .editor
+        )
+        manager.clearStaleDragState()
+        #expect(manager.activeDrag == nil)
+    }
+
+    // MARK: - insertBefore split
+
+    @Test func splitPane_insertBefore() {
+        let manager = PaneManager()
+        let first = manager.activePaneID
+        let newID = manager.splitPane(first, axis: .horizontal, insertBefore: true)
+        #expect(newID != nil)
+        #expect(manager.root.leafCount == 2)
+    }
+}

--- a/PineTests/PaneManagerEdgeTests.swift
+++ b/PineTests/PaneManagerEdgeTests.swift
@@ -151,18 +151,42 @@ struct PaneManagerEdgeTests {
 
         manager.updateRatio(for: first, ratio: 0.7)
         if case .split(_, _, _, let ratio) = manager.root {
-            #expect(abs(ratio - 0.7) < 0.001 || abs(ratio - 0.3) < 0.001)
+            // updateRatio sets the parent split's ratio to exactly the clamped value
+            #expect(abs(ratio - 0.7) < 0.001)
+        } else {
+            Issue.record("Expected root to be a split node")
         }
     }
 
     @Test func updateSplitRatio_changesRatio() {
         let manager = PaneManager()
         let first = manager.activePaneID
-        _ = manager.splitPane(first, axis: .horizontal)
+        // Create a two-level tree: root splits into (split(first, third), second)
+        guard let second = manager.splitPane(first, axis: .horizontal) else {
+            Issue.record("First split failed")
+            return
+        }
+        // Split 'first' again so it becomes a child of an inner split
+        guard let third = manager.splitPane(first, axis: .vertical) else {
+            Issue.record("Second split failed")
+            return
+        }
+        #expect(third != PaneID())
 
-        manager.updateSplitRatio(containing: first, ratio: 0.8)
-        // Just verify it doesn't crash
-        #expect(manager.root.leafCount == 2)
+        // Now 'first' is a direct leaf child of an inner split node.
+        // updateSplitRatio(containing: first) targets the root split (one level up).
+        if case .split(_, _, _, let ratioBefore) = manager.root {
+            manager.updateSplitRatio(containing: first, ratio: 0.8)
+            if case .split(_, _, _, let ratioAfter) = manager.root {
+                #expect(abs(ratioAfter - 0.8) < 0.001)
+                #expect(abs(ratioAfter - ratioBefore) > 0.01)
+            } else {
+                Issue.record("Expected root to remain a split node")
+            }
+        } else {
+            Issue.record("Expected root to be a split node")
+        }
+        _ = second // suppress unused warning
     }
 
     // MARK: - Drop zone management
@@ -268,12 +292,11 @@ struct PaneManagerEdgeTests {
     @Test func openFileInPane_opensFile() {
         let manager = PaneManager()
         let paneID = manager.activePaneID
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathComponent("test.swift")
-        try? FileManager.default.createDirectory(
-            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
-        )
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PaneMgrEdge-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("test.swift")
         try? "test".write(to: url, atomically: true, encoding: .utf8)
 
         manager.openFileInPane(url: url, paneID: paneID)
@@ -285,12 +308,11 @@ struct PaneManagerEdgeTests {
     @Test func splitAndOpenFile_createsNewPaneWithFile() {
         let manager = PaneManager()
         let paneID = manager.activePaneID
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathComponent("test.swift")
-        try? FileManager.default.createDirectory(
-            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
-        )
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PaneMgrEdge-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("test.swift")
         try? "test".write(to: url, atomically: true, encoding: .utf8)
 
         let newID = manager.splitAndOpenFile(url: url, relativeTo: paneID, axis: .horizontal)

--- a/PineTests/PaneManagerEdgeTests.swift
+++ b/PineTests/PaneManagerEdgeTests.swift
@@ -289,15 +289,15 @@ struct PaneManagerEdgeTests {
         #expect(manager.activeTabManager?.tabs.isEmpty == true)
     }
 
-    @Test func openFileInPane_opensFile() {
+    @Test func openFileInPane_opensFile() throws {
         let manager = PaneManager()
         let paneID = manager.activePaneID
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("PaneMgrEdge-\(UUID().uuidString)")
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
         let url = dir.appendingPathComponent("test.swift")
-        try? "test".write(to: url, atomically: true, encoding: .utf8)
+        try "test".write(to: url, atomically: true, encoding: .utf8)
 
         manager.openFileInPane(url: url, paneID: paneID)
         #expect(manager.activeTabManager?.tabs.count == 1)
@@ -305,15 +305,15 @@ struct PaneManagerEdgeTests {
 
     // MARK: - splitAndOpenFile
 
-    @Test func splitAndOpenFile_createsNewPaneWithFile() {
+    @Test func splitAndOpenFile_createsNewPaneWithFile() throws {
         let manager = PaneManager()
         let paneID = manager.activePaneID
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("PaneMgrEdge-\(UUID().uuidString)")
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
         let url = dir.appendingPathComponent("test.swift")
-        try? "test".write(to: url, atomically: true, encoding: .utf8)
+        try "test".write(to: url, atomically: true, encoding: .utf8)
 
         let newID = manager.splitAndOpenFile(url: url, relativeTo: paneID, axis: .horizontal)
         #expect(newID != nil)

--- a/PineTests/ProjectSearchProviderEdgeTests.swift
+++ b/PineTests/ProjectSearchProviderEdgeTests.swift
@@ -1,0 +1,208 @@
+//
+//  ProjectSearchProviderEdgeTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+@testable import Pine
+
+@Suite("ProjectSearchProvider Edge Case Tests")
+@MainActor
+struct ProjectSearchProviderEdgeTests {
+
+    private func createTestProject(files: [String: String]) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineSearchEdge-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        for (name, content) in files {
+            let fileURL = dir.appendingPathComponent(name)
+            let parent = fileURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+            try content.write(to: fileURL, atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+
+    private func cleanup(_ dir: URL) {
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    // MARK: - isBinaryFile
+
+    @Test func isBinaryFile_image() {
+        let url = URL(fileURLWithPath: "/tmp/test.png")
+        #expect(ProjectSearchProvider.isBinaryFile(url: url))
+    }
+
+    @Test func isBinaryFile_pdf() {
+        let url = URL(fileURLWithPath: "/tmp/test.pdf")
+        #expect(ProjectSearchProvider.isBinaryFile(url: url))
+    }
+
+    @Test func isBinaryFile_font() {
+        let url = URL(fileURLWithPath: "/tmp/test.ttf")
+        #expect(ProjectSearchProvider.isBinaryFile(url: url))
+    }
+
+    @Test func isBinaryFile_swift_notBinary() {
+        let url = URL(fileURLWithPath: "/tmp/test.swift")
+        #expect(!ProjectSearchProvider.isBinaryFile(url: url))
+    }
+
+    @Test func isBinaryFile_js_overrideNotBinary() {
+        let url = URL(fileURLWithPath: "/tmp/test.js")
+        #expect(!ProjectSearchProvider.isBinaryFile(url: url))
+    }
+
+    @Test func isBinaryFile_ts_overrideNotBinary() {
+        let url = URL(fileURLWithPath: "/tmp/test.ts")
+        #expect(!ProjectSearchProvider.isBinaryFile(url: url))
+    }
+
+    @Test func isBinaryFile_tsx_overrideNotBinary() {
+        let url = URL(fileURLWithPath: "/tmp/test.tsx")
+        #expect(!ProjectSearchProvider.isBinaryFile(url: url))
+    }
+
+    @Test func isBinaryFile_vue_overrideNotBinary() {
+        let url = URL(fileURLWithPath: "/tmp/App.vue")
+        #expect(!ProjectSearchProvider.isBinaryFile(url: url))
+    }
+
+    @Test func isBinaryFile_svelte_overrideNotBinary() {
+        let url = URL(fileURLWithPath: "/tmp/App.svelte")
+        #expect(!ProjectSearchProvider.isBinaryFile(url: url))
+    }
+
+    @Test func isBinaryFile_mjs_overrideNotBinary() {
+        let url = URL(fileURLWithPath: "/tmp/module.mjs")
+        #expect(!ProjectSearchProvider.isBinaryFile(url: url))
+    }
+
+    @Test func isBinaryFile_cjs_overrideNotBinary() {
+        let url = URL(fileURLWithPath: "/tmp/module.cjs")
+        #expect(!ProjectSearchProvider.isBinaryFile(url: url))
+    }
+
+    @Test func isBinaryFile_unknownExtension() {
+        let url = URL(fileURLWithPath: "/tmp/test.xyz_unknown_ext")
+        // Unknown extension → no UTType → not binary
+        #expect(!ProjectSearchProvider.isBinaryFile(url: url))
+    }
+
+    // MARK: - searchFile edge cases
+
+    @Test func searchFile_multipleMatchesPerLine() throws {
+        let dir = try createTestProject(files: ["test.txt": "aaa"])
+        defer { cleanup(dir) }
+
+        let matches = ProjectSearchProvider.searchFile(
+            at: dir.appendingPathComponent("test.txt"),
+            query: "a",
+            isCaseSensitive: false
+        )
+        #expect(matches.count == 3)
+    }
+
+    @Test func searchFile_respectsRemainingCapacity() throws {
+        let dir = try createTestProject(files: ["test.txt": "a\na\na\na\na"])
+        defer { cleanup(dir) }
+
+        let matches = ProjectSearchProvider.searchFile(
+            at: dir.appendingPathComponent("test.txt"),
+            query: "a",
+            isCaseSensitive: false,
+            remainingCapacity: 2
+        )
+        #expect(matches.count == 2)
+    }
+
+    @Test func searchFile_nonexistentFile() {
+        let matches = ProjectSearchProvider.searchFile(
+            at: URL(fileURLWithPath: "/tmp/nonexistent_\(UUID()).txt"),
+            query: "test",
+            isCaseSensitive: false
+        )
+        #expect(matches.isEmpty)
+    }
+
+    @Test func searchFile_emptyFile() throws {
+        let dir = try createTestProject(files: ["empty.txt": ""])
+        defer { cleanup(dir) }
+
+        let matches = ProjectSearchProvider.searchFile(
+            at: dir.appendingPathComponent("empty.txt"),
+            query: "test",
+            isCaseSensitive: false
+        )
+        #expect(matches.isEmpty)
+    }
+
+    @Test func searchFile_leadsWithWhitespace_offsetAdjusted() throws {
+        let dir = try createTestProject(files: ["test.txt": "    hello world"])
+        defer { cleanup(dir) }
+
+        let matches = ProjectSearchProvider.searchFile(
+            at: dir.appendingPathComponent("test.txt"),
+            query: "hello",
+            isCaseSensitive: false
+        )
+        #expect(matches.count == 1)
+        // matchRangeStart should be relative to trimmed content
+        #expect(matches[0].matchRangeStart == 0)
+    }
+
+    // MARK: - SearchMatch
+
+    @Test func searchMatch_id_isDeterministic() {
+        let m1 = SearchMatch(lineNumber: 5, lineContent: "test", matchRangeStart: 0, matchRangeLength: 4)
+        let m2 = SearchMatch(lineNumber: 5, lineContent: "test", matchRangeStart: 0, matchRangeLength: 4)
+        #expect(m1.id == m2.id)
+    }
+
+    @Test func searchMatch_differentPositions_differentIds() {
+        let m1 = SearchMatch(lineNumber: 1, lineContent: "test", matchRangeStart: 0, matchRangeLength: 4)
+        let m2 = SearchMatch(lineNumber: 2, lineContent: "test", matchRangeStart: 0, matchRangeLength: 4)
+        #expect(m1.id != m2.id)
+    }
+
+    // MARK: - SearchFileGroup
+
+    @Test func searchFileGroup_idIsURL() {
+        let url = URL(fileURLWithPath: "/tmp/test.swift")
+        let group = SearchFileGroup(url: url, relativePath: "test.swift", matches: [])
+        #expect(group.id == url)
+    }
+
+    // MARK: - ProjectSearchProvider state
+
+    @Test func cancel_stopsSearch() {
+        let provider = ProjectSearchProvider()
+        provider.query = "test"
+        provider.cancel()
+        #expect(provider.isSearching == false)
+    }
+
+    // MARK: - collectSearchableFiles
+
+    @Test func collectSearchableFiles_skipsHiddenGit() throws {
+        let dir = try createTestProject(files: [
+            "visible.swift": "hello"
+        ])
+        // Create .git directory
+        let gitDir = dir.appendingPathComponent(".git")
+        try FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+        try "ref".write(to: gitDir.appendingPathComponent("HEAD"), atomically: true, encoding: .utf8)
+        defer { cleanup(dir) }
+
+        let rootPath = dir.resolvingSymlinksInPath().path
+        let resolvedRoot = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        let files = ProjectSearchProvider.collectSearchableFiles(
+            rootURL: dir, ignoredDirs: [], resolvedRootPath: resolvedRoot
+        )
+        let fileNames = files.map { $0.0.lastPathComponent }
+        #expect(fileNames.contains("visible.swift"))
+        #expect(!fileNames.contains("HEAD"))
+    }
+}

--- a/PineTests/ProjectSearchProviderEdgeTests.swift
+++ b/PineTests/ProjectSearchProviderEdgeTests.swift
@@ -118,6 +118,31 @@ struct ProjectSearchProviderEdgeTests {
         #expect(matches.count == 2)
     }
 
+    @Test func searchFile_caseSensitive_matchesExactCase() throws {
+        let dir = try createTestProject(files: ["test.txt": "Hello hello HELLO"])
+        defer { cleanup(dir) }
+
+        let matches = ProjectSearchProvider.searchFile(
+            at: dir.appendingPathComponent("test.txt"),
+            query: "Hello",
+            isCaseSensitive: true
+        )
+        #expect(matches.count == 1)
+        #expect(matches[0].matchRangeStart == 0)
+    }
+
+    @Test func searchFile_caseSensitive_noMatch() throws {
+        let dir = try createTestProject(files: ["test.txt": "hello world"])
+        defer { cleanup(dir) }
+
+        let matches = ProjectSearchProvider.searchFile(
+            at: dir.appendingPathComponent("test.txt"),
+            query: "Hello",
+            isCaseSensitive: true
+        )
+        #expect(matches.isEmpty)
+    }
+
     @Test func searchFile_nonexistentFile() {
         let matches = ProjectSearchProvider.searchFile(
             at: URL(fileURLWithPath: "/tmp/nonexistent_\(UUID()).txt"),

--- a/PineTests/QuickOpenProviderEdgeTests.swift
+++ b/PineTests/QuickOpenProviderEdgeTests.swift
@@ -156,6 +156,73 @@ struct QuickOpenProviderEdgeTests {
         #expect(results.count == 1)
     }
 
+    // MARK: - buildIndex and invalidateIndex
+
+    @Test func buildIndex_populatesFileIndex() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineQOBuild-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "content".write(
+            to: dir.appendingPathComponent("main.swift"), atomically: true, encoding: .utf8
+        )
+        try "content".write(
+            to: dir.appendingPathComponent("utils.swift"), atomically: true, encoding: .utf8
+        )
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let root = FileNode(url: dir, projectRoot: dir)
+        let provider = QuickOpenProvider()
+        provider.buildIndex(from: [root], rootURL: dir)
+
+        let results = provider.search(query: "main")
+        #expect(!results.isEmpty)
+        #expect(results[0].fileName == "main.swift")
+    }
+
+    @Test func buildIndex_skipsRebuildWhenSameRoot() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineQOSkip-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "a".write(
+            to: dir.appendingPathComponent("alpha.swift"), atomically: true, encoding: .utf8
+        )
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let root = FileNode(url: dir, projectRoot: dir)
+        let provider = QuickOpenProvider()
+        provider.buildIndex(from: [root], rootURL: dir)
+        let countBefore = provider.search(query: "alpha").count
+
+        // Add a new file and call buildIndex again — should be cached (same root)
+        try "b".write(
+            to: dir.appendingPathComponent("beta.swift"), atomically: true, encoding: .utf8
+        )
+        provider.buildIndex(from: [root], rootURL: dir)
+        let betaResults = provider.search(query: "beta")
+
+        #expect(countBefore == 1)
+        // "beta.swift" not indexed because buildIndex was cached (same root)
+        #expect(betaResults.isEmpty)
+    }
+
+    @Test func invalidateIndex_clearsIndex() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineQOInv-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "x".write(
+            to: dir.appendingPathComponent("x.swift"), atomically: true, encoding: .utf8
+        )
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let root = FileNode(url: dir, projectRoot: dir)
+        let provider = QuickOpenProvider()
+        provider.buildIndex(from: [root], rootURL: dir)
+        #expect(!provider.search(query: "x").isEmpty)
+
+        provider.invalidateIndex()
+        #expect(provider.search(query: "x").isEmpty)
+    }
+
     // MARK: - Empty index search
 
     @Test func search_emptyIndex_returnsEmpty() {

--- a/PineTests/QuickOpenProviderEdgeTests.swift
+++ b/PineTests/QuickOpenProviderEdgeTests.swift
@@ -1,0 +1,180 @@
+//
+//  QuickOpenProviderEdgeTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+@testable import Pine
+
+@Suite("QuickOpenProvider Edge Case Tests")
+@MainActor
+struct QuickOpenProviderEdgeTests {
+
+    // MARK: - relativePath with originalRootPrefix fallback
+
+    @Test func relativePath_fallbackToOriginalRootPrefix() {
+        // When resolvedPath doesn't match but originalRootPrefix does
+        let result = QuickOpenProvider.relativePath(
+            for: URL(fileURLWithPath: "/var/folders/project/src/main.swift"),
+            rootPrefix: "/private/var/folders/project/",
+            originalRootPrefix: "/var/folders/project/"
+        )
+        #expect(result == "src/main.swift")
+    }
+
+    @Test func relativePath_neitherPrefixMatches() {
+        let result = QuickOpenProvider.relativePath(
+            for: URL(fileURLWithPath: "/other/path/file.swift"),
+            rootPrefix: "/usr/local/",
+            originalRootPrefix: "/usr/share/"
+        )
+        #expect(result == "/other/path/file.swift")
+    }
+
+    @Test func relativePath_emptyOriginalRootPrefix() {
+        let result = QuickOpenProvider.relativePath(
+            for: URL(fileURLWithPath: "/other/path/file.swift"),
+            rootPrefix: "/usr/local/",
+            originalRootPrefix: ""
+        )
+        #expect(result == "/other/path/file.swift")
+    }
+
+    // MARK: - isSubsequence edge cases
+
+    @Test func isSubsequence_emptyTarget() {
+        #expect(!QuickOpenProvider.isSubsequence("a", of: ""))
+    }
+
+    @Test func isSubsequence_bothEmpty() {
+        #expect(QuickOpenProvider.isSubsequence("", of: ""))
+    }
+
+    @Test func isSubsequence_queryLongerThanTarget() {
+        #expect(!QuickOpenProvider.isSubsequence("abcdef", of: "abc"))
+    }
+
+    @Test func isSubsequence_singleCharMatch() {
+        #expect(QuickOpenProvider.isSubsequence("a", of: "abc"))
+    }
+
+    @Test func isSubsequence_singleCharNoMatch() {
+        #expect(!QuickOpenProvider.isSubsequence("z", of: "abc"))
+    }
+
+    // MARK: - fuzzyScore edge cases
+
+    @Test func fuzzyScore_exactMatchScoredHighest() {
+        let provider = QuickOpenProvider()
+        guard let exact = provider.fuzzyScore(
+            queryLower: "main.swift",
+            fileNameLower: "main.swift",
+            pathLower: "main.swift",
+            pathLength: 10
+        ) else {
+            Issue.record("Expected non-nil exact score")
+            return
+        }
+        guard let prefix = provider.fuzzyScore(
+            queryLower: "main",
+            fileNameLower: "main.swift",
+            pathLower: "main.swift",
+            pathLength: 10
+        ) else {
+            Issue.record("Expected non-nil prefix score")
+            return
+        }
+        #expect(exact > prefix)
+    }
+
+    @Test func fuzzyScore_fileSubsequenceMatchLower() {
+        let provider = QuickOpenProvider()
+        guard let subseq = provider.fuzzyScore(
+            queryLower: "mn",
+            fileNameLower: "main.swift",
+            pathLower: "main.swift",
+            pathLength: 10
+        ) else {
+            Issue.record("Expected non-nil subseq score")
+            return
+        }
+        guard let prefixScore = provider.fuzzyScore(
+            queryLower: "mai",
+            fileNameLower: "main.swift",
+            pathLower: "main.swift",
+            pathLength: 10
+        ) else {
+            Issue.record("Expected non-nil prefix score")
+            return
+        }
+        #expect(prefixScore > subseq)
+    }
+
+    @Test func fuzzyScore_pathOnlyMatchLowestScore() {
+        let provider = QuickOpenProvider()
+        let score = provider.fuzzyScore(
+            queryLower: "sr",
+            fileNameLower: "file.swift",
+            pathLower: "src/file.swift",
+            pathLength: 14
+        )
+        #expect(score != nil)
+        if let score {
+            // Path-only match: 10 - pathLength
+            #expect(score < 50)
+        }
+    }
+
+    // MARK: - maxIndexDepth
+
+    @Test func maxIndexDepth_isReasonable() {
+        #expect(QuickOpenProvider.maxIndexDepth == 100)
+    }
+
+    // MARK: - Multiple recordOpened deduplicates
+
+    @Test func recordOpened_deduplicates() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineQOEdge-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let fileURL = dir.appendingPathComponent("test.swift")
+        try "".write(to: fileURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let root = FileNode(url: dir, projectRoot: dir)
+        let provider = QuickOpenProvider()
+        provider.buildIndex(from: [root], rootURL: dir)
+
+        // Record same file multiple times
+        provider.recordOpened(url: fileURL)
+        provider.recordOpened(url: fileURL)
+        provider.recordOpened(url: fileURL)
+
+        let results = provider.search(query: "")
+        // Should only appear once in recent results
+        #expect(results.count == 1)
+    }
+
+    // MARK: - Empty index search
+
+    @Test func search_emptyIndex_returnsEmpty() {
+        let provider = QuickOpenProvider()
+        let results = provider.search(query: "anything")
+        #expect(results.isEmpty)
+    }
+
+    // MARK: - Result struct
+
+    @Test func result_urlEqualsId() {
+        let url = URL(fileURLWithPath: "/tmp/test.swift")
+        let result = QuickOpenProvider.Result(
+            id: url,
+            fileName: "test.swift",
+            relativePath: "test.swift",
+            score: 100
+        )
+        #expect(result.url == url)
+        #expect(result.id == url)
+    }
+}

--- a/PineTests/QuickOpenProviderEdgeTests.swift
+++ b/PineTests/QuickOpenProviderEdgeTests.swift
@@ -128,8 +128,10 @@ struct QuickOpenProviderEdgeTests {
 
     // MARK: - maxIndexDepth
 
-    @Test func maxIndexDepth_isReasonable() {
-        #expect(QuickOpenProvider.maxIndexDepth == 100)
+    @Test func maxIndexDepth_preventsInfiniteRecursion() {
+        // maxIndexDepth should be positive and bounded to prevent runaway traversal
+        #expect(QuickOpenProvider.maxIndexDepth > 0)
+        #expect(QuickOpenProvider.maxIndexDepth <= 1000)
     }
 
     // MARK: - Multiple recordOpened deduplicates

--- a/PineTests/SymbolParserEdgeTests.swift
+++ b/PineTests/SymbolParserEdgeTests.swift
@@ -1,0 +1,262 @@
+//
+//  SymbolParserEdgeTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("SymbolParser Edge Case Tests")
+@MainActor
+struct SymbolParserEdgeTests {
+
+    // MARK: - Ruby
+
+    @Test("Ruby: parses modules")
+    func rubyModules() {
+        let code = """
+        module MyModule
+            def hello
+            end
+        end
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "rb")
+        #expect(symbols.contains { $0.name == "MyModule" && $0.kind == .class })
+        #expect(symbols.contains { $0.name == "hello" && $0.kind == .function })
+    }
+
+    @Test("Ruby: self.method")
+    func rubySelfMethod() {
+        let code = """
+        class Foo
+            def self.bar
+            end
+        end
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "rb")
+        #expect(symbols.contains { $0.name == "bar" && $0.kind == .function })
+    }
+
+    @Test("Ruby: question mark and bang methods")
+    func rubySpecialMethods() {
+        let code = """
+        def valid?
+        end
+        def save!
+        end
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "rb")
+        let funcs = symbols.filter { $0.kind == .function }
+        #expect(funcs.count == 2)
+        #expect(funcs[0].name == "valid?")
+        #expect(funcs[1].name == "save!")
+    }
+
+    @Test("Ruby: comments exclude symbols")
+    func rubyCommentExclusion() {
+        let code = """
+        # def not_a_function
+        def real_function
+        end
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "rb")
+        #expect(symbols.count == 1)
+        #expect(symbols[0].name == "real_function")
+    }
+
+    // MARK: - Java/Kotlin
+
+    @Test("Java: parses classes, interfaces, enums")
+    func javaSymbols() {
+        let code = """
+        public class MyService {
+            public void handle() {}
+        }
+        public interface IHandler {
+        }
+        public enum Status {
+        }
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "java")
+        #expect(symbols.contains { $0.name == "MyService" && $0.kind == .class })
+        #expect(symbols.contains { $0.name == "IHandler" && $0.kind == .interface })
+        #expect(symbols.contains { $0.name == "Status" && $0.kind == .enum })
+    }
+
+    @Test("Kotlin: parses suspend fun")
+    func kotlinSuspendFun() {
+        let code = """
+        suspend fun fetchData() {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "kt")
+        let funcs = symbols.filter { $0.kind == .function }
+        #expect(funcs.count == 1)
+        #expect(funcs[0].name == "fetchData")
+    }
+
+    @Test("Kotlin: parses via kts extension")
+    func kotlinScriptExtension() {
+        let code = """
+        class BuildScript {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "kts")
+        #expect(symbols.contains { $0.name == "BuildScript" && $0.kind == .class })
+    }
+
+    // MARK: - TypeScript edge cases
+
+    @Test("TypeScript: abstract class")
+    func typescriptAbstractClass() {
+        let code = """
+        export abstract class BaseService {
+        }
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "ts")
+        #expect(symbols.contains { $0.name == "BaseService" && $0.kind == .class })
+    }
+
+    @Test("TypeScript: arrow function export")
+    func typescriptArrowFunctionExport() {
+        let code = """
+        export const processData = async (input) => {
+        }
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "tsx")
+        let funcs = symbols.filter { $0.kind == .function }
+        #expect(funcs.count == 1)
+        #expect(funcs[0].name == "processData")
+    }
+
+    // MARK: - Rust edge cases
+
+    @Test("Rust: pub(crate) visibility")
+    func rustPubCrate() {
+        let code = """
+        pub(crate) struct Internal {
+        }
+        pub(crate) fn helper() {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "rs")
+        #expect(symbols.contains { $0.name == "Internal" && $0.kind == .struct })
+        #expect(symbols.contains { $0.name == "helper" && $0.kind == .function })
+    }
+
+    // MARK: - Go edge cases
+
+    @Test("Go: method receiver")
+    func goMethodReceiver() {
+        let code = """
+        func (s *Server) Start() {}
+        func (s Server) Stop() {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "go")
+        #expect(symbols.contains { $0.name == "Start" && $0.kind == .function })
+        #expect(symbols.contains { $0.name == "Stop" && $0.kind == .function })
+    }
+
+    // MARK: - Python edge cases
+
+    @Test("Python: .pyw extension")
+    func pythonPywExtension() {
+        let code = """
+        class GuiApp:
+            pass
+        def main():
+            pass
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "pyw")
+        #expect(symbols.contains { $0.name == "GuiApp" && $0.kind == .class })
+        #expect(symbols.contains { $0.name == "main" && $0.kind == .function })
+    }
+
+    // MARK: - JavaScript edge cases
+
+    @Test("JavaScript: generator function")
+    func jsGeneratorFunction() {
+        let code = """
+        function* generate() {
+            yield 1;
+        }
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "js")
+        let funcs = symbols.filter { $0.kind == .function }
+        #expect(funcs.count == 1)
+        #expect(funcs[0].name == "generate")
+    }
+
+    @Test("JavaScript: mjs extension")
+    func jsMjsExtension() {
+        let code = """
+        function main() {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "mjs")
+        #expect(symbols.contains { $0.name == "main" && $0.kind == .function })
+    }
+
+    // MARK: - lineNumber edge cases
+
+    @Test("lineNumber: offset beyond content returns last line")
+    func lineNumberBeyondContent() {
+        let content = "abc\ndef"
+        // offset 100 is way beyond the text
+        let line = SymbolParser.lineNumber(at: 100, in: content)
+        #expect(line == 2)
+    }
+
+    @Test("lineNumber: multi-byte characters")
+    func lineNumberMultiByte() {
+        let content = "café\nbar"
+        // "café" is 5 UTF-16 units (c, a, f, é is 1 unit, \n), bar starts at offset 5
+        let line = SymbolParser.lineNumber(at: 5, in: content)
+        #expect(line == 2)
+    }
+
+    // MARK: - PineSymbol Equatable
+
+    @Test("PineSymbol equality by value, not id")
+    func pineSymbolEquality() {
+        let a = PineSymbol(name: "foo", kind: .function, line: 1)
+        let b = PineSymbol(name: "foo", kind: .function, line: 1)
+        #expect(a == b) // same values, different UUIDs
+    }
+
+    @Test("PineSymbol inequality when kind differs")
+    func pineSymbolInequalityKind() {
+        let a = PineSymbol(name: "Foo", kind: .class, line: 1)
+        let b = PineSymbol(name: "Foo", kind: .struct, line: 1)
+        #expect(a != b)
+    }
+
+    // MARK: - Swift: access modifiers
+
+    @Test("Swift: open class")
+    func swiftOpenClass() {
+        let code = """
+        open class BaseViewModel {
+        }
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "swift")
+        #expect(symbols.contains { $0.name == "BaseViewModel" && $0.kind == .class })
+    }
+
+    @Test("Swift: fileprivate struct")
+    func swiftFileprivateStruct() {
+        let code = """
+        fileprivate struct InternalModel {
+        }
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "swift")
+        #expect(symbols.contains { $0.name == "InternalModel" && $0.kind == .struct })
+    }
+
+    @Test("Swift: mutating func")
+    func swiftMutatingFunc() {
+        let code = """
+        mutating func update() {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "swift")
+        #expect(symbols.contains { $0.name == "update" && $0.kind == .function })
+    }
+}

--- a/PineTests/SymbolParserEdgeTests.swift
+++ b/PineTests/SymbolParserEdgeTests.swift
@@ -12,6 +12,51 @@ import Testing
 @MainActor
 struct SymbolParserEdgeTests {
 
+    // MARK: - Empty / unsupported inputs
+
+    @Test("Empty file returns no symbols")
+    func emptyFile() {
+        let symbols = SymbolParser.parse(content: "", fileExtension: "swift")
+        #expect(symbols.isEmpty)
+    }
+
+    @Test("Empty extension returns no symbols")
+    func emptyExtension() {
+        let code = "class Foo {}"
+        let symbols = SymbolParser.parse(content: code, fileExtension: "")
+        #expect(symbols.isEmpty)
+    }
+
+    @Test("C file returns no symbols (unsupported)")
+    func cFileUnsupported() {
+        let code = """
+        void main() {}
+        struct Point { int x; int y; };
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "c")
+        #expect(symbols.isEmpty)
+    }
+
+    @Test("C++ file returns no symbols (unsupported)")
+    func cppFileUnsupported() {
+        let code = """
+        class Widget {};
+        void render() {}
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "cpp")
+        #expect(symbols.isEmpty)
+    }
+
+    @Test("Header file returns no symbols (unsupported)")
+    func headerFileUnsupported() {
+        let code = """
+        @interface NSObject
+        @end
+        """
+        let symbols = SymbolParser.parse(content: code, fileExtension: "h")
+        #expect(symbols.isEmpty)
+    }
+
     // MARK: - Ruby
 
     @Test("Ruby: parses modules")

--- a/PineTests/SyntaxHighlighterEdgeTests.swift
+++ b/PineTests/SyntaxHighlighterEdgeTests.swift
@@ -1,0 +1,235 @@
+//
+//  SyntaxHighlighterEdgeTests.swift
+//  PineTests
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+@Suite(.serialized)
+@MainActor
+struct SyntaxHighlighterEdgeTests {
+
+    nonisolated(unsafe) private let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+
+    // MARK: - HighlightGeneration
+
+    @Test func highlightGeneration_initialValueIsZero() {
+        let gen = HighlightGeneration()
+        #expect(gen.current == 0)
+    }
+
+    @Test func highlightGeneration_incrementReturnsNewValue() {
+        let gen = HighlightGeneration()
+        let val = gen.increment()
+        #expect(val == 1)
+        #expect(gen.current == 1)
+    }
+
+    @Test func highlightGeneration_multipleIncrements() {
+        let gen = HighlightGeneration()
+        _ = gen.increment()
+        _ = gen.increment()
+        let val = gen.increment()
+        #expect(val == 3)
+        #expect(gen.current == 3)
+    }
+
+    // MARK: - commentStyle
+
+    @Test func commentStyle_swiftReturnsLineComment() {
+        let hl = SyntaxHighlighter.shared
+        let style = hl.commentStyle(forExtension: "swift", fileName: nil)
+        if case .line(let prefix) = style {
+            #expect(prefix == "//")
+        } else {
+            Issue.record("Expected line comment for swift")
+        }
+    }
+
+    @Test func commentStyle_unknownExtensionReturnsNil() {
+        let hl = SyntaxHighlighter.shared
+        let style = hl.commentStyle(forExtension: "xyz_unknown_ext", fileName: nil)
+        #expect(style == nil)
+    }
+
+    @Test func commentStyle_pythonReturnsHashComment() {
+        let hl = SyntaxHighlighter.shared
+        let style = hl.commentStyle(forExtension: "py", fileName: nil)
+        if case .line(let prefix) = style {
+            #expect(prefix == "#")
+        } else {
+            Issue.record("Expected line comment for python")
+        }
+    }
+
+    // MARK: - lineComment lookup
+
+    @Test func lineComment_forExtension() {
+        let hl = SyntaxHighlighter.shared
+        #expect(hl.lineComment(forExtension: "swift") == "//")
+        #expect(hl.lineComment(forExtension: "py") == "#")
+    }
+
+    @Test func lineComment_forExtension_unknownReturnsNil() {
+        let hl = SyntaxHighlighter.shared
+        #expect(hl.lineComment(forExtension: "unknownExt123") == nil)
+    }
+
+    // MARK: - resolveGrammarByTag
+
+    @Test func resolveGrammarByTag_directExtension() {
+        let hl = SyntaxHighlighter.shared
+        let result = hl.resolveGrammarByTag("swift")
+        #expect(result != nil)
+        #expect(result?.0.name.lowercased().contains("swift") == true)
+    }
+
+    @Test func resolveGrammarByTag_alias() {
+        let hl = SyntaxHighlighter.shared
+        // "javascript" is aliased to "js"
+        let result = hl.resolveGrammarByTag("javascript")
+        #expect(result != nil)
+    }
+
+    @Test func resolveGrammarByTag_unknownReturnsNil() {
+        let hl = SyntaxHighlighter.shared
+        let result = hl.resolveGrammarByTag("brainfuck")
+        #expect(result == nil)
+    }
+
+    @Test func resolveGrammarByTag_caseInsensitive() {
+        let hl = SyntaxHighlighter.shared
+        let result = hl.resolveGrammarByTag("Python")
+        #expect(result != nil)
+    }
+
+    // MARK: - Theme
+
+    @Test func theme_colorForKnownScope() {
+        let theme = Theme.default
+        #expect(theme.color(for: "keyword") != nil)
+        #expect(theme.color(for: "comment") != nil)
+        #expect(theme.color(for: "string") != nil)
+    }
+
+    @Test func theme_colorForUnknownScopeReturnsNil() {
+        let theme = Theme.default
+        #expect(theme.color(for: "nonexistent.scope") == nil)
+    }
+
+    // MARK: - registerGrammar
+
+    @Test func registerGrammar_makesGrammarAvailable() {
+        let hl = SyntaxHighlighter.shared
+        let testGrammar = Grammar(
+            name: "TestLangEdge",
+            extensions: ["testedge"],
+            rules: [GrammarRule(pattern: "\\btest\\b", scope: "keyword")]
+        )
+        hl.registerGrammar(testGrammar)
+
+        let style = hl.commentStyle(forExtension: "testedge", fileName: nil)
+        // No comment style defined → nil
+        #expect(style == nil)
+
+        // But it should be recognized
+        let result = hl.resolveGrammarByTag("testedge")
+        #expect(result != nil)
+        #expect(result?.0.name == "TestLangEdge")
+    }
+
+    @Test func registerGrammar_withFileNames() {
+        let hl = SyntaxHighlighter.shared
+        let testGrammar = Grammar(
+            name: "TestFileNameGrammar",
+            extensions: ["tfn"],
+            rules: [GrammarRule(pattern: "\\bfoo\\b", scope: "keyword")],
+            fileNames: ["TestSpecialFile"]
+        )
+        hl.registerGrammar(testGrammar)
+
+        let comment = hl.lineComment(forFileName: "TestSpecialFile")
+        // No line comment defined → nil, but grammar should be loadable
+        #expect(comment == nil)
+    }
+
+    // MARK: - invalidateCache
+
+    @Test func invalidateCache_removesEntry() {
+        let hl = SyntaxHighlighter.shared
+        let storage = NSTextStorage(string: "test content")
+        // Highlight to populate cache
+        let testGrammar = Grammar(
+            name: "CacheLang",
+            extensions: ["cachelang"],
+            rules: [GrammarRule(pattern: "\\btest\\b", scope: "keyword")]
+        )
+        hl.registerGrammar(testGrammar)
+        hl.highlight(textStorage: storage, language: "cachelang", font: font)
+
+        // Should not crash
+        hl.invalidateCache(for: storage)
+    }
+
+    // MARK: - commentAndStringRanges
+
+    @Test func commentAndStringRanges_returnsCommentRanges() {
+        let hl = SyntaxHighlighter.shared
+        let text = "// a comment\nlet x = 1"
+        let ranges = hl.commentAndStringRanges(in: text, language: "swift")
+        #expect(!ranges.isEmpty)
+    }
+
+    @Test func commentAndStringRanges_unknownLanguageReturnsEmpty() {
+        let hl = SyntaxHighlighter.shared
+        let ranges = hl.commentAndStringRanges(in: "some text", language: "xyz_unknown_edge")
+        #expect(ranges.isEmpty)
+    }
+
+    // MARK: - HighlightMatch / HighlightMatchResult
+
+    @Test func highlightMatch_struct() {
+        let match = HighlightMatch(range: NSRange(location: 0, length: 5), scope: "keyword", priority: 10)
+        #expect(match.scope == "keyword")
+        #expect(match.priority == 10)
+        #expect(match.range.length == 5)
+    }
+
+    @Test func highlightMatchResult_struct() {
+        let result = HighlightMatchResult(
+            matches: [],
+            repaintRange: NSRange(location: 0, length: 10),
+            multilineFingerprint: [3, 5]
+        )
+        #expect(result.matches.isEmpty)
+        #expect(result.repaintRange.length == 10)
+        #expect(result.multilineFingerprint == [3, 5])
+    }
+
+    // MARK: - GrammarRule / Grammar structs
+
+    @Test func grammarRule_optionsNilByDefault() {
+        let rule = GrammarRule(pattern: "\\bfoo\\b", scope: "keyword")
+        #expect(rule.options == nil)
+    }
+
+    @Test func grammar_optionalFieldsNilByDefault() {
+        let grammar = Grammar(
+            name: "Test",
+            extensions: ["tst"],
+            rules: []
+        )
+        #expect(grammar.fileNames == nil)
+        #expect(grammar.filePatterns == nil)
+        #expect(grammar.lineComment == nil)
+        #expect(grammar.blockComment == nil)
+    }
+
+    @Test func blockCommentDelimiters_fields() {
+        let delims = BlockCommentDelimiters(open: "/*", close: "*/")
+        #expect(delims.open == "/*")
+        #expect(delims.close == "*/")
+    }
+}

--- a/PineTests/SyntaxHighlighterEdgeTests.swift
+++ b/PineTests/SyntaxHighlighterEdgeTests.swift
@@ -13,18 +13,6 @@ struct SyntaxHighlighterEdgeTests {
 
     nonisolated(unsafe) private let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
 
-    /// Grammars registered during tests, cleaned up after each test.
-    private static let testGrammarNames = ["TestLangEdge", "TestFileNameGrammar", "CacheLang"]
-
-    /// Removes test grammars from shared singleton to avoid polluting other tests.
-    private func cleanupTestGrammars() {
-        let hl = SyntaxHighlighter.shared
-        for name in Self.testGrammarNames {
-            let grammar = Grammar(name: name, extensions: [], rules: [])
-            hl.unregisterGrammar(grammar)
-        }
-    }
-
     // MARK: - HighlightGeneration
 
     @Test func highlightGeneration_initialValueIsZero() {
@@ -242,9 +230,17 @@ struct SyntaxHighlighterEdgeTests {
         #expect(grammar.blockComment == nil)
     }
 
-    @Test func blockCommentDelimiters_fields() {
-        let delims = BlockCommentDelimiters(open: "/*", close: "*/")
-        #expect(delims.open == "/*")
-        #expect(delims.close == "*/")
+    @Test func blockCommentDelimiters_roundTrip() {
+        let grammar = Grammar(
+            name: "BlockTest",
+            extensions: ["blk"],
+            rules: [],
+            blockComment: BlockCommentDelimiters(open: "/*", close: "*/")
+        )
+        #expect(grammar.blockComment?.open == "/*")
+        #expect(grammar.blockComment?.close == "*/")
+        // Ensure a grammar without block comment returns nil
+        let noBlock = Grammar(name: "NoBlock", extensions: ["nb"], rules: [])
+        #expect(noBlock.blockComment == nil)
     }
 }

--- a/PineTests/SyntaxHighlighterEdgeTests.swift
+++ b/PineTests/SyntaxHighlighterEdgeTests.swift
@@ -7,11 +7,23 @@ import Testing
 import AppKit
 @testable import Pine
 
-@Suite(.serialized)
+@Suite("SyntaxHighlighter Edge Case Tests", .serialized)
 @MainActor
 struct SyntaxHighlighterEdgeTests {
 
     nonisolated(unsafe) private let font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+
+    /// Grammars registered during tests, cleaned up after each test.
+    private static let testGrammarNames = ["TestLangEdge", "TestFileNameGrammar", "CacheLang"]
+
+    /// Removes test grammars from shared singleton to avoid polluting other tests.
+    private func cleanupTestGrammars() {
+        let hl = SyntaxHighlighter.shared
+        for name in Self.testGrammarNames {
+            let grammar = Grammar(name: name, extensions: [], rules: [])
+            hl.unregisterGrammar(grammar)
+        }
+    }
 
     // MARK: - HighlightGeneration
 
@@ -129,6 +141,7 @@ struct SyntaxHighlighterEdgeTests {
             rules: [GrammarRule(pattern: "\\btest\\b", scope: "keyword")]
         )
         hl.registerGrammar(testGrammar)
+        defer { hl.unregisterGrammar(testGrammar) }
 
         let style = hl.commentStyle(forExtension: "testedge", fileName: nil)
         // No comment style defined → nil
@@ -149,6 +162,7 @@ struct SyntaxHighlighterEdgeTests {
             fileNames: ["TestSpecialFile"]
         )
         hl.registerGrammar(testGrammar)
+        defer { hl.unregisterGrammar(testGrammar) }
 
         let comment = hl.lineComment(forFileName: "TestSpecialFile")
         // No line comment defined → nil, but grammar should be loadable
@@ -167,6 +181,7 @@ struct SyntaxHighlighterEdgeTests {
             rules: [GrammarRule(pattern: "\\btest\\b", scope: "keyword")]
         )
         hl.registerGrammar(testGrammar)
+        defer { hl.unregisterGrammar(testGrammar) }
         hl.highlight(textStorage: storage, language: "cachelang", font: font)
 
         // Should not crash

--- a/PineTests/TabManagerEdgeTests.swift
+++ b/PineTests/TabManagerEdgeTests.swift
@@ -1,0 +1,563 @@
+//
+//  TabManagerEdgeTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+@testable import Pine
+
+@Suite("TabManager Edge Case Tests")
+@MainActor
+struct TabManagerEdgeTests {
+
+    private func makeTabManager() -> TabManager {
+        let suite = "TabManagerEdgeTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fatalError("Failed to create UserDefaults")
+        }
+        defaults.removePersistentDomain(forName: suite)
+        let settings = EditorSettings(defaults: defaults)
+        settings.insertFinalNewline = false
+        settings.stripTrailingWhitespace = false
+        settings.formatOnSave = false
+        let manager = TabManager()
+        manager.editorSettings = settings
+        return manager
+    }
+
+    private func tempFileURL(name: String = "test.swift", content: String = "hello") -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(name)
+        try? content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    // MARK: - Tab navigation
+
+    @Test func selectTab_validIndex() {
+        let manager = makeTabManager()
+        let url1 = tempFileURL(name: "a.swift")
+        let url2 = tempFileURL(name: "b.swift")
+        manager.openTab(url: url1)
+        manager.openTab(url: url2)
+
+        manager.selectTab(at: 0)
+        #expect(manager.activeTab?.url == url1)
+    }
+
+    @Test func selectTab_negativeIndex_noOp() {
+        let manager = makeTabManager()
+        manager.openTab(url: tempFileURL())
+        let id = manager.activeTabID
+        manager.selectTab(at: -1)
+        #expect(manager.activeTabID == id)
+    }
+
+    @Test func selectTab_outOfBounds_noOp() {
+        let manager = makeTabManager()
+        manager.openTab(url: tempFileURL())
+        let id = manager.activeTabID
+        manager.selectTab(at: 100)
+        #expect(manager.activeTabID == id)
+    }
+
+    @Test func selectLastTab() {
+        let manager = makeTabManager()
+        let url1 = tempFileURL(name: "a.swift")
+        let url2 = tempFileURL(name: "b.swift")
+        let url3 = tempFileURL(name: "c.swift")
+        manager.openTab(url: url1)
+        manager.openTab(url: url2)
+        manager.openTab(url: url3)
+
+        manager.selectTab(at: 0) // Switch to first
+        manager.selectLastTab()
+        #expect(manager.activeTab?.url == url3)
+    }
+
+    @Test func selectLastTab_emptyTabs_noOp() {
+        let manager = makeTabManager()
+        manager.selectLastTab()
+        #expect(manager.activeTabID == nil)
+    }
+
+    @Test func selectNextTab_wraps() {
+        let manager = makeTabManager()
+        let url1 = tempFileURL(name: "a.swift")
+        let url2 = tempFileURL(name: "b.swift")
+        manager.openTab(url: url1)
+        manager.openTab(url: url2)
+
+        // Active is url2 (last opened = index 1)
+        manager.selectNextTab() // wraps to index 0
+        #expect(manager.activeTab?.url == url1)
+    }
+
+    @Test func selectNextTab_emptyTabs_noOp() {
+        let manager = makeTabManager()
+        manager.selectNextTab()
+        #expect(manager.activeTabID == nil)
+    }
+
+    @Test func selectPreviousTab_wraps() {
+        let manager = makeTabManager()
+        let url1 = tempFileURL(name: "a.swift")
+        let url2 = tempFileURL(name: "b.swift")
+        manager.openTab(url: url1)
+        manager.openTab(url: url2)
+
+        manager.selectTab(at: 0) // at first
+        manager.selectPreviousTab() // wraps to last
+        #expect(manager.activeTab?.url == url2)
+    }
+
+    @Test func selectPreviousTab_emptyTabs_noOp() {
+        let manager = makeTabManager()
+        manager.selectPreviousTab()
+        #expect(manager.activeTabID == nil)
+    }
+
+    // MARK: - Pin tabs
+
+    @Test func togglePin_pinsTab() {
+        let manager = makeTabManager()
+        let url = tempFileURL()
+        manager.openTab(url: url)
+        guard let id = manager.activeTabID else { return }
+
+        manager.togglePin(id: id)
+        #expect(manager.activeTab?.isPinned == true)
+        #expect(manager.pinnedTabCount == 1)
+    }
+
+    @Test func togglePin_unpinsTab() {
+        let manager = makeTabManager()
+        let url = tempFileURL()
+        manager.openTab(url: url)
+        guard let id = manager.activeTabID else { return }
+
+        manager.togglePin(id: id)
+        manager.togglePin(id: id) // Unpin
+        #expect(manager.activeTab?.isPinned == false)
+        #expect(manager.pinnedTabCount == 0)
+    }
+
+    @Test func pinnedTab_resistsClose() {
+        let manager = makeTabManager()
+        let url = tempFileURL()
+        manager.openTab(url: url)
+        guard let id = manager.activeTabID else { return }
+
+        manager.togglePin(id: id)
+        manager.closeTab(id: id) // Should not close (not forced)
+        #expect(manager.tabs.count == 1)
+    }
+
+    @Test func pinnedTab_closesWhenForced() {
+        let manager = makeTabManager()
+        let url = tempFileURL()
+        manager.openTab(url: url)
+        guard let id = manager.activeTabID else { return }
+
+        manager.togglePin(id: id)
+        manager.closeTab(id: id, force: true)
+        #expect(manager.tabs.isEmpty)
+    }
+
+    @Test func restorePinnedState() {
+        let manager = makeTabManager()
+        let url1 = tempFileURL(name: "a.swift")
+        let url2 = tempFileURL(name: "b.swift")
+        manager.openTab(url: url1)
+        manager.openTab(url: url2)
+
+        manager.restorePinnedState(pinnedPaths: [url1.path])
+        #expect(manager.tabs[0].isPinned == true)
+        #expect(manager.tabs[1].isPinned == false)
+    }
+
+    // MARK: - Close operations
+
+    @Test func closeOtherTabs_keepsPinnedAndTarget() {
+        let manager = makeTabManager()
+        let url1 = tempFileURL(name: "a.swift")
+        let url2 = tempFileURL(name: "b.swift")
+        let url3 = tempFileURL(name: "c.swift")
+        manager.openTab(url: url1)
+        manager.openTab(url: url2)
+        manager.openTab(url: url3)
+
+        let id1 = manager.tabs[0].id
+        manager.togglePin(id: manager.tabs[1].id) // Pin b.swift
+
+        manager.closeOtherTabs(keeping: id1, force: true)
+        // Should keep a.swift (target) and b.swift (pinned)
+        #expect(manager.tabs.count == 2)
+    }
+
+    @Test func closeTabsToTheRight() {
+        let manager = makeTabManager()
+        let url1 = tempFileURL(name: "a.swift")
+        let url2 = tempFileURL(name: "b.swift")
+        let url3 = tempFileURL(name: "c.swift")
+        manager.openTab(url: url1)
+        manager.openTab(url: url2)
+        manager.openTab(url: url3)
+
+        let id1 = manager.tabs[0].id
+        manager.closeTabsToTheRight(of: id1, force: true)
+        #expect(manager.tabs.count == 1)
+        #expect(manager.tabs[0].url == url1)
+    }
+
+    @Test func closeTabsToTheRight_pinnedPreserved() {
+        let manager = makeTabManager()
+        let url1 = tempFileURL(name: "a.swift")
+        let url2 = tempFileURL(name: "b.swift")
+        let url3 = tempFileURL(name: "c.swift")
+        manager.openTab(url: url1)
+        manager.openTab(url: url2)
+        manager.openTab(url: url3)
+
+        // Pin b.swift (index 1) — pinned tabs move to front
+        let bID = manager.tabs[1].id
+        manager.togglePin(id: bID)
+        // After pinning, order is: b(pinned), a, c
+        // Find a.swift and close everything to its right
+        guard let aTab = manager.tabs.first(where: { $0.url == url1 }) else {
+            Issue.record("Expected to find a.swift tab")
+            return
+        }
+        manager.closeTabsToTheRight(of: aTab.id, force: true)
+        // c.swift (to the right of a) is unpinned → closed
+        // b.swift is pinned but to the left → unaffected
+        #expect(manager.tabs.count == 2)
+        #expect(manager.tabs.contains { $0.isPinned })
+    }
+
+    @Test func closeAllTabs_force() {
+        let manager = makeTabManager()
+        manager.openTab(url: tempFileURL(name: "a.swift"))
+        manager.openTab(url: tempFileURL(name: "b.swift"))
+
+        manager.closeAllTabs(force: true)
+        #expect(manager.tabs.isEmpty)
+    }
+
+    @Test func dirtyTabsForCloseOthers() {
+        let manager = makeTabManager()
+        let url1 = tempFileURL(name: "a.swift")
+        let url2 = tempFileURL(name: "b.swift")
+        manager.openTab(url: url1)
+        manager.openTab(url: url2)
+
+        // Make url2 dirty
+        manager.activeTabID = manager.tabs[1].id
+        manager.updateContent("changed")
+
+        let dirty = manager.dirtyTabsForCloseOthers(keeping: manager.tabs[0].id)
+        #expect(dirty.count == 1)
+    }
+
+    @Test func dirtyTabsForCloseRight() {
+        let manager = makeTabManager()
+        let url1 = tempFileURL(name: "a.swift")
+        let url2 = tempFileURL(name: "b.swift")
+        manager.openTab(url: url1)
+        manager.openTab(url: url2)
+
+        manager.activeTabID = manager.tabs[1].id
+        manager.updateContent("changed")
+
+        let dirty = manager.dirtyTabsForCloseRight(of: manager.tabs[0].id)
+        #expect(dirty.count == 1)
+    }
+
+    @Test func dirtyTabsForCloseAll() {
+        let manager = makeTabManager()
+        let url = tempFileURL()
+        manager.openTab(url: url)
+        manager.updateContent("changed")
+
+        let dirty = manager.dirtyTabsForCloseAll()
+        #expect(dirty.count == 1)
+    }
+
+    // MARK: - Tab reordering
+
+    @Test func reorderTab_swapsPositions() {
+        let manager = makeTabManager()
+        let url1 = tempFileURL(name: "a.swift")
+        let url2 = tempFileURL(name: "b.swift")
+        manager.openTab(url: url1)
+        manager.openTab(url: url2)
+
+        let id1 = manager.tabs[0].id
+        let id2 = manager.tabs[1].id
+        manager.reorderTab(draggedID: id1, targetID: id2)
+
+        #expect(manager.tabs[0].id == id2 || manager.tabs[1].id == id1)
+    }
+
+    @Test func reorderTab_sameID_noOp() {
+        let manager = makeTabManager()
+        let url = tempFileURL()
+        manager.openTab(url: url)
+        let id = manager.tabs[0].id
+
+        manager.reorderTab(draggedID: id, targetID: id)
+        #expect(manager.tabs.count == 1)
+    }
+
+    @Test func reorderTab_pinnedToUnpinned_blocked() {
+        let manager = makeTabManager()
+        let url1 = tempFileURL(name: "a.swift")
+        let url2 = tempFileURL(name: "b.swift")
+        manager.openTab(url: url1)
+        manager.openTab(url: url2)
+
+        let id1 = manager.tabs[0].id
+        let id2 = manager.tabs[1].id
+        manager.togglePin(id: id1) // Pin first
+
+        // Try to move pinned to unpinned position — should be blocked
+        let originalOrder = manager.tabs.map(\.id)
+        manager.reorderTab(draggedID: id1, targetID: id2)
+        #expect(manager.tabs.map(\.id) == originalOrder)
+    }
+
+    // MARK: - moveTab
+
+    @Test func moveTab_fromOffsets() {
+        let manager = makeTabManager()
+        let url1 = tempFileURL(name: "a.swift")
+        let url2 = tempFileURL(name: "b.swift")
+        let url3 = tempFileURL(name: "c.swift")
+        manager.openTab(url: url1)
+        manager.openTab(url: url2)
+        manager.openTab(url: url3)
+
+        manager.moveTab(fromOffsets: IndexSet(integer: 2), toOffset: 0)
+        #expect(manager.tabs[0].url == url3)
+    }
+
+    // MARK: - Line endings
+
+    @Test func convertActiveTabLineEndings_changesToCRLF() {
+        let manager = makeTabManager()
+        let url = tempFileURL(content: "line1\nline2\n")
+        manager.openTab(url: url)
+        manager.convertActiveTabLineEndings(to: .crlf)
+        #expect(manager.activeTab?.content.contains("\r\n") == true)
+    }
+
+    @Test func convertActiveTabLineEndings_noChangeIfSame() {
+        let manager = makeTabManager()
+        let url = tempFileURL(content: "line1\nline2\n")
+        manager.openTab(url: url)
+
+        let contentBefore = manager.activeTab?.content
+        manager.convertActiveTabLineEndings(to: .lf)
+        #expect(manager.activeTab?.content == contentBefore)
+    }
+
+    @Test func convertActiveTabLineEndings_noActiveTab() {
+        let manager = makeTabManager()
+        // No crash when no active tab
+        manager.convertActiveTabLineEndings(to: .crlf)
+    }
+
+    // MARK: - File rename handling
+
+    @Test func handleFileRenamed_updatesURL() {
+        let manager = makeTabManager()
+        let oldURL = tempFileURL(name: "old.swift")
+        manager.openTab(url: oldURL)
+
+        let newURL = oldURL.deletingLastPathComponent().appendingPathComponent("new.swift")
+        manager.handleFileRenamed(oldURL: oldURL, newURL: newURL)
+
+        #expect(manager.tabs[0].url == newURL)
+    }
+
+    @Test func handleFileRenamed_updatesChildPaths() {
+        let manager = makeTabManager()
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir.appendingPathComponent("oldDir"), withIntermediateDirectories: true)
+        let childURL = dir.appendingPathComponent("oldDir/child.swift")
+        try? "test".write(to: childURL, atomically: true, encoding: .utf8)
+        manager.openTab(url: childURL)
+
+        let oldDir = dir.appendingPathComponent("oldDir")
+        let newDir = dir.appendingPathComponent("newDir")
+        manager.handleFileRenamed(oldURL: oldDir, newURL: newDir)
+
+        #expect(manager.tabs[0].url.path.contains("newDir"))
+    }
+
+    // MARK: - Update operations
+
+    @Test func updateFoldState() {
+        let manager = makeTabManager()
+        let url = tempFileURL()
+        manager.openTab(url: url)
+
+        let foldState = FoldState()
+        manager.updateFoldState(foldState)
+        #expect(manager.activeTab?.foldState != nil)
+    }
+
+    @Test func updateEditorState() {
+        let manager = makeTabManager()
+        let url = tempFileURL(content: "line1\nline2\n")
+        manager.openTab(url: url)
+
+        manager.updateEditorState(cursorPosition: 6, scrollOffset: 100)
+        #expect(manager.activeTab?.cursorPosition == 6)
+        #expect(manager.activeTab?.scrollOffset == 100)
+    }
+
+    // MARK: - Preview file detection
+
+    @Test func isPreviewFile_imageIsPreview() {
+        let manager = makeTabManager()
+        let url = URL(fileURLWithPath: "/tmp/test.png")
+        #expect(manager.isPreviewFile(url: url))
+    }
+
+    @Test func isPreviewFile_pdfIsPreview() {
+        let manager = makeTabManager()
+        let url = URL(fileURLWithPath: "/tmp/test.pdf")
+        #expect(manager.isPreviewFile(url: url))
+    }
+
+    @Test func isPreviewFile_swiftIsNotPreview() {
+        let manager = makeTabManager()
+        let url = URL(fileURLWithPath: "/tmp/test.swift")
+        #expect(!manager.isPreviewFile(url: url))
+    }
+
+    @Test func isPreviewFile_unknownIsNotPreview() {
+        let manager = makeTabManager()
+        let url = URL(fileURLWithPath: "/tmp/test.xyz_unknown")
+        #expect(!manager.isPreviewFile(url: url))
+    }
+
+    // MARK: - hasUnsavedChanges / dirtyTabs
+
+    @Test func hasUnsavedChanges_false_whenClean() {
+        let manager = makeTabManager()
+        let url = tempFileURL()
+        manager.openTab(url: url)
+        #expect(!manager.hasUnsavedChanges)
+        #expect(manager.dirtyTabs.isEmpty)
+    }
+
+    @Test func hasUnsavedChanges_true_whenDirty() {
+        let manager = makeTabManager()
+        let url = tempFileURL()
+        manager.openTab(url: url)
+        manager.updateContent("changed")
+        #expect(manager.hasUnsavedChanges)
+        #expect(manager.dirtyTabs.count == 1)
+    }
+
+    // MARK: - tabsAffectedByDeletion
+
+    @Test func tabsAffectedByDeletion_exactMatch() {
+        let manager = makeTabManager()
+        let url = tempFileURL()
+        manager.openTab(url: url)
+        let affected = manager.tabsAffectedByDeletion(url: url)
+        #expect(affected.count == 1)
+    }
+
+    @Test func tabsAffectedByDeletion_childOfDirectory() {
+        let manager = makeTabManager()
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir.appendingPathComponent("subdir"), withIntermediateDirectories: true)
+        let childURL = dir.appendingPathComponent("subdir/child.swift")
+        try? "test".write(to: childURL, atomically: true, encoding: .utf8)
+        manager.openTab(url: childURL)
+
+        let affected = manager.tabsAffectedByDeletion(url: dir.appendingPathComponent("subdir"))
+        #expect(affected.count == 1)
+    }
+
+    // MARK: - contentPreparedForSave
+
+    @Test func contentPreparedForSave_allDisabled() {
+        let suite = "TestSuite-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else { return }
+        let settings = EditorSettings(defaults: defaults)
+        settings.stripTrailingWhitespace = false
+        settings.insertFinalNewline = false
+        settings.formatOnSave = false
+
+        let result = TabManager.contentPreparedForSave("hello  \n", settings: settings)
+        #expect(result == "hello  \n")
+    }
+
+    @Test func contentPreparedForSave_stripWhitespace() {
+        let suite = "TestSuite-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else { return }
+        let settings = EditorSettings(defaults: defaults)
+        settings.stripTrailingWhitespace = true
+        settings.insertFinalNewline = false
+
+        let result = TabManager.contentPreparedForSave("hello   \n", settings: settings)
+        #expect(result == "hello\n")
+    }
+
+    @Test func contentPreparedForSave_insertNewline() {
+        let suite = "TestSuite-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else { return }
+        let settings = EditorSettings(defaults: defaults)
+        settings.stripTrailingWhitespace = false
+        settings.insertFinalNewline = true
+
+        let result = TabManager.contentPreparedForSave("hello", settings: settings)
+        #expect(result == "hello\n")
+    }
+
+    // MARK: - Markdown preview toggle
+
+    @Test func togglePreviewMode_nonMarkdown_noOp() {
+        let manager = makeTabManager()
+        let url = tempFileURL(name: "test.swift")
+        manager.openTab(url: url)
+        manager.togglePreviewMode()
+        // Should not crash, no preview mode on swift files
+    }
+
+    // MARK: - openTabAndGoToLine
+
+    @Test func openTabAndGoToLine_setsPendingLine() {
+        let manager = makeTabManager()
+        let url = tempFileURL(content: "line1\nline2\nline3")
+        manager.openTabAndGoToLine(url: url, line: 2)
+        #expect(manager.pendingGoToLine == 2)
+    }
+
+    // MARK: - Auto-save
+
+    @Test func autoSaveDelay_default() {
+        let manager = makeTabManager()
+        #expect(manager.autoSaveDelay == 1.0)
+    }
+
+    @Test func setAutoSaveDelay() {
+        let manager = makeTabManager()
+        manager.setAutoSaveDelay(0.5)
+        #expect(manager.autoSaveDelay == 0.5)
+    }
+
+    @Test func cancelAutoSave() {
+        let manager = makeTabManager()
+        manager.cancelAutoSave()
+        #expect(!manager.hasScheduledAutoSave)
+    }
+}

--- a/PineTests/TabManagerEdgeTests.swift
+++ b/PineTests/TabManagerEdgeTests.swift
@@ -27,10 +27,10 @@ struct TabManagerEdgeTests {
     }
 
     /// Creates a temp directory. Caller must use `defer { cleanup(dir) }`.
-    private func makeTempDir() -> URL {
+    private func makeTempDir() throws -> URL {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("TabMgrEdge-\(UUID().uuidString)")
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir
     }
 
@@ -38,9 +38,9 @@ struct TabManagerEdgeTests {
         in dir: URL,
         name: String = "test.swift",
         content: String = "hello"
-    ) -> URL {
+    ) throws -> URL {
         let url = dir.appendingPathComponent(name)
-        try? content.write(to: url, atomically: true, encoding: .utf8)
+        try content.write(to: url, atomically: true, encoding: .utf8)
         return url
     }
 
@@ -50,12 +50,12 @@ struct TabManagerEdgeTests {
 
     // MARK: - Tab navigation
 
-    @Test func selectTab_validIndex() {
-        let dir = makeTempDir()
+    @Test func selectTab_validIndex() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFile(in: dir, name: "a.swift")
-        let url2 = tempFile(in: dir, name: "b.swift")
+        let url1 = try tempFile(in: dir, name: "a.swift")
+        let url2 = try tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
@@ -63,33 +63,33 @@ struct TabManagerEdgeTests {
         #expect(manager.activeTab?.url == url1)
     }
 
-    @Test func selectTab_negativeIndex_noOp() {
-        let dir = makeTempDir()
+    @Test func selectTab_negativeIndex_noOp() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        manager.openTab(url: tempFile(in: dir))
+        manager.openTab(url: try tempFile(in: dir))
         let id = manager.activeTabID
         manager.selectTab(at: -1)
         #expect(manager.activeTabID == id)
     }
 
-    @Test func selectTab_outOfBounds_noOp() {
-        let dir = makeTempDir()
+    @Test func selectTab_outOfBounds_noOp() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        manager.openTab(url: tempFile(in: dir))
+        manager.openTab(url: try tempFile(in: dir))
         let id = manager.activeTabID
         manager.selectTab(at: 100)
         #expect(manager.activeTabID == id)
     }
 
-    @Test func selectLastTab() {
-        let dir = makeTempDir()
+    @Test func selectLastTab() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFile(in: dir, name: "a.swift")
-        let url2 = tempFile(in: dir, name: "b.swift")
-        let url3 = tempFile(in: dir, name: "c.swift")
+        let url1 = try tempFile(in: dir, name: "a.swift")
+        let url2 = try tempFile(in: dir, name: "b.swift")
+        let url3 = try tempFile(in: dir, name: "c.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
         manager.openTab(url: url3)
@@ -105,12 +105,12 @@ struct TabManagerEdgeTests {
         #expect(manager.activeTabID == nil)
     }
 
-    @Test func selectNextTab_wraps() {
-        let dir = makeTempDir()
+    @Test func selectNextTab_wraps() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFile(in: dir, name: "a.swift")
-        let url2 = tempFile(in: dir, name: "b.swift")
+        let url1 = try tempFile(in: dir, name: "a.swift")
+        let url2 = try tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
@@ -124,12 +124,12 @@ struct TabManagerEdgeTests {
         #expect(manager.activeTabID == nil)
     }
 
-    @Test func selectPreviousTab_wraps() {
-        let dir = makeTempDir()
+    @Test func selectPreviousTab_wraps() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFile(in: dir, name: "a.swift")
-        let url2 = tempFile(in: dir, name: "b.swift")
+        let url1 = try tempFile(in: dir, name: "a.swift")
+        let url2 = try tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
@@ -146,11 +146,11 @@ struct TabManagerEdgeTests {
 
     // MARK: - Pin tabs
 
-    @Test func togglePin_pinsTab() {
-        let dir = makeTempDir()
+    @Test func togglePin_pinsTab() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir)
+        let url = try tempFile(in: dir)
         manager.openTab(url: url)
         guard let id = manager.activeTabID else { return }
 
@@ -159,11 +159,11 @@ struct TabManagerEdgeTests {
         #expect(manager.pinnedTabCount == 1)
     }
 
-    @Test func togglePin_unpinsTab() {
-        let dir = makeTempDir()
+    @Test func togglePin_unpinsTab() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir)
+        let url = try tempFile(in: dir)
         manager.openTab(url: url)
         guard let id = manager.activeTabID else { return }
 
@@ -173,11 +173,11 @@ struct TabManagerEdgeTests {
         #expect(manager.pinnedTabCount == 0)
     }
 
-    @Test func pinnedTab_resistsClose() {
-        let dir = makeTempDir()
+    @Test func pinnedTab_resistsClose() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir)
+        let url = try tempFile(in: dir)
         manager.openTab(url: url)
         guard let id = manager.activeTabID else { return }
 
@@ -186,11 +186,11 @@ struct TabManagerEdgeTests {
         #expect(manager.tabs.count == 1)
     }
 
-    @Test func pinnedTab_closesWhenForced() {
-        let dir = makeTempDir()
+    @Test func pinnedTab_closesWhenForced() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir)
+        let url = try tempFile(in: dir)
         manager.openTab(url: url)
         guard let id = manager.activeTabID else { return }
 
@@ -199,12 +199,12 @@ struct TabManagerEdgeTests {
         #expect(manager.tabs.isEmpty)
     }
 
-    @Test func restorePinnedState() {
-        let dir = makeTempDir()
+    @Test func restorePinnedState() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFile(in: dir, name: "a.swift")
-        let url2 = tempFile(in: dir, name: "b.swift")
+        let url1 = try tempFile(in: dir, name: "a.swift")
+        let url2 = try tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
@@ -215,13 +215,13 @@ struct TabManagerEdgeTests {
 
     // MARK: - Close operations
 
-    @Test func closeOtherTabs_keepsPinnedAndTarget() {
-        let dir = makeTempDir()
+    @Test func closeOtherTabs_keepsPinnedAndTarget() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFile(in: dir, name: "a.swift")
-        let url2 = tempFile(in: dir, name: "b.swift")
-        let url3 = tempFile(in: dir, name: "c.swift")
+        let url1 = try tempFile(in: dir, name: "a.swift")
+        let url2 = try tempFile(in: dir, name: "b.swift")
+        let url3 = try tempFile(in: dir, name: "c.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
         manager.openTab(url: url3)
@@ -233,13 +233,13 @@ struct TabManagerEdgeTests {
         #expect(manager.tabs.count == 2)
     }
 
-    @Test func closeTabsToTheRight() {
-        let dir = makeTempDir()
+    @Test func closeTabsToTheRight() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFile(in: dir, name: "a.swift")
-        let url2 = tempFile(in: dir, name: "b.swift")
-        let url3 = tempFile(in: dir, name: "c.swift")
+        let url1 = try tempFile(in: dir, name: "a.swift")
+        let url2 = try tempFile(in: dir, name: "b.swift")
+        let url3 = try tempFile(in: dir, name: "c.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
         manager.openTab(url: url3)
@@ -250,13 +250,13 @@ struct TabManagerEdgeTests {
         #expect(manager.tabs[0].url == url1)
     }
 
-    @Test func closeTabsToTheRight_pinnedPreserved() {
-        let dir = makeTempDir()
+    @Test func closeTabsToTheRight_pinnedPreserved() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFile(in: dir, name: "a.swift")
-        let url2 = tempFile(in: dir, name: "b.swift")
-        let url3 = tempFile(in: dir, name: "c.swift")
+        let url1 = try tempFile(in: dir, name: "a.swift")
+        let url2 = try tempFile(in: dir, name: "b.swift")
+        let url3 = try tempFile(in: dir, name: "c.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
         manager.openTab(url: url3)
@@ -272,23 +272,23 @@ struct TabManagerEdgeTests {
         #expect(manager.tabs.contains { $0.isPinned })
     }
 
-    @Test func closeAllTabs_force() {
-        let dir = makeTempDir()
+    @Test func closeAllTabs_force() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        manager.openTab(url: tempFile(in: dir, name: "a.swift"))
-        manager.openTab(url: tempFile(in: dir, name: "b.swift"))
+        manager.openTab(url: try tempFile(in: dir, name: "a.swift"))
+        manager.openTab(url: try tempFile(in: dir, name: "b.swift"))
 
         manager.closeAllTabs(force: true)
         #expect(manager.tabs.isEmpty)
     }
 
-    @Test func dirtyTabsForCloseOthers() {
-        let dir = makeTempDir()
+    @Test func dirtyTabsForCloseOthers() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFile(in: dir, name: "a.swift")
-        let url2 = tempFile(in: dir, name: "b.swift")
+        let url1 = try tempFile(in: dir, name: "a.swift")
+        let url2 = try tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
@@ -299,12 +299,12 @@ struct TabManagerEdgeTests {
         #expect(dirty.count == 1)
     }
 
-    @Test func dirtyTabsForCloseRight() {
-        let dir = makeTempDir()
+    @Test func dirtyTabsForCloseRight() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFile(in: dir, name: "a.swift")
-        let url2 = tempFile(in: dir, name: "b.swift")
+        let url1 = try tempFile(in: dir, name: "a.swift")
+        let url2 = try tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
@@ -315,11 +315,11 @@ struct TabManagerEdgeTests {
         #expect(dirty.count == 1)
     }
 
-    @Test func dirtyTabsForCloseAll() {
-        let dir = makeTempDir()
+    @Test func dirtyTabsForCloseAll() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir)
+        let url = try tempFile(in: dir)
         manager.openTab(url: url)
         manager.updateContent("changed")
 
@@ -329,12 +329,12 @@ struct TabManagerEdgeTests {
 
     // MARK: - Tab reordering
 
-    @Test func reorderTab_swapsPositions() {
-        let dir = makeTempDir()
+    @Test func reorderTab_swapsPositions() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFile(in: dir, name: "a.swift")
-        let url2 = tempFile(in: dir, name: "b.swift")
+        let url1 = try tempFile(in: dir, name: "a.swift")
+        let url2 = try tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
@@ -342,14 +342,14 @@ struct TabManagerEdgeTests {
         let id2 = manager.tabs[1].id
         manager.reorderTab(draggedID: id1, targetID: id2)
 
-        #expect(manager.tabs[0].id == id2 || manager.tabs[1].id == id1)
+        #expect(manager.tabs[0].id == id2 && manager.tabs[1].id == id1)
     }
 
-    @Test func reorderTab_sameID_noOp() {
-        let dir = makeTempDir()
+    @Test func reorderTab_sameID_noOp() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir)
+        let url = try tempFile(in: dir)
         manager.openTab(url: url)
         let id = manager.tabs[0].id
 
@@ -357,12 +357,12 @@ struct TabManagerEdgeTests {
         #expect(manager.tabs.count == 1)
     }
 
-    @Test func reorderTab_pinnedToUnpinned_blocked() {
-        let dir = makeTempDir()
+    @Test func reorderTab_pinnedToUnpinned_blocked() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFile(in: dir, name: "a.swift")
-        let url2 = tempFile(in: dir, name: "b.swift")
+        let url1 = try tempFile(in: dir, name: "a.swift")
+        let url2 = try tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
@@ -377,13 +377,13 @@ struct TabManagerEdgeTests {
 
     // MARK: - moveTab
 
-    @Test func moveTab_fromOffsets() {
-        let dir = makeTempDir()
+    @Test func moveTab_fromOffsets() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFile(in: dir, name: "a.swift")
-        let url2 = tempFile(in: dir, name: "b.swift")
-        let url3 = tempFile(in: dir, name: "c.swift")
+        let url1 = try tempFile(in: dir, name: "a.swift")
+        let url2 = try tempFile(in: dir, name: "b.swift")
+        let url3 = try tempFile(in: dir, name: "c.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
         manager.openTab(url: url3)
@@ -394,21 +394,21 @@ struct TabManagerEdgeTests {
 
     // MARK: - Line endings
 
-    @Test func convertActiveTabLineEndings_changesToCRLF() {
-        let dir = makeTempDir()
+    @Test func convertActiveTabLineEndings_changesToCRLF() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir, content: "line1\nline2\n")
+        let url = try tempFile(in: dir, content: "line1\nline2\n")
         manager.openTab(url: url)
         manager.convertActiveTabLineEndings(to: .crlf)
         #expect(manager.activeTab?.content.contains("\r\n") == true)
     }
 
-    @Test func convertActiveTabLineEndings_noChangeIfSame() {
-        let dir = makeTempDir()
+    @Test func convertActiveTabLineEndings_noChangeIfSame() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir, content: "line1\nline2\n")
+        let url = try tempFile(in: dir, content: "line1\nline2\n")
         manager.openTab(url: url)
 
         let contentBefore = manager.activeTab?.content
@@ -423,11 +423,11 @@ struct TabManagerEdgeTests {
 
     // MARK: - File rename handling
 
-    @Test func handleFileRenamed_updatesURL() {
-        let dir = makeTempDir()
+    @Test func handleFileRenamed_updatesURL() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let oldURL = tempFile(in: dir, name: "old.swift")
+        let oldURL = try tempFile(in: dir, name: "old.swift")
         manager.openTab(url: oldURL)
 
         let newURL = oldURL.deletingLastPathComponent().appendingPathComponent("new.swift")
@@ -436,15 +436,15 @@ struct TabManagerEdgeTests {
         #expect(manager.tabs[0].url == newURL)
     }
 
-    @Test func handleFileRenamed_updatesChildPaths() {
-        let dir = makeTempDir()
+    @Test func handleFileRenamed_updatesChildPaths() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        try? FileManager.default.createDirectory(
+        try FileManager.default.createDirectory(
             at: dir.appendingPathComponent("oldDir"), withIntermediateDirectories: true
         )
         let childURL = dir.appendingPathComponent("oldDir/child.swift")
-        try? "test".write(to: childURL, atomically: true, encoding: .utf8)
+        try "test".write(to: childURL, atomically: true, encoding: .utf8)
         manager.openTab(url: childURL)
 
         let oldDir = dir.appendingPathComponent("oldDir")
@@ -456,11 +456,11 @@ struct TabManagerEdgeTests {
 
     // MARK: - Update operations
 
-    @Test func updateFoldState() {
-        let dir = makeTempDir()
+    @Test func updateFoldState() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir)
+        let url = try tempFile(in: dir)
         manager.openTab(url: url)
 
         let foldState = FoldState()
@@ -468,11 +468,11 @@ struct TabManagerEdgeTests {
         #expect(manager.activeTab?.foldState != nil)
     }
 
-    @Test func updateEditorState() {
-        let dir = makeTempDir()
+    @Test func updateEditorState() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir, content: "line1\nline2\n")
+        let url = try tempFile(in: dir, content: "line1\nline2\n")
         manager.openTab(url: url)
 
         manager.updateEditorState(cursorPosition: 6, scrollOffset: 100)
@@ -508,21 +508,21 @@ struct TabManagerEdgeTests {
 
     // MARK: - hasUnsavedChanges / dirtyTabs
 
-    @Test func hasUnsavedChanges_false_whenClean() {
-        let dir = makeTempDir()
+    @Test func hasUnsavedChanges_false_whenClean() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir)
+        let url = try tempFile(in: dir)
         manager.openTab(url: url)
         #expect(!manager.hasUnsavedChanges)
         #expect(manager.dirtyTabs.isEmpty)
     }
 
-    @Test func hasUnsavedChanges_true_whenDirty() {
-        let dir = makeTempDir()
+    @Test func hasUnsavedChanges_true_whenDirty() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir)
+        let url = try tempFile(in: dir)
         manager.openTab(url: url)
         manager.updateContent("changed")
         #expect(manager.hasUnsavedChanges)
@@ -531,25 +531,25 @@ struct TabManagerEdgeTests {
 
     // MARK: - tabsAffectedByDeletion
 
-    @Test func tabsAffectedByDeletion_exactMatch() {
-        let dir = makeTempDir()
+    @Test func tabsAffectedByDeletion_exactMatch() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir)
+        let url = try tempFile(in: dir)
         manager.openTab(url: url)
         let affected = manager.tabsAffectedByDeletion(url: url)
         #expect(affected.count == 1)
     }
 
-    @Test func tabsAffectedByDeletion_childOfDirectory() {
-        let dir = makeTempDir()
+    @Test func tabsAffectedByDeletion_childOfDirectory() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        try? FileManager.default.createDirectory(
+        try FileManager.default.createDirectory(
             at: dir.appendingPathComponent("subdir"), withIntermediateDirectories: true
         )
         let childURL = dir.appendingPathComponent("subdir/child.swift")
-        try? "test".write(to: childURL, atomically: true, encoding: .utf8)
+        try "test".write(to: childURL, atomically: true, encoding: .utf8)
         manager.openTab(url: childURL)
 
         let affected = manager.tabsAffectedByDeletion(url: dir.appendingPathComponent("subdir"))
@@ -594,22 +594,22 @@ struct TabManagerEdgeTests {
 
     // MARK: - Markdown preview toggle
 
-    @Test func togglePreviewMode_nonMarkdown_noOp() {
-        let dir = makeTempDir()
+    @Test func togglePreviewMode_nonMarkdown_noOp() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir, name: "test.swift")
+        let url = try tempFile(in: dir, name: "test.swift")
         manager.openTab(url: url)
         manager.togglePreviewMode()
     }
 
     // MARK: - openTabAndGoToLine
 
-    @Test func openTabAndGoToLine_setsPendingLine() {
-        let dir = makeTempDir()
+    @Test func openTabAndGoToLine_setsPendingLine() throws {
+        let dir = try makeTempDir()
         defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFile(in: dir, content: "line1\nline2\nline3")
+        let url = try tempFile(in: dir, content: "line1\nline2\nline3")
         manager.openTabAndGoToLine(url: url, line: 2)
         #expect(manager.pendingGoToLine == 2)
     }

--- a/PineTests/TabManagerEdgeTests.swift
+++ b/PineTests/TabManagerEdgeTests.swift
@@ -26,21 +26,36 @@ struct TabManagerEdgeTests {
         return manager
     }
 
-    private func tempFileURL(name: String = "test.swift", content: String = "hello") -> URL {
+    /// Creates a temp directory. Caller must use `defer { cleanup(dir) }`.
+    private func makeTempDir() -> URL {
         let dir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("TabMgrEdge-\(UUID().uuidString)")
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func tempFile(
+        in dir: URL,
+        name: String = "test.swift",
+        content: String = "hello"
+    ) -> URL {
         let url = dir.appendingPathComponent(name)
         try? content.write(to: url, atomically: true, encoding: .utf8)
         return url
     }
 
+    private func cleanup(_ dir: URL) {
+        try? FileManager.default.removeItem(at: dir)
+    }
+
     // MARK: - Tab navigation
 
     @Test func selectTab_validIndex() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFileURL(name: "a.swift")
-        let url2 = tempFileURL(name: "b.swift")
+        let url1 = tempFile(in: dir, name: "a.swift")
+        let url2 = tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
@@ -49,31 +64,37 @@ struct TabManagerEdgeTests {
     }
 
     @Test func selectTab_negativeIndex_noOp() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        manager.openTab(url: tempFileURL())
+        manager.openTab(url: tempFile(in: dir))
         let id = manager.activeTabID
         manager.selectTab(at: -1)
         #expect(manager.activeTabID == id)
     }
 
     @Test func selectTab_outOfBounds_noOp() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        manager.openTab(url: tempFileURL())
+        manager.openTab(url: tempFile(in: dir))
         let id = manager.activeTabID
         manager.selectTab(at: 100)
         #expect(manager.activeTabID == id)
     }
 
     @Test func selectLastTab() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFileURL(name: "a.swift")
-        let url2 = tempFileURL(name: "b.swift")
-        let url3 = tempFileURL(name: "c.swift")
+        let url1 = tempFile(in: dir, name: "a.swift")
+        let url2 = tempFile(in: dir, name: "b.swift")
+        let url3 = tempFile(in: dir, name: "c.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
         manager.openTab(url: url3)
 
-        manager.selectTab(at: 0) // Switch to first
+        manager.selectTab(at: 0)
         manager.selectLastTab()
         #expect(manager.activeTab?.url == url3)
     }
@@ -85,14 +106,15 @@ struct TabManagerEdgeTests {
     }
 
     @Test func selectNextTab_wraps() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFileURL(name: "a.swift")
-        let url2 = tempFileURL(name: "b.swift")
+        let url1 = tempFile(in: dir, name: "a.swift")
+        let url2 = tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
-        // Active is url2 (last opened = index 1)
-        manager.selectNextTab() // wraps to index 0
+        manager.selectNextTab()
         #expect(manager.activeTab?.url == url1)
     }
 
@@ -103,14 +125,16 @@ struct TabManagerEdgeTests {
     }
 
     @Test func selectPreviousTab_wraps() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFileURL(name: "a.swift")
-        let url2 = tempFileURL(name: "b.swift")
+        let url1 = tempFile(in: dir, name: "a.swift")
+        let url2 = tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
-        manager.selectTab(at: 0) // at first
-        manager.selectPreviousTab() // wraps to last
+        manager.selectTab(at: 0)
+        manager.selectPreviousTab()
         #expect(manager.activeTab?.url == url2)
     }
 
@@ -123,8 +147,10 @@ struct TabManagerEdgeTests {
     // MARK: - Pin tabs
 
     @Test func togglePin_pinsTab() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL()
+        let url = tempFile(in: dir)
         manager.openTab(url: url)
         guard let id = manager.activeTabID else { return }
 
@@ -134,31 +160,37 @@ struct TabManagerEdgeTests {
     }
 
     @Test func togglePin_unpinsTab() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL()
+        let url = tempFile(in: dir)
         manager.openTab(url: url)
         guard let id = manager.activeTabID else { return }
 
         manager.togglePin(id: id)
-        manager.togglePin(id: id) // Unpin
+        manager.togglePin(id: id)
         #expect(manager.activeTab?.isPinned == false)
         #expect(manager.pinnedTabCount == 0)
     }
 
     @Test func pinnedTab_resistsClose() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL()
+        let url = tempFile(in: dir)
         manager.openTab(url: url)
         guard let id = manager.activeTabID else { return }
 
         manager.togglePin(id: id)
-        manager.closeTab(id: id) // Should not close (not forced)
+        manager.closeTab(id: id)
         #expect(manager.tabs.count == 1)
     }
 
     @Test func pinnedTab_closesWhenForced() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL()
+        let url = tempFile(in: dir)
         manager.openTab(url: url)
         guard let id = manager.activeTabID else { return }
 
@@ -168,9 +200,11 @@ struct TabManagerEdgeTests {
     }
 
     @Test func restorePinnedState() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFileURL(name: "a.swift")
-        let url2 = tempFileURL(name: "b.swift")
+        let url1 = tempFile(in: dir, name: "a.swift")
+        let url2 = tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
@@ -182,27 +216,30 @@ struct TabManagerEdgeTests {
     // MARK: - Close operations
 
     @Test func closeOtherTabs_keepsPinnedAndTarget() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFileURL(name: "a.swift")
-        let url2 = tempFileURL(name: "b.swift")
-        let url3 = tempFileURL(name: "c.swift")
+        let url1 = tempFile(in: dir, name: "a.swift")
+        let url2 = tempFile(in: dir, name: "b.swift")
+        let url3 = tempFile(in: dir, name: "c.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
         manager.openTab(url: url3)
 
         let id1 = manager.tabs[0].id
-        manager.togglePin(id: manager.tabs[1].id) // Pin b.swift
+        manager.togglePin(id: manager.tabs[1].id)
 
         manager.closeOtherTabs(keeping: id1, force: true)
-        // Should keep a.swift (target) and b.swift (pinned)
         #expect(manager.tabs.count == 2)
     }
 
     @Test func closeTabsToTheRight() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFileURL(name: "a.swift")
-        let url2 = tempFileURL(name: "b.swift")
-        let url3 = tempFileURL(name: "c.swift")
+        let url1 = tempFile(in: dir, name: "a.swift")
+        let url2 = tempFile(in: dir, name: "b.swift")
+        let url3 = tempFile(in: dir, name: "c.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
         manager.openTab(url: url3)
@@ -214,47 +251,47 @@ struct TabManagerEdgeTests {
     }
 
     @Test func closeTabsToTheRight_pinnedPreserved() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFileURL(name: "a.swift")
-        let url2 = tempFileURL(name: "b.swift")
-        let url3 = tempFileURL(name: "c.swift")
+        let url1 = tempFile(in: dir, name: "a.swift")
+        let url2 = tempFile(in: dir, name: "b.swift")
+        let url3 = tempFile(in: dir, name: "c.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
         manager.openTab(url: url3)
 
-        // Pin b.swift (index 1) — pinned tabs move to front
         let bID = manager.tabs[1].id
         manager.togglePin(id: bID)
-        // After pinning, order is: b(pinned), a, c
-        // Find a.swift and close everything to its right
         guard let aTab = manager.tabs.first(where: { $0.url == url1 }) else {
             Issue.record("Expected to find a.swift tab")
             return
         }
         manager.closeTabsToTheRight(of: aTab.id, force: true)
-        // c.swift (to the right of a) is unpinned → closed
-        // b.swift is pinned but to the left → unaffected
         #expect(manager.tabs.count == 2)
         #expect(manager.tabs.contains { $0.isPinned })
     }
 
     @Test func closeAllTabs_force() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        manager.openTab(url: tempFileURL(name: "a.swift"))
-        manager.openTab(url: tempFileURL(name: "b.swift"))
+        manager.openTab(url: tempFile(in: dir, name: "a.swift"))
+        manager.openTab(url: tempFile(in: dir, name: "b.swift"))
 
         manager.closeAllTabs(force: true)
         #expect(manager.tabs.isEmpty)
     }
 
     @Test func dirtyTabsForCloseOthers() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFileURL(name: "a.swift")
-        let url2 = tempFileURL(name: "b.swift")
+        let url1 = tempFile(in: dir, name: "a.swift")
+        let url2 = tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
-        // Make url2 dirty
         manager.activeTabID = manager.tabs[1].id
         manager.updateContent("changed")
 
@@ -263,9 +300,11 @@ struct TabManagerEdgeTests {
     }
 
     @Test func dirtyTabsForCloseRight() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFileURL(name: "a.swift")
-        let url2 = tempFileURL(name: "b.swift")
+        let url1 = tempFile(in: dir, name: "a.swift")
+        let url2 = tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
@@ -277,8 +316,10 @@ struct TabManagerEdgeTests {
     }
 
     @Test func dirtyTabsForCloseAll() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL()
+        let url = tempFile(in: dir)
         manager.openTab(url: url)
         manager.updateContent("changed")
 
@@ -289,9 +330,11 @@ struct TabManagerEdgeTests {
     // MARK: - Tab reordering
 
     @Test func reorderTab_swapsPositions() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFileURL(name: "a.swift")
-        let url2 = tempFileURL(name: "b.swift")
+        let url1 = tempFile(in: dir, name: "a.swift")
+        let url2 = tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
@@ -303,8 +346,10 @@ struct TabManagerEdgeTests {
     }
 
     @Test func reorderTab_sameID_noOp() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL()
+        let url = tempFile(in: dir)
         manager.openTab(url: url)
         let id = manager.tabs[0].id
 
@@ -313,17 +358,18 @@ struct TabManagerEdgeTests {
     }
 
     @Test func reorderTab_pinnedToUnpinned_blocked() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFileURL(name: "a.swift")
-        let url2 = tempFileURL(name: "b.swift")
+        let url1 = tempFile(in: dir, name: "a.swift")
+        let url2 = tempFile(in: dir, name: "b.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
 
         let id1 = manager.tabs[0].id
         let id2 = manager.tabs[1].id
-        manager.togglePin(id: id1) // Pin first
+        manager.togglePin(id: id1)
 
-        // Try to move pinned to unpinned position — should be blocked
         let originalOrder = manager.tabs.map(\.id)
         manager.reorderTab(draggedID: id1, targetID: id2)
         #expect(manager.tabs.map(\.id) == originalOrder)
@@ -332,10 +378,12 @@ struct TabManagerEdgeTests {
     // MARK: - moveTab
 
     @Test func moveTab_fromOffsets() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url1 = tempFileURL(name: "a.swift")
-        let url2 = tempFileURL(name: "b.swift")
-        let url3 = tempFileURL(name: "c.swift")
+        let url1 = tempFile(in: dir, name: "a.swift")
+        let url2 = tempFile(in: dir, name: "b.swift")
+        let url3 = tempFile(in: dir, name: "c.swift")
         manager.openTab(url: url1)
         manager.openTab(url: url2)
         manager.openTab(url: url3)
@@ -347,16 +395,20 @@ struct TabManagerEdgeTests {
     // MARK: - Line endings
 
     @Test func convertActiveTabLineEndings_changesToCRLF() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL(content: "line1\nline2\n")
+        let url = tempFile(in: dir, content: "line1\nline2\n")
         manager.openTab(url: url)
         manager.convertActiveTabLineEndings(to: .crlf)
         #expect(manager.activeTab?.content.contains("\r\n") == true)
     }
 
     @Test func convertActiveTabLineEndings_noChangeIfSame() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL(content: "line1\nline2\n")
+        let url = tempFile(in: dir, content: "line1\nline2\n")
         manager.openTab(url: url)
 
         let contentBefore = manager.activeTab?.content
@@ -366,15 +418,16 @@ struct TabManagerEdgeTests {
 
     @Test func convertActiveTabLineEndings_noActiveTab() {
         let manager = makeTabManager()
-        // No crash when no active tab
         manager.convertActiveTabLineEndings(to: .crlf)
     }
 
     // MARK: - File rename handling
 
     @Test func handleFileRenamed_updatesURL() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let oldURL = tempFileURL(name: "old.swift")
+        let oldURL = tempFile(in: dir, name: "old.swift")
         manager.openTab(url: oldURL)
 
         let newURL = oldURL.deletingLastPathComponent().appendingPathComponent("new.swift")
@@ -384,9 +437,12 @@ struct TabManagerEdgeTests {
     }
 
     @Test func handleFileRenamed_updatesChildPaths() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        try? FileManager.default.createDirectory(at: dir.appendingPathComponent("oldDir"), withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("oldDir"), withIntermediateDirectories: true
+        )
         let childURL = dir.appendingPathComponent("oldDir/child.swift")
         try? "test".write(to: childURL, atomically: true, encoding: .utf8)
         manager.openTab(url: childURL)
@@ -401,8 +457,10 @@ struct TabManagerEdgeTests {
     // MARK: - Update operations
 
     @Test func updateFoldState() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL()
+        let url = tempFile(in: dir)
         manager.openTab(url: url)
 
         let foldState = FoldState()
@@ -411,8 +469,10 @@ struct TabManagerEdgeTests {
     }
 
     @Test func updateEditorState() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL(content: "line1\nline2\n")
+        let url = tempFile(in: dir, content: "line1\nline2\n")
         manager.openTab(url: url)
 
         manager.updateEditorState(cursorPosition: 6, scrollOffset: 100)
@@ -449,16 +509,20 @@ struct TabManagerEdgeTests {
     // MARK: - hasUnsavedChanges / dirtyTabs
 
     @Test func hasUnsavedChanges_false_whenClean() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL()
+        let url = tempFile(in: dir)
         manager.openTab(url: url)
         #expect(!manager.hasUnsavedChanges)
         #expect(manager.dirtyTabs.isEmpty)
     }
 
     @Test func hasUnsavedChanges_true_whenDirty() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL()
+        let url = tempFile(in: dir)
         manager.openTab(url: url)
         manager.updateContent("changed")
         #expect(manager.hasUnsavedChanges)
@@ -468,17 +532,22 @@ struct TabManagerEdgeTests {
     // MARK: - tabsAffectedByDeletion
 
     @Test func tabsAffectedByDeletion_exactMatch() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL()
+        let url = tempFile(in: dir)
         manager.openTab(url: url)
         let affected = manager.tabsAffectedByDeletion(url: url)
         #expect(affected.count == 1)
     }
 
     @Test func tabsAffectedByDeletion_childOfDirectory() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        try? FileManager.default.createDirectory(at: dir.appendingPathComponent("subdir"), withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("subdir"), withIntermediateDirectories: true
+        )
         let childURL = dir.appendingPathComponent("subdir/child.swift")
         try? "test".write(to: childURL, atomically: true, encoding: .utf8)
         manager.openTab(url: childURL)
@@ -526,18 +595,21 @@ struct TabManagerEdgeTests {
     // MARK: - Markdown preview toggle
 
     @Test func togglePreviewMode_nonMarkdown_noOp() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL(name: "test.swift")
+        let url = tempFile(in: dir, name: "test.swift")
         manager.openTab(url: url)
         manager.togglePreviewMode()
-        // Should not crash, no preview mode on swift files
     }
 
     // MARK: - openTabAndGoToLine
 
     @Test func openTabAndGoToLine_setsPendingLine() {
+        let dir = makeTempDir()
+        defer { cleanup(dir) }
         let manager = makeTabManager()
-        let url = tempFileURL(content: "line1\nline2\nline3")
+        let url = tempFile(in: dir, content: "line1\nline2\nline3")
         manager.openTabAndGoToLine(url: url, line: 2)
         #expect(manager.pendingGoToLine == 2)
     }


### PR DESCRIPTION
## Summary
- Added 9 new edge case test files (~280 test cases) for core modules
- Covers `FoldRangeCalculator`, `SymbolParser`, `SyntaxHighlighter`, `GitStatusProvider`, `ConfigValidator`, `TabManager`, `PaneManager`, `ProjectSearchProvider`, `QuickOpenProvider`
- Focus on edge cases, error paths, boundary conditions, and untested public API

## Code Coverage

| Target | Coverage |
|--------|----------|
| Pine.app | **51.93%** (13197/25412 lines) |
| PineTests.xctest | 98.52% (41466/42088 lines) |

Coverage measured with `xcodebuild test -enableCodeCoverage YES -only-testing:PineTests`.

## Test files added

| File | Module | Tests |
|------|--------|-------|
| `FoldRangeCalculatorEdgeTests.swift` | FoldRangeCalculator | maxStackDepth, all bracket types, Unicode, skip ranges, interleaved brackets |
| `SymbolParserEdgeTests.swift` | SymbolParser | Ruby (modules, self.method, ?/!), Java/Kotlin, Rust pub(crate), Go receivers, TypeScript abstract, lineNumber edge cases |
| `SyntaxHighlighterEdgeTests.swift` | SyntaxHighlighter | HighlightGeneration, commentStyle, resolveGrammarByTag, Theme colors, registerGrammar, invalidateCache, model structs |
| `GitStatusProviderEdgeTests.swift` | GitStatusProvider | unquoteGitPath (all escape types), parseBlame (cache, invalid), parseDiff, parseStatusOutput (all statuses), parseIgnoredOutput, changeRegionStarts, next/prev navigation |
| `ConfigValidatorEdgeTests.swift` | ConfigValidator | Builtin YAML/Dockerfile/Shell validators, shellcheck/terraform/hadolint/yamllint parsers, ValidationDiagnostic equality |
| `TabManagerEdgeTests.swift` | TabManager | Tab navigation (select/next/prev/last), pin/unpin, close operations, reorder, line endings, file rename, preview detection, contentPreparedForSave |
| `PaneManagerEdgeTests.swift` | PaneManager | Maximize/restore, terminal panes, drop zones, ensureEditorPane, removePane, split operations, openFileInPane |
| `ProjectSearchProviderEdgeTests.swift` | ProjectSearchProvider | isBinaryFile overrides (js/ts/vue/svelte), searchFile edge cases, collectSearchableFiles |
| `QuickOpenProviderEdgeTests.swift` | QuickOpenProvider | relativePath fallback, isSubsequence edge cases, fuzzyScore ranking, recordOpened dedup |

## Review fixes applied
- Removed dead code: `cleanupTestGrammars()` and `testGrammarNames` from `SyntaxHighlighterEdgeTests`
- Replaced `try?` with `throws` in setup helpers (`TabManagerEdgeTests`, `PaneManagerEdgeTests`)
- Wrapped `unregisterGrammar` in `#if DEBUG` in `SyntaxHighlighter.swift`
- Replaced trivial tautology tests with behavioral tests (`ValidationSeverity`, `BlockCommentDelimiters`, `maxIndexDepth`)
- Fixed `reorderTab_swapsPositions` assertion to check exact expected order (`&&` instead of `||`)

## Test plan
- [x] All 3510 tests pass
- [x] SwiftLint: 0 violations
- [x] Code coverage data added

Closes #791