### PR TITLE
fix: make editor and terminal tabs reliably draggable

### DIFF
--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -53,7 +53,6 @@ struct EditorTabBar: View {
     @Environment(PaneManager.self) private var paneManager
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    @State private var draggingTabID: UUID?
     @State private var hoverTargetTabID: UUID?
 
     /// Minimum tab width before scrolling kicks in.
@@ -99,8 +98,13 @@ struct EditorTabBar: View {
                                 pinnedCount: pinnedCount
                             )
                             ForEach(tabManager.tabs) { tab in
+                                let paneID = overridePaneID ?? paneManager.activePaneID
                                 let isActive = tab.id == tabManager.activeTabID
-                                let isDragged = tab.id == draggingTabID
+                                let isDragged = paneManager.activeDrag.map { drag in
+                                    drag.paneID == paneID.id
+                                        && drag.tabID == tab.id
+                                        && drag.contentType == .editor
+                                } ?? false
                                 EditorTabItem(
                                     tab: tab,
                                     isActive: isActive,
@@ -151,8 +155,6 @@ struct EditorTabBar: View {
                                 .transaction { $0.animation = nil }
                                 .id(tab.id)
                                 .onDrag {
-                                    draggingTabID = tab.id
-                                    let paneID = overridePaneID ?? paneManager.activePaneID
                                     let info = TabDragInfo(
                                         paneID: paneID.id,
                                         tabID: tab.id,
@@ -160,21 +162,13 @@ struct EditorTabBar: View {
                                     )
                                     // Store in shared state for synchronous access by drop delegates
                                     paneManager.activeDrag = info
-                                    let provider = NSItemProvider()
-                                    provider.registerDataRepresentation(
-                                        forTypeIdentifier: UTType.paneTabDrag.identifier,
-                                        visibility: .ownProcess
-                                    ) { completion in
-                                        let data = info.encoded.data(using: .utf8) ?? Data()
-                                        completion(data, nil)
-                                        return nil
-                                    }
-                                    return provider
+                                    return info.itemProvider()
                                 }
                                 .onDrop(of: [.paneTabDrag], delegate: TabDropDelegate(
                                     tabManager: tabManager,
+                                    paneManager: paneManager,
+                                    targetPaneID: paneID,
                                     targetTabID: tab.id,
-                                    draggingTabID: $draggingTabID,
                                     hoverTargetTabID: $hoverTargetTabID,
                                     onReorder: onReorder
                                 ))
@@ -278,29 +272,63 @@ struct EditorTabBar: View {
 /// Provides visual feedback via `hoverTargetTabID` and smooth spring animations.
 struct TabDropDelegate: DropDelegate {
     let tabManager: TabManager
+    let paneManager: PaneManager
+    let targetPaneID: PaneID
     let targetTabID: UUID
-    @Binding var draggingTabID: UUID?
     @Binding var hoverTargetTabID: UUID?
     var onReorder: (() -> Void)?
 
     /// Spring animation matching Safari's tab reordering feel.
     private static let reorderAnimation: Animation = .spring(response: 0.3, dampingFraction: 0.8)
 
-    func performDrop(info: DropInfo) -> Bool {
+    /// Resolves whether this item-level delegate should reorder locally or
+    /// leave the drag for the enclosing pane drop delegate.
+    func routingDecision() -> TabItemDropDecision {
+        TabItemDropRouter.decide(
+            drag: paneManager.activeDrag,
+            targetPaneID: targetPaneID,
+            targetContent: .editor
+        )
+    }
+
+    func validateDrop(info: DropInfo) -> Bool {
+        guard info.hasItemsConforming(to: [.paneTabDrag]) else { return false }
+        guard case .localReorder = routingDecision() else { return false }
+        return true
+    }
+
+    /// Applies the local reorder path without requiring a synthetic DropInfo.
+    /// Kept internal so routing and state cleanup can be covered by unit tests.
+    @discardableResult
+    func handleDropEntered(decision: TabItemDropDecision) -> Bool {
+        guard case .localReorder(let draggedTabID) = decision else { return false }
+        guard draggedTabID != targetTabID else { return true }
+        hoverTargetTabID = targetTabID
+        withAnimation(Self.reorderAnimation) {
+            tabManager.reorderTab(draggedID: draggedTabID, targetID: targetTabID)
+        }
+        return true
+    }
+
+    /// Completes a local item-level drop. Deferred pane drops must retain the
+    /// shared drag payload for the enclosing pane delegate.
+    @discardableResult
+    func finishDrop(decision: TabItemDropDecision) -> Bool {
+        guard case .localReorder = decision else { return false }
         withAnimation(Self.reorderAnimation) {
             hoverTargetTabID = nil
-            draggingTabID = nil
         }
+        paneManager.activeDrag = nil
         onReorder?()
         return true
     }
 
+    func performDrop(info: DropInfo) -> Bool {
+        finishDrop(decision: routingDecision())
+    }
+
     func dropEntered(info: DropInfo) {
-        guard let dragging = draggingTabID, dragging != targetTabID else { return }
-        hoverTargetTabID = targetTabID
-        withAnimation(Self.reorderAnimation) {
-            tabManager.reorderTab(draggedID: dragging, targetID: targetTabID)
-        }
+        handleDropEntered(decision: routingDecision())
     }
 
     func dropExited(info: DropInfo) {
@@ -308,7 +336,8 @@ struct TabDropDelegate: DropDelegate {
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
-        DropProposal(operation: .move)
+        guard case .localReorder = routingDecision() else { return nil }
+        return DropProposal(operation: .move)
     }
 }
 
@@ -329,6 +358,7 @@ struct EditorTabItem: View {
     var constrainedWidth: CGFloat?
 
     @State private var isHovering = false
+    @State private var closeGlyphFrame = CGRect.null
 
     var body: some View {
         Group {
@@ -345,10 +375,27 @@ struct EditorTabItem: View {
                 : isHovering ? Color.primary.opacity(0.05) : .clear,
             in: Capsule()
         )
-        .contentShape(Capsule())
+        .frame(height: LayoutMetrics.tabBarHeight)
+        .coordinateSpace(name: TabSlotHitTesting.coordinateSpaceName)
+        .contentShape(.interaction, Rectangle())
+        .contentShape(.dragPreview, Capsule())
         .animation(PineAnimation.quick, value: isActive)
         .animation(PineAnimation.quick, value: isHovering)
-        .onTapGesture(perform: onSelect)
+        .gesture(
+            SpatialTapGesture()
+                .onEnded { value in
+                    switch TabSlotHitTesting.target(
+                        at: value.location,
+                        canClose: !tab.isPinned,
+                        closeGlyphFrame: closeGlyphFrame
+                    ) {
+                    case .close:
+                        onClose()
+                    case .select:
+                        onSelect()
+                    }
+                }
+        )
         .onHover { isHovering = $0 }
         .contextMenu {
             Button {
@@ -424,6 +471,9 @@ struct EditorTabItem: View {
             }
             .accessibilityIdentifier(AccessibilityID.editorTabRevealInFinder(tab.fileName))
         }
+        .onPreferenceChange(TabCloseGlyphFramePreferenceKey.self) { frame in
+            closeGlyphFrame = frame
+        }
         .accessibilityRepresentation {
             HStack {
                 Button(tab.fileName, action: onSelect)
@@ -458,31 +508,28 @@ struct EditorTabItem: View {
     /// Standard unpinned tab with close button and file name.
     private var unpinnedBody: some View {
         HStack(spacing: 4) {
-            // Close button — visible on hover or when active
-            Button(action: onClose) {
-                ZStack {
-                    if tab.isDirty && !isHovering {
-                        // Dirty dot when not hovering
-                        Circle()
-                            .fill(Color.primary.opacity(0.5))
-                            .frame(width: 6, height: 6)
-                    } else {
-                        Image(systemName: "xmark")
-                            .font(.system(size: 7, weight: .bold))
-                            .foregroundStyle(.secondary)
-                    }
+            // Passive close affordance. The full tab slot owns tap-vs-drag
+            // routing so dragging can begin directly over this glyph.
+            ZStack {
+                if tab.isDirty && !isHovering {
+                    // Dirty dot when not hovering
+                    Circle()
+                        .fill(Color.primary.opacity(0.5))
+                        .frame(width: 6, height: 6)
+                } else {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 7, weight: .bold))
+                        .foregroundStyle(.secondary)
                 }
-                .frame(width: 14, height: 14)
-                .background(
-                    isHovering ? Color.primary.opacity(0.1) : .clear,
-                    in: Circle()
-                )
             }
-            .buttonStyle(.plain)
+            .frame(width: 14, height: 14)
+            .background(
+                isHovering ? Color.primary.opacity(0.1) : .clear,
+                in: Circle()
+            )
             .opacity(isHovering || isActive || tab.isDirty ? 1 : 0.35)
-            .accessibilityLabel(Strings.a11yCloseTabLabel)
-            .accessibilityHint(Strings.a11yCloseTabHint)
-            .accessibilityIdentifier(AccessibilityID.editorTabCloseButton(tab.fileName))
+            .allowsHitTesting(false)
+            .reportsTabCloseGlyphFrame()
 
             Image(systemName: FileIconMapper.iconForFile(tab.fileName))
                 .font(.system(size: LayoutMetrics.iconSmallFontSize))

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -39,7 +39,7 @@ final class PaneManager {
     var activePaneID: PaneID
 
     /// Shared drag state for synchronous tab drag between panes.
-    /// Set by EditorTabBar.onDrag, read by drop delegates.
+    /// Set by editor and terminal tab drag sources, read by drop delegates.
     /// Using shared state avoids unreliable async NSItemProvider loading.
     var activeDrag: TabDragInfo?
 
@@ -86,15 +86,17 @@ final class PaneManager {
         !dropZones.isEmpty || rootDropZone != nil
     }
 
-    /// Clears any visible drop zone overlays if the system reports that no
-    /// mouse button is pressed (i.e. there cannot be an active drag session).
+    /// Clears any visible drop zone overlays and the shared payload if the
+    /// system reports that no mouse button is pressed (i.e. there cannot be
+    /// an active drag session).
     /// This is a defensive cleanup hook used by polling and notification
     /// observers in case SwiftUI's `DropDelegate` fails to call `dropExited`
     /// or `performDrop` (issue #710).
     func clearStaleDropZonesIfNoDragActive() {
-        guard hasActiveDropZones else { return }
+        guard hasActiveDropZones || activeDrag != nil else { return }
         if !isMouseButtonPressed() {
             clearAllDropZones()
+            clearStaleDragState()
         }
     }
 
@@ -176,6 +178,7 @@ final class PaneManager {
                 if self.hasActiveDropZones {
                     self.clearAllDropZones()
                 }
+                self.clearStaleDragState()
             }
         }
 
@@ -205,7 +208,10 @@ final class PaneManager {
                 object: nil,
                 queue: .main
             ) { [weak self] _ in
-                self?.clearAllDropZones()
+                DispatchQueue.main.async {
+                    self?.clearAllDropZones()
+                    self?.clearStaleDragState()
+                }
             }
             deactivationObservers.append(observer)
         }

--- a/Pine/TabDragInfo.swift
+++ b/Pine/TabDragInfo.swift
@@ -38,6 +38,22 @@ struct TabDragInfo: Codable, Sendable {
         return try? JSONDecoder().decode(TabDragInfo.self, from: data)
     }
 
+    /// Creates the in-process item provider used by every tab drag source.
+    /// Keeping provider construction next to the payload prevents editor and
+    /// terminal tabs from drifting into subtly different transfer formats.
+    func itemProvider() -> NSItemProvider {
+        let provider = NSItemProvider()
+        let payload = encoded
+        provider.registerDataRepresentation(
+            forTypeIdentifier: UTType.paneTabDrag.identifier,
+            visibility: .ownProcess
+        ) { completion in
+            completion(payload.data(using: .utf8) ?? Data(), nil)
+            return nil
+        }
+        return provider
+    }
+
     init(paneID: UUID, tabID: UUID, fileURL: URL? = nil, contentType: PaneContent = .editor) {
         self.paneID = paneID
         self.tabID = tabID
@@ -58,5 +74,35 @@ struct TabDragInfo: Codable, Sendable {
         tabID = try container.decode(UUID.self, forKey: .tabID)
         fileURL = try container.decodeIfPresent(URL.self, forKey: .fileURL)
         contentType = try container.decodeIfPresent(PaneContent.self, forKey: .contentType) ?? .editor
+    }
+}
+
+/// Routing decision for the drop destination attached to an individual tab.
+/// Cross-pane drags must bypass that nested destination so the surrounding
+/// pane can handle moving or splitting the tab.
+enum TabItemDropDecision: Equatable {
+    case localReorder(draggedTabID: UUID)
+    case deferToPane
+    case reject
+}
+
+/// Pure routing shared by editor and terminal tab drop delegates.
+nonisolated enum TabItemDropRouter {
+    static func decide(
+        drag: TabDragInfo?,
+        targetPaneID: PaneID,
+        targetContent: PaneContent
+    ) -> TabItemDropDecision {
+        guard let drag else { return .reject }
+
+        guard drag.paneID == targetPaneID.id else {
+            return .deferToPane
+        }
+
+        guard drag.contentType == targetContent else {
+            return .reject
+        }
+
+        return .localReorder(draggedTabID: drag.tabID)
     }
 }

--- a/Pine/TabSlotHitTesting.swift
+++ b/Pine/TabSlotHitTesting.swift
@@ -1,0 +1,69 @@
+//
+//  TabSlotHitTesting.swift
+//  Pine
+//
+//  Shared pointer routing for editor and terminal tab slots.
+//
+
+import SwiftUI
+
+/// Action produced by a stationary click inside a tab slot.
+enum TabSlotTapTarget: Equatable {
+    case select
+    case close
+}
+
+/// Geometry shared by editor and terminal tabs.
+///
+/// The entire rectangular 30-point slot remains one drag source. A completed
+/// stationary click is routed to the close affordance only when it lands in
+/// the leading close target; movement is left to SwiftUI's system drag
+/// recognizer and therefore cannot accidentally close the tab.
+nonisolated enum TabSlotHitTesting {
+    static let closeGlyphSize: CGFloat = 14
+    static let closeHitSlop: CGFloat = 4
+    static let coordinateSpaceName = "pine.tab-slot"
+
+    static func closeRect(for glyphFrame: CGRect) -> CGRect {
+        guard !glyphFrame.isNull, !glyphFrame.isInfinite else { return .null }
+        return glyphFrame.insetBy(dx: -closeHitSlop, dy: -closeHitSlop)
+    }
+
+    static func target(
+        at point: CGPoint,
+        canClose: Bool,
+        closeGlyphFrame: CGRect
+    ) -> TabSlotTapTarget {
+        guard canClose else { return .select }
+        return closeRect(for: closeGlyphFrame).contains(point) ? .close : .select
+    }
+}
+
+/// Reports the close glyph's actual frame inside its tab slot. Editor tab
+/// content is centered within a flexible width, so deriving this frame from
+/// fixed leading padding would make the visible close affordance miss clicks.
+struct TabCloseGlyphFramePreferenceKey: PreferenceKey {
+    static let defaultValue = CGRect.null
+
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        let next = nextValue()
+        if !next.isNull {
+            value = next
+        }
+    }
+}
+
+extension View {
+    func reportsTabCloseGlyphFrame() -> some View {
+        background {
+            GeometryReader { geometry in
+                Color.clear.preference(
+                    key: TabCloseGlyphFramePreferenceKey.self,
+                    value: geometry.frame(
+                        in: .named(TabSlotHitTesting.coordinateSpaceName)
+                    )
+                )
+            }
+        }
+    }
+}

--- a/Pine/TerminalBarView.swift
+++ b/Pine/TerminalBarView.swift
@@ -63,23 +63,25 @@ struct TerminalNativeTabItem: View {
     let onClose: () -> Void
 
     @State private var isHovering = false
+    @State private var closeGlyphFrame = CGRect.null
 
     var body: some View {
         HStack(spacing: 4) {
             if canClose {
-                Button(action: onClose) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 7, weight: .bold))
-                        .foregroundStyle(.secondary)
-                        .frame(width: 14, height: 14)
-                        .background(
-                            isHovering ? Color.primary.opacity(0.1) : .clear,
-                            in: Circle()
-                        )
-                }
-                .buttonStyle(.plain)
-                .opacity(isHovering || isActive ? 1 : 0.35)
-                .accessibilityIdentifier("closeTerminalTab_\(tab.stableLabel)")
+                Image(systemName: "xmark")
+                    .font(.system(size: 7, weight: .bold))
+                    .foregroundStyle(.secondary)
+                    .frame(
+                        width: TabSlotHitTesting.closeGlyphSize,
+                        height: TabSlotHitTesting.closeGlyphSize
+                    )
+                    .background(
+                        isHovering ? Color.primary.opacity(0.1) : .clear,
+                        in: Circle()
+                    )
+                    .opacity(isHovering || isActive ? 1 : 0.35)
+                    .allowsHitTesting(false)
+                    .reportsTabCloseGlyphFrame()
             }
 
             Image(systemName: "terminal")
@@ -102,11 +104,41 @@ struct TerminalNativeTabItem: View {
                 : isHovering ? Color.primary.opacity(0.05) : .clear,
             in: Capsule()
         )
-        .contentShape(Capsule())
-        .onTapGesture(perform: onSelect)
+        .frame(height: LayoutMetrics.tabBarHeight)
+        .coordinateSpace(name: TabSlotHitTesting.coordinateSpaceName)
+        .contentShape(.interaction, Rectangle())
+        .contentShape(.dragPreview, Capsule())
+        .gesture(
+            SpatialTapGesture()
+                .onEnded { value in
+                    switch TabSlotHitTesting.target(
+                        at: value.location,
+                        canClose: canClose,
+                        closeGlyphFrame: closeGlyphFrame
+                    ) {
+                    case .select:
+                        onSelect()
+                    case .close:
+                        onClose()
+                    }
+                }
+        )
         .onHover { isHovering = $0 }
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier(AccessibilityID.terminalTab(tab.stableLabel))
+        .onPreferenceChange(TabCloseGlyphFramePreferenceKey.self) { frame in
+            closeGlyphFrame = frame
+        }
+        .accessibilityRepresentation {
+            HStack {
+                Button(tab.name, action: onSelect)
+                    .accessibilityIdentifier(AccessibilityID.terminalTab(tab.stableLabel))
+                    .accessibilityAddTraits(isActive ? .isSelected : [])
+                if canClose {
+                    Button(Strings.a11yCloseTabLabel, action: onClose)
+                        .accessibilityHint(Strings.a11yCloseTabHint)
+                        .accessibilityIdentifier("closeTerminalTab_\(tab.stableLabel)")
+                }
+            }
+        }
     }
 }
 

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -14,7 +14,6 @@ struct TerminalPaneTabBar: View {
     let terminalState: TerminalPaneState
     var workingDirectory: URL?
     @Environment(PaneManager.self) private var paneManager
-    @State private var draggingTabID: UUID?
 
     private func closeTerminalTabWithConfirmation(_ tab: TerminalTab) {
         guard TabCloseHelper.confirmTerminalProcessStop(tabs: [tab]) else { return }
@@ -31,7 +30,11 @@ struct TerminalPaneTabBar: View {
                 HStack(spacing: 2) {
                     ForEach(terminalState.terminalTabs) { tab in
                         let isActive = tab.id == terminalState.activeTerminalID
-                        let isDragged = tab.id == draggingTabID
+                        let isDragged = paneManager.activeDrag.map { drag in
+                            drag.paneID == paneID.id
+                                && drag.tabID == tab.id
+                                && drag.contentType == .terminal
+                        } ?? false
                         TerminalNativeTabItem(
                             tab: tab,
                             isActive: isActive,
@@ -46,7 +49,6 @@ struct TerminalPaneTabBar: View {
                         .scaleEffect(isDragged ? 0.95 : 1.0)
                         .transaction { $0.animation = nil }
                         .onDrag {
-                            draggingTabID = tab.id
                             let info = TabDragInfo(
                                 paneID: paneID.id,
                                 tabID: tab.id,
@@ -54,21 +56,13 @@ struct TerminalPaneTabBar: View {
                                 contentType: .terminal
                             )
                             paneManager.activeDrag = info
-                            let provider = NSItemProvider()
-                            provider.registerDataRepresentation(
-                                forTypeIdentifier: UTType.paneTabDrag.identifier,
-                                visibility: .ownProcess
-                            ) { completion in
-                                let data = info.encoded.data(using: .utf8) ?? Data()
-                                completion(data, nil)
-                                return nil
-                            }
-                            return provider
+                            return info.itemProvider()
                         }
                         .onDrop(of: [.paneTabDrag], delegate: TerminalTabDropDelegate(
                             terminalState: terminalState,
                             targetTabID: tab.id,
-                            draggingTabID: $draggingTabID
+                            targetPaneID: paneID,
+                            paneManager: paneManager
                         ))
                     }
                 }
@@ -135,7 +129,7 @@ struct TerminalPaneTabBar: View {
             .help(Strings.hideTerminal)
             .accessibilityIdentifier(AccessibilityID.hideTerminalButton)
         }
-        .frame(height: 30)
+        .frame(height: LayoutMetrics.tabBarHeight)
         .background(.bar)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier(AccessibilityID.terminalTabBar)
@@ -146,25 +140,58 @@ struct TerminalPaneTabBar: View {
 struct TerminalTabDropDelegate: DropDelegate {
     let terminalState: TerminalPaneState
     let targetTabID: UUID
-    @Binding var draggingTabID: UUID?
+    let targetPaneID: PaneID
+    let paneManager: PaneManager
 
     private static let reorderAnimation: Animation = .spring(response: 0.3, dampingFraction: 0.8)
 
+    func validateDrop(info: DropInfo) -> Bool {
+        guard info.hasItemsConforming(to: [.paneTabDrag]) else { return false }
+        guard case .localReorder = routingDecision() else { return false }
+        return true
+    }
+
     func performDrop(info: DropInfo) -> Bool {
+        finishDrop(decision: routingDecision())
+    }
+
+    func dropEntered(info: DropInfo) {
+        _ = handleDropEntered(decision: routingDecision())
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        guard case .localReorder = routingDecision() else { return nil }
+        return DropProposal(operation: .move)
+    }
+
+    /// Returns whether this tab-local destination should reorder, defer to the
+    /// surrounding pane, or reject the drag entirely.
+    func routingDecision() -> TabItemDropDecision {
+        TabItemDropRouter.decide(
+            drag: paneManager.activeDrag,
+            targetPaneID: targetPaneID,
+            targetContent: .terminal
+        )
+    }
+
+    /// Testable mutation seam for `dropEntered(info:)`.
+    @discardableResult
+    func handleDropEntered(decision: TabItemDropDecision) -> Bool {
+        guard case .localReorder(let draggedTabID) = decision else { return false }
+        guard draggedTabID != targetTabID else { return true }
         withAnimation(Self.reorderAnimation) {
-            draggingTabID = nil
+            terminalState.reorderTab(draggedID: draggedTabID, targetID: targetTabID)
         }
         return true
     }
 
-    func dropEntered(info: DropInfo) {
-        guard let dragging = draggingTabID, dragging != targetTabID else { return }
-        withAnimation(Self.reorderAnimation) {
-            terminalState.reorderTab(draggedID: dragging, targetID: targetTabID)
-        }
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        DropProposal(operation: .move)
+    /// Testable completion seam for `performDrop(info:)`.
+    /// Deferred and rejected drops must leave the shared payload untouched so
+    /// an ancestor pane destination can finish the operation.
+    @discardableResult
+    func finishDrop(decision: TabItemDropDecision) -> Bool {
+        guard case .localReorder = decision else { return false }
+        paneManager.activeDrag = nil
+        return true
     }
 }

--- a/PineTests/PaneManagerStaleDropZoneTests.swift
+++ b/PineTests/PaneManagerStaleDropZoneTests.swift
@@ -69,20 +69,44 @@ struct PaneManagerStaleDropZoneTests {
         let manager = PaneManager()
         manager.dropZones[manager.activePaneID] = .center
         manager.rootDropZone = .left
+        manager.activeDrag = TabDragInfo(
+            paneID: manager.activePaneID.id,
+            tabID: UUID()
+        )
         manager.isMouseButtonPressed = { false }
 
         manager.clearStaleDropZonesIfNoDragActive()
         #expect(manager.hasActiveDropZones == false)
+        #expect(manager.activeDrag == nil)
+    }
+
+    @Test func clearStale_clearsPayloadWithoutOverlayWhenMouseUp() {
+        let manager = PaneManager()
+        manager.activeDrag = TabDragInfo(
+            paneID: manager.activePaneID.id,
+            tabID: UUID()
+        )
+        manager.isMouseButtonPressed = { false }
+
+        manager.clearStaleDropZonesIfNoDragActive()
+
+        #expect(manager.activeDrag == nil)
     }
 
     @Test func clearStale_keepsZonesWhenMouseStillPressed() {
         let manager = PaneManager()
         manager.dropZones[manager.activePaneID] = .center
+        let drag = TabDragInfo(
+            paneID: manager.activePaneID.id,
+            tabID: UUID()
+        )
+        manager.activeDrag = drag
         manager.isMouseButtonPressed = { true }
 
         manager.clearStaleDropZonesIfNoDragActive()
         #expect(manager.dropZones[manager.activePaneID] == .center)
         #expect(manager.hasActiveDropZones == true)
+        #expect(manager.activeDrag?.tabID == drag.tabID)
     }
 
     @Test func clearStale_clearsRootOnlyWhenMouseUp() {
@@ -111,16 +135,27 @@ struct PaneManagerStaleDropZoneTests {
     @Test func startStaleDropPolling_clearsOverlayOnTimerTick() async {
         let manager = PaneManager()
         manager.dropZones[manager.activePaneID] = .center
+        manager.activeDrag = TabDragInfo(
+            paneID: manager.activePaneID.id,
+            tabID: UUID()
+        )
         manager.isMouseButtonPressed = { false }
         #expect(manager.hasActiveDropZones == true)
+        #expect(manager.activeDrag != nil)
 
         manager.startStaleDropPollingIfNeeded()
 
-        // Timer cadence is 0.12s; wait ~250ms to allow at least one fire and
-        // the subsequent self-invalidation pass.
-        try? await Task.sleep(nanoseconds: 250_000_000)
+        // Timer cadence is 0.12s. Poll for the observable outcome instead of
+        // relying on a single tight deadline that can flake on a loaded CI
+        // main loop.
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while manager.hasActiveDropZones, clock.now < deadline {
+            try? await clock.sleep(for: .milliseconds(50))
+        }
 
         #expect(manager.hasActiveDropZones == false)
+        #expect(manager.activeDrag == nil)
     }
 
     // MARK: - Edge cases

--- a/PineTests/TabDragInfoTests.swift
+++ b/PineTests/TabDragInfoTests.swift
@@ -171,6 +171,82 @@ struct TabDragInfoTests {
         let decoded = TabDragInfo.decode(from: json)
         #expect(decoded?.contentType == .editor)
     }
+
+    // MARK: - NSItemProvider transport
+
+    @Test func itemProvider_registersPaneTabDragType() {
+        let info = TabDragInfo(paneID: UUID(), tabID: UUID())
+        let provider = info.itemProvider()
+
+        #expect(provider.hasItemConformingToTypeIdentifier(UTType.paneTabDrag.identifier))
+        #expect(provider.registeredTypeIdentifiers.contains(UTType.paneTabDrag.identifier))
+    }
+
+    @Test func itemProvider_editorPayloadRoundtrips() async throws {
+        let paneUUID = UUID()
+        let tabUUID = UUID()
+        let url = URL(fileURLWithPath: "/tmp/Editor File.swift")
+        let info = TabDragInfo(
+            paneID: paneUUID,
+            tabID: tabUUID,
+            fileURL: url,
+            contentType: .editor
+        )
+
+        let decoded = try await loadPayload(from: info.itemProvider())
+
+        #expect(decoded.paneID == paneUUID)
+        #expect(decoded.tabID == tabUUID)
+        #expect(decoded.fileURL == url)
+        #expect(decoded.contentType == .editor)
+    }
+
+    @Test func itemProvider_terminalPayloadRoundtrips() async throws {
+        let paneUUID = UUID()
+        let tabUUID = UUID()
+        let info = TabDragInfo(
+            paneID: paneUUID,
+            tabID: tabUUID,
+            fileURL: nil,
+            contentType: .terminal
+        )
+
+        let decoded = try await loadPayload(from: info.itemProvider())
+
+        #expect(decoded.paneID == paneUUID)
+        #expect(decoded.tabID == tabUUID)
+        #expect(decoded.fileURL == nil)
+        #expect(decoded.contentType == .terminal)
+    }
+
+    private func loadPayload(from provider: NSItemProvider) async throws -> TabDragInfo {
+        let data: Data = try await withCheckedThrowingContinuation { continuation in
+            provider.loadDataRepresentation(
+                forTypeIdentifier: UTType.paneTabDrag.identifier
+            ) { data, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let data {
+                    continuation.resume(returning: data)
+                } else {
+                    continuation.resume(throwing: ItemProviderTestError.missingData)
+                }
+            }
+        }
+        guard let payload = String(data: data, encoding: .utf8) else {
+            throw ItemProviderTestError.invalidUTF8
+        }
+        guard let decoded = TabDragInfo.decode(from: payload) else {
+            throw ItemProviderTestError.invalidPayload
+        }
+        return decoded
+    }
+
+    private enum ItemProviderTestError: Error {
+        case missingData
+        case invalidUTF8
+        case invalidPayload
+    }
 }
 
 @Suite("PaneDropZone Tests")

--- a/PineTests/TabDragInteractionTests.swift
+++ b/PineTests/TabDragInteractionTests.swift
@@ -1,0 +1,541 @@
+//
+//  TabDragInteractionTests.swift
+//  PineTests
+//
+//  Deterministic coverage for tab hit geometry and nested drop routing.
+//
+
+import CoreGraphics
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+@Suite("Tab Slot Hit Testing")
+struct TabSlotHitTestingTests {
+    private let slotHeight: CGFloat = 30
+    private let epsilon: CGFloat = 0.001
+    private let glyphFrame = CGRect(x: 58, y: 8, width: 14, height: 14)
+
+    @Test("Close target expands the visible glyph by the configured hit slop")
+    func closeTargetUsesConfiguredGeometry() {
+        let rect = TabSlotHitTesting.closeRect(for: glyphFrame)
+        let expectedHitSize = TabSlotHitTesting.closeGlyphSize
+            + (TabSlotHitTesting.closeHitSlop * 2)
+
+        #expect(TabSlotHitTesting.closeGlyphSize == 14)
+        #expect(TabSlotHitTesting.closeHitSlop == 4)
+        #expect(rect.minX == glyphFrame.minX - TabSlotHitTesting.closeHitSlop)
+        #expect(rect.midX == glyphFrame.midX)
+        #expect(rect.midY == glyphFrame.midY)
+        #expect(rect.width == expectedHitSize)
+        #expect(rect.height == expectedHitSize)
+    }
+
+    @Test("Close target follows the measured glyph anywhere in a flexible tab")
+    func closeTargetFollowsMeasuredGlyph() {
+        let frames = [
+            CGRect(x: 10, y: 8, width: 14, height: 14),
+            CGRect(x: 58, y: 8, width: 14, height: 14),
+            CGRect(x: 132, y: 8, width: 14, height: 14)
+        ]
+
+        for frame in frames {
+            let rect = TabSlotHitTesting.closeRect(for: frame)
+            #expect(rect.midX == frame.midX)
+            #expect(rect.midY == frame.midY)
+        }
+    }
+
+    @Test("Points immediately inside every close-target boundary close the tab")
+    func insideCloseTargetBoundariesClose() {
+        let rect = TabSlotHitTesting.closeRect(for: glyphFrame)
+        let points = [
+            CGPoint(x: rect.minX, y: rect.midY),
+            CGPoint(x: rect.maxX - epsilon, y: rect.midY),
+            CGPoint(x: rect.midX, y: rect.minY),
+            CGPoint(x: rect.midX, y: rect.maxY - epsilon),
+            CGPoint(x: rect.minX, y: rect.minY),
+            CGPoint(x: rect.maxX - epsilon, y: rect.maxY - epsilon)
+        ]
+
+        for point in points {
+            #expect(TabSlotHitTesting.target(
+                at: point,
+                canClose: true,
+                closeGlyphFrame: glyphFrame
+            ) == .close)
+        }
+    }
+
+    @Test("Points immediately outside every close-target boundary select the tab")
+    func outsideCloseTargetBoundariesSelect() {
+        let rect = TabSlotHitTesting.closeRect(for: glyphFrame)
+        let points = [
+            CGPoint(x: rect.minX - epsilon, y: rect.midY),
+            CGPoint(x: rect.maxX, y: rect.midY),
+            CGPoint(x: rect.midX, y: rect.minY - epsilon),
+            CGPoint(x: rect.midX, y: rect.maxY)
+        ]
+
+        for point in points {
+            #expect(TabSlotHitTesting.target(
+                at: point,
+                canClose: true,
+                closeGlyphFrame: glyphFrame
+            ) == .select)
+        }
+    }
+
+    @Test("Upper, lower, and trailing slot padding select the tab")
+    func slotPaddingSelects() {
+        let closeRect = TabSlotHitTesting.closeRect(for: glyphFrame)
+        let points = [
+            CGPoint(x: closeRect.midX, y: epsilon),
+            CGPoint(x: closeRect.midX, y: slotHeight - epsilon),
+            CGPoint(x: closeRect.maxX + 20, y: slotHeight / 2)
+        ]
+
+        for point in points {
+            #expect(TabSlotHitTesting.target(
+                at: point,
+                canClose: true,
+                closeGlyphFrame: glyphFrame
+            ) == .select)
+        }
+    }
+
+    @Test("Tabs that cannot close always select, including over the close target")
+    func cannotCloseAlwaysSelects() {
+        let rect = TabSlotHitTesting.closeRect(for: glyphFrame)
+        let points = [
+            CGPoint(x: rect.midX, y: rect.midY),
+            CGPoint(x: rect.minX, y: rect.minY),
+            CGPoint(x: rect.maxX - epsilon, y: rect.maxY - epsilon)
+        ]
+
+        for point in points {
+            #expect(TabSlotHitTesting.target(
+                at: point,
+                canClose: false,
+                closeGlyphFrame: glyphFrame
+            ) == .select)
+        }
+    }
+
+    @Test("Missing glyph measurement cannot accidentally close a tab")
+    func missingGlyphMeasurementSelects() {
+        #expect(TabSlotHitTesting.target(
+            at: CGPoint(x: 10, y: slotHeight / 2),
+            canClose: true,
+            closeGlyphFrame: .null
+        ) == .select)
+    }
+}
+
+@Suite("Tab Item Drop Routing")
+struct TabItemDropRouterTests {
+    @Test("Missing shared drag state is rejected")
+    func missingDragIsRejected() {
+        let decision = TabItemDropRouter.decide(
+            drag: nil,
+            targetPaneID: PaneID(),
+            targetContent: .editor
+        )
+
+        #expect(decision == .reject)
+    }
+
+    @Test("Editor drag in its source editor pane reorders locally")
+    func localEditorDragReorders() {
+        let paneID = PaneID()
+        let tabID = UUID()
+        let drag = makeDrag(paneID: paneID, tabID: tabID, content: .editor)
+
+        let decision = TabItemDropRouter.decide(
+            drag: drag,
+            targetPaneID: paneID,
+            targetContent: .editor
+        )
+
+        #expect(decision == .localReorder(draggedTabID: tabID))
+    }
+
+    @Test("Terminal drag in its source terminal pane reorders locally")
+    func localTerminalDragReorders() {
+        let paneID = PaneID()
+        let tabID = UUID()
+        let drag = makeDrag(paneID: paneID, tabID: tabID, content: .terminal)
+
+        let decision = TabItemDropRouter.decide(
+            drag: drag,
+            targetPaneID: paneID,
+            targetContent: .terminal
+        )
+
+        #expect(decision == .localReorder(draggedTabID: tabID))
+    }
+
+    @Test("Editor drag targeting another editor pane defers to the pane delegate")
+    func crossPaneEditorDragDefers() {
+        let drag = makeDrag(paneID: PaneID(), content: .editor)
+
+        let decision = TabItemDropRouter.decide(
+            drag: drag,
+            targetPaneID: PaneID(),
+            targetContent: .editor
+        )
+
+        #expect(decision == .deferToPane)
+    }
+
+    @Test("Terminal drag targeting another terminal pane defers to the pane delegate")
+    func crossPaneTerminalDragDefers() {
+        let drag = makeDrag(paneID: PaneID(), content: .terminal)
+
+        let decision = TabItemDropRouter.decide(
+            drag: drag,
+            targetPaneID: PaneID(),
+            targetContent: .terminal
+        )
+
+        #expect(decision == .deferToPane)
+    }
+
+    @Test("Editor drag targeting a terminal pane defers to cross-type pane handling")
+    func crossPaneEditorToTerminalDefers() {
+        let drag = makeDrag(paneID: PaneID(), content: .editor)
+
+        let decision = TabItemDropRouter.decide(
+            drag: drag,
+            targetPaneID: PaneID(),
+            targetContent: .terminal
+        )
+
+        #expect(decision == .deferToPane)
+    }
+
+    @Test("Terminal drag targeting an editor pane defers to cross-type pane handling")
+    func crossPaneTerminalToEditorDefers() {
+        let drag = makeDrag(paneID: PaneID(), content: .terminal)
+
+        let decision = TabItemDropRouter.decide(
+            drag: drag,
+            targetPaneID: PaneID(),
+            targetContent: .editor
+        )
+
+        #expect(decision == .deferToPane)
+    }
+
+    @Test("Editor payload claiming its source is a terminal pane is rejected")
+    func samePaneEditorToTerminalIsRejected() {
+        let paneID = PaneID()
+        let drag = makeDrag(paneID: paneID, content: .editor)
+
+        let decision = TabItemDropRouter.decide(
+            drag: drag,
+            targetPaneID: paneID,
+            targetContent: .terminal
+        )
+
+        #expect(decision == .reject)
+    }
+
+    @Test("Terminal payload claiming its source is an editor pane is rejected")
+    func samePaneTerminalToEditorIsRejected() {
+        let paneID = PaneID()
+        let drag = makeDrag(paneID: paneID, content: .terminal)
+
+        let decision = TabItemDropRouter.decide(
+            drag: drag,
+            targetPaneID: paneID,
+            targetContent: .editor
+        )
+
+        #expect(decision == .reject)
+    }
+
+    private func makeDrag(
+        paneID: PaneID,
+        tabID: UUID = UUID(),
+        content: PaneContent
+    ) -> TabDragInfo {
+        TabDragInfo(
+            paneID: paneID.id,
+            tabID: tabID,
+            fileURL: content == .editor ? URL(fileURLWithPath: "/tmp/test.swift") : nil,
+            contentType: content
+        )
+    }
+}
+
+@Suite("Editor Tab Drop Delegate Routing")
+@MainActor
+struct EditorTabDropDelegateRoutingTests {
+    @Test("Local editor drop reorders, consumes payload, and reports completion")
+    func localDropCompletes() {
+        let paneManager = PaneManager()
+        let paneID = paneManager.activePaneID
+        guard let tabManager = paneManager.tabManager(for: paneID) else {
+            Issue.record("Missing initial editor tab manager")
+            return
+        }
+        let first = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/first.swift"),
+            content: "",
+            savedContent: ""
+        )
+        let second = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/second.swift"),
+            content: "",
+            savedContent: ""
+        )
+        tabManager.tabs = [first, second]
+        paneManager.activeDrag = TabDragInfo(
+            paneID: paneID.id,
+            tabID: first.id,
+            fileURL: first.url
+        )
+        var completionCount = 0
+        let delegate = TabDropDelegate(
+            tabManager: tabManager,
+            paneManager: paneManager,
+            targetPaneID: paneID,
+            targetTabID: second.id,
+            hoverTargetTabID: .constant(nil),
+            onReorder: { completionCount += 1 }
+        )
+
+        let decision = delegate.routingDecision()
+        #expect(decision == .localReorder(draggedTabID: first.id))
+        #expect(delegate.handleDropEntered(decision: decision))
+        #expect(tabManager.tabs.map(\.id) == [second.id, first.id])
+        #expect(delegate.finishDrop(decision: decision))
+        #expect(paneManager.activeDrag == nil)
+        #expect(completionCount == 1)
+    }
+
+    @Test("Cross-pane editor drop leaves payload and order for the pane delegate")
+    func crossPaneDropDefers() {
+        let paneManager = PaneManager()
+        let targetPaneID = paneManager.activePaneID
+        guard let tabManager = paneManager.tabManager(for: targetPaneID) else {
+            Issue.record("Missing initial editor tab manager")
+            return
+        }
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/target.swift"),
+            content: "",
+            savedContent: ""
+        )
+        tabManager.tabs = [tab]
+        let drag = TabDragInfo(
+            paneID: PaneID().id,
+            tabID: UUID(),
+            fileURL: URL(fileURLWithPath: "/tmp/source.swift")
+        )
+        paneManager.activeDrag = drag
+        let delegate = TabDropDelegate(
+            tabManager: tabManager,
+            paneManager: paneManager,
+            targetPaneID: targetPaneID,
+            targetTabID: tab.id,
+            hoverTargetTabID: .constant(nil)
+        )
+
+        let decision = delegate.routingDecision()
+        #expect(decision == .deferToPane)
+        #expect(!delegate.handleDropEntered(decision: decision))
+        #expect(!delegate.finishDrop(decision: decision))
+        #expect(tabManager.tabs.map(\.id) == [tab.id])
+        #expect(paneManager.activeDrag?.tabID == drag.tabID)
+    }
+}
+
+@Suite("Terminal Tab Drop Delegate Routing")
+@MainActor
+struct TerminalTabDropDelegateRoutingTests {
+    @Test("Local terminal drop reorders and consumes the shared payload")
+    func localDropCompletes() {
+        let paneManager = PaneManager()
+        let paneID = PaneID()
+        let state = TerminalPaneState()
+        let first = TerminalTab(name: "Terminal 1")
+        let second = TerminalTab(name: "Terminal 2")
+        state.terminalTabs = [first, second]
+        paneManager.activeDrag = TabDragInfo(
+            paneID: paneID.id,
+            tabID: first.id,
+            contentType: .terminal
+        )
+        let delegate = TerminalTabDropDelegate(
+            terminalState: state,
+            targetTabID: second.id,
+            targetPaneID: paneID,
+            paneManager: paneManager
+        )
+
+        let decision = delegate.routingDecision()
+        #expect(decision == .localReorder(draggedTabID: first.id))
+        #expect(delegate.handleDropEntered(decision: decision))
+        #expect(state.terminalTabs.map(\.id) == [second.id, first.id])
+        #expect(delegate.finishDrop(decision: decision))
+        #expect(paneManager.activeDrag == nil)
+    }
+
+    @Test("Cross-pane terminal drop leaves payload and order for the pane delegate")
+    func crossPaneDropDefers() {
+        let paneManager = PaneManager()
+        let targetPaneID = PaneID()
+        let state = TerminalPaneState()
+        let tab = TerminalTab(name: "Terminal 1")
+        state.terminalTabs = [tab]
+        let drag = TabDragInfo(
+            paneID: PaneID().id,
+            tabID: UUID(),
+            contentType: .terminal
+        )
+        paneManager.activeDrag = drag
+        let delegate = TerminalTabDropDelegate(
+            terminalState: state,
+            targetTabID: tab.id,
+            targetPaneID: targetPaneID,
+            paneManager: paneManager
+        )
+
+        let decision = delegate.routingDecision()
+        #expect(decision == .deferToPane)
+        #expect(!delegate.handleDropEntered(decision: decision))
+        #expect(!delegate.finishDrop(decision: decision))
+        #expect(state.terminalTabs.map(\.id) == [tab.id])
+        #expect(paneManager.activeDrag?.tabID == drag.tabID)
+    }
+}
+
+@Suite("Nested Tab-to-Pane Drop Integration")
+@MainActor
+struct NestedTabToPaneDropIntegrationTests {
+    @Test("Deferred editor item drop is completed by the target pane")
+    func deferredEditorDropMovesThroughPaneDelegate() throws {
+        let paneManager = PaneManager()
+        let sourcePaneID = paneManager.activePaneID
+        let sourceTabManager = try #require(paneManager.tabManager(for: sourcePaneID))
+        let sourceTab = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/source.swift"),
+            content: "source",
+            savedContent: "source"
+        )
+        sourceTabManager.tabs = [sourceTab]
+        sourceTabManager.activeTabID = sourceTab.id
+
+        let targetPaneID = try #require(
+            paneManager.splitPane(sourcePaneID, axis: .horizontal)
+        )
+        let targetTabManager = try #require(paneManager.tabManager(for: targetPaneID))
+        let targetTab = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/target.swift"),
+            content: "target",
+            savedContent: "target"
+        )
+        targetTabManager.tabs = [targetTab]
+        targetTabManager.activeTabID = targetTab.id
+
+        let drag = TabDragInfo(
+            paneID: sourcePaneID.id,
+            tabID: sourceTab.id,
+            fileURL: sourceTab.url,
+            contentType: .editor
+        )
+        paneManager.activeDrag = drag
+        let itemDelegate = TabDropDelegate(
+            tabManager: targetTabManager,
+            paneManager: paneManager,
+            targetPaneID: targetPaneID,
+            targetTabID: targetTab.id,
+            hoverTargetTabID: .constant(nil)
+        )
+
+        let decision = itemDelegate.routingDecision()
+        #expect(decision == .deferToPane)
+        #expect(!itemDelegate.handleDropEntered(decision: decision))
+        #expect(!itemDelegate.finishDrop(decision: decision))
+        #expect(paneManager.activeDrag?.paneID == drag.paneID)
+        #expect(paneManager.activeDrag?.tabID == drag.tabID)
+        #expect(paneManager.activeDrag?.fileURL == drag.fileURL)
+        #expect(paneManager.activeDrag?.contentType == drag.contentType)
+        #expect(targetTabManager.tabs.map(\.id) == [targetTab.id])
+        #expect(sourceTabManager.tabs.map(\.id) == [sourceTab.id])
+
+        let paneDelegate = PaneSplitDropDelegate(
+            paneID: targetPaneID,
+            paneManager: paneManager,
+            paneSize: CGSize(width: 400, height: 300)
+        )
+
+        #expect(paneDelegate.performPaneTabDrop(zone: .center))
+        #expect(paneManager.activeDrag == nil)
+        #expect(targetTabManager.tabs.contains { $0.id == targetTab.id })
+        #expect(targetTabManager.tabs.contains { $0.url == sourceTab.url })
+        #expect(targetTabManager.tabs.count == 2)
+        #expect(paneManager.tabManager(for: sourcePaneID) == nil)
+        #expect(paneManager.root.content(for: sourcePaneID) == nil)
+        #expect(paneManager.root.content(for: targetPaneID) == .editor)
+    }
+
+    @Test("Deferred terminal item drop is completed by the target pane")
+    func deferredTerminalDropMovesThroughPaneDelegate() throws {
+        let paneManager = PaneManager()
+        let sourcePaneID = paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let sourceState = try #require(paneManager.terminalState(for: sourcePaneID))
+        let sourceTab = try #require(sourceState.terminalTabs.first)
+
+        let targetPaneID = try #require(paneManager.createTerminalPane(
+            relativeTo: sourcePaneID,
+            axis: .horizontal,
+            workingDirectory: nil
+        ))
+        let targetState = try #require(paneManager.terminalState(for: targetPaneID))
+        let targetTab = try #require(targetState.terminalTabs.first)
+
+        let drag = TabDragInfo(
+            paneID: sourcePaneID.id,
+            tabID: sourceTab.id,
+            contentType: .terminal
+        )
+        paneManager.activeDrag = drag
+        let itemDelegate = TerminalTabDropDelegate(
+            terminalState: targetState,
+            targetTabID: targetTab.id,
+            targetPaneID: targetPaneID,
+            paneManager: paneManager
+        )
+
+        let decision = itemDelegate.routingDecision()
+        #expect(decision == .deferToPane)
+        #expect(!itemDelegate.handleDropEntered(decision: decision))
+        #expect(!itemDelegate.finishDrop(decision: decision))
+        #expect(paneManager.activeDrag?.paneID == drag.paneID)
+        #expect(paneManager.activeDrag?.tabID == drag.tabID)
+        #expect(paneManager.activeDrag?.fileURL == drag.fileURL)
+        #expect(paneManager.activeDrag?.contentType == drag.contentType)
+        #expect(targetState.terminalTabs.map(\.id) == [targetTab.id])
+        #expect(sourceState.terminalTabs.map(\.id) == [sourceTab.id])
+
+        let paneDelegate = PaneSplitDropDelegate(
+            paneID: targetPaneID,
+            paneManager: paneManager,
+            paneSize: CGSize(width: 400, height: 300)
+        )
+
+        #expect(paneDelegate.performPaneTabDrop(zone: .center))
+        #expect(paneManager.activeDrag == nil)
+        #expect(targetState.terminalTabs.map(\.id).contains(targetTab.id))
+        #expect(targetState.terminalTabs.map(\.id).contains(sourceTab.id))
+        #expect(targetState.terminalTabs.count == 2)
+        #expect(paneManager.terminalState(for: sourcePaneID) == nil)
+        #expect(paneManager.root.content(for: sourcePaneID) == nil)
+        #expect(paneManager.root.content(for: targetPaneID) == .terminal)
+    }
+}


### PR DESCRIPTION
## Summary

- make the full rectangular editor and terminal tab slot draggable, including padding and the close affordance
- route stationary clicks using the measured close-glyph frame while preserving close/select accessibility actions
- keep same-pane reordering local and defer cross-pane drops to the enclosing pane destination
- clear shared drag state after completed or cancelled drags

## Testing

- [x] 57 focused hit-testing, payload, delegate-routing, nested-drop, and cleanup tests
- [x] 52 existing tab reorder and cross-pane regression tests
- [x] 12 EditorTabItem snapshot tests with unchanged references
- [x] SwiftLint strict on changed files (0 violations)
- [x] full Xcode build

## Manual verification

SwiftUI pasteboard-driven pointer drags cannot be synthesized reliably by XCUITest. Please verify pickup from the title, icon, padding, and close-glyph regions in both editor and terminal tabs, plus cross-pane center and edge drops.

Closes #1161