### PR TITLE
fix(editor): dispatch ExternalFileFormatter to background queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,10 +533,11 @@ jobs:
               -only-testing:PineUITests/ScreenshotTests
               -only-testing:PineUITests/BranchSwitcherTests
               -only-testing:PineUITests/CheckForUpdatesTests
-          # Shard 5 — Files & Save (26 tests)
+          # Shard 5 — Files & Save (27 tests)
           - shard-name: "Files & Save"
             test-classes: >-
               -only-testing:PineUITests/EditorSaveFlowTests
+              -only-testing:PineUITests/HCLFormatOnSaveTests
               -only-testing:PineUITests/DeleteTests
               -only-testing:PineUITests/SidebarRenameTests
               -only-testing:PineUITests/SidebarFileOperationsTests

--- a/Pine/ExternalFileFormatter.swift
+++ b/Pine/ExternalFileFormatter.swift
@@ -202,12 +202,24 @@ nonisolated final class ExternalFileFormatter: FileFormatter, Sendable {
             return content
         }
 
-        let result = processRunner.run(
-            executablePath: executablePath,
-            arguments: arguments,
-            stdin: content,
-            timeout: timeout
+        // Dispatch to a background queue so RealProcessRunner's main-thread
+        // precondition is satisfied. The caller (trySaveTab) runs on main;
+        // DispatchGroup.wait() blocks it briefly while the process executes.
+        nonisolated(unsafe) var result = ProcessRunResult(
+            stdout: "", stderr: "", exitCode: -1, timedOut: true
         )
+        let group = DispatchGroup()
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            result = self.processRunner.run(
+                executablePath: executablePath,
+                arguments: self.arguments,
+                stdin: content,
+                timeout: self.timeout
+            )
+            group.leave()
+        }
+        group.wait()
 
         // Fall back to original on any failure
         guard !result.timedOut,

--- a/PineTests/HCLFileFormatterTests.swift
+++ b/PineTests/HCLFileFormatterTests.swift
@@ -206,6 +206,75 @@ struct HCLFileFormatterTests {
         #expect(runner.lastStdinContent == "resource \"null\" {}\n")
     }
 
+    // MARK: - Tofu formatting
+
+    @Test("Tofu formats .tf files when it is the resolved tool")
+    func tofuFormatsTFFiles() {
+        let runner = MockProcessRunner(
+            stdout: "resource \"aws_instance\" \"web\" {\n  ami = \"abc-123\"\n}\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner, toolPath: "/opt/homebrew/bin/tofu", toolName: "tofu")
+        let result = formatter.format(
+            "resource \"aws_instance\" \"web\" {\nami = \"abc-123\"\n}\n",
+            url: URL(fileURLWithPath: "/project/main.tf")
+        )
+        #expect(result == "resource \"aws_instance\" \"web\" {\n  ami = \"abc-123\"\n}\n")
+    }
+
+    @Test("Tofu formats .tfvars files")
+    func tofuFormatsTFVarsFiles() {
+        let runner = MockProcessRunner(stdout: "region = \"us-east-1\"\n", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner, toolPath: "/opt/homebrew/bin/tofu", toolName: "tofu")
+        let result = formatter.format(
+            "region=\"us-east-1\"\n",
+            url: URL(fileURLWithPath: "/project/terraform.tfvars")
+        )
+        #expect(result == "region = \"us-east-1\"\n")
+    }
+
+    @Test("Tofu formats .hcl files")
+    func tofuFormatsHCLFiles() {
+        let runner = MockProcessRunner(
+            stdout: "variable \"region\" {\n  default = \"us-east-1\"\n}\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner, toolPath: "/opt/homebrew/bin/tofu", toolName: "tofu")
+        let result = formatter.format(
+            "variable \"region\" {\ndefault = \"us-east-1\"\n}\n",
+            url: URL(fileURLWithPath: "/project/config.hcl")
+        )
+        #expect(result == "variable \"region\" {\n  default = \"us-east-1\"\n}\n")
+    }
+
+    @Test("Tofu non-zero exit code — returns original content")
+    func tofuNonZeroExitReturnsOriginal() {
+        let runner = MockProcessRunner(stdout: "partial", stderr: "Error", exitCode: 1)
+        let formatter = makeFormatter(runner: runner, toolPath: "/opt/homebrew/bin/tofu", toolName: "tofu")
+        let result = formatter.format("invalid { hcl", url: URL(fileURLWithPath: "/project/main.tf"))
+        #expect(result == "invalid { hcl")
+    }
+
+    // MARK: - Main-thread safety (regression for #873)
+
+    @Test("format() can be called from the main thread without crashing")
+    @MainActor
+    func formatFromMainThreadDoesNotCrash() {
+        let runner = MockProcessRunner(
+            stdout: "resource \"aws_instance\" \"web\" {\n  ami = \"abc-123\"\n}\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let result = formatter.format(
+            "resource \"aws_instance\" \"web\" {\nami = \"abc-123\"\n}\n",
+            url: URL(fileURLWithPath: "/project/main.tf")
+        )
+        #expect(result == "resource \"aws_instance\" \"web\" {\n  ami = \"abc-123\"\n}\n")
+    }
+
     // MARK: - Registry integration
 
     @Test("HCL formatter coexists with JSON formatter in registry")

--- a/PineUITests/HCLFormatOnSaveTests.swift
+++ b/PineUITests/HCLFormatOnSaveTests.swift
@@ -1,0 +1,85 @@
+//
+//  HCLFormatOnSaveTests.swift
+//  PineUITests
+//
+//  UI tests for HCL/Terraform format-on-save.
+//  Verifies the app does not crash when saving .tf files
+//  with terraform/tofu installed (issue: precondition failure
+//  in RealProcessRunner on main thread).
+//
+
+import XCTest
+
+final class HCLFormatOnSaveTests: PineUITestCase {
+
+    private var projectURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        // Write formatOnSave as a proper boolean into UserDefaults.
+        // Launch arguments store values as strings, and EditorSettings
+        // reads with `object(forKey:) as? Bool` which returns nil for strings.
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        proc.arguments = ["write", "io.github.batonogov.pine", "editor.formatOnSave", "-bool", "YES"]
+        proc.environment = ["DEVELOPER_DIR": "/Applications/Xcode.app/Contents/Developer"]
+        try proc.run()
+        proc.waitUntilExit()
+
+        projectURL = try createTempProject(files: [
+            "main.tf": "resource \"aws_instance\" \"example\" {\n  ami           = \"ami-12345\"\n  instance_type = \"t2.micro\"\n}\n"
+        ])
+    }
+
+    override func tearDownWithError() throws {
+        // Restore formatOnSave to its default (off)
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        proc.arguments = ["delete", "io.github.batonogov.pine", "editor.formatOnSave"]
+        proc.environment = ["DEVELOPER_DIR": "/Applications/Xcode.app/Contents/Developer"]
+        try? proc.run()
+        proc.waitUntilExit()
+
+        if let url = projectURL { cleanupProject(url) }
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Save .tf file does not crash
+
+    func testSaveTerraformFileWithFormatOnSaveDoesNotCrash() throws {
+        // Skip if neither terraform nor tofu is installed
+        let hasTerraform = FileManager.default.isExecutableFile(atPath: "/opt/homebrew/bin/terraform")
+            || FileManager.default.isExecutableFile(atPath: "/usr/local/bin/terraform")
+        let hasTofu = FileManager.default.isExecutableFile(atPath: "/opt/homebrew/bin/tofu")
+            || FileManager.default.isExecutableFile(atPath: "/usr/local/bin/tofu")
+        try XCTSkipUnless(hasTerraform || hasTofu, "terraform or tofu must be installed")
+
+        launchWithProject(projectURL)
+
+        openFile("main.tf")
+
+        // Save via File menu — this triggers format-on-save for .tf
+        app.activate()
+        clickMenuBarItem("File")
+
+        let saveItem = app.menuItems["Save"]
+        XCTAssertTrue(
+            waitForExistence(saveItem, timeout: 3),
+            "Save menu item should exist"
+        )
+        saveItem.click()
+
+        // If the app crashed (precondition failure on main thread),
+        // the window will disappear. Verify the app is still alive.
+        let tab = editorTab("main.tf")
+        XCTAssertTrue(
+            waitForExistence(tab, timeout: 5),
+            "App should still be running after saving .tf file — editor tab must exist"
+        )
+
+        // Verify the file was actually written to disk
+        let content = try String(contentsOf: projectURL.appendingPathComponent("main.tf"), encoding: .utf8)
+        XCTAssertFalse(content.isEmpty, "Saved file should not be empty")
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes crash when saving `.tf`/`.tfvars`/`.hcl` files with Format on Save enabled and terraform/tofu installed
- `ExternalFileFormatter.format()` now dispatches `processRunner.run()` to a background queue via `DispatchGroup`, satisfying `RealProcessRunner`'s main-thread precondition
- Adds 5 unit tests for tofu formatting and main-thread safety regression test
- Adds UI test for the save-crash scenario (skips if terraform/tofu not installed)

Closes #873

## Test plan

- [x] Unit tests: `PineTests/HCLFileFormatterTests` — 19 tests pass (including new tofu + @MainActor regression)
- [x] UI test: `PineUITests/HCLFormatOnSaveTests` — verifies save doesn't crash with formatOnSave enabled
- [ ] Manual: open Pine → enable Format on Save → open .tf file → Cmd+S → app stays alive