### PR TITLE
ci: add alls-green aggregator for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -843,3 +843,43 @@ jobs:
           name: performance-results-xcresult
           path: PerformanceResults.xcresult
           retention-days: 14
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Aggregator job — single required check for branch protection.
+  #
+  # Branch protection treats `skipped` jobs as NOT passing, which blocks
+  # docs-only PRs (where `changes` job sets `code=false` and downstream jobs
+  # are skipped via `if:` guards). The "alls-green" pattern moves the gate
+  # off individual job contexts and onto this aggregator: it depends on every
+  # required job and passes if all of them are either `success` or `skipped`.
+  # Only `failure` or `cancelled` will fail this job.
+  #
+  # After merging, branch protection should require ONLY `CI Required` from
+  # this workflow (plus any always-runs checks like `Detect Changes`). All
+  # other contexts (`SwiftLint`, `Build for Testing`, `Unit Tests`,
+  # `Verify UI Test Shards`, every `UI Tests (...)` shard, `Flaky Test
+  # Summary`) can be removed from required — this job covers them.
+  ci-required:
+    name: CI Required
+    if: always()
+    needs:
+      - changes
+      - lint
+      - build
+      - unit-tests
+      - verify-ui-shards
+      - ui-tests
+      - flaky-summary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$NEEDS" | jq .
+          echo "$NEEDS" | jq -e '
+            to_entries
+            | map(select(.value.result == "failure" or .value.result == "cancelled"))
+            | length == 0
+          ' >/dev/null


### PR DESCRIPTION
## Summary

- Adds a `ci-required` aggregator job to `.github/workflows/ci.yml` that depends on every CI job currently listed as required by the `main` branch ruleset (`changes`, `lint`, `build`, `unit-tests`, `verify-ui-shards`, `ui-tests` matrix, `flaky-summary`).
- Uses `if: always()` plus a `jq` check on `toJSON(needs)`: passes when every dependency is `success` or `skipped`, fails only on `failure` or `cancelled`.
- Unblocks docs-only PRs (e.g. #875): the existing `changes` job sets `code=false` and skips the heavy jobs, but branch protection currently treats those `skipped` checks as failing and marks the PR `BLOCKED`. With the aggregator as the sole required check, `skipped` becomes a pass and the PR can merge.

## Why this design

- Single source of truth: when CI gains/loses jobs, only the aggregator's `needs:` list and (optionally) the protection rule have to change — not the protection rule for every individual context.
- Cheap: `ubuntu-latest` runner, one `jq` step. No macOS minutes burned.
- Fail-safe: a real `failure` in any required job still flips the aggregator red, so production safety is preserved. Only `skipped` (intentional skip via `if:`) and `success` count as pass.
- `flaky-summary` is included in `needs:` even though it is not currently required, so a real failure there still surfaces; on docs-only PRs it skips alongside the rest and the aggregator stays green.

## Test plan

- [ ] Wait for this PR's CI run; confirm `CI Required` job appears and passes (all dependencies should be `success`).
- [ ] After merge + branch-protection update, open a docs-only follow-up PR and verify it can be merged without "Update Branch / re-run CI".
- [ ] Open a PR that intentionally breaks SwiftLint; confirm `CI Required` fails and blocks merge.

## Manual follow-up after merge

The aggregator only helps once branch protection points at it. The `main` branch ruleset currently lists each individual job as required. After this PR is merged, the repo admin needs to update the ruleset on github.com:

1. Open Settings -> Rules -> Rulesets -> the active ruleset for `main` (or Settings -> Branches -> Branch protection rule for `main` if classic protection is in use).
2. Under "Require status checks to pass before merging", remove these required contexts:
   - `SwiftLint`
   - `Build for Testing`
   - `Unit Tests`
   - `Verify UI Test Shards`
   - `UI Tests (Welcome & Session)`
   - `UI Tests (Editor Chrome)`
   - `UI Tests (Files & Save)`
   - `UI Tests (Search & Panes)`
   - `UI Tests (Navigation)`
   - `UI Tests (Terminal)`
   - `UI Tests (Security & Layout)`
   - `Flaky Test Summary` (only if it is listed today)
3. Add this required context:
   - `CI Required`
4. Leave any other required checks untouched (`claude-review`, `Detect Changes`, `docs-check`, etc. — keep whatever is required today and is not in the list above).
5. Save the ruleset.

Order matters: do not remove the old contexts before this PR is merged, otherwise nothing gates the protected branch in between.