### PR TITLE
chore(release): hide chore commits from changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,7 @@
         { "type": "refactor", "section": "Code Refactoring" },
         { "type": "docs", "section": "Documentation" },
         { "type": "test", "section": "Tests", "hidden": true },
-        { "type": "chore", "section": "Miscellaneous" }
+        { "type": "chore", "section": "Miscellaneous", "hidden": true }
       ]
     }
   }


### PR DESCRIPTION
## Summary

`chore` commits currently appear in user-facing release notes (e.g. `chore: update screenshots` landed in the 1.30.1 changelog via release-please PR #1050). Per Conventional Commits, `chore` is maintenance work that should not surface in release notes.

## Change

Added `"hidden": true` to the `chore` section in `release-please-config.json`:

```diff
- { "type": "chore", "section": "Miscellaneous" }
+ { "type": "chore", "section": "Miscellaneous", "hidden": true }
```

Matches the existing treatment of `test` commits.

## Effect

- Auto-generated artifacts (screenshot updates, .gitignore tweaks, CI workflow churn) no longer pollute the changelog.
- After this merges, release-please regenerates PR #1050 (1.30.1) automatically on the next push to `main`, dropping the screenshot line.
- Genuinely user-relevant maintenance (e.g. deployment-target bumps) should be filed as `feat!`/`fix`/`docs` rather than `chore` going forward.

## Verification

- JSON validates.
- Single-line diff, no behavior change to existing `feat`/`fix`/`perf`/`docs`/`refactor` sections.
