### PR TITLE
fix(terminal): dampen scrollback scroll speed to prevent runaway momentum

### DIFF
--- a/Pine/MouseScrollForwarder.swift
+++ b/Pine/MouseScrollForwarder.swift
@@ -110,4 +110,48 @@ enum MouseScrollForwarder {
         }
         return 1
     }
+
+    /// Points of trackpad delta that correspond to one line of scrollback.
+    static let trackpadLineThreshold: CGFloat = 10
+
+    /// Result of a normal-mode scroll calculation.
+    struct NormalScrollResult {
+        /// Number of scrollback lines to scroll.
+        let lines: Int
+        /// Remaining accumulated delta after consuming whole lines.
+        let remainingDelta: CGFloat
+    }
+
+    /// Calculates controlled scroll lines for normal-mode terminal scrollback.
+    ///
+    /// Trackpad scrolling accumulates precise deltas and scrolls one line per
+    /// `trackpadLineThreshold` points, preventing macOS momentum from scrolling
+    /// entire pages. Mouse wheel scrolling uses a clamped delta (1–3 lines).
+    ///
+    /// - Parameters:
+    ///   - accumulatedDelta: Previously accumulated trackpad delta (ignored for mouse wheel).
+    ///   - newDelta: The current event's scroll delta.
+    ///   - isPrecise: Whether the event comes from a trackpad (`hasPreciseScrollingDeltas`).
+    ///   - phaseBegan: Whether the gesture phase is `.began` (resets accumulation).
+    /// - Returns: The number of lines to scroll and the remaining delta.
+    static func normalScrollLines(
+        accumulatedDelta: CGFloat,
+        newDelta: CGFloat,
+        isPrecise: Bool,
+        phaseBegan: Bool
+    ) -> NormalScrollResult {
+        if isPrecise {
+            let accumulated = phaseBegan ? newDelta : accumulatedDelta + newDelta
+            let linesToScroll = Int(abs(accumulated) / trackpadLineThreshold)
+            if linesToScroll > 0 {
+                let consumed = CGFloat(linesToScroll) * trackpadLineThreshold
+                let remaining = accumulated - consumed * (accumulated > 0 ? 1 : -1)
+                return NormalScrollResult(lines: linesToScroll, remainingDelta: remaining)
+            }
+            return NormalScrollResult(lines: 0, remainingDelta: accumulated)
+        } else {
+            let lines = min(max(Int(abs(newDelta)), 1), 3)
+            return NormalScrollResult(lines: lines, remainingDelta: 0)
+        }
+    }
 }

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -500,8 +500,23 @@ class TerminalContainerView: NSView {
                 return nil
             }
 
-            // Normal mode — let SwiftTerm handle scrollback
-            return event
+            // Normal mode — controlled scrollback instead of SwiftTerm's raw
+            // velocity which jumps to full-page scrolls at delta > 9.
+            let result = MouseScrollForwarder.normalScrollLines(
+                accumulatedDelta: self.accumulatedScrollDelta,
+                newDelta: scrollDelta,
+                isPrecise: event.hasPreciseScrollingDeltas,
+                phaseBegan: event.phase == .began
+            )
+            self.accumulatedScrollDelta = result.remainingDelta
+            if result.lines > 0 {
+                if scrollDelta > 0 {
+                    terminalView.scrollUp(lines: result.lines)
+                } else {
+                    terminalView.scrollDown(lines: result.lines)
+                }
+            }
+            return nil
         }
     }
 

--- a/PineTests/TerminalScrollForwardingTests.swift
+++ b/PineTests/TerminalScrollForwardingTests.swift
@@ -459,4 +459,196 @@ struct TerminalScrollForwardingTests {
         )
         #expect(pos.row == 0) // top of screen = first row
     }
+
+    // MARK: - Normal-mode scrollback line calculation
+
+    @Test func normalScrollTrackpadSingleLineThreshold() {
+        let result = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0,
+            newDelta: 10,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.lines == 1)
+        #expect(result.remainingDelta == 0)
+    }
+
+    @Test func normalScrollTrackpadMultipleLines() {
+        let result = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0,
+            newDelta: 35,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.lines == 3)
+        #expect(result.remainingDelta == 5)
+    }
+
+    @Test func normalScrollTrackpadAccumulation() {
+        // First event: delta 6, below threshold
+        let r1 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0,
+            newDelta: 6,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(r1.lines == 0)
+        #expect(r1.remainingDelta == 6)
+
+        // Second event: delta 6, accumulated = 12, crosses threshold
+        let r2 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: r1.remainingDelta,
+            newDelta: 6,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(r2.lines == 1)
+        #expect(r2.remainingDelta == 2)
+    }
+
+    @Test func normalScrollTrackpadPhaseBeganResetsAccumulation() {
+        // phaseBegan = true ignores the accumulated delta and starts fresh
+        let result = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 999,
+            newDelta: 5,
+            isPrecise: true,
+            phaseBegan: true
+        )
+        #expect(result.lines == 0)
+        #expect(result.remainingDelta == 5)
+    }
+
+    @Test func normalScrollTrackpadNegativeDelta() {
+        let result = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0,
+            newDelta: -25,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.lines == 2)
+        #expect(result.remainingDelta == -5)
+    }
+
+    @Test func normalScrollTrackpadAlternatingDirection() {
+        // Scroll up 15, then down 5 — remaining should be 5 (positive)
+        let r1 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0,
+            newDelta: 15,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(r1.lines == 1)
+        #expect(r1.remainingDelta == 5)
+
+        let r2 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: r1.remainingDelta,
+            newDelta: -5,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(r2.lines == 0)
+        #expect(r2.remainingDelta == 0)
+    }
+
+    @Test func normalScrollTrackpadTinyDeltaNoScroll() {
+        let result = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0,
+            newDelta: 3,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.lines == 0)
+        #expect(result.remainingDelta == 3)
+    }
+
+    @Test func normalScrollMouseWheelSmallDelta() {
+        let result = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0,
+            newDelta: 1,
+            isPrecise: false,
+            phaseBegan: false
+        )
+        #expect(result.lines == 1)
+        #expect(result.remainingDelta == 0)
+    }
+
+    @Test func normalScrollMouseWheelMediumDelta() {
+        let result = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0,
+            newDelta: 2,
+            isPrecise: false,
+            phaseBegan: false
+        )
+        #expect(result.lines == 2)
+        #expect(result.remainingDelta == 0)
+    }
+
+    @Test func normalScrollMouseWheelLargeDeltaCappedAt3() {
+        let result = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0,
+            newDelta: 15,
+            isPrecise: false,
+            phaseBegan: false
+        )
+        #expect(result.lines == 3)
+        #expect(result.remainingDelta == 0)
+    }
+
+    @Test func normalScrollMouseWheelIgnoresAccumulation() {
+        let result = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 500,
+            newDelta: 1,
+            isPrecise: false,
+            phaseBegan: false
+        )
+        // Mouse wheel never accumulates — ignores accumulated delta
+        #expect(result.lines == 1)
+        #expect(result.remainingDelta == 0)
+    }
+
+    @Test func normalScrollMouseWheelNegativeDelta() {
+        let result = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0,
+            newDelta: -3,
+            isPrecise: false,
+            phaseBegan: false
+        )
+        #expect(result.lines == 3)
+    }
+
+    @Test func normalScrollTrackpadLargeMomentumDelta() {
+        // Simulates a large momentum event that would have scrolled
+        // an entire page with SwiftTerm's default velocity.
+        let result = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0,
+            newDelta: 150,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        // 150 / 10 = 15 lines — controlled, not a full page
+        #expect(result.lines == 15)
+        #expect(result.remainingDelta == 0)
+    }
+
+    @Test func normalScrollTrackpadCarriesRemainderAcrossEvents() {
+        // Three events of delta 7 each: 7 → 14 → 21
+        // 7/10=0, 14/10=1 (rem 4), 11/10=1 (rem 1)
+        let r1 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: 7, isPrecise: true, phaseBegan: false
+        )
+        #expect(r1.lines == 0)
+        #expect(r1.remainingDelta == 7)
+
+        let r2 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: r1.remainingDelta, newDelta: 7, isPrecise: true, phaseBegan: false
+        )
+        #expect(r2.lines == 1)
+        #expect(r2.remainingDelta == 4)
+
+        let r3 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: r2.remainingDelta, newDelta: 7, isPrecise: true, phaseBegan: false
+        )
+        #expect(r3.lines == 1)
+        #expect(r3.remainingDelta == 1)
+    }
 }


### PR DESCRIPTION
## Summary
- SwiftTerm's default `calcScrollingVelocity` scrolls `max(terminal.rows, 20)` lines when `deltaY > 9`, so macOS trackpad momentum events fly through the entire scrollback buffer
- Replace raw event forwarding with controlled line-by-line scrolling: trackpad accumulates precise deltas (1 line per 10 points), mouse wheel is capped at 1–3 lines per tick
- Extract scroll calculation into `MouseScrollForwarder.normalScrollLines()` for testability

## Test plan
- [x] 63 unit tests pass (14 new `normalScrollLines` tests covering trackpad accumulation, phase reset, negative deltas, remainder carry, mouse wheel clamping, momentum dampening)
- [ ] Manual: open terminal, run a long-running command (e.g. `claude`), scroll back with trackpad — should be smooth and controlled, no page jumps
- [ ] Manual: verify mouse wheel scrolling still works (1–3 lines per tick)
- [ ] Manual: verify TUI apps (htop, vim, k9s) still scroll correctly via mouse reporting / arrow key fallback