### PR TITLE
ci: always run full test matrix on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,76 +23,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  # Detect whether the PR/push touches only docs/config files.
-  # When only non-code files change, downstream jobs are skipped —
-  # GitHub treats skipped required checks as passed because
-  # strict_required_status_checks_policy is OFF in branch protection.
-  # If strict policy is ever enabled, skipped jobs will BLOCK merges.
-  changes:
-    name: Detect Changes
-    runs-on: ubuntu-latest
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          # Full history so the base SHA is always reachable. Shallow checkout
-          # used to silently break the diff when base wasn't in the shallow
-          # window, treating real code changes as docs-only and skipping every
-          # downstream job. See #751.
-          fetch-depth: 0
-
-      - name: Check for code changes
-        id: filter
-        # Strict mode: any failure here MUST surface, never silently fall
-        # through to "skip everything". See #751 for the postmortem.
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-            HEAD="${{ github.event.pull_request.head.sha }}"
-          else
-            BASE="${{ github.event.before }}"
-            HEAD="${{ github.sha }}"
-          fi
-
-          # On branch creation, github.event.before is the null SHA — fall back to parent
-          if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
-            BASE="HEAD~1"
-          fi
-
-          # Sanity check: both SHAs MUST be reachable. If not (e.g. shallow
-          # clone window doesn't cover the base), we default to running all
-          # jobs rather than silently skipping them. "Fail safe", not "fail
-          # open" — better to waste a few CI minutes than to merge untested
-          # code on a green checkmark.
-          if ! git rev-parse --verify --quiet "$BASE^{commit}" >/dev/null \
-             || ! git rev-parse --verify --quiet "$HEAD^{commit}" >/dev/null; then
-            echo "::warning::Base or head SHA unreachable (BASE=$BASE HEAD=$HEAD); running all CI jobs as safety fallback"
-            echo "code=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # List changed files, exclude docs/config-only paths.
-          # Note: no `|| true` — pipefail will catch git errors loudly.
-          CHANGED=$(git diff --name-only "$BASE" "$HEAD" \
-            | grep -cvE '^(.*\.md|docs/.*|assets/.*|LICENSE|\.github/ISSUE_TEMPLATE/.*|\.release-please-manifest\.json|release-please-config\.json)$' \
-            || CHANGED=0)
-
-          if [ "$CHANGED" -gt 0 ]; then
-            echo "code=true" >> "$GITHUB_OUTPUT"
-            echo "Code changes detected ($CHANGED files)"
-          else
-            echo "code=false" >> "$GITHUB_OUTPUT"
-            echo "Docs-only changes, skipping CI jobs"
-          fi
-
   lint:
     name: SwiftLint
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     env:
       SWIFTLINT_VERSION: "0.63.2"
@@ -120,8 +52,6 @@ jobs:
 
   build:
     name: Build for Testing
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -513,8 +443,6 @@ jobs:
   # Fails CI if someone adds a new test class and forgets to shard it.
   verify-ui-shards:
     name: Verify UI Test Shards
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

- Remove the `Detect Changes` job and the `needs: changes` / `if: needs.changes.outputs.code == 'true'` predicates from `lint`, `build`, and `verify-ui-shards` in `.github/workflows/ci.yml`.
- SwiftLint, Build for Testing, Unit Tests, the UI Test shard matrix, Verify UI Test Shards, and Flaky Test Summary now always run on every PR, regardless of which files changed.
- The Docs workflow (`docs.yml`) is unchanged — it still runs as a separate cheap job on docs-only diffs. The on-demand `Performance Tests` job keeps its existing `workflow_dispatch` + `perf`-label trigger.

## Why

Branch protection requires status checks to report `SUCCESS`. GitHub reports skipped jobs as `SKIPPED`, not `SUCCESS`, so docs-only PRs were blocked from merging:

> 7 of 11 required status checks are expected

This affected stale docs-only PRs like #875 (`docs/update-claude-md`). With this change PR #875 will become mergeable once the full matrix runs and goes green.

The CI minutes cost on docs-only PRs is small (and rare), and predictability of "every PR runs the same checks" is worth it. Removing the dead `changes` detection logic also drops ~70 lines of bash that historically caused subtle bugs (e.g. #751, where shallow checkout silently treated code changes as docs-only).

## Test plan

- [ ] CI runs the full matrix on this PR (this PR itself touches CI, so all jobs should run regardless).
- [ ] After merge, re-run CI on PR #875 (docs-only) and confirm Build / Unit Tests / UI Test shards / SwiftLint / Flaky Summary all execute and report SUCCESS.
- [ ] Confirm `Performance Tests (on-demand)` still does NOT run on PRs that lack the `perf` label.