### PR TITLE
chore: remove dead notifications and unused accessibility IDs (#896)

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -7,7 +7,6 @@
 
 nonisolated enum AccessibilityID {
     // MARK: - Welcome window
-    static let welcomeWindow = "welcomeWindow"
     static let welcomeOpenFolderButton = "welcomeOpenFolderButton"
     static let welcomeRecentProjectsList = "welcomeRecentProjectsList"
     static let welcomeSearchField = "welcomeSearchField"
@@ -16,12 +15,10 @@ nonisolated enum AccessibilityID {
 
     // MARK: - Main editor window
     static let sidebar = "sidebar"
-    static let sidebarFileList = "sidebarFileList"
     static func fileNode(_ name: String) -> String { "fileNode_\(name)" }
     static let inlineRenameTextField = "inlineRenameTextField"
 
     // MARK: - Editor
-    static let editorArea = "editorArea"
     static let editorTabBar = "editorTabBar"
     static func editorTab(_ name: String) -> String { "editorTab_\(name)" }
     static func editorTabCloseButton(_ name: String) -> String { "editorTabClose_\(name)" }
@@ -52,7 +49,6 @@ nonisolated enum AccessibilityID {
     static func breadcrumbSegment(_ name: String) -> String { "breadcrumbSegment_\(name)" }
 
     // MARK: - Terminal
-    static let terminalArea = "terminalArea"
     static let terminalTabBar = "terminalTabBar"
     static func terminalTab(_ name: String) -> String { "terminalTab_\(name)" }
     static let newTerminalButton = "newTerminalButton"
@@ -76,7 +72,6 @@ nonisolated enum AccessibilityID {
     static let goToLineField = "goToLineField"
 
     // MARK: - Branch switcher
-    static let branchSwitcherButton = "branchSwitcherButton"
     static let branchSearchField = "branchSearchField"
     static func branchItem(_ name: String) -> String { "branchItem_\(name)" }
 

--- a/Pine/PineAppNotifications.swift
+++ b/Pine/PineAppNotifications.swift
@@ -64,5 +64,4 @@ extension Notification.Name {
 
     // MARK: - Git
     static let refreshLineDiffs = Notification.Name("refreshLineDiffs")
-    static let switchBranch = Notification.Name("switchBranch")
 }

--- a/PineTests/PineAppMenuCommandsTests.swift
+++ b/PineTests/PineAppMenuCommandsTests.swift
@@ -36,7 +36,7 @@ struct PineAppMenuCommandsTests {
     @Test
     func notificationNamesAreUniqueAndNonEmpty() {
         let names: [Notification.Name] = [
-            .openFolder, .closeTab, .switchBranch, .goToLine,
+            .openFolder, .closeTab, .goToLine,
             .findInFile, .findAndReplace, .findNext, .findPrevious,
             .useSelectionForFind, .toggleWordWrap, .toggleComment,
             .showProjectSearch, .navigateChange, .foldCode,


### PR DESCRIPTION
## Summary

Removes 6 dead constants identified by codebase audit in #896:

- `Notification.Name.switchBranch` — `Pine/PineAppNotifications.swift`
- `AccessibilityID.welcomeWindow`
- `AccessibilityID.sidebarFileList`
- `AccessibilityID.editorArea`
- `AccessibilityID.terminalArea`
- `AccessibilityID.branchSwitcherButton`

Also drops the now-stale `.switchBranch` entry from the
`PineAppMenuCommandsTests.notificationNamesAreUniqueAndNonEmpty`
allowlist so the sanity test stays in sync with the declarations.

Split into two commits (notification / accessibility IDs) per the
issue's "clean revert" guidance.

## Verification

Each symbol was verified before deletion. For every candidate I ran:
1. `Grep` for the bare symbol name across `Pine/`, `PineTests/`, `PineUITests/`, `.github/`, and `scripts/`.
2. `Grep` for `\.<symbol>` member-access usage to catch false positives in shared substrings.
3. `Grep` for the literal string value (e.g. `"welcomeWindow"`).
4. `Grep` for any dynamic interpolation pattern `AccessibilityID\.\(...)` — none exist anywhere in the repo.

| Symbol | Bare grep | `.symbol` grep | String-value grep | Dynamic interp |
|---|---|---|---|---|
| `Notification.Name.switchBranch` | only declaration + sanity-test allowlist + unrelated `Strings.menuSwitchBranch` (different constant) + `Localizable.xcstrings` (`menu.switchBranch` localization key) | only allowlist | n/a | none |
| `AccessibilityID.welcomeWindow` | only declaration; `app.windows["welcome"]` in UI tests is a different identifier (string `"welcome"`, not `"welcomeWindow"`); `appDelegate?.welcomeWindow` is a separate `NSWindow?` field on `AppDelegate` (different namespace) | none | only declaration | none |
| `AccessibilityID.sidebarFileList` | only declaration | none | only declaration | none |
| `AccessibilityID.editorArea` | only declaration; `var editorArea: some View` in `ContentView.swift:239` is an unrelated SwiftUI sub-view builder, not an accessibility id | none | only declaration | none |
| `AccessibilityID.terminalArea` | only declaration | none | only declaration | none |
| `AccessibilityID.branchSwitcherButton` | only declaration | none | only declaration | none |

## Test plan

- [x] `swiftlint --strict` clean — `Done linting! Found 0 violations, 0 serious in 355 files.`
- [x] `xcodebuild build` succeeds — `** BUILD SUCCEEDED **`
- [x] `xcodebuild test -only-testing:PineTests` — 3745 tests across 214 suites; `PineAppMenuCommandsTests.notificationNamesAreUniqueAndNonEmpty` (the test affected by my edit) passed in 0.002s. One unrelated flaky test (`DebouncerTests/rapidTriggersCoalesce`) failed once on a heavily loaded machine and passed cleanly on isolated re-run in 0.484s — pure timing flakiness in the rapid-trigger coalescing test, no link to the constants removed in this PR.
- [ ] No UI test shard run locally (issue allows for this; CI's 6-shard PineUITests pipeline will validate).

Closes #896