### PR TITLE
fix: screenshot manifest parser for Xcode 26

### DIFF
--- a/scripts/update-screenshots.sh
+++ b/scripts/update-screenshots.sh
@@ -115,15 +115,17 @@ def walk(node):
         atts = node.get("attachments")
         if isinstance(atts, list):
             for att in atts:
-                name = att.get("name", "") or ""
-                suggested = (
-                    att.get("exportedFileName")
+                # Xcode 26 manifest schema has no "name" field.
+                # The XCTAttachment name is stored in
+                # "suggestedHumanReadableName".
+                name = (
+                    att.get("name")
                     or att.get("suggestedHumanReadableName")
-                    or att.get("filename")
                     or ""
                 )
-                if name.startswith("screenshot-") and suggested:
-                    print(f"{name}\t{suggested}")
+                exported = att.get("exportedFileName", "")
+                if name.startswith("screenshot-") and exported:
+                    print(f"{name}\t{exported}")
         for v in node.values():
             walk(v)
     elif isinstance(node, list):


### PR DESCRIPTION
## Summary

- Fix screenshot extraction in `scripts/update-screenshots.sh` — Xcode 26 manifest.json has no `name` field on attachments, the XCTAttachment name is in `suggestedHumanReadableName`
- The parser was checking `att.get("name")` which always returned `None`, so the `startswith("screenshot-")` check never matched
- This caused fallback to raw filesystem walk → `screenshot-unknown-N.png` → deleted by commit step → no screenshots updated

## Test plan

- [ ] Merge and trigger `Update Screenshots` workflow (manual dispatch or next release)
- [ ] Verify logs show `Extracted screenshot-welcome.png` etc. (not `screenshot-unknown-N.png`)
- [ ] Verify commit with updated PNGs appears in `assets/`