### PR TITLE
chore: ignore .pi agent artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,6 @@ assets/screenshot-unknown-*.png
 # Snapshot test failure artifacts
 PineTests/SnapshotTests/__Snapshots__/*.actual.png
 
-# Claude Code
+# Agents
 .claude/
+.pi/


### PR DESCRIPTION
## Summary

Add `.pi/` to `.gitignore` and rename the ignore section from "Claude Code" to "Agents" so it covers the `.pi/` directory (per-project agent artifacts: review notes, positioning docs, scratch files) alongside the existing `.claude/`.

## Motivation

Pine is being positioned as an editor for AI-agent-driven workflows (#933). The global AGENTS.md convention stores agent artifacts under `<project>/.pi/`. These are local working files, not project deliverables, and should never be committed. Renaming the section to "Agents" makes the intent general rather than tool-specific.

## Changes

```
-# Claude Code
+# Agents
 .claude/
+.pi/
```

## Checklist
- [x] Single-purpose diff (one file, cosmetic + one new entry)
- [x] Conventional Commit (`chore:`)
- [x] No code changes, no lockfiles, no project.pbxproj
- [x] Ready to merge

Closes nothing — housekeeping.