### PR TITLE
fix(sidebar): preserve loaded children across tree refresh

### DIFF
--- a/Pine/FileNode.swift
+++ b/Pine/FileNode.swift
@@ -201,13 +201,18 @@ nonisolated final class FileNode: Identifiable, Hashable, @unchecked Sendable {
     ) {
         guard !oldNodes.isEmpty else { return }
 
-        // Index previously-loaded (non-deferred) directories by URL so a
-        // deferred counterpart in the new tree can adopt their children.
+        // Index directories that have loaded children by URL so a deferred
+        // counterpart in the new tree can adopt them. Include directories
+        // that are themselves still flagged deferred but already carry
+        // (previously-merged) children — this chains merged children across
+        // successive setRootNodes calls (Phase 1 → Phase 2, or rapid
+        // successive refreshes) so a gitignored subdir does not briefly go
+        // empty between phases while its background reload is in flight.
         var loadedByURL: [URL: FileNode] = [:]
         var oldStack: [FileNode] = oldNodes
         while let n = oldStack.popLast() {
             guard n.isDirectory else { continue }
-            if !n.hasDeferredChildren, let kids = n.children, !kids.isEmpty {
+            if let kids = n.children, !kids.isEmpty {
                 loadedByURL[n.url] = n
             }
             if let kids = n.children { oldStack.append(contentsOf: kids) }

--- a/Pine/FileNode.swift
+++ b/Pine/FileNode.swift
@@ -172,6 +172,68 @@ nonisolated final class FileNode: Identifiable, Hashable, @unchecked Sendable {
         hasDeferredChildren = false
     }
 
+    /// Transfers previously-loaded children from `oldNodes` into matching
+    /// deferred nodes inside `newNodes` (keyed by URL), so that expanded
+    /// deep folders do not lose their content when a refresh replaces the
+    /// tree with fresh (shallow) instances.
+    ///
+    /// Without this, every FSEvents-triggered `setRootNodes(shallowChildren)`
+    /// replaces the whole tree with fresh instances where folders beyond
+    /// `shallowDepth` (and every gitignored subdirectory) are
+    /// `hasDeferredChildren = true, children = []`. The sidebar then shows a
+    /// `ProgressView` gap while `.onChange(of: treeRevision)` re-triggers an
+    /// async deferred load — visible as flicker (#1097).
+    ///
+    /// Merging adopts the previously-loaded children WITHOUT clearing
+    /// `hasDeferredChildren`. Keeping the deferred flag true lets the
+    /// sidebar's `.onChange(of: treeRevision)` re-trigger
+    /// `loadDeferredChildrenIfNeeded`, which reloads fresh data in the
+    /// background while the old children stay visible (no ProgressView gap).
+    /// This is essential for gitignored subdirectories (e.g. `node_modules/*`):
+    /// they are always shallow-loaded (`maxDepth: 0`) on a separate
+    /// `LoadContext`, so `wasDepthLimit` does not propagate and Phase 2 never
+    /// refreshes them — without the background reload they would go stale.
+    ///
+    /// Pure static helper so it is unit-testable without a WorkspaceManager.
+    static func mergeLoadedSubtrees(
+        into newNodes: [FileNode],
+        preservingFrom oldNodes: [FileNode]
+    ) {
+        guard !oldNodes.isEmpty else { return }
+
+        // Index previously-loaded (non-deferred) directories by URL so a
+        // deferred counterpart in the new tree can adopt their children.
+        var loadedByURL: [URL: FileNode] = [:]
+        var oldStack: [FileNode] = oldNodes
+        while let n = oldStack.popLast() {
+            guard n.isDirectory else { continue }
+            if !n.hasDeferredChildren, let kids = n.children, !kids.isEmpty {
+                loadedByURL[n.url] = n
+            }
+            if let kids = n.children { oldStack.append(contentsOf: kids) }
+        }
+        guard !loadedByURL.isEmpty else { return }
+
+        // Walk the new tree; for each deferred directory with an empty
+        // children array that has a loaded counterpart, adopt its children.
+        // Transferred children are already fully loaded (loadedChildren uses
+        // maxDepth = .max), so we do not descend into them. Crucially, we keep
+        // `hasDeferredChildren = true` (do NOT call replaceChildren) so the
+        // sidebar re-triggers a background reload of fresh data.
+        var newStack: [FileNode] = newNodes
+        while let n = newStack.popLast() {
+            guard n.isDirectory else { continue }
+            if n.hasDeferredChildren,
+               n.children?.isEmpty ?? true,
+               let old = loadedByURL[n.url],
+               let oldKids = old.children, !oldKids.isEmpty {
+                n.children = oldKids
+                continue
+            }
+            if let kids = n.children { newStack.append(contentsOf: kids) }
+        }
+    }
+
     /// Result of a depth-limited tree build, including whether the depth limit was reached.
     struct LoadResult {
         let root: FileNode

--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -85,7 +85,17 @@ final class WorkspaceManager {
     /// Sets `rootNodes`, bumps `rootNodesRevision`, and schedules a debounced
     /// `onRootNodesChanged` notification. Centralised so every assignment site
     /// (initial load, shallow refresh, full refresh) emits the same signals.
+    ///
+    /// Before replacing the tree, previously-loaded children of deep folders
+    /// are merged from the current tree into matching deferred nodes of the
+    /// new tree. This prevents expanded deep folders from briefly showing an
+    /// empty/ProgressView gap when a refresh replaces the tree — the residual
+    /// flicker left after #1098 (#1097). The merge keeps `hasDeferredChildren`
+    /// true so the sidebar still reloads fresh data in the background; this is
+    /// required for gitignored subdirectories (e.g. `node_modules/*`) which
+    /// Phase 2 never refreshes.
     private func setRootNodes(_ nodes: [FileNode]) {
+        FileNode.mergeLoadedSubtrees(into: nodes, preservingFrom: rootNodes)
         rootNodes = nodes
         rootNodesRevision += 1
         notifyRootNodesChanged()

--- a/PineTests/FileNodeTests.swift
+++ b/PineTests/FileNodeTests.swift
@@ -598,4 +598,143 @@ struct FileNodeTests {
         #expect(names.contains("new.swift"))
         #expect(names.contains("vendor"))
     }
+
+    // MARK: - mergeLoadedSubtrees (sidebar flicker fix, #1097)
+
+    /// Helper: walk a tree following a slash-separated path of names.
+    private func descend(_ path: String, from node: FileNode) -> FileNode? {
+        var current = node
+        for component in path.split(separator: "/") {
+            guard let next = current.children?.first(where: { $0.name == String(component) }) else {
+                return nil
+            }
+            current = next
+        }
+        return current
+    }
+
+    @Test func mergeLoadedSubtreesPreservesDeepChildrenAcrossShallowRefresh() throws {
+        // Regression for sidebar flicker (#1097): a refresh rebuilds the
+        // tree with a shallow depth limit, making a previously-expanded
+        // deep folder deferred again (empty children). Without merging,
+        // the sidebar shows a ProgressView gap until the deferred load
+        // re-runs. mergeLoadedSubtrees must carry the previously-loaded
+        // children over so there is no empty gap.
+        let tempDir = try makeTempDirectory()
+        defer { cleanup(tempDir) }
+
+        // Structure: root/a/b/c/d/file.txt (d is beyond shallowDepth=3)
+        let deepDir = tempDir.appendingPathComponent("a/b/c/d")
+        try FileManager.default.createDirectory(at: deepDir, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: deepDir.appendingPathComponent("file.txt").path, contents: nil)
+
+        // Old tree: fully loaded (simulates the user having expanded `d`).
+        let oldTree = FileNode.loadTree(url: tempDir, projectRoot: tempDir, ignoredPaths: [], maxDepth: .max)
+        let oldD = descend("a/b/c/d", from: oldTree.root)
+        #expect(oldD?.hasDeferredChildren == false)
+        #expect(oldD?.children?.contains { $0.name == "file.txt" } == true)
+
+        // New shallow tree: `d` is deferred (depth 4 > shallowDepth 3).
+        let newTree = FileNode.loadTree(url: tempDir, projectRoot: tempDir, ignoredPaths: [], maxDepth: 3)
+        let newNodes = newTree.root.children ?? []
+        let newD = descend("a/b/c/d", from: newTree.root)
+        #expect(newD?.hasDeferredChildren == true)
+        #expect(newD?.children?.isEmpty ?? true)
+
+        // Merge previously-loaded children into the new (deferred) tree.
+        FileNode.mergeLoadedSubtrees(into: newNodes, preservingFrom: oldTree.root.children ?? [])
+
+        // After merge: `d` keeps its children — no empty gap. The deferred
+        // flag stays true so the sidebar reloads fresh data in the background
+        // (essential for gitignored subdirs that Phase 2 never refreshes).
+        #expect(newD?.hasDeferredChildren == true)
+        #expect(newD?.children?.contains { $0.name == "file.txt" } == true)
+    }
+
+    @Test func mergeLoadedSubtreesSkipsFoldersWithoutLoadedChildren() throws {
+        // A deep folder that was never expanded (still deferred in the old
+        // tree) must not gain phantom children from an unrelated node.
+        let tempDir = try makeTempDirectory()
+        defer { cleanup(tempDir) }
+
+        let deepDir = tempDir.appendingPathComponent("a/b/c/d")
+        try FileManager.default.createDirectory(at: deepDir, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: deepDir.appendingPathComponent("file.txt").path, contents: nil)
+
+        // Old tree is ALSO shallow — `d` was never expanded, so it has no
+        // loaded children to merge.
+        let oldTree = FileNode.loadTree(url: tempDir, projectRoot: tempDir, ignoredPaths: [], maxDepth: 3)
+        let newTree = FileNode.loadTree(url: tempDir, projectRoot: tempDir, ignoredPaths: [], maxDepth: 3)
+        let newNodes = newTree.root.children ?? []
+
+        FileNode.mergeLoadedSubtrees(into: newNodes, preservingFrom: oldTree.root.children ?? [])
+
+        let newD = descend("a/b/c/d", from: newTree.root)
+        #expect(newD?.hasDeferredChildren == true)
+        #expect(newD?.children?.isEmpty ?? true)
+    }
+
+    @Test func mergeLoadedSubtreesIsNoOpWhenOldTreeEmpty() throws {
+        let tempDir = try makeTempDirectory()
+        defer { cleanup(tempDir) }
+
+        let deepDir = tempDir.appendingPathComponent("a/b/c/d")
+        try FileManager.default.createDirectory(at: deepDir, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: deepDir.appendingPathComponent("file.txt").path, contents: nil)
+
+        let newTree = FileNode.loadTree(url: tempDir, projectRoot: tempDir, ignoredPaths: [], maxDepth: 3)
+        let newNodes = newTree.root.children ?? []
+
+        // No old tree to merge from — must not crash and must not change state.
+        FileNode.mergeLoadedSubtrees(into: newNodes, preservingFrom: [])
+
+        let newD = descend("a/b/c/d", from: newTree.root)
+        #expect(newD?.hasDeferredChildren == true)
+        #expect(newD?.children?.isEmpty ?? true)
+    }
+
+    @Test func mergeLoadedSubtreesKeepsDeferredFlagForGitignoredSubdirs() throws {
+        // Regression for the staleness bug found in review of the #1097 fix:
+        // gitignored directories (e.g. node_modules) are shallow-loaded with
+        // a separate LoadContext(maxDepth: 0), so their subdirectories are
+        // deferred and Phase 2 never refreshes them. The merge must keep
+        // `hasDeferredChildren = true` after adopting old children so the
+        // sidebar still reloads fresh data in the background — otherwise the
+        // merged children would freeze forever.
+        let tempDir = try makeTempDirectory()
+        defer { cleanup(tempDir) }
+
+        // Structure: root/vendor/express/index.js — `vendor` is gitignored.
+        let vendorDir = tempDir.appendingPathComponent("vendor/express")
+        try FileManager.default.createDirectory(at: vendorDir, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: vendorDir.appendingPathComponent("index.js").path, contents: nil)
+
+        // Old tree: vendor is shallow (gitignored), express deferred until
+        // the user expands it (simulated here via loadChildren).
+        let oldTree = FileNode.loadTree(
+            url: tempDir, projectRoot: tempDir, ignoredPaths: ["vendor"], maxDepth: .max
+        )
+        let oldExpress = try #require(descend("vendor/express", from: oldTree.root))
+        // Before expansion express is deferred (empty) — gitignored shallow load
+        // uses maxDepth: 0 regardless of the tree's maxDepth.
+        #expect(oldExpress.hasDeferredChildren == true)
+        oldExpress.loadChildren()  // simulate the user expanding express
+        #expect(oldExpress.children?.contains { $0.name == "index.js" } == true)
+
+        // New shallow tree: express is deferred (empty children) again.
+        let newTree = FileNode.loadTree(
+            url: tempDir, projectRoot: tempDir, ignoredPaths: ["vendor"], maxDepth: 3
+        )
+        let newNodes = newTree.root.children ?? []
+        let newExpress = descend("vendor/express", from: newTree.root)
+        #expect(newExpress?.hasDeferredChildren == true)
+        #expect(newExpress?.children?.isEmpty ?? true)
+
+        FileNode.mergeLoadedSubtrees(into: newNodes, preservingFrom: oldTree.root.children ?? [])
+
+        // Children adopted (no empty gap) AND deferred flag preserved so the
+        // sidebar background-reloads fresh data.
+        #expect(newExpress?.hasDeferredChildren == true)
+        #expect(newExpress?.children?.contains { $0.name == "index.js" } == true)
+    }
 }

--- a/PineTests/SidebarExpandedRefreshTests.swift
+++ b/PineTests/SidebarExpandedRefreshTests.swift
@@ -246,4 +246,61 @@ struct SidebarExpandedRefreshTests {
             "Deep project should have at least 2 revision increments (shallow + full phases)"
         )
     }
+
+    // MARK: - Sidebar flicker fix (#1097): loaded children survive refresh
+
+    @Test("Deep loaded folder retains children after sync refresh (no empty gap)")
+    @MainActor
+    func deepLoadedFolderRetainsChildrenAfterSyncRefresh() async throws {
+        // Regression for the #1097 flicker fix: a previously-expanded deep
+        // folder must not briefly go empty when a refresh rebuilds the tree
+        // with a shallow depth limit. `refreshFileTree()` runs Phase 1
+        // (shallow) synchronously via `setRootNodes`, which must merge the
+        // folder's previously-loaded children into the fresh deferred node.
+        // The assertions run synchronously on the main thread before the
+        // async Phase 2 (`loadDirectoryContentsAsync`) can replace rootNodes,
+        // so this is deterministic.
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        // `d` is beyond shallowDepth=3 → deferred on shallow rebuilds.
+        let deepDir = dir.appendingPathComponent("a/b/c/d")
+        try FileManager.default.createDirectory(at: deepDir, withIntermediateDirectories: true)
+        try "x".write(
+            to: deepDir.appendingPathComponent("file.txt"),
+            atomically: true, encoding: .utf8
+        )
+
+        let manager = WorkspaceManager()
+        manager.loadDirectory(url: dir)
+        // Wait for the initial two-phase load to finish (Phase 2 loads `d` fully).
+        for _ in 0..<200 {
+            try await Task.sleep(for: .milliseconds(50))
+            if !manager.isLoading { break }
+        }
+
+        func findD() -> FileNode? {
+            manager.rootNodes.first { $0.name == "a" }?
+                .children?.first { $0.name == "b" }?
+                .children?.first { $0.name == "c" }?
+                .children?.first { $0.name == "d" }
+        }
+        #expect(
+            findD()?.children?.contains { $0.name == "file.txt" } == true,
+            "`d` should be fully loaded after the initial Phase 2"
+        )
+
+        // Synchronous shallow refresh — must merge `d`'s children, not drop them.
+        manager.refreshFileTree()
+
+        let d = findD()
+        #expect(
+            d?.hasDeferredChildren == true,
+            "`d` stays deferred so the sidebar background-reloads fresh data"
+        )
+        #expect(
+            d?.children?.contains { $0.name == "file.txt" } == true,
+            "Previously-loaded children survive the sync shallow refresh (no flicker gap)"
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the residual sidebar flicker when navigating deep folders (#1097). The `#1098` fix turned the blank gap into a spinner gap without removing the root cause.

## Root cause

Flicker is **not** caused by navigation itself (expanding a folder is a read-only `contentsOfDirectory`, FSEvents does not fire). It happens when an FSEvents event fires **in parallel** with navigation — which is constant during active development (dev server, `tsc --watch`, Pine's terminal, git, Spotlight, another IDE).

Every FSEvents event triggers `refreshFileTreeAsync()` → two-phase `setRootNodes`:

1. **Phase 1 (shallow, depth 3):** replaces the **entire** tree with fresh `FileNode` instances. Folders deeper than level 3 get `children = []`, `hasDeferredChildren = true` → previously-loaded children **lost**.
2. `.onChange(of: treeRevision)` re-triggers the async deferred load → `children.isEmpty && isLoadingDeferredChildren` → **ProgressView** (content gone, spinner appears).
3. **Phase 2 (full, depth .max):** restores children → spinner disappears.

The gap between phases = time of a full tree walk. That gap *is* the flicker: content → spinner → content. `loadedChildren()` loading the entire subtree (`maxDepth = .max`) makes the spinner longer.

## Implementation

In `setRootNodes`, **before** replacing the tree, transfer previously-loaded children from the old tree into matching deferred nodes of the new tree (`FileNode.mergeLoadedSubtrees`) — **without clearing `hasDeferredChildren`**. Then:

- old children stay visible immediately → no empty gap, no spinner (flicker gone);
- `.onChange(of: treeRevision)` still fires (`hasDeferredChildren == true`) → background reload fetches fresh data;
- old children show while fresh ones load → no jump, data stays current.

Keeping `hasDeferredChildren` true is essential for **gitignored subdirectories** (e.g. `node_modules/*`): they are always shallow-loaded (`maxDepth: 0`) on a separate `LoadContext`, so `wasDepthLimited` does not propagate and Phase 2 never refreshes them — only the background reload keeps them fresh. This staleness regression in the first iteration was found by fresh-context review and fixed (test added).

## Files changed

- `Pine/FileNode.swift` — new static pure `mergeLoadedSubtrees(into:preservingFrom:)`
- `Pine/WorkspaceManager.swift` — call it in `setRootNodes`
- `PineTests/FileNodeTests.swift` — 4 regression tests

## Verification

- `xcodebuild test -only-testing:PineTests/FileNodeTests` → **32/32 passed** (4 new merge tests)
- `xcodebuild test -only-testing:PineTests/SidebarExpandedRefreshTests` + `SidebarExpansionStateTests` → **19/19 passed** (new files still appear, revision still increments — no regressions)
- `swiftlint lint` → **0 violations**
- `scripts/check-no-post-under-inout.py` → **clean** (no reentrancy/exclusivity risk)
- `xcodebuild build` → **BUILD SUCCEEDED**
- Independent fresh-context review: first iteration found a MAJOR staleness bug for gitignored subdirs → fixed + regression test added; second iteration green.

## Not tested

- UI tests (`PineUITests`) run only on CI; the flicker itself (async gap between phases) is hard to assert reliably in a UI test.
- Manual run in the GUI not performed. Recommend opening a project with an active dev server/watcher, expanding several deep folders, and confirming no spinners appear on background changes.

## Out of scope (follow-ups)

- `refreshFileTree()` redundancy (3 `setRootNodes` per user op, up to 5 with FSEvents double-fire) — not addressed; merge makes each replacement safe.
- `loadedChildren()` loads the whole subtree (`maxDepth = .max`) → slow background reload for huge `node_modules`. Optional one-level load is a separate task.

## Merge readiness

Ready to merge once CI is green. No breaking changes; pure additive behavior preserved (new files appear after refresh, expansion state retained).
