### PR TITLE
feat(agent): add AgentDetector for process-name detection

### DIFF
--- a/Pine/Agent/AgentDetector.swift
+++ b/Pine/Agent/AgentDetector.swift
@@ -1,0 +1,177 @@
+//
+//  AgentDetector.swift
+//  Pine
+//
+//  Detects running AI agent CLI processes from process snapshots and tracks
+//  them as `AgentSession`s (vision #933, Phase 1 — Awareness).
+//
+//  This implementation covers ONLY process-name matching: the executable name
+//  extracted from a process command line is resolved against
+//  `AgentType.cliNames`. Output-pattern matching, file-system event
+//  correlation, and terminal-tab wiring are intentionally out of scope and
+//  tracked as separate issues (see #950 Out of scope, #951, #952).
+//
+
+import Foundation
+
+/// A single process entry in a snapshot handed to `AgentDetector`.
+///
+/// Callers (e.g. a future terminal coordinator) produce these by shelling out
+/// to `ps` off the main thread. The detector never shells out itself — it
+/// consumes injected snapshots — which keeps the detection logic pure and
+/// trivially unit-testable.
+///
+/// `cwd` is carried for future file-system correlation (Phase 2) but is NOT
+/// used for matching in this implementation.
+struct DetectedProcess: Sendable, Equatable {
+    /// Operating-system process id.
+    let pid: Int32
+    /// Full command line as reported by `ps -o command=` (executable + args).
+    let command: String
+    /// Working directory of the process, if known. Reserved for Phase 2
+    /// (file-system correlation); not consulted for matching in this PR.
+    let cwd: URL?
+
+    init(pid: Int32, command: String, cwd: URL? = nil) {
+        self.pid = pid
+        self.command = command
+        self.cwd = cwd
+    }
+}
+
+/// Detects AI agent CLI processes from injected process snapshots and tracks
+/// their lifecycle as `AgentSession`s.
+///
+/// The detector is `@MainActor` + `@Observable` so SwiftUI consumers
+/// (terminal-tab badges #951, status-bar agent summary #952) can observe
+/// `detectedSessions` / `activeSessions` directly. All mutation happens on
+/// the main thread; callers dispatch the `ps` snapshot capture off-main and
+/// hand the result back via `processSnapshotDidUpdate(_:)`.
+///
+/// **Scope (issue #950, narrowed):** only process-name matching is
+/// implemented here. A process is recognised as an agent iff the executable
+/// name (last path component of the first command token) resolves to a
+/// known, non-generic `AgentType`. Unknown commands — `bash`, `ls`, `git`,
+/// `vim`, etc. — are never tracked, which keeps false positives at zero.
+///
+/// **Lifecycle:** a newly recognised agent pid creates an `AgentSession` in
+/// `.idle` state (we know the process is alive but, without output-pattern
+/// matching, cannot tell what it is doing). When a pid disappears from the
+/// snapshot the corresponding session transitions to `.done` and is
+/// disassociated from the pid so that a future pid reuse creates a fresh
+/// session rather than resurrecting a finished one.
+@MainActor
+@Observable
+final class AgentDetector {
+    /// All sessions the detector has ever recognised, in detection order,
+    /// including finished ones (`.done`). Consumers that only want live
+    /// agents should read `activeSessions`.
+    private(set) var detectedSessions: [AgentSession] = []
+
+    /// Active sessions keyed by pid for O(1) lookup during reconciliation.
+    /// A session is removed from this map (but kept in `detectedSessions`)
+    /// once its pid is no longer observed.
+    private var sessionsByPID: [Int32: AgentSession] = [:]
+
+    /// Sessions whose state is not `.done`.
+    var activeSessions: [AgentSession] {
+        detectedSessions.filter { $0.state != .done }
+    }
+
+    /// Convenience accessor for the number of currently-active agent sessions.
+    var activeCount: Int { activeSessions.count }
+
+    /// Processes a full process snapshot: recognises new agent processes,
+    /// and reconciles (marks `.done`) sessions whose pids are absent.
+    ///
+    /// Idempotent for a given snapshot: feeding the same snapshot twice does
+    /// not duplicate sessions — the second call only runs reconciliation,
+    /// which is a no-op when nothing changed.
+    ///
+    /// - Parameter processes: the full process list as captured by the
+    ///   caller (e.g. via `ps -eo pid=,command=`). Order is not significant.
+    func processSnapshotDidUpdate(_ processes: [DetectedProcess]) {
+        let snapshotPIDs = Set(processes.map(\.pid))
+
+        // 1. Detect: create sessions for newly-recognised agent pids.
+        for process in processes {
+            let executableName = Self.extractExecutableName(from: process.command)
+            guard let resolved = AgentType.resolve(fromProcessName: executableName),
+                  !Self.isGeneric(resolved) else { continue }
+
+            // Already tracked and still active — nothing to do in this PR.
+            // State refinement (thinking / executing / waitingInput) requires
+            // output-pattern matching, which is out of scope.
+            if sessionsByPID[process.pid] != nil { continue }
+
+            let session = AgentSession(agentType: resolved, state: .idle)
+            sessionsByPID[process.pid] = session
+            detectedSessions.append(session)
+        }
+
+        // 2. Reconcile: mark sessions for pids no longer present as done.
+        reconcile(activePIDs: snapshotPIDs)
+    }
+
+    /// Marks every tracked session whose pid is not in `activePIDs` as
+    /// `.done` and disassociates it from its pid.
+    ///
+    /// Also called internally by `processSnapshotDidUpdate(_:)`. Exposed so a
+    /// caller that receives a single process-exit signal (e.g. `SIGCHLD`)
+    /// can reconcile without producing a full snapshot.
+    func reconcile(activePIDs: Set<Int32>) {
+        let trackedPIDs = Array(sessionsByPID.keys)
+        for pid in trackedPIDs where !activePIDs.contains(pid) {
+            markDone(pid: pid)
+        }
+    }
+
+    /// Removes all `.done` sessions from `detectedSessions`, freeing memory.
+    /// Active sessions are never removed. Useful for periodic cleanup by the
+    /// owner of the detector.
+    func clearFinishedSessions() {
+        detectedSessions.removeAll { $0.state == .done }
+    }
+
+    // MARK: - Internal
+
+    /// Transitions the session for `pid` to `.done` and removes the pid
+    /// mapping so that pid reuse later creates a fresh session.
+    private func markDone(pid: Int32) {
+        guard let session = sessionsByPID.removeValue(forKey: pid) else { return }
+        session.state = .done
+    }
+
+    /// Returns true if `type` is the `.generic` case.
+    ///
+    /// Generic agents have no registered `cliNames` and must not be tracked
+    /// by process-name matching alone — doing so would track every unknown
+    /// process (`bash`, `ls`, ...) and cause constant false positives.
+    private static func isGeneric(_ type: AgentType) -> Bool {
+        if case .generic = type { return true }
+        return false
+    }
+
+    /// Extracts the executable name from a `ps -o command=` string.
+    ///
+    /// Handles three shapes:
+    /// - `claude` → `claude`
+    /// - `/usr/local/bin/claude` → `claude`
+    /// - `/usr/local/bin/claude --verbose` → `claude`
+    ///
+    /// Node-wrapper invocation (`node /path/to/claude.js`) resolves to
+    /// `node` and is therefore NOT detected by process-name matching in this
+    /// PR; that case is left to output-pattern matching (out of scope).
+    static func extractExecutableName(from command: String) -> String {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+
+        let firstToken: String
+        if let spaceIndex = trimmed.firstIndex(of: " ") {
+            firstToken = String(trimmed[..<spaceIndex])
+        } else {
+            firstToken = trimmed
+        }
+        return (firstToken as NSString).lastPathComponent
+    }
+}

--- a/Pine/Agent/AgentModels.swift
+++ b/Pine/Agent/AgentModels.swift
@@ -104,7 +104,7 @@ enum AgentState: Equatable, Sendable {
 /// terminal tab. `id` is stable for the session lifetime; mutable properties
 /// (`state`, `currentTask`, `filesModified`, `filesRead`) are updated by an
 /// `AgentDetector` as the session progresses.
-@Observable
+@MainActor @Observable
 final class AgentSession: Identifiable {
     /// Stable identifier for this session.
     let id: UUID
@@ -147,13 +147,13 @@ final class AgentSession: Identifiable {
 }
 
 extension AgentSession: Equatable {
-    static func == (lhs: AgentSession, rhs: AgentSession) -> Bool {
+    nonisolated static func == (lhs: AgentSession, rhs: AgentSession) -> Bool {
         lhs.id == rhs.id
     }
 }
 
 extension AgentSession: Hashable {
-    func hash(into hasher: inout Hasher) {
+    nonisolated func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }
 }

--- a/Pine/Agent/AgentModels.swift
+++ b/Pine/Agent/AgentModels.swift
@@ -24,6 +24,8 @@ enum AgentType: Equatable, Sendable {
     case aider
     /// GitHub Copilot CLI (`github-copilot-cli`).
     case copilot
+    /// pi coding agent (`pi`).
+    case pi
     /// Any other/unrecognised agent, identified by a free-form name.
     case generic(name: String)
 
@@ -34,6 +36,7 @@ enum AgentType: Equatable, Sendable {
         case .codex: "Codex"
         case .aider: "Aider"
         case .copilot: "Copilot"
+        case .pi: "Pi"
         case .generic(let name): name
         }
     }
@@ -46,6 +49,7 @@ enum AgentType: Equatable, Sendable {
         case .codex: ["codex"]
         case .aider: ["aider"]
         case .copilot: ["github-copilot-cli", "copilot"]
+        case .pi: ["pi"]
         case .generic: []
         }
     }
@@ -57,6 +61,7 @@ enum AgentType: Equatable, Sendable {
         case .codex: .systemGreen
         case .aider: .systemPurple
         case .copilot: .systemBlue
+        case .pi: .systemTeal
         case .generic: .systemGray
         }
     }
@@ -70,7 +75,7 @@ enum AgentType: Equatable, Sendable {
         guard !trimmed.isEmpty else { return nil }
         let lowered = trimmed.lowercased()
 
-        let known: [AgentType] = [.claudeCode, .codex, .aider, .copilot]
+        let known: [AgentType] = [.claudeCode, .codex, .aider, .copilot, .pi]
         for agent in known where agent.cliNames.contains(lowered) {
             return agent
         }

--- a/Pine/Agent/AgentModels.swift
+++ b/Pine/Agent/AgentModels.swift
@@ -1,0 +1,159 @@
+//
+//  AgentModels.swift
+//  Pine
+//
+//  Foundation data models for AI agent tracking (vision #933, Phase 1 — Awareness).
+//  Pure models: no detection logic, no UI. Consumed by AgentDetector (#950),
+//  terminal tab badges (#951), and the status bar agent summary (#952).
+//
+
+import AppKit
+import Foundation
+
+/// Identifies a known AI coding agent CLI tool.
+///
+/// `cliNames` is the set of process/command names an `AgentDetector` matches
+/// against (e.g. from `ps` output or terminal prompts). `color` drives UI
+/// color-coding for agent badges and indicators.
+enum AgentType: Equatable, Sendable {
+    /// Anthropic Claude Code (`claude`).
+    case claudeCode
+    /// OpenAI Codex CLI (`codex`).
+    case codex
+    /// Aider (`aider`).
+    case aider
+    /// GitHub Copilot CLI (`github-copilot-cli`).
+    case copilot
+    /// Any other/unrecognised agent, identified by a free-form name.
+    case generic(name: String)
+
+    /// Human-readable name for display (status bar, badges).
+    var displayName: String {
+        switch self {
+        case .claudeCode: "Claude Code"
+        case .codex: "Codex"
+        case .aider: "Aider"
+        case .copilot: "Copilot"
+        case .generic(let name): name
+        }
+    }
+
+    /// Process/command names an `AgentDetector` matches against for this agent.
+    /// Lowercased to allow case-insensitive matching.
+    var cliNames: Set<String> {
+        switch self {
+        case .claudeCode: ["claude"]
+        case .codex: ["codex"]
+        case .aider: ["aider"]
+        case .copilot: ["github-copilot-cli", "copilot"]
+        case .generic: []
+        }
+    }
+
+    /// Semantic system color used for UI color-coding of this agent.
+    var color: NSColor {
+        switch self {
+        case .claudeCode: .systemOrange
+        case .codex: .systemGreen
+        case .aider: .systemPurple
+        case .copilot: .systemBlue
+        case .generic: .systemGray
+        }
+    }
+
+    /// Resolves an `AgentType` from a process/command name (case-insensitive).
+    /// Returns the first known agent whose `cliNames` contains the name, or
+    /// `.generic(name:)` for an unrecognised name. An empty name resolves to
+    /// `nil`.
+    static func resolve(fromProcessName name: String) -> AgentType? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let lowered = trimmed.lowercased()
+
+        let known: [AgentType] = [.claudeCode, .codex, .aider, .copilot]
+        for agent in known where agent.cliNames.contains(lowered) {
+            return agent
+        }
+        return .generic(name: trimmed)
+    }
+}
+
+/// Lifecycle state of an agent session within a terminal tab.
+enum AgentState: Equatable, Sendable {
+    case idle
+    case thinking
+    case executing
+    case waitingInput
+    case done
+
+    /// Human-readable label for display (status bar, activity indicators).
+    var displayName: String {
+        switch self {
+        case .idle: "Idle"
+        case .thinking: "Thinking"
+        case .executing: "Executing"
+        case .waitingInput: "Waiting for input"
+        case .done: "Done"
+        }
+    }
+}
+
+/// Tracks a single AI agent session running within a terminal tab.
+///
+/// Identity semantics: an `AgentSession` represents one run of one agent in one
+/// terminal tab. `id` is stable for the session lifetime; mutable properties
+/// (`state`, `currentTask`, `filesModified`, `filesRead`) are updated by an
+/// `AgentDetector` as the session progresses.
+@Observable
+final class AgentSession: Identifiable {
+    /// Stable identifier for this session.
+    let id: UUID
+
+    /// Which agent this session is running.
+    let agentType: AgentType
+
+    /// Current lifecycle state of the session.
+    var state: AgentState
+
+    /// When the session started.
+    let startedAt: Date
+
+    /// Optional human-readable description of the task the agent is working on.
+    var currentTask: String?
+
+    /// Files the agent has modified during this session.
+    var filesModified: [URL]
+
+    /// Files the agent has read during this session.
+    var filesRead: [URL]
+
+    init(
+        id: UUID = UUID(),
+        agentType: AgentType,
+        state: AgentState = .idle,
+        startedAt: Date = Date(),
+        currentTask: String? = nil,
+        filesModified: [URL] = [],
+        filesRead: [URL] = []
+    ) {
+        self.id = id
+        self.agentType = agentType
+        self.state = state
+        self.startedAt = startedAt
+        self.currentTask = currentTask
+        self.filesModified = filesModified
+        self.filesRead = filesRead
+    }
+}
+
+extension AgentSession: Equatable {
+    static func == (lhs: AgentSession, rhs: AgentSession) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+extension AgentSession: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}

--- a/PineTests/AgentDetectorTests.swift
+++ b/PineTests/AgentDetectorTests.swift
@@ -1,0 +1,352 @@
+//
+//  AgentDetectorTests.swift
+//  PineTests
+//
+//  Tests for AgentDetector (vision #933, Phase 1 — process-name detection).
+//
+
+import Testing
+@testable import Pine
+
+@MainActor
+struct AgentDetectorTests {
+
+    // MARK: - Detection of known agents
+
+    @Test func detectsClaudeCode() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 100, command: "claude"),
+        ])
+        #expect(detector.detectedSessions.count == 1)
+        #expect(detector.detectedSessions[0].agentType == .claudeCode)
+        #expect(detector.detectedSessions[0].state == .idle)
+        #expect(detector.activeCount == 1)
+    }
+
+    @Test func detectsCodex() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 101, command: "codex"),
+        ])
+        #expect(detector.detectedSessions.count == 1)
+        #expect(detector.detectedSessions[0].agentType == .codex)
+    }
+
+    @Test func detectsAider() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 102, command: "aider"),
+        ])
+        #expect(detector.detectedSessions.count == 1)
+        #expect(detector.detectedSessions[0].agentType == .aider)
+    }
+
+    @Test func detectsPi() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 103, command: "pi"),
+        ])
+        #expect(detector.detectedSessions.count == 1)
+        #expect(detector.detectedSessions[0].agentType == .pi)
+    }
+
+    @Test func detectsCopilotViaBothCliNames() {
+        let detector1 = AgentDetector()
+        detector1.processSnapshotDidUpdate([
+            DetectedProcess(pid: 110, command: "github-copilot-cli"),
+        ])
+        #expect(detector1.detectedSessions[0].agentType == .copilot)
+
+        let detector2 = AgentDetector()
+        detector2.processSnapshotDidUpdate([
+            DetectedProcess(pid: 111, command: "copilot"),
+        ])
+        #expect(detector2.detectedSessions[0].agentType == .copilot)
+    }
+
+    // MARK: - Full-path resolution
+
+    @Test func detectsAgentFromFullPath() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 200, command: "/usr/local/bin/claude --verbose"),
+        ])
+        #expect(detector.detectedSessions.count == 1)
+        #expect(detector.detectedSessions[0].agentType == .claudeCode)
+    }
+
+    @Test func detectsAgentFromBinPathWithoutArgs() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 201, command: "/opt/homebrew/bin/codex"),
+        ])
+        #expect(detector.detectedSessions.count == 1)
+        #expect(detector.detectedSessions[0].agentType == .codex)
+    }
+
+    // MARK: - No false positives
+
+    @Test func noFalsePositivesOnShellCommands() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 1, command: "bash"),
+            DetectedProcess(pid: 2, command: "ls -la"),
+            DetectedProcess(pid: 3, command: "git status"),
+            DetectedProcess(pid: 4, command: "vim README.md"),
+            DetectedProcess(pid: 5, command: "node server.js"),
+            DetectedProcess(pid: 6, command: "/bin/zsh"),
+            DetectedProcess(pid: 7, command: "python3 script.py"),
+        ])
+        #expect(detector.detectedSessions.isEmpty)
+        #expect(detector.activeCount == 0)
+    }
+
+    @Test func noFalsePositivesOnAgentAdjacentNames() {
+        // Names that resemble agent CLIs but are not exact matches must not
+        // trigger detection (cliNames uses exact membership).
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 10, command: "claude-code"),
+            DetectedProcess(pid: 11, command: "myclaude"),
+            DetectedProcess(pid: 12, command: "codex-helper"),
+            DetectedProcess(pid: 13, command: "/usr/bin/ping"),
+        ])
+        #expect(detector.detectedSessions.isEmpty)
+    }
+
+    @Test func ignoresEmptyCommand() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 20, command: ""),
+            DetectedProcess(pid: 21, command: "   "),
+        ])
+        #expect(detector.detectedSessions.isEmpty)
+    }
+
+    // MARK: - Idempotency
+
+    @Test func idempotentSameSnapshotDoesNotDuplicate() {
+        let detector = AgentDetector()
+        let snapshot = [DetectedProcess(pid: 300, command: "claude")]
+
+        detector.processSnapshotDidUpdate(snapshot)
+        #expect(detector.detectedSessions.count == 1)
+        let firstSessionID = detector.detectedSessions[0].id
+
+        detector.processSnapshotDidUpdate(snapshot)
+        #expect(detector.detectedSessions.count == 1)
+        #expect(detector.detectedSessions[0].id == firstSessionID)
+    }
+
+    @Test func idempotentMultipleAgentsStableIDs() {
+        let detector = AgentDetector()
+        let snapshot = [
+            DetectedProcess(pid: 310, command: "claude"),
+            DetectedProcess(pid: 311, command: "codex"),
+            DetectedProcess(pid: 312, command: "aider"),
+        ]
+
+        detector.processSnapshotDidUpdate(snapshot)
+        let idsAfterFirst = detector.detectedSessions.map(\.id)
+
+        detector.processSnapshotDidUpdate(snapshot)
+        let idsAfterSecond = detector.detectedSessions.map(\.id)
+
+        #expect(idsAfterFirst == idsAfterSecond)
+        #expect(detector.detectedSessions.count == 3)
+    }
+
+    // MARK: - Lifecycle
+
+    @Test func lifecycleStartThenDoneWhenPidDisappears() {
+        let detector = AgentDetector()
+
+        // Start: agent detected.
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 400, command: "claude"),
+        ])
+        #expect(detector.activeCount == 1)
+        #expect(detector.detectedSessions[0].state == .idle)
+
+        // Snapshot no longer includes the pid → session marked .done.
+        detector.processSnapshotDidUpdate([])
+        #expect(detector.activeCount == 0)
+        #expect(detector.detectedSessions.count == 1)
+        #expect(detector.detectedSessions[0].state == .done)
+    }
+
+    @Test func lifecycleOnlyExitedPidsMarkedDone() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 410, command: "claude"),
+            DetectedProcess(pid: 411, command: "codex"),
+        ])
+        #expect(detector.activeCount == 2)
+
+        // Only claude disappears.
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 411, command: "codex"),
+        ])
+        #expect(detector.activeCount == 1)
+        let claudeSession = detector.detectedSessions.first { $0.agentType == .claudeCode }
+        let codexSession = detector.detectedSessions.first { $0.agentType == .codex }
+        #expect(claudeSession?.state == .done)
+        #expect(codexSession?.state == .idle)
+    }
+
+    @Test func reconcileMarksMissingPidsDone() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 420, command: "claude"),
+            DetectedProcess(pid: 421, command: "pi"),
+        ])
+        #expect(detector.activeCount == 2)
+
+        // Standalone reconcile: only pid 420 still alive.
+        detector.reconcile(activePIDs: [420])
+        #expect(detector.activeCount == 1)
+        let piSession = detector.detectedSessions.first { $0.agentType == .pi }
+        #expect(piSession?.state == .done)
+    }
+
+    @Test func reconcileIsNoOpWhenAllPidsActive() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 430, command: "claude"),
+        ])
+        detector.reconcile(activePIDs: [430])
+        #expect(detector.activeCount == 1)
+        #expect(detector.detectedSessions[0].state == .idle)
+    }
+
+    // MARK: - Pid reuse creates a new session
+
+    @Test func pidReuseCreatesNewSession() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 500, command: "claude"),
+        ])
+        let originalID = detector.detectedSessions[0].id
+
+        // Process exits.
+        detector.processSnapshotDidUpdate([])
+        #expect(detector.detectedSessions[0].state == .done)
+
+        // Same pid reappears (OS recycled it) → new session, not resurrection.
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 500, command: "claude"),
+        ])
+        let allClaude = detector.detectedSessions.filter { $0.agentType == .claudeCode }
+        #expect(allClaude.count == 2)
+        #expect(allClaude[1].id != originalID)
+        #expect(allClaude[1].state == .idle)
+        #expect(allClaude[0].state == .done)
+    }
+
+    // MARK: - Mixed snapshot: agents + non-agents
+
+    @Test func mixedSnapshotDetectsOnlyAgents() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 600, command: "bash"),
+            DetectedProcess(pid: 601, command: "claude"),
+            DetectedProcess(pid: 602, command: "git log"),
+            DetectedProcess(pid: 603, command: "codex"),
+            DetectedProcess(pid: 604, command: "vim"),
+        ])
+        #expect(detector.detectedSessions.count == 2)
+        let types = detector.detectedSessions.map(\.agentType)
+        #expect(types.contains(.claudeCode))
+        #expect(types.contains(.codex))
+    }
+
+    // MARK: - clearFinishedSessions
+
+    @Test func clearFinishedSessionsRemovesOnlyDone() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 700, command: "claude"),
+            DetectedProcess(pid: 701, command: "codex"),
+        ])
+        // Codex exits.
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 700, command: "claude"),
+        ])
+        #expect(detector.detectedSessions.count == 2)
+
+        detector.clearFinishedSessions()
+        #expect(detector.detectedSessions.count == 1)
+        #expect(detector.detectedSessions[0].agentType == .claudeCode)
+        #expect(detector.detectedSessions[0].state == .idle)
+    }
+
+    // MARK: - activeSessions computed property
+
+    @Test func activeSessionsExcludesDone() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 800, command: "claude"),
+            DetectedProcess(pid: 801, command: "pi"),
+        ])
+        // Claude exits.
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 801, command: "pi"),
+        ])
+        #expect(detector.detectedSessions.count == 2)
+        #expect(detector.activeSessions.count == 1)
+        #expect(detector.activeSessions[0].agentType == .pi)
+    }
+
+    // MARK: - extractExecutableName helper
+
+    @Test func extractExecutableNameFromBareName() {
+        #expect(AgentDetector.extractExecutableName(from: "claude") == "claude")
+    }
+
+    @Test func extractExecutableNameFromFullPath() {
+        #expect(AgentDetector.extractExecutableName(from: "/usr/local/bin/claude") == "claude")
+    }
+
+    @Test func extractExecutableNameFromFullPathWithArgs() {
+        #expect(AgentDetector.extractExecutableName(from: "/opt/homebrew/bin/codex --verbose") == "codex")
+    }
+
+    @Test func extractExecutableNameFromEmpty() {
+        #expect(AgentDetector.extractExecutableName(from: "") == "")
+        #expect(AgentDetector.extractExecutableName(from: "   ") == "")
+    }
+
+    // MARK: - Multiple sequential updates
+
+    @Test func sequentialUpdatesAccumulateAndReconcile() {
+        let detector = AgentDetector()
+
+        // 1. Only claude.
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 900, command: "claude"),
+        ])
+        #expect(detector.activeCount == 1)
+
+        // 2. Codex joins.
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 900, command: "claude"),
+            DetectedProcess(pid: 901, command: "codex"),
+        ])
+        #expect(detector.activeCount == 2)
+
+        // 3. Claude leaves, aider joins.
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 901, command: "codex"),
+            DetectedProcess(pid: 902, command: "aider"),
+        ])
+        #expect(detector.activeCount == 2)
+        let activeTypes = detector.activeSessions.map(\.agentType)
+        #expect(activeTypes.contains(.codex))
+        #expect(activeTypes.contains(.aider))
+        #expect(!activeTypes.contains(.claudeCode))
+
+        // History preserves all three.
+        #expect(detector.detectedSessions.count == 3)
+    }
+}

--- a/PineTests/AgentModelsTests.swift
+++ b/PineTests/AgentModelsTests.swift
@@ -1,0 +1,199 @@
+//
+//  AgentModelsTests.swift
+//  PineTests
+//
+//  Tests for AgentType, AgentState, and AgentSession (vision #933, Phase 1).
+//
+
+import AppKit
+import Testing
+@testable import Pine
+
+@MainActor
+struct AgentModelsTests {
+
+    // MARK: - AgentType properties
+
+    @Test func displayName_returnsExpectedNames() {
+        #expect(AgentType.claudeCode.displayName == "Claude Code")
+        #expect(AgentType.codex.displayName == "Codex")
+        #expect(AgentType.aider.displayName == "Aider")
+        #expect(AgentType.copilot.displayName == "Copilot")
+        #expect(AgentType.generic(name: "Custom").displayName == "Custom")
+    }
+
+    @Test func cliNames_containExpectedValues() {
+        #expect(AgentType.claudeCode.cliNames == ["claude"])
+        #expect(AgentType.codex.cliNames == ["codex"])
+        #expect(AgentType.aider.cliNames == ["aider"])
+        // Copilot registers both the full CLI name and the short alias.
+        #expect(AgentType.copilot.cliNames.contains("github-copilot-cli"))
+        #expect(AgentType.copilot.cliNames.contains("copilot"))
+        // Generic agents have no known CLI names.
+        #expect(AgentType.generic(name: "Custom").cliNames.isEmpty)
+    }
+
+    @Test func color_isNotNil() {
+        // All cases must return a concrete system color for UI color-coding.
+        for agent in [AgentType.claudeCode, .codex, .aider, .copilot, .generic(name: "X")] {
+            // NSColor is always non-nil here; exercise the getter to ensure
+            // no crash and a valid object is returned for every case.
+            #expect(agent.color != NSColor.clear)
+        }
+    }
+
+    // MARK: - AgentType.resolve(fromProcessName:)
+
+    @Test func resolve_returnsClaudeCodeForKnownName() {
+        #expect(AgentType.resolve(fromProcessName: "claude") == .claudeCode)
+    }
+
+    @Test func resolve_returnsCodexForKnownName() {
+        #expect(AgentType.resolve(fromProcessName: "codex") == .codex)
+    }
+
+    @Test func resolve_returnsAiderForKnownName() {
+        #expect(AgentType.resolve(fromProcessName: "aider") == .aider)
+    }
+
+    @Test func resolve_returnsCopilotForKnownNames() {
+        #expect(AgentType.resolve(fromProcessName: "github-copilot-cli") == .copilot)
+        #expect(AgentType.resolve(fromProcessName: "copilot") == .copilot)
+    }
+
+    @Test func resolve_isCaseInsensitive() {
+        #expect(AgentType.resolve(fromProcessName: "CLAUDE") == .claudeCode)
+        #expect(AgentType.resolve(fromProcessName: "Codex") == .codex)
+        #expect(AgentType.resolve(fromProcessName: "AIDER") == .aider)
+    }
+
+    @Test func resolve_trimsWhitespace() {
+        #expect(AgentType.resolve(fromProcessName: "  claude  ") == .claudeCode)
+        #expect(AgentType.resolve(fromProcessName: "\tcodex\n") == .codex)
+    }
+
+    @Test func resolve_returnsGenericForUnknownName() {
+        let result = AgentType.resolve(fromProcessName: "my-custom-agent")
+        if case .generic(let name) = result {
+            #expect(name == "my-custom-agent")
+        } else {
+            Issue.record("expected .generic, got \(result)")
+        }
+    }
+
+    @Test func resolve_returnsNilForEmptyName() {
+        #expect(AgentType.resolve(fromProcessName: "") == nil)
+        #expect(AgentType.resolve(fromProcessName: "   ") == nil)
+        #expect(AgentType.resolve(fromProcessName: "\t\n") == nil)
+    }
+
+    // MARK: - AgentState
+
+    @Test func agentState_displayNames() {
+        #expect(AgentState.idle.displayName == "Idle")
+        #expect(AgentState.thinking.displayName == "Thinking")
+        #expect(AgentState.executing.displayName == "Executing")
+        #expect(AgentState.waitingInput.displayName == "Waiting for input")
+        #expect(AgentState.done.displayName == "Done")
+    }
+
+    // MARK: - AgentSession
+
+    @Test func agentSession_defaultsToIdleAndEmptyFileLists() {
+        let session = AgentSession(agentType: .claudeCode)
+        #expect(session.agentType == .claudeCode)
+        #expect(session.state == .idle)
+        #expect(session.currentTask == nil)
+        #expect(session.filesModified.isEmpty)
+        #expect(session.filesRead.isEmpty)
+    }
+
+    @Test func agentSession_acceptsInitializerValues() {
+        let id = UUID()
+        let date = Date(timeIntervalSince1970: 1_000_000)
+        let modified = [URL(fileURLWithPath: "/tmp/a.swift")]
+        let read = [URL(fileURLWithPath: "/tmp/b.swift")]
+        let session = AgentSession(
+            id: id,
+            agentType: .codex,
+            state: .executing,
+            startedAt: date,
+            currentTask: "fix bug",
+            filesModified: modified,
+            filesRead: read
+        )
+        #expect(session.id == id)
+        #expect(session.agentType == .codex)
+        #expect(session.state == .executing)
+        #expect(session.startedAt == date)
+        #expect(session.currentTask == "fix bug")
+        #expect(session.filesModified == modified)
+        #expect(session.filesRead == read)
+    }
+
+    @Test func agentSession_stateTransitions() {
+        let session = AgentSession(agentType: .claudeCode)
+        #expect(session.state == .idle)
+
+        session.state = .thinking
+        #expect(session.state == .thinking)
+
+        session.state = .executing
+        #expect(session.state == .executing)
+
+        session.state = .waitingInput
+        #expect(session.state == .waitingInput)
+
+        session.state = .done
+        #expect(session.state == .done)
+    }
+
+    @Test func agentSession_updatesCurrentTask() {
+        let session = AgentSession(agentType: .aider)
+        #expect(session.currentTask == nil)
+
+        session.currentTask = "refactor parser"
+        #expect(session.currentTask == "refactor parser")
+
+        session.currentTask = nil
+        #expect(session.currentTask == nil)
+    }
+
+    @Test func agentSession_accumulatesModifiedAndReadFiles() {
+        let session = AgentSession(agentType: .copilot)
+        let fileA = URL(fileURLWithPath: "/src/a.swift")
+        let fileB = URL(fileURLWithPath: "/src/b.swift")
+
+        session.filesModified.append(fileA)
+        session.filesModified.append(fileB)
+        #expect(session.filesModified == [fileA, fileB])
+
+        session.filesRead.append(fileA)
+        #expect(session.filesRead == [fileA])
+    }
+
+    @Test func agentSession_identityIsStableAcrossMutations() {
+        let session = AgentSession(agentType: .claudeCode)
+        let originalID = session.id
+
+        session.state = .executing
+        session.currentTask = "new task"
+        session.filesModified.append(URL(fileURLWithPath: "/tmp/x.swift"))
+
+        #expect(session.id == originalID)
+    }
+
+    @Test func agentSession_equalityIsByIDOnly() {
+        let id = UUID()
+        let a = AgentSession(id: id, agentType: .claudeCode)
+        let b = AgentSession(id: id, agentType: .codex, state: .done)
+        // Same id => equal even if other fields differ (identity semantics).
+        #expect(a == b)
+    }
+
+    @Test func agentSession_distinctIDsAreNotEqual() {
+        let a = AgentSession(agentType: .claudeCode)
+        let b = AgentSession(agentType: .claudeCode)
+        #expect(a != b)
+    }
+}

--- a/PineTests/AgentModelsTests.swift
+++ b/PineTests/AgentModelsTests.swift
@@ -33,12 +33,21 @@ struct AgentModelsTests {
         #expect(AgentType.generic(name: "Custom").cliNames.isEmpty)
     }
 
-    @Test func color_isNotNil() {
-        // All cases must return a concrete system color for UI color-coding.
-        for agent in [AgentType.claudeCode, .codex, .aider, .copilot, .generic(name: "X")] {
-            // NSColor is always non-nil here; exercise the getter to ensure
-            // no crash and a valid object is returned for every case.
-            #expect(agent.color != NSColor.clear)
+    @Test func color_isDistinctAndNotClearPerAgent() {
+        let agents: [AgentType] = [.claudeCode, .codex, .aider, .copilot, .generic(name: "X")]
+
+        // Every case must resolve to a concrete, non-transparent color.
+        for agent in agents {
+            #expect(agent.color != .clear)
+        }
+
+        // Known agents must return distinct colors so UI badges stay distinguishable.
+        let known = [AgentType.claudeCode, .codex, .aider, .copilot]
+        for i in known.indices {
+            for j in (i + 1)..<known.count {
+                #expect(known[i].color != known[j].color,
+                        "\(known[i]) and \(known[j]) should have distinct colors")
+            }
         }
     }
 
@@ -85,6 +94,24 @@ struct AgentModelsTests {
         #expect(AgentType.resolve(fromProcessName: "") == nil)
         #expect(AgentType.resolve(fromProcessName: "   ") == nil)
         #expect(AgentType.resolve(fromProcessName: "\t\n") == nil)
+    }
+
+    @Test func resolve_rejectsInexactCliName() {
+        // cliNames uses exact membership, not prefix/substring matching.
+        // "claude-code" resembles the registered "claude" but must not match it.
+        let result = AgentType.resolve(fromProcessName: "claude-code")
+        #expect(result == .generic(name: "claude-code"))
+        #expect(result != .claudeCode)
+    }
+
+    @Test func resolve_preservesCaseForGenericName() {
+        // Unknown names keep their original case (not lowercased) in .generic.
+        let result = AgentType.resolve(fromProcessName: "MyAgent")
+        if case .generic(let name) = result {
+            #expect(name == "MyAgent")
+        } else {
+            Issue.record("expected .generic, got \(result)")
+        }
     }
 
     // MARK: - AgentState

--- a/PineTests/AgentModelsTests.swift
+++ b/PineTests/AgentModelsTests.swift
@@ -19,6 +19,7 @@ struct AgentModelsTests {
         #expect(AgentType.codex.displayName == "Codex")
         #expect(AgentType.aider.displayName == "Aider")
         #expect(AgentType.copilot.displayName == "Copilot")
+        #expect(AgentType.pi.displayName == "Pi")
         #expect(AgentType.generic(name: "Custom").displayName == "Custom")
     }
 
@@ -29,12 +30,13 @@ struct AgentModelsTests {
         // Copilot registers both the full CLI name and the short alias.
         #expect(AgentType.copilot.cliNames.contains("github-copilot-cli"))
         #expect(AgentType.copilot.cliNames.contains("copilot"))
+        #expect(AgentType.pi.cliNames == ["pi"])
         // Generic agents have no known CLI names.
         #expect(AgentType.generic(name: "Custom").cliNames.isEmpty)
     }
 
     @Test func color_isDistinctAndNotClearPerAgent() {
-        let agents: [AgentType] = [.claudeCode, .codex, .aider, .copilot, .generic(name: "X")]
+        let agents: [AgentType] = [.claudeCode, .codex, .aider, .copilot, .pi, .generic(name: "X")]
 
         // Every case must resolve to a concrete, non-transparent color.
         for agent in agents {
@@ -42,7 +44,7 @@ struct AgentModelsTests {
         }
 
         // Known agents must return distinct colors so UI badges stay distinguishable.
-        let known = [AgentType.claudeCode, .codex, .aider, .copilot]
+        let known = [AgentType.claudeCode, .codex, .aider, .copilot, .pi]
         for i in known.indices {
             for j in (i + 1)..<known.count {
                 #expect(known[i].color != known[j].color,
@@ -70,10 +72,22 @@ struct AgentModelsTests {
         #expect(AgentType.resolve(fromProcessName: "copilot") == .copilot)
     }
 
+    @Test func resolve_returnsPiForKnownName() {
+        // Exact match resolves to the first-class .pi case, not .generic.
+        #expect(AgentType.resolve(fromProcessName: "pi") == .pi)
+    }
+
+    @Test func pi_isDistinctFromGenericNamedPi() {
+        // .pi is a first-class case and must not collapse into a generic
+        // agent whose free-form name happens to be "pi".
+        #expect(AgentType.pi != .generic(name: "pi"))
+    }
+
     @Test func resolve_isCaseInsensitive() {
         #expect(AgentType.resolve(fromProcessName: "CLAUDE") == .claudeCode)
         #expect(AgentType.resolve(fromProcessName: "Codex") == .codex)
         #expect(AgentType.resolve(fromProcessName: "AIDER") == .aider)
+        #expect(AgentType.resolve(fromProcessName: "PI") == .pi)
     }
 
     @Test func resolve_trimsWhitespace() {


### PR DESCRIPTION
## Summary

`AgentDetector` recognises AI agent CLI processes (Claude Code, Codex, Aider, Copilot, Pi) from injected process snapshots and tracks their lifecycle as `AgentSession` instances. This is Phase 1 (Awareness) of vision #933, issue #950.

## Scope — intentionally narrowed

Issue #950 describes three detection strategies. **This PR implements ONLY process-name matching.** The rest is explicitly out of scope:

| Strategy | This PR | Why |
|---|---|---|
| Process-name matching (`ps` → `AgentType.cliNames`) | ✅ | Core, cheap, zero false positives |
| Output-pattern matching (prompts, banners) | ❌ | Flaky, needs real terminal output access |
| File-system event correlation | ❌ | Phase 2 (Visibility) |
| TerminalTab/TerminalPaneState wiring | ❌ | #951 (badges) — this is pure logic + public API |

## Design decisions

1. **Injected snapshots, not direct `ps` calls.** The detector consumes `[DetectedProcess]` from the caller. This makes the detection logic a pure function — trivially unit-testable without shelling out.

2. **`@MainActor @Observable`** — matches the model layer from #1031 (`AgentSession`). All mutation happens on the main thread. Callers dispatch `ps` capture off-main and hand the snapshot back.

3. **Only known agents tracked.** `AgentType.resolve` returns `.generic(name:)` for unknown processes. The detector filters generics out — otherwise every `bash`/`ls`/`git` would create a session. Zero false positives by construction.

4. **Lifecycle: `.idle` on detect, `.done` on exit.** A newly recognised agent pid creates a session in `.idle` (we know it is alive but, without output-pattern matching, cannot tell what it is doing). When a pid disappears from the snapshot, the session transitions to `.done` and is disassociated from the pid so that OS pid-reuse creates a fresh session.

5. **Executable name extraction.** Handles bare names (`claude`), full paths (`/usr/local/bin/claude`), and paths with args (`/opt/homebrew/bin/codex --verbose`). Node-wrapper case (`node /path/to/claude.js`) resolves to `node` and is NOT detected — left to output-pattern matching.

## Public API

```swift
@MainActor @Observable
final class AgentDetector {
    private(set) var detectedSessions: [AgentSession]   // full history incl. .done
    var activeSessions: [AgentSession]                    // computed: state != .done
    var activeCount: Int                                  // convenience

    func processSnapshotDidUpdate(_ processes: [DetectedProcess])  // detect + reconcile
    func reconcile(activePIDs: Set<Int32>)                         // standalone exit handling
    func clearFinishedSessions()                                   // memory cleanup
}

struct DetectedProcess: Sendable, Equatable {
    let pid: Int32
    let command: String
    let cwd: URL?   // reserved for Phase 2, not used for matching
}
```

## Diff note

This branch is based on `feat/agent-models` (#1031), not `main`, because `AgentDetector` depends on `AgentType`/`AgentSession` from #948. **The diff currently shows 4 files** (2 from #1031 + 2 new). Once #1031 is merged to `main`, GitHub will auto-shrink this PR to show only the 2 new files (`AgentDetector.swift` + `AgentDetectorTests.swift`).

## Tests — 25 tests, all green

| Coverage area | Tests |
|---|---|
| Detects all known agents (claude, codex, aider, pi) | 4 |
| Copilot dual CLI names | 1 |
| Full-path resolution | 2 |
| No false positives (shell commands, agent-adjacent names, empty) | 3 |
| Idempotency (same snapshot, multiple agents) | 2 |
| Lifecycle (start→done, partial exit, standalone reconcile) | 4 |
| Pid reuse creates new session | 1 |
| Mixed snapshot (agents + non-agents) | 1 |
| `clearFinishedSessions` | 1 |
| `activeSessions` computed property | 1 |
| `extractExecutableName` helper | 4 |
| Sequential accumulate + reconcile | 1 |

## Follow-up notes

- **Milestone:** #950 has `milestone: null` (same as #948/#951/#952). All Phase 1 issues should be assigned to a milestone per AGENTS.md convention.
- **`AgentType` is not `Hashable`** — prevented using `Set<AgentType>` in tests. Consider adding `Hashable` conformance in a future PR if Set/Dictionary usage is needed.

Closes #950.