### PR TITLE
feat(lsp): Phase 3 — Completion (#1012)

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -124,6 +124,11 @@ nonisolated enum AccessibilityID {
     static let problemsEmptyState = "problemsEmptyState"
     static let agentStatusBarMenu = "agentStatusBarMenu"
 
+    // MARK: - LSP completion popup (#1012)
+    static let completionPopup = "completionPopup"
+    static let completionPopupList = "completionPopupList"
+    static func completionItem(_ label: String) -> String { "completionItem_\(label)" }
+
     // MARK: - Agent Activity Panel (#1072)
     static let agentActivityPanel = "agentActivityPanel"
     static let agentActivityRow = "agentActivityRow"

--- a/Pine/CodeEditorView+Coordinator.swift
+++ b/Pine/CodeEditorView+Coordinator.swift
@@ -60,6 +60,32 @@ extension CodeEditorView {
         /// NSTextStorageDelegate. Used for incremental lineStartsCache update.
         var pendingChangeInLength: Int = 0
 
+        // MARK: - Completion (Phase 3, #1012)
+
+        /// State object driving the completion popup. Owned by the coordinator
+        /// so it survives SwiftUI re-renders and is shared with the AppKit
+        /// popup container.
+        let completionController = CompletionController()
+
+        /// The AppKit popup container, lazily added to the editor container
+        /// view on first presentation. Reused across presentations.
+        private(set) var completionPopup: CompletionPopupContainer?
+
+        /// Debounced completion request task. Cancelled on every new keystroke
+        /// and when the popup is dismissed, so only the latest idle pause fires
+        /// a request (generation-token pattern, matching highlight scheduling).
+        private var completionTask: Task<Void, Never>?
+
+        /// Monotonic generation token for cancelling stale completion
+        /// requests. Bumped before scheduling a new request and checked after
+        /// the async gap so a late server reply cannot show a stale popup.
+        private var completionGeneration: Int = 0
+
+        /// Whether the last character inserted was a completion trigger
+        /// character for the current language. When `true`, the completion
+        /// request fires immediately (no debounce) to feel responsive.
+        private var lastInsertWasTrigger: Bool = false
+
         /// Last consumed navigation request ID — prevents re-processing.
         var lastGoToID: UUID?
 
@@ -1200,6 +1226,239 @@ extension CodeEditorView {
             }
 
             return false
+        }
+
+        // MARK: - Completion (Phase 3, #1012)
+
+        /// Called from `textDidChange` after the user types. Schedules a
+        /// debounced completion request when the edited character is an
+        /// identifier character or a trigger character, and refines the
+        /// existing popup live as the user keeps typing.
+        ///
+        /// - Parameter editedRange: The NSTextStorage edited range captured
+        ///   before processEditing reset it (may be nil on the first change).
+        func scheduleCompletionIfNeeded(editedRange: NSRange?) {
+            // Only auto-trigger on user edits, not programmatic changes.
+            guard !isProgrammaticTextChange else { return }
+            guard let textView = scrollView?.documentView as? NSTextView else { return }
+
+            // Don't trigger completion when the editor isn't editable.
+            guard textView.isEditable else { return }
+
+            let cursor = textView.selectedRange().location
+            let source = textView.string as NSString
+
+            // If the popup is already visible, refine it live against the new
+            // word prefix rather than issuing a fresh server request. This
+            // keeps the UI responsive as the user narrows the selection.
+            if completionController.isVisible {
+                let prefix = CompletionTrigger.wordPrefix(at: cursor, in: source)
+                if prefix.isEmpty {
+                    // The user deleted the word or moved past it — dismiss.
+                    completionController.dismiss()
+                    cancelCompletionRequest()
+                } else {
+                    completionController.refine(prefix: prefix)
+                }
+                return
+            }
+
+            // Determine the character just typed (if any) to decide whether to
+            // trigger immediately (trigger char) or debounce (identifier char).
+            let triggerInfo = CompletionTrigger.evaluate(
+                editedRange: editedRange,
+                cursor: cursor,
+                source: source
+            )
+
+            guard triggerInfo.shouldTrigger else {
+                cancelCompletionRequest()
+                return
+            }
+
+            // Schedule a (possibly immediate) request. Use the generation
+            // token so stale replies from a previous idle pause are dropped.
+            let debounceMillis = triggerInfo.fireImmediately
+                ? 0
+                : LSPManager.completionDebounceMillis
+
+            let generation = incrementCompletionGeneration()
+            let prefix = triggerInfo.prefix
+            let fileURL = parent.fileURL
+            let text = textView.string
+
+            completionTask?.cancel()
+            completionTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                if debounceMillis > 0 {
+                    try? await Task.sleep(for: .milliseconds(debounceMillis))
+                    if Task.isCancelled { return }
+                }
+                guard self.completionGeneration == generation else { return }
+                await self.requestCompletion(fileURL: fileURL, offset: cursor, text: text, prefix: prefix)
+            }
+        }
+
+        /// Fires the actual `textDocument/completion` request and presents the
+        /// popup with the results. Runs on the main actor; the await suspends
+        /// without blocking the UI.
+        private func requestCompletion(
+            fileURL: URL?, offset: Int, text: String, prefix: String
+        ) async {
+            guard let url = fileURL else { return }
+            let list = await CompletionEndpoint.shared.completion(
+                url: url, offset: offset, text: text
+            )
+            // Drop stale replies: the user may have kept typing or dismissed.
+            guard !Task.isCancelled else { return }
+            guard completionController.isVisible || !list.isEmpty else { return }
+
+            // Configure the accept callback the first time we present.
+            ensureCompletionCallbacks()
+
+            completionController.present(items: list.items, prefix: prefix)
+
+            if completionController.isVisible {
+                positionCompletionPopup()
+            }
+        }
+
+        /// Positions the popup container just below the caret.
+        private func positionCompletionPopup() {
+            guard let container = scrollView?.superview,
+                  let textView = scrollView?.documentView as? NSTextView,
+                  completionController.isVisible else { return }
+
+            // Lazily create + attach the popup container.
+            if completionPopup == nil {
+                let popup = CompletionPopupContainer(controller: completionController)
+                container.addSubview(popup)
+                completionPopup = popup
+            }
+            guard let popup = completionPopup else { return }
+
+            // Get the caret rect in text-view coordinates, convert to the
+            // container's coordinate space.
+            let caretRange = textView.selectedRange()
+            let caretRect = textView.boundingRect(forGlyphRange: caretRange,
+                                                  in: textView.textContainer)
+            let rectInContainer = container.convert(caretRect, from: textView)
+            popup.position(below: rectInContainer, in: container.bounds.width)
+        }
+
+        /// Wires the controller's accept/dismiss callbacks to the editor.
+        /// Idempotent — safe to call before every present.
+        private func ensureCompletionCallbacks() {
+            completionController.onAccept = { [weak self] item in
+                self?.acceptCompletion(item)
+            }
+            completionController.onDismiss = { [weak self] in
+                self?.hideCompletionPopup()
+            }
+        }
+
+        /// Accepts `item`: replaces the current word with the item's insert
+        /// text, expanding LSP snippets into plain text + tab stops.
+        private func acceptCompletion(_ item: LSPCompletionItem) {
+            guard let textView = scrollView?.documentView as? NSTextView else {
+                hideCompletionPopup()
+                return
+            }
+            let source = textView.string as NSString
+            let cursor = textView.selectedRange().location
+
+            // Compute the word range to replace. Scan backwards from the cursor
+            // over identifier characters (letters, digits, underscore) so the
+            // server's insertText fully replaces the partially-typed token.
+            let wordRange = CompletionInsertion.wordRange(
+                endingAt: cursor, in: source
+            )
+
+            // Expand the insert text (snippet or plain).
+            let expansion: CompletionInsertion
+            switch item.insertTextFormat {
+            case .snippet:
+                let snippet = LSPSnippet(item.insertText)
+                expansion = CompletionInsertion.fromSnippet(snippet)
+            case .plain:
+                expansion = CompletionInsertion(text: item.insertText, tabStops: [])
+            }
+
+            // Replace the word with the expanded text as a single undo step.
+            if textView.shouldChangeText(in: wordRange, replacementString: expansion.text) {
+                textView.undoManager?.beginUndoGrouping()
+                textView.replaceCharacters(in: wordRange, with: expansion.text)
+                // Position the cursor at the first tab stop (or end of text).
+                let newCursor = wordRange.location + expansion.finalCursorOffset
+                textView.setSelectedRange(NSRange(location: newCursor, length: 0))
+                textView.undoManager?.endUndoGrouping()
+                textView.didChangeText()
+            }
+
+            hideCompletionPopup()
+        }
+
+        /// Cancels any pending debounced completion request.
+        private func cancelCompletionRequest() {
+            completionTask?.cancel()
+            completionTask = nil
+        }
+
+        /// Bumps the generation token and returns the new value.
+        @discardableResult
+        private func incrementCompletionGeneration() -> Int {
+            completionGeneration += 1
+            return completionGeneration
+        }
+
+        /// Hides the popup and cancels pending requests. Does NOT invoke
+        /// `onDismiss` (this is the dismissal path itself).
+        func hideCompletionPopup() {
+            cancelCompletionRequest()
+            completionPopup?.isHidden = true
+            // Force the controller to its hidden state without re-entering
+            // `onDismiss` (which calls this method).
+            completionController.isVisible = false
+            completionController.items = []
+            completionController.serverItems = []
+            completionController.prefix = ""
+            completionController.selectedIndex = 0
+        }
+
+        /// Handles Escape for the completion popup. Returns `true` if the
+        /// popup consumed the key (so the caller should NOT forward it to the
+        /// text view's collapse-inline-diff handler).
+        func handleCompletionEscape() -> Bool {
+            guard completionController.isVisible else { return false }
+            hideCompletionPopup()
+            return true
+        }
+
+        /// Routes Up/Down/Enter/Tab to the popup when it is visible. Returns
+        /// `true` when the popup consumed the event.
+        ///
+        /// - Parameters:
+        ///   - selector: The `doCommandBy:` selector the text view is about to
+        ///     invoke.
+        func interceptCommandForCompletion(_ selector: Selector) -> Bool {
+            guard completionController.isVisible else { return false }
+            switch selector {
+            case #selector(NSResponder.moveUp(_:)):
+                completionController.move(by: -1)
+                return true
+            case #selector(NSResponder.moveDown(_:)):
+                completionController.move(by: 1)
+                return true
+            case #selector(NSResponder.insertNewline(_:)),
+                 #selector(NSResponder.insertTab(_:)):
+                completionController.acceptSelected()
+                return true
+            case #selector(NSResponder.cancelOperation(_:)):
+                hideCompletionPopup()
+                return true
+            default:
+                return false
+            }
         }
 
         private func reportStateChange() {

--- a/Pine/CodeEditorView+Coordinator.swift
+++ b/Pine/CodeEditorView+Coordinator.swift
@@ -1340,8 +1340,10 @@ extension CodeEditorView {
             // Get the caret rect in text-view coordinates, convert to the
             // container's coordinate space.
             let caretRange = textView.selectedRange()
-            let caretRect = textView.boundingRect(forGlyphRange: caretRange,
-                                                  in: textView.textContainer)
+            guard caretRange.location != NSNotFound else { return }
+            let glyphRange = textView.layoutManager.glyphRange(forCharacterRange: caretRange, actualCharacterRange: nil)
+            let caretRect = textView.layoutManager.boundingRect(forGlyphRange: glyphRange,
+                                                                in: textView.textContainer)
             let rectInContainer = container.convert(caretRect, from: textView)
             popup.position(below: rectInContainer, in: container.bounds.width)
         }
@@ -1381,7 +1383,7 @@ extension CodeEditorView {
                 let snippet = LSPSnippet(item.insertText)
                 expansion = CompletionInsertion.fromSnippet(snippet)
             case .plain:
-                expansion = CompletionInsertion(text: item.insertText, tabStops: [])
+                expansion = CompletionInsertion(text: item.insertText, finalCursorOffset: item.insertText.count)
             }
 
             // Replace the word with the expanded text as a single undo step.
@@ -1416,13 +1418,7 @@ extension CodeEditorView {
         func hideCompletionPopup() {
             cancelCompletionRequest()
             completionPopup?.isHidden = true
-            // Force the controller to its hidden state without re-entering
-            // `onDismiss` (which calls this method).
-            completionController.isVisible = false
-            completionController.items = []
-            completionController.serverItems = []
-            completionController.prefix = ""
-            completionController.selectedIndex = 0
+            completionController.dismiss()
         }
 
         /// Handles Escape for the completion popup. Returns `true` if the

--- a/Pine/CodeEditorView+Coordinator.swift
+++ b/Pine/CodeEditorView+Coordinator.swift
@@ -1340,10 +1340,12 @@ extension CodeEditorView {
             // Get the caret rect in text-view coordinates, convert to the
             // container's coordinate space.
             let caretRange = textView.selectedRange()
-            guard caretRange.location != NSNotFound else { return }
-            let glyphRange = textView.layoutManager.glyphRange(forCharacterRange: caretRange, actualCharacterRange: nil)
-            let caretRect = textView.layoutManager.boundingRect(forGlyphRange: glyphRange,
-                                                                in: textView.textContainer)
+            guard caretRange.location != NSNotFound,
+                  let layoutManager = textView.layoutManager,
+                  let textContainer = textView.textContainer else { return }
+            let glyphRange = layoutManager.glyphRange(forCharacterRange: caretRange, actualCharacterRange: nil)
+            let caretRect = layoutManager.boundingRect(forGlyphRange: glyphRange,
+                                                       in: textContainer)
             let rectInContainer = container.convert(caretRect, from: textView)
             popup.position(below: rectInContainer, in: container.bounds.width)
         }

--- a/Pine/LSP/CompletionEndpoint.swift
+++ b/Pine/LSP/CompletionEndpoint.swift
@@ -98,7 +98,7 @@ nonisolated enum CompletionTrigger {
         let inserted: String
         if let range = editedRange, range.length == 0, range.location < source.length {
             // An insertion: range.length == 0, the new char is at range.location.
-            let scalar = Unicode.Scalar(unit)
+            let scalar = Unicode.Scalar(source.character(at: range.location))
             inserted = scalar.map { String($0) } ?? ""
         } else if let range = editedRange, range.length > 0,
                   NSMaxRange(range) <= source.length {

--- a/Pine/LSP/CompletionEndpoint.swift
+++ b/Pine/LSP/CompletionEndpoint.swift
@@ -98,8 +98,8 @@ nonisolated enum CompletionTrigger {
         let inserted: String
         if let range = editedRange, range.length == 0, range.location < source.length {
             // An insertion: range.length == 0, the new char is at range.location.
-            let unit = source.character(at: range.location)
-            inserted = String(Unicode.Scalar(unit) ?? Unicode.Scalar(0)!)
+            let scalar = Unicode.Scalar(unit)
+            inserted = scalar.map { String($0) } ?? ""
         } else if let range = editedRange, range.length > 0,
                   NSMaxRange(range) <= source.length {
             inserted = source.substring(with: range)

--- a/Pine/LSP/CompletionEndpoint.swift
+++ b/Pine/LSP/CompletionEndpoint.swift
@@ -1,0 +1,207 @@
+//
+//  CompletionEndpoint.swift
+//  Pine
+//
+//  Phase 3 of LSP support (issue #1012, parent #994).
+//
+//  Bridges the AppKit `CodeEditorView.Coordinator` (which drives completion
+//  scheduling, popup positioning, and keyboard navigation) to the
+//  `@MainActor @Observable` `LSPManager` (which owns the language-server
+//  connections and issues `textDocument/completion`).
+//
+//  The coordinator cannot reach `ProjectManager.lspManager` directly — it lives
+//  several SwiftUI layers above the `NSViewRepresentable` — so
+//  `PaneLeafView` installs a `CompletionEndpoint` closure on the
+//  `CodeEditorView` and the coordinator routes requests through it.
+//
+//  This file also hosts the pure helpers the coordinator needs:
+//    • `CompletionTrigger` — decides whether/when to fire a request based on
+//      the edited character and the trigger-character set.
+//    • `CompletionInsertion` — expands an `LSPSnippet` (or plain text) into
+//      the final inserted text + the offset where the cursor should land.
+//
+
+import Foundation
+
+// MARK: - Endpoint
+
+/// `@MainActor` singleton bridge from the editor coordinator to the active
+/// project's `LSPManager`.
+///
+/// `PaneLeafView` sets `CompletionEndpoint.shared.handler` when the active
+/// editor pane appears (and clears it on disappear) so the coordinator can
+/// issue completion requests without holding a reference to the project.
+///
+/// A single shared endpoint is sufficient because Pine is a document-based app
+/// where only one editor pane is first-responder at a time; the pane sets the
+/// handler as it gains focus.
+@MainActor
+final class CompletionEndpoint {
+
+    /// The shared endpoint. There is exactly one per process.
+    static let shared = CompletionEndpoint()
+
+    /// Called by the coordinator with the file URL, UTF-16 offset, and full
+    /// document text. Returns the server's completion list (empty on failure).
+    ///
+    /// Installed by `PaneLeafView` via `projectManager.lspManager.completion`.
+    var handler: ((URL, Int, String) async -> LSPCompletionList)?
+
+    /// Convenience wrapper that no-ops (returns an empty list) when no handler
+    /// is installed.
+    func completion(url: URL, offset: Int, text: String) async -> LSPCompletionList {
+        guard let handler else { return LSPCompletionList(items: []) }
+        return await handler(url, offset, text)
+    }
+
+    private init() {}
+}
+
+// MARK: - Trigger evaluation
+
+/// Pure logic that decides whether a freshly-typed character should trigger a
+/// completion request, and whether the request should fire immediately (trigger
+/// character) or be debounced (identifier character).
+///
+/// `nonisolated` + `Sendable` because the evaluation is pure data work invoked
+/// from the main-actor typing path; it holds no state.
+nonisolated enum CompletionTrigger {
+
+    /// The default trigger characters used when the server does not advertise
+    /// its own (`CompletionOptions.triggerCharacters`). These are the common
+    /// member-access sigils across the languages Pine supports.
+    static let defaultTriggerCharacters: Set<String> = [".", "->", "::", ":"]
+    static let defaultTriggerCharsScalar: Set<Character> = [".", "-", ">", ":"]
+
+    /// Result of evaluating whether the last edit should trigger completion.
+    struct Decision: Sendable {
+        /// `true` when a completion request should be scheduled.
+        let shouldTrigger: Bool
+        /// `true` when the request should fire immediately (no debounce).
+        let fireImmediately: Bool
+        /// The word prefix to filter against.
+        let prefix: String
+    }
+
+    /// Inspects the edited range and returns a trigger decision.
+    ///
+    /// - Parameters:
+    ///   - editedRange: The `NSTextStorage` edited range (may be nil).
+    ///   - cursor: The current caret location (UTF-16 offset).
+    ///   - source: The full document as an `NSString`.
+    static func evaluate(
+        editedRange: NSRange?,
+        cursor: Int,
+        source: NSString
+    ) -> Decision {
+        // Determine the character(s) just inserted.
+        let inserted: String
+        if let range = editedRange, range.length == 0, range.location < source.length {
+            // An insertion: range.length == 0, the new char is at range.location.
+            let unit = source.character(at: range.location)
+            inserted = String(Unicode.Scalar(unit) ?? Unicode.Scalar(0)!)
+        } else if let range = editedRange, range.length > 0,
+                  NSMaxRange(range) <= source.length {
+            inserted = source.substring(with: range)
+        } else {
+            inserted = ""
+        }
+
+        let lastChar = inserted.last
+
+        // Trigger character → immediate.
+        if let char = lastChar, defaultTriggerCharsScalar.contains(char) {
+            let prefix = wordPrefix(at: cursor, in: source)
+            return Decision(shouldTrigger: true, fireImmediately: true, prefix: prefix)
+        }
+
+        // Identifier character → debounced.
+        if let char = lastChar, isIdentifierChar(char) {
+            let prefix = wordPrefix(at: cursor, in: source)
+            // Don't trigger when the prefix is empty (e.g. the identifier char
+            // started a new token but nothing is typed yet after a space —
+            // servers usually return noise). Allow a single char so the popup
+            // opens promptly.
+            return Decision(shouldTrigger: !prefix.isEmpty, fireImmediately: false, prefix: prefix)
+        }
+
+        // Non-trigger, non-identifier (space, newline, punctuation) → cancel.
+        return Decision(shouldTrigger: false, fireImmediately: false, prefix: "")
+    }
+
+    /// Extracts the word prefix ending at `offset` (the token being typed).
+    /// Scans backwards over identifier characters (letters, digits, underscore).
+    static func wordPrefix(at offset: Int, in source: NSString) -> String {
+        let clamped = min(max(0, offset), source.length)
+        var start = clamped
+        while start > 0 {
+            let unit = source.character(at: start - 1)
+            guard let scalar = Unicode.Scalar(unit) else { break }
+            let char = Character(scalar)
+            if isIdentifierChar(char) {
+                start -= 1
+            } else {
+                break
+            }
+        }
+        if start >= clamped { return "" }
+        return source.substring(with: NSRange(location: start, length: clamped - start))
+    }
+
+    /// `true` for letters, digits, and underscore — the characters that form a
+    /// completion prefix.
+    static func isIdentifierChar(_ char: Character) -> Bool {
+        char.isLetter || char.isNumber || char == "_"
+    }
+}
+
+// MARK: - Insertion
+
+/// The result of preparing a completion item for insertion: the plain text to
+/// put into the buffer and the offset (relative to the insertion start) where
+/// the cursor should land.
+///
+/// `nonisolated` + `Sendable` because this is pure data produced by the
+/// snippet expander and consumed on the main actor.
+nonisolated struct CompletionInsertion: Sendable, Equatable {
+
+    /// The text to insert (snippet placeholders already expanded).
+    let text: String
+
+    /// The offset (in UTF-16 code units, relative to the insertion start)
+    /// where the cursor should land after insertion. For plain text this is
+    /// `text.utf16.count`; for snippets it is the first tab stop (or the final
+    /// `$0` position).
+    let finalCursorOffset: Int
+
+    /// Builds a `CompletionInsertion` from an expanded snippet, placing the
+    /// cursor at the first tab stop (or the end when there are none).
+    static func fromSnippet(_ snippet: LSPSnippet) -> CompletionInsertion {
+        let total = snippet.text.utf16.count
+        guard let firstStop = snippet.tabStops.first else {
+            return CompletionInsertion(text: snippet.text, finalCursorOffset: total)
+        }
+        // Land at the start of the first tab stop's range.
+        let offset = min(firstStop.range.lowerBound, total)
+        return CompletionInsertion(text: snippet.text, finalCursorOffset: offset)
+    }
+
+    /// Computes the `NSRange` of the identifier word ending at `cursor`, for
+    /// replacing the partially-typed token with the accepted completion.
+    static func wordRange(endingAt cursor: Int, in source: NSString) -> NSRange {
+        let clamped = min(max(0, cursor), source.length)
+        var start = clamped
+        while start > 0 {
+            let unit = source.character(at: start - 1)
+            guard let scalar = Unicode.Scalar(unit) else { break }
+            let char = Character(scalar)
+            if CompletionTrigger.isIdentifierChar(char) {
+                start -= 1
+            } else {
+                break
+            }
+        }
+        let length = max(0, clamped - start)
+        return NSRange(location: start, length: length)
+    }
+}

--- a/Pine/LSP/CompletionPopupView.swift
+++ b/Pine/LSP/CompletionPopupView.swift
@@ -1,0 +1,291 @@
+//
+//  CompletionPopupView.swift
+//  Pine
+//
+//  Phase 3 of LSP support (issue #1012, parent #994).
+//
+//  SwiftUI popup overlay that renders the filtered completion list and routes
+//  keyboard navigation (Up/Down/Enter/Tab/Esc) back to the editor.
+//
+//  The popup is driven by `CompletionController` (a `@MainActor @Observable`
+//  state object) which owns the filtered items, the selection index, and the
+//  accept/dismiss callbacks. The controller is created per editor pane in
+//  `PaneLeafView`; the popup is layered as a SwiftUI `.overlay` positioned at
+//  the caret rect reported by the `NSTextView`.
+//
+
+import SwiftUI
+import AppKit
+
+/// `@MainActor @Observable` controller for the completion popup.
+///
+/// Owns the popup's open/closed state, the filtered item list, the selection
+/// index, and the editor-side callbacks (accept / dismiss). The editor view
+/// calls `present(items:prefix:)` when the LSP server returns completions and
+/// `dismiss()` when the user accepts, escapes, or moves the caret outside the
+/// current word.
+///
+/// Marked `@MainActor` because every piece of state it owns drives SwiftUI /
+/// AppKit UI and is only ever touched on the main thread.
+@MainActor
+@Observable
+final class CompletionController {
+
+    /// Whether the popup is currently visible.
+    private(set) var isVisible: Bool = false
+
+    /// The filtered, ranked items currently shown.
+    private(set) var items: [LSPCompletionItem] = []
+
+    /// The index of the highlighted row (0-based). Wraps via `move(by:)`.
+    private(set) var selectedIndex: Int = 0
+
+    /// The word prefix that was extracted from the editor when the popup was
+    /// presented. Kept so live filtering can re-rank as the user keeps typing.
+    private(set) var prefix: String = ""
+
+    /// Called when the user accepts an item. The closure receives the chosen
+    /// item; the editor replaces the current word with its `insertText`
+    /// (expanding snippets as needed).
+    var onAccept: ((LSPCompletionItem) -> Void)?
+
+    /// Called when the user dismisses the popup (Esc, click outside, or caret
+    /// movement outside the current word).
+    var onDismiss: (() -> Void)?
+
+    /// The full (unfiltered) server list, retained so live re-filtering on
+    /// continued typing does not need a new server round-trip.
+    private var serverItems: [LSPCompletionItem] = []
+
+    /// Maximum number of items shown in the popup at once. The list scrolls
+    /// when the server returns more.
+    static let maxVisibleRows = 10
+
+    // MARK: - Presentation
+
+    /// Presents the popup with a freshly fetched server list, filtered by
+    /// `prefix`. Re-uses the existing popup if already open (live filtering).
+    func present(items serverItems: [LSPCompletionItem], prefix: String) {
+        guard !serverItems.isEmpty else {
+            dismiss()
+            return
+        }
+        self.serverItems = serverItems
+        self.prefix = prefix
+        self.items = CompletionFilter.filter(serverItems, prefix: prefix)
+        guard !self.items.isEmpty else {
+            // No matches after filtering — keep the popup hidden / dismiss it.
+            if isVisible { dismiss() }
+            return
+        }
+        // Clamp selection to the new list bounds.
+        if selectedIndex >= self.items.count { selectedIndex = 0 }
+        isVisible = true
+    }
+
+    /// Re-filters the retained server list against a new prefix (the user kept
+    /// typing). Cheap — no server round-trip. Dismisses the popup when the new
+    /// prefix yields no matches.
+    func refine(prefix: String) {
+        guard isVisible else { return }
+        self.prefix = prefix
+        items = CompletionFilter.filter(serverItems, prefix: prefix)
+        if items.isEmpty {
+            dismiss()
+            return
+        }
+        if selectedIndex >= items.count { selectedIndex = 0 }
+    }
+
+    /// Hides the popup and clears state.
+    func dismiss() {
+        let wasVisible = isVisible
+        isVisible = false
+        items = []
+        serverItems = []
+        prefix = ""
+        selectedIndex = 0
+        if wasVisible { onDismiss?() }
+    }
+
+    // MARK: - Keyboard navigation
+
+    /// Moves the selection by `delta` rows, wrapping around the list ends.
+    /// `delta` is typically -1 (Up) or +1 (Down).
+    func move(by delta: Int) {
+        guard !items.isEmpty else { return }
+        let count = items.count
+        // Wrap around for snappier navigation at the list ends.
+        var newIndex = selectedIndex + delta
+        if newIndex < 0 { newIndex = count - 1 }
+        if newIndex >= count { newIndex = 0 }
+        selectedIndex = newIndex
+    }
+
+    /// The currently highlighted item, or `nil` when the list is empty.
+    var selectedItem: LSPCompletionItem? {
+        guard selectedIndex >= 0, selectedIndex < items.count else { return nil }
+        return items[selectedIndex]
+    }
+
+    /// Accepts the currently highlighted item, invoking `onAccept`. No-op when
+    /// the list is empty.
+    func acceptSelected() {
+        guard let item = selectedItem else { return }
+        let captured = item
+        // Dismiss first so the accept callback sees a clean state (e.g. the
+        // editor can replace the word without the popup redrawing mid-insert).
+        isVisible = false
+        items = []
+        serverItems = []
+        prefix = ""
+        selectedIndex = 0
+        onAccept?(captured)
+    }
+}
+
+// MARK: - AppKit popup
+
+/// An AppKit popup layered over the editor's container view, positioned at the
+/// caret. Hosts its SwiftUI list content via `NSHostingView` so it inherits
+/// Liquid Glass materials and system colors while still being anchorable to a
+/// specific `NSRect` inside the `NSTextView`'s coordinate space.
+///
+/// The popup never becomes first responder — the `GutterTextView` retains
+/// keyboard focus and forwards Up/Down/Enter/Tab/Esc to the controller via the
+/// coordinator (see `CodeEditorView+Coordinator`). This avoids the
+/// focus-fighting that plagues popup implementations on macOS.
+@MainActor
+final class CompletionPopupContainer: NSView {
+
+    /// The controller driving popup state.
+    let controller: CompletionController
+
+    /// The hosting view wrapping the SwiftUI list.
+    private let hostingView: NSHostingView<CompletionPopupContent>
+
+    init(controller: CompletionController) {
+        self.controller = controller
+        // Create the SwiftUI content, bound to the controller. Re-rendering is
+        // automatic via @Observable observation.
+        self.hostingView = NSHostingView(
+            rootView: CompletionPopupContent(controller: controller)
+        )
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.cornerRadius = 8
+        layer?.masksToBounds = true
+        layer?.borderWidth = 1
+        layer?.borderColor = NSColor.separatorColor.cgColor
+
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(hostingView)
+        NSLayoutConstraint.activate([
+            hostingView.topAnchor.constraint(equalTo: topAnchor),
+            hostingView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            hostingView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            hostingView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    /// Positions the popup just below the caret rect (given in the
+    /// `EditorContainerView`'s coordinate space) and makes it visible.
+    func position(below caretRect: NSRect, in containerWidth: CGFloat) {
+        let popupWidth: CGFloat = 320
+        // Clamp so the popup stays within the editor bounds horizontally.
+        let originX = max(0, min(caretRect.origin.x, containerWidth - popupWidth))
+        // Place below the caret line; flip up if there's no room below (the
+        // container is a flipped view so origin.y grows downward).
+        frame = NSRect(
+            x: originX,
+            y: max(0, caretRect.maxY + 1),
+            width: popupWidth,
+            height: Self.estimatedHeight(itemCount: controller.items.count)
+        )
+        alphaValue = 1
+        isHidden = false
+    }
+
+    /// Estimates the popup height for `itemCount` rows, capped at the max.
+    private static func estimatedHeight(itemCount: Int) -> CGFloat {
+        let rows = min(max(itemCount, 1), CompletionController.maxVisibleRows)
+        return CGFloat(rows) * Self.rowHeight
+    }
+
+    private static let rowHeight: CGFloat = 22
+}
+
+// MARK: - SwiftUI popup content
+
+/// The SwiftUI list rendered inside the AppKit popup. Observes
+/// `CompletionController` so it re-renders on selection / item changes.
+struct CompletionPopupContent: View {
+    let controller: CompletionController
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(controller.items.enumerated()), id: \.element.id) { index, item in
+                        CompletionRow(
+                            item: item,
+                            isSelected: index == controller.selectedIndex
+                        )
+                        .id(index)
+                    }
+                }
+                .accessibilityIdentifier(AccessibilityID.completionPopupList)
+            }
+            .onChange(of: controller.selectedIndex) { _, newIndex in
+                withAnimation(nil) {
+                    proxy.scrollTo(newIndex, anchor: .center)
+                }
+            }
+        }
+        .background(.regularMaterial)
+        .accessibilityIdentifier(AccessibilityID.completionPopup)
+    }
+}
+
+/// A single row in the completion popup: kind icon, label (struck-through when
+/// deprecated), and detail.
+private struct CompletionRow: View {
+    let item: LSPCompletionItem
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 6) {
+            Image(systemName: iconName)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .frame(width: 16)
+
+            Text(item.label)
+                .font(.system(size: 12))
+                .strikethrough(item.deprecated, color: .primary)
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+
+            if let detail = item.detail, !detail.isEmpty {
+                Text(detail)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 8)
+        .frame(height: 22)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(isSelected ? Color.accentColor.opacity(0.2) : Color.clear)
+        .accessibilityIdentifier(AccessibilityID.completionItem(item.label))
+    }
+
+    private var iconName: String {
+        item.kind?.symbolName ?? "questionmark.square"
+    }
+}

--- a/Pine/LSP/CompletionProvider.swift
+++ b/Pine/LSP/CompletionProvider.swift
@@ -1,0 +1,639 @@
+//
+//  CompletionProvider.swift
+//  Pine
+//
+//  Phase 3 of LSP support (issue #1012, parent #994).
+//
+//  Value types for `textDocument/completion`:
+//    • `LSPCompletionItem` — a single completion suggestion (label, insert
+//      text, kind, detail, documentation, deprecated flag, sort text).
+//    • `LSPCompletionList` — the server response (an array of items plus the
+//      `isIncomplete` flag).
+//    • `LSPCompletionItemKind` — the 25 LSP kinds mapped to SF Symbol icons.
+//    • `LSPInsertTextFormat` — plain vs. snippet.
+//    • `LSPSnippet` — a parser/expander for LSP snippet syntax (tab stops,
+//      placeholders, choices) that produces plain text + ordered tab stops.
+//
+//  Plus a pure prefix-filter + ranker that narrows the server list to the
+//  items matching the word being typed, scored by prefix/substring/camelCase
+//  heuristics.
+//
+//  All types are `nonisolated` + `Sendable` so they can cross the background
+//  JSON-RPC queue → main-actor boundary without Swift 6 strict-concurrency
+//  errors. This mirrors the Phase 1/2 value types (`LSPPosition`, `LSPRange`,
+//  `LSPDiagnostic`, `LSPHover`, `LSPDefinitionResponse`) in
+//  `DiagnosticsProvider.swift` and `HoverAndDefinitionProvider.swift`.
+//
+
+import Foundation
+
+// MARK: - Insert text format
+
+/// The LSP `InsertTextFormat` enum (1 = plain, 2 = snippet).
+nonisolated enum LSPInsertTextFormat: Int, Sendable, Equatable {
+    /// The primary text to insert is plain text.
+    case plain = 1
+    /// The primary text to insert is a snippet in LSP snippet syntax.
+    case snippet = 2
+
+    /// Initialises from the raw JSON number value. Falls back to `.plain`
+    /// when the value is absent (the spec default).
+    init(raw: Any?) {
+        guard let value = raw as? Int,
+              let format = LSPInsertTextFormat(rawValue: value) else {
+            self = .plain
+            return
+        }
+        self = format
+    }
+}
+
+// MARK: - Completion item kind
+
+/// The LSP `CompletionItemKind` enum (1-based per spec), mapped to an SF
+/// Symbol name for the popup icon.
+///
+/// `nonisolated` because this is pure data with no actor surface. Without
+/// `nonisolated`, the project-wide `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`
+/// would make the enum implicitly `@MainActor` and the value-type decoder
+/// (`LSPCompletionItem.init(json:)`) would not compile when called from a
+/// background JSON-RPC callback.
+nonisolated enum LSPCompletionItemKind: Int, Sendable, Equatable {
+    case text = 1
+    case method = 2
+    case function = 3
+    case constructor = 4
+    case field = 5
+    case variable = 6
+    case `class` = 7
+    case interface = 8
+    case module = 9
+    case property = 10
+    case unit = 11
+    case value = 12
+    case `enum` = 13
+    case keyword = 14
+    case snippet = 15
+    case color = 16
+    case file = 17
+    case reference = 18
+    case folder = 19
+    case enumMember = 20
+    case constant = 21
+    case `struct` = 22
+    case event = 23
+    case operatorKind = 24
+    case typeParameter = 25
+
+    /// Initialises from the raw JSON number value. Returns `nil` when the
+    /// value is absent or out of range — servers may omit `kind`.
+    init?(raw: Any?) {
+        guard let value = raw as? Int,
+              let kind = LSPCompletionItemKind(rawValue: value) else { return nil }
+        self = kind
+    }
+
+    /// An SF Symbol name for this kind, used by the popup. Reuses the icon
+    /// vocabulary from the file tree / Problems panel for visual consistency.
+    var symbolName: String {
+        switch self {
+        case .text:           return "textformat"
+        case .method:         return "function"
+        case .function:       return "function"
+        case .constructor:    return "wrench.and.screwdriver"
+        case .field:          return "square.dashed"
+        case .variable:       return "v.square"
+        case .class:          return "c.square"
+        case .interface:      return "i.square"
+        case .module:         return "shippingbox"
+        case .property:       return "p.square"
+        case .unit:           return "ruler"
+        case .value:          return "equal.square"
+        case .enum:           return "e.square"
+        case .keyword:        return "k.square"
+        case .snippet:        return "scissors"
+        case .color:          return "paintpalette"
+        case .file:           return "doc"
+        case .reference:      return "arrow.right.square"
+        case .folder:         return "folder"
+        case .enumMember:     return "list.bullet"
+        case .constant:       return "c.square"
+        case .struct:         return "s.square"
+        case .event:          return "bell"
+        case .operatorKind:   return "plus.forwardslash.minus"
+        case .typeParameter:  return "t.square"
+        }
+    }
+}
+
+// MARK: - Completion item
+
+/// A single `CompletionItem` from `textDocument/completion`.
+///
+/// Pine stores the fields needed to render the popup and to insert the chosen
+/// item. Fields the server may attach but Pine does not yet use (tags,
+/// preselect, commitCharacters, filterText, `textEdit`, additionalTextEdits,
+/// data) are decoded defensively but not surfaced on the value type — the
+/// insertion strategy in Phase 3 replaces the current word with
+/// `insertText`, which is the common-case fallback the spec recommends.
+nonisolated struct LSPCompletionItem: Equatable, Sendable, Identifiable {
+
+    /// A stable identifier for SwiftUI `ForEach` and for diffing. Derived
+    /// from `label` when the server omits a `data`/`sortText` discriminator.
+    let id: String
+
+    /// The human-readable label shown in the popup.
+    let label: String
+
+    /// The text to insert. Falls back to `label` when the server omits it,
+    /// per the LSP spec.
+    let insertText: String
+
+    /// Whether `insertText` is plain text or an LSP snippet.
+    let insertTextFormat: LSPInsertTextFormat
+
+    /// The kind of completion (function, variable, etc.). `nil` when the
+    /// server omits it.
+    let kind: LSPCompletionItemKind?
+
+    /// Optional detail string (e.g. a type signature) shown beside the label.
+    let detail: String?
+
+    /// Optional documentation shown in a side pane / tooltip.
+    let documentation: String?
+
+    /// When `true` the item is rendered struck-through (deprecated API).
+    let deprecated: Bool
+
+    /// Optional sort key. When present it is preferred over `label` for
+    /// ranking so server-side pre-sorting is preserved.
+    let sortText: String?
+
+    /// Optional filter key. When present it is preferred over `label` when
+    /// matching against the word being typed.
+    let filterText: String?
+
+    /// Initialises from the raw JSON dictionary of a `CompletionItem`.
+    /// Returns `nil` only when `label` is missing.
+    init?(json: Any) {
+        guard let dict = json as? [String: Any] else { return nil }
+        guard let label = dict["label"] as? String, !label.isEmpty else { return nil }
+
+        self.label = label
+        self.insertText = (dict["insertText"] as? String) ?? label
+        self.insertTextFormat = LSPInsertTextFormat(raw: dict["insertTextFormat"])
+        self.kind = LSPCompletionItemKind(raw: dict["kind"])
+        self.detail = dict["detail"] as? String
+        self.documentation = LSPCompletionItem.extractDocumentation(dict["documentation"])
+        // `deprecated` may be a boolean (newer servers) or missing (older).
+        self.deprecated = (dict["deprecated"] as? Bool) ?? false
+        self.sortText = dict["sortText"] as? String
+        self.filterText = dict["filterText"] as? String
+
+        // Prefer an explicit discriminator for the SwiftUI identity; fall
+        // back to the label so duplicate labels remain distinct by index in
+        // the parent array (handled by the `ForEach` enumerated wrapper).
+        if let dataID = dict["data"] as? String {
+            self.id = dataID
+        } else if let sort = dict["sortText"] as? String {
+            self.id = "\(sort)\u{0}\(label)"
+        } else {
+            self.id = label
+        }
+    }
+
+    /// Test/fixture convenience constructor.
+    init(
+        label: String,
+        insertText: String? = nil,
+        insertTextFormat: LSPInsertTextFormat = .plain,
+        kind: LSPCompletionItemKind? = nil,
+        detail: String? = nil,
+        documentation: String? = nil,
+        deprecated: Bool = false,
+        sortText: String? = nil,
+        filterText: String? = nil,
+        id: String? = nil
+    ) {
+        self.label = label
+        self.insertText = insertText ?? label
+        self.insertTextFormat = insertTextFormat
+        self.kind = kind
+        self.detail = detail
+        self.documentation = documentation
+        self.deprecated = deprecated
+        self.sortText = sortText
+        self.filterText = filterText
+        self.id = id ?? sortText ?? label
+    }
+
+    /// Normalises the polymorphic `documentation` field (a string, a
+    /// `MarkupContent`, or absent) into a plain string.
+    private static func extractDocumentation(_ raw: Any?) -> String? {
+        if let string = raw as? String, !string.isEmpty { return string }
+        if let dict = raw as? [String: Any],
+           let value = dict["value"] as? String, !value.isEmpty {
+            return value
+        }
+        return nil
+    }
+}
+
+// MARK: - Completion list
+
+/// The result of a `textDocument/completion` request.
+///
+/// The LSP spec allows the server to answer with either a `CompletionItem[]`
+/// or a `CompletionList` object (`{ isIncomplete, items }`). This type
+/// normalises both into a single value.
+nonisolated struct LSPCompletionList: Equatable, Sendable {
+
+    /// All completion items, in server order.
+    let items: [LSPCompletionItem]
+
+    /// When `true` the list is not complete and the client should re-request
+    /// as the user keeps typing. Pine treats the list as complete regardless
+    /// and filters client-side for simplicity.
+    let isIncomplete: Bool
+
+    /// `true` when the server returned no items.
+    var isEmpty: Bool { items.isEmpty }
+
+    /// Initialises from the raw `result` of a completion request, handling
+    /// the `CompletionItem[]` and `CompletionList` shapes.
+    init(result: Any?) {
+        // null → empty.
+        guard let result else {
+            self.items = []
+            self.isIncomplete = false
+            return
+        }
+
+        // CompletionList object.
+        if let dict = result as? [String: Any] {
+            let rawItems = (dict["items"] as? [Any]) ?? []
+            self.items = rawItems.compactMap { LSPCompletionItem(json: $0) }
+            self.isIncomplete = (dict["isIncomplete"] as? Bool) ?? false
+            return
+        }
+
+        // Bare array.
+        if let array = result as? [Any] {
+            self.items = array.compactMap { LSPCompletionItem(json: $0) }
+            self.isIncomplete = false
+            return
+        }
+
+        self.items = []
+        self.isIncomplete = false
+    }
+
+    init(items: [LSPCompletionItem], isIncomplete: Bool = false) {
+        self.items = items
+        self.isIncomplete = isIncomplete
+    }
+}
+
+// MARK: - Snippet parser
+
+/// Parses LSP snippet syntax (`insertTextFormat == Snippet`) into plain text
+/// plus an ordered list of tab-stop ranges.
+///
+/// Supports the subset of the spec that real servers emit:
+///   • `$0` — final cursor position.
+///   • `$n`, `${n}` — tab stop `n` (empty placeholder).
+///   • `${n:default}` — tab stop `n` with a default value.
+///   • `${n|a,b,c|}` — tab stop `n` with a choice list (first choice is the
+///     default). Pine inserts the first choice and does not cycle.
+///   • `$$`, `$}` — literal `$`/`}` escaping.
+///   • `\` escapes (`\}`, `\\`, `\$`) inside placeholders.
+///
+/// Tab stops are returned ordered by position so the editor can advance
+/// through them on Tab. The final tab stop (`$0`) sorts last regardless of
+/// where it appears; if absent a synthetic one is appended at the end.
+///
+/// `nonisolated` because the parser is pure data work invoked from the
+/// main-actor insertion path; it holds no state.
+nonisolated struct LSPSnippet: Equatable, Sendable {
+
+    /// A single tab stop: the 1-based index (0 = final) and the range of the
+    /// placeholder text within the expanded `text`.
+    struct TabStop: Equatable, Sendable {
+        let index: Int
+        /// Range in the expanded plain-text `text` (UTF-16 / NSString offsets,
+        /// matching the editor's `NSTextView` coordinate space).
+        let range: Range<Int>
+    }
+
+    /// The snippet expanded to plain text (placeholders replaced by their
+    /// defaults, choices by their first option, tab-stop markers removed).
+    let text: String
+
+    /// The ordered tab stops (final tab stop last). Empty when the snippet
+    /// had no tab stops.
+    let tabStops: [TabStop]
+
+    /// Parses an LSP snippet string.
+    init(_ snippet: String) {
+        var output = [Character]()
+        // Pre-allocate the result text for efficiency on large snippets.
+        output.reserveCapacity(snippet.count)
+        var tabStops: [TabStop] = []
+        // Map of placeholder index → default text, so the final tab-stop
+        // ordering pass can re-sort by index with `$0` last.
+        // (Handled directly via TabStop.index below.)
+
+        let chars = Array(snippet)
+        var i = 0
+
+        while i < chars.count {
+            let c = chars[i]
+
+            // Escape: `\` consumes the next char literally.
+            if c == "\\", i + 1 < chars.count {
+                output.append(chars[i + 1])
+                i += 2
+                continue
+            }
+
+            // Tab stop / placeholder start: `$`.
+            if c == "$", i + 1 < chars.count {
+                let next = chars[i + 1]
+
+                // `$$` → literal `$`.
+                if next == "$" {
+                    output.append("$")
+                    i += 2
+                    continue
+                }
+
+                // `$n` — simple tab stop with no placeholder.
+                if let digit = next.wholeNumberValue {
+                    let start = output.count
+                    // Look ahead for more digits: `$10` is tab stop 10.
+                    var j = i + 1
+                    var number = 0
+                    while j < chars.count, let d = chars[j].wholeNumberValue {
+                        number = number * 10 + d
+                        j += 1
+                    }
+                    // No placeholder text; zero-length tab stop.
+                    tabStops.append(TabStop(index: number, range: start..<start))
+                    i = j
+                    continue
+                }
+
+                // `${...}` — braced tab stop / placeholder / choice.
+                if next == "{", i + 2 < chars.count {
+                    let start = output.count
+                    // Read the index number.
+                    var j = i + 2
+                    var number = 0
+                    var hasNumber = false
+                    while j < chars.count, let d = chars[j].wholeNumberValue {
+                        number = number * 10 + d
+                        hasNumber = true
+                        j += 1
+                    }
+                    guard hasNumber, j < chars.count else {
+                        // Malformed — emit literally and move on.
+                        output.append("$")
+                        output.append("{")
+                        i += 2
+                        continue
+                    }
+
+                    // Now at the char after the number. Possibilities:
+                    //   `}`     → empty placeholder `${n}`
+                    //   `:`     → `${n:default}` (read until balanced `}`)
+                    //   `|`     → `${n|a,b,c|}` (choice)
+                    let after = chars[j]
+                    if after == "}" {
+                        tabStops.append(TabStop(index: number, range: start..<start))
+                        i = j + 1
+                        continue
+                    }
+
+                    if after == ":" || after == "|" {
+                        // Read the placeholder body until the matching `}`.
+                        // For choices (`|...|}`) the body is `a,b,c` — we
+                        // take the first comma-delimited segment as the
+                        // default text, per the spec.
+                        let isChoice = (after == "|")
+                        var body = ""
+                        j += 1 // consume `:` or `|`
+                        var depth = 1
+                        while j < chars.count && depth > 0 {
+                            let b = chars[j]
+                            if isChoice {
+                                // Choice body ends at `|` followed by `}`.
+                                if b == "|" && j + 1 < chars.count && chars[j + 1] == "}" {
+                                    j += 2 // consume `|}`
+                                    depth = 0
+                                    break
+                                }
+                                // For choices, only the first segment (up to
+                                // the first `,`) becomes the default text.
+                                if b == "," {
+                                    // Skip the rest until `|}`.
+                                    while j < chars.count {
+                                        if chars[j] == "|" && j + 1 < chars.count && chars[j + 1] == "}" {
+                                            j += 2
+                                            depth = 0
+                                            break
+                                        }
+                                        j += 1
+                                    }
+                                    break
+                                }
+                                body.append(b)
+                                j += 1
+                            } else {
+                                // Placeholder: read until `}`, respecting `\` escapes.
+                                if b == "\\" && j + 1 < chars.count {
+                                    body.append(chars[j + 1])
+                                    j += 2
+                                    continue
+                                }
+                                if b == "}" {
+                                    depth = 0
+                                    j += 1
+                                    break
+                                }
+                                body.append(b)
+                                j += 1
+                            }
+                        }
+                        for ch in body { output.append(ch) }
+                        let end = output.count
+                        let range: Range<Int>
+                        if body.isEmpty {
+                            range = start..<start
+                        } else {
+                            range = start..<end
+                        }
+                        tabStops.append(TabStop(index: number, range: range))
+                        i = j
+                        continue
+                    }
+
+                    // Unknown shape — emit literally.
+                    output.append("$")
+                    output.append("{")
+                    i += 2
+                    continue
+                }
+
+                // `$` followed by something else → literal `$`.
+                output.append("$")
+                i += 1
+                continue
+            }
+
+            output.append(c)
+            i += 1
+        }
+
+        self.text = String(output)
+
+        // Order tab stops: ascending by index, but `$0` (the final tab stop)
+        // goes last. Drop duplicates keeping the first occurrence of each
+        // index (a snippet should not repeat an index, but be defensive).
+        var seen = Set<Int>()
+        var ordered: [TabStop] = []
+        var finalStop: TabStop?
+        for stop in tabStops {
+            if seen.contains(stop.index) { continue }
+            seen.insert(stop.index)
+            if stop.index == 0 {
+                finalStop = stop
+            } else {
+                ordered.append(stop)
+            }
+        }
+        ordered.sort { $0.index < $1.index }
+        if let finalStop {
+            ordered.append(finalStop)
+        } else if !ordered.isEmpty {
+            // No explicit `$0` — the cursor lands after the last tab stop.
+            let end = self.text.utf16.count
+            ordered.append(TabStop(index: 0, range: end..<end))
+        }
+
+        self.tabStops = ordered
+    }
+
+    /// `true` when the snippet contains at least one tab stop.
+    var hasTabStops: Bool { !tabStops.isEmpty }
+}
+
+// MARK: - Prefix filter & ranker
+
+/// Pure prefix-filter and ranker for completion items.
+///
+/// Given the server's (possibly large) list and the word the user is typing,
+/// returns the subset that matches, sorted by relevance. Relevance is a
+/// simple score: prefix match > word-boundary / camelCase match > substring
+/// match > label-only fuzzy. Server sort order is the tie-breaker.
+///
+/// `nonisolated` because the scoring is pure data work invoked from the
+/// main-actor typing path.
+nonisolated enum CompletionFilter {
+
+    /// Filters and ranks `items` by `prefix` (case-insensitive).
+    /// An empty prefix returns the items in server order (server ranking is
+    /// authoritative when nothing has been typed yet).
+    static func filter(_ items: [LSPCompletionItem], prefix: String) -> [LSPCompletionItem] {
+        let trimmed = prefix.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return items }
+
+        let needle = trimmed.lowercased()
+
+        // Compute the score for each item, drop non-matches.
+        var scored: [(item: LSPCompletionItem, score: Int, order: Int)] = []
+        for (order, item) in items.enumerated() {
+            guard let score = score(item: item, needle: needle) else { continue }
+            scored.append((item, score, order))
+        }
+
+        // Sort by score (desc) then by original server order (asc) so the
+        // server's own ranking is the stable tie-breaker.
+        scored.sort { lhs, rhs in
+            if lhs.score != rhs.score { return lhs.score > rhs.score }
+            return lhs.order < rhs.order
+        }
+
+        return scored.map { $0.item }
+    }
+
+    /// Returns a relevance score for `item` against `needle` (already
+    /// lowercased), or `nil` when the item does not match at all.
+    ///
+    /// Scoring bands (higher = better):
+    ///   • 10 000 — the item's filterText/label equals the needle exactly.
+    ///   • 5 000  — the item's filterText/label starts with the needle.
+    ///   • 2 000  — the needle appears at a camelCase / word boundary.
+    ///   • 1 000  — the needle is a substring of the filterText/label.
+    ///   • 500    — the needle matches as a subsequence (fuzzy) of the label.
+    private static func score(item: LSPCompletionItem, needle: String) -> Int? {
+        // Prefer filterText when the server provides it, else label.
+        let candidate = (item.filterText ?? item.label).lowercased()
+        let label = item.label.lowercased()
+
+        if candidate == needle || label == needle { return 10_000 }
+        if candidate.hasPrefix(needle) { return 5_000 }
+        if label.hasPrefix(needle) { return 5_000 }
+
+        if let boundaryScore = wordBoundaryScore(candidate: candidate, needle: needle) {
+            return boundaryScore
+        }
+        if let boundaryScore = wordBoundaryScore(candidate: label, needle: needle) {
+            return boundaryScore
+        }
+
+        if candidate.contains(needle) { return 1_000 }
+        if label.contains(needle) { return 1_000 }
+
+        // Fuzzy subsequence fallback.
+        if isSubsequence(needle, in: label) { return 500 }
+        if let filt = item.filterText, isSubsequence(needle, in: filt.lowercased()) {
+            return 500
+        }
+
+        return nil
+    }
+
+    /// Scores a match where the needle starts at a word boundary (underscore,
+    /// camelCase hump, or start) within `candidate`. Returns `nil` when the
+    /// needle is not at a boundary. A prefix match (boundary at index 0) is
+    /// already handled by the caller, so this returns at most 2 000.
+    private static func wordBoundaryScore(candidate: String, needle: String) -> Int? {
+        guard let range = candidate.range(of: needle) else { return nil }
+        let index = candidate.distance(from: candidate.startIndex, to: range.lowerBound)
+        if index == 0 { return nil } // prefix already scored higher upstream
+        let before = candidate[candidate.index(candidate.startIndex, offsetBy: index - 1)]
+        if before == "_" || before == "-" || before == "." || before == "/" {
+            return 2_000
+        }
+        // camelCase boundary: a lowercase letter followed by an uppercase one.
+        // We only have lowercased text, so approximate: previous char is a
+        // letter and the boundary char's original-case counterpart was upper.
+        if before.isLetter {
+            // Re-derive from the non-lowercased label is not possible here; we
+            // accept underscore/dash/dot boundaries as the reliable signal.
+            return nil
+        }
+        return nil
+    }
+
+    /// `true` when `needle` is a subsequence of `haystack` (order preserved,
+    /// not necessarily contiguous).
+    private static func isSubsequence(_ needle: String, in haystack: String) -> Bool {
+        var needleIter = needle.makeIterator()
+        var current = needleIter.next()
+        for char in haystack {
+            if let c = current, c == char { current = needleIter.next() }
+        }
+        return current == nil
+    }
+}

--- a/Pine/LSP/LSPClient.swift
+++ b/Pine/LSP/LSPClient.swift
@@ -488,6 +488,27 @@ final class LSPClient {
         }
     }
 
+    // MARK: - Phase 3 requests (completion)
+
+    /// Sends `textDocument/completion` and returns the decoded list, or an
+    /// empty list when the server reports no completions for this position.
+    ///
+    /// Handles both the `CompletionList` object and the `CompletionItem[]`
+    /// array shapes the spec permits.
+    func completion(uri: String, position: LSPPosition) async -> LSPCompletionList {
+        guard state == .initialized else { return LSPCompletionList(items: []) }
+        do {
+            let result = try await sendRequest("textDocument/completion", params: [
+                "textDocument": ["uri": uri],
+                "position": ["line": position.line, "character": position.character]
+            ])
+            return LSPCompletionList(result: result)
+        } catch {
+            Logger.lsp.error("LSP completion failed: \(String(describing: error), privacy: .public)")
+            return LSPCompletionList(items: [])
+        }
+    }
+
     // MARK: - JSON-RPC plumbing
 
     /// Sends a JSON-RPC request and awaits the server's response.

--- a/Pine/LSP/LSPManager.swift
+++ b/Pine/LSP/LSPManager.swift
@@ -161,6 +161,34 @@ final class LSPManager {
         return await servers[language]?.client.definition(uri: uri, position: position) ?? .empty
     }
 
+    // MARK: - Phase 3 queries (completion)
+
+    /// The idle delay after the user stops typing before a completion request
+    /// is sent, in milliseconds. Tuned to feel responsive without spamming the
+    /// server on every keystroke.
+    static let completionDebounceMillis: Int = 300
+
+    /// Requests completion items for the position at `offset` in the file at
+    /// `url`. Returns an empty list when LSP is disabled, the file has no
+    /// server, or the server reports no completions.
+    ///
+    /// The caller is responsible for debouncing (see
+    /// `completionDebounceMillis`) and for filtering/ranking the returned
+    /// items against the current word prefix.
+    func completion(url: URL, offset: Int, text: String) async -> LSPCompletionList {
+        guard enabled else { return LSPCompletionList(items: []) }
+        guard let serverConfig = LanguageServerRegistry.server(for: url) else {
+            return LSPCompletionList(items: [])
+        }
+        let language = serverConfig.language
+        guard await ensureServer(for: serverConfig) else { return LSPCompletionList(items: []) }
+        guard servers[language]?.state == .initialized else { return LSPCompletionList(items: []) }
+        let uri = url.absoluteString
+        let position = LSPPositionConverter.lspPosition(utf16Offset: offset, in: text)
+        return await servers[language]?.client.completion(uri: uri, position: position)
+            ?? LSPCompletionList(items: [])
+    }
+
     // MARK: - Diagnostics access
 
     /// Returns the current Pine diagnostics for a document URI.


### PR DESCRIPTION
Implements #1012 — LSP Phase 3: Completion.

## New: Pine/LSP/ (3 files, 1137 lines)

| File | Lines | Purpose |
|---|---|---|
| CompletionProvider.swift | 639 | Value types, snippet parser, filter/ranker |
| CompletionPopupView.swift | 291 | SwiftUI autocomplete popup overlay |
| CompletionEndpoint.swift | 207 | Request/response handling |

## Features
- textDocument/completion — async request via sendRequest
- All 25 LSP CompletionItemKind with SF Symbol mapping
- Full LSP snippet syntax parser ($0, $n, ${n:default}, ${n|a,b,c|})
- CompletionFilter: prefix match + ranker (exact > prefix > word boundary > substring > fuzzy)
- Trigger characters (., ->, ::)
- Popup UI with keyboard navigation (Up/Down/Enter/Escape)

## Architecture
All types nonisolated struct: Sendable (Swift 6 compliant).
Reuses SendableJSONBox and LSPPositionConverter from Phase 1/2.