### PR TITLE
feat(lsp): Phase 1 — Diagnostics (LSP client foundation) (#1010)

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -117,6 +117,11 @@ nonisolated enum AccessibilityID {
     static let progressIndicator = "progressIndicator"
     static let agentStatusBar = "agentStatusBar"
     static let agentStatusBarItem = "agentStatusBarItem"
+
+    // MARK: - LSP / Problems panel (#1010)
+    static let problemsIndicator = "problemsIndicator"
+    static let problemsPanel = "problemsPanel"
+    static let problemsEmptyState = "problemsEmptyState"
     static let agentStatusBarMenu = "agentStatusBarMenu"
 
     // MARK: - Agent Activity Panel (#1072)

--- a/Pine/LSP/DiagnosticsProvider.swift
+++ b/Pine/LSP/DiagnosticsProvider.swift
@@ -1,0 +1,171 @@
+//
+//  DiagnosticsProvider.swift
+//  Pine
+//
+//  Phase 1 of LSP support (issue #1010).
+//
+//  Maps LSP `Diagnostic` values into Pine's existing `ValidationDiagnostic`
+//  model so they flow through the same gutter-icon + popover machinery that
+//  config validators already use (#679 / #781). Also aggregates diagnostics
+//  across all open documents for the Problems panel.
+//
+
+import Foundation
+
+// MARK: - LSP position / range
+
+/// An LSP `Position` (0-based line and character).
+struct LSPPosition: Equatable, Sendable {
+    let line: Int
+    let character: Int
+
+    /// Initialises from the raw JSON dictionary of an LSP `Position`.
+    init?(json: Any) {
+        guard let dict = json as? [String: Any] else { return nil }
+        guard let line = dict["line"] as? Int,
+              let character = dict["character"] as? Int else { return nil }
+        self.line = line
+        self.character = character
+    }
+
+    init(line: Int, character: Int) {
+        self.line = line
+        self.character = character
+    }
+}
+
+/// An LSP `Range` (start and end positions, 0-based).
+struct LSPRange: Equatable, Sendable {
+    let start: LSPPosition
+    let end: LSPPosition
+
+    init?(json: Any) {
+        guard let dict = json as? [String: Any] else { return nil }
+        guard let start = LSPPosition(json: dict["start"] ?? [:]),
+              let end = LSPPosition(json: dict["end"] ?? [:]) else { return nil }
+        self.start = start
+        self.end = end
+    }
+
+    init(start: LSPPosition, end: LSPPosition) {
+        self.start = start
+        self.end = end
+    }
+}
+
+// MARK: - LSP severity
+
+/// The LSP `DiagnosticSeverity` enum (1-based per spec).
+enum LSPDiagnosticSeverity: Int, Sendable, Equatable {
+    case error = 1
+    case warning = 2
+    case information = 3
+    case hint = 4
+
+    /// Maps to Pine's existing validation severity, falling back to `.info`.
+    var validationSeverity: ValidationSeverity {
+        switch self {
+        case .error: return .error
+        case .warning: return .warning
+        case .information, .hint: return .info
+        }
+    }
+
+    /// Initialises from the raw JSON number value. `nil` if the value is
+    /// absent or out of range — servers may omit severity.
+    init?(raw: Any?) {
+        guard let value = raw as? Int,
+              let severity = LSPDiagnosticSeverity(rawValue: value) else { return nil }
+        self = severity
+    }
+}
+
+// MARK: - LSP Diagnostic
+
+/// A single LSP `Diagnostic`.
+struct LSPDiagnostic: Equatable, Sendable {
+    let range: LSPRange
+    let severity: LSPDiagnosticSeverity?
+    let code: String?
+    let source: String?
+    let message: String
+
+    /// Initialises from the raw JSON dictionary of an LSP `Diagnostic`.
+    /// Returns `nil` if required fields (`range`, `message`) are missing.
+    init?(json: Any) {
+        guard let dict = json as? [String: Any] else { return nil }
+        guard let range = LSPRange(json: dict["range"] ?? [:]) else { return nil }
+        guard let message = dict["message"] as? String else { return nil }
+        self.range = range
+        self.severity = LSPDiagnosticSeverity(raw: dict["severity"])
+        // `code` may be a string or a number.
+        if let codeStr = dict["code"] as? String {
+            self.code = codeStr
+        } else if let codeNum = dict["code"] as? Int {
+            self.code = String(codeNum)
+        } else {
+            self.code = nil
+        }
+        self.source = dict["source"] as? String
+        self.message = message
+    }
+}
+
+// MARK: - publishDiagnostics notification
+
+/// The `textDocument/publishDiagnostics` notification payload.
+struct LSPDiagnosticsNotification: Equatable, Sendable {
+    let uri: String
+    let diagnostics: [LSPDiagnostic]
+
+    /// Initialises from the raw `params` dictionary. Returns `nil` if the URI
+    /// is missing (diagnostics may be an empty array — that's valid and means
+    /// "no problems for this file").
+    init?(params: [String: Any]) {
+        guard let uri = params["uri"] as? String else { return nil }
+        self.uri = uri
+        let rawArray = (params["diagnostics"] as? [Any]) ?? []
+        self.diagnostics = rawArray.compactMap { LSPDiagnostic(json: $0) }
+    }
+
+    /// Convenience constructor for tests / fixtures.
+    init(uri: String, diagnostics: [LSPDiagnostic]) {
+        self.uri = uri
+        self.diagnostics = diagnostics
+    }
+}
+
+// MARK: - Diagnostic mapping
+
+/// Pure mapping from LSP diagnostics to Pine's `ValidationDiagnostic` model.
+///
+/// LSP positions are 0-based; Pine's gutter/validator model is 1-based for
+/// lines. Columns are preserved as-is (1-based from the user's perspective)
+/// since the existing `ValidationDiagnostic.column` is `Int?`.
+///
+/// `nonisolated` because the mapping is pure data work — no actor isolation
+/// needed, and it is invoked from background diagnostic callbacks.
+nonisolated enum DiagnosticMapper {
+
+    /// Converts a single LSP diagnostic into a Pine validation diagnostic.
+    /// The `source` falls back to `"lsp"` when the server omits it.
+    static func map(_ lsp: LSPDiagnostic, fallbackSource: String = "lsp") -> ValidationDiagnostic {
+        // LSP line is 0-based; Pine lines are 1-based.
+        let pineLine = lsp.range.start.line + 1
+        // LSP character is 0-based; Pine columns are 1-based. Clamp negatives defensively.
+        let pineColumn = max(0, lsp.range.start.character) + 1
+        return ValidationDiagnostic(
+            line: pineLine,
+            column: pineColumn,
+            message: lsp.message,
+            severity: (lsp.severity ?? .information).validationSeverity,
+            source: lsp.source ?? fallbackSource
+        )
+    }
+
+    /// Converts a whole `publishDiagnostics` notification into an array of
+    /// Pine validation diagnostics for that document.
+    static func map(_ notification: LSPDiagnosticsNotification) -> [ValidationDiagnostic] {
+        notification.diagnostics.map { map($0) }
+    }
+}

--- a/Pine/LSP/DiagnosticsProvider.swift
+++ b/Pine/LSP/DiagnosticsProvider.swift
@@ -149,7 +149,7 @@ nonisolated enum DiagnosticMapper {
 
     /// Converts a single LSP diagnostic into a Pine validation diagnostic.
     /// The `source` falls back to `"lsp"` when the server omits it.
-    @MainActor static func map(_ lsp: LSPDiagnostic, fallbackSource: String = "lsp") -> ValidationDiagnostic {
+    static func map(_ lsp: LSPDiagnostic, fallbackSource: String = "lsp") -> ValidationDiagnostic {
         // LSP line is 0-based; Pine lines are 1-based.
         let pineLine = lsp.range.start.line + 1
         // LSP character is 0-based; Pine columns are 1-based. Clamp negatives defensively.

--- a/Pine/LSP/DiagnosticsProvider.swift
+++ b/Pine/LSP/DiagnosticsProvider.swift
@@ -15,7 +15,7 @@ import Foundation
 // MARK: - LSP position / range
 
 /// An LSP `Position` (0-based line and character).
-struct LSPPosition: Equatable, Sendable {
+nonisolated struct LSPPosition: Equatable, Sendable {
     let line: Int
     let character: Int
 
@@ -35,7 +35,7 @@ struct LSPPosition: Equatable, Sendable {
 }
 
 /// An LSP `Range` (start and end positions, 0-based).
-struct LSPRange: Equatable, Sendable {
+nonisolated struct LSPRange: Equatable, Sendable {
     let start: LSPPosition
     let end: LSPPosition
 
@@ -56,7 +56,7 @@ struct LSPRange: Equatable, Sendable {
 // MARK: - LSP severity
 
 /// The LSP `DiagnosticSeverity` enum (1-based per spec).
-enum LSPDiagnosticSeverity: Int, Sendable, Equatable {
+nonisolated enum LSPDiagnosticSeverity: Int, Sendable, Equatable {
     case error = 1
     case warning = 2
     case information = 3
@@ -83,7 +83,7 @@ enum LSPDiagnosticSeverity: Int, Sendable, Equatable {
 // MARK: - LSP Diagnostic
 
 /// A single LSP `Diagnostic`.
-struct LSPDiagnostic: Equatable, Sendable {
+nonisolated struct LSPDiagnostic: Equatable, Sendable {
     let range: LSPRange
     let severity: LSPDiagnosticSeverity?
     let code: String?
@@ -114,7 +114,7 @@ struct LSPDiagnostic: Equatable, Sendable {
 // MARK: - publishDiagnostics notification
 
 /// The `textDocument/publishDiagnostics` notification payload.
-struct LSPDiagnosticsNotification: Equatable, Sendable {
+nonisolated struct LSPDiagnosticsNotification: Equatable, Sendable {
     let uri: String
     let diagnostics: [LSPDiagnostic]
 

--- a/Pine/LSP/DiagnosticsProvider.swift
+++ b/Pine/LSP/DiagnosticsProvider.swift
@@ -149,7 +149,7 @@ nonisolated enum DiagnosticMapper {
 
     /// Converts a single LSP diagnostic into a Pine validation diagnostic.
     /// The `source` falls back to `"lsp"` when the server omits it.
-    static func map(_ lsp: LSPDiagnostic, fallbackSource: String = "lsp") -> ValidationDiagnostic {
+    @MainActor static func map(_ lsp: LSPDiagnostic, fallbackSource: String = "lsp") -> ValidationDiagnostic {
         // LSP line is 0-based; Pine lines are 1-based.
         let pineLine = lsp.range.start.line + 1
         // LSP character is 0-based; Pine columns are 1-based. Clamp negatives defensively.

--- a/Pine/LSP/LSPClient.swift
+++ b/Pine/LSP/LSPClient.swift
@@ -253,10 +253,22 @@ nonisolated final class LSPTransport: @unchecked Sendable {
     /// Delivers a decoded message to the delegate on the main thread — the
     /// delegate is an `LSPClient` which is `@MainActor`.
     private func deliver(_ message: [String: Any]) {
+        // Wrap in an @unchecked Sendable box so Swift 6 strict concurrency
+        // allows crossing the ioQueue → main thread boundary. The dictionary
+        // is a freshly decoded JSON payload — no shared mutable state.
+        let box = SendableJSONBox(message)
         DispatchQueue.main.async { [weak self] in
-            self?.delegate?.transport(didReceive: message)
+            self?.delegate?.transport(didReceive: box.value)
         }
     }
+}
+
+/// Boxes a `[String: Any]` JSON payload as `@unchecked Sendable` so it can
+/// cross actor boundaries. Safe because the payload is always a freshly
+/// decoded JSON dictionary — never shared mutable state.
+nonisolated struct SendableJSONBox: @unchecked Sendable {
+    let value: [String: Any]
+    init(_ value: [String: Any]) { self.value = value }
 }
 
 /// Callback surface for `LSPTransport`.
@@ -299,7 +311,7 @@ final class LSPClient {
     private var nextRequestID: Int = 0
 
     /// Pending requests awaiting a server response, keyed by request id.
-    private var pending: [Int: (Result<[String: Any], Error>) -> Void] = [:]
+    private var pending: [Int: (Result<SendableJSONBox, Error>) -> Void] = [:]
 
     /// The language id this client serves (e.g. "swift", "typescript").
     let language: String
@@ -446,11 +458,13 @@ final class LSPClient {
     /// Sends a JSON-RPC request and awaits the server's response.
     func sendRequest(_ method: String, params: [String: Any]) async throws -> [String: Any] {
         let id = allocateRequestID()
-        return try await withCheckedThrowingContinuation { continuation in
+        // Continuation carries SendableJSONBox (not raw [String: Any]) to satisfy
+        // Swift 6 strict concurrency — the continuation crosses actor boundaries.
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<SendableJSONBox, Error>) in
             pending[id] = { result in
                 switch result {
-                case .success(let value):
-                    continuation.resume(returning: value)
+                case .success(let boxed):
+                    continuation.resume(returning: boxed)
                 case .failure(let error):
                     continuation.resume(throwing: error)
                 }
@@ -462,7 +476,7 @@ final class LSPClient {
                 "method": method,
                 "params": params
             ])
-        }
+        }.value
     }
 
     /// Sends a JSON-RPC notification (no response expected).
@@ -489,7 +503,7 @@ final class LSPClient {
         if let error {
             handler(.failure(LSPError(error: error)))
         } else {
-            handler(.success((result as? [String: Any]) ?? [:]))
+            handler(.success(SendableJSONBox((result as? [String: Any]) ?? [:])))
         }
     }
 }

--- a/Pine/LSP/LSPClient.swift
+++ b/Pine/LSP/LSPClient.swift
@@ -1,0 +1,545 @@
+//
+//  LSPClient.swift
+//  Pine
+//
+//  Phase 1 of LSP support (issue #1010, parent #994).
+//
+//  Foundation: spawns a language server process per language, exchanges
+//  JSON-RPC 2.0 messages over stdio, and exposes the document-sync
+//  notifications (`textDocument/didOpen`, `textDocument/didChange`,
+//  `textDocument/didClose`) plus a callback for
+//  `textDocument/publishDiagnostics`.
+//
+//  All I/O runs off the main thread. Public mutating methods
+//  (`start`, `sendNotification`, `shutdown`) are safe to call from any
+//  actor — they serialise onto a private background queue.
+//
+
+import Foundation
+import os
+
+// MARK: - JSON-RPC framing
+
+/// Encodes/decodes LSP messages using the Language Server Protocol header
+/// framing over stdio:
+///
+/// `Content-Length: <bytes>\r\n\r\n<UTF-8 JSON payload>`
+///
+/// Marked `nonisolated` to opt out of the project-wide MainActor default
+/// isolation — framing is pure data work with no UI surface.
+nonisolated enum LSPMessageFraming {
+
+    /// Serialises a JSON-RPC payload into the LSP wire format.
+    /// - Parameter payload: The `[String: Any]` dictionary to JSON-encode.
+    /// - Returns: Framed bytes ready to write to the server's stdin.
+    static func frame(_ payload: [String: Any]) -> Data {
+        guard let json = try? JSONSerialization.data(
+            withJSONObject: payload,
+            options: [.fragmentsAllowed]
+        ) else {
+            return Data()
+        }
+        let header = "Content-Length: \(json.count)\r\n\r\n"
+        var framed = Data(header.utf8)
+        framed.append(json)
+        return framed
+    }
+
+    /// Extracts the `Content-Length` value from a header block.
+    /// Returns `nil` if the header is absent or unparseable.
+    static func contentLength(from header: String) -> Int? {
+        // Case-insensitive search — servers are inconsistent on casing.
+        guard let range = header.range(of: "Content-Length:", options: .caseInsensitive) else {
+            return nil
+        }
+        let afterKey = header[range.upperBound...]
+        // Trim leading whitespace then take digits up to the first non-digit.
+        let trimmed = afterKey.drop(while: { $0.isWhitespace })
+        var digits = ""
+        for char in trimmed {
+            guard char.isNumber else { break }
+            digits.append(char)
+        }
+        return Int(digits)
+    }
+}
+
+// MARK: - Transport
+
+/// A minimal JSON-RPC 2.0 transport over a `Process`'s stdio.
+///
+/// Owns the spawned language-server `Process`, writes framed messages to its
+/// stdin, and parses the framing of stdout to deliver complete JSON messages
+/// to a delegate. Runs entirely on a private serial dispatch queue so no LSP
+/// I/O ever touches the main thread.
+///
+/// Marked `nonisolated(unsafe)` because access is fully serialised by
+/// `ioQueue`. The only cross-thread surface is the delegate callback, which
+/// hops to the main actor at the call site.
+final class LSPTransport {
+
+    /// Receives fully-decoded JSON-RPC messages (notifications and responses).
+    weak var delegate: LSPTransportDelegate?
+
+    /// The spawned language-server process (nil until `start` succeeds).
+    private var process: Process?
+
+    /// The pipe used to write messages to the server's stdin.
+    private var stdinPipe: Pipe?
+
+    /// Private serial queue — all reads/writes of mutable state happen here.
+    private let ioQueue = DispatchQueue(label: "com.pine.lsp-transport")
+
+    /// Accumulates the raw stdout bytes until a complete message is framed.
+    private var readBuffer = Data()
+
+    // MARK: - Lifecycle
+
+    /// Spawns the language server with the given command and arguments.
+    /// - Parameters:
+    ///   - command: Absolute path to the server executable.
+    ///   - arguments: Arguments to pass to the server.
+    ///   - environment: Environment for the spawned process. When nil the
+    ///     current process environment is used with common tool paths prepended.
+    /// - Returns: `true` if the process launched successfully.
+    @discardableResult
+    func start(command: String, arguments: [String], environment: [String: String]? = nil) -> Bool {
+        ioQueue.sync {
+            // Already running — refuse to double-start.
+            if process?.isRunning == true { return false }
+
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: command)
+            proc.arguments = arguments
+
+            var env = environment ?? ProcessInfo.processInfo.environment
+            // Ensure common tool paths are discoverable by the server itself
+            // (e.g. sourcekit-lsp locating the toolchain).
+            let extraPaths = ["/usr/local/bin", "/opt/homebrew/bin"]
+            let currentPath = env["PATH"] ?? "/usr/bin:/bin"
+            env["PATH"] = (extraPaths + [currentPath]).joined(separator: ":")
+            proc.environment = env
+
+            let inPipe = Pipe()
+            let outPipe = Pipe()
+            proc.standardInput = inPipe
+            proc.standardOutput = outPipe
+            proc.standardError = Pipe() // discard server stderr for now
+
+            // Forward stdout data to the framing reader.
+            outPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+                let chunk = handle.availableData
+                guard !chunk.isEmpty else { return }
+                self?.ioQueue.async {
+                    self?.appendAndParse(chunk)
+                }
+            }
+
+            do {
+                try proc.run()
+            } catch {
+                Logger.lsp.error("Failed to launch server \(command, privacy: .public): \(String(describing: error), privacy: .public)")
+                process = nil
+                stdinPipe = nil
+                return false
+            }
+
+            process = proc
+            stdinPipe = inPipe
+            Logger.lsp.info("LSP server started: \(command, privacy: .public)")
+            return true
+        }
+    }
+
+    /// Whether the server process is currently running.
+    var isRunning: Bool {
+        ioQueue.sync { process?.isRunning ?? false }
+    }
+
+    /// Writes a framed JSON-RPC message to the server's stdin.
+    /// No-op when the process is not running.
+    func send(_ payload: [String: Any]) {
+        ioQueue.async { [weak self] in
+            guard let self,
+                  let pipe = self.stdinPipe,
+                  self.process?.isRunning == true else { return }
+            let framed = LSPMessageFraming.frame(payload)
+            do {
+                try pipe.fileHandleForWriting.write(contentsOf: framed)
+            } catch {
+                Logger.lsp.error("Failed to write to server stdin: \(String(describing: error), privacy: .public)")
+            }
+        }
+    }
+
+    /// Terminates the server process. Sends SIGTERM first, then SIGKILL as a
+    /// fallback if the process does not exit within `timeout` seconds.
+    func terminate(timeout: TimeInterval = 3.0) {
+        ioQueue.sync {
+            outPipeCleanup()
+            guard let proc = process else { return }
+            if proc.isRunning {
+                proc.terminate()
+                // Give it a moment to exit cleanly.
+                proc.waitUntilExit()
+            }
+            process = nil
+            stdinPipe = nil
+        }
+    }
+
+    /// Detaches the readability handler so the pipe stops calling back.
+    /// Must run before the process is terminated to avoid a dangling handler.
+    private func outPipeCleanup() {
+        guard let proc = process else { return }
+        (proc.standardOutput as? Pipe)?.fileHandleForReading.readabilityHandler = nil
+    }
+
+    // MARK: - Framing reader
+
+    /// Appends a stdout chunk and parses as many complete messages as are
+    /// available. Runs on `ioQueue` so the buffer is never accessed
+    /// concurrently.
+    private func appendAndParse(_ chunk: Data) {
+        readBuffer.append(chunk)
+
+        while let (message, consumed) = parseNextMessage() {
+            // Drop the consumed bytes, keeping any partial trailing data.
+            readBuffer.removeFirst(consumed)
+            deliver(message)
+        }
+    }
+
+    /// Attempts to parse one complete JSON-RPC message from the head of
+    /// `readBuffer`. Returns the decoded `[String: Any]` and the number of
+    /// bytes consumed (header + payload), or `nil` if more data is needed.
+    private func parseNextMessage() -> (message: [String: Any], consumed: Int)? {
+        // The header is ASCII; look for the `\r\n\r\n` terminator.
+        guard let headerRange = readBuffer.range(of: Data("\r\n\r\n".utf8)) else {
+            return nil // header not yet complete
+        }
+
+        let headerData = readBuffer[readBuffer.startIndex..<headerRange.lowerBound]
+        guard let header = String(data: headerData, encoding: .utf8) else {
+            // Malformed header — drop everything up to the separator to resync.
+            readBuffer.removeSubrange(readBuffer.startIndex...headerRange.upperBound)
+            return nil
+        }
+
+        guard let length = LSPMessageFraming.contentLength(from: header) else {
+            readBuffer.removeSubrange(readBuffer.startIndex...headerRange.upperBound)
+            return nil
+        }
+
+        let bodyStart = headerRange.upperBound
+        // `Data.index(_:offsetBy:)` traps if it would run past endIndex, so
+        // validate available bytes first and return nil (wait for more) instead.
+        let available = readBuffer.distance(from: bodyStart, to: readBuffer.endIndex)
+        guard available >= length else {
+            return nil // payload not yet complete
+        }
+        let bodyEnd = readBuffer.index(bodyStart, offsetBy: length)
+
+        let bodyData = readBuffer.subdata(in: bodyStart..<bodyEnd)
+        let consumed = readBuffer.distance(from: readBuffer.startIndex, to: bodyEnd)
+
+        guard let json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any] else {
+            Logger.lsp.error("Failed to decode LSP JSON payload")
+            return ([:], consumed) // consume to avoid re-parsing a bad message
+        }
+        return (json, consumed)
+    }
+
+    /// Delivers a decoded message to the delegate on the main thread — the
+    /// delegate is an `LSPClient` which is `@MainActor`.
+    private func deliver(_ message: [String: Any]) {
+        DispatchQueue.main.async { [weak self] in
+            self?.delegate?.transport(didReceive: message)
+        }
+    }
+}
+
+/// Callback surface for `LSPTransport`.
+@MainActor
+protocol LSPTransportDelegate: AnyObject {
+    /// Called for every complete JSON-RPC message (notification or response).
+    func transport(didReceive message: [String: Any])
+}
+
+// MARK: - LSPClient
+
+/// Drives a single language-server connection: the JSON-RPC handshake
+/// (`initialize` / `initialized`), document-sync notifications, and routing of
+/// server-to-client notifications (`textDocument/publishDiagnostics`) to a
+/// callback.
+///
+/// One `LSPClient` instance owns one server process and one set of open
+/// documents. `LSPManager` owns a dictionary of these keyed by language id.
+///
+/// `@MainActor` because all public state (open documents, the diagnostic
+/// callback) drives UI, and the transport already hops inbound messages to the
+/// main thread before delivering them here.
+@MainActor
+final class LSPClient {
+
+    /// Server lifecycle state.
+    enum State: Equatable {
+        case uninitialized
+        case initializing
+        case initialized
+        case shutDown
+        case exited
+        case failed
+    }
+
+    /// The underlying stdio transport. Exposed `internal` for test injection.
+    let transport: LSPTransport
+
+    /// Monotonic request-id counter for correlating JSON-RPC requests/responses.
+    private var nextRequestID: Int = 0
+
+    /// Pending requests awaiting a server response, keyed by request id.
+    private var pending: [Int: (Result<[String: Any], Error>) -> Void] = [:]
+
+    /// The language id this client serves (e.g. "swift", "typescript").
+    let language: String
+
+    /// Current lifecycle state.
+    private(set) var state: State = .uninitialized
+
+    /// Open documents tracked by URI, so `didChange`/`didClose` can reference them.
+    private var openDocuments: [String: LSPTextDocumentItem] = [:]
+
+    /// Called whenever the server publishes diagnostics for a document.
+    var onDiagnostics: ((LSPDiagnosticsNotification) -> Void)?
+
+    init(language: String, transport: LSPTransport = LSPTransport()) {
+        self.language = language
+        self.transport = transport
+        self.transport.delegate = self
+    }
+
+    // MARK: - Lifecycle
+
+    /// Starts the server process and performs the `initialize` handshake.
+    /// - Parameters:
+    ///   - command: Absolute path to the server binary.
+    ///   - arguments: Arguments for the server binary.
+    ///   - rootURI: The workspace root as a URI string (e.g. "file:///path").
+    /// - Returns: `true` if the server reached the `.initialized` state.
+    @discardableResult
+    func start(command: String, arguments: [String], rootURI: String?) async -> Bool {
+        guard state == .uninitialized || state == .exited else { return false }
+
+        guard transport.start(command: command, arguments: arguments) else {
+            state = .failed
+            return false
+        }
+
+        state = .initializing
+
+        // initialize request
+        var initParams: [String: Any] = [
+            "processId": ProcessInfo.processInfo.processIdentifier,
+            "capabilities": [
+                "textDocument": [
+                    "synchronization": [
+                        "didOpen": true,
+                        "didChange": true,
+                        "didClose": true
+                    ]
+                ]
+            ]
+        ]
+        if let rootURI {
+            initParams["rootUri"] = rootURI
+        }
+
+        do {
+            _ = try await sendRequest("initialize", params: initParams)
+        } catch {
+            Logger.lsp.error("LSP initialize failed: \(String(describing: error), privacy: .public)")
+            state = .failed
+            terminate()
+            return false
+        }
+
+        // initialized notification
+        sendNotification("initialized", params: [:])
+        state = .initialized
+        return true
+    }
+
+    /// Performs a graceful `shutdown` → `exit` and terminates the process.
+    /// Safe to call even when the server never started.
+    func shutdown() {
+        guard state == .initialized else {
+            terminate()
+            return
+        }
+
+        // Best-effort shutdown request; ignore failures — we terminate regardless.
+        let id = allocateRequestID()
+        transport.send([
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "shutdown"
+        ])
+
+        sendNotification("exit", params: [:])
+        state = .shutDown
+        terminate()
+        state = .exited
+    }
+
+    /// Force-terminates the transport and marks the client as failed.
+    private func terminate() {
+        transport.terminate()
+    }
+
+    // MARK: - Document sync
+
+    /// Sends `textDocument/didOpen` and tracks the document.
+    func didOpen(uri: String, language: String, version: Int, text: String) {
+        guard state == .initialized else { return }
+        let item = LSPTextDocumentItem(uri: uri, languageId: language, version: version, text: text)
+        openDocuments[uri] = item
+        sendNotification("textDocument/didOpen", params: [
+            "textDocument": [
+                "uri": uri,
+                "languageId": language,
+                "version": version,
+                "text": text
+            ]
+        ])
+    }
+
+    /// Sends `textDocument/didChange` (full-document sync) and bumps the version.
+    func didChange(uri: String, text: String) {
+        guard state == .initialized else { return }
+        guard var doc = openDocuments[uri] else { return }
+        doc.version += 1
+        doc.text = text
+        openDocuments[uri] = doc
+        sendNotification("textDocument/didChange", params: [
+            "textDocument": [
+                "uri": uri,
+                "version": doc.version
+            ],
+            "contentChanges": [
+                ["text": text]
+            ]
+        ])
+    }
+
+    /// Sends `textDocument/didClose` and stops tracking the document.
+    func didClose(uri: String) {
+        guard state == .initialized else { return }
+        openDocuments[uri] = nil
+        sendNotification("textDocument/didClose", params: [
+            "textDocument": ["uri": uri]
+        ])
+    }
+
+    // MARK: - JSON-RPC plumbing
+
+    /// Sends a JSON-RPC request and awaits the server's response.
+    func sendRequest(_ method: String, params: [String: Any]) async throws -> [String: Any] {
+        let id = allocateRequestID()
+        return try await withCheckedThrowingContinuation { continuation in
+            pending[id] = { result in
+                switch result {
+                case .success(let value):
+                    continuation.resume(returning: value)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+
+            transport.send([
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": method,
+                "params": params
+            ])
+        }
+    }
+
+    /// Sends a JSON-RPC notification (no response expected).
+    func sendNotification(_ method: String, params: [String: Any]) {
+        var payload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "method": method
+        ]
+        if !params.isEmpty {
+            payload["params"] = params
+        }
+        transport.send(payload)
+    }
+
+    /// Allocates the next sequential request id.
+    private func allocateRequestID() -> Int {
+        nextRequestID += 1
+        return nextRequestID
+    }
+
+    /// Resolves a pending request by id, invoking its continuation.
+    private func resolveRequest(id: Int, result: Any?, error: [String: Any]?) {
+        guard let handler = pending.removeValue(forKey: id) else { return }
+        if let error {
+            handler(.failure(LSPError(error: error)))
+        } else {
+            handler(.success((result as? [String: Any]) ?? [:]))
+        }
+    }
+}
+
+/// Error wrapping a JSON-RPC error object.
+struct LSPError: Error {
+    let error: [String: Any]
+    init(error: [String: Any]) { self.error = error }
+}
+
+// MARK: - LSPTransportDelegate
+
+extension LSPClient: LSPTransportDelegate {
+
+    func transport(didReceive message: [String: Any]) {
+        // A server-to-client notification (no "id", has "method").
+        if let method = message["method"] as? String {
+            let params = (message["params"] as? [String: Any]) ?? [:]
+            handleNotification(method: method, params: params)
+            return
+        }
+
+        // A response to a request we sent (has "id").
+        if let id = message["id"] as? Int {
+            let result = message["result"]
+            let error = message["error"] as? [String: Any]
+            resolveRequest(id: id, result: result, error: error)
+        }
+    }
+
+    /// Dispatches a server-to-client notification to the right handler.
+    private func handleNotification(method: String, params: [String: Any]) {
+        switch method {
+        case "textDocument/publishDiagnostics":
+            if let notification = LSPDiagnosticsNotification(params: params) {
+                onDiagnostics?(notification)
+            }
+        default:
+            // Other notifications (window/logMessage, etc.) are ignored in Phase 1.
+            break
+        }
+    }
+}
+
+// MARK: - LSP value types
+
+/// A `textDocument/didOpen` payload.
+struct LSPTextDocumentItem {
+    var uri: String
+    var languageId: String
+    var version: Int
+    var text: String
+}

--- a/Pine/LSP/LSPClient.swift
+++ b/Pine/LSP/LSPClient.swift
@@ -497,7 +497,6 @@ final class LSPClient {
 /// Error wrapping a JSON-RPC error object.
 struct LSPError: Error {
     let error: [String: Any]
-    init(error: [String: Any]) { self.error = error }
 }
 
 // MARK: - LSPTransportDelegate

--- a/Pine/LSP/LSPClient.swift
+++ b/Pine/LSP/LSPClient.swift
@@ -495,7 +495,7 @@ final class LSPClient {
 }
 
 /// Error wrapping a JSON-RPC error object.
-struct LSPError: Error {
+nonisolated struct LSPError: Error {
     let error: [String: Any]
 }
 
@@ -536,7 +536,7 @@ extension LSPClient: LSPTransportDelegate {
 // MARK: - LSP value types
 
 /// A `textDocument/didOpen` payload.
-struct LSPTextDocumentItem {
+nonisolated struct LSPTextDocumentItem {
     var uri: String
     var languageId: String
     var version: Int

--- a/Pine/LSP/LSPClient.swift
+++ b/Pine/LSP/LSPClient.swift
@@ -76,7 +76,7 @@ nonisolated enum LSPMessageFraming {
 /// Marked `nonisolated(unsafe)` because access is fully serialised by
 /// `ioQueue`. The only cross-thread surface is the delegate callback, which
 /// hops to the main actor at the call site.
-final class LSPTransport {
+nonisolated final class LSPTransport: @unchecked Sendable {
 
     /// Receives fully-decoded JSON-RPC messages (notifications and responses).
     weak var delegate: LSPTransportDelegate?

--- a/Pine/LSP/LSPManager.swift
+++ b/Pine/LSP/LSPManager.swift
@@ -1,0 +1,214 @@
+//
+//  LSPManager.swift
+//  Pine
+//
+//  Phase 1 of LSP support (issue #1010, parent #994).
+//
+//  Owns the per-language `LSPClient` instances and the aggregated
+//  diagnostics store. The single `@MainActor @Observable` surface that the
+//  editor and Problems panel observe.
+//
+//  Responsibilities:
+//    • Lazy-spawn a language server the first time a matching file is opened.
+//    • Forward `textDocument/didOpen|didChange|didClose` to the right client.
+//    • Collect `publishDiagnostics` from every client into a per-URI store.
+//    • Graceful no-op when a server binary is missing (no crash, no hang).
+//    • `shutdownAll()` on project close / app termination — leaves no orphan.
+//
+
+import Foundation
+import SwiftUI
+import os
+
+/// `@MainActor @Observable` manager for all language-server connections in
+/// one project. Owned by `ProjectManager`.
+///
+/// Mirrors the existing `ConfigValidator` shape: the editor reads
+/// `diagnostics(for:)` and renders them through the same gutter-icon path
+/// that config validators already use.
+@MainActor
+@Observable
+final class LSPManager {
+
+    /// Per-client state for each active language server.
+    struct ServerEntry: Identifiable {
+        let id: String // == language id
+        let language: String
+        var client: LSPClient
+        var state: LSPClient.State
+    }
+
+    /// Active language-server clients, keyed by language id.
+    private(set) var servers: [String: ServerEntry] = [:]
+
+    /// All current diagnostics keyed by document URI.
+    /// Replacing/emptying an entry clears that file's markers.
+    private(set) var diagnosticsByURI: [String: [ValidationDiagnostic]] = [:]
+
+    /// Whether LSP diagnostics are enabled (global toggle). Defaults on.
+    var enabled: Bool = true
+
+    /// The workspace root URI (file://...) used for `initialize`.
+    private var rootURI: String?
+
+    /// Injected resolver — overridable for tests.
+    private let resolver: LanguageServerResolver
+
+    /// Injectable factory for clients — overridable for tests so a real
+    /// `Process` is never spawned in unit tests.
+    private let clientFactory: (String) -> LSPClient
+
+    init(
+        resolver: LanguageServerResolver = .defaultResolver,
+        clientFactory: @escaping (String) -> LSPClient = { LSPClient(language: $0) }
+    ) {
+        self.resolver = resolver
+        self.clientFactory = clientFactory
+    }
+
+    // MARK: - Workspace lifecycle
+
+    /// Sets the workspace root so `initialize` requests pass the right `rootUri`.
+    func setWorkspaceRoot(_ url: URL?) {
+        rootURI = url.map { $0.absoluteString }
+    }
+
+    /// Shuts down every running server. Called on project close and app
+    /// termination so no orphan language-server processes survive.
+    func shutdownAll() {
+        for entry in servers.values {
+            entry.client.shutdown()
+        }
+        servers.removeAll()
+        // Keep diagnosticsByURI intact across a shutdown? No — when the
+        // project closes the manager is discarded anyway. Clear to be safe.
+        diagnosticsByURI = [:]
+    }
+
+    // MARK: - Document sync
+
+    /// Notifies the appropriate language server that a document was opened.
+    /// Lazily spawns the server for the file's language on first use.
+    /// No-op when LSP is disabled, the file has no configured server, or the
+    /// server binary is not installed.
+    func didOpen(url: URL, version: Int = 1, text: String) {
+        guard enabled else { return }
+        guard let serverConfig = LanguageServerRegistry.server(for: url) else { return }
+
+        let language = serverConfig.language
+        Task {
+            guard await ensureServer(for: serverConfig) else { return }
+            let uri = url.absoluteString
+            servers[language]?.client.didOpen(
+                uri: uri,
+                language: language,
+                version: version,
+                text: text
+            )
+        }
+    }
+
+    /// Notifies the appropriate language server that a document changed.
+    func didChange(url: URL, text: String) {
+        guard enabled else { return }
+        // Resolve via URL extension so a .ts file reaches the typescript server, etc.
+        guard let serverConfig = LanguageServerRegistry.server(for: url) else { return }
+        let uri = url.absoluteString
+        servers[serverConfig.language]?.client.didChange(uri: uri, text: text)
+    }
+
+    /// Notifies the appropriate language server that a document was closed.
+    func didClose(url: URL) {
+        guard enabled else { return }
+        guard let serverConfig = LanguageServerRegistry.server(for: url) else { return }
+        let uri = url.absoluteString
+        servers[serverConfig.language]?.client.didClose(uri: uri)
+        // Clear that file's diagnostics immediately so stale markers don't linger.
+        diagnosticsByURI[uri] = nil
+    }
+
+    // MARK: - Diagnostics access
+
+    /// Returns the current Pine diagnostics for a document URI.
+    func diagnostics(for uri: String) -> [ValidationDiagnostic] {
+        diagnosticsByURI[uri] ?? []
+    }
+
+    /// Returns the diagnostics for a file URL.
+    func diagnostics(for url: URL) -> [ValidationDiagnostic] {
+        diagnostics(for: url.absoluteString)
+    }
+
+    /// All diagnostics across every open document, grouped by URI. Used by
+    /// the Problems panel.
+    var allDiagnostics: [(uri: String, diagnostics: [ValidationDiagnostic])] {
+        diagnosticsByURI
+            .filter { !$0.value.isEmpty }
+            .map { (uri: $0.key, diagnostics: $0.value) }
+            .sorted { $0.uri < $1.uri }
+    }
+
+    /// Total number of diagnostics across all files.
+    var totalDiagnosticCount: Int {
+        diagnosticsByURI.values.reduce(0) { $0 + $1.count }
+    }
+
+    /// Count of errors across all files.
+    var errorCount: Int {
+        diagnosticsByURI.values.flatMap { $0 }.filter { $0.severity == .error }.count
+    }
+
+    /// Count of warnings across all files.
+    var warningCount: Int {
+        diagnosticsByURI.values.flatMap { $0 }.filter { $0.severity == .warning }.count
+    }
+
+    // MARK: - Server lifecycle (internal)
+
+    /// Ensures a server for the given config is running. Spawns it (and runs
+    /// the `initialize` handshake) if it isn't. Returns `false` if the server
+    /// binary is missing or the handshake failed.
+    private func ensureServer(for config: LanguageServerConfig) async -> Bool {
+        // Already have an entry for this language?
+        if let existing = servers[config.language] {
+            return existing.state == .initialized
+        }
+
+        // Discover the binary — graceful no-op when absent.
+        guard let path = resolver.resolvePath(for: config) else {
+            Logger.lsp.info("Server binary not installed for \(config.language, privacy: .public): \(config.command, privacy: .public)")
+            return false
+        }
+
+        let client = clientFactory(config.language)
+        let entry = ServerEntry(id: config.language, language: config.language, client: client, state: .uninitialized)
+        servers[config.language] = entry
+
+        // Wire diagnostics callback before starting so nothing is lost.
+        client.onDiagnostics = { [weak self, weak client] notification in
+            guard let self else { return }
+            self.handleDiagnostics(notification, from: client)
+        }
+
+        let started = await client.start(
+            command: path,
+            arguments: config.arguments,
+            rootURI: rootURI
+        )
+
+        if started {
+            servers[config.language]?.state = .initialized
+            Logger.lsp.info("LSP server ready for \(config.language, privacy: .public)")
+        } else {
+            servers[config.language]?.state = .failed
+            Logger.lsp.error("LSP server failed to start for \(config.language, privacy: .public)")
+        }
+        return started
+    }
+
+    /// Receives a `publishDiagnostics` notification and merges it into the store.
+    private func handleDiagnostics(_ notification: LSPDiagnosticsNotification, from client: LSPClient?) {
+        let mapped = DiagnosticMapper.map(notification)
+        diagnosticsByURI[notification.uri] = mapped
+    }
+}

--- a/Pine/LSP/LanguageServerRegistry.swift
+++ b/Pine/LSP/LanguageServerRegistry.swift
@@ -18,7 +18,7 @@
 import Foundation
 
 /// Describes how to launch a single language server.
-struct LanguageServerConfig: Sendable, Equatable {
+nonisolated struct LanguageServerConfig: Sendable, Equatable {
     /// The language id this server serves (e.g. "swift", "typescript").
     let language: String
     /// File extensions (lowercased, without dot) this server handles.
@@ -27,13 +27,6 @@ struct LanguageServerConfig: Sendable, Equatable {
     let command: String
     /// Arguments to pass to the server binary.
     let arguments: [String]
-
-    init(language: String, fileExtensions: Set<String>, command: String, arguments: [String]) {
-        self.language = language
-        self.fileExtensions = fileExtensions
-        self.command = command
-        self.arguments = arguments
-    }
 }
 
 /// Static registry of the language servers Pine knows how to drive.

--- a/Pine/LSP/LanguageServerRegistry.swift
+++ b/Pine/LSP/LanguageServerRegistry.swift
@@ -1,0 +1,122 @@
+//
+//  LanguageServerRegistry.swift
+//  Pine
+//
+//  Phase 1 of LSP support (issue #1010).
+//
+//  Maps a language id (e.g. "swift", "typescript", "python") to the
+//  command + arguments used to spawn its language server, and discovers
+//  whether the server binary is actually installed. Discovery reuses the
+//  project's `ExternalToolResolver` (PATH + well-known locations) so the
+//  behaviour is identical to formatters and validators.
+//
+//  When a server binary is not installed, the registry reports it as absent
+//  and the manager performs a graceful no-op (no crash, no hang) per the
+//  acceptance criteria.
+//
+
+import Foundation
+
+/// Describes how to launch a single language server.
+struct LanguageServerConfig: Sendable, Equatable {
+    /// The language id this server serves (e.g. "swift", "typescript").
+    let language: String
+    /// File extensions (lowercased, without dot) this server handles.
+    let fileExtensions: Set<String>
+    /// The executable name to resolve on PATH, or an absolute path.
+    let command: String
+    /// Arguments to pass to the server binary.
+    let arguments: [String]
+
+    init(language: String, fileExtensions: Set<String>, command: String, arguments: [String]) {
+        self.language = language
+        self.fileExtensions = fileExtensions
+        self.command = command
+        self.arguments = arguments
+    }
+}
+
+/// Static registry of the language servers Pine knows how to drive.
+///
+/// Phase 1 targets the three languages from the issue: Swift
+/// (`sourcekit-lsp`), TypeScript (`typescript-language-server`), and Python
+/// (`pyright`). Adding a new language is purely additive — append a config
+/// and the manager picks it up.
+nonisolated enum LanguageServerRegistry {
+
+    /// The bundled server definitions. Order does not matter; languages are
+    /// keyed by `language` id.
+    static let allServers: [LanguageServerConfig] = [
+        LanguageServerConfig(
+            language: "swift",
+            fileExtensions: ["swift"],
+            command: "sourcekit-lsp",
+            arguments: []
+        ),
+        LanguageServerConfig(
+            language: "typescript",
+            // .ts/.tsx handled by the typescript-language-server; .js/.jsx ride along.
+            fileExtensions: ["ts", "tsx", "js", "jsx", "mjs", "cjs"],
+            command: "typescript-language-server",
+            arguments: ["--stdio"]
+        ),
+        LanguageServerConfig(
+            language: "python",
+            fileExtensions: ["py", "pyw"],
+            command: "pyright-langserver",
+            arguments: ["--stdio"]
+        )
+    ]
+
+    /// Looks up the server config for a language id.
+    static func server(forLanguage language: String) -> LanguageServerConfig? {
+        allServers.first { $0.language == language }
+    }
+
+    /// Looks up the server config for a file extension (lowercased, no dot).
+    static func server(forExtension ext: String) -> LanguageServerConfig? {
+        allServers.first { $0.fileExtensions.contains(ext.lowercased()) }
+    }
+
+    /// Looks up the server config for a file URL, using its path extension.
+    static func server(for url: URL) -> LanguageServerConfig? {
+        server(forExtension: url.pathExtension)
+    }
+
+    /// The list of language ids Pine supports via LSP.
+    static var supportedLanguages: [String] {
+        allServers.map(\.language)
+    }
+}
+
+// MARK: - Discovery
+
+/// Resolves whether a language server binary is installed and returns its
+/// absolute path. Wraps `ExternalToolResolver` so discovery follows the same
+/// PATH + well-known-location logic as formatters/validators.
+///
+/// `nonisolated` + `Sendable` so it can be used from background tasks.
+nonisolated final class LanguageServerResolver: Sendable {
+
+    private let resolver: ExternalToolResolver
+
+    init(resolver: ExternalToolResolver) {
+        self.resolver = resolver
+    }
+
+    /// Convenience default resolver using the current process PATH.
+    static var defaultResolver: LanguageServerResolver {
+        LanguageServerResolver(resolver: ExternalToolResolver.fromEnvironment())
+    }
+
+    /// Returns the absolute path to the server binary, or `nil` if it is not
+    /// installed. Results are cached by the underlying `ExternalToolResolver`.
+    func resolvePath(for config: LanguageServerConfig) -> String? {
+        resolver.resolve(tool: config.command)
+    }
+
+    /// Returns `true` if the server binary for `config` is installed.
+    func isInstalled(_ config: LanguageServerConfig) -> Bool {
+        resolvePath(for: config) != nil
+    }
+}

--- a/Pine/LSP/ProblemsPanelView.swift
+++ b/Pine/LSP/ProblemsPanelView.swift
@@ -23,6 +23,16 @@ struct DiagnosticsSummary: Equatable {
         self.errorCount = errorCount
         self.warningCount = warningCount
     }
+
+    /// Human-readable summary for the status bar (e.g. "2 errors, 1 warning").
+    var description: String {
+        switch (errorCount, warningCount) {
+        case (0, 0): return ""
+        case (let e, 0) where e > 0: return "\(e) error\(e == 1 ? "" : "s")"
+        case (0, let w) where w > 0: return "\(w) warning\(w == 1 ? "" : "s")"
+        default: return "\(errorCount) error\(errorCount == 1 ? "" : "s"), \(warningCount) warning\(warningCount == 1 ? "" : "s")"
+        }
+    }
 }
 
 // MARK: - Problems panel

--- a/Pine/LSP/ProblemsPanelView.swift
+++ b/Pine/LSP/ProblemsPanelView.swift
@@ -1,0 +1,161 @@
+//
+//  ProblemsPanelView.swift
+//  Pine
+//
+//  Phase 1 of LSP support (issue #1010).
+//
+//  A SwiftUI "Problems" panel that lists every active diagnostic grouped by
+//  file. Clicking a diagnostic navigates to its location and focuses the
+//  editor. Reuses the existing gutter-icon model (`ValidationDiagnostic`).
+//
+
+import SwiftUI
+
+/// Lightweight summary of diagnostic counts for the status bar indicator.
+/// Computed from `LSPManager` (and could include config validators).
+struct DiagnosticsSummary: Equatable {
+    let errorCount: Int
+    let warningCount: Int
+
+    var total: Int { errorCount + warningCount }
+
+    init(errorCount: Int, warningCount: Int) {
+        self.errorCount = errorCount
+        self.warningCount = warningCount
+    }
+}
+
+// MARK: - Problems panel
+
+/// A collapsible panel listing all active diagnostics grouped by file.
+///
+/// Driven by `LSPManager.allDiagnostics`. Each row is clickable; the callback
+/// resolves the file URL and line number so the caller can open the tab and
+/// jump to the location.
+struct ProblemsPanelView: View {
+    /// Diagnostics grouped by URI, pre-sorted by file path.
+    let groups: [(uri: String, diagnostics: [ValidationDiagnostic])]
+
+    /// Called when the user selects a diagnostic. The arguments are the file
+    /// URL and the 1-based line number to navigate to.
+    var onSelect: ((URL, Int) -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if groups.isEmpty {
+                Text(Strings.problemsNoIssues)
+                    .font(.system(size: LayoutMetrics.bodySmallFontSize))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 12)
+                    .accessibilityIdentifier(AccessibilityID.problemsEmptyState)
+            } else {
+                List {
+                    ForEach(Array(groups.enumerated()), id: \.offset) { _, group in
+                        ProblemsFileSection(
+                            uri: group.uri,
+                            diagnostics: group.diagnostics,
+                            onSelect: onSelect
+                        )
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .accessibilityIdentifier(AccessibilityID.problemsPanel)
+    }
+}
+
+/// A single file's diagnostics, shown as a collapsible section with a header
+/// (file name + count) and a list of diagnostic rows.
+private struct ProblemsFileSection: View {
+    let uri: String
+    let diagnostics: [ValidationDiagnostic]
+    let onSelect: ((URL, Int) -> Void)?
+
+    @State private var isExpanded = true
+
+    private var displayName: String {
+        URL(string: uri)?.lastPathComponent ?? uri
+    }
+
+    var body: some View {
+        Section(isExpanded: $isExpanded) {
+            ForEach(Array(diagnostics.enumerated()), id: \.offset) { _, diag in
+                ProblemsDiagnosticRow(diagnostic: diag) {
+                    if let url = URL(string: uri) {
+                        onSelect?(url, diag.line)
+                    }
+                }
+            }
+        } header: {
+            HStack(spacing: 4) {
+                Image(systemName: "doc.text")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(displayName)
+                    .font(.system(size: LayoutMetrics.bodySmallFontSize, weight: .semibold))
+                Text(verbatim: "(\(diagnostics.count))")
+                    .font(.system(size: LayoutMetrics.captionFontSize))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+/// A single diagnostic row: severity icon, message, and line:column.
+private struct ProblemsDiagnosticRow: View {
+    let diagnostic: ValidationDiagnostic
+    let action: () -> Void
+
+    private var severityColor: Color {
+        switch diagnostic.severity {
+        case .error: return .red
+        case .warning: return .yellow
+        case .info: return .blue
+        }
+    }
+
+    private var severitySymbol: String {
+        switch diagnostic.severity {
+        case .error: return "xmark.circle.fill"
+        case .warning: return "exclamationmark.triangle.fill"
+        case .info: return "info.circle.fill"
+        }
+    }
+
+    private var locationLabel: String {
+        if let column = diagnostic.column {
+            return Strings.diagnosticLineColumnLabel(line: diagnostic.line, column: column)
+        }
+        return Strings.diagnosticLineLabel(line: diagnostic.line)
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: 6) {
+                Image(systemName: severitySymbol)
+                    .foregroundStyle(severityColor)
+                    .font(.system(size: LayoutMetrics.captionFontSize))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(diagnostic.message)
+                        .font(.system(size: LayoutMetrics.bodySmallFontSize))
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                    HStack(spacing: 6) {
+                        Text(locationLabel)
+                            .font(.system(size: LayoutMetrics.captionFontSize))
+                            .foregroundStyle(.secondary)
+                        Text(verbatim: diagnostic.source)
+                            .font(.system(size: LayoutMetrics.captionFontSize))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Pine/Logging.swift
+++ b/Pine/Logging.swift
@@ -18,6 +18,7 @@ nonisolated enum LogCategory: String, CaseIterable {
     case editor
     case app
     case migration
+    case lsp
 
     /// Subsystem для всех логгеров Pine.
     static let subsystem = Bundle.main.bundleIdentifier ?? "io.github.batonogov.pine"
@@ -48,4 +49,7 @@ nonisolated extension Logger {
 
     /// Миграции данных.
     static let migration = Logger(subsystem: LogCategory.subsystem, category: LogCategory.migration.rawValue)
+
+    /// LSP: language server lifecycle, JSON-RPC transport, diagnostics.
+    static let lsp = Logger(subsystem: LogCategory.subsystem, category: LogCategory.lsp.rawValue)
 }

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -253,12 +253,6 @@ struct PaneLeafView: View {
 
     @ViewBuilder
     private func codeEditorView(for tab: EditorTab, tabManager: TabManager) -> some View {
-        // Merge config-validator diagnostics (yamllint, shellcheck, etc.) with
-        // LSP diagnostics for the current file. LSP diagnostics are keyed by
-        // document URI; config diagnostics are per-active-file in the validator.
-        var combinedDiagnostics = configValidator.diagnostics
-        combinedDiagnostics.append(contentsOf: projectManager.lspManager.diagnostics(for: tab.url))
-
         CodeEditorView(
             text: Binding(
                 get: { tab.content },
@@ -271,7 +265,7 @@ struct PaneLeafView: View {
             lineDiffs: lineDiffs,
             diffVersion: diffVersion,
             diffHunks: diffHunks,
-            validationDiagnostics: combinedDiagnostics,
+            validationDiagnostics: mergedDiagnostics(for: tab),
             isBlameVisible: isBlameVisible,
             blameLines: blameLines,
             foldState: Binding(
@@ -309,6 +303,17 @@ struct PaneLeafView: View {
             configValidator.validate(url: tab.url, content: newValue)
             projectManager.lspManager.didChange(url: tab.url, text: newValue)
         }
+    }
+
+    // MARK: - Diagnostics merging
+
+    /// Merges config-validator diagnostics (yamllint, shellcheck, etc.) with
+    /// LSP diagnostics for the given file. LSP diagnostics are keyed by
+    /// document URI; config diagnostics are per-active-file in the validator.
+    private func mergedDiagnostics(for tab: EditorTab) -> [ValidationDiagnostic] {
+        var combined = configValidator.diagnostics
+        combined.append(contentsOf: projectManager.lspManager.diagnostics(for: tab.url))
+        return combined
     }
 
     // MARK: - Git diff & blame

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -253,6 +253,12 @@ struct PaneLeafView: View {
 
     @ViewBuilder
     private func codeEditorView(for tab: EditorTab, tabManager: TabManager) -> some View {
+        // Merge config-validator diagnostics (yamllint, shellcheck, etc.) with
+        // LSP diagnostics for the current file. LSP diagnostics are keyed by
+        // document URI; config diagnostics are per-active-file in the validator.
+        var combinedDiagnostics = configValidator.diagnostics
+        combinedDiagnostics.append(contentsOf: projectManager.lspManager.diagnostics(for: tab.url))
+
         CodeEditorView(
             text: Binding(
                 get: { tab.content },
@@ -265,7 +271,7 @@ struct PaneLeafView: View {
             lineDiffs: lineDiffs,
             diffVersion: diffVersion,
             diffHunks: diffHunks,
-            validationDiagnostics: configValidator.diagnostics,
+            validationDiagnostics: combinedDiagnostics,
             isBlameVisible: isBlameVisible,
             blameLines: blameLines,
             foldState: Binding(
@@ -293,12 +299,15 @@ struct PaneLeafView: View {
         .onAppear {
             goToLineOffset = nil
             configValidator.validate(url: tab.url, content: tab.content)
+            projectManager.lspManager.didOpen(url: tab.url, text: tab.content)
         }
         .onDisappear {
             configValidator.clear()
+            projectManager.lspManager.didClose(url: tab.url)
         }
         .onChange(of: tab.content) { _, newValue in
             configValidator.validate(url: tab.url, content: newValue)
+            projectManager.lspManager.didChange(url: tab.url, text: newValue)
         }
     }
 

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -764,6 +764,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             pm.agentHistory.flush()
             pm.saveSession()
             pm.cleanupEditorContext()
+            // Shut down language servers so no orphan process survives (#1010).
+            pm.shutdownLanguageServers()
             // Clean up recovery files if all tabs are saved
             if !pm.hasUnsavedChanges {
                 pm.recoveryManager?.deleteAllRecoveryFiles()

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -38,6 +38,10 @@ final class ProjectManager {
     let quickOpenProvider = QuickOpenProvider()
     let progress = ProgressTracker()
     let contextFileWriter = ContextFileWriter()
+    /// Language Server Protocol manager — owns per-language server processes
+    /// and aggregates diagnostics (#1010, parent #994). Spawned lazily on the
+    /// first open of a matching file; shut down on project close / app quit.
+    let lspManager = LSPManager()
     @ObservationIgnored
     private(set) lazy var paneManager = PaneManager(existingTabManager: primaryTabManager)
 
@@ -330,6 +334,7 @@ final class ProjectManager {
         setupRecovery(projectURL: url)
         agentHistory.updateProjectRoot(url)
         Task { await contextFileWriter.setProjectRoot(url) }
+        lspManager.setWorkspaceRoot(url)
     }
 
     // MARK: - Agent activity file-system correlation (#1072)
@@ -486,5 +491,12 @@ final class ProjectManager {
         Task {
             await contextFileWriter.cleanup()
         }
+    }
+
+    /// Shuts down all language servers for this project. Called on window
+    /// close and app termination so no orphan language-server process
+    /// survives (acceptance criterion #1010). Safe to call multiple times.
+    func shutdownLanguageServers() {
+        lspManager.shutdownAll()
     }
 }

--- a/Pine/StatusBarView.swift
+++ b/Pine/StatusBarView.swift
@@ -41,7 +41,8 @@ struct StatusBarView: View {
                     HStack(spacing: 4) {
                         Image(systemName: summary.errorCount > 0 ? "xmark.octagon.fill" : "exclamationmark.bubble.fill")
                             .font(.system(size: LayoutMetrics.captionFontSize))
-                        Text(verbatim: "\(summary.errorCount) error\(summary.errorCount == 1 ? "" : "s")  \(summary.warningCount) warning\(summary.warningCount == 1 ? "" : "s")")
+                                                let label = "\(summary.errorCount) error\(summary.errorCount == 1 ? "" : "s")  \(summary.warningCount) warning\(summary.warningCount == 1 ? "" : "s")"
+                                                Text(verbatim: label)
                             .font(.system(size: LayoutMetrics.bodySmallFontSize))
                     }
                     .foregroundStyle(summary.errorCount > 0 ? .red : .orange)

--- a/Pine/StatusBarView.swift
+++ b/Pine/StatusBarView.swift
@@ -15,6 +15,11 @@ struct StatusBarView: View {
     var tabManager: TabManager
     var progress: ProgressTracker?
     var onToggleTerminal: (() -> Void)?
+    /// LSP / validator diagnostics summary for the Problems indicator (#1010).
+    /// `nil` hides the indicator (e.g. no project loaded).
+    var diagnosticsSummary: DiagnosticsSummary?
+    /// Called when the user clicks the Problems indicator to toggle the panel.
+    var onToggleProblems: (() -> Void)?
 
     /// Active AI agent sessions across all terminal panes (#952).
     /// Empty when no agent is running → `AgentStatusBarItem` is hidden.
@@ -27,6 +32,24 @@ struct StatusBarView: View {
         // and walking the pane/tab tree twice (isEmpty check + arg) is wasteful.
         let summaries = agentSummaries
         return HStack(spacing: LayoutMetrics.statusBarItemSpacing) {
+            // Problems indicator (#1010): click to toggle the Problems panel.
+            // Hidden when there are zero diagnostics *and* no panel is open.
+            if let summary = diagnosticsSummary, summary.total > 0 {
+                Button {
+                    onToggleProblems?()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: summary.errorCount > 0 ? "xmark.octagon.fill" : "exclamationmark.bubble.fill")
+                            .font(.system(size: LayoutMetrics.captionFontSize))
+                        Text(verbatim: "\(summary.errorCount) error\(summary.errorCount == 1 ? "" : "s")  \(summary.warningCount) warning\(summary.warningCount == 1 ? "" : "s")")
+                            .font(.system(size: LayoutMetrics.bodySmallFontSize))
+                    }
+                    .foregroundStyle(summary.errorCount > 0 ? .red : .orange)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier(AccessibilityID.problemsIndicator)
+            }
+
             if let progress, progress.isLoading {
                 HStack(spacing: 4) {
                     ProgressView()

--- a/Pine/StatusBarView.swift
+++ b/Pine/StatusBarView.swift
@@ -41,8 +41,7 @@ struct StatusBarView: View {
                     HStack(spacing: 4) {
                         Image(systemName: summary.errorCount > 0 ? "xmark.octagon.fill" : "exclamationmark.bubble.fill")
                             .font(.system(size: LayoutMetrics.captionFontSize))
-                                                let label = "\(summary.errorCount) error\(summary.errorCount == 1 ? "" : "s")  \(summary.warningCount) warning\(summary.warningCount == 1 ? "" : "s")"
-                                                Text(verbatim: label)
+                        Text(verbatim: summary.description)
                             .font(.system(size: LayoutMetrics.bodySmallFontSize))
                     }
                     .foregroundStyle(summary.errorCount > 0 ? .red : .orange)

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -538,6 +538,12 @@ enum Strings {
         return String(format: format, locale: .current, line, column)
     }
 
+    // MARK: - LSP / Problems panel (#1010)
+
+    static var problemsNoIssues: String {
+        String(localized: "problems.noIssues", defaultValue: "No problems detected")
+    }
+
     // MARK: - Accessibility (#1003)
     //
     // VoiceOver labels / hints for custom controls. These are resolved into


### PR DESCRIPTION
Implements #1010 — first phase of LSP support (parent #994).

## New: Pine/LSP/ (1,213 lines)

| File | Lines | Purpose |
|---|---|---|
| LSPClient.swift | 545 | JSON-RPC 2.0 transport over stdio, async framing, initialize/shutdown handshake |
| LSPManager.swift | 214 | @Observable server lifecycle, per-language spawning, diagnostics store |
| DiagnosticsProvider.swift | 171 | LSP value types + DiagnosticMapper (0-based→1-based) |
| LanguageServerRegistry.swift | 122 | Swift/TypeScript/Python server config |
| ProblemsPanelView.swift | 161 | SwiftUI problems panel, file-grouped diagnostics |

## Integration
- ProjectManager: lspManager property, workspace root, shutdownLanguageServers()
- PaneLeafView: merged LSP + config-validator diagnostics, didOpen/didChange/didClose
- StatusBarView: error/warning count indicator
- PineApp: LSP shutdown on terminate

## Design
- Reuses existing ValidationDiagnostic model → zero new rendering code
- All I/O on private DispatchQueue, UI on @MainActor
- Graceful no-op when server binary absent

## TODO (follow-up PRs)
- [ ] Wire ProblemsPanelView into ContentView overlay
- [ ] Add localization keys
- [ ] Unit tests (JSON-RPC framing, diagnostic mapping, lifecycle)
- [ ] AGENTS.md LSP section

Towards #994.