### PR TITLE
fix(editor): cursor jumps to wrong position after pressing Enter

### DIFF
--- a/Pine/GutterTextView.swift
+++ b/Pine/GutterTextView.swift
@@ -544,10 +544,22 @@ final class GutterTextView: NSTextView {
         if let last = lastNonSpace, let first = firstNonSpaceAfter,
            Self.indentOpeners.contains(last) && Self.indentClosers.contains(first) {
             let closingIndent = leadingWhitespace
-            insertText("\n\(indent)\n\(closingIndent)", replacementRange: selectedRange())
-            // Ставим курсор на среднюю строку (с увеличенным отступом)
-            let newCursorPos = cursorLocation + 1 + indent.count
-            setSelectedRange(NSRange(location: newCursorPos, length: 0))
+            let insertedText = "\n\(indent)\n\(closingIndent)"
+            let insertRange = NSRange(location: cursorLocation, length: 0)
+            let newCursorPos = cursorLocation + 1 + (indent as NSString).length
+
+            // Use shouldChangeText/replaceCharacters/didChangeText pattern
+            // (matching toggleComment) instead of insertText so that:
+            // 1. The cursor is set before textDidChange fires — Coordinator
+            //    reads the correct position via reportStateChange
+            // 2. Undo grouping wraps the entire operation atomically
+            if shouldChangeText(in: insertRange, replacementString: insertedText) {
+                undoManager?.beginUndoGrouping()
+                replaceCharacters(in: insertRange, with: insertedText)
+                setSelectedRange(NSRange(location: newCursorPos, length: 0))
+                undoManager?.endUndoGrouping()
+                didChangeText()
+            }
             return
         }
 

--- a/PineTests/AutoIndentTests.swift
+++ b/PineTests/AutoIndentTests.swift
@@ -281,7 +281,7 @@ struct AutoIndentTests {
         #expect(view.string == "\t{\n\t    \n\t}")
     }
 
-    @Test func insertNewline_betweenColonAndCloseParen_noExpansion() {
+    @Test func insertNewline_betweenColonAndCloseParen_expansionCursorCorrect() {
         // ":" + ")" — both opener and closer, should trigger bracket expansion
         let view = makeGutterTextView(text: "case .foo:)")
         insertNewline(in: view, at: 10) // after ":"
@@ -353,11 +353,16 @@ struct AutoIndentTests {
     }
 
     @Test func insertNewline_braceExpansion_undoManagerAvailable() {
-        // Verify that undo manager is available after bracket expansion
+        // Verify that undo manager is available and functional after bracket expansion
         let view = makeGutterTextView(text: "{}")
         insertNewline(in: view, at: 1)
 
         // The expansion should modify text — verify text changed
         #expect(view.string == "{\n    \n}", "Text should be expanded to three lines")
+
+        // Undo should restore original text and cursor position
+        view.undoManager?.undo()
+        #expect(view.string == "{}", "Undo should restore original text")
+        #expect(view.selectedRange().location == 1, "Undo should restore cursor position")
     }
 }

--- a/PineTests/AutoIndentTests.swift
+++ b/PineTests/AutoIndentTests.swift
@@ -165,4 +165,199 @@ struct AutoIndentTests {
 
         #expect(view.string == "    return x\n    ")
     }
+
+    // MARK: - Bug #862: Cursor position after Enter in Swift files
+
+    @Test func insertNewline_betweenBracesWithSpaces_cursorPositionCorrect() {
+        // "{ }" with space between braces — cursor after "{"
+        let view = makeGutterTextView(text: "{ }")
+        insertNewline(in: view, at: 1) // between { and space
+
+        // Should expand braces, cursor on middle indented line
+        let cursor = view.selectedRange().location
+        // Expected text: "{\n    \n }"
+        // Cursor should be at position 1 + 1 + 4 = 6 (after \n + 4 spaces)
+        let expectedCursor = 6
+        #expect(cursor == expectedCursor, "Cursor should be on middle line at \(expectedCursor), got \(cursor)")
+        #expect(view.string == "{\n    \n }", "Text should expand braces correctly")
+    }
+
+    @Test func insertNewline_braceExpansionWithIndent_cursorNotOnClosingBrace() {
+        let view = makeGutterTextView(text: "    if true {}")
+        insertNewline(in: view, at: 13) // between { and }
+
+        let cursor = view.selectedRange().location
+        let text = view.string
+        // Expected text: "    if true {\n        \n    }"
+        // Expected cursor: 13 + 1 + 8 = 22 (after \n + 8 spaces on middle line)
+        let nsText = text as NSString
+        let closingBracePos = Int(nsText.range(of: "}", options: .backwards).location)
+        #expect(cursor != closingBracePos, "Cursor should NOT be on closing brace")
+        #expect(cursor == 22, "Cursor should be at position 22 (middle line), got \(cursor)")
+    }
+
+    @Test func insertNewline_betweenBraces_multilineCode_cursorOnNewLine() {
+        // Cursor at end of line inside a function body
+        let view = makeGutterTextView(text: "    let x = 1\n    }")
+        insertNewline(in: view, at: 13) // after "1" on first line
+
+        // Should just insert newline with preserved indent (4 spaces)
+        let cursor = view.selectedRange().location
+        let expectedCursor = 13 + 1 + 4 // after \n + 4 spaces
+        #expect(cursor == expectedCursor, "Cursor should be at \(expectedCursor), got \(cursor)")
+        #expect(view.string == "    let x = 1\n    \n    }")
+    }
+
+    @Test func insertNewline_betweenBracesInFunc_cursorNotOnClosingBrace() {
+        // "func foo() {\n}" — cursor after { on same line
+        let view = makeGutterTextView(text: "func foo() {\n}")
+        insertNewline(in: view, at: 12) // after "{", before "\n"
+
+        // Should insert "\n    " — increase indent after {
+        let cursor = view.selectedRange().location
+        // Expected text: "func foo() {\n    \n}"
+        // Expected cursor: 12 + 1 + 4 = 17
+        #expect(cursor == 17, "Cursor should be at 17 (new indented line), got \(cursor)")
+        #expect(view.string == "func foo() {\n    \n}")
+    }
+
+    @Test func insertNewline_nestedBraces_expansionCursorCorrect() {
+        let view = makeGutterTextView(text: "    if true {\n        {}\n    }")
+        // "    if true {\n" = 14 chars, "        {" = 9 chars → { at position 22
+        // between { and } is position 23
+        insertNewline(in: view, at: 23) // between { and } in inner "{}"
+
+        // Bracket expansion for inner {}
+        // leadingWhitespace = "        " (8 spaces from "        {}")
+        // indent = "        " + "    " = "            " (12 spaces)
+        // closingIndent = "        " (8 spaces)
+        let text = view.string
+        let cursor = view.selectedRange().location
+        // Expected: "    if true {\n        {\n            \n        }\n    }"
+        let expectedCursor = 23 + 1 + 12 // 36
+        #expect(cursor == expectedCursor, "Cursor should be at \(expectedCursor), got \(cursor)")
+    }
+
+    @Test func insertNewline_afterColonInSwitch_cursorNotOnClosingBrace() {
+        // Bug scenario: ":" is in indentOpeners, "}" after on same line triggers bracket expansion
+        let view = makeGutterTextView(text: "    case .foo:}")
+        insertNewline(in: view, at: 14) // after ":"
+
+        // This triggers bracket expansion: lastNonSpace = ":", firstNonSpaceAfter = "}"
+        let cursor = view.selectedRange().location
+        // Expected text: "    case .foo:\n        \n    }"
+        // indent = "    " + "    " = "        " (8 spaces)
+        // closingIndent = "    " (4 spaces)
+        // newCursorPos = 14 + 1 + 8 = 23
+        #expect(cursor == 23, "Cursor should be at 23, got \(cursor)")
+    }
+
+    @Test func insertNewline_emptyBracesAtEndOfFile_cursorCorrect() {
+        // No trailing newline — cursor between { and }
+        let view = makeGutterTextView(text: "class Foo {}")
+        insertNewline(in: view, at: 11) // between { and }
+
+        let cursor = view.selectedRange().location
+        // Expected: "class Foo {\n    \n}"
+        // leadingWhitespace = ""
+        // indent = "    "
+        // closingIndent = ""
+        // newCursorPos = 11 + 1 + 4 = 16
+        #expect(cursor == 16, "Cursor should be at 16, got \(cursor)")
+        #expect(view.string == "class Foo {\n    \n}")
+    }
+
+    @Test func insertNewline_withTabIndent_bracketExpansion_cursorCorrect() {
+        // Tab-based indent with bracket expansion
+        let view = makeGutterTextView(text: "\t{}")
+        insertNewline(in: view, at: 2) // between { and }
+
+        let cursor = view.selectedRange().location
+        // leadingWhitespace = "\t"
+        // indent = "\t" + "    " = "\t    " (5 chars, 5 UTF-16)
+        // closingIndent = "\t"
+        // newCursorPos = 2 + 1 + 5 = 8
+        #expect(cursor == 8, "Cursor should be at 8, got \(cursor)")
+        #expect(view.string == "\t{\n\t    \n\t}")
+    }
+
+    @Test func insertNewline_betweenColonAndCloseParen_noExpansion() {
+        // ":" + ")" — both opener and closer, should trigger bracket expansion
+        let view = makeGutterTextView(text: "case .foo:)")
+        insertNewline(in: view, at: 10) // after ":"
+
+        let cursor = view.selectedRange().location
+        // This IS bracket expansion: lastNonSpace = ":", firstNonSpaceAfter = ")"
+        // indent = "" + "    " = "    "
+        // closingIndent = ""
+        // newCursorPos = 10 + 1 + 4 = 15
+        #expect(cursor == 15, "Cursor should be at 15, got \(cursor)")
+    }
+
+    @Test func insertNewline_insideFunctionBody_preservesIndent() {
+        // Realistic Swift scenario: cursor at end of line inside function
+        let view = makeGutterTextView(text: "    var x = 42")
+        insertNewline(in: view, at: 14) // after "2"
+
+        let cursor = view.selectedRange().location
+        #expect(cursor == 14 + 1 + 4, "Cursor should be at 19, got \(cursor)")
+        #expect(view.string == "    var x = 42\n    ")
+    }
+
+    @Test func insertNewline_betweenParensWithContent_noExpansion() {
+        // "func()" — cursor after "c", before "c" — not between opener and closer
+        let view = makeGutterTextView(text: "func()")
+        insertNewline(in: view, at: 4) // after "c", before "("
+
+        // "c" is not an opener, so no indent increase
+        let cursor = view.selectedRange().location
+        #expect(cursor == 5, "Cursor should be at 5, got \(cursor)")
+        #expect(view.string == "func\n()")
+    }
+
+    @Test func insertNewline_afterReturnInFunc_noExtraIndent() {
+        let view = makeGutterTextView(text: "    return x")
+        insertNewline(in: view, at: 12)
+
+        let cursor = view.selectedRange().location
+        #expect(cursor == 12 + 1 + 4, "Cursor should preserve 4-space indent")
+        #expect(view.string == "    return x\n    ")
+    }
+
+    @Test func insertNewline_betweenBracesWithTrailingContent_cursorCorrect() {
+        // "{}" with content after — cursor between { and }
+        let view = makeGutterTextView(text: "{} // comment")
+        insertNewline(in: view, at: 1) // between { and }
+
+        // lastNonSpace = "{", firstNonSpaceAfter = "}" — bracket expansion triggers!
+        // Even though there's content after }, the closer is the first non-space after cursor
+        // indent = "" + "    " = "    ", closingIndent = ""
+        // Text becomes: "{\n    \n} // comment"
+        let cursor = view.selectedRange().location
+        #expect(cursor == 1 + 1 + 4, "Cursor should be at 6, got \(cursor)")
+        #expect(view.string == "{\n    \n} // comment")
+    }
+
+    @Test func insertNewline_nestedBracketsInOneLine_correctExpansion() {
+        // "(){}" — cursor between ( and )
+        let view = makeGutterTextView(text: "(){}")
+        insertNewline(in: view, at: 1) // between ( and )
+
+        // lastNonSpace = "(", firstNonSpaceAfter = ")"
+        // Bracket expansion for (): inserts "\n{indent}\n{closingIndent}"
+        // indent = "" + "    " = "    ", closingIndent = ""
+        // Text becomes: "(\n    \n){}"
+        let cursor = view.selectedRange().location
+        #expect(cursor == 1 + 1 + 4, "Cursor should be at 6, got \(cursor)")
+        #expect(view.string == "(\n    \n){}")
+    }
+
+    @Test func insertNewline_braceExpansion_undoManagerAvailable() {
+        // Verify that undo manager is available after bracket expansion
+        let view = makeGutterTextView(text: "{}")
+        insertNewline(in: view, at: 1)
+
+        // The expansion should modify text — verify text changed
+        #expect(view.string == "{\n    \n}", "Text should be expanded to three lines")
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #862 — cursor jumps to closing `}` instead of staying on the new indented line after pressing Enter in Swift files.

**Root cause:** Bracket expansion in `GutterTextView.insertNewline` used `insertText()` followed by a separate `setSelectedRange()` call. Between these two calls, `textDidChange` fired via the Coordinator and read an intermediate cursor position (end of inserted text, near the closing brace). This stale position was persisted via `reportStateChange` and could cause visible cursor jumps.

**Fix:** Replace `insertText()` + `setSelectedRange()` with the standard `shouldChangeText`/`replaceCharacters`/`setSelectedRange`/`didChangeText` pattern (matching `toggleComment`). This ensures the cursor is already correct when `textDidChange` fires. Wrap in `undoManager` grouping for atomic undo.

## Test plan

- [x] 16 new regression tests in `AutoIndentTests` covering:
  - Bracket expansion cursor positioning (basic, with indent, nested, tab indent)
  - Edge cases: colon + closer, trailing content, end-of-file, multiline code
  - Cursor never lands on closing brace after expansion
- [x] All 130 editor-related tests pass (AutoIndent, GutterTextView, BracketMatcher, BracketHighlight, SmartListContinuation, FoldState, FoldRangeCalculator)
- [x] SwiftLint strict: 0 violations