### PR TITLE
fix(lsp): reject invalid workspace edit ranges

### DIFF
--- a/Pine/LSP/HoverAndDefinitionProvider.swift
+++ b/Pine/LSP/HoverAndDefinitionProvider.swift
@@ -308,4 +308,63 @@ nonisolated enum LSPPositionConverter {
         let remaining = ns.length - offset
         return offset + min(max(0, character), remaining)
     }
+
+    /// Converts an LSP position to a UTF-16 offset only when the position is
+    /// inside the document. Unlike ``utf16Offset(line:character:in:)``, this
+    /// method does not clamp invalid positions and is therefore suitable for
+    /// validating server-supplied mutation ranges.
+    static func utf16OffsetIfValid(line: Int, character: Int, in text: String) -> Int? {
+        guard line >= 0, character >= 0 else { return nil }
+
+        let ns = text as NSString
+        var currentLine = 0
+        var lineStart = 0
+
+        while currentLine < line {
+            guard lineStart < ns.length else { return nil }
+
+            var lineEnd = lineStart
+            while lineEnd < ns.length, !isLineEnding(at: lineEnd, in: ns) {
+                lineEnd += 1
+            }
+            guard lineEnd < ns.length else { return nil }
+
+            lineStart = lineEnd + lineEndingLength(at: lineEnd, in: ns)
+            currentLine += 1
+        }
+
+        var lineEnd = lineStart
+        while lineEnd < ns.length, !isLineEnding(at: lineEnd, in: ns) {
+            lineEnd += 1
+        }
+
+        guard character <= lineEnd - lineStart else { return nil }
+        let offset = lineStart + character
+        guard isUnicodeScalarBoundary(offset, in: ns) else { return nil }
+        return offset
+    }
+
+    private static func isLineEnding(at offset: Int, in text: NSString) -> Bool {
+        let codeUnit = text.character(at: offset)
+        return codeUnit == ASCII.newline || codeUnit == ASCII.carriageReturn
+    }
+
+    private static func lineEndingLength(at offset: Int, in text: NSString) -> Int {
+        guard text.character(at: offset) == ASCII.carriageReturn,
+              offset + 1 < text.length,
+              text.character(at: offset + 1) == ASCII.newline else {
+            return 1
+        }
+        return 2
+    }
+
+    private static func isUnicodeScalarBoundary(_ offset: Int, in text: NSString) -> Bool {
+        guard offset > 0, offset < text.length else { return true }
+
+        let preceding = text.character(at: offset - 1)
+        let following = text.character(at: offset)
+        let splitsSurrogatePair = (0xD800...0xDBFF).contains(preceding)
+            && (0xDC00...0xDFFF).contains(following)
+        return !splitsSurrogatePair
+    }
 }

--- a/Pine/LSP/RenameProvider.swift
+++ b/Pine/LSP/RenameProvider.swift
@@ -300,32 +300,22 @@ nonisolated enum WorkspaceEditApplier {
             return WorkspaceEditApplyResult(newText: text)
         }
 
-        // Sort by descending start position (apply from end to start).
-        let sorted = edits.sorted { lhs, rhs in
-            if lhs.range.start.line != rhs.range.start.line {
-                return lhs.range.start.line > rhs.range.start.line
-            }
-            return lhs.range.start.character > rhs.range.start.character
-        }
+        // Resolve every range against the original text before mutating it.
+        // This prevents an invalid later edit from being interpreted against
+        // already-modified text and guarantees all-or-nothing application.
+        var preparedEdits: [(edit: LSPTextEdit, range: NSRange, originalIndex: Int)] = []
+        preparedEdits.reserveCapacity(edits.count)
 
-        let ns = text as NSString
-        var mutable = NSMutableString(string: text)
-
-        for edit in sorted {
-            let startOffset = LSPPositionConverter.utf16Offset(
+        for (originalIndex, edit) in edits.enumerated() {
+            guard let startOffset = LSPPositionConverter.utf16OffsetIfValid(
                 line: edit.range.start.line,
                 character: edit.range.start.character,
                 in: text
-            )
-            let endOffset = LSPPositionConverter.utf16Offset(
+            ), let endOffset = LSPPositionConverter.utf16OffsetIfValid(
                 line: edit.range.end.line,
                 character: edit.range.end.character,
                 in: text
-            )
-
-            // Validate bounds.
-            guard startOffset >= 0, startOffset <= ns.length,
-                  endOffset >= startOffset, endOffset <= ns.length else {
+            ), endOffset >= startOffset else {
                 let desc = "line \(edit.range.start.line):\(edit.range.start.character) – \(edit.range.end.line):\(edit.range.end.character)"
                 return WorkspaceEditApplyResult(
                     error: "Edit range out of bounds: \(desc)"
@@ -333,7 +323,53 @@ nonisolated enum WorkspaceEditApplier {
             }
 
             let range = NSRange(location: startOffset, length: endOffset - startOffset)
-            mutable.replaceCharacters(in: range, with: edit.newText)
+            preparedEdits.append((edit, range, originalIndex))
+        }
+
+        // Sort once for both conflict validation and application. Insertions
+        // precede a replacement at the same offset in this ascending order;
+        // iterating the array in reverse below therefore applies the
+        // replacement first and same-position insertions in reverse input
+        // order, preserving their final server-specified order.
+        preparedEdits.sort { lhs, rhs in
+            if lhs.range.location != rhs.range.location {
+                return lhs.range.location < rhs.range.location
+            }
+            if (lhs.range.length > 0) != (rhs.range.length > 0) {
+                return lhs.range.length == 0
+            }
+            return lhs.originalIndex < rhs.originalIndex
+        }
+
+        // Sweep the start-sorted ranges in O(E). Because overlapping
+        // non-empty ranges are rejected as soon as they are encountered, the
+        // most recent non-empty range is the only one that can contain the
+        // current start/insert position. Touching ranges and insertions at
+        // either boundary remain valid.
+        var activeNonemptyRange: NSRange?
+        for prepared in preparedEdits {
+            let range = prepared.range
+            if range.length == 0 {
+                if let activeNonemptyRange,
+                   activeNonemptyRange.location < range.location,
+                   range.location < NSMaxRange(activeNonemptyRange) {
+                    return WorkspaceEditApplyResult(error: "Edit ranges overlap")
+                }
+                continue
+            }
+
+            if let activeNonemptyRange,
+               NSMaxRange(activeNonemptyRange) > range.location {
+                return WorkspaceEditApplyResult(error: "Edit ranges overlap")
+            }
+            activeNonemptyRange = range
+        }
+
+        // Apply from end to start so earlier ranges keep their original
+        // offsets while later ranges change length.
+        let mutable = NSMutableString(string: text)
+        for prepared in preparedEdits.reversed() {
+            mutable.replaceCharacters(in: prepared.range, with: prepared.edit.newText)
         }
 
         return WorkspaceEditApplyResult(newText: mutable as String)

--- a/PineTests/LSPPositionConverterTests.swift
+++ b/PineTests/LSPPositionConverterTests.swift
@@ -206,6 +206,84 @@ struct LSPPositionConverterTests {
         #expect(offset == 4)
     }
 
+    // MARK: - Strict reverse conversion
+
+    @Test("Strict reverse accepts start and end of each line")
+    func strictReverseLineBoundaries() {
+        let text = "ab\ncd"
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 0, in: text) == 0)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 2, in: text) == 2)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 1, character: 0, in: text) == 3)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 1, character: 2, in: text) == 5)
+    }
+
+    @Test("Strict reverse rejects negative and out-of-document positions")
+    func strictReverseInvalidPositions() {
+        let text = "ab\ncd"
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: -1, character: 0, in: text) == nil)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: -1, in: text) == nil)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 3, in: text) == nil)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 1, character: 3, in: text) == nil)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 2, character: 0, in: text) == nil)
+    }
+
+    @Test("Strict reverse handles empty and trailing-empty documents")
+    func strictReverseEmptyLines() {
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 0, in: "") == 0)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 1, in: "") == nil)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 1, character: 0, in: "") == nil)
+
+        let trailingNewline = "ab\n"
+        #expect(LSPPositionConverter.utf16OffsetIfValid(
+            line: 1,
+            character: 0,
+            in: trailingNewline
+        ) == 3)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(
+            line: 2,
+            character: 0,
+            in: trailingNewline
+        ) == nil)
+    }
+
+    @Test("Strict reverse rejects positions inside UTF-16 surrogate pairs")
+    func strictReverseUTF16ScalarBoundaries() {
+        let utf16Text = "A😀B"
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 0, in: utf16Text) == 0)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 1, in: utf16Text) == 1)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 2, in: utf16Text) == nil)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 3, in: utf16Text) == 3)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 4, in: utf16Text) == 4)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 5, in: utf16Text) == nil)
+    }
+
+    @Test("Strict reverse excludes CRLF code units from line characters")
+    func strictReverseCRLF() {
+        let crlfText = "a\r\nb"
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 1, in: crlfText) == 1)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 2, in: crlfText) == nil)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 1, character: 0, in: crlfText) == 3)
+    }
+
+    @Test("Strict reverse recognizes CR-only line endings")
+    func strictReverseCROnly() {
+        let crText = "a\rb"
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 1, in: crText) == 1)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 2, in: crText) == nil)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 1, character: 0, in: crText) == 2)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 1, character: 1, in: crText) == 3)
+    }
+
+    @Test("Strict reverse exposes one empty line after trailing CRLF")
+    func strictReverseTrailingCRLF() {
+        let text = "ab\r\n"
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 2, in: text) == 2)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 0, character: 3, in: text) == nil)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 1, character: 0, in: text) == 4)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 1, character: 1, in: text) == nil)
+        #expect(LSPPositionConverter.utf16OffsetIfValid(line: 2, character: 0, in: text) == nil)
+    }
+
     // MARK: - Round-trip
 
     @Test("Round-trip: offset → position → offset")

--- a/PineTests/WorkspaceEditApplierTests.swift
+++ b/PineTests/WorkspaceEditApplierTests.swift
@@ -60,7 +60,7 @@ struct WorkspaceEditApplierTests {
             LSPTextEdit(
                 range: LSPRange(start: LSPPosition(line: 0, character: 0),
                                 end: LSPPosition(line: 0, character: 1)),
-                newText: "W"
+                newText: "H"
             ),
             LSPTextEdit(
                 range: LSPRange(start: LSPPosition(line: 0, character: 6),
@@ -77,8 +77,8 @@ struct WorkspaceEditApplierTests {
     func applyThreeEditsJumbled() {
         let edits = [
             LSPTextEdit(
-                range: LSPRange(start: LSPPosition(line: 0, character: 7),
-                                end: LSPPosition(line: 0, character: 12)),
+                range: LSPRange(start: LSPPosition(line: 0, character: 6),
+                                end: LSPPosition(line: 0, character: 11)),
                 newText: "Swift"
             ),
             LSPTextEdit(
@@ -88,7 +88,7 @@ struct WorkspaceEditApplierTests {
             ),
             LSPTextEdit(
                 range: LSPRange(start: LSPPosition(line: 0, character: 5),
-                                end: LSPPosition(line: 0, character: 7)),
+                                end: LSPPosition(line: 0, character: 6)),
                 newText: " "
             ),
         ]
@@ -108,7 +108,7 @@ struct WorkspaceEditApplierTests {
             ),
             LSPTextEdit(
                 range: LSPRange(start: LSPPosition(line: 1, character: 0),
-                                end: LSPPosition(line: 1, character: 6)),
+                                end: LSPPosition(line: 1, character: 5)),
                 newText: "second"
             ),
         ]
@@ -140,6 +140,55 @@ struct WorkspaceEditApplierTests {
             newText: "x"
         )
         let result = WorkspaceEditApplier.applyEdits([edit], to: "hello")
+        #expect(!result.success)
+        #expect(result.newText == nil)
+    }
+
+    @Test("Character past its line fails instead of spilling into next line")
+    func characterPastLineEnd() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 3),
+                            end: LSPPosition(line: 0, character: 3)),
+            newText: "x"
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "hi\nthere")
+        #expect(!result.success)
+        #expect(result.newText == nil)
+    }
+
+    @Test("Negative line or character fails")
+    func negativePosition() {
+        let negativeLine = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: -1, character: 0),
+                            end: LSPPosition(line: 0, character: 0)),
+            newText: "x"
+        )
+        let negativeCharacter = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: -1),
+                            end: LSPPosition(line: 0, character: 0)),
+            newText: "x"
+        )
+
+        #expect(!WorkspaceEditApplier.applyEdits([negativeLine], to: "hi").success)
+        #expect(!WorkspaceEditApplier.applyEdits([negativeCharacter], to: "hi").success)
+    }
+
+    @Test("One invalid range rejects the complete edit batch")
+    func invalidRangeIsAtomic() {
+        let edits = [
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 0),
+                                end: LSPPosition(line: 0, character: 5)),
+                newText: "changed"
+            ),
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 2, character: 0),
+                                end: LSPPosition(line: 2, character: 0)),
+                newText: "invalid"
+            ),
+        ]
+
+        let result = WorkspaceEditApplier.applyEdits(edits, to: "hello")
         #expect(!result.success)
         #expect(result.newText == nil)
     }
@@ -177,6 +226,184 @@ struct WorkspaceEditApplierTests {
         let result = WorkspaceEditApplier.applyEdits([edit], to: "hello")
         #expect(result.success)
         #expect(result.newText == "hello!")
+    }
+
+    @Test("Insert into an empty document at its only valid position")
+    func editEmptyDocument() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 0),
+                            end: LSPPosition(line: 0, character: 0)),
+            newText: "hello"
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "")
+        #expect(result.success)
+        #expect(result.newText == "hello")
+    }
+
+    @Test("Empty document rejects positions after line zero character zero")
+    func invalidEditInEmptyDocument() {
+        let invalidLine = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 1, character: 0),
+                            end: LSPPosition(line: 1, character: 0)),
+            newText: "x"
+        )
+        let invalidCharacter = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 1),
+                            end: LSPPosition(line: 0, character: 1)),
+            newText: "x"
+        )
+
+        #expect(!WorkspaceEditApplier.applyEdits([invalidLine], to: "").success)
+        #expect(!WorkspaceEditApplier.applyEdits([invalidCharacter], to: "").success)
+    }
+
+    @Test("Trailing newline creates one final empty line")
+    func editTrailingEmptyLine() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 1, character: 0),
+                            end: LSPPosition(line: 1, character: 0)),
+            newText: "second"
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "first\n")
+        #expect(result.success)
+        #expect(result.newText == "first\nsecond")
+    }
+
+    @Test("Line after a trailing empty line is invalid")
+    func editAfterTrailingEmptyLine() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 2, character: 0),
+                            end: LSPPosition(line: 2, character: 0)),
+            newText: "third"
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "first\n")
+        #expect(!result.success)
+        #expect(result.newText == nil)
+    }
+
+    @Test("Ranges use UTF-16 code-unit coordinates")
+    func editUTF16Range() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 1),
+                            end: LSPPosition(line: 0, character: 3)),
+            newText: "🙂"
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "A😀B")
+        #expect(result.success)
+        #expect(result.newText == "A🙂B")
+    }
+
+    @Test("Range boundary inside a UTF-16 surrogate pair fails")
+    func editInsideSurrogatePair() {
+        let edit = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 2),
+                            end: LSPPosition(line: 0, character: 3)),
+            newText: "x"
+        )
+        let result = WorkspaceEditApplier.applyEdits([edit], to: "A😀B")
+        #expect(!result.success)
+        #expect(result.newText == nil)
+    }
+
+    @Test("Overlapping replacement ranges reject the complete batch")
+    func overlappingReplacementsFailAtomically() {
+        let edits = [
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 0),
+                                end: LSPPosition(line: 0, character: 3)),
+                newText: "first"
+            ),
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 2),
+                                end: LSPPosition(line: 0, character: 5)),
+                newText: "second"
+            ),
+        ]
+
+        let result = WorkspaceEditApplier.applyEdits(edits, to: "abcdef")
+        #expect(!result.success)
+        #expect(result.newText == nil)
+    }
+
+    @Test("Insertion strictly inside a replacement range fails")
+    func insertionInsideReplacementFails() {
+        let edits = [
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 1),
+                                end: LSPPosition(line: 0, character: 4)),
+                newText: "X"
+            ),
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 2),
+                                end: LSPPosition(line: 0, character: 2)),
+                newText: "inside"
+            ),
+        ]
+
+        let result = WorkspaceEditApplier.applyEdits(edits, to: "abcdef")
+        #expect(!result.success)
+        #expect(result.newText == nil)
+    }
+
+    @Test("Insertions at replacement boundaries remain valid")
+    func insertionsAtReplacementBoundaries() {
+        let edits = [
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 1),
+                                end: LSPPosition(line: 0, character: 1)),
+                newText: "["
+            ),
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 1),
+                                end: LSPPosition(line: 0, character: 2)),
+                newText: "X"
+            ),
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 2),
+                                end: LSPPosition(line: 0, character: 2)),
+                newText: "]"
+            ),
+        ]
+
+        let result = WorkspaceEditApplier.applyEdits(edits, to: "abc")
+        #expect(result.success)
+        #expect(result.newText == "a[X]c")
+    }
+
+    @Test("Insertions at the same position preserve server order")
+    func samePositionInsertionsPreserveOrder() {
+        let edits = ["A", "B", "C"].map { newText in
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 1),
+                                end: LSPPosition(line: 0, character: 1)),
+                newText: newText
+            )
+        }
+
+        let result = WorkspaceEditApplier.applyEdits(edits, to: "abc")
+        #expect(result.success)
+        #expect(result.newText == "aABCbc")
+    }
+
+    @Test("Large non-conflicting batch applies successfully")
+    func largeNonconflictingBatch() {
+        let insertion = LSPTextEdit(
+            range: LSPRange(start: LSPPosition(line: 0, character: 0),
+                            end: LSPPosition(line: 0, character: 0)),
+            newText: ""
+        )
+        var edits = Array(repeating: insertion, count: 10_000)
+        edits.append(
+            LSPTextEdit(
+                range: LSPRange(start: LSPPosition(line: 0, character: 0),
+                                end: LSPPosition(line: 0, character: 1)),
+                newText: "B"
+            )
+        )
+
+        let result = WorkspaceEditApplier.applyEdits(edits, to: "a")
+        #expect(result.success)
+        #expect(result.newText == "B")
     }
 
     @Test("Edit replacing entire single line")


### PR DESCRIPTION
## Summary
- validate every LSP text-edit position against the original document instead of clamping invalid coordinates
- reject ranges that split UTF-16 surrogate pairs or overlap, while preserving valid boundary insertions and server order
- apply workspace edit batches atomically and keep validation at O(E log E)

## Testing
- Xcode 27 beta: 58 tests in `WorkspaceEditApplierTests` and `LSPPositionConverterTests`
- targeted strict SwiftLint: 0 violations
- `git show --check`

Closes #1145