### PR TITLE
fix(terminal): auto-scroll scrollback when dragging selection past view bounds (#915)

### DIFF
--- a/Pine/TerminalAutoScroll.swift
+++ b/Pine/TerminalAutoScroll.swift
@@ -77,7 +77,16 @@ enum TerminalAutoScroll {
     /// - Linear ramp: 1 line per `pointsPerLineStep` points beyond the edge.
     /// - Always at least 1 line once `distance > 0`, ceilinged at `maxLinesPerTick`.
     /// - Defensive against negative inputs (treats them as 0).
+    /// - Defensive against `NaN` / `-infinity` (treated as 0) and `+infinity`
+    ///   (clamped to `maxLinesPerTick`). `Int(_:)` of a non-finite `Double` is
+    ///   undefined behaviour in Swift (traps in debug, returns garbage in
+    ///   release), so we must intercept before constructing the integer.
     static func linesPerTick(forDistance distance: CGFloat) -> Int {
+        guard distance.isFinite else {
+            // +infinity should saturate at the cap; -infinity / NaN are
+            // treated as "no scroll" so they cannot stall or crash the loop.
+            return distance > 0 ? maxLinesPerTick : 0
+        }
         guard distance > 0 else { return 0 }
         let raw = Int((distance / pointsPerLineStep).rounded(.down))
         let withFloor = max(1, raw)

--- a/Pine/TerminalAutoScroll.swift
+++ b/Pine/TerminalAutoScroll.swift
@@ -1,0 +1,86 @@
+//
+//  TerminalAutoScroll.swift
+//  Pine
+//
+//  Pure helpers for computing terminal scrollback auto-scroll behaviour
+//  while the user drags a selection past the view bounds. Extracted from
+//  TerminalScrollInterceptor so the math can be unit-tested without timers,
+//  NSEvent, or AppKit views in the loop.
+//
+
+import Foundation
+import CoreGraphics
+
+/// Direction in which the scrollback buffer should auto-scroll while the
+/// user drags a selection past the terminal view bounds.
+enum TerminalAutoScrollDirection {
+    case up
+    case down
+}
+
+/// Pure utilities for the drag-selection auto-scroll feature.
+///
+/// All entry points are static functions of plain numeric types so they can
+/// be exercised by Swift Testing without spinning up `NSView`, `NSEvent`,
+/// timers, or a real terminal buffer.
+enum TerminalAutoScroll {
+
+    /// Tick interval for the auto-scroll timer. Roughly ~17 ticks/second
+    /// keeps scrolling smooth while the user holds the cursor outside the
+    /// view, without saturating the main thread.
+    static let tickInterval: TimeInterval = 0.06
+
+    /// Hard ceiling on lines scrolled per tick. Prevents runaway scroll
+    /// when the user flings the cursor far below the terminal.
+    static let maxLinesPerTick: Int = 8
+
+    /// Distance (points) over which one extra line per tick is added.
+    /// `lines = clamp(distance / linesPerPoint, 1, maxLinesPerTick)`.
+    static let pointsPerLineStep: CGFloat = 20
+
+    /// Returns the auto-scroll direction implied by `point` relative to
+    /// the terminal view's `bounds` (assumed flipped, y=0 at top).
+    ///
+    /// - Returns: `.up` if the cursor is above the view, `.down` if below,
+    ///   or `nil` when the cursor is inside the view (or exactly on the
+    ///   border — touching the edge does not trigger auto-scroll, matching
+    ///   how AppKit `NSTextView` behaves).
+    static func direction(forPoint point: CGPoint, in bounds: CGRect) -> TerminalAutoScrollDirection? {
+        guard bounds.height > 0, bounds.width > 0 else { return nil }
+        if point.y < bounds.minY {
+            return .up
+        }
+        if point.y > bounds.maxY {
+            return .down
+        }
+        return nil
+    }
+
+    /// Distance (in points) the cursor sits beyond the closer of the
+    /// two horizontal edges of `bounds`. Always non-negative.
+    ///
+    /// - Returns: 0 if the cursor is inside or exactly on either edge.
+    static func edgeDistance(forPoint point: CGPoint, in bounds: CGRect) -> CGFloat {
+        guard bounds.height > 0, bounds.width > 0 else { return 0 }
+        if point.y < bounds.minY {
+            return bounds.minY - point.y
+        }
+        if point.y > bounds.maxY {
+            return point.y - bounds.maxY
+        }
+        return 0
+    }
+
+    /// Lines to scroll per tick given how far the cursor sits beyond the view.
+    ///
+    /// - 0 distance → 0 lines (no-op; caller should not start a timer).
+    /// - Linear ramp: 1 line per `pointsPerLineStep` points beyond the edge.
+    /// - Always at least 1 line once `distance > 0`, ceilinged at `maxLinesPerTick`.
+    /// - Defensive against negative inputs (treats them as 0).
+    static func linesPerTick(forDistance distance: CGFloat) -> Int {
+        guard distance > 0 else { return 0 }
+        let raw = Int((distance / pointsPerLineStep).rounded(.down))
+        let withFloor = max(1, raw)
+        return min(maxLinesPerTick, withFloor)
+    }
+}

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -43,7 +43,43 @@ class TerminalScrollInterceptor: NSView {
     private var lastDragEvent: NSEvent?
     private var isMouseDown = false
 
-    // Forward mouse clicks, drags, and keyboard events to the terminal.
+    /// Global mouse-up monitor installed only while auto-scroll is active.
+    ///
+    /// AppKit only delivers `mouseUp` to a view when the press began inside
+    /// it AND the release happens while the app is key. If the user drags
+    /// past the window, releases over another app (Cmd+Tab, Mission Control,
+    /// the menu bar), or releases over a different window, the local
+    /// `mouseUp` override never fires and the auto-scroll timer would spin
+    /// forever. A global monitor catches the release in those cases.
+    private var globalMouseUpMonitor: Any?
+
+    /// Window-resign-key observer installed only while auto-scroll is active.
+    ///
+    /// Belt-and-braces alongside `globalMouseUpMonitor`: if focus moves to
+    /// another app (Mission Control, Spotlight, screen saver), the global
+    /// monitor may not see the release at all. Losing key status is a
+    /// reliable upper bound — there is nothing useful auto-scroll can do
+    /// against an unfocused window.
+    private var windowResignKeyObserver: NSObjectProtocol?
+
+    /// Test hook: whether the auto-scroll timer is currently running.
+    /// Internal so `@testable import Pine` can assert lifecycle correctness
+    /// without coupling tests to private state.
+    internal var isAutoScrollActive: Bool { autoScrollTimer != nil }
+
+    /// Test-only entry point that starts the auto-scroll timer (and the
+    /// associated safety-net subscriptions) without requiring a real
+    /// terminal view, NSEvent, or scrollback buffer. Tests use this to
+    /// verify that the various stop paths (window resign key, global mouse
+    /// up, active tab change, mouseUp, drag back into bounds) actually tear
+    /// the timer down. Production code never calls this.
+    internal func startAutoScrollForTesting() {
+        isMouseDown = true
+        if autoScrollTimer == nil {
+            startAutoScrollTimer()
+        }
+    }
+
     override func mouseDown(with event: NSEvent) {
         isMouseDown = true
         stopAutoScroll()
@@ -85,6 +121,31 @@ class TerminalScrollInterceptor: NSView {
             stopAutoScroll()
             isMouseDown = false
         }
+    }
+
+    /// Called when the active terminal tab changes, so an in-flight
+    /// auto-scroll on the outgoing tab cannot keep ticking against the
+    /// incoming tab's coordinates. Internal so the container view and
+    /// tests can both invoke it deterministically.
+    internal func handleActiveTabChange() {
+        isMouseDown = false
+        stopAutoScroll()
+    }
+
+    /// Test hook for the global mouse-up safety net. Calling this directly
+    /// is equivalent to a `leftMouseUp` arriving while focus is elsewhere
+    /// (Mission Control, Cmd+Tab, the menu bar, another app).
+    internal func handleGlobalMouseUp() {
+        isMouseDown = false
+        stopAutoScroll()
+    }
+
+    /// Test hook for the window-resign-key safety net. Calling this directly
+    /// is equivalent to the host window losing key status while a drag is
+    /// in flight.
+    internal func handleWindowResignKey() {
+        isMouseDown = false
+        stopAutoScroll()
     }
 
     // No `deinit` cleanup is required: `viewWillMove(toWindow: nil)` is the
@@ -149,11 +210,47 @@ class TerminalScrollInterceptor: NSView {
         // (default mode pauses while AppKit drives an event-tracking loop).
         RunLoop.main.add(timer, forMode: .common)
         autoScrollTimer = timer
+        installLostMouseUpSafetyNets()
     }
 
     private func stopAutoScroll() {
         autoScrollTimer?.invalidate()
         autoScrollTimer = nil
+        removeLostMouseUpSafetyNets()
+    }
+
+    /// Installs the global mouse-up monitor and window-resign-key observer
+    /// so the auto-scroll loop cannot leak past the end of the user's drag.
+    /// Idempotent — repeated calls do not stack monitors.
+    private func installLostMouseUpSafetyNets() {
+        if globalMouseUpMonitor == nil {
+            globalMouseUpMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseUp]) { [weak self] _ in
+                // `addGlobalMonitorForEvents` callbacks fire on the main
+                // thread per AppKit docs; safe to mutate UI state directly.
+                self?.handleGlobalMouseUp()
+            }
+        }
+        if windowResignKeyObserver == nil, let win = window {
+            windowResignKeyObserver = NotificationCenter.default.addObserver(
+                forName: NSWindow.didResignKeyNotification,
+                object: win,
+                queue: .main
+            ) { [weak self] _ in
+                self?.handleWindowResignKey()
+            }
+        }
+    }
+
+    /// Removes both safety-net subscriptions if installed. Idempotent.
+    private func removeLostMouseUpSafetyNets() {
+        if let monitor = globalMouseUpMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalMouseUpMonitor = nil
+        }
+        if let observer = windowResignKeyObserver {
+            NotificationCenter.default.removeObserver(observer)
+            windowResignKeyObserver = nil
+        }
     }
 
     @objc private func autoScrollTick(_ timer: Timer) {
@@ -252,6 +349,9 @@ class TerminalContainerView: NSView {
 
     func showTab(_ tab: TerminalTab?) {
         guard let tab else {
+            // Tab cleared (terminal pane closed) — kill any in-flight
+            // auto-scroll so it cannot tick against a now-detached view.
+            scrollInterceptor.handleActiveTabChange()
             subviews.forEach { $0.removeFromSuperview() }
             currentTabID = nil
             scrollInterceptor.terminalView = nil
@@ -259,6 +359,10 @@ class TerminalContainerView: NSView {
         }
         let tabChanged = tab.id != currentTabID || tab.terminalView.superview !== self
         if tabChanged {
+            // Auto-scroll started against the *outgoing* tab — stop it before
+            // we swap the underlying terminalView so the next tick cannot
+            // scroll the freshly-installed tab using stale coordinates.
+            scrollInterceptor.handleActiveTabChange()
             subviews.forEach { $0.removeFromSuperview() }
             currentTabID = tab.id
             let effectiveBounds = bounds.size.width > 0 && bounds.size.height > 0

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -67,6 +67,7 @@ class TerminalScrollInterceptor: NSView {
     /// without coupling tests to private state.
     internal var isAutoScrollActive: Bool { autoScrollTimer != nil }
 
+    #if DEBUG
     /// Test-only entry point that starts the auto-scroll timer (and the
     /// associated safety-net subscriptions) without requiring a real
     /// terminal view, NSEvent, or scrollback buffer. Tests use this to
@@ -79,6 +80,7 @@ class TerminalScrollInterceptor: NSView {
             startAutoScrollTimer()
         }
     }
+    #endif
 
     override func mouseDown(with event: NSEvent) {
         isMouseDown = true

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -19,6 +19,12 @@ import SwiftTerm
 /// Scroll events are handled separately via `NSEvent.addLocalMonitorForEvents`
 /// on `TerminalContainerView` because AppKit on macOS 26 does not dispatch
 /// `scrollWheel` to overlay views — events go directly to SwiftTerm's view.
+///
+/// While the user drags a selection past the top/bottom edges, the
+/// interceptor runs an auto-scroll timer that scrolls SwiftTerm's
+/// scrollback and replays the last drag event so the selection keeps
+/// extending — restoring the standard macOS `NSTextView` behaviour
+/// missing from SwiftTerm 1.13.0 (issue #915).
 class TerminalScrollInterceptor: NSView {
 
     /// The terminal view underneath this overlay.
@@ -31,15 +37,30 @@ class TerminalScrollInterceptor: NSView {
         return self
     }
 
+    // MARK: - Auto-scroll-on-drag state
+
+    private var autoScrollTimer: Timer?
+    private var lastDragEvent: NSEvent?
+    private var isMouseDown = false
+
     // Forward mouse clicks, drags, and keyboard events to the terminal.
     override func mouseDown(with event: NSEvent) {
+        isMouseDown = true
+        stopAutoScroll()
         if let tv = terminalView {
             window?.makeFirstResponder(tv)
             tv.mouseDown(with: event)
         }
     }
-    override func mouseUp(with event: NSEvent) { terminalView?.mouseUp(with: event) }
-    override func mouseDragged(with event: NSEvent) { terminalView?.mouseDragged(with: event) }
+    override func mouseUp(with event: NSEvent) {
+        isMouseDown = false
+        stopAutoScroll()
+        terminalView?.mouseUp(with: event)
+    }
+    override func mouseDragged(with event: NSEvent) {
+        terminalView?.mouseDragged(with: event)
+        updateAutoScroll(for: event)
+    }
     override func mouseMoved(with event: NSEvent) { terminalView?.mouseMoved(with: event) }
     override func rightMouseDown(with event: NSEvent) {
         if let tv = terminalView {
@@ -55,6 +76,140 @@ class TerminalScrollInterceptor: NSView {
     override func flagsChanged(with event: NSEvent) { terminalView?.flagsChanged(with: event) }
 
     override var acceptsFirstResponder: Bool { false }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        super.viewWillMove(toWindow: newWindow)
+        // Window detach (tab close, app quit) — drop the timer so it cannot
+        // fire against a dangling terminal view.
+        if newWindow == nil {
+            stopAutoScroll()
+            isMouseDown = false
+        }
+    }
+
+    // No `deinit` cleanup is required: `viewWillMove(toWindow: nil)` is the
+    // last call AppKit makes before the view is torn down (tab close, app
+    // quit), and we invalidate the timer there. Touching `autoScrollTimer`
+    // from a nonisolated `deinit` would require unsafe Sendable hops; the
+    // window-detach path is sufficient because the timer always retains
+    // `self`, so this view cannot deallocate while the timer is alive.
+
+    // MARK: - Auto-scroll-on-drag implementation
+
+    /// Updates the auto-scroll timer in response to a `mouseDragged` event.
+    ///
+    /// - Stores the latest event for the next timer tick to replay.
+    /// - Starts/keeps the timer running while the cursor is outside the
+    ///   bounds AND the terminal can actually scroll in that direction.
+    /// - Stops the timer the moment the cursor returns to the bounds, the
+    ///   user enters the alternate screen / a TUI app with mouse reporting,
+    ///   or the scrollback hits the corresponding edge.
+    private func updateAutoScroll(for event: NSEvent) {
+        lastDragEvent = event
+        guard let terminalView, isMouseDown else {
+            stopAutoScroll()
+            return
+        }
+
+        // Disable for TUI apps / alternate screen — selection there is
+        // app-driven and an auto-scroll would corrupt mouse reporting.
+        let term = terminalView.getTerminal()
+        if term.mouseMode != .off || term.isCurrentBufferAlternate {
+            stopAutoScroll()
+            return
+        }
+
+        let point = convert(event.locationInWindow, from: nil)
+        guard let direction = TerminalAutoScroll.direction(forPoint: point, in: bounds) else {
+            stopAutoScroll()
+            return
+        }
+
+        // Already pinned to the edge of scrollback in this direction —
+        // running a timer would just burn CPU. Bail out.
+        if !canScroll(direction: direction, in: terminalView) {
+            stopAutoScroll()
+            return
+        }
+
+        if autoScrollTimer == nil {
+            startAutoScrollTimer()
+        }
+    }
+
+    private func startAutoScrollTimer() {
+        let timer = Timer(
+            timeInterval: TerminalAutoScroll.tickInterval,
+            target: self,
+            selector: #selector(autoScrollTick(_:)),
+            userInfo: nil,
+            repeats: true
+        )
+        // Common run-loop mode keeps the timer firing during mouse tracking
+        // (default mode pauses while AppKit drives an event-tracking loop).
+        RunLoop.main.add(timer, forMode: .common)
+        autoScrollTimer = timer
+    }
+
+    private func stopAutoScroll() {
+        autoScrollTimer?.invalidate()
+        autoScrollTimer = nil
+    }
+
+    @objc private func autoScrollTick(_ timer: Timer) {
+        guard let terminalView, let event = lastDragEvent, isMouseDown else {
+            stopAutoScroll()
+            return
+        }
+
+        let point = convert(event.locationInWindow, from: nil)
+        guard let direction = TerminalAutoScroll.direction(forPoint: point, in: bounds) else {
+            stopAutoScroll()
+            return
+        }
+
+        let term = terminalView.getTerminal()
+        if term.mouseMode != .off || term.isCurrentBufferAlternate {
+            stopAutoScroll()
+            return
+        }
+
+        guard canScroll(direction: direction, in: terminalView) else {
+            stopAutoScroll()
+            return
+        }
+
+        let distance = TerminalAutoScroll.edgeDistance(forPoint: point, in: bounds)
+        let lines = TerminalAutoScroll.linesPerTick(forDistance: distance)
+        guard lines > 0 else { return }
+
+        switch direction {
+        case .up:
+            terminalView.scrollUp(lines: lines)
+        case .down:
+            terminalView.scrollDown(lines: lines)
+        }
+
+        // Replay the last drag event so SwiftTerm's mouseDragged recomputes
+        // the buffer row from the new yDisp and extends the selection to the
+        // freshly revealed line. Without this, selection would clip at the
+        // last buffer row computed before the scroll.
+        terminalView.mouseDragged(with: event)
+    }
+
+    /// Whether SwiftTerm has any scrollback to consume in the given
+    /// direction. Used to avoid spinning the timer for nothing once the
+    /// user has dragged all the way to the top or bottom of the buffer.
+    private func canScroll(direction: TerminalAutoScrollDirection,
+                           in terminalView: LocalProcessTerminalView) -> Bool {
+        guard terminalView.canScroll else { return false }
+        switch direction {
+        case .up:
+            return terminalView.scrollPosition > 0
+        case .down:
+            return terminalView.scrollPosition < 1
+        }
+    }
 }
 
 // MARK: - NSViewRepresentable обёртка для SwiftTerm

--- a/PineTests/TerminalAutoScrollTests.swift
+++ b/PineTests/TerminalAutoScrollTests.swift
@@ -4,7 +4,10 @@
 //
 //  Tests for the drag-selection auto-scroll feature in the terminal
 //  (issue #915). Pure-math helpers in `TerminalAutoScroll` are tested
-//  exhaustively without timers or AppKit views.
+//  exhaustively without timers or AppKit views; lifecycle of
+//  `TerminalScrollInterceptor` (start, stop on mouseUp / window detach /
+//  active tab change / global mouseUp / window resign key) is verified
+//  via the internal `isAutoScrollActive` test hook.
 //
 
 import Testing
@@ -244,6 +247,50 @@ struct TerminalAutoScrollTests {
         #expect(TerminalAutoScroll.linesPerTick(forDistance: 41) == 2)
     }
 
+    // MARK: - linesPerTick non-finite inputs (NaN / +∞ / -∞)
+    //
+    // Without an `isFinite` guard, `Int((nan / step).rounded(.down))` traps
+    // in debug and returns garbage in release. These tests pin the explicit
+    // contract: NaN and -∞ are treated as 0 (no scroll), +∞ saturates at
+    // the cap. Symmetric with the negative-distance test above — caller
+    // never has to launder its inputs before calling.
+
+    @Test func linesPerTickForNaNIsZero() {
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: .nan) == 0)
+    }
+
+    @Test func linesPerTickForPositiveInfinityIsCapped() {
+        #expect(
+            TerminalAutoScroll.linesPerTick(forDistance: .infinity)
+                == TerminalAutoScroll.maxLinesPerTick
+        )
+    }
+
+    @Test func linesPerTickForNegativeInfinityIsZero() {
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: -.infinity) == 0)
+    }
+
+    // MARK: - linesPerTick boundary around the maxLinesPerTick cap
+    //
+    // 200 px == 10 raw lines → clamped to 8 (the cap). 199 px == 9 raw → 8.
+    // 201 px == 10 raw → still 8. The cap should clamp from both directions
+    // smoothly, no off-by-one regressions if the constants ever change.
+
+    @Test func linesPerTickAtBoundary199() {
+        // 199 / 20 = 9.95 → floor 9 → clamped to 8.
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: 199) == TerminalAutoScroll.maxLinesPerTick)
+    }
+
+    @Test func linesPerTickAtBoundary200() {
+        // 200 / 20 = 10 → clamped to 8.
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: 200) == TerminalAutoScroll.maxLinesPerTick)
+    }
+
+    @Test func linesPerTickAtBoundary201() {
+        // 201 / 20 = 10.05 → floor 10 → clamped to 8.
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: 201) == TerminalAutoScroll.maxLinesPerTick)
+    }
+
     @Test func linesPerTickIsMonotonic() {
         // The ramp must be monotonic non-decreasing across the full range
         // we care about, so larger overshoots never scroll less.
@@ -284,42 +331,26 @@ struct TerminalAutoScrollTests {
     }
 
     // MARK: - TerminalScrollInterceptor lifecycle
+    //
+    // These tests use the internal `startAutoScrollForTesting()` hook to
+    // bring the interceptor into the "timer running" state without needing
+    // a fully-initialised `LocalProcessTerminalView` with real scrollback.
+    // Each test then exercises one of the stop paths and verifies the
+    // public test hook `isAutoScrollActive` flips back to `false`.
 
-    @Test func interceptorMouseDownClearsLastDragEvent() {
-        // mouseDown should reset any in-flight auto-scroll state from a
-        // previous drag (defensive — the timer is normally stopped on
-        // mouseUp, but we want a hard reset on the next press).
+    private func makeInterceptor() -> TerminalScrollInterceptor {
         let interceptor = TerminalScrollInterceptor()
         interceptor.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
-        // No terminalView attached; we just want to assert this does not
-        // crash and leaves the interceptor in a clean state. A nil
-        // terminalView short-circuits all mouse forwarding.
-        let event = NSEvent.mouseEvent(
-            with: .leftMouseDown,
-            location: NSPoint(x: 100, y: 100),
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: 0,
-            context: nil,
-            eventNumber: 0,
-            clickCount: 1,
-            pressure: 0
-        )
-        if let event {
-            interceptor.mouseDown(with: event)
-        }
-        // Direct API: there is no public way to assert "timer not running"
-        // without exposing internals; the lifecycle is covered indirectly
-        // by the deinit / window-detach paths below. This test mainly
-        // pins that mouseDown does not crash with no terminal attached.
+        return interceptor
     }
 
-    @Test func interceptorMouseUpDoesNotCrashWithoutTerminal() {
-        let interceptor = TerminalScrollInterceptor()
-        interceptor.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
-        let event = NSEvent.mouseEvent(
-            with: .leftMouseUp,
-            location: NSPoint(x: 100, y: 100),
+    private func makeMouseEvent(type: NSEvent.EventType, at point: NSPoint) -> NSEvent {
+        // NSEvent.mouseEvent(...) returns nil only for non-mouse `type`
+        // values, which we never pass — but we still avoid force-unwrap
+        // and fail the test loudly if AppKit ever changes that contract.
+        guard let event = NSEvent.mouseEvent(
+            with: type,
+            location: point,
             modifierFlags: [],
             timestamp: 0,
             windowNumber: 0,
@@ -327,31 +358,181 @@ struct TerminalAutoScrollTests {
             eventNumber: 0,
             clickCount: 1,
             pressure: 0
-        )
-        if let event {
-            interceptor.mouseUp(with: event)
+        ) else {
+            Issue.record("NSEvent.mouseEvent returned nil for type \(type)")
+            // Sentinel that will fail downstream if reached; swift-testing
+            // already recorded the failure above.
+            return NSEvent()
         }
-        // Just assert we got here.
-        #expect(true)
+        return event
     }
 
-    @Test func interceptorMouseDraggedDoesNotCrashWithoutTerminal() {
-        let interceptor = TerminalScrollInterceptor()
-        interceptor.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
-        let event = NSEvent.mouseEvent(
-            with: .leftMouseDragged,
-            location: NSPoint(x: 100, y: 600), // outside, should try to start auto-scroll
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: 0,
-            context: nil,
-            eventNumber: 0,
-            clickCount: 1,
-            pressure: 0
-        )
-        if let event {
-            interceptor.mouseDragged(with: event)
-        }
-        #expect(true)
+    @Test func interceptorStartsInactive() {
+        let interceptor = makeInterceptor()
+        #expect(interceptor.isAutoScrollActive == false)
+    }
+
+    @Test func interceptorTestHookStartsTimer() {
+        let interceptor = makeInterceptor()
+        interceptor.startAutoScrollForTesting()
+        #expect(interceptor.isAutoScrollActive == true)
+        // Cleanup so the timer cannot fire after the test exits.
+        interceptor.handleGlobalMouseUp()
+    }
+
+    @Test func interceptorMouseDownStopsActiveAutoScroll() {
+        // A new mouseDown means the user started a fresh drag — any
+        // in-flight auto-scroll from a previous (interrupted) drag must
+        // be torn down so the new gesture starts from a clean state.
+        let interceptor = makeInterceptor()
+        interceptor.startAutoScrollForTesting()
+        #expect(interceptor.isAutoScrollActive == true)
+
+        let event = makeMouseEvent(type: .leftMouseDown, at: NSPoint(x: 100, y: 100))
+        interceptor.mouseDown(with: event)
+        #expect(interceptor.isAutoScrollActive == false)
+    }
+
+    @Test func interceptorMouseUpStopsAutoScroll() {
+        let interceptor = makeInterceptor()
+        interceptor.startAutoScrollForTesting()
+        #expect(interceptor.isAutoScrollActive == true)
+
+        let event = makeMouseEvent(type: .leftMouseUp, at: NSPoint(x: 100, y: 100))
+        interceptor.mouseUp(with: event)
+        #expect(interceptor.isAutoScrollActive == false)
+    }
+
+    @Test func interceptorMouseDraggedWithoutTerminalStopsAutoScroll() {
+        // mouseDragged → updateAutoScroll early-returns when terminalView
+        // is nil, which calls stopAutoScroll(). This also covers the
+        // "drag back inside bounds" path indirectly: in both cases the
+        // updateAutoScroll guard chain must reach stopAutoScroll().
+        let interceptor = makeInterceptor()
+        interceptor.startAutoScrollForTesting()
+        #expect(interceptor.isAutoScrollActive == true)
+
+        let event = makeMouseEvent(type: .leftMouseDragged, at: NSPoint(x: 100, y: 100))
+        interceptor.mouseDragged(with: event)
+        #expect(interceptor.isAutoScrollActive == false)
+    }
+
+    @Test func interceptorWindowDetachStopsAutoScroll() {
+        // viewWillMove(toWindow: nil) is AppKit's "you are about to be
+        // unhooked" signal — the interceptor must drop the timer so it
+        // cannot fire against a torn-down view.
+        let interceptor = makeInterceptor()
+        interceptor.startAutoScrollForTesting()
+        #expect(interceptor.isAutoScrollActive == true)
+
+        interceptor.viewWillMove(toWindow: nil)
+        #expect(interceptor.isAutoScrollActive == false)
+    }
+
+    @Test func interceptorActiveTabChangeStopsAutoScroll() {
+        // When the user switches terminal tabs while a drag is active
+        // (e.g. clicks another tab), the auto-scroll loop is still
+        // pointing at the OLD tab's coordinates. handleActiveTabChange()
+        // is the hook the container calls before swapping terminalView.
+        let interceptor = makeInterceptor()
+        interceptor.startAutoScrollForTesting()
+        #expect(interceptor.isAutoScrollActive == true)
+
+        interceptor.handleActiveTabChange()
+        #expect(interceptor.isAutoScrollActive == false)
+    }
+
+    @Test func interceptorGlobalMouseUpStopsAutoScroll() {
+        // Safety net: if the user releases the mouse over another app
+        // (Cmd+Tab, Mission Control, the menu bar), the local mouseUp
+        // override never fires. handleGlobalMouseUp() is the path the
+        // global NSEvent monitor invokes; without it the timer would
+        // run forever.
+        let interceptor = makeInterceptor()
+        interceptor.startAutoScrollForTesting()
+        #expect(interceptor.isAutoScrollActive == true)
+
+        interceptor.handleGlobalMouseUp()
+        #expect(interceptor.isAutoScrollActive == false)
+    }
+
+    @Test func interceptorWindowResignKeyStopsAutoScroll() {
+        // Belt-and-braces alongside the global mouse-up monitor — losing
+        // key status means there is nothing useful auto-scroll can do
+        // against the now-unfocused window, and we want to release the
+        // run-loop tick promptly.
+        let interceptor = makeInterceptor()
+        interceptor.startAutoScrollForTesting()
+        #expect(interceptor.isAutoScrollActive == true)
+
+        interceptor.handleWindowResignKey()
+        #expect(interceptor.isAutoScrollActive == false)
+    }
+
+    @Test func interceptorStopIsIdempotent() {
+        // Calling any stop path twice must not crash and must keep
+        // isAutoScrollActive == false. Important because multiple
+        // safety-net signals (window resign + global mouse up) can
+        // arrive nearly simultaneously when focus moves away.
+        let interceptor = makeInterceptor()
+        interceptor.startAutoScrollForTesting()
+
+        interceptor.handleGlobalMouseUp()
+        #expect(interceptor.isAutoScrollActive == false)
+        interceptor.handleGlobalMouseUp()
+        #expect(interceptor.isAutoScrollActive == false)
+        interceptor.handleWindowResignKey()
+        #expect(interceptor.isAutoScrollActive == false)
+        interceptor.handleActiveTabChange()
+        #expect(interceptor.isAutoScrollActive == false)
+    }
+
+    @Test func interceptorRestartAfterStop() {
+        // After a full mouse-up / mouse-down cycle the interceptor must
+        // be reusable for the next drag. Verifies safety nets are torn
+        // down cleanly and re-installed on the next start.
+        let interceptor = makeInterceptor()
+        interceptor.startAutoScrollForTesting()
+        #expect(interceptor.isAutoScrollActive == true)
+        interceptor.handleGlobalMouseUp()
+        #expect(interceptor.isAutoScrollActive == false)
+
+        interceptor.startAutoScrollForTesting()
+        #expect(interceptor.isAutoScrollActive == true)
+        interceptor.handleGlobalMouseUp()
+        #expect(interceptor.isAutoScrollActive == false)
+    }
+
+    @Test func interceptorStartIsIdempotent() {
+        // Repeated startAutoScrollForTesting() calls must not stack
+        // timers — the existing one is reused. Without this guard we
+        // could leak Timer instances.
+        let interceptor = makeInterceptor()
+        interceptor.startAutoScrollForTesting()
+        let firstActive = interceptor.isAutoScrollActive
+        interceptor.startAutoScrollForTesting()
+        let secondActive = interceptor.isAutoScrollActive
+
+        #expect(firstActive == true)
+        #expect(secondActive == true)
+        // Cleanup
+        interceptor.handleGlobalMouseUp()
+    }
+
+    @Test func interceptorMouseDraggedInsideBoundsDoesNotStartAutoScroll() {
+        // Acceptance criterion from issue #915: cursor inside bounds
+        // must NOT trigger auto-scroll. With no terminalView the early
+        // guard short-circuits, but the contract is the same — the
+        // timer must remain inactive.
+        let interceptor = makeInterceptor()
+        // Simulate user pressing inside the view first.
+        let downEvent = makeMouseEvent(type: .leftMouseDown, at: NSPoint(x: 400, y: 150))
+        interceptor.mouseDown(with: downEvent)
+        #expect(interceptor.isAutoScrollActive == false)
+
+        // Drag inside the bounds — auto-scroll must NOT activate.
+        let dragEvent = makeMouseEvent(type: .leftMouseDragged, at: NSPoint(x: 400, y: 200))
+        interceptor.mouseDragged(with: dragEvent)
+        #expect(interceptor.isAutoScrollActive == false)
     }
 }

--- a/PineTests/TerminalAutoScrollTests.swift
+++ b/PineTests/TerminalAutoScrollTests.swift
@@ -372,6 +372,7 @@ struct TerminalAutoScrollTests {
         #expect(interceptor.isAutoScrollActive == false)
     }
 
+    #if DEBUG
     @Test func interceptorTestHookStartsTimer() {
         let interceptor = makeInterceptor()
         interceptor.startAutoScrollForTesting()
@@ -379,7 +380,9 @@ struct TerminalAutoScrollTests {
         // Cleanup so the timer cannot fire after the test exits.
         interceptor.handleGlobalMouseUp()
     }
+    #endif
 
+    #if DEBUG
     @Test func interceptorMouseDownStopsActiveAutoScroll() {
         // A new mouseDown means the user started a fresh drag — any
         // in-flight auto-scroll from a previous (interrupted) drag must
@@ -392,7 +395,9 @@ struct TerminalAutoScrollTests {
         interceptor.mouseDown(with: event)
         #expect(interceptor.isAutoScrollActive == false)
     }
+    #endif
 
+    #if DEBUG
     @Test func interceptorMouseUpStopsAutoScroll() {
         let interceptor = makeInterceptor()
         interceptor.startAutoScrollForTesting()
@@ -402,7 +407,9 @@ struct TerminalAutoScrollTests {
         interceptor.mouseUp(with: event)
         #expect(interceptor.isAutoScrollActive == false)
     }
+    #endif
 
+    #if DEBUG
     @Test func interceptorMouseDraggedWithoutTerminalStopsAutoScroll() {
         // mouseDragged → updateAutoScroll early-returns when terminalView
         // is nil, which calls stopAutoScroll(). This also covers the
@@ -416,7 +423,9 @@ struct TerminalAutoScrollTests {
         interceptor.mouseDragged(with: event)
         #expect(interceptor.isAutoScrollActive == false)
     }
+    #endif
 
+    #if DEBUG
     @Test func interceptorWindowDetachStopsAutoScroll() {
         // viewWillMove(toWindow: nil) is AppKit's "you are about to be
         // unhooked" signal — the interceptor must drop the timer so it
@@ -428,7 +437,9 @@ struct TerminalAutoScrollTests {
         interceptor.viewWillMove(toWindow: nil)
         #expect(interceptor.isAutoScrollActive == false)
     }
+    #endif
 
+    #if DEBUG
     @Test func interceptorActiveTabChangeStopsAutoScroll() {
         // When the user switches terminal tabs while a drag is active
         // (e.g. clicks another tab), the auto-scroll loop is still
@@ -441,7 +452,9 @@ struct TerminalAutoScrollTests {
         interceptor.handleActiveTabChange()
         #expect(interceptor.isAutoScrollActive == false)
     }
+    #endif
 
+    #if DEBUG
     @Test func interceptorGlobalMouseUpStopsAutoScroll() {
         // Safety net: if the user releases the mouse over another app
         // (Cmd+Tab, Mission Control, the menu bar), the local mouseUp
@@ -455,7 +468,9 @@ struct TerminalAutoScrollTests {
         interceptor.handleGlobalMouseUp()
         #expect(interceptor.isAutoScrollActive == false)
     }
+    #endif
 
+    #if DEBUG
     @Test func interceptorWindowResignKeyStopsAutoScroll() {
         // Belt-and-braces alongside the global mouse-up monitor — losing
         // key status means there is nothing useful auto-scroll can do
@@ -468,7 +483,9 @@ struct TerminalAutoScrollTests {
         interceptor.handleWindowResignKey()
         #expect(interceptor.isAutoScrollActive == false)
     }
+    #endif
 
+    #if DEBUG
     @Test func interceptorStopIsIdempotent() {
         // Calling any stop path twice must not crash and must keep
         // isAutoScrollActive == false. Important because multiple
@@ -486,7 +503,9 @@ struct TerminalAutoScrollTests {
         interceptor.handleActiveTabChange()
         #expect(interceptor.isAutoScrollActive == false)
     }
+    #endif
 
+    #if DEBUG
     @Test func interceptorRestartAfterStop() {
         // After a full mouse-up / mouse-down cycle the interceptor must
         // be reusable for the next drag. Verifies safety nets are torn
@@ -502,7 +521,9 @@ struct TerminalAutoScrollTests {
         interceptor.handleGlobalMouseUp()
         #expect(interceptor.isAutoScrollActive == false)
     }
+    #endif
 
+    #if DEBUG
     @Test func interceptorStartIsIdempotent() {
         // Repeated startAutoScrollForTesting() calls must not stack
         // timers — the existing one is reused. Without this guard we
@@ -518,6 +539,7 @@ struct TerminalAutoScrollTests {
         // Cleanup
         interceptor.handleGlobalMouseUp()
     }
+    #endif
 
     @Test func interceptorMouseDraggedInsideBoundsDoesNotStartAutoScroll() {
         // Acceptance criterion from issue #915: cursor inside bounds

--- a/PineTests/TerminalAutoScrollTests.swift
+++ b/PineTests/TerminalAutoScrollTests.swift
@@ -1,0 +1,357 @@
+//
+//  TerminalAutoScrollTests.swift
+//  PineTests
+//
+//  Tests for the drag-selection auto-scroll feature in the terminal
+//  (issue #915). Pure-math helpers in `TerminalAutoScroll` are tested
+//  exhaustively without timers or AppKit views.
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+@Suite("Terminal Auto-Scroll Tests")
+@MainActor
+struct TerminalAutoScrollTests {
+
+    // MARK: - direction(forPoint:in:)
+
+    private static let standardBounds = CGRect(x: 0, y: 0, width: 800, height: 300)
+
+    @Test func directionInsideBoundsIsNil() {
+        let direction = TerminalAutoScroll.direction(
+            forPoint: CGPoint(x: 400, y: 150),
+            in: Self.standardBounds
+        )
+        #expect(direction == nil)
+    }
+
+    @Test func directionAboveTopEdgeIsUp() {
+        let direction = TerminalAutoScroll.direction(
+            forPoint: CGPoint(x: 400, y: -1),
+            in: Self.standardBounds
+        )
+        #expect(direction == .up)
+    }
+
+    @Test func directionFarAboveTopEdgeIsUp() {
+        let direction = TerminalAutoScroll.direction(
+            forPoint: CGPoint(x: 400, y: -500),
+            in: Self.standardBounds
+        )
+        #expect(direction == .up)
+    }
+
+    @Test func directionBelowBottomEdgeIsDown() {
+        let direction = TerminalAutoScroll.direction(
+            forPoint: CGPoint(x: 400, y: 301),
+            in: Self.standardBounds
+        )
+        #expect(direction == .down)
+    }
+
+    @Test func directionFarBelowBottomEdgeIsDown() {
+        let direction = TerminalAutoScroll.direction(
+            forPoint: CGPoint(x: 400, y: 100_000),
+            in: Self.standardBounds
+        )
+        #expect(direction == .down)
+    }
+
+    @Test func directionExactlyOnTopEdgeIsNil() {
+        // Cursor sitting exactly on the top edge should not trigger
+        // auto-scroll, mirroring NSTextView behaviour.
+        let direction = TerminalAutoScroll.direction(
+            forPoint: CGPoint(x: 400, y: 0),
+            in: Self.standardBounds
+        )
+        #expect(direction == nil)
+    }
+
+    @Test func directionExactlyOnBottomEdgeIsNil() {
+        let direction = TerminalAutoScroll.direction(
+            forPoint: CGPoint(x: 400, y: 300),
+            in: Self.standardBounds
+        )
+        #expect(direction == nil)
+    }
+
+    @Test func directionForXOutsideBoundsStillFollowsYAxis() {
+        // Horizontal axis is irrelevant — only y matters because the
+        // terminal scrolls vertically. A point off the right edge but
+        // vertically inside should not trigger auto-scroll.
+        let direction = TerminalAutoScroll.direction(
+            forPoint: CGPoint(x: 5_000, y: 150),
+            in: Self.standardBounds
+        )
+        #expect(direction == nil)
+    }
+
+    @Test func directionForZeroHeightBoundsIsNil() {
+        // Collapsed pane — no terminal area to scroll over. Must not crash
+        // and must not return a direction.
+        let direction = TerminalAutoScroll.direction(
+            forPoint: CGPoint(x: 100, y: 100),
+            in: CGRect(x: 0, y: 0, width: 800, height: 0)
+        )
+        #expect(direction == nil)
+    }
+
+    @Test func directionForZeroWidthBoundsIsNil() {
+        let direction = TerminalAutoScroll.direction(
+            forPoint: CGPoint(x: 100, y: 100),
+            in: CGRect(x: 0, y: 0, width: 0, height: 300)
+        )
+        #expect(direction == nil)
+    }
+
+    // MARK: - edgeDistance(forPoint:in:)
+
+    @Test func edgeDistanceInsideBoundsIsZero() {
+        let distance = TerminalAutoScroll.edgeDistance(
+            forPoint: CGPoint(x: 400, y: 150),
+            in: Self.standardBounds
+        )
+        #expect(distance == 0)
+    }
+
+    @Test func edgeDistanceExactlyOnTopEdgeIsZero() {
+        let distance = TerminalAutoScroll.edgeDistance(
+            forPoint: CGPoint(x: 400, y: 0),
+            in: Self.standardBounds
+        )
+        #expect(distance == 0)
+    }
+
+    @Test func edgeDistanceExactlyOnBottomEdgeIsZero() {
+        let distance = TerminalAutoScroll.edgeDistance(
+            forPoint: CGPoint(x: 400, y: 300),
+            in: Self.standardBounds
+        )
+        #expect(distance == 0)
+    }
+
+    @Test func edgeDistanceOnePixelBelowIsOne() {
+        let distance = TerminalAutoScroll.edgeDistance(
+            forPoint: CGPoint(x: 400, y: 301),
+            in: Self.standardBounds
+        )
+        #expect(distance == 1)
+    }
+
+    @Test func edgeDistanceOnePixelAboveIsOne() {
+        let distance = TerminalAutoScroll.edgeDistance(
+            forPoint: CGPoint(x: 400, y: -1),
+            in: Self.standardBounds
+        )
+        #expect(distance == 1)
+    }
+
+    @Test func edgeDistanceFarBelowIsBigPositive() {
+        let distance = TerminalAutoScroll.edgeDistance(
+            forPoint: CGPoint(x: 400, y: 600),
+            in: Self.standardBounds
+        )
+        #expect(distance == 300)
+    }
+
+    @Test func edgeDistanceFarAboveIsBigPositive() {
+        let distance = TerminalAutoScroll.edgeDistance(
+            forPoint: CGPoint(x: 400, y: -250),
+            in: Self.standardBounds
+        )
+        #expect(distance == 250)
+    }
+
+    @Test func edgeDistanceForZeroHeightBoundsIsZero() {
+        let distance = TerminalAutoScroll.edgeDistance(
+            forPoint: CGPoint(x: 100, y: 100),
+            in: CGRect(x: 0, y: 0, width: 800, height: 0)
+        )
+        #expect(distance == 0)
+    }
+
+    @Test func edgeDistanceWithOriginOffset() {
+        // Bounds origin should not be assumed to be (0, 0).
+        let bounds = CGRect(x: 0, y: 50, width: 800, height: 300)
+        // Point above minY (50)
+        #expect(TerminalAutoScroll.edgeDistance(
+            forPoint: CGPoint(x: 100, y: 30),
+            in: bounds
+        ) == 20)
+        // Point below maxY (350)
+        #expect(TerminalAutoScroll.edgeDistance(
+            forPoint: CGPoint(x: 100, y: 400),
+            in: bounds
+        ) == 50)
+        // Point inside
+        #expect(TerminalAutoScroll.edgeDistance(
+            forPoint: CGPoint(x: 100, y: 200),
+            in: bounds
+        ) == 0)
+    }
+
+    // MARK: - linesPerTick(forDistance:)
+
+    @Test func linesPerTickAtZeroDistanceIsZero() {
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: 0) == 0)
+    }
+
+    @Test func linesPerTickAtOnePixelIsOne() {
+        // Tiny but non-zero distance should still scroll exactly one line
+        // per tick — this is what makes the feature feel responsive when
+        // the user just barely overshoots the edge.
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: 1) == 1)
+    }
+
+    @Test func linesPerTickAtOneStepStaysOne() {
+        // 20 px is exactly one step; floor(20/20) = 1 → 1 line.
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: 20) == 1)
+    }
+
+    @Test func linesPerTickJustBelowOneStepStaysOne() {
+        // 19 px → floor(19/20) = 0 → clamped up to 1.
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: 19) == 1)
+    }
+
+    @Test func linesPerTickAtTwoStepsIsTwo() {
+        // 40 px → floor(40/20) = 2 → 2 lines.
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: 40) == 2)
+    }
+
+    @Test func linesPerTickAtMaxIsCapped() {
+        // 200 px → 10, clamped to maxLinesPerTick (8).
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: 200) == TerminalAutoScroll.maxLinesPerTick)
+    }
+
+    @Test func linesPerTickFarBeyondMaxStaysCapped() {
+        // Runaway protection: a fling 10 000 px below should still cap
+        // at maxLinesPerTick — never pump dozens of lines per tick.
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: 10_000) == TerminalAutoScroll.maxLinesPerTick)
+    }
+
+    @Test func linesPerTickForNegativeDistanceIsZero() {
+        // Defensive — direction encodes sign, distance is always non-negative.
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: -1) == 0)
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: -1_000) == 0)
+    }
+
+    @Test func linesPerTickForFractionalDistance() {
+        // 30.5 → floor(30.5/20) = floor(1.525) = 1 → 1 line.
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: 30.5) == 1)
+        // 41 → floor(41/20) = floor(2.05) = 2 → 2 lines.
+        #expect(TerminalAutoScroll.linesPerTick(forDistance: 41) == 2)
+    }
+
+    @Test func linesPerTickIsMonotonic() {
+        // The ramp must be monotonic non-decreasing across the full range
+        // we care about, so larger overshoots never scroll less.
+        var previous = 0
+        for distance in stride(from: CGFloat(0), through: CGFloat(400), by: 1) {
+            let lines = TerminalAutoScroll.linesPerTick(forDistance: distance)
+            #expect(lines >= previous)
+            previous = lines
+        }
+    }
+
+    @Test func linesPerTickNeverExceedsCeiling() {
+        // Property check: under no input does linesPerTick exceed
+        // maxLinesPerTick.
+        for distance in stride(from: CGFloat(0), through: CGFloat(20_000), by: 7.5) {
+            #expect(TerminalAutoScroll.linesPerTick(forDistance: distance) <= TerminalAutoScroll.maxLinesPerTick)
+        }
+    }
+
+    // MARK: - Tick interval and constants are sane
+
+    @Test func tickIntervalIsBetween30And120Hz() {
+        // ~60 ms is the design target. Guard against accidentally setting
+        // it to 0 (busy loop) or > 1 s (sluggish).
+        #expect(TerminalAutoScroll.tickInterval > 0)
+        #expect(TerminalAutoScroll.tickInterval < 1.0)
+    }
+
+    @Test func maxLinesPerTickIsReasonable() {
+        // Should be high enough to feel fast at the edges, low enough
+        // to not jump entire pages per tick.
+        #expect(TerminalAutoScroll.maxLinesPerTick > 0)
+        #expect(TerminalAutoScroll.maxLinesPerTick <= 32)
+    }
+
+    @Test func pointsPerLineStepIsPositive() {
+        #expect(TerminalAutoScroll.pointsPerLineStep > 0)
+    }
+
+    // MARK: - TerminalScrollInterceptor lifecycle
+
+    @Test func interceptorMouseDownClearsLastDragEvent() {
+        // mouseDown should reset any in-flight auto-scroll state from a
+        // previous drag (defensive — the timer is normally stopped on
+        // mouseUp, but we want a hard reset on the next press).
+        let interceptor = TerminalScrollInterceptor()
+        interceptor.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        // No terminalView attached; we just want to assert this does not
+        // crash and leaves the interceptor in a clean state. A nil
+        // terminalView short-circuits all mouse forwarding.
+        let event = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: NSPoint(x: 100, y: 100),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 0
+        )
+        if let event {
+            interceptor.mouseDown(with: event)
+        }
+        // Direct API: there is no public way to assert "timer not running"
+        // without exposing internals; the lifecycle is covered indirectly
+        // by the deinit / window-detach paths below. This test mainly
+        // pins that mouseDown does not crash with no terminal attached.
+    }
+
+    @Test func interceptorMouseUpDoesNotCrashWithoutTerminal() {
+        let interceptor = TerminalScrollInterceptor()
+        interceptor.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        let event = NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: NSPoint(x: 100, y: 100),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 0
+        )
+        if let event {
+            interceptor.mouseUp(with: event)
+        }
+        // Just assert we got here.
+        #expect(true)
+    }
+
+    @Test func interceptorMouseDraggedDoesNotCrashWithoutTerminal() {
+        let interceptor = TerminalScrollInterceptor()
+        interceptor.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        let event = NSEvent.mouseEvent(
+            with: .leftMouseDragged,
+            location: NSPoint(x: 100, y: 600), // outside, should try to start auto-scroll
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 0
+        )
+        if let event {
+            interceptor.mouseDragged(with: event)
+        }
+        #expect(true)
+    }
+}


### PR DESCRIPTION
Closes #915

## Summary

Restores standard macOS `NSTextView` behaviour (TextEdit, Xcode, Safari, Notes) that was missing from SwiftTerm 1.13.0: when the user drags a mouse selection past the top or bottom edge of the terminal, the scrollback now auto-scrolls and the selection extends into the freshly revealed lines. This was tracked as issue #915 — `ls -la /usr/bin` and similar long-output commands could not be selected in a single gesture.

## Implementation

- New `Pine/TerminalAutoScroll.swift` — pure helpers for direction (up / down / nil) and a `linesPerTick` ramp (1 line per 20 px overshoot, capped at 8 lines/tick to prevent runaway). Zero timers, zero AppKit — just `CGFloat` math.
- `TerminalScrollInterceptor` (`Pine/TerminalSession.swift`) gains an auto-scroll `Timer` (`tickInterval = 60 ms`, `.common` run-loop mode so it fires during AppKit mouse tracking). On each tick it:
  1. Calls SwiftTerm's public `scrollUp(lines:)` / `scrollDown(lines:)`.
  2. Replays the last `mouseDragged` event so `MacTerminalView.calculateMouseHit` recomputes `bufferRow = row + yDisp` against the new `yDisp` and `selection.dragExtend` covers the freshly revealed line.
- The loop disables itself when `terminal.mouseMode != .off` (TUI mouse reporting), `terminal.isCurrentBufferAlternate` (vim/htop), or when `scrollPosition` already pinned at 0 / 1 — so it never burns CPU spinning against the edge.
- `viewWillMove(toWindow: nil)` invalidates the timer on tab close / app quit. (No `deinit` cleanup — `Timer` retains `self`, so the view cannot deallocate while the timer is alive; trying to touch the timer from a nonisolated `deinit` would require unsafe Sendable hops.)
- Why this couldn't be done by deferring to SwiftTerm: SwiftTerm has dead `autoScrollDelta` / `scrollingTimerElapsed` plumbing in `MacTerminalView`, but the timer is never started anywhere, so the feature does not work in 1.13.0. We use SwiftTerm's stable public scroll API and keep the fix entirely in Pine.

## Test plan

- [x] **Unit tests** (`PineTests/TerminalAutoScrollTests.swift`) — 36 new tests: direction inside / above / below / on each edge / zero bounds / origin offset; `edgeDistance` boundary and far cases; `linesPerTick` ramp at 0 / 1 / 19 / 20 / 40 / 200 / 10 000 / negative / fractional; monotonicity sweep; ceiling sweep; tick-interval and constant sanity; interceptor lifecycle (mouseDown / mouseUp / mouseDragged) without a terminal attached.
- [x] **Build** — `xcodebuild -scheme Pine build` → BUILD SUCCEEDED.
- [x] **SwiftLint** — clean (0 violations) on all three changed files.
- [x] **Existing terminal suites** still green (`TerminalScrollForwardingTests`, `TerminalTabTests`, `TerminalManagerTests`, `TerminalManagerCoordinatorTests`, `TerminalPaneStateTests`, `SendToTerminalTests`, `TerminalPaletteTests`, `TerminalThemeTests`, `TerminalTabReorderTests`, `TerminalTabDragBetweenPanesTests` — 275 tests across 10 suites pass).
- [ ] **Visual smoke (manual, by maintainer)** — please run the Debug build locally and confirm:
  - `ls -la /usr/bin` in a Pine terminal, drag past the bottom edge → scrollback scrolls smoothly, selection grows; far overshoot scrolls fast but stays bounded; pin to bottom → no CPU spin.
  - Same dragging past the top edge after scrolling up.
  - Open `vim` or `htop`, attempt to drag — auto-scroll does **not** activate; mouse events flow to the TUI as before.

I was not able to perform the drag-mouse visual check from this CLI environment (cannot manipulate the cursor inside the running app to verify dynamic selection growth). All non-interactive verification steps above are green; please give it a manual visual sanity-check before merge.