### PR TITLE
fix(editor): break menu-save reentrancy causing macOS exclusivity abort (#1058)

### DIFF
--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -88,12 +88,12 @@ struct PineAppMenuCommands: Commands {
         CommandGroup(replacing: .saveItem) {
             Button {
                 guard let pm = focusedProject else { return }
-                if pm.activeTabManager.saveActiveTab() {
-                    Task {
-                        await pm.workspace.gitProvider.refreshAsync()
-                        NotificationCenter.default.post(name: .refreshLineDiffs, object: nil)
-                    }
-                }
+                // Deferred via ProjectManager.saveActiveTabFromMenu() to break
+                // reentrancy (#XXXX): saveActiveTab mutates @Observable tab
+                // state synchronously when format-on-save changes content; doing
+                // that inside the ButtonAction callstack triggers an exclusivity
+                // abort on macOS 26.5.1.
+                pm.saveActiveTabFromMenu()
             } label: {
                 Label(Strings.menuSave, systemImage: MenuIcons.save)
             }
@@ -101,12 +101,8 @@ struct PineAppMenuCommands: Commands {
 
             Button {
                 guard let pm = focusedProject else { return }
-                if pm.saveAllPaneTabs() {
-                    Task {
-                        await pm.workspace.gitProvider.refreshAsync()
-                        NotificationCenter.default.post(name: .refreshLineDiffs, object: nil)
-                    }
-                }
+                // Same reentrancy rationale as Save (#XXXX).
+                pm.saveAllTabsFromMenu()
             } label: {
                 Label(Strings.menuSaveAll, systemImage: MenuIcons.saveAll)
             }
@@ -124,17 +120,24 @@ struct PineAppMenuCommands: Commands {
                     panel.directoryURL = dir
                 }
                 guard panel.runModal() == .OK, let url = panel.url else { return }
-                do {
-                    try pm.activeTabManager.saveActiveTabAs(to: url)
-                    Task {
-                        await pm.workspace.gitProvider.refreshAsync()
-                        NotificationCenter.default.post(name: .refreshLineDiffs, object: nil)
+                // Defer the save + refresh to break reentrancy (#XXXX):
+                // saveActiveTabAs mutates @Observable tab state synchronously
+                // when format-on-save changes content; doing that inside the
+                // ButtonAction callstack triggers an exclusivity abort on
+                // macOS 26.5.1. The panel stays synchronous (user interaction).
+                DispatchQueue.main.async {
+                    do {
+                        try pm.activeTabManager.saveActiveTabAs(to: url)
+                        Task {
+                            await pm.workspace.gitProvider.refreshAsync()
+                            NotificationCenter.default.post(name: .refreshLineDiffs, object: nil)
+                        }
+                    } catch {
+                        AlertTemplate.fileOperationErrorCritical.runModal(
+                            messageText: Strings.fileOperationErrorTitle,
+                            informativeText: error.localizedDescription
+                        )
                     }
-                } catch {
-                    AlertTemplate.fileOperationErrorCritical.runModal(
-                        messageText: Strings.fileOperationErrorTitle,
-                        informativeText: error.localizedDescription
-                    )
                 }
             } label: {
                 Label(Strings.menuSaveAs, systemImage: MenuIcons.saveAs)

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -89,7 +89,7 @@ struct PineAppMenuCommands: Commands {
             Button {
                 guard let pm = focusedProject else { return }
                 // Deferred via ProjectManager.saveActiveTabFromMenu() to break
-                // reentrancy (#XXXX): saveActiveTab mutates @Observable tab
+                // reentrancy (#1058): saveActiveTab mutates @Observable tab
                 // state synchronously when format-on-save changes content; doing
                 // that inside the ButtonAction callstack triggers an exclusivity
                 // abort on macOS 26.5.1.
@@ -101,7 +101,7 @@ struct PineAppMenuCommands: Commands {
 
             Button {
                 guard let pm = focusedProject else { return }
-                // Same reentrancy rationale as Save (#XXXX).
+                // Same reentrancy rationale as Save (#1058).
                 pm.saveAllTabsFromMenu()
             } label: {
                 Label(Strings.menuSaveAll, systemImage: MenuIcons.saveAll)
@@ -120,7 +120,7 @@ struct PineAppMenuCommands: Commands {
                     panel.directoryURL = dir
                 }
                 guard panel.runModal() == .OK, let url = panel.url else { return }
-                // Defer the save + refresh to break reentrancy (#XXXX):
+                // Defer the save + refresh to break reentrancy (#1058):
                 // saveActiveTabAs mutates @Observable tab state synchronously
                 // when format-on-save changes content; doing that inside the
                 // ButtonAction callstack triggers an exclusivity abort on

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -65,6 +65,48 @@ final class ProjectManager {
         return true
     }
 
+    // MARK: - Menu-triggered saves (reentrancy-safe)
+
+    /// Cmd+S from the File menu. Defers the save (and its synchronous
+    /// `@Observable` model mutation when format-on-save changes content) to
+    /// the next runloop so it does NOT execute inside the SwiftUI
+    /// `ButtonAction` callstack. That reentrancy forced a synchronous SwiftUI
+    /// body re-evaluation that collided with the button-action's exclusive
+    /// access and triggered `_swift_reportExclusivityConflict` → `abort()`
+    /// on macOS 26.5.1 when format-on-save reformatted the buffer (#XXXX).
+    ///
+    /// Autosave (`TabAutoSave`), close, and quit call
+    /// `activeTabManager.saveActiveTab()` directly — they are not invoked
+    /// from a `ButtonAction`, so there is no transactional exclusive access
+    /// to collide with and no deferral is needed.
+    ///
+    /// The disk write is deferred by ~1 runloop (imperceptible at 60 Hz);
+    /// the dirty indicator and git status settle one frame later.
+    func saveActiveTabFromMenu() {
+        performMenuSave { [weak self] in self?.activeTabManager.saveActiveTab() ?? false }
+    }
+
+    /// Cmd+Option+S (Save All) from the File menu. Same reentrancy rationale
+    /// as ``saveActiveTabFromMenu`` — Save All can also mutate `@Observable`
+    /// per-pane tab state synchronously when format-on-save changes content.
+    func saveAllTabsFromMenu() {
+        performMenuSave { [weak self] in self?.saveAllPaneTabs() ?? false }
+    }
+
+    /// Shared deferral for menu-triggered saves. Runs the save `operation`
+    /// on the next runloop (outside any `ButtonAction` callstack), then
+    /// refreshes git status + line diffs when it succeeded.
+    private func performMenuSave(_ operation: @escaping () -> Bool) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            guard operation() else { return }
+            Task {
+                await self.workspace.gitProvider.refreshAsync()
+                NotificationCenter.default.post(name: .refreshLineDiffs, object: nil)
+            }
+        }
+    }
+
     /// Checks every editor pane for externally modified or deleted files.
     /// Aggregates the per-pane results so global observers do not depend on
     /// the root environment's `TabManager`, which may be orphaned after pane

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -73,7 +73,7 @@ final class ProjectManager {
     /// `ButtonAction` callstack. That reentrancy forced a synchronous SwiftUI
     /// body re-evaluation that collided with the button-action's exclusive
     /// access and triggered `_swift_reportExclusivityConflict` → `abort()`
-    /// on macOS 26.5.1 when format-on-save reformatted the buffer (#XXXX).
+    /// on macOS 26.5.1 when format-on-save reformatted the buffer (#1058).
     ///
     /// Autosave (`TabAutoSave`), close, and quit call
     /// `activeTabManager.saveActiveTab()` directly — they are not invoked

--- a/PineTests/MenuSaveReentrancyTests.swift
+++ b/PineTests/MenuSaveReentrancyTests.swift
@@ -1,0 +1,183 @@
+//
+//  MenuSaveReentrancyTests.swift
+//  PineTests
+//
+//  Regression tests for the macOS 26 exclusivity abort (SIGABRT) triggered by
+//  the File menu Save / Save All / Save As commands when format-on-save (or
+//  any save transform: strip-trailing-whitespace, insert-final-newline)
+//  changes the buffer content.
+//
+//  Root cause: the menu command runs `activeTabManager.saveActiveTab()`
+//  synchronously inside the `ButtonAction` callstack. When format-on-save
+//  reformats the content, `TabPersistence.saveTabContent` mutates
+//  `@Observable TabManager.tabs` (`content`, `cachedHighlightResult`,
+//  `recomputeContentCaches()`) AND synchronously posts `.tabReloadedFromDisk`
+//  — all inside the button-action callstack. Mutating `@Observable` there
+//  forces a synchronous SwiftUI body re-evaluation that collides with the
+//  button-action's exclusive access to SwiftUI storage →
+//  `_swift_reportExclusivityConflict` → `abort()`.
+//
+//  Smart-list continuation is not itself the cause; it produces Markdown list
+//  markers / trailing whitespace that the save transforms (strip-whitespace /
+//  insert-final-newline / formatter) then modify, so `contentChanged == true`
+//  on save — which is what gates the synchronous mutation path.
+//
+//  This is the same class of bug as #1047 / #1051 / #1056 (fold observer) on
+//  the menu-save path. The fix defers the save (disk write + @Observable
+//  mutation + notification) to the next runloop via
+//  `ProjectManager.saveActiveTabFromMenu()` / `saveAllTabsFromMenu()`, so the
+//  button-action callstack unwinds first. Autosave / close / quit keep calling
+//  the synchronous `saveActiveTab()` directly — they are not invoked from a
+//  `ButtonAction`, so there is no transactional access to collide with.
+//
+//  These tests pin the contract via the observable side effect of the deferral:
+//  the file must NOT be rewritten synchronously when the menu-save method is
+//  invoked, but MUST be on the next runloop. Removing the
+//  `DispatchQueue.main.async` from `performMenuSave` turns the tests red —
+//  verified by regression injection.
+//
+
+import Testing
+import Foundation
+@testable import Pine
+
+@MainActor
+struct MenuSaveReentrancyTests {
+
+    // MARK: - Harness
+
+    private func makeTempFile(content: String, ext: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("menu-save-\(UUID().uuidString).\(ext)")
+        try content.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    private func readDisk(_ url: URL) -> String {
+        (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+    }
+
+    private func drainRunloop() async throws {
+        await Task.yield()
+        try await Task.sleep(for: .milliseconds(50))
+    }
+
+    // MARK: - saveActiveTabFromMenu defers the disk write (#XXXX)
+
+    @Test("saveActiveTabFromMenu does not rewrite the file synchronously when format-on-save changes content")
+    func saveActiveTabFromMenuNotSynchronous() async throws {
+        let pm = ProjectManager()
+        let settings = EditorSettings(defaults: makeIsolatedDefaults())
+        settings.formatOnSave = true
+        settings.insertFinalNewline = false
+        settings.stripTrailingWhitespace = false
+        pm.primaryTabManager.editorSettings = settings
+        pm.primaryTabManager.fileFormatters = .default
+
+        // Unformatted JSON — the pure-Swift JSONFileFormatter will pretty-print
+        // it on save, so `contentChanged == true` and the synchronous mutation
+        // path (the crash path) executes once the save actually runs.
+        let unformatted = "{\"a\":1,\"b\":2}"
+        let url = try makeTempFile(content: unformatted, ext: "json")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        pm.primaryTabManager.openTab(url: url)
+        let originalOnDisk = readDisk(url)
+
+        // Invoke the menu-save entry point — as the File menu ButtonAction does.
+        pm.saveActiveTabFromMenu()
+
+        // Contract #1 (the crash fix): the save must NOT have run
+        // synchronously. If it did, the @Observable mutation executed inside
+        // the (would-be) button-action callstack and the fix has regressed.
+        // We observe this via the file-on-disk side effect: format-on-save
+        // rewrites the file, so a synchronous save would have changed it.
+        #expect(readDisk(url) == originalOnDisk,
+                "saveActiveTabFromMenu must not perform the save synchronously (the reentrancy that triggers the exclusivity abort)")
+
+        // Contract #2: the deferred save must rewrite the file on the next
+        // runloop (format-on-save changed the content).
+        try await drainRunloop()
+        #expect(readDisk(url) != originalOnDisk,
+                "saveActiveTabFromMenu must perform the save on the next runloop")
+        #expect(readDisk(url).contains("\n"),
+                "deferred format-on-save must have pretty-printed the JSON")
+    }
+
+    // MARK: - saveAllTabsFromMenu defers too (#XXXX)
+
+    @Test("saveAllTabsFromMenu does not rewrite files synchronously")
+    func saveAllTabsFromMenuNotSynchronous() async throws {
+        let pm = ProjectManager()
+        let settings = EditorSettings(defaults: makeIsolatedDefaults())
+        settings.formatOnSave = true                  // changes content → contentChanged
+        settings.insertFinalNewline = false
+        settings.stripTrailingWhitespace = false
+        pm.primaryTabManager.editorSettings = settings
+        pm.primaryTabManager.fileFormatters = .default
+
+        let onDisk = "{\"a\":1}"
+        let url = try makeTempFile(content: onDisk, ext: "json")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        pm.primaryTabManager.openTab(url: url)
+        // saveAllTabs() only persists dirty tabs — set a different (still
+        // unformatted) content so the tab is dirty AND format-on-save will
+        // rewrite the file. saveActiveTab writes unconditionally; Save All
+        // does not, so the dirty setup is required here.
+        pm.primaryTabManager.updateContent("{\"a\":1,\"b\":2,\"c\":3}")
+        let originalOnDisk = readDisk(url)
+
+        pm.saveAllTabsFromMenu()
+
+        #expect(readDisk(url) == originalOnDisk,
+                "saveAllTabsFromMenu must not perform the save synchronously")
+
+        try await drainRunloop()
+        #expect(readDisk(url) != originalOnDisk,
+                "saveAllTabsFromMenu must perform the save on the next runloop")
+        #expect(readDisk(url).contains("\n"),
+                "deferred format-on-save must have pretty-printed the JSON")
+    }
+
+    // MARK: - Synchronous save path is unchanged for non-menu callers
+
+    @Test("direct saveActiveTab() (autosave/close/quit path) still saves synchronously")
+    func directSaveIsSynchronous() throws {
+        // Autosave, close, and quit call saveActiveTab() directly (NOT via the
+        // menu entry point). Those callers are not inside a ButtonAction, so
+        // there is no exclusivity conflict and the save MUST remain
+        // synchronous — otherwise autosave/close/quit semantics change. This
+        // test pins that the deferral lives ONLY in the menu entry points.
+        let pm = ProjectManager()
+        let settings = EditorSettings(defaults: makeIsolatedDefaults())
+        settings.formatOnSave = true
+        settings.insertFinalNewline = false
+        settings.stripTrailingWhitespace = false
+        pm.primaryTabManager.editorSettings = settings
+        pm.primaryTabManager.fileFormatters = .default
+
+        let unformatted = "{\"a\":1}"
+        let url = try makeTempFile(content: unformatted, ext: "json")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        pm.primaryTabManager.openTab(url: url)
+
+        // Direct synchronous call (the non-menu path) — must rewrite now.
+        _ = pm.activeTabManager.saveActiveTab()
+
+        #expect(readDisk(url) != unformatted,
+                "direct saveActiveTab() must save synchronously (menu-only deferral)")
+    }
+
+    // MARK: - Private helpers
+
+    private func makeIsolatedDefaults() -> UserDefaults {
+        let suiteName = "MenuSaveReentrancyTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            fatalError("Failed to create test UserDefaults suite")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/PineTests/MenuSaveReentrancyTests.swift
+++ b/PineTests/MenuSaveReentrancyTests.swift
@@ -62,7 +62,7 @@ struct MenuSaveReentrancyTests {
         try await Task.sleep(for: .milliseconds(50))
     }
 
-    // MARK: - saveActiveTabFromMenu defers the disk write (#XXXX)
+    // MARK: - saveActiveTabFromMenu defers the disk write (#1058)
 
     @Test("saveActiveTabFromMenu does not rewrite the file synchronously when format-on-save changes content")
     func saveActiveTabFromMenuNotSynchronous() async throws {
@@ -104,7 +104,7 @@ struct MenuSaveReentrancyTests {
                 "deferred format-on-save must have pretty-printed the JSON")
     }
 
-    // MARK: - saveAllTabsFromMenu defers too (#XXXX)
+    // MARK: - saveAllTabsFromMenu defers too (#1058)
 
     @Test("saveAllTabsFromMenu does not rewrite files synchronously")
     func saveAllTabsFromMenuNotSynchronous() async throws {
@@ -126,6 +126,11 @@ struct MenuSaveReentrancyTests {
         // rewrite the file. saveActiveTab writes unconditionally; Save All
         // does not, so the dirty setup is required here.
         pm.primaryTabManager.updateContent("{\"a\":1,\"b\":2,\"c\":3}")
+        // Explicit precondition: saveAllTabs only persists dirty tabs, so the
+        // deferred save is observable only when this holds. Asserting it here
+        // fails with a clear message if isDirty/updateContent semantics drift.
+        #expect(pm.primaryTabManager.activeTab?.isDirty == true,
+                "precondition: tab must be dirty for saveAllTabs to persist it")
         let originalOnDisk = readDisk(url)
 
         pm.saveAllTabsFromMenu()


### PR DESCRIPTION
Closes #1058.

## Summary

Swift exclusivity abort (`SIGABRT` via `_swift_reportExclusivityConflict`) на **macOS 26.5.1** при **Cmd+S / Cmd+Opt+S / Cmd+Shift+S** с включённым format-on-save (или любым save-transform) — **четвёртый путь** реентранси, не покрытый #1047 / #1051 / #1056 (fold).

Воспроизводится у мейнтейнера в связке format-on-save + «умное продолжение списков». Smart-list-continuation не причина — он создаёт Markdown-маркеры/трейлинг-whitespace, которые save-transform'ы меняют → `contentChanged == true` → синхронный путь мутации.

## Crash signature

```
ButtonAction (File → Save) → saveActiveTab()              // синхронно
→ saveTabContent → [contentChanged]:
    tabs[index].content = trimmed                         // мутация @Observable
    tabs[index].cachedHighlightResult = nil
    tabs[index].recomputeContentCaches()
    NotificationCenter.post(.tabReloadedFromDisk)         // синхронный пост
→ @Observable-уведомление → синхронный SwiftUI body re-eval
→ swift_beginAccess → 💥 exclusivity conflict → abort()
```

Блок `if contentChanged` — единственное, что отличает краш-случай от обычного сохранения. Без меняющих контент трансформаций блок пропускается → нет краша. Ровно механизм #1051, на пути сохранения.

## Fix

Defer на уровне menu-входов (как #1051 отложил handler'ы): save (диск + `@Observable`-мутация + нотификация + git-refresh) переносится на следующий runloop, чтобы callstack `ButtonAction` сначала освободил эксклюзивный доступ.

| Элемент | Изменение |
|---|---|
| `ProjectManager.saveActiveTabFromMenu()` / `saveAllTabsFromMenu()` + приватный `performMenuSave` | общий defer-вход для menu-save |
| Menu **Save** (Cmd+S) / **Save All** (Cmd+Opt+S) | вызывают новые методы |
| Menu **Save As** (Cmd+Shift+S) | оборачивает save+refresh в `DispatchQueue.main.async` (панель остаётся синхронной) |

Диск-запись откладывается на ~1 кадр (незаметно при 60 Hz). Dirty-индикатор и git-статус обновляются на кадр позже.

**Что НЕ меняется:** autosave (`TabAutoSave`), close, quit вызывают синхронный `saveActiveTab()` напрямую — они не из `ButtonAction`, конфликта нет. `trySaveTab` / `saveTabContent` не тронуты → format-on-save тесты остаются в силе.

## Testing

`MenuSaveReentrancyTests` (3 теста) пинят контракт через наблюдаемый side-effect (файл на диске):

- `saveActiveTabFromMenu does not rewrite the file synchronously` — файл не перезаписан синхронно, перезаписан на следующем runloop.
- `saveAllTabsFromMenu does not rewrite files synchronously` — то же для Save All.
- `direct saveActiveTab() (autosave/close/quit path) still saves synchronously` — пинит, что дефер живёт **только** в menu-входах (семантика autosave/close/quit не меняется).

**Регрессия проверена инъекцией:** удаление `DispatchQueue.main.async` из `performMenuSave` → оба дефер-теста красные (файл перезаписан синхронно), `directSaveIsSynchronous` остаётся зелёным.

### Чек-лист

- [x] `swiftlint` — 0 нарушений.
- [x] `MenuSaveReentrancyTests` — 3/3 ✔.
- [x] `FormatOnSaveHighlightTests` — 8/8 ✔ (`trySaveTab` не менялся).
- [x] `PineAppMenuCommandsTests`, `ProjectManagerSessionTests`, `TabManagerTests`, `FoldObserverReentrancyTests` — ✔.
- [x] Регрессия инъекцией — тесты краснеют без defer ✔.
- [ ] Полный CI (lint + build + unit + 7 UI-шардов) — на CI.

## Note

`StateChangeReentrancyTests` (#1047) при параллельном запуске 8 suite'ов иногда падает на 50ms-drain (pre-existing flakiness под нагрузкой); изолированно проходит ✔. Мой фикс его не трогает (`Coordinator.reportStateChange`).

## Files changed

- `Pine/ProjectManager.swift` — +41 (3 метода menu-save + `performMenuSave`).
- `Pine/PineAppMenuCommands.swift` — Save/SaveAll/SaveAs переведены на отложенный путь.
- `PineTests/MenuSaveReentrancyTests.swift` — новый файл, 3 теста.

## Risks / follow-up

- Диск-запись из меню отложена на ~1 кадр — незаметно, но теоретически за эти ~16ms второе действие может увидеть несохранённое состояние. На практике Cmd+S — терминальное действие пользователя.
- Это уже **четвёртый** путь того же класса (#1047/#1051/#1056/#1058). Стоит отдельным follow-up сделать аудит всех menu-`ButtonAction`, мутирующих `@Observable` синхронно, чтобы закрыть класс целиком, а не ловить по одному репорту.
