### PR TITLE
fix: prevent sidebar flicker during deep expansion

### DIFF
--- a/Pine/FileNode.swift
+++ b/Pine/FileNode.swift
@@ -23,6 +23,7 @@ nonisolated final class FileNode: Identifiable, Hashable, @unchecked Sendable {
     private let ignoredPaths: Set<String>?
 
     var children: [FileNode]?
+    private(set) var hasDeferredChildren = false
 
     /// Для List(children:): nil = лист (файл), непустой массив = папка с содержимым.
     var optionalChildren: [FileNode]? {
@@ -99,6 +100,7 @@ nonisolated final class FileNode: Identifiable, Hashable, @unchecked Sendable {
                 if depth > context.maxDepth {
                     context.reachedDepthLimit = true
                     self.children = []
+                    self.hasDeferredChildren = true
                     return
                 }
 
@@ -155,10 +157,19 @@ nonisolated final class FileNode: Identifiable, Hashable, @unchecked Sendable {
     }
 
     func loadChildren() {
+        replaceChildren(loadedChildren())
+    }
+
+    func loadedChildren() -> [FileNode] {
         let context = projectRoot.map {
             LoadContext(projectRoot: $0, ignoredPaths: ignoredPaths ?? [])
         }
-        children = Self.loadContents(of: url, context: context)
+        return Self.loadContents(of: url, context: context)
+    }
+
+    func replaceChildren(_ loadedChildren: [FileNode]) {
+        children = loadedChildren
+        hasDeferredChildren = false
     }
 
     /// Result of a depth-limited tree build, including whether the depth limit was reached.

--- a/Pine/SidebarExpansionState.swift
+++ b/Pine/SidebarExpansionState.swift
@@ -101,15 +101,24 @@ final class SidebarExpansionState {
     /// at `nodes`. Used to keep the set bounded after file deletions.
     func prune(toMatch nodes: [FileNode]) {
         var alive: Set<String> = []
+        var deferredRoots: Set<String> = []
         var stack: [FileNode] = nodes
         while let node = stack.popLast() {
             if node.isDirectory {
-                alive.insert(Self.key(for: node.url))
+                let key = Self.key(for: node.url)
+                alive.insert(key)
+                if node.hasDeferredChildren {
+                    deferredRoots.insert(key)
+                }
                 if let children = node.children {
                     stack.append(contentsOf: children)
                 }
             }
         }
-        expandedPaths.formIntersection(alive)
+        expandedPaths = expandedPaths.filter { path in
+            alive.contains(path) || deferredRoots.contains { root in
+                path == root || path.hasPrefix(root + "/")
+            }
+        }
     }
 }

--- a/Pine/SidebarFileTree.swift
+++ b/Pine/SidebarFileTree.swift
@@ -56,6 +56,12 @@ private struct SidebarFileTreeNode: View {
     @State private var fontSettings = FontSizeSettings.shared
     @State private var isLoadingDeferredChildren = false
     @State private var loadedChildrenRevision = 0
+    /// Monotonic generation token for in-flight deferred loads. Bumps on
+    /// every load start so a result computed against a pre-refresh subtree
+    /// is dropped after a refresh re-triggers the load with a fresh node
+    /// (see `loadDeferredChildrenIfNeeded`). Survives URL-stable row
+    /// rebuilds because SwiftUI keys `@State` by view identity, not struct.
+    @State private var deferredLoadGeneration = 0
 
     var body: some View {
         if node.isDirectory {
@@ -68,6 +74,12 @@ private struct SidebarFileTreeNode: View {
                 row(isFolder: true)
                 if isExpanded {
                     VStack(alignment: .leading, spacing: 0) {
+                        if children.isEmpty && isLoadingDeferredChildren {
+                            ProgressView()
+                                .controlSize(.small)
+                                .padding(.leading, SidebarRowMetrics.childIndent)
+                                .padding(.vertical, 2)
+                        }
                         ForEach(children) { child in
                             SidebarFileTreeNode(
                                 node: child,
@@ -90,14 +102,31 @@ private struct SidebarFileTreeNode: View {
                     loadDeferredChildrenIfNeeded()
                 }
             }
+            .onChange(of: treeRevision) { _, _ in
+                // A refresh (FSEvents/git) replaces this row's node with a
+                // new instance that is deferred again. `.onAppear` and
+                // `.onChange(of: isExpanded)` do not re-fire for URL-stable
+                // rows, so re-trigger the deferred load on each revision.
+                // Clearing the in-flight flag first lets the load restart
+                // even if a previous load (capturing the now-orphaned node)
+                // is still in flight; its result is dropped by the
+                // generation guard in `loadDeferredChildrenIfNeeded`.
+                if isExpanded, node.hasDeferredChildren {
+                    isLoadingDeferredChildren = false
+                    loadDeferredChildrenIfNeeded()
+                }
+            }
         } else {
             row(isFolder: false)
         }
     }
 
     private var visibleChildren: [FileNode] {
+        // Reading `loadedChildrenRevision` in the body registers the
+        // `@State` dependency so a deferred-load completion re-renders the
+        // row. (`treeRevision` is a plain `let` propagated by the parent's
+        // struct re-evaluation — no explicit read is needed.)
         _ = loadedChildrenRevision
-        _ = treeRevision
         return node.children ?? []
     }
 
@@ -152,12 +181,20 @@ private struct SidebarFileTreeNode: View {
     private func loadDeferredChildrenIfNeeded() {
         guard node.hasDeferredChildren, !isLoadingDeferredChildren else { return }
         isLoadingDeferredChildren = true
-        let node = node
+        deferredLoadGeneration += 1
+        let generation = deferredLoadGeneration
+        let capturedNode = node
         Task { @MainActor in
             let loadedChildren = await Task.detached(priority: .userInitiated) {
-                node.loadedChildren()
+                capturedNode.loadedChildren()
             }.value
-            node.replaceChildren(loadedChildren)
+            // Generation guard: a refresh can re-trigger this load (bumping
+            // `deferredLoadGeneration`) with a fresh node instance while the
+            // detached load was in flight. Drop the stale result so we never
+            // apply children computed against the pre-refresh subtree. This
+            // is the sidebar-local equivalent of `WorkspaceManager.loadGeneration`.
+            guard generation == deferredLoadGeneration else { return }
+            capturedNode.replaceChildren(loadedChildren)
             loadedChildrenRevision += 1
             isLoadingDeferredChildren = false
         }

--- a/Pine/SidebarFileTree.swift
+++ b/Pine/SidebarFileTree.swift
@@ -36,11 +36,12 @@ enum SidebarRowMetrics {
 
 struct SidebarFileTree: View {
     let nodes: [FileNode]
+    let treeRevision: Int
     @Binding var selection: FileNode?
 
     var body: some View {
         ForEach(nodes) { node in
-            SidebarFileTreeNode(node: node, selection: $selection)
+            SidebarFileTreeNode(node: node, treeRevision: treeRevision, selection: $selection)
         }
     }
 }
@@ -48,31 +49,56 @@ struct SidebarFileTree: View {
 /// A single node row in the recursive sidebar tree.
 private struct SidebarFileTreeNode: View {
     let node: FileNode
+    let treeRevision: Int
     @Binding var selection: FileNode?
     @Environment(SidebarExpansionState.self) private var expansion
     @Environment(SidebarEditState.self) private var editState
     @State private var fontSettings = FontSizeSettings.shared
+    @State private var isLoadingDeferredChildren = false
+    @State private var loadedChildrenRevision = 0
 
     var body: some View {
-        if node.isDirectory, let children = node.optionalChildren {
+        if node.isDirectory {
             // IMPORTANT: read `expansion.isExpanded(...)` directly in the
             // view body so SwiftUI's @Observable tracker registers the
             // dependency.
             let isExpanded = expansion.isExpanded(node.url)
+            let children = visibleChildren
             VStack(alignment: .leading, spacing: 0) {
                 row(isFolder: true)
                 if isExpanded {
                     VStack(alignment: .leading, spacing: 0) {
                         ForEach(children) { child in
-                            SidebarFileTreeNode(node: child, selection: $selection)
+                            SidebarFileTreeNode(
+                                node: child,
+                                treeRevision: treeRevision,
+                                selection: $selection
+                            )
                         }
                     }
+                    .id(children.map(\.id))
                     .padding(.leading, SidebarRowMetrics.childIndent)
+                }
+            }
+            .onAppear {
+                if isExpanded {
+                    loadDeferredChildrenIfNeeded()
+                }
+            }
+            .onChange(of: isExpanded) { _, expanded in
+                if expanded {
+                    loadDeferredChildrenIfNeeded()
                 }
             }
         } else {
             row(isFolder: false)
         }
+    }
+
+    private var visibleChildren: [FileNode] {
+        _ = loadedChildrenRevision
+        _ = treeRevision
+        return node.children ?? []
     }
 
     /// Single clickable row. The whole row is hit-tested via `contentShape`
@@ -116,7 +142,24 @@ private struct SidebarFileTreeNode: View {
         guard !isRenamingThisNode else { return }
         selection = node
         if isFolder {
+            if !expansion.isExpanded(node.url) {
+                loadDeferredChildrenIfNeeded()
+            }
             expansion.toggleDebounced(node.url)
+        }
+    }
+
+    private func loadDeferredChildrenIfNeeded() {
+        guard node.hasDeferredChildren, !isLoadingDeferredChildren else { return }
+        isLoadingDeferredChildren = true
+        let node = node
+        Task { @MainActor in
+            let loadedChildren = await Task.detached(priority: .userInitiated) {
+                node.loadedChildren()
+            }.value
+            node.replaceChildren(loadedChildren)
+            loadedChildrenRevision += 1
+            isLoadingDeferredChildren = false
         }
     }
 }

--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -172,8 +172,11 @@ struct SidebarView: View {
                     // `SidebarFileTree.row`.
                     ScrollView {
                         VStack(alignment: .leading, spacing: 0) {
-                            SidebarFileTree(nodes: workspace.rootNodes, selection: $selectedFile)
-                                .id(workspace.rootNodesRevision)
+                            SidebarFileTree(
+                                nodes: workspace.rootNodes,
+                                treeRevision: workspace.rootNodesRevision,
+                                selection: $selectedFile
+                            )
                         }
                         .padding(.vertical, 4)
                     }

--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -18,14 +18,8 @@ final class WorkspaceManager {
     nonisolated private static let logger = Logger.fileTree
     var rootNodes: [FileNode] = []
     /// Monotonically increasing counter bumped every time `rootNodes` is
-    /// assigned. Used by `SidebarView` as a SwiftUI `.id()` to force the
-    /// file tree to re-render after an external refresh (FSEvents).
-    ///
-    /// Without this, SwiftUI may not re-render expanded folders whose
-    /// `FileNode` identity (URL) is unchanged but whose children array has
-    /// been replaced with new instances — the nested `ForEach` keeps showing
-    /// stale children until the user manually collapses/expands the folder
-    /// (issue #1041).
+    /// assigned. Sidebar observers use this to prune expansion state after
+    /// refreshes without recreating the entire tree.
     private(set) var rootNodesRevision: Int = 0
     var projectName: String = "Pine"
     var rootURL: URL?
@@ -90,8 +84,7 @@ final class WorkspaceManager {
 
     /// Sets `rootNodes`, bumps `rootNodesRevision`, and schedules a debounced
     /// `onRootNodesChanged` notification. Centralised so every assignment site
-    /// (initial load, shallow refresh, full refresh) gets the revision bump
-    /// that drives the sidebar re-render fix (#1041).
+    /// (initial load, shallow refresh, full refresh) emits the same signals.
     private func setRootNodes(_ nodes: [FileNode]) {
         rootNodes = nodes
         rootNodesRevision += 1

--- a/PineTests/FileNodeTests.swift
+++ b/PineTests/FileNodeTests.swift
@@ -484,6 +484,44 @@ struct FileNodeTests {
         #expect(names.contains("file.txt"))
     }
 
+    @Test func depthLimitedDirectoryTracksDeferredChildrenUntilLoaded() throws {
+        let tempDir = try makeTempDirectory()
+        defer { cleanup(tempDir) }
+
+        let sub = tempDir.appendingPathComponent("sub")
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: sub.appendingPathComponent("file.txt").path, contents: nil)
+
+        let node = FileNode(url: tempDir, projectRoot: tempDir, ignoredPaths: [], maxDepth: 0)
+        let subNode = try #require(node.children?.first { $0.name == "sub" })
+
+        #expect(subNode.children?.isEmpty == true)
+        #expect(subNode.hasDeferredChildren == true)
+
+        subNode.loadChildren()
+
+        #expect(subNode.hasDeferredChildren == false)
+        #expect(subNode.children?.contains { $0.name == "file.txt" } == true)
+    }
+
+    @Test func emptyDepthLimitedDirectoryClearsDeferredFlagAfterLoad() throws {
+        let tempDir = try makeTempDirectory()
+        defer { cleanup(tempDir) }
+
+        let sub = tempDir.appendingPathComponent("empty")
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+
+        let node = FileNode(url: tempDir, projectRoot: tempDir, ignoredPaths: [], maxDepth: 0)
+        let subNode = try #require(node.children?.first { $0.name == "empty" })
+
+        #expect(subNode.hasDeferredChildren == true)
+
+        subNode.loadChildren()
+
+        #expect(subNode.children?.isEmpty == true)
+        #expect(subNode.hasDeferredChildren == false)
+    }
+
     @Test func maxDepthCombinesWithGitignore() throws {
         let tempDir = try makeTempDirectory()
         defer { cleanup(tempDir) }

--- a/PineTests/SidebarExpandedRefreshTests.swift
+++ b/PineTests/SidebarExpandedRefreshTests.swift
@@ -3,9 +3,9 @@
 //  PineTests
 //
 //  Regression tests for issue #1041: new files in expanded folders don't
-//  appear until the user manually collapses/expands. The fix adds a
-//  `rootNodesRevision` counter that bumps on every `rootNodes` assignment,
-//  enabling SidebarView to force a SwiftUI re-render via `.id()`.
+//  appear until the user manually collapses/expands. `rootNodesRevision`
+//  still bumps on every root tree assignment so observers can react to
+//  refreshes while SidebarView keeps rebuilds scoped to changed branches.
 //
 
 import Foundation
@@ -239,8 +239,8 @@ struct SidebarExpandedRefreshTests {
 
         // For a deep project: Phase 1 (shallow) sets rootNodes (revision=1),
         // Phase 2 (full) sets rootNodes again (revision=2).
-        // Both phases increment the revision, ensuring the sidebar re-renders
-        // after each phase — the fix for issue #1041.
+        // Both phases increment the revision, ensuring sidebar observers can
+        // react after each phase.
         #expect(
             manager.rootNodesRevision >= 2,
             "Deep project should have at least 2 revision increments (shallow + full phases)"

--- a/PineTests/SidebarExpansionStateTests.swift
+++ b/PineTests/SidebarExpansionStateTests.swift
@@ -167,6 +167,33 @@ struct SidebarExpansionStateTests {
         #expect(state.isExpanded(deep))
     }
 
+    @Test func pruneKeepsExpandedDescendantsAcrossDeferredRefresh() throws {
+        // Regression for the sidebar flicker fix (#1097/#1098): an
+        // FSEvents/git refresh rebuilds the tree, making a depth-limited
+        // folder deferred again (empty children). Pruning against the
+        // refreshed tree must still keep deep expansion state so the row can
+        // reload its deferred children via `onChange(of: treeRevision)`
+        // without collapsing the user's place in the tree.
+        let root = try makeTempTree(["a/b/c/d/e"])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let state = SidebarExpansionState()
+        let deep = root.appendingPathComponent("a/b/c/d/e")
+        state.setExpanded(deep, true)
+
+        // Initial load + prune.
+        let v1 = FileNode.loadTree(url: root, projectRoot: root, ignoredPaths: [], maxDepth: 1)
+        state.prune(toMatch: [v1.root])
+
+        // Simulate a refresh: rebuild with the same depth limit so `a` is
+        // deferred again (its subtree was never traversed).
+        let v2 = FileNode.loadTree(url: root, projectRoot: root, ignoredPaths: [], maxDepth: 1)
+        state.prune(toMatch: [v2.root])
+
+        #expect(v2.wasDepthLimited == true)
+        #expect(state.isExpanded(deep))
+    }
+
     // MARK: - Edge: massive number of folders
 
     @Test func canHoldThousandsOfExpandedFolders() {

--- a/PineTests/SidebarExpansionStateTests.swift
+++ b/PineTests/SidebarExpansionStateTests.swift
@@ -147,6 +147,26 @@ struct SidebarExpansionStateTests {
         #expect(state.isExpanded(deep))
     }
 
+    @Test func pruneKeepsExpandedDescendantsUnderDeferredFolder() throws {
+        let root = try makeTempTree(["a/b/c/d/e"])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let result = FileNode.loadTree(
+            url: root,
+            projectRoot: root,
+            ignoredPaths: [],
+            maxDepth: 1
+        )
+        let state = SidebarExpansionState()
+        let deep = root.appendingPathComponent("a/b/c/d/e")
+        state.setExpanded(deep, true)
+
+        state.prune(toMatch: [result.root])
+
+        #expect(result.wasDepthLimited == true)
+        #expect(state.isExpanded(deep))
+    }
+
     // MARK: - Edge: massive number of folders
 
     @Test func canHoldThousandsOfExpandedFolders() {


### PR DESCRIPTION
## Summary
- avoid recreating the whole sidebar tree for each root node revision
- load depth-limited folder children on demand when the user expands them
- preserve deep expansion state under deferred folders during shallow refreshes

Fixes #1097.

## Tests
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -derivedDataPath /private/tmp/pine-dd-sidebar -only-testing:PineTests/FileNodeTests -only-testing:PineTests/SidebarExpandedRefreshTests -only-testing:PineTests/SidebarExpansionStateTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swiftlint` (exit 0; existing warnings remain in generated `build/...` and `Pine/AboutInfo.swift`)
- `git diff --check`

Ready to merge when CI is green.