### PR TITLE
feat(editor): external formatter infrastructure

### DIFF
--- a/Pine/ExternalFileFormatter.swift
+++ b/Pine/ExternalFileFormatter.swift
@@ -24,6 +24,9 @@ protocol ProcessRunning: Sendable {
 }
 
 /// Runs a real `Process` with stdin/stdout piping and a timeout.
+///
+/// **Important:** `run()` blocks the calling thread until the process exits or times out.
+/// Must be called from a background queue — never from the main thread.
 struct RealProcessRunner: ProcessRunning {
     func run(
         executablePath: String,
@@ -31,6 +34,8 @@ struct RealProcessRunner: ProcessRunning {
         stdin: String,
         timeout: TimeInterval
     ) -> ProcessRunResult {
+        dispatchPrecondition(condition: .notOnQueue(.main))
+
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executablePath)
         process.arguments = arguments
@@ -51,30 +56,49 @@ struct RealProcessRunner: ProcessRunning {
             }
             stdinPipe.fileHandleForWriting.closeFile()
 
-            // Schedule timeout
+            // Schedule timeout with thread-safe flag via GCD
+            let timedOutQueue = DispatchQueue(label: "com.pine.process-timeout-flag")
+            nonisolated(unsafe) var timedOutValue = false
+
             let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
-            var timedOut = false
             timer.schedule(deadline: .now() + timeout)
             timer.setEventHandler {
-                timedOut = true
+                timedOutQueue.sync { timedOutValue = true }
                 if process.isRunning {
                     process.terminate()
                 }
             }
             timer.resume()
 
-            // Read pipes before waitUntilExit to avoid deadlock
-            let outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-            let errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            // Read both pipes concurrently in separate threads to avoid
+            // deadlock when stderr pipe buffer fills up (64KB)
+            let readGroup = DispatchGroup()
+            nonisolated(unsafe) var outData = Data()
+            nonisolated(unsafe) var errData = Data()
 
+            readGroup.enter()
+            DispatchQueue.global().async {
+                outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+                readGroup.leave()
+            }
+
+            readGroup.enter()
+            DispatchQueue.global().async {
+                errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+                readGroup.leave()
+            }
+
+            readGroup.wait()
             process.waitUntilExit()
             timer.cancel()
+
+            let didTimeout = timedOutQueue.sync { timedOutValue }
 
             return ProcessRunResult(
                 stdout: String(bytes: outData, encoding: .utf8) ?? "",
                 stderr: String(bytes: errData, encoding: .utf8) ?? "",
                 exitCode: process.terminationStatus,
-                timedOut: timedOut
+                timedOut: didTimeout
             )
         } catch {
             return ProcessRunResult(
@@ -91,7 +115,10 @@ struct RealProcessRunner: ProcessRunning {
 ///
 /// Falls back to the original content on any failure: tool not found, non-zero exit,
 /// timeout, or empty output. This guarantees save never blocks on a broken tool.
-final class ExternalFileFormatter: FileFormatter, @unchecked Sendable {
+///
+/// **Threading:** `format()` blocks the calling thread while the external process runs.
+/// Must be called from a background queue — never from the main thread.
+final class ExternalFileFormatter: FileFormatter, Sendable {
 
     /// Display name of the tool (e.g. "terraform", "shfmt", "prettier").
     let toolName: String
@@ -106,26 +133,23 @@ final class ExternalFileFormatter: FileFormatter, @unchecked Sendable {
     let timeout: TimeInterval
 
     /// Resolved path to the executable, or nil if not found.
-    private(set) var toolPath: String?
+    let toolPath: String?
 
     private let processRunner: ProcessRunning
 
-    /// Creates an external file formatter.
+    /// Creates an external file formatter that auto-resolves the tool from PATH.
     ///
     /// - Parameters:
     ///   - toolName: Name of the tool binary.
     ///   - extensions: File extensions to handle (without dot, case-insensitive).
     ///   - arguments: Arguments to pass to the tool.
     ///   - processRunner: Process runner implementation (use `RealProcessRunner` in production).
-    ///   - toolPath: Override the tool path (skips resolution). If nil and a real runner is used,
-    ///               the tool will be resolved via `ExternalToolResolver`.
     ///   - timeout: Maximum execution time (default 5 seconds).
     init(
         toolName: String,
         extensions: [String],
         arguments: [String],
         processRunner: ProcessRunning = RealProcessRunner(),
-        toolPath: String? = "RESOLVE",
         timeout: TimeInterval = 5.0
     ) {
         self.toolName = toolName
@@ -133,13 +157,32 @@ final class ExternalFileFormatter: FileFormatter, @unchecked Sendable {
         self.arguments = arguments
         self.processRunner = processRunner
         self.timeout = timeout
+        self.toolPath = ExternalToolResolver.fromEnvironment().resolve(tool: toolName)
+    }
 
-        if toolPath == "RESOLVE" {
-            // Auto-resolve from PATH
-            self.toolPath = ExternalToolResolver.fromEnvironment().resolve(tool: toolName)
-        } else {
-            self.toolPath = toolPath
-        }
+    /// Creates an external file formatter with an explicit tool path (skips resolution).
+    ///
+    /// - Parameters:
+    ///   - toolPath: Absolute path to the tool binary, or nil if tool is unavailable.
+    ///   - toolName: Display name of the tool.
+    ///   - extensions: File extensions to handle (without dot, case-insensitive).
+    ///   - arguments: Arguments to pass to the tool.
+    ///   - processRunner: Process runner implementation (use `RealProcessRunner` in production).
+    ///   - timeout: Maximum execution time (default 5 seconds).
+    init(
+        toolPath: String?,
+        toolName: String,
+        extensions: [String],
+        arguments: [String],
+        processRunner: ProcessRunning = RealProcessRunner(),
+        timeout: TimeInterval = 5.0
+    ) {
+        self.toolName = toolName
+        self.extensions = Set(extensions.map { $0.lowercased() })
+        self.arguments = arguments
+        self.processRunner = processRunner
+        self.timeout = timeout
+        self.toolPath = toolPath
     }
 
     func canFormat(url: URL) -> Bool {

--- a/Pine/ExternalFileFormatter.swift
+++ b/Pine/ExternalFileFormatter.swift
@@ -34,7 +34,7 @@ nonisolated struct RealProcessRunner: ProcessRunning {
         stdin: String,
         timeout: TimeInterval
     ) -> ProcessRunResult {
-        dispatchPrecondition(condition: .notOnQueue(.main))
+        precondition(!Thread.isMainThread, "RealProcessRunner.run() must not be called on the main thread")
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: executablePath)
@@ -56,14 +56,18 @@ nonisolated struct RealProcessRunner: ProcessRunning {
             }
             stdinPipe.fileHandleForWriting.closeFile()
 
-            // Schedule timeout with thread-safe flag via GCD
-            let timedOutQueue = DispatchQueue(label: "com.pine.process-timeout-flag")
+            // Schedule timeout with thread-safe flag via NSLock
+            // (GCD serial queue .sync crashes under Swift 6 cooperative threading
+            //  because swift_task_checkIsolatedSwift triggers dispatch_assert_queue)
+            let timedOutLock = NSLock()
             nonisolated(unsafe) var timedOutValue = false
 
             let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
             timer.schedule(deadline: .now() + timeout)
             timer.setEventHandler {
-                timedOutQueue.sync { timedOutValue = true }
+                timedOutLock.lock()
+                timedOutValue = true
+                timedOutLock.unlock()
                 if process.isRunning {
                     process.terminate()
                 }
@@ -92,7 +96,9 @@ nonisolated struct RealProcessRunner: ProcessRunning {
             process.waitUntilExit()
             timer.cancel()
 
-            let didTimeout = timedOutQueue.sync { timedOutValue }
+            timedOutLock.lock()
+            let didTimeout = timedOutValue
+            timedOutLock.unlock()
 
             return ProcessRunResult(
                 stdout: String(bytes: outData, encoding: .utf8) ?? "",

--- a/Pine/ExternalFileFormatter.swift
+++ b/Pine/ExternalFileFormatter.swift
@@ -27,7 +27,7 @@ protocol ProcessRunning: Sendable {
 ///
 /// **Important:** `run()` blocks the calling thread until the process exits or times out.
 /// Must be called from a background queue — never from the main thread.
-struct RealProcessRunner: ProcessRunning {
+nonisolated struct RealProcessRunner: ProcessRunning {
     func run(
         executablePath: String,
         arguments: [String],
@@ -118,7 +118,7 @@ struct RealProcessRunner: ProcessRunning {
 ///
 /// **Threading:** `format()` blocks the calling thread while the external process runs.
 /// Must be called from a background queue — never from the main thread.
-final class ExternalFileFormatter: FileFormatter, Sendable {
+nonisolated final class ExternalFileFormatter: FileFormatter, Sendable {
 
     /// Display name of the tool (e.g. "terraform", "shfmt", "prettier").
     let toolName: String

--- a/Pine/ExternalFileFormatter.swift
+++ b/Pine/ExternalFileFormatter.swift
@@ -1,0 +1,172 @@
+//
+//  ExternalFileFormatter.swift
+//  Pine
+//
+
+import Foundation
+
+/// Result of running an external process.
+struct ProcessRunResult: Sendable {
+    let stdout: String
+    let stderr: String
+    let exitCode: Int32
+    let timedOut: Bool
+}
+
+/// Abstraction for running external processes. Allows mocking in tests.
+protocol ProcessRunning: Sendable {
+    func run(
+        executablePath: String,
+        arguments: [String],
+        stdin: String,
+        timeout: TimeInterval
+    ) -> ProcessRunResult
+}
+
+/// Runs a real `Process` with stdin/stdout piping and a timeout.
+struct RealProcessRunner: ProcessRunning {
+    func run(
+        executablePath: String,
+        arguments: [String],
+        stdin: String,
+        timeout: TimeInterval
+    ) -> ProcessRunResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+
+            // Write stdin content and close
+            if let data = stdin.data(using: .utf8) {
+                stdinPipe.fileHandleForWriting.write(data)
+            }
+            stdinPipe.fileHandleForWriting.closeFile()
+
+            // Schedule timeout
+            let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+            var timedOut = false
+            timer.schedule(deadline: .now() + timeout)
+            timer.setEventHandler {
+                timedOut = true
+                if process.isRunning {
+                    process.terminate()
+                }
+            }
+            timer.resume()
+
+            // Read pipes before waitUntilExit to avoid deadlock
+            let outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+            let errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+
+            process.waitUntilExit()
+            timer.cancel()
+
+            return ProcessRunResult(
+                stdout: String(bytes: outData, encoding: .utf8) ?? "",
+                stderr: String(bytes: errData, encoding: .utf8) ?? "",
+                exitCode: process.terminationStatus,
+                timedOut: timedOut
+            )
+        } catch {
+            return ProcessRunResult(
+                stdout: "",
+                stderr: error.localizedDescription,
+                exitCode: -1,
+                timedOut: false
+            )
+        }
+    }
+}
+
+/// A file formatter that delegates to an external CLI tool via stdin/stdout.
+///
+/// Falls back to the original content on any failure: tool not found, non-zero exit,
+/// timeout, or empty output. This guarantees save never blocks on a broken tool.
+final class ExternalFileFormatter: FileFormatter, @unchecked Sendable {
+
+    /// Display name of the tool (e.g. "terraform", "shfmt", "prettier").
+    let toolName: String
+
+    /// File extensions this formatter handles (lowercase, without dot).
+    let extensions: Set<String>
+
+    /// Arguments to pass to the tool (the content comes via stdin).
+    let arguments: [String]
+
+    /// Maximum time to wait for the tool to finish.
+    let timeout: TimeInterval
+
+    /// Resolved path to the executable, or nil if not found.
+    private(set) var toolPath: String?
+
+    private let processRunner: ProcessRunning
+
+    /// Creates an external file formatter.
+    ///
+    /// - Parameters:
+    ///   - toolName: Name of the tool binary.
+    ///   - extensions: File extensions to handle (without dot, case-insensitive).
+    ///   - arguments: Arguments to pass to the tool.
+    ///   - processRunner: Process runner implementation (use `RealProcessRunner` in production).
+    ///   - toolPath: Override the tool path (skips resolution). If nil and a real runner is used,
+    ///               the tool will be resolved via `ExternalToolResolver`.
+    ///   - timeout: Maximum execution time (default 5 seconds).
+    init(
+        toolName: String,
+        extensions: [String],
+        arguments: [String],
+        processRunner: ProcessRunning = RealProcessRunner(),
+        toolPath: String? = "RESOLVE",
+        timeout: TimeInterval = 5.0
+    ) {
+        self.toolName = toolName
+        self.extensions = Set(extensions.map { $0.lowercased() })
+        self.arguments = arguments
+        self.processRunner = processRunner
+        self.timeout = timeout
+
+        if toolPath == "RESOLVE" {
+            // Auto-resolve from PATH
+            self.toolPath = ExternalToolResolver.fromEnvironment().resolve(tool: toolName)
+        } else {
+            self.toolPath = toolPath
+        }
+    }
+
+    func canFormat(url: URL) -> Bool {
+        guard toolPath != nil else { return false }
+        let ext = url.pathExtension.lowercased()
+        return extensions.contains(ext)
+    }
+
+    func format(_ content: String, url: URL) -> String {
+        guard let executablePath = toolPath else {
+            return content
+        }
+
+        let result = processRunner.run(
+            executablePath: executablePath,
+            arguments: arguments,
+            stdin: content,
+            timeout: timeout
+        )
+
+        // Fall back to original on any failure
+        guard !result.timedOut,
+              result.exitCode == 0,
+              !result.stdout.isEmpty else {
+            return content
+        }
+
+        return result.stdout
+    }
+}

--- a/Pine/ExternalToolResolver.swift
+++ b/Pine/ExternalToolResolver.swift
@@ -9,7 +9,7 @@ import Foundation
 /// install locations. Caches results for the lifetime of the resolver instance.
 ///
 /// Thread-safe: uses a serial queue to protect the cache dictionary.
-final class ExternalToolResolver: Sendable {
+nonisolated final class ExternalToolResolver: Sendable {
 
     /// Well-known directories that are always searched, even if not in PATH.
     /// Order matters — earlier entries are checked first.

--- a/Pine/ExternalToolResolver.swift
+++ b/Pine/ExternalToolResolver.swift
@@ -9,7 +9,7 @@ import Foundation
 /// install locations. Caches results for the lifetime of the resolver instance.
 ///
 /// Thread-safe: uses a serial queue to protect the cache dictionary.
-final class ExternalToolResolver: @unchecked Sendable {
+final class ExternalToolResolver: Sendable {
 
     /// Well-known directories that are always searched, even if not in PATH.
     /// Order matters — earlier entries are checked first.
@@ -25,19 +25,15 @@ final class ExternalToolResolver: @unchecked Sendable {
     /// Ordered, deduplicated list of directories to search.
     let searchDirectories: [String]
 
-    private let fileManager: FileManager
     private let cacheQueue = DispatchQueue(label: "com.pine.tool-resolver-cache")
-    private var cache: [String: String?] = [:]
+    nonisolated(unsafe) private var cache: [String: String?] = [:]
 
-    /// Creates a resolver with the given PATH string and file manager.
+    /// Creates a resolver with the given PATH string.
     ///
     /// - Parameters:
     ///   - pathString: Colon-separated PATH string (e.g. from `ProcessInfo.processInfo.environment["PATH"]`).
     ///                 If nil, only well-known directories are searched.
-    ///   - fileManager: FileManager to use for existence/executable checks.
-    init(pathString: String? = nil, fileManager: FileManager = .default) {
-        self.fileManager = fileManager
-
+    init(pathString: String? = nil) {
         var seen = Set<String>()
         var dirs: [String] = []
 
@@ -61,9 +57,9 @@ final class ExternalToolResolver: @unchecked Sendable {
     }
 
     /// Creates a resolver using the current process's PATH environment variable.
-    static func fromEnvironment(fileManager: FileManager = .default) -> ExternalToolResolver {
+    static func fromEnvironment() -> ExternalToolResolver {
         let path = ProcessInfo.processInfo.environment["PATH"]
-        return ExternalToolResolver(pathString: path, fileManager: fileManager)
+        return ExternalToolResolver(pathString: path)
     }
 
     /// Resolves the path to a CLI tool by name.
@@ -74,14 +70,17 @@ final class ExternalToolResolver: @unchecked Sendable {
     /// Returns the absolute path to the executable, or nil if not found.
     /// Results are cached.
     func resolve(tool: String) -> String? {
-        // Check cache first
-        if let cached = cacheQueue.sync(execute: { cache[tool] }) {
-            return cached
+        // Single atomic cache read — use index(forKey:) to distinguish
+        // "key absent" from "key present with nil value"
+        let cachedResult: (found: Bool, value: String?) = cacheQueue.sync {
+            if let idx = cache.index(forKey: tool) {
+                return (true, cache[idx].value)
+            }
+            return (false, nil)
         }
-        // Sentinel check: distinguish "not cached" from "cached as nil"
-        let hasCachedValue = cacheQueue.sync { cache.keys.contains(tool) }
-        if hasCachedValue {
-            return nil
+
+        if cachedResult.found {
+            return cachedResult.value
         }
 
         let result: String?
@@ -120,6 +119,7 @@ final class ExternalToolResolver: @unchecked Sendable {
     }
 
     private func isExecutableFile(_ path: String) -> Bool {
+        let fileManager = FileManager.default
         var isDir: ObjCBool = false
         guard fileManager.fileExists(atPath: path, isDirectory: &isDir), !isDir.boolValue else {
             return false

--- a/Pine/ExternalToolResolver.swift
+++ b/Pine/ExternalToolResolver.swift
@@ -1,0 +1,129 @@
+//
+//  ExternalToolResolver.swift
+//  Pine
+//
+
+import Foundation
+
+/// Discovers external CLI tools by searching PATH directories and well-known
+/// install locations. Caches results for the lifetime of the resolver instance.
+///
+/// Thread-safe: uses a serial queue to protect the cache dictionary.
+final class ExternalToolResolver: @unchecked Sendable {
+
+    /// Well-known directories that are always searched, even if not in PATH.
+    /// Order matters — earlier entries are checked first.
+    nonisolated static let wellKnownDirectories: [String] = [
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/bin",
+        "/bin",
+        "/usr/sbin",
+        "/sbin"
+    ]
+
+    /// Ordered, deduplicated list of directories to search.
+    let searchDirectories: [String]
+
+    private let fileManager: FileManager
+    private let cacheQueue = DispatchQueue(label: "com.pine.tool-resolver-cache")
+    private var cache: [String: String?] = [:]
+
+    /// Creates a resolver with the given PATH string and file manager.
+    ///
+    /// - Parameters:
+    ///   - pathString: Colon-separated PATH string (e.g. from `ProcessInfo.processInfo.environment["PATH"]`).
+    ///                 If nil, only well-known directories are searched.
+    ///   - fileManager: FileManager to use for existence/executable checks.
+    init(pathString: String? = nil, fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+
+        var seen = Set<String>()
+        var dirs: [String] = []
+
+        // 1. Directories from PATH
+        if let pathString, !pathString.isEmpty {
+            for dir in pathString.split(separator: ":").map(String.init) {
+                let clean = dir.trimmingCharacters(in: .whitespaces)
+                guard !clean.isEmpty, !seen.contains(clean) else { continue }
+                seen.insert(clean)
+                dirs.append(clean)
+            }
+        }
+
+        // 2. Well-known directories (appended if not already present)
+        for dir in Self.wellKnownDirectories where !seen.contains(dir) {
+            seen.insert(dir)
+            dirs.append(dir)
+        }
+
+        self.searchDirectories = dirs
+    }
+
+    /// Creates a resolver using the current process's PATH environment variable.
+    static func fromEnvironment(fileManager: FileManager = .default) -> ExternalToolResolver {
+        let path = ProcessInfo.processInfo.environment["PATH"]
+        return ExternalToolResolver(pathString: path, fileManager: fileManager)
+    }
+
+    /// Resolves the path to a CLI tool by name.
+    ///
+    /// If `tool` is an absolute path (starts with `/`), it is validated directly.
+    /// Otherwise, searches `searchDirectories` in order.
+    ///
+    /// Returns the absolute path to the executable, or nil if not found.
+    /// Results are cached.
+    func resolve(tool: String) -> String? {
+        // Check cache first
+        if let cached = cacheQueue.sync(execute: { cache[tool] }) {
+            return cached
+        }
+        // Sentinel check: distinguish "not cached" from "cached as nil"
+        let hasCachedValue = cacheQueue.sync { cache.keys.contains(tool) }
+        if hasCachedValue {
+            return nil
+        }
+
+        let result: String?
+
+        if tool.hasPrefix("/") {
+            // Absolute path — validate directly
+            result = isExecutableFile(tool) ? tool : nil
+        } else {
+            // Search PATH directories
+            result = searchInDirectories(tool)
+        }
+
+        cacheQueue.sync {
+            cache[tool] = result
+        }
+        return result
+    }
+
+    /// Clears the cached tool paths.
+    func clearCache() {
+        cacheQueue.sync {
+            cache.removeAll()
+        }
+    }
+
+    // MARK: - Private
+
+    private func searchInDirectories(_ tool: String) -> String? {
+        for dir in searchDirectories {
+            let candidate = (dir as NSString).appendingPathComponent(tool)
+            if isExecutableFile(candidate) {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    private func isExecutableFile(_ path: String) -> Bool {
+        var isDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: path, isDirectory: &isDir), !isDir.boolValue else {
+            return false
+        }
+        return fileManager.isExecutableFile(atPath: path)
+    }
+}

--- a/Pine/FileFormatter.swift
+++ b/Pine/FileFormatter.swift
@@ -12,8 +12,8 @@ import Foundation
 /// - **Idempotent** — `format(format(x)) == format(x)`.
 /// - **Safe on parse failure** — return the original string unchanged if the input cannot
 ///   be parsed, so save never blocks on malformed files.
-/// - **Sandbox-friendly** — no spawning of external binaries (we run inside the app
-///   sandbox and cannot exec `terraform`, `swift-format`, or `prettier`).
+/// - **Sandbox-friendly** — pure-Swift formatters should not spawn external binaries.
+///   For external tools, use `ExternalFileFormatter` which handles Process lifecycle.
 protocol FileFormatter: Sendable {
     /// Returns true when this formatter should be applied to the given file URL.
     func canFormat(url: URL) -> Bool
@@ -90,9 +90,9 @@ struct JSONFileFormatter: FileFormatter {
 struct FileFormatterRegistry: Sendable {
     let formatters: [FileFormatter]
 
-    /// Default registry. Currently ships a single in-Swift JSON formatter. Additional
-    /// formatters (YAML, Markdown, Terraform, Swift) can be added here once pure-Swift
-    /// implementations land — the sandbox prevents shelling out to external tools.
+    /// Default registry. Ships a pure-Swift JSON formatter. External tool formatters
+    /// (e.g. `ExternalFileFormatter` for terraform, shfmt, prettier) can be appended
+    /// by consumers — they participate in the same first-match dispatch.
     static let `default` = FileFormatterRegistry(formatters: [JSONFileFormatter()])
 
     /// Returns a formatted copy of `content` for the given URL, or the original if no

--- a/PineTests/ExternalFileFormatterTests.swift
+++ b/PineTests/ExternalFileFormatterTests.swift
@@ -20,11 +20,11 @@ struct ExternalFileFormatterTests {
         timeout: TimeInterval = 5.0
     ) -> ExternalFileFormatter {
         ExternalFileFormatter(
+            toolPath: toolPath,
             toolName: "testfmt",
             extensions: extensions,
             arguments: arguments,
             processRunner: runner,
-            toolPath: toolPath,
             timeout: timeout
         )
     }
@@ -125,11 +125,11 @@ struct ExternalFileFormatterTests {
     @Test("Integration: formats via real /bin/cat (identity transform)")
     func integrationWithCat() {
         let formatter = ExternalFileFormatter(
+            toolPath: "/bin/cat",
             toolName: "cat",
             extensions: ["txt"],
             arguments: [],
-            processRunner: RealProcessRunner(),
-            toolPath: "/bin/cat"
+            processRunner: RealProcessRunner()
         )
         let result = formatter.format("hello world", url: URL(fileURLWithPath: "/tmp/test.txt"))
         #expect(result == "hello world")

--- a/PineTests/ExternalFileFormatterTests.swift
+++ b/PineTests/ExternalFileFormatterTests.swift
@@ -124,14 +124,25 @@ struct ExternalFileFormatterTests {
 
     @Test("Integration: formats via real /bin/cat (identity transform)")
     func integrationWithCat() {
-        let formatter = ExternalFileFormatter(
-            toolPath: "/bin/cat",
-            toolName: "cat",
-            extensions: ["txt"],
-            arguments: [],
-            processRunner: RealProcessRunner()
-        )
-        let result = formatter.format("hello world", url: URL(fileURLWithPath: "/tmp/test.txt"))
+        // RealProcessRunner.run() requires a non-main thread.
+        // Swift Testing runs on the cooperative executor which may map to main,
+        // so we dispatch to a real GCD background thread.
+        let semaphore = DispatchSemaphore(value: 0)
+        nonisolated(unsafe) var result = ""
+
+        DispatchQueue.global().async {
+            let formatter = ExternalFileFormatter(
+                toolPath: "/bin/cat",
+                toolName: "cat",
+                extensions: ["txt"],
+                arguments: [],
+                processRunner: RealProcessRunner()
+            )
+            result = formatter.format("hello world", url: URL(fileURLWithPath: "/tmp/test.txt"))
+            semaphore.signal()
+        }
+
+        semaphore.wait()
         #expect(result == "hello world")
     }
 

--- a/PineTests/ExternalFileFormatterTests.swift
+++ b/PineTests/ExternalFileFormatterTests.swift
@@ -1,0 +1,201 @@
+//
+//  ExternalFileFormatterTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("ExternalFileFormatter")
+struct ExternalFileFormatterTests {
+
+    /// Helper to create a formatter with a mock tool path (bypasses real PATH resolution).
+    private func makeFormatter(
+        extensions: [String] = ["tf"],
+        arguments: [String] = ["fmt", "-"],
+        runner: MockProcessRunner,
+        toolPath: String? = "/mock/testfmt",
+        timeout: TimeInterval = 5.0
+    ) -> ExternalFileFormatter {
+        ExternalFileFormatter(
+            toolName: "testfmt",
+            extensions: extensions,
+            arguments: arguments,
+            processRunner: runner,
+            toolPath: toolPath,
+            timeout: timeout
+        )
+    }
+
+    // MARK: - ProcessRunner protocol for testability
+
+    @Test("Successful formatting returns stdout")
+    func successfulFormat() {
+        let runner = MockProcessRunner(stdout: "formatted output", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner)
+        let result = formatter.format("unformatted", url: URL(fileURLWithPath: "/tmp/main.tf"))
+        #expect(result == "formatted output")
+    }
+
+    @Test("Non-zero exit code returns original content")
+    func nonZeroExitFallback() {
+        let runner = MockProcessRunner(stdout: "partial", stderr: "error: syntax", exitCode: 1)
+        let formatter = makeFormatter(runner: runner)
+        let result = formatter.format("original", url: URL(fileURLWithPath: "/tmp/main.tf"))
+        #expect(result == "original")
+    }
+
+    @Test("Empty stdout on success returns original (safety)")
+    func emptyStdoutFallback() {
+        let runner = MockProcessRunner(stdout: "", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner)
+        let result = formatter.format("original", url: URL(fileURLWithPath: "/tmp/main.tf"))
+        #expect(result == "original")
+    }
+
+    @Test("Process launch failure returns original content")
+    func launchFailureFallback() {
+        let runner = MockProcessRunner(error: NSError(
+            domain: "test", code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "launch failed"]
+        ))
+        let formatter = makeFormatter(runner: runner)
+        let result = formatter.format("original", url: URL(fileURLWithPath: "/tmp/main.tf"))
+        #expect(result == "original")
+    }
+
+    @Test("Timeout returns original content")
+    func timeoutFallback() {
+        let runner = MockProcessRunner(stdout: "", stderr: "", exitCode: 0, simulateTimeout: true)
+        let formatter = makeFormatter(runner: runner, timeout: 0.1)
+        let result = formatter.format("original", url: URL(fileURLWithPath: "/tmp/main.tf"))
+        #expect(result == "original")
+    }
+
+    // MARK: - canFormat gating
+
+    @Test("canFormat matches configured extensions")
+    func canFormatMatches() {
+        let runner = MockProcessRunner(stdout: "", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(extensions: ["tf", "hcl"], runner: runner)
+        #expect(formatter.canFormat(url: URL(fileURLWithPath: "/tmp/main.tf")))
+        #expect(formatter.canFormat(url: URL(fileURLWithPath: "/tmp/config.hcl")))
+        #expect(!formatter.canFormat(url: URL(fileURLWithPath: "/tmp/main.swift")))
+        #expect(!formatter.canFormat(url: URL(fileURLWithPath: "/tmp/main.json")))
+    }
+
+    @Test("canFormat is case-insensitive")
+    func canFormatCaseInsensitive() {
+        let runner = MockProcessRunner(stdout: "", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner)
+        #expect(formatter.canFormat(url: URL(fileURLWithPath: "/tmp/main.TF")))
+    }
+
+    @Test("canFormat returns false when tool is not resolved")
+    func canFormatNoTool() {
+        let runner = MockProcessRunner(stdout: "", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner, toolPath: nil)
+        #expect(!formatter.canFormat(url: URL(fileURLWithPath: "/tmp/main.tf")))
+    }
+
+    // MARK: - stdin piping
+
+    @Test("Content is sent via stdin to the process")
+    func stdinPiping() {
+        let runner = MockProcessRunner(stdout: "FORMATTED", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner)
+        _ = formatter.format("input content", url: URL(fileURLWithPath: "/tmp/main.tf"))
+        #expect(runner.lastStdinContent == "input content")
+    }
+
+    // MARK: - format with nil toolPath returns original
+
+    @Test("format returns original content when toolPath is nil")
+    func formatWithNilToolPath() {
+        let runner = MockProcessRunner(stdout: "should not appear", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner, toolPath: nil)
+        let result = formatter.format("original", url: URL(fileURLWithPath: "/tmp/main.tf"))
+        #expect(result == "original")
+    }
+
+    // MARK: - Integration with real Process
+
+    @Test("Integration: formats via real /bin/cat (identity transform)")
+    func integrationWithCat() {
+        let formatter = ExternalFileFormatter(
+            toolName: "cat",
+            extensions: ["txt"],
+            arguments: [],
+            processRunner: RealProcessRunner(),
+            toolPath: "/bin/cat"
+        )
+        let result = formatter.format("hello world", url: URL(fileURLWithPath: "/tmp/test.txt"))
+        #expect(result == "hello world")
+    }
+
+    // MARK: - Registry integration
+
+    @Test("ExternalFileFormatter works in FileFormatterRegistry")
+    func registryIntegration() {
+        let runner = MockProcessRunner(stdout: "terraform-formatted", stderr: "", exitCode: 0)
+        let extFormatter = makeFormatter(runner: runner)
+        let registry = FileFormatterRegistry(formatters: [JSONFileFormatter(), extFormatter])
+
+        // .tf file should be handled by external formatter
+        let tfResult = registry.format(
+            content: "resource {}",
+            url: URL(fileURLWithPath: "/tmp/main.tf")
+        )
+        #expect(tfResult == "terraform-formatted")
+
+        // .json file should still be handled by JSON formatter
+        let jsonResult = registry.format(
+            content: #"{"a":1}"#,
+            url: URL(fileURLWithPath: "/tmp/a.json")
+        )
+        #expect(jsonResult.contains("\"a\" : 1"))
+    }
+}
+
+// MARK: - Mock ProcessRunner
+
+final class MockProcessRunner: ProcessRunning, @unchecked Sendable {
+    let stdout: String
+    let stderr: String
+    let exitCode: Int32
+    let error: Error?
+    let simulateTimeout: Bool
+    private(set) var lastStdinContent: String?
+
+    init(
+        stdout: String = "",
+        stderr: String = "",
+        exitCode: Int32 = 0,
+        error: Error? = nil,
+        simulateTimeout: Bool = false
+    ) {
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exitCode = exitCode
+        self.error = error
+        self.simulateTimeout = simulateTimeout
+    }
+
+    func run(
+        executablePath: String,
+        arguments: [String],
+        stdin: String,
+        timeout: TimeInterval
+    ) -> ProcessRunResult {
+        lastStdinContent = stdin
+        if let error {
+            return ProcessRunResult(stdout: "", stderr: error.localizedDescription, exitCode: -1, timedOut: false)
+        }
+        if simulateTimeout {
+            return ProcessRunResult(stdout: "", stderr: "timed out", exitCode: -1, timedOut: true)
+        }
+        return ProcessRunResult(stdout: stdout, stderr: stderr, exitCode: exitCode, timedOut: false)
+    }
+}

--- a/PineTests/ExternalToolResolverTests.swift
+++ b/PineTests/ExternalToolResolverTests.swift
@@ -1,0 +1,158 @@
+//
+//  ExternalToolResolverTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("ExternalToolResolver")
+struct ExternalToolResolverTests {
+
+    // MARK: - PATH parsing
+
+    @Test("Parses PATH string into directories")
+    func parsesPATH() {
+        let resolver = ExternalToolResolver(
+            pathString: "/usr/bin:/usr/local/bin:/opt/homebrew/bin",
+            fileManager: .default
+        )
+        #expect(resolver.searchDirectories.contains("/usr/bin"))
+        #expect(resolver.searchDirectories.contains("/usr/local/bin"))
+        #expect(resolver.searchDirectories.contains("/opt/homebrew/bin"))
+    }
+
+    @Test("Empty PATH string still includes well-known directories")
+    func emptyPATHIncludesWellKnown() {
+        let resolver = ExternalToolResolver(
+            pathString: "",
+            fileManager: .default
+        )
+        #expect(resolver.searchDirectories.contains("/opt/homebrew/bin"))
+        #expect(resolver.searchDirectories.contains("/usr/local/bin"))
+        #expect(resolver.searchDirectories.contains("/usr/bin"))
+    }
+
+    @Test("Nil PATH string still includes well-known directories")
+    func nilPATHIncludesWellKnown() {
+        let resolver = ExternalToolResolver(
+            pathString: nil,
+            fileManager: .default
+        )
+        #expect(resolver.searchDirectories.contains("/opt/homebrew/bin"))
+        #expect(resolver.searchDirectories.contains("/usr/local/bin"))
+        #expect(resolver.searchDirectories.contains("/usr/bin"))
+    }
+
+    @Test("Deduplicates directories from PATH and well-known")
+    func deduplicates() {
+        let resolver = ExternalToolResolver(
+            pathString: "/usr/bin:/usr/bin:/opt/homebrew/bin",
+            fileManager: .default
+        )
+        let count = resolver.searchDirectories.filter { $0 == "/usr/bin" }.count
+        #expect(count == 1)
+    }
+
+    // MARK: - Tool resolution
+
+    @Test("Finds an existing executable (git)")
+    func findsGit() {
+        let resolver = ExternalToolResolver(
+            pathString: "/usr/bin",
+            fileManager: .default
+        )
+        let path = resolver.resolve(tool: "git")
+        #expect(path != nil)
+        #expect(path?.hasSuffix("/git") == true)
+    }
+
+    @Test("Returns nil for a non-existent tool")
+    func returnsNilForMissing() {
+        let resolver = ExternalToolResolver(
+            pathString: "/usr/bin",
+            fileManager: .default
+        )
+        let path = resolver.resolve(tool: "pine_nonexistent_tool_12345")
+        #expect(path == nil)
+    }
+
+    @Test("Returns nil when tool is a directory, not a file")
+    func rejectsDirectory() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine_test_\(UUID().uuidString)")
+        let toolDir = tmpDir.appendingPathComponent("fakeTool")
+        try FileManager.default.createDirectory(at: toolDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let resolver = ExternalToolResolver(
+            pathString: tmpDir.path,
+            fileManager: .default
+        )
+        let path = resolver.resolve(tool: "fakeTool")
+        #expect(path == nil)
+    }
+
+    // MARK: - Caching
+
+    @Test("Caches resolved path after first lookup")
+    func cachesResolvedPath() {
+        let resolver = ExternalToolResolver(
+            pathString: "/usr/bin",
+            fileManager: .default
+        )
+        let first = resolver.resolve(tool: "git")
+        let second = resolver.resolve(tool: "git")
+        #expect(first == second)
+        #expect(first != nil)
+    }
+
+    @Test("Caches nil result for missing tool")
+    func cachesNilResult() {
+        let resolver = ExternalToolResolver(
+            pathString: "/usr/bin",
+            fileManager: .default
+        )
+        let first = resolver.resolve(tool: "pine_nonexistent_12345")
+        let second = resolver.resolve(tool: "pine_nonexistent_12345")
+        #expect(first == nil)
+        #expect(second == nil)
+    }
+
+    @Test("clearCache clears cached results")
+    func clearCacheWorks() {
+        let resolver = ExternalToolResolver(
+            pathString: "/usr/bin",
+            fileManager: .default
+        )
+        _ = resolver.resolve(tool: "git")
+        resolver.clearCache()
+        // After clearing, should resolve again (still finds it)
+        let after = resolver.resolve(tool: "git")
+        #expect(after != nil)
+    }
+
+    // MARK: - Absolute path passthrough
+
+    @Test("Absolute path bypasses search if executable exists")
+    func absolutePathPassthrough() {
+        let resolver = ExternalToolResolver(
+            pathString: "",
+            fileManager: .default
+        )
+        let path = resolver.resolve(tool: "/usr/bin/git")
+        #expect(path == "/usr/bin/git")
+    }
+
+    @Test("Absolute path returns nil if not executable")
+    func absolutePathNonExistent() {
+        let resolver = ExternalToolResolver(
+            pathString: "",
+            fileManager: .default
+        )
+        let path = resolver.resolve(tool: "/nonexistent/path/tool")
+        #expect(path == nil)
+    }
+}

--- a/PineTests/ExternalToolResolverTests.swift
+++ b/PineTests/ExternalToolResolverTests.swift
@@ -16,8 +16,7 @@ struct ExternalToolResolverTests {
     @Test("Parses PATH string into directories")
     func parsesPATH() {
         let resolver = ExternalToolResolver(
-            pathString: "/usr/bin:/usr/local/bin:/opt/homebrew/bin",
-            fileManager: .default
+            pathString: "/usr/bin:/usr/local/bin:/opt/homebrew/bin"
         )
         #expect(resolver.searchDirectories.contains("/usr/bin"))
         #expect(resolver.searchDirectories.contains("/usr/local/bin"))
@@ -27,8 +26,7 @@ struct ExternalToolResolverTests {
     @Test("Empty PATH string still includes well-known directories")
     func emptyPATHIncludesWellKnown() {
         let resolver = ExternalToolResolver(
-            pathString: "",
-            fileManager: .default
+            pathString: ""
         )
         #expect(resolver.searchDirectories.contains("/opt/homebrew/bin"))
         #expect(resolver.searchDirectories.contains("/usr/local/bin"))
@@ -38,8 +36,7 @@ struct ExternalToolResolverTests {
     @Test("Nil PATH string still includes well-known directories")
     func nilPATHIncludesWellKnown() {
         let resolver = ExternalToolResolver(
-            pathString: nil,
-            fileManager: .default
+            pathString: nil
         )
         #expect(resolver.searchDirectories.contains("/opt/homebrew/bin"))
         #expect(resolver.searchDirectories.contains("/usr/local/bin"))
@@ -49,8 +46,7 @@ struct ExternalToolResolverTests {
     @Test("Deduplicates directories from PATH and well-known")
     func deduplicates() {
         let resolver = ExternalToolResolver(
-            pathString: "/usr/bin:/usr/bin:/opt/homebrew/bin",
-            fileManager: .default
+            pathString: "/usr/bin:/usr/bin:/opt/homebrew/bin"
         )
         let count = resolver.searchDirectories.filter { $0 == "/usr/bin" }.count
         #expect(count == 1)
@@ -61,8 +57,7 @@ struct ExternalToolResolverTests {
     @Test("Finds an existing executable (git)")
     func findsGit() {
         let resolver = ExternalToolResolver(
-            pathString: "/usr/bin",
-            fileManager: .default
+            pathString: "/usr/bin"
         )
         let path = resolver.resolve(tool: "git")
         #expect(path != nil)
@@ -72,8 +67,7 @@ struct ExternalToolResolverTests {
     @Test("Returns nil for a non-existent tool")
     func returnsNilForMissing() {
         let resolver = ExternalToolResolver(
-            pathString: "/usr/bin",
-            fileManager: .default
+            pathString: "/usr/bin"
         )
         let path = resolver.resolve(tool: "pine_nonexistent_tool_12345")
         #expect(path == nil)
@@ -88,8 +82,7 @@ struct ExternalToolResolverTests {
         defer { try? FileManager.default.removeItem(at: tmpDir) }
 
         let resolver = ExternalToolResolver(
-            pathString: tmpDir.path,
-            fileManager: .default
+            pathString: tmpDir.path
         )
         let path = resolver.resolve(tool: "fakeTool")
         #expect(path == nil)
@@ -100,8 +93,7 @@ struct ExternalToolResolverTests {
     @Test("Caches resolved path after first lookup")
     func cachesResolvedPath() {
         let resolver = ExternalToolResolver(
-            pathString: "/usr/bin",
-            fileManager: .default
+            pathString: "/usr/bin"
         )
         let first = resolver.resolve(tool: "git")
         let second = resolver.resolve(tool: "git")
@@ -112,8 +104,7 @@ struct ExternalToolResolverTests {
     @Test("Caches nil result for missing tool")
     func cachesNilResult() {
         let resolver = ExternalToolResolver(
-            pathString: "/usr/bin",
-            fileManager: .default
+            pathString: "/usr/bin"
         )
         let first = resolver.resolve(tool: "pine_nonexistent_12345")
         let second = resolver.resolve(tool: "pine_nonexistent_12345")
@@ -124,8 +115,7 @@ struct ExternalToolResolverTests {
     @Test("clearCache clears cached results")
     func clearCacheWorks() {
         let resolver = ExternalToolResolver(
-            pathString: "/usr/bin",
-            fileManager: .default
+            pathString: "/usr/bin"
         )
         _ = resolver.resolve(tool: "git")
         resolver.clearCache()
@@ -139,8 +129,7 @@ struct ExternalToolResolverTests {
     @Test("Absolute path bypasses search if executable exists")
     func absolutePathPassthrough() {
         let resolver = ExternalToolResolver(
-            pathString: "",
-            fileManager: .default
+            pathString: ""
         )
         let path = resolver.resolve(tool: "/usr/bin/git")
         #expect(path == "/usr/bin/git")
@@ -149,10 +138,41 @@ struct ExternalToolResolverTests {
     @Test("Absolute path returns nil if not executable")
     func absolutePathNonExistent() {
         let resolver = ExternalToolResolver(
-            pathString: "",
-            fileManager: .default
+            pathString: ""
         )
         let path = resolver.resolve(tool: "/nonexistent/path/tool")
         #expect(path == nil)
+    }
+
+    // MARK: - Thread safety
+
+    @Test("Concurrent resolve from multiple threads does not crash")
+    func concurrentResolveThreadSafety() {
+        let resolver = ExternalToolResolver(
+            pathString: "/usr/bin"
+        )
+        let group = DispatchGroup()
+        let iterations = 10
+
+        for idx in 0..<iterations {
+            group.enter()
+            DispatchQueue.global().async {
+                defer { group.leave() }
+                // Mix of found and not-found tools to exercise both cache paths
+                let tool = idx % 2 == 0 ? "git" : "pine_nonexistent_\(idx)"
+                _ = resolver.resolve(tool: tool)
+                // Also exercise clearCache concurrently
+                if idx % 3 == 0 {
+                    resolver.clearCache()
+                }
+            }
+        }
+
+        let result = group.wait(timeout: .now() + 10)
+        #expect(result == .success)
+
+        // After all concurrent access, resolver should still work correctly
+        let gitPath = resolver.resolve(tool: "git")
+        #expect(gitPath != nil)
     }
 }


### PR DESCRIPTION
## Summary
- Add `ExternalToolResolver` — discovers CLI tools by scanning PATH directories and well-known locations (`/opt/homebrew/bin`, `/usr/local/bin`, etc.) with thread-safe caching
- Add `ExternalFileFormatter` — runs external formatters via stdin/stdout with configurable timeout (5s default), falls back to original content on any failure
- Add `ProcessRunning` protocol + `RealProcessRunner` + `MockProcessRunner` for full testability without spawning real processes
- Update `FileFormatter.swift` doc comments to reflect that external tools are now supported

## Test plan
- [x] ExternalToolResolverTests (12 tests): PATH parsing, well-known dirs, deduplication, tool resolution, caching, cache clearing, absolute path passthrough, directory rejection, concurrent thread safety
- [x] ExternalFileFormatterTests (12 tests): successful format, non-zero exit fallback, empty stdout fallback, launch failure fallback, timeout fallback, canFormat gating (extensions, case-insensitive, nil tool), stdin piping, nil toolPath, integration with /bin/cat, registry integration
- [x] Existing FileFormatterTests (22 tests): all passing, no regressions

## Follow-up
- UI indicator for active formatter (mentioned in #852) — will be implemented separately

Closes #852