### PR TITLE
refactor(panes): remove dead close-routing helpers from #1024

### DIFF
--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -355,18 +355,6 @@ extension ContentView {
 
 extension ContentView {
 
-    func closeOtherTabsWithConfirmation(keeping tabID: UUID) {
-        TabCloseHelper.closeOtherTabs(keeping: tabID, in: activeTabManager, gitProvider: workspace.gitProvider)
-    }
-
-    func closeTabsToTheRightWithConfirmation(of tabID: UUID) {
-        TabCloseHelper.closeTabsToTheRight(of: tabID, in: activeTabManager, gitProvider: workspace.gitProvider)
-    }
-
-    func closeAllTabsWithConfirmation() {
-        TabCloseHelper.closeAllTabs(in: activeTabManager, gitProvider: workspace.gitProvider)
-    }
-
     func closeTabWithConfirmation(_ tab: EditorTab) {
         TabCloseHelper.closeTab(tab, in: activeTabManager, gitProvider: workspace.gitProvider)
     }

--- a/PineTests/SplitPaneRoutingTests.swift
+++ b/PineTests/SplitPaneRoutingTests.swift
@@ -421,7 +421,7 @@ struct SplitPaneRoutingTests {
         #expect(firstTM.tabs.count == 1)
         #expect(secondTM.tabs.count == 1)
 
-        // Mirror ContentView.closeAllTabsWithConfirmation():
+        // Mirror the active-pane close-all contract (TabCloseHelper):
         //   TabCloseHelper.closeAllTabs(in: activeTabManager, gitProvider:)
         let provider = GitStatusProvider()
         TabCloseHelper.closeAllTabs(in: pm.activeTabManager, gitProvider: provider)


### PR DESCRIPTION
## Summary

Removes 3 dead functions from `Pine/ContentView+Helpers.swift` that were added in PR #1024 but never wired to any caller. The "Close Others / Close Right / Close All" functionality is fully provided by the per-pane `tabManager:` overloads in `PaneLeafView.swift` (used by the tab context menu), so no functionality is lost.

## What was removed

| Function | Why dead |
|----------|----------|
| `closeOtherTabsWithConfirmation(keeping:)` | 0 callers — context menu uses `PaneLeafView.closeOtherTabsWithConfirmation(keeping:tabManager:)` |
| `closeTabsToTheRightWithConfirmation(of:)` | 0 callers — context menu uses per-pane version |
| `closeAllTabsWithConfirmation()` | 0 callers — context menu uses per-pane version |

## What was kept

- `closeTabWithConfirmation(_:)` — **alive**, called from `ContentView.swift:243` via `onCloseTab` (File menu)
- All per-pane versions in `PaneLeafView.swift:417-436` — untouched
- `TabCloseHelper` static methods — shared implementation, untouched

## Proof of zero callers (grep before removal)

```bash
rg -n "closeOtherTabsWithConfirmation|closeTabsToTheRightWithConfirmation|closeAllTabsWithConfirmation" Pine/ PineTests/
# ContentView+Helpers.swift: 3 definitions (removed)
# PaneLeafView.swift: per-pane versions (kept — different signatures with tabManager: param)
# SplitPaneRoutingTests.swift: @Test display names + 1 comment (not call sites)
# PineApp.swift: 0 references
# ContentView.swift: 0 references (only closeTabWithConfirmation is called)
```

## Test comment update

One comment in `SplitPaneRoutingTests.swift:424` referenced the removed `ContentView.closeAllTabsWithConfirmation()` method. Updated to reference the `TabCloseHelper` contract directly to avoid a dangling code reference.

## Validation

- SwiftLint: clean on changed files
- `SplitPaneRoutingTests`: **24/24 passed** (covers close-all/other/right contracts via TabCloseHelper)
- Single-file typecheck: expected cross-file errors only (extension target)
- Full CI will run on this PR

## Files changed

```
Pine/ContentView+Helpers.swift        | 12 ------------
PineTests/SplitPaneRoutingTests.swift |  2 +-
2 files changed, 1 insertion(+), 13 deletions(-)
```

Closes #1044