### PR TITLE
chore: update swift-markdown to 0.8.0

### DIFF
--- a/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-cmark.git",
       "state" : {
-        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
-        "version" : "0.7.1"
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-markdown.git",
       "state" : {
-        "revision" : "7d9a5ce307528578dfa777d505496bd5f544ad94",
-        "version" : "0.7.3"
+        "revision" : "3c6f9523da3a1ec2fd829673e472d95b8097a3b8",
+        "version" : "0.8.0"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Update swift-markdown from 0.7.3 to 0.8.0.
- Update swift-cmark from 0.7.1 to 0.8.0 to match the resolved package graph.

## Why

Keep the Markdown preview dependency pins current and ensure Xcode resolves the 0.8.0 package graph consistently.

## Testing

- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swiftlint lint --strict --config .swiftlint.yml --cache-path /tmp/pine-swiftlint-cache Pine PineTests PineUITests PinePerformanceTests
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineTests/DebouncerTests -derivedDataPath /tmp/pine-pr-unit
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineTests -derivedDataPath /tmp/pine-pr-unit (build and package resolution succeeded; full suite hit timing-sensitive DebouncerTests failures: rapidBurstPreservesLast, rapidTriggersCoalesce; isolated DebouncerTests rerun passed)