### PR TITLE
ci: gate PR jobs behind run-ci label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 # NOTE: All third-party actions are pinned by full commit SHA for supply-chain safety.
 # To update an action: find the new version's commit SHA on GitHub (Tags → verify commit),
 # replace the SHA, and keep the "# vX" comment in sync.
+#
+# CI gate: PR jobs do NOT run until a maintainer adds the `run-ci` label.
+# Main-branch pushes and manual dispatch always run. Remove the label to
+# stop CI from re-running on subsequent pushes to the same PR.
+# Heavier opt-in jobs (perf, fuzz) keep their own labels on top of this gate.
 name: CI
 
 on:
@@ -35,6 +40,9 @@ jobs:
     name: SwiftLint
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'run-ci')
     env:
       SWIFTLINT_VERSION: "0.63.2"
       SWIFTLINT_SHA256: "dd1017cfd20a1457f264590bcb5875a6ee06cd75b9a9d4f77cd43a552499143b"
@@ -63,6 +71,9 @@ jobs:
     name: Build for Testing
     runs-on: macos-26
     timeout-minutes: 30
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'run-ci')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -469,6 +480,9 @@ jobs:
     name: Verify UI Test Shards
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'run-ci')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
## Summary

PR jobs no longer run on push by default. Add the `run-ci` label to a PR to run CI; remove it to keep subsequent pushes quiet. Main-branch pushes and `workflow_dispatch` are unaffected.

## What's gated

Three root jobs get the `if:` gate:
- `lint`
- `build`
- `verify-ui-shards`

Everything that `needs:` them skips automatically when they are skipped:
- `unit-tests` (`needs: build`)
- `ui-tests` (`needs: build`)
- `flaky-summary` (`needs: ui-tests`, already guards on `!= skipped`)

`performance-tests` and `fuzz-tests` are left untouched — they already have their own opt-in labels (`perf`, `fuzz`) layered on top.

## Condition

```yaml
if: >-
  github.event_name != 'pull_request' ||
  contains(github.event.pull_request.labels.*.name, 'run-ci')
```

"Run unless this is a PR without the `run-ci` label."

## Why

The maintainer is both author and reviewer of most PRs (including AI-agent-driven PRs), so the standard "CI on every push for fast author feedback" trade-off mostly burns macOS-runner minutes (~10× the cost of Linux) without buying signal — especially on docs/agent-models/gitignore PRs that can't touch UI. Gating behind an explicit label keeps CI opt-in per PR without changing the merge policy or branch protection.

## Behaviour

| Event | Runs? |
|---|---|
| Push to `main` | ✅ always |
| `workflow_dispatch` | ✅ always |
| PR opened/pushed, no label | ❌ silent |
| PR with `run-ci` label | ✅ runs |
| PR with `run-ci`, new push | ✅ runs again (label still present) |
| Remove `run-ci` label, push | ❌ silent |

## How to re-trigger after a push

The `run-ci` label persists across pushes, so CI re-runs automatically on every push while the label is on the PR. To force-stop CI on a PR, remove the label. To force a fresh run on a PR where the label is already present, remove and re-add it (the `labeled` event is already in the trigger list).

## Self-test

This PR's own CI will not run until `run-ci` is added to it. Add the label to validate the change, then merge.

## Checklist
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`)
- [x] Only root jobs gated; downstream jobs skip via existing `needs:` chains
- [x] Main-branch and dispatch paths unaffected
- [x] Conventional Commit (`ci:`)
- [x] No code changes

Closes nothing — CI housekeeping.