### PR TITLE
fix(ci): repair screenshots.yml + add failure notification

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -6,6 +6,13 @@ on:
   release:
     types: [published]
 
+# contents: write -> the Commit screenshots step pushes a chore commit back
+#   to the repo. issues: write -> the Create Issue on Failure step opens a
+#   tracking issue when the pipeline breaks (mirrors nightly-perf/nightly-fuzz).
+permissions:
+  contents: write
+  issues: write
+
 jobs:
   screenshots:
     runs-on: macos-26
@@ -69,3 +76,32 @@ jobs:
           fi
           git commit -m "chore: update screenshots"
           git push
+
+      # Mirrors the failure-notification pattern in nightly-perf.yml /
+      # nightly-fuzz.yml so a broken release-screenshot pipeline can never
+      # again stay broken across multiple releases unnoticed (see issue #996).
+      - name: Create Issue on Failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "Screenshots pipeline failed ($(date -u '+%Y-%m-%d'))" \
+            --body "## Summary
+
+          The release screenshots workflow failed. The marketing screenshots in
+          \`assets/\` were **NOT** updated for this release.
+
+          **Run:** $RUN_URL
+
+          ## Next steps
+
+          1. Check the workflow logs — the failure is usually in the
+             \`Run screenshot tests and extract\` step (xcresult extraction)
+          2. Download the \`screenshots-xcresult\` artifact (if uploaded) to
+             inspect the test bundle directly
+          3. Re-run locally with \`bash scripts/update-screenshots.sh\` to
+             reproduce, then re-trigger via Actions → Update Screenshots →
+             Run workflow after fixing the script" \
+            --label "bug,CI"

--- a/scripts/update-screenshots.sh
+++ b/scripts/update-screenshots.sh
@@ -78,6 +78,13 @@ mkdir -p "$ASSETS_DIR"
 # silently on some Xcode 26 CI runners.
 extract_named_screenshots() {
   local found_any=false
+  # Pass the known canonical screenshot names to the extractor so it can map
+  # Xcode 26's suffixed attachment names back to the names the workflow
+  # expects (e.g. screenshot-editor_0_<UUID>.png -> screenshot-editor).
+  # Computed once here (before the loop) because the process substitution
+  # feeding the `while read` is set up at loop entry, not per iteration.
+  local canon_arg
+  canon_arg=$(IFS=,; printf '%s' "${REQUIRED_NAMES[*]},${OPTIONAL_NAMES[*]}")
 
   while IFS=$'\t' read -r att_name payload_id; do
     [ -z "$att_name" ] && continue
@@ -86,24 +93,36 @@ extract_named_screenshots() {
       echo "  Skipping attachment with invalid name: $att_name" >&2
       continue
     fi
-    # Validate payload_id — only alphanumeric, dots, dashes, underscores
-    if [[ ! "$payload_id" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+    # Validate payload_id — Xcode 26 payload ids look like "0~<base64>=="
+    # and include '~' and '='. Allow those alongside alphanumerics, dots,
+    # dashes, and underscores.
+    if [[ ! "$payload_id" =~ ^[a-zA-Z0-9._~=-]+$ ]]; then
       echo "  Skipping attachment with invalid payload_id: $payload_id" >&2
       continue
     fi
-    local src="$RESULT_PATH/Data/$payload_id"
+    # Payloads are stored under Data/ with a "data." prefix on Xcode 26
+    # (e.g. Data/data.<payload_id>). Fall back to the unprefixed path for
+    # older bundle formats just in case.
+    local src="$RESULT_PATH/Data/data.$payload_id"
     if [ ! -f "$src" ]; then
-      echo "  Warning: payload not found at $src" >&2
+      src="$RESULT_PATH/Data/$payload_id"
+    fi
+    if [ ! -f "$src" ]; then
+      echo "  Warning: payload not found at $RESULT_PATH/Data/data.$payload_id" >&2
       continue
     fi
     cp -- "$src" "$ASSETS_DIR/${att_name}.png"
     echo "  Extracted ${att_name}.png"
     found_any=true
-  done < <(python3 - "$XCRESULTTOOL" "$RESULT_PATH" <<'PY'
+  done < <(python3 - "$XCRESULTTOOL" "$RESULT_PATH" "$canon_arg" <<'PY'
 import json, os, subprocess, sys
 
 xcresulttool = sys.argv[1]
 bundle_path = sys.argv[2]
+# Known screenshot base names (passed in from the bash arrays), used to map
+# Xcode 26's suffixed attachment names back to the canonical file names the
+# workflow expects.
+canonical_names = sys.argv[3].split(",") if len(sys.argv) > 3 else []
 
 def get_json(args):
     r = subprocess.run([xcresulttool] + args, capture_output=True, text=True)
@@ -131,20 +150,52 @@ def find_test_ids(node):
         results.extend(find_test_ids(child))
     return results
 
+def canonical_name(raw):
+    # Xcode 26 stores attachment names like
+    #   "screenshot-editor_0_<UUID>.png"
+    # rather than the bare "screenshot-editor" the workflow expects. Map the
+    # raw name back to a known canonical name so the required-names guardrail
+    # and the commit step keep working unchanged.
+    base = raw[:-4] if raw.endswith(".png") else raw
+    for c in canonical_names:
+        if base == c or base.startswith(c + "_"):
+            return c
+    return None
+
 def walk_activities(node):
-    for att in node.get("attachments", []):
-        att_name = att.get("name", "")
-        payload_id = att.get("payloadId", "")
-        if att_name.startswith("screenshot-") and payload_id:
-            print(f"{att_name}\t{payload_id}")
-    for child in node.get("childActivities", []):
-        walk_activities(child)
+    # Attachments live under testRuns[*].activities[*].attachments (with
+    # optional nested childActivities). The top-level activities JSON has a
+    # "testRuns" array rather than direct attachments, so this walker is
+    # seeded with each run's activities list — see call site below.
+    if isinstance(node, dict):
+        for att in node.get("attachments", []):
+            att_name = att.get("name", "")
+            payload_id = att.get("payloadId", "")
+            if not att_name or not payload_id:
+                continue
+            canon = canonical_name(att_name)
+            if canon:
+                print(f"{canon}\t{payload_id}")
+            else:
+                print(f"  Skipping non-canonical attachment: {att_name}", file=sys.stderr)
+        for child in node.get("childActivities", []):
+            walk_activities(child)
+    elif isinstance(node, list):
+        for item in node:
+            walk_activities(item)
 
 data = get_json(["get", "test-results", "tests", "--path", bundle_path])
 if not data:
     sys.exit(1)
 
-test_ids = find_test_ids(data)
+# On Xcode 26 the test tree is rooted at top-level "testNodes" — the whole
+# document has no "children" key — so seed find_test_ids with each testNodes
+# entry rather than with the document root. (The previous implementation
+# walked the non-existent root "children" and silently found zero tests,
+# which is what made this workflow fail on every release since v1.26.3.)
+test_ids = []
+for root in data.get("testNodes", []):
+    test_ids.extend(find_test_ids(root))
 if not test_ids:
     print("  No screenshot test cases found in xcresult bundle.", file=sys.stderr)
     # Diagnostic: show first 5 files in Data/ to help debug extraction failures
@@ -157,12 +208,13 @@ if not test_ids:
         print(f"  Diagnostic: Data/ directory does not exist at {data_dir}", file=sys.stderr)
     sys.exit(1)
 
-for i, tid in enumerate(test_ids):
+for tid in test_ids:
     act_data = get_json(["get", "test-results", "activities",
                          "--path", bundle_path, "--test-id", tid])
     if not act_data:
         continue
-    walk_activities(act_data)
+    for run in act_data.get("testRuns", []):
+        walk_activities(run.get("activities", []))
 PY
   )
 


### PR DESCRIPTION
Closes #996

## Summary

`scripts/update-screenshots.sh` / `.github/workflows/screenshots.yml` has silently failed on **every release since v1.26.3 (6 consecutive failures)**, leaving stale marketing screenshots on the GitHub/landing page. This PR **repairs the root cause** and **adds a failure notification** so it can never again break unnoticed.

## Root cause

PR #939 (shipped in v1.26.3) replaced the working `xcresulttool export attachments` extractor with a new Python extractor using `xcresulttool get test-results tests/activities`. The new extractor did not match the **actual Xcode 26 xcresult JSON schema**, so it found zero test cases every run (`No screenshot test cases found in xcresult bundle`) — even though all 6 screenshot tests passed and attachments were captured (confirmed in the v1.28.1 run logs: `Executed 6 tests, with 0 failures`).

## What's fixed (`scripts/update-screenshots.sh`)

Four schema mismatches, all verified against the xcresult artifact downloaded from the most recent failing run (v1.28.1, run 27788333883):

1. **Test tree location** — the tree is rooted at top-level `testNodes`, but `find_test_ids()` walked the non-existent root `children`. Now seeds the walker with each `testNodes` entry.
2. **Attachment nesting** — attachments live under `testRuns[*].activities[*].attachments`, not the top-level `attachments`/`childActivities`. Walker is now seeded with each run's `activities` list.
3. **Attachment names** — Xcode 26 stores them as `screenshot-editor_0_<UUID>.png`, not the bare `screenshot-editor` the guardrail/commit expect. Added a canonical-name mapping against the known `REQUIRED_NAMES`/`OPTIONAL_NAMES` set.
4. **Payload path + id** — payload files are stored as `Data/data.<payload_id>` (with a `data.` prefix), and payload ids contain `~` and `=`. Fixed the path (with a fallback to the unprefixed form) and broadened the validation regex.

## What's added (`.github/workflows/screenshots.yml`)

- **`Create Issue on Failure`** step mirroring `nightly-perf.yml` / `nightly-fuzz.yml` (`if: failure()`, `gh issue create --label "bug,CI"`). Placed last so it catches a failure in any earlier step.
- Explicit **`permissions: contents: write, issues: write`** block — needed for both the existing `git push` (commit step) and the new issue-creation step.

## Validation

- `bash -n scripts/update-screenshots.sh` -> OK
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/screenshots.yml'))"` -> OK
- `shellcheck -S warning scripts/update-screenshots.sh` -> clean
- **End-to-end repair verification**: ran the (verbatim) edited script against the real `screenshots-xcresult` artifact from the v1.28.1 failing run -> all 6 canonical screenshots extracted as valid PNGs, required-names guardrail passes, **exit 0**:
  ```
  Extracted screenshot-editor.png / markdown.png / minimap.png / sidebar.png / terminal.png / welcome.png
  Done! 6 screenshot file(s) in assets/
  ```
- All third-party actions pinned by full commit SHA; the new step uses the `gh` CLI (no third-party action added).

## Not done / follow-ups

- Did **not** add back the old `export attachments` strategy as a second fallback — the corrected `get test-results` path is verified working, and the new failure-notification step now catches any future schema regression loudly instead of silently.
- The actual screenshot PNGs in `assets/` will be regenerated on the next release (or by a manual `workflow_dispatch` run of this workflow). This PR only fixes the pipeline.

## Branch ready to merge when

- CI is green.
- (Optional) a maintainer triggers `Actions -> Update Screenshots -> Run workflow` on this branch to confirm the repair end-to-end on CI before the next release.
