### PR TITLE
fix(lsp): parse bare code action commands

### DIFF
--- a/Pine/LSP/CodeActionProvider.swift
+++ b/Pine/LSP/CodeActionProvider.swift
@@ -144,6 +144,12 @@ nonisolated struct LSPCodeAction: @unchecked Sendable, Identifiable {
     init?(json: Any) {
         guard let dict = json as? [String: Any] else { return nil }
         guard let title = dict["title"] as? String, !title.isEmpty else { return nil }
+        // The code-action response is a union of CodeAction and Command.
+        // A top-level string is the Command discriminator; CodeAction.command
+        // is a nested Command object. Reject the bare form here so the response
+        // parser can decode it with LSPCommand instead of swallowing it as a
+        // disabled CodeAction.
+        guard !(dict["command"] is String) else { return nil }
         self.title = title
         self.kind = LSPCodeActionKind(raw: dict["kind"])
         self.isPreferred = (dict["isPreferred"] as? Bool) ?? false

--- a/PineTests/LSPCodeActionResponseTests.swift
+++ b/PineTests/LSPCodeActionResponseTests.swift
@@ -131,7 +131,18 @@ struct LSPCodeActionResponseTests {
         ]
         let response = LSPCodeActionResponse(result: json)
         #expect(response.commands.count == 1)
-        #expect(response.commands[0].arguments != nil)
+        #expect(response.commands.first?.title == "Go to")
+        #expect(response.commands.first?.command == "navigate")
+        #expect(response.commands.first?.arguments != nil)
+    }
+
+    @Test("Bare Command with empty identifier is skipped")
+    func emptyBareCommandIdentifierSkipped() {
+        let json: [Any] = [
+            ["title": "Invalid", "command": ""]
+        ]
+        let response = LSPCodeActionResponse(result: json)
+        #expect(response.isEmpty)
     }
 
     // MARK: - Null response


### PR DESCRIPTION
## Summary

- distinguish protocol-level bare `Command` entries from `CodeAction.command` objects
- keep bare commands executable instead of swallowing them as disabled code actions
- remove the unsafe test subscript that crashed the test host and cover an empty command identifier

## Testing

- Xcode 27 beta: `LSPCodeActionResponseTests` — 18/18 passed
- SwiftLint 0.63.2 strict (`--no-cache`)
- `git diff --check`

Fixes #1139