### PR TITLE
fix(editor): compile notification observers with Xcode 27

### DIFF
--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -261,7 +261,7 @@ extension ContentView {
 extension ContentView {
 
     /// Used by GitAndNotificationObserver — internal visibility required for cross-struct access.
-    enum ChangeDirection { case next, previous }
+    enum ChangeDirection: Equatable, Sendable { case next, previous }
 
     /// Navigates to the next/previous git change region in the **active**
     /// editor pane. Fetches fresh diffs for the active tab so it does not
@@ -517,6 +517,56 @@ extension ContentView {
 
         // Send text followed by newline to execute
         activeTab.sendText(text + "\n")
+    }
+
+    // MARK: - Menu notification handlers (#1051, #1133)
+
+    /// Keeps the mutation deferred so synchronous menu-notification delivery
+    /// cannot re-enter SwiftUI's `@AppStorage` access (#1051).
+    func handleToggleWordWrap() {
+        DispatchQueue.main.async {
+            self.isWordWrapEnabled.toggle()
+        }
+    }
+
+    /// Extracted from `body` to keep Xcode 27's SwiftUI type-checker within
+    /// budget while preserving the existing next-runloop mutation (#1133).
+    func handleRevealInSidebar(_ notification: Notification) {
+        guard let url = Self.resolveRevealInSidebarURL(from: notification) else { return }
+        DispatchQueue.main.async {
+            if let node = self.findNode(url: url, in: self.workspace.rootNodes) {
+                self.selectedNode = node
+                self.columnVisibility = .all
+            }
+        }
+    }
+
+    /// Extracted from `body` without changing focus gating or the reentrancy
+    /// defer required before mutating terminal state (#1051, #1133).
+    func handleSendTextToTerminal(_ notification: Notification) {
+        guard let text = Self.resolveTerminalText(
+            from: notification,
+            isKeyWindow: controlActiveState == .key
+        ) else { return }
+        DispatchQueue.main.async {
+            self.sendTextToTerminal(text)
+        }
+    }
+
+    static func resolveRevealInSidebarURL(from notification: Notification) -> URL? {
+        notification.userInfo?["url"] as? URL
+    }
+
+    /// Whitespace-only text remains valid; the pre-#1133 observer rejected
+    /// only the empty string.
+    static func resolveTerminalText(
+        from notification: Notification,
+        isKeyWindow: Bool
+    ) -> String? {
+        guard isKeyWindow,
+              let text = notification.userInfo?["text"] as? String,
+              !text.isEmpty else { return nil }
+        return text
     }
 }
 

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -252,32 +252,13 @@ struct ContentView: View {
             onInlineDiffAction: { handleInlineDiffAction($0) }
         ))
         .onReceive(NotificationCenter.default.publisher(for: .toggleWordWrap)) { _ in
-            // Defer to break reentrancy (#1051): @AppStorage mutation from
-            // a menu→notification callstack (⌥Z).
-            DispatchQueue.main.async {
-                isWordWrapEnabled.toggle()
-            }
+            handleToggleWordWrap()
         }
         .onReceive(NotificationCenter.default.publisher(for: .revealInSidebar)) { notification in
-            guard let url = notification.userInfo?["url"] as? URL else { return }
-            // Defer to break reentrancy (#1051): mutating @State
-            // (selectedNode + columnVisibility).
-            DispatchQueue.main.async {
-                if let node = findNode(url: url, in: workspace.rootNodes) {
-                    selectedNode = node
-                    columnVisibility = .all
-                }
-            }
+            handleRevealInSidebar(notification)
         }
         .onReceive(NotificationCenter.default.publisher(for: .sendTextToTerminal)) { notification in
-            guard controlActiveState == .key,
-                  let text = notification.userInfo?["text"] as? String,
-                  !text.isEmpty else { return }
-            // Defer to break reentrancy (#1051): sendTextToTerminal mutates
-            // @Observable terminal state.
-            DispatchQueue.main.async {
-                sendTextToTerminal(text)
-            }
+            handleSendTextToTerminal(notification)
         }
     }
 

--- a/Pine/GitAndNotificationObserver.swift
+++ b/Pine/GitAndNotificationObserver.swift
@@ -53,7 +53,7 @@ struct GitAndNotificationObserver: ViewModifier {
     private var activeTabManager: TabManager { projectManager.activeTabManager }
 
     func body(content: Content) -> some View {
-        content
+        let contentWithFileObservers = content
             .onChange(of: workspace.gitProvider.isGitRepository) { _, isRepo in
                 if isRepo {
                     onRefreshLineDiffs()
@@ -87,6 +87,8 @@ struct GitAndNotificationObserver: ViewModifier {
                 guard let deletedURL = notification.userInfo?["url"] as? URL else { return }
                 handleFileDeleted(deletedURL)
             }
+
+        return contentWithFileObservers
             .onChange(of: workspace.externalChangeToken) { _, _ in
                 // Issue #838: never gate the FSEvents path on focus. The
                 // previous `controlActiveState == .key` guard meant that
@@ -141,14 +143,10 @@ struct GitAndNotificationObserver: ViewModifier {
                 handleOpenFileAtLine(notification)
             }
             .onReceive(NotificationCenter.default.publisher(for: .navigateChange)) { notification in
-                guard controlActiveState == .key,
-                      let direction = notification.userInfo?["direction"] as? String else { return }
-                onNavigateToChange(direction == "next" ? .next : .previous)
+                handleNavigateChange(notification)
             }
             .onReceive(NotificationCenter.default.publisher(for: .inlineDiffAction)) { notification in
-                guard controlActiveState == .key,
-                      let action = notification.userInfo?["action"] as? InlineDiffAction else { return }
-                onInlineDiffAction(action)
+                handleInlineDiffAction(notification)
             }
     }
 
@@ -226,6 +224,51 @@ struct GitAndNotificationObserver: ViewModifier {
             // results land in the editor the user is looking at (#971).
             self.activeTabManager.openTabAndGoToLine(url: url, line: line)
         }
+    }
+
+    /// Kept out of the modifier closure so Xcode 27's SwiftUI type-checker
+    /// does not have to solve payload parsing inside the long modifier chain
+    /// (issue #1133).
+    func handleNavigateChange(_ notification: Notification) {
+        guard let direction = Self.resolveChangeDirection(
+            from: notification,
+            isKeyWindow: controlActiveState == .key
+        ) else { return }
+        onNavigateToChange(direction)
+    }
+
+    /// Mirrors `handleNavigateChange` for the adjacent inline-diff command.
+    /// Leaving this payload cast inline merely moved Xcode 27's type-checking
+    /// failure to the next modifier (issue #1133).
+    func handleInlineDiffAction(_ notification: Notification) {
+        guard let action = Self.resolveInlineDiffAction(
+            from: notification,
+            isKeyWindow: controlActiveState == .key
+        ) else { return }
+        onInlineDiffAction(action)
+    }
+
+    /// Pure resolver used by the notification handler and its regression
+    /// tests. Any string other than `"next"` intentionally maps to
+    /// `.previous`, preserving the command's pre-#1133 behavior.
+    static func resolveChangeDirection(
+        from notification: Notification,
+        isKeyWindow: Bool
+    ) -> ContentView.ChangeDirection? {
+        guard isKeyWindow,
+              let direction = notification.userInfo?["direction"] as? String else { return nil }
+        return direction == "next" ? .next : .previous
+    }
+
+    /// Pure resolver for inline-diff notifications. The payload must contain
+    /// an `InlineDiffAction` value; raw strings are deliberately not decoded.
+    static func resolveInlineDiffAction(
+        from notification: Notification,
+        isKeyWindow: Bool
+    ) -> InlineDiffAction? {
+        guard isKeyWindow,
+              let action = notification.userInfo?["action"] as? InlineDiffAction else { return nil }
+        return action
     }
 }
 

--- a/PineTests/ContentViewNotificationResolverTests.swift
+++ b/PineTests/ContentViewNotificationResolverTests.swift
@@ -1,0 +1,115 @@
+//
+//  ContentViewNotificationResolverTests.swift
+//  PineTests
+//
+//  Regression coverage for the ContentView notification extraction in #1133.
+//
+
+import Foundation
+import Testing
+@testable import Pine
+
+@MainActor
+struct ContentViewNotificationResolverTests {
+
+    // MARK: - Reveal in sidebar
+
+    @Test("Reveal-in-sidebar resolver preserves a URL payload")
+    func revealInSidebarPreservesURL() {
+        let expectedURL = URL(fileURLWithPath: "/tmp/pine/sidebar.swift")
+        let notification = Notification(
+            name: .revealInSidebar,
+            userInfo: ["url": expectedURL]
+        )
+
+        let resolved = ContentView.resolveRevealInSidebarURL(from: notification)
+
+        #expect(resolved == expectedURL)
+    }
+
+    @Test("Reveal-in-sidebar resolver rejects missing and incorrectly typed payloads")
+    func revealInSidebarRejectsInvalidPayloads() {
+        let notifications = [
+            Notification(name: .revealInSidebar),
+            Notification(name: .revealInSidebar, userInfo: [:]),
+            Notification(name: .revealInSidebar, userInfo: ["url": NSNull()]),
+            Notification(name: .revealInSidebar, userInfo: ["url": 1]),
+            Notification(name: .revealInSidebar, userInfo: ["url": "/tmp/pine/sidebar.swift"])
+        ]
+
+        for notification in notifications {
+            #expect(ContentView.resolveRevealInSidebarURL(from: notification) == nil)
+        }
+    }
+
+    // MARK: - Send text to terminal
+
+    @Test("Terminal-text resolver preserves non-empty text, including whitespace")
+    func terminalTextPreservesNonEmptyText() {
+        let payloads = ["echo pine", " ", "\n", "  padded  "]
+
+        for payload in payloads {
+            let notification = Notification(
+                name: .sendTextToTerminal,
+                userInfo: ["text": payload]
+            )
+
+            let resolved = ContentView.resolveTerminalText(
+                from: notification,
+                isKeyWindow: true
+            )
+
+            #expect(resolved == payload)
+        }
+    }
+
+    @Test("Terminal-text resolver rejects an empty string")
+    func terminalTextRejectsEmptyString() {
+        let notification = Notification(
+            name: .sendTextToTerminal,
+            userInfo: ["text": ""]
+        )
+
+        let resolved = ContentView.resolveTerminalText(
+            from: notification,
+            isKeyWindow: true
+        )
+
+        #expect(resolved == nil)
+    }
+
+    @Test("Terminal-text resolver rejects missing and incorrectly typed payloads")
+    func terminalTextRejectsInvalidPayloads() {
+        let notifications = [
+            Notification(name: .sendTextToTerminal),
+            Notification(name: .sendTextToTerminal, userInfo: [:]),
+            Notification(name: .sendTextToTerminal, userInfo: ["text": NSNull()]),
+            Notification(name: .sendTextToTerminal, userInfo: ["text": 1]),
+            Notification(name: .sendTextToTerminal, userInfo: ["text": Data()])
+        ]
+
+        for notification in notifications {
+            let resolved = ContentView.resolveTerminalText(
+                from: notification,
+                isKeyWindow: true
+            )
+
+            #expect(resolved == nil)
+        }
+    }
+
+    @Test("Terminal-text resolver ignores notifications for non-key windows")
+    func terminalTextRequiresKeyWindow() {
+        let notification = Notification(
+            name: .sendTextToTerminal,
+            userInfo: ["text": "echo pine"]
+        )
+
+        let resolved = ContentView.resolveTerminalText(
+            from: notification,
+            isKeyWindow: false
+        )
+
+        #expect(resolved == nil)
+    }
+}

--- a/PineTests/GitAndNotificationObserverTests.swift
+++ b/PineTests/GitAndNotificationObserverTests.swift
@@ -1,0 +1,145 @@
+//
+//  GitAndNotificationObserverTests.swift
+//  PineTests
+//
+//  Regression coverage for the notification resolver extraction in #1133.
+//
+
+import Foundation
+import Testing
+@testable import Pine
+
+@MainActor
+struct GitAndNotificationObserverTests {
+
+    // MARK: - Navigate change
+
+    @Test("Navigate-change resolver maps the supported direction strings")
+    func navigateChangeMapsSupportedDirections() {
+        let cases: [(payload: String, expected: ContentView.ChangeDirection)] = [
+            (payload: "next", expected: .next),
+            (payload: "previous", expected: .previous)
+        ]
+
+        for testCase in cases {
+            let notification = Notification(
+                name: .navigateChange,
+                userInfo: ["direction": testCase.payload]
+            )
+            let resolved = GitAndNotificationObserver.resolveChangeDirection(
+                from: notification,
+                isKeyWindow: true
+            )
+
+            #expect(resolved == testCase.expected)
+        }
+    }
+
+    @Test("Navigate-change resolver preserves the previous fallback for other strings")
+    func navigateChangePreservesPreviousFallback() {
+        let fallbackPayloads = ["", "NEXT", "next ", "unexpected"]
+
+        for payload in fallbackPayloads {
+            let notification = Notification(
+                name: .navigateChange,
+                userInfo: ["direction": payload]
+            )
+            let resolved = GitAndNotificationObserver.resolveChangeDirection(
+                from: notification,
+                isKeyWindow: true
+            )
+
+            #expect(resolved == .previous)
+        }
+    }
+
+    @Test("Navigate-change resolver rejects missing and non-string payloads")
+    func navigateChangeRejectsInvalidPayloads() {
+        let notifications = [
+            Notification(name: .navigateChange),
+            Notification(name: .navigateChange, userInfo: [:]),
+            Notification(name: .navigateChange, userInfo: ["direction": NSNull()]),
+            Notification(name: .navigateChange, userInfo: ["direction": 1]),
+            Notification(name: .navigateChange, userInfo: ["direction": InlineDiffAction.accept])
+        ]
+
+        for notification in notifications {
+            let resolved = GitAndNotificationObserver.resolveChangeDirection(
+                from: notification,
+                isKeyWindow: true
+            )
+
+            #expect(resolved == nil)
+        }
+    }
+
+    @Test("Navigate-change resolver ignores notifications for non-key windows")
+    func navigateChangeRequiresKeyWindow() {
+        let notification = Notification(
+            name: .navigateChange,
+            userInfo: ["direction": "next"]
+        )
+
+        let resolved = GitAndNotificationObserver.resolveChangeDirection(
+            from: notification,
+            isKeyWindow: false
+        )
+
+        #expect(resolved == nil)
+    }
+
+    // MARK: - Inline diff action
+
+    @Test("Inline-diff resolver preserves every typed action")
+    func inlineDiffPreservesTypedActions() {
+        let actions: [InlineDiffAction] = [.accept, .revert, .acceptAll, .revertAll]
+
+        for action in actions {
+            let notification = Notification(
+                name: .inlineDiffAction,
+                userInfo: ["action": action]
+            )
+            let resolved = GitAndNotificationObserver.resolveInlineDiffAction(
+                from: notification,
+                isKeyWindow: true
+            )
+
+            #expect(resolved?.rawValue == action.rawValue)
+        }
+    }
+
+    @Test("Inline-diff resolver rejects missing and incorrectly typed payloads")
+    func inlineDiffRejectsInvalidPayloads() {
+        let notifications = [
+            Notification(name: .inlineDiffAction),
+            Notification(name: .inlineDiffAction, userInfo: [:]),
+            Notification(name: .inlineDiffAction, userInfo: ["action": NSNull()]),
+            Notification(name: .inlineDiffAction, userInfo: ["action": 1]),
+            Notification(name: .inlineDiffAction, userInfo: ["action": "accept"])
+        ]
+
+        for notification in notifications {
+            let resolved = GitAndNotificationObserver.resolveInlineDiffAction(
+                from: notification,
+                isKeyWindow: true
+            )
+
+            #expect(resolved == nil)
+        }
+    }
+
+    @Test("Inline-diff resolver ignores notifications for non-key windows")
+    func inlineDiffRequiresKeyWindow() {
+        let notification = Notification(
+            name: .inlineDiffAction,
+            userInfo: ["action": InlineDiffAction.accept]
+        )
+
+        let resolved = GitAndNotificationObserver.resolveInlineDiffAction(
+            from: notification,
+            isKeyWindow: false
+        )
+
+        #expect(resolved == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- split the long GitAndNotificationObserver modifier chain at a stable inference boundary and move notification payload parsing into named handlers
- extract the adjacent ContentView notification handlers that Xcode 27 exposed next, while preserving focus gating, active-pane timing, and existing reentrancy defers
- add pure payload resolvers and 12 edge-case tests for direction, inline-diff action, sidebar URL, and terminal text notifications

## Related issue

Closes #1133

This unblocks the Xcode 27 preview compatibility lane added by #1134. Recommended merge order: this PR first, then update or rerun #1134.

## Test plan

- [x] Xcode 27 beta 3 build-for-testing with MACOSX_DEPLOYMENT_TARGET=26.0
- [x] Xcode 27 targeted tests: PineTests/GitAndNotificationObserverTests and PineTests/ContentViewNotificationResolverTests
- [x] SwiftLint 0.63.2 strict mode across Pine and all test source trees
- [x] Nonisolated and NotificationCenter reentrancy guards
- [x] git diff --check
- [x] Independent review for semantic preservation and Swift concurrency/reentrancy

## Compatibility matrix

- macOS 26: Not tested locally; existing CI provides stable compiler/runtime coverage
- macOS 27 beta: Tested on macOS 27.0 build 26A5378n
- Xcode: 27.0 build 27A5218g
- macOS SDK: 27.0 build 26A5378i

### Terminal renderer coverage

- Default path (Metal when available): N/A — compiler-only observer refactor
- CoreGraphics (--disable-metal): N/A — compiler-only observer refactor

## Manual testing checklist

- [x] Preserved unknown direction string to previous fallback behavior
- [x] Preserved typed-only InlineDiffAction payload handling
- [x] Preserved synchronous active-pane capture for navigation and inline diff commands
- [x] Preserved existing next-runloop defers for word wrap, sidebar reveal, and terminal text delivery
- [x] Kept the deployment target at macOS 26.0