### PR TITLE
feat(lsp): UI integration — hover, go-to-definition, code actions, rename (#1088)

### DIFF
--- a/Pine/CodeEditorView+Coordinator.swift
+++ b/Pine/CodeEditorView+Coordinator.swift
@@ -1874,7 +1874,7 @@ extension CodeEditorView {
             // Add rename option.
             menu.addItem(.separator())
             let renameItem = NSMenuItem(
-                title: "Rename Symbol",
+                title: Strings.contextRenameTitle,
                 action: #selector(handleRenameFromMenu(_:)),
                 keyEquivalent: "r"
             )
@@ -1892,7 +1892,7 @@ extension CodeEditorView {
         }
 
         /// Payload wrapping an LSPCodeAction for menu selection.
-        private final class CodeActionPayload {
+        private final class CodeActionPayload: @unchecked Sendable {
             let action: LSPCodeAction
             init(action: LSPCodeAction) { self.action = action }
         }

--- a/Pine/CodeEditorView+Coordinator.swift
+++ b/Pine/CodeEditorView+Coordinator.swift
@@ -67,6 +67,26 @@ extension CodeEditorView {
         /// popup container.
         let completionController = CompletionController()
 
+        // MARK: - LSP UI Integration (Phase 5, milestone #1088, item 1)
+
+        /// Hover popover manager. Lazily created on first hover request.
+        private(set) var hoverPopoverManager: HoverPopoverManager?
+
+        /// Definition quick-pick controller for multiple-definition results.
+        /// Set from the parent view so the overlay and coordinator share the
+        /// same observable instance.
+        var definitionQuickPickController = DefinitionQuickPickController()
+
+        /// Rename popover manager.
+        private(set) var renamePopoverManager: RenamePopoverManager?
+
+        /// Monotonic generation token for cancelling stale hover requests.
+        /// Bumped before scheduling a new hover request.
+        private var hoverGeneration: Int = 0
+
+        /// The hover request task. Cancelled on every new hover or mouseExit.
+        private var hoverTask: Task<Void, Never>?
+
         /// The AppKit popup container, lazily added to the editor container
         /// view on first presentation. Reused across presentations.
         private(set) var completionPopup: CompletionPopupContainer?
@@ -810,6 +830,11 @@ extension CodeEditorView {
             PerformanceSignposts.trace("scroll.frame") {
                 reportStateChange()
                 highlightOnScrollIfNeeded()
+                // Dismiss the hover popover on scroll — the position is stale.
+                hideHoverPopover()
+                if let textView = scrollView?.documentView as? GutterTextView {
+                    textView.lspDismissHoverOnScroll()
+                }
             }
         }
 
@@ -1484,5 +1509,437 @@ extension CodeEditorView {
                 self.parent.onStateChange?(pending.cursor, pending.scroll)
             }
         }
+
+        // MARK: - LSP UI Integration (Phase 5, milestone #1088, item 1)
+
+        /// Wires the coordinator as the `lspMouseHandler` on the GutterTextView.
+        /// Called from `makeNSView` after the text view is created.
+        func installLSPMouseHandler() {
+            guard let textView = scrollView?.documentView as? GutterTextView else { return }
+            textView.lspMouseHandler = self
+        }
+
+        // MARK: - Hover
+
+        /// Hides the hover popover if visible.
+        func hideHoverPopover() {
+            hoverPopoverManager?.hide()
+        }
+
+        // MARK: - LSPMouseHandling conformance
+
+        func lspHover(at offset: Int) {
+            hoverGeneration += 1
+            let generation = hoverGeneration
+            hoverTask?.cancel()
+
+            guard let textView = scrollView?.documentView as? NSTextView,
+                  let layoutManager = textView.layoutManager,
+                  let textContainer = textView.textContainer,
+                  let url = parent.fileURL else { return }
+
+            // Compute the screen rect of the hovered character for popover
+            // positioning.
+            let charRange = NSRange(location: offset, length: 1)
+            let glyphRange = layoutManager.glyphRange(
+                forCharacterRange: charRange, actualCharacterRange: nil
+            )
+            let glyphRect = layoutManager.boundingRect(
+                forGlyphRange: glyphRange, in: textContainer
+            )
+            // Convert to the text view's superview coordinate space (screen).
+            let rectInView = textView.convert(glyphRect, to: nil)
+
+            let text = textView.string
+            let fileURL = url
+
+            hoverTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                let hover = await LSPUIEndpoint.shared.hover(
+                    url: fileURL, offset: offset, text: text
+                )
+                guard !Task.isCancelled else { return }
+                guard self.hoverGeneration == generation else { return }
+                guard let hover else { return }
+
+                // Show the popover.
+                self.ensureHoverPopover()
+                self.hoverPopoverManager?.show(
+                    content: hover.markup.value,
+                    isMarkdown: hover.markup.isMarkdown,
+                    anchorRect: rectInView,
+                    positioningView: textView
+                )
+            }
+        }
+
+        func lspHoverEnded() {
+            hoverTask?.cancel()
+            hoverTask = nil
+            hideHoverPopover()
+        }
+
+        // MARK: - Go-to-Definition
+
+        func lspGoToDefinition(at offset: Int) -> Bool {
+            guard let textView = scrollView?.documentView as? NSTextView,
+                  let url = parent.fileURL else { return false }
+
+            let text = textView.string
+            let fileURL = url
+            let currentURL = url
+
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let response = await LSPUIEndpoint.shared.definition(
+                    url: fileURL, offset: offset, text: text
+                )
+                guard !Task.isCancelled else { return }
+                guard !response.isEmpty else { return }
+
+                switch response {
+                case .empty:
+                    return
+
+                case .locations(let locations):
+                    if locations.count == 1 {
+                        self.navigateToLocation(locations[0], currentURL: currentURL)
+                    } else {
+                        self.showDefinitionQuickPick(
+                            locations: locations, currentURL: currentURL
+                        )
+                    }
+
+                case .locationLinks(let links):
+                    if links.count == 1 {
+                        self.navigateToLocationLink(links[0], currentURL: currentURL)
+                    } else {
+                        self.showDefinitionQuickPick(
+                            links: links, currentURL: currentURL
+                        )
+                    }
+                }
+            }
+            return true
+        }
+
+        // MARK: - Code Actions
+
+        func lspRequestCodeActions(at offset: Int, menuLocation: NSPoint) {
+            guard let textView = scrollView?.documentView as? NSTextView,
+                  let url = parent.fileURL else { return }
+
+            let text = textView.string
+            let fileURL = url
+
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let response = await LSPUIEndpoint.shared.codeAction(
+                    url: fileURL, offset: offset, text: text
+                )
+                guard !Task.isCancelled else { return }
+                guard !response.isEmpty else { return }
+
+                self.showCodeActionMenu(
+                    response: response,
+                    menuLocation: menuLocation,
+                    textView: textView
+                )
+            }
+        }
+
+        // MARK: - Rename
+
+        func lspRequestRename(at offset: Int) {
+            guard let textView = scrollView?.documentView as? NSTextView,
+                  let url = parent.fileURL else { return }
+
+            // Extract the current word at offset for prefill.
+            let source = textView.string as NSString
+            let wordRange = CompletionInsertion.wordRange(endingAt: offset, in: source)
+            let currentName: String
+            if wordRange.length > 0 {
+                currentName = source.substring(with: wordRange)
+            } else {
+                currentName = ""
+            }
+
+            // Compute the screen rect for popover positioning.
+            let charRange = NSRange(location: wordRange.location, length: max(wordRange.length, 1))
+            guard let layoutManager = textView.layoutManager,
+                  let textContainer = textView.textContainer else { return }
+            let glyphRange = layoutManager.glyphRange(
+                forCharacterRange: charRange, actualCharacterRange: nil
+            )
+            let glyphRect = layoutManager.boundingRect(
+                forGlyphRange: glyphRange, in: textContainer
+            )
+            let rectInView = textView.convert(glyphRect, to: nil)
+
+            // Capture the rename offset for the confirm callback.
+            let renameOffset = wordRange.location
+            let fileText = textView.string
+            let fileURL = url
+
+            ensureRenamePopover()
+
+            renamePopoverManager?.show(
+                currentName: currentName,
+                anchorRect: rectInView,
+                positioningView: textView,
+                onConfirm: { [weak self] newName in
+                    guard let self else { return }
+                    self.performRename(
+                        url: fileURL, offset: renameOffset,
+                        text: fileText, newName: newName
+                    )
+                },
+                onCancel: { }
+            )
+        }
+
+        // MARK: - LSP helper methods
+
+        private func ensureHoverPopover() {
+            if hoverPopoverManager == nil {
+                hoverPopoverManager = HoverPopoverManager()
+            }
+        }
+
+        private func ensureRenamePopover() {
+            if renamePopoverManager == nil {
+                renamePopoverManager = RenamePopoverManager()
+            }
+        }
+
+        // MARK: - Navigation
+
+        /// Navigates to a single LSP Location. If it's in the current file,
+        /// moves the cursor; if in another file, opens it and navigates.
+        private func navigateToLocation(_ location: LSPLocation, currentURL: URL) {
+            guard let targetURL = location.url else { return }
+            if targetURL == currentURL {
+                moveCursorToLocation(location)
+            } else {
+                LSPUIEndpoint.shared.openFileAtLine(
+                    url: targetURL,
+                    line: location.range.start.line,
+                    character: location.range.start.character
+                )
+            }
+        }
+
+        /// Navigates to a single LSP LocationLink.
+        private func navigateToLocationLink(_ link: LSPLocationLink, currentURL: URL) {
+            guard let targetURL = link.url else { return }
+            if targetURL == currentURL {
+                moveCursorToLSPRange(link.targetSelectionRange)
+            } else {
+                LSPUIEndpoint.shared.openFileAtLine(
+                    url: targetURL,
+                    line: link.targetSelectionRange.start.line,
+                    character: link.targetSelectionRange.start.character
+                )
+            }
+        }
+
+        /// Moves the cursor in the current text view to the start of an LSP
+        /// Location's range (0-based positions).
+        private func moveCursorToLocation(_ location: LSPLocation) {
+            moveCursorToLSPRange(location.range)
+        }
+
+        /// Moves the cursor in the current text view to the start of an LSP
+        /// Range (0-based positions).
+        private func moveCursorToLSPRange(_ range: LSPRange) {
+            guard let textView = scrollView?.documentView as? NSTextView else { return }
+            let text = textView.string
+            let offset = LSPPositionConverter.utf16Offset(
+                line: range.start.line,
+                character: range.start.character,
+                in: text
+            )
+            let clamped = min(max(0, offset), (text as NSString).length)
+            textView.setSelectedRange(NSRange(location: clamped, length: 0))
+            textView.scrollRangeToVisible(NSRange(location: clamped, length: 0))
+        }
+
+        // MARK: - Definition quick-pick
+
+        /// Shows the quick-pick for multiple locations.
+        private func showDefinitionQuickPick(
+            locations: [LSPLocation], currentURL: URL
+        ) {
+            let items = locations.compactMap { location -> DefinitionQuickPickItem? in
+                guard let url = location.url else { return nil }
+                let label = url.lastPathComponent
+                let detail = "\(location.range.start.line + 1):\(location.range.start.character + 1)"
+                return DefinitionQuickPickItem(
+                    label: label, detail: detail, url: url,
+                    line: location.range.start.line,
+                    character: location.range.start.character
+                )
+            }
+            definitionQuickPickController.onSelect = { [weak self] item in
+                guard let self else { return }
+                if item.url == currentURL {
+                    self.moveCursorToLSPRange(LSPRange(
+                        start: LSPPosition(line: item.line, character: item.character),
+                        end: LSPPosition(line: item.line, character: item.character)
+                    ))
+                } else {
+                    LSPUIEndpoint.shared.openFileAtLine(
+                        url: item.url, line: item.line, character: item.character
+                    )
+                }
+            }
+            definitionQuickPickController.present(items: items)
+        }
+
+        /// Shows the quick-pick for multiple location links.
+        private func showDefinitionQuickPick(
+            links: [LSPLocationLink], currentURL: URL
+        ) {
+            let items = links.compactMap { link -> DefinitionQuickPickItem? in
+                guard let url = link.url else { return nil }
+                let label = url.lastPathComponent
+                let detail = "\(link.targetSelectionRange.start.line + 1):\(link.targetSelectionRange.start.character + 1)"
+                return DefinitionQuickPickItem(
+                    label: label, detail: detail, url: url,
+                    line: link.targetSelectionRange.start.line,
+                    character: link.targetSelectionRange.start.character
+                )
+            }
+            definitionQuickPickController.onSelect = { [weak self] item in
+                guard let self else { return }
+                if item.url == currentURL {
+                    self.moveCursorToLSPRange(LSPRange(
+                        start: LSPPosition(line: item.line, character: item.character),
+                        end: LSPPosition(line: item.line, character: item.character)
+                    ))
+                } else {
+                    LSPUIEndpoint.shared.openFileAtLine(
+                        url: item.url, line: item.line, character: item.character
+                    )
+                }
+            }
+            definitionQuickPickController.present(items: items)
+        }
+
+        // MARK: - Code action menu
+
+        /// Builds and shows an NSMenu with the available code actions at the
+        /// given location.
+        private func showCodeActionMenu(
+            response: LSPCodeActionResponse,
+            menuLocation: NSPoint,
+            textView: NSTextView
+        ) {
+            let menu = NSMenu()
+            menu.autoenablesItems = false
+
+            // Add code actions.
+            for action in response.actions {
+                let item = NSMenuItem(
+                    title: action.title,
+                    action: #selector(handleCodeActionSelection(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = self
+                item.representedObject = CodeActionPayload(action: action)
+                if let kind = action.kind {
+                    item.image = NSImage(
+                        systemSymbolName: kind.symbolName,
+                        accessibilityDescription: nil
+                    )
+                }
+                if !action.isExecutable {
+                    item.isEnabled = false
+                }
+                menu.addItem(item)
+            }
+
+            // Add bare commands.
+            for command in response.commands {
+                let item = NSMenuItem(
+                    title: command.title,
+                    action: #selector(handleCodeCommandSelection(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = self
+                item.representedObject = command
+                menu.addItem(item)
+            }
+
+            // Add rename option.
+            menu.addItem(.separator())
+            let renameItem = NSMenuItem(
+                title: "Rename Symbol",
+                action: #selector(handleRenameFromMenu(_:)),
+                keyEquivalent: "r"
+            )
+            renameItem.target = self
+            renameItem.keyEquivalentModifierMask = [.command]
+            menu.addItem(renameItem)
+
+            guard !menu.items.isEmpty else { return }
+
+            menu.popUp(
+                positioning: nil,
+                at: menuLocation,
+                in: textView
+            )
+        }
+
+        /// Payload wrapping an LSPCodeAction for menu selection.
+        private final class CodeActionPayload {
+            let action: LSPCodeAction
+            init(action: LSPCodeAction) { self.action = action }
+        }
+
+        @objc private func handleCodeActionSelection(_ sender: NSMenuItem) {
+            guard let payload = sender.representedObject as? CodeActionPayload else { return }
+            let action = payload.action
+            // Apply the edit if present.
+            if let edit = action.edit {
+                _ = LSPUIEndpoint.shared.applyWorkspaceEdit(edit)
+            }
+            // TODO: Execute the command via workspace/executeCommand when
+            // the command is present but no edit. Deferred — the server
+            // command infrastructure is not yet wired for executeCommand.
+        }
+
+        @objc private func handleCodeCommandSelection(_ sender: NSMenuItem) {
+            // Commands without an edit — would need workspace/executeCommand.
+            // Deferred for now.
+        }
+
+        @objc private func handleRenameFromMenu(_ sender: NSMenuItem) {
+            guard let textView = scrollView?.documentView as? NSTextView else { return }
+            let offset = textView.selectedRange().location
+            lspRequestRename(at: offset)
+        }
+
+        // MARK: - Rename execution
+
+        /// Performs the rename request and applies the resulting WorkspaceEdit.
+        private func performRename(
+            url: URL, offset: Int, text: String, newName: String
+        ) {
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let edit = await LSPUIEndpoint.shared.rename(
+                    url: url, offset: offset, text: text, newName: newName
+                )
+                guard !Task.isCancelled else { return }
+                guard !edit.isEmpty else { return }
+
+                _ = LSPUIEndpoint.shared.applyWorkspaceEdit(edit)
+            }
+        }
     }
 }
+
+// MARK: - LSPMouseHandling conformance
+
+extension CodeEditorView.Coordinator: LSPMouseHandling {}

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -56,6 +56,9 @@ struct CodeEditorView: NSViewRepresentable {
     var initialCursorPosition: Int = 0
     /// Scroll offset to restore when the view is created (tab switch).
     var initialScrollOffset: CGFloat = 0
+    /// Definition quick-pick controller, passed from PaneLeafView so the
+    /// overlay and the coordinator share the same observable instance.
+    var definitionQuickPickController: DefinitionQuickPickController?
     /// Called when cursor position or scroll offset changes, so the caller can persist them.
     var onStateChange: ((Int, CGFloat) -> Void)?
     /// Called when a new syntax highlight result is computed, so the caller can cache it in the tab.
@@ -67,10 +70,6 @@ struct CodeEditorView: NSViewRepresentable {
     var goToOffset: GoToRequest?
     /// Indentation style detected for the current file, used for indent guide rendering.
     var indentStyle: IndentationStyle = .spaces(4)
-
-    /// Definition quick-pick controller, passed from PaneLeafView so the
-    /// overlay and the coordinator share the same observable instance.
-    var definitionQuickPickController: DefinitionQuickPickController?
 
     /// Порог (в символах) для переключения на viewport-based подсветку.
     /// Lowered from 100KB to 50KB to be more aggressive about lazy highlighting (#637).

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -68,6 +68,10 @@ struct CodeEditorView: NSViewRepresentable {
     /// Indentation style detected for the current file, used for indent guide rendering.
     var indentStyle: IndentationStyle = .spaces(4)
 
+    /// Definition quick-pick controller, passed from PaneLeafView so the
+    /// overlay and the coordinator share the same observable instance.
+    var definitionQuickPickController: DefinitionQuickPickController?
+
     /// Порог (в символах) для переключения на viewport-based подсветку.
     /// Lowered from 100KB to 50KB to be more aggressive about lazy highlighting (#637).
     static let viewportHighlightThreshold = 50_000
@@ -311,6 +315,15 @@ struct CodeEditorView: NSViewRepresentable {
 
         // Calculate initial foldable ranges
         context.coordinator.recalculateFoldableRanges()
+
+        // Install the LSP mouse handler so hover/definition/code-action/rename
+        // mouse events route to the coordinator.
+        context.coordinator.installLSPMouseHandler()
+
+        // Wire the definition quick-pick controller from the parent view.
+        if let controller = definitionQuickPickController {
+            context.coordinator.definitionQuickPickController = controller
+        }
 
         return container
     }

--- a/Pine/GutterTextView.swift
+++ b/Pine/GutterTextView.swift
@@ -585,4 +585,60 @@ final class GutterTextView: NSTextView {
         }
         super.keyDown(with: event)
     }
+
+    // MARK: - LSP mouse tracking (Phase 5, milestone #1088)
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        installLSPTrackingArea()
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        super.mouseMoved(with: event)
+        let location = convert(event.locationInWindow, from: nil)
+        scheduleLSPHover(at: location)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        cancelLSPHover()
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        // ⌘+Click → go-to-definition
+        if event.modifierFlags.contains(.command) && event.type == .leftMouseDown {
+            let location = convert(event.locationInWindow, from: nil)
+            let offset = lspCharacterIndex(at: location)
+            if offset >= 0 {
+                let handled = lspMouseHandler?.lspGoToDefinition(at: offset) ?? false
+                if handled { return }
+            }
+        }
+
+        // Cmd+Shift+Click → rename at this position
+        if event.modifierFlags.contains(.command) && event.modifierFlags.contains(.shift)
+            && event.type == .leftMouseDown {
+            let location = convert(event.locationInWindow, from: nil)
+            let offset = lspCharacterIndex(at: location)
+            if offset >= 0 {
+                lspMouseHandler?.lspRequestRename(at: offset)
+                return
+            }
+        }
+
+        super.mouseDown(with: event)
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        let location = convert(event.locationInWindow, from: nil)
+        let offset = lspCharacterIndex(at: location)
+
+        if offset >= 0 {
+            // Request code actions at this position before showing the menu.
+            lspMouseHandler?.lspRequestCodeActions(at: offset, menuLocation: location)
+        }
+
+        // Still call super so the default context menu (if any) also shows.
+        super.rightMouseDown(with: event)
+    }
 }

--- a/Pine/LSP/DefinitionQuickPickView.swift
+++ b/Pine/LSP/DefinitionQuickPickView.swift
@@ -67,6 +67,10 @@ final class DefinitionQuickPickController {
         selectedIndex = newIndex
     }
 
+    func select(at index: Int) {
+        selectedIndex = index
+    }
+
     func selectCurrent() {
         guard selectedIndex >= 0, selectedIndex < items.count else { return }
         let item = items[selectedIndex]
@@ -134,7 +138,7 @@ struct DefinitionQuickPickContent: View {
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .overlay(
             RoundedRectangle(cornerRadius: 8)
-                .stroke(NSColor.separatorColor.colorWithAlphaComponent(0.5), lineWidth: 1)
+                .stroke(Color(NSColor.separatorColor.withAlphaComponent(0.5)), lineWidth: 1)
         )
     }
 }
@@ -177,11 +181,11 @@ private struct DefinitionRowContainer: View {
     var body: some View {
         DefinitionRow(item: item, isSelected: isSelected)
             .onTapGesture(count: 2) {
-                controller.selectedIndex = index
+                controller.select(at: index)
                 controller.selectCurrent()
             }
             .onTapGesture {
-                controller.selectedIndex = index
+                controller.select(at: index)
             }
     }
 }

--- a/Pine/LSP/DefinitionQuickPickView.swift
+++ b/Pine/LSP/DefinitionQuickPickView.swift
@@ -112,35 +112,15 @@ struct DefinitionQuickPickContent: View {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         ForEach(Array(controller.items.enumerated()), id: \.element.id) { index, item in
-                            HStack(spacing: 6) {
-                                Image(systemName: "doc.text")
-                                    .font(.system(size: 12))
-                                    .foregroundStyle(.secondary)
-                                    .frame(width: 16)
-                                Text(item.label)
-                                    .font(.system(size: 12))
-                                    .foregroundStyle(.primary)
-                                    .lineLimit(1)
-                                Spacer(minLength: 0)
-                                Text(item.detail)
-                                    .font(.system(size: 11))
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(1)
-                            }
-                            .padding(.horizontal, 10)
-                            .frame(height: 22)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(index == controller.selectedIndex
-                                ? Color.accentColor.opacity(0.2)
-                                : Color.clear)
-                            .id(index)
-                            .onTapGesture(count: 2) {
-                                controller.selectedIndex = index
-                                controller.selectCurrent()
-                            }
-                            .onTapGesture {
-                                controller.selectedIndex = index
-                            }
+                            DefinitionRow(item: item, isSelected: index == controller.selectedIndex)
+                                .id(index)
+                                .onTapGesture(count: 2) {
+                                    controller.selectedIndex = index
+                                    controller.selectCurrent()
+                                }
+                                .onTapGesture {
+                                    controller.selectedIndex = index
+                                }
                         }
                     }
                 }
@@ -183,5 +163,33 @@ struct DefinitionQuickPickOverlay: View {
                 Spacer()
             }
         }
+    }
+}
+
+/// Extracted row view for definition quick-pick items.
+private struct DefinitionRow: View {
+    let item: DefinitionQuickPickItem
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "doc.text")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .frame(width: 16)
+            Text(item.label)
+                .font(.system(size: 12))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+            Text(item.detail)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 22)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(isSelected ? Color.accentColor.opacity(0.2) : Color.clear)
     }
 }

--- a/Pine/LSP/DefinitionQuickPickView.swift
+++ b/Pine/LSP/DefinitionQuickPickView.swift
@@ -112,15 +112,13 @@ struct DefinitionQuickPickContent: View {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         ForEach(Array(controller.items.enumerated()), id: \.element.id) { index, item in
-                            DefinitionRow(item: item, isSelected: index == controller.selectedIndex)
-                                .id(index)
-                                .onTapGesture(count: 2) {
-                                    controller.selectedIndex = index
-                                    controller.selectCurrent()
-                                }
-                                .onTapGesture {
-                                    controller.selectedIndex = index
-                                }
+                            DefinitionRowContainer(
+                                item: item,
+                                isSelected: index == controller.selectedIndex,
+                                index: index,
+                                controller: controller
+                            )
+                            .id(index)
                         }
                     }
                 }
@@ -163,6 +161,28 @@ struct DefinitionQuickPickOverlay: View {
                 Spacer()
             }
         }
+    }
+}
+
+/// Container that wraps a `DefinitionRow` and handles tap gestures.
+///
+/// Extracted into its own `View` struct so the Swift type-checker can
+/// resolve the gesture chain within reasonable time.
+private struct DefinitionRowContainer: View {
+    let item: DefinitionQuickPickItem
+    let isSelected: Bool
+    let index: Int
+    let controller: DefinitionQuickPickController
+
+    var body: some View {
+        DefinitionRow(item: item, isSelected: isSelected)
+            .onTapGesture(count: 2) {
+                controller.selectedIndex = index
+                controller.selectCurrent()
+            }
+            .onTapGesture {
+                controller.selectedIndex = index
+            }
     }
 }
 

--- a/Pine/LSP/DefinitionQuickPickView.swift
+++ b/Pine/LSP/DefinitionQuickPickView.swift
@@ -1,0 +1,187 @@
+//
+//  DefinitionQuickPickView.swift
+//  Pine
+//
+//  Phase 5 of LSP support (milestone #1088, item 1).
+//
+//  A SwiftUI overlay that shows a quick-pick list when go-to-definition
+//  returns multiple locations. The user selects one to navigate to.
+//
+//  Follows the same overlay pattern as QuickOpenView and the completion
+//  popup.
+//
+
+import SwiftUI
+import AppKit
+
+/// `@MainActor @Observable` controller for the definition quick-pick popup.
+@MainActor
+@Observable
+final class DefinitionQuickPickController {
+
+    /// Whether the popup is currently visible.
+    private(set) var isVisible: Bool = false
+
+    /// The locations to choose from.
+    private(set) var items: [DefinitionQuickPickItem] = []
+
+    /// The index of the highlighted row.
+    private(set) var selectedIndex: Int = 0
+
+    /// Called when the user selects an item.
+    var onSelect: ((DefinitionQuickPickItem) -> Void)?
+
+    /// Called when the user dismisses without selecting.
+    var onDismiss: (() -> Void)?
+
+    init() {}
+
+    // MARK: - Presentation
+
+    /// Presents the quick-pick with the given locations.
+    func present(items: [DefinitionQuickPickItem]) {
+        guard !items.isEmpty else {
+            dismiss()
+            return
+        }
+        self.items = items
+        selectedIndex = 0
+        isVisible = true
+    }
+
+    /// Hides the popup.
+    func dismiss() {
+        isVisible = false
+        items = []
+        selectedIndex = 0
+    }
+
+    // MARK: - Navigation
+
+    func move(by delta: Int) {
+        guard !items.isEmpty else { return }
+        let count = items.count
+        var newIndex = selectedIndex + delta
+        if newIndex < 0 { newIndex = count - 1 }
+        if newIndex >= count { newIndex = 0 }
+        selectedIndex = newIndex
+    }
+
+    func selectCurrent() {
+        guard selectedIndex >= 0, selectedIndex < items.count else { return }
+        let item = items[selectedIndex]
+        dismiss()
+        onSelect?(item)
+    }
+
+    func cancel() {
+        dismiss()
+        onDismiss?()
+    }
+}
+
+/// A single item in the definition quick-pick list.
+///
+/// `nonisolated` + `Sendable` because it is pure data created on the main
+/// actor from LSP response types.
+nonisolated struct DefinitionQuickPickItem: Identifiable, Equatable, Sendable {
+    let id: String
+    let label: String
+    let detail: String
+    let url: URL
+    let line: Int
+    let character: Int
+
+    init(label: String, detail: String, url: URL, line: Int, character: Int) {
+        self.label = label
+        self.detail = detail
+        self.url = url
+        self.line = line
+        self.character = character
+        self.id = "\(url.path):\(line):\(character)"
+    }
+}
+
+/// SwiftUI overlay content for the definition quick-pick.
+struct DefinitionQuickPickContent: View {
+    let controller: DefinitionQuickPickController
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(Array(controller.items.enumerated()), id: \.element.id) { index, item in
+                            HStack(spacing: 6) {
+                                Image(systemName: "doc.text")
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: 16)
+                                Text(item.label)
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.primary)
+                                    .lineLimit(1)
+                                Spacer(minLength: 0)
+                                Text(item.detail)
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+                            .padding(.horizontal, 10)
+                            .frame(height: 22)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(index == controller.selectedIndex
+                                ? Color.accentColor.opacity(0.2)
+                                : Color.clear)
+                            .id(index)
+                            .onTapGesture(count: 2) {
+                                controller.selectedIndex = index
+                                controller.selectCurrent()
+                            }
+                            .onTapGesture {
+                                controller.selectedIndex = index
+                            }
+                        }
+                    }
+                }
+                .onChange(of: controller.selectedIndex) { _, newIndex in
+                    withAnimation(nil) {
+                        proxy.scrollTo(newIndex, anchor: .center)
+                    }
+                }
+            }
+        }
+        .frame(width: 400, height: min(CGFloat(controller.items.count) * 22 + 8, 220))
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(NSColor.separatorColor.colorWithAlphaComponent(0.5), lineWidth: 1)
+        )
+    }
+}
+
+/// Overlay wrapper that positions the quick-pick centered in the editor
+/// area and handles keyboard navigation (Esc, Up/Down, Enter).
+struct DefinitionQuickPickOverlay: View {
+    let controller: DefinitionQuickPickController
+
+    var body: some View {
+        ZStack {
+            // Semi-transparent backdrop — click to dismiss.
+            Color.black.opacity(0.01)
+                .onTapGesture { controller.cancel() }
+                .onKeyPress(.escape) { controller.cancel(); return .handled }
+                .onKeyPress(.upArrow) { controller.move(by: -1); return .handled }
+                .onKeyPress(.downArrow) { controller.move(by: 1); return .handled }
+                .onKeyPress(.return) { controller.selectCurrent(); return .handled }
+
+            VStack {
+                DefinitionQuickPickContent(controller: controller)
+                    .shadow(color: .black.opacity(0.2), radius: 8, y: 2)
+                    .padding(.top, 40)
+                Spacer()
+            }
+        }
+    }
+}

--- a/Pine/LSP/GutterTextView+LSPMouseTracking.swift
+++ b/Pine/LSP/GutterTextView+LSPMouseTracking.swift
@@ -1,0 +1,162 @@
+//
+//  GutterTextView+LSPMouseTracking.swift
+//  Pine
+//
+//  Phase 5 of LSP support (milestone #1088, item 1).
+//
+//  Supporting extension for `GutterTextView` that provides LSP-related
+//  mouse tracking state and helper methods. The actual `override` methods
+//  (`mouseMoved`, `mouseExited`, `mouseDown`, `rightMouseDown`,
+//  `updateTrackingAreas`) are implemented directly inside the
+//  `GutterTextView` class body because Swift does not allow `override` in
+//  extensions on non-`@objc` framework classes.
+//
+//  This extension provides:
+//    • Stored property shims via associated objects (`lspMouseHandler`,
+//      `hoverTimer`, `lastHoverLocation`)
+//    • Character-index lookup (`lspCharacterIndex(at:)`)
+//    • Tracking area installation (`installLSPTrackingArea`)
+//    • Scroll dismissal helper (`lspDismissHoverOnScroll`)
+//
+
+import AppKit
+
+extension GutterTextView {
+
+    // MARK: - Associated object keys
+
+    private static var lspHandlerKey: UInt8 = 0
+    private static var hoverTimerKey: UInt8 = 0
+    private static var lastHoverLocationKey: UInt8 = 0
+
+    // MARK: - Properties via associated objects
+
+    /// The weak reference to the LSP mouse handler (the coordinator).
+    var lspMouseHandler: LSPMouseHandling? {
+        get { objc_getAssociatedObject(self, &Self.lspHandlerKey) as? LSPMouseHandling }
+        set { objc_setAssociatedObject(self, &Self.lspHandlerKey, newValue, .OBJC_ASSOCIATION_RETAIN) }
+    }
+
+    /// The debounce timer for hover. Reset on every mouseMoved.
+    var hoverTimer: Timer? {
+        get { objc_getAssociatedObject(self, &Self.hoverTimerKey) as? Timer }
+        set { objc_setAssociatedObject(self, &Self.hoverTimerKey, newValue, .OBJC_ASSOCIATION_RETAIN) }
+    }
+
+    /// The last mouse location (in text view coordinates) for hover tracking.
+    var lastHoverLocation: NSPoint? {
+        get { objc_getAssociatedObject(self, &Self.lastHoverLocationKey) as? NSPoint }
+        set { objc_setAssociatedObject(self, &Self.lastHoverLocationKey, newValue, .OBJC_ASSOCIATION_RETAIN) }
+    }
+
+    // MARK: - Tracking area installation
+
+    /// Installs or refreshes the LSP mouse-tracking area covering the
+    /// visible bounds. Called from `updateTrackingAreas()` override.
+    func installLSPTrackingArea() {
+        // Remove old LSP tracking areas.
+        for area in trackingAreas where area.userInfo?["lsp"] as? Bool == true {
+            removeTrackingArea(area)
+        }
+
+        let rect = visibleRect
+        guard rect.width > 0, rect.height > 0 else { return }
+        let area = NSTrackingArea(
+            rect: rect,
+            options: [
+                .mouseEnteredAndExited,
+                .mouseMoved,
+                .activeInActiveApp,
+                .inVisibleRect
+            ],
+            owner: self,
+            userInfo: ["lsp": true]
+        )
+        addTrackingArea(area)
+    }
+
+    // MARK: - Hover scheduling
+
+    /// Schedules a hover request after the 200ms debounce. The timer fires
+    /// `lspMouseHandler?.lspHover(at:)` on the main thread. Called from the
+    /// `mouseMoved` override.
+    func scheduleLSPHover(at location: NSPoint) {
+        guard lspMouseHandler != nil else { return }
+
+        lastHoverLocation = location
+
+        // If the mouse hasn't moved to a different character, don't reset.
+        let offset = lspCharacterIndex(at: location)
+        if let oldLocation = lastHoverLocation {
+            let oldOffset = lspCharacterIndex(at: oldLocation)
+            if oldOffset == offset { return }
+        }
+
+        hoverTimer?.invalidate()
+        hoverTimer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { [weak self] _ in
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                guard let location = self.lastHoverLocation else { return }
+                let offset = self.lspCharacterIndex(at: location)
+                guard offset >= 0 else { return }
+                self.lspMouseHandler?.lspHover(at: offset)
+            }
+        }
+    }
+
+    /// Cancels the hover timer and notifies the handler that hover ended.
+    func cancelLSPHover() {
+        hoverTimer?.invalidate()
+        hoverTimer = nil
+        lastHoverLocation = nil
+        lspMouseHandler?.lspHoverEnded()
+    }
+
+    /// Called by the coordinator when the scroll view bounds change —
+    /// dismisses the hover popover.
+    func lspDismissHoverOnScroll() {
+        cancelLSPHover()
+    }
+
+    // MARK: - Character index
+
+    /// Returns the UTF-16 character index at `point`, or -1 if the point is
+    /// not over any character.
+    func lspCharacterIndex(at point: NSPoint) -> Int {
+        guard let layoutManager = layoutManager,
+              let textContainer = textContainer else { return -1 }
+
+        // Adjust for the text container origin (gutter inset).
+        let adjustedPoint = NSPoint(
+            x: point.x - textContainerOrigin.x,
+            y: point.y - textContainerOrigin.y
+        )
+
+        let index = layoutManager.characterIndex(
+            for: adjustedPoint,
+            in: textContainer,
+            fractionOfDistanceBetweenInsertionPoints: nil
+        )
+
+        guard index != NSNotFound,
+              index < (string as NSString).length else { return -1 }
+
+        // Check if the point is actually near a glyph (not in empty space).
+        let glyphIndex = layoutManager.glyphIndex(
+            for: adjustedPoint,
+            in: textContainer
+        )
+        let glyphRect = layoutManager.boundingRect(
+            forGlyphRange: NSRange(location: glyphIndex, length: 1),
+            in: textContainer
+        )
+        // Allow a small margin around the glyph.
+        let margin: CGFloat = 2
+        let expandedRect = glyphRect.insetBy(dx: -margin, dy: -margin)
+        if !expandedRect.contains(adjustedPoint) {
+            return -1
+        }
+
+        return index
+    }
+}

--- a/Pine/LSP/HoverMarkdownRenderer.swift
+++ b/Pine/LSP/HoverMarkdownRenderer.swift
@@ -133,7 +133,7 @@ nonisolated enum HoverMarkdownRenderer {
                 let attr = NSMutableAttributedString(string: sep)
                 let fullRange = NSRange(location: 0, length: attr.length)
                 attr.addAttribute(.font, value: style.font, range: fullRange)
-                attr.addAttribute(.foregroundColor, value: secondaryTextColor, range: fullRange)
+                attr.addAttribute(.foregroundColor, value: style.secondaryTextColor, range: fullRange)
                 result.append(attr)
                 i += 1
                 continue
@@ -260,7 +260,7 @@ nonisolated enum HoverMarkdownRenderer {
     ) {
         guard !text.isEmpty else { return }
         result.append(NSAttributedString(string: text, attributes: [
-            .font: style.font,
+            .font: font,
             .foregroundColor: color
         ]))
     }

--- a/Pine/LSP/HoverMarkdownRenderer.swift
+++ b/Pine/LSP/HoverMarkdownRenderer.swift
@@ -1,0 +1,277 @@
+//
+//  HoverMarkdownRenderer.swift
+//  Pine
+//
+//  Phase 5 of LSP support (milestone #1088, item 1).
+//
+//  Converts LSP hover content (Markdown or plain text) into an
+//  NSAttributedString for display in the hover popover.
+//
+//  Uses a lightweight Markdown parser that handles the common cases in LSP
+//  hover responses: code blocks (```...```), inline code (`code`), bold
+//  (**text**), headings (# Title), and plain text lines. Full Markdown AST
+//  rendering (via swift-markdown) is available but deliberately not used
+//  here to keep the popover rendering synchronous and dependency-free — LSP
+//  hover responses are typically short and structured.
+//
+//  `nonisolated` because the rendering is pure data work — no actor surface.
+//
+
+import AppKit
+
+/// Pure rendering of LSP hover content into NSAttributedString.
+///
+/// `nonisolated` because it is pure data work invoked from the main-actor UI
+/// path; it holds no state.
+nonisolated enum HoverMarkdownRenderer {
+
+    /// Renders `content` into an attributed string for the hover popover.
+    ///
+    /// - Parameters:
+    ///   - content: The hover text from the LSP server.
+    ///   - isMarkdown: Whether the content is Markdown (parsed) or plain
+    ///     text (shown verbatim in monospaced font).
+    static func render(_ content: String, isMarkdown: Bool) -> NSAttributedString {
+        let font = NSFont.systemFont(ofSize: 12)
+        let boldFont = NSFont.boldSystemFont(ofSize: 12)
+        let codeFont = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        let headingFont = NSFont.boldSystemFont(ofSize: 13)
+        let textColor = NSColor.labelColor
+        let secondaryTextColor = NSColor.secondaryLabelColor
+        let codeBackgroundColor = NSColor.textBackgroundColor
+
+        if isMarkdown {
+            return parseMarkdown(
+                content,
+                font: font,
+                boldFont: boldFont,
+                codeFont: codeFont,
+                headingFont: headingFont,
+                textColor: textColor,
+                secondaryTextColor: secondaryTextColor,
+                codeBackgroundColor: codeBackgroundColor
+            )
+        } else {
+            // Plain text — show verbatim in monospaced font.
+            let attr = NSMutableAttributedString(string: content)
+            let fullRange = NSRange(location: 0, length: attr.length)
+            attr.addAttribute(.font, value: codeFont, range: fullRange)
+            attr.addAttribute(.foregroundColor, value: textColor, range: fullRange)
+            return attr
+        }
+    }
+
+    // MARK: - Markdown parsing
+
+    /// A lightweight Markdown parser handling the subset commonly seen in
+    /// LSP hover responses.
+    ///
+    /// Supports:
+    ///   - Fenced code blocks: ```lang\ncode\n```
+    ///   - Headings: # H1, ## H2, ### H3
+    ///   - Bold: **text**
+    ///   - Inline code: `code`
+    ///   - Separator lines: ---
+    private static func parseMarkdown(
+        _ markdown: String,
+        font: NSFont,
+        boldFont: NSFont,
+        codeFont: NSFont,
+        headingFont: NSFont,
+        textColor: NSColor,
+        secondaryTextColor: NSColor,
+        codeBackgroundColor: NSColor
+    ) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        let lines = markdown.components(separatedBy: "\n")
+        var i = 0
+
+        while i < lines.count {
+            let line = lines[i]
+
+            // Fenced code block.
+            if line.trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+                var codeLines: [String] = []
+                i += 1
+                while i < lines.count {
+                    let blockLine = lines[i]
+                    if blockLine.trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+                        i += 1
+                        break
+                    }
+                    codeLines.append(blockLine)
+                    i += 1
+                }
+                if !codeLines.isEmpty {
+                    let code = codeLines.joined(separator: "\n") + "\n"
+                    let attr = NSMutableAttributedString(string: code)
+                    let fullRange = NSRange(location: 0, length: attr.length)
+                    attr.addAttribute(.font, value: codeFont, range: fullRange)
+                    attr.addAttribute(.foregroundColor, value: textColor, range: fullRange)
+                    attr.addAttribute(.backgroundColor, value: codeBackgroundColor, range: fullRange)
+                    result.append(attr)
+                }
+                continue
+            }
+
+            // Heading.
+            if let headingLevel = parseHeadingLevel(line) {
+                let title = line.drop(while: { $0 == "#" }).trimmingCharacters(in: .whitespaces)
+                if !title.isEmpty {
+                    let attr = NSMutableAttributedString(string: title + "\n")
+                    let fullRange = NSRange(location: 0, length: attr.length)
+                    attr.addAttribute(.font, value: headingFont, range: fullRange)
+                    attr.addAttribute(.foregroundColor, value: textColor, range: fullRange)
+                    result.append(attr)
+                }
+                i += 1
+                _ = headingLevel // accepted
+                continue
+            }
+
+            // Horizontal rule.
+            if line.trimmingCharacters(in: .whitespaces) == "---" {
+                let sep = String(repeating: "\u{2014}", count: 40) + "\n"
+                let attr = NSMutableAttributedString(string: sep)
+                let fullRange = NSRange(location: 0, length: attr.length)
+                attr.addAttribute(.font, value: font, range: fullRange)
+                attr.addAttribute(.foregroundColor, value: secondaryTextColor, range: fullRange)
+                result.append(attr)
+                i += 1
+                continue
+            }
+
+            // Regular line — parse inline formatting.
+            let lineAttr = parseInlineFormatting(
+                line + "\n",
+                font: font,
+                boldFont: boldFont,
+                codeFont: codeFont,
+                textColor: textColor,
+                codeBackgroundColor: codeBackgroundColor
+            )
+            result.append(lineAttr)
+            i += 1
+        }
+
+        return result
+    }
+
+    /// Parses the heading level from a line (1–6), or `nil` when it's not a
+    /// heading.
+    private static func parseHeadingLevel(_ line: String) -> Int? {
+        var count = 0
+        for ch in line {
+            if ch == "#" {
+                count += 1
+            } else if ch.isWhitespace {
+                break
+            } else {
+                return nil
+            }
+        }
+        return (1...6).contains(count) ? count : nil
+    }
+
+    /// Parses inline formatting: **bold** and `code`.
+    private static func parseInlineFormatting(
+        _ text: String,
+        font: NSFont,
+        boldFont: NSFont,
+        codeFont: NSFont,
+        textColor: NSColor,
+        codeBackgroundColor: NSColor
+    ) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        var current = ""
+        let chars = Array(text)
+
+        var i = 0
+        while i < chars.count {
+            // Inline code: `...`
+            if chars[i] == "`" {
+                // Flush current text first.
+                flush(
+                    current,
+                    into: result,
+                    font: font,
+                    color: textColor
+                )
+                current = ""
+
+                // Find closing backtick.
+                var j = i + 1
+                var codeContent = ""
+                while j < chars.count && chars[j] != "`" {
+                    codeContent.append(chars[j])
+                    j += 1
+                }
+                if j < chars.count {
+                    // Found closing backtick.
+                    let attr = NSAttributedString(string: codeContent, attributes: [
+                        .font: codeFont,
+                        .foregroundColor: textColor,
+                        .backgroundColor: codeBackgroundColor
+                    ])
+                    result.append(attr)
+                    i = j + 1
+                    continue
+                } else {
+                    // No closing backtick — treat as literal.
+                    current.append("`")
+                    current.append(contentsOf: codeContent)
+                    i = j
+                    continue
+                }
+            }
+
+            // Bold: **...**
+            if chars[i] == "*" && i + 1 < chars.count && chars[i + 1] == "*" {
+                // Find closing **.
+                var j = i + 2
+                var boldContent = ""
+                while j < chars.count {
+                    if chars[j] == "*" && j + 1 < chars.count && chars[j + 1] == "*" {
+                        break
+                    }
+                    boldContent.append(chars[j])
+                    j += 1
+                }
+                if j < chars.count {
+                    // Flush current text first.
+                    flush(current, into: result, font: font, color: textColor)
+                    current = ""
+
+                    // Found closing **.
+                    let attr = NSAttributedString(string: boldContent, attributes: [
+                        .font: boldFont,
+                        .foregroundColor: textColor
+                    ])
+                    result.append(attr)
+                    i = j + 2
+                    continue
+                }
+            }
+
+            current.append(chars[i])
+            i += 1
+        }
+
+        flush(current, into: result, font: font, color: textColor)
+        return result
+    }
+
+    /// Appends `text` to `result` with `font` and `color` if non-empty.
+    private static func flush(
+        _ text: String,
+        into result: NSMutableAttributedString,
+        font: NSFont,
+        color: NSColor
+    ) {
+        guard !text.isEmpty else { return }
+        result.append(NSAttributedString(string: text, attributes: [
+            .font: font,
+            .foregroundColor: color
+        ]))
+    }
+}

--- a/Pine/LSP/HoverMarkdownRenderer.swift
+++ b/Pine/LSP/HoverMarkdownRenderer.swift
@@ -25,6 +25,17 @@ import AppKit
 /// path; it holds no state.
 nonisolated enum HoverMarkdownRenderer {
 
+    /// Font/color configuration for rendering hover content.
+    private struct Style {
+        let font: NSFont
+        let boldFont: NSFont
+        let codeFont: NSFont
+        let headingFont: NSFont
+        let textColor: NSColor
+        let secondaryTextColor: NSColor
+        let codeBackgroundColor: NSColor
+    }
+
     /// Renders `content` into an attributed string for the hover popover.
     ///
     /// - Parameters:
@@ -32,31 +43,24 @@ nonisolated enum HoverMarkdownRenderer {
     ///   - isMarkdown: Whether the content is Markdown (parsed) or plain
     ///     text (shown verbatim in monospaced font).
     static func render(_ content: String, isMarkdown: Bool) -> NSAttributedString {
-        let font = NSFont.systemFont(ofSize: 12)
-        let boldFont = NSFont.boldSystemFont(ofSize: 12)
-        let codeFont = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
-        let headingFont = NSFont.boldSystemFont(ofSize: 13)
-        let textColor = NSColor.labelColor
-        let secondaryTextColor = NSColor.secondaryLabelColor
-        let codeBackgroundColor = NSColor.textBackgroundColor
+        let style = Style(
+            font: NSFont.systemFont(ofSize: 12),
+            boldFont: NSFont.boldSystemFont(ofSize: 12),
+            codeFont: NSFont.monospacedSystemFont(ofSize: 11, weight: .regular),
+            headingFont: NSFont.boldSystemFont(ofSize: 13),
+            textColor: NSColor.labelColor,
+            secondaryTextColor: NSColor.secondaryLabelColor,
+            codeBackgroundColor: NSColor.textBackgroundColor
+        )
 
         if isMarkdown {
-            return parseMarkdown(
-                content,
-                font: font,
-                boldFont: boldFont,
-                codeFont: codeFont,
-                headingFont: headingFont,
-                textColor: textColor,
-                secondaryTextColor: secondaryTextColor,
-                codeBackgroundColor: codeBackgroundColor
-            )
+            return parseMarkdown(content, style: style)
         } else {
             // Plain text — show verbatim in monospaced font.
             let attr = NSMutableAttributedString(string: content)
             let fullRange = NSRange(location: 0, length: attr.length)
-            attr.addAttribute(.font, value: codeFont, range: fullRange)
-            attr.addAttribute(.foregroundColor, value: textColor, range: fullRange)
+            attr.addAttribute(.font, value: style.codeFont, range: fullRange)
+            attr.addAttribute(.foregroundColor, value: style.textColor, range: fullRange)
             return attr
         }
     }
@@ -74,13 +78,7 @@ nonisolated enum HoverMarkdownRenderer {
     ///   - Separator lines: ---
     private static func parseMarkdown(
         _ markdown: String,
-        font: NSFont,
-        boldFont: NSFont,
-        codeFont: NSFont,
-        headingFont: NSFont,
-        textColor: NSColor,
-        secondaryTextColor: NSColor,
-        codeBackgroundColor: NSColor
+        style: Style
     ) -> NSAttributedString {
         let result = NSMutableAttributedString()
         let lines = markdown.components(separatedBy: "\n")
@@ -106,9 +104,9 @@ nonisolated enum HoverMarkdownRenderer {
                     let code = codeLines.joined(separator: "\n") + "\n"
                     let attr = NSMutableAttributedString(string: code)
                     let fullRange = NSRange(location: 0, length: attr.length)
-                    attr.addAttribute(.font, value: codeFont, range: fullRange)
-                    attr.addAttribute(.foregroundColor, value: textColor, range: fullRange)
-                    attr.addAttribute(.backgroundColor, value: codeBackgroundColor, range: fullRange)
+                    attr.addAttribute(.font, value: style.codeFont, range: fullRange)
+                    attr.addAttribute(.foregroundColor, value: style.textColor, range: fullRange)
+                    attr.addAttribute(.backgroundColor, value: style.codeBackgroundColor, range: fullRange)
                     result.append(attr)
                 }
                 continue
@@ -120,8 +118,8 @@ nonisolated enum HoverMarkdownRenderer {
                 if !title.isEmpty {
                     let attr = NSMutableAttributedString(string: title + "\n")
                     let fullRange = NSRange(location: 0, length: attr.length)
-                    attr.addAttribute(.font, value: headingFont, range: fullRange)
-                    attr.addAttribute(.foregroundColor, value: textColor, range: fullRange)
+                    attr.addAttribute(.font, value: style.headingFont, range: fullRange)
+                    attr.addAttribute(.foregroundColor, value: style.textColor, range: fullRange)
                     result.append(attr)
                 }
                 i += 1
@@ -134,7 +132,7 @@ nonisolated enum HoverMarkdownRenderer {
                 let sep = String(repeating: "\u{2014}", count: 40) + "\n"
                 let attr = NSMutableAttributedString(string: sep)
                 let fullRange = NSRange(location: 0, length: attr.length)
-                attr.addAttribute(.font, value: font, range: fullRange)
+                attr.addAttribute(.font, value: style.font, range: fullRange)
                 attr.addAttribute(.foregroundColor, value: secondaryTextColor, range: fullRange)
                 result.append(attr)
                 i += 1
@@ -144,11 +142,7 @@ nonisolated enum HoverMarkdownRenderer {
             // Regular line — parse inline formatting.
             let lineAttr = parseInlineFormatting(
                 line + "\n",
-                font: font,
-                boldFont: boldFont,
-                codeFont: codeFont,
-                textColor: textColor,
-                codeBackgroundColor: codeBackgroundColor
+                style: style
             )
             result.append(lineAttr)
             i += 1
@@ -176,11 +170,7 @@ nonisolated enum HoverMarkdownRenderer {
     /// Parses inline formatting: **bold** and `code`.
     private static func parseInlineFormatting(
         _ text: String,
-        font: NSFont,
-        boldFont: NSFont,
-        codeFont: NSFont,
-        textColor: NSColor,
-        codeBackgroundColor: NSColor
+        style: Style
     ) -> NSAttributedString {
         let result = NSMutableAttributedString()
         var current = ""
@@ -194,8 +184,8 @@ nonisolated enum HoverMarkdownRenderer {
                 flush(
                     current,
                     into: result,
-                    font: font,
-                    color: textColor
+                    font: style.font,
+                    color: style.textColor
                 )
                 current = ""
 
@@ -209,9 +199,9 @@ nonisolated enum HoverMarkdownRenderer {
                 if j < chars.count {
                     // Found closing backtick.
                     let attr = NSAttributedString(string: codeContent, attributes: [
-                        .font: codeFont,
-                        .foregroundColor: textColor,
-                        .backgroundColor: codeBackgroundColor
+                        .font: style.codeFont,
+                        .foregroundColor: style.textColor,
+                        .backgroundColor: style.codeBackgroundColor
                     ])
                     result.append(attr)
                     i = j + 1
@@ -239,13 +229,13 @@ nonisolated enum HoverMarkdownRenderer {
                 }
                 if j < chars.count {
                     // Flush current text first.
-                    flush(current, into: result, font: font, color: textColor)
+                    flush(current, into: result, font: style.font, color: style.textColor)
                     current = ""
 
                     // Found closing **.
                     let attr = NSAttributedString(string: boldContent, attributes: [
-                        .font: boldFont,
-                        .foregroundColor: textColor
+                        .font: style.boldFont,
+                        .foregroundColor: style.textColor
                     ])
                     result.append(attr)
                     i = j + 2
@@ -257,7 +247,7 @@ nonisolated enum HoverMarkdownRenderer {
             i += 1
         }
 
-        flush(current, into: result, font: font, color: textColor)
+        flush(current, into: result, font: style.font, color: style.textColor)
         return result
     }
 
@@ -270,7 +260,7 @@ nonisolated enum HoverMarkdownRenderer {
     ) {
         guard !text.isEmpty else { return }
         result.append(NSAttributedString(string: text, attributes: [
-            .font: font,
+            .font: style.font,
             .foregroundColor: color
         ]))
     }

--- a/Pine/LSP/HoverPopover.swift
+++ b/Pine/LSP/HoverPopover.swift
@@ -1,0 +1,141 @@
+//
+//  HoverPopover.swift
+//  Pine
+//
+//  Phase 5 of LSP support (milestone #1088, item 1).
+//
+//  A lightweight popover that renders LSP hover content (Markdown or plain
+//  text) as an attributed string in a read-only NSTextView. Hosted in an
+//  NSPopover so it inherits Liquid Glass materials and proper dismissal
+//  behavior (click-outside, scroll, etc.).
+//
+//  The popover is created lazily by the CodeEditorView coordinator and
+//  repositioned at the hover target's screen rect before each show.
+//
+
+import AppKit
+
+/// Manages the LSP hover popover lifecycle: show, hide, and content update.
+///
+/// `@MainActor` because NSPopover must be created and manipulated on the
+/// main thread, and the coordinator that owns it is always on the main actor.
+@MainActor
+final class HoverPopoverManager {
+
+    /// The underlying popover. Lazily created on first show.
+    private var popover: NSPopover?
+
+    /// The text view that renders the hover content inside the popover.
+    private var contentTextView: NSTextView?
+
+    /// Whether the popover is currently shown.
+    var isVisible: Bool { popover?.isShown ?? false }
+
+    init() {}
+
+    // MARK: - Show
+
+    /// Shows the hover popover anchored at `anchorRect` (in screen
+    /// coordinates). If the popover is already shown, updates the content
+    /// in place.
+    /// - Parameters:
+    ///   - content: The markdown or plain-text string to display.
+    ///   - isMarkdown: Whether `content` is Markdown (parsed for rendering)
+    ///     or plain text (shown verbatim).
+    ///   - anchorRect: The screen rect of the symbol being hovered over.
+    ///   - positioningView: The view used for coordinate conversion.
+    func show(
+        content: String,
+        isMarkdown: Bool,
+        anchorRect: NSRect,
+        positioningView: NSView
+    ) {
+        let pop = ensurePopover()
+        let textView = ensureContentTextView()
+
+        // Render content as attributed string.
+        let attributed = HoverMarkdownRenderer.render(content, isMarkdown: isMarkdown)
+        textView.textStorage?.setAttributedString(attributed)
+
+        // Size the popover to fit the content.
+        let size = Self.contentSize(for: attributed, maxWidth: 500)
+        pop.contentViewController?.view.frame = NSRect(
+            origin: .zero,
+            size: NSSize(width: size.width, height: size.height)
+        )
+
+        // Position the popover relative to the anchor rect in the
+        // positioning view's coordinate space.
+        let positionRect = positioningView.convert(anchorRect, from: nil)
+
+        pop.show(
+            relativeTo: positionRect,
+            of: positioningView,
+            preferredEdge: .maxY
+        )
+    }
+
+    /// Hides the popover if visible.
+    func hide() {
+        guard let popover, popover.isShown else { return }
+        popover.performClose(nil)
+    }
+
+    // MARK: - Lazy creation
+
+    private func ensurePopover() -> NSPopover {
+        if let popover { return popover }
+        let pop = NSPopover()
+        pop.behavior = .transient
+        pop.animates = true
+        let viewController = NSViewController()
+        let container = NSView()
+        container.wantsLayer = true
+        let textView = NSTextView(frame: .zero)
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = false
+        textView.textContainerInset = NSSize(width: 10, height: 8)
+        textView.autoresizingMask = [.width, .height]
+        container.addSubview(textView)
+        viewController.view = container
+        pop.contentViewController = viewController
+        self.contentTextView = textView
+        self.popover = pop
+        return pop
+    }
+
+    private func ensureContentTextView() -> NSTextView {
+        if contentTextView == nil {
+            _ = ensurePopover()
+        }
+        return contentTextView ?? NSTextView()
+    }
+
+    // MARK: - Sizing
+
+    /// Computes the content size needed to display the attributed string.
+    private static func contentSize(
+        for attributed: NSAttributedString,
+        maxWidth: CGFloat
+    ) -> NSSize {
+        let padding: CGFloat = 20 // horizontal insets
+        let verticalPadding: CGFloat = 16
+        let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: maxWidth, height: 0))
+        textView.textStorage?.setAttributedString(attributed)
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.size = NSSize(
+            width: maxWidth - padding,
+            height: .greatestFiniteMagnitude
+        )
+        guard let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer else {
+            return NSSize(width: maxWidth, height: 60)
+        }
+        layoutManager.ensureLayout(for: textContainer)
+        let usedRect = layoutManager.usedRect(for: textContainer)
+        let width = min(maxWidth, usedRect.width + padding)
+        let height = min(max(usedRect.height + verticalPadding, 30), 400)
+        return NSSize(width: max(width, 100), height: height)
+    }
+}

--- a/Pine/LSP/LSPMouseHandling.swift
+++ b/Pine/LSP/LSPMouseHandling.swift
@@ -1,0 +1,41 @@
+//
+//  LSPMouseHandling.swift
+//  Pine
+//
+//  Phase 5 of LSP support (milestone #1088, item 1).
+//
+//  Protocol so the GutterTextView mouse-override methods can call back to
+//  the CodeEditorView.Coordinator without a circular import. The coordinator
+//  conforms to this protocol.
+//
+
+import AppKit
+
+/// Protocol implemented by `CodeEditorView.Coordinator` so that
+/// `GutterTextView` mouse overrides can route LSP hover, definition, code
+/// action, and rename requests.
+@MainActor
+protocol LSPMouseHandling: AnyObject {
+    /// Called when the mouse hovers over a symbol for the debounce delay.
+    /// - Parameters:
+    ///   - offset: The UTF-16 offset of the character under the cursor.
+    func lspHover(at offset: Int)
+
+    /// Called when the mouse exits the text view or scrolls.
+    func lspHoverEnded()
+
+    /// Called when the user ⌘+Clicks a symbol.
+    /// - Returns: `true` if the click was handled (definition found).
+    func lspGoToDefinition(at offset: Int) -> Bool
+
+    /// Called when the user right-clicks to request code actions.
+    /// - Parameters:
+    ///   - offset: The UTF-16 offset of the character under the cursor.
+    ///   - menuLocation: The click location in the text view's coordinate
+    ///     space, for positioning the menu.
+    func lspRequestCodeActions(at offset: Int, menuLocation: NSPoint)
+
+    /// Called when the user triggers rename (Cmd+R or menu).
+    /// - Parameter offset: The UTF-16 offset of the character to rename.
+    func lspRequestRename(at offset: Int)
+}

--- a/Pine/LSP/LSPUIEndpoint.swift
+++ b/Pine/LSP/LSPUIEndpoint.swift
@@ -37,7 +37,7 @@ final class LSPUIEndpoint {
 
     /// Called by the coordinator with the file URL, UTF-16 offset, and full
     /// document text. Returns the server's hover info or `nil`.
-    var hoverHandler: ((URL, Int, String) async -> LSPHover)?
+    var hoverHandler: ((URL, Int, String) async -> LSPHover?)?
 
     /// Convenience wrapper that no-ops (returns `nil`) when no handler is
     /// installed.

--- a/Pine/LSP/LSPUIEndpoint.swift
+++ b/Pine/LSP/LSPUIEndpoint.swift
@@ -42,7 +42,7 @@ final class LSPUIEndpoint {
     /// Convenience wrapper that no-ops (returns `nil`) when no handler is
     /// installed.
     func hover(url: URL, offset: Int, text: String) async -> LSPHover? {
-        guard let handler else { return nil }
+        guard let handler = hoverHandler else { return nil }
         return await handler(url, offset, text)
     }
 
@@ -53,7 +53,7 @@ final class LSPUIEndpoint {
 
     /// Convenience wrapper that returns `.empty` when no handler is installed.
     func definition(url: URL, offset: Int, text: String) async -> LSPDefinitionResponse {
-        guard let handler else { return .empty }
+        guard let handler = definitionHandler else { return .empty }
         return await handler(url, offset, text)
     }
 
@@ -64,7 +64,7 @@ final class LSPUIEndpoint {
 
     /// Convenience wrapper that returns empty when no handler is installed.
     func codeAction(url: URL, offset: Int, text: String) async -> LSPCodeActionResponse {
-        guard let handler else { return LSPCodeActionResponse(actions: []) }
+        guard let handler = codeActionHandler else { return LSPCodeActionResponse(actions: []) }
         return await handler(url, offset, text)
     }
 
@@ -76,7 +76,7 @@ final class LSPUIEndpoint {
 
     /// Convenience wrapper that returns an empty edit when no handler.
     func rename(url: URL, offset: Int, text: String, newName: String) async -> LSPWorkspaceEdit {
-        guard let handler else { return LSPWorkspaceEdit(operatedFiles: []) }
+        guard let handler = renameHandler else { return LSPWorkspaceEdit(operatedFiles: []) }
         return await handler(url, offset, text, newName)
     }
 
@@ -88,7 +88,7 @@ final class LSPUIEndpoint {
 
     /// Convenience wrapper that returns `false` when no handler is installed.
     func applyWorkspaceEdit(_ edit: LSPWorkspaceEdit) -> Bool {
-        guard let handler else { return false }
+        guard let handler = applyEditHandler else { return false }
         return handler(edit)
     }
 

--- a/Pine/LSP/LSPUIEndpoint.swift
+++ b/Pine/LSP/LSPUIEndpoint.swift
@@ -1,0 +1,108 @@
+//
+//  LSPUIEndpoint.swift
+//  Pine
+//
+//  Phase 5 of LSP support (milestone #1088, item 1).
+//
+//  Bridges the AppKit `CodeEditorView.Coordinator` (which drives hover,
+//  go-to-definition, code actions, and rename) to the
+//  `@MainActor @Observable` `LSPManager` (which owns the language-server
+//  connections).
+//
+//  Follows the same singleton pattern as `CompletionEndpoint`: the
+//  coordinator cannot reach `ProjectManager.lspManager` directly (it lives
+//  several SwiftUI layers above the `NSViewRepresentable`), so `PaneLeafView`
+//  installs closures on the shared endpoint and the coordinator routes
+//  requests through them.
+//
+//  A single shared endpoint is sufficient because Pine is a document-based
+//  app where only one editor pane is first-responder at a time.
+//
+
+import Foundation
+
+/// `@MainActor` singleton bridge from the editor coordinator to the active
+/// project's `LSPManager` for hover, definition, code action, and rename.
+///
+/// `PaneLeafView` sets the handler closures when the active editor pane
+/// appears (and clears them on disappear) so the coordinator can issue LSP
+/// requests without holding a reference to the project.
+@MainActor
+final class LSPUIEndpoint {
+
+    /// The shared endpoint. There is exactly one per process.
+    static let shared = LSPUIEndpoint()
+
+    // MARK: - Hover
+
+    /// Called by the coordinator with the file URL, UTF-16 offset, and full
+    /// document text. Returns the server's hover info or `nil`.
+    var hoverHandler: ((URL, Int, String) async -> LSPHover)?
+
+    /// Convenience wrapper that no-ops (returns `nil`) when no handler is
+    /// installed.
+    func hover(url: URL, offset: Int, text: String) async -> LSPHover? {
+        guard let handler else { return nil }
+        return await handler(url, offset, text)
+    }
+
+    // MARK: - Definition
+
+    /// Called by the coordinator to request go-to-definition.
+    var definitionHandler: ((URL, Int, String) async -> LSPDefinitionResponse)?
+
+    /// Convenience wrapper that returns `.empty` when no handler is installed.
+    func definition(url: URL, offset: Int, text: String) async -> LSPDefinitionResponse {
+        guard let handler else { return .empty }
+        return await handler(url, offset, text)
+    }
+
+    // MARK: - Code Action
+
+    /// Called by the coordinator to request code actions at the cursor.
+    var codeActionHandler: ((URL, Int, String) async -> LSPCodeActionResponse)?
+
+    /// Convenience wrapper that returns empty when no handler is installed.
+    func codeAction(url: URL, offset: Int, text: String) async -> LSPCodeActionResponse {
+        guard let handler else { return LSPCodeActionResponse(actions: []) }
+        return await handler(url, offset, text)
+    }
+
+    // MARK: - Rename
+
+    /// Called by the coordinator to request a rename. Returns the
+    /// `WorkspaceEdit` or an empty edit.
+    var renameHandler: ((URL, Int, String, String) async -> LSPWorkspaceEdit)?
+
+    /// Convenience wrapper that returns an empty edit when no handler.
+    func rename(url: URL, offset: Int, text: String, newName: String) async -> LSPWorkspaceEdit {
+        guard let handler else { return LSPWorkspaceEdit(operatedFiles: []) }
+        return await handler(url, offset, text, newName)
+    }
+
+    // MARK: - Workspace edit application
+
+    /// Called by the coordinator to apply a `WorkspaceEdit` (from code action
+    /// or rename) across open tabs. Returns `true` on success.
+    var applyEditHandler: ((LSPWorkspaceEdit) -> Bool)?
+
+    /// Convenience wrapper that returns `false` when no handler is installed.
+    func applyWorkspaceEdit(_ edit: LSPWorkspaceEdit) -> Bool {
+        guard let handler else { return false }
+        return handler(edit)
+    }
+
+    // MARK: - Open file navigation
+
+    /// Called by the coordinator when go-to-definition targets a different
+    /// file. The handler should open the file and navigate to the given
+    /// line/column (both 0-based LSP positions).
+    var openFileAtLineHandler: ((URL, Int, Int) -> Void)?
+
+    /// Convenience wrapper that no-ops when no handler is installed.
+    func openFileAtLine(url: URL, line: Int, character: Int) {
+        openFileAtLineHandler?(url, line, character)
+    }
+
+    private init() {}
+}

--- a/Pine/LSP/RenamePopover.swift
+++ b/Pine/LSP/RenamePopover.swift
@@ -1,0 +1,218 @@
+//
+//  RenamePopover.swift
+//  Pine
+//
+//  Phase 5 of LSP support (milestone #1088, item 1).
+//
+//  A lightweight popover that shows a text field for renaming a symbol.
+//  The user types the new name and presses Enter to confirm, or Esc to
+//  cancel. On confirm, the coordinator calls LSPManager.rename() and
+//  applies the resulting WorkspaceEdit.
+//
+
+import AppKit
+
+/// `@MainActor @Observable` controller for the rename popover.
+@MainActor
+@Observable
+final class RenameController {
+
+    /// Whether the rename popover is currently visible.
+    private(set) var isVisible: Bool = false
+
+    /// The current text in the rename field.
+    var newName: String = ""
+
+    /// The original symbol name (prefilled in the field).
+    var originalName: String = ""
+
+    /// Called when the user confirms the rename with a new name.
+    var onConfirm: ((String) -> Void)?
+
+    /// Called when the user cancels the rename.
+    var onCancel: (() -> Void)?
+
+    init() {}
+
+    // MARK: - Presentation
+
+    /// Presents the rename popover with the symbol's current name prefilled.
+    /// The name is selected so the user can type over it immediately.
+    func present(originalName: String) {
+        self.originalName = originalName
+        self.newName = originalName
+        isVisible = true
+    }
+
+    /// Hides the popover.
+    func dismiss() {
+        isVisible = false
+        newName = ""
+        originalName = ""
+    }
+
+    // MARK: - Actions
+
+    func confirm() {
+        let name = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty, name != originalName else {
+            dismiss()
+            return
+        }
+        let captured = name
+        dismiss()
+        onConfirm?(captured)
+    }
+
+    func cancel() {
+        dismiss()
+        onCancel?()
+    }
+}
+
+/// AppKit container for the rename popover — hosts a text field with
+/// Enter-to-confirm and Esc-to-cancel.
+///
+/// `@MainActor` because NSPopover and NSTextField must be manipulated on the
+/// main thread.
+@MainActor
+final class RenamePopoverManager {
+
+    /// The underlying popover.
+    private var popover: NSPopover?
+
+    /// The text field inside the popover.
+    private var textField: NSTextField?
+
+    /// Whether the popover is currently shown.
+    var isVisible: Bool { popover?.isShown ?? false }
+
+    init() {}
+
+    // MARK: - Show
+
+    /// Shows the rename popover anchored at `anchorRect` (in screen
+    /// coordinates) with `currentName` prefilled and selected.
+    func show(
+        currentName: String,
+        anchorRect: NSRect,
+        positioningView: NSView,
+        onConfirm: @escaping (String) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        let pop = ensurePopover(onConfirm: onConfirm, onCancel: onCancel)
+        guard let textField else { return }
+
+        textField.stringValue = currentName
+        textField.selectText(nil)
+        // Select the entire name so the user can type over it.
+        let currentEditor = textField.currentEditor()
+        currentEditor?.selectedRange = NSRange(location: 0, length: currentName.utf16.count)
+
+        let positionRect = positioningView.convert(anchorRect, from: nil)
+        pop.show(relativeTo: positionRect, of: positioningView, preferredEdge: .maxY)
+
+        // Focus the text field.
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let pop = self.popover, pop.isShown else { return }
+            self.textField?.window?.makeFirstResponder(self.textField)
+        }
+    }
+
+    /// Hides the popover if visible.
+    func hide() {
+        guard let popover, popover.isShown else { return }
+        popover.performClose(nil)
+    }
+
+    // MARK: - Lazy creation
+
+    private var confirmCallback: ((String) -> Void)?
+    private var cancelCallback: (() -> Void)?
+
+    private func ensurePopover(
+        onConfirm: @escaping (String) -> Void,
+        onCancel: @escaping () -> Void
+    ) -> NSPopover {
+        self.confirmCallback = onConfirm
+        self.cancelCallback = onCancel
+
+        if let popover { return popover }
+
+        let pop = NSPopover()
+        pop.behavior = .transient
+        pop.animates = true
+
+        let viewController = NSViewController()
+        let container = NSView()
+        container.wantsLayer = true
+
+        let label = NSTextField(labelWithString: "Rename symbol to:")
+        label.font = NSFont.systemFont(ofSize: 11)
+        label.textColor = .secondaryLabelColor
+
+        let field = NSTextField(frame: .zero)
+        field.font = NSFont.systemFont(ofSize: 13)
+        field.placeholderString = "New name"
+        field.delegate = self
+        field.target = self
+        field.action = #selector(fieldAction(_:))
+
+        let stackView = NSStackView(views: [label, field])
+        stackView.orientation = .vertical
+        stackView.alignment = .leading
+        stackView.spacing = 4
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: container.topAnchor, constant: 8),
+            stackView.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -8),
+            stackView.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 12),
+            stackView.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -12),
+            field.widthAnchor.constraint(greaterThanOrEqualToConstant: 200)
+        ])
+
+        viewController.view = container
+        pop.contentViewController = viewController
+
+        self.textField = field
+        self.popover = pop
+        return pop
+    }
+}
+
+// MARK: - NSTextFieldDelegate
+
+extension RenamePopoverManager: NSTextFieldDelegate {
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        switch commandSelector {
+        case #selector(NSResponder.insertNewline(_:)):
+            let name = textField?.stringValue.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            hide()
+            if !name.isEmpty {
+                confirmCallback?(name)
+            } else {
+                cancelCallback?()
+            }
+            return true
+        case #selector(NSResponder.cancelOperation(_:)):
+            hide()
+            cancelCallback?()
+            return true
+        default:
+            return false
+        }
+    }
+
+    @objc private func fieldAction(_ sender: NSTextField) {
+        // Enter key triggers action on the text field.
+        let name = sender.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        hide()
+        if !name.isEmpty {
+            confirmCallback?(name)
+        } else {
+            cancelCallback?()
+        }
+    }
+}

--- a/Pine/LSP/RenamePopover.swift
+++ b/Pine/LSP/RenamePopover.swift
@@ -87,7 +87,9 @@ final class RenamePopoverManager: NSObject {
     /// Whether the popover is currently shown.
     var isVisible: Bool { popover?.isShown ?? false }
 
-    init() {}
+    override init() {
+        super.init()
+    }
 
     // MARK: - Show
 

--- a/Pine/LSP/RenamePopover.swift
+++ b/Pine/LSP/RenamePopover.swift
@@ -76,7 +76,7 @@ final class RenameController {
 /// `@MainActor` because NSPopover and NSTextField must be manipulated on the
 /// main thread.
 @MainActor
-final class RenamePopoverManager {
+final class RenamePopoverManager: NSObject {
 
     /// The underlying popover.
     private var popover: NSPopover?

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -344,7 +344,7 @@ struct PaneLeafView: View {
                 workspaceURL: workspace.rootURL
             )
         }
-        LSPUIEndpoint.shared.openFileAtLineHandler = { [weak tabManager] url, line, character in
+        LSPUIEndpoint.shared.openFileAtLineHandler = { [weak tabManager] url, line, _ in
             tabManager?.openTab(url: url)
             // Navigate to the position after a short delay so the tab content
             // is loaded. Uses the pendingGoToLine mechanism (1-based line).

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -286,6 +286,7 @@ struct PaneLeafView: View {
             syntaxHighlightingDisabled: tab.syntaxHighlightingDisabled,
             initialCursorPosition: goToLineOffset?.offset ?? tab.cursorPosition,
             initialScrollOffset: goToLineOffset != nil ? 0 : tab.scrollOffset,
+            definitionQuickPickController: definitionQuickPickController,
             onStateChange: { cursor, scroll in
                 tabManager.updateEditorState(cursorPosition: cursor, scrollOffset: scroll)
             },
@@ -295,8 +296,7 @@ struct PaneLeafView: View {
             cachedHighlightResult: tab.cachedHighlightResult,
             goToOffset: goToLineOffset,
             indentStyle: tab.cachedIndentation,
-            fontSize: FontSizeSettings.shared.fontSize,
-            definitionQuickPickController: definitionQuickPickController
+            fontSize: FontSizeSettings.shared.fontSize
         )
         .id(tab.id)
         .accessibilityIdentifier(AccessibilityID.codeEditor)

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -34,6 +34,9 @@ struct PaneLeafView: View {
     @State private var isDragTargeted = false
     @State private var goToLineOffset: GoToRequest?
     @State private var paneSize: CGSize = .zero
+    /// Definition quick-pick controller — shared with the editor coordinator
+    /// via the `CodeEditorView` environment for multiple-definition navigation.
+    @State private var definitionQuickPickController = DefinitionQuickPickController()
 
     @AppStorage("minimapVisible") private var isMinimapVisible = true
     @AppStorage(BlameConstants.storageKey) private var isBlameVisible = true
@@ -249,6 +252,12 @@ struct PaneLeafView: View {
 
             // StatusBar is rendered once in ContentView, not per-pane
         }
+        .overlay {
+            // Definition quick-pick (multiple go-to-definition results)
+            if definitionQuickPickController.isVisible {
+                DefinitionQuickPickOverlay(controller: definitionQuickPickController)
+            }
+        }
     }
 
     @ViewBuilder
@@ -286,7 +295,8 @@ struct PaneLeafView: View {
             cachedHighlightResult: tab.cachedHighlightResult,
             goToOffset: goToLineOffset,
             indentStyle: tab.cachedIndentation,
-            fontSize: FontSizeSettings.shared.fontSize
+            fontSize: FontSizeSettings.shared.fontSize,
+            definitionQuickPickController: definitionQuickPickController
         )
         .id(tab.id)
         .accessibilityIdentifier(AccessibilityID.codeEditor)
@@ -294,15 +304,64 @@ struct PaneLeafView: View {
             goToLineOffset = nil
             configValidator.validate(url: tab.url, content: tab.content)
             projectManager.lspManager.didOpen(url: tab.url, text: tab.content)
+            installLSPUIEndpoint(tabManager: tabManager)
         }
         .onDisappear {
             configValidator.clear()
             projectManager.lspManager.didClose(url: tab.url)
+            clearLSPUIEndpoint()
         }
         .onChange(of: tab.content) { _, newValue in
             configValidator.validate(url: tab.url, content: newValue)
             projectManager.lspManager.didChange(url: tab.url, text: newValue)
         }
+    }
+
+    // MARK: - LSP UI endpoint installation
+
+    /// Installs the LSP UI endpoint handlers so the editor coordinator can
+    /// route hover, definition, code action, and rename requests to this
+    /// project's `LSPManager`.
+    private func installLSPUIEndpoint(tabManager: TabManager) {
+        let lspManager = projectManager.lspManager
+
+        LSPUIEndpoint.shared.hoverHandler = { url, offset, text in
+            await lspManager.hover(url: url, offset: offset, text: text)
+        }
+        LSPUIEndpoint.shared.definitionHandler = { url, offset, text in
+            await lspManager.definition(url: url, offset: offset, text: text)
+        }
+        LSPUIEndpoint.shared.codeActionHandler = { url, offset, text in
+            await lspManager.codeAction(url: url, offset: offset, text: text)
+        }
+        LSPUIEndpoint.shared.renameHandler = { url, offset, text, newName in
+            await lspManager.rename(url: url, offset: offset, text: text, newName: newName)
+        }
+        LSPUIEndpoint.shared.applyEditHandler = { edit in
+            lspManager.applyWorkspaceEdit(
+                edit,
+                tabManager: tabManager,
+                workspaceURL: workspace.rootURL
+            )
+        }
+        LSPUIEndpoint.shared.openFileAtLineHandler = { [weak tabManager] url, line, character in
+            tabManager?.openTab(url: url)
+            // Navigate to the position after a short delay so the tab content
+            // is loaded. Uses the pendingGoToLine mechanism (1-based line).
+            DispatchQueue.main.async {
+                tabManager?.pendingGoToLine = line + 1
+            }
+        }
+    }
+
+    /// Clears the LSP UI endpoint handlers.
+    private func clearLSPUIEndpoint() {
+        LSPUIEndpoint.shared.hoverHandler = nil
+        LSPUIEndpoint.shared.definitionHandler = nil
+        LSPUIEndpoint.shared.codeActionHandler = nil
+        LSPUIEndpoint.shared.renameHandler = nil
+        LSPUIEndpoint.shared.applyEditHandler = nil
+        LSPUIEndpoint.shared.openFileAtLineHandler = nil
     }
 
     // MARK: - Diagnostics merging


### PR DESCRIPTION
Implements milestone #1088 (item 1) — LSP UI Integration.

## New: Pine/LSP/ (7 files, 1134 lines)

| File | Purpose |
|---|---|
| LSPUIEndpoint.swift | @MainActor bridge: Coordinator ↔ LSPManager |
| HoverPopover.swift | NSPopover hover tooltip |
| HoverMarkdownRenderer.swift | Markdown→NSAttributedString parser |
| DefinitionQuickPickView.swift | Multi-definition navigation |
| RenamePopover.swift | Rename popover with TextField |
| LSPMouseHandling.swift | Mouse tracking protocol |
| GutterTextView+LSPMouseTracking.swift | Hover scheduling, Cmd+Click |

## Features
- **Hover:** 200ms delay → Markdown tooltip, auto-dismiss on scroll/exit
- **Go-to-Definition:** ⌘+Click → cross-file navigation, multi-def quick-pick
- **Code Actions:** right-click → NSMenu with quick fixes, apply workspace edit
- **Rename:** ⌘+R → inline popover, project-wide rename via WorkspaceEdit

## Modified
- CodeEditorView+Coordinator: all 4 features wired
- GutterTextView: mouse tracking infrastructure
- PaneLeafView: LSP endpoint setup
