### PR TITLE
refactor: extract UITimings constants for delays and debounces (#899)

### DIFF
--- a/Pine/BranchSubtitleClickHandler.swift
+++ b/Pine/BranchSubtitleClickHandler.swift
@@ -68,7 +68,7 @@ struct BranchSubtitleClickHandler: NSViewRepresentable {
         let view = NSView(frame: .zero)
         view.alphaValue = 0
         // Delayed install — titlebar views may not exist yet at first layout.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + UITimings.Delay.standard) {
             guard let window = view.window else { return }
             self.installIfNeeded(in: window, coordinator: context.coordinator)
         }

--- a/Pine/CodeEditorView+Coordinator.swift
+++ b/Pine/CodeEditorView+Coordinator.swift
@@ -77,7 +77,7 @@ extension CodeEditorView {
             highlightTask = task
         }
         /// Задержка дебаунсинга
-        private let highlightDelay: TimeInterval = 0.1
+        private let highlightDelay: TimeInterval = UITimings.Debounce.edit
 
         /// True while `updateContentIfNeeded` is replacing text programmatically.
         /// Prevents `textDidChange` from scheduling a competing debounced highlight
@@ -90,9 +90,9 @@ extension CodeEditorView {
         /// Дебаунс для подсветки при скролле.
         private var scrollHighlightWorkItem: DispatchWorkItem?
         /// Задержка дебаунсинга скролла (~3 кадра при 120fps ProMotion)
-        private let scrollHighlightDelay: TimeInterval = 0.050
+        private let scrollHighlightDelay: TimeInterval = UITimings.Debounce.scroll
         /// Задержка дебаунсинга пересчёта фолдинга (тяжелее подсветки)
-        private let foldRecalcDelay: TimeInterval = 0.15
+        private let foldRecalcDelay: TimeInterval = UITimings.Debounce.foldRecalc
 
         init(parent: CodeEditorView) {
             self.parent = parent

--- a/Pine/ConfigValidator.swift
+++ b/Pine/ConfigValidator.swift
@@ -725,7 +725,7 @@ final class ConfigValidator {
     private(set) var toolAvailable = false
 
     /// Debounce interval in seconds.
-    nonisolated static let debounceInterval: TimeInterval = 0.3
+    nonisolated static let debounceInterval: TimeInterval = UITimings.Debounce.configValidation
 
     /// Generation token to discard stale results.
     private var generation: UInt64 = 0
@@ -757,7 +757,7 @@ final class ConfigValidator {
 
         debounceTask = Task { [weak self] in
             // Debounce
-            try? await Task.sleep(for: .milliseconds(300))
+            try? await Task.sleep(for: .seconds(Self.debounceInterval))
             guard !Task.isCancelled, let self else { return }
 
             self.runValidation(url: url, content: content, kind: kind, expectedGen: currentGen)

--- a/Pine/GitAndNotificationObserver.swift
+++ b/Pine/GitAndNotificationObserver.swift
@@ -197,7 +197,7 @@ struct ProjectSearchModifier: ViewModifier {
 
     /// Finds the NSSearchToolbarItem in the window toolbar and sets preferred width (Finder-style).
     private func configureSearchToolbarItem() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + UITimings.Delay.standard) {
             guard let window = NSApp.keyWindow,
                   let toolbar = window.toolbar else { return }
             for item in toolbar.items {

--- a/Pine/MarkdownPreviewView.swift
+++ b/Pine/MarkdownPreviewView.swift
@@ -59,7 +59,7 @@ struct MarkdownPreviewView: NSViewRepresentable {
                 self.textView?.textStorage?.setAttributedString(attributed)
             }
             renderWorkItem = workItem
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: workItem)
+            DispatchQueue.main.asyncAfter(deadline: .now() + UITimings.Delay.standard, execute: workItem)
         }
     }
 }

--- a/Pine/MinimapView.swift
+++ b/Pine/MinimapView.swift
@@ -160,7 +160,7 @@ final class MinimapView: NSView {
     }
 
     /// Throttle interval for scroll-triggered redraws (~3 frames at 120fps ProMotion).
-    private static let scrollThrottleInterval: TimeInterval = 0.025
+    private static let scrollThrottleInterval: TimeInterval = UITimings.Render.minimapRedraw
     /// Timestamp of last scroll-triggered redraw.
     private var lastScrollRedrawTime: CFTimeInterval = 0
     /// Pending throttled redraw work item.

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -450,7 +450,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         openNamedWindow?("welcome")
 
         // Give SwiftUI a moment to process, then verify and fallback via AppKit.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + UITimings.Delay.short) { [weak self] in
             guard let self else { return }
             self.ensureWelcomeVisible()
         }
@@ -610,7 +610,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
         // Ensure Welcome is visible if SwiftUI didn't present it automatically
         // (e.g. when window restoration state interferes with defaultLaunchBehavior)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + UITimings.Delay.long) { [weak self] in
             let hasVisibleWindow = NSApp.windows.contains { $0.isVisible && !$0.title.isEmpty }
             if !hasVisibleWindow {
                 self?.showWelcome()
@@ -682,7 +682,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
                 openProjectWindow?(projectDir)
                 welcomeWindow?.orderOut(nil)
                 // Open files after project initializes
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                DispatchQueue.main.asyncAfter(deadline: .now() + UITimings.Delay.standard) { [weak self] in
                     guard let pm = self?.registry.openProjects[projectDir] else { return }
                     DropHandler.openFilesAsTabs(classified.files, in: pm.activeTabManager)
                 }

--- a/Pine/ProjectSearchProvider.swift
+++ b/Pine/ProjectSearchProvider.swift
@@ -46,7 +46,7 @@ final class ProjectSearchProvider {
     /// Maximum matches per file in parallel search to avoid unbounded memory use.
     nonisolated private static let maxResultsPerFile = 100
     /// Debounce interval for search.
-    nonisolated static let debounceInterval: Duration = .milliseconds(300)
+    nonisolated static let debounceInterval: Duration = .seconds(UITimings.Debounce.projectSearch)
 
     private var searchTask: Task<Void, Never>?
 

--- a/Pine/ToastManager.swift
+++ b/Pine/ToastManager.swift
@@ -81,7 +81,7 @@ final class ToastManager {
             let work = DispatchWorkItem { [weak self] in
                 self?.present(next)
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
+            DispatchQueue.main.asyncAfter(deadline: .now() + UITimings.Delay.standard, execute: work)
         }
     }
 

--- a/Pine/UITimings.swift
+++ b/Pine/UITimings.swift
@@ -1,0 +1,116 @@
+//
+//  UITimings.swift
+//  Pine
+//
+//  Centralised, named constants for UI delays, debounces, and render
+//  cadences. Replaces scattered magic-number `TimeInterval` literals
+//  (`.now() + 0.3`, `.milliseconds(300)`, `Task.sleep(for: .seconds(0.5))`,
+//  …) with intent-tagged identifiers so the call site says *why* a delay
+//  exists, not just *how long* it lasts.
+//
+//  Conventions:
+//  - Values are `TimeInterval` (seconds). `Duration` call-sites convert
+//    via `.seconds(UITimings.…)` so we keep one source of truth.
+//  - Doc comments describe *intent* (why this delay exists), not the
+//    numeric value — the constant declaration shows the value once and
+//    is the only place to tune it.
+//  - 120 Hz ProMotion targets <4 ms of main-thread work per scroll
+//    frame; render-side cadences are tuned with that ceiling in mind.
+//
+//  Out of scope: SwiftUI `.animation()` durations, XCUITest timeouts,
+//  business-logic `Task.sleep` (e.g. periodic snapshots) — those have
+//  their own ergonomics and live with the code that owns them.
+//
+
+import Foundation
+
+/// Typed namespace for UI-facing delays, debounces, and render cadences.
+///
+/// Marked `nonisolated` so the compile-time constants can be referenced
+/// from `nonisolated` static properties (e.g. `ProjectSearchProvider.
+/// debounceInterval`) under Pine's project-wide
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` setting. The whole enum
+/// is pure constant data, so isolation never matters at runtime — but
+/// without `nonisolated` Swift 6 inherits MainActor isolation and
+/// rejects the cross-context reference.
+nonisolated enum UITimings {
+
+    /// One-shot delays before performing a UI action. Used when SwiftUI's
+    /// own lifecycle hooks fire too early and we need AppKit / the run
+    /// loop to catch up — e.g. a window has been requested but isn't yet
+    /// installed in the hierarchy.
+    enum Delay {
+        /// Tiny pause to let SwiftUI process the previous tick before we
+        /// verify state via AppKit (e.g. confirming a window appeared
+        /// after `openWindow(id:)`). Short enough to feel instantaneous.
+        static let short: TimeInterval = 0.15
+
+        /// Standard "let the UI sync" pause used after asynchronous
+        /// transitions: drop-to-open project, sheet → search-bar
+        /// configuration, post-action menu shows. Long enough that
+        /// SwiftUI has settled, short enough that users perceive it as
+        /// part of the originating action.
+        static let standard: TimeInterval = 0.3
+
+        /// AppKit fallback window for paths where SwiftUI may silently
+        /// skip window creation (macOS 26 + LaunchServices bypass — see
+        /// `createWelcomeWindowViaAppKit`). Long enough that a real
+        /// SwiftUI window has had time to appear before we force-create
+        /// one, short enough that users on the slow path don't sit
+        /// staring at an empty screen.
+        static let long: TimeInterval = 0.5
+    }
+
+    /// Debounce intervals for trailing-edge work that's expensive to run
+    /// per-event (regex highlighting, fold recalculation, project-wide
+    /// search, FSEvents fan-out, validators).
+    enum Debounce {
+        /// Syntax highlight on scroll. Roughly three frames at 120 Hz —
+        /// fast enough to feel instant on ProMotion, slow enough to
+        /// coalesce a flick of scroll-wheel events into one regex pass.
+        /// Stays under the 4 ms-per-frame budget on the main thread.
+        static let scroll: TimeInterval = 0.05
+
+        /// Syntax highlight on text edit. Coalesces fast typing into a
+        /// single regex pass; long enough that every keystroke doesn't
+        /// trigger a full repaint, short enough that highlight catches
+        /// up before the user finishes a token.
+        static let edit: TimeInterval = 0.1
+
+        /// Fold-range recalculation. Heavier than highlighting (full
+        /// bracket-matching scan with comment/string skip ranges), so
+        /// it's debounced longer than `edit` to avoid stalling typing.
+        static let foldRecalc: TimeInterval = 0.15
+
+        /// FSEvents debounce for the workspace file watcher. Short
+        /// enough that changes made in the built-in terminal show up in
+        /// the sidebar almost immediately, long enough to coalesce
+        /// bursts (npm install, git checkout) into a handful of
+        /// refreshes. See WorkspaceManager#839.
+        static let fileWatcher: TimeInterval = 0.15
+
+        /// Project-wide search debounce — full-tree text scan with
+        /// `.gitignore` filtering. Tuned so a fast typist sees results
+        /// once they pause, not once per keystroke.
+        static let projectSearch: TimeInterval = 0.3
+
+        /// Config validator (yamllint / shellcheck / hadolint /
+        /// terraform validate) debounce. Validators spawn external
+        /// processes and write a temp file; this delay prevents
+        /// per-keystroke fork+exec while keeping diagnostics current
+        /// during a brief typing pause.
+        static let configValidation: TimeInterval = 0.3
+    }
+
+    /// Render-side cadences — throttling for views that redraw on every
+    /// scroll/edit notification. These are *upper bounds* on redraw
+    /// frequency, not delays before a single action.
+    enum Render {
+        /// Minimap redraw throttle (~3 frames at 120 Hz ProMotion). Each
+        /// minimap repaint enumerates layout-manager line fragments and
+        /// re-walks per-glyph foreground colors, so it must stay under
+        /// the per-frame budget; trailing redraws coalesce via a
+        /// scheduled work item to capture the final scroll position.
+        static let minimapRedraw: TimeInterval = 0.025
+    }
+}

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -213,7 +213,7 @@ struct WelcomeView: View {
             guard let url = appDelegate?.pendingProjectURL else { return }
             appDelegate?.pendingProjectURL = nil
             // Wait for initial SwiftUI layout to complete.
-            try? await Task.sleep(for: .seconds(0.5))
+            try? await Task.sleep(for: .seconds(UITimings.Delay.long))
             openProject(at: url)
         }
     }
@@ -238,7 +238,7 @@ struct WelcomeView: View {
                         let projectDir = file.deletingLastPathComponent()
                         openProject(at: projectDir)
                         // Give the project window time to initialize, then open the file
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + UITimings.Delay.standard) {
                             let canonical = projectDir.resolvingSymlinksInPath()
                             registry.openProjects[canonical]?.primaryTabManager.openTab(url: file)
                         }

--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -67,19 +67,20 @@ final class WorkspaceManager {
     /// never resumes after a newer one has started.
     private var loadingTask: Task<Void, Never>?
 
-    /// `FileSystemWatcher` debounce interval. Short enough (150 ms) that
-    /// changes made in the built-in terminal or by external processes
-    /// appear in the sidebar almost immediately while still coalescing
-    /// rapid bursts (npm install, git checkout) into a handful of refreshes.
+    /// `FileSystemWatcher` debounce interval. Short enough that changes
+    /// made in the built-in terminal or by external processes appear in
+    /// the sidebar almost immediately while still coalescing rapid bursts
+    /// (npm install, git checkout) into a handful of refreshes.
     ///
     /// Note: a previous post-refresh suppression window (`suppressWatcherUntil`)
     /// was removed in the fix for issue #839 — it was responsible for
     /// swallowing genuine external FSEvents that happened to land in the
-    /// 150 ms after any in-app sidebar action (rename / create / delete).
-    /// `loadGeneration` already guarantees that overlapping refreshes never
-    /// corrupt `rootNodes`, and `refreshFileTreeAsync` is cheap enough that
-    /// the duplicate cost of an echoed event is invisible to users.
-    static let watcherDebounce: TimeInterval = 0.15
+    /// debounce window after any in-app sidebar action (rename / create /
+    /// delete). `loadGeneration` already guarantees that overlapping
+    /// refreshes never corrupt `rootNodes`, and `refreshFileTreeAsync` is
+    /// cheap enough that the duplicate cost of an echoed event is invisible
+    /// to users.
+    static let watcherDebounce: TimeInterval = UITimings.Debounce.fileWatcher
 
     /// Schedules a debounced `onRootNodesChanged` notification.
     /// Cancels any pending notification so rapid updates coalesce into one.

--- a/PineTests/UITimingsTests.swift
+++ b/PineTests/UITimingsTests.swift
@@ -1,0 +1,201 @@
+//
+//  UITimingsTests.swift
+//  PineTests
+//
+//  Guards the centralised UI timings namespace from accidental drift.
+//  These constants are referenced from many call-sites, and a silent
+//  numeric change here would alter user-facing latency / debounce
+//  behavior across the editor. The tests are deliberately strict:
+//  pinning exact values, ordering relationships, and physical sanity
+//  bounds.
+//
+
+import Foundation
+import Testing
+@testable import Pine
+
+struct UITimingsTests {
+
+    // MARK: - Exact values
+
+    /// `Delay.short` pins the SwiftUI-tick acknowledgement window. If
+    /// this drifts, every "verify a window exists" check after
+    /// `openWindow(id:)` will fire either too soon (no window yet) or
+    /// too late (perceived UI lag).
+    @Test func delayShortIsExactly150ms() {
+        #expect(UITimings.Delay.short == 0.15)
+    }
+
+    /// `Delay.standard` is the canonical "let SwiftUI breathe" value
+    /// shared by drop-handler post-open, branch menu install, search
+    /// toolbar configure, toast hand-off, markdown preview render.
+    /// Unifying them is the whole point of this namespace — a value
+    /// change here moves all of them.
+    @Test func delayStandardIsExactly300ms() {
+        #expect(UITimings.Delay.standard == 0.3)
+    }
+
+    /// `Delay.long` is the AppKit-fallback window for macOS 26 launches
+    /// that bypass LaunchServices (XCUITest / direct binary). Too short
+    /// and the SwiftUI window doesn't get a chance to appear before we
+    /// force-create one; too long and slow-path users sit on a blank
+    /// screen.
+    @Test func delayLongIsExactly500ms() {
+        #expect(UITimings.Delay.long == 0.5)
+    }
+
+    /// Scroll-debounce is calibrated to ~3 frames at 120 Hz ProMotion.
+    @Test func debounceScrollIsExactly50ms() {
+        #expect(UITimings.Debounce.scroll == 0.05)
+    }
+
+    @Test func debounceEditIsExactly100ms() {
+        #expect(UITimings.Debounce.edit == 0.1)
+    }
+
+    @Test func debounceFoldRecalcIsExactly150ms() {
+        #expect(UITimings.Debounce.foldRecalc == 0.15)
+    }
+
+    @Test func debounceFileWatcherIsExactly150ms() {
+        #expect(UITimings.Debounce.fileWatcher == 0.15)
+    }
+
+    @Test func debounceProjectSearchIsExactly300ms() {
+        #expect(UITimings.Debounce.projectSearch == 0.3)
+    }
+
+    @Test func debounceConfigValidationIsExactly300ms() {
+        #expect(UITimings.Debounce.configValidation == 0.3)
+    }
+
+    @Test func renderMinimapRedrawIsExactly25ms() {
+        #expect(UITimings.Render.minimapRedraw == 0.025)
+    }
+
+    // MARK: - Ordering invariants
+
+    /// Render cadence must be at least as tight as the edit-debounce —
+    /// otherwise the minimap would lag the syntax highlighter that
+    /// drives its colors, briefly showing stale colors after each
+    /// keystroke. Documents the contract in code so a casual tune of
+    /// either constant can't violate it silently.
+    @Test func renderMinimapRedrawIsTighterThanEditDebounce() {
+        #expect(UITimings.Render.minimapRedraw <= UITimings.Debounce.edit)
+    }
+
+    /// Scroll highlighting fires faster than edit highlighting. Edits
+    /// finish on key release; scrolls happen continuously and need a
+    /// tighter loop to feel native.
+    @Test func scrollDebounceIsTighterThanEditDebounce() {
+        #expect(UITimings.Debounce.scroll < UITimings.Debounce.edit)
+    }
+
+    /// Fold recalculation is heavier than syntax highlighting (full
+    /// bracket-matching + comment/string skip ranges) and is therefore
+    /// debounced longer, never shorter, than `edit`.
+    @Test func foldRecalcDebounceIsAtLeastEditDebounce() {
+        #expect(UITimings.Debounce.foldRecalc >= UITimings.Debounce.edit)
+    }
+
+    /// Project-wide search fires far less often than per-tab edit
+    /// highlighting — it walks the entire file tree and reads every
+    /// matching file. Must outpace `edit` by a real margin.
+    @Test func projectSearchDebounceIsLongerThanEditDebounce() {
+        #expect(UITimings.Debounce.projectSearch > UITimings.Debounce.edit)
+    }
+
+    /// Delay tier ordering: short < standard < long. If anyone "tunes"
+    /// these without checking, they'd silently invert the meaning.
+    @Test func delayTiersAreInAscendingOrder() {
+        #expect(UITimings.Delay.short < UITimings.Delay.standard)
+        #expect(UITimings.Delay.standard < UITimings.Delay.long)
+    }
+
+    /// Render cadence must be the smallest constant in the namespace —
+    /// it's a per-frame throttle, not a debounce. Sanity-check it
+    /// against the entire namespace so a future addition doesn't slot
+    /// in below.
+    @Test func renderMinimapRedrawIsSmallestConstant() {
+        let allDebounces = [
+            UITimings.Debounce.scroll,
+            UITimings.Debounce.edit,
+            UITimings.Debounce.foldRecalc,
+            UITimings.Debounce.fileWatcher,
+            UITimings.Debounce.projectSearch,
+            UITimings.Debounce.configValidation
+        ]
+        let allDelays = [
+            UITimings.Delay.short,
+            UITimings.Delay.standard,
+            UITimings.Delay.long
+        ]
+        for value in allDebounces + allDelays {
+            #expect(UITimings.Render.minimapRedraw <= value)
+        }
+    }
+
+    // MARK: - Physical sanity bounds
+
+    /// Every UI timing must be strictly positive. A zero or negative
+    /// value would either skip the debounce entirely (lock-up risk in
+    /// debounced computations) or, for `asyncAfter`, still fire but
+    /// hide the bug from review.
+    @Test func allTimingsArePositive() {
+        let everything: [TimeInterval] = [
+            UITimings.Delay.short,
+            UITimings.Delay.standard,
+            UITimings.Delay.long,
+            UITimings.Debounce.scroll,
+            UITimings.Debounce.edit,
+            UITimings.Debounce.foldRecalc,
+            UITimings.Debounce.fileWatcher,
+            UITimings.Debounce.projectSearch,
+            UITimings.Debounce.configValidation,
+            UITimings.Render.minimapRedraw
+        ]
+        for value in everything {
+            #expect(value > 0)
+        }
+    }
+
+    /// No UI timing should exceed one second. Any longer and the user
+    /// would notice the lag and file a bug — meaning the constant is
+    /// in the wrong category and probably belongs to a different
+    /// system (recovery snapshot interval, CLI watchdog, etc.).
+    @Test func allTimingsAreUnderOneSecond() {
+        let everything: [TimeInterval] = [
+            UITimings.Delay.short,
+            UITimings.Delay.standard,
+            UITimings.Delay.long,
+            UITimings.Debounce.scroll,
+            UITimings.Debounce.edit,
+            UITimings.Debounce.foldRecalc,
+            UITimings.Debounce.fileWatcher,
+            UITimings.Debounce.projectSearch,
+            UITimings.Debounce.configValidation,
+            UITimings.Render.minimapRedraw
+        ]
+        for value in everything {
+            #expect(value <= 1.0)
+        }
+    }
+
+    // MARK: - Duration bridging
+
+    /// `Task.sleep(for:)` accepts `Duration`. Confirm that
+    /// `.seconds(UITimings.…)` round-trips to the expected millisecond
+    /// quantity — guards against a future Swift change to `Duration`'s
+    /// conversion of `Double` seconds.
+    @Test func projectSearchDurationRoundsTripToMilliseconds() {
+        let asSeconds: Duration = .seconds(UITimings.Debounce.projectSearch)
+        let asMilliseconds: Duration = .milliseconds(300)
+        #expect(asSeconds == asMilliseconds)
+    }
+
+    @Test func delayLongDurationRoundsTripToMilliseconds() {
+        let asSeconds: Duration = .seconds(UITimings.Delay.long)
+        let asMilliseconds: Duration = .milliseconds(500)
+        #expect(asSeconds == asMilliseconds)
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a typed `UITimings` namespace (in `Pine/UITimings.swift`) that
collects every hardcoded UI-facing delay, debounce, and render cadence
into one auditable file with intent-tagged identifiers. All call-sites
in the issue's known-list — plus a few directly-related siblings — now
reference these constants instead of bare `TimeInterval` / `Duration`
literals. Numeric values are preserved exactly; this is a readability
and discoverability change, not a behavior change.

## Mapping

| File:line | Literal | New constant |
|---|---|---|
| `PineApp.swift:453` | `0.15` | `Delay.short` |
| `PineApp.swift:613` | `0.5` | `Delay.long` |
| `PineApp.swift:685` | `0.3` | `Delay.standard` |
| `WelcomeView.swift:216` | `.seconds(0.5)` | `Delay.long` |
| `WelcomeView.swift:241` | `0.3` | `Delay.standard` |
| `GitAndNotificationObserver.swift:200` | `0.3` | `Delay.standard` |
| `BranchSubtitleClickHandler.swift:71` | `0.3` | `Delay.standard` |
| `ToastManager.swift:84` | `0.3` | `Delay.standard` |
| `MarkdownPreviewView.swift:62` | `0.3` | `Delay.standard` |
| `CodeEditorView+Coordinator.swift:80` (`highlightDelay`) | `0.1` | `Debounce.edit` |
| `CodeEditorView+Coordinator.swift:93` (`scrollHighlightDelay`) | `0.050` | `Debounce.scroll` |
| `CodeEditorView+Coordinator.swift:95` (`foldRecalcDelay`) | `0.15` | `Debounce.foldRecalc` |
| `WorkspaceManager.swift:82` (`watcherDebounce`) | `0.15` | `Debounce.fileWatcher` |
| `ProjectSearchProvider.swift:49` (`debounceInterval`) | `.milliseconds(300)` | `.seconds(Debounce.projectSearch)` |
| `ConfigValidator.swift:728` (`debounceInterval`) | `0.3` | `Debounce.configValidation` |
| `ConfigValidator.swift:760` (inline `Task.sleep`) | `.milliseconds(300)` | `.seconds(Self.debounceInterval)` |
| `MinimapView.swift:163` (`scrollThrottleInterval`) | `0.025` | `Render.minimapRedraw` |

## Decisions

- **Single source of truth in TimeInterval.** All constants are
  `TimeInterval` (seconds). `Duration`-shaped call-sites
  (`Task.sleep(for:)`) consume them via `.seconds(UITimings.…)`. Tests
  pin the round-trip so a future Swift change to `Duration`'s second
  conversion doesn't silently shift the debounce.
- **`nonisolated enum`.** Pine sets `SWIFT_DEFAULT_ACTOR_ISOLATION =
  MainActor`, which would otherwise force MainActor isolation on the
  enum and reject references from `nonisolated` static properties
  (e.g. `ProjectSearchProvider.debounceInterval`). The constants are
  pure data, so isolation is meaningless at runtime; declaring the
  enum `nonisolated` makes the intent explicit and the references work.
- **`ConfigValidator` already had a typed `debounceInterval` constant
  but the inline `Task.sleep(for: .milliseconds(300))` ignored it.**
  Migrated the inline literal to `.seconds(Self.debounceInterval)` so
  there is now one source of truth — a tiny pre-existing duplication
  fixed in passing because it was the *whole point* of the refactor.
- **Migrated the named delay constants in `CodeEditorView+
  Coordinator.swift` (`highlightDelay`, `scrollHighlightDelay`,
  `foldRecalcDelay`) even though they were already named.** Issue #899
  specifically lists the underlying 100ms/50ms/150ms values from these
  call-sites; leaving them as standalone literals would mean two
  parallel sources of truth for the same debounce. The local constants
  remain (so coordinator code reads naturally) but they now derive from
  `UITimings.Debounce.*`.
- **Kept `Delay.short` and `Debounce.foldRecalc` / `Debounce.fileWatcher`
  separate even though they're all `0.15`.** They serve different
  purposes (post-window verification vs fold recalculation vs FSEvents
  fan-out) and a future tuning of one shouldn't drag the others
  along — exactly what the issue's "audit if any two values that look
  identical actually serve different purposes" guidance asks for.

## Out of scope (deliberate, raise-concern style)

Found during the audit but not migrated, to keep this PR a true
no-behavior-change refactor:

- `PaneManager.swift:113` — `Timer.scheduledTimer(withTimeInterval: 0.12, …)`
  for stale drop-zone polling. New category (drag/drop visual polling),
  not in the issue's known list, would need its own constant family.
- `CodeEditorView+Coordinator.swift:865` — `0.4` flash-highlight for
  send-to-terminal. Animation/UX flash, not a debounce — out of scope
  per the issue's "animation durations" exclusion.
- `QuickOpenView.swift:134` and `TerminalBarView.swift:114` — both
  `.milliseconds(150)` search debounces. Distinct semantics from
  `Debounce.fileWatcher`/`Debounce.foldRecalc` (also 0.15), would need
  e.g. `Debounce.quickSearch` to avoid coalescing unrelated meanings.
- `TabManager.swift:741` (`autoSaveDelay = 1.0`), `PaneLeafView.swift:293`
  (`diffDebounce = .milliseconds(150)`) — already named with their own
  doc comments. Future cleanup if a `Debounce.gitDiff` /
  `Delay.autoSave` tier is wanted.

Happy to follow up these in a sibling PR if reviewers want them folded
in here instead.

## Test plan
- [x] `swiftlint --strict` clean (357 files, 0 violations)
- [x] `xcodebuild build` succeeded
- [x] `PineTests/UITimingsTests` added — **20 tests**, all green
  (exact values, ordering invariants, sanity bounds, Duration bridging)
- [x] Targeted suites green: ConfigValidator, ConfigValidatorEdge,
  ToastManager, IntegrationSearch, MinimapView, FoldRangeCalculator,
  FoldRangeCalculatorEdge, AsyncSyntaxHighlighter, CodeEditorCoordinator,
  CoordinatorExtended (256 tests, all green)
- [x] Full `PineTests` run: **3763 / 3765** pass. The two failures are
  `DebouncerTests/{rapidTriggersCoalesce, lastCallTimingMatters}` — pre-existing
  flaky timing assertions unrelated to this refactor (Debouncer.swift
  is untouched, and both pass cleanly when the suite runs in isolation).
  CI's flaky-test auto-retry is expected to mask them.
- [ ] Performance benchmarks: not run locally; debounce-dependent
  benchmarks should be unaffected since numeric values are preserved.

Closes #899