### PR TITLE
fix(ci): screenshot extraction via xcresulttool get test-results

### DIFF
--- a/scripts/update-screenshots.sh
+++ b/scripts/update-screenshots.sh
@@ -86,17 +86,17 @@ extract_named_screenshots() {
       echo "  Skipping attachment with invalid name: $att_name" >&2
       continue
     fi
-    local src=""
-    if [ -f "$RESULT_PATH/Data/$payload_id" ]; then
-      src="$RESULT_PATH/Data/$payload_id"
-    else
-      src=$(find "$RESULT_PATH/Data" -name "$payload_id" -type f -print -quit 2>/dev/null)
-    fi
-    if [ -z "$src" ]; then
-      echo "  Warning: payload not found for $att_name (id=$payload_id)" >&2
+    # Validate payload_id — only alphanumeric, dots, dashes, underscores
+    if [[ ! "$payload_id" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+      echo "  Skipping attachment with invalid payload_id: $payload_id" >&2
       continue
     fi
-    cp "$src" "$ASSETS_DIR/${att_name}.png"
+    local src="$RESULT_PATH/Data/$payload_id"
+    if [ ! -f "$src" ]; then
+      echo "  Warning: payload not found at $src" >&2
+      continue
+    fi
+    cp -- "$src" "$ASSETS_DIR/${att_name}.png"
     echo "  Extracted ${att_name}.png"
     found_any=true
   done < <(python3 - "$XCRESULTTOOL" "$RESULT_PATH" <<'PY'
@@ -122,6 +122,8 @@ def find_test_ids(node):
     node_type = node.get("nodeType", "")
     name = node.get("name", "")
     if node_type == "Test Case" and name.startswith("testCapture"):
+        # xcresulttool uses nodeIdentifierURL as test identifier for --test-id;
+        # fall back to nodeIdentifier for older Xcode versions
         tid = node.get("nodeIdentifierURL", "") or node.get("nodeIdentifier", "")
         if tid:
             results.append(tid)
@@ -148,8 +150,9 @@ if not test_ids:
     # Diagnostic: show first 5 files in Data/ to help debug extraction failures
     data_dir = bundle_path + "/Data"
     if os.path.isdir(data_dir):
-        entries = sorted(os.listdir(data_dir))[:5]
-        print(f"  Diagnostic: Data/ directory has {len(os.listdir(data_dir))} entries, first 5: {entries}", file=sys.stderr)
+        all_entries = os.listdir(data_dir)
+        entries = sorted(all_entries)[:5]
+        print(f"  Diagnostic: Data/ directory has {len(all_entries)} entries, first 5: {entries}", file=sys.stderr)
     else:
         print(f"  Diagnostic: Data/ directory does not exist at {data_dir}", file=sys.stderr)
     sys.exit(1)

--- a/scripts/update-screenshots.sh
+++ b/scripts/update-screenshots.sh
@@ -142,11 +142,14 @@ if not test_ids:
     print("  No screenshot test cases found in xcresult bundle.", file=sys.stderr)
     sys.exit(1)
 
-for tid in test_ids:
+for i, tid in enumerate(test_ids):
     act_data = get_json(["get", "test-results", "activities",
                          "--path", bundle_path, "--test-id", tid])
     if not act_data:
         continue
+    if i == 0:
+        preview = json.dumps(act_data, indent=2)[:2000]
+        print(f"  DEBUG activities schema for {tid}:\n{preview}", file=sys.stderr)
     walk_activities(act_data)
 PY
   )

--- a/scripts/update-screenshots.sh
+++ b/scripts/update-screenshots.sh
@@ -100,7 +100,7 @@ extract_named_screenshots() {
     echo "  Extracted ${att_name}.png"
     found_any=true
   done < <(python3 - "$XCRESULTTOOL" "$RESULT_PATH" <<'PY'
-import json, subprocess, sys
+import json, os, subprocess, sys
 
 xcresulttool = sys.argv[1]
 bundle_path = sys.argv[2]
@@ -110,7 +110,12 @@ def get_json(args):
     if r.returncode != 0:
         print(f"  xcresulttool error: {r.stderr}", file=sys.stderr)
         return None
-    return json.loads(r.stdout)
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError as e:
+        print(f"  Failed to parse xcresulttool output as JSON: {e}", file=sys.stderr)
+        print(f"  Output preview: {r.stdout[:200]}", file=sys.stderr)
+        return None
 
 def find_test_ids(node):
     results = []
@@ -140,6 +145,13 @@ if not data:
 test_ids = find_test_ids(data)
 if not test_ids:
     print("  No screenshot test cases found in xcresult bundle.", file=sys.stderr)
+    # Diagnostic: show first 5 files in Data/ to help debug extraction failures
+    data_dir = bundle_path + "/Data"
+    if os.path.isdir(data_dir):
+        entries = sorted(os.listdir(data_dir))[:5]
+        print(f"  Diagnostic: Data/ directory has {len(os.listdir(data_dir))} entries, first 5: {entries}", file=sys.stderr)
+    else:
+        print(f"  Diagnostic: Data/ directory does not exist at {data_dir}", file=sys.stderr)
     sys.exit(1)
 
 for i, tid in enumerate(test_ids):
@@ -147,14 +159,14 @@ for i, tid in enumerate(test_ids):
                          "--path", bundle_path, "--test-id", tid])
     if not act_data:
         continue
-    if i == 0:
-        preview = json.dumps(act_data, indent=2)[:2000]
-        print(f"  DEBUG activities schema for {tid}:\n{preview}", file=sys.stderr)
     walk_activities(act_data)
 PY
   )
 
   [ "$found_any" = true ] && return 0
+  echo "  No attachments were extracted from any test case." >&2
+  echo "  Diagnostic: listing first 5 files in Data/ directory:" >&2
+  ls "$RESULT_PATH/Data/" 2>/dev/null | head -5 >&2 || echo "  (Data/ directory not found or empty)" >&2
   return 1
 }
 

--- a/scripts/update-screenshots.sh
+++ b/scripts/update-screenshots.sh
@@ -13,9 +13,8 @@
 #     committing zero changes.
 #
 # Compatibility:
-#   - Primary path uses `xcrun xcresulttool export attachments` (Xcode 16+).
-#   - Falls back to a raw filesystem scan of the .xcresult bundle for any
-#     PNG payloads matching screenshot manifest entries.
+#   - Uses `xcresulttool get test-results tests/activities` (Xcode 16+) to
+#     enumerate attachments by name and extract payloads directly.
 
 set -uo pipefail
 
@@ -71,108 +70,97 @@ fi
 
 mkdir -p "$ASSETS_DIR"
 
-# --- Strategy 1: Modern xcresulttool (Xcode 16+) -----------------------------
-# `xcresulttool export attachments` writes every XCTAttachment payload into a
-# directory along with a manifest.json that records the original attachment
-# `name` (without an extension). We honor that name and rename to `.png`.
-extract_with_export_attachments() {
-  local export_dir
-  export_dir=$(mktemp -d)
-
-  if ! "$XCRESULTTOOL" export attachments \
-       --path "$RESULT_PATH" \
-       --output-path "$export_dir" >/dev/null 2>&1; then
-    rm -rf "$export_dir"
-    return 1
-  fi
-
+# --- Extract named screenshots via xcresulttool get test-results --------------
+# Uses `xcresulttool get test-results tests` to enumerate test cases,
+# then `xcresulttool get test-results activities --test-id <id>` to get
+# attachment name + payloadId mappings, and copies payloads directly from
+# the bundle's Data directory. Avoids `export attachments` which fails
+# silently on some Xcode 26 CI runners.
+extract_named_screenshots() {
   local found_any=false
-  local manifest="$export_dir/manifest.json"
-  if [ -f "$manifest" ]; then
-    # Walk the manifest, pull every attachment whose declared name starts
-    # with `screenshot-`, and copy <exported file> -> assets/<name>.png.
-    while IFS=$'\t' read -r att_name suggested; do
-      [ -z "$att_name" ] && continue
-      [ -z "$suggested" ] && continue
-      # Path-traversal guard: only accept well-formed screenshot names.
-      # Rejects "../", slashes, and any other shell-meaningful characters.
-      if [[ ! "$att_name" =~ ^screenshot-[a-zA-Z0-9_-]+$ ]]; then
-        echo "  Skipping attachment with invalid name: $att_name" >&2
-        continue
-      fi
-      local src="$export_dir/$suggested"
-      [ -f "$src" ] || continue
-      cp "$src" "$ASSETS_DIR/${att_name}.png"
-      echo "  Extracted ${att_name}.png"
-      found_any=true
-    done < <(python3 - "$manifest" <<'PY'
-import json, sys
-with open(sys.argv[1]) as f:
-    data = json.load(f)
 
-def walk(node):
-    if isinstance(node, dict):
-        atts = node.get("attachments")
-        if isinstance(atts, list):
-            for att in atts:
-                # Xcode 26 manifest schema has no "name" field.
-                # The XCTAttachment name is stored in
-                # "suggestedHumanReadableName".
-                name = (
-                    att.get("name")
-                    or att.get("suggestedHumanReadableName")
-                    or ""
-                )
-                exported = att.get("exportedFileName", "")
-                if name.startswith("screenshot-") and exported:
-                    print(f"{name}\t{exported}")
-        for v in node.values():
-            walk(v)
-    elif isinstance(node, list):
-        for item in node:
-            walk(item)
-
-walk(data)
-PY
-)
-  fi
-
-  rm -rf "$export_dir"
-  [ "$found_any" = true ] && return 0
-  return 1
-}
-
-# --- Strategy 2: Raw filesystem walk -----------------------------------------
-# As a last resort, scan the bundle for any PNG payloads. Each xcresult
-# attachment is stored as an opaque hash file with no name metadata at this
-# layer, so we cannot recover the original screenshot names here. We simply
-# number the PNGs sequentially (`screenshot-unknown-N.png`) so the workflow
-# notices that "something" was extracted; the required-names guardrail below
-# will then fail loudly because the expected names are still missing.
-extract_with_filesystem() {
-  local found_any=false
-  local idx=0
-  while IFS= read -r -d '' file; do
-    if head -c 4 "$file" 2>/dev/null | xxd -p 2>/dev/null | grep -q '^89504e47'; then
-      idx=$((idx + 1))
-      cp "$file" "$ASSETS_DIR/screenshot-unknown-${idx}.png"
-      echo "  Extracted screenshot-unknown-${idx}.png (raw filesystem)"
-      found_any=true
+  while IFS=$'\t' read -r att_name payload_id; do
+    [ -z "$att_name" ] && continue
+    [ -z "$payload_id" ] && continue
+    if [[ ! "$att_name" =~ ^screenshot-[a-zA-Z0-9_-]+$ ]]; then
+      echo "  Skipping attachment with invalid name: $att_name" >&2
+      continue
     fi
-  done < <(find "$RESULT_PATH" -type f -print0 2>/dev/null)
+    local src=""
+    if [ -f "$RESULT_PATH/Data/$payload_id" ]; then
+      src="$RESULT_PATH/Data/$payload_id"
+    else
+      src=$(find "$RESULT_PATH/Data" -name "$payload_id" -type f -print -quit 2>/dev/null)
+    fi
+    if [ -z "$src" ]; then
+      echo "  Warning: payload not found for $att_name (id=$payload_id)" >&2
+      continue
+    fi
+    cp "$src" "$ASSETS_DIR/${att_name}.png"
+    echo "  Extracted ${att_name}.png"
+    found_any=true
+  done < <(python3 - "$XCRESULTTOOL" "$RESULT_PATH" <<'PY'
+import json, subprocess, sys
+
+xcresulttool = sys.argv[1]
+bundle_path = sys.argv[2]
+
+def get_json(args):
+    r = subprocess.run([xcresulttool] + args, capture_output=True, text=True)
+    if r.returncode != 0:
+        print(f"  xcresulttool error: {r.stderr}", file=sys.stderr)
+        return None
+    return json.loads(r.stdout)
+
+def find_test_ids(node):
+    results = []
+    node_type = node.get("nodeType", "")
+    name = node.get("name", "")
+    if node_type == "Test Case" and name.startswith("testCapture"):
+        tid = node.get("nodeIdentifierURL", "") or node.get("nodeIdentifier", "")
+        if tid:
+            results.append(tid)
+    for child in node.get("children", []):
+        results.extend(find_test_ids(child))
+    return results
+
+def walk_activities(node):
+    for att in node.get("attachments", []):
+        att_name = att.get("name", "")
+        payload_id = att.get("payloadId", "")
+        if att_name.startswith("screenshot-") and payload_id:
+            print(f"{att_name}\t{payload_id}")
+    for child in node.get("childActivities", []):
+        walk_activities(child)
+
+data = get_json(["get", "test-results", "tests", "--path", bundle_path])
+if not data:
+    sys.exit(1)
+
+test_ids = find_test_ids(data)
+if not test_ids:
+    print("  No screenshot test cases found in xcresult bundle.", file=sys.stderr)
+    sys.exit(1)
+
+for tid in test_ids:
+    act_data = get_json(["get", "test-results", "activities",
+                         "--path", bundle_path, "--test-id", tid])
+    if not act_data:
+        continue
+    walk_activities(act_data)
+PY
+  )
+
   [ "$found_any" = true ] && return 0
   return 1
 }
 
-echo "Extracting screenshots via xcresulttool export attachments..."
-if extract_with_export_attachments; then
-  echo "Extraction complete (export attachments)."
+echo "Extracting named screenshots via xcresulttool..."
+if extract_named_screenshots; then
+  echo "Extraction complete."
 else
-  echo "Modern API yielded no screenshots, falling back to raw filesystem walk..."
-  if ! extract_with_filesystem; then
-    echo "Error: all extraction strategies failed (no PNG payloads found)." >&2
-    exit 1
-  fi
+  echo "Error: failed to extract named screenshots." >&2
+  exit 1
 fi
 
 # --- Guardrail ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace broken `xcresulttool export attachments` with `xcresulttool get test-results tests/activities` to extract named screenshots from xcresult bundles
- The old approach failed silently on every release for 2+ months — screenshots haven't updated since March 18 (19 releases ago)
- New approach uses the same `get test-results` API already proven in `detect_flaky_tests.py` and `ci.yml`

## What was wrong

1. `xcresulttool export attachments` fails on CI (error hidden by `>/dev/null 2>&1`)
2. Fallback filesystem walk finds PNGs but can't recover XCTAttachment names → produces `screenshot-unknown-N.png`
3. Commit step looks for canonical names (`screenshot-welcome.png`, etc.) → finds old files → "No screenshot changes to commit"

## What changed

New `extract_named_screenshots()` function:
1. `xcresulttool get test-results tests` → enumerate test cases (same API as `detect_flaky_tests.py`)
2. `xcresulttool get test-results activities --test-id <id>` → get attachment `name` + `payloadId` mapping
3. Copy `<bundle>/Data/<payloadId>` → `assets/<name>.png`

Removed the broken `extract_with_export_attachments()` and the useless `extract_with_filesystem()` fallback.

## Test plan

- [x] Bash syntax check passes
- [x] Python syntax check passes
- [ ] Screenshots workflow succeeds on CI and commits updated screenshots
- [ ] Verify `assets/screenshot-*.png` files are refreshed