### PR TITLE
fix(workspace): clean up ProgressTracker operations on cancelled loads

### DIFF
--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -235,7 +235,14 @@ final class WorkspaceManager {
             )
             let shallowChildren = shallowResult.root.children ?? []
 
-            if Task.isCancelled { return }
+            if Task.isCancelled {
+                if let progressID {
+                    await MainActor.run { [weak self] in
+                        self?.progressTracker?.endOperation(progressID)
+                    }
+                }
+                return
+            }
 
             await MainActor.run { [weak self] in
                 guard let self, self.loadGeneration == generation else {
@@ -269,13 +276,27 @@ final class WorkspaceManager {
             //    For shallow projects this avoids redundant tree construction.
             guard shallowResult.wasDepthLimited else { return }
 
-            if Task.isCancelled { return }
+            if Task.isCancelled {
+                if let progressID {
+                    await MainActor.run { [weak self] in
+                        self?.progressTracker?.endOperation(progressID)
+                    }
+                }
+                return
+            }
 
             let fullChildren = Self.loadTopLevelInParallel(
                 url: url, ignoredPaths: gitInfo.ignoredPaths
             )
 
-            if Task.isCancelled { return }
+            if Task.isCancelled {
+                if let progressID {
+                    await MainActor.run { [weak self] in
+                        self?.progressTracker?.endOperation(progressID)
+                    }
+                }
+                return
+            }
 
             await MainActor.run { [weak self] in
                 guard let self, self.loadGeneration == generation else {

--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -222,6 +222,17 @@ final class WorkspaceManager {
         let progressID = progressTracker?.beginOperation(Strings.progressLoadingProject)
 
         loadingTask = Task.detached(priority: .userInitiated) { [weak self] in
+            // Shared cleanup closure — ends the progress operation on MainActor.
+            // Extracted to avoid repeating the same 5-line block at every
+            // cancellation / early-return site.
+            let cleanupProgress: () async -> Void = {
+                if let progressID {
+                    await MainActor.run { [weak self] in
+                        self?.progressTracker?.endOperation(progressID)
+                    }
+                }
+            }
+
             // 1. Git setup — pure nonisolated work using static helpers.
             //    No `@MainActor` object is created off-main: avoids the
             //    `nonisolated-check:ignore` workaround the GCD path needed.
@@ -235,14 +246,7 @@ final class WorkspaceManager {
             )
             let shallowChildren = shallowResult.root.children ?? []
 
-            if Task.isCancelled {
-                if let progressID {
-                    await MainActor.run { [weak self] in
-                        self?.progressTracker?.endOperation(progressID)
-                    }
-                }
-                return
-            }
+            if Task.isCancelled { await cleanupProgress(); return }
 
             await MainActor.run { [weak self] in
                 guard let self, self.loadGeneration == generation else {
@@ -274,29 +278,17 @@ final class WorkspaceManager {
 
             // 3. Phase 2: full tree only if Phase 1 hit the depth limit.
             //    For shallow projects this avoids redundant tree construction.
+            //    Safe to return without cleanup — endOperation was already called
+            //    inside Phase 1's MainActor.run block for non-depth-limited trees.
             guard shallowResult.wasDepthLimited else { return }
 
-            if Task.isCancelled {
-                if let progressID {
-                    await MainActor.run { [weak self] in
-                        self?.progressTracker?.endOperation(progressID)
-                    }
-                }
-                return
-            }
+            if Task.isCancelled { await cleanupProgress(); return }
 
             let fullChildren = Self.loadTopLevelInParallel(
                 url: url, ignoredPaths: gitInfo.ignoredPaths
             )
 
-            if Task.isCancelled {
-                if let progressID {
-                    await MainActor.run { [weak self] in
-                        self?.progressTracker?.endOperation(progressID)
-                    }
-                }
-                return
-            }
+            if Task.isCancelled { await cleanupProgress(); return }
 
             await MainActor.run { [weak self] in
                 guard let self, self.loadGeneration == generation else {

--- a/PineTests/ProgressTrackerLeakTests.swift
+++ b/PineTests/ProgressTrackerLeakTests.swift
@@ -1,0 +1,275 @@
+//
+//  ProgressTrackerLeakTests.swift
+//  PineTests
+//
+//  Verifies that ProgressTracker operations are always cleaned up,
+//  even when loading tasks are cancelled mid-flight.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("ProgressTracker Leak Tests")
+struct ProgressTrackerLeakTests {
+
+    private func makeTempDirectory() throws -> URL {
+        let rawDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-progress-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: rawDir, withIntermediateDirectories: true)
+        guard let resolved = realpath(rawDir.path, nil) else { throw CocoaError(.fileNoSuchFile) }
+        defer { free(resolved) }
+        return URL(fileURLWithPath: String(cString: resolved))
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - ProgressTracker unit tests
+
+    @Test("beginOperation increments count, endOperation decrements it")
+    @MainActor
+    func beginEndOperationBasic() {
+        let tracker = ProgressTracker()
+        #expect(tracker.activeOperationCount == 0)
+        #expect(!tracker.isLoading)
+
+        let id1 = tracker.beginOperation("Op 1")
+        #expect(tracker.activeOperationCount == 1)
+        #expect(tracker.isLoading)
+        #expect(tracker.message == "Op 1")
+
+        let id2 = tracker.beginOperation("Op 2")
+        #expect(tracker.activeOperationCount == 2)
+        #expect(tracker.message == "Op 2")
+
+        tracker.endOperation(id1)
+        #expect(tracker.activeOperationCount == 1)
+        #expect(tracker.message == "Op 2")
+
+        tracker.endOperation(id2)
+        #expect(tracker.activeOperationCount == 0)
+        #expect(!tracker.isLoading)
+    }
+
+    @Test("endOperation with unknown ID is a no-op")
+    @MainActor
+    func endOperationUnknownID() {
+        let tracker = ProgressTracker()
+        let id = tracker.beginOperation("Op")
+        tracker.endOperation(UUID()) // unknown ID
+        #expect(tracker.activeOperationCount == 1)
+        tracker.endOperation(id)
+        #expect(tracker.activeOperationCount == 0)
+    }
+
+    @Test("endOperation called twice with same ID is a no-op on second call")
+    @MainActor
+    func endOperationIdempotent() {
+        let tracker = ProgressTracker()
+        let id = tracker.beginOperation("Op")
+        tracker.endOperation(id)
+        #expect(tracker.activeOperationCount == 0)
+        tracker.endOperation(id) // second call — should not underflow
+        #expect(tracker.activeOperationCount == 0)
+    }
+
+    // MARK: - WorkspaceManager + ProgressTracker integration
+
+    @Test("Normal load completes and cleans up progress operation")
+    @MainActor
+    func normalLoadCleansUpProgress() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        try "hello".write(
+            to: dir.appendingPathComponent("file.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let tracker = ProgressTracker()
+        let manager = WorkspaceManager()
+        manager.progressTracker = tracker
+
+        manager.loadDirectory(url: dir)
+
+        // Wait for async load to complete
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(50))
+            if !manager.isLoading { break }
+        }
+
+        #expect(!manager.isLoading)
+        #expect(
+            tracker.activeOperationCount == 0,
+            "Progress operation must be cleaned up after normal load completes"
+        )
+    }
+
+    @Test("Cancelled load cleans up progress operation (no leak)")
+    @MainActor
+    func cancelledLoadCleansUpProgress() async throws {
+        let dir1 = try makeTempDirectory()
+        let dir2 = try makeTempDirectory()
+        defer { cleanup(dir1); cleanup(dir2) }
+
+        // Create deeply nested structure in dir1 to make Phase 2 slow enough to cancel
+        let deep = dir1
+            .appendingPathComponent("a")
+            .appendingPathComponent("b")
+            .appendingPathComponent("c")
+            .appendingPathComponent("d")
+            .appendingPathComponent("e")
+        try FileManager.default.createDirectory(at: deep, withIntermediateDirectories: true)
+        try "deep".write(
+            to: deep.appendingPathComponent("file.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        try "simple".write(
+            to: dir2.appendingPathComponent("simple.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let tracker = ProgressTracker()
+        let manager = WorkspaceManager()
+        manager.progressTracker = tracker
+
+        // Start loading dir1 (triggers beginOperation)
+        manager.loadDirectory(url: dir1)
+
+        // Immediately load dir2 — this cancels dir1's task
+        manager.loadDirectory(url: dir2)
+
+        // Wait for dir2's load to complete
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(50))
+            if !manager.isLoading && manager.rootNodes.contains(where: { $0.name == "simple.txt" }) {
+                break
+            }
+        }
+
+        // Both the cancelled dir1 operation and completed dir2 operation
+        // must have called endOperation. At most one operation should remain
+        // (dir2's if it's still finishing), but typically zero.
+        // Give a bit more time for cleanup of cancelled task.
+        for _ in 0..<20 {
+            try await Task.sleep(for: .milliseconds(50))
+            if tracker.activeOperationCount == 0 { break }
+        }
+
+        #expect(
+            tracker.activeOperationCount == 0,
+            "Cancelled load must not leak progress operations; found \(tracker.activeOperationCount) active"
+        )
+    }
+
+    @Test("Multiple rapid refreshFileTreeAsync calls do not leak progress operations")
+    @MainActor
+    func rapidRefreshDoesNotLeakProgress() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        // Create some files to load
+        for i in 0..<5 {
+            try "content\(i)".write(
+                to: dir.appendingPathComponent("file\(i).txt"),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        let tracker = ProgressTracker()
+        let manager = WorkspaceManager()
+        manager.progressTracker = tracker
+
+        manager.loadDirectory(url: dir)
+
+        // Wait for initial load
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(50))
+            if !manager.isLoading { break }
+        }
+
+        #expect(tracker.activeOperationCount == 0, "Initial load must clean up")
+
+        // Fire multiple rapid async refreshes — each cancels the previous
+        for _ in 0..<10 {
+            manager.refreshFileTreeAsync()
+        }
+
+        // Wait for the last refresh to settle
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(50))
+            if tracker.activeOperationCount == 0 { break }
+        }
+
+        #expect(
+            tracker.activeOperationCount == 0,
+            "Rapid refreshes must not leak progress operations; found \(tracker.activeOperationCount) active"
+        )
+    }
+
+    @Test("loadDirectory followed by refreshFileTreeAsync does not leak")
+    @MainActor
+    func loadThenRefreshDoesNotLeak() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        try "a".write(
+            to: dir.appendingPathComponent("a.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let tracker = ProgressTracker()
+        let manager = WorkspaceManager()
+        manager.progressTracker = tracker
+
+        // Load directory then immediately refresh — both create progress operations
+        manager.loadDirectory(url: dir)
+        manager.refreshFileTreeAsync()
+
+        // Wait for everything to settle
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(50))
+            if tracker.activeOperationCount == 0 && !manager.isLoading { break }
+        }
+
+        #expect(
+            tracker.activeOperationCount == 0,
+            "loadDirectory + refreshFileTreeAsync must not leak; found \(tracker.activeOperationCount) active"
+        )
+    }
+
+    @Test("Progress tracker without progressTracker set does not crash")
+    @MainActor
+    func noTrackerDoesNotCrash() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        try "content".write(
+            to: dir.appendingPathComponent("file.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let manager = WorkspaceManager()
+        // progressTracker is nil — should not crash
+
+        manager.loadDirectory(url: dir)
+
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(50))
+            if !manager.isLoading { break }
+        }
+
+        #expect(!manager.isLoading)
+        #expect(manager.rootNodes.contains { $0.name == "file.txt" })
+    }
+}

--- a/PineTests/ProgressTrackerLeakTests.swift
+++ b/PineTests/ProgressTrackerLeakTests.swift
@@ -18,9 +18,7 @@ struct ProgressTrackerLeakTests {
         let rawDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("pine-progress-test-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: rawDir, withIntermediateDirectories: true)
-        guard let resolved = realpath(rawDir.path, nil) else { throw CocoaError(.fileNoSuchFile) }
-        defer { free(resolved) }
-        return URL(fileURLWithPath: String(cString: resolved))
+        return rawDir.resolvingSymlinksInPath()
     }
 
     private func cleanup(_ url: URL) {

--- a/PineTests/ProgressTrackerLeakTests.swift
+++ b/PineTests/ProgressTrackerLeakTests.swift
@@ -95,12 +95,7 @@ struct ProgressTrackerLeakTests {
         manager.progressTracker = tracker
 
         manager.loadDirectory(url: dir)
-
-        // Wait for async load to complete
-        for _ in 0..<100 {
-            try await Task.sleep(for: .milliseconds(50))
-            if !manager.isLoading { break }
-        }
+        await manager.waitForLoadingComplete()
 
         #expect(!manager.isLoading)
         #expect(
@@ -109,6 +104,11 @@ struct ProgressTrackerLeakTests {
         )
     }
 
+    // NOTE: On a fast machine dir1 may complete before the second loadDirectory
+    // call cancels it, so the cancellation path is not always exercised.
+    // The test still validates correctness — it just may not exercise the fix
+    // on every run. A synthetic delay in the loader would make it deterministic
+    // but adds complexity not warranted here.
     @Test("Cancelled load cleans up progress operation (no leak)")
     @MainActor
     func cancelledLoadCleansUpProgress() async throws {
@@ -147,20 +147,13 @@ struct ProgressTrackerLeakTests {
         manager.loadDirectory(url: dir2)
 
         // Wait for dir2's load to complete
-        for _ in 0..<100 {
-            try await Task.sleep(for: .milliseconds(50))
-            if !manager.isLoading && manager.rootNodes.contains(where: { $0.name == "simple.txt" }) {
-                break
-            }
-        }
+        await manager.waitForLoadingComplete()
 
-        // Both the cancelled dir1 operation and completed dir2 operation
-        // must have called endOperation. At most one operation should remain
-        // (dir2's if it's still finishing), but typically zero.
-        // Give a bit more time for cleanup of cancelled task.
+        // The cancelled dir1 task's cleanup runs asynchronously on MainActor.
+        // Poll briefly for its endOperation to land.
         for _ in 0..<20 {
-            try await Task.sleep(for: .milliseconds(50))
             if tracker.activeOperationCount == 0 { break }
+            try await Task.sleep(for: .milliseconds(50))
         }
 
         #expect(
@@ -189,12 +182,7 @@ struct ProgressTrackerLeakTests {
         manager.progressTracker = tracker
 
         manager.loadDirectory(url: dir)
-
-        // Wait for initial load
-        for _ in 0..<100 {
-            try await Task.sleep(for: .milliseconds(50))
-            if !manager.isLoading { break }
-        }
+        await manager.waitForLoadingComplete()
 
         #expect(tracker.activeOperationCount == 0, "Initial load must clean up")
 
@@ -204,9 +192,12 @@ struct ProgressTrackerLeakTests {
         }
 
         // Wait for the last refresh to settle
-        for _ in 0..<100 {
-            try await Task.sleep(for: .milliseconds(50))
+        await manager.waitForLoadingComplete()
+
+        // Poll briefly for any cancelled task cleanup to land
+        for _ in 0..<20 {
             if tracker.activeOperationCount == 0 { break }
+            try await Task.sleep(for: .milliseconds(50))
         }
 
         #expect(
@@ -235,10 +226,12 @@ struct ProgressTrackerLeakTests {
         manager.loadDirectory(url: dir)
         manager.refreshFileTreeAsync()
 
-        // Wait for everything to settle
-        for _ in 0..<100 {
+        await manager.waitForLoadingComplete()
+
+        // Poll briefly for any cancelled task cleanup to land
+        for _ in 0..<20 {
+            if tracker.activeOperationCount == 0 { break }
             try await Task.sleep(for: .milliseconds(50))
-            if tracker.activeOperationCount == 0 && !manager.isLoading { break }
         }
 
         #expect(
@@ -263,11 +256,7 @@ struct ProgressTrackerLeakTests {
         // progressTracker is nil — should not crash
 
         manager.loadDirectory(url: dir)
-
-        for _ in 0..<100 {
-            try await Task.sleep(for: .milliseconds(50))
-            if !manager.isLoading { break }
-        }
+        await manager.waitForLoadingComplete()
 
         #expect(!manager.isLoading)
         #expect(manager.rootNodes.contains { $0.name == "file.txt" })


### PR DESCRIPTION
## Summary

- Fix `ProgressTracker` operation leak when `WorkspaceManager`'s loading task is cancelled mid-flight — the spinner "Загрузка проекта..." would stay visible forever
- Root cause: three `Task.isCancelled` early-return paths in `loadDirectoryContentsAsync` returned without calling `endOperation(progressID)`
- Added `endOperation` cleanup at all three cancellation sites via `await MainActor.run`

## Test plan

- [x] 8 new tests in `ProgressTrackerLeakTests`:
  - `beginEndOperationBasic` — basic begin/end lifecycle
  - `endOperationUnknownID` — unknown ID is a no-op
  - `endOperationIdempotent` — double-end doesn't underflow
  - `normalLoadCleansUpProgress` — normal load cleans up
  - `cancelledLoadCleansUpProgress` — **cancelled load cleans up (was the bug)**
  - `rapidRefreshDoesNotLeakProgress` — 10 rapid refreshes don't leak
  - `loadThenRefreshDoesNotLeak` — load + immediate refresh don't leak
  - `noTrackerDoesNotCrash` — nil tracker doesn't crash
- [x] All existing `WorkspaceManagerTests` pass
- [x] SwiftLint clean