### PR TITLE
feat(git): add branch switch command

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -144,8 +144,13 @@ struct ContentView: View {
             )
             .padding(12)
         }
-        .onReceive(NotificationCenter.default.publisher(for: .showBranchSwitcher)) { _ in
-            guard workspace.gitProvider.isGitRepository else { return }
+        .onReceive(NotificationCenter.default.publisher(for: .showBranchSwitcher)) { notification in
+            guard Self.shouldPresentBranchSwitcher(
+                notificationObject: notification.object,
+                currentProject: projectManager,
+                isKeyWindow: controlActiveState == .key,
+                isGitRepository: workspace.gitProvider.isGitRepository
+            ) else { return }
             isBranchSwitcherPresented = true
         }
         .onReceive(NotificationCenter.default.publisher(for: .symbolNavigate)) { notification in
@@ -243,6 +248,18 @@ struct ContentView: View {
     /// Kept as a static function for testability.
     static func branchSubtitle(isGitRepo: Bool, branchName: String) -> String {
         isGitRepo ? "\(branchName) ▾" : ""
+    }
+
+    static func shouldPresentBranchSwitcher(
+        notificationObject: Any?,
+        currentProject: ProjectManager,
+        isKeyWindow: Bool,
+        isGitRepository: Bool
+    ) -> Bool {
+        guard isGitRepository else { return false }
+        guard let notificationObject else { return isKeyWindow }
+        guard let targetProject = notificationObject as? ProjectManager else { return false }
+        return targetProject === currentProject
     }
 
     // MARK: - Subview builders

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -33,6 +33,7 @@ struct ContentView: View {
     @State var isDragTargeted = false
     @State var isQuickOpenPresented = false
     @State var isSymbolNavigatorPresented = false
+    @State var isBranchSwitcherPresented = false
     @State var showGoToLine = false
     @AppStorage("minimapVisible") var isMinimapVisible = true
     @AppStorage(BlameConstants.storageKey) var isBlameVisible = true
@@ -135,6 +136,17 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .showSymbolNavigator)) { _ in
             guard tabManager.activeTab != nil else { return }
             isSymbolNavigatorPresented = true
+        }
+        .sheet(isPresented: $isBranchSwitcherPresented) {
+            BranchSwitcherView(
+                gitProvider: workspace.gitProvider,
+                isPresented: $isBranchSwitcherPresented
+            )
+            .padding(12)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .showBranchSwitcher)) { _ in
+            guard workspace.gitProvider.isGitRepository else { return }
+            isBranchSwitcherPresented = true
         }
         .onReceive(NotificationCenter.default.publisher(for: .symbolNavigate)) { notification in
             guard let offset = notification.userInfo?["offset"] as? Int else { return }

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -49,6 +49,9 @@ nonisolated enum MenuIcons {
     static let revealFileInFinder = "doc.viewfinder"
     static let revealProjectInFinder = "arrow.right.circle"
 
+    // MARK: - Git menu
+    static let switchBranch = "arrow.triangle.branch"
+
     // MARK: - Terminal menu
     static let newTerminalTab = "plus"
     static let sendToTerminal = "paperplane"

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -562,10 +562,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // across keyboard layouts while the menu item remains discoverable.
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift],
-                  event.keyCode == 11 else {
+                  event.keyCode == 11,
+                  let window = NSApp.keyWindow,
+                  let closeDelegate = window.delegate as? CloseDelegate,
+                  closeDelegate.projectManager.workspace.gitProvider.isGitRepository else {
                 return event
             }
-            NotificationCenter.default.post(name: .showBranchSwitcher, object: nil)
+            NotificationCenter.default.post(
+                name: .showBranchSwitcher,
+                object: closeDelegate.projectManager
+            )
             return nil // consume event
         }
 

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -558,6 +558,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             return nil // consume event
         }
 
+        // Intercept Cmd+Shift+B by physical keyCode so branch switching works
+        // across keyboard layouts while the menu item remains discoverable.
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift],
+                  event.keyCode == 11 else {
+                return event
+            }
+            NotificationCenter.default.post(name: .showBranchSwitcher, object: nil)
+            return nil // consume event
+        }
+
         // Intercept Ctrl+Tab and Ctrl+Shift+Tab for tab cycling.
         // Tab key generates keyCode 48. Must intercept via event monitor
         // because SwiftUI's keyboardShortcut doesn't support the Tab key.

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -449,7 +449,8 @@ struct PineAppMenuCommands: Commands {
         // MARK: - Git menu
         CommandMenu(Strings.menuGit) {
             Button {
-                NotificationCenter.default.post(name: .showBranchSwitcher, object: nil)
+                guard let focusedProject else { return }
+                NotificationCenter.default.post(name: .showBranchSwitcher, object: focusedProject)
             } label: {
                 Label(Strings.menuSwitchBranch, systemImage: MenuIcons.switchBranch)
             }

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -14,7 +14,7 @@
 //
 //  Declaration order mirrors the macOS menu bar left-to-right:
 //  App (about/CLI) → File (open/save) → Edit (find/fold/diff) →
-//  View (font/minimap/reveal) → Terminal.
+//  View (font/minimap/reveal) → Git → Terminal.
 //
 
 import AppKit
@@ -444,6 +444,17 @@ struct PineAppMenuCommands: Commands {
                 Label(Strings.menuRevealProjectInFinder, systemImage: MenuIcons.revealProjectInFinder)
             }
             .disabled(focusedProject?.workspace.rootURL == nil)
+        }
+
+        // MARK: - Git menu
+        CommandMenu(Strings.menuGit) {
+            Button {
+                NotificationCenter.default.post(name: .showBranchSwitcher, object: nil)
+            } label: {
+                Label(Strings.menuSwitchBranch, systemImage: MenuIcons.switchBranch)
+            }
+            .keyboardShortcut("b", modifiers: [.command, .shift])
+            .disabled(focusedProject?.workspace.gitProvider.isGitRepository != true)
         }
 
         // MARK: - Terminal menu

--- a/Pine/PineAppNotifications.swift
+++ b/Pine/PineAppNotifications.swift
@@ -63,5 +63,6 @@ extension Notification.Name {
     static let sendTextToTerminal = Notification.Name("sendTextToTerminal")
 
     // MARK: - Git
+    static let showBranchSwitcher = Notification.Name("showBranchSwitcher")
     static let refreshLineDiffs = Notification.Name("refreshLineDiffs")
 }

--- a/PineTests/MenuIconTests.swift
+++ b/PineTests/MenuIconTests.swift
@@ -34,6 +34,7 @@ struct MenuIconTests {
         (MenuIcons.findInProject, "Find in Project"),
         (MenuIcons.nextChange, "Next Change"),
         (MenuIcons.previousChange, "Previous Change"),
+        (MenuIcons.switchBranch, "Switch Branch"),
     ])
     func mainMenuIconExists(_ symbol: String, _ menuItem: String) {
         #expect(

--- a/PineTests/PineAppMenuCommandsTests.swift
+++ b/PineTests/PineAppMenuCommandsTests.swift
@@ -43,10 +43,20 @@ struct PineAppMenuCommandsTests {
             .findInTerminal, .showQuickOpen, .showSymbolNavigator,
             .symbolNavigate, .sendToTerminal, .sendTextToTerminal,
             .revealInSidebar, .inlineDiffAction, .tabReloadedFromDisk,
-            .refreshLineDiffs, .fileRenamed, .fileDeleted
+            .showBranchSwitcher, .refreshLineDiffs, .fileRenamed, .fileDeleted
         ]
         let raws = names.map(\.rawValue)
         #expect(Set(raws).count == raws.count, "Notification names must be unique")
         #expect(raws.allSatisfy { !$0.isEmpty }, "Notification names must be non-empty")
+    }
+
+    @Test
+    func branchSwitchShortcutIsDocumentedInReadme() throws {
+        let readmeURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("README.md")
+        let content = try String(contentsOf: readmeURL, encoding: .utf8)
+        #expect(content.contains("| `Cmd+Shift+B` | Switch branch |"))
     }
 }

--- a/PineTests/PineAppMenuCommandsTests.swift
+++ b/PineTests/PineAppMenuCommandsTests.swift
@@ -59,4 +59,47 @@ struct PineAppMenuCommandsTests {
         let content = try String(contentsOf: readmeURL, encoding: .utf8)
         #expect(content.contains("| `Cmd+Shift+B` | Switch branch |"))
     }
+
+    @Test
+    func branchSwitcherNotificationScopeMatchesTargetProjectOrKeyWindow() {
+        let currentProject = ProjectManager()
+        let otherProject = ProjectManager()
+
+        #expect(ContentView.shouldPresentBranchSwitcher(
+            notificationObject: currentProject,
+            currentProject: currentProject,
+            isKeyWindow: false,
+            isGitRepository: true
+        ))
+        #expect(!ContentView.shouldPresentBranchSwitcher(
+            notificationObject: otherProject,
+            currentProject: currentProject,
+            isKeyWindow: true,
+            isGitRepository: true
+        ))
+        #expect(ContentView.shouldPresentBranchSwitcher(
+            notificationObject: nil,
+            currentProject: currentProject,
+            isKeyWindow: true,
+            isGitRepository: true
+        ))
+        #expect(!ContentView.shouldPresentBranchSwitcher(
+            notificationObject: nil,
+            currentProject: currentProject,
+            isKeyWindow: false,
+            isGitRepository: true
+        ))
+        #expect(!ContentView.shouldPresentBranchSwitcher(
+            notificationObject: currentProject,
+            currentProject: currentProject,
+            isKeyWindow: true,
+            isGitRepository: false
+        ))
+        #expect(!ContentView.shouldPresentBranchSwitcher(
+            notificationObject: "unexpected",
+            currentProject: currentProject,
+            isKeyWindow: true,
+            isGitRepository: true
+        ))
+    }
 }

--- a/PineUITests/BranchSwitcherTests.swift
+++ b/PineUITests/BranchSwitcherTests.swift
@@ -8,8 +8,8 @@
 //  recognizer (BranchSubtitleClickHandler), which XCUITest cannot
 //  interact with directly (window chrome is not an accessibility element).
 //  Cmd+Shift+B is handled via NSEvent.addLocalMonitorForEvents, which
-//  XCUITest's typeKey() bypasses. Therefore, these tests verify the
-//  display of branch information and external branch switch detection.
+//  XCUITest's typeKey() bypasses. Therefore, these tests open the switcher
+//  through the Git menu and verify the displayed branch information.
 //
 
 import XCTest
@@ -109,16 +109,31 @@ final class BranchSwitcherTests: PineUITestCase {
         )
     }
 
-    // MARK: - Git menu not in menu bar (lives in subtitle popup instead)
+    // MARK: - Git menu opens branch switcher
 
-    func testGitMenuDoesNotExist() throws {
+    func testGitMenuOpensBranchSwitcher() throws {
         launchWithProject(projectURL)
 
         let window = app.windows.firstMatch
         XCTAssertTrue(window.waitForExistence(timeout: 10))
 
         let gitMenu = app.menuBars.menuBarItems["Git"]
-        XCTAssertFalse(gitMenu.exists, "Git menu should not exist in the menu bar")
+        XCTAssertTrue(gitMenu.waitForExistence(timeout: 5), "Git menu should exist in the menu bar")
+        gitMenu.click()
+
+        let switchBranch = app.menuItems["Switch Branch…"]
+        XCTAssertTrue(
+            switchBranch.waitForExistence(timeout: 5),
+            "Git menu should contain Switch Branch"
+        )
+        XCTAssertTrue(switchBranch.isEnabled, "Switch Branch should be enabled for git projects")
+        switchBranch.click()
+
+        let searchField = app.textFields["branchSearchField"]
+        XCTAssertTrue(
+            searchField.waitForExistence(timeout: 5),
+            "Switch Branch should open the branch switcher"
+        )
     }
 
     // MARK: - External branch switch updates subtitle

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pine is a code editor for developers who want a fast, native Mac app without the
 - **Syntax highlighting** — 37 languages including Swift, TypeScript, Python, Go, Rust, Java, Kotlin, Ruby, C/C++, and more
 - **Split panes** — Drag tabs to edges to split horizontally or vertically. Drag between panes to move. Resize with divider
 - **Built-in terminal** — Full VT100/xterm emulator via [SwiftTerm](https://github.com/migueldeicaza/SwiftTerm). Terminal panes live in the split layout alongside code. Multiple tabs, maximize, colors, TUI apps, oh-my-zsh
-- **Git integration** — File status in sidebar, diff markers in gutter, blame view, branch switching from title bar or search sheet
+- **Git integration** — File status in sidebar, diff markers in gutter, blame view, branch switching from title bar or Git menu
 - **Symbol navigation** — Jump to functions and classes with Cmd+R
 - **Code folding** — Fold/unfold blocks from the gutter or via menu
 - **Minimap** — Scaled code overview with syntax colors and diff markers. Click to navigate


### PR DESCRIPTION
Closes #973

Summary:
- add Git > Switch Branch… menu command that opens the existing BranchSwitcherView
- wire Cmd+Shift+B through the menu and a physical-key local monitor for keyboard-layout safety
- update README docs and focused coverage for notification names, menu icon validity, README shortcut consistency, and the UI menu path

Tests:
- git diff --check
- /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild test -project Pine.xcodeproj -scheme Pine -destination "platform=macOS" -derivedDataPath /tmp/pine-pr973-unit -only-testing:PineTests/PineAppMenuCommandsTests -only-testing:PineTests/MenuIconTests CODE_SIGN_IDENTITY=- CODE_SIGNING_ALLOWED=NO
- /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild test-without-building -project Pine.xcodeproj -scheme Pine -destination "platform=macOS" -derivedDataPath /tmp/pine-pr973-unit -only-testing:PineTests/PineAppMenuCommandsTests -only-testing:PineTests/MenuIconTests CODE_SIGN_IDENTITY=- CODE_SIGNING_ALLOWED=NO

Not run locally:
- PineUITests/BranchSwitcherTests, because macOS reported PineUITests-Runner as damaged; leaving UI validation to CI.