### PR TITLE
fix(concurrency): cancel outstanding highlight work in Coordinator.deinit

### DIFF
--- a/Pine/CodeEditorView+Coordinator.swift
+++ b/Pine/CodeEditorView+Coordinator.swift
@@ -198,8 +198,47 @@ extension CodeEditorView {
             scheduleViewportHighlighting(textView: textView)
         }
 
+        // Cancel all outstanding async syntax-highlighting and debounced
+        // recalculation work so an in-flight `Task` or `DispatchWorkItem`
+        // cannot fire against a now-detached `NSTextView`. The generation
+        // token (`HighlightGeneration`) already discards stale results, but
+        // cancelling at deinit is cheaper and closes the race window
+        // entirely (issue #1007).
+        //
+        // Undo/highlight race window (issue #650 family):
+        // Even with this cancellation, a residual window remains between the
+        // moment a highlight `Task`'s background regex work finishes and the
+        // moment it checks the generation token on the main actor. If an
+        // undo/redo is in flight on the main thread at that exact instant,
+        // the apply path relies on `isUndoRedoInProgress` /
+        // `undoManager.isUndoing` guards (see `scheduleDeferredHighlight`
+        // and `SyntaxHighlightEngine.applyMatches`) rather than on
+        // cancellation. The deinit cancellation shrinks — but does not
+        // eliminate — that window, because the `Task` may already be past
+        // its cancellation point by the time deinit runs. Documented here so
+        // future work does not re-discover it.
         deinit {
             NotificationCenter.default.removeObserver(self)
+            // Coordinator is a UI coordinator owned by SwiftUI's
+            // NSViewRepresentable lifecycle and AppKit delegate roles — it is
+            // always torn down on the main thread, so assuming MainActor
+            // isolation here is safe and lets us cancel the non-Sendable
+            // DispatchWorkItem / Task properties directly.
+            MainActor.assumeIsolated {
+                highlightWorkItem?.cancel()
+                highlightWorkItem = nil
+                scrollHighlightWorkItem?.cancel()
+                scrollHighlightWorkItem = nil
+                foldWorkItem?.cancel()
+                foldWorkItem = nil
+                highlightTask?.cancel()
+                highlightTask = nil
+                // Bump the generation so any async highlight that already
+                // passed its cancellation point discards its result instead
+                // of applying attributes to the coordinator's
+                // soon-to-be-detached text view.
+                highlightGeneration.increment()
+            }
         }
 
         /// Отменяет отложенную подсветку. Вызывается при смене файла


### PR DESCRIPTION
## Summary

Closes #1007.

`CodeEditorView.Coordinator` scheduled async syntax-highlighting (`Task`s on `com.pine.syntax-highlight`) and debounced recalculation (`DispatchWorkItem`s) but never cancelled them in `deinit`. An in-flight highlight task could complete and try to apply attributes to a now-detached `NSTextView`, or race with undo state. The `HighlightGeneration` token usually discarded stale results, but cancelling at `deinit` is cheaper and removes the race window entirely.

## Changes

**`Pine/CodeEditorView+Coordinator.swift`** (+39 lines, 0 deletions) — single-file additive change inside the existing `Coordinator.deinit`:

- Cancels all four outstanding work items: `highlightWorkItem`, `scrollHighlightWorkItem`, `foldWorkItem`, `highlightTask`.
- Bumps `highlightGeneration` so any async work that already passed its `Task.cancel()` point still discards its result via the generation-token check in `SyntaxHighlightAsync`.
- Wraps the cancellation block in `MainActor.assumeIsolated { ... }` to satisfy Swift 6 strict-concurrency access of non-`Sendable` `DispatchWorkItem?` properties from a nonisolated `deinit`. Matches the established codebase pattern (`PineApp.swift`, `ProjectManager.swift`, 4 other call sites) and is safe because the Coordinator is owned by SwiftUI's `NSViewRepresentable` lifecycle and AppKit delegate roles — always torn down on the main thread.
- Adds a documentation comment covering issue #1007 (rationale) and the issue #650 family (residual undo/highlight race window that `deinit` cancellation shrinks but does not eliminate — the apply path still relies on `isUndoRedoInProgress` /\ `undoManager.isUndoing` guards because a `Task` may already be past its cancellation point by the time `deinit` runs).

## Why `CodeEditorView+Coordinator.swift` and not `CodeEditorView.swift`

The task brief referenced `CodeEditorView.swift`, but the `Coordinator` class was extracted into the companion file on 2026-04-09 per issue #755 (see file header). The `Coordinator.deinit` only exists in `CodeEditorView+Coordinator.swift`, so the change could only land there. No edit to `CodeEditorView.swift` was possible or needed.

## Retain-cycle audit

Every existing `DispatchWorkItem` and `Task` closure in the file already uses `[weak self]` (the one exception at line ~566 captures only locals and never references `self`). The fact that `deinit` is reachable — and now does meaningful cancellation work — is itself proof that no cycle exists.

## Validation

- SwiftLint on the touched files: 0 violations.
- Full `xcodebuild build -scheme Pine -destination 'platform=macOS'`: **BUILD SUCCEEDED**.
- Unit tests: `UndoHighlightSafetyTests`, `CodeEditorCoordinatorTests`, `HighlightPersistenceTests`, `HighlightFlickerTests` — 39/39 passed.
- (Single-file `swiftc -typecheck` was infeasible due to transitive dependencies; the full build substitutes.)

## Merge readiness

Ready to merge when CI is green. No merge / force-push / amend performed.