### PR TITLE
ci(security): SHA-pin Claude workflows to match repo policy

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,3 +1,6 @@
+# NOTE: All third-party actions are pinned by full commit SHA for supply-chain safety.
+# To update an action: find the new version's commit SHA on GitHub (Tags → verify commit),
+# replace the SHA, and keep the "# vX" comment in sync.
 name: Claude Code Review
 
 on:
@@ -27,14 +30,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@51705da45eecce209d4700538bf8377d5b5fc695 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,6 @@
+# NOTE: All third-party actions are pinned by full commit SHA for supply-chain safety.
+# To update an action: find the new version's commit SHA on GitHub (Tags → verify commit),
+# replace the SHA, and keep the "# vX" comment in sync.
 name: Claude Code
 
 on:
@@ -26,13 +29,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@51705da45eecce209d4700538bf8377d5b5fc695 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary

Pin the two Claude workflows (`claude.yml`, `claude-code-review.yml`) by full commit SHA instead of mutable tags, to match the supply-chain policy already enforced in the other 7 workflows.

Closes #995

## Changes

Both files received the standard repo header (`# NOTE: All third-party actions are pinned by full commit SHA…`) and the two mutable tags were replaced with verified 40-char commit SHAs:

- `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4`
  - SHA verified via `gh api repos/actions/checkout/git/refs/tags/v4` (direct commit ref). This is the tip of `v4` = `v4.3.1`.
- `anthropics/claude-code-action@v1` → `anthropics/claude-code-action@51705da45eecce209d4700538bf8377d5b5fc695 # v1`
  - `v1` is an annotated tag (`6fd32ea…`); dereferenced via `gh api repos/anthropics/claude-code-action/git/tags/6fd32ea…` to the underlying commit.

Files:
- `.github/workflows/claude.yml`
- `.github/workflows/claude-code-review.yml`

## Why

Both Claude workflows request `id-token: write` + `pull-requests: write` on every PR open/sync. A compromised `anthropics/claude-code-action` moving tag would gain OIDC minting + PR write across the repo. Pinning eliminates that vector. This was the only exception to the repo-wide SHA-pinning policy documented in `AGENTS.md` (## Release & CI).

## Validation

- `grep -nE 'uses: .*@v[0-9]' .github/workflows/claude.yml .github/workflows/claude-code-review.yml` → no matches (no mutable tags remain).
- `python3 -c "import yaml; …"` → both files parse as valid YAML.
- Header wording + `# vX` comment format identical to `ci.yml`, `release.yml`, etc.

## Checklist

- [x] Only two files changed (`claude.yml`, `claude-code-review.yml`)
- [x] Full 40-char SHAs (not short)
- [x] Standard SHA-pinning header added to both files
- [x] `# vX` comment kept in sync with the pinned version
- [x] No merge / force-push / amend (squash-merge by maintainer)
