### PR TITLE
docs: move CLAUDE.md to AGENTS.md and document maintainer workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for AI coding agents (Claude Code, pi, and others) working in this repository.
 
 ## Project Overview
 
@@ -188,3 +188,35 @@ When creating issues, always:
 - Add appropriate labels from the repo's label set (e.g. `enhancement`, `bug`, `editor`, `UX`, `priority: high/medium/low`, etc.)
 - Use a clear, concise title
 - Include **Summary**, **Motivation**, and **Implementation ideas** sections in the body
+- **Always assign the issue to a milestone.** Work is milestone-driven: pick the next task from the current milestone, prioritizing by the `priority:` labels. No milestone = no work.
+
+## Workflow
+
+How the maintainer works day-to-day. Documents intent and handoff conventions for contributors and AI agents.
+
+### Prioritization
+- Work is driven by **milestones**. The next task is picked from the active milestone, prioritized by labels (`priority: high` first).
+- An issue is filed **before or alongside** implementation and always assigned to a milestone (see `## GitHub Issues`).
+
+### Branches & PRs
+- **One task = one short-lived branch**, named by type with no issue number: `feat/terminal-scroll`, `fix/gutter-bug`.
+- No long-lived feature branches. Nothing is committed directly to `main`.
+- PRs are **squash-merged** into `main` (one commit per PR).
+- The PR description states **when the branch is ready to merge** — do not merge before that.
+
+### Local development loop
+- Code is edited **inside Pine itself**, or via AI agents in the terminal.
+- Fast feedback loop: **single-file typecheck** (`swiftc -typecheck`, see `## Build & Run`) — not a full build on every change.
+- A full `xcodebuild build` is run **before opening a PR**.
+- Run locally: `swiftlint` + the unit tests in `PineTests` that cover the touched area.
+- **UI tests (`PineUITests`, 7 shards) run only on CI** — almost never locally.
+
+### Working with AI agents
+- Typical handoff: **"реши issue #N"** (solve issue #N) — the agent reads the issue **and all its comments** in full, then plans, implements, writes tests, and opens a PR.
+- Agents may freely, without asking: edit code, run single-file typecheck, run unit tests, create branches, open PRs.
+- **Explicit confirmation required** for: merging a PR, and anything in the destructive-command list in `AGENTS.md` (deletions, force-pushes, infrastructure changes).
+- Agents should run unit tests themselves — no need to ask first.
+
+### Releases
+- **No fixed cadence** — release when ready, by merging the Release Please PR.
+- Manual work before tagging is kept to a minimum; Release Please handles `version.txt` and `CHANGELOG.md` automatically (see `## Release & CI`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Pine follows **MVVM** with SwiftUI views backed by AppKit via `NSViewRepresentab
 - **`SyntaxHighlighter`** loads JSON grammar files from `Pine/Grammars/` for syntax highlighting
 - Menu commands are defined in `PineApp.swift` and dispatched via `NotificationCenter`
 
-For more details, see the Architecture section in [CLAUDE.md](CLAUDE.md).
+For more details, see the Architecture section in [AGENTS.md](AGENTS.md).
 
 ## Making Changes
 

--- a/PineUITests/SidebarRenameTests.swift
+++ b/PineUITests/SidebarRenameTests.swift
@@ -36,7 +36,7 @@ final class SidebarRenameTests: PineUITestCase {
     /// `.onKeyPress(.return)` handler, which wires up the Finder-style
     /// Enter-to-rename shortcut in `SidebarView`, does not receive XCUITest
     /// synthetic key events on macOS 26 — the same class of flake documented
-    /// for `NSEvent.addLocalMonitorForEvents` in `CLAUDE.md`. Using the
+    /// for `NSEvent.addLocalMonitorForEvents` in `AGENTS.md`. Using the
     /// context-menu trigger keeps the rest of the rename flow under real
     /// end-to-end coverage (inline editor appears, typing, commit path,
     /// file-system effects) while sidestepping the synthetic-event race on
@@ -239,7 +239,7 @@ final class SidebarRenameTests: PineUITestCase {
     /// The Enter-trigger path lives in `SidebarView`'s `.onKeyPress(.return)`
     /// handler, which under XCUITest on macOS 26 does not reliably receive
     /// synthetic key events (same class of flake as the Cmd+W local event
-    /// monitor documented in `CLAUDE.md`). When the trigger fails to fire,
+    /// monitor documented in `AGENTS.md`). When the trigger fails to fire,
     /// we `XCTSkip` rather than fail — the commit path itself is covered
     /// end-to-end by the tests above, and the `startRename` logic is
     /// covered by unit tests on `SidebarEditState`.

--- a/PineUITests/TerminalTests.swift
+++ b/PineUITests/TerminalTests.swift
@@ -738,7 +738,7 @@ final class TerminalTests: PineUITestCase {
 
         // Click `+` — this is the exact path users hit per issue #918.
         // Cmd+T cannot be used because XCUITest's typeKey() bypasses the
-        // app's NSEvent.addLocalMonitorForEvents (see CLAUDE.md).
+        // app's NSEvent.addLocalMonitorForEvents (see AGENTS.md).
         newTerminalButton.click()
 
         let tab2 = terminalTab("Terminal 2")


### PR DESCRIPTION
## Summary

- **Rename `CLAUDE.md` → `AGENTS.md`** — adopt the universal agent-guidance filename so the same doc is picked up by Claude Code, pi, and other AI coding agents. Git detects the rename (92% similarity), so blame/history is preserved.
- **Add a new `## Workflow` section** capturing the maintainer's day-to-day flow (gathered via a short interview), so contributors and agents share the same expectations:
  - Milestone-driven prioritization by `priority:` labels
  - One task = one short-lived, typed branch (`feat/…`, `fix/…`, no issue number)
  - Squash-merge into `main`; PR description signals merge-readiness
  - Inner loop: single-file `swiftc -typecheck`; full build only before a PR
  - Unit tests (`PineTests`) run locally; UI tests (`PineUITests`, 7 shards) only on CI
  - AI agent handoff: "реши issue #N" → agent reads issue + comments, edits/types/runs unit tests/opens PR freely; **merge still needs explicit confirmation**
  - Releases on demand via Release Please, no fixed cadence
- **Update references** to the renamed file in `CONTRIBUTING.md`, `PineUITests/TerminalTests.swift`, `PineUITests/SidebarRenameTests.swift`. `CHANGELOG.md` is left untouched (historical release notes).

## Merge-readiness

✅ Ready to merge — all checks expected to pass; docs-only change, no runtime impact.

## Files changed

- `CLAUDE.md` → `AGENTS.md` (rename + new Workflow section)
- `CONTRIBUTING.md` (link update)
- `PineUITests/TerminalTests.swift` (comment)
- `PineUITests/SidebarRenameTests.swift` (2 comments)