### PR TITLE
Fix terminal redraw backing artifacts

### DIFF
--- a/Pine/TerminalPalette.swift
+++ b/Pine/TerminalPalette.swift
@@ -12,11 +12,9 @@
 //
 //  Scope of `install(on:)`:
 //  ONLY the 16 ANSI palette slots are touched here. Background / foreground
-//  / cursor / selection are deliberately NOT set — `TerminalSession` keeps
-//  them on semantic `NSColor.textBackgroundColor` / `NSColor.textColor` so
-//  the terminal stays adaptive to light/dark mode and respects the system
-//  appearance the way every other native macOS app does. TUI apps paint
-//  their own background through ANSI sequences anyway.
+//  / cursor / selection are deliberately NOT set — `TerminalSession` owns
+//  the default terminal colors and reapplies them when the system appearance
+//  changes. TUI apps paint their own background through ANSI sequences anyway.
 //
 //  Coverage across SGR forms — and the SwiftTerm 1.13.0 collapse quirk:
 //

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -8,6 +8,34 @@
 import SwiftUI
 import SwiftTerm
 
+/// Pine-specific terminal view wrapper.
+///
+/// SwiftTerm's CoreGraphics renderer only paints cells that have an explicit
+/// background attribute; cells with the default terminal background rely on
+/// the view/layer background. When a TUI briefly paints a colored rectangle
+/// and then returns those cells to the default background, stale pixels can
+/// remain in the layer. Pine drops the stale layer contents and promotes
+/// partial invalidations to full redraws so default-background cells are
+/// repainted against the current layer background.
+final class PineTerminalView: LocalProcessTerminalView {
+    private var redrawBackgroundColor: CGColor?
+
+    func prepareLayerForRedraw(background: NSColor? = nil) {
+        if let background {
+            redrawBackgroundColor = background.cgColor
+        }
+        if let redrawBackgroundColor {
+            layer?.backgroundColor = redrawBackgroundColor
+        }
+        layer?.contents = nil
+    }
+
+    override func setNeedsDisplay(_ invalidRect: NSRect) {
+        prepareLayerForRedraw()
+        super.setNeedsDisplay(bounds.isEmpty ? invalidRect : bounds)
+    }
+}
+
 // MARK: - Click interceptor overlay for terminal focus management
 
 /// Transparent overlay NSView placed on top of `LocalProcessTerminalView`.
@@ -687,18 +715,13 @@ final class TerminalTab: Identifiable, Hashable {
         self.name = name
         self.stableLabel = name
         self.shellSettings = shellSettings
-        self.terminalView = LocalProcessTerminalView(frame: TerminalContainerView.defaultTerminalFrame)
+        self.terminalView = PineTerminalView(frame: TerminalContainerView.defaultTerminalFrame)
         self.delegate = TerminalTabDelegate()
         self.delegate.tab = self
         self.terminalView.processDelegate = self.delegate
 
         // Настраиваем внешний вид сразу — шрифт определяет размер ячейки
         terminalView.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-        // Background adapts to system appearance — One Dark (#282C34) in
-        // dark mode, Catppuccin Latte base (#EFF1F5) in light mode.
-        // Foreground stays semantic so it adapts to light/dark appearance.
-        terminalView.nativeForegroundColor = .textColor
-        terminalView.nativeBackgroundColor = TerminalPalette.currentBackgroundColor()
 
         // Match Ghostty / modern terminal behaviour: do NOT auto-promote bold
         // text to the bright color variant. SwiftTerm's default of `true`
@@ -707,17 +730,38 @@ final class TerminalTab: Identifiable, Hashable {
         // native macOS terminals (issue #733).
         terminalView.useBrightColors = false
 
+        applyCurrentTerminalAppearance(forceRedraw: false)
+
+        // Re-apply palette and background when system appearance changes.
+        appearanceObservation = NSApp.observe(\.effectiveAppearance, options: .new) { [weak self] _, _ in
+            Task { @MainActor [weak self] in
+                self?.applyCurrentTerminalAppearance(forceRedraw: true)
+            }
+        }
+    }
+
+    /// Applies Pine's appearance-aware terminal colors and keeps SwiftTerm's
+    /// layer background in sync with the terminal model. SwiftTerm only sets
+    /// `layer.backgroundColor` during initial setup, so Pine must refresh it
+    /// when the app moves between light and dark appearances.
+    private func applyCurrentTerminalAppearance(forceRedraw: Bool) {
+        let background = TerminalPalette.currentBackgroundColor()
+        terminalView.nativeForegroundColor = .textColor
+        terminalView.nativeBackgroundColor = background
+        if let pineTerminalView = terminalView as? PineTerminalView {
+            pineTerminalView.prepareLayerForRedraw(background: background)
+        } else {
+            terminalView.layer?.backgroundColor = background.cgColor
+        }
+
         // Apply Pine's terminal palette (issue #816, #931).
         // Centralised in `TerminalPalette` so it can be unit-tested
         // independently of the SwiftTerm view and kept as a single source of
         // truth. The palette adapts to the current system appearance.
         TerminalPalette.install(on: terminalView)
 
-        // Re-apply palette and background when system appearance changes.
-        appearanceObservation = NSApp.observe(\.effectiveAppearance, options: .new) { [weak self] _, _ in
-            guard let self else { return }
-            self.terminalView.nativeBackgroundColor = TerminalPalette.currentBackgroundColor()
-            TerminalPalette.install(on: self.terminalView)
+        if forceRedraw {
+            forceFullRedraw()
         }
     }
 
@@ -835,6 +879,11 @@ final class TerminalTab: Identifiable, Hashable {
     /// Safe to call when the view is detached from a window — AppKit
     /// silently no-ops `displayIfNeeded()` in that state.
     func forceFullRedraw() {
+        if let pineTerminalView = terminalView as? PineTerminalView {
+            pineTerminalView.prepareLayerForRedraw(background: terminalView.nativeBackgroundColor)
+        } else {
+            terminalView.layer?.backgroundColor = terminalView.nativeBackgroundColor.cgColor
+        }
         let term = terminalView.getTerminal()
         term.updateFullScreen()
         terminalView.setNeedsDisplay(terminalView.bounds)

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -22,6 +22,11 @@ struct TerminalTabTests {
         #expect(tab.currentMatchIndex == -1)
     }
 
+    @Test @MainActor func terminalTabUsesPineTerminalView() {
+        let tab = TerminalTab(name: "zsh")
+        #expect(tab.terminalView is PineTerminalView)
+    }
+
     @Test @MainActor func terminalTabsHaveUniqueIDs() {
         let tab1 = TerminalTab(name: "tab1")
         let tab2 = TerminalTab(name: "tab2")
@@ -776,6 +781,40 @@ struct TerminalTabTests {
         let range = term.getUpdateRange()
         #expect(range?.startY == 0)
         #expect(range?.endY == term.rows)
+    }
+
+    /// SwiftTerm's layer background can drift from Pine's appearance-aware
+    /// native background when AppKit recreates or reuses backing layers.
+    /// `forceFullRedraw` must restore it before asking SwiftTerm to paint.
+    @Test @MainActor func forceFullRedrawSyncsLayerBackground() {
+        let tab = TerminalTab(name: "test")
+        let expected = tab.terminalView.nativeBackgroundColor.cgColor
+        let staleContents = "stale-terminal-backing" as NSString
+        tab.terminalView.layer?.backgroundColor = NSColor.black.cgColor
+        tab.terminalView.layer?.contents = staleContents
+
+        tab.forceFullRedraw()
+
+        #expect(tab.terminalView.layer?.backgroundColor == expected)
+        #expect((tab.terminalView.layer?.contents as? NSString) != staleContents)
+    }
+
+    /// PineTerminalView drops stale layer contents before scheduling a full
+    /// redraw. This prevents colored rectangles from remaining when a terminal
+    /// program returns cells to the default background.
+    @Test @MainActor func pineTerminalViewClearsLayerContentsBeforeRedraw() {
+        let view = PineTerminalView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        let background = NSColor(srgbRed: 0.90, green: 0.91, blue: 0.92, alpha: 1)
+        let staleContents = "stale-terminal-backing" as NSString
+        view.nativeBackgroundColor = background
+        view.prepareLayerForRedraw(background: background)
+        view.layer?.backgroundColor = NSColor.black.cgColor
+        view.layer?.contents = staleContents
+
+        view.setNeedsDisplay(NSRect(x: 0, y: 0, width: 10, height: 10))
+
+        #expect(view.layer?.backgroundColor == background.cgColor)
+        #expect(view.layer?.contents == nil)
     }
 
     /// `kickPTYWindowSize` must be a safe no-op when the shell process is


### PR DESCRIPTION
## Summary
- add PineTerminalView to clear stale terminal layer contents before redraw
- promote terminal invalidations to full-bounds redraws to avoid stale colored rectangles
- reapply terminal appearance with a forced redraw on system appearance changes
- add TerminalTab coverage for the Pine terminal view and backing-layer cleanup

## Tests
- /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild test -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -derivedDataPath /tmp/pine-terminal-glitch-tests -only-testing:PineTests/TerminalTabTests CODE_SIGN_IDENTITY=- CODE_SIGNING_ALLOWED=NO