### PR TITLE
Fix tfvars URL syntax highlighting

### DIFF
--- a/Pine/SyntaxHighlighter.swift
+++ b/Pine/SyntaxHighlighter.swift
@@ -916,7 +916,7 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
         let multilineRange = fullRange
 
         var matches: [HighlightMatch] = []
-        var highlightedRanges: [(range: NSRange, priority: Int)] = []
+        var highlightedRanges: [(range: NSRange, priority: Int, scope: String)] = []
         // Fingerprint is collected inline during the main iteration to avoid
         // a redundant second full-text scan of multiline rules (see #789 review).
         var multilineFingerprint: [Int] = []
@@ -947,16 +947,37 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
                 let clipped = NSIntersectionRange(matchRange, repaintRange)
                 guard clipped.length > 0 else { return }
 
-                let isOverridden = highlightedRanges.contains { existing in
-                    existing.priority > priority &&
-                    NSIntersectionRange(existing.range, clipped).length > 0
+                var isOverridden = false
+                var lexicalRangesToReplace: [NSRange] = []
+                for existing in highlightedRanges {
+                    guard NSIntersectionRange(existing.range, clipped).length > 0 else {
+                        continue
+                    }
+                    if self.areMutuallyExclusiveLexicalScopes(rule.scope, existing.scope) {
+                        if NSLocationInRange(clipped.location, existing.range) {
+                            isOverridden = true
+                            break
+                        }
+                        lexicalRangesToReplace.append(existing.range)
+                        continue
+                    }
+                    if existing.priority > priority {
+                        isOverridden = true
+                        break
+                    }
                 }
 
                 if !isOverridden {
+                    if !lexicalRangesToReplace.isEmpty {
+                        highlightedRanges.removeAll { existing in
+                            self.areMutuallyExclusiveLexicalScopes(rule.scope, existing.scope) &&
+                            lexicalRangesToReplace.contains { NSEqualRanges($0, existing.range) }
+                        }
+                    }
                     matches.append(HighlightMatch(
                         range: clipped, scope: rule.scope, priority: priority
                     ))
-                    highlightedRanges.append((range: clipped, priority: priority))
+                    highlightedRanges.append((range: clipped, priority: priority, scope: rule.scope))
                 }
             }
         }
@@ -976,6 +997,10 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
             repaintRange: repaintRange,
             multilineFingerprint: fingerprint
         )
+    }
+
+    private func areMutuallyExclusiveLexicalScopes(_ lhs: String, _ rhs: String) -> Bool {
+        (lhs == "comment" && rhs == "string") || (lhs == "string" && rhs == "comment")
     }
 
     /// Applies pre-computed matches to NSTextStorage.

--- a/Pine/SyntaxHighlighter.swift
+++ b/Pine/SyntaxHighlighter.swift
@@ -916,7 +916,9 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
         let multilineRange = fullRange
 
         var matches: [HighlightMatch] = []
-        var highlightedRanges: [(range: NSRange, priority: Int, scope: String)] = []
+        var highlightedRanges: [
+            (repaintRange: NSRange, originalRange: NSRange, priority: Int, scope: String)
+        ] = []
         // Fingerprint is collected inline during the main iteration to avoid
         // a redundant second full-text scan of multiline rules (see #789 review).
         var multilineFingerprint: [Int] = []
@@ -950,15 +952,15 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
                 var isOverridden = false
                 var lexicalRangesToReplace: [NSRange] = []
                 for existing in highlightedRanges {
-                    guard NSIntersectionRange(existing.range, clipped).length > 0 else {
+                    guard NSIntersectionRange(existing.repaintRange, clipped).length > 0 else {
                         continue
                     }
                     if self.areMutuallyExclusiveLexicalScopes(rule.scope, existing.scope) {
-                        if NSLocationInRange(clipped.location, existing.range) {
+                        if NSLocationInRange(matchRange.location, existing.originalRange) {
                             isOverridden = true
                             break
                         }
-                        lexicalRangesToReplace.append(existing.range)
+                        lexicalRangesToReplace.append(existing.originalRange)
                         continue
                     }
                     if existing.priority > priority {
@@ -971,13 +973,18 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
                     if !lexicalRangesToReplace.isEmpty {
                         highlightedRanges.removeAll { existing in
                             self.areMutuallyExclusiveLexicalScopes(rule.scope, existing.scope) &&
-                            lexicalRangesToReplace.contains { NSEqualRanges($0, existing.range) }
+                            lexicalRangesToReplace.contains { NSEqualRanges($0, existing.originalRange) }
                         }
                     }
                     matches.append(HighlightMatch(
                         range: clipped, scope: rule.scope, priority: priority
                     ))
-                    highlightedRanges.append((range: clipped, priority: priority, scope: rule.scope))
+                    highlightedRanges.append((
+                        repaintRange: clipped,
+                        originalRange: matchRange,
+                        priority: priority,
+                        scope: rule.scope
+                    ))
                 }
             }
         }

--- a/PineTests/TerraformGrammarTests.swift
+++ b/PineTests/TerraformGrammarTests.swift
@@ -107,6 +107,36 @@ struct TerraformGrammarTests {
         #expect(textStorage.attribute(.foregroundColor, at: quotePos, effectiveRange: nil) as? NSColor == commentColor)
     }
 
+    @Test func partialHeredocRepaintKeepsSlashSlashLineAsString() throws {
+        let highlighter = SyntaxHighlighter.shared
+        let text = """
+        payload = <<EOF
+        line 1
+        // not a comment
+        line 3
+        EOF
+        """
+        let source = text as NSString
+        let repaintStart = source.range(of: "// not a comment").location
+        let repaintRange = NSRange(location: repaintStart, length: source.length - repaintStart)
+        let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+        let result = try #require(highlighter.computeMatches(
+            text: text,
+            language: "tfvars",
+            repaintRange: repaintRange,
+            searchRange: repaintRange
+        ))
+        let textStorage = NSTextStorage(string: text)
+        highlighter.applyMatches(result, to: textStorage, font: font)
+
+        let stringColor = try #require(highlighter.theme.color(for: "string"))
+        let commentColor = try #require(highlighter.theme.color(for: "comment"))
+
+        #expect(textStorage.attribute(.foregroundColor, at: repaintStart, effectiveRange: nil) as? NSColor == stringColor)
+        #expect(textStorage.attribute(.foregroundColor, at: repaintStart, effectiveRange: nil) as? NSColor != commentColor)
+    }
+
     // MARK: - Interpolation
 
     @Test func interpolationExpression() {

--- a/PineTests/TerraformGrammarTests.swift
+++ b/PineTests/TerraformGrammarTests.swift
@@ -5,6 +5,7 @@
 
 import Testing
 import Foundation
+import AppKit
 @testable import Pine
 
 @MainActor
@@ -71,6 +72,39 @@ struct TerraformGrammarTests {
     @Test func doubleQuotedString() {
         let rule = grammar.rules.first { $0.scope == "string" && $0.pattern.contains("\"") }
         #expect(rule != nil)
+    }
+
+    @Test func urlStringDoesNotTreatSlashSlashAsComment() throws {
+        let highlighter = SyntaxHighlighter.shared
+        let text = #"virtual_environment_endpoint = "https://10.206.101.10:8006/""#
+        let textStorage = NSTextStorage(string: text)
+        let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+        highlighter.highlight(textStorage: textStorage, language: "tfvars", font: font)
+
+        let stringColor = try #require(highlighter.theme.color(for: "string"))
+        let commentColor = try #require(highlighter.theme.color(for: "comment"))
+        let source = text as NSString
+        let schemePos = source.range(of: "https:").location
+        let slashSlashPos = source.range(of: "//10").location
+
+        #expect(textStorage.attribute(.foregroundColor, at: schemePos, effectiveRange: nil) as? NSColor == stringColor)
+        #expect(textStorage.attribute(.foregroundColor, at: slashSlashPos, effectiveRange: nil) as? NSColor == stringColor)
+        #expect(textStorage.attribute(.foregroundColor, at: slashSlashPos, effectiveRange: nil) as? NSColor != commentColor)
+    }
+
+    @Test func quotedTextInsideLineCommentRemainsComment() throws {
+        let highlighter = SyntaxHighlighter.shared
+        let text = #"// "https://example.com""#
+        let textStorage = NSTextStorage(string: text)
+        let font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+
+        highlighter.highlight(textStorage: textStorage, language: "tfvars", font: font)
+
+        let commentColor = try #require(highlighter.theme.color(for: "comment"))
+        let quotePos = (text as NSString).range(of: "\"").location
+
+        #expect(textStorage.attribute(.foregroundColor, at: quotePos, effectiveRange: nil) as? NSColor == commentColor)
     }
 
     // MARK: - Interpolation


### PR DESCRIPTION
## Summary
- keep quoted tfvars URL values highlighted as strings when they contain `//`
- preserve comment highlighting for quoted text inside line comments
- add Terraform grammar regression coverage

## Tests
- `xcodebuild test -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -derivedDataPath /tmp/pine-tfvars-highlight-test -only-testing:PineTests/TerraformGrammarTests`\n- `xcodebuild test -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -derivedDataPath /tmp/pine-tfvars-highlight-test -only-testing:PineTests/SyntaxHighlighterTests`