### PR TITLE
fix(sidebar): new files in expanded folders don't appear until collapse/expand

### DIFF
--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -173,16 +173,17 @@ struct SidebarView: View {
                     ScrollView {
                         VStack(alignment: .leading, spacing: 0) {
                             SidebarFileTree(nodes: workspace.rootNodes, selection: $selectedFile)
+                                .id(workspace.rootNodesRevision)
                         }
                         .padding(.vertical, 4)
                     }
                     .accessibilityIdentifier("sidebar")
                     .environment(editState)
                     .environment(expansion)
-                    .onChange(of: workspace.rootNodes) { _, newNodes in
+                    .onChange(of: workspace.rootNodesRevision) { _, _ in
                         // Drop expanded entries for folders that disappeared
                         // (e.g. after delete) so the set stays bounded.
-                        expansion.prune(toMatch: newNodes)
+                        expansion.prune(toMatch: workspace.rootNodes)
                     }
                     .onKeyPress(.return) {
                         // Finder-style: Enter on a selected sidebar item starts inline rename.

--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -17,6 +17,16 @@ import SwiftUI
 final class WorkspaceManager {
     nonisolated private static let logger = Logger.fileTree
     var rootNodes: [FileNode] = []
+    /// Monotonically increasing counter bumped every time `rootNodes` is
+    /// assigned. Used by `SidebarView` as a SwiftUI `.id()` to force the
+    /// file tree to re-render after an external refresh (FSEvents).
+    ///
+    /// Without this, SwiftUI may not re-render expanded folders whose
+    /// `FileNode` identity (URL) is unchanged but whose children array has
+    /// been replaced with new instances — the nested `ForEach` keeps showing
+    /// stale children until the user manually collapses/expands the folder
+    /// (issue #1041).
+    private(set) var rootNodesRevision: Int = 0
     var projectName: String = "Pine"
     var rootURL: URL?
     /// True while the initial directory load is in progress (shallow or full phase).
@@ -77,6 +87,16 @@ final class WorkspaceManager {
     /// cheap enough that the duplicate cost of an echoed event is invisible
     /// to users.
     static let watcherDebounce: TimeInterval = UITimings.Debounce.fileWatcher
+
+    /// Sets `rootNodes`, bumps `rootNodesRevision`, and schedules a debounced
+    /// `onRootNodesChanged` notification. Centralised so every assignment site
+    /// (initial load, shallow refresh, full refresh) gets the revision bump
+    /// that drives the sidebar re-render fix (#1041).
+    private func setRootNodes(_ nodes: [FileNode]) {
+        rootNodes = nodes
+        rootNodesRevision += 1
+        notifyRootNodesChanged()
+    }
 
     /// Schedules a debounced `onRootNodesChanged` notification.
     /// Cancels any pending notification so rapid updates coalesce into one.
@@ -255,8 +275,7 @@ final class WorkspaceManager {
                     if let progressID { self?.progressTracker?.endOperation(progressID) }
                     return
                 }
-                self.rootNodes = shallowChildren
-                self.notifyRootNodesChanged()
+                self.setRootNodes(shallowChildren)
                 self.gitProvider.repositoryURL = gitInfo.repositoryURL
                 self.gitProvider.gitRootPath = gitInfo.gitRootPath
                 // Atomically apply git state in a single equality-checked
@@ -299,8 +318,7 @@ final class WorkspaceManager {
                     if let progressID { self?.progressTracker?.endOperation(progressID) }
                     return
                 }
-                self.rootNodes = fullChildren
-                self.notifyRootNodesChanged()
+                self.setRootNodes(fullChildren)
                 self.isLoading = false
                 self.resumeLoadingContinuations()
                 if let progressID { self.progressTracker?.endOperation(progressID) }
@@ -438,8 +456,7 @@ final class WorkspaceManager {
             ignoredPaths: ignoredPaths,
             maxDepth: Self.shallowDepth
         )
-        rootNodes = shallowResult.root.children ?? []
-        notifyRootNodesChanged()
+        setRootNodes(shallowResult.root.children ?? [])
 
         // Phase 2 (async): full tree (if depth-limited) + git status refresh,
         // off the main thread. Reuses the shared two-phase loader so race

--- a/PineTests/SidebarExpandedRefreshTests.swift
+++ b/PineTests/SidebarExpandedRefreshTests.swift
@@ -1,0 +1,249 @@
+//
+//  SidebarExpandedRefreshTests.swift
+//  PineTests
+//
+//  Regression tests for issue #1041: new files in expanded folders don't
+//  appear until the user manually collapses/expands. The fix adds a
+//  `rootNodesRevision` counter that bumps on every `rootNodes` assignment,
+//  enabling SidebarView to force a SwiftUI re-render via `.id()`.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Sidebar Expanded Folder Refresh — Issue #1041")
+struct SidebarExpandedRefreshTests {
+
+    private func makeTempDirectory() throws -> URL {
+        let rawDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-sidebar-refresh-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: rawDir, withIntermediateDirectories: true)
+        guard let resolved = realpath(rawDir.path, nil) else { throw CocoaError(.fileNoSuchFile) }
+        defer { free(resolved) }
+        return URL(fileURLWithPath: String(cString: resolved))
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    // MARK: - rootNodesRevision increments on refresh
+
+    @Test("rootNodesRevision starts at zero")
+    @MainActor
+    func revisionStartsAtZero() {
+        let manager = WorkspaceManager()
+        #expect(manager.rootNodesRevision == 0)
+    }
+
+    @Test("rootNodesRevision increments after loadDirectory")
+    @MainActor
+    func revisionIncrementsAfterLoad() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        let manager = WorkspaceManager()
+        manager.loadDirectory(url: dir)
+
+        // Wait for the async load to set rootNodes (and bump revision).
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(50))
+            if manager.rootNodesRevision > 0 { break }
+        }
+
+        #expect(manager.rootNodesRevision > 0, "rootNodesRevision should increment after loadDirectory")
+    }
+
+    @Test("rootNodesRevision increments after refreshFileTreeAsync")
+    @MainActor
+    func revisionIncrementsAfterAsyncRefresh() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        let manager = WorkspaceManager()
+        manager.loadDirectory(url: dir)
+
+        // Wait for initial load
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(50))
+            if manager.rootNodesRevision > 0 { break }
+        }
+
+        let revisionBeforeRefresh = manager.rootNodesRevision
+
+        // Simulate an external FSEvents-triggered refresh
+        manager.refreshFileTreeAsync()
+
+        // Wait for the async refresh to complete
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(50))
+            if manager.rootNodesRevision > revisionBeforeRefresh { break }
+        }
+
+        #expect(
+            manager.rootNodesRevision > revisionBeforeRefresh,
+            "rootNodesRevision should increment after refreshFileTreeAsync"
+        )
+    }
+
+    // MARK: - New files appear in rootNodes after external refresh
+
+    @Test("New file in subfolder appears in rootNodes children after refreshFileTreeAsync")
+    @MainActor
+    func newFileInSubfolderAppearsAfterAsyncRefresh() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        // Create initial structure: project/src/existing.swift
+        let srcDir = dir.appendingPathComponent("src")
+        try FileManager.default.createDirectory(at: srcDir, withIntermediateDirectories: true)
+        try "existing".write(
+            to: srcDir.appendingPathComponent("existing.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let manager = WorkspaceManager()
+        manager.loadDirectory(url: dir)
+
+        // Wait for initial load to complete
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(50))
+            if !manager.rootNodes.isEmpty { break }
+        }
+
+        // Verify src/ is loaded with existing.swift
+        let srcNode = manager.rootNodes.first { $0.name == "src" }
+        #expect(srcNode != nil, "src directory should be in rootNodes")
+        let initialChildren = srcNode?.children ?? []
+        #expect(initialChildren.contains { $0.name == "existing.swift" })
+
+        // Simulate external change: agent creates a new file in src/
+        try "new content".write(
+            to: srcDir.appendingPathComponent("new_agent_file.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Trigger the same path the FileSystemWatcher would take
+        manager.refreshFileTreeAsync()
+
+        // Wait for the async refresh to complete and pick up the new file
+        for _ in 0..<200 {
+            try await Task.sleep(for: .milliseconds(25))
+            let src = manager.rootNodes.first { $0.name == "src" }
+            if let children = src?.children,
+               children.contains(where: { $0.name == "new_agent_file.swift" }) {
+                break
+            }
+        }
+
+        // Verify the new file appears in src/'s children
+        let refreshedSrcNode = manager.rootNodes.first { $0.name == "src" }
+        let refreshedChildren = refreshedSrcNode?.children ?? []
+        #expect(
+            refreshedChildren.contains { $0.name == "new_agent_file.swift" },
+            "New file created in expanded subfolder should appear in rootNodes children after refresh"
+        )
+        #expect(
+            refreshedChildren.contains { $0.name == "existing.swift" },
+            "Existing file should still be present after refresh"
+        )
+    }
+
+    @Test("New file in deeply nested folder appears after refreshFileTreeAsync")
+    @MainActor
+    func newFileInDeepFolderAppearsAfterAsyncRefresh() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        // Create: project/a/b/c/file.swift (depth 3, within shallowDepth=3)
+        let deepDir = dir
+            .appendingPathComponent("a")
+            .appendingPathComponent("b")
+            .appendingPathComponent("c")
+        try FileManager.default.createDirectory(at: deepDir, withIntermediateDirectories: true)
+        try "original".write(
+            to: deepDir.appendingPathComponent("original.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let manager = WorkspaceManager()
+        manager.loadDirectory(url: dir)
+
+        // Wait for initial load
+        for _ in 0..<100 {
+            try await Task.sleep(for: .milliseconds(50))
+            if !manager.rootNodes.isEmpty { break }
+        }
+
+        // Simulate agent creating a new file deep in the tree
+        try "agent output".write(
+            to: deepDir.appendingPathComponent("agent_new.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        manager.refreshFileTreeAsync()
+
+        // Wait for refresh and navigate the tree to find the new file
+        for _ in 0..<200 {
+            try await Task.sleep(for: .milliseconds(25))
+            let aNode = manager.rootNodes.first { $0.name == "a" }
+            let bNode = aNode?.children?.first { $0.name == "b" }
+            let cNode = bNode?.children?.first { $0.name == "c" }
+            if let cChildren = cNode?.children,
+               cChildren.contains(where: { $0.name == "agent_new.swift" }) {
+                break
+            }
+        }
+
+        // Navigate to verify
+        let aNode = manager.rootNodes.first { $0.name == "a" }
+        let bNode = aNode?.children?.first { $0.name == "b" }
+        let cNode = bNode?.children?.first { $0.name == "c" }
+        let cChildren = cNode?.children ?? []
+        #expect(
+            cChildren.contains { $0.name == "agent_new.swift" },
+            "New file in deeply nested folder should appear after refresh"
+        )
+    }
+
+    @Test("rootNodesRevision increments for each phase (shallow + full)")
+    @MainActor
+    func revisionIncrementsForEachPhase() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        // Create a deep structure that triggers Phase 2 (full load)
+        let deepDir = dir
+            .appendingPathComponent("a")
+            .appendingPathComponent("b")
+            .appendingPathComponent("c")
+            .appendingPathComponent("d")
+            .appendingPathComponent("e")
+        try FileManager.default.createDirectory(at: deepDir, withIntermediateDirectories: true)
+        try "deep".write(to: deepDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+
+        let manager = WorkspaceManager()
+        manager.loadDirectory(url: dir)
+
+        // Wait for both phases to complete
+        for _ in 0..<200 {
+            try await Task.sleep(for: .milliseconds(50))
+            if !manager.isLoading && manager.rootNodesRevision >= 2 { break }
+        }
+
+        // For a deep project: Phase 1 (shallow) sets rootNodes (revision=1),
+        // Phase 2 (full) sets rootNodes again (revision=2).
+        // Both phases increment the revision, ensuring the sidebar re-renders
+        // after each phase — the fix for issue #1041.
+        #expect(
+            manager.rootNodesRevision >= 2,
+            "Deep project should have at least 2 revision increments (shallow + full phases)"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

New files created by AI agents (or any external process) in **expanded** sidebar folders did not appear until the user manually collapsed and re-expanded the folder. This is a core pain point for the maintainer's agent-driven workflow (#933).

Closes #1041.

## Root cause

`FileNode` is a `nonisolated final class` — intentionally NOT `@Observable`. Two SwiftUI issues combine:

1. **`FileNode: Equatable`** uses `id == url` (URL-based equality). When a file is created in a subfolder, the top-level `rootNodes` array elements have the same URLs. So `[FileNode].==` returns `true`, and `onChange(of: workspace.rootNodes)` does **not** fire.

2. **`FileNode: Identifiable`** uses `id == url`. SwiftUI's `ForEach` considers folders with the same URL as the same view. While `@Observable` does fire on `set`, the view diffing for reference-type items with URL-based identity can fail to propagate updates to nested `ForEach` views that render expanded folder children.

## Fix

Add a `rootNodesRevision: Int` counter to `WorkspaceManager` that increments every time `rootNodes` is set (via a centralised `setRootNodes(_:)` method). 

- **`SidebarView`**: use `.id(workspace.rootNodesRevision)` on `SidebarFileTree` to force SwiftUI to recreate the tree views on every refresh
- **`SidebarView`**: switch `onChange` from `rootNodes` (URL-equality, unreliable) to `rootNodesRevision` (Int, always changes) so `prune()` runs on every refresh

## Changes

| File | Change |
|------|--------|
| `Pine/WorkspaceManager.swift` | +`rootNodesRevision` counter, +`setRootNodes(_:)` centralised setter, 3 call sites updated |
| `Pine/SidebarView.swift` | `.id(rootNodesRevision)` on `SidebarFileTree`, `onChange` switched to `rootNodesRevision` |
| `PineTests/SidebarExpandedRefreshTests.swift` | 6 new regression tests |

## CI hang hypothesis (issue #1041 task)

**Verdict: NOT related.** The CI hang on PR #1031 was a `Unit Tests` job cancelled after 45 min (timeout from #1029). Tests using `waitForLoadingComplete()` all have `.timeLimit(.minutes(2))`. The hang is in a different test entirely (after WorkspaceManager tests, before the next suite). This fix does not address the CI hang.

## What is NOT changed

- `FileNode` internals (still not `@Observable` — intentional)
- `shallowDepth` (still 3)
- Debounce values (150ms file watcher)
- `project.pbxproj`

## Test results

```
✔ Suite "Sidebar Expanded Folder Refresh — Issue #1041" passed after 0.189 seconds.
✔ Suite "WorkspaceManager Tests" passed after 2.932 seconds.
✔ Suite "Sidebar Refresh Tests — Issue #439" passed after 2.339 seconds.
✔ Test run with 36 tests in 3 suites passed.
```

All 30 existing + 6 new tests pass. SwiftLint clean.

## Checklist
- [x] Conventional Commit (`fix(sidebar):`)
- [x] Minimal diff (3 files, +275/-8)
- [x] SwiftLint clean
- [x] Unit tests added and passing (6 new + 30 existing)
- [x] No `project.pbxproj` changes (PBXFileSystemSynchronizedRootGroup)
- [x] No lockfile changes
- [x] Ready to merge after CI green