### PR TITLE
fix(agent): detect interpreter-wrapped agent CLIs (node/python/bun/…)

### DIFF
--- a/Pine/Agent/AgentDetector.swift
+++ b/Pine/Agent/AgentDetector.swift
@@ -170,24 +170,65 @@ final class AgentDetector {
 
     /// Extracts the executable name from a `ps -o command=` string.
     ///
-    /// Handles three shapes:
+    /// Handles these shapes:
     /// - `claude` → `claude`
     /// - `/usr/local/bin/claude` → `claude`
     /// - `/usr/local/bin/claude --verbose` → `claude`
+    /// - `node /opt/homebrew/bin/pi` → `pi`  (interpreter-wrapper form)
+    /// - `node /usr/local/lib/.../claude.js` → `claude`  (script extension stripped)
     ///
-    /// Node-wrapper invocation (`node /path/to/claude.js`) resolves to
-    /// `node` and is therefore NOT detected by process-name matching in this
-    /// PR; that case is left to output-pattern matching (out of scope).
+    /// Many agent CLIs ship as script files launched through an interpreter
+    /// (`pi`, `claude`, `aider`, …). Homebrew's `pi`, for example, is a
+    /// `node` script, so `ps` reports it as `node /opt/homebrew/bin/pi`. The
+    /// bare first token (`node`) resolves to a generic name and would never
+    /// match. When the first token is a known interpreter, we therefore treat
+    /// the *second* token as the real CLI, resolving its basename and stripping
+    /// a common script extension. A second token that is not a known agent
+    /// (e.g. `server.js`) still resolves to `.generic` and is not tracked.
     static func extractExecutableName(from command: String) -> String {
         let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return "" }
 
-        let firstToken: String
-        if let spaceIndex = trimmed.firstIndex(of: " ") {
-            firstToken = String(trimmed[..<spaceIndex])
-        } else {
-            firstToken = trimmed
+        let tokens = trimmed.split(separator: " ", omittingEmptySubsequences: true)
+        guard let firstToken = tokens.first else { return "" }
+        let firstBase = (String(firstToken) as NSString).lastPathComponent
+
+        // Interpreter-wrapper form: `node /path/pi`, `python3 …/aider`, …
+        // The second token is the real CLI; resolve its basename and strip a
+        // common script extension so `claude.js` → `claude`.
+        if Self.interpreterWrappers.contains(firstBase.lowercased()), tokens.count >= 2 {
+            let scriptBase = (String(tokens[1]) as NSString).lastPathComponent
+            return Self.strippingScriptExtension(scriptBase)
         }
-        return (firstToken as NSString).lastPathComponent
+        return firstBase
+    }
+
+    /// Interpreter executable basenames that wrap a script CLI. When the first
+    /// token of a command is one of these, the second token holds the real CLI.
+    /// Lowercased; compared case-insensitively.
+    private static let interpreterWrappers: Set<String> = [
+        "node", "node.exe",
+        "python", "python3", "python3.exe",
+        "ruby", "ruby.exe",
+        "bun", "bun.exe",
+        "deno", "deno.exe",
+        "tsx", "tsx.exe",
+        "npx",
+    ]
+
+    /// Script-file extensions stripped from a wrapped script's basename so
+    /// `node …/claude.js` resolves to `claude`.
+    private static let scriptExtensions: Set<String> = [
+        "js", "mjs", "cjs", "ts", "mts", "cts",
+    ]
+
+    /// Returns `name` with a single trailing script extension removed (if any),
+    /// preserving the original casing of the stem.
+    private static func strippingScriptExtension(_ name: String) -> String {
+        let lower = name.lowercased()
+        for ext in scriptExtensions where lower.hasSuffix("." + ext) {
+            return String(name.dropLast(ext.count + 1))
+        }
+        return name
     }
 }

--- a/PineTests/AgentDetectorTests.swift
+++ b/PineTests/AgentDetectorTests.swift
@@ -85,6 +85,70 @@ struct AgentDetectorTests {
         #expect(detector.detectedSessions[0].agentType == .codex)
     }
 
+    // MARK: - Interpreter-wrapper resolution (node/python/… script CLIs)
+
+    @Test func detectsPiLaunchedViaNodeWrapper() {
+        // Homebrew `pi` is a node script: `ps` reports `node /opt/homebrew/bin/pi`.
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 250, command: "node /opt/homebrew/bin/pi"),
+        ])
+        #expect(detector.detectedSessions.count == 1)
+        #expect(detector.detectedSessions[0].agentType == .pi)
+    }
+
+    @Test func detectsAgentViaNodeWrapperWithArgs() {
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 251, command: "/opt/homebrew/opt/node/bin/node /opt/homebrew/bin/pi -p \"task\""),
+        ])
+        #expect(detector.detectedSessions.count == 1)
+        #expect(detector.detectedSessions[0].agentType == .pi)
+    }
+
+    @Test func detectsAgentViaNodeWrapperScriptExtension() {
+        // When an agent ships as a `<name>.js` script, the wrapper resolves
+        // to the agent's CLI name (extension stripped): `claude.js` → `claude`.
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 252, command: "node /usr/local/bin/claude.js"),
+        ])
+        #expect(detector.detectedSessions.count == 1)
+        #expect(detector.detectedSessions[0].agentType == .claudeCode)
+    }
+
+    @Test func doesNotResolveNestedScriptNamedAfterEntryPoint() {
+        // A script whose filename is NOT an agent CLI name (e.g. a generic
+        // `cli.js` buried under `node_modules/`) resolves to that filename and
+        // is not tracked — precise resolution of such paths is left to output-
+        // pattern matching (out of scope for process-name detection).
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 257, command: "node /usr/local/lib/node_modules/acme/cli.js"),
+        ])
+        #expect(detector.detectedSessions.isEmpty)
+    }
+
+    @Test func noFalsePositiveOnNodeScriptNotMatchingAgent() {
+        // `node server.js` → `server` → generic → not tracked (no false positive).
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 253, command: "node server.js"),
+            DetectedProcess(pid: 254, command: "python3 unrelated_script.py"),
+        ])
+        #expect(detector.detectedSessions.isEmpty)
+    }
+
+    @Test func interpreterAloneDoesNotMatch() {
+        // A bare interpreter with no second token resolves to itself (`node`),
+        // which is generic and must not be tracked.
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 255, command: "node"),
+        ])
+        #expect(detector.detectedSessions.isEmpty)
+    }
+
     // MARK: - No false positives
 
     @Test func noFalsePositivesOnShellCommands() {
@@ -315,6 +379,35 @@ struct AgentDetectorTests {
     @Test func extractExecutableNameFromEmpty() {
         #expect(AgentDetector.extractExecutableName(from: "") == "")
         #expect(AgentDetector.extractExecutableName(from: "   ") == "")
+    }
+
+    @Test func extractExecutableNameFromNodeWrapper() {
+        // Homebrew `pi` shape: `node /opt/homebrew/bin/pi` → `pi`.
+        #expect(AgentDetector.extractExecutableName(from: "node /opt/homebrew/bin/pi") == "pi")
+    }
+
+    @Test func extractExecutableNameFromNodeWrapperFullPathWithArgs() {
+        #expect(
+            AgentDetector.extractExecutableName(from: "/opt/homebrew/opt/node/bin/node /opt/homebrew/bin/pi -p task") == "pi"
+        )
+    }
+
+    @Test func extractExecutableNameFromNodeWrapperStripsScriptExtension() {
+        #expect(AgentDetector.extractExecutableName(from: "node /usr/local/lib/.../claude.js") == "claude")
+        #expect(AgentDetector.extractExecutableName(from: "bun /x/aider.ts") == "aider")
+    }
+
+    @Test func extractExecutableNameFromPythonWrapper() {
+        #expect(AgentDetector.extractExecutableName(from: "python3 /usr/local/bin/aider") == "aider")
+    }
+
+    @Test func extractExecutableNamePreservesStemCase() {
+        #expect(AgentDetector.extractExecutableName(from: "node /x/MyAgent.js") == "MyAgent")
+    }
+
+    @Test func extractExecutableNameBareInterpreter() {
+        // No second token → resolves to the interpreter itself.
+        #expect(AgentDetector.extractExecutableName(from: "node") == "node")
     }
 
     // MARK: - Multiple sequential updates

--- a/PineTests/AgentDetectorTests.swift
+++ b/PineTests/AgentDetectorTests.swift
@@ -122,6 +122,12 @@ struct AgentDetectorTests {
         // `cli.js` buried under `node_modules/`) resolves to that filename and
         // is not tracked — precise resolution of such paths is left to output-
         // pattern matching (out of scope for process-name detection).
+        //
+        // Pin both halves explicitly: the `.js` extension IS stripped (`cli.js` →
+        // `cli`), but `cli` is not a registered agent CLI name, so the entry is
+        // not tracked. A bare `.isEmpty` assertion would pass even if stripping
+        // silently regressed.
+        #expect(AgentDetector.extractExecutableName(from: "node /usr/local/lib/node_modules/acme/cli.js") == "cli")
         let detector = AgentDetector()
         detector.processSnapshotDidUpdate([
             DetectedProcess(pid: 257, command: "node /usr/local/lib/node_modules/acme/cli.js"),
@@ -147,6 +153,61 @@ struct AgentDetectorTests {
             DetectedProcess(pid: 255, command: "node"),
         ])
         #expect(detector.detectedSessions.isEmpty)
+    }
+
+    // MARK: - Interpreter-wrapper resolution — extended coverage
+
+    @Test func detectsAgentLaunchedViaNpx() {
+        // `npx` is in the interpreter-wrapper set: `npx <pkg>` resolves to the
+        // package name. `npx claude` → `claude` → `.claudeCode`.
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 260, command: "npx claude --verbose"),
+        ])
+        #expect(detector.detectedSessions.count == 1)
+        #expect(detector.detectedSessions[0].agentType == .claudeCode)
+    }
+
+    @Test func extractExecutableNameFromTsxWrapperStripsTsExtension() {
+        // `tsx` is in the wrapper set; the `.ts` extension is stripped.
+        #expect(AgentDetector.extractExecutableName(from: "tsx /opt/aider/aider.ts") == "aider")
+    }
+
+    @Test func extractExecutableNameFromExeInterpreterVariant() {
+        // The `*.exe` interpreter variants are declared for completeness; pin
+        // that the lowercased comparison resolves them like the bare form.
+        #expect(AgentDetector.extractExecutableName(from: "node.exe /opt/homebrew/bin/pi") == "pi")
+    }
+
+    @Test func extractExecutableNameCaseInsensitiveInterpreter() {
+        // The interpreter name is matched case-insensitively, while the resolved
+        // CLI stem preserves its original casing.
+        #expect(AgentDetector.extractExecutableName(from: "NODE /opt/homebrew/bin/pi") == "pi")
+        #expect(AgentDetector.extractExecutableName(from: "Python3 /usr/local/bin/aider") == "aider")
+    }
+
+    @Test func extractExecutableNameFromNodeWrapperMultipleSpaces() {
+        // `split(omittingEmptySubsequences:)` collapses internal runs of spaces
+        // so the wrapper still resolves with extra spacing in `ps` output.
+        #expect(AgentDetector.extractExecutableName(from: "node    /opt/homebrew/bin/pi") == "pi")
+    }
+
+    @Test func pythonWrapperDoesNotStripPyExtension() {
+        // Only JS/TS script extensions are stripped; a `.py`/`.rb` script is
+        // left as-is, so `aider.py` does not match the `aider` CLI name and is
+        // not tracked. (pip/npm install agents as plain executables without an
+        // extension, so this is the intended behavior.)
+        #expect(AgentDetector.extractExecutableName(from: "python3 /x/aider.py") == "aider.py")
+    }
+
+    @Test func idempotentWrapperFormDoesNotDuplicate() {
+        // A wrapper-form pid is deduplicated by pid just like a bare command.
+        let detector = AgentDetector()
+        let snapshot = [DetectedProcess(pid: 320, command: "node /opt/homebrew/bin/pi")]
+        detector.processSnapshotDidUpdate(snapshot)
+        detector.processSnapshotDidUpdate(snapshot)
+        #expect(detector.detectedSessions.count == 1)
+        #expect(detector.detectedSessions[0].agentType == .pi)
     }
 
     // MARK: - No false positives


### PR DESCRIPTION
## Summary

Pine failed to detect `pi` (and any node/python/bun-wrapped CLI) because `ps` reports these as `node /opt/homebrew/bin/pi`. The detector took the first token (`node`) → resolved to `.generic` → never matched. This silently broke the core Phase 2 features shipped in 1.32 (Agent Activity Panel, Agent History & Undo, `.pine/agent-log.json`) for the most common installation method of agent CLIs.

`AgentDetector.extractExecutableName` now recognises the interpreter-wrapper form: when the first token is a known interpreter, the **second** token is treated as the real CLI, with a common script extension stripped so `claude.js` → `claude`.

### Covered wrappers
`node` · `python`/`python3` · `ruby` · `bun` · `deno` · `tsx` · `npx`

### Examples
| `ps` command | resolves to | tracked? |
|---|---|---|
| `node /opt/homebrew/bin/pi` | `pi` | ✅ `.pi` |
| `/opt/homebrew/opt/node/bin/node /opt/homebrew/bin/pi -p task` | `pi` | ✅ `.pi` |
| `node /usr/local/bin/claude.js` | `claude` | ✅ `.claudeCode` |
| `python3 /usr/local/bin/aider` | `aider` | ✅ `.aider` |
| `bun /x/aider.ts` | `aider` | ✅ `.aider` |
| `node server.js` | `server` | ❌ generic — no false positive |
| `node` | `node` | ❌ generic — no false positive |

A second token that is not a known agent still resolves to `.generic` and is **not** tracked — no new false positives over the existing `node server.js` behaviour.

## Motivation

The user's own `pi` (Homebrew) is a node script. Without this fix, Agent History never writes `.pine/` for `pi` runs, and the Activity Panel / status-bar badge never light up. Found while validating release 1.32 (#1076).

Related: vision #933 Phase 2 (Visibility), #1072, #1073.

## Tests

`AgentDetectorTests.swift` — +12 tests:
- 5 end-to-end detection through the wrapper (pi, claude via `.js`, args, no-false-positive, bare interpreter)
- 7 unit tests on `extractExecutableName` (node/python wrapper, full-path-with-args, extension stripping, case preservation, bare interpreter)

All **42 AgentDetector + AgentDetectionCoordinator tests pass** locally. `swiftlint` clean.

```bash
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test \
  -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' \
  -only-testing:PineTests/AgentDetectorTests \
  -only-testing:PineTests/AgentDetectionCoordinatorTests
# ** TEST SUCCEEDED **
```

## Verification

Manual smoke test still TODO — run `pi` in Pine's terminal and confirm the Pi badge + `.pine/agent-log.json` appear after exit. Code is ready to merge once CI is green.

## Checklist

- [x] Conventional commit title (`fix(agent): …`)
- [x] Unit tests added (12 new, all passing)
- [x] `swiftlint` clean
- [x] No new false positives (`node server.js` etc. unchanged)
- [x] No unrelated files changed