### PR TITLE
fix(terminal): pixel-precise mouse forwarding for TUI scroll

### DIFF
--- a/Pine/MouseScrollForwarder.swift
+++ b/Pine/MouseScrollForwarder.swift
@@ -96,21 +96,6 @@ enum MouseScrollForwarder {
         deltaY > 0 ? "\u{1b}OA" : "\u{1b}OB"
     }
 
-    /// Computes scroll velocity (number of events to send) based on scroll delta magnitude.
-    ///
-    /// - Parameter delta: Absolute scroll delta value.
-    /// - Returns: Number of scroll events to send (1–3).
-    static func scrollVelocity(delta: CGFloat) -> Int {
-        let absDelta = abs(delta)
-        if absDelta > 5 {
-            return 3
-        }
-        if absDelta > 1 {
-            return Int(min(absDelta, 3))
-        }
-        return 1
-    }
-
     /// Points of trackpad delta that correspond to one line of scrollback.
     static let trackpadLineThreshold: CGFloat = 10
 
@@ -152,6 +137,75 @@ enum MouseScrollForwarder {
         } else {
             let lines = min(max(Int(abs(newDelta)), 1), 3)
             return NormalScrollResult(lines: lines, remainingDelta: 0)
+        }
+    }
+
+    // MARK: - Mouse-reporting scroll forwarding
+
+    /// Result of a mouse-reporting scroll calculation.
+    ///
+    /// `events` is the number of VT100 mouse-button events to forward to the
+    /// TUI app (each one represents a single wheel click in the TUI's view).
+    /// `remainingDelta` is the residual trackpad delta carried into the next
+    /// scroll event so sub-threshold motion is not lost.
+    struct MouseReportingScrollResult {
+        /// Number of VT100 mouse-button events to send.
+        let events: Int
+        /// Remaining accumulated delta after consuming whole thresholds.
+        let remainingDelta: CGFloat
+    }
+
+    /// Calculates how many VT100 mouse-button events to forward to a TUI app
+    /// that has mouse reporting enabled (vim `set mouse=a`, lazygit, htop,
+    /// k9s, etc.).
+    ///
+    /// This mirrors `normalScrollLines`'s trackpad accumulator pattern
+    /// (accumulate precise deltas, consume whole `trackpadLineThreshold`
+    /// multiples, preserve the remainder, reset on `phaseBegan`) but differs
+    /// in two important ways:
+    ///
+    /// 1. **Each threshold crossing emits exactly one event, not `n`.**
+    ///    TUI apps treat every VT100 mouse-button-4/5 event as a discrete
+    ///    wheel click, so emitting `n` per `n × threshold` of motion produces
+    ///    `n`-line jumps. Forwarding one event per threshold crossing lets the
+    ///    TUI pace itself to the actual gesture (Ghostty/WezTerm/iTerm2
+    ///    behavior).
+    ///
+    /// 2. **Non-precise (mouse wheel) input always returns exactly one event**
+    ///    with no accumulation. A physical mouse wheel tick is already a
+    ///    single discrete click; scaling it to 1–3 (as `normalScrollLines`
+    ///    does for scrollback) would again cause multi-line jumps in the TUI.
+    ///
+    /// - Parameters:
+    ///   - accumulatedDelta: Previously accumulated trackpad delta (ignored
+    ///     for non-precise input and on `phaseBegan`).
+    ///   - newDelta: The current event's scroll delta.
+    ///   - isPrecise: Whether the event comes from a trackpad
+    ///     (`hasPreciseScrollingDeltas`).
+    ///   - phaseBegan: Whether the gesture phase is `.began` (resets
+    ///     accumulation).
+    /// - Returns: The number of events to forward and the remaining delta.
+    static func mouseReportingScrollEvents(
+        accumulatedDelta: CGFloat,
+        newDelta: CGFloat,
+        isPrecise: Bool,
+        phaseBegan: Bool
+    ) -> MouseReportingScrollResult {
+        if isPrecise {
+            let accumulated = phaseBegan ? newDelta : accumulatedDelta + newDelta
+            let crossings = Int(abs(accumulated) / trackpadLineThreshold)
+            if crossings > 0 {
+                // One event per threshold crossing — the TUI sees one wheel
+                // click per `trackpadLineThreshold` of motion, not a burst.
+                let consumed = CGFloat(crossings) * trackpadLineThreshold
+                let remaining = accumulated - consumed * (accumulated > 0 ? 1 : -1)
+                return MouseReportingScrollResult(events: crossings, remainingDelta: remaining)
+            }
+            return MouseReportingScrollResult(events: 0, remainingDelta: accumulated)
+        } else {
+            // Physical mouse wheel: one discrete click → one event, no scaling,
+            // no accumulation (consistent with how TUIs expect wheel input).
+            return MouseReportingScrollResult(events: 1, remainingDelta: 0)
         }
     }
 }

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -451,6 +451,13 @@ class TerminalContainerView: NSView {
     private let scrollInterceptor = TerminalScrollInterceptor()
     private var scrollMonitor: Any?
     private var accumulatedScrollDelta: CGFloat = 0
+    /// Dedicated accumulator for the mouse-reporting branch of
+    /// `installScrollMonitor` (the `term.mouseMode != .off` path). Kept
+    /// separate from `accumulatedScrollDelta` — which is shared by the
+    /// alternate-screen and normal-mode branches — so this change stays
+    /// cleanly mergeable with the sibling PR for issue #979 that reworks
+    /// the alternate-screen branch.
+    private var mouseReportingAccumulatedDelta: CGFloat = 0
     /// Notification observer that re-renders the active terminal when the
     /// host window regains key focus. After a long Cmd+Tab into another app
     /// AppKit may discard the layer's backing store; without this observer
@@ -575,9 +582,25 @@ class TerminalContainerView: NSView {
                     isFlipped: terminalView.isFlipped
                 )
 
-                let velocity = MouseScrollForwarder.scrollVelocity(delta: scrollDelta)
-                for _ in 0..<velocity {
-                    term.sendEvent(buttonFlags: buttonFlags, x: pos.col, y: pos.row)
+                let velocity = MouseScrollForwarder.mouseReportingScrollEvents(
+                    accumulatedDelta: self.mouseReportingAccumulatedDelta,
+                    newDelta: scrollDelta,
+                    isPrecise: event.hasPreciseScrollingDeltas,
+                    phaseBegan: event.phase == .began
+                )
+                self.mouseReportingAccumulatedDelta = velocity.remainingDelta
+                // Forward exactly one VT100 mouse-button event per accumulated
+                // threshold crossing (trackpad) or one per tick (mouse wheel),
+                // using the SwiftTerm pixel overload so SGR-pixel-capable TUIs
+                // (mode 1016) can do sub-row scrolling.
+                for _ in 0..<velocity.events {
+                    term.sendEvent(
+                        buttonFlags: buttonFlags,
+                        x: pos.col,
+                        y: pos.row,
+                        pixelX: Int(locationInTerminal.x),
+                        pixelY: Int(locationInTerminal.y)
+                    )
                 }
                 return nil
             }

--- a/PineTests/TerminalScrollForwardingTests.swift
+++ b/PineTests/TerminalScrollForwardingTests.swift
@@ -145,8 +145,6 @@ struct TerminalScrollForwardingTests {
 
     // NOTE: Non-flipped coordinate tests are in the "Grid position edge cases (#551)" section below.
 
-    // NOTE: Velocity threshold tests are in the "Scroll velocity threshold tests (#551)" section below.
-
     // MARK: - TerminalContainerView scroll forwarding integration
 
     @Test func containerViewIsFlipped() {
@@ -214,20 +212,7 @@ struct TerminalScrollForwardingTests {
         #expect(key == "\u{1b}OB")
     }
 
-    // MARK: - Scroll velocity edge cases
-
-    @Test func scrollVelocityForNegativeDelta() {
-        let velocity = MouseScrollForwarder.scrollVelocity(delta: -3.0)
-        #expect(velocity == 3)
-    }
-
-    @Test func scrollVelocityForNegativeLargeDelta() {
-        let velocity = MouseScrollForwarder.scrollVelocity(delta: -10.0)
-        #expect(velocity == 3)
-    }
-
-    // NOTE: Scroll velocity boundary and grid position edge case tests
-    // are in the "#551" sections below — duplicates removed.
+    // MARK: - Arrow key zero-delta
 
     @Test func arrowKeyForScrollZeroDelta() {
         // Zero delta defaults to scroll down (ESC O B) since 0 > 0 is false
@@ -337,59 +322,212 @@ struct TerminalScrollForwardingTests {
         #expect(flags == 73)
     }
 
-    // MARK: - Scroll velocity threshold tests (#551)
+    // MARK: - Mouse-reporting scroll forwarding (#978)
+    //
+    // When a TUI app enables mouse reporting (mouseMode != .off), scroll
+    // events are forwarded as VT100 mouse-button-4/5 events. The helper
+    // emits exactly one event per `trackpadLineThreshold` of accumulated
+    // trackpad motion (not a burst), and exactly one event per mouse-wheel
+    // tick. The former `scrollVelocity` 1–3 burst helper was removed in
+    // favor of this accumulator; see issue #978.
 
-    @Test func scrollVelocityAtExactThresholdOne() {
-        // delta exactly 1.0 → absDelta is 1.0, not > 1 → velocity = 1
-        let v = MouseScrollForwarder.scrollVelocity(delta: 1.0)
-        #expect(v == 1)
+    @Test func mouseReportingPreciseDeltaBelowThresholdEmitsNothing() {
+        // A single precise (trackpad) delta below the threshold produces no
+        // events and carries the full delta forward into the accumulator.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: 5,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.events == 0)
+        #expect(result.remainingDelta == 5)
     }
 
-    @Test func scrollVelocityJustAboveThresholdOne() {
-        // delta 1.01 → absDelta > 1 → velocity = Int(min(1.01, 3)) = 1
-        let v = MouseScrollForwarder.scrollVelocity(delta: 1.01)
-        #expect(v == 1)
+    @Test func mouseReportingPreciseDeltaExactlyAtThresholdEmitsOne() {
+        // Exactly one threshold worth of motion → exactly one event.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: MouseScrollForwarder.trackpadLineThreshold,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.events == 1)
+        #expect(result.remainingDelta == 0)
     }
 
-    @Test func scrollVelocityAtExactThresholdFive() {
-        // delta exactly 5.0 → absDelta is 5.0, which is > 1 but not > 5 → velocity = Int(min(5.0, 3)) = 3
-        let v = MouseScrollForwarder.scrollVelocity(delta: 5.0)
-        #expect(v == 3)
+    @Test func mouseReportingPreciseDeltaMultipleCrossingsEmitsOnePerCrossing() {
+        // delta 25 at threshold 10 → 2 crossings (2 events), remainder 5.
+        // This is the key difference from the old `scrollVelocity` burst:
+        // each crossing is exactly one wheel click in the TUI's view, so a
+        // flick scrolls two lines, not a 3× burst × something.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: 25,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.events == 2)
+        #expect(result.remainingDelta == 5)
     }
 
-    @Test func scrollVelocityJustAboveThresholdFive() {
-        // delta 5.01 → absDelta > 5 → velocity = 3
-        let v = MouseScrollForwarder.scrollVelocity(delta: 5.01)
-        #expect(v == 3)
+    @Test func mouseReportingPreciseAccumulatesAcrossEvents() {
+        // First event: delta 6 (below threshold) → 0 events, remaining 6.
+        let r1 = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: 6,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(r1.events == 0)
+        #expect(r1.remainingDelta == 6)
+
+        // Second event: delta 6, accumulated = 12 → 1 crossing, remaining 2.
+        let r2 = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: r1.remainingDelta,
+            newDelta: 6,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(r2.events == 1)
+        #expect(r2.remainingDelta == 2)
     }
 
-    @Test func scrollVelocityWithNegativeDelta() {
-        // Negative deltas should use abs() and produce same velocities
-        #expect(MouseScrollForwarder.scrollVelocity(delta: -1.0) == 1)
-        #expect(MouseScrollForwarder.scrollVelocity(delta: -3.0) == 3)
-        #expect(MouseScrollForwarder.scrollVelocity(delta: -7.0) == 3)
+    @Test func mouseReportingPreciseNegativeDeltaEmitsPerCrossing() {
+        // Scrolling down accumulates negative deltas; 25 points → 2 events,
+        // remainder -5. The sign of the remaining delta is preserved.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: -25,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.events == 2)
+        #expect(result.remainingDelta == -5)
     }
 
-    @Test func scrollVelocityForMediumValues() {
-        // delta 2.0 → absDelta > 1, not > 5 → Int(min(2.0, 3)) = 2
-        #expect(MouseScrollForwarder.scrollVelocity(delta: 2.0) == 2)
-        // delta 2.5 → Int(min(2.5, 3)) = 2
-        #expect(MouseScrollForwarder.scrollVelocity(delta: 2.5) == 2)
+    @Test func mouseReportingPreciseLargeMomentumDelta() {
+        // A large trackpad-momentum delta of 150 → 15 crossings (15 single
+        // events), no remainder. Previously this would have been clamped to a
+        // 3-event burst regardless of magnitude.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: 150,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.events == 15)
+        #expect(result.remainingDelta == 0)
     }
 
-    @Test func scrollVelocityNeverExceedsThree() {
-        // Even with extremely large deltas, velocity should cap at 3
-        let v = MouseScrollForwarder.scrollVelocity(delta: 1000.0)
-        #expect(v == 3)
-        let vNeg = MouseScrollForwarder.scrollVelocity(delta: -1000.0)
-        #expect(vNeg == 3)
+    @Test func mouseReportingPreciseCarriesRemainderAcrossEvents() {
+        // Three events of delta 7 each: 7 → 14 → 21
+        // 7/10=0 (rem 7), 14/10=1 (rem 4), 11/10=1 (rem 1)
+        let r1 = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0, newDelta: 7, isPrecise: true, phaseBegan: false
+        )
+        #expect(r1.events == 0)
+        #expect(r1.remainingDelta == 7)
+
+        let r2 = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: r1.remainingDelta, newDelta: 7, isPrecise: true, phaseBegan: false
+        )
+        #expect(r2.events == 1)
+        #expect(r2.remainingDelta == 4)
+
+        let r3 = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: r2.remainingDelta, newDelta: 7, isPrecise: true, phaseBegan: false
+        )
+        #expect(r3.events == 1)
+        #expect(r3.remainingDelta == 1)
     }
 
-    @Test func scrollVelocityIsAlwaysAtLeastOne() {
-        // Even for tiny deltas, velocity should be at least 1
-        #expect(MouseScrollForwarder.scrollVelocity(delta: 0.001) >= 1)
-        #expect(MouseScrollForwarder.scrollVelocity(delta: -0.001) >= 1)
-        #expect(MouseScrollForwarder.scrollVelocity(delta: 0.0) >= 1)
+    @Test func mouseReportingPhaseBeganResetsAccumulation() {
+        // A residual of 999 must be discarded when a new gesture begins; the
+        // new gesture's first delta (5, below threshold) becomes the seed.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 999,
+            newDelta: 5,
+            isPrecise: true,
+            phaseBegan: true
+        )
+        #expect(result.events == 0)
+        #expect(result.remainingDelta == 5)
+    }
+
+    @Test func mouseReportingPhaseBeganWithLargeDeltaEmitsImmediately() {
+        // If the very first event of a gesture is large enough to cross the
+        // threshold, events are emitted right away (phaseBegan seeds then
+        // consumes in one step).
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 999,
+            newDelta: 25,
+            isPrecise: true,
+            phaseBegan: true
+        )
+        #expect(result.events == 2)
+        #expect(result.remainingDelta == 5)
+    }
+
+    @Test func mouseReportingMouseWheelAlwaysOneEvent() {
+        // Non-precise (physical mouse wheel) input always produces exactly one
+        // event regardless of magnitude — a wheel tick is a single discrete
+        // click, and there is no accumulation between ticks.
+        let small = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0, newDelta: 1, isPrecise: false, phaseBegan: false
+        )
+        #expect(small.events == 1)
+        #expect(small.remainingDelta == 0)
+
+        let medium = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0, newDelta: 2, isPrecise: false, phaseBegan: false
+        )
+        #expect(medium.events == 1)
+        #expect(medium.remainingDelta == 0)
+
+        let large = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0, newDelta: 15, isPrecise: false, phaseBegan: false
+        )
+        #expect(large.events == 1)
+        #expect(large.remainingDelta == 0)
+    }
+
+    @Test func mouseReportingMouseWheelIgnoresAccumulatedDelta() {
+        // Mouse wheel never accumulates — a leftover trackpad residual must
+        // not turn a single wheel tick into multiple events.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 500,
+            newDelta: 1,
+            isPrecise: false,
+            phaseBegan: false
+        )
+        #expect(result.events == 1)
+        #expect(result.remainingDelta == 0)
+    }
+
+    @Test func mouseReportingMouseWheelNegativeDeltaOneEvent() {
+        // Scrolling down with a mouse wheel is also a single event.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: -3,
+            isPrecise: false,
+            phaseBegan: false
+        )
+        #expect(result.events == 1)
+        #expect(result.remainingDelta == 0)
+    }
+
+    @Test func mouseReportingMouseWheelIgnoresPhaseBegan() {
+        // phaseBegan only matters for the precise accumulator; a mouse wheel
+        // tick at gesture start is still one event with no remainder.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: 1,
+            isPrecise: false,
+            phaseBegan: true
+        )
+        #expect(result.events == 1)
+        #expect(result.remainingDelta == 0)
     }
 
     // MARK: - Grid position edge cases (#551)

--- a/PineTests/TerminalScrollForwardingTests.swift
+++ b/PineTests/TerminalScrollForwardingTests.swift
@@ -421,7 +421,7 @@ struct TerminalScrollForwardingTests {
     }
 
     @Test func mouseReportingPreciseCarriesRemainderAcrossEvents() {
-        // Three events of delta 7 each: 7 → 14 → 21
+        // Three events of delta 7 each: 7 → 14 → 11
         // 7/10=0 (rem 7), 14/10=1 (rem 4), 11/10=1 (rem 1)
         let r1 = MouseScrollForwarder.mouseReportingScrollEvents(
             accumulatedDelta: 0, newDelta: 7, isPrecise: true, phaseBegan: false
@@ -467,6 +467,39 @@ struct TerminalScrollForwardingTests {
         )
         #expect(result.events == 2)
         #expect(result.remainingDelta == 5)
+    }
+
+    // MARK: - Sign-flip mid-gesture (mouse reporting)
+
+    @Test func mouseReportingPreciseSubThresholdSignFlipFoldsResidual() {
+        // Direction reversal while a sub-threshold residual is pending: the
+        // old +8 residual folds into the new-direction accumulation. This
+        // matches `normalScrollLines` by design — the residual is not reset
+        // mid-gesture, it carries into the new direction.
+        // accumulated = 8 + (-15) = -7, |−7|/10 = 0 crossings, rem −7.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 8,
+            newDelta: -15,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.events == 0)
+        #expect(result.remainingDelta == -7)
+    }
+
+    @Test func mouseReportingPreciseCrossingSignFlipEmitsInNewDirection() {
+        // Direction reversal with enough magnitude to cross the threshold in
+        // the new direction: one event is emitted, and the residual is carried.
+        // accumulated = 8 + (-25) = -17, |−17|/10 = 1 crossing,
+        // consumed = 1*10 = 10, rem = -17 - 10*(-1) = -7.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 8,
+            newDelta: -25,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.events == 1)
+        #expect(result.remainingDelta == -7)
     }
 
     @Test func mouseReportingMouseWheelAlwaysOneEvent() {


### PR DESCRIPTION
## Summary

Replaces the burst-based scroll forwarding for TUI apps with **mouse reporting enabled** (`term.mouseMode != .off`) with one-event-per-threshold-crossing forwarding that also threads real pixel coordinates through SwiftTerm's SGR-pixel overload.

Closes #978.

## Motivation

`Pine/TerminalSession.swift` called `MouseScrollForwarder.scrollVelocity(delta:)`, which returns up to **3** when `abs(delta) > 5`, then emitted that many `sendEvent(...)` in a tight loop:

```swift
let velocity = MouseScrollForwarder.scrollVelocity(delta: scrollDelta)
for _ in 0..<velocity {
    term.sendEvent(buttonFlags: buttonFlags, x: pos.col, y: pos.row)
}
```

A trackpad easily produces `deltaY` of 10–40 per event, so every `scrollWheel` fired a burst of 3 VT100 mouse-button events. TUI apps treat each one as a discrete wheel click → ~9-line jumps in vim, multi-element skips in lazygit, jerky htop. There was no accumulation and no sub-grid precision, so the gesture felt quantized rather than smooth. Ghostty, WezTerm and iTerm2 forward **one** event per threshold crossing with real pixel coordinates.

## Changes

- **`Pine/MouseScrollForwarder.swift`**
  - Removed the `scrollVelocity(delta:)` burst helper (now dead code — its only call site is reworked).
  - Added `mouseReportingScrollEvents(accumulatedDelta:newDelta:isPrecise:phaseBegan:) -> MouseReportingScrollResult { events; remainingDelta }`. It mirrors the proven `normalScrollLines` trackpad accumulator pattern (accumulate precise deltas, consume whole `trackpadLineThreshold` multiples, preserve the remainder, reset on `.began`) but emits **exactly one** event per threshold crossing instead of `n`, and for non-precise (physical mouse wheel) input always returns exactly one event with no accumulation — a wheel tick is a single discrete click in the TUI's view.

- **`Pine/TerminalSession.swift`** (only the `term.mouseMode != .off` branch of `installScrollMonitor`)
  - Calls the new helper and forwards its event count to the SwiftTerm pixel overload `sendEvent(buttonFlags:x:y:pixelX:pixelY:)` using `locationInTerminal.x` / `locationInTerminal.y` so SGR-pixel-capable TUIs (mode 1016) get sub-row precision.
  - Uses a dedicated `mouseReportingAccumulatedDelta` field (kept separate from the shared `accumulatedScrollDelta` used by the alternate-screen and normal-mode branches) so this PR stays cleanly mergeable with the sibling #979 rework.
  - The alternate-screen branch and the normal-mode branch are intentionally untouched (separate concerns — #979 / #965).

- **`PineTests/TerminalScrollForwardingTests.swift`**
  - Removed the now-dead `scrollVelocity` unit tests.
  - Added a full `Mouse-reporting scroll forwarding (#978)` test section: precise delta below threshold (0 events, remainder carried), exact threshold (1 event), multiple crossings (1 per crossing with remainder), cross-event accumulation, negative deltas, large momentum, `.began` reset (incl. large first delta), and the non-precise always-one-event / no-accumulation / ignores-`phaseBegan` cases.

## Manual test checklist

- [ ] vim with `set mouse=a` — trackpad scroll moves one line per threshold crossing (no 9-line jumps), smooth flicks.
- [ ] lazygit — scroll moves one entry at a time (no 3-element skips).
- [ ] htop — smooth scroll, no jerky bursts.
- [ ] Physical mouse wheel — still exactly one line/click of scroll in each TUI.
- [ ] On an SGR-pixel-capable TUI (mode 1016), sub-row pixel coordinates are received.

## Validation

- `swiftlint lint` on all three changed files: **0 violations**.
- `xcodebuild test -only-testing:PineTests/TerminalScrollForwardingTests`: **66 tests passed**.


## Test coverage notes

- The pure helper `MouseScrollForwarder.mouseReportingScrollEvents(...)` is fully unit-tested in `PineTests/TerminalScrollForwardingTests.swift`, including sub-threshold deltas, exact/multiple threshold crossings, cross-event accumulation, `.began` reset, and **sign-flip mid-gesture** cases (direction reversal while a residual is pending — the residual folds into the new-direction accumulation, matching `normalScrollLines` by design).
- The SwiftTerm pixel-overload call site `term.sendEvent(buttonFlags:x:y:pixelX:pixelY:)` in `Pine/TerminalSession.swift` is **verified manually, not via unit test**. The project has no spy/mock harness for SwiftTerm's `Terminal.sendEvent`, so wiring the pixel coordinates through the live SwiftTerm view cannot be exercised by the unit-test suite. This is a pre-existing testability gap shared with the normal-mode and alternate-screen branches (their `scrollUp`/`scrollDown`/`sendResponse` call sites are likewise unit-untested). Building such a harness is out of scope for this PR.
- The **Manual test checklist** above covers end-to-end verification of the SGR-pixel (mode 1016) path: vim `set mouse=a`, lazygit, htop, physical mouse wheel, and a sub-row pixel check on a pixel-capable TUI.