### PR TITLE
test: cover all current logging categories

### DIFF
--- a/PineTests/LoggerTests.swift
+++ b/PineTests/LoggerTests.swift
@@ -59,6 +59,22 @@ struct LoggerTests {
         #expect(LogCategory.app.rawValue == "app")
     }
 
+    @Test func migrationCategoryRawValue() {
+        #expect(LogCategory.migration.rawValue == "migration")
+    }
+
+    @Test func lspCategoryRawValue() {
+        #expect(LogCategory.lsp.rawValue == "lsp")
+    }
+
+    @Test func taskCategoryRawValue() {
+        #expect(LogCategory.task.rawValue == "task")
+    }
+
+    @Test func extensibilityCategoryRawValue() {
+        #expect(LogCategory.extensibility.rawValue == "extensibility")
+    }
+
     // MARK: - Uniqueness
 
     @Test func allCategoriesAreUnique() {
@@ -69,11 +85,23 @@ struct LoggerTests {
     // MARK: - CaseIterable
 
     @Test func expectedCategoryCount() {
-        #expect(LogCategory.allCases.count == 8)
+        #expect(LogCategory.allCases.count == 11)
     }
 
     @Test func allCasesContainsAllCategories() {
-        let expected: Set<LogCategory> = [.syntax, .git, .fileTree, .search, .terminal, .editor, .app, .migration]
+        let expected: Set<LogCategory> = [
+            .syntax,
+            .git,
+            .fileTree,
+            .search,
+            .terminal,
+            .editor,
+            .app,
+            .migration,
+            .lsp,
+            .task,
+            .extensibility,
+        ]
         #expect(Set(LogCategory.allCases) == expected)
     }
 
@@ -88,6 +116,9 @@ struct LoggerTests {
         Logger.editor.debug("test")
         Logger.app.debug("test")
         Logger.migration.debug("test")
+        Logger.lsp.debug("test")
+        Logger.task.debug("test")
+        Logger.extensibility.debug("test")
     }
 
     // MARK: - Logger creation from category


### PR DESCRIPTION
## Summary

- update the exhaustive logger category fixture from 8 to 11 cases
- cover raw values for migration, LSP, task, and extensibility categories
- exercise every current static `Logger` accessor

## Testing

- Xcode 27: `LoggerTests` — 18/18 passed
- SwiftLint 0.63.2 strict — 0 violations
- `git diff --check`

Closes #1148