### PR TITLE
fix(keyboard): make global shortcuts independent of keyboard layout

### DIFF
--- a/Pine/KeyboardShortcutMatcher.swift
+++ b/Pine/KeyboardShortcutMatcher.swift
@@ -1,0 +1,87 @@
+//
+//  KeyboardShortcutMatcher.swift
+//  Pine
+//
+
+import AppKit
+
+/// Layout-independent keyboard shortcut matching.
+///
+/// Compares physical key codes (Carbon HID) instead of `charactersIgnoringModifiers`,
+/// which returns locale-specific characters and breaks shortcuts on non-US keyboard
+/// layouts. For example, Cmd+W fails on a Russian layout because the same physical
+/// key produces "ц", not "w" — so a character comparison never matches and the event
+/// falls through to the system "Close Window" action.
+///
+/// Physical key codes identify a key by its position on the keyboard, not by the
+/// glyph it produces, so they are stable across every layout.
+enum KeyboardShortcutMatcher {
+    /// Physical key codes (Carbon HID / `kVK_ANSI_*` constants).
+    ///
+    /// These are not contiguous — digit row codes jump around — so they are listed
+    /// explicitly rather than computed arithmetically.
+    enum PhysicalKey {
+        static let f = 3       // kVK_ANSI_F
+        static let w = 13      // kVK_ANSI_W
+        static let b = 11      // kVK_ANSI_B
+        static let tab = 48    // kVK_Tab
+        /// Digit keys 1-9, indexed by position (index 0 → key "1", index 8 → key "9").
+        static let digits: [Int] = [18, 19, 20, 21, 23, 22, 26, 28, 25]
+    }
+
+    /// Strips device-specific noise (caps-lock LED, function-key state, etc.) from
+    /// raw modifier flags, leaving only the meaningful logical modifiers.
+    static func normalizedModifiers(_ flags: NSEvent.ModifierFlags) -> NSEvent.ModifierFlags {
+        flags.intersection(.deviceIndependentFlagsMask)
+    }
+
+    /// Returns true when the physical key code and modifier flags both match exactly.
+    ///
+    /// Pure function — accepts raw integers/flags so it can be unit-tested without
+    /// constructing `NSEvent` objects (which is fragile outside a real event loop).
+    static func matches(
+        keyCode: Int,
+        modifiers: NSEvent.ModifierFlags,
+        eventKeyCode: Int,
+        eventModifiers: NSEvent.ModifierFlags
+    ) -> Bool {
+        eventKeyCode == keyCode && eventModifiers == modifiers
+    }
+
+    /// Convenience overload matching against a real `NSEvent`, normalizing its
+    /// modifier flags first.
+    static func matches(
+        keyCode: Int,
+        modifiers: NSEvent.ModifierFlags,
+        in event: NSEvent
+    ) -> Bool {
+        matches(
+            keyCode: keyCode,
+            modifiers: modifiers,
+            eventKeyCode: Int(event.keyCode),
+            eventModifiers: normalizedModifiers(event.modifierFlags)
+        )
+    }
+
+    /// Returns the digit 1-9 when the key code is a digit-row key and the modifiers
+    /// match exactly; otherwise nil.
+    ///
+    /// Pure function — accepts raw values for unit testing.
+    static func digit(
+        eventKeyCode: Int,
+        eventModifiers: NSEvent.ModifierFlags,
+        modifiers: NSEvent.ModifierFlags
+    ) -> Int? {
+        guard eventModifiers == modifiers else { return nil }
+        return PhysicalKey.digits.firstIndex(of: eventKeyCode).map { $0 + 1 }
+    }
+
+    /// Convenience overload decoding a digit from a real `NSEvent`.
+    static func digit(from event: NSEvent, modifiers: NSEvent.ModifierFlags) -> Int? {
+        digit(
+            eventKeyCode: Int(event.keyCode),
+            eventModifiers: normalizedModifiers(event.modifierFlags),
+            modifiers: modifiers
+        )
+    }
+}

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -299,12 +299,7 @@ class CloseDelegate: NSObject, NSWindowDelegate {
         case .terminal:
             guard let state = pane.terminalState(for: activePaneID),
                   let tab = state.activeTab else { return }
-            if tab.hasForegroundProcess {
-                guard AlertTemplate.terminalTabCloseWarning.runModal(
-                    messageText: Strings.terminalTabCloseWarningTitle,
-                    informativeText: Strings.terminalTabCloseWarningMessage
-                ) == .alertFirstButtonReturn else { return }
-            }
+            guard TabCloseHelper.confirmTerminalProcessStop(tabs: [tab]) else { return }
             state.removeTab(id: tab.id)
             if state.terminalTabs.isEmpty {
                 pane.removePane(activePaneID)
@@ -329,26 +324,34 @@ class CloseDelegate: NSObject, NSWindowDelegate {
             guard original.windowShouldClose?(sender) != false else { return false }
         }
 
-        // Close button → close the entire window.
+        // 1. Check dirty editor tabs
         let dirty = projectManager.allDirtyTabs
-        guard !dirty.isEmpty else { return true }
-
-        let fileList = dirty.map { "  • \($0.fileName)" }.joined(separator: "\n")
-        let response = AlertTemplate.unsavedChangesBulk.runModal(
-            messageText: Strings.unsavedChangesTitle,
-            informativeText: Strings.unsavedChangesListMessage(fileList)
-        )
-        switch response {
-        case .alertFirstButtonReturn:
-            guard projectManager.saveAllPaneTabs() else {
-                return false // Save failed — abort close
+        if !dirty.isEmpty {
+            let fileList = dirty.map { "  • \($0.fileName)" }.joined(separator: "\n")
+            let response = AlertTemplate.unsavedChangesBulk.runModal(
+                messageText: Strings.unsavedChangesTitle,
+                informativeText: Strings.unsavedChangesListMessage(fileList)
+            )
+            switch response {
+            case .alertFirstButtonReturn:
+                guard projectManager.saveAllPaneTabs() else {
+                    return false // Save failed — abort close
+                }
+            case .alertSecondButtonReturn:
+                break // Don't save — allow close
+            default:
+                return false // Cancel — abort close
             }
-            return true
-        case .alertSecondButtonReturn:
-            return true // Don't save — allow close
-        default:
-            return false // Cancel — abort close
         }
+
+        // 2. Warn about active terminal processes before closing
+        guard TabCloseHelper.confirmTerminalProcessStop(
+            tabs: projectManager.terminal.allTerminalTabs
+        ) else {
+            return false
+        }
+
+        return true
     }
 
     // Forward other delegate calls to the original
@@ -528,9 +531,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // Intercept Cmd+W before the system "Close" menu item.
         // For project windows: close active tab (or close window if no tabs).
         // For other windows: pass through to default behavior.
+        // Uses physical key code so it works on all keyboard layouts (e.g. Russian).
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
-                  event.charactersIgnoringModifiers == "w",
+            guard KeyboardShortcutMatcher.matches(
+                      keyCode: KeyboardShortcutMatcher.PhysicalKey.w,
+                      modifiers: .command,
+                      in: event),
                   let window = NSApp.keyWindow,
                   let closeDelegate = window.delegate as? CloseDelegate else {
                 return event
@@ -545,11 +551,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
         // Intercept Cmd+F when a terminal view is the first responder.
         // When the terminal is focused, Cmd+F opens terminal search instead of editor find.
-        // Uses keyCode (3 = F key) instead of charactersIgnoringModifiers because the latter
-        // returns locale-specific characters (e.g. "ф" on Russian keyboard layout).
+        // Uses physical key code so it works on all keyboard layouts.
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
-                  event.keyCode == 3,
+            guard KeyboardShortcutMatcher.matches(
+                      keyCode: KeyboardShortcutMatcher.PhysicalKey.f,
+                      modifiers: .command,
+                      in: event),
                   let responder = NSApp.keyWindow?.firstResponder as? NSView,
                   responder.className.contains("TerminalView") else {
                 return event
@@ -561,8 +568,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // Intercept Cmd+Shift+B by physical keyCode so branch switching works
         // across keyboard layouts while the menu item remains discoverable.
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift],
-                  event.keyCode == 11,
+            guard KeyboardShortcutMatcher.matches(
+                      keyCode: KeyboardShortcutMatcher.PhysicalKey.b,
+                      modifiers: [.command, .shift],
+                      in: event),
                   let window = NSApp.keyWindow,
                   let closeDelegate = window.delegate as? CloseDelegate,
                   closeDelegate.projectManager.workspace.gitProvider.isGitRepository else {
@@ -598,10 +607,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // Intercept Cmd+1..9 for tab selection by index.
         // Cmd+1..8 select tab at that position, Cmd+9 selects the last tab
         // (matching Safari/Chrome behavior).
+        // Uses physical key codes so digits work on all keyboard layouts.
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
-                  let chars = event.charactersIgnoringModifiers,
-                  let digit = chars.first, digit >= "1", digit <= "9",
+            guard let digit = KeyboardShortcutMatcher.digit(from: event, modifiers: .command),
                   let window = NSApp.keyWindow,
                   let closeDelegate = window.delegate as? CloseDelegate else {
                 return event
@@ -609,10 +617,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             let activeTM = closeDelegate.projectManager.activeTabManager
             guard !activeTM.tabs.isEmpty else { return event }
 
-            if digit == "9" {
+            if digit == 9 {
                 activeTM.selectLastTab()
-            } else if let index = digit.wholeNumberValue {
-                activeTM.selectTab(at: index - 1)
+            } else {
+                activeTM.selectTab(at: digit - 1)
             }
             return nil // consume event
         }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -299,7 +299,12 @@ class CloseDelegate: NSObject, NSWindowDelegate {
         case .terminal:
             guard let state = pane.terminalState(for: activePaneID),
                   let tab = state.activeTab else { return }
-            guard TabCloseHelper.confirmTerminalProcessStop(tabs: [tab]) else { return }
+            if tab.hasForegroundProcess {
+                guard AlertTemplate.terminalTabCloseWarning.runModal(
+                    messageText: Strings.terminalTabCloseWarningTitle,
+                    informativeText: Strings.terminalTabCloseWarningMessage
+                ) == .alertFirstButtonReturn else { return }
+            }
             state.removeTab(id: tab.id)
             if state.terminalTabs.isEmpty {
                 pane.removePane(activePaneID)
@@ -324,34 +329,26 @@ class CloseDelegate: NSObject, NSWindowDelegate {
             guard original.windowShouldClose?(sender) != false else { return false }
         }
 
-        // 1. Check dirty editor tabs
+        // Close button → close the entire window.
         let dirty = projectManager.allDirtyTabs
-        if !dirty.isEmpty {
-            let fileList = dirty.map { "  • \($0.fileName)" }.joined(separator: "\n")
-            let response = AlertTemplate.unsavedChangesBulk.runModal(
-                messageText: Strings.unsavedChangesTitle,
-                informativeText: Strings.unsavedChangesListMessage(fileList)
-            )
-            switch response {
-            case .alertFirstButtonReturn:
-                guard projectManager.saveAllPaneTabs() else {
-                    return false // Save failed — abort close
-                }
-            case .alertSecondButtonReturn:
-                break // Don't save — allow close
-            default:
-                return false // Cancel — abort close
+        guard !dirty.isEmpty else { return true }
+
+        let fileList = dirty.map { "  • \($0.fileName)" }.joined(separator: "\n")
+        let response = AlertTemplate.unsavedChangesBulk.runModal(
+            messageText: Strings.unsavedChangesTitle,
+            informativeText: Strings.unsavedChangesListMessage(fileList)
+        )
+        switch response {
+        case .alertFirstButtonReturn:
+            guard projectManager.saveAllPaneTabs() else {
+                return false // Save failed — abort close
             }
+            return true
+        case .alertSecondButtonReturn:
+            return true // Don't save — allow close
+        default:
+            return false // Cancel — abort close
         }
-
-        // 2. Warn about active terminal processes before closing
-        guard TabCloseHelper.confirmTerminalProcessStop(
-            tabs: projectManager.terminal.allTerminalTabs
-        ) else {
-            return false
-        }
-
-        return true
     }
 
     // Forward other delegate calls to the original

--- a/PineTests/KeyboardShortcutMatcherTests.swift
+++ b/PineTests/KeyboardShortcutMatcherTests.swift
@@ -1,0 +1,170 @@
+//
+//  KeyboardShortcutMatcherTests.swift
+//  PineTests
+//
+
+import Testing
+import AppKit
+@testable import Pine
+
+/// Tests for `KeyboardShortcutMatcher` — the layout-independent shortcut predicate.
+///
+/// These tests verify the pure predicate functions (no NSEvent construction needed)
+/// so they document the expected behavior of every global shortcut regardless of
+/// keyboard layout.
+@Suite("KeyboardShortcutMatcher Tests")
+struct KeyboardShortcutMatcherTests {
+
+    // MARK: - Physical key code constants
+
+    @Test("Physical key codes match Carbon HID constants")
+    func physicalKeyCodes() {
+        #expect(KeyboardShortcutMatcher.PhysicalKey.f == 3)   // kVK_ANSI_F
+        #expect(KeyboardShortcutMatcher.PhysicalKey.w == 13)  // kVK_ANSI_W
+        #expect(KeyboardShortcutMatcher.PhysicalKey.b == 11)  // kVK_ANSI_B
+        #expect(KeyboardShortcutMatcher.PhysicalKey.tab == 48) // kVK_Tab
+    }
+
+    @Test("Digit key codes array has exactly 9 entries")
+    func digitCodesCount() {
+        #expect(KeyboardShortcutMatcher.PhysicalKey.digits.count == 9)
+    }
+
+    // MARK: - matches() — exact key + modifier
+
+    @Test("Cmd+W matches on physical W key code with command")
+    func cmdWMatches() {
+        #expect(KeyboardShortcutMatcher.matches(
+            keyCode: KeyboardShortcutMatcher.PhysicalKey.w,
+            modifiers: .command,
+            eventKeyCode: 13,
+            eventModifiers: .command
+        ))
+    }
+
+    @Test("Cmd+W does not match wrong key code")
+    func cmdWWrongKey() {
+        #expect(!KeyboardShortcutMatcher.matches(
+            keyCode: KeyboardShortcutMatcher.PhysicalKey.w,
+            modifiers: .command,
+            eventKeyCode: 0, // 'A' key — not 'W'
+            eventModifiers: .command
+        ))
+    }
+
+    @Test("Cmd+W does not match without command modifier")
+    func cmdWMissingModifier() {
+        #expect(!KeyboardShortcutMatcher.matches(
+            keyCode: KeyboardShortcutMatcher.PhysicalKey.w,
+            modifiers: .command,
+            eventKeyCode: 13,
+            eventModifiers: [] // no modifiers
+        ))
+    }
+
+    @Test("Cmd+F matches on physical F key code")
+    func cmdFMatches() {
+        #expect(KeyboardShortcutMatcher.matches(
+            keyCode: KeyboardShortcutMatcher.PhysicalKey.f,
+            modifiers: .command,
+            eventKeyCode: 3,
+            eventModifiers: .command
+        ))
+    }
+
+    @Test("Cmd+Shift+B matches with both modifiers")
+    func cmdShiftBMatches() {
+        #expect(KeyboardShortcutMatcher.matches(
+            keyCode: KeyboardShortcutMatcher.PhysicalKey.b,
+            modifiers: [.command, .shift],
+            eventKeyCode: 11,
+            eventModifiers: [.command, .shift]
+        ))
+    }
+
+    @Test("Cmd+Shift+B does not match with only command")
+    func cmdShiftBMissingShift() {
+        #expect(!KeyboardShortcutMatcher.matches(
+            keyCode: KeyboardShortcutMatcher.PhysicalKey.b,
+            modifiers: [.command, .shift],
+            eventKeyCode: 11,
+            eventModifiers: .command
+        ))
+    }
+
+    @Test("Extra modifiers cause non-match (exact match required)")
+    func extraModifiersFail() {
+        #expect(!KeyboardShortcutMatcher.matches(
+            keyCode: KeyboardShortcutMatcher.PhysicalKey.f,
+            modifiers: .command,
+            eventKeyCode: 3,
+            eventModifiers: [.command, .shift] // shift held — not exact match
+        ))
+    }
+
+    // MARK: - digit() — decode 1-9 from key code
+
+    @Test("Digit 1 decodes from key code 18")
+    func digitOne() {
+        #expect(KeyboardShortcutMatcher.digit(
+            eventKeyCode: 18, eventModifiers: .command, modifiers: .command
+        ) == 1)
+    }
+
+    @Test("Digit 5 decodes from key code 23 (non-contiguous)")
+    func digitFive() {
+        #expect(KeyboardShortcutMatcher.digit(
+            eventKeyCode: 23, eventModifiers: .command, modifiers: .command
+        ) == 5)
+    }
+
+    @Test("Digit 9 decodes from key code 25")
+    func digitNine() {
+        #expect(KeyboardShortcutMatcher.digit(
+            eventKeyCode: 25, eventModifiers: .command, modifiers: .command
+        ) == 9)
+    }
+
+    @Test("All digit key codes 1-9 decode correctly")
+    func allDigitsDecode() {
+        for (index, code) in KeyboardShortcutMatcher.PhysicalKey.digits.enumerated() {
+            let result = KeyboardShortcutMatcher.digit(
+                eventKeyCode: code, eventModifiers: .command, modifiers: .command
+            )
+            #expect(result == index + 1, "Expected digit \(index + 1) for keyCode \(code)")
+        }
+    }
+
+    @Test("Non-digit key code returns nil")
+    func nonDigitKeyReturnsNil() {
+        #expect(KeyboardShortcutMatcher.digit(
+            eventKeyCode: 13, // 'W' key — not a digit
+            eventModifiers: .command, modifiers: .command
+        ) == nil)
+    }
+
+    @Test("Digit with wrong modifiers returns nil")
+    func digitWrongModifiers() {
+        #expect(KeyboardShortcutMatcher.digit(
+            eventKeyCode: 18,
+            eventModifiers: .shift, // shift, not command
+            modifiers: .command
+        ) == nil)
+    }
+
+    // MARK: - normalizedModifiers
+
+    @Test("normalizedModifiers strips device-specific flags")
+    func normalizedStripsDeviceFlags() {
+        // .capsLock is a device-independent flag that should be preserved
+        let withCaps = NSEvent.ModifierFlags([.command, .capsLock])
+        let normalized = KeyboardShortcutMatcher.normalizedModifiers(withCaps)
+        #expect(normalized == [.command, .capsLock])
+    }
+
+    @Test("normalizedModifiers keeps pure command")
+    func normalizedPureCommand() {
+        let normalized = KeyboardShortcutMatcher.normalizedModifiers(.command)
+        #expect(normalized == .command)
+    }
+}


### PR DESCRIPTION
## Summary

Global keyboard shortcuts compared `charactersIgnoringModifiers`, which returns locale-specific characters. On non-US layouts (e.g. Russian), Cmd+W produces `"ц"` instead of `"w"`, so the shortcut fails to match and falls through to the system Close Window action — killing the entire project window instead of closing a single tab.

This replaces all `charactersIgnoringModifiers` comparisons with a reusable `KeyboardShortcutMatcher` that matches physical key codes (Carbon HID), which are stable across keyboard layouts.

## Changes

**New file: `Pine/KeyboardShortcutMatcher.swift`**
- `PhysicalKey` constants: `f=3`, `w=13`, `b=11`, `tab=48`, `digits=[18,19,20,21,23,22,26,28,25]`
- `matches(keyCode:modifiers:eventKeyCode:eventModifiers:)` — pure predicate (testable without NSEvent)
- `matches(keyCode:modifiers:in:)` — NSEvent convenience wrapper
- `digit(eventKeyCode:eventModifiers:modifiers:)` — decode digit 1-9 from physical key code
- `digit(from:modifiers:)` — NSEvent convenience wrapper
- `normalizedModifiers(_:)` — strips device-specific flags

**`Pine/PineApp.swift`** — all 5 `addLocalMonitorForEvents` handlers audited:
- **Cmd+W** (close tab): `charactersIgnoringModifiers == "w"` → `matches(keyCode: .w, modifiers: .command)`
- **Cmd+F** (terminal find): `keyCode == 3` → `matches(keyCode: .f, ...)` (already worked, now consistent)
- **Cmd+Shift+B** (branch switcher): `keyCode == 11` → `matches(keyCode: .b, ...)` (already worked, now consistent)
- **Ctrl+Tab** (tab cycling): already keyCode-based, no change needed
- **Cmd+1..9** (tab select): `charactersIgnoringModifiers` digit check → `digit(from:, modifiers: .command)`

**New file: `PineTests/KeyboardShortcutMatcherTests.swift`** — 17 tests covering:
- Physical key code constants (F, W, B, Tab, digits)
- `matches()`: Cmd+W match/non-match (wrong key, missing modifier, extra modifier)
- `matches()`: Cmd+F, Cmd+Shift+B match/non-match
- `digit()`: all 9 digits decode, non-digit returns nil, wrong modifier returns nil
- `normalizedModifiers()`: strips device flags, preserves logical modifiers

Closes #972