### PR TITLE
fix(agent): break MainActor-isolated timer handler causing crash on project open

### DIFF
--- a/Pine/Agent/AgentDetectionCoordinator.swift
+++ b/Pine/Agent/AgentDetectionCoordinator.swift
@@ -17,10 +17,9 @@ import Foundation
 /// Marked `nonisolated` (not `@MainActor`) because it owns a background
 /// `DispatchQueue` for polling. This matches the project's canonical pattern
 /// for background-queue owners — see `FileSystemWatcher`. The project-wide
-/// `-default-isolation=MainActor` flag means an unannotated class would be
-/// implicitly `@MainActor`, which is exactly the crash pattern forbidden by
-/// `check_nonisolated.py` (a `@MainActor` type that schedules work on a
-/// background queue is the bug from #613/#693).
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` build setting means an
+/// unannotated class would be implicitly `@MainActor`; a `@MainActor` type
+/// that owns a background dispatch queue is the crash pattern from #613/#693.
 ///
 /// The polling path (`captureSnapshot`) runs on `pollQueue`, parses `ps`
 /// output via the `nonisolated` `parsePsOutput`, then hops to main using a
@@ -30,6 +29,18 @@ import Foundation
 /// `@MainActor` closure never captures `self` (which is nonisolated and
 /// non-Sendable). The static `applySnapshot(_:detector:terminalManager:)`
 /// method is `@MainActor` and takes its dependencies as parameters.
+///
+/// **Timer handler isolation (release 1.31.1 crash fix):** the
+/// `DispatchSource` timer fires on `pollQueue` and invokes its handler
+/// closure directly — no actor hop. A closure literal inherits the isolation
+/// of its *enclosing* function, so a handler written inline inside the
+/// `@MainActor` `start()` is MainActor-isolated; running it off-main trips
+/// Swift's `swift_task_isCurrentExecutorWithFlagsImpl` check
+/// (`dispatch_assert_queue(main)`) and traps the process (the macOS 27 crash
+/// on project open in 1.31.1). The handler is therefore built in the
+/// `nonisolated` `makePollHandler()` so the closure is nonisolated. Note that
+/// `captureSnapshot` being `nonisolated` is NOT sufficient on its own — only
+/// the closure literal's own isolation matters at the dispatch boundary.
 nonisolated final class AgentDetectionCoordinator {
     let detector: AgentDetector
     weak var terminalManager: TerminalManager?
@@ -59,9 +70,26 @@ nonisolated final class AgentDetectionCoordinator {
         isRunning = true
         let timer = DispatchSource.makeTimerSource(queue: pollQueue)
         timer.schedule(deadline: .now() + pollInterval, repeating: pollInterval)
-        timer.setEventHandler { [weak self] in self?.captureSnapshot() }
+        // Build the handler via the nonisolated makePollHandler(): a closure
+        // literal written here (inside the @MainActor start()) would inherit
+        // MainActor isolation and trap when the source invokes it on
+        // pollQueue — see the class doc and the release 1.31.1 crash fix.
+        timer.setEventHandler(handler: makePollHandler())
         timer.resume()
         self.timer = timer
+    }
+
+    /// Builds the timer's event handler in a `nonisolated` function so the
+    /// returned closure is nonisolated. The `DispatchSource` timer invokes
+    /// this handler directly on `pollQueue` (no actor hop); a MainActor-
+    /// isolated handler would trip Swift's executor-isolation assertion
+    /// (`swift_task_isCurrentExecutorWithFlagsImpl` → `dispatch_assert_queue`)
+    /// and trap the process (release 1.31.1 crash). `captureSnapshot` is
+    /// itself `nonisolated`, so a nonisolated handler can call it directly.
+    /// Returns `() -> Void` (not `@Sendable`) so the closure may capture the
+    /// non-Sendable `self` without a strict-concurrency violation.
+    nonisolated private func makePollHandler() -> () -> Void {
+        { [weak self] in self?.captureSnapshot() }
     }
 
     @MainActor func stop() {
@@ -75,9 +103,12 @@ nonisolated final class AgentDetectionCoordinator {
     deinit { timer?.cancel() }
 
     /// Runs on `pollQueue`: captures the process list, parses it, then hops
-    /// to main to apply the snapshot. Stays `nonisolated` so the timer event
-    /// handler closure does not inherit MainActor isolation (which would
-    /// crash at runtime — see `check_nonisolated.py` / #693).
+    /// to main to apply the snapshot. `nonisolated` so the nonisolated timer
+    /// handler (`makePollHandler`) can call it directly off-main. A handler's
+    /// isolation is determined by where its closure literal is written, not
+    /// by this method's isolation — that is why the handler lives in
+    /// `makePollHandler`, not inline in `start()` (see the class doc and the
+    /// release 1.31.1 crash fix).
     ///
     /// Uses `DispatchWorkItem` + `MainActor.assumeIsolated` instead of
     /// `Task { @MainActor in }` to match the `FileSystemWatcher` pattern:

--- a/PineTests/AgentDetectionCoordinatorTests.swift
+++ b/PineTests/AgentDetectionCoordinatorTests.swift
@@ -86,6 +86,37 @@ struct AgentDetectionCoordinatorTests {
         coordinator.stop()
     }
 
+    @Test func start_pollsOffMainWithoutCrashing() async throws {
+        // Regression for the macOS 27 crash shipped in release 1.31.1: the
+        // timer's `setEventHandler` closure was written inline inside the
+        // `@MainActor` `start()`, so under `SWIFT_DEFAULT_ACTOR_ISOLATION =
+        // MainActor` the closure literal inherited MainActor isolation. The
+        // `DispatchSource` timer invokes its handler directly on `pollQueue`
+        // (no actor hop), so Swift's `swift_task_isCurrentExecutorWithFlagsImpl`
+        // check tripped `dispatch_assert_queue(main)` and trapped the process
+        // ~2s after the first terminal was created — i.e. right after opening
+        // a project. The handler is now built in the `nonisolated`
+        // `makePollHandler()` so the closure is nonisolated.
+        //
+        // `runSnapshotForTesting()` cannot catch this — it bypasses the
+        // dispatch queue entirely. This test lets the real timer fire several
+        // times on `pollQueue`: with the bug the process traps here (failing
+        // the whole suite); with the nonisolated handler it completes.
+        let detector = AgentDetector()
+        let runner: ProcessRunner = { _, _, _, _ in
+            ProcessRunResult(stdout: "100 claude", stderr: "", exitCode: 0, timedOut: false)
+        }
+        let coordinator = AgentDetectionCoordinator(
+            detector: detector, terminalManager: nil,
+            processRunner: runner, pollInterval: 0.05
+        )
+        coordinator.start()
+        // ~6 polls on pollQueue; the bug would kill the process in this window.
+        try await Task.sleep(for: .milliseconds(300))
+        coordinator.stop()
+        #expect(!coordinator.isRunning)
+    }
+
     @Test func sessionForPIDReturnsActiveSession() {
         let detector = AgentDetector()
         detector.processSnapshotDidUpdate([DetectedProcess(pid: 500, command: "claude")])

--- a/PineTests/AgentDetectionCoordinatorTests.swift
+++ b/PineTests/AgentDetectionCoordinatorTests.swift
@@ -102,9 +102,28 @@ struct AgentDetectionCoordinatorTests {
         // dispatch queue entirely. This test lets the real timer fire several
         // times on `pollQueue`: with the bug the process traps here (failing
         // the whole suite); with the nonisolated handler it completes.
+        //
+        // This is the SOLE automated guard for the timer-handler isolation
+        // class — the repo's `check_nonisolated.py` lint operates at type
+        // granularity and its queue patterns do not cover `DispatchSource` /
+        // `setEventHandler`, so it cannot see closure-literal isolation. Keep
+        // this test behavioral (assert the handler fired AND the snapshot
+        // reached the detector), not just "process survived".
+        //
+        // Reference-type box so the @Sendable mock runner can bump a counter
+        // without capturing a mutable local (strict concurrency forbids
+        // capturing `var` in @Sendable closures). Atomic via NSLock.
+        nonisolated final class FireCounter: @unchecked Sendable {
+            private let lock = NSLock()
+            private var value = 0
+            func increment() { lock.lock(); value += 1; lock.unlock() }
+            var count: Int { lock.lock(); defer { lock.unlock() }; return value }
+        }
         let detector = AgentDetector()
+        let fires = FireCounter()
         let runner: ProcessRunner = { _, _, _, _ in
-            ProcessRunResult(stdout: "100 claude", stderr: "", exitCode: 0, timedOut: false)
+            fires.increment()
+            return ProcessRunResult(stdout: "100 claude", stderr: "", exitCode: 0, timedOut: false)
         }
         let coordinator = AgentDetectionCoordinator(
             detector: detector, terminalManager: nil,
@@ -114,6 +133,17 @@ struct AgentDetectionCoordinatorTests {
         // ~6 polls on pollQueue; the bug would kill the process in this window.
         try await Task.sleep(for: .milliseconds(300))
         coordinator.stop()
+        // The timer handler actually fired on pollQueue (guards against a
+        // false pass under extreme CI load where no fire occurs).
+        #expect(fires.count >= 1)
+        // The snapshot reached the detector via the real dispatch path
+        // (pollQueue -> captureSnapshot -> DispatchQueue.main.async hop ->
+        // applySnapshot). The main hop drains while `Task.sleep` suspends the
+        // @MainActor test, so `detectedSessions` is populated by now. This is
+        // the assertion that proves end-to-end polling works — without it the
+        // test reduces to "the process didn't trap".
+        #expect(detector.detectedSessions.count >= 1)
+        #expect(detector.detectedSessions.first?.agentType == .claudeCode)
         #expect(!coordinator.isRunning)
     }
 


### PR DESCRIPTION
## Summary

Fixes the release 1.31.1 crash on project open (macOS 27): `EXC_BREAKPOINT (SIGTRAP)` on the `com.pine.agent-detection` queue ~2s after opening any project.

```
Thread ... Crashed::  Dispatch queue: com.pine.agent-detection
0  _dispatch_assert_queue_fail
1  dispatch_assert_queue$V2.cold.1
2  dispatch_assert_queue
3  _swift_task_checkIsolatedSwift
4  swift_task_isCurrentExecutorWithFlagsImpl(...)
   ... protocol witness table for DispatchMainExecutor
```

## Root cause

`AgentDetectionCoordinator.start()` is `@MainActor`. Under the project's `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, the inline `setEventHandler` closure literal **inherited MainActor isolation**:

```swift
// @MainActor func start()
timer.setEventHandler { [weak self] in self?.captureSnapshot() }  // ❌ MainActor-isolated
```

A `DispatchSource` timer invokes its handler **directly on `pollQueue` with no actor hop**, so Swift's runtime executor-isolation assertion (`dispatch_assert_queue(main)`) trapped the process ~2s after the first terminal was created — i.e. right after opening a project.

The pre-existing comment claiming "`captureSnapshot` being `nonisolated` prevents the closure from inheriting MainActor isolation" was wrong: a closure literal's isolation is determined by **where the literal is written**, not by the isolation of the method it calls.

Existing unit tests could not catch this because `runSnapshotForTesting()` bypasses the dispatch queue entirely.

## Fix

Build the timer handler in a new `nonisolated makePollHandler()` so the closure is nonisolated:

```swift
timer.setEventHandler(handler: makePollHandler())
...
nonisolated private func makePollHandler() -> () -> Void {
    { [weak self] in self?.captureSnapshot() }
}
```

The handler calls the already-nonisolated `captureSnapshot()` on `pollQueue`. The main-thread hop (`DispatchWorkItem` + `MainActor.assumeIsolated` via `DispatchQueue.main.async`) is unchanged.

The two other `setEventHandler` call sites (`ExternalFileFormatter.runRealProcess`, `GitCommand.run`) live inside `nonisolated` functions, so their closures are already nonisolated and are not affected.

## Regression test

`start_pollsOffMainWithoutCrashing` starts the real timer on `pollQueue` and lets it fire several times. With the bug the process traps inside the test; with the fix it completes.

## Verification

- ✅ `swiftlint` clean (0 violations)
- ✅ Isolated compile of the exact structure with `-default-isolation MainActor` succeeds
- ✅ Probe proves the handler is now nonisolated (cannot call a `@MainActor` func directly — would error)
- ⚠️ Full `xcodebuild test` could not run locally (Xcode-beta here is missing the Metal Toolchain that SwiftTerm requires); CI will cover it

## Notes

Distinct from the `#1047/#1051/#1056/#1058/#1066` reentrancy/exclusivity family — no `inout`, no `NotificationCenter`, no SwiftUI `@State`/`@Observable`. This is a closure-isolation-at-a-dispatch-boundary class.

**Not ready to merge until CI is fully green** (all checks must pass per branch protection).

 ---
- [x] Code follows project conventions (Conventional Commits, `nonisolated` pattern matches `FileSystemWatcher`)
- [x] Regression test included
- [ ] CI green (pending)
