### PR TITLE
feat(editor): Shell script format-on-save via shfmt (#855)

### DIFF
--- a/Pine/FileFormatter.swift
+++ b/Pine/FileFormatter.swift
@@ -179,6 +179,108 @@ enum HCLFileFormatter {
     }
 }
 
+/// Formats shell scripts via `shfmt -i 2 -ci -bn`. Handles `.sh`, `.bash`, `.zsh` extensions
+/// and detects shell shebangs (`#!/bin/sh`, `#!/bin/bash`, `#!/usr/bin/env bash`, etc.)
+/// in extensionless files. Gracefully no-ops when `shfmt` is not installed.
+struct ShellFileFormatter: FileFormatter, Sendable {
+    /// Shell file extensions (lowercase, without dot).
+    private static let shellExtensions: Set<String> = ["sh", "bash", "zsh"]
+
+    /// Shebang patterns that indicate a shell script.
+    /// Matches lines like `#!/bin/sh`, `#!/bin/bash -e`, `#!/usr/bin/env bash`.
+    private static let shellShebangPattern: String = {
+        let interpreters = [
+            "/bin/sh",
+            "/bin/bash",
+            "/bin/zsh",
+            "/usr/bin/env sh",
+            "/usr/bin/env bash",
+            "/usr/bin/env zsh"
+        ]
+        let alt = interpreters.map { NSRegularExpression.escapedPattern(for: $0) }.joined(separator: "|")
+        return "^#!.*(" + alt + ")(\\s|$)"
+    }()
+
+    private let formatter: ExternalFileFormatter
+
+    /// Whether to claim extensionless files (needed for shebang detection in `format()`).
+    /// Set to `false` when shfmt is not installed.
+    private let claimExtensionless: Bool
+
+    init(formatter: ExternalFileFormatter, claimExtensionless: Bool = true) {
+        self.formatter = formatter
+        self.claimExtensionless = claimExtensionless
+    }
+
+    static func resolve(
+        processRunner: @escaping ProcessRunner = runRealProcess,
+        resolver: ExternalToolResolver = .fromEnvironment()
+    ) -> ShellFileFormatter {
+        let extensions = ["sh", "bash", "zsh"]
+        let arguments = ["-i", "2", "-ci", "-bn"]
+
+        let external: ExternalFileFormatter
+        if let path = resolver.resolve(tool: "shfmt") {
+            external = ExternalFileFormatter(
+                toolPath: path,
+                toolName: "shfmt",
+                extensions: extensions,
+                arguments: arguments,
+                processRunner: processRunner
+            )
+            return ShellFileFormatter(formatter: external, claimExtensionless: true)
+        } else {
+            external = ExternalFileFormatter(
+                toolPath: nil,
+                toolName: "shfmt",
+                extensions: extensions,
+                arguments: arguments,
+                processRunner: processRunner
+            )
+            return ShellFileFormatter(formatter: external, claimExtensionless: false)
+        }
+    }
+
+    func canFormat(url: URL) -> Bool {
+        let ext = url.pathExtension.lowercased()
+        // Files with shell extensions
+        if Self.shellExtensions.contains(ext) {
+            return formatter.toolPath != nil
+        }
+        // Extensionless files — claim conditionally for shebang detection in format()
+        if ext.isEmpty && claimExtensionless {
+            return true
+        }
+        return false
+    }
+
+    func format(_ content: String, url: URL) -> String {
+        let ext = url.pathExtension.lowercased()
+
+        // For extensionless files, verify shell shebang before formatting
+        if ext.isEmpty {
+            guard hasShellShebang(content) else {
+                return content
+            }
+        }
+
+        return formatter.format(content, url: url)
+    }
+
+    /// Checks whether the content starts with a shell shebang line.
+    private func hasShellShebang(_ content: String) -> Bool {
+        guard content.hasPrefix("#!") else { return false }
+        guard let firstLine = content.split(separator: "\n", maxSplits: 1).first else {
+            return false
+        }
+        guard let regex = try? NSRegularExpression(pattern: Self.shellShebangPattern) else {
+            return false
+        }
+        let range = NSRange(firstLine.startIndex..., in: firstLine)
+        return regex.firstMatch(in: String(firstLine), range: range) != nil
+    }
+}
+
 /// Composes an ordered list of formatters, applying the first whose `canFormat` returns
 /// true. The empty registry is a no-op — safe default for files with no known formatter.
 struct FileFormatterRegistry: Sendable {
@@ -187,10 +289,13 @@ struct FileFormatterRegistry: Sendable {
     /// Default registry. Ships a pure-Swift JSON formatter. External tool formatters
     /// (e.g. `ExternalFileFormatter` for terraform, shfmt, prettier) can be appended
     /// by consumers — they participate in the same first-match dispatch.
+    /// ShellFileFormatter is listed last so it doesn't intercept extensionless files
+    /// before other formatters get a chance.
     static let `default` = FileFormatterRegistry(formatters: [
         JSONFileFormatter(),
         HCLFileFormatter.resolve(),
-        YAMLFileFormatter.resolve()
+        YAMLFileFormatter.resolve(),
+        ShellFileFormatter.resolve()
     ])
 
     /// Returns a formatted copy of `content` for the given URL, or the original if no

--- a/Pine/FileFormatter.swift
+++ b/Pine/FileFormatter.swift
@@ -186,30 +186,27 @@ struct ShellFileFormatter: FileFormatter, Sendable {
     /// Shell file extensions (lowercase, without dot).
     private static let shellExtensions: Set<String> = ["sh", "bash", "zsh"]
 
-    /// Shebang patterns that indicate a shell script.
+    /// Maximum content size to format. Larger files are left as-is
+    /// to avoid blocking the UI with an external process.
+    private static let maxFormatSize = 100_000
+
+    /// Pre-compiled regex for shell shebang detection.
     /// Matches lines like `#!/bin/sh`, `#!/bin/bash -e`, `#!/usr/bin/env bash`.
-    private static let shellShebangPattern: String = {
+    private static let shellShebangRegex: NSRegularExpression = {
         let interpreters = [
-            "/bin/sh",
-            "/bin/bash",
-            "/bin/zsh",
-            "/usr/bin/env sh",
-            "/usr/bin/env bash",
-            "/usr/bin/env zsh"
+            "/bin/sh", "/bin/bash", "/bin/zsh", "/bin/dash",
+            "/usr/bin/env sh", "/usr/bin/env bash", "/usr/bin/env zsh", "/usr/bin/env dash"
         ]
         let alt = interpreters.map { NSRegularExpression.escapedPattern(for: $0) }.joined(separator: "|")
-        return "^#!.*(" + alt + ")(\\s|$)"
+        let pattern = "^#!.*(" + alt + ")(\\s|$)"
+        // swiftlint:disable:next force_try
+        return try! NSRegularExpression(pattern: pattern)
     }()
 
     private let formatter: ExternalFileFormatter
 
-    /// Whether to claim extensionless files (needed for shebang detection in `format()`).
-    /// Set to `false` when shfmt is not installed.
-    private let claimExtensionless: Bool
-
-    init(formatter: ExternalFileFormatter, claimExtensionless: Bool = true) {
+    init(formatter: ExternalFileFormatter) {
         self.formatter = formatter
-        self.claimExtensionless = claimExtensionless
     }
 
     static func resolve(
@@ -228,7 +225,6 @@ struct ShellFileFormatter: FileFormatter, Sendable {
                 arguments: arguments,
                 processRunner: processRunner
             )
-            return ShellFileFormatter(formatter: external, claimExtensionless: true)
         } else {
             external = ExternalFileFormatter(
                 toolPath: nil,
@@ -237,8 +233,8 @@ struct ShellFileFormatter: FileFormatter, Sendable {
                 arguments: arguments,
                 processRunner: processRunner
             )
-            return ShellFileFormatter(formatter: external, claimExtensionless: false)
         }
+        return ShellFileFormatter(formatter: external)
     }
 
     func canFormat(url: URL) -> Bool {
@@ -247,14 +243,16 @@ struct ShellFileFormatter: FileFormatter, Sendable {
         if Self.shellExtensions.contains(ext) {
             return formatter.toolPath != nil
         }
-        // Extensionless files — claim conditionally for shebang detection in format()
-        if ext.isEmpty && claimExtensionless {
-            return true
+        // Extensionless files — claim when shfmt is available for shebang detection in format()
+        if ext.isEmpty {
+            return formatter.toolPath != nil
         }
         return false
     }
 
     func format(_ content: String, url: URL) -> String {
+        guard content.utf8.count < Self.maxFormatSize else { return content }
+
         let ext = url.pathExtension.lowercased()
 
         // For extensionless files, verify shell shebang before formatting
@@ -273,11 +271,8 @@ struct ShellFileFormatter: FileFormatter, Sendable {
         guard let firstLine = content.split(separator: "\n", maxSplits: 1).first else {
             return false
         }
-        guard let regex = try? NSRegularExpression(pattern: Self.shellShebangPattern) else {
-            return false
-        }
         let range = NSRange(firstLine.startIndex..., in: firstLine)
-        return regex.firstMatch(in: String(firstLine), range: range) != nil
+        return Self.shellShebangRegex.firstMatch(in: String(firstLine), range: range) != nil
     }
 }
 

--- a/PineTests/ShellFileFormatterTests.swift
+++ b/PineTests/ShellFileFormatterTests.swift
@@ -160,6 +160,34 @@ struct ShellFileFormatterTests {
         #expect(result == "#!/bin/bash -e\necho hello\n")
     }
 
+    @Test("Shebang #!/bin/dash detected — formats file without extension")
+    func shebangBinDashDetected() {
+        let runner = MockProcessRunner(
+            stdout: "#!/bin/dash\necho hello\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/dashscript")
+        #expect(formatter.canFormat(url: url))
+        let result = formatter.format("#!/bin/dash\necho hello\n", url: url)
+        #expect(result == "#!/bin/dash\necho hello\n")
+    }
+
+    @Test("Shebang #!/usr/bin/env dash detected — formats file without extension")
+    func shebangEnvDashDetected() {
+        let runner = MockProcessRunner(
+            stdout: "#!/usr/bin/env dash\necho hello\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/envdash")
+        #expect(formatter.canFormat(url: url))
+        let result = formatter.format("#!/usr/bin/env dash\necho hello\n", url: url)
+        #expect(result == "#!/usr/bin/env dash\necho hello\n")
+    }
+
     @Test("No shebang and no shell extension — format() returns original")
     func noShebangNoExtensionNotFormatted() {
         let runner = MockProcessRunner(stdout: "formatted", stderr: "", exitCode: 0)
@@ -265,6 +293,22 @@ struct ShellFileFormatterTests {
             url: URL(fileURLWithPath: "/project/script.sh")
         )
         #expect(result == "#!/bin/sh\necho hello\n")
+    }
+
+    // MARK: - Size limit
+
+    @Test("Large file — returns original content (maxFormatSize exceeded)")
+    func largeFileReturnsOriginal() {
+        let runner = MockProcessRunner(stdout: "formatted", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner)
+        // Create content larger than maxFormatSize (100_000 bytes)
+        let largeContent = String(repeating: "#!/bin/sh\necho hello\n", count: 5_000)
+        #expect(largeContent.utf8.count > 100_000)
+        let result = formatter.format(
+            largeContent,
+            url: URL(fileURLWithPath: "/project/large.sh")
+        )
+        #expect(result == largeContent)
     }
 
     // MARK: - Extension handling

--- a/PineTests/ShellFileFormatterTests.swift
+++ b/PineTests/ShellFileFormatterTests.swift
@@ -1,0 +1,408 @@
+//
+//  ShellFileFormatterTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("ShellFileFormatter")
+struct ShellFileFormatterTests {
+
+    // MARK: - Helper
+
+    private func makeFormatter(
+        runner: MockProcessRunner,
+        toolPath: String? = "/usr/local/bin/shfmt"
+    ) -> ShellFileFormatter {
+        let external = ExternalFileFormatter(
+            toolPath: toolPath,
+            toolName: "shfmt",
+            extensions: ["sh", "bash", "zsh"],
+            arguments: ["-i", "2", "-ci", "-bn"],
+            processRunner: runner.run
+        )
+        return ShellFileFormatter(formatter: external)
+    }
+
+    // MARK: - shfmt found — extension-based formatting
+
+    @Test("shfmt found — formats .sh files")
+    func shfmtFormatsSHFiles() {
+        let runner = MockProcessRunner(
+            stdout: "#!/bin/sh\necho \"hello\"\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let result = formatter.format(
+            "#!/bin/sh\necho \"hello\"\n",
+            url: URL(fileURLWithPath: "/project/script.sh")
+        )
+        #expect(result == "#!/bin/sh\necho \"hello\"\n")
+    }
+
+    @Test("shfmt found — formats .bash files")
+    func shfmtFormatsBashFiles() {
+        let runner = MockProcessRunner(
+            stdout: "#!/bin/bash\nif true; then\n  echo yes\nfi\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let result = formatter.format(
+            "#!/bin/bash\nif true; then\necho yes\nfi\n",
+            url: URL(fileURLWithPath: "/project/script.bash")
+        )
+        #expect(result == "#!/bin/bash\nif true; then\n  echo yes\nfi\n")
+    }
+
+    @Test("shfmt found — formats .zsh files")
+    func shfmtFormatsZshFiles() {
+        let runner = MockProcessRunner(
+            stdout: "#!/bin/zsh\necho \"zsh script\"\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let result = formatter.format(
+            "#!/bin/zsh\necho \"zsh script\"\n",
+            url: URL(fileURLWithPath: "/project/script.zsh")
+        )
+        #expect(result == "#!/bin/zsh\necho \"zsh script\"\n")
+    }
+
+    // MARK: - Shebang detection — files without shell extension
+
+    @Test("Shebang #!/bin/sh detected — formats file without extension")
+    func shebangBinShDetected() {
+        let runner = MockProcessRunner(
+            stdout: "#!/bin/sh\necho hello\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/myscript")
+        #expect(formatter.canFormat(url: url))
+        let result = formatter.format("#!/bin/sh\necho hello\n", url: url)
+        #expect(result == "#!/bin/sh\necho hello\n")
+    }
+
+    @Test("Shebang #!/bin/bash detected — formats file without extension")
+    func shebangBinBashDetected() {
+        let runner = MockProcessRunner(
+            stdout: "#!/bin/bash\necho hello\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/runme")
+        #expect(formatter.canFormat(url: url))
+        let result = formatter.format("#!/bin/bash\necho hello\n", url: url)
+        #expect(result == "#!/bin/bash\necho hello\n")
+    }
+
+    @Test("Shebang #!/usr/bin/env bash detected — formats file without extension")
+    func shebangEnvBashDetected() {
+        let runner = MockProcessRunner(
+            stdout: "#!/usr/bin/env bash\necho hello\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/setup")
+        #expect(formatter.canFormat(url: url))
+        let result = formatter.format("#!/usr/bin/env bash\necho hello\n", url: url)
+        #expect(result == "#!/usr/bin/env bash\necho hello\n")
+    }
+
+    @Test("Shebang #!/usr/bin/env sh detected — formats file without extension")
+    func shebangEnvShDetected() {
+        let runner = MockProcessRunner(
+            stdout: "#!/usr/bin/env sh\necho hello\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/bootstrap")
+        #expect(formatter.canFormat(url: url))
+        let result = formatter.format("#!/usr/bin/env sh\necho hello\n", url: url)
+        #expect(result == "#!/usr/bin/env sh\necho hello\n")
+    }
+
+    @Test("Shebang #!/usr/bin/env zsh detected — formats file without extension")
+    func shebangEnvZshDetected() {
+        let runner = MockProcessRunner(
+            stdout: "#!/usr/bin/env zsh\necho hello\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/zshrc-setup")
+        #expect(formatter.canFormat(url: url))
+        let result = formatter.format("#!/usr/bin/env zsh\necho hello\n", url: url)
+        #expect(result == "#!/usr/bin/env zsh\necho hello\n")
+    }
+
+    @Test("Shebang with options — #!/bin/bash -e detected")
+    func shebangWithOptionsDetected() {
+        let runner = MockProcessRunner(
+            stdout: "#!/bin/bash -e\necho hello\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/deploy")
+        #expect(formatter.canFormat(url: url))
+        let result = formatter.format("#!/bin/bash -e\necho hello\n", url: url)
+        #expect(result == "#!/bin/bash -e\necho hello\n")
+    }
+
+    @Test("No shebang and no shell extension — format() returns original")
+    func noShebangNoExtensionNotFormatted() {
+        let runner = MockProcessRunner(stdout: "formatted", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/readme")
+        // canFormat claims extensionless files for shebang detection
+        #expect(formatter.canFormat(url: url))
+        // But format() returns original because there's no shell shebang
+        let content = "This is just a text file\n"
+        let result = formatter.format(content, url: url)
+        #expect(result == content)
+    }
+
+    @Test("Non-shell shebang — format() returns original")
+    func nonShellShebangNotFormatted() {
+        let runner = MockProcessRunner(stdout: "formatted", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/script.py")
+        #expect(!formatter.canFormat(url: url))
+    }
+
+    @Test("Non-shell shebang in extensionless file — format() returns original")
+    func nonShellShebangExtensionlessNotFormatted() {
+        let runner = MockProcessRunner(stdout: "formatted", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/script")
+        let content = "#!/usr/bin/python3\nprint('hello')\n"
+        let result = formatter.format(content, url: url)
+        #expect(result == content)
+    }
+
+    @Test("Empty content — format() returns original (no shebang)")
+    func emptyContentNotMatched() {
+        let runner = MockProcessRunner(stdout: "formatted", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/empty")
+        // canFormat claims extensionless files for shebang detection
+        #expect(formatter.canFormat(url: url))
+        // But format() returns original because content is empty (no shebang)
+        let result = formatter.format("", url: url)
+        #expect(result == "")
+    }
+
+    // MARK: - shfmt not found
+
+    @Test("shfmt not found — returns original content (no-op formatter)")
+    func shfmtNotFoundReturnsOriginal() {
+        let runner = MockProcessRunner(stdout: "should not appear", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner, toolPath: nil)
+
+        #expect(!formatter.canFormat(url: URL(fileURLWithPath: "/project/script.sh")))
+
+        let result = formatter.format(
+            "#!/bin/sh\necho hello\n",
+            url: URL(fileURLWithPath: "/project/script.sh")
+        )
+        #expect(result == "#!/bin/sh\necho hello\n")
+    }
+
+    // MARK: - Error handling
+
+    @Test("Non-zero exit code — returns original content")
+    func nonZeroExitReturnsOriginal() {
+        let runner = MockProcessRunner(
+            stdout: "partial output",
+            stderr: "Error: syntax error",
+            exitCode: 1
+        )
+        let formatter = makeFormatter(runner: runner)
+        let result = formatter.format(
+            "invalid shell syntax {",
+            url: URL(fileURLWithPath: "/project/script.sh")
+        )
+        #expect(result == "invalid shell syntax {")
+    }
+
+    @Test("Timeout — returns original content")
+    func timeoutReturnsOriginal() {
+        let external = ExternalFileFormatter(
+            toolPath: "/usr/local/bin/shfmt",
+            toolName: "shfmt",
+            extensions: ["sh", "bash", "zsh"],
+            arguments: ["-i", "2", "-ci", "-bn"],
+            processRunner: MockProcessRunner(
+                stdout: "", stderr: "", exitCode: 0, simulateTimeout: true
+            ).run,
+            timeout: 0.1
+        )
+        let formatter = ShellFileFormatter(formatter: external)
+        let result = formatter.format(
+            "#!/bin/sh\necho hello\n",
+            url: URL(fileURLWithPath: "/project/script.sh")
+        )
+        #expect(result == "#!/bin/sh\necho hello\n")
+    }
+
+    @Test("Empty stdout — returns original content")
+    func emptyStdoutReturnsOriginal() {
+        let runner = MockProcessRunner(stdout: "", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner)
+        let result = formatter.format(
+            "#!/bin/sh\necho hello\n",
+            url: URL(fileURLWithPath: "/project/script.sh")
+        )
+        #expect(result == "#!/bin/sh\necho hello\n")
+    }
+
+    // MARK: - Extension handling
+
+    @Test("Case-insensitive extensions — .SH, .BASH, .ZSH are formatted")
+    func caseInsensitiveExtensions() {
+        let runner = MockProcessRunner(stdout: "formatted", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner)
+        #expect(formatter.canFormat(url: URL(fileURLWithPath: "/project/SCRIPT.SH")))
+        #expect(formatter.canFormat(url: URL(fileURLWithPath: "/project/script.BASH")))
+        #expect(formatter.canFormat(url: URL(fileURLWithPath: "/project/script.ZSH")))
+        #expect(formatter.canFormat(url: URL(fileURLWithPath: "/project/mixed.Sh")))
+    }
+
+    @Test("Non-shell files are not formatted")
+    func nonShellFilesIgnored() {
+        let runner = MockProcessRunner(stdout: "formatted", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner)
+        #expect(!formatter.canFormat(url: URL(fileURLWithPath: "/project/main.swift")))
+        #expect(!formatter.canFormat(url: URL(fileURLWithPath: "/project/config.json")))
+        #expect(!formatter.canFormat(url: URL(fileURLWithPath: "/project/style.css")))
+        #expect(!formatter.canFormat(url: URL(fileURLWithPath: "/project/main.tf")))
+    }
+
+    // MARK: - Stdin piping
+
+    @Test("File content is piped to the process via stdin")
+    func stdinReceivesFileContent() {
+        let runner = MockProcessRunner(stdout: "formatted", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner)
+        _ = formatter.format(
+            "#!/bin/bash\necho hello\n",
+            url: URL(fileURLWithPath: "/project/script.sh")
+        )
+        #expect(runner.lastStdinContent == "#!/bin/bash\necho hello\n")
+    }
+
+    // MARK: - Resolve
+
+    @Test("ShellFileFormatter.resolve uses shfmt when available")
+    func resolveUsesShfmtWhenAvailable() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let shfmtPath = tempDir.appendingPathComponent("shfmt")
+        FileManager.default.createFile(
+            atPath: shfmtPath.path,
+            contents: Data("#!/bin/sh\n".utf8)
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: shfmtPath.path
+        )
+
+        let resolver = ExternalToolResolver(searchDirectories: [tempDir.path])
+        let runner = MockProcessRunner(stdout: "formatted", stderr: "", exitCode: 0)
+        let formatter = ShellFileFormatter.resolve(
+            processRunner: runner.run,
+            resolver: resolver
+        )
+
+        #expect(formatter.canFormat(url: URL(fileURLWithPath: "/project/script.sh")))
+        let result = formatter.format(
+            "#!/bin/sh\necho hello\n",
+            url: URL(fileURLWithPath: "/project/script.sh")
+        )
+        #expect(result == "formatted")
+    }
+
+    @Test("ShellFileFormatter.resolve is no-op when shfmt is missing")
+    func resolveNoOpWhenShfmtMissing() {
+        let resolver = ExternalToolResolver(searchDirectories: [])
+        let runner = MockProcessRunner(stdout: "formatted", stderr: "", exitCode: 0)
+        let formatter = ShellFileFormatter.resolve(
+            processRunner: runner.run,
+            resolver: resolver
+        )
+
+        #expect(!formatter.canFormat(url: URL(fileURLWithPath: "/project/script.sh")))
+    }
+
+    // MARK: - Main-thread safety
+
+    @Test("format() can be called from the main thread without crashing")
+    @MainActor
+    func formatFromMainThreadDoesNotCrash() {
+        let runner = MockProcessRunner(
+            stdout: "#!/bin/sh\necho hello\n",
+            stderr: "",
+            exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let result = formatter.format(
+            "#!/bin/sh\necho hello\n",
+            url: URL(fileURLWithPath: "/project/script.sh")
+        )
+        #expect(result == "#!/bin/sh\necho hello\n")
+    }
+
+    // MARK: - Registry integration
+
+    @Test("Shell formatter coexists with JSON, HCL, and YAML formatters in registry")
+    func registryIntegration() {
+        let runner = MockProcessRunner(stdout: "shell-formatted", stderr: "", exitCode: 0)
+        let shellFormatter = makeFormatter(runner: runner)
+        let registry = FileFormatterRegistry(formatters: [
+            JSONFileFormatter(),
+            shellFormatter
+        ])
+
+        // .sh file — Shell formatter
+        let shResult = registry.format(
+            content: "#!/bin/sh\necho hello\n",
+            url: URL(fileURLWithPath: "/project/script.sh")
+        )
+        #expect(shResult == "shell-formatted")
+
+        // .bash file — Shell formatter
+        let bashResult = registry.format(
+            content: "#!/bin/bash\necho hello\n",
+            url: URL(fileURLWithPath: "/project/run.bash")
+        )
+        #expect(bashResult == "shell-formatted")
+
+        // .json file — JSON formatter
+        let jsonResult = registry.format(
+            content: #"{"key":"value"}"#,
+            url: URL(fileURLWithPath: "/project/config.json")
+        )
+        #expect(jsonResult.contains("\"key\""))
+
+        // .swift file — no formatter
+        let swiftResult = registry.format(
+            content: "let x = 1",
+            url: URL(fileURLWithPath: "/project/main.swift")
+        )
+        #expect(swiftResult == "let x = 1")
+    }
+}

--- a/PineTests/ShellFileFormatterTests.swift
+++ b/PineTests/ShellFileFormatterTests.swift
@@ -74,6 +74,40 @@ struct ShellFileFormatterTests {
         #expect(result == "#!/bin/zsh\necho \"zsh script\"\n")
     }
 
+    @Test(".sh file without shebang — formats because shfmt detects language by extension")
+    func shFileWithoutShebang() {
+        let runner = MockProcessRunner(stdout: "echo hello\n", stderr: "", exitCode: 0)
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/script.sh")
+        #expect(formatter.canFormat(url: url))
+        let result = formatter.format("echo hello\n", url: url)
+        #expect(result == "echo hello\n")
+    }
+
+    @Test("Non-standard path — #!/usr/local/bin/bash detected via regex")
+    func nonStandardPathBash() {
+        let runner = MockProcessRunner(
+            stdout: "#!/usr/local/bin/bash\necho hello\n", stderr: "", exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/runme")
+        #expect(formatter.canFormat(url: url))
+        let result = formatter.format("#!/usr/local/bin/bash\necho hello\n", url: url)
+        #expect(result == "#!/usr/local/bin/bash\necho hello\n")
+    }
+
+    @Test("Non-standard path — #!/opt/homebrew/bin/zsh detected via regex")
+    func nonStandardPathZsh() {
+        let runner = MockProcessRunner(
+            stdout: "#!/opt/homebrew/bin/zsh\necho hello\n", stderr: "", exitCode: 0
+        )
+        let formatter = makeFormatter(runner: runner)
+        let url = URL(fileURLWithPath: "/project/setup")
+        #expect(formatter.canFormat(url: url))
+        let result = formatter.format("#!/opt/homebrew/bin/zsh\necho hello\n", url: url)
+        #expect(result == "#!/opt/homebrew/bin/zsh\necho hello\n")
+    }
+
     // MARK: - Shebang detection — files without shell extension
 
     @Test("Shebang #!/bin/sh detected — formats file without extension")


### PR DESCRIPTION
## Summary
- Adds `ShellFileFormatter` that formats shell scripts via `shfmt -i 2 -ci -bn`
- Supports `.sh`, `.bash`, `.zsh` file extensions
- Detects shell shebangs (`#!/bin/sh`, `#!/bin/bash`, `#!/usr/bin/env bash`, etc.) in extensionless files
- Gracefully no-ops when `shfmt` is not installed
- Registered in `FileFormatterRegistry.default` (listed last to avoid intercepting extensionless files before other formatters)

## Implementation details
- `ShellFileFormatter` wraps `ExternalFileFormatter` (same pattern as `YAMLFileFormatter`)
- Shebang detection uses regex matching against known shell interpreter paths
- `canFormat(url:)` claims extensionless files when `shfmt` is available; `format()` verifies shebang before delegating
- Default flags: `-i 2 -ci -bn` (2-space indent, indent case bodies, binary ops start of line)

## Test plan
- [x] 24 unit tests covering all scenarios:
  - Valid script formatting (.sh, .bash, .zsh)
  - Invalid script passthrough (non-zero exit)
  - shfmt not found (graceful no-op)
  - Shebang detection (6 variants including env-style and options)
  - Non-shell shebang rejection
  - Empty content handling
  - Case-insensitive extensions
  - Registry integration
  - Main-thread safety
  - Resolve with/without shfmt installed
  - Timeout handling
- [x] All 97 formatter tests pass (JSON, HCL, YAML, Shell, External, Registry)
- [x] SwiftLint --strict: 0 violations

Closes #855