### PR TITLE
ci(release): bound notarytool wait with timeout-minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions: {}
 jobs:
   build-and-release:
     runs-on: macos-26
+    timeout-minutes: 45
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

Add a 45-minute job-level `timeout-minutes` to `build-and-release` in `.github/workflows/release.yml`, so a stalled `notarytool submit --wait` (e.g. during an Apple outage) can no longer hold the runner up to GitHub's 360-minute default.

## Motivation

`release.yml`'s `build-and-release` job has no `timeout-minutes`. `notarytool submit --wait` blocks until notarization completes; with no job timeout the only ceiling is GitHub's 360-min default. Recent notarizations finish in minutes (releases run 3-5 min total), but an Apple outage could stall the job for hours, tying up a runner and silently delaying a release. See #1000.

## Change

- Added `timeout-minutes: 45` at the job level of `build-and-release`, right after `runs-on:` to match the existing convention used by the other macOS runner jobs (`ci.yml` uses 60/30, `nightly-perf.yml` 60, `nightly-fuzz.yml` 30).
- 45 min is generous over the observed 3-5 min runs while still bounding the worst case.

This is a single-line, config-only change scoped to `.github/workflows/release.yml`.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` -> YAML valid
- `git diff --name-only main...HEAD` -> only `.github/workflows/release.yml`
- Diff matches the convention used by the other workflows.

Closes #1000
