### PR TITLE
test: add unit tests for LSP pure logic (#1088)

### DIFF
--- a/PineTests/CompletionFilterTests.swift
+++ b/PineTests/CompletionFilterTests.swift
@@ -1,0 +1,209 @@
+//
+//  CompletionFilterTests.swift
+//  PineTests
+//
+//  Unit tests for CompletionFilter — pure prefix-filter + ranker for LSP
+//  completion items. Scoring: exact > prefix > word boundary > substring >
+//  fuzzy subsequence.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("CompletionFilter Tests")
+struct CompletionFilterTests {
+
+    // MARK: - Exact match (highest rank)
+
+    @Test("Exact match ranks highest")
+    func exactMatchRanksHighest() {
+        let items = [
+            LSPCompletionItem(label: "bar"),
+            LSPCompletionItem(label: "foo"),
+            LSPCompletionItem(label: "foobar"),
+        ]
+        let result = CompletionFilter.filter(items, prefix: "foo")
+        #expect(result.first?.label == "foo")
+    }
+
+    @Test("Exact match is case insensitive")
+    func exactMatchCaseInsensitive() {
+        let items = [
+            LSPCompletionItem(label: "Bar"),
+            LSPCompletionItem(label: "FOO"),
+        ]
+        let result = CompletionFilter.filter(items, prefix: "foo")
+        #expect(result.first?.label == "FOO")
+    }
+
+    // MARK: - Prefix match
+
+    @Test("Prefix match ranks above substring")
+    func prefixAboveSubstring() {
+        let items = [
+            LSPCompletionItem(label: "xfoo"),      // substring only
+            LSPCompletionItem(label: "foobar"),    // prefix match
+        ]
+        let result = CompletionFilter.filter(items, prefix: "foo")
+        #expect(result[0].label == "foobar")
+        #expect(result[1].label == "xfoo")
+    }
+
+    // MARK: - Word boundary match
+
+    @Test("Word boundary via underscore ranks above substring")
+    func wordBoundaryUnderscore() {
+        let items = [
+            LSPCompletionItem(label: "xfoo"),      // substring
+            LSPCompletionItem(label: "my_foo"),    // word boundary (_)
+        ]
+        let result = CompletionFilter.filter(items, prefix: "foo")
+        #expect(result[0].label == "my_foo")
+        #expect(result[1].label == "xfoo")
+    }
+
+    @Test("Word boundary via dash")
+    func wordBoundaryDash() {
+        let items = [
+            LSPCompletionItem(label: "xfoo"),
+            LSPCompletionItem(label: "my-foo"),
+        ]
+        let result = CompletionFilter.filter(items, prefix: "foo")
+        #expect(result[0].label == "my-foo")
+    }
+
+    @Test("Word boundary via dot")
+    func wordBoundaryDot() {
+        let items = [
+            LSPCompletionItem(label: "xfoo"),
+            LSPCompletionItem(label: "obj.foo"),
+        ]
+        let result = CompletionFilter.filter(items, prefix: "foo")
+        #expect(result[0].label == "obj.foo")
+    }
+
+    // MARK: - Substring match
+
+    @Test("Substring match included when no prefix/boundary")
+    func substringMatch() {
+        let items = [
+            LSPCompletionItem(label: "xfoobar"),
+        ]
+        let result = CompletionFilter.filter(items, prefix: "foo")
+        #expect(result.count == 1)
+        #expect(result[0].label == "xfoobar")
+    }
+
+    // MARK: - Fuzzy subsequence match
+
+    @Test("Fuzzy subsequence match")
+    func fuzzySubsequence() {
+        let items = [
+            LSPCompletionItem(label: "football"),
+        ]
+        // "ftl" is a subsequence of "football": f-o-o-t-b-a-l-l
+        let result = CompletionFilter.filter(items, prefix: "ftl")
+        #expect(result.count == 1)
+    }
+
+    @Test("Fuzzy ranks below substring")
+    func fuzzyBelowSubstring() {
+        let items = [
+            LSPCompletionItem(label: "football"),  // fuzzy: "ftl" subsequence
+            LSPCompletionItem(label: "aftl"),      // substring: contains "ftl"
+        ]
+        let result = CompletionFilter.filter(items, prefix: "ftl")
+        #expect(result[0].label == "aftl")
+        #expect(result[1].label == "football")
+    }
+
+    // MARK: - Non-match filtered out
+
+    @Test("Non-matching items are filtered out")
+    func nonMatchFiltered() {
+        let items = [
+            LSPCompletionItem(label: "foo"),
+            LSPCompletionItem(label: "bar"),
+            LSPCompletionItem(label: "baz"),
+        ]
+        let result = CompletionFilter.filter(items, prefix: "foo")
+        #expect(result.count == 1)
+    }
+
+    // MARK: - Empty prefix
+
+    @Test("Empty prefix returns all items in server order")
+    func emptyPrefixReturnsAll() {
+        let items = [
+            LSPCompletionItem(label: "foo"),
+            LSPCompletionItem(label: "bar"),
+            LSPCompletionItem(label: "baz"),
+        ]
+        let result = CompletionFilter.filter(items, prefix: "")
+        #expect(result.count == 3)
+        #expect(result.map(\.label) == ["foo", "bar", "baz"])
+    }
+
+    @Test("Whitespace-only prefix returns all items")
+    func whitespacePrefixReturnsAll() {
+        let items = [
+            LSPCompletionItem(label: "foo"),
+            LSPCompletionItem(label: "bar"),
+        ]
+        let result = CompletionFilter.filter(items, prefix: "   ")
+        #expect(result.count == 2)
+    }
+
+    // MARK: - Server order as tiebreaker
+
+    @Test("Server order preserved for equal scores")
+    func serverOrderPreserved() {
+        let items = [
+            LSPCompletionItem(label: "fooA"),
+            LSPCompletionItem(label: "fooB"),
+            LSPCompletionItem(label: "fooC"),
+        ]
+        let result = CompletionFilter.filter(items, prefix: "foo")
+        // All prefix-match with equal score — server order is the tiebreaker
+        #expect(result.map(\.label) == ["fooA", "fooB", "fooC"])
+    }
+
+    // MARK: - filterText preference
+
+    @Test("filterText used for matching when present")
+    func filterTextUsedForMatching() {
+        let items = [
+            LSPCompletionItem(label: "displayLabel", filterText: "foo"),
+        ]
+        let result = CompletionFilter.filter(items, prefix: "foo")
+        #expect(result.count == 1)
+    }
+
+    @Test("filterText exact match ranks highest")
+    func filterTextExactMatch() {
+        let items = [
+            LSPCompletionItem(label: "fooA"),
+            LSPCompletionItem(label: "displayLabel", filterText: "foo"),
+        ]
+        let result = CompletionFilter.filter(items, prefix: "foo")
+        // filterText "foo" exact-matches needle "foo" → score 10_000
+        #expect(result[0].label == "displayLabel")
+    }
+
+    // MARK: - Full hierarchy ranking
+
+    @Test("Full ranking hierarchy: exact > prefix > boundary > substring > fuzzy")
+    func fullHierarchy() {
+        let items = [
+            LSPCompletionItem(label: "xfoobar"),       // substring
+            LSPCompletionItem(label: "football"),       // fuzzy (ftl subsequence)
+            LSPCompletionItem(label: "ftl"),            // exact
+            LSPCompletionItem(label: "my_ftl"),         // word boundary
+            LSPCompletionItem(label: "ftl_extra"),      // prefix
+        ]
+        let result = CompletionFilter.filter(items, prefix: "ftl")
+        #expect(result.map(\.label) == ["ftl", "ftl_extra", "my_ftl", "xfoobar", "football"])
+    }
+}

--- a/PineTests/DiagnosticMapperTests.swift
+++ b/PineTests/DiagnosticMapperTests.swift
@@ -161,6 +161,7 @@ struct DiagnosticMapperTests {
         ]
         if let severity { json["severity"] = severity }
         if let source { json["source"] = source }
+        // swiftlint:disable:next force_unwrapping
         return LSPDiagnostic(json: json)!
     }
 }

--- a/PineTests/DiagnosticMapperTests.swift
+++ b/PineTests/DiagnosticMapperTests.swift
@@ -1,0 +1,166 @@
+//
+//  DiagnosticMapperTests.swift
+//  PineTests
+//
+//  Unit tests for DiagnosticMapper — pure logic mapping LSP diagnostics
+//  (0-based positions) into Pine's ValidationDiagnostic (1-based).
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("DiagnosticMapper Tests")
+struct DiagnosticMapperTests {
+
+    // MARK: - Line conversion (LSP 0-based → Pine 1-based)
+
+    @Test("LSP line 0 maps to Pine line 1")
+    func lineZeroMapsToOne() {
+        let diag = makeDiagnostic(line: 0, character: 0)
+        let result = DiagnosticMapper.map(diag)
+        #expect(result.line == 1)
+    }
+
+    @Test("LSP line 5 maps to Pine line 6")
+    func lineFiveMapsToSix() {
+        let diag = makeDiagnostic(line: 5, character: 0)
+        let result = DiagnosticMapper.map(diag)
+        #expect(result.line == 6)
+    }
+
+    // MARK: - Column conversion (LSP 0-based character → Pine 1-based column)
+
+    @Test("LSP character 0 maps to Pine column 1")
+    func characterZeroMapsToOne() {
+        let diag = makeDiagnostic(line: 0, character: 0)
+        let result = DiagnosticMapper.map(diag)
+        #expect(result.column == 1)
+    }
+
+    @Test("LSP character 10 maps to Pine column 11")
+    func characterTenMapsToEleven() {
+        let diag = makeDiagnostic(line: 0, character: 10)
+        let result = DiagnosticMapper.map(diag)
+        #expect(result.column == 11)
+    }
+
+    // MARK: - Negative character clamping
+
+    @Test("Negative character clamps to column 1")
+    func negativeCharacterClamps() {
+        let diag = makeDiagnostic(line: 0, character: -1)
+        let result = DiagnosticMapper.map(diag)
+        #expect(result.column == 1)  // max(0, -1) + 1 = 1
+    }
+
+    @Test("Large negative character clamps to column 1")
+    func largeNegativeCharacterClamps() {
+        let diag = makeDiagnostic(line: 0, character: -42)
+        let result = DiagnosticMapper.map(diag)
+        #expect(result.column == 1)  // max(0, -42) + 1 = 1
+    }
+
+    // MARK: - Missing severity defaults
+
+    @Test("Missing severity defaults to info")
+    func missingSeverityDefaultsToInfo() {
+        let diag = makeDiagnostic(line: 0, character: 0)
+        let result = DiagnosticMapper.map(diag)
+        #expect(result.severity == .info)
+    }
+
+    @Test("Error severity maps correctly")
+    func errorSeverity() {
+        let diag = makeDiagnostic(line: 0, character: 0, severity: 1)
+        #expect(DiagnosticMapper.map(diag).severity == .error)
+    }
+
+    @Test("Warning severity maps correctly")
+    func warningSeverity() {
+        let diag = makeDiagnostic(line: 0, character: 0, severity: 2)
+        #expect(DiagnosticMapper.map(diag).severity == .warning)
+    }
+
+    @Test("Information severity maps to info")
+    func informationSeverity() {
+        let diag = makeDiagnostic(line: 0, character: 0, severity: 3)
+        #expect(DiagnosticMapper.map(diag).severity == .info)
+    }
+
+    @Test("Hint severity maps to info")
+    func hintSeverity() {
+        let diag = makeDiagnostic(line: 0, character: 0, severity: 4)
+        #expect(DiagnosticMapper.map(diag).severity == .info)
+    }
+
+    // MARK: - Missing source defaults
+
+    @Test("Missing source defaults to 'lsp'")
+    func missingSourceDefaultsToLSP() {
+        let diag = makeDiagnostic(line: 0, character: 0)
+        #expect(DiagnosticMapper.map(diag).source == "lsp")
+    }
+
+    @Test("Custom fallback source used when source missing")
+    func customFallbackSource() {
+        let diag = makeDiagnostic(line: 0, character: 0)
+        #expect(DiagnosticMapper.map(diag, fallbackSource: "eslint").source == "eslint")
+    }
+
+    @Test("Explicit source preserved over fallback")
+    func explicitSourcePreserved() {
+        let diag = makeDiagnostic(line: 0, character: 0, source: "swift-format")
+        #expect(DiagnosticMapper.map(diag).source == "swift-format")
+    }
+
+    // MARK: - Notification mapping
+
+    @Test("Notification maps all diagnostics")
+    func notificationMapsAll() {
+        let d1 = makeDiagnostic(line: 0, character: 0, message: "first")
+        let d2 = makeDiagnostic(line: 3, character: 5, message: "second")
+        let notification = LSPDiagnosticsNotification(uri: "file:///test.swift", diagnostics: [d1, d2])
+        let results = DiagnosticMapper.map(notification)
+        #expect(results.count == 2)
+        #expect(results[0].line == 1)
+        #expect(results[1].line == 4)
+        #expect(results[1].column == 6)
+    }
+
+    @Test("Empty diagnostics notification produces empty array")
+    func emptyNotification() {
+        let notification = LSPDiagnosticsNotification(uri: "file:///test.swift", diagnostics: [])
+        let results = DiagnosticMapper.map(notification)
+        #expect(results.isEmpty)
+    }
+
+    // MARK: - Message preservation
+
+    @Test("Message is preserved through mapping")
+    func messagePreserved() {
+        let diag = makeDiagnostic(line: 2, character: 3, message: "Variable never used")
+        #expect(DiagnosticMapper.map(diag).message == "Variable never used")
+    }
+
+    // MARK: - Helpers
+
+    private func rangeDict(line: Int, character: Int) -> [String: Any] {
+        ["start": ["line": line, "character": character],
+         "end": ["line": line, "character": character + 5]]
+    }
+
+    private func makeDiagnostic(
+        line: Int, character: Int, severity: Int? = nil,
+        source: String? = nil, message: String = "test"
+    ) -> LSPDiagnostic {
+        var json: [String: Any] = [
+            "range": rangeDict(line: line, character: character),
+            "message": message
+        ]
+        if let severity { json["severity"] = severity }
+        if let source { json["source"] = source }
+        return LSPDiagnostic(json: json)!
+    }
+}

--- a/PineTests/LSPCodeActionResponseTests.swift
+++ b/PineTests/LSPCodeActionResponseTests.swift
@@ -142,7 +142,8 @@ struct LSPCodeActionResponseTests {
         #expect(response.isEmpty)
         #expect(response.actions.isEmpty)
         #expect(response.commands.isEmpty)
-        #expect(response.count == 0)
+        // count is also 0
+        #expect(response.isEmpty)
     }
 
     @Test("Non-array response produces empty result")
@@ -170,7 +171,6 @@ struct LSPCodeActionResponseTests {
     func emptyArray() {
         let response = LSPCodeActionResponse(result: [])
         #expect(response.isEmpty)
-        #expect(response.count == 0)
     }
 
     // MARK: - Malformed entries skipped

--- a/PineTests/LSPCodeActionResponseTests.swift
+++ b/PineTests/LSPCodeActionResponseTests.swift
@@ -1,0 +1,234 @@
+//
+//  LSPCodeActionResponseTests.swift
+//  PineTests
+//
+//  Unit tests for LSPCodeActionResponse — parses arrays of CodeAction and/or
+//  bare Command objects, plus null/empty responses.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("LSPCodeActionResponse Tests")
+struct LSPCodeActionResponseTests {
+
+    // MARK: - Array of CodeAction objects
+
+    @Test("Parse array of CodeAction objects")
+    func parseCodeActions() {
+        let json: [Any] = [
+            ["title": "Fix typo", "kind": "quickfix"],
+            ["title": "Extract method", "kind": "refactor.extract"]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(response.actions.count == 2)
+        #expect(response.commands.isEmpty)
+        #expect(response.count == 2)
+    }
+
+    @Test("Parse CodeAction with edit")
+    func parseCodeActionWithEdit() {
+        let json: [Any] = [
+            [
+                "title": "Add missing import",
+                "kind": "quickfix",
+                "edit": [
+                    "documentChanges": [
+                        [
+                            "textDocument": ["uri": "file:///test.swift", "version": 1],
+                            "edits": [
+                                ["range": ["start": ["line": 0, "character": 0],
+                                            "end": ["line": 0, "character": 0]],
+                                 "newText": "import Foundation\n"]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(response.actions.count == 1)
+        let action = response.actions[0]
+        #expect(action.title == "Add missing import")
+        #expect(action.kind == .quickFix)
+        #expect(action.edit != nil)
+        #expect(action.edit?.operatedFiles.count == 1)
+    }
+
+    @Test("Parse CodeAction with isPreferred")
+    func parseCodeActionIsPreferred() {
+        let json: [Any] = [
+            ["title": "Fix all", "kind": "quickfix", "isPreferred": true]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(response.actions[0].isPreferred)
+    }
+
+    @Test("isPreferred defaults to false")
+    func isPreferredDefaultsFalse() {
+        let json: [Any] = [
+            ["title": "Fix", "kind": "quickfix"]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(!response.actions[0].isPreferred)
+    }
+
+    @Test("Parse CodeAction with command")
+    func parseCodeActionWithCommand() {
+        let json: [Any] = [
+            [
+                "title": "Run formatter",
+                "command": ["title": "Format", "command": "swift-format.run"]
+            ]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(response.actions.count == 1)
+        #expect(response.actions[0].command != nil)
+        #expect(response.actions[0].command?.command == "swift-format.run")
+    }
+
+    @Test("isExecutable true when action has edit")
+    func isExecutableWithEdit() {
+        let json: [Any] = [
+            [
+                "title": "Fix",
+                "edit": ["changes": [:]]
+            ]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(response.actions[0].isExecutable)
+    }
+
+    @Test("isExecutable false when no edit and no command")
+    func isNotExecutableWithoutEditOrCommand() {
+        let json: [Any] = [
+            ["title": "Disabled fix"]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(!response.actions[0].isExecutable)
+    }
+
+    // MARK: - Bare Command objects
+
+    @Test("Parse array with bare Command objects")
+    func parseBareCommands() {
+        let json: [Any] = [
+            ["title": "Run tests", "command": "test.run"],
+            ["title": "Build", "command": "build.run"]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(response.actions.isEmpty)
+        #expect(response.commands.count == 2)
+        #expect(response.count == 2)
+    }
+
+    @Test("Parse bare Command with arguments")
+    func parseBareCommandWithArgs() {
+        let json: [Any] = [
+            ["title": "Go to", "command": "navigate", "arguments": ["line", 42]]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(response.commands.count == 1)
+        #expect(response.commands[0].arguments != nil)
+    }
+
+    // MARK: - Null response
+
+    @Test("Null response produces empty result")
+    func nullResponse() {
+        let response = LSPCodeActionResponse(result: nil)
+        #expect(response.isEmpty)
+        #expect(response.actions.isEmpty)
+        #expect(response.commands.isEmpty)
+        #expect(response.count == 0)
+    }
+
+    @Test("Non-array response produces empty result")
+    func nonArrayResponse() {
+        let response = LSPCodeActionResponse(result: "not an array")
+        #expect(response.isEmpty)
+    }
+
+    // MARK: - Mixed CodeAction + Command array
+
+    @Test("Parse mixed CodeAction + Command array")
+    func parseMixedArray() {
+        let json: [Any] = [
+            ["title": "Quick fix", "kind": "quickfix", "edit": ["changes": [:]]],
+            ["title": "Run tool", "command": "tool.run"],
+            ["title": "Refactor", "kind": "refactor", "command": ["title": "Do", "command": "do.refactor"]]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(response.actions.count == 2)   // first and third are CodeActions
+        #expect(response.commands.count == 1)  // second is bare Command
+        #expect(response.count == 3)
+    }
+
+    @Test("Empty array produces empty result")
+    func emptyArray() {
+        let response = LSPCodeActionResponse(result: [])
+        #expect(response.isEmpty)
+        #expect(response.count == 0)
+    }
+
+    // MARK: - Malformed entries skipped
+
+    @Test("Malformed entries are skipped")
+    func malformedEntriesSkipped() {
+        let json: [Any] = [
+            ["kind": "quickfix"],  // missing title → not a CodeAction, not a Command
+            "garbage string",
+            ["title": "Valid", "kind": "quickfix"]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(response.actions.count == 1)
+        #expect(response.actions[0].title == "Valid")
+    }
+
+    // MARK: - Kind parsing
+
+    @Test("Parse all code action kinds")
+    func parseAllKinds() {
+        let json: [Any] = [
+            ["title": "a", "kind": "quickfix"],
+            ["title": "b", "kind": "refactor"],
+            ["title": "c", "kind": "refactor.extract"],
+            ["title": "d", "kind": "refactor.inline"],
+            ["title": "e", "kind": "refactor.rewrite"],
+            ["title": "f", "kind": "source"],
+            ["title": "g", "kind": "source.organizeImports"],
+            ["title": "h", "kind": "source.fixAll"]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(response.actions.count == 8)
+        #expect(response.actions[0].kind == .quickFix)
+        #expect(response.actions[1].kind == .refactor)
+        #expect(response.actions[2].kind == .refactorExtract)
+        #expect(response.actions[3].kind == .refactorInline)
+        #expect(response.actions[4].kind == .refactorRewrite)
+        #expect(response.actions[5].kind == .source)
+        #expect(response.actions[6].kind == .sourceOrganizeImports)
+        #expect(response.actions[7].kind == .sourceFixAll)
+    }
+
+    @Test("Unknown kind is nil (not an error)")
+    func unknownKindNil() {
+        let json: [Any] = [
+            ["title": "Custom", "kind": "custom.weird.kind"]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(response.actions.count == 1)
+        #expect(response.actions[0].kind == nil)
+    }
+
+    @Test("Missing kind is nil")
+    func missingKindNil() {
+        let json: [Any] = [
+            ["title": "No kind", "edit": ["changes": [:]]]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(response.actions[0].kind == nil)
+    }
+}

--- a/PineTests/LSPHoverTests.swift
+++ b/PineTests/LSPHoverTests.swift
@@ -1,0 +1,215 @@
+//
+//  LSPHoverTests.swift
+//  PineTests
+//
+//  Unit tests for LSPHover — parses the polymorphic `contents` field of a
+//  textDocument/hover response (MarkupContent, MarkedString, array of
+//  MarkedStrings) into a normalised LSPMarkupContent.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("LSPHover Tests")
+struct LSPHoverTests {
+
+    // MARK: - MarkupContent normalization
+
+    @Test("Parse MarkupContent markdown")
+    func parseMarkupContentMarkdown() {
+        let json: [String: Any] = [
+            "contents": [
+                "kind": "markdown",
+                "value": "## Heading\nSome text"
+            ]
+        ]
+        let hover = LSPHover(result: json)
+        #expect(hover != nil)
+        #expect(hover?.markup.value == "## Heading\nSome text")
+        #expect(hover?.markup.isMarkdown == true)
+    }
+
+    @Test("Parse MarkupContent plaintext")
+    func parseMarkupContentPlaintext() {
+        let json: [String: Any] = [
+            "contents": [
+                "kind": "plaintext",
+                "value": "Just plain text"
+            ]
+        ]
+        let hover = LSPHover(result: json)
+        #expect(hover?.markup.value == "Just plain text")
+        #expect(hover?.markup.isMarkdown == false)
+    }
+
+    @Test("MarkupContent without kind defaults to plaintext")
+    func markupContentNoKind() {
+        let json: [String: Any] = [
+            "contents": ["value": "no kind field"]
+        ]
+        let hover = LSPHover(result: json)
+        #expect(hover?.markup.value == "no kind field")
+        #expect(hover?.markup.isMarkdown == false)
+    }
+
+    // MARK: - Plain MarkedString (bare string)
+
+    @Test("Parse plain MarkedString (bare string)")
+    func parseBareString() {
+        let json: [String: Any] = [
+            "contents": "This is a hover string"
+        ]
+        let hover = LSPHover(result: json)
+        #expect(hover != nil)
+        #expect(hover?.markup.value == "This is a hover string")
+        #expect(hover?.markup.isMarkdown == false)
+    }
+
+    // MARK: - Code MarkedString ({language, value})
+
+    @Test("Parse code MarkedString")
+    func parseCodeMarkedString() {
+        let json: [String: Any] = [
+            "contents": [
+                "language": "swift",
+                "value": "func hello() {}"
+            ]
+        ]
+        let hover = LSPHover(result: json)
+        #expect(hover != nil)
+        #expect(hover?.markup.value == "func hello() {}")
+        #expect(hover?.markup.isMarkdown == false)
+    }
+
+    @Test("Code MarkedString without language")
+    func parseCodeMarkedStringNoLanguage() {
+        let json: [String: Any] = [
+            "contents": ["value": "code block"]
+        ]
+        let hover = LSPHover(result: json)
+        #expect(hover?.markup.value == "code block")
+        #expect(hover?.markup.isMarkdown == false)
+    }
+
+    // MARK: - Array of MarkedStrings
+
+    @Test("Parse array of bare strings")
+    func parseArrayOfStrings() {
+        let json: [String: Any] = [
+            "contents": ["First part", "Second part"]
+        ]
+        let hover = LSPHover(result: json)
+        #expect(hover != nil)
+        #expect(hover?.markup.value == "First part\n\nSecond part")
+    }
+
+    @Test("Parse array of code MarkedStrings")
+    func parseArrayOfCodeMarkedStrings() {
+        let json: [String: Any] = [
+            "contents": [
+                ["language": "swift", "value": "let x = 1"],
+                ["language": "python", "value": "x = 1"]
+            ]
+        ]
+        let hover = LSPHover(result: json)
+        #expect(hover != nil)
+        #expect(hover?.markup.isMarkdown == true)
+        #expect(hover?.markup.value.contains("```swift") == true)
+        #expect(hover?.markup.value.contains("let x = 1") == true)
+        #expect(hover?.markup.value.contains("```python") == true)
+        #expect(hover?.markup.value.contains("x = 1") == true)
+    }
+
+    @Test("Parse mixed array of strings and code MarkedStrings")
+    func parseMixedArray() {
+        let json: [String: Any] = [
+            "contents": [
+                "Description text",
+                ["language": "swift", "value": "code()"]
+            ]
+        ]
+        let hover = LSPHover(result: json)
+        #expect(hover != nil)
+        #expect(hover?.markup.isMarkdown == true)
+        #expect(hover?.markup.value.contains("Description text") == true)
+        #expect(hover?.markup.value.contains("```swift") == true)
+    }
+
+    @Test("Array elements joined with double newline")
+    func arrayJoinedWithDoubleNewline() {
+        let json: [String: Any] = [
+            "contents": ["A", "B", "C"]
+        ]
+        let hover = LSPHover(result: json)
+        #expect(hover?.markup.value == "A\n\nB\n\nC")
+    }
+
+    // MARK: - Null / empty contents
+
+    @Test("Null result returns nil")
+    func nullResult() {
+        let hover = LSPHover(result: nil)
+        #expect(hover == nil)
+    }
+
+    @Test("Non-dictionary result returns nil")
+    func nonDictionaryResult() {
+        let hover = LSPHover(result: "just a string")
+        #expect(hover == nil)
+    }
+
+    @Test("Empty contents returns nil")
+    func emptyContents() {
+        let json: [String: Any] = ["contents": ""]
+        let hover = LSPHover(result: json)
+        #expect(hover == nil)
+    }
+
+    @Test("Empty array contents returns nil")
+    func emptyArrayContents() {
+        let json: [String: Any] = ["contents": []]
+        let hover = LSPHover(result: json)
+        #expect(hover == nil)
+    }
+
+    @Test("Missing contents key returns nil")
+    func missingContents() {
+        let json: [String: Any] = ["range": [:]]
+        let hover = LSPHover(result: json)
+        #expect(hover == nil)
+    }
+
+    @Test("Array of empty strings returns nil")
+    func arrayOfEmptyStrings() {
+        let json: [String: Any] = ["contents": ["", ""]]
+        let hover = LSPHover(result: json)
+        #expect(hover == nil)
+    }
+
+    // MARK: - Range parsing
+
+    @Test("Optional range parsed when present")
+    func rangeParsed() {
+        let json: [String: Any] = [
+            "contents": "text",
+            "range": [
+                "start": ["line": 2, "character": 3],
+                "end": ["line": 2, "character": 8]
+            ]
+        ]
+        let hover = LSPHover(result: json)
+        #expect(hover?.range != nil)
+        #expect(hover?.range?.start.line == 2)
+        #expect(hover?.range?.start.character == 3)
+        #expect(hover?.range?.end.character == 8)
+    }
+
+    @Test("Range is nil when absent")
+    func rangeAbsent() {
+        let json: [String: Any] = ["contents": "text"]
+        let hover = LSPHover(result: json)
+        #expect(hover?.range == nil)
+    }
+}

--- a/PineTests/LSPPositionConverterTests.swift
+++ b/PineTests/LSPPositionConverterTests.swift
@@ -1,0 +1,215 @@
+//
+//  LSPPositionConverterTests.swift
+//  PineTests
+//
+//  Unit tests for LSPPositionConverter — pure logic that maps a UTF-16 offset
+//  to an LSP Position (0-based line + character), handling multi-byte chars
+//  and CRLF line endings.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("LSPPositionConverter Tests")
+struct LSPPositionConverterTests {
+
+    // MARK: - Empty string
+
+    @Test("Offset 0 in empty string")
+    func emptyStringOffsetZero() {
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 0, in: "")
+        #expect(pos.line == 0)
+        #expect(pos.character == 0)
+    }
+
+    // MARK: - Single line
+
+    @Test("Single line, offset at start")
+    func singleLineStart() {
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 0, in: "hello world")
+        #expect(pos.line == 0)
+        #expect(pos.character == 0)
+    }
+
+    @Test("Single line, offset at end")
+    func singleLineEnd() {
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 5, in: "hello")
+        #expect(pos.line == 0)
+        #expect(pos.character == 5)
+    }
+
+    @Test("Single line, offset in middle")
+    func singleLineMiddle() {
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 3, in: "hello")
+        #expect(pos.line == 0)
+        #expect(pos.character == 3)
+    }
+
+    // MARK: - Multi-line (LF)
+
+    @Test("Multi-line, offset on second line")
+    func multiLineSecondLine() {
+        let text = "line1\nline2"
+        // offset 8 → 'n' in "line2" (0-based: l=0,i=1,n=2,e=3,2=4 within line 1)
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 8, in: text)
+        #expect(pos.line == 1)
+        #expect(pos.character == 2)
+    }
+
+    @Test("Multi-line, offset at newline character")
+    func multiLineAtNewline() {
+        let text = "ab\ncd"
+        // offset 2 = '\n'
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 2, in: text)
+        #expect(pos.line == 0)
+        #expect(pos.character == 2)
+    }
+
+    @Test("Multi-line, offset right after newline")
+    func multiLineAfterNewline() {
+        let text = "ab\ncd"
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 3, in: text)
+        #expect(pos.line == 1)
+        #expect(pos.character == 0)
+    }
+
+    @Test("Three lines, offset on third line")
+    func threeLines() {
+        let text = "a\nb\nc"
+        // offset 4 = 'c' on line 2
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 4, in: text)
+        #expect(pos.line == 2)
+        #expect(pos.character == 1)
+    }
+
+    // MARK: - Multi-byte characters (emoji)
+
+    @Test("Emoji counts as 2 UTF-16 code units")
+    func emojiCharacters() {
+        let text = "😀abc"
+        // NSString length = 5 (2 for emoji surrogate pair + 3 ASCII)
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 3, in: text)
+        #expect(pos.line == 0)
+        #expect(pos.character == 3)  // 2 (emoji) + 1 (a) = 3
+    }
+
+    @Test("Emoji with newline")
+    func emojiWithNewline() {
+        let text = "😀\nabc"
+        // NSString length = 6 (2 emoji + 1 \n + 3 abc)
+        // offset 3 = right after \n → start of line 1
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 3, in: text)
+        #expect(pos.line == 1)
+        #expect(pos.character == 0)
+    }
+
+    // MARK: - Multi-byte characters (CJK)
+
+    @Test("CJK characters (1 UTF-16 code unit each)")
+    func cjkCharacters() {
+        let text = "你好世界"
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 2, in: text)
+        #expect(pos.line == 0)
+        #expect(pos.character == 2)
+    }
+
+    @Test("Mixed ASCII and CJK")
+    func mixedAsciiCJK() {
+        let text = "abc你好"
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 4, in: text)
+        #expect(pos.line == 0)
+        #expect(pos.character == 4)  // 3 ASCII + 1 CJK
+    }
+
+    // MARK: - CRLF line endings
+
+    @Test("CRLF: CR counted as character on the line")
+    func crlfCrCounted() {
+        let text = "ab\r\ncd"
+        // NSString: a=0, b=1, \r=2, \n=3, c=4, d=5
+        // offset 4 = 'c' → line 1, char 0
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 4, in: text)
+        #expect(pos.line == 1)
+        #expect(pos.character == 0)
+    }
+
+    @Test("CRLF: offset at carriage return")
+    func crlfAtCR() {
+        let text = "ab\r\ncd"
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 2, in: text)
+        #expect(pos.line == 0)
+        #expect(pos.character == 2)  // a + b
+    }
+
+    @Test("CRLF: offset at newline")
+    func crlfAtNewline() {
+        let text = "ab\r\ncd"
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 3, in: text)
+        #expect(pos.line == 0)
+        #expect(pos.character == 3)  // \r counted as 1 char
+    }
+
+    @Test("CRLF: offset after newline on second line")
+    func crlfAfterNewline() {
+        let text = "ab\r\ncd"
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 5, in: text)
+        #expect(pos.line == 1)
+        #expect(pos.character == 1)  // c=0, d=1
+    }
+
+    // MARK: - Clamping
+
+    @Test("Offset beyond string length clamps to end")
+    func offsetBeyondLength() {
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: 100, in: "abc")
+        #expect(pos.line == 0)
+        #expect(pos.character == 3)
+    }
+
+    @Test("Negative offset clamps to 0")
+    func negativeOffset() {
+        let pos = LSPPositionConverter.lspPosition(utf16Offset: -5, in: "abc")
+        #expect(pos.line == 0)
+        #expect(pos.character == 0)
+    }
+
+    // MARK: - Reverse conversion (line + character → offset)
+
+    @Test("Reverse: line 0 char 0 → offset 0")
+    func reverseStart() {
+        let offset = LSPPositionConverter.utf16Offset(line: 0, character: 0, in: "abc")
+        #expect(offset == 0)
+    }
+
+    @Test("Reverse: line 0 char 2 → offset 2")
+    func reverseMidSingleLine() {
+        let offset = LSPPositionConverter.utf16Offset(line: 0, character: 2, in: "abc")
+        #expect(offset == 2)
+    }
+
+    @Test("Reverse: line 1 char 0 → offset 3")
+    func reverseLine1Char0() {
+        let offset = LSPPositionConverter.utf16Offset(line: 1, character: 0, in: "ab\ncd")
+        #expect(offset == 3)
+    }
+
+    @Test("Reverse: line 1 char 1 → offset 4")
+    func reverseLine1Char1() {
+        let offset = LSPPositionConverter.utf16Offset(line: 1, character: 1, in: "ab\ncd")
+        #expect(offset == 4)
+    }
+
+    // MARK: - Round-trip
+
+    @Test("Round-trip: offset → position → offset")
+    func roundTrip() {
+        let text = "func hello() {\n    print(\"hi\")\n}"
+        for offset in 0...text.utf16.count {
+            let pos = LSPPositionConverter.lspPosition(utf16Offset: offset, in: text)
+            let back = LSPPositionConverter.utf16Offset(line: pos.line, character: pos.character, in: text)
+            #expect(back == offset)
+        }
+    }
+}

--- a/PineTests/LSPSnippetTests.swift
+++ b/PineTests/LSPSnippetTests.swift
@@ -1,0 +1,234 @@
+//
+//  LSPSnippetTests.swift
+//  PineTests
+//
+//  Unit tests for LSPSnippet — pure logic that parses LSP snippet syntax
+//  (tab stops, placeholders, choices, escapes) into plain text + ordered
+//  tab-stop ranges.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("LSPSnippet Tests")
+struct LSPSnippetTests {
+
+    // MARK: - Simple tab stops ($0, $1, $2)
+
+    @Test("Parse $0 as final tab stop")
+    func parseFinalTabStop() {
+        let snippet = LSPSnippet("hello$0")
+        #expect(snippet.text == "hello")
+        #expect(snippet.tabStops.count == 1)
+        #expect(snippet.tabStops[0].index == 0)
+        #expect(snippet.tabStops[0].range == 5..<5)
+    }
+
+    @Test("Parse $1 and $2 tab stops")
+    func parseNumberedTabStops() {
+        let snippet = LSPSnippet("$1$2")
+        #expect(snippet.text == "")
+        #expect(snippet.tabStops.count == 2)
+        #expect(snippet.tabStops[0].index == 1)
+        #expect(snippet.tabStops[1].index == 2)
+    }
+
+    @Test("Parse tab stops interleaved with text")
+    func parseTabStopsInText() {
+        let snippet = LSPSnippet("func $1($2) {$0}")
+        #expect(snippet.text == "func () {}")
+        #expect(snippet.tabStops.count == 3)
+        // Ordered by index: $1, $2, then $0 last
+        #expect(snippet.tabStops[0].index == 1)
+        #expect(snippet.tabStops[0].range == 5..<5)
+        #expect(snippet.tabStops[1].index == 2)
+        #expect(snippet.tabStops[1].range == 6..<6)
+        #expect(snippet.tabStops[2].index == 0)
+        #expect(snippet.tabStops[2].range == 9..<9)
+    }
+
+    @Test("Parse multi-digit tab stop $10")
+    func parseMultiDigitTabStop() {
+        let snippet = LSPSnippet("$10")
+        #expect(snippet.text == "")
+        #expect(snippet.tabStops.count == 1)
+        #expect(snippet.tabStops[0].index == 10)
+    }
+
+    // MARK: - Placeholders ${1:default}
+
+    @Test("Parse ${1:default} placeholder")
+    func parsePlaceholder() {
+        let snippet = LSPSnippet("${1:default}")
+        #expect(snippet.text == "default")
+        #expect(snippet.tabStops.count == 1)
+        #expect(snippet.tabStops[0].index == 1)
+        #expect(snippet.tabStops[0].range == 0..<7)
+    }
+
+    @Test("Parse placeholder with surrounding text")
+    func parsePlaceholderWithText() {
+        let snippet = LSPSnippet("var ${1:name} = ${2:value}")
+        #expect(snippet.text == "var name = value")
+        #expect(snippet.tabStops.count == 2)
+        #expect(snippet.tabStops[0].index == 1)
+        #expect(snippet.tabStops[0].range == 4..<8)
+        #expect(snippet.tabStops[1].index == 2)
+        #expect(snippet.tabStops[1].range == 11..<16)
+    }
+
+    @Test("Parse empty braced tab stop ${1}")
+    func parseEmptyBracedTabStop() {
+        let snippet = LSPSnippet("${1}")
+        #expect(snippet.text == "")
+        #expect(snippet.tabStops.count == 1)
+        #expect(snippet.tabStops[0].index == 1)
+        #expect(snippet.tabStops[0].range == 0..<0)
+    }
+
+    // MARK: - Choices ${1|a,b,c|}
+
+    @Test("Parse ${1|a,b,c|} choice — first option used")
+    func parseChoice() {
+        let snippet = LSPSnippet("${1|a,b,c|}")
+        #expect(snippet.text == "a")
+        #expect(snippet.tabStops.count == 1)
+        #expect(snippet.tabStops[0].index == 1)
+        #expect(snippet.tabStops[0].range == 0..<1)
+    }
+
+    @Test("Parse choice with multi-word options")
+    func parseChoiceMultiWord() {
+        let snippet = LSPSnippet("${1|let,var,const|}")
+        #expect(snippet.text == "let")
+        #expect(snippet.tabStops[0].range == 0..<3)
+    }
+
+    @Test("Parse choice within surrounding text")
+    func parseChoiceWithText() {
+        let snippet = LSPSnippet("type: ${1|Int,String,Bool|}")
+        #expect(snippet.text == "type: Int")
+        #expect(snippet.tabStops[0].range == 6..<9)
+    }
+
+    // MARK: - Escape sequences
+
+    @Test("Escape dollar sign with backslash (\\$)")
+    func escapeDollar() {
+        // Swift "\\$" → actual string \$  → literal $
+        let snippet = LSPSnippet("\\$")
+        #expect(snippet.text == "$")
+        #expect(snippet.tabStops.isEmpty)
+    }
+
+    @Test("Escape backslash (\\\\)")
+    func escapeBackslash() {
+        // Swift "\\\\" → actual string \\ → literal \
+        let snippet = LSPSnippet("\\\\")
+        #expect(snippet.text == "\\")
+        #expect(snippet.tabStops.isEmpty)
+    }
+
+    @Test("Double dollar ($$) produces literal dollar")
+    func dollarLiteral() {
+        let snippet = LSPSnippet("$$")
+        #expect(snippet.text == "$")
+        #expect(snippet.tabStops.isEmpty)
+    }
+
+    @Test("Escape inside placeholder body")
+    func escapeInPlaceholder() {
+        // Swift "${1:val\\$}" → actual ${1:val\$}
+        // Parser reads body: v-a-l then \$ → appends $, skips both
+        let snippet = LSPSnippet("${1:val\\$}")
+        #expect(snippet.text == "val$")
+        #expect(snippet.tabStops[0].range == 0..<4)
+    }
+
+    // MARK: - Tab stop ordering ($0 always last)
+
+    @Test("$0 sorts last regardless of position in snippet")
+    func finalTabStopSortsLast() {
+        let snippet = LSPSnippet("$0$1$2")
+        #expect(snippet.tabStops.count == 3)
+        #expect(snippet.tabStops[0].index == 1)
+        #expect(snippet.tabStops[1].index == 2)
+        #expect(snippet.tabStops[2].index == 0)
+    }
+
+    @Test("Tab stops ordered ascending by index")
+    func tabStopsOrderedAscending() {
+        let snippet = LSPSnippet("$3$1$2$0")
+        #expect(snippet.tabStops.count == 4)
+        #expect(snippet.tabStops[0].index == 1)
+        #expect(snippet.tabStops[1].index == 2)
+        #expect(snippet.tabStops[2].index == 3)
+        #expect(snippet.tabStops[3].index == 0)
+    }
+
+    @Test("Synthetic final tab stop appended when no $0")
+    func syntheticFinalTabStop() {
+        let snippet = LSPSnippet("hello $1")
+        #expect(snippet.tabStops.count == 2)
+        #expect(snippet.tabStops[0].index == 1)
+        #expect(snippet.tabStops[1].index == 0)  // synthetic, at end of text
+    }
+
+    @Test("Duplicate index deduplicated")
+    func duplicateIndexDeduplicated() {
+        let snippet = LSPSnippet("$1$1")
+        // First $1 kept, second dropped. Synthetic $0 appended.
+        #expect(snippet.tabStops.count == 2)
+        #expect(snippet.tabStops[0].index == 1)
+        #expect(snippet.tabStops[1].index == 0)
+    }
+
+    // MARK: - No tab stops
+
+    @Test("Plain text with no tab stops")
+    func plainTextNoTabStops() {
+        let snippet = LSPSnippet("plain text")
+        #expect(snippet.text == "plain text")
+        #expect(snippet.tabStops.isEmpty)
+        #expect(!snippet.hasTabStops)
+    }
+
+    @Test("Empty snippet")
+    func emptySnippet() {
+        let snippet = LSPSnippet("")
+        #expect(snippet.text == "")
+        #expect(snippet.tabStops.isEmpty)
+        #expect(!snippet.hasTabStops)
+    }
+
+    @Test("hasTabStops is true when tab stops present")
+    func hasTabStopsTrue() {
+        let snippet = LSPSnippet("$1")
+        #expect(snippet.hasTabStops)
+    }
+
+    // MARK: - Complex snippets
+
+    @Test("Function snippet with placeholder and final cursor")
+    func functionSnippet() {
+        let snippet = LSPSnippet("func ${1:name}(${2:args}) {\n\t$0\n}")
+        #expect(snippet.text == "func name(args) {\n\t\n}")
+        #expect(snippet.tabStops.count == 3)
+        #expect(snippet.tabStops[0].index == 1)
+        #expect(snippet.tabStops[1].index == 2)
+        #expect(snippet.tabStops[2].index == 0)
+    }
+
+    @Test("For-loop snippet")
+    func forLoopSnippet() {
+        let snippet = LSPSnippet("for ${1:i} in ${2:0}..<${3:n} {\n\t$0\n}")
+        #expect(snippet.text == "for i in 0..<n {\n\t\n}")
+        #expect(snippet.tabStops.count == 4)
+        #expect(snippet.tabStops[0].index == 1)  // i
+        #expect(snippet.tabStops[1].index == 2)  // 0
+        #expect(snippet.tabStops[2].index == 3)  // n
+        #expect(snippet.tabStops[3].index == 0)  // final cursor
+    }
+}

--- a/PineTests/LSPWorkspaceEditTests.swift
+++ b/PineTests/LSPWorkspaceEditTests.swift
@@ -1,0 +1,281 @@
+//
+//  LSPWorkspaceEditTests.swift
+//  PineTests
+//
+//  Unit tests for LSPWorkspaceEdit — parses documentChanges and legacy
+//  changes forms, plus CreateFile/RenameFile/DeleteFile operations.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("LSPWorkspaceEdit Tests")
+struct LSPWorkspaceEditTests {
+
+    // MARK: - documentChanges (TextDocumentEdit)
+
+    @Test("Parse documentChanges with TextDocumentEdit")
+    func parseDocumentChanges() {
+        let json: [String: Any] = [
+            "documentChanges": [
+                [
+                    "textDocument": ["uri": "file:///test.swift", "version": 1],
+                    "edits": [
+                        ["range": ["start": ["line": 0, "character": 0],
+                                    "end": ["line": 0, "character": 5]],
+                         "newText": "world"]
+                    ]
+                ]
+            ]
+        ]
+        let edit = LSPWorkspaceEdit(json: json)
+        #expect(!edit.isEmpty)
+        #expect(edit.operatedFiles.count == 1)
+        #expect(edit.operatedFiles[0].uri == "file:///test.swift")
+        #expect(edit.operatedFiles[0].kind == .edit)
+        #expect(edit.operatedFiles[0].edits.count == 1)
+        #expect(edit.operatedFiles[0].edits[0].newText == "world")
+    }
+
+    @Test("Parse multiple TextDocumentEdits")
+    func parseMultipleDocumentChanges() {
+        let json: [String: Any] = [
+            "documentChanges": [
+                [
+                    "textDocument": ["uri": "file:///a.swift", "version": 1],
+                    "edits": [
+                        ["range": ["start": ["line": 0, "character": 0],
+                                    "end": ["line": 0, "character": 1]],
+                         "newText": "A"]
+                    ]
+                ],
+                [
+                    "textDocument": ["uri": "file:///b.swift", "version": 1],
+                    "edits": [
+                        ["range": ["start": ["line": 0, "character": 0],
+                                    "end": ["line": 0, "character": 1]],
+                         "newText": "B"]
+                    ]
+                ]
+            ]
+        ]
+        let edit = LSPWorkspaceEdit(json: json)
+        #expect(edit.operatedFiles.count == 2)
+        #expect(edit.totalTextEditCount == 2)
+    }
+
+    // MARK: - Legacy changes ({uri: [TextEdit]})
+
+    @Test("Parse legacy changes dictionary")
+    func parseLegacyChanges() {
+        let json: [String: Any] = [
+            "changes": [
+                "file:///test.swift": [
+                    ["range": ["start": ["line": 0, "character": 0],
+                               "end": ["line": 0, "character": 5]],
+                     "newText": "world"]
+                ]
+            ]
+        ]
+        let edit = LSPWorkspaceEdit(json: json)
+        #expect(!edit.isEmpty)
+        #expect(edit.operatedFiles.count == 1)
+        #expect(edit.operatedFiles[0].uri == "file:///test.swift")
+        #expect(edit.operatedFiles[0].kind == .edit)
+        #expect(edit.operatedFiles[0].edits.count == 1)
+    }
+
+    @Test("Parse legacy changes with multiple files")
+    func parseLegacyChangesMultipleFiles() {
+        let json: [String: Any] = [
+            "changes": [
+                "file:///a.swift": [
+                    ["range": ["start": ["line": 0, "character": 0],
+                               "end": ["line": 0, "character": 1]],
+                     "newText": "A"]
+                ],
+                "file:///b.swift": [
+                    ["range": ["start": ["line": 0, "character": 0],
+                               "end": ["line": 0, "character": 1]],
+                     "newText": "B"]
+                ]
+            ]
+        ]
+        let edit = LSPWorkspaceEdit(json: json)
+        #expect(edit.operatedFiles.count == 2)
+    }
+
+    @Test("documentChanges preferred over legacy changes")
+    func documentChangesPreferred() {
+        let json: [String: Any] = [
+            "documentChanges": [
+                [
+                    "textDocument": ["uri": "file:///modern.swift", "version": 1],
+                    "edits": []
+                ]
+            ],
+            "changes": [
+                "file:///legacy.swift": []
+            ]
+        ]
+        let edit = LSPWorkspaceEdit(json: json)
+        #expect(edit.operatedFiles.count == 1)
+        #expect(edit.operatedFiles[0].uri == "file:///modern.swift")
+    }
+
+    // MARK: - Empty / null response
+
+    @Test("Empty dictionary produces empty edit")
+    func emptyDictionary() {
+        let edit = LSPWorkspaceEdit(json: [:])
+        #expect(edit.isEmpty)
+        #expect(edit.operatedFiles.isEmpty)
+    }
+
+    @Test("Dictionary with empty documentChanges produces empty edit")
+    func emptyDocumentChanges() {
+        let edit = LSPWorkspaceEdit(json: ["documentChanges": []])
+        #expect(edit.isEmpty)
+    }
+
+    @Test("Dictionary with empty changes produces empty edit")
+    func emptyChanges() {
+        let edit = LSPWorkspaceEdit(json: ["changes": [:]])
+        #expect(edit.isEmpty)
+    }
+
+    @Test("Non-dictionary input produces empty edit")
+    func nonDictionaryInput() {
+        let edit = LSPWorkspaceEdit(json: "not a dict")
+        #expect(edit.isEmpty)
+    }
+
+    // MARK: - CreateFile
+
+    @Test("Parse CreateFile operation")
+    func parseCreateFile() {
+        let json: [String: Any] = [
+            "documentChanges": [
+                ["kind": "create", "uri": "file:///new.swift"]
+            ]
+        ]
+        let edit = LSPWorkspaceEdit(json: json)
+        #expect(edit.operatedFiles.count == 1)
+        let file = edit.operatedFiles[0]
+        #expect(file.kind == .create)
+        #expect(file.uri == "file:///new.swift")
+        #expect(file.edits.isEmpty)
+    }
+
+    // MARK: - RenameFile
+
+    @Test("Parse RenameFile operation")
+    func parseRenameFile() {
+        let json: [String: Any] = [
+            "documentChanges": [
+                ["kind": "rename", "oldUri": "file:///old.swift", "newUri": "file:///new.swift"]
+            ]
+        ]
+        let edit = LSPWorkspaceEdit(json: json)
+        #expect(edit.operatedFiles.count == 1)
+        let file = edit.operatedFiles[0]
+        #expect(file.kind == .rename)
+        #expect(file.uri == "file:///old.swift")
+        #expect(file.newURI == "file:///new.swift")
+        #expect(file.edits.isEmpty)
+    }
+
+    // MARK: - DeleteFile
+
+    @Test("Parse DeleteFile operation")
+    func parseDeleteFile() {
+        let json: [String: Any] = [
+            "documentChanges": [
+                ["kind": "delete", "uri": "file:///gone.swift"]
+            ]
+        ]
+        let edit = LSPWorkspaceEdit(json: json)
+        #expect(edit.operatedFiles.count == 1)
+        let file = edit.operatedFiles[0]
+        #expect(file.kind == .delete)
+        #expect(file.uri == "file:///gone.swift")
+        #expect(file.edits.isEmpty)
+    }
+
+    // MARK: - Mixed operations
+
+    @Test("Parse mixed documentChanges (edit + create + rename + delete)")
+    func parseMixedOperations() {
+        let json: [String: Any] = [
+            "documentChanges": [
+                [
+                    "textDocument": ["uri": "file:///edit.swift", "version": 1],
+                    "edits": [
+                        ["range": ["start": ["line": 0, "character": 0],
+                                    "end": ["line": 0, "character": 1]],
+                         "newText": "X"]
+                    ]
+                ],
+                ["kind": "create", "uri": "file:///new.swift"],
+                ["kind": "rename", "oldUri": "file:///old.swift", "newUri": "file:///renamed.swift"],
+                ["kind": "delete", "uri": "file:///trash.swift"]
+            ]
+        ]
+        let edit = LSPWorkspaceEdit(json: json)
+        #expect(edit.operatedFiles.count == 4)
+        #expect(edit.operatedFiles[0].kind == .edit)
+        #expect(edit.operatedFiles[1].kind == .create)
+        #expect(edit.operatedFiles[2].kind == .rename)
+        #expect(edit.operatedFiles[3].kind == .delete)
+    }
+
+    // MARK: - Convenience properties
+
+    @Test("totalTextEditCount counts edits across files")
+    func totalTextEditCount() {
+        let json: [String: Any] = [
+            "documentChanges": [
+                [
+                    "textDocument": ["uri": "file:///a.swift", "version": 1],
+                    "edits": [
+                        ["range": ["start": ["line": 0, "character": 0],
+                                    "end": ["line": 0, "character": 1]],
+                         "newText": "A"],
+                        ["range": ["start": ["line": 1, "character": 0],
+                                    "end": ["line": 1, "character": 1]],
+                         "newText": "B"]
+                    ]
+                ],
+                ["kind": "create", "uri": "file:///b.swift"]
+            ]
+        ]
+        let edit = LSPWorkspaceEdit(json: json)
+        #expect(edit.totalTextEditCount == 2)  // create has 0 edits
+    }
+
+    // MARK: - URL decoding
+
+    @Test("File URL decoded from URI")
+    func urlDecoding() {
+        let json: [String: Any] = [
+            "documentChanges": [
+                ["kind": "create", "uri": "file:///path/to/file.swift"]
+            ]
+        ]
+        let edit = LSPWorkspaceEdit(json: json)
+        #expect(edit.operatedFiles[0].url?.path == "/path/to/file.swift")
+    }
+
+    @Test("New URL decoded for rename")
+    func newURLDecoding() {
+        let json: [String: Any] = [
+            "documentChanges": [
+                ["kind": "rename", "oldUri": "file:///old.swift", "newUri": "file:///new.swift"]
+            ]
+        ]
+        let edit = LSPWorkspaceEdit(json: json)
+        #expect(edit.operatedFiles[0].newURL?.path == "/new.swift")
+    }
+}

--- a/PineTests/WorkspaceEditApplierTests.swift
+++ b/PineTests/WorkspaceEditApplierTests.swift
@@ -1,0 +1,224 @@
+//
+//  WorkspaceEditApplierTests.swift
+//  PineTests
+//
+//  Unit tests for WorkspaceEditApplier — pure logic that applies a list of
+//  LSPTextEdit values to a text string in reverse position order.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("WorkspaceEditApplier Tests")
+struct WorkspaceEditApplierTests {
+
+    // MARK: - Single edit
+
+    @Test("Apply single edit replaces range")
+    func applySingleEdit() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 0),
+                            end: LSPPosition(line: 0, character: 5)),
+            newText: "world"
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "hello world")
+        #expect(result.success)
+        #expect(result.newText == "world world")
+    }
+
+    @Test("Apply single edit inserting text at position")
+    func applyInsertionEdit() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 5),
+                            end: LSPPosition(line: 0, character: 5)),
+            newText: " beautiful"
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "hello world")
+        #expect(result.success)
+        #expect(result.newText == "hello beautiful world")
+    }
+
+    @Test("Apply single edit deleting range")
+    func applyDeletionEdit() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 5),
+                            end: LSPPosition(line: 0, character: 11)),
+            newText: ""
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "hello world")
+        #expect(result.success)
+        #expect(result.newText == "hello")
+    }
+
+    // MARK: - Multiple non-overlapping edits (reverse order)
+
+    @Test("Apply multiple non-overlapping edits")
+    func applyMultipleEdits() {
+        let edits = [
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 0),
+                                end: LSPPosition(line: 0, character: 1)),
+                newText: "W"
+            ),
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 6),
+                                end: LSPPosition(line: 0, character: 11)),
+                newText: "there"
+            ),
+        ]
+        let result = WorkspaceEditApplier.applyEdits(edits, to: "hello world")
+        #expect(result.success)
+        #expect(result.newText == "Hello there")
+    }
+
+    @Test("Apply three edits in jumbled order")
+    func applyThreeEditsJumbled() {
+        let edits = [
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 7),
+                                end: LSPPosition(line: 0, character: 12)),
+                newText: "Swift"
+            ),
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 0),
+                                end: LSPPosition(line: 0, character: 5)),
+                newText: "I love"
+            ),
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 5),
+                                end: LSPPosition(line: 0, character: 7)),
+                newText: " "
+            ),
+        ]
+        // "hello world" → "I love Swift"
+        let result = WorkspaceEditApplier.applyEdits(edits, to: "hello world")
+        #expect(result.success)
+        #expect(result.newText == "I love Swift")
+    }
+
+    @Test("Apply edits across multiple lines")
+    func applyEditsMultipleLines() {
+        let edits = [
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 0),
+                                end: LSPPosition(line: 0, character: 5)),
+                newText: "first"
+            ),
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 1, character: 0),
+                                end: LSPPosition(line: 1, character: 6)),
+                newText: "second"
+            ),
+        ]
+        let result = WorkspaceEditApplier.applyEdits(edits, to: "hello\nworld!")
+        #expect(result.success)
+        #expect(result.newText == "first\nsecond!")
+    }
+
+    // MARK: - Out-of-bounds range → failure
+
+    @Test("Out-of-bounds end position fails")
+    func outOfBoundsEnd() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 0),
+                            end: LSPPosition(line: 0, character: 100)),
+            newText: "x"
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "hello")
+        #expect(!result.success)
+        #expect(result.newText == nil)
+        #expect(result.errorMessage != nil)
+    }
+
+    @Test("Out-of-bounds line fails")
+    func outOfBoundsLine() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 5, character: 0),
+                            end: LSPPosition(line: 5, character: 3)),
+            newText: "x"
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "hello")
+        #expect(!result.success)
+        #expect(result.newText == nil)
+    }
+
+    @Test("Reversed range (end < start) fails")
+    func reversedRange() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 5),
+                            end: LSPPosition(line: 0, character: 0)),
+            newText: "x"
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "hello")
+        #expect(!result.success)
+    }
+
+    // MARK: - Empty edits list
+
+    @Test("Empty edits list returns original text unchanged")
+    func emptyEditsList() {
+        let original = "hello world"
+        let result = WorkspaceEditApplier.applyEdits([], to: original)
+        #expect(result.success)
+        #expect(result.newText == original)
+    }
+
+    // MARK: - Edge cases
+
+    @Test("Edit at end of string")
+    func editAtEnd() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 5),
+                            end: LSPPosition(line: 0, character: 5)),
+            newText: "!"
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "hello")
+        #expect(result.success)
+        #expect(result.newText == "hello!")
+    }
+
+    @Test("Edit replacing entire single line")
+    func editReplaceEntireLine() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 0),
+                            end: LSPPosition(line: 0, character: 5)),
+            newText: "replaced"
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "hello")
+        #expect(result.success)
+        #expect(result.newText == "replaced")
+    }
+
+    @Test("Edit with multi-line replacement")
+    func editMultiLineReplacement() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 0),
+                            end: LSPPosition(line: 0, character: 5)),
+            newText: "line1\nline2"
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "hello world")
+        #expect(result.success)
+        #expect(result.newText == "line1\nline2 world")
+    }
+
+    // MARK: - editPlan helper
+
+    @Test("editPlan extracts edit-only operations sorted by URL")
+    func editPlanFiltersNonEdits() {
+        let editFile = LSPOperatedFile(
+            uri: "file:///b.swift", kind: .edit,
+            edits: [LSPTextEdit(range: LSPRange(start: LSPPosition(line: 0, character: 0),
+                                                end: LSPPosition(line: 0, character: 1)),
+                                newText: "x")]
+        )
+        let createFile = LSPOperatedFile(uri: "file:///a.txt", kind: .create)
+        let renameFile = LSPOperatedFile(uri: "file:///c.txt", kind: .rename, newURI: "file:///d.txt")
+
+        let workspaceEdit = LSPWorkspaceEdit(operatedFiles: [editFile, createFile, renameFile])
+        let plan = WorkspaceEditApplier.editPlan(from: workspaceEdit)
+        #expect(plan.count == 1)
+        #expect(plan[0].url.path == "/b.swift")
+    }
+}


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for the pure, macOS/UI-independent logic in `Pine/LSP/`, covering all 8 areas requested in milestone #1088 (release 1.32.0 blocker).

## Test files (8 files, ~100 test cases)

| File | Coverage |
|------|----------|
| `DiagnosticMapperTests.swift` | LSP 0-based → Pine 1-based line/column conversion, negative clamping, missing severity/source defaults, notification mapping |
| `LSPPositionConverterTests.swift` | UTF-16 offset → LSP Position, multi-byte chars (emoji, CJK), CRLF line endings, clamping, round-trip conversion |
| `LSPSnippetTests.swift` | Tab stops (`$0`/`$1`/`$2`), placeholders (`${1:default}`), choices (`${1\|a,b,c\|}`), escape sequences (`\$`, `\\`), tab stop ordering (`$0` always last), deduplication |
| `CompletionFilterTests.swift` | Exact/prefix/word-boundary/substring/fuzzy scoring hierarchy, empty prefix, filterText preference, server order tiebreaker |
| `WorkspaceEditApplierTests.swift` | Single/multiple edits, reverse-order application, out-of-bounds failure, empty edits list, multi-line replacement |
| `LSPWorkspaceEditTests.swift` | `documentChanges` (TextDocumentEdit), legacy `changes`, empty/null, CreateFile/RenameFile/DeleteFile, mixed operations |
| `LSPCodeActionResponseTests.swift` | CodeAction/Command parsing, mixed arrays, null response, all 8 kinds, malformed entry skipping |
| `LSPHoverTests.swift` | MarkupContent normalization, plain/code MarkedString, array of MarkedStrings, null/empty contents, range parsing |

## Approach

All tests exercise **pure value-type logic only** — no macOS frameworks, no UI, no actor isolation. Each file uses Swift Testing (`import Testing`, `@Test`, `#expect`) matching the existing `PineTests` conventions. New `.swift` files in `PineTests/` are auto-picked up by the Xcode project (`PBXFileSystemSynchronizedRootGroup`).

Closes milestone #1088.