### PR TITLE
chore: add macOS 27 compatibility workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,237 @@
+name: Bug report
+description: Report a reproducible problem in Pine
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Pine. Please include exact version and build numbers so we can distinguish macOS 26 issues from macOS 27 beta regressions.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the problem and its visible impact.
+      placeholder: A concise description of what is broken.
+    validations:
+      required: true
+
+  - type: input
+    id: pine_version
+    attributes:
+      label: Pine version
+      description: The version shown in Pine > About Pine, or the commit SHA for a source build.
+      placeholder: "1.33.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: pine_source
+    attributes:
+      label: Installation source
+      description: Where this Pine build came from.
+      options:
+        - GitHub release
+        - Homebrew
+        - Built from source
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: macos_version
+    attributes:
+      label: macOS version
+      description: The full version reported by System Settings or `sw_vers -productVersion`.
+      placeholder: "27.0"
+    validations:
+      required: true
+
+  - type: input
+    id: macos_build
+    attributes:
+      label: macOS build
+      description: The build reported by System Settings or `sw_vers -buildVersion`.
+      placeholder: "26A5378n"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: macos_channel
+    attributes:
+      label: macOS release channel
+      options:
+        - Stable
+        - Developer beta
+        - Public beta
+        - Release candidate
+        - Other or unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: development_toolchain
+    attributes:
+      label: Xcode and macOS SDK
+      description: For source builds or SDK-specific bugs, paste `xcodebuild -version`, `xcrun --sdk macosx --show-sdk-version`, and `xcrun --sdk macosx --show-sdk-build-version`. For a release build with no local Xcode, write "Not applicable — release build".
+      placeholder: |
+        Xcode 27.0
+        Build version 27A5218g
+        macOS SDK: 27.0 (26A5378i)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: architecture
+    attributes:
+      label: Architecture
+      options:
+        - Apple silicon (arm64)
+        - Intel (x86_64)
+        - Other or unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: hardware_displays
+    attributes:
+      label: Hardware and displays
+      description: Include the Mac model, chip, memory, and every relevant built-in or external display, resolution/scaling, refresh rate, and HDR setting.
+      placeholder: |
+        MacBook Pro (14-inch, M4 Pro, 24 GB)
+        Built-in Liquid Retina XDR, 3024x1964, ProMotion, HDR enabled
+        External Studio Display, 5120x2880, default scaling, 60 Hz
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Terminal
+        - Code editor or code rendering
+        - Both terminal and code editor
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Start from launching Pine and list the smallest reliable sequence that triggers the bug.
+      placeholder: |
+        1. Open Pine...
+        2. Open...
+        3. Observe...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: Describe what should happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: Describe what happens instead, including any visible artifacts or error messages.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Explain how the bug affects your workflow, data, readability, or ability to use Pine.
+      placeholder: Why this problem matters in day-to-day use.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: Frequency
+      options:
+        - Every time
+        - Often
+        - Intermittently
+        - Happened once
+    validations:
+      required: true
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Regression
+      description: Did the same workflow work correctly on an older Pine or macOS version?
+      options:
+        - "Yes"
+        - "No"
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: last_known_good
+    attributes:
+      label: Last known working version
+      description: If this is a regression, provide the last working Pine version and macOS version/build.
+      placeholder: "Pine 1.32.0 on macOS 26.5 (25F90)"
+
+  - type: textarea
+    id: terminal_environment
+    attributes:
+      label: Terminal environment
+      description: Required for terminal bugs. Include the shell and version, `$TERM`, the command or TUI application, and whether the session is local, SSH, or another environment.
+      placeholder: |
+        Shell: /bin/zsh 5.9
+        TERM: xterm-256color
+        Command/TUI: vim 9.1
+        Session: local
+
+  - type: textarea
+    id: renderer_comparison
+    attributes:
+      label: Metal and CoreGraphics comparison
+      description: For terminal bugs, reproduce once through the default path (Metal when available; note any fallback log) and once with `--disable-metal` or `PINE_DISABLE_METAL=1` (forced CoreGraphics). If you cannot run one mode, say why.
+      placeholder: |
+        Default path (effective renderer + fallback log):
+        Forced CoreGraphics (--disable-metal):
+        Difference between modes:
+
+  - type: textarea
+    id: implementation_ideas
+    attributes:
+      label: Implementation ideas
+      description: Optional technical clues, suspected causes, or possible fixes.
+      placeholder: Leave blank if you do not have implementation suggestions.
+
+  - type: textarea
+    id: media_logs
+    attributes:
+      label: Screenshots, recordings, and logs
+      description: Drag in screenshots or a screen recording and paste relevant Console output, crash reports, or logs. Remove secrets and personal data first.
+      placeholder: Attach media and logs here, or write "None".
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Final checks
+      options:
+        - label: I searched for an existing issue that describes this problem.
+          required: true
+        - label: I removed passwords, tokens, private paths, and other sensitive information from the report.
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        Maintainers: add the appropriate area and priority labels and assign the issue to the active milestone before implementation begins.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,30 @@
 
 <!-- What does this PR do? 1-3 bullet points -->
 
+## Related issue
+
+<!-- Closes #1234 -->
+
 ## Test plan
 
 - [ ] Unit tests added/updated
 - [ ] UI tests added/updated (if applicable)
+
+## Compatibility matrix
+
+<!-- Use Tested, Not tested, or N/A. For tested rows, include the exact version and build. -->
+
+- macOS 26: <!-- Tested / Not tested / N/A — version + build -->
+- macOS 27 beta: <!-- Tested / Not tested / N/A — version + build + Developer/Public beta/RC channel -->
+- Xcode: <!-- version + build, or Not tested / N/A -->
+- macOS SDK: <!-- version + build, or Not tested / N/A -->
+
+### Terminal renderer coverage
+
+<!-- Complete for terminal-related changes. Use Tested, Not tested, or N/A. -->
+
+- Default path (Metal when available): <!-- Tested / Not tested / N/A — effective renderer, fallback log, result -->
+- CoreGraphics (`--disable-metal`): <!-- Tested / Not tested / N/A — result -->
 
 ## Manual testing checklist
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,116 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  # Compiler/SDK compatibility lane for the Xcode 27 preview image. The
+  # hosted runner still uses macOS 26, so runtime coverage on macOS 27 must
+  # continue on real hardware. Keep this non-blocking while the image is in
+  # preview; failures should remain visible without becoming required checks.
+  xcode-27-compatibility:
+    name: Xcode 27 Preview Compatibility
+    runs-on: xcode-27
+    continue-on-error: true
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Do not use the stable select-xcode helper here: xcode-27 runners
+      # provide the preview Xcode/SDK pair as their active toolchain.
+      - name: Report Preview Environment
+        run: |
+          sw_vers
+          uname -m
+          xcodebuild -version
+          echo "macOS SDK version: $(xcrun --sdk macosx --show-sdk-version)"
+          echo "macOS SDK build: $(xcrun --sdk macosx --show-sdk-build-version)"
+          echo "macOS SDK path: $(xcrun --sdk macosx --show-sdk-path)"
+
+      - name: Ensure Metal Toolchain
+        run: |
+          if xcodebuild -showComponent MetalToolchain -json 2>/dev/null; then
+            echo "Metal Toolchain is already installed"
+            exit 0
+          fi
+
+          for attempt in 1 2 3; do
+            echo "Downloading Metal Toolchain (attempt $attempt of 3)"
+            if xcodebuild -downloadComponent MetalToolchain \
+              && xcodebuild -showComponent MetalToolchain -json; then
+              exit 0
+            fi
+
+            if [ "$attempt" -lt 3 ]; then
+              echo "::warning::Metal Toolchain download failed; retrying in 10 seconds"
+              sleep 10
+            fi
+          done
+
+          echo "::error::Metal Toolchain could not be installed after 3 attempts"
+          exit 1
+
+      - name: Cache SPM Dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: DerivedData-Xcode27/SourcePackages
+          key: spm-xcode-27-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            spm-xcode-27-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Verify macOS 26 Deployment Target
+        run: |
+          deployment_target="$(
+            xcodebuild \
+              -project Pine.xcodeproj \
+              -scheme Pine \
+              -destination "platform=macOS" \
+              -derivedDataPath DerivedData-Xcode27 \
+              -showBuildSettings \
+              -json \
+              | jq -r '.[] | select(.target == "Pine") | .buildSettings.MACOSX_DEPLOYMENT_TARGET'
+          )"
+
+          if [ "$deployment_target" != "26.0" ]; then
+            echo "::error::Expected MACOSX_DEPLOYMENT_TARGET=26.0, got $deployment_target"
+            exit 1
+          fi
+
+          echo "Verified MACOSX_DEPLOYMENT_TARGET=$deployment_target"
+
+      - name: Build App with Xcode 27
+        run: |
+          xcodebuild build \
+            -project Pine.xcodeproj \
+            -scheme Pine \
+            -destination "platform=macOS" \
+            -derivedDataPath DerivedData-Xcode27 \
+            MACOSX_DEPLOYMENT_TARGET=26.0 \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO
+
+      - name: Unit Tests with Xcode 27
+        run: |
+          xcodebuild test \
+            -project Pine.xcodeproj \
+            -scheme Pine \
+            -destination "platform=macOS" \
+            -derivedDataPath DerivedData-Xcode27 \
+            -only-testing:PineTests \
+            -skip-testing:PineTests/FuzzGitDiffParserTests \
+            -skip-testing:PineTests/FuzzGitBlameParserTests \
+            -skip-testing:PineTests/FuzzGitStatusParserTests \
+            -skip-testing:PineTests/FuzzSyntaxHighlighterTests \
+            -skip-testing:PineTests/FuzzQuickOpenProviderTests \
+            -skip-testing:PineTests/FuzzSymbolParserTests \
+            -skip-testing:PineTests/FuzzConfigValidatorTests \
+            -skip-testing:PineTests/FuzzGoToLineParserTests \
+            -retry-tests-on-failure \
+            -test-timeouts-enabled \
+            -resultBundlePath Xcode27TestResults.xcresult \
+            MACOSX_DEPLOYMENT_TARGET=26.0 \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO
+
   unit-tests:
     name: Unit Tests
     runs-on: macos-26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Validate structural-intelligence prototype inputs
         run: python3 scripts/structural-intelligence/benchmark.py --validate-only
 
+      - name: Tests for Metal toolchain installer
+        run: bash scripts/tests/test-ensure-metal-toolchain.sh
+
   build:
     name: Build for Testing
     runs-on: macos-26
@@ -186,27 +189,7 @@ jobs:
           echo "macOS SDK path: $(xcrun --sdk macosx --show-sdk-path)"
 
       - name: Ensure Metal Toolchain
-        run: |
-          if xcodebuild -showComponent MetalToolchain -json 2>/dev/null; then
-            echo "Metal Toolchain is already installed"
-            exit 0
-          fi
-
-          for attempt in 1 2 3; do
-            echo "Downloading Metal Toolchain (attempt $attempt of 3)"
-            if xcodebuild -downloadComponent MetalToolchain \
-              && xcodebuild -showComponent MetalToolchain -json; then
-              exit 0
-            fi
-
-            if [ "$attempt" -lt 3 ]; then
-              echo "::warning::Metal Toolchain download failed; retrying in 10 seconds"
-              sleep 10
-            fi
-          done
-
-          echo "::error::Metal Toolchain could not be installed after 3 attempts"
-          exit 1
+        run: bash scripts/ensure-metal-toolchain.sh
 
       - name: Cache SPM Dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Tests for Metal toolchain installer
         run: bash scripts/tests/test-ensure-metal-toolchain.sh
 
+      - name: Tests for xcodebuild CLI options
+        run: bash scripts/tests/test-xcodebuild-cli-options.sh
+
   build:
     name: Build for Testing
     runs-on: macos-26
@@ -248,7 +251,7 @@ jobs:
             -skip-testing:PineTests/FuzzConfigValidatorTests \
             -skip-testing:PineTests/FuzzGoToLineParserTests \
             -retry-tests-on-failure \
-            -test-timeouts-enabled \
+            -test-timeouts-enabled YES \
             -resultBundlePath Xcode27TestResults.xcresult \
             MACOSX_DEPLOYMENT_TARGET=26.0 \
             CODE_SIGN_IDENTITY=- \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for AI coding agents (Claude Code, pi, and others) working in this repo
 
 ## Project Overview
 
-Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Targets macOS 26 (Tahoe) with Liquid Glass UI.
+Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Its minimum deployment target is macOS 26.0 (Tahoe), and compatibility work must cover both macOS 26 and the current macOS 27 beta.
 
 **Dependencies** (via Xcode SPM):
 - [SwiftTerm](https://github.com/migueldeicaza/SwiftTerm) — terminal emulator
@@ -13,7 +13,9 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Targets 
 
 ## Build & Run
 
-- **Xcode 26+** required, macOS 26+ deployment target
+- **Xcode 26+** required. Keep `MACOSX_DEPLOYMENT_TARGET` at `26.0`; macOS 27 is an additional compatibility target, not a new minimum requirement
+- Test compatibility-sensitive changes on both macOS 26 and the current macOS 27 beta when those runtimes are available. Do not fix a macOS 27 regression by breaking or raising the macOS 26 baseline
+- For OS- or SDK-specific reports, include the complete output of `sw_vers`, `xcodebuild -version`, `xcrun --sdk macosx --show-sdk-version`, and `xcrun --sdk macosx --show-sdk-build-version`; labels such as "macOS 27" or "Xcode beta" are not precise enough
 - Open `Pine.xcodeproj` in Xcode, build and run (Cmd+R)
 - CLI build: `xcodebuild -project Pine.xcodeproj -scheme Pine build` (requires `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`)
 - Type-check a single file (no sudo needed): `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -typecheck -target arm64-apple-macos26.0 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk <file.swift>`
@@ -39,6 +41,7 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Targets 
 - **Quick terminal:** a system-wide ⌃⌥Space hotkey (`Carbon RegisterEventHotKey`, no Accessibility permission required, works in the App Sandbox) toggles a floating drop-down terminal over any application (#1113). The session is keep-alive — scrollback survives toggles; Esc and ⌘W hide it. The working directory resolves to an open Pine project (current implementation picks `openProjects.keys.first` — Dictionary order, not the key window; key-window resolution is a follow-up), else the most-recent project, else `$HOME`. Disable with `--disable-quick-terminal` or `PINE_DISABLE_QUICK_TERMINAL` (used by UI tests). Agent detection (#950) does NOT cover the quick-terminal tab (it lives outside the pane tree) — a follow-up wires it in. A menu item, Settings UI (custom hotkey, screen edge, height), and per-pane quick terminals are follow-ups — v1 ships the hotkey + window only.
 - **Known issue:** XCUITest launch arguments (`-key YES`) store values as strings in NSArgumentDomain. `UserDefaults.object(forKey:) as? Bool` returns nil for strings. To set boolean UserDefaults for UI tests, use `defaults write <bundle-id> <key> -bool YES` via `Process` in setUp, and `defaults delete` in tearDown
 - **Known issue:** Pine's terminal opts into SwiftTerm's Metal renderer (`setUseMetal(true)`) once the view lands in a window, replacing the layer-backed CoreGraphics raster with a GPU swapchain and eliminating the entire black-screen class (#64, #661, #871, #918, #923, #966, #1094, #1108). On failure (headless CI VM, old GPU, virtual display without a Metal device) it silently falls back to CoreGraphics. UI tests pass `--disable-metal` to pin CoreGraphics on macOS-26 virtual displays; production users can opt out with `--disable-metal` or `PINE_DISABLE_METAL`.
+- **Terminal rendering compatibility:** manually reproduce rendering bugs once through the default path (Metal when available; record any fallback-to-CoreGraphics log) and once after relaunching with `--disable-metal` or `PINE_DISABLE_METAL=1` to force CoreGraphics. Record the effective renderer, Mac model/chip, display configuration, and whether the result differs on macOS 26 versus the current macOS 27 beta
 - To interact with menu items in UI tests, use `app.menuBars.menuBarItems["File"].click()` then `app.menuItems["Item Name"].click()` with English names (locale is forced to `en`)
 - Accessibility identifiers defined in `Pine/AccessibilityIdentifiers.swift` — used by both app views and UI tests
 
@@ -201,11 +204,13 @@ Pine uses a minimal zero-dependency visual snapshot harness for SwiftUI views. R
 
 ## GitHub Issues
 
-When creating issues, always:
+When creating or triaging issues, always:
 - Add appropriate labels from the repo's label set (e.g. `enhancement`, `bug`, `editor`, `UX`, `priority: high/medium/low`, etc.)
 - Use a clear, concise title
 - Include **Summary**, **Motivation**, and **Implementation ideas** sections in the body
 - **Always assign the issue to a milestone.** Work is milestone-driven: pick the next task from the current milestone, prioritizing by the `priority:` labels. No milestone = no work.
+
+The public bug-report form can apply the static `bug` label but cannot assign dynamic area/priority labels or a milestone. A maintainer or agent must complete that triage before implementation begins.
 
 ## Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,27 @@ xcodebuild -project Pine.xcodeproj -scheme Pine build
 
 New `.swift` files placed in `Pine/`, `PineTests/`, or `PineUITests/` are automatically picked up by Xcode (the project uses `PBXFileSystemSynchronizedRootGroup`). No manual `project.pbxproj` edits needed.
 
+## macOS Compatibility
+
+Pine's minimum deployment target remains macOS 26.0. The current macOS 27 beta is an additional compatibility target, so compatibility fixes must preserve macOS 26 support rather than raising the deployment target.
+
+For OS-, SDK-, or rendering-specific bug reports and pull requests, capture the exact environment instead of reporting only a major version or "Xcode beta":
+
+```bash
+sw_vers
+xcodebuild -version
+xcrun --sdk macosx --show-sdk-version
+xcrun --sdk macosx --show-sdk-build-version
+```
+
+Include the complete output, the Mac model/chip, and the display configuration. When both runtimes are available, state the result separately for macOS 26 and the current macOS 27 beta; use `not tested` where a runtime was unavailable.
+
+For terminal rendering bugs, perform a manual comparison after each code change:
+
+1. Launch normally to exercise the default path (Metal when available), and note any fallback-to-CoreGraphics message in Console.
+2. Quit Pine completely, then relaunch with the `--disable-metal` argument or `PINE_DISABLE_METAL=1` environment variable to force CoreGraphics.
+3. Report the effective renderer that reproduces the problem and whether behavior differs between macOS 26 and macOS 27 beta.
+
 ## Running Tests
 
 ### Unit tests

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 Pine keeps CLI agents in the terminal and the code in view. It reflects agent activity, file changes, diagnostics, and Git context across a fast native workspace without turning into another AI dashboard. Built with SwiftUI and AppKit for macOS 26 Liquid Glass — no Electron runtime.
 
+Pine keeps macOS 26.0 as its minimum deployment target while actively tracking compatibility with the current macOS 27 beta. The installation requirement remains macOS 26 or later.
+
 ## Features
 
 - **Native macOS** — SwiftUI + AppKit, Liquid Glass UI, system text handling. No browser engine, no runtime

--- a/scripts/ensure-metal-toolchain.sh
+++ b/scripts/ensure-metal-toolchain.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Install Xcode's separately distributed Metal toolchain when it is absent.
+# `xcodebuild -showComponent` can exit successfully while reporting
+# `{"status":"uninstalled"}`, so the JSON status is authoritative.
+set -euo pipefail
+
+MAX_ATTEMPTS="${METAL_TOOLCHAIN_MAX_ATTEMPTS:-3}"
+RETRY_DELAY_SECONDS="${METAL_TOOLCHAIN_RETRY_DELAY_SECONDS:-10}"
+
+case "$MAX_ATTEMPTS" in
+    ""|0|*[!0-9]*)
+        echo "::error::METAL_TOOLCHAIN_MAX_ATTEMPTS must be a positive integer"
+        exit 2
+        ;;
+esac
+
+case "$RETRY_DELAY_SECONDS" in
+    ""|*[!0-9]*)
+        echo "::error::METAL_TOOLCHAIN_RETRY_DELAY_SECONDS must be a non-negative integer"
+        exit 2
+        ;;
+esac
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "::error::jq is required to inspect the Metal Toolchain status"
+    exit 2
+fi
+
+metal_toolchain_status() {
+    local component_json
+    local component_status
+
+    if ! component_json="$(xcodebuild -showComponent MetalToolchain -json 2>/dev/null)"; then
+        echo "unknown"
+        return
+    fi
+
+    if component_status="$(
+        printf '%s\n' "$component_json" \
+            | jq -er '.status | select(type == "string")' 2>/dev/null
+    )" && [ -n "$component_status" ]; then
+        echo "$component_status"
+    else
+        echo "unknown"
+    fi
+}
+
+metal_toolchain_is_installed() {
+    case "$1" in
+        installed|installedUpdateAvailable)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+status="$(metal_toolchain_status)"
+# IDEFoundation treats both statuses as usable installed components.
+if metal_toolchain_is_installed "$status"; then
+    echo "Metal Toolchain is already installed"
+    exit 0
+fi
+
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    echo "Downloading Metal Toolchain (attempt $attempt of $MAX_ATTEMPTS; current status: $status)"
+
+    if xcodebuild -downloadComponent MetalToolchain; then
+        download_succeeded=true
+    else
+        download_succeeded=false
+    fi
+
+    # The component may be installed even if xcodebuild reports a late error,
+    # so query the authoritative status after every attempt, including the last.
+    status="$(metal_toolchain_status)"
+    if metal_toolchain_is_installed "$status"; then
+        echo "Metal Toolchain installed successfully"
+        exit 0
+    fi
+
+    if [ "$download_succeeded" = true ]; then
+        echo "::warning::Metal Toolchain download completed but status is '$status'"
+    else
+        echo "::warning::Metal Toolchain download command failed; status is '$status'"
+    fi
+
+    if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+        echo "Retrying in $RETRY_DELAY_SECONDS seconds"
+        sleep "$RETRY_DELAY_SECONDS"
+        status="$(metal_toolchain_status)"
+        if metal_toolchain_is_installed "$status"; then
+            echo "Metal Toolchain installed successfully"
+            exit 0
+        fi
+    fi
+done
+
+echo "::error::Metal Toolchain is not installed after $MAX_ATTEMPTS attempts (status: $status)"
+exit 1

--- a/scripts/tests/test-ensure-metal-toolchain.sh
+++ b/scripts/tests/test-ensure-metal-toolchain.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+# Regression tests for ensure-metal-toolchain.sh. The fake xcodebuild models
+# Xcode 27's surprising contract: `-showComponent` may exit 0 while returning
+# `{"status":"uninstalled"}`.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/ensure-metal-toolchain.sh"
+PASS=0
+FAIL=0
+TEST_ROOT=""
+
+cleanup() {
+    [ -n "$TEST_ROOT" ] && rm -rf "$TEST_ROOT"
+    TEST_ROOT=""
+}
+trap cleanup EXIT
+
+pass() {
+    echo "  ✓ $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "  ✗ $1"
+    FAIL=$((FAIL + 1))
+}
+
+setup_fake_xcodebuild() {
+    TEST_ROOT="$(mktemp -d)"
+    mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/state"
+
+    cat > "$TEST_ROOT/bin/xcodebuild" <<'FAKE_XCODEBUILD'
+#!/bin/bash
+set -euo pipefail
+
+scenario="${TEST_SCENARIO:?}"
+state_dir="${TEST_STATE_DIR:?}"
+
+if [ "$#" -eq 3 ] \
+    && [ "$1" = "-showComponent" ] \
+    && [ "$2" = "MetalToolchain" ] \
+    && [ "$3" = "-json" ]; then
+    action="show"
+elif [ "$#" -eq 2 ] \
+    && [ "$1" = "-downloadComponent" ] \
+    && [ "$2" = "MetalToolchain" ]; then
+    action="download"
+else
+    echo "unexpected xcodebuild arguments: $*" >&2
+    exit 64
+fi
+
+case "$action" in
+    show)
+        case "$scenario" in
+            already_installed)
+                status="installed"
+                ;;
+            show_error_then_installed)
+                if [ ! -f "$state_dir/downloaded" ]; then
+                    exit 70
+                fi
+                status="installed"
+                ;;
+            malformed_then_installed)
+                if [ ! -f "$state_dir/downloaded" ]; then
+                    echo "not-json"
+                    exit 0
+                fi
+                status="installed"
+                ;;
+            uninstalled_then_installed|download_errors_after_install)
+                if [ -f "$state_dir/downloaded" ]; then
+                    status="installed"
+                else
+                    status="uninstalled"
+                fi
+                ;;
+            update_available_then_installed)
+                if [ -f "$state_dir/downloaded" ]; then
+                    status="installed"
+                else
+                    status="installedUpdateAvailable"
+                fi
+                ;;
+            delayed_install)
+                if [ ! -f "$state_dir/downloaded" ]; then
+                    status="uninstalled"
+                elif [ -f "$state_dir/post-download-status-seen" ]; then
+                    status="installed"
+                else
+                    touch "$state_dir/post-download-status-seen"
+                    status="uninstalled"
+                fi
+                ;;
+            uninstalled_forever|download_fails)
+                status="uninstalled"
+                ;;
+            *)
+                echo "unknown test scenario: $scenario" >&2
+                exit 64
+                ;;
+        esac
+
+        printf '{"buildVersion":"test","status":"%s"}\n' "$status"
+        ;;
+    download)
+        count=0
+        if [ -f "$state_dir/download-count" ]; then
+            count="$(cat "$state_dir/download-count")"
+        fi
+        echo "$((count + 1))" > "$state_dir/download-count"
+
+        if [ "$scenario" = "download_fails" ]; then
+            exit 1
+        fi
+
+        touch "$state_dir/downloaded"
+        if [ "$scenario" = "download_errors_after_install" ]; then
+            exit 1
+        fi
+        ;;
+esac
+FAKE_XCODEBUILD
+    chmod +x "$TEST_ROOT/bin/xcodebuild"
+}
+
+run_installer() {
+    PATH="$TEST_ROOT/bin:$PATH" \
+        TEST_SCENARIO="$1" \
+        TEST_STATE_DIR="$TEST_ROOT/state" \
+        METAL_TOOLCHAIN_MAX_ATTEMPTS=3 \
+        METAL_TOOLCHAIN_RETRY_DELAY_SECONDS=0 \
+        bash "$SCRIPT"
+}
+
+download_count() {
+    if [ -f "$TEST_ROOT/state/download-count" ]; then
+        cat "$TEST_ROOT/state/download-count"
+    else
+        echo 0
+    fi
+}
+
+echo "Test 1: installed status skips the download"
+setup_fake_xcodebuild
+if run_installer already_installed >/dev/null 2>&1 && [ "$(download_count)" -eq 0 ]; then
+    pass "already-installed component accepted"
+else
+    fail "installed component should not be downloaded"
+fi
+cleanup
+
+echo "Test 2: uninstalled status with exit 0 triggers the download"
+setup_fake_xcodebuild
+if run_installer uninstalled_then_installed >/dev/null 2>&1 && [ "$(download_count)" -eq 1 ]; then
+    pass "uninstalled JSON status rejected and installed"
+else
+    fail "uninstalled status was treated as installed"
+fi
+cleanup
+
+echo "Test 3: failed status query triggers the download"
+setup_fake_xcodebuild
+if run_installer show_error_then_installed >/dev/null 2>&1 && [ "$(download_count)" -eq 1 ]; then
+    pass "failed status query recovered"
+else
+    fail "failed status query did not recover"
+fi
+cleanup
+
+echo "Test 4: malformed status JSON triggers the download"
+setup_fake_xcodebuild
+if run_installer malformed_then_installed >/dev/null 2>&1 && [ "$(download_count)" -eq 1 ]; then
+    pass "malformed status response recovered"
+else
+    fail "malformed status response did not recover"
+fi
+cleanup
+
+echo "Test 5: successful downloads without installed status exhaust retries"
+setup_fake_xcodebuild
+if run_installer uninstalled_forever >/dev/null 2>&1; then
+    fail "uninstalled status should fail after retries"
+elif [ "$(download_count)" -eq 3 ]; then
+    pass "uninstalled status exhausted all retries"
+else
+    fail "unexpected retry count for uninstalled status"
+fi
+cleanup
+
+echo "Test 6: installed component with an update available remains usable"
+setup_fake_xcodebuild
+if run_installer update_available_then_installed >/dev/null 2>&1 && [ "$(download_count)" -eq 0 ]; then
+    pass "installedUpdateAvailable status accepted"
+else
+    fail "usable installed component was downloaded again"
+fi
+cleanup
+
+echo "Test 7: delayed installed status avoids a duplicate download"
+setup_fake_xcodebuild
+if run_installer delayed_install >/dev/null 2>&1 && [ "$(download_count)" -eq 1 ]; then
+    pass "delayed installed status accepted after retry delay"
+else
+    fail "delayed installed status caused a duplicate download"
+fi
+cleanup
+
+echo "Test 8: installed status wins over a late download error"
+setup_fake_xcodebuild
+if run_installer download_errors_after_install >/dev/null 2>&1 && [ "$(download_count)" -eq 1 ]; then
+    pass "installed component accepted after download command error"
+else
+    fail "late download error masked the installed status"
+fi
+cleanup
+
+echo "Test 9: failed downloads exhaust retries"
+setup_fake_xcodebuild
+if run_installer download_fails >/dev/null 2>&1; then
+    fail "failed downloads should return non-zero"
+elif [ "$(download_count)" -eq 3 ]; then
+    pass "failed downloads exhausted all retries"
+else
+    fail "unexpected retry count for failed downloads"
+fi
+cleanup
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test-xcodebuild-cli-options.sh
+++ b/scripts/tests/test-xcodebuild-cli-options.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Guard xcodebuild options whose argument requirements differ across Xcode
+# releases. Xcode 27 consumes the next token when -test-timeouts-enabled has
+# no explicit YES/NO value, which can turn a result-bundle path into an
+# "unknown build action".
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+CI_WORKFLOW="$SCRIPT_DIR/.github/workflows/ci.yml"
+
+timeout_lines="$(
+    grep -nF -- '-test-timeouts-enabled' "$CI_WORKFLOW" \
+        | grep -vE '^[0-9]+:[[:space:]]*#' \
+        || true
+)"
+if [ -z "$timeout_lines" ]; then
+    echo "✗ CI workflow no longer exercises test timeouts"
+    exit 1
+fi
+
+timeout_count="$(printf '%s\n' "$timeout_lines" | wc -l | tr -d '[:space:]')"
+if [ "$timeout_count" -ne 2 ]; then
+    echo "✗ Expected timeout options in the Xcode 26 and Xcode 27 unit-test lanes; found $timeout_count"
+    echo "$timeout_lines"
+    exit 1
+fi
+
+invalid_lines="$(
+    printf '%s\n' "$timeout_lines" \
+        | grep -vE -- '-test-timeouts-enabled[[:space:]]+YES([[:space:]]|$)' \
+        || true
+)"
+
+if [ -n "$invalid_lines" ]; then
+    echo "✗ Every -test-timeouts-enabled option must pass an explicit YES value:"
+    echo "$invalid_lines"
+    exit 1
+fi
+
+echo "✓ All xcodebuild test-timeout options pass an explicit YES value"


### PR DESCRIPTION
## Summary

- document macOS 26.0 as the unchanged minimum and macOS 27 beta as an active compatibility target
- add structured bug-report and PR compatibility fields for exact OS, Xcode, SDK, hardware, and terminal renderer data
- add a non-blocking Xcode 27 preview CI lane that verifies the 26.0 deployment target, builds, and runs PineTests
- harden Metal toolchain installation checks and pin explicit xcodebuild timeout values across Xcode 26/27

## Related issue

Closes #1132

The earlier Xcode 27 compiler and test blockers tracked in #1133 and #1146 are resolved on main; this branch is rebased onto those fixes and #1157.

## Test plan

- [x] Parsed the workflow and issue form as YAML
- [x] Verified all 22 issue-form field IDs are unique
- [x] Ran git diff --check
- [x] Ran SwiftLint strict across project and test Swift files
- [x] Ran the nonisolated and NotificationCenter reentrancy guards
- [x] Verified Pine MACOSX_DEPLOYMENT_TARGET resolves to 26.0 through xcodebuild build settings
- [x] Metal toolchain installer regression suite: 9/9
- [x] xcodebuild CLI option regression suite
- [x] Full local PineTests on Xcode 27: exit 0 in 61.1 seconds after rebase onto #1157
- [ ] Fresh GitHub CI on head 3eb3d1b, including Xcode 27 preview, Unit Tests, 7 UI shards, and Flaky Summary

## Compatibility matrix

- macOS 26: Not tested locally; stable GitHub CI is the coverage lane
- macOS 27 beta: Tested locally on macOS 27.0 build 26A5378n
- Xcode: 27.0 build 27A5218g
- macOS SDK: 27.0 build 26A5378i

### Terminal renderer coverage

- Default path (Metal when available): N/A — documentation and CI infrastructure only
- CoreGraphics (--disable-metal): N/A — documentation and CI infrastructure only

## Manual testing checklist

- [x] Verified the issue form, PR template, and contributor guidance agree on required environment data
- [x] Confirmed the Xcode 27 lane is non-blocking while the hosted image remains preview
- [x] Confirmed the deployment target remains macOS 26.0
- [x] Confirmed release workflow behavior is unchanged