### PR TITLE
test: align LSP parser fixtures with documented behavior

### DIFF
--- a/PineTests/CompletionFilterTests.swift
+++ b/PineTests/CompletionFilterTests.swift
@@ -197,13 +197,13 @@ struct CompletionFilterTests {
     @Test("Full ranking hierarchy: exact > prefix > boundary > substring > fuzzy")
     func fullHierarchy() {
         let items = [
-            LSPCompletionItem(label: "xfoobar"),       // substring
+            LSPCompletionItem(label: "xftlbar"),       // substring
             LSPCompletionItem(label: "football"),       // fuzzy (ftl subsequence)
             LSPCompletionItem(label: "ftl"),            // exact
             LSPCompletionItem(label: "my_ftl"),         // word boundary
             LSPCompletionItem(label: "ftl_extra"),      // prefix
         ]
         let result = CompletionFilter.filter(items, prefix: "ftl")
-        #expect(result.map(\.label) == ["ftl", "ftl_extra", "my_ftl", "xfoobar", "football"])
+        #expect(result.map(\.label) == ["ftl", "ftl_extra", "my_ftl", "xftlbar", "football"])
     }
 }

--- a/PineTests/LSPPositionConverterTests.swift
+++ b/PineTests/LSPPositionConverterTests.swift
@@ -78,10 +78,15 @@ struct LSPPositionConverterTests {
     @Test("Three lines, offset on third line")
     func threeLines() {
         let text = "a\nb\nc"
-        // offset 4 = 'c' on line 2
-        let pos = LSPPositionConverter.lspPosition(utf16Offset: 4, in: text)
-        #expect(pos.line == 2)
-        #expect(pos.character == 1)
+        // offset 4 is immediately before 'c' on line 2.
+        let start = LSPPositionConverter.lspPosition(utf16Offset: 4, in: text)
+        #expect(start.line == 2)
+        #expect(start.character == 0)
+
+        // offset 5 is immediately after 'c', at the end of the document.
+        let end = LSPPositionConverter.lspPosition(utf16Offset: 5, in: text)
+        #expect(end.line == 2)
+        #expect(end.character == 1)
     }
 
     // MARK: - Multi-byte characters (emoji)

--- a/PineTests/LSPSnippetTests.swift
+++ b/PineTests/LSPSnippetTests.swift
@@ -21,40 +21,33 @@ struct LSPSnippetTests {
     func parseFinalTabStop() {
         let snippet = LSPSnippet("hello$0")
         #expect(snippet.text == "hello")
-        #expect(snippet.tabStops.count == 1)
-        #expect(snippet.tabStops[0].index == 0)
-        #expect(snippet.tabStops[0].range == 5..<5)
+        #expect(snippet.tabStops.map(\.index) == [0])
+        #expect(snippet.tabStops.map(\.range) == [5..<5])
     }
 
     @Test("Parse $1 and $2 tab stops")
     func parseNumberedTabStops() {
         let snippet = LSPSnippet("$1$2")
         #expect(snippet.text == "")
-        #expect(snippet.tabStops.count == 2)
-        #expect(snippet.tabStops[0].index == 1)
-        #expect(snippet.tabStops[1].index == 2)
+        #expect(snippet.tabStops.map(\.index) == [1, 2, 0])
+        #expect(snippet.tabStops.map(\.range) == [0..<0, 0..<0, 0..<0])
     }
 
     @Test("Parse tab stops interleaved with text")
     func parseTabStopsInText() {
         let snippet = LSPSnippet("func $1($2) {$0}")
         #expect(snippet.text == "func () {}")
-        #expect(snippet.tabStops.count == 3)
         // Ordered by index: $1, $2, then $0 last
-        #expect(snippet.tabStops[0].index == 1)
-        #expect(snippet.tabStops[0].range == 5..<5)
-        #expect(snippet.tabStops[1].index == 2)
-        #expect(snippet.tabStops[1].range == 6..<6)
-        #expect(snippet.tabStops[2].index == 0)
-        #expect(snippet.tabStops[2].range == 9..<9)
+        #expect(snippet.tabStops.map(\.index) == [1, 2, 0])
+        #expect(snippet.tabStops.map(\.range) == [5..<5, 6..<6, 9..<9])
     }
 
     @Test("Parse multi-digit tab stop $10")
     func parseMultiDigitTabStop() {
         let snippet = LSPSnippet("$10")
         #expect(snippet.text == "")
-        #expect(snippet.tabStops.count == 1)
-        #expect(snippet.tabStops[0].index == 10)
+        #expect(snippet.tabStops.map(\.index) == [10, 0])
+        #expect(snippet.tabStops.map(\.range) == [0..<0, 0..<0])
     }
 
     // MARK: - Placeholders ${1:default}
@@ -63,29 +56,24 @@ struct LSPSnippetTests {
     func parsePlaceholder() {
         let snippet = LSPSnippet("${1:default}")
         #expect(snippet.text == "default")
-        #expect(snippet.tabStops.count == 1)
-        #expect(snippet.tabStops[0].index == 1)
-        #expect(snippet.tabStops[0].range == 0..<7)
+        #expect(snippet.tabStops.map(\.index) == [1, 0])
+        #expect(snippet.tabStops.map(\.range) == [0..<7, 7..<7])
     }
 
     @Test("Parse placeholder with surrounding text")
     func parsePlaceholderWithText() {
         let snippet = LSPSnippet("var ${1:name} = ${2:value}")
         #expect(snippet.text == "var name = value")
-        #expect(snippet.tabStops.count == 2)
-        #expect(snippet.tabStops[0].index == 1)
-        #expect(snippet.tabStops[0].range == 4..<8)
-        #expect(snippet.tabStops[1].index == 2)
-        #expect(snippet.tabStops[1].range == 11..<16)
+        #expect(snippet.tabStops.map(\.index) == [1, 2, 0])
+        #expect(snippet.tabStops.map(\.range) == [4..<8, 11..<16, 16..<16])
     }
 
     @Test("Parse empty braced tab stop ${1}")
     func parseEmptyBracedTabStop() {
         let snippet = LSPSnippet("${1}")
         #expect(snippet.text == "")
-        #expect(snippet.tabStops.count == 1)
-        #expect(snippet.tabStops[0].index == 1)
-        #expect(snippet.tabStops[0].range == 0..<0)
+        #expect(snippet.tabStops.map(\.index) == [1, 0])
+        #expect(snippet.tabStops.map(\.range) == [0..<0, 0..<0])
     }
 
     // MARK: - Choices ${1|a,b,c|}
@@ -94,23 +82,22 @@ struct LSPSnippetTests {
     func parseChoice() {
         let snippet = LSPSnippet("${1|a,b,c|}")
         #expect(snippet.text == "a")
-        #expect(snippet.tabStops.count == 1)
-        #expect(snippet.tabStops[0].index == 1)
-        #expect(snippet.tabStops[0].range == 0..<1)
+        #expect(snippet.tabStops.map(\.index) == [1, 0])
+        #expect(snippet.tabStops.map(\.range) == [0..<1, 1..<1])
     }
 
     @Test("Parse choice with multi-word options")
     func parseChoiceMultiWord() {
         let snippet = LSPSnippet("${1|let,var,const|}")
         #expect(snippet.text == "let")
-        #expect(snippet.tabStops[0].range == 0..<3)
+        #expect(snippet.tabStops.map(\.range) == [0..<3, 3..<3])
     }
 
     @Test("Parse choice within surrounding text")
     func parseChoiceWithText() {
         let snippet = LSPSnippet("type: ${1|Int,String,Bool|}")
         #expect(snippet.text == "type: Int")
-        #expect(snippet.tabStops[0].range == 6..<9)
+        #expect(snippet.tabStops.map(\.range) == [6..<9, 9..<9])
     }
 
     // MARK: - Escape sequences
@@ -144,7 +131,7 @@ struct LSPSnippetTests {
         // Parser reads body: v-a-l then \$ → appends $, skips both
         let snippet = LSPSnippet("${1:val\\$}")
         #expect(snippet.text == "val$")
-        #expect(snippet.tabStops[0].range == 0..<4)
+        #expect(snippet.tabStops.map(\.range) == [0..<4, 4..<4])
     }
 
     // MARK: - Tab stop ordering ($0 always last)
@@ -152,37 +139,27 @@ struct LSPSnippetTests {
     @Test("$0 sorts last regardless of position in snippet")
     func finalTabStopSortsLast() {
         let snippet = LSPSnippet("$0$1$2")
-        #expect(snippet.tabStops.count == 3)
-        #expect(snippet.tabStops[0].index == 1)
-        #expect(snippet.tabStops[1].index == 2)
-        #expect(snippet.tabStops[2].index == 0)
+        #expect(snippet.tabStops.map(\.index) == [1, 2, 0])
     }
 
     @Test("Tab stops ordered ascending by index")
     func tabStopsOrderedAscending() {
         let snippet = LSPSnippet("$3$1$2$0")
-        #expect(snippet.tabStops.count == 4)
-        #expect(snippet.tabStops[0].index == 1)
-        #expect(snippet.tabStops[1].index == 2)
-        #expect(snippet.tabStops[2].index == 3)
-        #expect(snippet.tabStops[3].index == 0)
+        #expect(snippet.tabStops.map(\.index) == [1, 2, 3, 0])
     }
 
     @Test("Synthetic final tab stop appended when no $0")
     func syntheticFinalTabStop() {
         let snippet = LSPSnippet("hello $1")
-        #expect(snippet.tabStops.count == 2)
-        #expect(snippet.tabStops[0].index == 1)
-        #expect(snippet.tabStops[1].index == 0)  // synthetic, at end of text
+        #expect(snippet.tabStops.map(\.index) == [1, 0])
+        #expect(snippet.tabStops.map(\.range) == [6..<6, 6..<6])
     }
 
     @Test("Duplicate index deduplicated")
     func duplicateIndexDeduplicated() {
         let snippet = LSPSnippet("$1$1")
         // First $1 kept, second dropped. Synthetic $0 appended.
-        #expect(snippet.tabStops.count == 2)
-        #expect(snippet.tabStops[0].index == 1)
-        #expect(snippet.tabStops[1].index == 0)
+        #expect(snippet.tabStops.map(\.index) == [1, 0])
     }
 
     // MARK: - No tab stops
@@ -215,20 +192,13 @@ struct LSPSnippetTests {
     func functionSnippet() {
         let snippet = LSPSnippet("func ${1:name}(${2:args}) {\n\t$0\n}")
         #expect(snippet.text == "func name(args) {\n\t\n}")
-        #expect(snippet.tabStops.count == 3)
-        #expect(snippet.tabStops[0].index == 1)
-        #expect(snippet.tabStops[1].index == 2)
-        #expect(snippet.tabStops[2].index == 0)
+        #expect(snippet.tabStops.map(\.index) == [1, 2, 0])
     }
 
     @Test("For-loop snippet")
     func forLoopSnippet() {
         let snippet = LSPSnippet("for ${1:i} in ${2:0}..<${3:n} {\n\t$0\n}")
         #expect(snippet.text == "for i in 0..<n {\n\t\n}")
-        #expect(snippet.tabStops.count == 4)
-        #expect(snippet.tabStops[0].index == 1)  // i
-        #expect(snippet.tabStops[1].index == 2)  // 0
-        #expect(snippet.tabStops[2].index == 3)  // n
-        #expect(snippet.tabStops[3].index == 0)  // final cursor
+        #expect(snippet.tabStops.map(\.index) == [1, 2, 3, 0])
     }
 }


### PR DESCRIPTION
## Summary

- assert the documented synthetic final `$0` tab stop in snippet fixtures
- correct the UTF-16 coordinate at the start of the third line and cover the document end
- use an actual substring fixture for completion ranking
- replace unchecked tab-stop subscripts with collection assertions so expectation failures cannot crash the test host

## Testing

- Xcode 27: `LSPSnippetTests`, `LSPPositionConverterTests`, and `CompletionFilterTests` — 62/62 passed
- SwiftLint 0.63.2 strict — 0 violations
- `git diff --check`

Closes #1150