### PR TITLE
ci: dedupe screenshots workflow — fixed branch, skip no-op runs

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -96,7 +96,7 @@ jobs:
           # main is accepted (GH013: "Repository rule violations found for
           # refs/heads/main"). The previous approach (checkout main → commit
           # → push) was rejected at push time (#1038). Instead we create a
-          # dated branch, commit there, and open a PR for manual merge.
+          # branch, commit there, and open a PR for manual merge.
           #
           # GH_TOKEN uses RELEASE_PLEASE_TOKEN (an existing PAT) when
           # available so that CI workflows actually trigger on the PR —
@@ -104,11 +104,34 @@ jobs:
           # downstream workflow runs (known GitHub limitation), which
           # would leave the PR without the required status checks and
           # block the merge.
+          #
+          # Dedupe (#1077): a FIXED branch name is used instead of a
+          # timestamped one. Before pushing, any pre-existing open PR on
+          # this branch is closed (and its branch deleted) so repeated
+          # workflow_dispatch / release triggers never pile up duplicate
+          # screenshot PRs. Combined with the git diff --staged --quiet
+          # guard above, a run with no meaningful pixel change opens no
+          # PR at all.
           # ------------------------------------------------------------------
-          BRANCH="chore/screenshots-update-$(date -u '+%Y-%m-%d-%H%M%S')"
-          git checkout -b "$BRANCH"
+          BRANCH="chore/screenshots-update"
+
+          # Close any pre-existing open PR on this branch and delete the
+          # stale remote branch so the force-push below is clean. `gh pr
+          # list` returns at most one number for a fixed head branch.
+          EXISTING_PRS=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')
+          if [ -n "$EXISTING_PRS" ]; then
+            for pr in $EXISTING_PRS; do
+              echo "Closing stale screenshot PR #$pr before re-running."
+              gh pr close "$pr" --delete-branch || true
+            done
+          fi
+
+          # Reset to a fresh branch off main and commit the staged changes.
+          git checkout -B "$BRANCH"
           git commit -m "chore: update screenshots"
-          git push -u origin "$BRANCH"
+          # Force-push: the branch name is fixed and any stale copy was
+          # already deleted above (or never existed).
+          git push --force -u origin "$BRANCH"
 
           gh pr create \
             --base main \


### PR DESCRIPTION
## Summary

The `Update Screenshots` workflow opens a **new timestamped branch + PR on every run**, so repeated triggers (manual re-runs, back-to-back releases) pile up duplicate `chore: update screenshots` PRs that compete for the same CI slots and age out behind the slow `macos-26` Unit Tests (#1060). Three such PRs (#1071, #1068, #1063) had to be closed manually as stale today.

## Changes

Implements issue #1077 option 1 (reuse a single long-lived branch):

- **Fixed branch name** `chore/screenshots-update` instead of `chore/screenshots-update-<timestamp>`.
- **Close any pre-existing open PR** on that branch and delete the stale remote branch (`gh pr close --delete-branch`) before pushing, so repeated `workflow_dispatch` / `release` triggers never produce more than one open screenshot PR at a time.
- **Force-push** the new commit onto the fixed branch and open a fresh PR.

## Acceptance criteria (#1077)

- [x] Repeated `workflow_dispatch` / `release` triggers no longer produce more than one open screenshot PR at a time.
- [x] A run that produces no meaningful pixel change does not open a PR (the existing `git diff --staged --quiet` guard already handles this).
- [x] `scripts/update-screenshots.sh` and the workflow still hard-fail when extraction produces no usable PNGs (existing safety check preserved — untouched).
- [x] One PR, squashed, conventional-commit title `ci: ...`.

Closes #1077.