### PR TITLE
fix(sidebar): suppress progress indicator flicker during incremental refresh

### DIFF
--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -210,13 +210,16 @@ final class WorkspaceManager {
     /// then the full tree replaces it once ready.
     private func loadDirectoryContentsAsync(
         url: URL,
-        generation: Int
+        generation: Int,
+        showProgress: Bool = true
     ) {
         // Cancel any prior in-flight load so its `MainActor.run` blocks
         // become no-ops after the generation check below.
         loadingTask?.cancel()
 
-        let progressID = progressTracker?.beginOperation(Strings.progressLoadingProject)
+        let progressID = showProgress
+            ? progressTracker?.beginOperation(Strings.progressLoadingProject)
+            : nil
 
         loadingTask = Task.detached(priority: .userInitiated) { [weak self] in
             // 1. Git setup — pure nonisolated work using static helpers.
@@ -433,6 +436,6 @@ final class WorkspaceManager {
         guard let url = rootURL else { return }
         loadGeneration += 1
         let generation = loadGeneration
-        loadDirectoryContentsAsync(url: url, generation: generation)
+        loadDirectoryContentsAsync(url: url, generation: generation, showProgress: false)
     }
 }

--- a/PineTests/SidebarLoadingFlickerTests.swift
+++ b/PineTests/SidebarLoadingFlickerTests.swift
@@ -1,0 +1,201 @@
+//
+//  SidebarLoadingFlickerTests.swift
+//  PineTests
+//
+//  Tests that the progress indicator does not flicker during incremental
+//  file tree refreshes triggered by the file system watcher (issue #877).
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Sidebar Loading Flicker Tests (issue #877)")
+@MainActor
+struct SidebarLoadingFlickerTests {
+
+    private func makeTempDirectory() throws -> URL {
+        let rawDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-flicker-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: rawDir, withIntermediateDirectories: true)
+        guard let resolved = realpath(rawDir.path, nil) else { throw CocoaError(.fileNoSuchFile) }
+        defer { free(resolved) }
+        return URL(fileURLWithPath: String(cString: resolved))
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - refreshFileTreeAsync must NOT trigger progress indicator
+
+    @Test("refreshFileTreeAsync does not activate progress tracker")
+    func refreshFileTreeAsyncNoProgress() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        try "hello".write(
+            to: dir.appendingPathComponent("file.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let manager = WorkspaceManager()
+        let tracker = ProgressTracker()
+        manager.progressTracker = tracker
+
+        // Initial load — should use progress tracker
+        manager.loadDirectory(url: dir)
+        #expect(tracker.isLoading, "Initial loadDirectory should activate progress tracker")
+
+        await manager.waitForLoadingComplete()
+        #expect(!tracker.isLoading, "Progress tracker should be idle after initial load")
+
+        // Simulate watcher-triggered refresh (what happens on file save, git status, etc.)
+        manager.refreshFileTreeAsync()
+
+        // Progress tracker must NOT activate for incremental refresh
+        #expect(
+            !tracker.isLoading,
+            "refreshFileTreeAsync must not activate progress tracker (causes flicker)"
+        )
+
+        // Wait for async load to complete and re-verify
+        for _ in 0..<30 {
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        #expect(
+            !tracker.isLoading,
+            "Progress tracker must remain idle after incremental refresh completes"
+        )
+    }
+
+    @Test("refreshFileTree (sync) does not activate progress tracker")
+    func refreshFileTreeSyncNoProgress() throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        try "hello".write(
+            to: dir.appendingPathComponent("file.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let manager = WorkspaceManager()
+        let tracker = ProgressTracker()
+        manager.progressTracker = tracker
+
+        manager.loadDirectory(url: dir)
+        // Reset tracker state by simulating initial load completion
+        // (loadDirectory fires async — we don't need to wait, just need rootURL set)
+
+        // Now do sync refresh — must not trigger progress
+        manager.refreshFileTree()
+
+        // Progress tracker should still reflect only the initial loadDirectory,
+        // NOT the refreshFileTree call
+        // Note: loadDirectory's progress may still be active (async) — that's fine.
+        // The point is refreshFileTree itself does NOT add a new operation.
+        #expect(
+            tracker.activeOperationCount <= 1,
+            "refreshFileTree must not add its own progress operation"
+        )
+    }
+
+    @Test("loadDirectory activates progress tracker")
+    func loadDirectoryActivatesProgress() throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        let manager = WorkspaceManager()
+        let tracker = ProgressTracker()
+        manager.progressTracker = tracker
+
+        #expect(!tracker.isLoading)
+
+        manager.loadDirectory(url: dir)
+        #expect(tracker.isLoading, "loadDirectory must activate progress tracker")
+    }
+
+    @Test("isLoading stays false during refreshFileTreeAsync after initial load")
+    func isLoadingStaysFalseDuringRefresh() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        try "content".write(
+            to: dir.appendingPathComponent("test.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let manager = WorkspaceManager()
+        manager.loadDirectory(url: dir)
+        await manager.waitForLoadingComplete()
+
+        #expect(!manager.isLoading)
+
+        // Watcher-triggered refresh
+        manager.refreshFileTreeAsync()
+
+        // isLoading must NOT flip to true for incremental refresh
+        #expect(
+            !manager.isLoading,
+            "isLoading must stay false during incremental refresh (causes sidebar flicker)"
+        )
+    }
+
+    @Test("Multiple rapid refreshFileTreeAsync calls do not activate progress tracker")
+    func rapidRefreshesNoProgress() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        try "data".write(
+            to: dir.appendingPathComponent("data.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let manager = WorkspaceManager()
+        let tracker = ProgressTracker()
+        manager.progressTracker = tracker
+
+        manager.loadDirectory(url: dir)
+        await manager.waitForLoadingComplete()
+        #expect(!tracker.isLoading)
+
+        // Simulate rapid watcher events (e.g., npm install creating many files)
+        for _ in 0..<10 {
+            manager.refreshFileTreeAsync()
+        }
+
+        #expect(
+            !tracker.isLoading,
+            "Rapid incremental refreshes must not activate progress tracker"
+        )
+    }
+
+    @Test("loadDirectory after refresh correctly shows progress")
+    func loadDirectoryAfterRefreshShowsProgress() async throws {
+        let dir1 = try makeTempDirectory()
+        let dir2 = try makeTempDirectory()
+        defer { cleanup(dir1); cleanup(dir2) }
+
+        let manager = WorkspaceManager()
+        let tracker = ProgressTracker()
+        manager.progressTracker = tracker
+
+        // Initial load of dir1
+        manager.loadDirectory(url: dir1)
+        await manager.waitForLoadingComplete()
+        #expect(!tracker.isLoading)
+
+        // Incremental refresh — no progress
+        manager.refreshFileTreeAsync()
+        #expect(!tracker.isLoading)
+
+        // Load a new project — MUST show progress
+        manager.loadDirectory(url: dir2)
+        #expect(tracker.isLoading, "Loading a new project must show progress indicator")
+    }
+}


### PR DESCRIPTION
## Summary

- Fix status bar spinner flashing on every file change (save, git status update, etc.) — closes #877
- Add `showProgress` parameter to `loadDirectoryContentsAsync`: `true` for initial project load, `false` for FileSystemWatcher-triggered refreshes
- Progress indicator now only appears during initial `loadDirectory` call, not during incremental `refreshFileTreeAsync`

## Root cause

`refreshFileTreeAsync()` (called by `FileSystemWatcher` callback on every FSEvents event) delegated to `loadDirectoryContentsAsync()` which unconditionally called `progressTracker?.beginOperation()`. Each file save or git status change created a brief `begin → end` cycle on the ProgressTracker, causing the status bar spinner to flash.

## Test plan

- [x] 6 new tests in `SidebarLoadingFlickerTests` covering:
  - `refreshFileTreeAsync` does not activate progress tracker
  - `refreshFileTree` (sync) does not activate progress tracker
  - `loadDirectory` correctly activates progress tracker
  - `isLoading` stays false during incremental refresh
  - Multiple rapid refreshes do not activate progress
  - `loadDirectory` after refresh correctly shows progress
- [x] All existing `WorkspaceManagerTests` pass (20 tests)
- [x] All existing `LayoutStabilityTests` pass (12 tests)
- [x] All existing `ProgressIndicatorTests` pass (8 tests)
- [x] SwiftLint strict: 0 violations
- [x] Build succeeds