### PR TITLE
fix(terminal): recover terminal backing store on occlusion/hide/minimize

### DIFF
--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -488,21 +488,27 @@ class TerminalContainerView: NSView {
     /// a different backingScaleFactor). The backing store may be invalidated
     /// in this case, leaving the terminal black (issue #1094).
     private var didChangeScreenObserver: NSObjectProtocol?
-    /// Notification observer that re-renders the active terminal when the
-    /// window transitions from occluded to visible. macOS aggressively
-    /// purges the backing store of fully-occluded windows; without recovery
-    /// the terminal stays black after the covering window moves away (issue #1094).
+    /// Defensive repaint when the window becomes visible again after being
+    /// fully occluded. macOS suppresses drawing for occluded windows; if a
+    /// pending redraw was dropped or the cached frame is stale on reveal,
+    /// this forces a fresh paint so the terminal is never left black
+    /// (issue #1094 family). Coalesced (occlusion can toggle in bursts).
     private var didChangeOcclusionStateObserver: NSObjectProtocol?
-    /// Notification observer that re-renders the active terminal when the
-    /// app is reactivated (Cmd+H hide → reveal, Spaces / Mission Control
-    /// return). `didBecomeKey` does NOT fire if the window was already key
-    /// before the hide, so the terminal would stay black until a manual
-    /// resize (issue #1094). App-level, so `object: nil`.
+    /// Defensive repaint on app reactivation (Cmd+H hide → reveal, Spaces /
+    /// Mission Control return). `didBecomeKey` does NOT fire if the window
+    /// was already key before the hide, so this covers the gap. App-level
+    /// (`object: nil`); coalesced since it can fire in bursts (issue #1094 family).
     private var didBecomeActiveObserver: NSObjectProtocol?
-    /// Notification observer that re-renders the active terminal when the
-    /// window is restored from the Dock. AppKit may discard the layer's
-    /// backing store while the window is minimized (issue #1094).
+    /// Defensive repaint when the window is restored from the Dock, in case
+    /// the cached frame is stale after minimization (issue #1094 family).
     private var didDeminiaturizeObserver: NSObjectProtocol?
+    /// Trailing-edge coalescer for the burst-prone observer recovery repaints
+    /// (occlusion toggling during Mission Control / Stage Manager, app
+    /// reactivation). Collapses a flurry of visibility transitions into a
+    /// single `forceFullRedraw()` (a synchronous full-buffer `displayIfNeeded()`).
+    /// Lazily created; captures `self` weakly. See `scheduleCoalescedRecovery()`
+    /// and `UITimings.Debounce.terminalRecovery`.
+    private var recoveryDebouncer: Debouncer?
 
     func showTab(_ tab: TerminalTab?) {
         guard let tab else {
@@ -785,6 +791,9 @@ class TerminalContainerView: NSView {
             NotificationCenter.default.removeObserver(observer)
             didDeminiaturizeObserver = nil
         }
+        // Cancel any pending coalesced recovery so it cannot fire against a
+        // detached container or a new host window (issue #1094 family).
+        recoveryDebouncer?.cancel()
         observedWindow = nil
     }
 
@@ -795,6 +804,27 @@ class TerminalContainerView: NSView {
         guard let tab = terminalPaneState?.activeTab,
               tab.terminalView.superview === self else { return }
         tab.refreshAfterReparent()
+    }
+
+    /// Schedules a trailing-edge-coalesced recovery repaint for the burst-prone
+    /// observer triggers (`didChangeOcclusionState`, `didBecomeActive`). A
+    /// flurry of visibility transitions within one animation (Mission Control,
+    /// Stage Manager, app reactivation) collapses into a single
+    /// `forceFullRedraw()` — a synchronous full-buffer `displayIfNeeded()` —
+    /// instead of firing N times. The delay is `UITimings.Debounce.terminalRecovery`
+    /// (~50 ms: imperceptible for recovery, collapses a burst). Low-frequency
+    /// observers (`becomeKey`, `didChangeScreen`, `didDeminiaturize`) and the
+    /// lifecycle hooks (`viewDidMoveToWindow`, `viewDidChangeBackingProperties`)
+    /// call `refreshActiveTerminalAfterReparent()` directly for a prompt paint.
+    private func scheduleCoalescedRecovery() {
+        if recoveryDebouncer == nil {
+            recoveryDebouncer = Debouncer(delay: UITimings.Debounce.terminalRecovery) { [weak self] in
+                MainActor.assumeIsolated {
+                    self?.refreshActiveTerminalAfterReparent()
+                }
+            }
+        }
+        recoveryDebouncer?.schedule()
     }
 
     /// Requests first responder on the terminal view.
@@ -832,13 +862,14 @@ class TerminalContainerView: NSView {
         ) { [weak self] _ in
             self?.refreshActiveTerminalAfterReparent()
         }
-        // Re-render when the window becomes at least partially visible again.
-        // macOS purges the backing store of fully-occluded windows; without
-        // recovery the terminal stays black after the covering window moves
-        // away (issue #1094). The handler repaints only when the resulting
-        // occlusion state still contains `.visible` — a transition into full
-        // occlusion (`.visible` absent) is skipped because the window is
-        // off-screen anyway.
+        // Defensive repaint when the window becomes visible again after being
+        // fully occluded. macOS suppresses (not purges) drawing for occluded
+        // windows, so a pending redraw may have been dropped or the cached
+        // frame may be stale on reveal — this guarantees a fresh paint. It
+        // repaints only when the resulting occlusion state contains `.visible`
+        // (skips becoming fully occluded, which is off-screen) and is coalesced
+        // because occlusion can toggle repeatedly during Mission Control / window
+        // drag (issue #1094 family).
         didChangeOcclusionStateObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didChangeOcclusionStateNotification,
             object: win,
@@ -846,21 +877,24 @@ class TerminalContainerView: NSView {
         ) { [weak self, weak win] _ in
             guard let win,
                   Self.shouldRecoverAfterOcclusionChange(occlusionState: win.occlusionState) else { return }
-            self?.refreshActiveTerminalAfterReparent()
+            self?.scheduleCoalescedRecovery()
         }
-        // Re-render on app reactivation (Cmd+H hide → reveal, Spaces / Mission
-        // Control return). `didBecomeKey` does NOT fire if the window was
-        // already key before the hide, so without this the terminal stays
-        // black until a manual resize (issue #1094).
+        // Defensive repaint on app reactivation (Cmd+H hide → reveal, Spaces /
+        // Mission Control return). `didBecomeKey` does NOT fire if the window
+        // was already key before the hide, so this covers the gap. App-level
+        // (`object: nil`) and coalesced: it can fire in bursts (reactivation
+        // while occlusion is also settling), so route through the coalesced
+        // recovery path (issue #1094 family).
         didBecomeActiveObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didBecomeActiveNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.refreshActiveTerminalAfterReparent()
+            self?.scheduleCoalescedRecovery()
         }
-        // Re-render when the window is restored from the Dock. AppKit may
-        // discard the layer's backing store while the window is minimized (issue #1094).
+        // Defensive repaint when the window is restored from the Dock, in case
+        // the cached frame is stale after minimization. Low-frequency, so kept
+        // synchronous (not coalesced) (issue #1094 family).
         didDeminiaturizeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didDeminiaturizeNotification,
             object: win,
@@ -919,11 +953,11 @@ class TerminalContainerView: NSView {
     }
 
     /// Whether the container should repaint after a window occlusion-state
-    /// change. Only the occluded → visible transition needs recovery: macOS
-    /// purges the backing store of fully-occluded windows, and that store must
-    /// be rebuilt when the window is revealed again. Repainting when becoming
-    /// occluded is wasteful (the window is off-screen). Internal so unit tests
-    /// can pin the visible-edge decision without a live window (issue #1094).
+    /// change. Only repaint when the window is at least partially visible
+    /// again — repainting while fully occluded (off-screen) is wasteful, since
+    /// macOS suppresses drawing for occluded windows anyway. Internal so unit
+    /// tests can pin the visible-edge decision without a live window
+    /// (issue #1094 family).
     internal static func shouldRecoverAfterOcclusionChange(
         occlusionState: NSWindow.OcclusionState
     ) -> Bool {

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -832,11 +832,13 @@ class TerminalContainerView: NSView {
         ) { [weak self] _ in
             self?.refreshActiveTerminalAfterReparent()
         }
-        // Re-render when the window transitions from occluded to visible.
+        // Re-render when the window becomes at least partially visible again.
         // macOS purges the backing store of fully-occluded windows; without
         // recovery the terminal stays black after the covering window moves
-        // away (issue #1094). Only repaint on the occluded → visible edge —
-        // repainting when becoming occluded is wasteful (window off-screen).
+        // away (issue #1094). The handler repaints only when the resulting
+        // occlusion state still contains `.visible` — a transition into full
+        // occlusion (`.visible` absent) is skipped because the window is
+        // off-screen anyway.
         didChangeOcclusionStateObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didChangeOcclusionStateNotification,
             object: win,

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -488,6 +488,21 @@ class TerminalContainerView: NSView {
     /// a different backingScaleFactor). The backing store may be invalidated
     /// in this case, leaving the terminal black (issue #1094).
     private var didChangeScreenObserver: NSObjectProtocol?
+    /// Notification observer that re-renders the active terminal when the
+    /// window transitions from occluded to visible. macOS aggressively
+    /// purges the backing store of fully-occluded windows; without recovery
+    /// the terminal stays black after the covering window moves away (issue #1094).
+    private var didChangeOcclusionStateObserver: NSObjectProtocol?
+    /// Notification observer that re-renders the active terminal when the
+    /// app is reactivated (Cmd+H hide → reveal, Spaces / Mission Control
+    /// return). `didBecomeKey` does NOT fire if the window was already key
+    /// before the hide, so the terminal would stay black until a manual
+    /// resize (issue #1094). App-level, so `object: nil`.
+    private var didBecomeActiveObserver: NSObjectProtocol?
+    /// Notification observer that re-renders the active terminal when the
+    /// window is restored from the Dock. AppKit may discard the layer's
+    /// backing store while the window is minimized (issue #1094).
+    private var didDeminiaturizeObserver: NSObjectProtocol?
 
     func showTab(_ tab: TerminalTab?) {
         guard let tab else {
@@ -741,11 +756,15 @@ class TerminalContainerView: NSView {
 
     override func removeFromSuperview() {
         removeScrollMonitor()
-        removeBecomeKeyObserver()
+        removeWindowObservers()
         super.removeFromSuperview()
     }
 
-    private func removeBecomeKeyObserver() {
+    /// Tears down every window/app-level notification observer registered in
+    /// ``viewDidMoveToWindow()``. Called on superview removal and whenever the
+    /// host window changes, so observers registered for a previous window
+    /// cannot fire against the new one (issue #1094 recovery-trigger family).
+    private func removeWindowObservers() {
         if let observer = becomeKeyObserver {
             NotificationCenter.default.removeObserver(observer)
             becomeKeyObserver = nil
@@ -753,6 +772,18 @@ class TerminalContainerView: NSView {
         if let observer = didChangeScreenObserver {
             NotificationCenter.default.removeObserver(observer)
             didChangeScreenObserver = nil
+        }
+        if let observer = didChangeOcclusionStateObserver {
+            NotificationCenter.default.removeObserver(observer)
+            didChangeOcclusionStateObserver = nil
+        }
+        if let observer = didBecomeActiveObserver {
+            NotificationCenter.default.removeObserver(observer)
+            didBecomeActiveObserver = nil
+        }
+        if let observer = didDeminiaturizeObserver {
+            NotificationCenter.default.removeObserver(observer)
+            didDeminiaturizeObserver = nil
         }
         observedWindow = nil
     }
@@ -783,7 +814,7 @@ class TerminalContainerView: NSView {
         // AppKit may call this method multiple times for the same window —
         // skip the observer dance when nothing has actually changed.
         guard window !== observedWindow else { return }
-        removeBecomeKeyObserver()
+        removeWindowObservers()
         guard let win = window else { return }
         becomeKeyObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didBecomeKeyNotification,
@@ -796,6 +827,40 @@ class TerminalContainerView: NSView {
         // scale factor may differ, invalidating the layer's contents (issue #1094).
         didChangeScreenObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didChangeScreenNotification,
+            object: win,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshActiveTerminalAfterReparent()
+        }
+        // Re-render when the window transitions from occluded to visible.
+        // macOS purges the backing store of fully-occluded windows; without
+        // recovery the terminal stays black after the covering window moves
+        // away (issue #1094). Only repaint on the occluded → visible edge —
+        // repainting when becoming occluded is wasteful (window off-screen).
+        didChangeOcclusionStateObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didChangeOcclusionStateNotification,
+            object: win,
+            queue: .main
+        ) { [weak self, weak win] _ in
+            guard let win,
+                  Self.shouldRecoverAfterOcclusionChange(occlusionState: win.occlusionState) else { return }
+            self?.refreshActiveTerminalAfterReparent()
+        }
+        // Re-render on app reactivation (Cmd+H hide → reveal, Spaces / Mission
+        // Control return). `didBecomeKey` does NOT fire if the window was
+        // already key before the hide, so without this the terminal stays
+        // black until a manual resize (issue #1094).
+        didBecomeActiveObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshActiveTerminalAfterReparent()
+        }
+        // Re-render when the window is restored from the Dock. AppKit may
+        // discard the layer's backing store while the window is minimized (issue #1094).
+        didDeminiaturizeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didDeminiaturizeNotification,
             object: win,
             queue: .main
         ) { [weak self] _ in
@@ -849,6 +914,18 @@ class TerminalContainerView: NSView {
     override func viewDidChangeBackingProperties() {
         super.viewDidChangeBackingProperties()
         refreshActiveTerminalAfterReparent()
+    }
+
+    /// Whether the container should repaint after a window occlusion-state
+    /// change. Only the occluded → visible transition needs recovery: macOS
+    /// purges the backing store of fully-occluded windows, and that store must
+    /// be rebuilt when the window is revealed again. Repainting when becoming
+    /// occluded is wasteful (the window is off-screen). Internal so unit tests
+    /// can pin the visible-edge decision without a live window (issue #1094).
+    internal static func shouldRecoverAfterOcclusionChange(
+        occlusionState: NSWindow.OcclusionState
+    ) -> Bool {
+        occlusionState.contains(.visible)
     }
 }
 

--- a/Pine/UITimings.swift
+++ b/Pine/UITimings.swift
@@ -100,6 +100,15 @@ nonisolated enum UITimings {
         /// per-keystroke fork+exec while keeping diagnostics current
         /// during a brief typing pause.
         static let configValidation: TimeInterval = 0.3
+
+        /// Terminal backing-store recovery repaint coalesce. The burst-prone
+        /// observer triggers (window occlusion toggling during Mission Control /
+        /// Stage Manager, app reactivation) each perform a synchronous
+        /// full-buffer `displayIfNeeded()` via `forceFullRedraw()`; this
+        /// trailing-edge delay collapses a flurry of visibility transitions
+        /// into a single repaint while staying imperceptible for recovery
+        /// (~3 frames at 120 Hz). Issue #1094 family.
+        static let terminalRecovery: TimeInterval = 0.05
     }
 
     /// Render-side cadences — throttling for views that redraw on every

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -994,11 +994,13 @@ struct TerminalTabTests {
         #expect(range != nil, "Layout with new bounds must re-seed the dirty range")
     }
 
-    /// After `removeFromSuperview` the container must clean up its
-    /// become-key observer so it cannot fire against a now-detached
-    /// terminal view. Verified indirectly: posting the notification
-    /// does not crash and does not re-seed the dirty range.
-    @Test @MainActor func removeFromSuperviewClearsBecomeKeyObserver() throws {
+    /// After `removeFromSuperview` the container must clean up EVERY
+    /// backing-store recovery observer (become-key, change-screen,
+    /// change-occlusion-state, app-become-active, deminiaturize) so none
+    /// can fire against a now-detached terminal view. Verified indirectly:
+    /// posting each notification does not crash and does not re-seed the
+    /// dirty range (issue #1094 recovery-trigger family).
+    @Test @MainActor func removeFromSuperviewClearsAllRecoveryObservers() throws {
         let state = TerminalPaneState()
         let tab = state.addTab(workingDirectory: nil)
         state.startTabs(workingDirectory: nil)
@@ -1025,6 +1027,16 @@ struct TerminalTabTests {
 
         #expect(tab.terminalView.getTerminal().getUpdateRange() == nil,
                 "Detached container must not respond to becomeKey notifications")
+
+        // The three new recovery triggers added for occlusion/hide/minimize
+        // (issue #1094) must likewise be torn down — posting any of them
+        // against the orphaned window/app must not re-seed the dirty range.
+        NotificationCenter.default.post(name: NSWindow.didChangeOcclusionStateNotification, object: window)
+        NotificationCenter.default.post(name: NSApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.post(name: NSWindow.didDeminiaturizeNotification, object: window)
+
+        #expect(tab.terminalView.getTerminal().getUpdateRange() == nil,
+                "Detached container must not respond to occlusion/app-active/deminimize notifications")
     }
 
     /// When the host window receives `didBecomeKey`, the active terminal

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -836,6 +836,18 @@ struct TerminalTabTests {
         #expect(view.layer?.contents == nil)
     }
 
+    // MARK: - Backing-store recovery triggers (occlusion / hide / minimize)
+
+    /// The terminal must recover its backing store on the occluded → visible
+    /// window transition only. Becoming occluded (window fully covered) must
+    /// NOT trigger a repaint — it is wasteful and the window is off-screen.
+    /// Pins the visible-edge decision without instantiating a live window,
+    /// so CI headless runners can exercise it (issue #1094 family).
+    @Test func recoverAfterOcclusionOnlyWhenBecomingVisible() {
+        #expect(TerminalContainerView.shouldRecoverAfterOcclusionChange(occlusionState: [.visible]))
+        #expect(!TerminalContainerView.shouldRecoverAfterOcclusionChange(occlusionState: []))
+    }
+
     /// `kickPTYWindowSize` must be a safe no-op when the shell process is
     /// not running. Calling it on a freshly-created tab (which has not
     /// reached `startIfNeeded`) must not crash, and `isProcessRunning`


### PR DESCRIPTION
## Summary

Follow-up to #1094 (#1095) for the *"terminal sometimes goes black; resizing the pane split and back fixes it"* symptom. Adds defensive repaint triggers for the window/app visibility transitions that the existing recovery hooks did not cover, and coalesces the burst-prone ones.

> ⚠️ **Premise note (from fresh-context API-fidelity review).** The original framing ("macOS aggressively purges the backing store of occluded/hidden/minimized windows") is **factually imprecise**. SwiftTerm is a layer-backed `draw(_:)` view; macOS **suppresses (not purges)** drawing for occluded/hidden windows and retains the cached pixels. The one genuinely purge-correlated signal (`viewDidChangeBackingProperties`, scale/colorspace change) is already wired from #1095. So these new observers are best understood as a **defensive repaint net for visibility transitions** — guarding against a dropped pending redraw or a stale cached frame — **not** literal backing-store-purge recovery. The #1094 `setNeedsDisplay` race (the proven black-screen cause) was already fixed in #1095. **This PR's efficacy against the reported symptom should be confirmed by testing the branch against your repro.**

## Which transitions are now covered

`TerminalContainerView` already recovered on: `showTab`, `viewDidMoveToWindow`, `didBecomeKey`, `didChangeScreen`, `viewDidChangeBackingProperties`, and `layout()` frame-change. This PR adds defensive repaints on:

| Transition | Observer | Path |
|---|---|---|
| Window revealed after being occluded | `NSWindow.didChangeOcclusionStateNotification` (`.visible` edge only) | coalesced |
| App reactivated (Cmd+H reveal, Spaces/Mission Control return) | `NSApplication.didBecomeActiveNotification` (`object: nil`) | coalesced |
| Window restored from Dock | `NSWindow.didDeminiaturizeNotification` | synchronous (low-frequency) |

`didBecomeKey` does **not** refire if the window was already key before a hide — the app-level `didBecomeActive` observer covers that gap.

## Performance — burst coalescing (fresh-context perf review)

The recovery repaint (`forceFullRedraw()`) is a **synchronous full-buffer `displayIfNeeded()`**. The two new high-frequency triggers can fire in bursts (occlusion toggling during Mission Control / Stage Manager / window drag; app reactivation). Without coalescing that is N synchronous repaints per burst — inconsistent with the repo's `UITimings.Debounce` convention and the <4ms-per-frame 120Hz budget.

- New `UITimings.Debounce.terminalRecovery` (50ms trailing-edge).
- New `recoveryDebouncer` (`Debouncer`) + `scheduleCoalescedRecovery()`, mirroring the `WorkspaceManager` pattern (lazy, `[weak self]`, `MainActor.assumeIsolated`).
- **Only** `didChangeOcclusionState` + `didBecomeActive` route through it. `becomeKey` / `didChangeScreen` / `didDeminiaturize` stay synchronous (low-frequency; keeps `windowBecomeKeyTriggersTerminalRedraw` synchronous/green).
- The debouncer is cancelled in `removeWindowObservers()`.

## Changes

**`Pine/TerminalSession.swift`** — 3 new observers in `TerminalContainerView`; `scheduleCoalescedRecovery()` + `recoveryDebouncer`; teardown extended (`removeWindowObservers()`, renamed from `removeBecomeKeyObserver()` since it now manages 5 observers + the coalescer); testable `internal static shouldRecoverAfterOcclusionChange(_:)`; comment accuracy fixed.

**`Pine/UITimings.swift`** — `Debounce.terminalRecovery`.

**`PineTests/TerminalTabTests.swift`** — `recoverAfterOcclusionOnlyWhenBecomingVisible` (visible-edge decision) + `removeFromSuperviewClearsAllRecoveryObservers` (teardown of all 5 observers). The recovery *mechanism* (`forceFullRedraw`) is covered by existing tests.

## Verification

- ✅ `TerminalTabTests` — **71/71 passed** (across all iterations), incl. the synchronous `windowBecomeKeyTriggersTerminalRedraw` and the extended teardown test.
- ✅ SwiftLint — 0 violations on all changed files.
- ✅ Fresh-context review, **3 angles**: Concurrency (APPROVE), Performance (request-changes → addressed), API fidelity (APPROVE with premise note → comments corrected).
- ⏳ Full `xcodebuild build` + CI UI shards — pending on CI.

## Non-goals / follow-ups

- A structural self-recovery fix for SwiftTerm's renderer is upstream work, tracked separately.
- `didBecomeActive` (`object: nil`) still repaints every terminal container on each app activation. A future occlusion-aware guard (skip when nothing was actually hidden) could reduce that; deferred — the per-container work is one debounced repaint and cheap for typical N=1–3.
- The reported symptom has no captured repro; **please test this branch against your repro** before merge.

## Ready to merge when

CI is fully green (lint + build + unit tests + 7 UI shards) **and** you've confirmed the branch against your repro.
