### PR TITLE
test(ci): move fuzz tests to non-blocking nightly job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    # `labeled` lets the `perf` label trigger the performance-tests job
+    # `labeled` lets the `perf` / `fuzz` labels trigger opt-in jobs
     # on-demand from a PR without re-running the rest of CI.
     types: [opened, synchronize, reopened, labeled]
   push:
@@ -162,6 +162,11 @@ jobs:
           sha256sum -c build-products.sha256
           tar --zstd -xf build-products.tar.zst
 
+      # Fuzz tests are excluded from the blocking CI pipeline because they
+      # generate random input data and occasionally hit pathological cases
+      # (large strings, regex backtracking) that exceed the 60s time limit.
+      # They run in a separate nightly job (.github/workflows/nightly-fuzz.yml)
+      # and can be triggered on-demand via the `fuzz` label on a PR.
       - name: Unit Tests
         run: |
           set +e
@@ -171,6 +176,14 @@ jobs:
             -destination "platform=macOS" \
             -derivedDataPath DerivedData \
             -only-testing:PineTests \
+            -skip-testing:PineTests/FuzzGitDiffParserTests \
+            -skip-testing:PineTests/FuzzGitBlameParserTests \
+            -skip-testing:PineTests/FuzzGitStatusParserTests \
+            -skip-testing:PineTests/FuzzSyntaxHighlighterTests \
+            -skip-testing:PineTests/FuzzQuickOpenProviderTests \
+            -skip-testing:PineTests/FuzzSymbolParserTests \
+            -skip-testing:PineTests/FuzzConfigValidatorTests \
+            -skip-testing:PineTests/FuzzGoToLineParserTests \
             -retry-tests-on-failure \
             -enableCodeCoverage YES \
             -resultBundlePath TestResults.xcresult \
@@ -770,4 +783,82 @@ jobs:
         with:
           name: performance-results-xcresult
           path: PerformanceResults.xcresult
+          retention-days: 14
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Fuzz tests — OPT-IN only.
+  #
+  # Fuzz tests generate random input data and can occasionally hit pathological
+  # cases (large strings, regex backtracking) that exceed the default test time
+  # limit. They are excluded from the blocking unit-tests job via -skip-testing:
+  # flags and run here only when:
+  #
+  #   1. A PR is labeled `fuzz` — add the label to run fuzz tests against a
+  #      pull request without re-running the whole pipeline.
+  #
+  # For nightly scheduled runs, see .github/workflows/nightly-fuzz.yml.
+  fuzz-tests:
+    name: Fuzz Tests (on-demand)
+    runs-on: macos-26
+    timeout-minutes: 30
+    concurrency:
+      group: fuzz-${{ github.ref }}
+      cancel-in-progress: false
+    if: >-
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'fuzz')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Select Xcode
+        uses: ./.github/actions/select-xcode
+
+      - name: Download Metal Toolchain
+        run: |
+          xcodebuild -downloadComponent MetalToolchain
+
+      - name: Cache SPM Dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: DerivedData/SourcePackages
+          key: spm-${{ runner.os }}-${{ hashFiles('Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
+      - name: Build for Testing
+        run: |
+          xcodebuild build-for-testing \
+            -project Pine.xcodeproj \
+            -scheme Pine \
+            -destination "platform=macOS" \
+            -derivedDataPath DerivedData \
+            -only-testing:PineTests \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Run Fuzz Tests
+        run: |
+          xcodebuild test-without-building \
+            -project Pine.xcodeproj \
+            -scheme Pine \
+            -destination "platform=macOS" \
+            -derivedDataPath DerivedData \
+            -only-testing:PineTests/FuzzGitDiffParserTests \
+            -only-testing:PineTests/FuzzGitBlameParserTests \
+            -only-testing:PineTests/FuzzGitStatusParserTests \
+            -only-testing:PineTests/FuzzSyntaxHighlighterTests \
+            -only-testing:PineTests/FuzzQuickOpenProviderTests \
+            -only-testing:PineTests/FuzzSymbolParserTests \
+            -only-testing:PineTests/FuzzConfigValidatorTests \
+            -only-testing:PineTests/FuzzGoToLineParserTests \
+            -resultBundlePath FuzzResults.xcresult \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Upload Fuzz Results
+        if: success() || failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: fuzz-results-xcresult
+          path: FuzzResults.xcresult
           retention-days: 14

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -1,0 +1,131 @@
+# NOTE: All third-party actions are pinned by full commit SHA for supply-chain safety.
+# To update an action: find the new version's commit SHA on GitHub (Tags → verify commit),
+# replace the SHA, and keep the "# vX" comment in sync.
+name: Nightly Fuzz Tests
+
+on:
+  schedule:
+    # Run daily at 4:00 AM UTC (one hour after nightly-perf to avoid resource contention)
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  fuzz-tests:
+    name: Fuzz Tests
+    runs-on: macos-26
+    timeout-minutes: 30
+    concurrency:
+      group: nightly-fuzz
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Select Xcode
+        uses: ./.github/actions/select-xcode
+
+      - name: Download Metal Toolchain
+        run: |
+          xcodebuild -downloadComponent MetalToolchain
+
+      - name: Cache SPM Dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: DerivedData/SourcePackages
+          key: spm-${{ runner.os }}-${{ hashFiles('Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+
+      - name: Build for Testing
+        run: |
+          xcodebuild build-for-testing \
+            -project Pine.xcodeproj \
+            -scheme Pine \
+            -destination "platform=macOS" \
+            -derivedDataPath DerivedData \
+            -only-testing:PineTests \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_ALLOWED=NO
+
+      # Fuzz tests live in PineTests alongside unit tests but are excluded
+      # from the blocking CI pipeline via -skip-testing: flags. This job
+      # runs only the fuzz suites with an extended time limit (2 minutes
+      # per suite via .timeLimit(.minutes(2)) in the test suites).
+      - name: Run Fuzz Tests
+        run: |
+          xcodebuild test-without-building \
+            -project Pine.xcodeproj \
+            -scheme Pine \
+            -destination "platform=macOS" \
+            -derivedDataPath DerivedData \
+            -only-testing:PineTests/FuzzGitDiffParserTests \
+            -only-testing:PineTests/FuzzGitBlameParserTests \
+            -only-testing:PineTests/FuzzGitStatusParserTests \
+            -only-testing:PineTests/FuzzSyntaxHighlighterTests \
+            -only-testing:PineTests/FuzzQuickOpenProviderTests \
+            -only-testing:PineTests/FuzzSymbolParserTests \
+            -only-testing:PineTests/FuzzConfigValidatorTests \
+            -only-testing:PineTests/FuzzGoToLineParserTests \
+            -resultBundlePath FuzzResults.xcresult \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Fuzz Test Summary
+        if: success() || failure()
+        run: |
+          XCRESULT="FuzzResults.xcresult"
+          if [ ! -d "$XCRESULT" ]; then
+            echo "No .xcresult bundle found"
+            exit 0
+          fi
+
+          echo "## Nightly Fuzz Test Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Date:** $(date -u '+%Y-%m-%d %H:%M UTC')" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          # Extract test results using jq
+          xcrun xcresulttool get test-results summary \
+            --path "$XCRESULT" \
+            --compact 2>/dev/null \
+          | jq -r '
+            "| Metric | Value |",
+            "|--------|-------|",
+            "| Total tests | \(.passedTests + .failedTests) |",
+            "| Passed | \(.passedTests) |",
+            "| Failed | \(.failedTests) |"
+          ' >> "$GITHUB_STEP_SUMMARY" || echo "Could not extract test summary" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Fuzz Results
+        if: success() || failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: FuzzResults-${{ github.run_id }}
+          path: FuzzResults.xcresult
+          retention-days: 14
+
+      - name: Create Issue on Failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "Nightly fuzz tests failed ($(date -u '+%Y-%m-%d'))" \
+            --body "## Summary
+
+          The nightly fuzz test run failed. This typically indicates a crash or
+          pathological input that exposed a parser bug.
+
+          **Run:** $RUN_URL
+
+          ## Next steps
+
+          1. Check the workflow logs for the failing test class and seed
+          2. Download the \`FuzzResults.xcresult\` artifact for detailed failure info
+          3. Reproduce locally using the seed from the failing test
+          4. Fix the parser/handler to gracefully handle the problematic input" \
+            --label "bug,testing"


### PR DESCRIPTION
## Summary

- Add `.github/workflows/nightly-fuzz.yml` — runs all 8 fuzz test suites nightly (4:00 AM UTC) and via `workflow_dispatch`. Auto-creates a GitHub issue on failure with reproduction steps.
- Exclude fuzz tests from the blocking `unit-tests` CI job via `-skip-testing:` flags for all 8 fuzz suites.
- Add opt-in `fuzz-tests` job to `ci.yml` triggered by the `fuzz` label on a PR (same pattern as `perf` label for performance tests).
- Create `fuzz` label in the repository.

Closes #865

## Fuzz test suites excluded

| Suite | File |
|-------|------|
| FuzzGitDiffParserTests | FuzzGitParserTests.swift |
| FuzzGitBlameParserTests | FuzzGitParserTests.swift |
| FuzzGitStatusParserTests | FuzzGitParserTests.swift |
| FuzzSyntaxHighlighterTests | FuzzSyntaxHighlighterTests.swift |
| FuzzQuickOpenProviderTests | FuzzQuickOpenTests.swift |
| FuzzSymbolParserTests | FuzzSymbolParserTests.swift |
| FuzzConfigValidatorTests | FuzzConfigValidatorTests.swift |
| FuzzGoToLineParserTests | FuzzGoToLineParserTests.swift |

## Test plan

- [x] Verify CI workflow YAML syntax is valid
- [x] Verify all 8 fuzz suites are listed in both `-skip-testing:` (ci.yml) and `-only-testing:` (nightly-fuzz.yml)
- [ ] Push this PR and verify the unit-tests job skips fuzz suites
- [ ] Manually trigger nightly-fuzz workflow from Actions tab to verify it runs
- [ ] Add `fuzz` label to this PR to verify the opt-in job triggers