### PR TITLE
fix(terminal): fix root cause of black screen — setNeedsDisplay race condition (#1094)

### DIFF
--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -30,8 +30,18 @@ final class PineTerminalView: LocalProcessTerminalView {
         layer?.contents = nil
     }
 
+    /// Promotes partial invalidations to full-bounds redraws so default-
+    /// background cells are repainted (SwiftTerm only paints cells with
+    /// explicit background attributes).
+    ///
+    /// IMPORTANT: do NOT call `prepareLayerForRedraw()` here. Zeroing
+    /// `layer.contents` on every `setNeedsDisplay` call (including cursor
+    /// blink, single-char input) creates a race: between `contents = nil`
+    /// and the actual display cycle, AppKit may coalesce or cancel the
+    /// pending `needsDisplay`, leaving the layer permanently black (issue
+    /// #1094). Only clear `contents` from `forceFullRedraw()`, where the
+    /// nil is immediately followed by a synchronous `displayIfNeeded()`.
     override func setNeedsDisplay(_ invalidRect: NSRect) {
-        prepareLayerForRedraw()
         super.setNeedsDisplay(bounds.isEmpty ? invalidRect : bounds)
     }
 }
@@ -469,6 +479,11 @@ class TerminalContainerView: NSView {
     /// so without this we would tear down and re-install the observer on
     /// every `viewDidMoveToWindow` even when the window did not change.
     private weak var observedWindow: NSWindow?
+    /// Notification observer that re-renders the active terminal when the
+    /// host window moves to a different screen (e.g. external display with
+    /// a different backingScaleFactor). The backing store may be invalidated
+    /// in this case, leaving the terminal black (issue #1094).
+    private var didChangeScreenObserver: NSObjectProtocol?
 
     func showTab(_ tab: TerminalTab?) {
         guard let tab else {
@@ -731,6 +746,10 @@ class TerminalContainerView: NSView {
             NotificationCenter.default.removeObserver(observer)
             becomeKeyObserver = nil
         }
+        if let observer = didChangeScreenObserver {
+            NotificationCenter.default.removeObserver(observer)
+            didChangeScreenObserver = nil
+        }
         observedWindow = nil
     }
 
@@ -764,6 +783,15 @@ class TerminalContainerView: NSView {
         guard let win = window else { return }
         becomeKeyObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didBecomeKeyNotification,
+            object: win,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshActiveTerminalAfterReparent()
+        }
+        // Re-render when the window moves to a different screen — the backing
+        // scale factor may differ, invalidating the layer's contents (issue #1094).
+        didChangeScreenObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didChangeScreenNotification,
             object: win,
             queue: .main
         ) { [weak self] _ in
@@ -806,6 +834,18 @@ class TerminalContainerView: NSView {
     }
 
     override var isFlipped: Bool { true }
+
+    // MARK: - Backing store invalidation (issue #1094)
+
+    /// AppKit calls this when the view's backing properties change — display
+    /// scale (Retina ↔ external), Liquid Glass layer management, memory
+    /// pressure purge, screen sleep/wake. In all these cases the layer's
+    /// backing store may be discarded, leaving a black terminal. Force a
+    /// synchronous repaint from SwiftTerm's displayBuffer to recover.
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        refreshActiveTerminalAfterReparent()
+    }
 }
 
 // MARK: - Terminal search

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -14,9 +14,13 @@ import SwiftTerm
 /// background attribute; cells with the default terminal background rely on
 /// the view/layer background. When a TUI briefly paints a colored rectangle
 /// and then returns those cells to the default background, stale pixels can
-/// remain in the layer. Pine drops the stale layer contents and promotes
-/// partial invalidations to full redraws so default-background cells are
-/// repainted against the current layer background.
+/// remain in the layer. Pine addresses this in `forceFullRedraw()` (called
+/// at every re-parent / layout / backing-store-invalidation boundary) by
+/// dropping the stale layer contents before a synchronous repaint.
+///
+/// `setNeedsDisplay` is overridden to promote partial invalidations to
+/// full-bounds redraws (so SwiftTerm repaints as many cells as possible),
+/// but deliberately does NOT zero `layer.contents` — see issue #1094.
 final class PineTerminalView: LocalProcessTerminalView {
     private var redrawBackgroundColor: CGColor?
 

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -799,19 +799,38 @@ struct TerminalTabTests {
         #expect((tab.terminalView.layer?.contents as? NSString) != staleContents)
     }
 
-    /// PineTerminalView drops stale layer contents before scheduling a full
-    /// redraw. This prevents colored rectangles from remaining when a terminal
-    /// program returns cells to the default background.
-    @Test @MainActor func pineTerminalViewClearsLayerContentsBeforeRedraw() {
+    /// `setNeedsDisplay` promotes partial invalidations to full-bounds
+    /// redraws but does NOT zero `layer.contents` — zeroing on every call
+    /// created a race where AppKit cancelled the pending display cycle,
+    /// leaving the layer permanently black (issue #1094). Contents are
+    /// only cleared by `prepareLayerForRedraw()` / `forceFullRedraw()`,
+    /// where the nil is immediately followed by synchronous
+    /// `displayIfNeeded()`.
+    @Test @MainActor func pineTerminalViewSetNeedsDisplayDoesNotClearContents() {
+        let view = PineTerminalView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        let background = NSColor(srgbRed: 0.90, green: 0.91, blue: 0.92, alpha: 1)
+        let existingContents = "valid-backing" as NSString
+        view.nativeBackgroundColor = background
+        view.prepareLayerForRedraw(background: background)
+        view.layer?.contents = existingContents
+
+        view.setNeedsDisplay(NSRect(x: 0, y: 0, width: 10, height: 10))
+
+        // Background must be preserved, contents must NOT be nil'd.
+        #expect(view.layer?.backgroundColor == background.cgColor)
+        #expect(view.layer?.contents != nil)
+    }
+
+    /// `prepareLayerForRedraw` (called from `forceFullRedraw`) DOES clear
+    /// stale contents — this is the safe call site because it is always
+    /// followed by synchronous `displayIfNeeded()`.
+    @Test @MainActor func prepareLayerForRedrawClearsStaleContents() {
         let view = PineTerminalView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
         let background = NSColor(srgbRed: 0.90, green: 0.91, blue: 0.92, alpha: 1)
         let staleContents = "stale-terminal-backing" as NSString
-        view.nativeBackgroundColor = background
-        view.prepareLayerForRedraw(background: background)
-        view.layer?.backgroundColor = NSColor.black.cgColor
         view.layer?.contents = staleContents
 
-        view.setNeedsDisplay(NSRect(x: 0, y: 0, width: 10, height: 10))
+        view.prepareLayerForRedraw(background: background)
 
         #expect(view.layer?.backgroundColor == background.cgColor)
         #expect(view.layer?.contents == nil)


### PR DESCRIPTION
## Closes #1094

## Problem

The terminal intermittently becomes completely black. This is a **chronic recurring issue** — it has been "fixed" at least 6 times (#64, #661/#662, #871, #918/#921, #923, #966), but each fix only patched one trigger path while the root cause persisted.

## Root Cause

### `PineTerminalView.setNeedsDisplay` override — race condition

```swift
// BEFORE (race condition):
override func setNeedsDisplay(_ invalidRect: NSRect) {
    prepareLayerForRedraw()        // ← layer?.contents = nil on EVERY call
    super.setNeedsDisplay(bounds.isEmpty ? invalidRect : bounds)
}
```

This fired on **every** `setNeedsDisplay` — including cursor blink, single-character input. Each time:

1. `contents = nil` — layer instantly goes black
2. `super.setNeedsDisplay(bounds)` — marks for redraw
3. If a layout pass / event tracking cycle runs between steps 1 and 2, AppKit coalesces/cancels the `needsDisplay`
4. The redraw **never fires** — layer stays black indefinitely

### Missing `viewDidChangeBackingProperties`

AppKit discards the backing store in scenarios not covered by existing hooks:
- Display scale change (Retina ↔ external monitor)
- macOS 26 Liquid Glass layer management
- Memory pressure → purged backing store
- Screen sleep/wake

## Fix (3 changes, all in `TerminalSession.swift`)

| Fix | What | Why |
|---|---|---|
| **1** | Remove `prepareLayerForRedraw()` from `setNeedsDisplay` override | Stops zeroing `layer.contents` on every redraw request — only clear it from `forceFullRedraw()` where it is immediately followed by synchronous `displayIfNeeded()` |
| **2** | Add `viewDidChangeBackingProperties()` to `TerminalContainerView` | Catches backing store purges from display scale changes, Liquid Glass, memory pressure, screen sleep/wake |
| **3** | Add `NSWindow.didChangeScreenNotification` observer | Catches window moving between displays with different `backingScaleFactor` |

## Testing

- [ ] CI green (Build for Testing, Unit Tests, UI Tests — Terminal shard)
- [ ] Manual: open terminal, use vim/k9s, Cmd+Tab away and back — verify no black screen
- [ ] Manual: connect/disconnect external display — verify no black screen