### PR TITLE
fix(terminal): force needsDisplay after re-parenting to prevent blank terminal

### DIFF
--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -115,6 +115,9 @@ class TerminalContainerView: NSView {
             scrollInterceptor.frame = effectiveBounds
             scrollInterceptor.terminalView = tab.terminalView
             addSubview(scrollInterceptor)
+
+            tab.terminalView.needsLayout = true
+            tab.terminalView.needsDisplay = true
         }
 
         installScrollMonitor()
@@ -230,6 +233,16 @@ class TerminalContainerView: NSView {
         }
     }
 
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard window != nil else { return }
+        guard let terminalPaneState, let tab = terminalPaneState.activeTab else { return }
+        if tab.terminalView.superview === self {
+            tab.terminalView.needsLayout = true
+            tab.terminalView.needsDisplay = true
+        }
+    }
+
     override func layout() {
         super.layout()
         guard let terminalPaneState, let tab = terminalPaneState.activeTab else { return }
@@ -239,18 +252,10 @@ class TerminalContainerView: NSView {
         guard bounds.size.width > 0, bounds.size.height > 0 else { return }
         if tab.terminalView.superview === self {
             // Terminal view is already in the hierarchy — just update its frame.
-            // Only set needsDisplay when the size actually changed to avoid
-            // redundant redraws on no-op layout passes.
-            let sizeChanged = tab.terminalView.frame.size != bounds.size
             tab.terminalView.frame = bounds
             tab.terminalView.needsLayout = true
+            tab.terminalView.needsDisplay = true
             scrollInterceptor.frame = bounds
-            if sizeChanged {
-                // Force SwiftTerm to recalculate cols/rows and re-render.
-                // This handles the transition from a placeholder frame to the
-                // real container size, ensuring the PTY gets the correct window size.
-                tab.terminalView.needsDisplay = true
-            }
             tab.startIfNeeded()
         } else {
             // Terminal view was removed (e.g. tab switch race) — re-add it.


### PR DESCRIPTION
## Summary

- Fixes intermittent bug where terminal pane goes completely black (background color visible, no text content)
- Root cause: `needsDisplay` was gated behind a `sizeChanged` check in `TerminalContainerView.layout()` — when SwiftUI recreated the NSViewRepresentable and re-parented the terminal view with the same frame size, `needsDisplay` was never set
- Three targeted fixes in `TerminalSession.swift`:
  - `showTab()`: mark `needsLayout`/`needsDisplay` immediately after `addSubview`
  - `viewDidMoveToWindow()`: force redraw when container enters a window
  - `layout()`: always set `needsDisplay` (AppKit coalesces redundant calls)

## Test plan

- [ ] Open a project with a terminal pane, verify terminal renders correctly
- [ ] Maximize and restore terminal pane — verify content stays visible
- [ ] Drag terminal tab between panes — verify content stays visible
- [ ] Create multiple terminal tabs, switch rapidly — verify no blank screens
- [ ] Session restore with terminal panes — verify terminals render on reopen
- [ ] Unit tests pass (3668 tests verified)
- [ ] SwiftLint clean (0 violations)