### PR TITLE
fix(terminal): bump SwiftTerm to 1.14.0 to fix Metal cursor + TUI scroll artifacts

### DIFF
--- a/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle.git",
       "state" : {
-        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
-        "version" : "2.9.3"
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/migueldeicaza/SwiftTerm.git",
       "state" : {
-        "revision" : "8e7a1e154f470e19c709a00a8768df348ba5fc43",
-        "version" : "1.13.0"
+        "revision" : "849e8a4f3d6f79ddee07152400137f1370c32621",
+        "version" : "1.14.0"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Bumps SwiftTerm `1.13.0` → `1.14.0` (and Sparkle `2.9.3` → `2.9.4`, same `Package.resolved` update). SwiftTerm 1.13.0 was enabled in 1.33.0 (#1118) and shipped two visible Metal-renderer regressions that 1.14.0 fixes upstream.

## Problem

Two terminal symptoms appeared in the 1.33.0 release:

1. **Stale cursor during input.** Cursor-only buffer moves (`CSI Ps C` / `CSI Ps D`, e.g. shell responses to Option+Arrow word jumps) mutate `buffer.x` without dirtying any row, so the Metal renderer never redraws and the cursor freezes at its old screen position until the next unrelated frame (typing / scrolling). User-reported as *"cursor is offset during input, everything else is fine"*. → upstream #547.
2. **Rows jittering in k9s.** DEC mode 2026 (synchronized output), used by k9s, Neovim, Claude Code and ratatui/bubbletea TUIs, did not suppress rendering during sync blocks, producing visible shifting-row / scroll-through artifacts on rapid screen updates. User-reported as *"rows jittering in k9s"*. → upstream #498 / #525.

## Fix

Upgrade to SwiftTerm 1.14.0, which includes the fixes for both symptoms plus several other Metal-renderer issues relevant to Pine:

| Upstream commit | What it fixes |
|---|---|
| `3f5c89c` (#547) | Stale Metal cursor on cursor-only buffer moves |
| `468d0a8` (#498) | DEC 2026 synchronized output rendering |
| `d024ed7` (#526) | Sync output debounce 100ms → 16ms (removes TUI input lag) |
| `5716b03` | Metal row cache invalidation via `BufferLine` generation |
| `b0730ad` (#546) | sRGB colorspace for `CAMetalLayer` (oversaturated selection under Metal) |
| `13732b7` | Text alignment when switching to Metal |
| `a24f65c` (#548) | Rebind Metal renderer on window reparent — relevant for pane split / quick-terminal; picked up for free since `PineTerminalView` calls `super.viewDidMoveToWindow()` |

## No Pine code changes

Every API `PineTerminalView` uses — `setUseMetal(_:)`, `isUsingMetalRenderer`, `viewDidMoveToWindow()` — is present in 1.14.0. `Pine/TerminalSession.swift` is unchanged. The existing `TerminalMetalRendererTests` still cover the opt-out / no-window / idempotency invariants.

## Verification

- [x] `xcodebuild build` — **BUILD SUCCEEDED** (no SwiftTerm/terminal warnings)
- [x] API compatibility confirmed against the resolved 1.14.0 checkout
- [ ] Manual: cursor position during Option+Arrow word-jump — *needs hands-on*
- [ ] Manual: k9s / TUI row stability on rapid updates — *needs hands-on*

## Diff

```
SwiftTerm  8e7a1e1 (1.13.0) → 849e8a4 (1.14.0)
Sparkle    d46d456 (2.9.3)  → b6496a7 (2.9.4)
```

Rollback, if ever needed: pin SwiftTerm back to `8e7a1e1`.
