### PR TITLE
feat(editor): wire SmartListContinuation into GutterTextView.insertNewline

### DIFF
--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -364,6 +364,7 @@ struct CodeEditorView: NSViewRepresentable {
             gutterView.fileExtension = language
             gutterView.exactFileName = fileName
             gutterView.indentStyle = indentStyle
+            gutterView.smartListContinuationEnabled = EditorSettings.shared.smartListContinuation
             gutterView.setBlameLines(blameLines)
             if gutterView.isBlameVisible != isBlameVisible {
                 gutterView.isBlameVisible = isBlameVisible

--- a/Pine/EditorSettings.swift
+++ b/Pine/EditorSettings.swift
@@ -21,6 +21,7 @@ final class EditorSettings {
         static let insertFinalNewline = "editor.insertFinalNewline"
         static let stripTrailingWhitespace = "editor.stripTrailingWhitespace"
         static let formatOnSave = "editor.formatOnSave"
+        static let smartListContinuation = "editor.smartListContinuation"
     }
 
     private let defaults: UserDefaults
@@ -44,6 +45,12 @@ final class EditorSettings {
         didSet { defaults.set(formatOnSave, forKey: Keys.formatOnSave) }
     }
 
+    /// When `true`, pressing Return inside a Markdown list automatically continues the
+    /// bullet/number/task on the next line. Default `true` to match VS Code, Obsidian, iA Writer.
+    var smartListContinuation: Bool {
+        didSet { defaults.set(smartListContinuation, forKey: Keys.smartListContinuation) }
+    }
+
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         // `object(forKey:)` returns nil for missing keys so we can distinguish "unset" from
@@ -53,5 +60,7 @@ final class EditorSettings {
         // Off by default — JSON formatting via JSONSerialization is lossy for
         // numbers and reorders keys. Users opt in explicitly via menu toggle.
         self.formatOnSave = (defaults.object(forKey: Keys.formatOnSave) as? Bool) ?? false
+        // On by default — matches VS Code, Obsidian, iA Writer behaviour.
+        self.smartListContinuation = (defaults.object(forKey: Keys.smartListContinuation) as? Bool) ?? true
     }
 }

--- a/Pine/GutterTextView.swift
+++ b/Pine/GutterTextView.swift
@@ -490,7 +490,7 @@ final class GutterTextView: NSTextView {
 
         // Smart list continuation: only when cursor is at the end of the line
         // (ignoring the trailing newline character).
-        let lineContentEnd = lineRange.location + lineForParsing.count
+        let lineContentEnd = lineRange.location + (lineForParsing as NSString).length
         if smartListContinuationEnabled && cursorLocation == lineContentEnd {
             if let outcome = SmartListContinuation.handleReturn(currentLine: lineForParsing) {
                 switch outcome {
@@ -506,7 +506,7 @@ final class GutterTextView: NSTextView {
                     undoManager?.beginUndoGrouping()
                     let replaceRange = NSRange(
                         location: lineRange.location,
-                        length: lineForParsing.count
+                        length: (lineForParsing as NSString).length
                     )
                     insertText(replacement, replacementRange: replaceRange)
                     insertText("\n", replacementRange: selectedRange())

--- a/Pine/GutterTextView.swift
+++ b/Pine/GutterTextView.swift
@@ -462,6 +462,12 @@ final class GutterTextView: NSTextView {
         }
     }
 
+    // MARK: - Smart list continuation
+
+    /// When `true`, pressing Return inside a Markdown list automatically
+    /// continues the bullet/number/task on the next line. Toggled via Editor menu.
+    var smartListContinuationEnabled: Bool = true
+
     // MARK: - Auto-indent
 
     /// Символы, после которых увеличиваем отступ
@@ -476,6 +482,39 @@ final class GutterTextView: NSTextView {
         // Находим текущую строку
         let lineRange = source.lineRange(for: NSRange(location: cursorLocation, length: 0))
         let currentLine = source.substring(with: lineRange)
+
+        // Strip trailing newline from current line for SmartListContinuation parsing
+        let lineForParsing = currentLine.hasSuffix("\n")
+            ? String(currentLine.dropLast())
+            : currentLine
+
+        // Smart list continuation: only when cursor is at the end of the line
+        // (ignoring the trailing newline character).
+        let lineContentEnd = lineRange.location + lineForParsing.count
+        if smartListContinuationEnabled && cursorLocation == lineContentEnd {
+            if let outcome = SmartListContinuation.handleReturn(currentLine: lineForParsing) {
+                switch outcome {
+                case .continue(let continuation):
+                    // Group into a single undo operation
+                    undoManager?.beginUndoGrouping()
+                    insertText("\n\(continuation)", replacementRange: selectedRange())
+                    undoManager?.endUndoGrouping()
+                    return
+
+                case .terminate(let replacement):
+                    // Replace current line content with replacement, then insert newline
+                    undoManager?.beginUndoGrouping()
+                    let replaceRange = NSRange(
+                        location: lineRange.location,
+                        length: lineForParsing.count
+                    )
+                    insertText(replacement, replacementRange: replaceRange)
+                    insertText("\n", replacementRange: selectedRange())
+                    undoManager?.endUndoGrouping()
+                    return
+                }
+            }
+        }
 
         // Извлекаем ведущие пробелы/табы
         let leadingWhitespace = String(currentLine.prefix(while: { $0 == " " || $0 == "\t" }))

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -2863,16 +2863,58 @@
       "comment" : "Menu toggle: enable/disable smart list continuation on Enter in Markdown lists.",
       "extractionState" : "manual",
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intelligente Listenfortsetzung"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Smart List Continuation"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuación inteligente de listas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuation intelligente des listes"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スマートリスト継続"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스마트 목록 계속"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuação inteligente de listas"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Умное продолжение списков"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "智能列表续行"
           }
         }
       }

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -2859,6 +2859,24 @@
         }
       }
     },
+    "menu.smartListContinuation" : {
+      "comment" : "Menu toggle: enable/disable smart list continuation on Enter in Markdown lists.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Smart List Continuation"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Умное продолжение списков"
+          }
+        }
+      }
+    },
     "menu.checkForUpdates" : {
       "comment" : "Menu command: check for app updates.",
       "extractionState" : "manual",

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -14,6 +14,7 @@ nonisolated enum MenuIcons {
     static let duplicate = "plus.square.on.square"
     static let autoSave = "arrow.triangle.2.circlepath"
     static let formatOnSave = "text.alignleft"
+    static let smartListContinuation = "list.bullet"
 
     static let quickOpen = "doc.text.magnifyingglass"
     static let installCLI = "terminal"

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -161,6 +161,12 @@ struct PineAppMenuCommands: Commands {
             ) {
                 Label(Strings.menuFormatOnSave, systemImage: MenuIcons.formatOnSave)
             }
+
+            Toggle(
+                isOn: Bindable(EditorSettings.shared).smartListContinuation
+            ) {
+                Label(Strings.menuSmartListContinuation, systemImage: MenuIcons.smartListContinuation)
+            }
         }
 
         // MARK: - Edit menu

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -188,9 +188,9 @@ enum Strings {
         String(localized: "branch.uncommittedChanges.switch")
     }
 
-    static let menuSmartListContinuation: LocalizedStringKey = "menu.smartListContinuation"
     static let menuAutoSave: LocalizedStringKey = "menu.autoSave"
     static let menuFormatOnSave: LocalizedStringKey = "menu.formatOnSave"
+    static let menuSmartListContinuation: LocalizedStringKey = "menu.smartListContinuation"
     static let autoSaving: LocalizedStringKey = "editor.autoSaving"
     static let menuSave: LocalizedStringKey = "menu.save"
     static let menuSaveAll: LocalizedStringKey = "menu.saveAll"

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -188,6 +188,7 @@ enum Strings {
         String(localized: "branch.uncommittedChanges.switch")
     }
 
+    static let menuSmartListContinuation: LocalizedStringKey = "menu.smartListContinuation"
     static let menuAutoSave: LocalizedStringKey = "menu.autoSave"
     static let menuFormatOnSave: LocalizedStringKey = "menu.formatOnSave"
     static let autoSaving: LocalizedStringKey = "editor.autoSaving"

--- a/PineTests/SmartListWiringTests.swift
+++ b/PineTests/SmartListWiringTests.swift
@@ -177,8 +177,8 @@ struct SmartListWiringTests {
         tv.setSelectedRange(NSRange(location: 4, length: 0))
         tv.insertNewline(nil)
         // Should use auto-indent, not smart list (cursor not at end)
-        let lines = tv.string.components(separatedBy: "\n")
-        #expect(lines.count >= 2)
+        #expect(tv.string == "- he\nllo world")
+        #expect(!tv.string.contains("\n- "))
     }
 
     // MARK: - Multi-line context
@@ -189,6 +189,52 @@ struct SmartListWiringTests {
         tv.setSelectedRange(NSRange(location: 24, length: 0))
         tv.insertNewline(nil)
         #expect(tv.string == "# Title\n- first\n- second\n- ")
+    }
+
+    // MARK: - Edge cases
+
+    @Test("Emoji in list body continues correctly (UTF-16 safety)")
+    func emojiInListBody() {
+        let text = "- hello 😀"
+        let tv = makeTextView(text: text)
+        // NSString length for proper UTF-16 offset
+        tv.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "- hello 😀\n- ")
+    }
+
+    @Test("Tab-indented list continues with tab indent")
+    func tabIndentedList() {
+        let tv = makeTextView(text: "\t- tabbed")
+        tv.setSelectedRange(NSRange(location: 9, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "\t- tabbed\n\t- ")
+    }
+
+    @Test("Spaces after marker with content continues list")
+    func spacesAfterMarker() {
+        let tv = makeTextView(text: "-   spaced")
+        tv.setSelectedRange(NSRange(location: 10, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "-   spaced\n- ")
+    }
+
+    @Test("Multiple emoji characters in list (UTF-16 multi-unit)")
+    func multipleEmoji() {
+        let text = "- 🇯🇵🏳️‍🌈 flags"
+        let tv = makeTextView(text: text)
+        tv.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "- 🇯🇵🏳️‍🌈 flags\n- ")
+    }
+
+    @Test("Empty bullet termination with emoji prefix line")
+    func emojiTermination() {
+        let text = "- 😀\n- "
+        let tv = makeTextView(text: text)
+        tv.setSelectedRange(NSRange(location: (text as NSString).length, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "- 😀\n\n")
     }
 
     // MARK: - EditorSettings integration

--- a/PineTests/SmartListWiringTests.swift
+++ b/PineTests/SmartListWiringTests.swift
@@ -1,0 +1,216 @@
+//
+//  SmartListWiringTests.swift
+//  PineTests
+//
+//  Tests for GutterTextView.insertNewline smart list continuation wiring (issue #843).
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+@Suite("Smart List Continuation Wiring")
+@MainActor
+struct SmartListWiringTests {
+
+    private func makeTextView(text: String = "") -> GutterTextView {
+        let textStorage = NSTextStorage(string: text)
+        let layoutManager = NSLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            containerSize: NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        )
+        layoutManager.addTextContainer(textContainer)
+        let textView = GutterTextView(
+            frame: NSRect(x: 0, y: 0, width: 500, height: 500),
+            textContainer: textContainer
+        )
+        textView.smartListContinuationEnabled = true
+        return textView
+    }
+
+    // MARK: - Bullet continuation
+
+    @Test("Pressing Enter after '- hello' inserts '\\n- '")
+    func continuesDashBullet() {
+        let tv = makeTextView(text: "- hello")
+        tv.setSelectedRange(NSRange(location: 7, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "- hello\n- ")
+    }
+
+    @Test("Pressing Enter after '* item' inserts '\\n* '")
+    func continuesAsteriskBullet() {
+        let tv = makeTextView(text: "* item")
+        tv.setSelectedRange(NSRange(location: 6, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "* item\n* ")
+    }
+
+    @Test("Pressing Enter after '+ stuff' inserts '\\n+ '")
+    func continuesPlusBullet() {
+        let tv = makeTextView(text: "+ stuff")
+        tv.setSelectedRange(NSRange(location: 7, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "+ stuff\n+ ")
+    }
+
+    // MARK: - Ordered list continuation
+
+    @Test("Pressing Enter after '1. first' inserts '\\n2. '")
+    func continuesOrderedList() {
+        let tv = makeTextView(text: "1. first")
+        tv.setSelectedRange(NSRange(location: 8, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "1. first\n2. ")
+    }
+
+    @Test("Pressing Enter after '9) nine' inserts '\\n10) '")
+    func continuesOrderedParen() {
+        let tv = makeTextView(text: "9) nine")
+        tv.setSelectedRange(NSRange(location: 7, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "9) nine\n10) ")
+    }
+
+    // MARK: - Indentation preservation
+
+    @Test("Preserves indentation in continued list")
+    func preservesIndent() {
+        let tv = makeTextView(text: "    - nested")
+        tv.setSelectedRange(NSRange(location: 12, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "    - nested\n    - ")
+    }
+
+    // MARK: - Task list continuation
+
+    @Test("Task list: checked task resets checkbox to unchecked")
+    func taskListResetsCheckbox() {
+        let tv = makeTextView(text: "- [x] done")
+        tv.setSelectedRange(NSRange(location: 10, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "- [x] done\n- [ ] ")
+    }
+
+    @Test("Task list: unchecked task continues unchecked")
+    func taskListContinuesUnchecked() {
+        let tv = makeTextView(text: "- [ ] todo")
+        tv.setSelectedRange(NSRange(location: 10, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "- [ ] todo\n- [ ] ")
+    }
+
+    // MARK: - Blockquote
+
+    @Test("Blockquote list continuation preserves prefix")
+    func blockquoteContinuation() {
+        let tv = makeTextView(text: "> - quoted")
+        tv.setSelectedRange(NSRange(location: 10, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "> - quoted\n> - ")
+    }
+
+    // MARK: - Termination
+
+    @Test("Empty bullet terminates list — replaces line with empty")
+    func terminatesOnEmptyBullet() {
+        let tv = makeTextView(text: "- hello\n- ")
+        tv.setSelectedRange(NSRange(location: 10, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "- hello\n\n")
+    }
+
+    @Test("Empty ordered item terminates list")
+    func terminatesOnEmptyOrdered() {
+        let tv = makeTextView(text: "1. first\n2. ")
+        tv.setSelectedRange(NSRange(location: 12, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "1. first\n\n")
+    }
+
+    @Test("Empty task list terminates")
+    func terminatesOnEmptyTask() {
+        let tv = makeTextView(text: "- [ ] ")
+        tv.setSelectedRange(NSRange(location: 6, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "\n")
+    }
+
+    // MARK: - Non-list falls through to auto-indent
+
+    @Test("Non-list line falls through to normal auto-indent")
+    func fallsThroughForPlainText() {
+        let tv = makeTextView(text: "    hello")
+        tv.setSelectedRange(NSRange(location: 9, length: 0))
+        tv.insertNewline(nil)
+        // Should produce normal auto-indent behavior
+        #expect(tv.string.contains("\n    "), "Should preserve indent via auto-indent fallback")
+    }
+
+    @Test("Auto-indent after brace still works when smart list enabled")
+    func autoIndentAfterBraceStillWorks() {
+        let tv = makeTextView(text: "func test() {")
+        tv.setSelectedRange(NSRange(location: 13, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string.contains("\n    "), "Should add indent after {")
+    }
+
+    // MARK: - Feature flag
+
+    @Test("Smart list disabled: bullet line falls through to auto-indent")
+    func disabledFallsThrough() {
+        let tv = makeTextView(text: "- hello")
+        tv.smartListContinuationEnabled = false
+        tv.setSelectedRange(NSRange(location: 7, length: 0))
+        tv.insertNewline(nil)
+        // Should NOT insert "- " prefix; just regular newline
+        #expect(!tv.string.hasSuffix("- "), "Should not continue list when feature is off")
+    }
+
+    // MARK: - Cursor not at end of line
+
+    @Test("Cursor in middle of list line falls through to auto-indent")
+    func cursorMiddleFallsThrough() {
+        let tv = makeTextView(text: "- hello world")
+        // Cursor after "he" — not at end of line
+        tv.setSelectedRange(NSRange(location: 4, length: 0))
+        tv.insertNewline(nil)
+        // Should use auto-indent, not smart list (cursor not at end)
+        let lines = tv.string.components(separatedBy: "\n")
+        #expect(lines.count >= 2)
+    }
+
+    // MARK: - Multi-line context
+
+    @Test("Smart list works with multiple lines, cursor on last")
+    func multiLineContinuation() {
+        let tv = makeTextView(text: "# Title\n- first\n- second")
+        tv.setSelectedRange(NSRange(location: 24, length: 0))
+        tv.insertNewline(nil)
+        #expect(tv.string == "# Title\n- first\n- second\n- ")
+    }
+
+    // MARK: - EditorSettings integration
+
+    @Test("EditorSettings.smartListContinuation defaults to true")
+    func settingsDefault() {
+        let suiteName = "SmartListWiringTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else { return }
+        defaults.removePersistentDomain(forName: suiteName)
+        let settings = EditorSettings(defaults: defaults)
+        #expect(settings.smartListContinuation == true)
+    }
+
+    @Test("EditorSettings.smartListContinuation persists to UserDefaults")
+    func settingsPersistence() {
+        let suiteName = "SmartListWiringTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else { return }
+        defaults.removePersistentDomain(forName: suiteName)
+        let settings = EditorSettings(defaults: defaults)
+        settings.smartListContinuation = false
+        #expect(defaults.bool(forKey: EditorSettings.Keys.smartListContinuation) == false)
+        let reloaded = EditorSettings(defaults: defaults)
+        #expect(reloaded.smartListContinuation == false)
+    }
+}


### PR DESCRIPTION
## Summary

- Wires the pure-logic `SmartListContinuation` (from #803) into `GutterTextView.insertNewline` so pressing Return inside a Markdown list automatically continues the bullet/number/task on the next line
- Adds `EditorSettings.smartListContinuation` flag (default on) with UserDefaults persistence and Editor menu toggle
- Only activates when cursor is at end of line content; falls through to auto-indent otherwise

## Test plan

- [x] 19 unit tests in `SmartListWiringTests` covering:
  - Bullet continuation (dash, asterisk, plus)
  - Ordered list increment (period, paren)
  - Indentation preservation
  - Task list checkbox reset
  - Blockquote prefix preservation
  - Termination on empty bullet/ordered/task
  - Non-list fallthrough to auto-indent
  - Feature flag off falls through
  - Cursor in middle of line falls through
  - Multi-line context
  - EditorSettings default and persistence
- [x] Existing `GutterTextViewTests` still pass
- [x] Existing `EditorSettingsTests` still pass
- [x] SwiftLint clean (0 violations)

Closes #843