### PR TITLE
fix(terminal): flush residual delta on scroll gesture phase boundaries

### DIFF
--- a/Pine/MouseScrollForwarder.swift
+++ b/Pine/MouseScrollForwarder.swift
@@ -96,6 +96,23 @@ enum MouseScrollForwarder {
         deltaY > 0 ? "\u{1b}OA" : "\u{1b}OB"
     }
 
+    /// Returns the number of arrow keys the alternate-screen scroll path should
+    /// emit for a given `NormalScrollResult`.
+    ///
+    /// The alternate-screen path (TUI apps without mouse reporting: vim/less/man,
+    /// k9s without mouse) emits one application cursor sequence
+    /// (`ESC O A`/`ESC O B`) per scrollback line, so this forwards `result.lines`.
+    /// Centralizing the mapping keeps the integration between
+    /// `normalScrollLines` and the arrow-key emitter unit-testable without a
+    /// live terminal, and documents that the arrow cadence intentionally
+    /// matches normal-mode scrollback.
+    ///
+    /// - Parameter result: The result of `normalScrollLines` for the scroll event.
+    /// - Returns: Number of arrow key sequences to emit.
+    static func arrowKeyCount(for result: NormalScrollResult) -> Int {
+        result.lines
+    }
+
     /// Computes scroll velocity (number of events to send) based on scroll delta magnitude.
     ///
     /// - Parameter delta: Absolute scroll delta value.

--- a/Pine/MouseScrollForwarder.swift
+++ b/Pine/MouseScrollForwarder.swift
@@ -96,21 +96,6 @@ enum MouseScrollForwarder {
         deltaY > 0 ? "\u{1b}OA" : "\u{1b}OB"
     }
 
-    /// Computes scroll velocity (number of events to send) based on scroll delta magnitude.
-    ///
-    /// - Parameter delta: Absolute scroll delta value.
-    /// - Returns: Number of scroll events to send (1–3).
-    static func scrollVelocity(delta: CGFloat) -> Int {
-        let absDelta = abs(delta)
-        if absDelta > 5 {
-            return 3
-        }
-        if absDelta > 1 {
-            return Int(min(absDelta, 3))
-        }
-        return 1
-    }
-
     /// Points of trackpad delta that correspond to one line of scrollback.
     static let trackpadLineThreshold: CGFloat = 10
 
@@ -152,6 +137,75 @@ enum MouseScrollForwarder {
         } else {
             let lines = min(max(Int(abs(newDelta)), 1), 3)
             return NormalScrollResult(lines: lines, remainingDelta: 0)
+        }
+    }
+
+    // MARK: - Mouse-reporting scroll forwarding
+
+    /// Result of a mouse-reporting scroll calculation.
+    ///
+    /// `events` is the number of VT100 mouse-button events to forward to the
+    /// TUI app (each one represents a single wheel click in the TUI's view).
+    /// `remainingDelta` is the residual trackpad delta carried into the next
+    /// scroll event so sub-threshold motion is not lost.
+    struct MouseReportingScrollResult {
+        /// Number of VT100 mouse-button events to send.
+        let events: Int
+        /// Remaining accumulated delta after consuming whole thresholds.
+        let remainingDelta: CGFloat
+    }
+
+    /// Calculates how many VT100 mouse-button events to forward to a TUI app
+    /// that has mouse reporting enabled (vim `set mouse=a`, lazygit, htop,
+    /// k9s, etc.).
+    ///
+    /// This mirrors `normalScrollLines`'s trackpad accumulator pattern
+    /// (accumulate precise deltas, consume whole `trackpadLineThreshold`
+    /// multiples, preserve the remainder, reset on `phaseBegan`) but differs
+    /// in two important ways:
+    ///
+    /// 1. **Each threshold crossing emits exactly one event, not `n`.**
+    ///    TUI apps treat every VT100 mouse-button-4/5 event as a discrete
+    ///    wheel click, so emitting `n` per `n × threshold` of motion produces
+    ///    `n`-line jumps. Forwarding one event per threshold crossing lets the
+    ///    TUI pace itself to the actual gesture (Ghostty/WezTerm/iTerm2
+    ///    behavior).
+    ///
+    /// 2. **Non-precise (mouse wheel) input always returns exactly one event**
+    ///    with no accumulation. A physical mouse wheel tick is already a
+    ///    single discrete click; scaling it to 1–3 (as `normalScrollLines`
+    ///    does for scrollback) would again cause multi-line jumps in the TUI.
+    ///
+    /// - Parameters:
+    ///   - accumulatedDelta: Previously accumulated trackpad delta (ignored
+    ///     for non-precise input and on `phaseBegan`).
+    ///   - newDelta: The current event's scroll delta.
+    ///   - isPrecise: Whether the event comes from a trackpad
+    ///     (`hasPreciseScrollingDeltas`).
+    ///   - phaseBegan: Whether the gesture phase is `.began` (resets
+    ///     accumulation).
+    /// - Returns: The number of events to forward and the remaining delta.
+    static func mouseReportingScrollEvents(
+        accumulatedDelta: CGFloat,
+        newDelta: CGFloat,
+        isPrecise: Bool,
+        phaseBegan: Bool
+    ) -> MouseReportingScrollResult {
+        if isPrecise {
+            let accumulated = phaseBegan ? newDelta : accumulatedDelta + newDelta
+            let crossings = Int(abs(accumulated) / trackpadLineThreshold)
+            if crossings > 0 {
+                // One event per threshold crossing — the TUI sees one wheel
+                // click per `trackpadLineThreshold` of motion, not a burst.
+                let consumed = CGFloat(crossings) * trackpadLineThreshold
+                let remaining = accumulated - consumed * (accumulated > 0 ? 1 : -1)
+                return MouseReportingScrollResult(events: crossings, remainingDelta: remaining)
+            }
+            return MouseReportingScrollResult(events: 0, remainingDelta: accumulated)
+        } else {
+            // Physical mouse wheel: one discrete click → one event, no scaling,
+            // no accumulation (consistent with how TUIs expect wheel input).
+            return MouseReportingScrollResult(events: 1, remainingDelta: 0)
         }
     }
 }

--- a/Pine/MouseScrollForwarder.swift
+++ b/Pine/MouseScrollForwarder.swift
@@ -115,12 +115,44 @@ enum MouseScrollForwarder {
     /// Points of trackpad delta that correspond to one line of scrollback.
     static let trackpadLineThreshold: CGFloat = 10
 
+    /// Minimum residual trackpad delta (points) that still commits a final
+    /// line when a scroll gesture ends. Half the per-line `trackpadLineThreshold`
+    /// so the last partial line is not lost, while sub-threshold noise is
+    /// dropped to avoid a stray 1-line twitch.
+    static let gestureEndSettleThreshold: CGFloat = trackpadLineThreshold / 2
+
     /// Result of a normal-mode scroll calculation.
     struct NormalScrollResult {
         /// Number of scrollback lines to scroll.
         let lines: Int
         /// Remaining accumulated delta after consuming whole lines.
         let remainingDelta: CGFloat
+    }
+
+    /// Returns how many whole lines of residual delta to commit when a scroll
+    /// gesture ends (trackpad phase `.ended`, including the final momentum
+    /// `.ended`), so a partial line above the settle threshold is not silently
+    /// dropped.
+    ///
+    /// Both `normalScrollLines` and `mouseReportingScrollEvents` always consume
+    /// whole `trackpadLineThreshold` multiples during the gesture, so the
+    /// residual reaching `.ended` is strictly below one full threshold.
+    /// Therefore this returns `0` or `1`: commit the single final partial line
+    /// when the residual meets `gestureEndSettleThreshold` (half a line), or
+    /// drop it to avoid a stray twitch. This matches the Ghostty/iTerm2 gesture
+    /// model where `.ended` flushes the residual so the buffer lands exactly
+    /// where the fingers stopped.
+    ///
+    /// - Parameters:
+    ///   - accumulatedDelta: The residual delta carried by the active branch.
+    ///   - settleThreshold: Minimum residual magnitude that still emits. Defaults
+    ///     to `gestureEndSettleThreshold` (`trackpadLineThreshold / 2`).
+    /// - Returns: `1` when the residual should commit its final line, else `0`.
+    static func flushResidual(
+        accumulatedDelta: CGFloat,
+        settleThreshold: CGFloat = gestureEndSettleThreshold
+    ) -> Int {
+        abs(accumulatedDelta) >= settleThreshold ? 1 : 0
     }
 
     /// Calculates controlled scroll lines for normal-mode terminal scrollback.

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -451,6 +451,13 @@ class TerminalContainerView: NSView {
     private let scrollInterceptor = TerminalScrollInterceptor()
     private var scrollMonitor: Any?
     private var accumulatedScrollDelta: CGFloat = 0
+    /// Dedicated accumulator for the mouse-reporting branch of
+    /// `installScrollMonitor` (the `term.mouseMode != .off` path). Kept
+    /// separate from `accumulatedScrollDelta` — which is shared by the
+    /// alternate-screen and normal-mode branches — so this change stays
+    /// cleanly mergeable with the sibling PR for issue #979 that reworks
+    /// the alternate-screen branch.
+    private var mouseReportingAccumulatedDelta: CGFloat = 0
     /// Notification observer that re-renders the active terminal when the
     /// host window regains key focus. After a long Cmd+Tab into another app
     /// AppKit may discard the layer's backing store; without this observer
@@ -575,9 +582,25 @@ class TerminalContainerView: NSView {
                     isFlipped: terminalView.isFlipped
                 )
 
-                let velocity = MouseScrollForwarder.scrollVelocity(delta: scrollDelta)
-                for _ in 0..<velocity {
-                    term.sendEvent(buttonFlags: buttonFlags, x: pos.col, y: pos.row)
+                let velocity = MouseScrollForwarder.mouseReportingScrollEvents(
+                    accumulatedDelta: self.mouseReportingAccumulatedDelta,
+                    newDelta: scrollDelta,
+                    isPrecise: event.hasPreciseScrollingDeltas,
+                    phaseBegan: event.phase == .began
+                )
+                self.mouseReportingAccumulatedDelta = velocity.remainingDelta
+                // Forward exactly one VT100 mouse-button event per accumulated
+                // threshold crossing (trackpad) or one per tick (mouse wheel),
+                // using the SwiftTerm pixel overload so SGR-pixel-capable TUIs
+                // (mode 1016) can do sub-row scrolling.
+                for _ in 0..<velocity.events {
+                    term.sendEvent(
+                        buttonFlags: buttonFlags,
+                        x: pos.col,
+                        y: pos.row,
+                        pixelX: Int(locationInTerminal.x),
+                        pixelY: Int(locationInTerminal.y)
+                    )
                 }
                 return nil
             }

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -585,21 +585,20 @@ class TerminalContainerView: NSView {
             if term.isCurrentBufferAlternate {
                 // Alternate screen (k9s, htop, vim, etc.) without mouse reporting —
                 // convert scroll to arrow keys like Ghostty/WezTerm/iTerm2.
-                // Accumulate trackpad deltas and emit 1 arrow key per threshold.
-                let arrowKey: String = scrollDelta > 0 ? "\u{1b}OA" : "\u{1b}OB"
-                if event.hasPreciseScrollingDeltas {
-                    self.accumulatedScrollDelta += scrollDelta
-                    // Reset accumulator on gesture start
-                    if event.phase == .began {
-                        self.accumulatedScrollDelta = scrollDelta
-                    }
-                    let threshold: CGFloat = 25
-                    if abs(self.accumulatedScrollDelta) >= threshold {
-                        term.sendResponse(text: arrowKey)
-                        self.accumulatedScrollDelta = 0
-                    }
-                } else {
-                    // Mouse wheel: 1 arrow key per tick
+                // Reuse the shared `normalScrollLines` helper so the arrow-key
+                // cadence matches normal-mode scrollback (1 arrow per
+                // `trackpadLineThreshold` = 10 points) and residual delta is
+                // preserved via `remainingDelta` (no lost overshoot).
+                let arrowKey = MouseScrollForwarder.arrowKeyForScroll(deltaY: scrollDelta)
+                let result = MouseScrollForwarder.normalScrollLines(
+                    accumulatedDelta: self.accumulatedScrollDelta,
+                    newDelta: scrollDelta,
+                    isPrecise: event.hasPreciseScrollingDeltas,
+                    phaseBegan: event.phase == .began
+                )
+                self.accumulatedScrollDelta = result.remainingDelta
+                let arrowCount = MouseScrollForwarder.arrowKeyCount(for: result)
+                for _ in 0..<arrowCount {
                     term.sendResponse(text: arrowKey)
                 }
                 return nil

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -559,7 +559,16 @@ class TerminalContainerView: NSView {
 
             // Use scrollingDeltaY for trackpad (precise), deltaY for mouse wheel
             let scrollDelta = event.hasPreciseScrollingDeltas ? event.scrollingDeltaY : event.deltaY
-            guard scrollDelta != 0 else { return event }
+            // Trackpad gesture/momentum phase boundaries (.began / .ended)
+            // frequently carry a zero scrolling delta but still must reach the
+            // per-branch logic: .began resets the active accumulator and .ended
+            // flushes residual delta so the final partial line is committed
+            // rather than dropped. Non-phase events with zero delta (e.g. inert
+            // ticks) are ignored as before. Momentum phase lives in
+            // `momentumPhase` (not `phase`), so both are consulted.
+            let phaseBegan = event.phase == .began || event.momentumPhase == .began
+            let phaseEnded = event.phase == .ended || event.momentumPhase == .ended
+            guard scrollDelta != 0 || phaseBegan || phaseEnded else { return event }
 
             let term = terminalView.getTerminal()
 
@@ -586,7 +595,7 @@ class TerminalContainerView: NSView {
                     accumulatedDelta: self.mouseReportingAccumulatedDelta,
                     newDelta: scrollDelta,
                     isPrecise: event.hasPreciseScrollingDeltas,
-                    phaseBegan: event.phase == .began
+                    phaseBegan: phaseBegan
                 )
                 self.mouseReportingAccumulatedDelta = velocity.remainingDelta
                 // Forward exactly one VT100 mouse-button event per accumulated
@@ -601,6 +610,33 @@ class TerminalContainerView: NSView {
                         pixelX: Int(locationInTerminal.x),
                         pixelY: Int(locationInTerminal.y)
                     )
+                }
+                // On gesture/momentum end, flush residual delta above the settle
+                // threshold so the final partial threshold crossing is committed
+                // instead of being silently dropped (Ghostty/iTerm2 behavior).
+                if phaseEnded {
+                    let residual = self.mouseReportingAccumulatedDelta
+                    let flushCount = MouseScrollForwarder.flushResidual(accumulatedDelta: residual)
+                    self.mouseReportingAccumulatedDelta = 0
+                    if flushCount > 0 {
+                        // Direction comes from the residual sign, not scrollDelta,
+                        // because .ended markers often carry a zero delta.
+                        let flushButtonFlags = MouseScrollForwarder.encodeScrollButton(
+                            deltaY: residual,
+                            shift: modifiers.contains(.shift),
+                            option: modifiers.contains(.option),
+                            control: modifiers.contains(.control)
+                        )
+                        for _ in 0..<flushCount {
+                            term.sendEvent(
+                                buttonFlags: flushButtonFlags,
+                                x: pos.col,
+                                y: pos.row,
+                                pixelX: Int(locationInTerminal.x),
+                                pixelY: Int(locationInTerminal.y)
+                            )
+                        }
+                    }
                 }
                 return nil
             }
@@ -617,12 +653,28 @@ class TerminalContainerView: NSView {
                     accumulatedDelta: self.accumulatedScrollDelta,
                     newDelta: scrollDelta,
                     isPrecise: event.hasPreciseScrollingDeltas,
-                    phaseBegan: event.phase == .began
+                    phaseBegan: phaseBegan
                 )
                 self.accumulatedScrollDelta = result.remainingDelta
                 let arrowCount = MouseScrollForwarder.arrowKeyCount(for: result)
                 for _ in 0..<arrowCount {
                     term.sendResponse(text: arrowKey)
+                }
+                // On gesture/momentum end, flush residual delta above the settle
+                // threshold so the final partial line is committed instead of
+                // being silently dropped (Ghostty/iTerm2 behavior).
+                if phaseEnded {
+                    let residual = self.accumulatedScrollDelta
+                    let flushCount = MouseScrollForwarder.flushResidual(accumulatedDelta: residual)
+                    self.accumulatedScrollDelta = 0
+                    if flushCount > 0 {
+                        // Direction comes from the residual sign, not scrollDelta,
+                        // because .ended markers often carry a zero delta.
+                        let flushKey = MouseScrollForwarder.arrowKeyForScroll(deltaY: residual)
+                        for _ in 0..<flushCount {
+                            term.sendResponse(text: flushKey)
+                        }
+                    }
                 }
                 return nil
             }
@@ -633,7 +685,7 @@ class TerminalContainerView: NSView {
                 accumulatedDelta: self.accumulatedScrollDelta,
                 newDelta: scrollDelta,
                 isPrecise: event.hasPreciseScrollingDeltas,
-                phaseBegan: event.phase == .began
+                phaseBegan: phaseBegan
             )
             self.accumulatedScrollDelta = result.remainingDelta
             if result.lines > 0 {
@@ -641,6 +693,23 @@ class TerminalContainerView: NSView {
                     terminalView.scrollUp(lines: result.lines)
                 } else {
                     terminalView.scrollDown(lines: result.lines)
+                }
+            }
+            // On gesture/momentum end, flush residual delta above the settle
+            // threshold so the final partial line is committed instead of
+            // being silently dropped (Ghostty/iTerm2 behavior).
+            if phaseEnded {
+                let residual = self.accumulatedScrollDelta
+                let flushCount = MouseScrollForwarder.flushResidual(accumulatedDelta: residual)
+                self.accumulatedScrollDelta = 0
+                if flushCount > 0 {
+                    // Direction comes from the residual sign, not scrollDelta,
+                    // because .ended markers often carry a zero delta.
+                    if residual > 0 {
+                        terminalView.scrollUp(lines: flushCount)
+                    } else {
+                        terminalView.scrollDown(lines: flushCount)
+                    }
                 }
             }
             return nil

--- a/PineTests/TerminalScrollForwardingTests.swift
+++ b/PineTests/TerminalScrollForwardingTests.swift
@@ -651,4 +651,98 @@ struct TerminalScrollForwardingTests {
         #expect(r3.lines == 1)
         #expect(r3.remainingDelta == 1)
     }
+
+    // MARK: - Alternate-screen arrow-key emission (#979)
+
+    // The alternate-screen scroll path (TUI apps without mouse reporting:
+    // vim/less/man, k9s without mouse) feeds `normalScrollLines` into an
+    // arrow-key emitter: one `ESC O A`/`ESC O B` sequence per resulting line.
+    // These tests verify that integration — the cadence matches normal-mode
+    // scrollback (1 arrow per `trackpadLineThreshold` = 10 points) and residual
+    // delta is preserved.
+
+    @Test func alternateScreenArrowTrackpadBelowThresholdEmitsNothing() {
+        // Precise delta < 10 → 0 arrows, remaining carried forward
+        let result = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: 5, isPrecise: true, phaseBegan: false
+        )
+        let arrowCount = MouseScrollForwarder.arrowKeyCount(for: result)
+        #expect(arrowCount == 0)
+        #expect(result.remainingDelta == 5) // carried forward, not discarded
+    }
+
+    @Test func alternateScreenArrowTrackpadAccumulatedTo25EmitsTwoArrows() {
+        // Precise delta = 25 → 2 arrows (25/10 = 2), remaining = 5
+        let result = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: 25, isPrecise: true, phaseBegan: false
+        )
+        let arrowCount = MouseScrollForwarder.arrowKeyCount(for: result)
+        #expect(arrowCount == 2)
+        #expect(result.remainingDelta == 5) // overshoot preserved
+    }
+
+    @Test func alternateScreenArrowPhaseBeganResetsAccumulation() {
+        // .began phase resets accumulation; previously accumulated 999 is
+        // discarded instead of being added to the new delta.
+        let result = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 999, newDelta: 5, isPrecise: true, phaseBegan: true
+        )
+        let arrowCount = MouseScrollForwarder.arrowKeyCount(for: result)
+        #expect(arrowCount == 0)
+        #expect(result.remainingDelta == 5) // not 1004 — accumulation was reset
+    }
+
+    @Test func alternateScreenArrowMouseWheelEmitsOneToThreeArrows() {
+        // Non-precise mouse wheel: 1..3 arrows scaled by delta magnitude.
+        // This is an intentional behavior change from the previous code, which
+        // always emitted exactly 1 arrow per tick — see PR body for rationale.
+        let small = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: 1, isPrecise: false, phaseBegan: false
+        )
+        #expect(MouseScrollForwarder.arrowKeyCount(for: small) >= 1)
+        #expect(small.remainingDelta == 0)
+
+        let medium = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: 2, isPrecise: false, phaseBegan: false
+        )
+        #expect(MouseScrollForwarder.arrowKeyCount(for: medium) == 2)
+
+        let large = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: 15, isPrecise: false, phaseBegan: false
+        )
+        #expect(MouseScrollForwarder.arrowKeyCount(for: large) == 3) // capped at 3
+    }
+
+    @Test func alternateScreenArrowDirectionDeterminesSequence() {
+        // Direction determines ESC O A (up) vs ESC O B (down); count is symmetric.
+        let up = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: 25, isPrecise: true, phaseBegan: false
+        )
+        let down = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: -25, isPrecise: true, phaseBegan: false
+        )
+        #expect(MouseScrollForwarder.arrowKeyCount(for: up) == 2)
+        #expect(MouseScrollForwarder.arrowKeyCount(for: down) == 2)
+        #expect(MouseScrollForwarder.arrowKeyForScroll(deltaY: 25) == "\u{1b}OA")
+        #expect(MouseScrollForwarder.arrowKeyForScroll(deltaY: -25) == "\u{1b}OB")
+    }
+
+    @Test func alternateScreenArrowResidualCarriedAcrossEvents() {
+        // Demonstrates residual preservation across events — the central fix.
+        // Event 1: delta 12 → emit 1 arrow, remaining 2.
+        // Event 2: delta 8 → accumulated 10 → emit 1 arrow, remaining 0.
+        // With the old code (threshold 25, reset to 0), neither event would
+        // have emitted any arrow key.
+        let r1 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: 12, isPrecise: true, phaseBegan: false
+        )
+        #expect(MouseScrollForwarder.arrowKeyCount(for: r1) == 1)
+        #expect(r1.remainingDelta == 2)
+
+        let r2 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: r1.remainingDelta, newDelta: 8, isPrecise: true, phaseBegan: false
+        )
+        #expect(MouseScrollForwarder.arrowKeyCount(for: r2) == 1)
+        #expect(r2.remainingDelta == 0)
+    }
 }

--- a/PineTests/TerminalScrollForwardingTests.swift
+++ b/PineTests/TerminalScrollForwardingTests.swift
@@ -883,4 +883,165 @@ struct TerminalScrollForwardingTests {
         #expect(MouseScrollForwarder.arrowKeyCount(for: r2) == 1)
         #expect(r2.remainingDelta == 0)
     }
+
+    // MARK: - Gesture phase boundary flush (#980)
+
+    // On trackpad gesture end (phase `.ended`, including the final momentum
+    // `.ended`), residual delta above the settle threshold
+    // (`gestureEndSettleThreshold` = `trackpadLineThreshold / 2` = 5) is flushed
+    // so the final partial line is committed instead of being silently dropped.
+    // Residual below the settle threshold is dropped to avoid a stray twitch.
+    // Because the per-event helpers always consume whole thresholds during the
+    // gesture, the residual reaching `.ended` is below one full threshold, so
+    // `flushResidual` returns 0 or 1.
+
+    @Test func flushResidualAboveSettleThresholdCommitsOneLine() {
+        // Residual 8 (>= settle 5) → commit the final partial line.
+        #expect(MouseScrollForwarder.flushResidual(accumulatedDelta: 8) == 1)
+        // Exactly at the settle boundary.
+        #expect(MouseScrollForwarder.flushResidual(accumulatedDelta: 5) == 1)
+        // Negative residual scrolls down and still commits.
+        #expect(MouseScrollForwarder.flushResidual(accumulatedDelta: -8) == 1)
+    }
+
+    @Test func flushResidualBelowSettleThresholdDropsNothing() {
+        // Residual 3 (< settle 5) → dropped to avoid a stray 1-line twitch.
+        #expect(MouseScrollForwarder.flushResidual(accumulatedDelta: 3) == 0)
+        // Just under the boundary.
+        #expect(MouseScrollForwarder.flushResidual(accumulatedDelta: 4.9) == 0)
+        // Zero residual → nothing to flush.
+        #expect(MouseScrollForwarder.flushResidual(accumulatedDelta: 0) == 0)
+        // Small negative residual → also dropped.
+        #expect(MouseScrollForwarder.flushResidual(accumulatedDelta: -2) == 0)
+    }
+
+    @Test func flushResidualCustomSettleThreshold() {
+        // A custom settle threshold changes the gate but still returns 0/1 for
+        // sub-threshold residuals.
+        #expect(MouseScrollForwarder.flushResidual(accumulatedDelta: 4, settleThreshold: 4) == 1)
+        #expect(MouseScrollForwarder.flushResidual(accumulatedDelta: 3.9, settleThreshold: 4) == 0)
+    }
+
+    // The following tests simulate full synthetic gesture sequences — threading
+    // residual delta through the per-event helpers, then flushing on `.ended` —
+    // exactly as `TerminalContainerView.installScrollMonitor` does at runtime.
+
+    @Test func gestureEndFlushCommitsFinalPartialLine() {
+        // Sequence: .began(delta 8) → 0 lines, residual 8. Then .ended carries
+        // delta 0: normalScrollLines keeps residual 8, then flushResidual(8)
+        // commits the final partial line. The last line the user intended is
+        // not lost.
+        let began = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: 8, isPrecise: true, phaseBegan: true
+        )
+        #expect(began.lines == 0)
+        #expect(began.remainingDelta == 8)
+
+        let ended = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: began.remainingDelta, newDelta: 0, isPrecise: true, phaseBegan: false
+        )
+        #expect(ended.lines == 0)
+        #expect(ended.remainingDelta == 8)
+
+        let flushCount = MouseScrollForwarder.flushResidual(accumulatedDelta: ended.remainingDelta)
+        #expect(flushCount == 1)
+    }
+
+    @Test func gestureEndWithTinyResidualEmitsNothing() {
+        // Sequence: .began(delta 3) → 0 lines, residual 3. .ended → residual
+        // still 3, below settle threshold → no spurious emit (no twitch).
+        let began = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: 3, isPrecise: true, phaseBegan: true
+        )
+        let ended = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: began.remainingDelta, newDelta: 0, isPrecise: true, phaseBegan: false
+        )
+        let flushCount = MouseScrollForwarder.flushResidual(accumulatedDelta: ended.remainingDelta)
+        #expect(flushCount == 0)
+    }
+
+    @Test func mouseReportingGestureEndFlushCommitsFinalEvent() {
+        // Mouse-reporting path: .began(delta 8) → 0 events, residual 8. .ended
+        // → flushResidual(8) commits one final VT100 mouse-button event.
+        let began = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0, newDelta: 8, isPrecise: true, phaseBegan: true
+        )
+        #expect(began.events == 0)
+        #expect(began.remainingDelta == 8)
+
+        let flushCount = MouseScrollForwarder.flushResidual(accumulatedDelta: began.remainingDelta)
+        #expect(flushCount == 1)
+    }
+
+    @Test func momentumContinuesUnderSamePerLineThreshold() {
+        // After the main gesture `.ended` flushes and resets the accumulator to
+        // 0, momentum `.changed` events accumulate under the SAME per-line
+        // threshold (no cap, no multiply). Then the momentum `.ended` flushes
+        // its own residual.
+        //
+        // Main gesture: .began(8) → residual 8, flush → 1 line, reset to 0.
+        let began = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: 8, isPrecise: true, phaseBegan: true
+        )
+        let mainFlush = MouseScrollForwarder.flushResidual(accumulatedDelta: began.remainingDelta)
+        #expect(mainFlush == 1)
+        // Accumulator reset to 0 on .ended (runtime does this).
+        var residual: CGFloat = 0
+
+        // Momentum .changed(12) → 1 line (12/10), residual 2 — same threshold.
+        let momentum = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: residual, newDelta: 12, isPrecise: true, phaseBegan: false
+        )
+        #expect(momentum.lines == 1)
+        #expect(momentum.remainingDelta == 2)
+        residual = momentum.remainingDelta
+
+        // Momentum .ended → residual 2 below settle → no flush.
+        let momentumFlush = MouseScrollForwarder.flushResidual(accumulatedDelta: residual)
+        #expect(momentumFlush == 0)
+    }
+
+    @Test func beganResetsStaleAccumulatorFromPreviousGesture() {
+        // A previous gesture leaves a stale residual of 7. A new gesture starts
+        // with .began(delta 4): phaseBegan discards the stale 7 and seeds 4,
+        // so no phantom jump carries over from the old gesture.
+        let staleResidual: CGFloat = 7
+        let newBegan = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: staleResidual, newDelta: 4, isPrecise: true, phaseBegan: true
+        )
+        #expect(newBegan.lines == 0)
+        #expect(newBegan.remainingDelta == 4) // not 11 — stale residual discarded
+    }
+
+    @Test func fullGestureSequenceAccumulatesThenFlushes() {
+        // End-to-end: .began(7) → .changed(7) → .ended, simulating a flick.
+        // .began(7): reset, residual 7, 0 lines.
+        let r0 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: 7, isPrecise: true, phaseBegan: true
+        )
+        #expect(r0.lines == 0)
+        #expect(r0.remainingDelta == 7)
+        // .changed(7): accumulated 14 → 1 line, residual 4.
+        let r1 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: r0.remainingDelta, newDelta: 7, isPrecise: true, phaseBegan: false
+        )
+        #expect(r1.lines == 1)
+        #expect(r1.remainingDelta == 4)
+        // .ended: residual 4 < settle 5 → no flush. Final tally: 1 line.
+        let flush = MouseScrollForwarder.flushResidual(accumulatedDelta: r1.remainingDelta)
+        #expect(flush == 0)
+
+        // Contrast: .began(7) → .changed(8) → .ended leaves residual 5.
+        let s0 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: 7, isPrecise: true, phaseBegan: true
+        )
+        let s1 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: s0.remainingDelta, newDelta: 8, isPrecise: true, phaseBegan: false
+        )
+        #expect(s1.lines == 1)
+        #expect(s1.remainingDelta == 5)
+        // .ended: residual 5 >= settle 5 → flush 1 line. Final tally: 2 lines.
+        let flush2 = MouseScrollForwarder.flushResidual(accumulatedDelta: s1.remainingDelta)
+        #expect(flush2 == 1)
+    }
 }

--- a/PineTests/TerminalScrollForwardingTests.swift
+++ b/PineTests/TerminalScrollForwardingTests.swift
@@ -1044,4 +1044,41 @@ struct TerminalScrollForwardingTests {
         let flush2 = MouseScrollForwarder.flushResidual(accumulatedDelta: s1.remainingDelta)
         #expect(flush2 == 1)
     }
+
+    @Test func gestureEndFlushAfterMultipleChangedEvents() {
+        // Issue #980 requires ".began + several .changed + .ended with residual"
+        // to assert the final flush count. Multiple .changed(3) events accumulate
+        // below the per-line threshold so 0 lines are emitted during the gesture,
+        // and the residual crosses the settle threshold only at .ended.
+        // Math: 3 → 6 → 9, none crosses threshold 10, so 0 per-event lines and
+        // residual 9 at .ended; 9 ≥ 5 settle → flush 1.
+        let r0 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: 0, newDelta: 3, isPrecise: true, phaseBegan: true
+        )
+        #expect(r0.lines == 0)
+        #expect(r0.remainingDelta == 3)
+
+        let r1 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: r0.remainingDelta, newDelta: 3, isPrecise: true, phaseBegan: false
+        )
+        #expect(r1.lines == 0)
+        #expect(r1.remainingDelta == 6)
+
+        let r2 = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: r1.remainingDelta, newDelta: 3, isPrecise: true, phaseBegan: false
+        )
+        #expect(r2.lines == 0)
+        #expect(r2.remainingDelta == 9)
+
+        // .ended carries delta 0: residual stays 9, no per-event line.
+        let rEnd = MouseScrollForwarder.normalScrollLines(
+            accumulatedDelta: r2.remainingDelta, newDelta: 0, isPrecise: true, phaseBegan: false
+        )
+        #expect(rEnd.lines == 0)
+        #expect(rEnd.remainingDelta == 9)
+
+        // .ended flush: residual 9 ≥ settle 5 → commit the final partial line.
+        let flushCount = MouseScrollForwarder.flushResidual(accumulatedDelta: rEnd.remainingDelta)
+        #expect(flushCount == 1)
+    }
 }

--- a/PineTests/TerminalScrollForwardingTests.swift
+++ b/PineTests/TerminalScrollForwardingTests.swift
@@ -145,8 +145,6 @@ struct TerminalScrollForwardingTests {
 
     // NOTE: Non-flipped coordinate tests are in the "Grid position edge cases (#551)" section below.
 
-    // NOTE: Velocity threshold tests are in the "Scroll velocity threshold tests (#551)" section below.
-
     // MARK: - TerminalContainerView scroll forwarding integration
 
     @Test func containerViewIsFlipped() {
@@ -214,20 +212,7 @@ struct TerminalScrollForwardingTests {
         #expect(key == "\u{1b}OB")
     }
 
-    // MARK: - Scroll velocity edge cases
-
-    @Test func scrollVelocityForNegativeDelta() {
-        let velocity = MouseScrollForwarder.scrollVelocity(delta: -3.0)
-        #expect(velocity == 3)
-    }
-
-    @Test func scrollVelocityForNegativeLargeDelta() {
-        let velocity = MouseScrollForwarder.scrollVelocity(delta: -10.0)
-        #expect(velocity == 3)
-    }
-
-    // NOTE: Scroll velocity boundary and grid position edge case tests
-    // are in the "#551" sections below — duplicates removed.
+    // MARK: - Arrow key zero-delta
 
     @Test func arrowKeyForScrollZeroDelta() {
         // Zero delta defaults to scroll down (ESC O B) since 0 > 0 is false
@@ -337,59 +322,212 @@ struct TerminalScrollForwardingTests {
         #expect(flags == 73)
     }
 
-    // MARK: - Scroll velocity threshold tests (#551)
+    // MARK: - Mouse-reporting scroll forwarding (#978)
+    //
+    // When a TUI app enables mouse reporting (mouseMode != .off), scroll
+    // events are forwarded as VT100 mouse-button-4/5 events. The helper
+    // emits exactly one event per `trackpadLineThreshold` of accumulated
+    // trackpad motion (not a burst), and exactly one event per mouse-wheel
+    // tick. The former `scrollVelocity` 1–3 burst helper was removed in
+    // favor of this accumulator; see issue #978.
 
-    @Test func scrollVelocityAtExactThresholdOne() {
-        // delta exactly 1.0 → absDelta is 1.0, not > 1 → velocity = 1
-        let v = MouseScrollForwarder.scrollVelocity(delta: 1.0)
-        #expect(v == 1)
+    @Test func mouseReportingPreciseDeltaBelowThresholdEmitsNothing() {
+        // A single precise (trackpad) delta below the threshold produces no
+        // events and carries the full delta forward into the accumulator.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: 5,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.events == 0)
+        #expect(result.remainingDelta == 5)
     }
 
-    @Test func scrollVelocityJustAboveThresholdOne() {
-        // delta 1.01 → absDelta > 1 → velocity = Int(min(1.01, 3)) = 1
-        let v = MouseScrollForwarder.scrollVelocity(delta: 1.01)
-        #expect(v == 1)
+    @Test func mouseReportingPreciseDeltaExactlyAtThresholdEmitsOne() {
+        // Exactly one threshold worth of motion → exactly one event.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: MouseScrollForwarder.trackpadLineThreshold,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.events == 1)
+        #expect(result.remainingDelta == 0)
     }
 
-    @Test func scrollVelocityAtExactThresholdFive() {
-        // delta exactly 5.0 → absDelta is 5.0, which is > 1 but not > 5 → velocity = Int(min(5.0, 3)) = 3
-        let v = MouseScrollForwarder.scrollVelocity(delta: 5.0)
-        #expect(v == 3)
+    @Test func mouseReportingPreciseDeltaMultipleCrossingsEmitsOnePerCrossing() {
+        // delta 25 at threshold 10 → 2 crossings (2 events), remainder 5.
+        // This is the key difference from the old `scrollVelocity` burst:
+        // each crossing is exactly one wheel click in the TUI's view, so a
+        // flick scrolls two lines, not a 3× burst × something.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: 25,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.events == 2)
+        #expect(result.remainingDelta == 5)
     }
 
-    @Test func scrollVelocityJustAboveThresholdFive() {
-        // delta 5.01 → absDelta > 5 → velocity = 3
-        let v = MouseScrollForwarder.scrollVelocity(delta: 5.01)
-        #expect(v == 3)
+    @Test func mouseReportingPreciseAccumulatesAcrossEvents() {
+        // First event: delta 6 (below threshold) → 0 events, remaining 6.
+        let r1 = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: 6,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(r1.events == 0)
+        #expect(r1.remainingDelta == 6)
+
+        // Second event: delta 6, accumulated = 12 → 1 crossing, remaining 2.
+        let r2 = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: r1.remainingDelta,
+            newDelta: 6,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(r2.events == 1)
+        #expect(r2.remainingDelta == 2)
     }
 
-    @Test func scrollVelocityWithNegativeDelta() {
-        // Negative deltas should use abs() and produce same velocities
-        #expect(MouseScrollForwarder.scrollVelocity(delta: -1.0) == 1)
-        #expect(MouseScrollForwarder.scrollVelocity(delta: -3.0) == 3)
-        #expect(MouseScrollForwarder.scrollVelocity(delta: -7.0) == 3)
+    @Test func mouseReportingPreciseNegativeDeltaEmitsPerCrossing() {
+        // Scrolling down accumulates negative deltas; 25 points → 2 events,
+        // remainder -5. The sign of the remaining delta is preserved.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: -25,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.events == 2)
+        #expect(result.remainingDelta == -5)
     }
 
-    @Test func scrollVelocityForMediumValues() {
-        // delta 2.0 → absDelta > 1, not > 5 → Int(min(2.0, 3)) = 2
-        #expect(MouseScrollForwarder.scrollVelocity(delta: 2.0) == 2)
-        // delta 2.5 → Int(min(2.5, 3)) = 2
-        #expect(MouseScrollForwarder.scrollVelocity(delta: 2.5) == 2)
+    @Test func mouseReportingPreciseLargeMomentumDelta() {
+        // A large trackpad-momentum delta of 150 → 15 crossings (15 single
+        // events), no remainder. Previously this would have been clamped to a
+        // 3-event burst regardless of magnitude.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: 150,
+            isPrecise: true,
+            phaseBegan: false
+        )
+        #expect(result.events == 15)
+        #expect(result.remainingDelta == 0)
     }
 
-    @Test func scrollVelocityNeverExceedsThree() {
-        // Even with extremely large deltas, velocity should cap at 3
-        let v = MouseScrollForwarder.scrollVelocity(delta: 1000.0)
-        #expect(v == 3)
-        let vNeg = MouseScrollForwarder.scrollVelocity(delta: -1000.0)
-        #expect(vNeg == 3)
+    @Test func mouseReportingPreciseCarriesRemainderAcrossEvents() {
+        // Three events of delta 7 each: 7 → 14 → 21
+        // 7/10=0 (rem 7), 14/10=1 (rem 4), 11/10=1 (rem 1)
+        let r1 = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0, newDelta: 7, isPrecise: true, phaseBegan: false
+        )
+        #expect(r1.events == 0)
+        #expect(r1.remainingDelta == 7)
+
+        let r2 = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: r1.remainingDelta, newDelta: 7, isPrecise: true, phaseBegan: false
+        )
+        #expect(r2.events == 1)
+        #expect(r2.remainingDelta == 4)
+
+        let r3 = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: r2.remainingDelta, newDelta: 7, isPrecise: true, phaseBegan: false
+        )
+        #expect(r3.events == 1)
+        #expect(r3.remainingDelta == 1)
     }
 
-    @Test func scrollVelocityIsAlwaysAtLeastOne() {
-        // Even for tiny deltas, velocity should be at least 1
-        #expect(MouseScrollForwarder.scrollVelocity(delta: 0.001) >= 1)
-        #expect(MouseScrollForwarder.scrollVelocity(delta: -0.001) >= 1)
-        #expect(MouseScrollForwarder.scrollVelocity(delta: 0.0) >= 1)
+    @Test func mouseReportingPhaseBeganResetsAccumulation() {
+        // A residual of 999 must be discarded when a new gesture begins; the
+        // new gesture's first delta (5, below threshold) becomes the seed.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 999,
+            newDelta: 5,
+            isPrecise: true,
+            phaseBegan: true
+        )
+        #expect(result.events == 0)
+        #expect(result.remainingDelta == 5)
+    }
+
+    @Test func mouseReportingPhaseBeganWithLargeDeltaEmitsImmediately() {
+        // If the very first event of a gesture is large enough to cross the
+        // threshold, events are emitted right away (phaseBegan seeds then
+        // consumes in one step).
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 999,
+            newDelta: 25,
+            isPrecise: true,
+            phaseBegan: true
+        )
+        #expect(result.events == 2)
+        #expect(result.remainingDelta == 5)
+    }
+
+    @Test func mouseReportingMouseWheelAlwaysOneEvent() {
+        // Non-precise (physical mouse wheel) input always produces exactly one
+        // event regardless of magnitude — a wheel tick is a single discrete
+        // click, and there is no accumulation between ticks.
+        let small = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0, newDelta: 1, isPrecise: false, phaseBegan: false
+        )
+        #expect(small.events == 1)
+        #expect(small.remainingDelta == 0)
+
+        let medium = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0, newDelta: 2, isPrecise: false, phaseBegan: false
+        )
+        #expect(medium.events == 1)
+        #expect(medium.remainingDelta == 0)
+
+        let large = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0, newDelta: 15, isPrecise: false, phaseBegan: false
+        )
+        #expect(large.events == 1)
+        #expect(large.remainingDelta == 0)
+    }
+
+    @Test func mouseReportingMouseWheelIgnoresAccumulatedDelta() {
+        // Mouse wheel never accumulates — a leftover trackpad residual must
+        // not turn a single wheel tick into multiple events.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 500,
+            newDelta: 1,
+            isPrecise: false,
+            phaseBegan: false
+        )
+        #expect(result.events == 1)
+        #expect(result.remainingDelta == 0)
+    }
+
+    @Test func mouseReportingMouseWheelNegativeDeltaOneEvent() {
+        // Scrolling down with a mouse wheel is also a single event.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: -3,
+            isPrecise: false,
+            phaseBegan: false
+        )
+        #expect(result.events == 1)
+        #expect(result.remainingDelta == 0)
+    }
+
+    @Test func mouseReportingMouseWheelIgnoresPhaseBegan() {
+        // phaseBegan only matters for the precise accumulator; a mouse wheel
+        // tick at gesture start is still one event with no remainder.
+        let result = MouseScrollForwarder.mouseReportingScrollEvents(
+            accumulatedDelta: 0,
+            newDelta: 1,
+            isPrecise: false,
+            phaseBegan: true
+        )
+        #expect(result.events == 1)
+        #expect(result.remainingDelta == 0)
     }
 
     // MARK: - Grid position edge cases (#551)


### PR DESCRIPTION
## Summary

Centralize trackpad gesture/momentum phase handling across all three terminal scroll branches so a scroll gesture starts clean, commits its final line, and coasts to a stop the way it does in Ghostty/iTerm2.

Closes #980.

## ⚠️ Includes merge commits of #989 and #991

Issue #980 explicitly depends on its two sibling issues: _"Depends on: the two sibling issues in this milestone (pixel-precise forwarding, arrow-key accumulator) — implement those first so there is a single accumulator per branch to flush."_

This PR therefore merges both sibling branches on top of `main`:
- `origin/fix/terminal-pixel-precise-mouse-forwarding-978` (#989 / #978)
- `origin/fix/terminal-arrow-key-residual-delta-979` (#991 / #979)

**Once #989 and #991 are merged first, GitHub recomputes this PR's diff to show ONLY the #980 delta.** The merge commits are kept (not squashed away) so the dependency is documented; they will disappear from the diff automatically after the siblings land. The one conflict (`MouseScrollForwarder.swift`) was resolved by keeping #979's `arrowKeyCount(for:)` and honoring #978's removal of the now-dead `scrollVelocity` (referenced nowhere except in test comments).

## Motivation

`TerminalContainerView.installScrollMonitor()` has three scroll branches (mouse reporting, alternate-screen arrows, normal scrollback). The closure read `event.phase` in only **one** place — the `.began` reset inside the alternate branch — and **none** of the three branches flushed residual accumulator state when the gesture ended:

- Fingers lifting with ~8 points still accumulated silently dropped that residual on `.ended` → the last line the user intended never scrolled.
- Momentum events arrive via `event.momentumPhase` (not `event.phase`) after `.ended`; without a clean handoff the accumulator carried stale state into the coast, producing a phantom jump.

## Changes

- **`.began` — reset (all branches).** A shared `phaseBegan` flag covers both `event.phase == .began` and `event.momentumPhase == .began` and is passed to every per-branch helper. (The siblings already reset on `event.phase == .began`; this extends the reset to the momentum path so the accumulator never carries a stale value into a new gesture/coast.)
- **`.ended` — flush (all branches).** Residual delta above the **settle threshold** (`trackpadLineThreshold / 2` = 5) commits its final line; residual below it is dropped to avoid a stray 1-line twitch. Flush **direction comes from the residual sign**, not `scrollDelta`, because `.ended` markers frequently carry a zero delta.
- **Momentum `.changed` / `.ended`** continue under the same per-line threshold as the main gesture (no cap, no multiply) so the buffer coasts to a stop.
- **Shared pure helper** `MouseScrollForwarder.flushResidual(accumulatedDelta:settleThreshold:)` holds the threshold math. Per-branch flush is kept because the emit mechanism differs (`sendEvent` / `sendResponse` / `scrollUp`-`scrollDown`); extracting a full `ScrollPhaseTracker` struct would be over-engineering for three emit paths.
- **Guard fix:** the closure previously short-circuited on `scrollDelta == 0`; phase-boundary events often carry a zero delta, so they must now reach the per-branch logic for reset/flush. The guard admits events where `scrollDelta != 0 || phaseBegan || phaseEnded`.

### Settle-threshold decision

`gestureEndSettleThreshold = trackpadLineThreshold / 2` (5 points). Rationale: the per-event helpers always consume whole thresholds during the gesture, so the residual reaching `.ended` is strictly below one full threshold (range `(-10, 10)`). Committing at half a threshold (≥5) ensures the final partial line lands, while dropping smaller residuals avoids a twitch. In practice `flushResidual` returns `0` or `1`. Tested in `flushResidualCustomSettleThreshold` to confirm the gate is parameterizable.

## Manual test checklist

- [ ] vim (alternate screen, no `set mouse=`): flick-and-release scrolls the last intended line; coast decays smoothly with no end-of-flick stutter.
- [ ] lazygit / htop with mouse reporting (`mouse=a`): flick-and-release commits the final wheel click; no phantom jump when momentum begins.
- [ ] plain shell scrollback (normal mode): flick-and-release lands the final line and coasts to a stop.

## Test coverage notes

The phase-boundary helpers (`flushResidual`, `normalScrollLines`, `mouseReportingScrollEvents`) are fully unit-tested, including multi-event gesture sequences (`.began` + several `.changed` + `.ended`). The runtime `installScrollMonitor` phase handling — the guard expansion (`scrollDelta != 0 || phaseBegan || phaseEnded`), the `phaseBegan`/`phaseEnded` derivation, the per-branch accumulator selection, the per-branch emit mechanism, and the post-flush `= 0` reset — is exercised via pure-helper simulations rather than a live terminal, because the project lacks a SwiftTerm `Terminal` spy harness. This is the same testability limitation as the sibling PRs (#978, #979), which likewise simulate the closure through pure helpers. The Manual test checklist above covers the perceived UX (flick-and-release in vim, lazygit/htop, and a plain shell), which is where the integration behavior is meaningfully observable.

## Validation

- `swiftlint lint` on the three changed files: 0 violations.
- `PineTests/TerminalScrollForwardingTests`: 81 tests pass (72 sibling + 9 new phase-sequence tests).
- Sibling tests (#978/#979) confirmed passing in the merged tree.