### PR TITLE
docs: document milestone-driven subagent orchestration workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,24 @@ How the maintainer works day-to-day. Documents intent and handoff conventions fo
 - **Explicit confirmation required** for: merging a PR, and anything in the destructive-command list in `AGENTS.md` (deletions, force-pushes, infrastructure changes).
 - Agents should run unit tests themselves — no need to ask first.
 
+### Milestone orchestration with subagents
+
+For a milestone with multiple issues, the maintainer (or a parent agent) orchestrates implementation across subagents instead of doing all the work in one session. Used for parallelizable issues, large features, or when strict adversarial review is wanted. The full loop runs inside the agent; the human only merges at the end.
+
+Flow:
+1. **Scope first.** Read every issue in the milestone end-to-end, identify shared files, and note dependencies (`blocked-by`, or an explicit "depends on #X" in the body). Order implementation and merge accordingly.
+2. **One issue = one worker = one PR.** Delegate each issue to a worker subagent in an isolated worktree (`worktree: true`). Each worker creates its own branch and opens its own PR against `main`. Pass each worker explicit permissions in the task (which `git` / `gh` / `xcodebuild` commands are allowed) and an `acceptance` contract with `verify` commands and `stopRules` (notably: never merge, never force-push, never amend).
+3. **Respect cross-issue boundaries.** Tell each worker exactly which files/branches it may touch so sibling PRs stay mergeable (e.g. add a dedicated accumulator field per branch instead of repurposing a shared one). When an issue depends on siblings not yet merged, the dependent worker merges those sibling branches into its own branch and documents it in the PR body — GitHub auto-shrinks the diff once the siblings land.
+4. **Strict review from fresh context.** Once PRs are open, run fresh-context `reviewer` subagents with distinct angles (e.g. correctness/regressions, tests/validation) against the actual diff. Reviewers are read-only — they must not edit.
+5. **Fix on the existing branch.** Synthesize reviewer findings and hand them to a fix-worker that checks out the **existing** PR branch and adds a follow-up commit. Never amend, force-push, or open a new branch for fixes. Repeat the review/fix loop until reviewers return a clean verdict (typically ~2 rounds).
+6. **Verify before handoff.** Confirm every PR is `MERGEABLE`, CI is green (or explicitly note which checks are still pending), and state the merge order.
+7. **Never merge.** The agent opens and reviews PRs; only the human merges them.
+
+Operational notes:
+- Worktree isolation requires a clean main tree — remove stray artifacts (e.g. a `reviews/` folder written by reviewers) before launching new worktree runs.
+- "needs attention" control signals from a finished run are stale noise; trust `gh pr checks` / `gh pr view` as ground truth.
+- Acceptance-gate / parse-report errors in the subagent harness do not mean the work failed — check the PR and CI; the code usually landed.
+
 ### Releases
 - **No fixed cadence** — release when ready, by merging the Release Please PR.
 - Manual work before tagging is kept to a minimum; Release Please handles `version.txt` and `CHANGELOG.md` automatically (see `## Release & CI`).


### PR DESCRIPTION
## Summary

Add a new `### Milestone orchestration with subagents` subsection under `## Workflow` in `AGENTS.md`, capturing the orchestration flow we used for milestone 10 (terminal: Ghostty-grade scroll for TUI apps).

## Motivation

The repo already documents single-issue AI-agent handoffs (`### Working with AI agents`), but not the multi-issue milestone pattern where a parent agent delegates to workers, runs adversarial review, and drives a fix loop. This flow is now proven (milestone 10: 3 issues → 3 PRs + strict review + fix rounds) and worth pinning so future runs (human-initiated or agent-initiated) follow the same shape.

## Changes

One new subsection (`+18` lines) between `### Working with AI agents` and `### Releases`. It documents the 7-step flow:

1. **Scope first** — read every issue, find shared files and dependencies, order implementation/merge.
2. **One issue = one worker = one PR** — worktree-isolated workers, each with explicit permissions and an `acceptance` contract (`verify` + `stopRules`: never merge / force-push / amend).
3. **Respect cross-issue boundaries** — keep sibling PRs mergeable (e.g. dedicated fields per branch); dependent issues merge sibling branches and let GitHub auto-shrink the diff.
4. **Strict review from fresh context** — read-only `reviewer` subagents with distinct angles (correctness, tests).
5. **Fix on the existing branch** — fix-workers add follow-up commits; never amend, force-push, or branch again; loop ~2 rounds.
6. **Verify before handoff** — `MERGEABLE`, CI green (or pending noted), explicit merge order.
7. **Never merge** — the agent opens and reviews; only the human merges.

Plus operational notes about clean worktrees, stale `needs_attention` signals, and acceptance-gate/parse-report noise vs. real failures.

No code changes. No `## Build & Run`, `## Release & CI`, or other sections touched.

## Validation

- Docs-only change; no build or tests affected.
- SwiftLint not applicable (Markdown).
- Markdown rendered locally; heading hierarchy intact (`grep -nE "^#{2,3} " AGENTS.md` shows the new `###` sits correctly between its siblings).

## Notes

- Branch named per repo convention (`docs/...`, no issue number).
- No issue opened — this is a direct docs change requested by the maintainer; happy to file a tracking issue retroactively if wanted.