### PR TITLE
fix(editor): break @State reentrancy in .onReceive handlers (#1051)

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -147,7 +147,13 @@ struct ContentView: View {
                 .environment(projectManager)
         }
         .onReceive(NotificationCenter.default.publisher(for: .showQuickOpen)) { _ in
-            isQuickOpenPresented = true
+            // Defer to break reentrancy (#1051): mutating @State
+            // synchronously from a menu→notification callstack collides with
+            // the button-action's exclusive access to SwiftUI storage →
+            // exclusivity abort.
+            DispatchQueue.main.async {
+                isQuickOpenPresented = true
+            }
         }
         .sheet(isPresented: $isSymbolNavigatorPresented) {
             SymbolNavigatorView(isPresented: $isSymbolNavigatorPresented)
@@ -155,7 +161,10 @@ struct ContentView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .showSymbolNavigator)) { _ in
             guard activeTabManager.activeTab != nil else { return }
-            isSymbolNavigatorPresented = true
+            // Defer to break reentrancy (#1051).
+            DispatchQueue.main.async {
+                isSymbolNavigatorPresented = true
+            }
         }
         .sheet(isPresented: $isBranchSwitcherPresented) {
             BranchSwitcherView(
@@ -171,18 +180,25 @@ struct ContentView: View {
                 isKeyWindow: controlActiveState == .key,
                 isGitRepository: workspace.gitProvider.isGitRepository
             ) else { return }
-            isBranchSwitcherPresented = true
+            // Defer to break reentrancy (#1051).
+            DispatchQueue.main.async {
+                isBranchSwitcherPresented = true
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .symbolNavigate)) { notification in
             guard let offset = notification.userInfo?["offset"] as? Int,
                   let tab = activeTabManager.activeTab else { return }
-            // Convert the symbol's UTF-16 offset to a 1-based line and route
-            // through `pendingGoToLine` on the active pane's TabManager so
-            // the focused `PaneLeafView` performs the actual navigation.
-            // The previous implementation wrote a `GoToRequest` into root
-            // `ContentView` state that no `PaneLeafView` ever consumed.
-            let line = Self.lineNumber(forOffset: offset, in: tab.content)
-            activeTabManager.pendingGoToLine = line
+            // Defer to break reentrancy (#1051): pendingGoToLine is an
+            // @Observable mutation on TabManager.
+            DispatchQueue.main.async {
+                // Convert the symbol's UTF-16 offset to a 1-based line and route
+                // through `pendingGoToLine` on the active pane's TabManager so
+                // the focused `PaneLeafView` performs the actual navigation.
+                // The previous implementation wrote a `GoToRequest` into root
+                // `ContentView` state that no `PaneLeafView` ever consumed.
+                let line = Self.lineNumber(forOffset: offset, in: tab.content)
+                activeTabManager.pendingGoToLine = line
+            }
         }
         .sheet(isPresented: $showGoToLine) {
             GoToLineView(
@@ -248,20 +264,32 @@ struct ContentView: View {
             onInlineDiffAction: { handleInlineDiffAction($0) }
         ))
         .onReceive(NotificationCenter.default.publisher(for: .toggleWordWrap)) { _ in
-            isWordWrapEnabled.toggle()
+            // Defer to break reentrancy (#1051): @AppStorage mutation from
+            // a menu→notification callstack (⌥Z).
+            DispatchQueue.main.async {
+                isWordWrapEnabled.toggle()
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .revealInSidebar)) { notification in
             guard let url = notification.userInfo?["url"] as? URL else { return }
-            if let node = findNode(url: url, in: workspace.rootNodes) {
-                selectedNode = node
-                columnVisibility = .all
+            // Defer to break reentrancy (#1051): mutating @State
+            // (selectedNode + columnVisibility).
+            DispatchQueue.main.async {
+                if let node = findNode(url: url, in: workspace.rootNodes) {
+                    selectedNode = node
+                    columnVisibility = .all
+                }
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .sendTextToTerminal)) { notification in
             guard controlActiveState == .key,
                   let text = notification.userInfo?["text"] as? String,
                   !text.isEmpty else { return }
-            sendTextToTerminal(text)
+            // Defer to break reentrancy (#1051): sendTextToTerminal mutates
+            // @Observable terminal state.
+            DispatchQueue.main.async {
+                sendTextToTerminal(text)
+            }
         }
     }
 

--- a/Pine/GitAndNotificationObserver.swift
+++ b/Pine/GitAndNotificationObserver.swift
@@ -74,26 +74,18 @@ struct GitAndNotificationObserver: ViewModifier {
                 onRefreshBlame()
             }
             .onReceive(NotificationCenter.default.publisher(for: .closeTab)) { _ in
-                guard controlActiveState == .key,
-                      let tab = activeTabManager.activeTab else { return }
-                onCloseTab(tab)
+                handleCloseTab()
             }
             .onReceive(NotificationCenter.default.publisher(for: .openFolder)) { _ in
                 guard controlActiveState == .key else { return }
                 onOpenNewProject()
             }
             .onReceive(NotificationCenter.default.publisher(for: .fileRenamed)) { notification in
-                guard let oldURL = notification.userInfo?["oldURL"] as? URL,
-                      let newURL = notification.userInfo?["newURL"] as? URL else { return }
-                // Route through ProjectManager so the rename is reflected in
-                // every pane (the same file can be open in multiple panes),
-                // not just the primary TabManager.
-                projectManager.handleFileRenamed(oldURL: oldURL, newURL: newURL)
-                projectManager.saveSession()
+                handleFileRenamed(notification)
             }
             .onReceive(NotificationCenter.default.publisher(for: .fileDeleted)) { notification in
                 guard let deletedURL = notification.userInfo?["url"] as? URL else { return }
-                onHandleFileDeletion(deletedURL)
+                handleFileDeleted(deletedURL)
             }
             .onChange(of: workspace.externalChangeToken) { _, _ in
                 // Issue #838: never gate the FSEvents path on focus. The
@@ -140,24 +132,13 @@ struct GitAndNotificationObserver: ViewModifier {
                 onHandleExternalChanges(result)
             }
             .onReceive(NotificationCenter.default.publisher(for: .showProjectSearch)) { _ in
-                withAnimation(PineAnimation.quick) {
-                    columnVisibility = .all
-                }
-                isSearchPresented = true
+                handleShowProjectSearch()
             }
             .onReceive(NotificationCenter.default.publisher(for: .goToLine)) { _ in
-                guard controlActiveState == .key,
-                      activeTabManager.activeTab != nil else { return }
-                showGoToLine = true
+                handleGoToLine()
             }
             .onReceive(NotificationCenter.default.publisher(for: .openFileAtLine)) { notification in
-                guard let url = notification.userInfo?["url"] as? URL,
-                      let line = notification.userInfo?["line"] as? Int else { return }
-                // Column is parsed and passed for future use; the current
-                // navigation infrastructure is line-based (issue #949).
-                // Open into the focused pane so terminal ⌘-click and search
-                // results land in the editor the user is looking at (#971).
-                activeTabManager.openTabAndGoToLine(url: url, line: line)
+                handleOpenFileAtLine(notification)
             }
             .onReceive(NotificationCenter.default.publisher(for: .navigateChange)) { notification in
                 guard controlActiveState == .key,
@@ -169,6 +150,82 @@ struct GitAndNotificationObserver: ViewModifier {
                       let action = notification.userInfo?["action"] as? InlineDiffAction else { return }
                 onInlineDiffAction(action)
             }
+    }
+
+    // MARK: - Notification handlers (deferred to break reentrancy, #1051)
+    //
+    // Each handler that mutates @Binding / @State / @Observable state wraps
+    // the mutation in `DispatchQueue.main.async { ... }`. A menu command
+    // posts the notification synchronously inside the `ButtonAction`
+    // callstack, which holds exclusive access to SwiftUI storage; mutating
+    // observable state from the `.onReceive` closure synchronously forces a
+    // re-evaluation that collides with that access and triggers
+    // `_swift_reportExclusivityConflict` → `abort()` (issue #1051).
+    //
+    // Deferring lets the button-action callstack unwind first; the mutation
+    // then runs on the next runloop with no overlap — same pattern as the
+    // `reportStateChange` fix in #1047, applied to the SwiftUI side.
+    //
+    // The handlers are extracted into named methods (rather than inline
+    // closures) so the `body` type-checker stays fast and so the defer
+    // contract is directly unit-testable without a live SwiftUI view.
+
+    func handleCloseTab() {
+        guard controlActiveState == .key,
+              let tab = activeTabManager.activeTab else { return }
+        DispatchQueue.main.async {
+            self.onCloseTab(tab)
+        }
+    }
+
+    func handleFileRenamed(_ notification: Notification) {
+        guard let oldURL = notification.userInfo?["oldURL"] as? URL,
+              let newURL = notification.userInfo?["newURL"] as? URL else { return }
+        DispatchQueue.main.async {
+            // Route through ProjectManager so the rename is reflected in
+            // every pane (the same file can be open in multiple panes),
+            // not just the primary TabManager.
+            self.projectManager.handleFileRenamed(oldURL: oldURL, newURL: newURL)
+            self.projectManager.saveSession()
+        }
+    }
+
+    func handleFileDeleted(_ deletedURL: URL) {
+        DispatchQueue.main.async {
+            self.onHandleFileDeletion(deletedURL)
+        }
+    }
+
+    func handleShowProjectSearch() {
+        // Prime suspect for the Cmd+Shift+F crash: mutates two pieces of
+        // state (columnVisibility @Binding + isSearchPresented @Binding)
+        // and wraps one in withAnimation, maximising synchronous re-render.
+        DispatchQueue.main.async {
+            withAnimation(PineAnimation.quick) {
+                self.columnVisibility = .all
+            }
+            self.isSearchPresented = true
+        }
+    }
+
+    func handleGoToLine() {
+        guard controlActiveState == .key,
+              activeTabManager.activeTab != nil else { return }
+        DispatchQueue.main.async {
+            self.showGoToLine = true
+        }
+    }
+
+    func handleOpenFileAtLine(_ notification: Notification) {
+        guard let url = notification.userInfo?["url"] as? URL,
+              let line = notification.userInfo?["line"] as? Int else { return }
+        DispatchQueue.main.async {
+            // Column is parsed and passed for future use; the current
+            // navigation infrastructure is line-based (issue #949).
+            // Open into the focused pane so terminal ⌘-click and search
+            // results land in the editor the user is looking at (#971).
+            self.activeTabManager.openTabAndGoToLine(url: url, line: line)
+        }
     }
 }
 

--- a/Pine/TerminalBarView.swift
+++ b/Pine/TerminalBarView.swift
@@ -137,7 +137,16 @@ struct TerminalSearchObserver: ViewModifier {
         content
             .onReceive(NotificationCenter.default.publisher(for: .findInTerminal)) { _ in
                 guard controlActiveState == .key else { return }
-                terminalState.isSearchVisible = true
+                // Defer to break reentrancy (#1051): `.findInTerminal` is posted
+                // synchronously from the Terminal menu ButtonAction callstack
+                // (PineAppMenuCommands.swift). Mutating the @Observable
+                // `terminalState.isSearchVisible` synchronously here would
+                // collide with the button-action's exclusive access to SwiftUI
+                // storage and trigger the exclusivity abort — same class of
+                // bug fixed across the other .onReceive handlers in this PR.
+                DispatchQueue.main.async {
+                    terminalState.isSearchVisible = true
+                }
             }
             .onChange(of: terminalState.terminalSearchQuery) { _, newQuery in
                 searchTask?.cancel()

--- a/PineTests/OnReceiveReentrancyTests.swift
+++ b/PineTests/OnReceiveReentrancyTests.swift
@@ -39,6 +39,7 @@
 
 import Testing
 import Foundation
+import SwiftUI
 @testable import Pine
 
 @MainActor
@@ -157,5 +158,102 @@ struct OnReceiveReentrancyTests {
 
         #expect(counter.count == 1,
                 "control handler (no defer) must record synchronously — proves the harness is sensitive to the contract")
+    }
+
+    // MARK: - Production-code coverage: real handler methods don't mutate synchronously (#1051)
+    //
+    // These tests exercise the ACTUAL handler methods added in this PR
+    // (handleShowProjectSearch, handleFileDeleted), not an abstract model —
+    // so removing `DispatchQueue.main.async` from them turns the test red.
+    // Both handlers are testable outside a view hierarchy because they touch
+    // only @Binding/callback parameters (not @Environment). The other
+    // handlers (handleCloseTab, handleGoToLine, handleOpenFileAtLine,
+    // handleFileRenamed) read @Environment (controlActiveState,
+    // projectManager) and are covered by the abstract contract tests above.
+
+    /// Records writes to a value through a `Binding`, so the test can assert
+    /// *when* a handler mutated state (synchronously vs next runloop).
+    private final class Box<T> {
+        var value: T
+        init(_ value: T) { self.value = value }
+    }
+
+    @Test("handleShowProjectSearch does not mutate bindings synchronously (#1051)")
+    func handleShowProjectSearchDeferred() async throws {
+        let visibilityBox = Box<NavigationSplitViewVisibility?>(nil)
+        let searchBox = Box<Bool>(false)
+        let columnVisibility = Binding<NavigationSplitViewVisibility>(
+            get: { visibilityBox.value ?? .detailOnly },
+            set: { visibilityBox.value = $0 }
+        )
+        let isSearchPresented = Binding<Bool>(
+            get: { searchBox.value },
+            set: { searchBox.value = $0 }
+        )
+
+        // Memberwise init omits @Environment properties (they are injected by
+        // SwiftUI, not passed at construction). These two handlers never read
+        // @Environment, so the uninitialized environment values are unused.
+        let observer = GitAndNotificationObserver(
+            lineDiffs: .constant([]),
+            columnVisibility: columnVisibility,
+            isSearchPresented: isSearchPresented,
+            showGoToLine: .constant(false),
+            onRefreshLineDiffs: { },
+            onRefreshBlame: { },
+            onCloseTab: { _ in },
+            onOpenNewProject: { },
+            onHandleFileDeletion: { _ in },
+            onHandleExternalChanges: { _ in },
+            onNavigateToChange: { _ in },
+            onInlineDiffAction: { _ in }
+        )
+
+        // Invoke the real production handler — as `.onReceive` would.
+        observer.handleShowProjectSearch()
+
+        // Contract: NO synchronous mutation.
+        #expect(searchBox.value == false,
+                "handleShowProjectSearch must not set isSearchPresented synchronously (#1051)")
+        #expect(visibilityBox.value == nil,
+                "handleShowProjectSearch must not set columnVisibility synchronously (#1051)")
+
+        // Drain: both mutations must land on the next runloop.
+        try await drainRunloop()
+        #expect(searchBox.value == true,
+                "handleShowProjectSearch must set isSearchPresented on the next runloop")
+        #expect(visibilityBox.value == .all,
+                "handleShowProjectSearch must set columnVisibility to .all on the next runloop")
+    }
+
+    @Test("handleFileDeleted does not invoke callback synchronously (#1051)")
+    func handleFileDeletedDeferred() async throws {
+        let callBox = Box<Int>(0)
+        let deletedURL = URL(fileURLWithPath: "/tmp/pine-test-deleted.txt")
+
+        let observer = GitAndNotificationObserver(
+            lineDiffs: .constant([]),
+            columnVisibility: .constant(.all),
+            isSearchPresented: .constant(false),
+            showGoToLine: .constant(false),
+            onRefreshLineDiffs: { },
+            onRefreshBlame: { },
+            onCloseTab: { _ in },
+            onOpenNewProject: { },
+            onHandleFileDeletion: { _ in callBox.value += 1 },
+            onHandleExternalChanges: { _ in },
+            onNavigateToChange: { _ in },
+            onInlineDiffAction: { _ in }
+        )
+
+        observer.handleFileDeleted(deletedURL)
+
+        // Contract: callback must NOT fire synchronously.
+        #expect(callBox.value == 0,
+                "handleFileDeleted must not invoke onHandleFileDeletion synchronously (#1051)")
+
+        try await drainRunloop()
+        #expect(callBox.value == 1,
+                "handleFileDeleted must invoke onHandleFileDeletion on the next runloop")
     }
 }

--- a/PineTests/OnReceiveReentrancyTests.swift
+++ b/PineTests/OnReceiveReentrancyTests.swift
@@ -1,0 +1,161 @@
+//
+//  OnReceiveReentrancyTests.swift
+//  PineTests
+//
+//  Regression tests for issue #1051: Swift exclusivity abort on macOS 26.5.1
+//  caused by reentrant @State/@Observable mutation delivered synchronously
+//  from a SwiftUI `.onReceive(NotificationCenter...)` observer.
+//
+//  Root cause: menu commands post a NotificationCenter notification whose
+//  delivery runs the `.onReceive` closure synchronously *inside* the menu /
+//  `ButtonAction` callstack. When that closure mutates `@State` /
+//  `@Binding` / `@AppStorage` / `@Observable` state, SwiftUI is forced to
+//  re-evaluate a `body` while the outer callstack still holds exclusive
+//  access to the same SwiftUI storage → `_swift_reportExclusivityConflict`
+//  → `abort()`.
+//
+//  This is the SwiftUI-side twin of the AppKit-side bug fixed in #1032/#1047
+//  (where `reportStateChange` mutated `@Observable` fields from inside an
+//  AppKit text-storage / selection-notification callstack). #1047 closed
+//  the AppKit path; #1051 closes the SwiftUI `.onReceive` path.
+//
+//  Fix: every `.onReceive` handler that mutates observable state in
+//  `ContentView.swift` and `GitAndNotificationObserver.swift` now wraps the
+//  mutation in `DispatchQueue.main.async { ... }` via an extracted handler
+//  method (`handleCloseTab`, `handleShowProjectSearch`, `handleGoToLine`,
+//  `handleFileRenamed`, `handleFileDeleted`, `handleOpenFileAtLine` in
+//  GitAndNotificationObserver; inline-async in ContentView). Breaking the
+//  synchronous reentrancy lets the button-action callstack unwind first.
+//
+//  These tests pin the contract: the state mutation must NOT run
+//  synchronously when the notification handler is invoked, but MUST run on
+//  the next runloop. The contract is modelled directly because the real
+//  handlers mutate `@Environment`-injected state that cannot be
+//  instantiated outside a view hierarchy; the defer pattern itself
+//  (`DispatchQueue.main.async { mutation() }`) is exactly what each
+//  handler executes. A non-deferred control proves the harness is
+//  sensitive to the contract.
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+@MainActor
+struct OnReceiveReentrancyTests {
+
+    // MARK: - Harness
+
+    /// Mirrors the exact defer contract used by every `.onReceive` handler
+    /// fixed in #1051: the state mutation is wrapped in
+    /// `DispatchQueue.main.async { ... }`. `deferMutation` toggles the fix
+    /// so the same handler exercises both the contract path and the control
+    /// (pre-fix antipattern) path.
+    private struct NotificationHandler {
+        var deferMutation: Bool
+        var mutate: () -> Void
+
+        /// Called synchronously by a `.onReceive` closure — as
+        /// `NotificationCenter` delivery does inside the menu/button-action
+        /// callstack.
+        func handle() {
+            if deferMutation {
+                // The #1051 contract: defer so the mutation does not run
+                // synchronously inside the notification-delivery callstack.
+                DispatchQueue.main.async {
+                    self.mutate()
+                }
+            } else {
+                // Control: the pre-fix antipattern — mutate synchronously
+                // from the observer, colliding with the outer callstack's
+                // exclusive access → exclusivity abort.
+                mutate()
+            }
+        }
+    }
+
+    /// Drains the main runloop so deferred `DispatchQueue.main.async` blocks
+    /// fire. Mirrors the drain pattern in `StateChangeReentrancyTests`.
+    private func drainRunloop() async throws {
+        await Task.yield()
+        try await Task.sleep(for: .milliseconds(50))
+    }
+
+    // MARK: - Contract: a deferred handler mutation must NOT run synchronously (#1051)
+
+    /// Synchronous main-actor counter so the control test can observe
+    /// synchronous execution without the inherent async hop of `Task {}`
+    /// or an `actor`.
+    @MainActor
+    private final class Counter {
+        var count = 0
+    }
+
+    @Test("deferred notification-handler mutation does not fire synchronously (#1051)")
+    func deferredMutationNotSynchronous() async throws {
+        let counter = Counter()
+        let handler = NotificationHandler(deferMutation: true) {
+            counter.count += 1
+        }
+
+        // Simulate the `.onReceive` closure body invoking the handler
+        // synchronously (as NotificationCenter delivery does).
+        handler.handle()
+
+        // Contract: the mutation must NOT have run synchronously. If it did,
+        // that is the reentrancy that triggers the exclusivity abort and the
+        // fix has regressed.
+        // swiftlint:disable:next empty_count - Counter.count is a plain Int scalar, not a Collection; isEmpty is unavailable
+        #expect(counter.count == 0,
+                "deferred notification-handler mutation must not run synchronously from the notification-delivery callstack")
+
+        // Now drain the runloop: the deferred mutation must fire exactly once.
+        try await drainRunloop()
+        #expect(counter.count == 1,
+                "deferred notification-handler mutation must fire on the next runloop")
+    }
+
+    // MARK: - Each rapid invocation schedules its own deferred block
+
+    @Test("multiple rapid handler invocations each schedule their own deferred block (#1051)")
+    func multipleInvocationsDeliver() async throws {
+        let counter = Counter()
+        let handler = NotificationHandler(deferMutation: true) {
+            counter.count += 1
+        }
+
+        // Three synchronous invocations in the same runloop (as a user
+        // mashing the shortcut would produce). Each schedules an independent
+        // async block.
+        handler.handle()
+        handler.handle()
+        handler.handle()
+
+        // swiftlint:disable:next empty_count - plain Int scalar, not a Collection
+        #expect(counter.count == 0,
+                "no deferred mutation should run synchronously regardless of invocation count")
+
+        try await drainRunloop()
+        #expect(counter.count == 3,
+                "each handler invocation must schedule its own deferred mutation")
+    }
+
+    // MARK: - Control: without the defer, the mutation runs synchronously
+
+    @Test("non-deferred handler mutation fires synchronously (control for harness sensitivity)")
+    func nonDeferredMutationIsSynchronous() async throws {
+        let counter = Counter()
+        let handler = NotificationHandler(deferMutation: false) {
+            counter.count += 1
+        }
+
+        // The pre-fix antipattern: the control handler mutates synchronously.
+        // This test proves the harness CAN observe synchronous execution —
+        // so the "must be 0 synchronously" assertions above are meaningful
+        // and not vacuously true.
+        handler.handle()
+
+        #expect(counter.count == 1,
+                "control handler (no defer) must record synchronously — proves the harness is sensitive to the contract")
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1051.

Swift exclusivity abort (`SIGABRT` от `_swift_reportExclusivityConflict`) на **macOS 26.5.1** через **второй путь reentrancy**, который #1047 не покрыл. У мейнтейнера собрано **6 крашей** за 3 дня — баг стабильный и недооценённый (#1032 считал его воспроизводимым только на macOS 27 beta).

## Crash signature (build 89)

```
MenuItemCallback.menuAction → ButtonAction
→ Pine (menu command closure) → NotificationCenter.post
→ .onReceive observer (синхронно!)
→ синхронная мутация @State/@Observable → swift_beginAccess → 💥 exclusivity conflict
```

В стеке build 89 **нет** `NSTextStorage`/`setSelectedRanges`/`reportStateChange` — значит путь #1047 закрыт корректно, но остался SwiftUI-путь: меню → notification → `.onReceive` → синхронная мутация состояния.

## Fix

Тот же defer-паттерн, что в #1047, применённый к SwiftUI-стороне: каждый `.onReceive`-обработчик, мутирующий `@State`/`@Binding`/`@AppStorage`/`@Observable`, оборачивает мутацию в `DispatchQueue.main.async`. Button-action callstack завершается и освобождает эксклюзивный доступ, **затем** на следующем runloop мутируется состояние.

В `GitAndNotificationObserver` мутирующие обработчики вынесены в именованные методы — это и держит `body` type-checker быстрым (inline `DispatchQueue.main.async` в 6+ `.onReceive` перегружал type-inference: `compiler unable to type-check in reasonable time`), и делает defer-контракт unit-testable.

### Изменённые обработчики

**`GitAndNotificationObserver.swift`** (extracted в методы):
- `handleCloseTab` (.closeTab, Cmd+W)
- `handleFileRenamed` (.fileRenamed, FSEvents)
- `handleFileDeleted` (.fileDeleted, FSEvents)
- `handleShowProjectSearch` (.showProjectSearch, Cmd+Shift+F) — главный подозреваемый
- `handleGoToLine` (.goToLine, Cmd+L)
- `handleOpenFileAtLine` (.openFileAtLine, terminal ⌘-click)

**`ContentView.swift`** (inline async):
- `.showQuickOpen` (Cmd+P)
- `.showSymbolNavigator` (Cmd+R)
- `.showBranchSwitcher` (Cmd+Shift+B)
- `.symbolNavigate`
- `.toggleWordWrap` (⌥Z)
- `.revealInSidebar`
- `.sendTextToTerminal`

**Не тронуто** (уже безопасно): `navigateChange`/`inlineDiffAction` (мутации в `Task`), `refreshLineDiffs` (no-op stub), `openFolder` (модальная панель блокирует runloop).

## Verification

- ✅ `xcodebuild build` — BUILD SUCCEEDED
- ✅ `swiftlint` — 0 violations на изменённых файлах
- ✅ `PineTests/OnReceiveReentrancyTests` (3 теста, включая non-deferred control) — pass
- ✅ Смежные наборы: `StateChangeReentrancyTests`, `NotificationObserverScopingTests`, `SplitPaneRoutingTests`, `PaneLeafCloseTests`, `MultiPaneIntegrationTests` (63 теста) — pass

## Regression test

`PineTests/OnReceiveReentrancyTests.swift` — моделирует defer-контракт (`DispatchQueue.main.async { mutation() }`): мутация не выполняется синхронно, выполняется на следующем runloop; контрольный тест без defer доказывает чувствительность harness'а. Реальные handler-методы нельзя протестировать вне view-иерархии (они мутируют `@Environment`-injected состояние), поэтому тестируется сам паттерн — как `StateChangeReentrancyTests` тестирует Coordinator напрямую.

## Risks

- Презентация оверлеев (Quick Open, Go to Line, и т.п.) теперь на ~1 кадр (≈8 мс @120 Hz) позже — незаметно.
- `self.` capture в `DispatchQueue.main.async` внутри struct ViewModifier — value-type capture, без retain cycle.

## When ready to merge

CI зелёный + обзор. Не мерджить до проверки.
