### PR TITLE
refactor: add runOnBackground helper, migrate withCheckedContinuation call-sites (#898)

### DIFF
--- a/Pine/Concurrency/BackgroundDispatch.swift
+++ b/Pine/Concurrency/BackgroundDispatch.swift
@@ -1,0 +1,64 @@
+//
+//  BackgroundDispatch.swift
+//  Pine
+//
+//  Created for issue #898 — replaces the repeated
+//  `await withCheckedContinuation { DispatchQueue.global(qos: ...).async { ... } }`
+//  boilerplate with a single typed helper that can be called from any actor.
+//
+
+import Foundation
+
+// MARK: - runOnBackground (non-throwing)
+
+/// Runs `work` on a global dispatch queue at `qos` and bridges the result back
+/// to async/await via `withCheckedContinuation`.
+///
+/// Use this when you need to leave the current actor for CPU-bound or blocking
+/// I/O work (process spawning, regex computation, file enumeration) and resume
+/// once the result is ready. The closure is `@Sendable`, so callers must pass
+/// in pure values rather than capturing actor-isolated state.
+///
+/// - Parameters:
+///   - qos: Quality of service of the global queue. Defaults to `.userInitiated`
+///     to match Pine's existing call sites.
+///   - work: The synchronous work to perform off the calling actor.
+/// - Returns: The value produced by `work`.
+@inlinable
+func runOnBackground<T: Sendable>(
+    qos: DispatchQoS.QoSClass = .userInitiated,
+    _ work: @Sendable @escaping () -> T
+) async -> T {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.global(qos: qos).async {
+            continuation.resume(returning: work())
+        }
+    }
+}
+
+// MARK: - runOnBackground (throwing)
+
+/// Throwing variant of `runOnBackground(qos:_:)`. Errors thrown by `work` are
+/// propagated through the continuation and surface to the awaiting caller.
+///
+/// - Parameters:
+///   - qos: Quality of service of the global queue. Defaults to `.userInitiated`.
+///   - work: The synchronous work to perform off the calling actor.
+/// - Returns: The value produced by `work`.
+/// - Throws: Any error thrown by `work`.
+@inlinable
+func runOnBackground<T: Sendable>(
+    qos: DispatchQoS.QoSClass = .userInitiated,
+    _ work: @Sendable @escaping () throws -> T
+) async throws -> T {
+    try await withCheckedThrowingContinuation { continuation in
+        DispatchQueue.global(qos: qos).async {
+            do {
+                let result = try work()
+                continuation.resume(returning: result)
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}

--- a/Pine/GitStatusProvider.swift
+++ b/Pine/GitStatusProvider.swift
@@ -317,19 +317,16 @@ final class GitStatusProvider {
     /// on a background thread using parallel DispatchGroup, then updates
     /// properties on the main thread.
     func setupAsync(repositoryURL: URL) async {
-        let (isRepo, rootPath, branch, statuses, ignored, branchList) = await withCheckedContinuation { continuation in
-            // nonisolated-check:ignore — closure body only calls nonisolated static helpers; tracked in #720
-            DispatchQueue.global(qos: .userInitiated).async {
-                let result = GitStatusProvider.runGit(["rev-parse", "--show-toplevel"], at: repositoryURL)
-                let isRepo = result.exitCode == 0
-                guard isRepo else {
-                    continuation.resume(returning: (false, nil as String?, "", [:] as [String: GitFileStatus], Set<String>(), [String]()))
-                    return
-                }
-                let rootPath = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
-                let fetched = GitFetcher.fetchAllInParallel(at: repositoryURL)
-                continuation.resume(returning: (true, rootPath, fetched.branch, fetched.statuses, fetched.ignored, fetched.branches))
+        // nonisolated-check:ignore — closure body only calls nonisolated static helpers; tracked in #720
+        let (isRepo, rootPath, branch, statuses, ignored, branchList) = await runOnBackground {
+            let result = GitStatusProvider.runGit(["rev-parse", "--show-toplevel"], at: repositoryURL)
+            let isRepo = result.exitCode == 0
+            guard isRepo else {
+                return (false, nil as String?, "", [:] as [String: GitFileStatus], Set<String>(), [String]())
             }
+            let rootPath = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+            let fetched = GitFetcher.fetchAllInParallel(at: repositoryURL)
+            return (true, rootPath, fetched.branch, fetched.statuses, fetched.ignored, fetched.branches)
         }
 
         self.repositoryURL = repositoryURL
@@ -417,11 +414,9 @@ final class GitStatusProvider {
             if let progressID { self.progressTracker?.endOperation(progressID) }
         }
 
-        let fetched = await withCheckedContinuation { continuation in
-            // nonisolated-check:ignore — closure body only calls nonisolated static helpers; tracked in #720
-            DispatchQueue.global(qos: .userInitiated).async {
-                continuation.resume(returning: GitFetcher.fetchAllInParallel(at: url))
-            }
+        // nonisolated-check:ignore — closure body only calls nonisolated static helpers; tracked in #720
+        let fetched = await runOnBackground {
+            GitFetcher.fetchAllInParallel(at: url)
         }
 
         // Repository may have been torn down (e.g. .git deleted on the fly)
@@ -525,24 +520,16 @@ final class GitStatusProvider {
         guard isGitRepository, let repoURL = repositoryURL else { return [] }
         let filePath = url.path
 
-        return await withCheckedContinuation { continuation in
-            // nonisolated-check:ignore — closure body only calls nonisolated static helpers; tracked in #720
-            DispatchQueue.global(qos: .userInitiated).async {
-                let headCheck = GitStatusProvider.runGit(["rev-parse", "HEAD"], at: repoURL)
-                guard headCheck.exitCode == 0 else {
-                    continuation.resume(returning: [])
-                    return
-                }
-                let result = GitStatusProvider.runGit(
-                    ["diff", "HEAD", "--unified=0", "--", filePath],
-                    at: repoURL
-                )
-                guard result.exitCode == 0, !result.output.isEmpty else {
-                    continuation.resume(returning: [])
-                    return
-                }
-                continuation.resume(returning: GitStatusProvider.parseDiff(result.output))
-            }
+        // nonisolated-check:ignore — closure body only calls nonisolated static helpers; tracked in #720
+        return await runOnBackground {
+            let headCheck = GitStatusProvider.runGit(["rev-parse", "HEAD"], at: repoURL)
+            guard headCheck.exitCode == 0 else { return [] }
+            let result = GitStatusProvider.runGit(
+                ["diff", "HEAD", "--unified=0", "--", filePath],
+                at: repoURL
+            )
+            guard result.exitCode == 0, !result.output.isEmpty else { return [] }
+            return GitStatusProvider.parseDiff(result.output)
         }
     }
 
@@ -564,12 +551,9 @@ final class GitStatusProvider {
         guard let url = repositoryURL else { return (false, "No repository") }
         let progressID = progressTracker?.beginOperation(Strings.progressGitCheckout)
 
-        let result = await withCheckedContinuation { continuation in
-            // nonisolated-check:ignore — closure body only calls nonisolated static helpers; tracked in #720
-            DispatchQueue.global(qos: .userInitiated).async {
-                let gitResult = GitStatusProvider.runGit(["switch", branch], at: url)
-                continuation.resume(returning: gitResult)
-            }
+        // nonisolated-check:ignore — closure body only calls nonisolated static helpers; tracked in #720
+        let result = await runOnBackground {
+            GitStatusProvider.runGit(["switch", branch], at: url)
         }
 
         guard result.exitCode == 0 else {

--- a/Pine/InlineDiffProvider.swift
+++ b/Pine/InlineDiffProvider.swift
@@ -287,23 +287,15 @@ nonisolated enum InlineDiffProvider {
     /// Fetches diff hunks for a file asynchronously.
     /// Returns full `git diff HEAD` output parsed into hunks.
     static func fetchHunks(for fileURL: URL, repoURL: URL) async -> [DiffHunk] {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let headCheck = GitStatusProvider.runGit(["rev-parse", "HEAD"], at: repoURL)
-                guard headCheck.exitCode == 0 else {
-                    continuation.resume(returning: [])
-                    return
-                }
-                let result = GitStatusProvider.runGit(
-                    ["diff", "HEAD", "--unified=1", "--", fileURL.path],
-                    at: repoURL
-                )
-                guard result.exitCode == 0, !result.output.isEmpty else {
-                    continuation.resume(returning: [])
-                    return
-                }
-                continuation.resume(returning: parseHunks(result.output))
-            }
+        await runOnBackground {
+            let headCheck = GitStatusProvider.runGit(["rev-parse", "HEAD"], at: repoURL)
+            guard headCheck.exitCode == 0 else { return [] }
+            let result = GitStatusProvider.runGit(
+                ["diff", "HEAD", "--unified=1", "--", fileURL.path],
+                at: repoURL
+            )
+            guard result.exitCode == 0, !result.output.isEmpty else { return [] }
+            return parseHunks(result.output)
         }
     }
 
@@ -313,28 +305,20 @@ nonisolated enum InlineDiffProvider {
     /// The hunk patch is created from the raw diff text.
     @discardableResult
     static func acceptHunk(_ hunk: DiffHunk, fileURL: URL, repoURL: URL) async -> Bool {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                // Build a minimal patch from the hunk
-                let patch = buildPatch(hunk: hunk, fileURL: fileURL, repoURL: repoURL)
-                guard !patch.isEmpty else {
-                    continuation.resume(returning: false)
-                    return
-                }
-                let result = applyPatch(patch, args: ["apply", "--cached", "-"], at: repoURL)
-                continuation.resume(returning: result)
-            }
+        await runOnBackground {
+            // Build a minimal patch from the hunk
+            let patch = buildPatch(hunk: hunk, fileURL: fileURL, repoURL: repoURL)
+            guard !patch.isEmpty else { return false }
+            return applyPatch(patch, args: ["apply", "--cached", "-"], at: repoURL)
         }
     }
 
     /// Stages all hunks for a file (equivalent to `git add <file>`).
     @discardableResult
     static func acceptAllHunks(fileURL: URL, repoURL: URL) async -> Bool {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let result = GitStatusProvider.runGit(["add", "--", fileURL.path], at: repoURL)
-                continuation.resume(returning: result.exitCode == 0)
-            }
+        await runOnBackground {
+            let result = GitStatusProvider.runGit(["add", "--", fileURL.path], at: repoURL)
+            return result.exitCode == 0
         }
     }
 
@@ -343,40 +327,25 @@ nonisolated enum InlineDiffProvider {
     /// Reverts a specific hunk by applying the reverse with `git apply --reverse`.
     /// Returns the new file content after reverting, or nil on failure.
     static func revertHunk(_ hunk: DiffHunk, fileURL: URL, repoURL: URL) async -> String? {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let patch = buildPatch(hunk: hunk, fileURL: fileURL, repoURL: repoURL)
-                guard !patch.isEmpty else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-                let success = applyPatch(patch, args: ["apply", "--reverse", "-"], at: repoURL)
-                guard success else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-                // Read updated file content
-                let content = try? String(contentsOf: fileURL, encoding: .utf8)
-                continuation.resume(returning: content)
-            }
+        await runOnBackground { () -> String? in
+            let patch = buildPatch(hunk: hunk, fileURL: fileURL, repoURL: repoURL)
+            guard !patch.isEmpty else { return nil }
+            let success = applyPatch(patch, args: ["apply", "--reverse", "-"], at: repoURL)
+            guard success else { return nil }
+            // Read updated file content
+            return try? String(contentsOf: fileURL, encoding: .utf8)
         }
     }
 
     /// Reverts all changes in a file (equivalent to `git checkout HEAD -- <file>`).
     static func revertAllHunks(fileURL: URL, repoURL: URL) async -> String? {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let result = GitStatusProvider.runGit(
-                    ["checkout", "HEAD", "--", fileURL.path],
-                    at: repoURL
-                )
-                guard result.exitCode == 0 else {
-                    continuation.resume(returning: nil)
-                    return
-                }
-                let content = try? String(contentsOf: fileURL, encoding: .utf8)
-                continuation.resume(returning: content)
-            }
+        await runOnBackground { () -> String? in
+            let result = GitStatusProvider.runGit(
+                ["checkout", "HEAD", "--", fileURL.path],
+                at: repoURL
+            )
+            guard result.exitCode == 0 else { return nil }
+            return try? String(contentsOf: fileURL, encoding: .utf8)
         }
     }
 

--- a/Pine/ProjectSearchProvider.swift
+++ b/Pine/ProjectSearchProvider.swift
@@ -302,12 +302,9 @@ final class ProjectSearchProvider {
     /// Uses `git ls-files` to find ignored directories in a single git call
     /// (no need to enumerate the filesystem first).
     nonisolated static func gitIgnoredDirectories(rootURL: URL) async -> Set<String> {
-        await withCheckedContinuation { continuation in
-            // nonisolated-check:ignore — enclosing func is `nonisolated static`; closure body is pure
-            DispatchQueue.global(qos: .userInitiated).async {
-                let result = gitIgnoredDirectoriesSync(rootURL: rootURL)
-                continuation.resume(returning: result)
-            }
+        // nonisolated-check:ignore — enclosing func is `nonisolated static`; closure body is pure
+        await runOnBackground {
+            gitIgnoredDirectoriesSync(rootURL: rootURL)
         }
     }
 

--- a/PineTests/BackgroundDispatchTests.swift
+++ b/PineTests/BackgroundDispatchTests.swift
@@ -1,0 +1,254 @@
+//
+//  BackgroundDispatchTests.swift
+//  PineTests
+//
+//  Unit tests for `runOnBackground` — the helper that bridges
+//  `DispatchQueue.global(qos:).async` work back into Swift Concurrency.
+//  Covers issue #898.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("BackgroundDispatch Tests")
+struct BackgroundDispatchTests {
+
+    // MARK: - Result delivery
+
+    @Test("Non-throwing variant returns the closure's value verbatim")
+    func nonThrowingReturnsValue() async {
+        let result = await runOnBackground { 42 }
+        #expect(result == 42)
+    }
+
+    @Test("Non-throwing variant returns sentinel string unchanged")
+    func nonThrowingReturnsString() async {
+        let sentinel = "pine-runs-on-background"
+        let result = await runOnBackground { sentinel }
+        #expect(result == sentinel)
+    }
+
+    @Test("Non-throwing variant returns optional .none when closure does")
+    func nonThrowingReturnsNilOptional() async {
+        let result: Int? = await runOnBackground { Int?.none }
+        #expect(result == nil)
+    }
+
+    // MARK: - Off-main-thread execution
+
+    @Test("Closure body runs off the main thread")
+    func closureRunsOffMain() async {
+        let isMain = await runOnBackground { (pthread_main_np() != 0) }
+        #expect(isMain == false)
+    }
+
+    @Test("Closure body runs off the main thread when invoked from MainActor")
+    @MainActor
+    func closureRunsOffMainFromMainActor() async {
+        // Sanity: the test is genuinely starting from the main actor.
+        #expect((pthread_main_np() != 0))
+        let isMain = await runOnBackground { (pthread_main_np() != 0) }
+        #expect(isMain == false)
+    }
+
+    // MARK: - QoS forwarding
+
+    @Test("userInitiated QoS forwards to the queue (probed via qos_class_self)")
+    func userInitiatedQoSForwarded() async {
+        let qosClass = await runOnBackground(qos: .userInitiated) {
+            qos_class_self()
+        }
+        #expect(qosClass == QOS_CLASS_USER_INITIATED)
+    }
+
+    @Test("utility QoS forwards to the queue (probed via qos_class_self)")
+    func utilityQoSForwarded() async {
+        let qosClass = await runOnBackground(qos: .utility) {
+            qos_class_self()
+        }
+        #expect(qosClass == QOS_CLASS_UTILITY)
+    }
+
+    @Test("background QoS forwards to the queue (probed via qos_class_self)")
+    func backgroundQoSForwarded() async {
+        let qosClass = await runOnBackground(qos: .background) {
+            qos_class_self()
+        }
+        #expect(qosClass == QOS_CLASS_BACKGROUND)
+    }
+
+    // MARK: - Concurrency
+
+    @Test("Many concurrent runOnBackground calls all complete")
+    func concurrentCallsAllComplete() async {
+        let count = 64
+        let results: [Int] = await withTaskGroup(of: Int.self) { group in
+            for index in 0..<count {
+                group.addTask {
+                    await runOnBackground { index * 2 }
+                }
+            }
+            var collected: [Int] = []
+            for await value in group {
+                collected.append(value)
+            }
+            return collected.sorted()
+        }
+        let expected = (0..<count).map { $0 * 2 }
+        #expect(results == expected)
+    }
+
+    @Test("Concurrent calls execute on background threads (none of them on main)")
+    func concurrentCallsAllOffMain() async {
+        let count = 32
+        let allOffMain: Bool = await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<count {
+                group.addTask {
+                    await runOnBackground { !(pthread_main_np() != 0) }
+                }
+            }
+            var allOk = true
+            for await offMain in group where !offMain {
+                allOk = false
+            }
+            return allOk
+        }
+        #expect(allOffMain)
+    }
+
+    // MARK: - Throwing variant — success path
+
+    @Test("Throwing variant returns value when closure does not throw")
+    func throwingReturnsValueOnSuccess() async throws {
+        let result = try await runOnBackground { 7 * 6 }
+        #expect(result == 42)
+    }
+
+    @Test("Throwing variant runs body off the main thread")
+    func throwingRunsOffMain() async throws {
+        let isMain = try await runOnBackground { (pthread_main_np() != 0) }
+        #expect(isMain == false)
+    }
+
+    @Test("Throwing variant honours custom QoS")
+    func throwingHonoursQoS() async throws {
+        let qosClass = try await runOnBackground(qos: .utility) {
+            qos_class_self()
+        }
+        #expect(qosClass == QOS_CLASS_UTILITY)
+    }
+
+    // MARK: - Throwing variant — error path
+
+    /// Sentinel error type used to verify error propagation across the bridge.
+    private struct SentinelError: Error, Equatable {
+        let code: Int
+    }
+
+    @Test("Throwing variant propagates errors thrown by the closure")
+    func throwingPropagatesError() async {
+        await #expect(throws: SentinelError(code: 99)) {
+            try await runOnBackground { () -> Int in
+                throw SentinelError(code: 99)
+            }
+        }
+    }
+
+    @Test("Throwing variant propagates standard library errors")
+    func throwingPropagatesStandardError() async {
+        struct NotFound: Error {}
+        await #expect(throws: NotFound.self) {
+            try await runOnBackground { () -> String in
+                throw NotFound()
+            }
+        }
+    }
+
+    @Test("Throwing variant succeeds even when closure could throw but does not")
+    func throwingNoThrowSucceeds() async throws {
+        // Closure typed as `throws` — branch taken is the success branch.
+        let result = try await runOnBackground { () throws -> String in
+            if false { throw SentinelError(code: 0) }
+            return "ok"
+        }
+        #expect(result == "ok")
+    }
+
+    // MARK: - Sendable values flow correctly
+
+    @Test("Closure can return a struct of Sendable values")
+    func returnsSendableStruct() async {
+        struct Bundle: Sendable, Equatable {
+            let count: Int
+            let label: String
+        }
+        let result = await runOnBackground {
+            Bundle(count: 3, label: "ok")
+        }
+        #expect(result == Bundle(count: 3, label: "ok"))
+    }
+
+    @Test("Closure can return an array of Sendable values")
+    func returnsSendableArray() async {
+        let result = await runOnBackground { [1, 2, 3, 5, 8] }
+        #expect(result == [1, 2, 3, 5, 8])
+    }
+
+    // MARK: - Closure runs only once
+
+    @Test("Closure body executes exactly once per call")
+    func closureRunsOnce() async {
+        let counter = AtomicCounter()
+        _ = await runOnBackground {
+            counter.increment()
+        }
+        #expect(counter.value == 1)
+    }
+
+    @Test("Throwing closure body executes exactly once per call (success path)")
+    func throwingClosureRunsOnceOnSuccess() async throws {
+        let counter = AtomicCounter()
+        _ = try await runOnBackground {
+            counter.increment()
+        }
+        #expect(counter.value == 1)
+    }
+
+    @Test("Throwing closure body executes exactly once per call (error path)")
+    func throwingClosureRunsOnceOnError() async {
+        let counter = AtomicCounter()
+        await #expect(throws: SentinelError.self) {
+            try await runOnBackground { () -> Int in
+                counter.increment()
+                throw SentinelError(code: 1)
+            }
+        }
+        #expect(counter.value == 1)
+    }
+}
+
+// MARK: - Test helpers
+
+/// Lock-backed counter used to verify a closure body fires exactly once
+/// across thread boundaries. Marked `@unchecked Sendable` because the
+/// underlying `NSLock` provides serialization. All members are `nonisolated`
+/// so the struct's actor isolation cannot leak into the counter and confuse
+/// the closure-isolation inference inside `runOnBackground` test bodies.
+nonisolated final class AtomicCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue = 0
+
+    func increment() {
+        lock.lock()
+        storedValue += 1
+        lock.unlock()
+    }
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedValue
+    }
+}


### PR DESCRIPTION
## Summary

Wraps the recurring `await withCheckedContinuation { DispatchQueue.global(qos: ...).async { ... resume(returning:) } }` boilerplate in a single typed helper (`runOnBackground`) and migrates nine call sites across three files. Removes about 50 lines of plumbing and standardises QoS at the helper boundary instead of at each call site.

The helper lives in `Pine/Concurrency/BackgroundDispatch.swift` and provides both a non-throwing and a throwing variant.

## Migration map

| File | Function | Original lines | Throws? | QoS | Notes |
|---|---|---|---|---|---|
| `Pine/InlineDiffProvider.swift` | `fetchHunks(for:repoURL:)` | 290–308 | no | `.userInitiated` | static; no captured state |
| `Pine/InlineDiffProvider.swift` | `acceptHunk(_:fileURL:repoURL:)` | 315–328 | no | `.userInitiated` | static; no captured state |
| `Pine/InlineDiffProvider.swift` | `acceptAllHunks(fileURL:repoURL:)` | 332–339 | no | `.userInitiated` | static; no captured state |
| `Pine/InlineDiffProvider.swift` | `revertHunk(_:fileURL:repoURL:)` | 346–363 | no | `.userInitiated` | needed explicit `() -> String?` to disambiguate optional return |
| `Pine/InlineDiffProvider.swift` | `revertAllHunks(fileURL:repoURL:)` | 367–381 | no | `.userInitiated` | needed explicit `() -> String?` to disambiguate optional return |
| `Pine/GitStatusProvider.swift` | `setupAsync(repositoryURL:)` | 320–333 | no | `.userInitiated` | tuple return preserved verbatim; `nonisolated-check:ignore` kept as leading-line marker |
| `Pine/GitStatusProvider.swift` | `runSingleRefresh()` | 420–425 | no | `.userInitiated` | one-liner; closure now just returns `GitFetcher.fetchAllInParallel` |
| `Pine/GitStatusProvider.swift` | `diffForFileAsync(at:)` | 528–547 | no | `.userInitiated` | `filePath` already extracted before the closure pre-migration |
| `Pine/GitStatusProvider.swift` | `checkoutBranchAsync(_:)` | 567–573 | no | `.userInitiated` | one-liner |
| `Pine/ProjectSearchProvider.swift` | `gitIgnoredDirectories(rootURL:)` | 305–312 | no | `.userInitiated` | `nonisolated static` enclosing func; closure body already pure |

All nine sites used `qos: .userInitiated`, which matches the helper's default — the `qos:` argument is therefore omitted at the call sites. Behaviour is identical to the pre-migration code.

## Sendable handling

No call site captured `self` or any non-`Sendable` actor-isolated state — every closure body referenced static helpers (`GitStatusProvider.runGit`, `GitFetcher.fetchAllInParallel`, `parseHunks`, `applyPatch`) and value-typed parameters (`URL`, `String`, `DiffHunk`). No additional `let` extraction was required to satisfy `@Sendable`. The pre-existing `nonisolated-check:ignore` comments (issue #720) are preserved as leading-line markers above the new `await runOnBackground { ... }` calls.

## Out of scope

Three sites in `Pine/` and four in `PineTests/` were intentionally left alone:

- `SyntaxHighlighter.swift` (3 sites — `highlightAsync`, `highlightEditedAsync`, `highlightVisibleRangeAsync`) uses a bounded `OperationQueue` (`maxConcurrentOperationCount = 4`), not `DispatchQueue.global`. Migrating to the helper would change the concurrency contract and risk CPU saturation during session restore.
- `WorkspaceManager.waitForLoadingComplete` uses a continuation as an awaiter — stored in an array and resumed elsewhere — not a GCD bridge.
- `PineTests/ConcurrencyStressTests.swift` and `PineTests/GitStatusProviderTests.swift` retain raw `withCheckedContinuation` blocks because they are black-box thread-safety tests that intentionally exercise the underlying GCD pattern.

## Performance

Ran `xcodebuild test -only-testing:PinePerformanceTests/GitStatusParserPerformanceTests -only-testing:PinePerformanceTests/ProjectSearchPerformanceTests` locally on the migrated branch. All 19 tests pass within the configured `15 %` regression budget (`PinePerformanceTests/baselines.json`):

ProjectSearchPerformanceTests:
- `testSearchAcross200Files`: avg 0.044 s
- `testSearchAcross500Files`: avg 0.065 s
- `testSearchHighMatchDensity`: avg 0.122 s
- `testSearchLargeProject1000Files`: avg 0.468 s
- `testSearchLargeProjectCaseSensitive`: avg 0.106 s
- `testSearchRareTermLargeProject`: avg 0.502 s
- `testSearchSingleFileCaseSensitive`: avg 0.006 s
- `testSearchSingleLargeFile`: avg 0.009 s

GitStatusParserPerformanceTests:
- `testParseStatus500Entries`: avg 0.002 s (baseline 0.002)
- `testParseStatus2000Entries`: avg 0.006 s (baseline 0.008)
- `testParseDiff100Hunks`: avg 0.001 s
- `testParseDiff500Hunks`: avg 0.004 s
- `testParseBlame500Lines`: avg 0.004 s
- `testParseBlame2000Lines`: avg 0.011 s
- `testParseIgnored500Entries`: avg 0.001 s
- `testNextChangeLine`: avg 0.026 s
- `testChangeRegionStarts`: avg 0.000 s

These results are at or below baseline. The helper is `@inlinable`, so the optimiser can fold the wrapper into the call site if it chooses.

## Test plan

- [x] `swiftlint --strict` clean (357 files, 0 violations)
- [x] `xcodebuild build` succeeded
- [x] `BackgroundDispatchTests` added (21 tests, all passing) — covers result delivery, off-main execution, QoS forwarding for `.userInitiated` / `.utility` / `.background`, concurrent fan-out, throwing-variant success and error paths, and once-only invocation guarantees
- [x] Targeted regression suites pass (`PineTests/GitStatusProviderTests` + `InlineDiffProviderTests` + `InlineDiffExpandTests` + `InlineDiffRenderingTests` + `ProjectSearchProviderTests` + `ConcurrencyStressTests`)
- [x] `PinePerformanceTests/GitStatusParserPerformanceTests` and `PinePerformanceTests/ProjectSearchPerformanceTests` pass with no regression

Closes #898