### PR TITLE
test(terminal): extract & cover TerminalSession.swift pure logic

### DIFF
--- a/Pine/TerminalBufferSearch.swift
+++ b/Pine/TerminalBufferSearch.swift
@@ -1,0 +1,63 @@
+//
+//  TerminalBufferSearch.swift
+//  Pine
+//
+//  Pure helper that scans terminal buffer text for search matches.
+//
+//  Extracted verbatim from `TerminalTab.search(for:)` (TerminalSession.swift)
+//  so the match-finding algorithm can be unit-tested directly, without a
+//  live SwiftTerm `LocalProcessTerminalView`, a `Task.detached` hop, or
+//  `getBufferAsData()`. The behaviour is identical to the previously
+//  inlined implementation — only the call site changed.
+//
+
+import Foundation
+
+/// Scans newline-delimited terminal buffer text for occurrences of a query,
+/// returning one ``TerminalSearchMatch`` per occurrence together with the
+/// total number of rows scanned.
+///
+/// This is the pure, AppKit/SwiftTerm-free core of the terminal find bar.
+/// `TerminalTab.search(for:)` feeds it the buffer text it extracts via
+/// SwiftTerm's public `getBufferAsData()` API.
+///
+/// - Note: `query` must be non-empty. The call site (`TerminalTab.search`)
+///   short-circuits on an empty query before reaching this helper; passing an
+///   empty query here would loop forever on every position (matching the
+///   historical inlined behaviour), so callers are expected to guard first.
+nonisolated enum TerminalBufferSearch {
+
+    /// Scans `bufferText` (rows separated by `\n`) for `query`.
+    ///
+    /// - Parameters:
+    ///   - bufferText: Full buffer contents as decoded from
+    ///     `Terminal.getBufferAsData()`. Rows are separated by `\n`; empty
+    ///     rows are preserved (so the row index of each match matches what the
+    ///     user sees in the terminal).
+    ///   - query: The non-empty search needle.
+    ///   - caseSensitive: When `false`, both the needle and each haystack row
+    ///     are lowercased before matching (the default terminal-search
+    ///     behaviour).
+    /// - Returns: A tuple of the matches in reading order and the total number
+    ///   of rows (`totalRows`), used by `TerminalTab` for scroll positioning.
+    static func scan(
+        bufferText: String,
+        query: String,
+        caseSensitive: Bool
+    ) -> (matches: [TerminalSearchMatch], totalRows: Int) {
+        let lines = bufferText.split(separator: "\n", omittingEmptySubsequences: false)
+        let needle = caseSensitive ? query : query.lowercased()
+        var result: [TerminalSearchMatch] = []
+        for (row, line) in lines.enumerated() {
+            let haystack = caseSensitive ? String(line) : String(line).lowercased()
+            var searchStart = haystack.startIndex
+            while let range = haystack.range(of: needle, range: searchStart..<haystack.endIndex) {
+                let col = haystack.distance(from: haystack.startIndex, to: range.lowerBound)
+                let length = haystack.distance(from: range.lowerBound, to: range.upperBound)
+                result.append(TerminalSearchMatch(row: row, col: col, length: length))
+                searchStart = range.upperBound
+            }
+        }
+        return (result, lines.count)
+    }
+}

--- a/Pine/TerminalScrollEventInfo.swift
+++ b/Pine/TerminalScrollEventInfo.swift
@@ -1,0 +1,79 @@
+//
+//  TerminalScrollEventInfo.swift
+//  Pine
+//
+//  Pure resolution of a scroll-wheel event's scalar properties into the
+//  values the terminal scroll path consumes.
+//
+//  Extracted from `TerminalContainerView.installScrollMonitor`
+//  (TerminalSession.swift) so three pieces of pure logic can be unit-tested
+//  without constructing live NSEvents:
+//    1. delta selection — `scrollingDeltaY` for trackpad (precise),
+//       `deltaY` for a physical mouse wheel;
+//    2. gesture/momentum phase-boundary detection (`.began` / `.ended` live
+//       in either `phase` or `momentumPhase`);
+//    3. the "should this event reach the per-branch scroll logic" decision
+//       (events with zero delta and no phase boundary are inert and dropped).
+//
+//  Behaviour is identical to the previously inlined implementation — the
+//  call site now constructs this struct and consults `shouldIntercept`.
+//
+
+import AppKit
+
+/// Resolved, AppKit-free view of the scroll properties a terminal scroll
+/// event carries.
+///
+/// The terminal scroll monitor (`TerminalContainerView.installScrollMonitor`)
+/// builds this once per intercepted `scrollWheel` event and feeds its fields
+/// into the shared `MouseScrollForwarder` accumulators.
+///
+/// Marked `nonisolated` so it is directly unit-testable from any isolation
+/// context and stays a plain `Sendable` value crossing the main-thread scroll
+/// monitor closure.
+nonisolated struct TerminalScrollEventInfo {
+
+    /// Resolved scroll delta. Positive scrolls up, negative scrolls down.
+    /// `scrollingDeltaY` for trackpad input (precise), `deltaY` for a physical
+    /// mouse wheel.
+    let delta: CGFloat
+
+    /// `true` when the gesture or momentum phase is `.began`. The per-branch
+    /// accumulators use this to reset stale residual delta from a previous
+    /// gesture.
+    let phaseBegan: Bool
+
+    /// `true` when the gesture or momentum phase is `.ended`. The per-branch
+    /// logic uses this to flush residual delta above the settle threshold so
+    /// the final partial line is committed rather than dropped.
+    let phaseEnded: Bool
+
+    /// Whether the event comes from a trackpad (`hasPreciseScrollingDeltas`).
+    /// Selects the accumulator branch in `MouseScrollForwarder`.
+    let isPrecise: Bool
+
+    /// Whether the event must reach the per-branch scroll logic.
+    ///
+    /// Trackpad gesture/momentum phase boundaries (`.began` / `.ended`)
+    /// frequently carry a zero scrolling delta but still must reach the
+    /// per-branch logic: `.began` resets the active accumulator and `.ended`
+    /// flushes residual delta. Non-phase events with zero delta (e.g. inert
+    /// ticks) are dropped.
+    var shouldIntercept: Bool { delta != 0 || phaseBegan || phaseEnded }
+
+    /// Resolves the scroll properties of an `NSEvent` of type `scrollWheel`.
+    init(event: NSEvent) {
+        self.isPrecise = event.hasPreciseScrollingDeltas
+        self.delta = event.hasPreciseScrollingDeltas ? event.scrollingDeltaY : event.deltaY
+        self.phaseBegan = event.phase == .began || event.momentumPhase == .began
+        self.phaseEnded = event.phase == .ended || event.momentumPhase == .ended
+    }
+
+    /// Scalar initializer for direct unit-testing without constructing NSEvents.
+    init(delta: CGFloat, phaseBegan: Bool, phaseEnded: Bool, isPrecise: Bool) {
+        self.delta = delta
+        self.phaseBegan = phaseBegan
+        self.phaseEnded = phaseEnded
+        self.isPrecise = isPrecise
+    }
+}

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -557,18 +557,15 @@ class TerminalContainerView: NSView {
             let locationInSelf = self.convert(event.locationInWindow, from: nil)
             guard self.bounds.contains(locationInSelf) else { return event }
 
-            // Use scrollingDeltaY for trackpad (precise), deltaY for mouse wheel
-            let scrollDelta = event.hasPreciseScrollingDeltas ? event.scrollingDeltaY : event.deltaY
-            // Trackpad gesture/momentum phase boundaries (.began / .ended)
-            // frequently carry a zero scrolling delta but still must reach the
-            // per-branch logic: .began resets the active accumulator and .ended
-            // flushes residual delta so the final partial line is committed
-            // rather than dropped. Non-phase events with zero delta (e.g. inert
-            // ticks) are ignored as before. Momentum phase lives in
-            // `momentumPhase` (not `phase`), so both are consulted.
-            let phaseBegan = event.phase == .began || event.momentumPhase == .began
-            let phaseEnded = event.phase == .ended || event.momentumPhase == .ended
-            guard scrollDelta != 0 || phaseBegan || phaseEnded else { return event }
+            // Resolve the scroll delta, gesture/momentum phase boundaries, and
+            // the "should this event reach the per-branch logic" decision in
+            // one testable place (`TerminalScrollEventInfo`). See that type for
+            // the full rationale on phase-boundary handling and delta selection.
+            let scrollInfo = TerminalScrollEventInfo(event: event)
+            let scrollDelta = scrollInfo.delta
+            let phaseBegan = scrollInfo.phaseBegan
+            let phaseEnded = scrollInfo.phaseEnded
+            guard scrollInfo.shouldIntercept else { return event }
 
             let term = terminalView.getTerminal()
 
@@ -594,7 +591,7 @@ class TerminalContainerView: NSView {
                 let velocity = MouseScrollForwarder.mouseReportingScrollEvents(
                     accumulatedDelta: self.mouseReportingAccumulatedDelta,
                     newDelta: scrollDelta,
-                    isPrecise: event.hasPreciseScrollingDeltas,
+                    isPrecise: scrollInfo.isPrecise,
                     phaseBegan: phaseBegan
                 )
                 self.mouseReportingAccumulatedDelta = velocity.remainingDelta
@@ -652,7 +649,7 @@ class TerminalContainerView: NSView {
                 let result = MouseScrollForwarder.normalScrollLines(
                     accumulatedDelta: self.accumulatedScrollDelta,
                     newDelta: scrollDelta,
-                    isPrecise: event.hasPreciseScrollingDeltas,
+                    isPrecise: scrollInfo.isPrecise,
                     phaseBegan: phaseBegan
                 )
                 self.accumulatedScrollDelta = result.remainingDelta
@@ -684,7 +681,7 @@ class TerminalContainerView: NSView {
             let result = MouseScrollForwarder.normalScrollLines(
                 accumulatedDelta: self.accumulatedScrollDelta,
                 newDelta: scrollDelta,
-                isPrecise: event.hasPreciseScrollingDeltas,
+                isPrecise: scrollInfo.isPrecise,
                 phaseBegan: phaseBegan
             )
             self.accumulatedScrollDelta = result.remainingDelta
@@ -1143,27 +1140,21 @@ final class TerminalTab: Identifiable, Hashable {
         let terminal = terminalView.getTerminal()
         let bufferData = terminal.getBufferAsData()
 
-        // Search off main thread
+        // Search off main thread. The match-finding algorithm lives in the
+        // pure `TerminalBufferSearch` helper so it can be unit-tested without
+        // a live SwiftTerm terminal; this closure just decodes the buffer and
+        // delegates to it.
         let searchQuery = query
         let isCaseSensitive = caseSensitive
         let (matches, totalRows) = await Task.detached(priority: .userInitiated) {
             guard let bufferText = String(data: bufferData, encoding: .utf8) else {
                 return ([TerminalSearchMatch](), 0)
             }
-            let lines = bufferText.split(separator: "\n", omittingEmptySubsequences: false)
-            let needle = isCaseSensitive ? searchQuery : searchQuery.lowercased()
-            var result: [TerminalSearchMatch] = []
-            for (row, line) in lines.enumerated() {
-                let haystack = isCaseSensitive ? String(line) : String(line).lowercased()
-                var searchStart = haystack.startIndex
-                while let range = haystack.range(of: needle, range: searchStart..<haystack.endIndex) {
-                    let col = haystack.distance(from: haystack.startIndex, to: range.lowerBound)
-                    let length = haystack.distance(from: range.lowerBound, to: range.upperBound)
-                    result.append(TerminalSearchMatch(row: row, col: col, length: length))
-                    searchStart = range.upperBound
-                }
-            }
-            return (result, lines.count)
+            return TerminalBufferSearch.scan(
+                bufferText: bufferText,
+                query: searchQuery,
+                caseSensitive: isCaseSensitive
+            )
         }.value
 
         guard !Task.isCancelled else { return }

--- a/PineTests/TerminalSessionBridgeTests.swift
+++ b/PineTests/TerminalSessionBridgeTests.swift
@@ -1,0 +1,288 @@
+//
+//  TerminalSessionBridgeTests.swift
+//  PineTests
+//
+//  Unit tests for the pure helpers extracted from `TerminalSession.swift`
+//  (issue #997). These construct the helpers directly — no NSView, no live
+//  SwiftTerm `LocalProcessTerminalView`, no `Task.detached` — so the
+//  previously inlined arithmetic is covered without AppKit lifecycle.
+//
+//  Two helpers are covered here:
+//    - `TerminalBufferSearch` — the buffer-scanning algorithm pulled out of
+//      `TerminalTab.search(for:)`.
+//    - `TerminalScrollEventInfo` — the scroll-delta / phase-boundary / intercept
+//      decision pulled out of `TerminalContainerView.installScrollMonitor`.
+//
+//  Note on `TerminalScrollEventInfo.init(event:)`: that initializer is a
+//  four-line property mapping from an `NSEvent`. The macOS 26 SDK does not
+//  expose a reliable public constructor for synthetic `scrollWheel` events
+//  (the `NSEvent(scrollWheelEventWith:)` / `scrollWheelEvent(with:)` APIs are
+//  unavailable), and the existing `TerminalScrollForwardingTests` likewise
+//  avoid constructing real scroll-wheel `NSEvent`s. The decision logic that
+//  actually matters is therefore exercised through the scalar initializer
+//  below, mirroring how `MouseScrollForwarder` (the residual-delta helper
+//  from milestone 10) is already tested.
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+@Suite("TerminalSession Bridge Tests")
+@MainActor
+struct TerminalSessionBridgeTests {
+
+    // MARK: - TerminalBufferSearch
+
+    @Test("scan on empty buffer returns no matches and counts one row")
+    func scanEmptyBuffer() {
+        // `"".split(separator:"\n", omittingEmptySubsequences:false)` yields a
+        // single empty substring, so totalRows is 1 (matches the historical
+        // inlined behaviour). Empty query is never passed by the caller.
+        let result = TerminalBufferSearch.scan(bufferText: "", query: "x", caseSensitive: false)
+        #expect(result.matches.isEmpty)
+        #expect(result.totalRows == 1)
+    }
+
+    @Test("scan with no matches returns empty list and correct row count")
+    func scanNoMatches() {
+        let result = TerminalBufferSearch.scan(
+            bufferText: "hello world\nfoo bar",
+            query: "xyz",
+            caseSensitive: false
+        )
+        #expect(result.matches.isEmpty)
+        #expect(result.totalRows == 2)
+    }
+
+    @Test("scan finds a single match at the start of a line")
+    func scanSingleMatchAtStart() {
+        let result = TerminalBufferSearch.scan(bufferText: "hello world", query: "hello", caseSensitive: false)
+        #expect(result.matches.count == 1)
+        let match = result.matches[0]
+        #expect(match.row == 0)
+        #expect(match.col == 0)
+        #expect(match.length == 5)
+        #expect(result.totalRows == 1)
+    }
+
+    @Test("scan finds a match offset from the start of a line")
+    func scanMatchOffsetFromStart() {
+        let result = TerminalBufferSearch.scan(bufferText: "hello world", query: "world", caseSensitive: false)
+        #expect(result.matches.count == 1)
+        let match = result.matches[0]
+        #expect(match.row == 0)
+        #expect(match.col == 6)
+        #expect(match.length == 5)
+    }
+
+    @Test("scan finds multiple non-overlapping matches on the same line")
+    func scanMultipleMatchesSameLine() {
+        let result = TerminalBufferSearch.scan(bufferText: "abc abc abc", query: "abc", caseSensitive: false)
+        #expect(result.matches.count == 3)
+        #expect(result.matches[0].col == 0)
+        #expect(result.matches[1].col == 4)
+        #expect(result.matches[2].col == 8)
+        for match in result.matches {
+            #expect(match.length == 3)
+            #expect(match.row == 0)
+        }
+    }
+
+    @Test("scan matches do not overlap (stepping past the previous match)")
+    func scanOverlappingQueryStepsNonOverlapping() {
+        // "aaaa" with query "aa": first match at 0..<2, next search resumes at
+        // index 2, second match at 2..<4 → exactly 2 matches, not 3.
+        let result = TerminalBufferSearch.scan(bufferText: "aaaa", query: "aa", caseSensitive: false)
+        #expect(result.matches.count == 2)
+        #expect(result.matches[0].col == 0)
+        #expect(result.matches[1].col == 2)
+        #expect(result.matches[0].length == 2)
+        #expect(result.matches[1].length == 2)
+    }
+
+    @Test("scan reports matches across multiple rows in reading order")
+    func scanAcrossRows() {
+        let result = TerminalBufferSearch.scan(
+            bufferText: "hello\nhello\nhello",
+            query: "hello",
+            caseSensitive: false
+        )
+        #expect(result.matches.count == 3)
+        #expect(result.totalRows == 3)
+        #expect(result.matches[0].row == 0)
+        #expect(result.matches[0].col == 0)
+        #expect(result.matches[0].length == 5)
+        #expect(result.matches[1].row == 1)
+        #expect(result.matches[1].col == 0)
+        #expect(result.matches[2].row == 2)
+        #expect(result.matches[2].col == 0)
+    }
+
+    @Test("scan is case-insensitive by default")
+    func scanCaseInsensitiveByDefault() {
+        let result = TerminalBufferSearch.scan(
+            bufferText: "Hello HELLO hello",
+            query: "hello",
+            caseSensitive: false
+        )
+        #expect(result.matches.count == 3)
+        #expect(result.matches[0].col == 0)
+        #expect(result.matches[1].col == 6)
+        #expect(result.matches[2].col == 12)
+    }
+
+    @Test("scan respects the case-sensitive flag")
+    func scanCaseSensitive() {
+        let result = TerminalBufferSearch.scan(
+            bufferText: "Hello HELLO hello",
+            query: "hello",
+            caseSensitive: true
+        )
+        #expect(result.matches.count == 1)
+        #expect(result.matches[0].row == 0)
+        #expect(result.matches[0].col == 12)
+        #expect(result.matches[0].length == 5)
+    }
+
+    @Test("scan case-sensitive matches only the exact-case occurrences")
+    func scanCaseSensitiveMixedCase() {
+        let result = TerminalBufferSearch.scan(
+            bufferText: "AbC abc ABC",
+            query: "abc",
+            caseSensitive: true
+        )
+        #expect(result.matches.count == 1)
+        #expect(result.matches[0].col == 4)
+    }
+
+    @Test("scan preserves empty rows in the row index and totalRows count")
+    func scanPreservesEmptyRows() {
+        // The middle empty row must still count toward totalRows and the row
+        // index of the trailing match must be 2 (not 1). This guards the
+        // `omittingEmptySubsequences: false` contract.
+        let result = TerminalBufferSearch.scan(bufferText: "a\n\nb", query: "b", caseSensitive: false)
+        #expect(result.matches.count == 1)
+        #expect(result.matches[0].row == 2)
+        #expect(result.matches[0].col == 0)
+        #expect(result.matches[0].length == 1)
+        #expect(result.totalRows == 3)
+    }
+
+    @Test("scan treats a trailing newline as an extra empty row")
+    func scanTrailingNewline() {
+        let result = TerminalBufferSearch.scan(bufferText: "abc\n", query: "abc", caseSensitive: false)
+        #expect(result.matches.count == 1)
+        #expect(result.matches[0].row == 0)
+        #expect(result.matches[0].col == 0)
+        #expect(result.matches[0].length == 3)
+        #expect(result.totalRows == 2)
+    }
+
+    @Test("scan finds a match at the end of a line")
+    func scanMatchAtEndOfLine() {
+        let result = TerminalBufferSearch.scan(bufferText: "hello", query: "o", caseSensitive: false)
+        #expect(result.matches.count == 1)
+        #expect(result.matches[0].row == 0)
+        #expect(result.matches[0].col == 4)
+        #expect(result.matches[0].length == 1)
+    }
+
+    @Test("scan returns no matches when the query is longer than the buffer")
+    func scanQueryLongerThanLine() {
+        let result = TerminalBufferSearch.scan(bufferText: "ab", query: "abcd", caseSensitive: false)
+        #expect(result.matches.isEmpty)
+        #expect(result.totalRows == 1)
+    }
+
+    @Test("scan computes columns by grapheme cluster (String distance)")
+    func scanUnicodeColumnsAreGraphemeBased() {
+        // Columns come from `String.distance(from:to:)`, which counts Character
+        // (grapheme cluster) positions, not UTF-8/UTF-16 units. Each Greek
+        // letter is one grapheme, so γ is at column 2.
+        let result = TerminalBufferSearch.scan(bufferText: "αβγδε", query: "γ", caseSensitive: false)
+        #expect(result.matches.count == 1)
+        #expect(result.matches[0].col == 2)
+        #expect(result.matches[0].length == 1)
+    }
+
+    @Test("scan case-insensitive match keeps the match length equal to the query length")
+    func scanCaseInsensitiveLengthMatchesQuery() {
+        let result = TerminalBufferSearch.scan(
+            bufferText: "HELLO",
+            query: "hello",
+            caseSensitive: false
+        )
+        #expect(result.matches.count == 1)
+        // Match length is the lowercased-range length, which equals the query.
+        #expect(result.matches[0].length == 5)
+    }
+
+    @Test("scan matches only whole needle occurrences across a multi-row buffer")
+    func scanMultiRowWholeNeedleOnly() {
+        let result = TerminalBufferSearch.scan(
+            bufferText: "foo\nbar foo\nbaz",
+            query: "foo",
+            caseSensitive: false
+        )
+        #expect(result.matches.count == 2)
+        #expect(result.matches[0].row == 0)
+        #expect(result.matches[0].col == 0)
+        #expect(result.matches[1].row == 1)
+        #expect(result.matches[1].col == 4)
+        #expect(result.totalRows == 3)
+    }
+
+    // MARK: - TerminalScrollEventInfo (decision logic via scalar initializer)
+
+    @Test("shouldIntercept is true for a non-zero delta with no phase boundary")
+    func interceptNonZeroDelta() {
+        let info = TerminalScrollEventInfo(delta: 5, phaseBegan: false, phaseEnded: false, isPrecise: true)
+        #expect(info.shouldIntercept)
+    }
+
+    @Test("shouldIntercept is true for a negative (scroll-down) delta")
+    func interceptNegativeDelta() {
+        let info = TerminalScrollEventInfo(delta: -5, phaseBegan: false, phaseEnded: false, isPrecise: true)
+        #expect(info.shouldIntercept)
+    }
+
+    @Test("shouldIntercept drops inert zero-delta ticks with no phase boundary")
+    func interceptDropsInertTick() {
+        let info = TerminalScrollEventInfo(delta: 0, phaseBegan: false, phaseEnded: false, isPrecise: true)
+        #expect(!info.shouldIntercept)
+    }
+
+    @Test("shouldIntercept keeps a zero-delta .began boundary (resets accumulator)")
+    func interceptKeepsPhaseBegan() {
+        let info = TerminalScrollEventInfo(delta: 0, phaseBegan: true, phaseEnded: false, isPrecise: true)
+        #expect(info.shouldIntercept)
+    }
+
+    @Test("shouldIntercept keeps a zero-delta .ended boundary (flushes residual)")
+    func interceptKeepsPhaseEnded() {
+        let info = TerminalScrollEventInfo(delta: 0, phaseBegan: false, phaseEnded: true, isPrecise: true)
+        #expect(info.shouldIntercept)
+    }
+
+    @Test("shouldIntercept is true when both phase boundaries are set")
+    func interceptBothPhases() {
+        let info = TerminalScrollEventInfo(delta: 0, phaseBegan: true, phaseEnded: true, isPrecise: false)
+        #expect(info.shouldIntercept)
+    }
+
+    @Test("scalar initializer stores all resolved fields verbatim")
+    func scalarInitializerStoresFields() {
+        let info = TerminalScrollEventInfo(delta: -3.5, phaseBegan: true, phaseEnded: false, isPrecise: false)
+        #expect(info.delta == -3.5)
+        #expect(info.phaseBegan)
+        #expect(!info.phaseEnded)
+        #expect(!info.isPrecise)
+    }
+
+    @Test("a non-zero delta with phase boundaries still intercepts")
+    func interceptDeltaAndPhases() {
+        let info = TerminalScrollEventInfo(delta: 12, phaseBegan: true, phaseEnded: false, isPrecise: true)
+        #expect(info.shouldIntercept)
+    }
+}


### PR DESCRIPTION
Closes #997

## Summary

`Pine/TerminalSession.swift` (1248 LOC — the AppKit/SwiftTerm bridge: `TerminalScrollInterceptor`, `TerminalContentView`, `TerminalContainerView`, `TerminalSearchMatch`, `TerminalTabDelegate`) had **no** direct unit-test references and is **not** in the `EXCLUDED_VIEWS` coverage-exclusion set in `ci.yml`, so it counted against the 70% coverage threshold despite being regression-prone (three recent milestone-10 commits touched its scroll path with no automated safety net).

This PR extracts the testable pure logic into non-NSView helpers and covers it. The extraction is **behavior-preserving** — `TerminalSession.swift` now holds thin wrappers; observable behavior is unchanged.

## Extracted helpers

**`Pine/TerminalBufferSearch.swift`** (new) — the buffer-scanning algorithm previously inlined in `TerminalTab.search(for:)`'s `Task.detached` body. Pure `string → [TerminalSearchMatch]` logic (the issue's *"search-match geometry"* target). Marked `nonisolated` so it keeps running off-main as the original `Task.detached` did.

**`Pine/TerminalScrollEventInfo.swift`** (new) — scroll-delta resolution (`scrollingDeltaY` vs `deltaY`), gesture/momentum phase-boundary detection (`.began` / `.ended` live in either `phase` or `momentumPhase`), and the `shouldIntercept` decision, previously inlined in `TerminalContainerView.installScrollMonitor`. Provides a scalar initializer so the decision logic is unit-testable **without constructing scroll-wheel NSEvents** (the macOS 26 SDK exposes no public constructor for synthetic `scrollWheel` events).

`Pine/TerminalSession.swift` — the two call sites now delegate to these helpers:
- `installScrollMonitor` builds `TerminalScrollEventInfo(event:)` once and consults `shouldIntercept` / `delta` / `phaseBegan` / `phaseEnded` / `isPrecise`.
- `TerminalTab.search(for:)`'s detached closure decodes the buffer and delegates the scan to `TerminalBufferSearch.scan`.

## On the issue's "first target" (residual-delta from 508bb1f)

The residual-delta accumulation the issue lists as the mandatory first target was **already** extracted to `MouseScrollForwarder` (`normalScrollLines` / `mouseReportingScrollEvents` / `flushResidual`) and covered in `TerminalScrollForwardingTests.swift` (748 LOC, ~60 cases) by the prior milestone-10 commits (`508bb1f`, `53020ec`, `9c1d8d2`). It is therefore not re-extracted here; this PR covers the remaining inlined pure logic instead.

## Tests

`PineTests/TerminalSessionBridgeTests.swift` (new) — **25 `@Test`s** constructing the helpers directly (no NSView, no SwiftTerm, no `Task.detached`):

- **TerminalBufferSearch (17):** empty buffer, no matches, single match at start/offset, multiple non-overlapping matches per line, non-overlapping stepping for repeated needles (`"aaaa"`/`"aa"` → 2 matches), matches across multiple rows in reading order, case-insensitive default vs case-sensitive flag, empty rows / trailing newline row indexing (`omittingEmptySubsequences: false`), grapheme-based column counting (`String.distance`), query longer than line, match at line end.
- **TerminalScrollEventInfo (8):** `shouldIntercept` truth table (non-zero / negative / zero-with-phase / zero-inert / both-phases), scalar initializer field storage.

## Validation

- New suite `TerminalSessionBridgeTests`: **25/25 pass**.
- Existing terminal suites still pass (refactor behavior-preserving): `TerminalScrollForwardingTests` + `TerminalManagerTests` (**163**) + `TerminalAutoScrollTests`.
- SwiftLint: **0 violations** on all touched files.
- `project.pbxproj` untouched (new `.swift` files auto-picked by `PBXFileSystemSynchronizedRootGroup`).

## Notes on the Swift 6.2 isolation change

The Pine target uses `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` (Swift 6.2, SE-0466), so new types default to `@MainActor`. The two helpers are marked `nonisolated` so they remain callable from the off-main `Task.detached` search body (preserving the original threading) and are plain `Sendable` values.

The `TerminalScrollEventInfo.init(event:)` initializer is intentionally left untested via NSEvent: it is a four-line property mapping, and the macOS 26 SDK exposes no reliable public constructor for synthetic `scrollWheel` events. The decision logic that matters is exercised through the scalar initializer — the same approach already used for `MouseScrollForwarder` in `TerminalScrollForwardingTests`.

## Risk

Low. Extraction only; no behavior change. Not merging — ready for review.
