### PR TITLE
fix(editor): unify the editor canvas background

### DIFF
--- a/Pine/LineNumberGutter.swift
+++ b/Pine/LineNumberGutter.swift
@@ -24,8 +24,15 @@ final class LineNumberView: NSView {
         editorFont.ascender - gutterFont.ascender
     }
     private let gutterTextColor = NSColor.secondaryLabelColor
-    private let gutterBgColor = NSColor.controlBackgroundColor
     private let separatorColor = NSColor.separatorColor
+
+    /// The gutter is part of the document canvas, so it follows the adjacent
+    /// editor instead of introducing a separate control-background tint.
+    /// Falling back to the semantic text background keeps detached/test views
+    /// appearance-aware as well.
+    var canvasBackgroundColor: NSColor {
+        textView?.backgroundColor ?? .textBackgroundColor
+    }
 
     var gutterWidth: CGFloat = 40
     var lineDiffs: [GitLineDiff] = [] {
@@ -510,15 +517,16 @@ final class LineNumberView: NSView {
     }
 
     override func draw(_ dirtyRect: NSRect) {
+        // Fill even if the weak text-view reference has gone away so the
+        // gutter never exposes a transparent or stale backing layer.
+        canvasBackgroundColor.setFill()
+        bounds.fill()
+
         guard let textView = textView,
               let layoutManager = textView.layoutManager,
               let textContainer = textView.textContainer,
               let scrollView = textView.enclosingScrollView
         else { return }
-
-        // ── Фон ──
-        gutterBgColor.setFill()
-        bounds.fill()
 
         // ── Разделитель ──
         separatorColor.setStroke()

--- a/Pine/MinimapView.swift
+++ b/Pine/MinimapView.swift
@@ -73,13 +73,11 @@ final class MinimapView: NSView {
         return usedRect.height + textView.textContainerOrigin.y + textView.textContainerInset.height
     }
 
-    /// Background color — matches editor background.
-    private let bgColor = NSColor(name: nil) { appearance in
-        if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
-            return NSColor(srgbRed: 0.15, green: 0.15, blue: 0.17, alpha: 1)
-        } else {
-            return NSColor(srgbRed: 0.97, green: 0.97, blue: 0.98, alpha: 1)
-        }
+    /// The minimap is part of the document canvas, so its fill comes from the
+    /// adjacent editor. This avoids a visible seam and automatically follows
+    /// semantic appearance changes without duplicating light/dark RGB values.
+    var canvasBackgroundColor: NSColor {
+        textView?.backgroundColor ?? .textBackgroundColor
     }
 
     /// Viewport indicator fill.
@@ -247,14 +245,15 @@ final class MinimapView: NSView {
     // MARK: - Drawing
 
     override func draw(_ dirtyRect: NSRect) {
+        // Fill even if the weak text-view reference has gone away so the
+        // minimap never exposes a transparent or stale backing layer.
+        canvasBackgroundColor.setFill()
+        bounds.fill()
+
         guard let textView = textView,
               let layoutManager = textView.layoutManager,
               let textContainer = textView.textContainer,
               let textStorage = textView.textStorage else { return }
-
-        // Background
-        bgColor.setFill()
-        bounds.fill()
 
         let source = textView.string as NSString
         guard source.length > 0 else { return }

--- a/PineTests/EditorCanvasBackgroundTests.swift
+++ b/PineTests/EditorCanvasBackgroundTests.swift
@@ -1,0 +1,47 @@
+//
+//  EditorCanvasBackgroundTests.swift
+//  PineTests
+//
+//  Verifies that custom editor chrome stays visually continuous with the
+//  NSTextView document canvas on every system appearance.
+//
+
+import AppKit
+import Testing
+
+@testable import Pine
+
+@Suite("Editor Canvas Background Tests")
+@MainActor
+struct EditorCanvasBackgroundTests {
+    @Test("Gutter and minimap follow the editor background")
+    func chromeFollowsEditorBackground() {
+        let editor = NSTextView()
+        let customBackground = NSColor(
+            srgbRed: 0.21,
+            green: 0.32,
+            blue: 0.43,
+            alpha: 1
+        )
+        editor.backgroundColor = customBackground
+
+        let gutter = LineNumberView(textView: editor)
+        let minimap = MinimapView(textView: editor)
+
+        #expect(gutter.canvasBackgroundColor == customBackground)
+        #expect(minimap.canvasBackgroundColor == customBackground)
+    }
+
+    @Test("Detached editor chrome falls back to the semantic text background")
+    func detachedChromeUsesSemanticFallback() {
+        let editor = NSTextView()
+        let gutter = LineNumberView(textView: editor)
+        let minimap = MinimapView(textView: editor)
+
+        gutter.textView = nil
+        minimap.textView = nil
+
+        #expect(gutter.canvasBackgroundColor == NSColor.textBackgroundColor)
+        #expect(minimap.canvasBackgroundColor == NSColor.textBackgroundColor)
+    }
+}


### PR DESCRIPTION
## Summary

- derive the line-number gutter and minimap backgrounds from the adjacent editor canvas
- remove the hard-coded minimap light/dark RGB values and the separate gutter control tint
- preserve the system-managed Liquid Glass distinction between the sidebar and document content
- add regression coverage for editor background propagation and semantic fallback behavior

## Test plan

- [x] Added `EditorCanvasBackgroundTests`
- [x] Passed 32 related unit tests across editor canvas, minimap, gutter baseline, and editor container suites
- [x] Passed existing editor and minimap screenshot UI tests
- [x] Passed SwiftLint

## Manual testing checklist

- [x] Verified the editor, gutter, and minimap form a continuous canvas in dark appearance
- [x] Verified the sidebar remains a distinct system-managed navigation surface
- [x] No regressions found in related editor layout and minimap behavior

Closes #1164