### PR TITLE
fix: checkout main in screenshots workflow to avoid detached HEAD

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -18,6 +18,12 @@ jobs:
     runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Checkout main (not the release tag) so the Commit screenshots
+          # step can push back to main. Without this, release-published
+          # runs land in detached HEAD on the tag and `git push` fails with
+          # "You are not currently on a branch." (issue #1030)
+          ref: main
 
       - name: Run screenshot tests and extract
         # The script soft-fails xcodebuild but hard-fails if extraction


### PR DESCRIPTION
## Summary

The screenshots pipeline (issue #1030) failed at the `Commit screenshots` step, not at PNG generation. The release-published run checked out the release **tag**, landing the repo in **detached HEAD**:

```
[detached HEAD 03f9157] chore: update screenshots
fatal: You are not currently on a branch.
```

`git commit` succeeded, but `git push` cannot push from detached HEAD, so the workflow exited 128 and no screenshots landed in `assets/`.

## Fix

Pass `ref: main` to `actions/checkout` so the repo is always on `main` (HEAD attached to `refs/heads/main`) and the commit-push step can push back to `main`.

This is correct for the release trigger: the tag is produced by Release Please from a merge to `main`, so the tag's tree matches `HEAD` of `main` at publish time. Marketing screenshots in `assets/` are meant to reflect current `main` anyway.

## Validation

- YAML syntax validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`).
- The actual screenshots pipeline is CI-only (runs on `macos-26`); cannot be run locally. Re-trigger via **Actions → Update Screenshots → Run workflow** after merge, or on the next release.

## Not tested

- End-to-end workflow run (CI-only).
- Whether the next `release: published` run will succeed — needs a real release tag to fire that trigger; a `workflow_dispatch` re-run exercises the same code path and is the recommended verification.

Fixes #1030