### PR TITLE
test(perf): add baselines, thresholds, and regression alerts

### DIFF
--- a/.github/scripts/check_perf_regression.py
+++ b/.github/scripts/check_perf_regression.py
@@ -44,7 +44,11 @@ def load_baselines(path: str) -> dict:
     }
     """
     with open(path) as fh:
-        return json.load(fh)
+        try:
+            return json.load(fh)
+        except json.JSONDecodeError as exc:
+            print(f"Error: invalid JSON in {path}: {exc}", file=sys.stderr)
+            sys.exit(2)
 
 
 def extract_test_durations(xcresult_path: str) -> dict[str, float]:
@@ -71,8 +75,15 @@ def extract_test_durations(xcresult_path: str) -> dict[str, float]:
     return durations
 
 
-def _walk_test_nodes(node: dict, durations: dict[str, float], parent: str = "") -> None:
+def _walk_test_nodes(node: object, durations: dict[str, float], parent: str = "") -> None:
     """Recursively walk test result nodes to extract durations."""
+    if isinstance(node, list):
+        for item in node:
+            _walk_test_nodes(item, durations, parent)
+        return
+    if not isinstance(node, dict):
+        return
+
     node_type = node.get("nodeType", "")
     name = node.get("name", "")
 
@@ -156,12 +167,16 @@ def format_markdown_report(results: list[RegressionResult]) -> str:
 
     for r in results:
         status = "REGRESSION" if r.is_regression else "OK"
-        sign = "+" if r.change_percent > 0 else ""
+        if r.change_percent == float("inf"):
+            change_str = "N/A (baseline=0)"
+        else:
+            sign = "+" if r.change_percent > 0 else ""
+            change_str = f"{sign}{r.change_percent}%"
         lines.append(
             f"| {r.test_name} "
             f"| {r.baseline_seconds:.4f}s "
             f"| {r.actual_seconds:.4f}s "
-            f"| {sign}{r.change_percent}% "
+            f"| {change_str} "
             f"| {status} |"
         )
 

--- a/.github/scripts/check_perf_regression.py
+++ b/.github/scripts/check_perf_regression.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Compare performance test results against baselines and detect regressions.
+
+Usage:
+    python3 check_perf_regression.py <baselines.json> <xcresult_path>
+
+Exit code 0: all benchmarks within threshold.
+Exit code 1: at least one regression detected.
+
+The script outputs a markdown report to stdout suitable for GITHUB_STEP_SUMMARY.
+"""
+
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass
+class RegressionResult:
+    """Result of comparing one test against its baseline."""
+
+    test_name: str
+    baseline_seconds: float
+    actual_seconds: float
+    change_percent: float
+    threshold_percent: float
+    is_regression: bool
+    description: str
+
+
+def load_baselines(path: str) -> dict:
+    """Load baselines from a JSON file.
+
+    Expected format:
+    {
+        "threshold_percent": 15,
+        "tests": {
+            "TestClass/testMethod": {
+                "baseline_seconds": 0.005,
+                "description": "..."
+            }
+        }
+    }
+    """
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def extract_test_durations(xcresult_path: str) -> dict[str, float]:
+    """Extract average durations from xcresult using xcresulttool.
+
+    Returns a dict mapping "TestClass/testMethod" to average duration in seconds.
+    """
+    try:
+        output = subprocess.check_output(
+            [
+                "xcrun", "xcresulttool", "get", "test-results", "tests",
+                "--path", xcresult_path,
+                "--compact",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        data = json.loads(output)
+    except (subprocess.CalledProcessError, json.JSONDecodeError, FileNotFoundError):
+        return {}
+
+    durations: dict[str, float] = {}
+    _walk_test_nodes(data, durations)
+    return durations
+
+
+def _walk_test_nodes(node: dict, durations: dict[str, float], parent: str = "") -> None:
+    """Recursively walk test result nodes to extract durations."""
+    node_type = node.get("nodeType", "")
+    name = node.get("name", "")
+
+    if node_type == "Test Case" and "duration" in node:
+        # Build key as "TestClass/testMethod"
+        key = f"{parent}/{name}" if parent else name
+        # Remove parentheses from method names: "testFoo()" -> "testFoo"
+        key = key.replace("()", "")
+        try:
+            durations[key] = float(node["duration"])
+        except (ValueError, TypeError):
+            pass
+
+    for child in node.get("children", []):
+        next_parent = name if node_type == "Test Suite" else parent
+        _walk_test_nodes(child, durations, next_parent)
+
+
+def compare_results(
+    baselines: dict, actual: dict[str, float]
+) -> list[RegressionResult]:
+    """Compare actual test durations against baselines.
+
+    Only tests present in both baselines and actual are compared.
+    """
+    threshold = baselines.get("threshold_percent", 15)
+    results: list[RegressionResult] = []
+
+    for test_name, info in baselines.get("tests", {}).items():
+        if test_name not in actual:
+            continue
+
+        baseline_val = info["baseline_seconds"]
+        actual_val = actual[test_name]
+
+        if baseline_val <= 0:
+            # Zero baseline: any positive actual is a regression
+            change_pct = float("inf") if actual_val > 0 else 0.0
+            is_regression = actual_val > 0
+        else:
+            change_pct = ((actual_val - baseline_val) / baseline_val) * 100
+            is_regression = change_pct > threshold
+
+        results.append(
+            RegressionResult(
+                test_name=test_name,
+                baseline_seconds=baseline_val,
+                actual_seconds=actual_val,
+                change_percent=round(change_pct, 1),
+                threshold_percent=threshold,
+                is_regression=is_regression,
+                description=info.get("description", ""),
+            )
+        )
+
+    results.sort(key=lambda r: (-r.is_regression, -r.change_percent))
+    return results
+
+
+def format_markdown_report(results: list[RegressionResult]) -> str:
+    """Generate a markdown report from comparison results."""
+    if not results:
+        return "## Performance Baseline Comparison\n\nNo baseline comparisons available.\n"
+
+    regressions = [r for r in results if r.is_regression]
+    lines: list[str] = ["## Performance Baseline Comparison\n"]
+
+    if regressions:
+        lines.append(
+            f"**REGRESSION DETECTED:** {len(regressions)} regression(s) "
+            f"exceeded the {results[0].threshold_percent}% threshold.\n"
+        )
+    else:
+        lines.append(
+            f"All benchmarks within threshold "
+            f"({results[0].threshold_percent}%).\n"
+        )
+
+    lines.append("| Test | Baseline | Actual | Change | Status |")
+    lines.append("|------|----------|--------|--------|--------|")
+
+    for r in results:
+        status = "REGRESSION" if r.is_regression else "OK"
+        sign = "+" if r.change_percent > 0 else ""
+        lines.append(
+            f"| {r.test_name} "
+            f"| {r.baseline_seconds:.4f}s "
+            f"| {r.actual_seconds:.4f}s "
+            f"| {sign}{r.change_percent}% "
+            f"| {status} |"
+        )
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <baselines.json> <xcresult_path>", file=sys.stderr)
+        return 2
+
+    baselines_path = sys.argv[1]
+    xcresult_path = sys.argv[2]
+
+    baselines = load_baselines(baselines_path)
+    actual = extract_test_durations(xcresult_path)
+
+    if not actual:
+        print("Warning: no test durations extracted from xcresult", file=sys.stderr)
+
+    results = compare_results(baselines, actual)
+    report = format_markdown_report(results)
+    print(report)
+
+    regressions = [r for r in results if r.is_regression]
+    return 1 if regressions else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_check_perf_regression.py
+++ b/.github/scripts/test_check_perf_regression.py
@@ -10,6 +10,7 @@ from check_perf_regression import (
     compare_results,
     format_markdown_report,
     RegressionResult,
+    _walk_test_nodes,
 )
 
 
@@ -61,6 +62,162 @@ class TestLoadBaselines(unittest.TestCase):
             self.assertEqual(baselines["tests"], {})
         finally:
             os.unlink(path)
+
+    def test_load_invalid_json(self):
+        """Should exit on invalid JSON."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as fh:
+            fh.write("not valid json {{{")
+            path = fh.name
+        try:
+            with self.assertRaises(SystemExit) as cm:
+                load_baselines(path)
+            self.assertEqual(cm.exception.code, 2)
+        finally:
+            os.unlink(path)
+
+
+class TestWalkTestNodes(unittest.TestCase):
+    """Tests for _walk_test_nodes xcresult JSON parser."""
+
+    def test_single_test_case(self):
+        """Should extract duration from a simple test case node."""
+        node = {
+            "nodeType": "Test Suite",
+            "name": "MyTests",
+            "children": [
+                {
+                    "nodeType": "Test Case",
+                    "name": "testFoo()",
+                    "duration": "0.123",
+                }
+            ],
+        }
+        durations = {}
+        _walk_test_nodes(node, durations)
+        self.assertIn("MyTests/testFoo", durations)
+        self.assertAlmostEqual(durations["MyTests/testFoo"], 0.123)
+
+    def test_nested_suites(self):
+        """Should use innermost Test Suite as parent."""
+        node = {
+            "nodeType": "Test Suite",
+            "name": "All Tests",
+            "children": [
+                {
+                    "nodeType": "Test Suite",
+                    "name": "InnerSuite",
+                    "children": [
+                        {
+                            "nodeType": "Test Case",
+                            "name": "testBar()",
+                            "duration": "0.456",
+                        }
+                    ],
+                }
+            ],
+        }
+        durations = {}
+        _walk_test_nodes(node, durations)
+        self.assertIn("InnerSuite/testBar", durations)
+
+    def test_list_root(self):
+        """Should handle JSON array as root node."""
+        nodes = [
+            {
+                "nodeType": "Test Suite",
+                "name": "Suite1",
+                "children": [
+                    {
+                        "nodeType": "Test Case",
+                        "name": "testA()",
+                        "duration": "0.01",
+                    }
+                ],
+            },
+            {
+                "nodeType": "Test Suite",
+                "name": "Suite2",
+                "children": [
+                    {
+                        "nodeType": "Test Case",
+                        "name": "testB()",
+                        "duration": "0.02",
+                    }
+                ],
+            },
+        ]
+        durations = {}
+        _walk_test_nodes(nodes, durations)
+        self.assertIn("Suite1/testA", durations)
+        self.assertIn("Suite2/testB", durations)
+
+    def test_non_dict_node(self):
+        """Should gracefully handle non-dict, non-list input."""
+        durations = {}
+        _walk_test_nodes("invalid", durations)
+        self.assertEqual(durations, {})
+
+    def test_none_node(self):
+        """Should handle None input."""
+        durations = {}
+        _walk_test_nodes(None, durations)
+        self.assertEqual(durations, {})
+
+    def test_missing_duration(self):
+        """Test case without duration should be skipped."""
+        node = {
+            "nodeType": "Test Suite",
+            "name": "Tests",
+            "children": [
+                {
+                    "nodeType": "Test Case",
+                    "name": "testNoDuration()",
+                }
+            ],
+        }
+        durations = {}
+        _walk_test_nodes(node, durations)
+        self.assertEqual(durations, {})
+
+    def test_invalid_duration_value(self):
+        """Non-numeric duration should be skipped."""
+        node = {
+            "nodeType": "Test Suite",
+            "name": "Tests",
+            "children": [
+                {
+                    "nodeType": "Test Case",
+                    "name": "testBad()",
+                    "duration": "not-a-number",
+                }
+            ],
+        }
+        durations = {}
+        _walk_test_nodes(node, durations)
+        self.assertEqual(durations, {})
+
+    def test_empty_children(self):
+        """Node with empty children should not fail."""
+        node = {
+            "nodeType": "Test Suite",
+            "name": "Empty",
+            "children": [],
+        }
+        durations = {}
+        _walk_test_nodes(node, durations)
+        self.assertEqual(durations, {})
+
+    def test_no_children_key(self):
+        """Node without children key should not fail."""
+        node = {
+            "nodeType": "Test Suite",
+            "name": "NoChildren",
+        }
+        durations = {}
+        _walk_test_nodes(node, durations)
+        self.assertEqual(durations, {})
 
 
 class TestCompareResults(unittest.TestCase):
@@ -241,6 +398,23 @@ class TestFormatMarkdownReport(unittest.TestCase):
         self.assertIn("REGRESSION", report)
         self.assertIn("A/test1", report)
         self.assertIn("50.0%", report)
+
+    def test_inf_change_percent(self):
+        """Infinite change percent (baseline=0) should show N/A."""
+        results = [
+            RegressionResult(
+                test_name="A/test1",
+                baseline_seconds=0.0,
+                actual_seconds=0.001,
+                change_percent=float("inf"),
+                threshold_percent=15,
+                is_regression=True,
+                description="zero baseline",
+            )
+        ]
+        report = format_markdown_report(results)
+        self.assertIn("N/A (baseline=0)", report)
+        self.assertNotIn("inf%", report)
 
     def test_mixed_results(self):
         """Mixed results show both passing and failing."""

--- a/.github/scripts/test_check_perf_regression.py
+++ b/.github/scripts/test_check_perf_regression.py
@@ -1,0 +1,293 @@
+"""Unit tests for check_perf_regression.py."""
+
+import json
+import os
+import tempfile
+import unittest
+
+from check_perf_regression import (
+    load_baselines,
+    compare_results,
+    format_markdown_report,
+    RegressionResult,
+)
+
+
+class TestLoadBaselines(unittest.TestCase):
+    """Tests for loading baseline JSON."""
+
+    def test_load_valid_baselines(self):
+        """Should parse a valid baselines file."""
+        data = {
+            "threshold_percent": 15,
+            "tests": {
+                "FoldRangeCalculatorPerformanceTests/testManyBlocks": {
+                    "baseline_seconds": 0.005,
+                    "description": "500 flat brace blocks",
+                }
+            },
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as fh:
+            json.dump(data, fh)
+            path = fh.name
+        try:
+            baselines = load_baselines(path)
+            self.assertEqual(baselines["threshold_percent"], 15)
+            key = "FoldRangeCalculatorPerformanceTests/testManyBlocks"
+            self.assertIn(key, baselines["tests"])
+            self.assertAlmostEqual(
+                baselines["tests"][key]["baseline_seconds"], 0.005
+            )
+        finally:
+            os.unlink(path)
+
+    def test_load_missing_file(self):
+        """Should raise FileNotFoundError for missing file."""
+        with self.assertRaises(FileNotFoundError):
+            load_baselines("/nonexistent/baselines.json")
+
+    def test_load_empty_tests(self):
+        """Should handle empty tests dict."""
+        data = {"threshold_percent": 15, "tests": {}}
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as fh:
+            json.dump(data, fh)
+            path = fh.name
+        try:
+            baselines = load_baselines(path)
+            self.assertEqual(baselines["tests"], {})
+        finally:
+            os.unlink(path)
+
+
+class TestCompareResults(unittest.TestCase):
+    """Tests for comparing actual results against baselines."""
+
+    def _baselines(self, threshold=15, tests=None):
+        return {
+            "threshold_percent": threshold,
+            "tests": tests or {},
+        }
+
+    def test_no_regression(self):
+        """Result within threshold should not be flagged."""
+        baselines = self._baselines(
+            tests={
+                "TestClass/testFoo": {
+                    "baseline_seconds": 0.010,
+                    "description": "test foo",
+                }
+            }
+        )
+        actual = {"TestClass/testFoo": 0.011}  # 10% over — within 15%
+        results = compare_results(baselines, actual)
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0].is_regression)
+
+    def test_regression_detected(self):
+        """Result exceeding threshold should be flagged."""
+        baselines = self._baselines(
+            threshold=15,
+            tests={
+                "TestClass/testFoo": {
+                    "baseline_seconds": 0.010,
+                    "description": "test foo",
+                }
+            },
+        )
+        actual = {"TestClass/testFoo": 0.012}  # 20% over — exceeds 15%
+        results = compare_results(baselines, actual)
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].is_regression)
+        self.assertAlmostEqual(results[0].change_percent, 20.0)
+
+    def test_faster_result(self):
+        """Faster result should not be a regression."""
+        baselines = self._baselines(
+            tests={
+                "TestClass/testFoo": {
+                    "baseline_seconds": 0.010,
+                    "description": "test foo",
+                }
+            }
+        )
+        actual = {"TestClass/testFoo": 0.005}  # 50% faster
+        results = compare_results(baselines, actual)
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0].is_regression)
+        self.assertAlmostEqual(results[0].change_percent, -50.0)
+
+    def test_missing_actual_result(self):
+        """Test in baselines but not in actual should be skipped."""
+        baselines = self._baselines(
+            tests={
+                "TestClass/testFoo": {
+                    "baseline_seconds": 0.010,
+                    "description": "test foo",
+                }
+            }
+        )
+        actual = {}
+        results = compare_results(baselines, actual)
+        self.assertEqual(len(results), 0)
+
+    def test_extra_actual_result(self):
+        """Test in actual but not in baselines should be ignored."""
+        baselines = self._baselines(tests={})
+        actual = {"TestClass/testFoo": 0.010}
+        results = compare_results(baselines, actual)
+        self.assertEqual(len(results), 0)
+
+    def test_multiple_tests_mixed(self):
+        """Mixed results: one regression, one pass."""
+        baselines = self._baselines(
+            threshold=10,
+            tests={
+                "A/test1": {
+                    "baseline_seconds": 0.100,
+                    "description": "test 1",
+                },
+                "A/test2": {
+                    "baseline_seconds": 0.200,
+                    "description": "test 2",
+                },
+            },
+        )
+        actual = {
+            "A/test1": 0.105,  # 5% — within 10%
+            "A/test2": 0.250,  # 25% — exceeds 10%
+        }
+        results = compare_results(baselines, actual)
+        regressions = [r for r in results if r.is_regression]
+        passes = [r for r in results if not r.is_regression]
+        self.assertEqual(len(regressions), 1)
+        self.assertEqual(regressions[0].test_name, "A/test2")
+        self.assertEqual(len(passes), 1)
+
+    def test_exact_threshold(self):
+        """Result exactly at threshold should not be flagged."""
+        baselines = self._baselines(
+            threshold=15,
+            tests={
+                "A/test1": {
+                    "baseline_seconds": 0.100,
+                    "description": "test",
+                }
+            },
+        )
+        actual = {"A/test1": 0.115}  # exactly 15%
+        results = compare_results(baselines, actual)
+        self.assertFalse(results[0].is_regression)
+
+    def test_zero_baseline(self):
+        """Zero baseline should not cause division by zero."""
+        baselines = self._baselines(
+            tests={
+                "A/test1": {
+                    "baseline_seconds": 0.0,
+                    "description": "instant test",
+                }
+            }
+        )
+        actual = {"A/test1": 0.001}
+        results = compare_results(baselines, actual)
+        self.assertEqual(len(results), 1)
+        # With zero baseline, any positive value is a regression
+        self.assertTrue(results[0].is_regression)
+
+
+class TestFormatMarkdownReport(unittest.TestCase):
+    """Tests for markdown report generation."""
+
+    def test_no_results(self):
+        """Empty results should produce a minimal report."""
+        report = format_markdown_report([])
+        self.assertIn("No baseline comparisons", report)
+
+    def test_all_passing(self):
+        """All passing should show success."""
+        results = [
+            RegressionResult(
+                test_name="A/test1",
+                baseline_seconds=0.010,
+                actual_seconds=0.011,
+                change_percent=10.0,
+                threshold_percent=15,
+                is_regression=False,
+                description="test 1",
+            )
+        ]
+        report = format_markdown_report(results)
+        self.assertIn("All benchmarks within threshold", report)
+        self.assertIn("A/test1", report)
+
+    def test_with_regression(self):
+        """Regression should show warning."""
+        results = [
+            RegressionResult(
+                test_name="A/test1",
+                baseline_seconds=0.010,
+                actual_seconds=0.015,
+                change_percent=50.0,
+                threshold_percent=15,
+                is_regression=True,
+                description="test 1",
+            )
+        ]
+        report = format_markdown_report(results)
+        self.assertIn("REGRESSION", report)
+        self.assertIn("A/test1", report)
+        self.assertIn("50.0%", report)
+
+    def test_mixed_results(self):
+        """Mixed results show both passing and failing."""
+        results = [
+            RegressionResult(
+                test_name="A/test1",
+                baseline_seconds=0.010,
+                actual_seconds=0.011,
+                change_percent=10.0,
+                threshold_percent=15,
+                is_regression=False,
+                description="pass",
+            ),
+            RegressionResult(
+                test_name="A/test2",
+                baseline_seconds=0.010,
+                actual_seconds=0.015,
+                change_percent=50.0,
+                threshold_percent=15,
+                is_regression=True,
+                description="fail",
+            ),
+        ]
+        report = format_markdown_report(results)
+        self.assertIn("REGRESSION", report)
+        self.assertIn("1 regression", report)
+
+
+class TestRegressionResult(unittest.TestCase):
+    """Tests for RegressionResult dataclass."""
+
+    def test_fields(self):
+        """Should store all fields correctly."""
+        r = RegressionResult(
+            test_name="Foo/bar",
+            baseline_seconds=0.5,
+            actual_seconds=0.6,
+            change_percent=20.0,
+            threshold_percent=15,
+            is_regression=True,
+            description="desc",
+        )
+        self.assertEqual(r.test_name, "Foo/bar")
+        self.assertAlmostEqual(r.baseline_seconds, 0.5)
+        self.assertAlmostEqual(r.actual_seconds, 0.6)
+        self.assertTrue(r.is_regression)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/nightly-perf.yml
+++ b/.github/workflows/nightly-perf.yml
@@ -91,6 +91,35 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "_Download the PerformanceResults.xcresult artifact and open in Xcode Test Navigator for detailed measure {} timings._" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Check for Regressions
+        id: regression-check
+        if: success() || failure()
+        run: |
+          XCRESULT="PerformanceResults.xcresult"
+          BASELINES="PinePerformanceTests/baselines.json"
+
+          if [ ! -d "$XCRESULT" ] || [ ! -f "$BASELINES" ]; then
+            echo "Skipping regression check — missing xcresult or baselines"
+            echo "has_regression=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          set +e
+          REPORT=$(python3 .github/scripts/check_perf_regression.py "$BASELINES" "$XCRESULT" 2>&1)
+          EXIT_CODE=$?
+          set -e
+
+          echo "$REPORT" >> "$GITHUB_STEP_SUMMARY"
+
+          # Save report to a temp file for the issue body
+          echo "$REPORT" > /tmp/regression_report.md
+
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "has_regression=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_regression=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload Performance Results
         if: success() || failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -119,3 +148,31 @@ jobs:
           2. Download the \`PerformanceResults.xcresult\` artifact for detailed timings
           3. Investigate whether this is a flaky test or a real regression" \
             --label "bug,testing"
+
+      - name: Create Issue on Regression
+        if: steps.regression-check.outputs.has_regression == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          REGRESSION_REPORT=$(cat /tmp/regression_report.md 2>/dev/null || echo "Report unavailable")
+          BODY=$(cat <<ISSUE_EOF
+          ## Summary
+
+          Performance regression detected in nightly benchmarks.
+
+          **Run:** $RUN_URL
+
+          $REGRESSION_REPORT
+
+          ## Next steps
+
+          1. Download the \`PerformanceResults.xcresult\` artifact for detailed timings
+          2. Check recent commits for performance-impacting changes
+          3. If the regression is expected, update \`PinePerformanceTests/baselines.json\`
+          ISSUE_EOF
+          )
+          gh issue create \
+            --title "Performance regression detected ($(date -u '+%Y-%m-%d'))" \
+            --body "$BODY" \
+            --label "bug,performance,testing"

--- a/.github/workflows/nightly-perf.yml
+++ b/.github/workflows/nightly-perf.yml
@@ -105,9 +105,14 @@ jobs:
           fi
 
           set +e
-          REPORT=$(python3 .github/scripts/check_perf_regression.py "$BASELINES" "$XCRESULT" 2>&1)
+          REPORT=$(python3 .github/scripts/check_perf_regression.py "$BASELINES" "$XCRESULT" 2>/tmp/perf_stderr.log)
           EXIT_CODE=$?
           set -e
+
+          if [ -s /tmp/perf_stderr.log ]; then
+            echo "::warning::check_perf_regression.py stderr:"
+            cat /tmp/perf_stderr.log
+          fi
 
           echo "$REPORT" >> "$GITHUB_STEP_SUMMARY"
 
@@ -172,7 +177,16 @@ jobs:
           3. If the regression is expected, update \`PinePerformanceTests/baselines.json\`
           ISSUE_EOF
           )
-          gh issue create \
-            --title "Performance regression detected ($(date -u '+%Y-%m-%d'))" \
-            --body "$BODY" \
-            --label "bug,performance,testing"
+
+          # Check for existing open regression issue to avoid duplicates
+          EXISTING=$(gh issue list --label "performance" --state open --search "Performance regression detected" --json number --jq '.[0].number' 2>/dev/null || true)
+
+          if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
+            echo "Adding comment to existing issue #$EXISTING"
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create \
+              --title "Performance regression detected ($(date -u '+%Y-%m-%d'))" \
+              --body "$BODY" \
+              --label "bug,performance,testing"
+          fi

--- a/PinePerformanceTests/baselines.json
+++ b/PinePerformanceTests/baselines.json
@@ -1,5 +1,5 @@
 {
-    "_comment": "Performance test baselines. Update by running nightly-perf with PINE_UPDATE_BASELINES=1.",
+    "_comment": "Performance test baselines. Update by manually editing this file after reviewing nightly-perf results.",
     "threshold_percent": 15,
     "tests": {
         "FoldRangeCalculatorPerformanceTests/testDeeplyNestedBraces": {
@@ -201,6 +201,74 @@
         "EditorStressTests/testThroughputHighlightAndFoldCalculation": {
             "baseline_seconds": 0.050,
             "description": "Combined highlight + fold calculation throughput"
+        },
+        "EditorStressTests/testLargeFileContentUpdate": {
+            "baseline_seconds": 0.005,
+            "description": "Content update in 10K-line file"
+        },
+        "EditorStressTests/testLargeFileMemory": {
+            "baseline_seconds": 0.100,
+            "description": "Memory sanity check for 50K-line file open"
+        },
+        "EditorStressTests/testTabSwitching50Tabs": {
+            "baseline_seconds": 0.010,
+            "description": "Switch through 50 open tabs (200 lines each)"
+        },
+        "EditorStressTests/testTabSwitchingWith100TabsAndContentUpdate": {
+            "baseline_seconds": 0.200,
+            "description": "Switch + update content across 100 tabs"
+        },
+        "EditorStressTests/testRapidOpenCloseInterleavedSingle": {
+            "baseline_seconds": 0.100,
+            "description": "Interleaved open/close single tab x 50 files"
+        },
+        "EditorStressTests/testRapidContentUpdates": {
+            "baseline_seconds": 0.050,
+            "description": "1000 rapid content updates on single tab"
+        },
+        "EditorStressTests/testRapidSaveCycles": {
+            "baseline_seconds": 0.100,
+            "description": "100 update+save cycles on single tab"
+        },
+        "EditorStressTests/testThroughputSearchAndHighlight": {
+            "baseline_seconds": 0.050,
+            "description": "Combined highlight + project search throughput"
+        },
+        "EditorStressTests/testFileWatcherRapidStartStop": {
+            "baseline_seconds": 0.050,
+            "description": "100 rapid FileSystemWatcher start/stop cycles"
+        },
+        "EditorStressTests/testFileWatcherWithRapidFileCreation": {
+            "baseline_seconds": 1.000,
+            "description": "FileSystemWatcher callback with 50 rapid file creates"
+        },
+        "EditorStressTests/testExternalChangeDetection50Tabs": {
+            "baseline_seconds": 0.050,
+            "description": "External change detection across 50 open tabs"
+        },
+        "EditorStressTests/testLoadLargeFileTree": {
+            "baseline_seconds": 0.100,
+            "description": "WorkspaceManager load of 500-file directory tree"
+        },
+        "EditorStressTests/testOpen10MBFilePartialLoad": {
+            "baseline_seconds": 0.500,
+            "description": "Open 10MB file with partial load (first 1MB)"
+        },
+        "EditorStressTests/testOpen5MBFileNoHighlight": {
+            "baseline_seconds": 0.300,
+            "description": "Open 5MB file without syntax highlighting"
+        },
+        "EditorStressTests/testOpen1MBFileWithHighlight": {
+            "baseline_seconds": 0.500,
+            "description": "Open 1MB file with syntax highlighting enabled"
+        },
+        "EditorStressTests/testSequentialOpen5LargeFiles": {
+            "baseline_seconds": 1.000,
+            "description": "Sequential open of 5 x 2MB files"
+        },
+        "SyntaxHighlighterPerformanceTests/testViewportHighlightVsFullHighlight5000Lines": {
+            "baseline_seconds": 0.200,
+            "description": "Viewport vs full highlight comparison for 5000 lines"
         }
     }
 }

--- a/PinePerformanceTests/baselines.json
+++ b/PinePerformanceTests/baselines.json
@@ -1,0 +1,206 @@
+{
+    "_comment": "Performance test baselines. Update by running nightly-perf with PINE_UPDATE_BASELINES=1.",
+    "threshold_percent": 15,
+    "tests": {
+        "FoldRangeCalculatorPerformanceTests/testDeeplyNestedBraces": {
+            "baseline_seconds": 0.002,
+            "description": "100-level deep nested braces"
+        },
+        "FoldRangeCalculatorPerformanceTests/testManyBlocks": {
+            "baseline_seconds": 0.005,
+            "description": "500 flat brace blocks"
+        },
+        "FoldRangeCalculatorPerformanceTests/testMixedBrackets": {
+            "baseline_seconds": 0.003,
+            "description": "200 mixed bracket groups ({}, [], ())"
+        },
+        "FoldRangeCalculatorPerformanceTests/testLargeFileWithSkipRanges": {
+            "baseline_seconds": 0.004,
+            "description": "300 blocks with skip ranges"
+        },
+        "FoldRangeCalculatorPerformanceTests/testVeryLargeFile": {
+            "baseline_seconds": 0.015,
+            "description": "1000 blocks x 5 lines each"
+        },
+        "SyntaxHighlighterPerformanceTests/testFullHighlight500Lines": {
+            "baseline_seconds": 0.010,
+            "description": "Full syntax highlight of 500-line Swift file"
+        },
+        "SyntaxHighlighterPerformanceTests/testFullHighlight2000Lines": {
+            "baseline_seconds": 0.040,
+            "description": "Full syntax highlight of 2000-line Swift file"
+        },
+        "SyntaxHighlighterPerformanceTests/testFullHighlight5000Lines": {
+            "baseline_seconds": 0.100,
+            "description": "Full syntax highlight of 5000-line Swift file"
+        },
+        "SyntaxHighlighterPerformanceTests/testIncrementalHighlight": {
+            "baseline_seconds": 0.005,
+            "description": "Incremental re-highlight after small edit in 2000-line file"
+        },
+        "SyntaxHighlighterPerformanceTests/testComputeMatches2000Lines": {
+            "baseline_seconds": 0.030,
+            "description": "Pure regex match computation for 2000-line file"
+        },
+        "SyntaxHighlighterPerformanceTests/testViewportHighlight5000Lines": {
+            "baseline_seconds": 0.010,
+            "description": "Viewport-only highlight in middle of 5000-line file"
+        },
+        "SyntaxHighlighterPerformanceTests/testCommentAndStringRanges": {
+            "baseline_seconds": 0.015,
+            "description": "Comment/string range extraction for 2000-line file"
+        },
+        "GitStatusParserPerformanceTests/testParseStatus500Entries": {
+            "baseline_seconds": 0.002,
+            "description": "Parse 500 git status --porcelain lines"
+        },
+        "GitStatusParserPerformanceTests/testParseStatus2000Entries": {
+            "baseline_seconds": 0.008,
+            "description": "Parse 2000 git status --porcelain lines"
+        },
+        "GitStatusParserPerformanceTests/testParseIgnored500Entries": {
+            "baseline_seconds": 0.001,
+            "description": "Parse 500 ignored file entries"
+        },
+        "GitStatusParserPerformanceTests/testParseDiff100Hunks": {
+            "baseline_seconds": 0.002,
+            "description": "Parse git diff with 100 hunks"
+        },
+        "GitStatusParserPerformanceTests/testParseDiff500Hunks": {
+            "baseline_seconds": 0.008,
+            "description": "Parse git diff with 500 hunks"
+        },
+        "GitStatusParserPerformanceTests/testParseBlame500Lines": {
+            "baseline_seconds": 0.003,
+            "description": "Parse git blame output for 500 lines"
+        },
+        "GitStatusParserPerformanceTests/testParseBlame2000Lines": {
+            "baseline_seconds": 0.010,
+            "description": "Parse git blame output for 2000 lines"
+        },
+        "GitStatusParserPerformanceTests/testChangeRegionStarts": {
+            "baseline_seconds": 0.001,
+            "description": "Compute change region starts from 500 diffs"
+        },
+        "GitStatusParserPerformanceTests/testNextChangeLine": {
+            "baseline_seconds": 0.001,
+            "description": "Next change line lookup across 300 positions"
+        },
+        "ProjectSearchPerformanceTests/testSearchSingleLargeFile": {
+            "baseline_seconds": 0.005,
+            "description": "Search 5000-line file for common term"
+        },
+        "ProjectSearchPerformanceTests/testSearchSingleFileCaseSensitive": {
+            "baseline_seconds": 0.005,
+            "description": "Case-sensitive search in 5000-line file"
+        },
+        "ProjectSearchPerformanceTests/testSearchAcross200Files": {
+            "baseline_seconds": 0.050,
+            "description": "Search across 200 files (50 lines each)"
+        },
+        "ProjectSearchPerformanceTests/testSearchAcross500Files": {
+            "baseline_seconds": 0.100,
+            "description": "Search across 500 files (30 lines each)"
+        },
+        "ProjectSearchPerformanceTests/testCollectSearchableFiles": {
+            "baseline_seconds": 0.010,
+            "description": "Collect searchable files from 500-file tree"
+        },
+        "ProjectSearchPerformanceTests/testSearchLargeProject1000Files": {
+            "baseline_seconds": 0.500,
+            "description": "Search 1000 files (100 lines each) for common term"
+        },
+        "ProjectSearchPerformanceTests/testSearchLargeProjectCaseSensitive": {
+            "baseline_seconds": 0.300,
+            "description": "Case-sensitive search across 500 files"
+        },
+        "ProjectSearchPerformanceTests/testSearchRareTermLargeProject": {
+            "baseline_seconds": 0.200,
+            "description": "Search for rare term in 1000-file project"
+        },
+        "ProjectSearchPerformanceTests/testCollectSearchableFilesLargeTree": {
+            "baseline_seconds": 0.020,
+            "description": "Collect files from 1200-file directory tree"
+        },
+        "ProjectSearchPerformanceTests/testSearchHighMatchDensity": {
+            "baseline_seconds": 0.300,
+            "description": "Search 200 files with high match density"
+        },
+        "EditRehighlightPerformanceTests/testInsertLineAndRehighlight2000Lines": {
+            "baseline_seconds": 0.005,
+            "description": "Insert line + re-highlight in 2000-line file"
+        },
+        "EditRehighlightPerformanceTests/testPasteBlockAndRehighlight": {
+            "baseline_seconds": 0.005,
+            "description": "Paste 10-line block + re-highlight in 3000-line file"
+        },
+        "EditRehighlightPerformanceTests/testRapidTypingRehighlight": {
+            "baseline_seconds": 0.050,
+            "description": "100 single-char inserts with incremental re-highlight"
+        },
+        "EditRehighlightPerformanceTests/testDeleteBlockAndRehighlight": {
+            "baseline_seconds": 0.005,
+            "description": "Delete 500 chars + re-highlight in 2000-line file"
+        },
+        "MinimapRenderPerformanceTests/testMinimapDataPrep2000Lines": {
+            "baseline_seconds": 0.020,
+            "description": "Minimap data preparation for 2000-line file"
+        },
+        "MinimapRenderPerformanceTests/testMinimapDataPrep5000Lines": {
+            "baseline_seconds": 0.050,
+            "description": "Minimap data preparation for 5000-line file"
+        },
+        "MinimapRenderPerformanceTests/testMinimapDataPrepWithDiffMarkers": {
+            "baseline_seconds": 0.030,
+            "description": "Minimap data prep with diff markers for 3000-line file"
+        },
+        "MinimapRenderPerformanceTests/testMinimapFullPipeline3000Lines": {
+            "baseline_seconds": 0.060,
+            "description": "Full minimap pipeline (highlight + data prep) for 3000 lines"
+        },
+        "ScrollPerformanceTests/testScrollThrough100kLines": {
+            "baseline_seconds": 0.500,
+            "description": "Scroll through 100K-line file (layout + enumerate)"
+        },
+        "ScrollPerformanceTests/testViewportLayoutAtRandomPositions100kLines": {
+            "baseline_seconds": 0.050,
+            "description": "Viewport layout at 20 random positions in 100K-line file"
+        },
+        "ScrollPerformanceTests/testScrollWithHighlighting50kLines": {
+            "baseline_seconds": 1.000,
+            "description": "Scroll through 50K highlighted lines with color reads"
+        },
+        "EditorStressTests/testOpen10kLineFile": {
+            "baseline_seconds": 0.050,
+            "description": "Open and close 10K-line file"
+        },
+        "EditorStressTests/testOpen50kLineFile": {
+            "baseline_seconds": 0.200,
+            "description": "Open and close 50K-line file"
+        },
+        "EditorStressTests/testOpen100kLineFile": {
+            "baseline_seconds": 0.300,
+            "description": "Open and close 100K-line file (no highlighting)"
+        },
+        "EditorStressTests/testOpen50Tabs": {
+            "baseline_seconds": 0.100,
+            "description": "Open and close 50 tabs (100 lines each)"
+        },
+        "EditorStressTests/testOpen100Tabs": {
+            "baseline_seconds": 0.200,
+            "description": "Open and close 100 tabs (50 lines each)"
+        },
+        "EditorStressTests/testRapidOpenClose": {
+            "baseline_seconds": 0.500,
+            "description": "Rapid open/close 20 files x 50 cycles"
+        },
+        "EditorStressTests/testThroughputHighlightingAndGitParsing": {
+            "baseline_seconds": 0.050,
+            "description": "Combined highlight + git parse throughput"
+        },
+        "EditorStressTests/testThroughputHighlightAndFoldCalculation": {
+            "baseline_seconds": 0.050,
+            "description": "Combined highlight + fold calculation throughput"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Added `PinePerformanceTests/baselines.json` with initial baseline values for all 49 performance tests (15% regression threshold)
- Added `.github/scripts/check_perf_regression.py` — extracts test durations from `.xcresult` via `xcresulttool` and compares against baselines
- Added 16 unit tests for the regression checker covering load, compare, format, and edge cases (zero baseline, exact threshold, missing results)
- Updated `nightly-perf.yml` with a "Check for Regressions" step that appends a markdown comparison table to the step summary and creates a GitHub issue with `performance` label when regressions are detected

## How it works
1. After performance tests run, `check_perf_regression.py` is called with `baselines.json` and the `.xcresult` path
2. The script uses `xcrun xcresulttool get test-results tests` to extract per-test average durations
3. Each test is compared against its baseline — if the actual time exceeds `baseline + threshold%`, it's flagged as a regression
4. A markdown table is appended to `GITHUB_STEP_SUMMARY` showing all comparisons
5. If any regression is found, a GitHub issue is auto-created with the report

## Test plan
- [x] Python unit tests pass (16/16): `cd .github/scripts && python3 -m unittest test_check_perf_regression -v`
- [x] swiftlint passes with 0 violations
- [ ] Verify on CI that nightly-perf workflow runs the regression check step
- [ ] After first successful run, update baselines.json with actual CI values

Closes #832