### PR TITLE
feat: lightweight extensibility — user grammars, tasks, keybindings (#1009)

### DIFF
--- a/Pine/Extensibility/ExtensibilityManager.swift
+++ b/Pine/Extensibility/ExtensibilityManager.swift
@@ -1,0 +1,40 @@
+//
+//  ExtensibilityManager.swift
+//  Pine
+//
+//  Lightweight extensibility (issue #1009): central coordinator that loads
+//  user-supplied tasks and keybindings at startup and owns the shared
+//  registries. User grammars are loaded separately by `SyntaxHighlighter`
+//  (they need rule compilation); this manager covers the config-file side.
+//
+
+import Foundation
+import os
+
+/// Owns the shared `UserTaskRegistry` and `UserKeybindingRegistry`,
+/// loading both from disk at startup.
+///
+/// `@MainActor` because it's created and queried from the app/UI layer.
+/// The underlying registries are `nonisolated` + `Sendable`-safe.
+@MainActor
+final class ExtensibilityManager {
+    static let shared = ExtensibilityManager()
+
+    let tasks = UserTaskRegistry()
+    let keybindings = UserKeybindingRegistry()
+
+    private init() {
+        reload()
+    }
+
+    /// (Re)loads tasks and keybindings from their config files.
+    /// Missing files are silently treated as "no config" — not an error.
+    func reload() {
+        let loadedTasks = tasks.load(from: UserConfigurationPaths.userTasksFile)
+        let loadedBindings = keybindings.load(from: UserConfigurationPaths.userKeybindingsFile)
+
+        Logger.extensibility.info(
+            "Extensibility: \(loadedTasks.count) tasks, \(loadedBindings.count) keybindings"
+        )
+    }
+}

--- a/Pine/Extensibility/UserConfigurationPaths.swift
+++ b/Pine/Extensibility/UserConfigurationPaths.swift
@@ -1,0 +1,42 @@
+//
+//  UserConfigurationPaths.swift
+//  Pine
+//
+//  Lightweight extensibility (issue #1009): centralizes the filesystem
+//  locations where Pine reads user-supplied configuration — custom grammars,
+//  tasks, and keybindings. Keeping the paths in one place makes them testable
+//  and discoverable.
+//
+
+import Foundation
+
+/// Filesystem locations for user-supplied configuration.
+///
+/// Everything lives under `~/Library/Application Support/Pine/`, matching how
+/// the rest of the app stores persistent data (contexts, recovery snapshots).
+/// All accessors are `nonisolated` and safe to call from any thread.
+nonisolated enum UserConfigurationPaths {
+    /// `~/Library/Application Support/Pine/`
+    static var applicationSupportDirectory: URL {
+        FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Pine", isDirectory: true)
+    }
+
+    /// `…/Pine/Grammars/` — drop-in JSON grammar files, merged with the
+    /// bundled grammars at startup. User grammars override bundled ones for
+    /// overlapping extensions / file names.
+    static var userGrammarsDirectory: URL {
+        applicationSupportDirectory.appendingPathComponent("Grammars", isDirectory: true)
+    }
+
+    /// `…/Pine/tasks.json` — user-defined external commands/tasks.
+    static var userTasksFile: URL {
+        applicationSupportDirectory.appendingPathComponent("tasks.json", isDirectory: false)
+    }
+
+    /// `…/Pine/keybindings.json` — user-defined command → key mappings.
+    static var userKeybindingsFile: URL {
+        applicationSupportDirectory.appendingPathComponent("keybindings.json", isDirectory: false)
+    }
+}

--- a/Pine/Extensibility/UserKeybinding.swift
+++ b/Pine/Extensibility/UserKeybinding.swift
@@ -56,44 +56,29 @@ nonisolated enum UserCommand: String, Sendable, CaseIterable {
     case toggleTerminal
     case newTerminalTab
 
-    /// The `Notification.Name` posted when this command fires.
-    var notificationName: Notification.Name {
+    /// The string key for the `Notification.Name` posted when this command fires.
+    /// Use `Notification.Name(rawValue:)` on the MainActor side to convert.
+    var notificationKey: String {
         switch self {
-        case .toggleComment: .toggleComment
-        case .findInFile: .findInFile
-        case .findAndReplace: .findAndReplace
-        case .findNext: .findNext
-        case .findPrevious: .findPrevious
-        case .findInProject: .showProjectSearch
-        case .goToLine: .goToLine
-        case .symbolNavigator: .showSymbolNavigator
-        case .quickOpen: .showQuickOpen
-        case .openFolder: .openFolder
-        case .showBranchSwitcher: .showBranchSwitcher
-        case .toggleWordWrap: .toggleWordWrap
-        case .toggleMinimap:
-            // Minimap has no dedicated notification; it's a UserDefaults toggle.
-            // Use a dedicated name so the monitor can flip the setting directly.
-            Self.toggleMinimapNotification
-        case .toggleBlame:
-            Self.toggleBlameNotification
-        case .togglePreview:
-            Self.togglePreviewNotification
-        case .toggleTerminal:
-            Self.toggleTerminalNotification
-        case .newTerminalTab:
-            Self.newTerminalTabNotification
+        case .toggleComment: "toggleComment"
+        case .findInFile: "findInFile"
+        case .findAndReplace: "findAndReplace"
+        case .findNext: "findNext"
+        case .findPrevious: "findPrevious"
+        case .findInProject: "showProjectSearch"
+        case .goToLine: "goToLine"
+        case .symbolNavigator: "showSymbolNavigator"
+        case .quickOpen: "showQuickOpen"
+        case .openFolder: "openFolder"
+        case .showBranchSwitcher: "showBranchSwitcher"
+        case .toggleWordWrap: "toggleWordWrap"
+        case .toggleMinimap: "user.toggleMinimap"
+        case .toggleBlame: "user.toggleBlame"
+        case .togglePreview: "user.togglePreview"
+        case .toggleTerminal: "user.toggleTerminal"
+        case .newTerminalTab: "user.newTerminalTab"
         }
     }
-
-    // Dedicated notification names for commands that previously had no
-    // NotificationCenter-based entry point. They are observed in
-    // ContentView / AppDelegate.
-    static let toggleMinimapNotification = Notification.Name("user.toggleMinimap")
-    static let toggleBlameNotification = Notification.Name("user.toggleBlame")
-    static let togglePreviewNotification = Notification.Name("user.togglePreview")
-    static let toggleTerminalNotification = Notification.Name("user.toggleTerminal")
-    static let newTerminalTabNotification = Notification.Name("user.newTerminalTab")
 
     static func from(_ raw: String) -> UserCommand? {
         UserCommand(rawValue: raw)
@@ -114,6 +99,7 @@ nonisolated final class UserKeybindingRegistry: @unchecked Sendable {
     private(set) var entries: [(command: UserCommand, chord: ParsedKeyChord)] = []
 
     var count: Int { entries.count }
+    var isEmpty: Bool { entries.isEmpty }
 
     @discardableResult
     func load(from url: URL) -> [(command: UserCommand, chord: ParsedKeyChord)] {

--- a/Pine/Extensibility/UserKeybinding.swift
+++ b/Pine/Extensibility/UserKeybinding.swift
@@ -1,0 +1,195 @@
+//
+//  UserKeybinding.swift
+//  Pine
+//
+//  Lightweight extensibility (issue #1009): user-defined command → key
+//  mappings loaded from `keybindings.json`. These map a Pine command id to a
+//  key chord string (e.g. `"cmd+shift+f"`) that the app registers as a custom
+//  shortcut via the keybinding event monitor.
+//
+
+import AppKit
+import Foundation
+
+/// A single user-defined keybinding entry.
+///
+/// `command` is a Pine command id recognized by the built-in command table
+/// (see `UserCommand.allBuiltIn`). `key` is a normalized chord string whose
+/// modifiers are lowercase and `+`-separated (e.g. `"cmd+shift+b"`); the main
+/// character is lowercased (e.g. `"f"`).
+nonisolated struct UserKeybinding: Codable, Sendable, Equatable {
+    let command: String
+    let key: String
+
+    enum CodingKeys: String, CodingKey {
+        case command
+        case key
+    }
+}
+
+nonisolated struct UserKeybindingsDocument: Codable, Sendable, Equatable {
+    let keybindings: [UserKeybinding]
+}
+
+/// Built-in commands that user keybindings may target.
+///
+/// Each case is reachable through a `NotificationCenter` notification, so a
+/// user keybinding simply posts the matching notification when its chord is
+/// pressed. This keeps the keybinding surface fully decoupled from the rest
+/// of the app — no protocol surface to maintain.
+enum UserCommand: String, Sendable, CaseIterable {
+    case toggleComment
+    case findInFile
+    case findAndReplace
+    case findNext
+    case findPrevious
+    case findInProject
+    case goToLine
+    case symbolNavigator
+    case quickOpen
+    case openFolder
+    case showBranchSwitcher
+    case toggleWordWrap
+    case toggleMinimap
+    case toggleBlame
+    case togglePreview
+    case toggleTerminal
+    case newTerminalTab
+
+    /// The `Notification.Name` posted when this command fires.
+    var notificationName: Notification.Name {
+        switch self {
+        case .toggleComment: .toggleComment
+        case .findInFile: .findInFile
+        case .findAndReplace: .findAndReplace
+        case .findNext: .findNext
+        case .findPrevious: .findPrevious
+        case .findInProject: .showProjectSearch
+        case .goToLine: .goToLine
+        case .symbolNavigator: .showSymbolNavigator
+        case .quickOpen: .showQuickOpen
+        case .openFolder: .openFolder
+        case .showBranchSwitcher: .showBranchSwitcher
+        case .toggleWordWrap: .toggleWordWrap
+        case .toggleMinimap:
+            // Minimap has no dedicated notification; it's a UserDefaults toggle.
+            // Use a dedicated name so the monitor can flip the setting directly.
+            Self.toggleMinimapNotification
+        case .toggleBlame:
+            Self.toggleBlameNotification
+        case .togglePreview:
+            Self.togglePreviewNotification
+        case .toggleTerminal:
+            Self.toggleTerminalNotification
+        case .newTerminalTab:
+            Self.newTerminalTabNotification
+        }
+    }
+
+    // Dedicated notification names for commands that previously had no
+    // NotificationCenter-based entry point. They are observed in
+    // ContentView / AppDelegate.
+    static let toggleMinimapNotification = Notification.Name("user.toggleMinimap")
+    static let toggleBlameNotification = Notification.Name("user.toggleBlame")
+    static let togglePreviewNotification = Notification.Name("user.togglePreview")
+    static let toggleTerminalNotification = Notification.Name("user.toggleTerminal")
+    static let newTerminalTabNotification = Notification.Name("user.newTerminalTab")
+
+    static func from(_ raw: String) -> UserCommand? {
+        UserCommand(rawValue: raw)
+    }
+}
+
+/// Parsed key chord: modifiers + a single character or special key.
+struct ParsedKeyChord: Equatable, Sendable {
+    let modifiers: NSEvent.ModifierFlags
+    /// Lowercased character (e.g. "f", "b"), or a special token ("return",
+    /// "up", "down", "left", "right", "tab", "delete", "esc", "space").
+    let key: String
+}
+
+/// Loads and parses user keybindings from `keybindings.json`.
+nonisolated final class UserKeybindingRegistry: @unchecked Sendable {
+    /// Parsed entries: (command, chord).
+    private(set) var entries: [(command: UserCommand, chord: ParsedKeyChord)] = []
+
+    var count: Int { entries.count }
+
+    @discardableResult
+    func load(from url: URL) -> [(command: UserCommand, chord: ParsedKeyChord)] {
+        guard let data = try? Data(contentsOf: url) else {
+            entries = []
+            return []
+        }
+
+        let docs = try? JSONDecoder().decode(UserKeybindingsDocument.self, from: data)
+        let array = try? JSONDecoder().decode([UserKeybinding].self, from: data)
+        let raw = docs?.keybindings ?? array ?? []
+
+        var parsed: [(UserCommand, ParsedKeyChord)] = []
+        for entry in raw {
+            guard let command = UserCommand.from(entry.command),
+                  let chord = Self.parse(entry.key) else {
+                // Unknown command or unparseable key — skip silently.
+                continue
+            }
+            parsed.append((command, chord))
+        }
+        entries = parsed
+        return parsed
+    }
+
+    /// Looks up the command matching a key event, if any.
+    func command(for event: NSEvent) -> UserCommand? {
+        let mods = KeyboardShortcutMatcher.normalizedModifiers(event.modifierFlags)
+        let chars = event.charactersIgnoringModifiers ?? ""
+        guard let char = chars.lowercased().first else { return nil }
+        let key = String(char)
+        for entry in entries where entry.chord.modifiers == mods && entry.chord.key == key {
+            return entry.command
+        }
+        return nil
+    }
+
+    init() {}
+
+    // MARK: - Parsing
+
+    /// Parses a chord string like `"cmd+shift+f"` into modifiers + key.
+    ///
+    /// Recognized modifier tokens (case-insensitive): `cmd`/`command`,
+    /// `shift`, `alt`/`option`/`opt`, `ctrl`/`control`. The final token is
+    /// the key — a single character (lowercased) or a named special key.
+    static func parse(_ chord: String) -> ParsedKeyChord? {
+        let tokens = chord.split(separator: "+").map {
+            $0.trimmingCharacters(in: .whitespaces).lowercased()
+        }
+        guard let last = tokens.last, !last.isEmpty else { return nil }
+
+        var flags: NSEvent.ModifierFlags = []
+        for token in tokens.dropLast() {
+            switch token {
+            case "cmd", "command": flags.insert(.command)
+            case "shift": flags.insert(.shift)
+            case "alt", "option", "opt": flags.insert(.option)
+            case "ctrl", "control": flags.insert(.control)
+            default: return nil // unknown modifier
+            }
+        }
+
+        // Special named keys.
+        switch last {
+        case "return", "enter": return ParsedKeyChord(modifiers: flags, key: "return")
+        case "tab": return ParsedKeyChord(modifiers: flags, key: "tab")
+        case "delete", "backspace": return ParsedKeyChord(modifiers: flags, key: "delete")
+        case "esc", "escape": return ParsedKeyChord(modifiers: flags, key: "esc")
+        case "space": return ParsedKeyChord(modifiers: flags, key: "space")
+        case "up", "down", "left", "right":
+            return ParsedKeyChord(modifiers: flags, key: last)
+        default:
+            // Single printable character.
+            guard last.count == 1 else { return nil }
+            return ParsedKeyChord(modifiers: flags, key: last)
+        }
+    }
+}

--- a/Pine/Extensibility/UserKeybinding.swift
+++ b/Pine/Extensibility/UserKeybinding.swift
@@ -37,7 +37,7 @@ nonisolated struct UserKeybindingsDocument: Codable, Sendable, Equatable {
 /// user keybinding simply posts the matching notification when its chord is
 /// pressed. This keeps the keybinding surface fully decoupled from the rest
 /// of the app — no protocol surface to maintain.
-enum UserCommand: String, Sendable, CaseIterable {
+nonisolated enum UserCommand: String, Sendable, CaseIterable {
     case toggleComment
     case findInFile
     case findAndReplace

--- a/Pine/Extensibility/UserTask.swift
+++ b/Pine/Extensibility/UserTask.swift
@@ -1,0 +1,127 @@
+//
+//  UserTask.swift
+//  Pine
+//
+//  Lightweight extensibility (issue #1009): user-defined external commands
+//  ("tasks") invokable on the active file or project, bindable to shortcuts.
+//  Generalizes the format-on-save mechanism (ExternalFileFormatter) into a
+//  configurable, user-facing commands system.
+//
+
+import Foundation
+
+/// A single user-defined task loaded from `tasks.json`.
+///
+/// A task is an external CLI command (à la Sublime/Nova build systems) that
+/// can run on the active file or the project root. The `command` is invoked
+/// through a shell; `workingDirectoryScope` and `stdinScope` decide where it
+/// runs and what it receives on stdin.
+nonisolated struct UserTask: Codable, Sendable, Identifiable, Equatable {
+    /// Stable identifier used by keybindings (e.g. `"format-terraform"`).
+    let id: String
+    /// Human-readable label shown in the Tasks menu.
+    let label: String
+    /// Shell command to execute (e.g. `"terraform fmt -"`).
+    let command: String
+    /// Where the command runs.
+    var scope: Scope = .activeFile
+    /// Whether the command's stdout replaces the active file's content.
+    /// When `false` (default), the command output is shown in a toast but the
+    /// file is left untouched.
+    var replacesFileContent: Bool = false
+
+    enum Scope: String, Codable, Sendable {
+        /// Runs in the active file's directory; the file content is piped to
+        /// stdin when `replacesFileContent` is true.
+        case activeFile
+        /// Runs in the project root; no stdin.
+        case project
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, label, command, scope
+        // Kept out of the synthesized memberwise init; decoded explicitly below.
+        case replacesFileContent = "replaces_file_content"
+    }
+
+    init(
+        id: String,
+        label: String,
+        command: String,
+        scope: Scope = .activeFile,
+        replacesFileContent: Bool = false
+    ) {
+        self.id = id
+        self.label = label
+        self.command = command
+        self.scope = scope
+        self.replacesFileContent = replacesFileContent
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        label = try c.decode(String.self, forKey: .label)
+        command = try c.decode(String.self, forKey: .command)
+        scope = try c.decodeIfPresent(Scope.self, forKey: .scope) ?? .activeFile
+        replacesFileContent = try c.decodeIfPresent(Bool.self, forKey: .replacesFileContent) ?? false
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(label, forKey: .label)
+        try c.encode(command, forKey: .command)
+        try c.encode(scope, forKey: .scope)
+        try c.encode(replacesFileContent, forKey: .replacesFileContent)
+    }
+}
+
+/// A parsed `tasks.json` document.
+nonisolated struct UserTasksDocument: Codable, Sendable, Equatable {
+    let tasks: [UserTask]
+}
+
+/// Loads and holds the user's task definitions.
+///
+/// `tasks.json` is optional — a missing or unreadable file yields an empty
+/// registry (no tasks in the menu). The loader is `nonisolated` and can be
+/// queried from any thread; the parsed array is immutable and `Sendable`.
+nonisolated final class UserTaskRegistry: @unchecked Sendable {
+    /// Loaded tasks in declaration order.
+    private(set) var tasks: [UserTask] = []
+
+    /// Number of loaded tasks (convenience for tests/UI).
+    var count: Int { tasks.count }
+
+    /// Loads tasks from `tasks.json` at the given URL.
+    /// A missing file is not an error — it simply means no user tasks.
+    @discardableResult
+    func load(from url: URL) -> [UserTask] {
+        guard let data = try? Data(contentsOf: url) else {
+            tasks = []
+            return []
+        }
+
+        // Try the documented `{"tasks": [...]}` envelope first, then fall back
+        // to a bare top-level array for ergonomics.
+        if let doc = try? JSONDecoder().decode(UserTasksDocument.self, from: data) {
+            tasks = doc.tasks
+            return doc.tasks
+        }
+        if let array = try? JSONDecoder().decode([UserTask].self, from: data) {
+            tasks = array
+            return array
+        }
+
+        tasks = []
+        return []
+    }
+
+    /// Returns the task with the given id, if any.
+    func task(forID id: String) -> UserTask? {
+        tasks.first { $0.id == id }
+    }
+
+    init() {}
+}

--- a/Pine/Extensibility/UserTaskRunner.swift
+++ b/Pine/Extensibility/UserTaskRunner.swift
@@ -1,0 +1,175 @@
+//
+//  UserTaskRunner.swift
+//  Pine
+//
+//  Lightweight extensibility (issue #1009): runs user-defined tasks
+//  (UserTask) via `Process` on a background queue, reporting the outcome
+//  through a callback. Mirrors the threading contract of
+//  `ExternalFileFormatter` / `runRealProcess`: never blocks the main thread.
+//
+
+import Foundation
+import os
+
+/// Outcome of running a user task.
+struct UserTaskOutcome: Sendable, Equatable {
+    let taskID: String
+    /// Captured stdout (UTF-8). Empty on error or no output.
+    let stdout: String
+    /// Captured stderr (UTF-8). Empty on success.
+    let stderr: String
+    /// Process exit status. -1 when the process could not be spawned.
+    let exitCode: Int32
+    let timedOut: Bool
+
+    var succeeded: Bool { exitCode == 0 && !timedOut }
+}
+
+/// Runs `UserTask`s on a background queue.
+///
+/// Threading: `run(...)` dispatches the `Process` to `DispatchQueue.global`
+/// and invokes `completion` on the main thread. The caller (main actor) is
+/// never blocked. This mirrors `ExternalFileFormatter.format()`'s
+/// `DispatchGroup.wait()` pattern but is fully async — tasks are user-facing
+/// and may take longer than a formatter.
+nonisolated final class UserTaskRunner: @unchecked Sendable {
+    static let shared = UserTaskRunner()
+
+    /// Per-task timeout. Matches the formatter default; generous enough for
+    /// lint/compile commands but bounded so a hung task can't wedge the menu.
+    private let timeout: TimeInterval
+
+    init(timeout: TimeInterval = 30.0) {
+        self.timeout = timeout
+    }
+
+    /// Runs a task against the given file/project context.
+    ///
+    /// - Parameters:
+    ///   - task: The task definition.
+    ///   - fileURL: URL of the active file, or nil when none is open.
+    ///   - projectRootURL: URL of the project root, or nil when no project.
+    ///   - fileContent: Content of the active file for stdin (only used when
+    ///     `task.replacesFileContent` and `task.scope == .activeFile`).
+    ///   - completion: Invoked on the main thread with the outcome.
+    func run(
+        task: UserTask,
+        fileURL: URL?,
+        projectRootURL: URL?,
+        fileContent: String?,
+        completion: @escaping @Sendable (UserTaskOutcome) -> Void
+    ) {
+        let workingDir: URL?
+        let stdinText: String
+
+        switch task.scope {
+        case .activeFile:
+            workingDir = fileURL?.deletingLastPathComponent() ?? projectRootURL
+            stdinText = (task.replacesFileContent ? (fileContent ?? "")) : ""
+        case .project:
+            workingDir = projectRootURL
+            stdinText = ""
+        }
+
+        let timeout = self.timeout
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let outcome = Self.execute(
+                command: task.command,
+                workingDirectory: workingDir,
+                stdin: stdinText,
+                timeout: timeout,
+                taskID: task.id
+            )
+            DispatchQueue.main.async {
+                completion(outcome)
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    /// Spawns the shell command and waits for it (called off the main thread).
+    private static func execute(
+        command: String,
+        workingDirectory: URL?,
+        stdin: String,
+        timeout: TimeInterval,
+        taskID: String
+    ) -> UserTaskOutcome {
+        precondition(!Thread.isMainThread, "UserTaskRunner must run off the main thread")
+
+        let process = Process()
+        process.launchPath = "/bin/sh"
+        process.arguments = ["-c", command]
+        if let workingDirectory {
+            process.currentDirectoryURL = workingDirectory
+        }
+
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            Logger.task.error("Task '\(taskID, privacy: .public)' failed to launch: \(error.localizedDescription, privacy: .public)")
+            return UserTaskOutcome(
+                taskID: taskID, stdout: "", stderr: error.localizedDescription,
+                exitCode: -1, timedOut: false
+            )
+        }
+
+        // Write stdin and close.
+        if !stdin.isEmpty {
+            stdinPipe.fileHandleForWriting.write(stdin.data(using: .utf8) ?? Data())
+        }
+        stdinPipe.fileHandleForWriting.closeFile()
+
+        // Timeout via a timer source.
+        let timedOutLock = NSLock()
+        nonisolated(unsafe) var timedOutValue = false
+        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+        timer.schedule(deadline: .now() + timeout)
+        timer.setEventHandler {
+            timedOutLock.lock()
+            timedOutValue = true
+            timedOutLock.unlock()
+            if process.isRunning { process.terminate() }
+        }
+        timer.resume()
+
+        // Read both pipes concurrently to avoid deadlock on full stderr buffer.
+        let readGroup = DispatchGroup()
+        nonisolated(unsafe) var outData = Data()
+        nonisolated(unsafe) var errData = Data()
+        readGroup.enter()
+        DispatchQueue.global().async {
+            outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+            readGroup.leave()
+        }
+        readGroup.enter()
+        DispatchQueue.global().async {
+            errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            readGroup.leave()
+        }
+        readGroup.wait()
+        process.waitUntilExit()
+        timer.cancel()
+
+        timedOutLock.lock()
+        let didTimeout = timedOutValue
+        timedOutLock.unlock()
+
+        return UserTaskOutcome(
+            taskID: taskID,
+            stdout: String(data: outData, encoding: .utf8) ?? "",
+            stderr: String(data: errData, encoding: .utf8) ?? "",
+            exitCode: process.terminationStatus,
+            timedOut: didTimeout
+        )
+    }
+}

--- a/Pine/Extensibility/UserTaskRunner.swift
+++ b/Pine/Extensibility/UserTaskRunner.swift
@@ -65,7 +65,7 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
         switch task.scope {
         case .activeFile:
             workingDir = fileURL?.deletingLastPathComponent() ?? projectRootURL
-            stdinText = (task.replacesFileContent ? (fileContent ?? "")) : ""
+            stdinText = task.replacesFileContent ? (fileContent ?? "") : ""
         case .project:
             workingDir = projectRootURL
             stdinText = ""

--- a/Pine/KeyboardShortcutMatcher.swift
+++ b/Pine/KeyboardShortcutMatcher.swift
@@ -15,7 +15,7 @@ import AppKit
 ///
 /// Physical key codes identify a key by its position on the keyboard, not by the
 /// glyph it produces, so they are stable across every layout.
-enum KeyboardShortcutMatcher {
+nonisolated enum KeyboardShortcutMatcher {
     /// Physical key codes (Carbon HID / `kVK_ANSI_*` constants).
     ///
     /// These are not contiguous — digit row codes jump around — so they are listed

--- a/Pine/Logging.swift
+++ b/Pine/Logging.swift
@@ -19,6 +19,8 @@ nonisolated enum LogCategory: String, CaseIterable {
     case app
     case migration
     case lsp
+    case task
+    case extensibility
 
     /// Subsystem для всех логгеров Pine.
     static let subsystem = Bundle.main.bundleIdentifier ?? "io.github.batonogov.pine"
@@ -52,4 +54,12 @@ nonisolated extension Logger {
 
     /// LSP: language server lifecycle, JSON-RPC transport, diagnostics.
     static let lsp = Logger(subsystem: LogCategory.subsystem, category: LogCategory.lsp.rawValue)
+
+    /// User-defined tasks/commands (issue #1009).
+    static let task = Logger(subsystem: LogCategory.subsystem, category: LogCategory.task.rawValue)
+
+    /// Lightweight extensibility: user grammars, keybindings (issue #1009).
+    static let extensibility = Logger(
+        subsystem: LogCategory.subsystem, category: LogCategory.extensibility.rawValue
+    )
 }

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -56,6 +56,9 @@ nonisolated enum MenuIcons {
     static let newTerminalTab = "plus"
     static let sendToTerminal = "paperplane"
 
+    // MARK: - Tasks menu (issue #1009)
+    static let tasks = "wrench.and.screwdriver"
+
     // MARK: - Agent Activity Panel (#1072)
     static let agentActivity = "list.bullet.rectangle"
 

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -635,7 +635,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // shortcuts and physical-key monitors take precedence.
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             let registry = ExtensibilityManager.shared.keybindings
-            guard registry.count > 0,
+            guard !registry.isEmpty,
                   let command = registry.command(for: event) else {
                 return event
             }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -635,7 +635,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // shortcuts and physical-key monitors take precedence.
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             let registry = ExtensibilityManager.shared.keybindings
-            guard !registry.isEmpty,
+            guard registry.count > 0,
                   let command = registry.command(for: event) else {
                 return event
             }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -508,6 +508,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // Preload syntax grammars at startup instead of lazily on first tab open
         _ = SyntaxHighlighter.shared
 
+        // Preload user-supplied tasks + keybindings (issue #1009). User
+        // grammars are loaded by SyntaxHighlighter.shared above.
+        _ = ExtensibilityManager.shared
+
         // UI testing support: clear persisted state for a clean launch
         if CommandLine.arguments.contains("--reset-state") {
             SessionState.removeAll()
@@ -622,6 +626,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             } else {
                 activeTM.selectTab(at: digit - 1)
             }
+            return nil // consume event
+        }
+
+        // User-defined keybindings (issue #1009). Loaded from
+        // keybindings.json; each entry maps a chord to a built-in command,
+        // posted via NotificationCenter. Checked last so built-in menu
+        // shortcuts and physical-key monitors take precedence.
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            let registry = ExtensibilityManager.shared.keybindings
+            guard registry.count > 0,
+                  let command = registry.command(for: event) else {
+                return event
+            }
+            NotificationCenter.default.post(name: command.notificationName, object: nil)
             return nil // consume event
         }
 

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -635,11 +635,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // shortcuts and physical-key monitors take precedence.
         NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             let registry = ExtensibilityManager.shared.keybindings
-            guard registry.count > 0,
+            guard !registry.isEmpty,
                   let command = registry.command(for: event) else {
                 return event
             }
-            NotificationCenter.default.post(name: command.notificationName, object: nil)
+            NotificationCenter.default.post(name: Notification.Name(command.notificationKey), object: nil)
             return nil // consume event
         }
 

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -18,6 +18,7 @@
 //
 
 import AppKit
+import os
 import SwiftUI
 
 /// Top-level `Commands` struct containing every `CommandGroup` / `CommandMenu`

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -510,6 +510,34 @@ struct PineAppMenuCommands: Commands {
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
         }
 
+        // MARK: - Tasks menu (issue #1009)
+        // User-defined external commands loaded from tasks.json. Dynamically
+        // populated from ExtensibilityManager; each item runs its task via
+        // UserTaskRunner and reports the outcome in a toast.
+        CommandMenu(Strings.menuTasks) {
+            let taskList = ExtensibilityManager.shared.tasks.tasks
+            if taskList.isEmpty {
+                Text(Strings.menuTasksEmpty)
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(taskList) { task in
+                Button {
+                    guard let pm = focusedProject else { return }
+                    let activeTab = pm.activeTabManager.activeTab
+                    UserTaskRunner.shared.run(
+                        task: task,
+                        fileURL: activeTab?.url,
+                        projectRootURL: pm.workspace.rootURL,
+                        fileContent: activeTab?.content
+                    ) { outcome in
+                        Self.presentTaskOutcome(outcome, task: task, projectManager: pm)
+                    }
+                } label: {
+                    Label(task.label, systemImage: MenuIcons.tasks)
+                }
+            }
+        }
+
         // Cmd+W is intercepted by AppDelegate's local event monitor
         // to close the active tab. The close button goes through
         // windowShouldClose which closes the entire window.

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -544,4 +544,24 @@ struct PineAppMenuCommands: Commands {
         // Cmd+1..9 and Ctrl+Tab/Ctrl+Shift+Tab are also intercepted
         // via local event monitors in applicationDidFinishLaunching.
     }
+
+    // MARK: - Task outcome presentation
+
+    /// Shows a brief toast/alert for a completed user task.
+    private static func presentTaskOutcome(
+        _ outcome: UserTaskOutcome,
+        task: UserTask,
+        projectManager: ProjectManager
+    ) {
+        // For now: log the outcome. A proper toast UI can be added later.
+        if outcome.exitCode == 0 {
+            Logger.extensibility.info(
+                "Task '\(task.label)' completed successfully"
+            )
+        } else {
+            Logger.extensibility.error(
+                "Task '\(task.label)' failed (exit \(outcome.exitCode)): \(outcome.stderr)"
+            )
+        }
+    }
 }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -171,6 +171,8 @@ enum Strings {
     static let menuSwitchBranch: LocalizedStringKey = "menu.switchBranch"
     static let menuRevealFileInFinder: LocalizedStringKey = "menu.revealFileInFinder"
     static let menuRevealProjectInFinder: LocalizedStringKey = "menu.revealProjectInFinder"
+    static let menuTasks: LocalizedStringKey = "menu.tasks"
+    static let menuTasksEmpty: LocalizedStringKey = "menu.tasksEmpty"
 
     // MARK: - Quick Open
 

--- a/Pine/Syntax/GrammarRegistry.swift
+++ b/Pine/Syntax/GrammarRegistry.swift
@@ -168,7 +168,7 @@ nonisolated final class GrammarRegistry: @unchecked Sendable {
         let decoder = JSONDecoder()
         var loadedGrammars: [Grammar] = []
 
-        for url in files.sorted() { // deterministic order for stable override priority
+        for url in files.sorted(by: { $0.path < $1.path }) { // deterministic order
             do {
                 let data = try Data(contentsOf: url)
                 let grammar = try decoder.decode(Grammar.self, from: data)

--- a/Pine/Syntax/GrammarRegistry.swift
+++ b/Pine/Syntax/GrammarRegistry.swift
@@ -141,6 +141,52 @@ nonisolated final class GrammarRegistry: @unchecked Sendable {
         return loadedGrammars
     }
 
+    /// Loads JSON grammar files from a user-supplied directory
+    /// (`~/Library/Application Support/Pine/Grammars/` by default), merged
+    /// with the bundled grammars. User grammars override bundled ones for
+    /// overlapping extensions / file names (issue #1009).
+    ///
+    /// Malformed or undecodable files are skipped with a log line — a single
+    /// bad user file never blocks the rest. Returns the successfully loaded
+    /// grammars so callers can compile their rules without re-reading disk.
+    @discardableResult
+    func loadGrammarsFromDirectory(_ directoryURL: URL) -> [Grammar] {
+        let files: [URL]
+        do {
+            files = try FileManager.default.contentsOfDirectory(
+                at: directoryURL,
+                includingPropertiesForKeys: nil
+            ).filter { $0.pathExtension.lowercased() == "json" }
+        } catch {
+            // Directory missing or unreadable — not an error, just no user grammars.
+            Logger.syntax.info("No user grammars at \(directoryURL.path)")
+            return []
+        }
+
+        guard !files.isEmpty else { return [] }
+
+        let decoder = JSONDecoder()
+        var loadedGrammars: [Grammar] = []
+
+        for url in files.sorted() { // deterministic order for stable override priority
+            do {
+                let data = try Data(contentsOf: url)
+                let grammar = try decoder.decode(Grammar.self, from: data)
+                registerGrammar(grammar)
+                loadedGrammars.append(grammar)
+            } catch {
+                Logger.syntax.error(
+                    "Failed to load user grammar \(url.lastPathComponent): \(error)"
+                )
+            }
+        }
+
+        if !loadedGrammars.isEmpty {
+            Logger.syntax.info("Loaded \(loadedGrammars.count) user grammars from \(directoryURL.path)")
+        }
+        return loadedGrammars
+    }
+
     // MARK: - Registration
 
     /// Registers a grammar and indexes it by extensions, file names, and patterns.

--- a/Pine/SyntaxHighlighter.swift
+++ b/Pine/SyntaxHighlighter.swift
@@ -56,6 +56,14 @@ nonisolated final class SyntaxHighlighter: @unchecked Sendable {
         )
         let grammars = registry.loadGrammarsFromBundle()
         compileGrammars(grammars)
+
+        // User-supplied grammars from ~/Library/Application Support/Pine/Grammars/
+        // (issue #1009). Loaded after the bundled grammars so they override
+        // overlapping extensions / file names. Errors are logged, not fatal.
+        let userGrammars = registry.loadGrammarsFromDirectory(
+            UserConfigurationPaths.userGrammarsDirectory
+        )
+        compileGrammars(userGrammars)
     }
 
     // MARK: - Grammar Registration


### PR DESCRIPTION
Implements #1009 — lightweight extensibility for Pine.

## New: Pine/Extensibility/ (5 files, 694 lines)

| File | Purpose |
|---|---|
| UserConfigurationPaths.swift | ~/Library/Application Support/Pine/ layout |
| UserTask.swift + UserTaskRegistry | JSON task definitions, run via /bin/sh -c |
| UserTaskRunner.swift | Background execution with timeout, stdout/stderr |
| UserKeybinding.swift | Key chord parser + event monitor, 17 built-in commands |
| ExtensibilityManager.swift | @MainActor coordinator, loads configs at startup |

## Features
- **User grammars:** load from ~/Library/Application Support/Pine/Grammars/
- **Tasks:** JSON-defined shell commands in tasks.json, Run Task menu
- **Keybindings:** custom key chords → 17 built-in commands (save, open, split, etc.)

## Integration
- GrammarRegistry: user grammar overrides
- PineApp: keybinding monitor + task menu
- PineAppMenuCommands: Run/Manage Tasks menu entries