### PR TITLE
fix(terminal): improve light ANSI palette contrast

### DIFF
--- a/Pine/TerminalPalette.swift
+++ b/Pine/TerminalPalette.swift
@@ -6,9 +6,9 @@
 //
 //  Pine uses appearance-aware ANSI palettes for the 16 ANSI slots that TUI
 //  apps such as k9s, htop, lazygit, btop and vim drive directly via
-//  `\e[3xm` / `tput setaf`. One Dark is used in dark mode; Catppuccin Latte
-//  in light mode. Both provide excellent readability on their respective
-//  backgrounds.
+//  `\e[3xm` / `tput setaf`. One Dark is used in dark mode; a
+//  contrast-adjusted Catppuccin Latte palette is used in light mode. Both
+//  provide excellent readability on their respective backgrounds.
 //
 //  Scope of `install(on:)`:
 //  ONLY the 16 ANSI palette slots are touched here. Background / foreground
@@ -196,7 +196,7 @@ enum TerminalPalette {
         return entries
     }()
 
-    // MARK: - Light palette (Catppuccin Latte)
+    // MARK: - Light palette (Catppuccin Latte base)
 
     /// Light-mode ghost text override for slot 0. Catppuccin Latte's Subtext 0
     /// (#6C6F85) — readable grey for ghost text on the light background.
@@ -225,10 +225,36 @@ enum TerminalPalette {
         .init(red: 0xBC, green: 0xC0, blue: 0xCC), // 15 bright white
     ]
 
-    /// Light-mode ANSI palette with ghost-text slot-0 override applied.
+    /// Pine-specific light-palette adjustments for ANSI colors that do not
+    /// reach 3:1 against Catppuccin Latte Base (#EFF1F5). Each color is a
+    /// proportional sRGB darkening of its upstream value, preserving hue.
+    /// Normal/bright chromatic pairs continue to share one value, while both
+    /// neutral whites use the same 72% scale so bright white stays brighter.
+    ///
+    /// These are intentional deviations from upstream Catppuccin Latte:
+    /// - green: #40A02B -> #3F9E2B (99%)
+    /// - yellow: #DF8E1D -> #C07A19 (86%)
+    /// - magenta: #EA76CB -> #CC67B1 (87%)
+    /// - white: #ACB0BE -> #7C7F89 (72%)
+    /// - bright white: #BCC0CC -> #878A93 (72%)
+    private static let lightContrastGreen = TerminalPaletteEntry(red: 0x3F, green: 0x9E, blue: 0x2B)
+    private static let lightContrastYellow = TerminalPaletteEntry(red: 0xC0, green: 0x7A, blue: 0x19)
+    private static let lightContrastMagenta = TerminalPaletteEntry(red: 0xCC, green: 0x67, blue: 0xB1)
+    private static let lightContrastWhite = TerminalPaletteEntry(red: 0x7C, green: 0x7F, blue: 0x89)
+    private static let lightContrastBrightWhite = TerminalPaletteEntry(red: 0x87, green: 0x8A, blue: 0x93)
+
+    /// Light-mode ANSI palette with ghost-text and contrast overrides applied.
     static let lightPalette: [TerminalPaletteEntry] = {
         var entries = catppuccinLatte
         entries[0] = lightGhostTextOverride
+        entries[2] = lightContrastGreen
+        entries[3] = lightContrastYellow
+        entries[5] = lightContrastMagenta
+        entries[7] = lightContrastWhite
+        entries[10] = lightContrastGreen
+        entries[11] = lightContrastYellow
+        entries[13] = lightContrastMagenta
+        entries[15] = lightContrastBrightWhite
         return entries
     }()
 

--- a/PineTests/TerminalPaletteTests.swift
+++ b/PineTests/TerminalPaletteTests.swift
@@ -303,24 +303,24 @@ struct TerminalPaletteTests {
 
     // MARK: - Light palette reference values
 
-    @Test func lightPaletteReferenceIsPreserved() {
+    @Test func lightPalettePineReferenceIsPreserved() {
         let expected: [(UInt8, UInt8, UInt8)] = [
             (0x6C, 0x6F, 0x85), // 0  black (ghost text override)
             (0xD2, 0x0F, 0x39), // 1  red
-            (0x40, 0xA0, 0x2B), // 2  green
-            (0xDF, 0x8E, 0x1D), // 3  yellow
+            (0x3F, 0x9E, 0x2B), // 2  green (contrast adjusted)
+            (0xC0, 0x7A, 0x19), // 3  yellow (contrast adjusted)
             (0x1E, 0x66, 0xF5), // 4  blue
-            (0xEA, 0x76, 0xCB), // 5  magenta
+            (0xCC, 0x67, 0xB1), // 5  magenta (contrast adjusted)
             (0x17, 0x92, 0x99), // 6  cyan
-            (0xAC, 0xB0, 0xBE), // 7  white
+            (0x7C, 0x7F, 0x89), // 7  white (contrast adjusted)
             (0x6C, 0x6F, 0x85), // 8  bright black
             (0xD2, 0x0F, 0x39), // 9  bright red
-            (0x40, 0xA0, 0x2B), // 10 bright green
-            (0xDF, 0x8E, 0x1D), // 11 bright yellow
+            (0x3F, 0x9E, 0x2B), // 10 bright green (contrast adjusted)
+            (0xC0, 0x7A, 0x19), // 11 bright yellow (contrast adjusted)
             (0x1E, 0x66, 0xF5), // 12 bright blue
-            (0xEA, 0x76, 0xCB), // 13 bright magenta
+            (0xCC, 0x67, 0xB1), // 13 bright magenta (contrast adjusted)
             (0x17, 0x92, 0x99), // 14 bright cyan
-            (0xBC, 0xC0, 0xCC), // 15 bright white
+            (0x87, 0x8A, 0x93), // 15 bright white (contrast adjusted)
         ]
         let entries = TerminalPalette.lightPalette
         #expect(entries.count == expected.count)
@@ -330,6 +330,22 @@ struct TerminalPaletteTests {
             #expect(entry.green == exp.1, "Light ANSI \(index) green mismatch")
             #expect(entry.blue == exp.2, "Light ANSI \(index) blue mismatch")
         }
+    }
+
+    @Test func lightPalettePreservesNormalBrightRelationships() {
+        let pairedSlots = [(1, 9), (2, 10), (3, 11), (4, 12), (5, 13), (6, 14)]
+        for (normal, bright) in pairedSlots {
+            #expect(
+                TerminalPalette.lightPalette[normal] == TerminalPalette.lightPalette[bright],
+                "Light ANSI slots \(normal) and \(bright) must remain paired"
+            )
+        }
+
+        #expect(
+            relativeLuminance(TerminalPalette.lightPalette[15])
+            > relativeLuminance(TerminalPalette.lightPalette[7]),
+            "Light ANSI bright white must remain brighter than white"
+        )
     }
 
     // MARK: - Light palette readability


### PR DESCRIPTION
## Summary

- darken the failing green, yellow, magenta, white, and bright-white ANSI entries in Pine’s light palette
- preserve chromatic normal/bright relationships and keep bright white lighter than normal white
- document the intentional Pine deviations from Catppuccin Latte
- retain the 3:1 contrast threshold instead of weakening the test

The adjusted colors measure 3.026–3.535:1 against the actual `#EFF1F5` terminal background.

## Testing

- Xcode 27 / macOS 27: `TerminalPaletteTests` passed
- SwiftLint 0.63.2 strict — 0 violations
- independent review: clean
- `git diff --check`

Closes #1147