### PR TITLE
fix(terminal): auto-focus terminal after Cmd+T

### DIFF
--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -48,15 +48,16 @@ final class TerminalManager {
         guard let pm = paneManager else { return }
 
         if let tpID = lastActiveTerminalPaneID,
-           pm.terminalState(for: tpID) != nil {
+           let state = pm.terminalState(for: tpID) {
             pm.activePaneID = tpID
+            state.pendingFocusTabID = state.activeTerminalID
+        } else if let firstTP = pm.terminalPaneIDs.first,
+                  let state = pm.terminalState(for: firstTP) {
+            pm.activePaneID = firstTP
+            lastActiveTerminalPaneID = firstTP
+            state.pendingFocusTabID = state.activeTerminalID
         } else {
-            if let firstTP = pm.terminalPaneIDs.first {
-                pm.activePaneID = firstTP
-                lastActiveTerminalPaneID = firstTP
-            } else {
-                createTerminalTab(relativeTo: editorPaneID, workingDirectory: workingDirectory)
-            }
+            createTerminalTab(relativeTo: editorPaneID, workingDirectory: workingDirectory)
         }
     }
 

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -536,14 +536,14 @@ class TerminalContainerView: NSView {
     }
 
     /// Requests first responder on the terminal view.
-    /// If the view is not yet in a window, defers the call via async dispatch.
+    /// Always deferred via async dispatch so that the focus request lands
+    /// *after* SwiftUI finishes its layout pass — otherwise SwiftUI can
+    /// restore first-responder to the editor's GutterTextView, undoing
+    /// the terminal focus requested by Cmd+T / Cmd+`.
     private func focusTerminalView(_ terminalView: LocalProcessTerminalView) {
-        if let win = window {
-            win.makeFirstResponder(terminalView)
-        } else {
-            DispatchQueue.main.async { [weak self] in
-                self?.window?.makeFirstResponder(terminalView)
-            }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.window?.makeFirstResponder(terminalView)
         }
     }
 

--- a/PineTests/TerminalManagerCoordinatorTests.swift
+++ b/PineTests/TerminalManagerCoordinatorTests.swift
@@ -64,6 +64,69 @@ struct TerminalManagerCoordinatorTests {
         #expect(paneManager.activePaneID == tpID)
     }
 
+    @Test func focusOrCreateTerminal_existingPane_setsPendingFocusTabID() {
+        let paneManager = PaneManager()
+        let terminal = TerminalManager()
+        terminal.paneManager = paneManager
+
+        let editorPane = paneManager.activePaneID
+        guard let tpID = paneManager.createTerminalPane(
+            relativeTo: editorPane, axis: .vertical, workingDirectory: nil
+        ) else {
+            Issue.record("createTerminalPane failed")
+            return
+        }
+        terminal.lastActiveTerminalPaneID = tpID
+        paneManager.activePaneID = editorPane
+
+        let activeTabID = paneManager.terminalState(for: tpID)?.activeTerminalID
+        terminal.focusOrCreateTerminal(relativeTo: editorPane, workingDirectory: nil)
+
+        #expect(paneManager.terminalState(for: tpID)?.pendingFocusTabID == activeTabID)
+    }
+
+    @Test func focusOrCreateTerminal_fallbackToFirstPane_setsPendingFocusTabID() {
+        let paneManager = PaneManager()
+        let terminal = TerminalManager()
+        terminal.paneManager = paneManager
+
+        let editorPane = paneManager.activePaneID
+        guard let tpID = paneManager.createTerminalPane(
+            relativeTo: editorPane, axis: .vertical, workingDirectory: nil
+        ) else {
+            Issue.record("createTerminalPane failed")
+            return
+        }
+        // No lastActiveTerminalPaneID — should fall back to first terminal pane
+        let activeTabID = paneManager.terminalState(for: tpID)?.activeTerminalID
+
+        terminal.focusOrCreateTerminal(relativeTo: editorPane, workingDirectory: nil)
+
+        #expect(paneManager.activePaneID == tpID)
+        #expect(paneManager.terminalState(for: tpID)?.pendingFocusTabID == activeTabID)
+    }
+
+    @Test func createTerminalTab_existingPane_setsPendingFocusTabID() {
+        let paneManager = PaneManager()
+        let terminal = TerminalManager()
+        terminal.paneManager = paneManager
+
+        let editorPane = paneManager.activePaneID
+        guard let tpID = paneManager.createTerminalPane(
+            relativeTo: editorPane, axis: .vertical, workingDirectory: nil
+        ) else {
+            Issue.record("createTerminalPane failed")
+            return
+        }
+        terminal.lastActiveTerminalPaneID = tpID
+
+        terminal.createTerminalTab(relativeTo: editorPane, workingDirectory: nil)
+
+        let state = paneManager.terminalState(for: tpID)
+        #expect(state?.tabCount == 2)
+        #expect(state?.pendingFocusTabID == state?.activeTerminalID)
+    }
+
     @Test func focusOrCreateTerminal_noPane_createsOne() {
         let paneManager = PaneManager()
         let terminal = TerminalManager()


### PR DESCRIPTION
## Summary
- Defer `makeFirstResponder` via `DispatchQueue.main.async` so the focus request lands *after* SwiftUI finishes its layout pass
- Without this fix, SwiftUI restores first-responder back to the editor's `GutterTextView`, forcing the user to click the terminal manually after every Cmd+T

## Test plan
- [ ] Open a project with a file in the editor
- [ ] Press Cmd+T — terminal should appear and keyboard focus should be in the terminal (type something to verify)
- [ ] Press Cmd+T again — new terminal tab should be focused (no mouse click needed)
- [ ] Click back to editor, press Cmd+T — focus should move to terminal again
- [ ] Existing terminal focus tests pass (`TerminalTabTests`, `TerminalPaneStateTests`, `TerminalManagerCoordinatorTests`)