### PR TITLE
feat(terminal): parse and make file:line references clickable in terminal output

### DIFF
--- a/Pine/GitAndNotificationObserver.swift
+++ b/Pine/GitAndNotificationObserver.swift
@@ -142,6 +142,13 @@ struct GitAndNotificationObserver: ViewModifier {
                       tabManager.activeTab != nil else { return }
                 showGoToLine = true
             }
+            .onReceive(NotificationCenter.default.publisher(for: .openFileAtLine)) { notification in
+                guard let url = notification.userInfo?["url"] as? URL,
+                      let line = notification.userInfo?["line"] as? Int else { return }
+                // Column is parsed and passed for future use; the current
+                // navigation infrastructure is line-based (issue #949).
+                tabManager.openTabAndGoToLine(url: url, line: line)
+            }
             .onReceive(NotificationCenter.default.publisher(for: .navigateChange)) { notification in
                 guard controlActiveState == .key,
                       let direction = notification.userInfo?["direction"] as? String else { return }

--- a/Pine/PineAppNotifications.swift
+++ b/Pine/PineAppNotifications.swift
@@ -54,6 +54,12 @@ extension Notification.Name {
     /// userInfo: ["url": URL, "text": String]
     static let tabReloadedFromDisk = Notification.Name("tabReloadedFromDisk")
 
+    /// Opens a file at a specific line and optional column.
+    /// Posted when the user clicks a `file:line` reference in terminal
+    /// output (issue #949).
+    /// userInfo: ["url": URL, "line": Int, "column": Int?]
+    static let openFileAtLine = Notification.Name("openFileAtLine")
+
     // MARK: - Terminal
     /// Find in Terminal (issue #308)
     static let findInTerminal = Notification.Name("findInTerminal")

--- a/Pine/Terminal/TerminalLink.swift
+++ b/Pine/Terminal/TerminalLink.swift
@@ -1,0 +1,32 @@
+//
+//  TerminalLink.swift
+//  Pine
+//
+//  Represents a clickable file:line reference detected in terminal output.
+//
+
+import Foundation
+
+/// A clickable file-path reference found in terminal output text.
+///
+/// Stores the `NSRange` (NSString-based, multibyte-safe) of the full
+/// `path:line[:column]` token within the source text, the resolved
+/// absolute file URL, and the parsed line/column numbers.
+///
+/// Clicking a link opens the file in Pine's editor at the corresponding
+/// line and column (issue #949).
+struct TerminalLink: Equatable {
+    /// Range of the full ``path:line[:column]`` token in the original text.
+    /// Computed against `NSString` length so it is safe for multibyte content.
+    let range: NSRange
+
+    /// Resolved, absolute URL of the file on disk.
+    /// Only created after verifying the file exists via `FileManager`.
+    let fileURL: URL
+
+    /// 1-based line number to navigate to.
+    let line: Int
+
+    /// 1-based column number, if the reference included one (e.g. `file:42:10`).
+    let column: Int?
+}

--- a/Pine/Terminal/TerminalOutputParser.swift
+++ b/Pine/Terminal/TerminalOutputParser.swift
@@ -1,0 +1,157 @@
+//
+//  TerminalOutputParser.swift
+//  Pine
+//
+//  Pure functions for detecting file:line references in terminal output.
+//
+
+import Foundation
+
+/// Detects `file:line[:column]` references in terminal output text and
+/// resolves them to verified on-disk files.
+///
+/// AI agents and compiler tools constantly emit references like
+/// `Server.swift:42` or `/abs/path/config.yml:15:3`. This parser scans
+/// text for such patterns, validates that the referenced file actually
+/// exists on disk, and returns ``TerminalLink`` values for rendering
+/// clickable regions.
+///
+/// The parser is a pure function — no side effects beyond a
+/// `FileManager.fileExists` check — making it trivially unit-testable.
+enum TerminalOutputParser {
+
+    // MARK: - Configuration
+
+    /// Characters that are valid in a file-path token.
+    ///
+    /// Word characters (`\w` = letters, digits, underscore) plus the path
+    /// separators and special characters commonly found in real paths:
+    /// dot, slash, hyphen, plus, tilde.
+    ///
+    /// Wrapping punctuation — `(`, `[`, `{`, `"`, `'` — is intentionally
+    /// excluded so that `(file.swift:42)` only matches `file.swift:42`.
+    private static let pathCharacters = #"[\w.~+/\-]"#
+
+    /// Compiled regex for `path:line[:column]`.
+    ///
+    /// Captures:
+    /// 1. The file path (characters from ``pathCharacters``).
+    /// 2. The 1-based line number (digits).
+    /// 3. The optional 1-based column number (digits).
+    private static let pattern = #"(\#(pathCharacters)+):(\d+)(?::(\d+))?"#
+
+    private static let regex: NSRegularExpression? = {
+        try? NSRegularExpression(pattern: pattern)
+    }()
+
+    // MARK: - Public API
+
+    /// Scans `text` for `file:line[:column]` references and returns verified links.
+    ///
+    /// - Parameters:
+    ///   - text: Terminal output to scan.
+    ///   - workingDirectory: The directory used to resolve relative paths.
+    ///   - fileManager: Injected `FileManager` (defaults to `.default` for tests).
+    /// - Returns: Links for every reference whose file exists on disk.
+    ///   Relative paths are resolved against `workingDirectory`; absolute paths
+    ///   (starting with `/`) and home-relative paths (starting with `~`) are
+    ///   resolved independently.
+    static func parseFilePaths(
+        in text: String,
+        workingDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [TerminalLink] {
+        guard let regex else { return [] }
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        let matches = regex.matches(in: text, range: fullRange)
+
+        var links: [TerminalLink] = []
+        links.reserveCapacity(matches.count)
+
+        for match in matches {
+            guard let link = makeLink(from: match, in: nsText,
+                                      workingDirectory: workingDirectory,
+                                      fileManager: fileManager) else {
+                continue
+            }
+            links.append(link)
+        }
+        return links
+    }
+
+    /// Convenience: returns the first link whose `NSRange` contains the given
+    /// column index (0-based, counting `NSString` characters).
+    ///
+    /// Used by the Cmd+click handler to find the link under the cursor without
+    /// iterating all matches manually.
+    static func link(atColumn column: Int, in links: [TerminalLink]) -> TerminalLink? {
+        links.first { NSLocationInRange(column, $0.range) }
+    }
+
+    // MARK: - Internal helpers
+
+    /// Builds a ``TerminalLink`` from a single regex match, validating file
+    /// existence on disk. Returns `nil` if the file does not exist.
+    private static func makeLink(
+        from match: NSTextCheckingResult,
+        in nsText: NSString,
+        workingDirectory: URL,
+        fileManager: FileManager
+    ) -> TerminalLink? {
+        let pathMatch = match.range(at: 1)
+        let lineMatch = match.range(at: 2)
+        let columnMatch = match.range(at: 3)
+
+        guard pathMatch.location != NSNotFound,
+              lineMatch.location != NSNotFound else {
+            return nil
+        }
+
+        let pathString = nsText.substring(with: pathMatch)
+        let lineString = nsText.substring(with: lineMatch)
+
+        guard let line = Int(lineString), line > 0 else { return nil }
+
+        let column: Int? = columnMatch.location != NSNotFound
+            ? Int(nsText.substring(with: columnMatch))
+            : nil
+
+        // Resolve and validate file existence before creating a link.
+        let resolvedURL = resolvePath(pathString, workingDirectory: workingDirectory)
+        guard fileManager.fileExists(atPath: resolvedURL.path) else { return nil }
+
+        return TerminalLink(
+            range: match.range,
+            fileURL: resolvedURL,
+            line: line,
+            column: column
+        )
+    }
+
+    /// Resolves a path string (absolute, home-relative, or relative) to a
+    /// concrete file URL.
+    static func resolvePath(_ path: String, workingDirectory: URL) -> URL {
+        if path.hasPrefix("/") {
+            // Absolute path — use as-is.
+            return URL(fileURLWithPath: path)
+        }
+        if path.hasPrefix("~") {
+            // Home-relative path — expand `~`.
+            let home = ProcessInfo.processInfo.environment["HOME"] ?? NSHomeDirectory()
+            let expanded: String
+            if path == "~" {
+                expanded = home
+            } else if path.hasPrefix("~/") {
+                expanded = home + String(path.dropFirst(1))
+            } else {
+                // `~user` syntax — rare; treat as-is (validation will reject
+                // if the file doesn't exist).
+                expanded = path
+            }
+            return URL(fileURLWithPath: expanded)
+        }
+        // Relative path — resolve against the working directory.
+        return workingDirectory.appendingPathComponent(path)
+    }
+}

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -58,6 +58,11 @@ class TerminalScrollInterceptor: NSView {
     /// The terminal view underneath this overlay.
     weak var terminalView: LocalProcessTerminalView?
 
+    /// Working directory of the active terminal tab. Used to resolve
+    /// relative `file:line` references when the user Cmd+clicks terminal
+    /// output (issue #949). Set by `TerminalContainerView.showTab`.
+    var workingDirectory: URL?
+
     override var isFlipped: Bool { true }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
@@ -111,6 +116,14 @@ class TerminalScrollInterceptor: NSView {
     #endif
 
     override func mouseDown(with event: NSEvent) {
+        // Cmd+click: detect and open file:line references in terminal output (issue #949).
+        // When the Command modifier is held, the click is interpreted as a
+        // navigation gesture rather than terminal input. If a file:line
+        // reference is found under the cursor, the file is opened in the
+        // editor; otherwise the click falls through to the terminal.
+        if event.modifierFlags.contains(.command), handleFileLinkClick(event) {
+            return
+        }
         isMouseDown = true
         stopAutoScroll()
         if let tv = terminalView {
@@ -118,6 +131,68 @@ class TerminalScrollInterceptor: NSView {
             tv.mouseDown(with: event)
         }
     }
+
+    // MARK: - File link click handling (issue #949)
+
+    /// Attempts to open a `file:line` reference under the cursor.
+    ///
+    /// Maps the click point to a terminal grid cell, extracts the full row
+    /// text from SwiftTerm's buffer, runs it through ``TerminalOutputParser``,
+    /// and if a link spans the clicked column, posts an ``.openFileAtLine``
+    /// notification that `ContentView` observes to open the file.
+    ///
+    /// - Parameter event: The mouse-down event (expected to carry `.command`).
+    /// - Returns: `true` if a file link was found and the notification was posted,
+    ///   `false` if no link was under the cursor (caller should fall through
+    ///   to normal terminal mouse handling).
+    @discardableResult
+    internal func handleFileLinkClick(_ event: NSEvent) -> Bool {
+        guard let terminalView, let workingDirectory else { return false }
+        let term = terminalView.getTerminal()
+
+        // Map the click location to terminal grid coordinates.
+        let point = convert(event.locationInWindow, from: nil)
+        let grid = MouseScrollForwarder.gridPosition(
+            point: point,
+            viewBounds: terminalView.bounds,
+            cols: term.cols,
+            rows: term.rows,
+            isFlipped: terminalView.isFlipped
+        )
+
+        // Extract the text of the clicked row from SwiftTerm's buffer.
+        guard let line = term.getLine(row: grid.row) else { return false }
+        let rowText = line.translateToString()
+        guard !rowText.isEmpty else { return false }
+
+        // Parse file:line references in the row text.
+        let links = TerminalOutputParser.parseFilePaths(
+            in: rowText,
+            workingDirectory: workingDirectory
+        )
+        guard !links.isEmpty else { return false }
+
+        // Find the link that spans the clicked column.
+        guard let link = TerminalOutputParser.link(atColumn: grid.col, in: links) else {
+            return false
+        }
+
+        // Post the notification — ContentView observes this and opens the file.
+        var userInfo: [String: Any] = [
+            "url": link.fileURL,
+            "line": link.line,
+        ]
+        if let column = link.column {
+            userInfo["column"] = column
+        }
+        NotificationCenter.default.post(
+            name: .openFileAtLine,
+            object: nil,
+            userInfo: userInfo
+        )
+        return true
+    }
+
     override func mouseUp(with event: NSEvent) {
         isMouseDown = false
         stopAutoScroll()
@@ -396,6 +471,7 @@ class TerminalContainerView: NSView {
             subviews.forEach { $0.removeFromSuperview() }
             currentTabID = nil
             scrollInterceptor.terminalView = nil
+            scrollInterceptor.workingDirectory = nil
             return
         }
         let tabChanged = tab.id != currentTabID || tab.terminalView.superview !== self
@@ -414,6 +490,7 @@ class TerminalContainerView: NSView {
             // Place click interceptor on top of the terminal view
             scrollInterceptor.frame = effectiveBounds
             scrollInterceptor.terminalView = tab.terminalView
+            scrollInterceptor.workingDirectory = tab.workingDirectoryURL
             addSubview(scrollInterceptor)
 
             tab.terminalView.needsLayout = true
@@ -832,6 +909,11 @@ final class TerminalTab: Identifiable, Hashable {
     func resolveWorkingDirectory() -> String {
         workingDirectory?.path ?? (ProcessInfo.processInfo.environment["HOME"] ?? "/")
     }
+
+    /// The configured working directory URL, or `nil` if none was set.
+    /// Used by the file-link click handler to resolve relative `file:line`
+    /// references in terminal output (issue #949).
+    var workingDirectoryURL: URL? { workingDirectory }
 
     /// Запускает процесс если ещё не запущен и view добавлен в иерархию.
     /// The terminal view must have a non-zero frame so SwiftTerm can calculate

--- a/PineTests/TerminalOutputParserTests.swift
+++ b/PineTests/TerminalOutputParserTests.swift
@@ -1,0 +1,321 @@
+//
+//  TerminalOutputParserTests.swift
+//  PineTests
+//
+//  Tests for TerminalOutputParser — detects file:line references in
+//  terminal output and resolves them against the working directory.
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+@Suite("Terminal Output Parser Tests")
+struct TerminalOutputParserTests {
+
+    // MARK: - Test fixtures
+
+    /// Creates a temporary directory with the given relative files, returns
+    /// the directory URL. Files are cleaned up automatically by `TempDir`.
+    private func makeWorkDir(with files: [String]) throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-parser-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        for file in files {
+            let url = tempDir.appendingPathComponent(file)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data().write(to: url)
+        }
+        return tempDir
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - Standard patterns
+
+    @Test func parsesSimpleFileNameWithLine() throws {
+        let dir = try makeWorkDir(with: ["Server.swift"])
+        defer { cleanup(dir) }
+
+        let text = "Error in Server.swift:42"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.count == 1)
+        let link = try #require(links.first)
+        #expect(link.line == 42)
+        #expect(link.column == nil)
+        #expect(link.fileURL.lastPathComponent == "Server.swift")
+        #expect(link.fileURL.deletingLastPathComponent().path == dir.path)
+    }
+
+    @Test func parsesAbsolutePathWithLineAndColumn() throws {
+        let dir = try makeWorkDir(with: [])
+        let absFile = dir.appendingPathComponent("Module.swift")
+        try Data().write(to: absFile)
+        defer { cleanup(dir) }
+
+        let text = "\(absFile.path):10:5"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.count == 1)
+        let link = try #require(links.first)
+        #expect(link.line == 10)
+        #expect(link.column == 5)
+        #expect(link.fileURL.path == absFile.path)
+    }
+
+    @Test func parsesRelativePathWithSubdirectory() throws {
+        let dir = try makeWorkDir(with: ["src/config.yml"])
+        defer { cleanup(dir) }
+
+        let text = "Check src/config.yml:3"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.count == 1)
+        let link = try #require(links.first)
+        #expect(link.line == 3)
+        #expect(link.column == nil)
+        #expect(link.fileURL.lastPathComponent == "config.yml")
+    }
+
+    @Test func parsesLineOnlyWithoutColumn() throws {
+        let dir = try makeWorkDir(with: ["app.ts"])
+        defer { cleanup(dir) }
+
+        let text = "app.ts:100"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.count == 1)
+        let link = try #require(links.first)
+        #expect(link.line == 100)
+        #expect(link.column == nil)
+    }
+
+    @Test func parsesLineAndColumn() throws {
+        let dir = try makeWorkDir(with: ["app.ts"])
+        defer { cleanup(dir) }
+
+        let text = "app.ts:100:25"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.count == 1)
+        let link = try #require(links.first)
+        #expect(link.line == 100)
+        #expect(link.column == 25)
+    }
+
+    // MARK: - Non-file rejection
+
+    @Test func rejectsHttpURLs() throws {
+        let dir = try makeWorkDir(with: [])
+        defer { cleanup(dir) }
+
+        let text = "Visit https://example.com/page for docs"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.isEmpty)
+    }
+
+    @Test func rejectsNonExistentFile() throws {
+        let dir = try makeWorkDir(with: [])
+        defer { cleanup(dir) }
+
+        let text = "Missing.swift:42 does not exist"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.isEmpty)
+    }
+
+    @Test func rejectsPlainWordsThatLookLikeReferences() throws {
+        let dir = try makeWorkDir(with: [])
+        defer { cleanup(dir) }
+
+        // "warning:42" — no file called "warning" exists, so no link.
+        let text = "warning:42 this is not a file path"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.isEmpty)
+    }
+
+    // MARK: - Multiline / multiple references
+
+    @Test func parsesMultipleReferencesInMultilineText() throws {
+        let dir = try makeWorkDir(with: ["Alpha.swift", "Beta.swift", "Gamma.swift"])
+        defer { cleanup(dir) }
+
+        let text = """
+        Compiling...
+        Error in Alpha.swift:10
+        Warning in Beta.swift:25:5
+        Also see Gamma.swift:3
+        """
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.count == 3)
+        #expect(links[0].line == 10)
+        #expect(links[1].line == 25)
+        #expect(links[1].column == 5)
+        #expect(links[2].line == 3)
+    }
+
+    @Test func parsesReferenceInSentenceWithSurroundingPunctuation() throws {
+        let dir = try makeWorkDir(with: ["main.py"])
+        defer { cleanup(dir) }
+
+        // Trailing comma and closing parenthesis should not break the match.
+        let text = "See (main.py:7), for details."
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.count == 1)
+        let link = try #require(links.first)
+        #expect(link.line == 7)
+    }
+
+    // MARK: - NSRange correctness
+
+    @Test func nsrangePointsToExactTokenInText() throws {
+        let dir = try makeWorkDir(with: ["index.js"])
+        defer { cleanup(dir) }
+
+        let text = "See index.js:15 here"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.count == 1)
+        let link = try #require(links.first)
+        let nsText = text as NSString
+        let extracted = nsText.substring(with: link.range)
+        #expect(extracted == "index.js:15")
+    }
+
+    @Test func nsrangeHandlesMultibyteText() throws {
+        let dir = try makeWorkDir(with: ["main.swift"])
+        defer { cleanup(dir) }
+
+        // Leading multibyte characters shift byte offsets; NSString ranges
+        // must be character-based, not byte-based.
+        let text = "エラー main.swift:42 発生"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.count == 1)
+        let link = try #require(links.first)
+        let nsText = text as NSString
+        let extracted = nsText.substring(with: link.range)
+        #expect(extracted == "main.swift:42")
+    }
+
+    // MARK: - Edge cases
+
+    @Test func doesNotMatchLineZero() throws {
+        let dir = try makeWorkDir(with: ["edge.txt"])
+        defer { cleanup(dir) }
+
+        // Line 0 is not a valid compiler reference — most tools use 1-based lines.
+        let text = "edge.txt:0"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.isEmpty)
+    }
+
+    @Test func matchesFilesWithoutExtension() throws {
+        let dir = try makeWorkDir(with: ["Makefile"])
+        defer { cleanup(dir) }
+
+        let text = "Makefile:15"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.count == 1)
+        let link = try #require(links.first)
+        #expect(link.line == 15)
+    }
+
+    @Test func matchesDeeplyNestedRelativePath() throws {
+        let dir = try makeWorkDir(with: ["Sources/App/Models/User.swift"])
+        defer { cleanup(dir) }
+
+        let text = "Sources/App/Models/User.swift:30:12"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.count == 1)
+        let link = try #require(links.first)
+        #expect(link.line == 30)
+        #expect(link.column == 12)
+    }
+
+    @Test func matchesFileWithDashesAndUnderscores() throws {
+        let dir = try makeWorkDir(with: ["my-cool_file.spec.ts"])
+        defer { cleanup(dir) }
+
+        let text = "my-cool_file.spec.ts:8"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        #expect(links.count == 1)
+        #expect(links.first?.line == 8)
+    }
+
+    // MARK: - link(atColumn:) helper
+
+    @Test func linkAtColumnFindsLinkUnderCursor() throws {
+        let dir = try makeWorkDir(with: ["app.ts"])
+        defer { cleanup(dir) }
+
+        let text = "app.ts:100"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+
+        // "app.ts:100" starts at index 0, length 11.
+        // Column 5 should be inside the range.
+        #expect(TerminalOutputParser.link(atColumn: 5, in: links) != nil)
+        // Column 0 should be inside the range.
+        #expect(TerminalOutputParser.link(atColumn: 0, in: links) != nil)
+        // Column 11 (past the end) should be nil.
+        #expect(TerminalOutputParser.link(atColumn: 11, in: links) == nil)
+    }
+
+    @Test func linkAtColumnReturnsNilForEmptyLinks() {
+        #expect(TerminalOutputParser.link(atColumn: 0, in: []) == nil)
+    }
+
+    // MARK: - Empty input
+
+    @Test func returnsEmptyForEmptyText() throws {
+        let dir = try makeWorkDir(with: [])
+        defer { cleanup(dir) }
+
+        let links = TerminalOutputParser.parseFilePaths(in: "", workingDirectory: dir)
+        #expect(links.isEmpty)
+    }
+
+    @Test func returnsEmptyForTextWithNoReferences() throws {
+        let dir = try makeWorkDir(with: [])
+        defer { cleanup(dir) }
+
+        let text = "Just some regular terminal output without any file references"
+        let links = TerminalOutputParser.parseFilePaths(in: text, workingDirectory: dir)
+        #expect(links.isEmpty)
+    }
+
+    // MARK: - resolvePath
+
+    @Test func resolvePathHandlesAbsolutePaths() {
+        let dir = URL(fileURLWithPath: "/tmp")
+        let resolved = TerminalOutputParser.resolvePath("/usr/local/bin/file", workingDirectory: dir)
+        #expect(resolved.path == "/usr/local/bin/file")
+    }
+
+    @Test func resolvePathHandlesRelativePaths() {
+        let dir = URL(fileURLWithPath: "/projects/pine")
+        let resolved = TerminalOutputParser.resolvePath("src/main.swift", workingDirectory: dir)
+        #expect(resolved.path == "/projects/pine/src/main.swift")
+    }
+
+    @Test func resolvePathExpandsHomeTilde() {
+        let dir = URL(fileURLWithPath: "/tmp")
+        let resolved = TerminalOutputParser.resolvePath("~/file.swift", workingDirectory: dir)
+        let home = ProcessInfo.processInfo.environment["HOME"] ?? NSHomeDirectory()
+        #expect(resolved.path == "\(home)/file.swift")
+    }
+}


### PR DESCRIPTION
Closes #949

## Summary

Detects `file:line[:column]` references in terminal output and makes them clickable. **Cmd+click** on a `Server.swift:42` reference in the terminal opens the file in Pine's editor at line 42.

This is the highest-value quick win for agent integration — AI agents (Claude Code, Codex, etc.) constantly output `file:line` references in terminal output.

## Implementation

### Core (pure, fully tested)
- **`Pine/Terminal/TerminalLink.swift`** — `TerminalLink` struct: `range: NSRange`, `fileURL: URL`, `line: Int`, `column: Int?`. Equatable.
- **`Pine/Terminal/TerminalOutputParser.swift`** — `parseFilePaths(in:workingDirectory:)` pure function:
  - Regex `[\w.~+/\-]+:(\d+)(?::(\d+))?` matches `path:line` and `path:line:column`
  - Character class excludes wrapping punctuation (`()[]{}`) so `(file.swift:42)` matches correctly
  - Validates file existence on disk before creating a link (absolute, relative, and `~`-expanded paths)
  - NSRange computed against `NSString` for multibyte safety
  - `link(atColumn:in:)` helper for hit-testing

### Integration (Cmd+click)
- **`TerminalScrollInterceptor.mouseDown`** — when Cmd modifier is held, maps the click point to a terminal grid cell, extracts the row text via SwiftTerm's `getLine(row:).translateToString()`, parses it, and if a link spans the clicked column, posts `.openFileAtLine` notification
- **`TerminalContainerView.showTab`** — wires `scrollInterceptor.workingDirectory` from `TerminalTab.workingDirectoryURL`
- **`GitAndNotificationObserver`** — observes `.openFileAtLine` and calls `tabManager.openTabAndGoToLine(url:line:)`
- **`PineAppNotifications.swift`** — new `.openFileAtLine` notification name

### Tests
23 unit tests covering: standard patterns (`file.swift:42`, `/abs/path.swift:10:5`, `relative/path.yml:3`), line:column, HTTP URL rejection, non-existent file rejection, multiline output, trailing punctuation, multibyte NSRange, line 0 rejection, files without extension, deeply nested paths, `link(atColumn:)` hit-testing, `resolvePath` for absolute/relative/home paths.

## Known limitations / follow-ups
- **Column navigation**: the parser captures and passes the column number in the notification, but the current editor navigation infrastructure (`pendingGoToLine` → `GoToRequest`) is line-based. Column-level cursor positioning is a follow-up enhancement.
- **Rendering**: links are not visually styled/underlined in the terminal — SwiftTerm uses CoreGraphics cell rendering, not NSTextStorage. Cmd+click is the discovery mechanism. Visual underlining would require SwiftTerm internals changes.
- Parsing is scoped to the clicked row only (single line), keeping it O(1) per click with no perf impact.

Part of #933 Phase 1.