### PR TITLE
refactor: introduce AlertTemplate builder to deduplicate NSAlert boilerplate

### DIFF
--- a/Pine/AlertTemplate.swift
+++ b/Pine/AlertTemplate.swift
@@ -1,0 +1,157 @@
+//
+//  AlertTemplate.swift
+//  Pine
+//
+//  A single enum + factory that replaces all direct NSAlert() constructions
+//  across the codebase. Each case encodes button labels, alert style,
+//  and destructive-button position so every call site is one line.
+//
+
+import AppKit
+
+/// Templates for all NSAlert dialogs used in Pine.
+///
+/// Usage:
+/// ```swift
+/// let response = AlertTemplate.unsavedChangesSingle.runModal(
+///     messageText: Strings.unsavedChangesTitle,
+///     informativeText: Strings.unsavedChangesMessage
+/// )
+/// ```
+enum AlertTemplate: Sendable {
+    // MARK: - Unsaved changes
+
+    /// Save / Don't Save / Cancel  — single file close confirmation.
+    case unsavedChangesSingle
+
+    /// Save All / Don't Save / Cancel  — bulk close / window close / app quit.
+    case unsavedChangesBulk
+
+    // MARK: - Terminal
+
+    /// Close / Cancel  — closing a terminal tab with a foreground process.
+    case terminalTabCloseWarning
+
+    /// Quit / Cancel  — quitting the app with active terminal processes.
+    case terminalActiveProcessWarning
+
+    // MARK: - External changes
+
+    /// Reload / Keep  — file was modified externally.
+    case externalModifyConflict
+
+    /// Save As / Don't Save / Cancel  — file was deleted externally.
+    case fileDeletedSaveAs
+
+    // MARK: - File operations
+
+    /// OK only, `.critical` style  — save/duplicate/as-error alert.
+    case fileOperationErrorCritical
+
+    /// OK only, `.warning` style  — save-as fallback error, sidebar error.
+    case fileOperationErrorWarning
+
+    /// Open Without Highlighting / Open With Highlighting / Cancel  — large file warning.
+    case largeFileWarning
+
+    // MARK: - Git
+
+    /// Switch Anyway / Cancel  — branch switch with uncommitted changes.
+    case branchUncommittedChanges
+
+    // MARK: - Revert
+
+    /// Revert All / Cancel  — confirm reverting all changes in a file.
+    case revertAllConfirmation
+
+    // MARK: - CLI Installer
+
+    /// OK only, `.informational` style  — CLI install/uninstall notification.
+    case cliInstallerInfo
+}
+
+// MARK: - Factory
+
+extension AlertTemplate {
+    /// Creates a fully configured `NSAlert` for this template.
+    ///
+    /// - Parameters:
+    ///   - messageText: The primary message (bold title).
+    ///   - informativeText: Optional secondary message. Pass `nil` to omit.
+    /// - Returns: A configured `NSAlert` ready for `runModal()`.
+    @MainActor
+    func makeAlert(messageText: String, informativeText: String? = nil) -> NSAlert {
+        let alert = NSAlert()
+        alert.messageText = messageText
+        if let informativeText {
+            alert.informativeText = informativeText
+        }
+        alert.alertStyle = style
+
+        for buttonTitle in buttonTitles {
+            alert.addButton(withTitle: buttonTitle)
+        }
+
+        return alert
+    }
+
+    /// Creates and runs a modal alert for this template.
+    ///
+    /// - Parameters:
+    ///   - messageText: The primary message (bold title).
+    ///   - informativeText: Optional secondary message.
+    /// - Returns: The modal response from the alert.
+    @discardableResult
+    @MainActor
+    func runModal(messageText: String, informativeText: String? = nil) -> NSApplication.ModalResponse {
+        makeAlert(messageText: messageText, informativeText: informativeText).runModal()
+    }
+}
+
+// MARK: - Template Configuration
+
+extension AlertTemplate {
+    /// The alert style for this template.
+    private var style: NSAlert.Style {
+        switch self {
+        case .fileOperationErrorCritical:
+            return .critical
+        case .cliInstallerInfo:
+            return .informational
+        default:
+            return .warning
+        }
+    }
+
+    /// The button titles in order (first button = `.alertFirstButtonReturn`).
+    private var buttonTitles: [String] {
+        switch self {
+        case .unsavedChangesSingle:
+            return [Strings.dialogSave, Strings.dialogDontSave, Strings.dialogCancel]
+        case .unsavedChangesBulk:
+            return [Strings.dialogSaveAll, Strings.dialogDontSave, Strings.dialogCancel]
+        case .terminalTabCloseWarning:
+            return [Strings.terminalTabCloseWarningClose, Strings.dialogCancel]
+        case .terminalActiveProcessWarning:
+            return [Strings.terminalActiveProcessWarningQuit, Strings.dialogCancel]
+        case .externalModifyConflict:
+            return [Strings.externalModifyReload, Strings.externalModifyKeep]
+        case .fileDeletedSaveAs:
+            return [Strings.fileDeletedSaveAs, Strings.dialogDontSave, Strings.dialogCancel]
+        case .fileOperationErrorCritical, .fileOperationErrorWarning:
+            return [Strings.dialogOK]
+        case .largeFileWarning:
+            return [
+                Strings.largeFileOpenWithoutHighlighting,
+                Strings.largeFileOpenWithHighlighting,
+                Strings.dialogCancel,
+            ]
+        case .branchUncommittedChanges:
+            return [Strings.branchUncommittedChangesSwitch, Strings.dialogCancel]
+        case .revertAllConfirmation:
+            return [Strings.revertAllButton, Strings.dialogCancel]
+        case .cliInstallerInfo:
+            return [Strings.dialogOK]
+        }
+    }
+}

--- a/Pine/AlertTemplate.swift
+++ b/Pine/AlertTemplate.swift
@@ -118,7 +118,11 @@ extension AlertTemplate {
             return .critical
         case .cliInstallerInfo:
             return .informational
-        default:
+        case .unsavedChangesSingle, .unsavedChangesBulk,
+             .terminalTabCloseWarning, .terminalActiveProcessWarning,
+             .externalModifyConflict, .fileDeletedSaveAs,
+             .fileOperationErrorWarning, .largeFileWarning,
+             .branchUncommittedChanges, .revertAllConfirmation:
             return .warning
         }
     }

--- a/Pine/BranchSwitcherView.swift
+++ b/Pine/BranchSwitcherView.swift
@@ -75,13 +75,10 @@ struct BranchSwitcherView: View {
         }
 
         if gitProvider.hasUncommittedChanges {
-            let alert = NSAlert()
-            alert.messageText = Strings.branchUncommittedChangesTitle
-            alert.informativeText = Strings.branchUncommittedChangesMessage(branch)
-            alert.addButton(withTitle: Strings.branchUncommittedChangesSwitch)
-            alert.addButton(withTitle: Strings.dialogCancel)
-            alert.alertStyle = .warning
-            guard alert.runModal() == .alertFirstButtonReturn else { return }
+            guard AlertTemplate.branchUncommittedChanges.runModal(
+                messageText: Strings.branchUncommittedChangesTitle,
+                informativeText: Strings.branchUncommittedChangesMessage(branch)
+            ) == .alertFirstButtonReturn else { return }
         }
 
         Task {

--- a/Pine/CLIInstaller.swift
+++ b/Pine/CLIInstaller.swift
@@ -136,6 +136,7 @@ enum CLIInstaller {
 
     // MARK: - Private
 
+    // TODO: Swift 6 — mark CLIInstaller or this method as @MainActor
     private static func showAlert(title: String, message: String) {
         AlertTemplate.cliInstallerInfo.runModal(
             messageText: title,

--- a/Pine/CLIInstaller.swift
+++ b/Pine/CLIInstaller.swift
@@ -137,11 +137,9 @@ enum CLIInstaller {
     // MARK: - Private
 
     private static func showAlert(title: String, message: String) {
-        let alert = NSAlert()
-        alert.messageText = title
-        alert.informativeText = message
-        alert.alertStyle = .informational
-        alert.addButton(withTitle: "OK")
-        alert.runModal()
+        AlertTemplate.cliInstallerInfo.runModal(
+            messageText: title,
+            informativeText: message
+        )
     }
 }

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -316,13 +316,10 @@ extension ContentView {
     /// Shows a confirmation dialog before reverting all changes in a file.
     static func confirmRevertAll(fileName: String, completion: @escaping (Bool) -> Void) {
         DispatchQueue.main.async {
-            let alert = NSAlert()
-            alert.messageText = "Revert All Changes?"
-            alert.informativeText = "All changes in \"\(fileName)\" will be permanently lost. This action cannot be undone."
-            alert.alertStyle = .warning
-            alert.addButton(withTitle: "Revert All")
-            alert.addButton(withTitle: "Cancel")
-            let response = alert.runModal()
+            let response = AlertTemplate.revertAllConfirmation.runModal(
+                messageText: Strings.revertAllTitle,
+                informativeText: Strings.revertAllMessage(fileName)
+            )
             completion(response == .alertFirstButtonReturn)
         }
     }
@@ -359,14 +356,12 @@ extension ContentView {
 
         if !modified.isEmpty {
             let names = Array(Set(modified.map(\.url.lastPathComponent))).sorted().joined(separator: ", ")
-            let alert = NSAlert()
-            alert.messageText = Strings.externalModifyTitle
-            alert.informativeText = Strings.externalModifyMessage(names)
-            alert.addButton(withTitle: Strings.externalModifyReload)
-            alert.addButton(withTitle: Strings.externalModifyKeep)
-            alert.alertStyle = .warning
+            let response = AlertTemplate.externalModifyConflict.runModal(
+                messageText: Strings.externalModifyTitle,
+                informativeText: Strings.externalModifyMessage(names)
+            )
 
-            if alert.runModal() == .alertFirstButtonReturn {
+            if response == .alertFirstButtonReturn {
                 for conflict in modified {
                     projectManager.reloadTabs(url: conflict.url)
                 }
@@ -384,15 +379,10 @@ extension ContentView {
 
         let dirtyTabs = affected.filter { $0.isDirty }
         if !dirtyTabs.isEmpty {
-            let alert = NSAlert()
-            alert.messageText = Strings.fileDeletedTitle
-            alert.informativeText = Strings.fileDeletedMessage
-            alert.addButton(withTitle: Strings.fileDeletedSaveAs)
-            alert.addButton(withTitle: Strings.dialogDontSave)
-            alert.addButton(withTitle: Strings.dialogCancel)
-            alert.alertStyle = .warning
-
-            let response = alert.runModal()
+            let response = AlertTemplate.fileDeletedSaveAs.runModal(
+                messageText: Strings.fileDeletedTitle,
+                informativeText: Strings.fileDeletedMessage
+            )
             switch response {
             case .alertFirstButtonReturn:
                 for tab in dirtyTabs {
@@ -402,11 +392,10 @@ extension ContentView {
                     do {
                         try tab.content.write(to: saveURL, atomically: true, encoding: .utf8)
                     } catch {
-                        let errAlert = NSAlert()
-                        errAlert.messageText = Strings.fileOperationErrorTitle
-                        errAlert.informativeText = error.localizedDescription
-                        errAlert.alertStyle = .warning
-                        errAlert.runModal()
+                        AlertTemplate.fileOperationErrorWarning.runModal(
+                            messageText: Strings.fileOperationErrorTitle,
+                            informativeText: error.localizedDescription
+                        )
                         return
                     }
                 }

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -1503,6 +1503,186 @@
         }
       }
     },
+    "revertAll.button" : {
+      "comment" : "Button to confirm reverting all changes in a file.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revert All"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle zurücksetzen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revertir todo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout annuler"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべて復元"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모두 되돌리기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reverter tudo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вернуть всё"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部还原"
+          }
+        }
+      }
+    },
+    "revertAll.message" : {
+      "comment" : "Message for the revert-all confirmation dialog.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All changes in \"%@\" will be permanently lost. This action cannot be undone."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Änderungen in \"%@\" gehen dauerhaft verloren. Diese Aktion kann nicht rückgängig gemacht werden."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos los cambios en \"%@\" se perderán permanentemente. Esta acción no se puede deshacer."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toutes les modifications dans \"%@\" seront définitivement perdues. Cette action est irréversible."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"%@\" のすべての変更が永久に失われます。この操作は元に戻せません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"%@\"의 모든 변경 사항이 영구적으로 손실됩니다. 이 작업은 취소할 수 없습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todas as alterações em \"%@\" serão permanentemente perdidas. Esta ação não pode ser desfeita."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все изменения в \"%@\" будут безвозвратно потеряны. Это действие нельзя отменить."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"%@\" 中的所有更改将永久丢失。此操作无法撤销。"
+          }
+        }
+      }
+    },
+    "revertAll.title" : {
+      "comment" : "Title for the revert-all confirmation dialog.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revert All Changes?"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Änderungen zurücksetzen?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Revertir todos los cambios?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler toutes les modifications ?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべての変更を復元しますか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 변경 사항을 되돌리시겠습니까?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reverter todas as alterações?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вернуть все изменения?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "还原所有更改？"
+          }
+        }
+      }
+    },
     "dialog.unsavedChanges.cancel" : {
       "comment" : "Button to cancel closing the tab in the unsaved-changes alert.",
       "extractionState" : "manual",

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -300,13 +300,10 @@ class CloseDelegate: NSObject, NSWindowDelegate {
             guard let state = pane.terminalState(for: activePaneID),
                   let tab = state.activeTab else { return }
             if tab.hasForegroundProcess {
-                let alert = NSAlert()
-                alert.messageText = Strings.terminalTabCloseWarningTitle
-                alert.informativeText = Strings.terminalTabCloseWarningMessage
-                alert.addButton(withTitle: Strings.terminalTabCloseWarningClose)
-                alert.addButton(withTitle: Strings.dialogCancel)
-                alert.alertStyle = .warning
-                guard alert.runModal() == .alertFirstButtonReturn else { return }
+                guard AlertTemplate.terminalTabCloseWarning.runModal(
+                    messageText: Strings.terminalTabCloseWarningTitle,
+                    informativeText: Strings.terminalTabCloseWarningMessage
+                ) == .alertFirstButtonReturn else { return }
             }
             state.removeTab(id: tab.id)
             if state.terminalTabs.isEmpty {
@@ -337,15 +334,10 @@ class CloseDelegate: NSObject, NSWindowDelegate {
         guard !dirty.isEmpty else { return true }
 
         let fileList = dirty.map { "  • \($0.fileName)" }.joined(separator: "\n")
-        let alert = NSAlert()
-        alert.messageText = Strings.unsavedChangesTitle
-        alert.informativeText = Strings.unsavedChangesListMessage(fileList)
-        alert.addButton(withTitle: Strings.dialogSaveAll)
-        alert.addButton(withTitle: Strings.dialogDontSave)
-        alert.addButton(withTitle: Strings.dialogCancel)
-        alert.alertStyle = .warning
-
-        let response = alert.runModal()
+        let response = AlertTemplate.unsavedChangesBulk.runModal(
+            messageText: Strings.unsavedChangesTitle,
+            informativeText: Strings.unsavedChangesListMessage(fileList)
+        )
         switch response {
         case .alertFirstButtonReturn:
             guard projectManager.saveAllPaneTabs() else {
@@ -760,15 +752,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             guard !dirty.isEmpty else { continue }
 
             let fileList = dirty.map { "  • \($0.fileName)" }.joined(separator: "\n")
-            let alert = NSAlert()
-            alert.messageText = Strings.unsavedChangesTitle
-            alert.informativeText = Strings.unsavedChangesListMessage(fileList)
-            alert.addButton(withTitle: Strings.dialogSaveAll)
-            alert.addButton(withTitle: Strings.dialogDontSave)
-            alert.addButton(withTitle: Strings.dialogCancel)
-            alert.alertStyle = .warning
-
-            let response = alert.runModal()
+            let response = AlertTemplate.unsavedChangesBulk.runModal(
+                messageText: Strings.unsavedChangesTitle,
+                informativeText: Strings.unsavedChangesListMessage(fileList)
+            )
             switch response {
             case .alertFirstButtonReturn:
                 guard pm.saveAllPaneTabs() else {
@@ -786,14 +773,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // Check for active terminal processes
         let hasActiveProcesses = registry.openProjects.values.contains { $0.terminal.hasActiveProcesses }
         if hasActiveProcesses {
-            let alert = NSAlert()
-            alert.messageText = Strings.terminalActiveProcessWarningTitle
-            alert.informativeText = Strings.terminalActiveProcessWarningMessage
-            alert.addButton(withTitle: Strings.terminalActiveProcessWarningQuit)
-            alert.addButton(withTitle: Strings.dialogCancel)
-            alert.alertStyle = .warning
-
-            if alert.runModal() != .alertFirstButtonReturn {
+            if AlertTemplate.terminalActiveProcessWarning.runModal(
+                messageText: Strings.terminalActiveProcessWarningTitle,
+                informativeText: Strings.terminalActiveProcessWarningMessage
+            ) != .alertFirstButtonReturn {
                 isTerminating = false
                 return .terminateCancel
             }

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -131,11 +131,10 @@ struct PineAppMenuCommands: Commands {
                         NotificationCenter.default.post(name: .refreshLineDiffs, object: nil)
                     }
                 } catch {
-                    let alert = NSAlert()
-                    alert.messageText = Strings.fileOperationErrorTitle
-                    alert.informativeText = error.localizedDescription
-                    alert.alertStyle = .critical
-                    alert.runModal()
+                    AlertTemplate.fileOperationErrorCritical.runModal(
+                        messageText: Strings.fileOperationErrorTitle,
+                        informativeText: error.localizedDescription
+                    )
                 }
             } label: {
                 Label(Strings.menuSaveAs, systemImage: MenuIcons.saveAs)

--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -117,11 +117,10 @@ final class SidebarEditState {
 
     /// Shows an AppKit error alert for file operations.
     static func showFileError(_ message: String) {
-        let alert = NSAlert()
-        alert.messageText = Strings.fileOperationErrorTitle
-        alert.informativeText = message
-        alert.alertStyle = .warning
-        alert.runModal()
+        AlertTemplate.fileOperationErrorWarning.runModal(
+            messageText: Strings.fileOperationErrorTitle,
+            informativeText: message
+        )
     }
 }
 

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -247,6 +247,23 @@ enum Strings {
         String(localized: "dialog.ok")
     }
 
+    // MARK: - Revert All Confirmation
+
+    static var revertAllTitle: String {
+        String(localized: "revertAll.title", defaultValue: "Revert All Changes?")
+    }
+
+    static func revertAllMessage(_ fileName: String) -> String {
+        String(
+            localized: "revertAll.message",
+            defaultValue: "All changes in \"\(fileName)\" will be permanently lost. This action cannot be undone."
+        )
+    }
+
+    static var revertAllButton: String {
+        String(localized: "revertAll.button", defaultValue: "Revert All")
+    }
+
     // MARK: - Save As Panel (AppKit)
 
     static var saveAsPanelTitle: String {

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -19,15 +19,10 @@ enum TabCloseHelper {
         gitProvider: GitStatusProvider
     ) -> Bool {
         if tab.isDirty {
-            let alert = NSAlert()
-            alert.messageText = Strings.unsavedChangesTitle
-            alert.informativeText = Strings.unsavedChangesMessage
-            alert.addButton(withTitle: Strings.dialogSave)
-            alert.addButton(withTitle: Strings.dialogDontSave)
-            alert.addButton(withTitle: Strings.dialogCancel)
-            alert.alertStyle = .warning
-
-            let response = alert.runModal()
+            let response = AlertTemplate.unsavedChangesSingle.runModal(
+                messageText: Strings.unsavedChangesTitle,
+                informativeText: Strings.unsavedChangesMessage
+            )
             switch response {
             case .alertFirstButtonReturn:
                 guard let index = tabManager.tabs.firstIndex(where: { $0.id == tab.id }) else { return false }
@@ -55,15 +50,10 @@ enum TabCloseHelper {
         guard !dirtyTabs.isEmpty else { return true }
 
         let fileList = dirtyTabs.map { "  \u{2022} \($0.fileName)" }.joined(separator: "\n")
-        let alert = NSAlert()
-        alert.messageText = Strings.unsavedChangesTitle
-        alert.informativeText = Strings.unsavedChangesListMessage(fileList)
-        alert.addButton(withTitle: Strings.dialogSaveAll)
-        alert.addButton(withTitle: Strings.dialogDontSave)
-        alert.addButton(withTitle: Strings.dialogCancel)
-        alert.alertStyle = .warning
-
-        let response = alert.runModal()
+        let response = AlertTemplate.unsavedChangesBulk.runModal(
+            messageText: Strings.unsavedChangesTitle,
+            informativeText: Strings.unsavedChangesListMessage(fileList)
+        )
         switch response {
         case .alertFirstButtonReturn:
             for tab in dirtyTabs {

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -214,15 +214,10 @@ final class TabManager {
 
     /// Shows a warning alert for large files. Returns the user's choice.
     private func showLargeFileAlert(fileName: String, sizeMB: Double) -> LargeFileAlertResult {
-        let alert = NSAlert()
-        alert.messageText = Strings.largeFileWarningTitle
-        alert.informativeText = Strings.largeFileWarningMessage(fileName, sizeMB)
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: Strings.largeFileOpenWithoutHighlighting)
-        alert.addButton(withTitle: Strings.largeFileOpenWithHighlighting)
-        alert.addButton(withTitle: Strings.dialogCancel)
-
-        let response = alert.runModal()
+        let response = AlertTemplate.largeFileWarning.runModal(
+            messageText: Strings.largeFileWarningTitle,
+            informativeText: Strings.largeFileWarningMessage(fileName, sizeMB)
+        )
         switch response {
         case .alertFirstButtonReturn:
             return .openWithoutHighlighting
@@ -385,11 +380,10 @@ final class TabManager {
         do {
             return try trySaveTab(at: index)
         } catch {
-            let alert = NSAlert()
-            alert.messageText = Strings.fileOperationErrorTitle
-            alert.informativeText = error.localizedDescription
-            alert.alertStyle = .critical
-            alert.runModal()
+            AlertTemplate.fileOperationErrorCritical.runModal(
+                messageText: Strings.fileOperationErrorTitle,
+                informativeText: error.localizedDescription
+            )
             return false
         }
     }
@@ -581,11 +575,10 @@ final class TabManager {
             try trySaveAllTabs()
             return true
         } catch {
-            let alert = NSAlert()
-            alert.messageText = Strings.fileOperationErrorTitle
-            alert.informativeText = error.localizedDescription
-            alert.alertStyle = .critical
-            alert.runModal()
+            AlertTemplate.fileOperationErrorCritical.runModal(
+                messageText: Strings.fileOperationErrorTitle,
+                informativeText: error.localizedDescription
+            )
             return false
         }
     }
@@ -664,11 +657,10 @@ final class TabManager {
         do {
             return try tryDuplicateActiveTab(projectRoot: projectRoot)
         } catch {
-            let alert = NSAlert()
-            alert.messageText = Strings.fileOperationErrorTitle
-            alert.informativeText = error.localizedDescription
-            alert.alertStyle = .critical
-            alert.runModal()
+            AlertTemplate.fileOperationErrorCritical.runModal(
+                messageText: Strings.fileOperationErrorTitle,
+                informativeText: error.localizedDescription
+            )
             return false
         }
     }

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -18,14 +18,10 @@ struct TerminalPaneTabBar: View {
 
     private func closeTerminalTabWithConfirmation(_ tab: TerminalTab) {
         if tab.hasForegroundProcess {
-            let alert = NSAlert()
-            alert.messageText = Strings.terminalTabCloseWarningTitle
-            alert.informativeText = Strings.terminalTabCloseWarningMessage
-            alert.addButton(withTitle: Strings.terminalTabCloseWarningClose)
-            alert.addButton(withTitle: Strings.dialogCancel)
-            alert.alertStyle = .warning
-
-            guard alert.runModal() == .alertFirstButtonReturn else { return }
+            guard AlertTemplate.terminalTabCloseWarning.runModal(
+                messageText: Strings.terminalTabCloseWarningTitle,
+                informativeText: Strings.terminalTabCloseWarningMessage
+            ) == .alertFirstButtonReturn else { return }
         }
         terminalState.removeTab(id: tab.id)
         // Remove the pane if no tabs remain
@@ -126,13 +122,10 @@ struct TerminalPaneTabBar: View {
             Button {
                 // Warn if any tab has a foreground process
                 if terminalState.terminalTabs.contains(where: { $0.hasForegroundProcess }) {
-                    let alert = NSAlert()
-                    alert.messageText = Strings.terminalTabCloseWarningTitle
-                    alert.informativeText = Strings.terminalTabCloseWarningMessage
-                    alert.addButton(withTitle: Strings.terminalTabCloseWarningClose)
-                    alert.addButton(withTitle: Strings.dialogCancel)
-                    alert.alertStyle = .warning
-                    guard alert.runModal() == .alertFirstButtonReturn else { return }
+                    guard AlertTemplate.terminalTabCloseWarning.runModal(
+                        messageText: Strings.terminalTabCloseWarningTitle,
+                        informativeText: Strings.terminalTabCloseWarningMessage
+                    ) == .alertFirstButtonReturn else { return }
                 }
                 // Stop all tabs and remove pane
                 for tab in terminalState.terminalTabs {

--- a/PineTests/AlertTemplateTests.swift
+++ b/PineTests/AlertTemplateTests.swift
@@ -1,0 +1,181 @@
+//
+//  AlertTemplateTests.swift
+//  PineTests
+//
+//  Tests for AlertTemplate: template-to-buttons mapping, alert style, and default-button selection.
+//
+
+import AppKit
+import Testing
+
+@testable import Pine
+
+@MainActor
+struct AlertTemplateTests {
+
+    // MARK: - Button labels
+
+    @Test("unsavedChangesSingle has Save / Don't Save / Cancel")
+    func unsavedChangesSingleButtons() {
+        let template = AlertTemplate.unsavedChangesSingle
+        let alert = template.makeAlert(messageText: "Test", informativeText: "Info")
+        let buttons = alert.buttons
+        #expect(buttons.count == 3)
+        #expect(buttons[0].title == Strings.dialogSave)
+        #expect(buttons[1].title == Strings.dialogDontSave)
+        #expect(buttons[2].title == Strings.dialogCancel)
+    }
+
+    @Test("unsavedChangesBulk has Save All / Don't Save / Cancel")
+    func unsavedChangesBulkButtons() {
+        let template = AlertTemplate.unsavedChangesBulk
+        let alert = template.makeAlert(messageText: "Test", informativeText: "Info")
+        let buttons = alert.buttons
+        #expect(buttons.count == 3)
+        #expect(buttons[0].title == Strings.dialogSaveAll)
+        #expect(buttons[1].title == Strings.dialogDontSave)
+        #expect(buttons[2].title == Strings.dialogCancel)
+    }
+
+    @Test("terminalTabCloseWarning has Close / Cancel")
+    func terminalTabCloseWarningButtons() {
+        let template = AlertTemplate.terminalTabCloseWarning
+        let alert = template.makeAlert(messageText: "Test")
+        let buttons = alert.buttons
+        #expect(buttons.count == 2)
+        #expect(buttons[0].title == Strings.terminalTabCloseWarningClose)
+        #expect(buttons[1].title == Strings.dialogCancel)
+    }
+
+    @Test("terminalActiveProcessWarning has Quit / Cancel")
+    func terminalActiveProcessWarningButtons() {
+        let template = AlertTemplate.terminalActiveProcessWarning
+        let alert = template.makeAlert(messageText: "Test")
+        let buttons = alert.buttons
+        #expect(buttons.count == 2)
+        #expect(buttons[0].title == Strings.terminalActiveProcessWarningQuit)
+        #expect(buttons[1].title == Strings.dialogCancel)
+    }
+
+    @Test("externalModifyConflict has Reload / Keep")
+    func externalModifyConflictButtons() {
+        let template = AlertTemplate.externalModifyConflict
+        let alert = template.makeAlert(messageText: "Test")
+        let buttons = alert.buttons
+        #expect(buttons.count == 2)
+        #expect(buttons[0].title == Strings.externalModifyReload)
+        #expect(buttons[1].title == Strings.externalModifyKeep)
+    }
+
+    @Test("fileDeletedSaveAs has Save As / Don't Save / Cancel")
+    func fileDeletedSaveAsButtons() {
+        let template = AlertTemplate.fileDeletedSaveAs
+        let alert = template.makeAlert(messageText: "Test")
+        let buttons = alert.buttons
+        #expect(buttons.count == 3)
+        #expect(buttons[0].title == Strings.fileDeletedSaveAs)
+        #expect(buttons[1].title == Strings.dialogDontSave)
+        #expect(buttons[2].title == Strings.dialogCancel)
+    }
+
+    @Test("fileOperationError critical has OK button and critical style")
+    func fileOperationErrorCritical() {
+        let template = AlertTemplate.fileOperationErrorCritical
+        let alert = template.makeAlert(messageText: "Test", informativeText: "Error details")
+        let buttons = alert.buttons
+        #expect(buttons.count == 1)
+        #expect(buttons[0].title == Strings.dialogOK)
+        #expect(alert.alertStyle == .critical)
+    }
+
+    @Test("fileOperationError warning has OK button and warning style")
+    func fileOperationErrorWarning() {
+        let template = AlertTemplate.fileOperationErrorWarning
+        let alert = template.makeAlert(messageText: "Test", informativeText: "Error details")
+        let buttons = alert.buttons
+        #expect(buttons.count == 1)
+        #expect(buttons[0].title == Strings.dialogOK)
+        #expect(alert.alertStyle == .warning)
+    }
+
+    @Test("largeFileWarning has Without Highlighting / With Highlighting / Cancel")
+    func largeFileWarningButtons() {
+        let template = AlertTemplate.largeFileWarning
+        let alert = template.makeAlert(messageText: "Test")
+        let buttons = alert.buttons
+        #expect(buttons.count == 3)
+        #expect(buttons[0].title == Strings.largeFileOpenWithoutHighlighting)
+        #expect(buttons[1].title == Strings.largeFileOpenWithHighlighting)
+        #expect(buttons[2].title == Strings.dialogCancel)
+    }
+
+    @Test("branchUncommittedChanges has Switch / Cancel")
+    func branchUncommittedChangesButtons() {
+        let template = AlertTemplate.branchUncommittedChanges
+        let alert = template.makeAlert(messageText: "Test")
+        let buttons = alert.buttons
+        #expect(buttons.count == 2)
+        #expect(buttons[0].title == Strings.branchUncommittedChangesSwitch)
+        #expect(buttons[1].title == Strings.dialogCancel)
+    }
+
+    @Test("revertAllConfirmation has Revert All / Cancel")
+    func revertAllConfirmationButtons() {
+        let template = AlertTemplate.revertAllConfirmation
+        let alert = template.makeAlert(messageText: "Revert?")
+        let buttons = alert.buttons
+        #expect(buttons.count == 2)
+        #expect(buttons[0].title == Strings.revertAllButton)
+        #expect(buttons[1].title == Strings.dialogCancel)
+    }
+
+    @Test("cliInstallerInfo has OK and informational style")
+    func cliInstallerInfoButtons() {
+        let template = AlertTemplate.cliInstallerInfo
+        let alert = template.makeAlert(messageText: "Title", informativeText: "Message")
+        let buttons = alert.buttons
+        #expect(buttons.count == 1)
+        #expect(buttons[0].title == Strings.dialogOK)
+        #expect(alert.alertStyle == .informational)
+    }
+
+    // MARK: - Alert style defaults
+
+    @Test("most templates default to warning style")
+    func warningStyles() {
+        let warningTemplates: [AlertTemplate] = [
+            .unsavedChangesSingle,
+            .unsavedChangesBulk,
+            .terminalTabCloseWarning,
+            .terminalActiveProcessWarning,
+            .externalModifyConflict,
+            .fileDeletedSaveAs,
+            .largeFileWarning,
+            .branchUncommittedChanges,
+            .revertAllConfirmation,
+            .fileOperationErrorWarning,
+        ]
+        for template in warningTemplates {
+            let alert = template.makeAlert(messageText: "Test")
+            #expect(alert.alertStyle == .warning, "Expected .warning for \(template)")
+        }
+    }
+
+    // MARK: - Message text propagation
+
+    @Test("messageText and informativeText are set correctly")
+    func messageTextPropagation() {
+        let template = AlertTemplate.unsavedChangesSingle
+        let alert = template.makeAlert(messageText: "My Title", informativeText: "My Details")
+        #expect(alert.messageText == "My Title")
+        #expect(alert.informativeText == "My Details")
+    }
+
+    @Test("messageText works without informativeText")
+    func messageTextOnly() {
+        let template = AlertTemplate.terminalTabCloseWarning
+        let alert = template.makeAlert(messageText: "Just title")
+        #expect(alert.messageText == "Just title")
+        #expect(alert.informativeText == "")
+    }
+}


### PR DESCRIPTION
## Summary

Closes #897

Introduces a single `AlertTemplate` enum + factory that replaces all 20 direct `NSAlert()` constructions across the codebase. Each call site is now 1-3 lines instead of 6-9.

## Migrated call sites

| File | Template | Before (lines) |
|------|----------|----------------|
| `TabCloseHelper.swift` | `unsavedChangesSingle`, `unsavedChangesBulk` | 7-8 → 3-4 |
| `TabManager.swift` | `largeFileWarning`, `fileOperationErrorCritical` x3 | 6-9 → 3-4 |
| `ContentView+Helpers.swift` | `revertAllConfirmation`, `externalModifyConflict`, `fileDeletedSaveAs`, `fileOperationErrorWarning` | 6-9 → 3-4 |
| `PineApp.swift` | `terminalTabCloseWarning`, `unsavedChangesBulk` x2, `terminalActiveProcessWarning` | 7-8 → 3-4 |
| `TerminalPaneTabBar.swift` | `terminalTabCloseWarning` x2 | 7 → 3 |
| `PineAppMenuCommands.swift` | `fileOperationErrorCritical` | 6 → 3 |
| `SidebarView.swift` | `fileOperationErrorWarning` | 5 → 3 |
| `BranchSwitcherView.swift` | `branchUncommittedChanges` | 7 → 3 |
| `CLIInstaller.swift` | `cliInstallerInfo` | 6 → 3 |

## Templates

| Case | Buttons | Style |
|------|---------|-------|
| `unsavedChangesSingle` | Save / Don't Save / Cancel | `.warning` |
| `unsavedChangesBulk` | Save All / Don't Save / Cancel | `.warning` |
| `terminalTabCloseWarning` | Close / Cancel | `.warning` |
| `terminalActiveProcessWarning` | Quit / Cancel | `.warning` |
| `externalModifyConflict` | Reload / Keep | `.warning` |
| `fileDeletedSaveAs` | Save As / Don't Save / Cancel | `.warning` |
| `fileOperationErrorCritical` | OK | `.critical` |
| `fileOperationErrorWarning` | OK | `.warning` |
| `largeFileWarning` | Without Highlighting / With Highlighting / Cancel | `.warning` |
| `branchUncommittedChanges` | Switch Anyway / Cancel | `.warning` |
| `revertAllConfirmation` | Revert All / Cancel | `.warning` |
| `cliInstallerInfo` | OK | `.informational` |

## Changes

- **New:** `Pine/AlertTemplate.swift` — enum with 12 cases, `makeAlert()` and `runModal()` helpers
- **New:** `PineTests/AlertTemplateTests.swift` — 15 unit tests covering button labels, alert styles, text propagation
- **New:** `Strings.revertAllTitle`, `Strings.revertAllMessage`, `Strings.revertAllButton` — replaces hardcoded English strings in `ContentView+Helpers`
- **New:** Localization entries for revertAll keys in all 9 languages
- **Migrated:** 20 NSAlert constructions across 9 files
- **Net:** -60 lines of boilerplate

## Acceptance criteria

- [x] Single `AlertTemplate` type covers every existing alert in `Pine/`
- [x] Zero direct `NSAlert()` constructors remain outside `AlertTemplate.swift`
- [x] Localization unchanged (same `Strings.` keys, same wording) + new revertAll keys localized in all 9 languages
- [x] Unit tests cover the template-to-buttons mapping and default-button selection (15 tests, all passing)
- [x] `swiftlint --strict` — 0 violations

## Test plan

- [ ] Verify all alert dialogs still appear correctly (unsaved changes, terminal close, external modify, large file, branch switch, revert all, file operation errors)
- [ ] Verify button labels match before migration
- [ ] Verify localization works for revertAll keys in all 9 languages