### PR TITLE
fix(editor): restore Python declaration highlighting

### DIFF
--- a/Pine/Grammars/python.json
+++ b/Pine/Grammars/python.json
@@ -41,16 +41,16 @@
             "scope": "attribute"
         },
         {
+            "pattern": "\\b(def|class|if|elif|else|for|while|return|import|from|as|try|except|finally|with|raise|pass|break|continue|in|not|and|or|is|lambda|yield|global|nonlocal|assert|del|async|await|match|case)\\b",
+            "scope": "keyword"
+        },
+        {
             "pattern": "\\bdef\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
             "scope": "function"
         },
         {
             "pattern": "\\bclass\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
             "scope": "function"
-        },
-        {
-            "pattern": "\\b(def|class|if|elif|else|for|while|return|import|from|as|try|except|finally|with|raise|pass|break|continue|in|not|and|or|is|lambda|yield|global|nonlocal|assert|del|async|await|match|case)\\b",
-            "scope": "keyword"
         },
         {
             "pattern": "\\b(True|False|None)\\b",

--- a/PineTests/NestedFencedHighlightTests.swift
+++ b/PineTests/NestedFencedHighlightTests.swift
@@ -95,10 +95,10 @@ struct NestedFencedHighlightTests {
         // `def hello` matches as function scope in Python grammar (def + name),
         // so `def` gets function color, not keyword color.
         let defPos = position(of: "def", in: storage)
-        #expect(color(in: storage, at: defPos) == functionColor)
+        #expect(color(in: storage, at: defPos) === functionColor)
 
         let passPos = position(of: "pass", in: storage)
-        #expect(color(in: storage, at: passPos) == keywordColor)
+        #expect(color(in: storage, at: passPos) === keywordColor)
     }
 
     @Test func pythonFunctionHighlightedInsideFencedBlock() throws {
@@ -110,7 +110,7 @@ struct NestedFencedHighlightTests {
         """
         let storage = try highlight(text)
         let helloPos = position(of: "hello", in: storage)
-        #expect(color(in: storage, at: helloPos) == functionColor)
+        #expect(color(in: storage, at: helloPos) === functionColor)
     }
 
     // MARK: - No language tag
@@ -155,14 +155,14 @@ struct NestedFencedHighlightTests {
         let storage = try highlight(text)
 
         let letPos = position(of: "let", in: storage)
-        #expect(color(in: storage, at: letPos) == keywordColor)
+        #expect(color(in: storage, at: letPos) === keywordColor)
 
         // `def hello` matches as function scope in Python grammar
         let defPos = position(of: "def", in: storage)
-        #expect(color(in: storage, at: defPos) == functionColor)
+        #expect(color(in: storage, at: defPos) === functionColor)
 
         let passPos = position(of: "pass", in: storage)
-        #expect(color(in: storage, at: passPos) == keywordColor)
+        #expect(color(in: storage, at: passPos) === keywordColor)
     }
 
     // MARK: - Bash/shell alias

--- a/PineTests/PythonGrammarTests.swift
+++ b/PineTests/PythonGrammarTests.swift
@@ -23,6 +23,7 @@ struct PythonGrammarTests {
     private var numberColor: NSColor { hl.theme.color(for: "number")! } // swiftlint:disable:this force_unwrapping
     private var typeColor: NSColor { hl.theme.color(for: "type")! } // swiftlint:disable:this force_unwrapping
     private var attributeColor: NSColor { hl.theme.color(for: "attribute")! } // swiftlint:disable:this force_unwrapping
+    private var functionColor: NSColor { hl.theme.color(for: "function")! } // swiftlint:disable:this force_unwrapping
 
     // MARK: - Helpers
 
@@ -183,6 +184,24 @@ struct PythonGrammarTests {
     }
 
     // MARK: - Keywords / numbers / types still work
+
+    @Test func functionDeclarationOverridesKeywordScope() throws {
+        let storage = try highlight("def hello():\n    pass")
+        let defPos = position(of: "def", in: storage)
+        let namePos = position(of: "hello", in: storage)
+
+        #expect(color(in: storage, at: defPos) === functionColor)
+        #expect(color(in: storage, at: namePos) === functionColor)
+    }
+
+    @Test func classDeclarationOverridesKeywordScope() throws {
+        let storage = try highlight("class Foo:\n    pass")
+        let classPos = position(of: "class", in: storage)
+        let namePos = position(of: "Foo", in: storage)
+
+        #expect(color(in: storage, at: classPos) === functionColor)
+        #expect(color(in: storage, at: namePos) === functionColor)
+    }
 
     @Test func keywordHighlightingStillWorks() throws {
         let storage = try highlight("if x: pass")


### PR DESCRIPTION
## Summary

- restore the intended equal-priority rule order so Python `def` and `class` declarations keep function scope
- add direct regression coverage for both declaration keywords and names
- replace fragile dynamic `NSColor ==` assertions in fenced-code tests with exact theme-color identity checks

## Testing

- Xcode 27 beta: `PythonGrammarTests` + `NestedFencedHighlightTests` — 37/37 passed
- SwiftLint 0.63.2 strict (`--no-cache`)
- Python grammar JSON validation
- `git diff --check`

Fixes #1141