### PR TITLE
fix(terminal): stop clearing layer.contents outside forceFullRedraw in appearance apply

### DIFF
--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -1074,15 +1074,26 @@ final class TerminalTab: Identifiable, Hashable {
     /// layer background in sync with the terminal model. SwiftTerm only sets
     /// `layer.backgroundColor` during initial setup, so Pine must refresh it
     /// when the app moves between light and dark appearances.
-    private func applyCurrentTerminalAppearance(forceRedraw: Bool) {
+    ///
+    /// `internal` (not `private`) so unit tests can pin the invariant that
+    /// this method does NOT clear `layer.contents` without a synchronous
+    /// repaint (issue #1107).
+    internal func applyCurrentTerminalAppearance(forceRedraw: Bool) {
         let background = TerminalPalette.currentBackgroundColor()
         terminalView.nativeForegroundColor = .textColor
         terminalView.nativeBackgroundColor = background
-        if let pineTerminalView = terminalView as? PineTerminalView {
-            pineTerminalView.prepareLayerForRedraw(background: background)
-        } else {
-            terminalView.layer?.backgroundColor = background.cgColor
-        }
+        // Sync the layer's background colour WITHOUT clearing `contents`.
+        // `prepareLayerForRedraw()` nils `layer.contents`, which is only safe
+        // from `forceFullRedraw()` — where the nil is immediately followed by
+        // a synchronous `displayIfNeeded()`. Calling it here unconditionally
+        // (including the `forceRedraw == false` init path) leaves the layer
+        // black when the subsequent repaint is a no-op: window minimized /
+        // occluded / view detached, e.g. an appearance change firing while
+        // the window is hidden (issue #1107, #1094 invariant).
+        // `forceFullRedraw()` already syncs the background and clears contents
+        // itself, so the explicit `prepareLayerForRedraw` here was both racy
+        // and redundant on the `forceRedraw == true` path.
+        terminalView.layer?.backgroundColor = background.cgColor
 
         // Apply Pine's terminal palette (issue #816, #931).
         // Centralised in `TerminalPalette` so it can be unit-tested

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -836,6 +836,44 @@ struct TerminalTabTests {
         #expect(view.layer?.contents == nil)
     }
 
+    /// `applyCurrentTerminalAppearance(forceRedraw: false)` must sync the
+    /// layer background WITHOUT clearing `contents`. Clearing contents here —
+    /// when no synchronous repaint follows — leaves the layer black if the
+    /// window is minimized/occluded (e.g. an appearance change firing while
+    /// the window is hidden). Contents clearing belongs exclusively in
+    /// `forceFullRedraw()`, where a synchronous `displayIfNeeded()` always
+    /// follows (issue #1107, #1094 invariant).
+    @Test @MainActor func applyCurrentTerminalAppearanceDoesNotClearContentsWithoutRedraw() {
+        let tab = TerminalTab(name: "test")
+        let existingContents = "valid-backing" as NSString
+        tab.terminalView.layer?.contents = existingContents
+
+        tab.applyCurrentTerminalAppearance(forceRedraw: false)
+
+        // Background must be synced to the appearance-aware native background,
+        // but contents must NOT be nil'd — no synchronous repaint follows.
+        let expected = tab.terminalView.nativeBackgroundColor.cgColor
+        #expect(tab.terminalView.layer?.backgroundColor == expected)
+        #expect((tab.terminalView.layer?.contents as? NSString) == existingContents)
+    }
+
+    /// `applyCurrentTerminalAppearance(forceRedraw: true)` keeps the safe
+    /// behaviour: `forceFullRedraw()` clears stale contents and syncs the
+    /// background. This pins that the `forceRedraw == true` path did not
+    /// regress when the unconditional `prepareLayerForRedraw` was removed
+    /// from `applyCurrentTerminalAppearance` (issue #1107).
+    @Test @MainActor func applyCurrentTerminalAppearanceForceRedrawClearsContents() {
+        let tab = TerminalTab(name: "test")
+        let staleContents = "stale-terminal-backing" as NSString
+        tab.terminalView.layer?.contents = staleContents
+
+        tab.applyCurrentTerminalAppearance(forceRedraw: true)
+
+        let expected = tab.terminalView.nativeBackgroundColor.cgColor
+        #expect(tab.terminalView.layer?.backgroundColor == expected)
+        #expect((tab.terminalView.layer?.contents as? NSString) != staleContents)
+    }
+
     // MARK: - Backing-store recovery triggers (occlusion / hide / minimize)
 
     /// The terminal must recover its backing store on the occluded → visible

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -871,6 +871,11 @@ struct TerminalTabTests {
 
         let expected = tab.terminalView.nativeBackgroundColor.cgColor
         #expect(tab.terminalView.layer?.backgroundColor == expected)
+        // forceFullRedraw() runs the safe clear path (prepareLayerForRedraw +
+        // synchronous repaint), so the stale backing must have been replaced.
+        // Uses `!= staleContents` (not `== nil`) because SwiftTerm may repaint
+        // into a fresh CGImage even on a detached view — consistent with the
+        // sibling `forceFullRedrawSyncsLayerBackground` test.
         #expect((tab.terminalView.layer?.contents as? NSString) != staleContents)
     }
 


### PR DESCRIPTION
## Summary

Closes #1107.

`TerminalTab.applyCurrentTerminalAppearance(forceRedraw:)` called `PineTerminalView.prepareLayerForRedraw(background:)` — which nils `layer.contents` — on **every** invocation, but only ran the synchronous `forceFullRedraw()` repaint when `forceRedraw == true`. This violated the `#1094` invariant: contents must only be cleared from `forceFullRedraw()`, where a synchronous `displayIfNeeded()` always follows.

The call was added in #966 (10 Jun), before the root-cause fix #1095 (5 Jul). #1095/#1101 removed the `contents = nil` from `PineTerminalView.setNeedsDisplay` but missed this second call site.

## Repro (before fix)

1. Open a terminal pane (Cmd+`)
2. Minimize the window (Cmd+M) or switch to another Space
3. Change the system appearance (light<->dark)
4. `NSApp.observe(\.effectiveAppearance)` fires `applyCurrentTerminalAppearance(forceRedraw: true)` → `prepareLayerForRedraw` nils `layer.contents` → `forceFullRedraw`'s `displayIfNeeded()` is a **no-op** (window hidden) → layer stays black

## Fix

Sync only `layer.backgroundColor` in `applyCurrentTerminalAppearance` (no `contents = nil`). `forceFullRedraw()` already syncs the background and clears contents itself, so the explicit `prepareLayerForRedraw` was both racy and redundant on the `forceRedraw == true` path. Made the method `internal` so the invariant can be pinned by unit tests (same pattern as `TerminalContainerView.shouldRecoverAfterOcclusionChange`).

## Tests

- `applyCurrentTerminalAppearanceDoesNotClearContentsWithoutRedraw` — `forceRedraw == false` must NOT nil contents.
- `applyCurrentTerminalAppearanceForceRedrawClearsContents` — `forceRedraw == true` still clears stale contents via `forceFullRedraw`.

Full `TerminalTabTests` suite: 73/73 passed. SwiftLint: 0 violations.

## Strategic follow-up

#1108 tracks switching to SwiftTerm's Metal renderer, which eliminates the entire layer-backing-store black-screen class (Metal's `CAMetalLayer` drawables hold no CGImage raster in `layer.contents`, so there is nothing to purge / nil). This PR is the tactical fix for the immediate trigger; the Metal switch is the strategic fix for the whole class.

## Checklist

- [x] Unit tests added / updated
- [x] `swiftlint` clean
- [x] Conventional Commit message
- [x] Minimal diff (2 files, +55/-6)
- [ ] CI green (pending)
