### PR TITLE
fix: enable PinePerformanceTests in scheme to fix nightly CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -698,10 +698,12 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────────
   # Performance tests — OPT-IN only.
   #
-  # PinePerformanceTests is skipped from the default Pine scheme because
-  # XCTest `measure {}` blocks are flaky on shared GitHub Actions runners
-  # (noisy neighbors, no thermal guarantees). Running them on every PR would
-  # produce false regressions. Instead this job only runs when:
+  # PinePerformanceTests is enabled in the Pine scheme (`skipped="NO"`), so
+  # Cmd+U in Xcode runs them locally. They are excluded from CI because every
+  # CI job uses explicit `-only-testing:` filters that target only PineTests or
+  # PineUITests. XCTest `measure {}` blocks are flaky on shared GitHub Actions
+  # runners (noisy neighbors, no thermal guarantees), so running them on every
+  # PR would produce false regressions. Instead this job only runs when:
   #
   #   1. Manually dispatched from the Actions tab (workflow_dispatch).
   #   2. A PR is labeled `perf` — add the label to run one-off benchmarks
@@ -735,10 +737,11 @@ jobs:
           restore-keys: |
             spm-${{ runner.os }}-
 
-      # PinePerformanceTests is marked `skipped="YES"` in the Pine scheme so
-      # -only-testing: is required to force it to run. build-for-testing is a
-      # separate step so a missing-target failure surfaces clearly before the
-      # measure {} loop kicks in.
+      # PinePerformanceTests is enabled in the scheme (`skipped="NO"`) but CI
+      # jobs normally exclude it via `-only-testing:` filters. This job uses
+      # `-only-testing:PinePerformanceTests` to run only the perf suite.
+      # build-for-testing is a separate step so a missing-target failure
+      # surfaces clearly before the measure {} loop kicks in.
       - name: Build for Testing
         run: |
           xcodebuild build-for-testing \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ Pine uses GCD for background work, bridged to async/await via `withCheckedContin
 - `QuickOpenView.swift` — Sheet overlay with live search, arrow key navigation, file icons
 - `PineTests/` — Unit tests (50+ files, Swift Testing framework)
 - `PineUITests/` — XCUITest suite (18+ files), base class `PineUITestCase`
-- `PinePerformanceTests/` — XCTest `measure {}` benchmarks for FoldRange, SyntaxHighlighter, ProjectSearch, GitStatus. Skipped from the default Pine scheme because `measure {}` blocks are flaky on shared GitHub Actions runners. Wired into CI as an opt-in `performance-tests` job triggered two ways: (1) `workflow_dispatch` from the Actions tab, or (2) adding the `perf` label to a pull request. Results upload as a `PerformanceResults.xcresult` artifact (14-day retention) for inspection in Xcode's Test Navigator. Run locally with `xcodebuild test -only-testing:PinePerformanceTests ...`
+- `PinePerformanceTests/` — XCTest `measure {}` benchmarks for FoldRange, SyntaxHighlighter, ProjectSearch, GitStatus. Enabled in the default Pine scheme (`skipped="NO"`), so Cmd+U in Xcode runs them locally alongside unit tests. Not executed in CI because all CI jobs use explicit `-only-testing:` filters targeting PineTests or PineUITests. Wired into CI as an opt-in `performance-tests` job triggered two ways: (1) `workflow_dispatch` from the Actions tab, or (2) adding the `perf` label to a pull request. Results upload as a `PerformanceResults.xcresult` artifact (14-day retention) for inspection in Xcode's Test Navigator. Run locally with `xcodebuild test -only-testing:PinePerformanceTests ...`
 
 ## Release & CI
 

--- a/Pine.xcodeproj/xcshareddata/xcschemes/Pine.xcscheme
+++ b/Pine.xcodeproj/xcshareddata/xcschemes/Pine.xcscheme
@@ -51,7 +51,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F1B3CEEE6D109B5E2447458C"


### PR DESCRIPTION
## Summary
- Fixed `PinePerformanceTests` being marked `skipped="YES"` in `Pine.xcscheme`, which caused `xcodebuild -only-testing:PinePerformanceTests` to fail with "isn't a member of the specified test plan or scheme" on Xcode 26.5
- Setting `skipped="NO"` is safe because all CI jobs use explicit `-only-testing:` filters (PineTests, PineUITests/<class>) that already exclude perf tests from normal runs
- Updated CI workflow comments and CLAUDE.md to reflect the new `skipped="NO"` state

## Root cause
Xcode 26.5 with `shouldAutocreateTestPlan="YES"` generates an implicit test plan that excludes `skipped="YES"` targets entirely. The `-only-testing:` flag filters within the test plan, but cannot add targets not included in it.

## Local behavior change
With `skipped="NO"`, pressing **Cmd+U** in Xcode will now run `PinePerformanceTests` alongside unit and UI tests. This is intentional — developers can run perf benchmarks locally to catch regressions early. To skip them locally, use `-skip-testing:PinePerformanceTests`.

## Test plan
- [x] Verified the nightly-perf.yml workflow uses `-only-testing:PinePerformanceTests` which requires the target to be in the scheme's test plan
- [x] Verified CI unit tests use `-only-testing:PineTests` — perf tests won't run
- [x] Verified CI UI tests use `-only-testing:PineUITests/<class>` — perf tests won't run
- [x] Updated CI comments (lines ~701 and ~738) to reflect `skipped="NO"`
- [x] Updated CLAUDE.md Key Files section to match new scheme state

Closes #844