### PR TITLE
feat(terminal): zoom-to-fullscreen pane toggle

### DIFF
--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -5516,6 +5516,66 @@
         }
       }
     },
+    "menu.toggleTerminalZoom": {
+      "comment": "Menu item: toggle zoom-to-fullscreen of the focused terminal pane (#1115).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal-Zoom umschalten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Terminal Zoom"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alternar zoom del terminal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Basculer le zoom du terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルのズームを切り替え"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널 확대 전환"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alternar zoom do terminal"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переключить масштаб терминала"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换终端缩放"
+          }
+        }
+      }
+    },
     "menu.smartListContinuation": {
       "comment": "Menu toggle: enable/disable smart list continuation on Enter in Markdown lists.",
       "extractionState": "manual",

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -55,6 +55,7 @@ nonisolated enum MenuIcons {
     // MARK: - Terminal menu
     static let newTerminalTab = "plus"
     static let sendToTerminal = "paperplane"
+    static let maximizeTerminal = "arrow.up.left.and.arrow.down.right"
 
     // MARK: - Tasks menu (issue #1009)
     static let tasks = "wrench.and.screwdriver"

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -566,6 +566,20 @@ final class PaneManager {
         maximizedPaneID = nil
     }
 
+    /// Toggles zoom on the focused terminal pane (#1115): maximizes the
+    /// active pane if it is a terminal and nothing is zoomed; restores the
+    /// full layout if a pane is currently zoomed. No-op when the focus is
+    /// not on a terminal pane and nothing is zoomed (so the user can always
+    /// escape zoom with the same shortcut regardless of focus).
+    func toggleMaximizeOnActiveTerminalPane() {
+        if isMaximized {
+            restoreFromMaximize()
+            return
+        }
+        guard terminalPaneIDs.contains(activePaneID) else { return }
+        maximize(paneID: activePaneID)
+    }
+
     // MARK: - Session restore
 
     /// Restores a previously saved pane layout.

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -509,6 +509,23 @@ struct PineAppMenuCommands: Commands {
             }
             .keyboardShortcut(.return, modifiers: [.command, .shift])
             .disabled(focusedProject?.activeTabManager.activeTab == nil)
+
+            Divider()
+
+            // Zoom the focused terminal pane to fill the detail area
+            // (tmux-style). Cmd+Shift+Return is taken by Send to Terminal,
+            // so zoom uses Cmd+Option+Return (#1115). Auto-collapsing the
+            // sidebar from this shortcut is tracked as a follow-up — v1 ships
+            // the pane-level zoom + shortcut, matching the existing tab-bar
+            // maximize button (#1048).
+            Button {
+                guard let pm = focusedProject else { return }
+                pm.paneManager.toggleMaximizeOnActiveTerminalPane()
+            } label: {
+                Label(Strings.menuToggleTerminalZoom, systemImage: MenuIcons.maximizeTerminal)
+            }
+            .keyboardShortcut(.return, modifiers: [.command, .option])
+            .disabled(focusedProject?.hasTerminalPanes != true)
         }
 
         // MARK: - Tasks menu (issue #1009)

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -393,6 +393,7 @@ enum Strings {
     static let terminalSearchPlaceholder: LocalizedStringKey = "terminal.search.placeholder"
     static let menuFindInTerminal: LocalizedStringKey = "menu.findInTerminal"
     static let menuSendToTerminal: LocalizedStringKey = "menu.sendToTerminal"
+    static let menuToggleTerminalZoom: LocalizedStringKey = "menu.toggleTerminalZoom"
 
     static var terminalSearchPreviousTooltip: String {
         String(localized: "terminal.search.previousTooltip")

--- a/PineTests/PaneManagerEdgeTests.swift
+++ b/PineTests/PaneManagerEdgeTests.swift
@@ -55,6 +55,40 @@ struct PaneManagerEdgeTests {
         #expect(manager.isMaximized == false)
     }
 
+    // MARK: - Toggle zoom on active terminal pane (#1115)
+
+    @Test func toggleZoom_maximizesActiveTerminalPane() {
+        let manager = PaneManager()
+        let terminalPane = manager.createTerminalPaneAtBottom(workingDirectory: nil)
+        manager.activePaneID = terminalPane
+        #expect(manager.terminalPaneIDs.contains(terminalPane))
+
+        manager.toggleMaximizeOnActiveTerminalPane()
+        #expect(manager.isMaximized)
+        #expect(manager.maximizedPaneID == terminalPane)
+    }
+
+    @Test func toggleZoom_restoresWhenAlreadyMaximized() {
+        let manager = PaneManager()
+        let terminalPane = manager.createTerminalPaneAtBottom(workingDirectory: nil)
+        manager.activePaneID = terminalPane
+        manager.toggleMaximizeOnActiveTerminalPane()
+        #expect(manager.isMaximized)
+
+        // Toggle again from anywhere (even non-terminal focus) always exits zoom.
+        manager.toggleMaximizeOnActiveTerminalPane()
+        #expect(manager.isMaximized == false)
+        #expect(manager.maximizedPaneID == nil)
+    }
+
+    @Test func toggleZoom_noTerminalPane_noOp() {
+        // Default PaneManager has only an editor pane; toggle must no-op
+        // rather than maximize the editor (#1115: zoom is terminal-only).
+        let manager = PaneManager()
+        manager.toggleMaximizeOnActiveTerminalPane()
+        #expect(manager.isMaximized == false)
+    }
+
     @Test func persistableRoot_returnsFullLayoutWhenMaximized() {
         let manager = PaneManager()
         let paneID = manager.activePaneID

--- a/PineTests/PaneManagerEdgeTests.swift
+++ b/PineTests/PaneManagerEdgeTests.swift
@@ -68,22 +68,55 @@ struct PaneManagerEdgeTests {
         #expect(manager.maximizedPaneID == terminalPane)
     }
 
-    @Test func toggleZoom_restoresWhenAlreadyMaximized() {
+    @Test func toggleZoom_restoresWhenAlreadyMaximized() throws {
         let manager = PaneManager()
         let terminalPane = manager.createTerminalPaneAtBottom(workingDirectory: nil)
         manager.activePaneID = terminalPane
+        // Capture the editor pane id BEFORE maximize — after maximize `root`
+        // is a single terminal leaf and the editor lives only in
+        // `savedRootBeforeMaximize`, so `root.leafIDs` would not find it.
+        let editorPane = try #require(manager.root.leafIDs.first { $0 != terminalPane })
         manager.toggleMaximizeOnActiveTerminalPane()
         #expect(manager.isMaximized)
 
-        // Toggle again from anywhere (even non-terminal focus) always exits zoom.
+        // Toggle from ANY focus (even non-terminal) always exits zoom —
+        // `isMaximized` is checked before the focus guard.
+        manager.activePaneID = editorPane
         manager.toggleMaximizeOnActiveTerminalPane()
         #expect(manager.isMaximized == false)
         #expect(manager.maximizedPaneID == nil)
+        // Layout restored exactly: editor + terminal split (2 leaves).
+        #expect(manager.root.leafCount == 2)
+    }
+
+    @Test func toggleZoom_idempotentCycle() {
+        // maximize → restore → maximize-again must return to the same zoomed
+        // state without corrupting the saved root. The headline "toggle" UX.
+        let manager = PaneManager()
+        let terminalPane = manager.createTerminalPaneAtBottom(workingDirectory: nil)
+        manager.activePaneID = terminalPane
+
+        manager.toggleMaximizeOnActiveTerminalPane() // maximize
+        #expect(manager.isMaximized)
+        manager.toggleMaximizeOnActiveTerminalPane() // restore
+        #expect(manager.isMaximized == false)
+        #expect(manager.root.leafCount == 2)
+        manager.toggleMaximizeOnActiveTerminalPane() // maximize again
+        #expect(manager.isMaximized)
+        #expect(manager.maximizedPaneID == terminalPane)
+        #expect(manager.root.leafCount == 1)
     }
 
     @Test func toggleZoom_noTerminalPane_noOp() {
         // Default PaneManager has only an editor pane; toggle must no-op
         // rather than maximize the editor (#1115: zoom is terminal-only).
+        //
+        // Note: the 'editor focused but a terminal exists elsewhere' variant
+        // is covered by `toggleZoom_restoresWhenAlreadyMaximized`, which
+        // switches activePaneID to the editor leaf mid-test.
+        // `createTerminalPaneAtBottom` switches active to the new terminal,
+        // so an editor-focused setup cannot be constructed via that helper
+        // alone — the editor leaf is obtained from `root.leafIDs` instead.
         let manager = PaneManager()
         manager.toggleMaximizeOnActiveTerminalPane()
         #expect(manager.isMaximized == false)


### PR DESCRIPTION
## Summary

Add a keyboard shortcut to zoom the focused terminal pane to fill the detail area — tmux-style. Closes #1115.

`PaneManager.toggleMaximizeOnActiveTerminalPane()` maximizes the active pane when it is a terminal pane; the same shortcut always exits zoom regardless of current focus. Builds on the existing maximize/restore machinery (#1048) — the pane tree is preserved across the zoom and restored exactly.

## Why this is small

Pane-level maximize **already works** via the tab-bar button (#1048: `PaneManager.maximize(paneID:)` / `restoreFromMaximize()`, swaps `root` for a single `.leaf`, restores on un-zoom). What was missing:
1. A **keyboard shortcut** (the issue proposed ⌘⇧Return — already taken by Send to Terminal, so this uses ⌘⌥Return).
2. A **toggle** that does not require the user to remember whether a pane is currently zoomed (the shortcut always exits zoom, regardless of focus).

## Changes

- **`Pine/PaneManager.swift`** — `toggleMaximizeOnActiveTerminalPane()`: maximize the active pane if it is a terminal and nothing is zoomed; `restoreFromMaximize()` if something is zoomed; no-op otherwise.
- **`Pine/PineAppMenuCommands.swift`** — Terminal menu: "Toggle Terminal Zoom" (`Cmd+Option+Return`), disabled when no terminal pane exists. Direct `focusedProject` call (no Notification round-trip).
- **`Pine/Strings.swift`** + **`Pine/MenuIcons.swift`** — `menuToggleTerminalZoom` string + `maximizeTerminal` SF Symbol.
- **`PineTests/PaneManagerEdgeTests.swift`** — 3 tests: toggle maximizes an active terminal pane; toggle restores when already zoomed; toggle is a no-op when no terminal pane exists.

## Non-goal (follow-up, called out honestly)

The issue also asked to **auto-collapse the sidebar** to `.detailOnly` on zoom so the terminal fills the entire window. **This is NOT in the PR.** `ContentView.body`'s modifier chain is at the SwiftUI type-checker's budget — adding `.onReceive`/`.onChange` for the sidebar-collapse, or even a small `ViewModifier`, tipped it past "unable to type-check in reasonable time". Wiring the sidebar collapse cleanly (likely by splitting `ContentView.body` or routing through a dedicated scene modifier) is tracked as a separate follow-up rather than risking the existing layout. **v1 ships pane-level zoom + shortcut**, matching the existing tab-bar maximize behavior — which already gives the terminal the full detail area, just with the sidebar still visible.

## Testing

- ✅ `xcodebuild build` — **BUILD SUCCEEDED**, 0 errors.
- ✅ `xcodebuild test -only-testing:PineTests/PaneManagerEdgeTests` — 34/34 pass (including the 3 new toggle tests).
- ✅ `swiftlint` on changed files — clean.
- ⏳ **UI tests (7 CI shards)** — not run locally (repo convention).
- ⏳ **Manual smoke-test** — recommended before merge:
  1. Focus a terminal pane, press ⌘⌥Return → it fills the detail area.
  2. Press ⌘⌥Return again → the pane layout is restored exactly (splits, ratios).
  3. With focus on an editor pane and no zoom, ⌘⌥Return is a no-op (menu item disabled).
  4. The existing tab-bar maximize button still works independently.

## Ready to merge when

- CI is fully green.
- A manual smoke-test (above) confirms zoom in/out preserves the pane layout.

Does **not** merge itself — leaving that to the maintainer.

Closes #1115.
