### PR TITLE
Fix open tabs not reloading after external file changes

### DIFF
--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -358,7 +358,7 @@ extension ContentView {
         let deleted = result.conflicts.filter { $0.kind == .deleted }
 
         if !modified.isEmpty {
-            let names = modified.map(\.url.lastPathComponent).joined(separator: ", ")
+            let names = Array(Set(modified.map(\.url.lastPathComponent))).sorted().joined(separator: ", ")
             let alert = NSAlert()
             alert.messageText = Strings.externalModifyTitle
             alert.informativeText = Strings.externalModifyMessage(names)
@@ -368,7 +368,7 @@ extension ContentView {
 
             if alert.runModal() == .alertFirstButtonReturn {
                 for conflict in modified {
-                    tabManager.reloadTab(url: conflict.url)
+                    projectManager.reloadTabs(url: conflict.url)
                 }
             }
         }
@@ -379,7 +379,7 @@ extension ContentView {
     }
 
     func handleFileDeletion(_ deletedURL: URL) {
-        let affected = tabManager.tabsAffectedByDeletion(url: deletedURL)
+        let affected = projectManager.tabsAffectedByDeletion(url: deletedURL)
         guard !affected.isEmpty else { return }
 
         let dirtyTabs = affected.filter { $0.isDirty }
@@ -417,7 +417,7 @@ extension ContentView {
             }
         }
 
-        tabManager.closeTabsForDeletedFile(url: deletedURL)
+        projectManager.closeTabsForDeletedFile(url: deletedURL)
     }
 }
 

--- a/Pine/GitAndNotificationObserver.swift
+++ b/Pine/GitAndNotificationObserver.swift
@@ -97,7 +97,7 @@ struct GitAndNotificationObserver: ViewModifier {
                 // → .active transition entirely. `checkExternalChanges()`
                 // is cheap (one `stat()` per open tab) and silent when no
                 // tab changed, so it is safe to run unconditionally.
-                let result = tabManager.checkExternalChanges()
+                let result = projectManager.checkExternalChanges()
                 onHandleExternalChanges(result)
             }
             .onChange(of: controlActiveState) { _, newState in
@@ -108,7 +108,7 @@ struct GitAndNotificationObserver: ViewModifier {
                 // bar interactions on macOS 26 with Liquid Glass) —
                 // see issue #838.
                 guard newState != .inactive else { return }
-                let result = tabManager.checkExternalChanges()
+                let result = projectManager.checkExternalChanges()
                 onHandleExternalChanges(result)
             }
             // Defense in depth: AppKit's `didBecomeActive` is the
@@ -120,7 +120,7 @@ struct GitAndNotificationObserver: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(
                 for: NSApplication.didBecomeActiveNotification
             )) { _ in
-                let result = tabManager.checkExternalChanges()
+                let result = projectManager.checkExternalChanges()
                 onHandleExternalChanges(result)
             }
             // …and per-window key changes. Some app-switcher paths only
@@ -128,7 +128,7 @@ struct GitAndNotificationObserver: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(
                 for: NSWindow.didBecomeKeyNotification
             )) { _ in
-                let result = tabManager.checkExternalChanges()
+                let result = projectManager.checkExternalChanges()
                 onHandleExternalChanges(result)
             }
             .onReceive(NotificationCenter.default.publisher(for: .showProjectSearch)) { _ in

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -106,6 +106,7 @@ final class ProjectManager {
             tabManager.closeTabsForDeletedFile(url: url)
         }
     }
+
     let toastManager = ToastManager()
     // nonisolated(unsafe) allows deinit to call stopPeriodicSnapshots().
     // RecoveryManager is only mutated on @MainActor; deinit is the only

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -64,6 +64,48 @@ final class ProjectManager {
         }
         return true
     }
+
+    /// Checks every editor pane for externally modified or deleted files.
+    /// Aggregates the per-pane results so global observers do not depend on
+    /// the root environment's `TabManager`, which may be orphaned after pane
+    /// pruning or simply not own the currently visible tab.
+    func checkExternalChanges() -> TabManager.ExternalChangeResult {
+        var conflicts: [TabManager.ExternalConflict] = []
+        var reloadedFileNames: [String] = []
+        var seenReloadedFileNames = Set<String>()
+
+        for tabManager in paneManager.allTabManagers {
+            let result = tabManager.checkExternalChanges()
+            conflicts.append(contentsOf: result.conflicts)
+            for fileName in result.reloadedFileNames
+                where seenReloadedFileNames.insert(fileName).inserted {
+                reloadedFileNames.append(fileName)
+            }
+        }
+
+        return .init(conflicts: conflicts, reloadedFileNames: reloadedFileNames)
+    }
+
+    /// Reloads matching tabs in every editor pane. The same file can be open
+    /// in multiple panes, and the primary TabManager may not own any visible
+    /// editor after pane pruning.
+    func reloadTabs(url: URL) {
+        for tabManager in paneManager.allTabManagers {
+            tabManager.reloadTab(url: url)
+        }
+    }
+
+    /// Returns all open tabs affected by deletion across every editor pane.
+    func tabsAffectedByDeletion(url: URL) -> [EditorTab] {
+        paneManager.allTabManagers.flatMap { $0.tabsAffectedByDeletion(url: url) }
+    }
+
+    /// Closes matching tabs for a deleted path across every editor pane.
+    func closeTabsForDeletedFile(url: URL) {
+        for tabManager in paneManager.allTabManagers {
+            tabManager.closeTabsForDeletedFile(url: url)
+        }
+    }
     let toastManager = ToastManager()
     // nonisolated(unsafe) allows deinit to call stopPeriodicSnapshots().
     // RecoveryManager is only mutated on @MainActor; deinit is the only

--- a/PineTests/ExternalChangeRefreshRegressionTests.swift
+++ b/PineTests/ExternalChangeRefreshRegressionTests.swift
@@ -574,6 +574,93 @@ struct ExternalChangeRefreshRegressionTests {
         }
     }
 
+    // MARK: - #846: reloadTabs / closeTabsForDeletedFile / tabsAffectedByDeletion across panes
+
+    /// `reloadTabs(url:)` must update the tab content in every editor pane,
+    /// not just the primary one.
+    @Test("Issue #846: reloadTabs(url:) reloads file content across all split panes")
+    func reloadTabsUpdatesAllPanes() throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let url = dir.appendingPathComponent("shared.txt")
+        try "original".write(to: url, atomically: true, encoding: .utf8)
+
+        let projectManager = ProjectManager()
+        let primaryPaneID = projectManager.paneManager.activePaneID
+        guard let secondPaneID = projectManager.paneManager.splitPane(primaryPaneID, axis: .horizontal),
+              let secondTM = projectManager.paneManager.tabManager(for: secondPaneID) else {
+            Issue.record("Failed to create second editor pane")
+            return
+        }
+
+        projectManager.primaryTabManager.openTab(url: url)
+        secondTM.openTab(url: url)
+        #expect(projectManager.primaryTabManager.activeTab?.content == "original")
+        #expect(secondTM.activeTab?.content == "original")
+
+        // External edit
+        try "updated externally".write(to: url, atomically: true, encoding: .utf8)
+
+        projectManager.reloadTabs(url: url)
+
+        #expect(projectManager.primaryTabManager.activeTab?.content == "updated externally")
+        #expect(secondTM.activeTab?.content == "updated externally")
+    }
+
+    /// `closeTabsForDeletedFile(url:)` must remove matching tabs from every
+    /// editor pane, not just the primary one.
+    @Test("Issue #846: closeTabsForDeletedFile(url:) closes tabs across all split panes")
+    func closeTabsForDeletedFileClosesAllPanes() throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let url = dir.appendingPathComponent("doomed.txt")
+        try "content".write(to: url, atomically: true, encoding: .utf8)
+
+        let projectManager = ProjectManager()
+        let primaryPaneID = projectManager.paneManager.activePaneID
+        guard let secondPaneID = projectManager.paneManager.splitPane(primaryPaneID, axis: .horizontal),
+              let secondTM = projectManager.paneManager.tabManager(for: secondPaneID) else {
+            Issue.record("Failed to create second editor pane")
+            return
+        }
+
+        projectManager.primaryTabManager.openTab(url: url)
+        secondTM.openTab(url: url)
+        #expect(projectManager.primaryTabManager.tabs.count == 1)
+        #expect(secondTM.tabs.count == 1)
+
+        projectManager.closeTabsForDeletedFile(url: url)
+
+        #expect(projectManager.primaryTabManager.tabs.isEmpty)
+        #expect(secondTM.tabs.isEmpty)
+    }
+
+    /// `tabsAffectedByDeletion(url:)` must return tabs from every editor
+    /// pane so the caller can display a complete list.
+    @Test("Issue #846: tabsAffectedByDeletion(url:) returns tabs from all split panes")
+    func tabsAffectedByDeletionReturnsAllPanes() throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let url = dir.appendingPathComponent("multi.txt")
+        try "data".write(to: url, atomically: true, encoding: .utf8)
+
+        let projectManager = ProjectManager()
+        let primaryPaneID = projectManager.paneManager.activePaneID
+        guard let secondPaneID = projectManager.paneManager.splitPane(primaryPaneID, axis: .horizontal),
+              let secondTM = projectManager.paneManager.tabManager(for: secondPaneID) else {
+            Issue.record("Failed to create second editor pane")
+            return
+        }
+
+        projectManager.primaryTabManager.openTab(url: url)
+        secondTM.openTab(url: url)
+
+        let affected = projectManager.tabsAffectedByDeletion(url: url)
+
+        #expect(affected.count == 2, "Expected tabs from both panes, got \(affected.count)")
+        #expect(affected.allSatisfy { $0.url == url })
+    }
+
     // MARK: - Tree traversal helper
 
     /// Walks `nodes` along `path` (folder names) and returns the leaf node

--- a/PineTests/ExternalChangeRefreshRegressionTests.swift
+++ b/PineTests/ExternalChangeRefreshRegressionTests.swift
@@ -2,7 +2,7 @@
 //  ExternalChangeRefreshRegressionTests.swift
 //  PineTests
 //
-//  Regression tests for issues #838 and #839:
+//  Regression tests for issues #838, #839, and #846:
 //   - #838: external file edits (e.g. nano) not reloaded into open tab
 //     because `controlActiveState == .key` guard was too strict and the
 //     activation re-check missed transitions through `.active`.
@@ -11,6 +11,10 @@
 //     (suppressWatcherUntil window swallowed the FSEvents notification
 //     and Phase 1 of refreshFileTreeAsync wiped already-loaded children
 //     of folders deeper than `shallowDepth`).
+//   - #846: external file reload was routed only through the root
+//     environment's primary TabManager, so tabs opened in other editor
+//     panes (including a recreated editor after terminals-only pruning)
+//     never refreshed.
 //
 //  These tests are intentionally architectural: they drive the same code
 //  paths the runtime triggers fire, without relying on FSEvents timing
@@ -22,7 +26,7 @@ import Testing
 
 @testable import Pine
 
-@Suite("External change refresh regressions — #838 / #839")
+@Suite("External change refresh regressions — #838 / #839 / #846")
 @MainActor
 struct ExternalChangeRefreshRegressionTests {
 
@@ -214,6 +218,77 @@ struct ExternalChangeRefreshRegressionTests {
                 "Second call must be a no-op: file was already reloaded")
         #expect(third.reloadedFileNames.isEmpty)
         #expect(manager.activeTab?.content == "# v2")
+    }
+
+    // MARK: - #846: external reload reaches every editor pane
+
+    /// Splitting creates a non-primary editor pane with its own TabManager.
+    /// The global external-change observer must still reload tabs opened there.
+    @Test("Issue #846: project-level external check reloads tab in non-primary split pane")
+    func projectLevelCheckReloadsNonPrimarySplitPane() throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let url = dir.appendingPathComponent("split.txt")
+        try "v1".write(to: url, atomically: true, encoding: .utf8)
+
+        let projectManager = ProjectManager()
+        let primaryPaneID = projectManager.paneManager.activePaneID
+        guard let secondPaneID = projectManager.paneManager.splitPane(primaryPaneID, axis: .horizontal),
+              let secondTM = projectManager.paneManager.tabManager(for: secondPaneID) else {
+            Issue.record("Failed to create second editor pane")
+            return
+        }
+
+        secondTM.openTab(url: url)
+        #expect(projectManager.primaryTabManager.tabs.isEmpty)
+        #expect(secondTM.activeTab?.content == "v1")
+
+        try "v2".write(to: url, atomically: true, encoding: .utf8)
+        touch(url)
+
+        let result = projectManager.checkExternalChanges()
+
+        #expect(result.reloadedFileNames == ["split.txt"])
+        #expect(secondTM.activeTab?.content == "v2")
+        #expect(projectManager.primaryTabManager.tabs.isEmpty)
+    }
+
+    /// After `pruneEmptyEditorLeaves()` the original primary TabManager can
+    /// be orphaned. Opening a file from the sidebar recreates a fresh editor
+    /// leaf via `ensureEditorPane()`, and external reload must follow that
+    /// new TabManager rather than the stale primary reference.
+    @Test("Issue #846: project-level external check reloads tab in recreated editor pane")
+    func projectLevelCheckReloadsRecreatedEditorPane() throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let url = dir.appendingPathComponent("recreated.txt")
+        try "v1".write(to: url, atomically: true, encoding: .utf8)
+
+        let projectManager = ProjectManager()
+        let initialEditorID = projectManager.paneManager.activePaneID
+        _ = projectManager.paneManager.createTerminalPane(
+            relativeTo: initialEditorID,
+            axis: .horizontal,
+            workingDirectory: nil
+        )
+        projectManager.paneManager.pruneEmptyEditorLeaves()
+        #expect(projectManager.paneManager.root.leafCount(ofType: .editor) == 0)
+
+        let recreatedTM = projectManager.paneManager.ensureEditorPane()
+        #expect(recreatedTM !== projectManager.primaryTabManager)
+
+        recreatedTM.openTab(url: url)
+        #expect(projectManager.primaryTabManager.tabs.isEmpty)
+        #expect(recreatedTM.activeTab?.content == "v1")
+
+        try "v2".write(to: url, atomically: true, encoding: .utf8)
+        touch(url)
+
+        let result = projectManager.checkExternalChanges()
+
+        #expect(result.reloadedFileNames == ["recreated.txt"])
+        #expect(recreatedTM.activeTab?.content == "v2")
+        #expect(projectManager.primaryTabManager.tabs.isEmpty)
     }
 
     // MARK: - #839: deep file appears in sidebar without manual interaction


### PR DESCRIPTION
## Summary

- route external-change checks through `ProjectManager` so open tabs reload across all editor panes instead of only `primaryTabManager`
- reload and close matching tabs across panes when the user resolves external-modify or delete conflicts
- add regression coverage for split-pane and recreated-editor-pane flows

Closes #846.

## Test plan

- [x] Unit tests added/updated
- [ ] UI tests added/updated (if applicable)

Automated:
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -derivedDataPath /tmp/pine-review-test -only-testing:PineTests/ExternalChangeRefreshRegressionTests`

## Manual testing checklist

- [ ] Verified the change works as expected
- [ ] No regressions in related features
