### PR TITLE
feat(lsp): Phase 4 — Code actions + Rename (#1013)

### DIFF
--- a/Pine/LSP/CodeActionProvider.swift
+++ b/Pine/LSP/CodeActionProvider.swift
@@ -120,7 +120,7 @@ nonisolated struct LSPCommand: @unchecked Sendable, Identifiable {
 /// The `edit` is stored as the raw `LSPWorkspaceEdit` value type (defined in
 /// `RenameProvider.swift`) so it can be applied by the same trusted path that
 /// rename uses.
-nonisolated struct LSPCodeAction: Equatable, Sendable, Identifiable {
+nonisolated struct LSPCodeAction: @unchecked Sendable, Identifiable {
     /// Stable identifier for menu identity (derived from `title` + `kind`).
     let id: String
     /// Human-readable title shown in the menu.
@@ -199,7 +199,7 @@ nonisolated struct LSPCodeAction: Equatable, Sendable, Identifiable {
 /// The LSP spec allows the server to answer with an array of `CodeAction`
 /// and/or `Command` objects, or `null` (no actions available). This type
 /// normalises all forms into a single value.
-nonisolated struct LSPCodeActionResponse: Equatable, Sendable {
+nonisolated struct LSPCodeActionResponse: @unchecked Sendable {
     /// All code actions, in server order.
     let actions: [LSPCodeAction]
     /// All bare commands (when the server returns `Command` objects without

--- a/Pine/LSP/CodeActionProvider.swift
+++ b/Pine/LSP/CodeActionProvider.swift
@@ -1,0 +1,241 @@
+//
+//  CodeActionProvider.swift
+//  Pine
+//
+//  Phase 4 of LSP support (issue #1013, parent #994).
+//
+//  Value types for `textDocument/codeAction`:
+//    • `LSPCodeAction` — a single code action (quick fix, refactoring,
+//      source action) with optional `WorkspaceEdit` and/or `Command`.
+//    • `LSPCommand` — a command the server suggests executing.
+//    • `LSPCodeActionKind` — the LSP kind enum (quickfix, refactor, etc.).
+//    • `LSPCodeActionResponse` — the server response (an array of
+//      `CodeAction` and/or `Command` objects).
+//
+//  All types are `nonisolated` + `Sendable` so they can cross the background
+//  JSON-RPC queue → main-actor boundary without Swift 6 strict-concurrency
+//  errors. This mirrors the Phase 1/2/3 value types (`LSPPosition`,
+//  `LSPRange`, `LSPDiagnostic`, `LSPHover`, `LSPDefinitionResponse`,
+//  `LSPCompletionItem`) in `DiagnosticsProvider.swift`,
+//  `HoverAndDefinitionProvider.swift`, and `CompletionProvider.swift`.
+//
+
+import Foundation
+
+// MARK: - Code action kind
+
+/// The LSP `CodeActionKind` enum, represented as a string per spec.
+///
+/// `nonisolated` because this is pure data with no actor surface. Without
+/// `nonisolated`, the project-wide `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`
+/// would make the enum implicitly `@MainActor` and the value-type decoder
+/// would not compile when called from a background JSON-RPC callback.
+nonisolated enum LSPCodeActionKind: String, Sendable, Equatable {
+    case quickFix = "quickfix"
+    case refactor = "refactor"
+    case refactorExtract = "refactor.extract"
+    case refactorInline = "refactor.inline"
+    case refactorRewrite = "refactor.rewrite"
+    case source = "source"
+    case sourceOrganizeImports = "source.organizeImports"
+    case sourceFixAll = "source.fixAll"
+
+    /// Initialises from the raw JSON string value. Returns `nil` when the
+    /// value is absent or an unrecognised kind — servers may use custom kinds.
+    init?(raw: Any?) {
+        guard let value = raw as? String else { return nil }
+        self.init(rawValue: value)
+    }
+
+    /// An SF Symbol name for this kind, used by the menu. Reuses the icon
+    /// vocabulary from elsewhere in Pine for visual consistency.
+    var symbolName: String {
+        switch self {
+        case .quickFix:               return "wrench.and.screwdriver"
+        case .refactor:               return "arrow.triangle.swap"
+        case .refactorExtract:        return "scissors"
+        case .refactorInline:         return "arrow.merge"
+        case .refactorRewrite:        return "pencil.and.outline"
+        case .source:                 return "doc.text"
+        case .sourceOrganizeImports:  return "list.bullet.indent"
+        case .sourceFixAll:           return "checkmark.circle"
+        }
+    }
+}
+
+// MARK: - Command
+
+/// An LSP `Command` — a title + command identifier + optional arguments.
+///
+/// The server may return a `Command` instead of a `CodeAction` (or a
+/// `CodeAction` with a `command` but no `edit`). Pine presents the title in
+/// the menu and, on selection, sends `workspace/executeCommand` if the
+/// command has no pre-attached `edit`.
+nonisolated struct LSPCommand: Equatable, Sendable, Identifiable {
+    /// Stable identifier for menu identity (derived from `command` + `title`).
+    let id: String
+    /// Human-readable title shown in the menu.
+    let title: String
+    /// The command identifier (server-defined).
+    let command: String
+    /// Optional arguments passed to `workspace/executeCommand`.
+    let arguments: [Any]?
+
+    /// Initialises from the raw JSON dictionary of a `Command`.
+    /// Returns `nil` when `title` or `command` is missing.
+    init?(json: Any) {
+        guard let dict = json as? [String: Any] else { return nil }
+        guard let title = dict["title"] as? String, !title.isEmpty else { return nil }
+        guard let command = dict["command"] as? String, !command.isEmpty else { return nil }
+        self.title = title
+        self.command = command
+        self.arguments = dict["arguments"] as? [Any]
+        self.id = "\(command)\u{0}\(title)"
+    }
+
+    /// Test/fixture convenience constructor.
+    init(title: String, command: String, arguments: [Any]? = nil) {
+        self.title = title
+        self.command = command
+        self.arguments = arguments
+        self.id = "\(command)\u{0}\(title)"
+    }
+}
+
+// MARK: - Code action
+
+/// A single `CodeAction` from `textDocument/codeAction`.
+///
+/// Per the LSP spec, a `CodeAction` has a `title`, an optional `kind`, an
+/// optional `edit` (`WorkspaceEdit`), and/or an optional `command`. When the
+/// user selects the action, Pine first applies `edit` (if present) and then
+/// sends `workspace/executeCommand` for `command` (if present).
+///
+/// The `edit` is stored as the raw `LSPWorkspaceEdit` value type (defined in
+/// `RenameProvider.swift`) so it can be applied by the same trusted path that
+/// rename uses.
+nonisolated struct LSPCodeAction: Equatable, Sendable, Identifiable {
+    /// Stable identifier for menu identity (derived from `title` + `kind`).
+    let id: String
+    /// Human-readable title shown in the menu.
+    let title: String
+    /// The kind of code action. `nil` when the server omits it.
+    let kind: LSPCodeActionKind?
+    /// Whether this action is the preferred fix for its diagnostics.
+    let isPreferred: Bool
+    /// The workspace edit to apply when the action is selected. `nil` when
+    /// the action has only a `command` or is disabled.
+    let edit: LSPWorkspaceEdit?
+    /// The command to execute when the action is selected. `nil` when the
+    /// action has only an `edit`.
+    let command: LSPCommand?
+    /// The diagnostic messages this action addresses (informational only).
+    let diagnostics: [LSPDiagnostic]
+
+    /// Initialises from the raw JSON dictionary of a `CodeAction`.
+    /// Returns `nil` when `title` is missing or the entry is a bare `Command`
+    /// (which should be handled by `LSPCommand(json:)` instead).
+    init?(json: Any) {
+        guard let dict = json as? [String: Any] else { return nil }
+        guard let title = dict["title"] as? String, !title.isEmpty else { return nil }
+        self.title = title
+        self.kind = LSPCodeActionKind(raw: dict["kind"])
+        self.isPreferred = (dict["isPreferred"] as? Bool) ?? false
+
+        if let editJSON = dict["edit"] {
+            self.edit = LSPWorkspaceEdit(json: editJSON)
+        } else {
+            self.edit = nil
+        }
+
+        if let cmdJSON = dict["command"] {
+            self.command = LSPCommand(json: cmdJSON)
+        } else {
+            self.command = nil
+        }
+
+        let rawDiag = (dict["diagnostics"] as? [Any]) ?? []
+        self.diagnostics = rawDiag.compactMap { LSPDiagnostic(json: $0) }
+
+        let kindStr = (dict["kind"] as? String) ?? ""
+        self.id = "\(kindStr)\u{0}\(title)"
+    }
+
+    /// Test/fixture convenience constructor.
+    init(
+        title: String,
+        kind: LSPCodeActionKind? = nil,
+        isPreferred: Bool = false,
+        edit: LSPWorkspaceEdit? = nil,
+        command: LSPCommand? = nil,
+        diagnostics: [LSPDiagnostic] = []
+    ) {
+        self.title = title
+        self.kind = kind
+        self.isPreferred = isPreferred
+        self.edit = edit
+        self.command = command
+        self.diagnostics = diagnostics
+        let kindStr = kind?.rawValue ?? ""
+        self.id = "\(kindStr)\u{0}\(title)"
+    }
+
+    /// `true` when the action carries an `edit` or a `command` — i.e. the
+    /// user can actually apply it. Actions with neither are typically
+    /// disabled markers.
+    var isExecutable: Bool { edit != nil || command != nil }
+}
+
+// MARK: - Code action response
+
+/// The result of a `textDocument/codeAction` request.
+///
+/// The LSP spec allows the server to answer with an array of `CodeAction`
+/// and/or `Command` objects, or `null` (no actions available). This type
+/// normalises all forms into a single value.
+nonisolated struct LSPCodeActionResponse: Equatable, Sendable {
+    /// All code actions, in server order.
+    let actions: [LSPCodeAction]
+    /// All bare commands (when the server returns `Command` objects without
+    /// wrapping them in `CodeAction`).
+    let commands: [LSPCommand]
+
+    /// `true` when the server returned nothing actionable.
+    var isEmpty: Bool { actions.isEmpty && commands.isEmpty }
+
+    /// The total number of menu items.
+    var count: Int { actions.count + commands.count }
+
+    /// Initialises from the raw `result` of a code action request.
+    init(result: Any?) {
+        guard let result else {
+            self.actions = []
+            self.commands = []
+            return
+        }
+
+        guard let array = result as? [Any] else {
+            self.actions = []
+            self.commands = []
+            return
+        }
+
+        var actions: [LSPCodeAction] = []
+        var commands: [LSPCommand] = []
+        for element in array {
+            // Prefer `CodeAction` (has `title` + `edit`/`command`/`kind`).
+            if let action = LSPCodeAction(json: element) {
+                actions.append(action)
+            } else if let cmd = LSPCommand(json: element) {
+                commands.append(cmd)
+            }
+        }
+        self.actions = actions
+        self.commands = commands
+    }
+
+    init(actions: [LSPCodeAction], commands: [LSPCommand] = []) {
+        self.actions = actions
+        self.commands = commands
+    }
+}

--- a/Pine/LSP/CodeActionProvider.swift
+++ b/Pine/LSP/CodeActionProvider.swift
@@ -71,7 +71,7 @@ nonisolated enum LSPCodeActionKind: String, Sendable, Equatable {
 /// `CodeAction` with a `command` but no `edit`). Pine presents the title in
 /// the menu and, on selection, sends `workspace/executeCommand` if the
 /// command has no pre-attached `edit`.
-nonisolated struct LSPCommand: Equatable, Sendable, Identifiable {
+nonisolated struct LSPCommand: @unchecked Sendable, Identifiable {
     /// Stable identifier for menu identity (derived from `command` + `title`).
     let id: String
     /// Human-readable title shown in the menu.
@@ -79,7 +79,8 @@ nonisolated struct LSPCommand: Equatable, Sendable, Identifiable {
     /// The command identifier (server-defined).
     let command: String
     /// Optional arguments passed to `workspace/executeCommand`.
-    let arguments: [Any]?
+    /// Stored as raw JSON string to satisfy Sendable.
+    let arguments: String?
 
     /// Initialises from the raw JSON dictionary of a `Command`.
     /// Returns `nil` when `title` or `command` is missing.
@@ -89,12 +90,17 @@ nonisolated struct LSPCommand: Equatable, Sendable, Identifiable {
         guard let command = dict["command"] as? String, !command.isEmpty else { return nil }
         self.title = title
         self.command = command
-        self.arguments = dict["arguments"] as? [Any]
+        if let args = dict["arguments"] {
+            self.arguments = (try? JSONSerialization.data(withJSONObject: args))
+                .flatMap { String(data: $0, encoding: .utf8) }
+        } else {
+            self.arguments = nil
+        }
         self.id = "\(command)\u{0}\(title)"
     }
 
     /// Test/fixture convenience constructor.
-    init(title: String, command: String, arguments: [Any]? = nil) {
+    init(title: String, command: String, arguments: String? = nil) {
         self.title = title
         self.command = command
         self.arguments = arguments

--- a/Pine/LSP/LSPClient.swift
+++ b/Pine/LSP/LSPClient.swift
@@ -509,6 +509,79 @@ final class LSPClient {
         }
     }
 
+    // MARK: - Phase 4 requests (code action + rename)
+
+    /// Sends `textDocument/codeAction` and returns the decoded response.
+    /// Returns an empty response when the server reports no actions for
+    /// this position/range or the feature is unsupported.
+    ///
+    /// - Parameters:
+    ///   - uri: The document URI.
+    ///   - range: The LSP range to request actions for.
+    ///   - diagnostics: The diagnostics at the range (passed as context so
+    ///     the server can return targeted quick fixes).
+    func codeAction(uri: String, range: LSPRange, diagnostics: [LSPDiagnostic]) async -> LSPCodeActionResponse {
+        guard state == .initialized else { return LSPCodeActionResponse(actions: []) }
+        do {
+            let rawDiagnostics: [[String: Any]] = diagnostics.map { diag in
+                var dict: [String: Any] = [
+                    "range": [
+                        "start": ["line": diag.range.start.line, "character": diag.range.start.character],
+                        "end": ["line": diag.range.end.line, "character": diag.range.end.character]
+                    ],
+                    "message": diag.message
+                ]
+                if let severity = diag.severity {
+                    dict["severity"] = severity.rawValue
+                }
+                if let source = diag.source {
+                    dict["source"] = source
+                }
+                if let code = diag.code {
+                    dict["code"] = code
+                }
+                return dict
+            }
+            let result = try await sendRequest("textDocument/codeAction", params: [
+                "textDocument": ["uri": uri],
+                "range": [
+                    "start": ["line": range.start.line, "character": range.start.character],
+                    "end": ["line": range.end.line, "character": range.end.character]
+                ],
+                "context": [
+                    "diagnostics": rawDiagnostics
+                ]
+            ])
+            return LSPCodeActionResponse(result: result)
+        } catch {
+            Logger.lsp.error("LSP codeAction failed: \(String(describing: error), privacy: .public)")
+            return LSPCodeActionResponse(actions: [])
+        }
+    }
+
+    /// Sends `textDocument/rename` and returns the decoded `WorkspaceEdit`.
+    /// Returns an empty edit when the server reports no rename targets for
+    /// this position or the feature is unsupported.
+    ///
+    /// - Parameters:
+    ///   - uri: The document URI.
+    ///   - position: The cursor position on the symbol to rename.
+    ///   - newName: The new name for the symbol.
+    func rename(uri: String, position: LSPPosition, newName: String) async -> LSPWorkspaceEdit {
+        guard state == .initialized else { return LSPWorkspaceEdit(operatedFiles: []) }
+        do {
+            let result = try await sendRequest("textDocument/rename", params: [
+                "textDocument": ["uri": uri],
+                "position": ["line": position.line, "character": position.character],
+                "newName": newName
+            ])
+            return LSPWorkspaceEdit(json: result)
+        } catch {
+            Logger.lsp.error("LSP rename failed: \(String(describing: error), privacy: .public)")
+            return LSPWorkspaceEdit(operatedFiles: [])
+        }
+    }
+
     // MARK: - JSON-RPC plumbing
 
     /// Sends a JSON-RPC request and awaits the server's response.

--- a/Pine/LSP/LSPManager.swift
+++ b/Pine/LSP/LSPManager.swift
@@ -283,7 +283,8 @@ final class LSPManager {
                 let original = tabManager.tabs[tabIndex].content
                 let result = WorkspaceEditApplier.applyEdits(operated.edits, to: original)
                 guard result.success, let newText = result.newText else {
-                    Logger.lsp.error("WorkspaceEdit apply failed for \(fileURL.lastPathComponent, privacy: .public): \(result.errorMessage ?? "unknown", privacy: .public)")
+                    let msg = result.errorMessage ?? "unknown"
+                    Logger.lsp.error("WorkspaceEdit apply failed for \(fileURL.lastPathComponent, privacy: .public): \(msg, privacy: .public)")
                     return false
                 }
                 pendingChanges.append((tabIndex: tabIndex, newText: newText, fileURL: fileURL))
@@ -295,7 +296,8 @@ final class LSPManager {
                 }
                 let result = WorkspaceEditApplier.applyEdits(operated.edits, to: original)
                 guard result.success, let newText = result.newText else {
-                    Logger.lsp.error("WorkspaceEdit apply failed for \(fileURL.lastPathComponent, privacy: .public): \(result.errorMessage ?? "unknown", privacy: .public)")
+                    let msg = result.errorMessage ?? "unknown"
+                    Logger.lsp.error("WorkspaceEdit apply failed for \(fileURL.lastPathComponent, privacy: .public): \(msg, privacy: .public)")
                     return false
                 }
                 diskWrites.append((url: fileURL, newText: newText))
@@ -304,8 +306,8 @@ final class LSPManager {
 
         // Phase 2: commit all changes.
         for change in pendingChanges {
-            // Use the tab's direct content update — the edit is already computed.
-            tabManager.applyExternalEdit(at: change.tabIndex, newText: change.newText)
+            // Update the tab content directly — the edit is already computed.
+            tabManager.tabs[change.tabIndex].content = change.newText
             // Notify the LSP server of the change.
             didChange(url: change.fileURL, text: change.newText)
         }
@@ -314,7 +316,8 @@ final class LSPManager {
             do {
                 try write.newText.write(to: write.url, atomically: true, encoding: .utf8)
             } catch {
-                Logger.lsp.error("WorkspaceEdit: cannot write file \(write.url.lastPathComponent, privacy: .public): \(String(describing: error), privacy: .public)")
+                let errDesc = String(describing: error)
+                Logger.lsp.error("WorkspaceEdit: cannot write \(write.url.lastPathComponent, privacy: .public): \(errDesc, privacy: .public)")
                 return false
             }
         }

--- a/Pine/LSP/LSPManager.swift
+++ b/Pine/LSP/LSPManager.swift
@@ -45,6 +45,11 @@ final class LSPManager {
     /// Replacing/emptying an entry clears that file's markers.
     private(set) var diagnosticsByURI: [String: [ValidationDiagnostic]] = [:]
 
+    /// Raw LSP diagnostics keyed by URI, retained for code-action context.
+    /// These are the original `LSPDiagnostic` structs (0-based LSP positions)
+    /// needed when building the `CodeActionContext.diagnostics` array.
+    private var rawDiagnosticsByURI: [String: [LSPDiagnostic]] = [:]
+
     /// Whether LSP diagnostics are enabled (global toggle). Defaults on.
     var enabled: Bool = true
 
@@ -125,6 +130,7 @@ final class LSPManager {
         servers[serverConfig.language]?.client.didClose(uri: uri)
         // Clear that file's diagnostics immediately so stale markers don't linger.
         diagnosticsByURI[uri] = nil
+        rawDiagnosticsByURI[uri] = nil
     }
 
     // MARK: - Phase 2 queries (hover + definition)
@@ -187,6 +193,134 @@ final class LSPManager {
         let position = LSPPositionConverter.lspPosition(utf16Offset: offset, in: text)
         return await servers[language]?.client.completion(uri: uri, position: position)
             ?? LSPCompletionList(items: [])
+    }
+
+    // MARK: - Phase 4 queries (code action + rename)
+
+    /// Requests code actions for the symbol at `offset` in the file at `url`.
+    /// Returns an empty response when LSP is disabled, the file has no server,
+    /// or the server reports no actions.
+    func codeAction(url: URL, offset: Int, text: String) async -> LSPCodeActionResponse {
+        guard enabled else { return LSPCodeActionResponse(actions: []) }
+        guard let serverConfig = LanguageServerRegistry.server(for: url) else {
+            return LSPCodeActionResponse(actions: [])
+        }
+        let language = serverConfig.language
+        guard await ensureServer(for: serverConfig) else {
+            return LSPCodeActionResponse(actions: [])
+        }
+        guard servers[language]?.state == .initialized else {
+            return LSPCodeActionResponse(actions: [])
+        }
+        let uri = url.absoluteString
+        let position = LSPPositionConverter.lspPosition(utf16Offset: offset, in: text)
+        // Build a range from the word at the cursor (or a zero-length range).
+        let range = wordRange(at: offset, in: text) ?? LSPRange(start: position, end: position)
+        // Gather diagnostics for this file so the server can target fixes.
+        let lspDiagnostics = lspDiagnosticsForApply(uri: uri)
+        return await servers[language]?.client.codeAction(uri: uri, range: range, diagnostics: lspDiagnostics)
+            ?? LSPCodeActionResponse(actions: [])
+    }
+
+    /// Requests a project-wide rename for the symbol at `offset` in the file
+    /// at `url`. Returns the `WorkspaceEdit` describing all changes, or an
+    /// empty edit when LSP is disabled or the server reports no targets.
+    func rename(url: URL, offset: Int, text: String, newName: String) async -> LSPWorkspaceEdit {
+        guard enabled else { return LSPWorkspaceEdit(operatedFiles: []) }
+        guard let serverConfig = LanguageServerRegistry.server(for: url) else {
+            return LSPWorkspaceEdit(operatedFiles: [])
+        }
+        let language = serverConfig.language
+        guard await ensureServer(for: serverConfig) else {
+            return LSPWorkspaceEdit(operatedFiles: [])
+        }
+        guard servers[language]?.state == .initialized else {
+            return LSPWorkspaceEdit(operatedFiles: [])
+        }
+        let uri = url.absoluteString
+        let position = LSPPositionConverter.lspPosition(utf16Offset: offset, in: text)
+        return await servers[language]?.client.rename(uri: uri, position: position, newName: newName)
+            ?? LSPWorkspaceEdit(operatedFiles: [])
+    }
+
+    // MARK: - WorkspaceEdit application
+
+    /// Applies a `WorkspaceEdit` transactionally across open tabs.
+    ///
+    /// For each `.edit` operation:
+    ///   1. If the file is open in any tab, applies the edits to the tab
+    ///      content in memory (marking it dirty for save).
+    ///   2. If the file is not open, reads it from disk, applies the edits,
+    ///      and writes back.
+    ///
+    /// If any file's edit fails to apply, no partial state is committed and
+    /// the method returns `false`.
+    ///
+    /// - Parameters:
+    ///   - workspaceEdit: The edit to apply.
+    ///   - tabManager: The active project's tab manager (for in-memory edits).
+    ///   - workspaceURL: The project root URL (for resolving relative paths).
+    /// - Returns: `true` when all edits were applied successfully.
+    func applyWorkspaceEdit(
+        _ workspaceEdit: LSPWorkspaceEdit,
+        tabManager: TabManager,
+        workspaceURL: URL?
+    ) -> Bool {
+        guard !workspaceEdit.isEmpty else { return true }
+
+        // Phase 1: compute all new texts without committing any changes.
+        // This ensures the operation is transactional — if any file fails,
+        // nothing is modified.
+        var pendingChanges: [(tabIndex: Int, newText: String, fileURL: URL)] = []
+        var diskWrites: [(url: URL, newText: String)] = []
+
+        for operated in workspaceEdit.operatedFiles where operated.kind == .edit {
+            guard let fileURL = operated.url else { continue }
+            guard !operated.edits.isEmpty else { continue }
+
+            // Check if this file is open in a tab.
+            if let tabIndex = tabManager.tabs.firstIndex(where: { $0.url == fileURL }) {
+                let original = tabManager.tabs[tabIndex].content
+                let result = WorkspaceEditApplier.applyEdits(operated.edits, to: original)
+                guard result.success, let newText = result.newText else {
+                    Logger.lsp.error("WorkspaceEdit apply failed for \(fileURL.lastPathComponent, privacy: .public): \(result.errorMessage ?? "unknown", privacy: .public)")
+                    return false
+                }
+                pendingChanges.append((tabIndex: tabIndex, newText: newText, fileURL: fileURL))
+            } else {
+                // File not open — read from disk, apply, write back.
+                guard let original = try? String(contentsOf: fileURL, encoding: .utf8) else {
+                    Logger.lsp.error("WorkspaceEdit: cannot read file \(fileURL.lastPathComponent, privacy: .public)")
+                    return false
+                }
+                let result = WorkspaceEditApplier.applyEdits(operated.edits, to: original)
+                guard result.success, let newText = result.newText else {
+                    Logger.lsp.error("WorkspaceEdit apply failed for \(fileURL.lastPathComponent, privacy: .public): \(result.errorMessage ?? "unknown", privacy: .public)")
+                    return false
+                }
+                diskWrites.append((url: fileURL, newText: newText))
+            }
+        }
+
+        // Phase 2: commit all changes.
+        for change in pendingChanges {
+            // Use the tab's direct content update — the edit is already computed.
+            tabManager.applyExternalEdit(at: change.tabIndex, newText: change.newText)
+            // Notify the LSP server of the change.
+            didChange(url: change.fileURL, text: change.newText)
+        }
+
+        for write in diskWrites {
+            do {
+                try write.newText.write(to: write.url, atomically: true, encoding: .utf8)
+            } catch {
+                Logger.lsp.error("WorkspaceEdit: cannot write file \(write.url.lastPathComponent, privacy: .public): \(String(describing: error), privacy: .public)")
+                return false
+            }
+        }
+
+        Logger.lsp.info("WorkspaceEdit applied: \(pendingChanges.count, privacy: .public) tab(s), \(diskWrites.count, privacy: .public) disk file(s)")
+        return true
     }
 
     // MARK: - Diagnostics access
@@ -272,5 +406,53 @@ final class LSPManager {
     private func handleDiagnostics(_ notification: LSPDiagnosticsNotification, from client: LSPClient?) {
         let mapped = DiagnosticMapper.map(notification)
         diagnosticsByURI[notification.uri] = mapped
+        rawDiagnosticsByURI[notification.uri] = notification.diagnostics
+    }
+
+    // MARK: - Phase 4 helpers
+
+    /// Extracts the word range at `offset` for the code action context, or
+    /// `nil` when the cursor is not on a word.
+    private func wordRange(at offset: Int, in text: String) -> LSPRange? {
+        let ns = text as NSString
+        let clamped = min(max(0, offset), ns.length)
+
+        // Scan backwards for word start.
+        var start = clamped
+        while start > 0 {
+            let unit = ns.character(at: start - 1)
+            guard let scalar = Unicode.Scalar(unit) else { break }
+            let char = Character(scalar)
+            if char.isLetter || char.isNumber || char == "_" {
+                start -= 1
+            } else {
+                break
+            }
+        }
+
+        // Scan forwards for word end.
+        var end = clamped
+        while end < ns.length {
+            let unit = ns.character(at: end)
+            guard let scalar = Unicode.Scalar(unit) else { break }
+            let char = Character(scalar)
+            if char.isLetter || char.isNumber || char == "_" {
+                end += 1
+            } else {
+                break
+            }
+        }
+
+        guard end > start else { return nil }
+        let startPos = LSPPositionConverter.lspPosition(utf16Offset: start, in: text)
+        let endPos = LSPPositionConverter.lspPosition(utf16Offset: end, in: text)
+        return LSPRange(start: startPos, end: endPos)
+    }
+
+    /// Returns the raw `LSPDiagnostic` values for a URI, needed for the code
+    /// action request context. These are the original structs with 0-based LSP
+    /// positions, retained alongside the mapped Pine diagnostics.
+    private func lspDiagnosticsForApply(uri: String) -> [LSPDiagnostic] {
+        rawDiagnosticsByURI[uri] ?? []
     }
 }

--- a/Pine/LSP/RenameProvider.swift
+++ b/Pine/LSP/RenameProvider.swift
@@ -309,7 +309,7 @@ nonisolated enum WorkspaceEditApplier {
         }
 
         let ns = text as NSString
-        var mutable = text as NSMutableString
+        var mutable = NSMutableString(string: text)
 
         for edit in sorted {
             let startOffset = LSPPositionConverter.utf16Offset(
@@ -326,8 +326,9 @@ nonisolated enum WorkspaceEditApplier {
             // Validate bounds.
             guard startOffset >= 0, startOffset <= ns.length,
                   endOffset >= startOffset, endOffset <= ns.length else {
+                let desc = "line \(edit.range.start.line):\(edit.range.start.character) – \(edit.range.end.line):\(edit.range.end.character)"
                 return WorkspaceEditApplyResult(
-                    error: "Edit range out of bounds: line \(edit.range.start.line):\(edit.range.start.character) – \(edit.range.end.line):\(edit.range.end.character)"
+                    error: "Edit range out of bounds: \(desc)"
                 )
             }
 

--- a/Pine/LSP/RenameProvider.swift
+++ b/Pine/LSP/RenameProvider.swift
@@ -1,0 +1,354 @@
+//
+//  RenameProvider.swift
+//  Pine
+//
+//  Phase 4 of LSP support (issue #1013, parent #994).
+//
+//  Value types and logic for `textDocument/rename` and `WorkspaceEdit`
+//  application:
+//    • `LSPWorkspaceEdit` — the server response (supports both
+//      `documentChanges` and legacy `changes` forms).
+//    • `LSPTextEdit` — a single edit within a document (range + new text).
+//    • `LSPOperatedFile` — a file + its edits, normalised from
+//      `TextDocumentEdit`, `CreateFile`, `RenameFile`, `DeleteFile`.
+//    • `WorkspaceEditApplier` — a pure function that applies a list of
+//      `LSPOperatedFile` edits to an in-memory text store, transactionally.
+//
+//  The actual I/O (opening tabs, writing to disk) is done by the
+//  `@MainActor @Observable` `LSPManager` which calls the pure applier for
+//  each affected file. The applier itself is pure data logic, testable
+//  without any UI.
+//
+//  All types are `nonisolated` + `Sendable` so they can cross the background
+//  JSON-RPC queue → main-actor boundary without Swift 6 strict-concurrency
+//  errors.
+//
+
+import Foundation
+
+// MARK: - Text edit
+
+/// An LSP `TextEdit` — a range replacement within a single document.
+///
+/// `nonisolated` + `Sendable` because this is pure data produced on a
+/// background JSON-RPC callback and consumed on the main actor.
+nonisolated struct LSPTextEdit: Equatable, Sendable {
+    /// The range to replace (LSP 0-based positions).
+    let range: LSPRange
+    /// The text to insert in place of the range.
+    let newText: String
+
+    /// Initialises from the raw JSON dictionary of a `TextEdit`.
+    /// Returns `nil` when `range` or `newText` is missing.
+    init?(json: Any) {
+        guard let dict = json as? [String: Any] else { return nil }
+        guard let range = LSPRange(json: dict["range"] ?? [:]) else { return nil }
+        guard let newText = dict["newText"] as? String else { return nil }
+        self.range = range
+        self.newText = newText
+    }
+
+    init(range: LSPRange, newText: String) {
+        self.range = range
+        self.newText = newText
+    }
+}
+
+// MARK: - Document change kind
+
+/// The kind of `DocumentChange` a `LSPOperatedFile` represents.
+///
+/// `nonisolated` because this is pure data with no actor surface.
+nonisolated enum LSPDocumentChangeKind: Sendable, Equatable {
+    /// Edit an existing file (one or more `TextEdit`s).
+    case edit
+    /// Create a new file.
+    case create
+    /// Rename a file (old → new URL).
+    case rename
+    /// Delete a file.
+    case delete
+}
+
+// MARK: - Operated file
+
+/// A single file + its edits, normalised from the various
+/// `documentChanges` forms (`TextDocumentEdit`, `CreateFile`, `RenameFile`,
+/// `DeleteFile`) or the legacy `changes` dictionary.
+///
+/// `nonisolated` + `Sendable` because this is pure data crossing the
+/// background → main-actor boundary.
+nonisolated struct LSPOperatedFile: Equatable, Sendable {
+    /// The file URI this entry operates on.
+    let uri: String
+    /// The kind of change.
+    let kind: LSPDocumentChangeKind
+    /// Text edits to apply (empty for create/rename/delete-only).
+    let edits: [LSPTextEdit]
+    /// For rename: the new URI. `nil` otherwise.
+    let newURI: String?
+
+    /// The file URL, decoded from the URI.
+    var url: URL? { URL(string: uri) }
+
+    /// For rename: the new file URL. `nil` otherwise.
+    var newURL: URL? {
+        guard let newURI else { return nil }
+        return URL(string: newURI)
+    }
+
+    /// Initialises from a `TextDocumentEdit` JSON dictionary.
+    /// `{ "textDocument": { "uri": ..., "version": ... }, "edits": [...] }`
+    init?(textDocumentEdit json: Any) {
+        guard let dict = json as? [String: Any] else { return nil }
+        guard let textDoc = dict["textDocument"] as? [String: Any] else { return nil }
+        guard let uri = textDoc["uri"] as? String else { return nil }
+        let rawEdits = (dict["edits"] as? [Any]) ?? []
+        self.uri = uri
+        self.kind = .edit
+        self.edits = rawEdits.compactMap { LSPTextEdit(json: $0) }
+        self.newURI = nil
+    }
+
+    /// Initialises from a legacy `changes` dictionary entry.
+    /// Key = URI string, Value = array of `TextEdit`.
+    init?(legacyChanges uri: String, edits: Any) {
+        guard let rawEdits = edits as? [Any] else { return nil }
+        self.uri = uri
+        self.kind = .edit
+        self.edits = rawEdits.compactMap { LSPTextEdit(json: $0) }
+        self.newURI = nil
+    }
+
+    /// Initialises from a `CreateFile` JSON dictionary.
+    /// `{ "kind": "create", "uri": "..." }`
+    init?(createFile json: Any) {
+        guard let dict = json as? [String: Any] else { return nil }
+        guard (dict["kind"] as? String) == "create" else { return nil }
+        guard let uri = dict["uri"] as? String else { return nil }
+        self.uri = uri
+        self.kind = .create
+        self.edits = []
+        self.newURI = nil
+    }
+
+    /// Initialises from a `RenameFile` JSON dictionary.
+    /// `{ "kind": "rename", "oldUri": "...", "newUri": "..." }`
+    init?(renameFile json: Any) {
+        guard let dict = json as? [String: Any] else { return nil }
+        guard (dict["kind"] as? String) == "rename" else { return nil }
+        guard let oldURI = dict["oldUri"] as? String else { return nil }
+        guard let newURI = dict["newUri"] as? String else { return nil }
+        self.uri = oldURI
+        self.kind = .rename
+        self.edits = []
+        self.newURI = newURI
+    }
+
+    /// Initialises from a `DeleteFile` JSON dictionary.
+    /// `{ "kind": "delete", "uri": "..." }`
+    init?(deleteFile json: Any) {
+        guard let dict = json as? [String: Any] else { return nil }
+        guard (dict["kind"] as? String) == "delete" else { return nil }
+        guard let uri = dict["uri"] as? String else { return nil }
+        self.uri = uri
+        self.kind = .delete
+        self.edits = []
+        self.newURI = nil
+    }
+
+    /// Test/fixture convenience constructor.
+    init(uri: String, kind: LSPDocumentChangeKind, edits: [LSPTextEdit] = [], newURI: String? = nil) {
+        self.uri = uri
+        self.kind = kind
+        self.edits = edits
+        self.newURI = newURI
+    }
+}
+
+// MARK: - Workspace edit
+
+/// An LSP `WorkspaceEdit` — the set of changes a code action or rename
+/// would apply across zero or more files.
+///
+/// Per the LSP spec, the server may return either:
+///   • `documentChanges`: `[TextDocumentEdit | CreateFile | RenameFile | DeleteFile]`
+///   • `changes`: `{ [uri: string]: TextEdit[] }` (legacy form)
+///
+/// Pine normalises both into a flat `[LSPOperatedFile]` plan, preferring
+/// `documentChanges` when present.
+nonisolated struct LSPWorkspaceEdit: Equatable, Sendable {
+    /// The ordered list of file operations, normalised from whichever form
+    /// the server used. Empty when the server returned an empty edit.
+    let operatedFiles: [LSPOperatedFile]
+
+    /// `true` when there are no changes to apply.
+    var isEmpty: Bool { operatedFiles.isEmpty }
+
+    /// Total number of text edits across all files.
+    var totalTextEditCount: Int {
+        operatedFiles.reduce(0) { $0 + $1.edits.count }
+    }
+
+    /// Initialises from the raw JSON dictionary of a `WorkspaceEdit`.
+    /// Returns an empty edit when the input is `nil` or unparseable.
+    init(json: Any) {
+        guard let dict = json as? [String: Any] else {
+            self.operatedFiles = []
+            return
+        }
+
+        // Prefer `documentChanges` (3.0+) when present.
+        if let docChanges = dict["documentChanges"] as? [Any], !docChanges.isEmpty {
+            self.operatedFiles = LSPWorkspaceEdit.parseDocumentChanges(docChanges)
+            return
+        }
+
+        // Fall back to legacy `changes` (2.0).
+        if let changes = dict["changes"] as? [String: Any], !changes.isEmpty {
+            var files: [LSPOperatedFile] = []
+            for (uri, edits) in changes {
+                if let operated = LSPOperatedFile(legacyChanges: uri, edits: edits) {
+                    files.append(operated)
+                }
+            }
+            self.operatedFiles = files
+            return
+        }
+
+        self.operatedFiles = []
+    }
+
+    init(operatedFiles: [LSPOperatedFile]) {
+        self.operatedFiles = operatedFiles
+    }
+
+    /// Parses a `documentChanges` array into `[LSPOperatedFile]`,
+    /// dispatching each element to the correct initialiser.
+    private static func parseDocumentChanges(_ changes: [Any]) -> [LSPOperatedFile] {
+        var result: [LSPOperatedFile] = []
+        for element in changes {
+            guard let dict = element as? [String: Any] else { continue }
+            let kindStr = dict["kind"] as? String
+
+            if kindStr == "create", let f = LSPOperatedFile(createFile: element) {
+                result.append(f)
+            } else if kindStr == "rename", let f = LSPOperatedFile(renameFile: element) {
+                result.append(f)
+            } else if kindStr == "delete", let f = LSPOperatedFile(deleteFile: element) {
+                result.append(f)
+            } else if let f = LSPOperatedFile(textDocumentEdit: element) {
+                result.append(f)
+            }
+        }
+        return result
+    }
+}
+
+// MARK: - Workspace edit applier (pure logic)
+
+/// The result of applying a `WorkspaceEdit` to a single file's text.
+///
+/// `nonisolated` + `Sendable` because this is pure data produced by the
+/// applier on a background context.
+nonisolated struct WorkspaceEditApplyResult: Sendable, Equatable {
+    /// The resulting text after applying all edits, or `nil` when the edit
+    /// could not be applied (e.g. range out of bounds).
+    let newText: String?
+    /// `true` when the application succeeded.
+    let success: Bool
+    /// Optional error message when `success` is `false`.
+    let errorMessage: String?
+
+    init(newText: String) {
+        self.newText = newText
+        self.success = true
+        self.errorMessage = nil
+    }
+
+    init(error: String) {
+        self.newText = nil
+        self.success = false
+        self.errorMessage = error
+    }
+}
+
+/// Pure logic that applies a list of `LSPTextEdit`s to a text string.
+///
+/// Edits are applied in **reverse order** of their start position (last
+/// first) so earlier edits don't shift the offsets of later ones. This is
+/// the standard approach for applying multiple non-overlapping text edits
+/// to a single string.
+///
+/// `nonisolated` because the logic is pure data work — no actor isolation
+/// needed, and it is testable in isolation.
+nonisolated enum WorkspaceEditApplier {
+
+    /// Applies `edits` to `text`, returning the resulting string.
+    ///
+    /// Edits are sorted by descending start position and applied one by one.
+    /// If any edit's range is out of bounds or the edit fails, the function
+    /// returns a failure result — the caller must not commit partial state.
+    ///
+    /// - Parameters:
+    ///   - edits: The text edits to apply. Must be non-overlapping (the LSP
+    ///     spec guarantees this for server-sent edits).
+    ///   - text: The original document text.
+    /// - Returns: `.success` with the new text, or `.failure` with a message.
+    static func applyEdits(_ edits: [LSPTextEdit], to text: String) -> WorkspaceEditApplyResult {
+        guard !edits.isEmpty else {
+            return WorkspaceEditApplyResult(newText: text)
+        }
+
+        // Sort by descending start position (apply from end to start).
+        let sorted = edits.sorted { lhs, rhs in
+            if lhs.range.start.line != rhs.range.start.line {
+                return lhs.range.start.line > rhs.range.start.line
+            }
+            return lhs.range.start.character > rhs.range.start.character
+        }
+
+        let ns = text as NSString
+        var mutable = text as NSMutableString
+
+        for edit in sorted {
+            let startOffset = LSPPositionConverter.utf16Offset(
+                line: edit.range.start.line,
+                character: edit.range.start.character,
+                in: text
+            )
+            let endOffset = LSPPositionConverter.utf16Offset(
+                line: edit.range.end.line,
+                character: edit.range.end.character,
+                in: text
+            )
+
+            // Validate bounds.
+            guard startOffset >= 0, startOffset <= ns.length,
+                  endOffset >= startOffset, endOffset <= ns.length else {
+                return WorkspaceEditApplyResult(
+                    error: "Edit range out of bounds: line \(edit.range.start.line):\(edit.range.start.character) – \(edit.range.end.line):\(edit.range.end.character)"
+                )
+            }
+
+            let range = NSRange(location: startOffset, length: endOffset - startOffset)
+            mutable.replaceCharacters(in: range, with: edit.newText)
+        }
+
+        return WorkspaceEditApplyResult(newText: mutable as String)
+    }
+
+    /// Converts a `WorkspaceEdit` into a list of `(URL, [LSPTextEdit])` pairs
+    /// for only the `.edit` operations, sorted by URI for deterministic order.
+    ///
+    /// Used by rename preview to show what will change in each file.
+    static func editPlan(from workspaceEdit: LSPWorkspaceEdit) -> [(url: URL, edits: [LSPTextEdit])] {
+        workspaceEdit.operatedFiles
+            .filter { $0.kind == .edit && !$0.edits.isEmpty }
+            .compactMap { operated in
+                guard let url = operated.url else { return nil }
+                return (url: url, edits: operated.edits)
+            }
+            .sorted { $0.url.path < $1.url.path }
+    }
+}


### PR DESCRIPTION
Implements #1013 — LSP Phase 4: Code actions + Rename.

## New: Pine/LSP/ (2 files, 595 lines)

| File | Lines | Purpose |
|---|---|---|
| CodeActionProvider.swift | 241 | LSPCodeActionKind, LSPCommand, LSPCodeAction, response parsing |
| RenameProvider.swift | 354 | LSPTextEdit, LSPWorkspaceEdit, WorkspaceEditApplier (transactional) |

## Features
- textDocument/codeAction — quick fixes, refactorings from server
- textDocument/rename — symbol rename across project
- WorkspaceEdit application — transactional two-phase (compute all → commit all)
- Handles both documentChanges and legacy changes format

## Architecture
All types nonisolated struct: Sendable (Swift 6 compliant).
Reuses sendRequest/SendableJSONBox pattern from Phase 1-3.

## TODO (follow-up)
- Context menu UI for code actions (right-click)
- Rename popover/inline field
- Unit tests