### PR TITLE
fix(terminal): redraw and SIGWINCH on re-parent for TUI alternate screen

### DIFF
--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -348,6 +348,12 @@ class TerminalContainerView: NSView {
     private let scrollInterceptor = TerminalScrollInterceptor()
     private var scrollMonitor: Any?
     private var accumulatedScrollDelta: CGFloat = 0
+    /// Notification observer that re-renders the active terminal when the
+    /// host window regains key focus. After a long Cmd+Tab into another app
+    /// AppKit may discard the layer's backing store; without this observer
+    /// the TUI alternate-screen content would stay blank until the next
+    /// keystroke or process tick.
+    private var becomeKeyObserver: NSObjectProtocol?
 
     func showTab(_ tab: TerminalTab?) {
         guard let tab else {
@@ -378,7 +384,6 @@ class TerminalContainerView: NSView {
             addSubview(scrollInterceptor)
 
             tab.terminalView.needsLayout = true
-            tab.terminalView.needsDisplay = true
 
             // Adding a second tab to an existing pane does not change the
             // container's bounds, so AppKit does NOT call `layout()` on its
@@ -386,9 +391,7 @@ class TerminalContainerView: NSView {
             // runs (issue #918). Without this, the new tab's PTY never spawns
             // and its `LocalProcessTerminalView` paints empty until the user
             // resizes the pane (which forces a fresh layout pass). Kick the
-            // process directly here using the frame we just installed, then
-            // also mark ourselves dirty so AppKit performs a final layout
-            // pass to reconcile any subsequent geometry change.
+            // process directly here using the frame we just installed.
             //
             // Only start when the container has REAL bounds — when the
             // container is zero-sized (first SwiftUI layout pass) we
@@ -402,14 +405,18 @@ class TerminalContainerView: NSView {
             self.needsLayout = true
             self.needsDisplay = true
 
-            // Force a synchronous redraw of the freshly inserted SwiftTerm
-            // view. SwiftTerm renders into a CALayer; `needsDisplay` only
-            // schedules the redraw, and the layer can stay blank for one
-            // tick while waiting for the next display loop. A synchronous
-            // pass guarantees the content appears on the *same* runloop
-            // turn as the tab swap, avoiding the visible black flash users
-            // saw when adding a second tab.
-            tab.terminalView.displayIfNeeded()
+            // Force a synchronous full repaint from the SwiftTerm display
+            // buffer. After re-parenting the layer's backing store may be
+            // empty, and TUI apps in alternate screen (k9s, htop, vim) won't
+            // emit any data on their own. `forceFullRedraw` covers the case
+            // where the buffer is valid but the layer is blank; for alternate
+            // screen specifically the buffer may also be blank because the
+            // TUI hasn't redrawn itself yet — `kickPTYWindowSize` raises
+            // SIGWINCH to nudge it.
+            tab.forceFullRedraw()
+            if tab.terminalView.getTerminal().isCurrentBufferAlternate {
+                tab.kickPTYWindowSize()
+            }
         }
 
         installScrollMonitor()
@@ -510,7 +517,27 @@ class TerminalContainerView: NSView {
 
     override func removeFromSuperview() {
         removeScrollMonitor()
+        removeBecomeKeyObserver()
         super.removeFromSuperview()
+    }
+
+    private func removeBecomeKeyObserver() {
+        if let observer = becomeKeyObserver {
+            NotificationCenter.default.removeObserver(observer)
+            becomeKeyObserver = nil
+        }
+    }
+
+    /// Repaints the active terminal and (for TUI apps in alternate screen)
+    /// raises SIGWINCH so the child redraws. Used by `viewDidMoveToWindow`
+    /// and the window-become-key observer.
+    private func refreshActiveTerminalAfterReparent() {
+        guard let tab = terminalPaneState?.activeTab,
+              tab.terminalView.superview === self else { return }
+        tab.forceFullRedraw()
+        if tab.terminalView.getTerminal().isCurrentBufferAlternate {
+            tab.kickPTYWindowSize()
+        }
     }
 
     /// Requests first responder on the terminal view.
@@ -527,12 +554,22 @@ class TerminalContainerView: NSView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        guard window != nil else { return }
-        guard let terminalPaneState, let tab = terminalPaneState.activeTab else { return }
-        if tab.terminalView.superview === self {
-            tab.terminalView.needsLayout = true
-            tab.terminalView.needsDisplay = true
+        // Window changed (attach/detach/reparent) — wire up the
+        // become-key observer to the new host window (or remove it if we
+        // no longer have a window).
+        removeBecomeKeyObserver()
+        guard let win = window else { return }
+        becomeKeyObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didBecomeKeyNotification,
+            object: win,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshActiveTerminalAfterReparent()
         }
+        // First repaint after attaching to the window — `displayIfNeeded`
+        // inside `showTab` is a no-op when the container had no window yet,
+        // so this is the first chance to actually paint the SwiftTerm view.
+        refreshActiveTerminalAfterReparent()
     }
 
     override func layout() {
@@ -543,19 +580,27 @@ class TerminalContainerView: NSView {
         // terminal which renders as a blank screen (issue #661).
         guard bounds.size.width > 0, bounds.size.height > 0 else { return }
         if tab.terminalView.superview === self {
-            // Terminal view is already in the hierarchy — just update its frame.
+            // Terminal view is already in the hierarchy — update its frame.
+            // Track whether the frame actually changed so we can force a
+            // redraw afterwards; SwiftTerm only emits SIGWINCH when cols/rows
+            // change, so a layout pass that shifts pixels by less than one
+            // cell would otherwise leave a TUI app's alternate screen blank.
+            let frameChanged = tab.terminalView.frame.size != bounds.size
             tab.terminalView.frame = bounds
             tab.terminalView.needsLayout = true
-            tab.terminalView.needsDisplay = true
             scrollInterceptor.frame = bounds
             tab.startIfNeeded()
+            if frameChanged {
+                tab.forceFullRedraw()
+                if tab.terminalView.getTerminal().isCurrentBufferAlternate {
+                    tab.kickPTYWindowSize()
+                }
+            }
         } else {
             // Terminal view was removed (e.g. tab switch race) — re-add it.
-            // Always set needsDisplay here because showTab just inserted a fresh
-            // subview that has never been drawn at this container's size.
+            // `showTab` already calls `forceFullRedraw` after the insert.
             showTab(tab)
             tab.terminalView.needsLayout = true
-            tab.terminalView.needsDisplay = true
             tab.startIfNeeded()
         }
     }
@@ -757,6 +802,52 @@ final class TerminalTab: Identifiable, Hashable {
         guard !isTerminated else { return }
         isTerminated = true
         terminalView.terminate()
+    }
+
+    /// Forces SwiftTerm to mark the entire visible buffer as dirty and the
+    /// view to redraw synchronously.
+    ///
+    /// Used after re-parenting the terminal view (tab switch, pane split,
+    /// maximize/restore, drag-and-drop) and when the host window regains
+    /// key focus. AppKit may have dropped the layer's backing store while
+    /// the view was detached, leaving a black frame after re-attach.
+    /// `setNeedsDisplay(bounds)` + `displayIfNeeded()` is enough to
+    /// repaint from `displayBuffer`, since SwiftTerm's `draw(_:)` paints
+    /// the full visible buffer for any `dirtyRect` it receives.
+    /// `terminal.updateFullScreen()` additionally seeds the dirty range
+    /// in case SwiftTerm's own throttled `updateDisplay` is the next path
+    /// to fire (e.g. on incoming PTY data).
+    ///
+    /// Safe to call when the view is detached from a window — AppKit
+    /// silently no-ops `displayIfNeeded()` in that state.
+    func forceFullRedraw() {
+        let term = terminalView.getTerminal()
+        term.updateFullScreen()
+        terminalView.setNeedsDisplay(terminalView.bounds)
+        terminalView.displayIfNeeded()
+    }
+
+    /// Sends the current PTY window size again via `TIOCSWINSZ`, which
+    /// raises `SIGWINCH` in the child process.
+    ///
+    /// Most TUI applications (k9s, htop, vim, less +F, tmux, btop) repaint
+    /// their entire alternate screen in response to `SIGWINCH`. After
+    /// re-parenting the terminal view, the alternate-screen buffer that
+    /// SwiftTerm holds may be empty (the TUI hasn't sent anything since
+    /// the last input) — `forceFullRedraw()` alone would just paint the
+    /// empty buffer. This method nudges the TUI to redraw itself.
+    ///
+    /// No-op when the process isn't running or the PTY fd is invalid.
+    /// Idempotent — sending the same winsize twice is harmless.
+    func kickPTYWindowSize() {
+        guard isProcessRunning else { return }
+        let fd = terminalView.process.childfd
+        guard fd >= 0 else { return }
+        var size = terminalView.getWindowSize()
+        _ = PseudoTerminalHelpers.setWinSize(
+            masterPtyDescriptor: fd,
+            windowSize: &size
+        )
     }
 
     /// Whether the shell process is still running.

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -354,6 +354,11 @@ class TerminalContainerView: NSView {
     /// the TUI alternate-screen content would stay blank until the next
     /// keystroke or process tick.
     private var becomeKeyObserver: NSObjectProtocol?
+    /// The window we are currently observing for `didBecomeKey`. Tracked
+    /// separately because `NSObjectProtocol` does not expose its target,
+    /// so without this we would tear down and re-install the observer on
+    /// every `viewDidMoveToWindow` even when the window did not change.
+    private weak var observedWindow: NSWindow?
 
     func showTab(_ tab: TerminalTab?) {
         guard let tab else {
@@ -406,17 +411,9 @@ class TerminalContainerView: NSView {
             self.needsDisplay = true
 
             // Force a synchronous full repaint from the SwiftTerm display
-            // buffer. After re-parenting the layer's backing store may be
-            // empty, and TUI apps in alternate screen (k9s, htop, vim) won't
-            // emit any data on their own. `forceFullRedraw` covers the case
-            // where the buffer is valid but the layer is blank; for alternate
-            // screen specifically the buffer may also be blank because the
-            // TUI hasn't redrawn itself yet — `kickPTYWindowSize` raises
-            // SIGWINCH to nudge it.
-            tab.forceFullRedraw()
-            if tab.terminalView.getTerminal().isCurrentBufferAlternate {
-                tab.kickPTYWindowSize()
-            }
+            // buffer (and raise SIGWINCH on alternate-screen TUIs so the
+            // child itself redraws — see `refreshAfterReparent` docs).
+            tab.refreshAfterReparent()
         }
 
         installScrollMonitor()
@@ -526,18 +523,16 @@ class TerminalContainerView: NSView {
             NotificationCenter.default.removeObserver(observer)
             becomeKeyObserver = nil
         }
+        observedWindow = nil
     }
 
-    /// Repaints the active terminal and (for TUI apps in alternate screen)
-    /// raises SIGWINCH so the child redraws. Used by `viewDidMoveToWindow`
+    /// Repaints the active terminal (and for TUI apps in alternate screen
+    /// raises SIGWINCH so the child redraws). Used by `viewDidMoveToWindow`
     /// and the window-become-key observer.
     private func refreshActiveTerminalAfterReparent() {
         guard let tab = terminalPaneState?.activeTab,
               tab.terminalView.superview === self else { return }
-        tab.forceFullRedraw()
-        if tab.terminalView.getTerminal().isCurrentBufferAlternate {
-            tab.kickPTYWindowSize()
-        }
+        tab.refreshAfterReparent()
     }
 
     /// Requests first responder on the terminal view.
@@ -554,9 +549,9 @@ class TerminalContainerView: NSView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        // Window changed (attach/detach/reparent) — wire up the
-        // become-key observer to the new host window (or remove it if we
-        // no longer have a window).
+        // AppKit may call this method multiple times for the same window —
+        // skip the observer dance when nothing has actually changed.
+        guard window !== observedWindow else { return }
         removeBecomeKeyObserver()
         guard let win = window else { return }
         becomeKeyObserver = NotificationCenter.default.addObserver(
@@ -566,6 +561,7 @@ class TerminalContainerView: NSView {
         ) { [weak self] _ in
             self?.refreshActiveTerminalAfterReparent()
         }
+        observedWindow = win
         // First repaint after attaching to the window — `displayIfNeeded`
         // inside `showTab` is a no-op when the container had no window yet,
         // so this is the first chance to actually paint the SwiftTerm view.
@@ -591,17 +587,13 @@ class TerminalContainerView: NSView {
             scrollInterceptor.frame = bounds
             tab.startIfNeeded()
             if frameChanged {
-                tab.forceFullRedraw()
-                if tab.terminalView.getTerminal().isCurrentBufferAlternate {
-                    tab.kickPTYWindowSize()
-                }
+                tab.refreshAfterReparent()
             }
         } else {
             // Terminal view was removed (e.g. tab switch race) — re-add it.
-            // `showTab` already calls `forceFullRedraw` after the insert.
+            // `showTab` already starts the PTY, marks needsLayout, and calls
+            // `refreshAfterReparent`, so nothing else to do here.
             showTab(tab)
-            tab.terminalView.needsLayout = true
-            tab.startIfNeeded()
         }
     }
 
@@ -839,6 +831,11 @@ final class TerminalTab: Identifiable, Hashable {
     ///
     /// No-op when the process isn't running or the PTY fd is invalid.
     /// Idempotent — sending the same winsize twice is harmless.
+    ///
+    /// There is a benign race window between the `isProcessRunning` check
+    /// and the `setWinSize` call: the child can exit in between, leaving
+    /// `childfd` closed. The ioctl on a closed fd returns `EBADF` which we
+    /// intentionally swallow — the result is the same as a normal no-op.
     func kickPTYWindowSize() {
         guard isProcessRunning else { return }
         let fd = terminalView.process.childfd
@@ -848,6 +845,17 @@ final class TerminalTab: Identifiable, Hashable {
             masterPtyDescriptor: fd,
             windowSize: &size
         )
+    }
+
+    /// Convenience wrapper: repaint the buffer and, for alternate-screen
+    /// TUIs, raise SIGWINCH so the child redraws. Used by every re-parent
+    /// site in `TerminalContainerView` (`showTab`, `viewDidMoveToWindow`,
+    /// `layout` on frame change, become-key observer).
+    func refreshAfterReparent() {
+        forceFullRedraw()
+        if terminalView.getTerminal().isCurrentBufferAlternate {
+            kickPTYWindowSize()
+        }
     }
 
     /// Whether the shell process is still running.

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -722,6 +722,272 @@ struct TerminalTabTests {
                 "Process must not start while the container has zero bounds")
     }
 
+    // MARK: - Black terminal on TUI fix
+    //
+    // After re-parenting the terminal view (tab switch, pane split, drag,
+    // window become-key, etc.) AppKit may discard the layer's backing store,
+    // and TUI apps in alternate screen (k9s, htop, vim) won't redraw on
+    // their own. Pine repaints from `displayBuffer` via `forceFullRedraw`
+    // and (for alternate screen) raises SIGWINCH via `kickPTYWindowSize` to
+    // nudge the TUI into redrawing.
+
+    /// `forceFullRedraw` must seed SwiftTerm's dirty range so a subsequent
+    /// `updateDisplay` (or our own synchronous `setNeedsDisplay`) repaints
+    /// the entire visible buffer. Without this, an idle TUI in alternate
+    /// screen leaves `getUpdateRange()` empty and SwiftTerm's throttled
+    /// path never schedules a redraw.
+    @Test @MainActor func forceFullRedrawSeedsDirtyRange() {
+        let tab = TerminalTab(name: "test")
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        let term = tab.terminalView.getTerminal()
+
+        term.clearUpdateRange()
+        #expect(term.getUpdateRange() == nil, "Precondition: dirty range must start empty")
+
+        tab.forceFullRedraw()
+
+        let range = term.getUpdateRange()
+        #expect(range != nil, "forceFullRedraw must seed a non-empty dirty range")
+        #expect(range?.startY == 0)
+        #expect(range?.endY == term.rows)
+    }
+
+    /// `forceFullRedraw` must not crash when the terminal view has no
+    /// host window — `displayIfNeeded` is a no-op in that state but the
+    /// dirty-range seeding and `setNeedsDisplay` calls must still succeed.
+    @Test @MainActor func forceFullRedrawSafeWithoutWindow() {
+        let tab = TerminalTab(name: "test")
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        // Not added to any window/superview.
+        tab.forceFullRedraw()
+        #expect(tab.terminalView.window == nil)
+    }
+
+    /// `forceFullRedraw` is idempotent: calling it twice in a row must
+    /// behave like calling it once — same dirty range, no crashes.
+    @Test @MainActor func forceFullRedrawIdempotent() {
+        let tab = TerminalTab(name: "test")
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        let term = tab.terminalView.getTerminal()
+
+        tab.forceFullRedraw()
+        tab.forceFullRedraw()
+
+        let range = term.getUpdateRange()
+        #expect(range?.startY == 0)
+        #expect(range?.endY == term.rows)
+    }
+
+    /// `kickPTYWindowSize` must be a safe no-op when the shell process is
+    /// not running. Calling it on a freshly-created tab (which has not
+    /// reached `startIfNeeded`) must not crash, and `isProcessRunning`
+    /// must stay false.
+    @Test @MainActor func kickPTYWindowSizeNoOpWhenProcessNotRunning() {
+        let tab = TerminalTab(name: "test")
+        // No `startIfNeeded` — process is not running.
+        tab.kickPTYWindowSize()
+        #expect(!tab.isProcessRunning)
+    }
+
+    /// `kickPTYWindowSize` against a running shell must not kill the
+    /// process. Sending the same winsize is identical to a no-change
+    /// `SIGWINCH` and is benign.
+    @Test @MainActor func kickPTYWindowSizeOnRunningProcessKeepsItAlive() throws {
+        let tab = TerminalTab(name: "test")
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        tab.configure(workingDirectory: nil)
+        tab.startIfNeeded()
+        try #require(tab.isProcessRunning)
+
+        tab.kickPTYWindowSize()
+        #expect(tab.isProcessRunning, "SIGWINCH with the same winsize must not terminate the shell")
+    }
+
+    /// `kickPTYWindowSize` after `stop()` must be a safe no-op — the
+    /// process is no longer running and the PTY fd may be invalid.
+    @Test @MainActor func kickPTYWindowSizeAfterStopIsNoOp() throws {
+        let tab = TerminalTab(name: "test")
+        tab.terminalView.frame = NSRect(x: 0, y: 0, width: 800, height: 300)
+        tab.configure(workingDirectory: nil)
+        tab.startIfNeeded()
+        try #require(tab.isProcessRunning)
+        tab.stop()
+        // Should not crash even though the PTY is being torn down.
+        tab.kickPTYWindowSize()
+        #expect(tab.isTerminated)
+    }
+
+    /// Switching back to a previously-active tab must seed its dirty
+    /// range so the layer repaints from the buffer. Reproduces the
+    /// scenario "k9s in tab1, switch to tab2, switch back to tab1 →
+    /// alternate-screen buffer never redrew → blank terminal".
+    @Test @MainActor func returningToPreviousTabRepaintsBuffer() throws {
+        let state = TerminalPaneState()
+        let tab1 = state.addTab(workingDirectory: nil)
+        state.startTabs(workingDirectory: nil)
+        let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        container.terminalPaneState = state
+        container.showTab(state.activeTab)
+
+        let tab2 = state.addTab(workingDirectory: nil)
+        container.showTab(state.activeTab) // installs tab2
+
+        // Imagine tab1's TUI has been idle on alternate screen for a while —
+        // its dirty range was consumed by SwiftTerm's last paint.
+        tab1.terminalView.getTerminal().clearUpdateRange()
+        #expect(tab1.terminalView.getTerminal().getUpdateRange() == nil)
+
+        // User clicks tab1 in the tab bar — Pine flips active and re-shows.
+        state.activeTerminalID = tab1.id
+        container.showTab(state.activeTab)
+
+        let range = tab1.terminalView.getTerminal().getUpdateRange()
+        #expect(range != nil, "Returning to tab1 must seed its dirty range so the buffer repaints")
+        #expect(range?.startY == 0)
+        _ = tab2 // suppress unused warning
+    }
+
+    /// The first time a `TerminalContainerView` enters a window, the
+    /// active tab's buffer must be marked dirty — `displayIfNeeded`
+    /// inside `showTab` is a no-op while the container has no window,
+    /// so `viewDidMoveToWindow` is the first chance to actually paint.
+    @Test @MainActor func viewDidMoveToWindowSeedsDirtyRange() throws {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        state.startTabs(workingDirectory: nil)
+        let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        container.terminalPaneState = state
+        container.showTab(state.activeTab)
+
+        // Drain the dirty range that `showTab` already seeded so the
+        // assertion below is about `viewDidMoveToWindow` specifically.
+        tab.terminalView.getTerminal().clearUpdateRange()
+        #expect(tab.terminalView.getTerminal().getUpdateRange() == nil)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+
+        let range = tab.terminalView.getTerminal().getUpdateRange()
+        #expect(range != nil, "Attaching to a window must seed the dirty range")
+        #expect(range?.startY == 0)
+    }
+
+    /// `layout()` with the same bounds twice must NOT re-trigger a
+    /// forceFullRedraw — the `frameChanged` guard prevents redundant
+    /// repaints on AppKit's no-op layout passes.
+    @Test @MainActor func layoutWithUnchangedBoundsDoesNotReseedDirtyRange() throws {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        state.startTabs(workingDirectory: nil)
+
+        let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        container.terminalPaneState = state
+        container.showTab(state.activeTab)
+        container.layout() // first layout pass — frame changed from showTab fallback to real
+
+        // Drain the dirty range so we can detect a re-seed unambiguously.
+        tab.terminalView.getTerminal().clearUpdateRange()
+        #expect(tab.terminalView.getTerminal().getUpdateRange() == nil)
+
+        // Second layout with identical bounds — must be a no-op for redraw.
+        container.layout()
+
+        #expect(tab.terminalView.getTerminal().getUpdateRange() == nil,
+                "Layout with unchanged bounds must not re-seed the dirty range")
+    }
+
+    /// `layout()` with new bounds must re-seed the dirty range so a TUI
+    /// app's alternate-screen content repaints after a sub-cell pixel
+    /// resize that did NOT trigger SwiftTerm's own size-change path.
+    @Test @MainActor func layoutWithChangedBoundsReseedsDirtyRange() throws {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        state.startTabs(workingDirectory: nil)
+
+        let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        container.terminalPaneState = state
+        container.showTab(state.activeTab)
+        container.layout()
+
+        tab.terminalView.getTerminal().clearUpdateRange()
+
+        // Resize the container — frame size differs from previous layout.
+        container.frame = NSRect(x: 0, y: 0, width: 1000, height: 400)
+        container.layout()
+
+        let range = tab.terminalView.getTerminal().getUpdateRange()
+        #expect(range != nil, "Layout with new bounds must re-seed the dirty range")
+    }
+
+    /// After `removeFromSuperview` the container must clean up its
+    /// become-key observer so it cannot fire against a now-detached
+    /// terminal view. Verified indirectly: posting the notification
+    /// does not crash and does not re-seed the dirty range.
+    @Test @MainActor func removeFromSuperviewClearsBecomeKeyObserver() throws {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        state.startTabs(workingDirectory: nil)
+
+        let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        container.terminalPaneState = state
+        container.showTab(state.activeTab)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+
+        container.removeFromSuperview()
+        tab.terminalView.getTerminal().clearUpdateRange()
+        #expect(tab.terminalView.getTerminal().getUpdateRange() == nil)
+
+        // Posting becomeKey on the (now-orphaned) window must not retrigger
+        // a redraw on the detached container.
+        NotificationCenter.default.post(name: NSWindow.didBecomeKeyNotification, object: window)
+
+        #expect(tab.terminalView.getTerminal().getUpdateRange() == nil,
+                "Detached container must not respond to becomeKey notifications")
+    }
+
+    /// When the host window receives `didBecomeKey`, the active terminal
+    /// must repaint so a previously-blanked alternate-screen buffer
+    /// becomes visible again.
+    @Test @MainActor func windowBecomeKeyTriggersTerminalRedraw() throws {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        state.startTabs(workingDirectory: nil)
+
+        let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        container.terminalPaneState = state
+        container.showTab(state.activeTab)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+
+        // Drain the dirty range that `viewDidMoveToWindow` just seeded.
+        tab.terminalView.getTerminal().clearUpdateRange()
+        #expect(tab.terminalView.getTerminal().getUpdateRange() == nil)
+
+        // Simulate user returning focus to the window via Cmd+Tab.
+        NotificationCenter.default.post(name: NSWindow.didBecomeKeyNotification, object: window)
+
+        let range = tab.terminalView.getTerminal().getUpdateRange()
+        #expect(range != nil, "didBecomeKey must trigger a buffer repaint on the active terminal")
+    }
+
     /// Stress test: rapidly creating, switching, and closing tabs must keep
     /// every running tab attached or cleanly detached, with no leaked
     /// subviews and no duplicated processes.

--- a/PineUITests/TerminalTests.swift
+++ b/PineUITests/TerminalTests.swift
@@ -794,4 +794,53 @@ final class TerminalTests: PineUITestCase {
         XCTAssertTrue(terminalTab("Terminal 1").exists)
         XCTAssertTrue(terminalTab("Terminal 2").exists)
     }
+
+    // MARK: - Black terminal on TUI fix (PR #923)
+
+    /// After switching away from a terminal tab and back, the pane must
+    /// remain interactive with a non-zero frame. UI tests cannot detect
+    /// "black layer vs valid pixels" — that's covered by unit tests on
+    /// the dirty range. This test guards against regressions where a
+    /// re-parent breaks the pane structure (zero frame, unhittable tabs,
+    /// disappearing plus button) — the visible-but-blank symptom of the
+    /// bug always co-occurs with a fully-rendered tab bar that can mask
+    /// model-level damage.
+    func testReturningToFirstTabKeepsPaneInteractive() throws {
+        launchAndWaitForLoad()
+
+        createTerminalViaMenu()
+        let tab1 = terminalTab("Terminal 1")
+        XCTAssertTrue(waitForExistence(tab1, timeout: 10), "Terminal 1 must appear")
+        XCTAssertTrue(waitForExistence(newTerminalButton, timeout: 5))
+
+        // Add a second tab — Terminal 2 becomes active.
+        newTerminalButton.click()
+        let tab2 = terminalTab("Terminal 2")
+        XCTAssertTrue(waitForExistence(tab2, timeout: 10), "Terminal 2 must appear")
+
+        // Switch back to Terminal 1 — this is the re-parent path that
+        // previously left the layer blank for alternate-screen TUIs.
+        terminalTab("Terminal 1").click()
+        Thread.sleep(forTimeInterval: 0.3)
+
+        // The pane must be alive and interactive after the swap.
+        let tab1AfterSwitch = terminalTab("Terminal 1")
+        XCTAssertTrue(tab1AfterSwitch.exists, "Terminal 1 must still exist after switching back")
+        let frame = tab1AfterSwitch.frame
+        XCTAssertGreaterThan(frame.width, 0, "Terminal 1 tab must have a non-zero width — zero-frame is a regression signature")
+        XCTAssertGreaterThan(frame.height, 0, "Terminal 1 tab must have a non-zero height")
+        XCTAssertTrue(newTerminalButton.isHittable, "Plus button must remain hittable after switching back")
+
+        // Cycle once more (1 → 2 → 1) — the observer / re-parent path
+        // must remain stable across multiple round-trips, not just the
+        // first one. This guards against a regression where the second
+        // attach to the same pane silently drops the dirty-range seed.
+        terminalTab("Terminal 2").click()
+        Thread.sleep(forTimeInterval: 0.2)
+        terminalTab("Terminal 1").click()
+        Thread.sleep(forTimeInterval: 0.2)
+        XCTAssertTrue(terminalTab("Terminal 1").exists)
+        XCTAssertTrue(terminalTab("Terminal 2").exists)
+        XCTAssertTrue(newTerminalButton.isHittable, "Plus button stays hittable across repeated tab cycles")
+    }
 }


### PR DESCRIPTION
## Summary

После re-parenting `LocalProcessTerminalView` (переключение вкладок, сплит панелей, drag-and-drop, возврат фокуса в окно) AppKit может сбросить backing store у CALayer. TUI-приложения в alternate screen (k9s, htop, vim, less +F, btop) **сами не перерисовываются** до следующего ввода или внутреннего тика — пользователь видит чёрный терминал.

Прошлый фикс #921 закрыл сценарий «открытие второй вкладки в той же панели». Этот PR покрывает остальные re-parent-сценарии.

## Что меняется

Два новых публичных метода на `TerminalTab`:

- **`forceFullRedraw()`** — `terminal.updateFullScreen()` + `setNeedsDisplay(bounds)` + `displayIfNeeded()`. Помечает буфер как dirty и синхронно перерисовывает из `displayBuffer`. Это закрывает случай «буфер у SwiftTerm валиден, но layer пустой после re-parent».
- **`kickPTYWindowSize()`** — повторно отправляет текущий `winsize` через `PseudoTerminalHelpers.setWinSize`, что генерирует `SIGWINCH` в дочернем процессе. Большинство TUI на этот сигнал перерисовывают весь экран. Закрывает случай «alternate-screen буфер реально пуст, потому что TUI не отрисовывался с момента re-parent».

Вызовы расставлены во всех re-parent-точках `TerminalContainerView`:

| Точка | Сценарий |
|---|---|
| `showTab` после `addSubview` | Tab switch / Cmd+T / drag tab между панелями |
| `viewDidMoveToWindow` | Первый attach к окну (когда `displayIfNeeded` в `showTab` был no-op) и при maximize/restore |
| `layout()` при `frameChanged` | Сплит панели / закрытие соседнего pane / resize |
| `NSWindow.didBecomeKeyNotification` (новый observer) | Возврат фокуса в окно после Cmd+Tab |

`kickPTYWindowSize` гейтится на `isCurrentBufferAlternate` — обычный shell не дёргается лишним prompt-redraw.

## Test plan

Юнит-тесты в `PineTests/TerminalTabTests.swift` (12 новых):
- [x] `forceFullRedrawSeedsDirtyRange` — после `clearUpdateRange()` + `forceFullRedraw()` `getUpdateRange()` возвращает `(0, rows)`
- [x] `forceFullRedrawSafeWithoutWindow` — без host-окна не крашится
- [x] `forceFullRedrawIdempotent` — два вызова подряд не ломают состояние
- [x] `kickPTYWindowSizeNoOpWhenProcessNotRunning` — без startIfNeeded — no-op
- [x] `kickPTYWindowSizeOnRunningProcessKeepsItAlive` — реальный shell остаётся жив после SIGWINCH
- [x] `kickPTYWindowSizeAfterStopIsNoOp` — после `stop()` — безопасно
- [x] `returningToPreviousTabRepaintsBuffer` — реакция на сценарий tab1=k9s → tab2 → tab1
- [x] `viewDidMoveToWindowSeedsDirtyRange` — первый attach к окну триггерит redraw
- [x] `layoutWithUnchangedBoundsDoesNotReseedDirtyRange` — без `frameChanged` нет лишних redraw
- [x] `layoutWithChangedBoundsReseedsDirtyRange` — при изменении bounds redraw триггерится
- [x] `removeFromSuperviewClearsBecomeKeyObserver` — observer чистится при detach
- [x] `windowBecomeKeyTriggersTerminalRedraw` — `didBecomeKey` перерисовывает активный таб

Manual / UI:
- [ ] Запустить k9s в терминальной вкладке, открыть Cmd+T новую — вернуться, не должно быть чёрного экрана
- [ ] htop / btop, сплит панели — содержимое сохраняется
- [ ] Cmd+Tab в другое приложение, возврат — TUI снова виден
- [ ] Drag terminal-таба между панелями — без чёрной вспышки
- [ ] Maximize / restore терминал-pane с запущенным TUI

Все 66 тестов в `TerminalTabTests` проходят локально. SwiftLint чисто.

## Related

Continuation of #871 (force `needsDisplay` on re-parent) and #921 (start PTY for second tab). Those addressed the **view side**; this addresses the **process side** — telling the TUI itself to redraw via SIGWINCH.