### PR TITLE
ci: bound blocking jobs with timeout-minutes to prevent 6h GHA hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
   lint:
     name: SwiftLint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       SWIFTLINT_VERSION: "0.63.2"
       SWIFTLINT_SHA256: "dd1017cfd20a1457f264590bcb5875a6ee06cd75b9a9d4f77cd43a552499143b"
@@ -53,6 +54,7 @@ jobs:
   build:
     name: Build for Testing
     runs-on: macos-26
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -144,6 +146,7 @@ jobs:
     name: Unit Tests
     runs-on: macos-26
     needs: build
+    timeout-minutes: 45
     env:
       COVERAGE_THRESHOLD: 70
     steps:
@@ -457,6 +460,7 @@ jobs:
   verify-ui-shards:
     name: Verify UI Test Shards
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -490,6 +494,7 @@ jobs:
     name: "UI Tests (${{ matrix.shard-name }})"
     runs-on: macos-26
     needs: build
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -606,6 +611,7 @@ jobs:
     name: Flaky Test Summary
     runs-on: ubuntu-latest
     needs: ui-tests
+    timeout-minutes: 10
     if: always() && needs.ui-tests.result != 'cancelled' && needs.ui-tests.result != 'skipped'
     steps:
       - name: Download Flaky Reports


### PR DESCRIPTION
## Summary

The release PR (#1027, `chore(main): release 1.29.0`) was blocked for **24+ hours** by a single `Unit Tests` check stuck `in_progress`. Root cause: a flaky test occasionally hangs in headless CI, and the `unit-tests` job had **no `timeout-minutes`**, so it fell back to the GitHub Actions **6-hour default** before failing with a useless timeout. Re-running just started the hang over.

For context: the **same code** on the `main` push 24s earlier passed `Unit Tests` in **~5.5 min**. The hang is environmental, not a code regression.

## Fix

Add explicit `timeout-minutes` to every blocking job that was missing it, so a hang **fails fast** instead of burning 6 hours:

| Job | New cap | Typical observed |
|-----|---------|------------------|
| `lint` (SwiftLint) | 15m | ~22s |
| `build` (Build for Testing) | 30m | ~3–4m |
| `unit-tests` | 45m | ~5–6m |
| `ui-tests` (per shard) | 30m | ~4–6m |
| `verify-ui-shards` | 10m | ~5s |
| `flaky-summary` | 10m | ~6s |

Caps are ~5–7× the observed duration — generous enough to absorb slow CI runners, tight enough to never wait 6 hours again. `performance-tests` (60m) and `fuzz-tests` (30m) already had caps and are untouched.

## Follow-up (not in this PR)

The per-test hang itself should be tracked separately — e.g. adding an Xcode per-test execution-time limit so the specific hanging test is named in the log instead of just killing the whole job. This PR only stops the 6-hour bleed so releases are no longer blocked by an environmental flake.

## Checklist
- [x] YAML validated (`yaml.safe_load`)
- [x] All blocking jobs now bounded
- [x] Conventional commit message

Ready to merge.