### PR TITLE
chore(deps): bump Sparkle 2.9.3, swift-argument-parser 1.8.2

### DIFF
--- a/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle.git",
       "state" : {
-        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
-        "version" : "2.9.2"
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
-        "version" : "1.7.1"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Sparkle 2.9.2 → 2.9.3
- swift-argument-parser 1.7.1 → 1.8.2

## Test plan
- [ ] Verify project builds without errors