### PR TITLE
fix: preserve tab state across pane interactions

### DIFF
--- a/Pine/PaneDropZone.swift
+++ b/Pine/PaneDropZone.swift
@@ -54,11 +54,23 @@ enum PaneDropZone: Equatable, Sendable {
     }
 }
 
+/// The payload category used to route a pane-level drop.
+///
+/// Kept separate from `DropInfo` so maximize routing can be covered without
+/// constructing SwiftUI's opaque drop event type.
+enum PaneDropPayload: Equatable, Sendable {
+    case paneTab
+    case sidebarFile
+    case fileURL
+}
+
 /// Visual overlay that shows the drop zone indicator.
 struct PaneDropOverlay: View {
     let dropZone: PaneDropZone?
 
     var body: some View {
+        // Maximized pane-tab drags are routed to nil, while permitted file
+        // drops are routed to .center and retain their visual feedback.
         if let zone = dropZone {
             GeometryReader { geometry in
                 let rect = dropRect(zone: zone, size: geometry.size)
@@ -109,9 +121,8 @@ struct PaneSplitDropDelegate: DropDelegate {
     let paneSize: CGSize
 
     func validateDrop(info: DropInfo) -> Bool {
-        info.hasItemsConforming(to: [.paneTabDrag])
-            || info.hasItemsConforming(to: [.sidebarFileDrag])
-            || info.hasItemsConforming(to: [.fileURL])
+        guard let payload = payload(for: info) else { return false }
+        return routedDropZone(for: payload, proposedZone: .center) != nil
     }
 
     func dropEntered(info: DropInfo) {
@@ -120,8 +131,11 @@ struct PaneSplitDropDelegate: DropDelegate {
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
         updateDropZone(info: info)
-        let operation: DropOperation = info.hasItemsConforming(to: [.paneTabDrag])
-            ? .move : .copy
+        guard let payload = payload(for: info),
+              routedDropZone(for: payload, proposedZone: .center) != nil else {
+            return nil
+        }
+        let operation: DropOperation = payload == .paneTab ? .move : .copy
         return DropProposal(operation: operation)
     }
 
@@ -130,24 +144,28 @@ struct PaneSplitDropDelegate: DropDelegate {
     }
 
     func performDrop(info: DropInfo) -> Bool {
+        guard let payload = payload(for: info) else { return false }
+
         // Snapshot zone and clear ALL overlays before tree mutations.
         let savedZone = paneManager.dropZones[paneID]
         paneManager.clearAllDropZones()
 
         // Pane tab drag takes priority
-        if info.hasItemsConforming(to: [.paneTabDrag]) {
+        if payload == .paneTab {
             return handlePaneTabDrop(zone: savedZone)
         }
 
         // Sidebar file drag — decode from item providers async
-        if info.hasItemsConforming(to: [.sidebarFileDrag]) {
+        if payload == .sidebarFile {
             let providers = info.itemProviders(for: [.sidebarFileDrag])
-            handleSidebarFileDrop(zone: savedZone, providers: providers)
+            let routedZone = routedDropZone(for: payload, proposedZone: savedZone)
+            guard routedZone != nil else { return false }
+            handleSidebarFileDrop(zone: routedZone, providers: providers)
             return true
         }
 
         // File drop from Finder — open as tab in this pane
-        if info.hasItemsConforming(to: [.fileURL]) {
+        if payload == .fileURL {
             handleFileDrop(providers: info.itemProviders(for: [.fileURL]))
             return true
         }
@@ -188,13 +206,15 @@ struct PaneSplitDropDelegate: DropDelegate {
     }
 
     private func handlePaneTabDrop(zone: PaneDropZone?) -> Bool {
-        guard let zone else { return false }
+        guard let zone = routedDropZone(for: .paneTab, proposedZone: zone) else {
+            return false
+        }
 
         // Use synchronous shared drag state instead of async NSItemProvider
         guard let dragInfo = paneManager.activeDrag else { return false }
-        paneManager.activeDrag = nil
 
         let sourcePaneID = PaneID(id: dragInfo.paneID)
+        let didPerformDrop: Bool
 
         switch zone {
         case .left, .right, .top, .bottom:
@@ -202,28 +222,41 @@ struct PaneSplitDropDelegate: DropDelegate {
             let axis: SplitAxis = (zone == .left || zone == .right) ? .horizontal : .vertical
             let before = (zone == .left || zone == .top)
             if dragInfo.contentType == .terminal {
-                paneManager.splitAndMoveTerminalTab(
+                didPerformDrop = paneManager.splitAndMoveTerminalTab(
                     tabID: dragInfo.tabID,
                     from: sourcePaneID,
                     relativeTo: paneID,
                     axis: axis,
                     insertBefore: before
-                )
+                ) != nil
             } else if let fileURL = dragInfo.fileURL {
-                paneManager.splitPane(
+                didPerformDrop = paneManager.splitPane(
                     paneID,
                     axis: axis,
+                    tabID: dragInfo.tabID,
                     tabURL: fileURL,
                     sourcePane: sourcePaneID,
                     insertBefore: before
-                )
+                ) != nil
+            } else {
+                didPerformDrop = false
             }
         case .center:
             // Center drop: same-type moves into the pane;
             // cross-type triggers an auto-split (issue #714).
-            paneManager.performCenterDrop(dragInfo: dragInfo, targetPaneID: paneID)
+            didPerformDrop = paneManager.performCenterDrop(
+                dragInfo: dragInfo,
+                targetPaneID: paneID
+            )
         }
-        return true
+
+        // Preserve the shared payload when this delegate rejects the drop so
+        // an ancestor/root target can still handle it. Consume it only after
+        // the corresponding model mutation has actually committed.
+        if didPerformDrop {
+            paneManager.activeDrag = nil
+        }
+        return didPerformDrop
     }
 
     private func handleFileDrop(providers: [NSItemProvider]) {
@@ -241,14 +274,62 @@ struct PaneSplitDropDelegate: DropDelegate {
     }
 
     private func updateDropZone(info: DropInfo) {
-        paneManager.dropZones[paneID] = PaneDropZone.zone(for: info.location, in: paneSize)
-        paneManager.startStaleDropPollingIfNeeded()
+        guard let payload = payload(for: info) else {
+            paneManager.dropZones[paneID] = nil
+            return
+        }
+        updateDropZone(for: payload, at: info.location)
+    }
+
+    private func payload(for info: DropInfo) -> PaneDropPayload? {
+        if info.hasItemsConforming(to: [.paneTabDrag]) {
+            return .paneTab
+        }
+        if info.hasItemsConforming(to: [.sidebarFileDrag]) {
+            return .sidebarFile
+        }
+        if info.hasItemsConforming(to: [.fileURL]) {
+            return .fileURL
+        }
+        return nil
     }
 }
 
 // MARK: - Test Support
 
 extension PaneSplitDropDelegate {
+    /// Routes a proposed pane drop through the maximize safety invariant.
+    /// Tab payloads must stay in their local tab-strip delegate while the
+    /// pane is maximized. File payloads remain useful, but are forced to the
+    /// non-structural center action.
+    func routedDropZone(
+        for payload: PaneDropPayload,
+        proposedZone: PaneDropZone?
+    ) -> PaneDropZone? {
+        guard paneManager.isMaximized else { return proposedZone }
+        switch payload {
+        case .paneTab:
+            return nil
+        case .sidebarFile, .fileURL:
+            return .center
+        }
+    }
+
+    /// Testable counterpart of `dropEntered` / `dropUpdated`.
+    @discardableResult
+    func updateDropZone(
+        for payload: PaneDropPayload,
+        at location: CGPoint
+    ) -> PaneDropZone? {
+        let proposedZone = PaneDropZone.zone(for: location, in: paneSize)
+        let zone = routedDropZone(for: payload, proposedZone: proposedZone)
+        paneManager.dropZones[paneID] = zone
+        if zone != nil {
+            paneManager.startStaleDropPollingIfNeeded()
+        }
+        return zone
+    }
+
     /// Testable entry point for the pane-tab branch of `performDrop(info:)`.
     ///
     /// Equivalent to invoking `performDrop` when

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -503,7 +503,12 @@ struct PaneLeafView: View {
     }
 
     private func closeAllTabsWithConfirmation(tabManager: TabManager) {
-        TabCloseHelper.closeAllTabs(in: tabManager, gitProvider: workspace.gitProvider)
-        paneManager.removePane(paneID)
+        let didClose = TabCloseHelper.closeAllTabs(
+            in: tabManager,
+            gitProvider: workspace.gitProvider
+        )
+        if didClose && tabManager.tabs.isEmpty {
+            paneManager.removePane(paneID)
+        }
     }
 }

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -22,6 +22,16 @@ final class PaneManager {
     /// Per-pane terminal states, keyed by PaneID.
     private(set) var terminalStates: [PaneID: TerminalPaneState] = [:]
 
+    /// Applies project-scoped services (recovery, editor-context callbacks,
+    /// and similar wiring) to every editor TabManager owned by this pane tree.
+    /// Setting the configurator also updates managers that already exist.
+    var configureEditorTabManager: ((TabManager) -> Void)? {
+        didSet {
+            guard let configureEditorTabManager else { return }
+            tabManagers.values.forEach(configureEditorTabManager)
+        }
+    }
+
     /// Saved root before maximize, for restore.
     private(set) var savedRootBeforeMaximize: PaneNode?
 
@@ -246,12 +256,14 @@ final class PaneManager {
     // MARK: - Split operations
 
     /// Splits a pane by placing a new pane alongside it.
-    /// The tab at the given URL is moved from the source pane to the new one.
+    /// The tab at the given identity (or legacy URL fallback) is moved from
+    /// the source pane to the new one.
     /// If `insertBefore` is true, the new pane is placed before (left/top of) the target.
     @discardableResult
     func splitPane(
         _ targetID: PaneID,
         axis: SplitAxis,
+        tabID: UUID? = nil,
         tabURL: URL? = nil,
         sourcePane: PaneID? = nil,
         insertBefore: Bool = false
@@ -265,28 +277,56 @@ final class PaneManager {
             insertBefore: insertBefore
         ) else { return nil }
 
-        root = newRoot
-        let newTabManager = TabManager()
-        tabManagers[newID] = newTabManager
+        let newTabManager = makeEditorTabManager()
 
-        // Move tab from source to new pane if specified
-        if let url = tabURL, let srcID = sourcePane, let srcTM = tabManagers[srcID] {
-            moveTab(url: url, from: srcTM, to: newTabManager)
+        // Resolve and detach the tab before committing the new tree. If any
+        // transfer precondition fails, no pane is created and the source is
+        // left untouched. Insertion is rollback-safe even if its identity
+        // precondition unexpectedly changes.
+        if tabID != nil || tabURL != nil {
+            guard let sourcePane,
+                  let source = tabManagers[sourcePane],
+                  let resolvedTabID = resolvedEditorTabID(tabID: tabID, url: tabURL, in: source),
+                  let tab = source.tabs.first(where: { $0.id == resolvedTabID }),
+                  newTabManager.canInsertTransferredTab(tab),
+                  let extraction = source.extractTab(id: resolvedTabID) else { return nil }
+
+            guard newTabManager.insertTransferredTab(extraction) else {
+                source.restoreExtractedTab(extraction)
+                return nil
+            }
         }
 
+        root = newRoot
+        tabManagers[newID] = newTabManager
         activePaneID = newID
+        newTabManager.onEditorContextChanged?()
+
+        // An edge/split move must obey the same empty-source invariant as a
+        // center move. The newly created destination is non-empty, so it is
+        // never selected as the pruning victim.
+        if tabID != nil || tabURL != nil {
+            pruneEmptyEditorLeaves()
+        }
         return newID
     }
 
     /// Moves a tab from one pane to another by URL.
-    func moveTabBetweenPanes(tabURL: URL, from sourceID: PaneID, to targetID: PaneID) {
-        guard let srcTM = tabManagers[sourceID],
-              let dstTM = tabManagers[targetID] else { return }
-        moveTab(url: tabURL, from: srcTM, to: dstTM)
-        activePaneID = targetID
+    @discardableResult
+    func moveTabBetweenPanes(tabURL: URL, from sourceID: PaneID, to targetID: PaneID) -> Bool {
+        transferEditorTab(tabID: nil, url: tabURL, from: sourceID, to: targetID)
+    }
 
-        // Clean up empty editor panes (centralized hook).
-        pruneEmptyEditorLeaves()
+    /// Moves the exact tab identity from one editor pane to another. The URL
+    /// is retained only as a compatibility fallback for legacy drag payloads.
+    @discardableResult
+    func moveTabBetweenPanes(
+        tabID: UUID,
+        tabURL: URL? = nil,
+        from sourceID: PaneID,
+        to targetID: PaneID
+    ) -> Bool {
+        transferEditorTab(tabID: tabID, url: tabURL, from: sourceID, to: targetID)
     }
 
     // MARK: - Empty editor leaf pruning
@@ -356,7 +396,7 @@ final class PaneManager {
         if let firstID = root.firstLeafID, let tm = tabManagers[firstID] {
             return tm
         }
-        let fresh = TabManager()
+        let fresh = makeEditorTabManager()
         let newID = PaneID()
         tabManagers[newID] = fresh
         root = .leaf(newID, .editor)
@@ -380,7 +420,7 @@ final class PaneManager {
             tabManagers[paneID] = nil
             terminalStates[paneID] = nil
             let newID = PaneID()
-            tabManagers[newID] = TabManager()
+            tabManagers[newID] = makeEditorTabManager()
             root = .leaf(newID, .editor)
             activePaneID = newID
             return
@@ -461,13 +501,17 @@ final class PaneManager {
         return newID
     }
 
-    func moveTerminalTab(_ tabID: UUID, from sourceID: PaneID, to targetID: PaneID) {
-        guard let srcState = terminalStates[sourceID],
+    @discardableResult
+    func moveTerminalTab(_ tabID: UUID, from sourceID: PaneID, to targetID: PaneID) -> Bool {
+        guard sourceID != targetID,
+              let srcState = terminalStates[sourceID],
               let dstState = terminalStates[targetID],
-              let tab = srcState.terminalTabs.first(where: { $0.id == tabID }) else { return }
+              !dstState.terminalTabs.contains(where: { $0.id == tabID }),
+              let tab = srcState.terminalTabs.first(where: { $0.id == tabID }) else { return false }
 
         dstState.terminalTabs.append(tab)
         dstState.activeTerminalID = tab.id
+        dstState.pendingFocusTabID = tab.id
         srcState.terminalTabs.removeAll { $0.id == tabID }
         if srcState.activeTerminalID == tabID {
             srcState.activeTerminalID = srcState.terminalTabs.last?.id
@@ -476,6 +520,7 @@ final class PaneManager {
         if srcState.terminalTabs.isEmpty {
             removePane(sourceID)
         }
+        return true
     }
 
     /// Splits a pane, creates a new terminal pane, and moves an existing terminal tab into it.
@@ -501,6 +546,7 @@ final class PaneManager {
 
         newState.terminalTabs.append(tab)
         newState.activeTerminalID = tab.id
+        newState.pendingFocusTabID = tab.id
         srcState.terminalTabs.removeAll { $0.id == tabID }
         if srcState.activeTerminalID == tabID {
             srcState.activeTerminalID = srcState.terminalTabs.last?.id
@@ -518,9 +564,14 @@ final class PaneManager {
     /// Wraps the entire root in a new split, creating a full-width/height terminal pane.
     /// Moves the specified terminal tab from the source pane to the new pane.
     /// Removes the source pane if it becomes empty.
-    func wrapRootWithTerminal(at zone: RootDropZone, from sourcePaneID: PaneID, tabID: UUID) {
+    @discardableResult
+    func wrapRootWithTerminal(
+        at zone: RootDropZone,
+        from sourcePaneID: PaneID,
+        tabID: UUID
+    ) -> Bool {
         guard let srcState = terminalStates[sourcePaneID],
-              let tab = srcState.terminalTabs.first(where: { $0.id == tabID }) else { return }
+              let tab = srcState.terminalTabs.first(where: { $0.id == tabID }) else { return false }
 
         // Remove tab from source BEFORE modifying the tree
         srcState.terminalTabs.removeAll { $0.id == tabID }
@@ -551,8 +602,10 @@ final class PaneManager {
         let newState = TerminalPaneState()
         newState.terminalTabs.append(tab)
         newState.activeTerminalID = tab.id
+        newState.pendingFocusTabID = tab.id
         terminalStates[newID] = newState
         activePaneID = newID
+        return true
     }
 
     // MARK: - Maximize
@@ -603,7 +656,7 @@ final class PaneManager {
         for leafID in leafIDs {
             switch node.content(for: leafID) {
             case .editor:
-                newTabManagers[leafID] = TabManager()
+                newTabManagers[leafID] = makeEditorTabManager()
             case .terminal:
                 newTerminalStates[leafID] = TerminalPaneState()
             case nil:
@@ -677,15 +730,14 @@ final class PaneManager {
         if dragInfo.contentType == targetContent {
             // Same-type: plain move.
             if dragInfo.contentType == .terminal {
-                guard terminalStates[sourcePaneID]?.terminalTabs
-                    .contains(where: { $0.id == dragInfo.tabID }) == true else { return false }
-                moveTerminalTab(dragInfo.tabID, from: sourcePaneID, to: targetPaneID)
-                return true
+                return moveTerminalTab(dragInfo.tabID, from: sourcePaneID, to: targetPaneID)
             } else if let fileURL = dragInfo.fileURL {
-                guard tabManagers[sourcePaneID]?.tabs
-                    .contains(where: { $0.url == fileURL }) == true else { return false }
-                moveTabBetweenPanes(tabURL: fileURL, from: sourcePaneID, to: targetPaneID)
-                return true
+                return moveTabBetweenPanes(
+                    tabID: dragInfo.tabID,
+                    tabURL: fileURL,
+                    from: sourcePaneID,
+                    to: targetPaneID
+                )
             }
             return false
         }
@@ -705,11 +757,10 @@ final class PaneManager {
             return newID != nil
         } else if let fileURL = dragInfo.fileURL {
             // Moving an editor tab into a terminal pane.
-            guard tabManagers[sourcePaneID]?.tabs
-                .contains(where: { $0.url == fileURL }) == true else { return false }
             let newID = splitPane(
                 targetPaneID,
                 axis: .vertical,
+                tabID: dragInfo.tabID,
                 tabURL: fileURL,
                 sourcePane: sourcePaneID,
                 insertBefore: false
@@ -727,18 +778,43 @@ final class PaneManager {
 
     // MARK: - Private helpers
 
-    private func moveTab(url: URL, from source: TabManager, to destination: TabManager) {
-        guard let srcIdx = source.tabs.firstIndex(where: { $0.url == url }) ?? source.tabs.firstIndex(where: {
-            $0.url.standardizedFileURL == url.standardizedFileURL
-        }) else { return }
-        // Take a copy of the full tab with all state
-        let tab = source.tabs[srcIdx]
-        // Re-mint identity so the tab is fresh in the destination
-        let movedTab = EditorTab.reidentified(from: tab)
-        // Add to destination FIRST — if this crashes, the tab is still in source
-        destination.tabs.append(movedTab)
-        destination.activeTabID = movedTab.id
-        // Now safe to remove from source (force: skip dirty check — we're moving, not discarding)
-        source.closeTab(id: tab.id, force: true)
+    private func makeEditorTabManager() -> TabManager {
+        let tabManager = TabManager()
+        configureEditorTabManager?(tabManager)
+        return tabManager
+    }
+
+    private func resolvedEditorTabID(tabID: UUID?, url: URL?, in source: TabManager) -> UUID? {
+        if let tabID {
+            return source.tabs.contains(where: { $0.id == tabID }) ? tabID : nil
+        }
+        guard let url else { return nil }
+        return source.tabs.first(where: { $0.url == url })?.id
+            ?? source.tabs.first(where: { $0.url.standardizedFileURL == url.standardizedFileURL })?.id
+    }
+
+    private func transferEditorTab(
+        tabID: UUID?,
+        url: URL?,
+        from sourceID: PaneID,
+        to targetID: PaneID
+    ) -> Bool {
+        guard sourceID != targetID,
+              let source = tabManagers[sourceID],
+              let destination = tabManagers[targetID],
+              let resolvedTabID = resolvedEditorTabID(tabID: tabID, url: url, in: source),
+              let tab = source.tabs.first(where: { $0.id == resolvedTabID }),
+              destination.canInsertTransferredTab(tab),
+              let extraction = source.extractTab(id: resolvedTabID) else { return false }
+
+        guard destination.insertTransferredTab(extraction) else {
+            source.restoreExtractedTab(extraction)
+            return false
+        }
+
+        activePaneID = targetID
+        destination.onEditorContextChanged?()
+        pruneEmptyEditorLeaves()
+        return true
     }
 }

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -20,8 +20,9 @@ final class ProjectManager {
     /// Persistent audit log of finished agent sessions for the History &
     /// Undo view (vision #933, Phase 2 — Visibility, issue #1073).
     let agentHistory = AgentHistoryStore()
-    /// The primary TabManager (root editor pane). Owns the recovery wiring and
-    /// editor-context subscription. For the *focused* pane's TabManager, use
+    /// The primary TabManager (initial root editor pane). Project-scoped
+    /// services are wired to every pane-owned manager by `PaneManager`'s
+    /// configurator. For the *focused* pane's TabManager, use
     /// ``activeTabManager`` which delegates to ``PaneManager/activeEditorTabManager``.
     ///
     /// Note: this instance can become an *orphan* — i.e. no pane in the
@@ -30,9 +31,8 @@ final class ProjectManager {
     /// session restore that does not bind it to any leaf. In that state it
     /// is harmless: it holds no tabs, contributes nothing to `allTabs`, and
     /// is recreated as a leaf-bound TabManager via `ensureEditorPane()`
-    /// when the user opens a file again. The reference is kept solely so
-    /// the recovery wiring and editor-context subscription survive across
-    /// such transitions.
+    /// when the user opens a file again. The reference remains as the stable
+    /// fallback used by project-level commands while no editor pane exists.
     let primaryTabManager = TabManager()
     let searchProvider = ProjectSearchProvider()
     let quickOpenProvider = QuickOpenProvider()
@@ -187,8 +187,8 @@ final class ProjectManager {
         }
         workspace.progressTracker = progress
         workspace.gitProvider.progressTracker = progress
-        primaryTabManager.onEditorContextChanged = { [weak self] in
-            self?.updateEditorContext()
+        paneManager.configureEditorTabManager = { [weak self] tabManager in
+            self?.configureEditorTabManager(tabManager)
         }
         // Wire TerminalManager to PaneManager (lazy wiring)
         terminal.paneManager = paneManager
@@ -211,9 +211,23 @@ final class ProjectManager {
         manager.tabsProvider = { [weak self] in
             self?.allTabs ?? []
         }
+        // The primary manager can temporarily be orphaned from the pane tree,
+        // so configure it explicitly as well as every currently visible pane.
         primaryTabManager.recoveryManager = manager
+        for tabManager in paneManager.allTabManagers {
+            tabManager.recoveryManager = manager
+        }
         manager.startPeriodicSnapshots()
         recoveryManager = manager
+    }
+
+    /// Applies project-owned services to every editor group, including groups
+    /// created later by pane splits or session restoration.
+    private func configureEditorTabManager(_ tabManager: TabManager) {
+        tabManager.recoveryManager = recoveryManager
+        tabManager.onEditorContextChanged = { [weak self] in
+            self?.updateEditorContext()
+        }
     }
 
     /// Persists current session (project + open file tabs) to UserDefaults.

--- a/Pine/RootDropZone.swift
+++ b/Pine/RootDropZone.swift
@@ -61,9 +61,12 @@ enum RootDropZone: Equatable, Sendable {
 /// Visual overlay showing the full-width/height drop zone indicator at window edges.
 struct RootDropOverlay: View {
     let dropZone: RootDropZone?
+    @Environment(PaneManager.self) private var paneManager
 
     var body: some View {
-        if let zone = dropZone {
+        // Root structural drops target the saved layout, never its temporary
+        // single-pane maximized projection.
+        if !paneManager.isMaximized, let zone = dropZone {
             GeometryReader { geometry in
                 let rect = dropRect(zone: zone, size: geometry.size)
                 Rectangle()
@@ -105,9 +108,7 @@ struct RootPaneSplitDropDelegate: DropDelegate {
 
     func validateDrop(info: DropInfo) -> Bool {
         guard info.hasItemsConforming(to: [.paneTabDrag]) else { return false }
-        guard let drag = paneManager.activeDrag,
-              drag.contentType == .terminal else { return false }
-        return paneManager.root.leafCount > 1
+        return canRouteStructuralDrop
     }
 
     func dropEntered(info: DropInfo) {
@@ -115,8 +116,7 @@ struct RootPaneSplitDropDelegate: DropDelegate {
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
-        updateZone(info: info)
-        let zone = RootDropZone.detect(location: info.location, in: containerSize)
+        let zone = updateRootDropZone(at: info.location)
         if zone != nil {
             paneManager.clearLeafDropZones()
             return DropProposal(operation: .move)
@@ -130,22 +130,60 @@ struct RootPaneSplitDropDelegate: DropDelegate {
     }
 
     func performDrop(info: DropInfo) -> Bool {
-        guard let zone = paneManager.rootDropZone else { return false }
-        paneManager.rootDropZone = nil
-        paneManager.clearAllDropZones()
-
-        guard let dragInfo = paneManager.activeDrag,
-              dragInfo.contentType == .terminal else { return false }
-        paneManager.activeDrag = nil
-
-        let sourcePaneID = PaneID(id: dragInfo.paneID)
-        paneManager.wrapRootWithTerminal(at: zone, from: sourcePaneID, tabID: dragInfo.tabID)
-        return true
+        performRootPaneTabDrop(zone: paneManager.rootDropZone)
     }
 
     private func updateZone(info: DropInfo) {
-        paneManager.rootDropZone = RootDropZone.detect(location: info.location, in: containerSize)
-        paneManager.startStaleDropPollingIfNeeded()
+        updateRootDropZone(at: info.location)
+    }
+}
+
+// MARK: - Test Support
+
+extension RootPaneSplitDropDelegate {
+    /// Whether the shared drag can mutate the real root layout.
+    var canRouteStructuralDrop: Bool {
+        guard !paneManager.isMaximized,
+              paneManager.root.leafCount > 1,
+              let drag = paneManager.activeDrag else {
+            return false
+        }
+        return drag.contentType == .terminal
+    }
+
+    /// Testable counterpart of the root delegate's hover routing.
+    @discardableResult
+    func updateRootDropZone(at location: CGPoint) -> RootDropZone? {
+        let zone = canRouteStructuralDrop
+            ? RootDropZone.detect(location: location, in: containerSize)
+            : nil
+        paneManager.rootDropZone = zone
+        if zone != nil {
+            paneManager.startStaleDropPollingIfNeeded()
+        }
+        return zone
+    }
+
+    /// Testable counterpart of `performDrop(info:)`.
+    @discardableResult
+    func performRootPaneTabDrop(zone: RootDropZone?) -> Bool {
+        paneManager.clearAllDropZones()
+        guard canRouteStructuralDrop,
+              let zone,
+              let dragInfo = paneManager.activeDrag else {
+            return false
+        }
+
+        let sourcePaneID = PaneID(id: dragInfo.paneID)
+        let didPerformDrop = paneManager.wrapRootWithTerminal(
+            at: zone,
+            from: sourcePaneID,
+            tabID: dragInfo.tabID
+        )
+        if didPerformDrop {
+            paneManager.activeDrag = nil
+        }
+        return didPerformDrop
     }
 }
 

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -47,20 +47,28 @@ enum TabCloseHelper {
     static func confirmBulkClose(
         dirtyTabs: [EditorTab],
         in tabManager: TabManager,
-        gitProvider: GitStatusProvider
+        gitProvider: GitStatusProvider,
+        presentAlert: (() -> NSApplication.ModalResponse)? = nil,
+        saveTab: ((Int) -> Bool)? = nil
     ) -> Bool {
         guard !dirtyTabs.isEmpty else { return true }
 
         let fileList = dirtyTabs.map { "  \u{2022} \($0.fileName)" }.joined(separator: "\n")
-        let response = AlertTemplate.unsavedChangesBulk.runModal(
-            messageText: Strings.unsavedChangesTitle,
-            informativeText: Strings.unsavedChangesListMessage(fileList)
-        )
+        let response: NSApplication.ModalResponse
+        if let presentAlert {
+            response = presentAlert()
+        } else {
+            response = AlertTemplate.unsavedChangesBulk.runModal(
+                messageText: Strings.unsavedChangesTitle,
+                informativeText: Strings.unsavedChangesListMessage(fileList)
+            )
+        }
         switch response {
         case .alertFirstButtonReturn:
             for tab in dirtyTabs {
                 guard let index = tabManager.tabs.firstIndex(where: { $0.id == tab.id }) else { continue }
-                guard tabManager.saveTab(at: index) else { return false }
+                let didSave = saveTab?(index) ?? tabManager.saveTab(at: index)
+                guard didSave else { return false }
             }
             Task { await gitProvider.refreshAsync() }
             return true
@@ -72,35 +80,68 @@ enum TabCloseHelper {
     }
 
     /// Closes all tabs except the one with the given ID, with unsaved-changes protection.
+    /// Returns `true` only when the close operation completed.
+    @discardableResult
     static func closeOtherTabs(
         keeping tabID: UUID,
         in tabManager: TabManager,
-        gitProvider: GitStatusProvider
-    ) {
+        gitProvider: GitStatusProvider,
+        presentAlert: (() -> NSApplication.ModalResponse)? = nil,
+        saveTab: ((Int) -> Bool)? = nil
+    ) -> Bool {
         let dirty = tabManager.dirtyTabsForCloseOthers(keeping: tabID)
-        guard confirmBulkClose(dirtyTabs: dirty, in: tabManager, gitProvider: gitProvider) else { return }
+        guard confirmBulkClose(
+            dirtyTabs: dirty,
+            in: tabManager,
+            gitProvider: gitProvider,
+            presentAlert: presentAlert,
+            saveTab: saveTab
+        ) else { return false }
         tabManager.closeOtherTabs(keeping: tabID, force: true)
+        return true
     }
 
     /// Closes all tabs to the right of the given tab, with unsaved-changes protection.
+    /// Returns `true` only when the close operation completed.
+    @discardableResult
     static func closeTabsToTheRight(
         of tabID: UUID,
         in tabManager: TabManager,
-        gitProvider: GitStatusProvider
-    ) {
+        gitProvider: GitStatusProvider,
+        presentAlert: (() -> NSApplication.ModalResponse)? = nil,
+        saveTab: ((Int) -> Bool)? = nil
+    ) -> Bool {
         let dirty = tabManager.dirtyTabsForCloseRight(of: tabID)
-        guard confirmBulkClose(dirtyTabs: dirty, in: tabManager, gitProvider: gitProvider) else { return }
+        guard confirmBulkClose(
+            dirtyTabs: dirty,
+            in: tabManager,
+            gitProvider: gitProvider,
+            presentAlert: presentAlert,
+            saveTab: saveTab
+        ) else { return false }
         tabManager.closeTabsToTheRight(of: tabID, force: true)
+        return true
     }
 
     /// Closes all tabs with unsaved-changes protection.
+    /// Returns `true` only when the close operation completed.
+    @discardableResult
     static func closeAllTabs(
         in tabManager: TabManager,
-        gitProvider: GitStatusProvider
-    ) {
+        gitProvider: GitStatusProvider,
+        presentAlert: (() -> NSApplication.ModalResponse)? = nil,
+        saveTab: ((Int) -> Bool)? = nil
+    ) -> Bool {
         let dirty = tabManager.dirtyTabsForCloseAll()
-        guard confirmBulkClose(dirtyTabs: dirty, in: tabManager, gitProvider: gitProvider) else { return }
+        guard confirmBulkClose(
+            dirtyTabs: dirty,
+            in: tabManager,
+            gitProvider: gitProvider,
+            presentAlert: presentAlert,
+            saveTab: saveTab
+        ) else { return false }
         tabManager.closeAllTabs(force: true)
+        return true
     }
 
     // MARK: - Terminal foreground-process confirmation

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -61,6 +61,17 @@ final class TabManager {
     var isAutoSaveEnabled: Bool { UserDefaults.standard.bool(forKey: Self.autoSaveKey) }
     var pinnedTabCount: Int { TabPinning.pinnedTabCount(in: tabs) }
 
+    /// A tab temporarily detached from this manager while it is transferred
+    /// to another editor pane. The original position and selection make a
+    /// failed transfer exactly reversible without invoking close/discard
+    /// cleanup (in particular, recovery files remain intact).
+    struct ExtractedTab {
+        let tab: EditorTab
+        fileprivate let originalIndex: Int
+        fileprivate let previousActiveTabID: UUID?
+        fileprivate let shouldResumeAutoSave: Bool
+    }
+
     // MARK: - Open
 
     func openTab(url: URL) {
@@ -91,7 +102,7 @@ final class TabManager {
     func closeTab(id: UUID, force: Bool = false) {
         guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
         if tabs[index].isPinned && !force { return }
-        cancelAutoSave()
+        cancelAutoSave(for: id)
         recoveryManager?.deleteRecoveryFile(for: id)
         let wasActive = activeTabID == id
         tabs.remove(at: index)
@@ -105,7 +116,6 @@ final class TabManager {
     }
 
     func closeOtherTabs(keeping tabID: UUID, force: Bool) {
-        cancelAutoSave()
         tabs.filter { $0.id != tabID && !$0.isPinned && (force || !$0.isDirty) }
             .map(\.id).forEach { closeTab(id: $0, force: true) }
         activeTabID = tabID
@@ -117,7 +127,6 @@ final class TabManager {
 
     func closeTabsToTheRight(of tabID: UUID, force: Bool) {
         guard let index = tabs.firstIndex(where: { $0.id == tabID }) else { return }
-        cancelAutoSave()
         tabs[(index + 1)...].filter { !$0.isPinned && (force || !$0.isDirty) }
             .reversed().forEach { closeTab(id: $0.id, force: true) }
     }
@@ -125,7 +134,6 @@ final class TabManager {
     func dirtyTabsForCloseAll() -> [EditorTab] { TabCollection.dirtyTabsForCloseAll(in: tabs) }
 
     func closeAllTabs(force: Bool) {
-        cancelAutoSave()
         tabs.filter { force || !$0.isDirty }.map(\.id).forEach { closeTab(id: $0, force: true) }
     }
 
@@ -176,7 +184,7 @@ final class TabManager {
     @discardableResult
     func saveActiveTab() -> Bool {
         guard let index = activeTabIndex else { return false }
-        cancelAutoSave()
+        cancelAutoSave(for: tabs[index].id)
         return saveTab(at: index)
     }
 
@@ -259,6 +267,84 @@ final class TabManager {
     }
 
     // MARK: - Reorder & Pin
+
+    /// Removes a tab for an in-window pane transfer.
+    ///
+    /// Unlike ``closeTab(id:force:)``, extraction does not delete recovery
+    /// data or otherwise treat the tab as discarded. Callers must either
+    /// insert the returned value into another manager or restore it here.
+    func extractTab(id: UUID) -> ExtractedTab? {
+        guard let index = tabs.firstIndex(where: { $0.id == id }) else { return nil }
+
+        let previousActiveTabID = activeTabID
+        let shouldResumeAutoSave = hasScheduledAutoSave(for: id)
+        if shouldResumeAutoSave {
+            cancelAutoSave(for: id)
+        }
+
+        let tab = tabs.remove(at: index)
+        if activeTabID == id {
+            activeTabID = tabs.isEmpty ? nil : tabs[min(index, tabs.count - 1)].id
+        }
+
+        return ExtractedTab(
+            tab: tab,
+            originalIndex: index,
+            previousActiveTabID: previousActiveTabID,
+            shouldResumeAutoSave: shouldResumeAutoSave
+        )
+    }
+
+    /// Whether this manager can accept the exact tab from another pane.
+    /// Duplicate identities and file URLs are rejected so each pane keeps
+    /// the same one-file/one-tab invariant as ``openTab(url:)``.
+    func canInsertTransferredTab(_ tab: EditorTab) -> Bool {
+        !tabs.contains { existing in
+            existing.id == tab.id
+                || existing.url.standardizedFileURL == tab.url.standardizedFileURL
+        }
+    }
+
+    /// Inserts a transferred tab and activates it. Pinned tabs join the end
+    /// of the pinned prefix; regular tabs are appended after that prefix.
+    @discardableResult
+    func insertTransferredTab(_ tab: EditorTab) -> Bool {
+        guard canInsertTransferredTab(tab) else { return false }
+
+        if tab.isPinned {
+            let firstUnpinned = tabs.firstIndex(where: { !$0.isPinned }) ?? tabs.endIndex
+            tabs.insert(tab, at: firstUnpinned)
+        } else {
+            tabs.append(tab)
+        }
+        activeTabID = tab.id
+        return true
+    }
+
+    /// Inserts a detached tab and resumes any auto-save that was pending in
+    /// its source manager. The destination owns the timer after the move, so
+    /// the callback resolves the tab in the manager that now contains it.
+    @discardableResult
+    func insertTransferredTab(_ extraction: ExtractedTab) -> Bool {
+        guard insertTransferredTab(extraction.tab) else { return false }
+        if extraction.shouldResumeAutoSave {
+            scheduleAutoSave(for: extraction.tab.id)
+        }
+        return true
+    }
+
+    /// Restores a failed extraction at its exact previous position and
+    /// selection. This is intentionally separate from normal insertion,
+    /// whose pinned-prefix policy is destination-oriented.
+    func restoreExtractedTab(_ extraction: ExtractedTab) {
+        guard !tabs.contains(where: { $0.id == extraction.tab.id }) else { return }
+        let index = min(extraction.originalIndex, tabs.count)
+        tabs.insert(extraction.tab, at: index)
+        activeTabID = extraction.previousActiveTabID
+        if extraction.shouldResumeAutoSave {
+            scheduleAutoSave(for: extraction.tab.id)
+        }
+    }
 
     func moveTab(fromOffsets source: IndexSet, toOffset destination: Int) {
         tabs.move(fromOffsets: source, toOffset: destination)
@@ -346,10 +432,15 @@ final class TabManager {
     func setAutoSaveDelay(_ delay: TimeInterval) { autoSaveCoordinator.delay = delay }
 
     func scheduleAutoSave() {
-        guard let index = activeTabIndex,
+        guard let tabID = activeTabID else { return }
+        scheduleAutoSave(for: tabID)
+    }
+
+    private func scheduleAutoSave(for tabID: UUID) {
+        guard let index = tabs.firstIndex(where: { $0.id == tabID }),
               FileManager.default.isWritableFile(atPath: tabs[index].url.path) else { return }
-        let tabID = tabs[index].id
         autoSaveCoordinator.schedule(
+            for: tabID,
             isStillDirty: { [weak self] in
                 guard let self, let idx = self.tabs.firstIndex(where: { $0.id == tabID }) else { return false }
                 return self.tabs[idx].isDirty
@@ -362,7 +453,11 @@ final class TabManager {
     }
 
     func cancelAutoSave() { autoSaveCoordinator.cancel() }
+    private func cancelAutoSave(for tabID: UUID) { autoSaveCoordinator.cancel(for: tabID) }
     var hasScheduledAutoSave: Bool { autoSaveCoordinator.hasScheduledSave }
+    func hasScheduledAutoSave(for tabID: UUID) -> Bool {
+        autoSaveCoordinator.hasScheduledSave(for: tabID)
+    }
 
     // MARK: - Markdown preview
 

--- a/Pine/Tabs/TabAutoSave.swift
+++ b/Pine/Tabs/TabAutoSave.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Manages debounced auto-save scheduling for editor tabs.
-/// Tracks a pending work item and fires a save callback after a delay.
+/// Tracks pending work per tab and fires save callbacks after a delay.
 @MainActor
 final class TabAutoSave {
     /// UserDefaults key for the auto-save toggle.
@@ -20,12 +20,25 @@ final class TabAutoSave {
     /// Whether auto-save is currently in progress (for UI indicator).
     private(set) var isSaving = false
 
-    /// Debounce work item.
-    private var workItem: DispatchWorkItem?
+    private struct PendingSave {
+        let generation: UUID
+        let workItem: DispatchWorkItem
+    }
+
+    /// Compatibility key for callers that do not identify a tab.
+    private let defaultKey = UUID()
+
+    /// Independent debounce work per tab. Editing or transferring one tab
+    /// must not cancel a save already scheduled for another tab.
+    private var pendingSaves: [UUID: PendingSave] = [:]
 
     /// Whether a pending auto-save is scheduled (for testing).
     var hasScheduledSave: Bool {
-        workItem != nil
+        !pendingSaves.isEmpty
+    }
+
+    func hasScheduledSave(for key: UUID) -> Bool {
+        pendingSaves[key] != nil
     }
 
     /// Schedules a debounced auto-save. The `saveAction` fires after `delay`
@@ -39,12 +52,24 @@ final class TabAutoSave {
         isStillDirty: @MainActor @escaping () -> Bool,
         saveAction: @MainActor @escaping () throws -> Void
     ) {
-        workItem?.cancel()
+        schedule(for: defaultKey, isStillDirty: isStillDirty, saveAction: saveAction)
+    }
+
+    /// Schedules a debounced save independently for `key`.
+    func schedule(
+        for key: UUID,
+        isStillDirty: @MainActor @escaping () -> Bool,
+        saveAction: @MainActor @escaping () throws -> Void
+    ) {
+        cancel(for: key)
+
+        let generation = UUID()
 
         let item = DispatchWorkItem { [weak self] in
-            guard let self else { return }
+            guard let self,
+                  self.pendingSaves[key]?.generation == generation else { return }
             guard isStillDirty() else {
-                self.workItem = nil
+                self.pendingSaves[key] = nil
                 return
             }
 
@@ -55,16 +80,23 @@ final class TabAutoSave {
                 // Silent failure — auto-save should not show alerts
             }
             self.isSaving = false
-            self.workItem = nil
+            if self.pendingSaves[key]?.generation == generation {
+                self.pendingSaves[key] = nil
+            }
         }
 
-        workItem = item
+        pendingSaves[key] = PendingSave(generation: generation, workItem: item)
         DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
     }
 
-    /// Cancels any pending auto-save.
+    /// Cancels the pending auto-save for one tab without disturbing others.
+    func cancel(for key: UUID) {
+        pendingSaves.removeValue(forKey: key)?.workItem.cancel()
+    }
+
+    /// Cancels every pending auto-save.
     func cancel() {
-        workItem?.cancel()
-        workItem = nil
+        pendingSaves.values.forEach { $0.workItem.cancel() }
+        pendingSaves.removeAll()
     }
 }

--- a/PineTests/CrossTypeCenterDropTests.swift
+++ b/PineTests/CrossTypeCenterDropTests.swift
@@ -18,6 +18,15 @@ import Testing
 @MainActor
 struct CrossTypeCenterDropTests {
 
+    private func editorTabID(
+        for url: URL,
+        in paneID: PaneID,
+        manager: PaneManager
+    ) throws -> UUID {
+        let tabManager = try #require(manager.tabManager(for: paneID))
+        return try #require(tabManager.tabs.first(where: { $0.url == url })?.id)
+    }
+
     // MARK: - Terminal tab → Editor pane center
 
     @Test("terminal tab center-dropped on editor pane creates vertical auto-split")
@@ -102,7 +111,7 @@ struct CrossTypeCenterDropTests {
 
         let drag = TabDragInfo(
             paneID: editorPaneID.id,
-            tabID: UUID(),
+            tabID: try editorTabID(for: fileA, in: editorPaneID, manager: manager),
             fileURL: fileA,
             contentType: .editor
         )
@@ -124,8 +133,8 @@ struct CrossTypeCenterDropTests {
         #expect(newTM.tabs[0].url == fileA)
     }
 
-    @Test("editor tab center-drop on terminal: last tab keeps source editor pane (invariant)")
-    func editorOnTerminalCenter_lastTab_keepsSourceEditor() throws {
+    @Test("editor tab center-drop on terminal prunes its empty source editor")
+    func editorOnTerminalCenterLastTabPrunesSourceEditor() throws {
         let manager = PaneManager()
         let editorPaneID = manager.activePaneID
         let editorTM = try #require(manager.tabManager(for: editorPaneID))
@@ -136,7 +145,7 @@ struct CrossTypeCenterDropTests {
 
         let drag = TabDragInfo(
             paneID: editorPaneID.id,
-            tabID: UUID(),
+            tabID: try editorTabID(for: fileA, in: editorPaneID, manager: manager),
             fileURL: fileA,
             contentType: .editor
         )
@@ -144,23 +153,19 @@ struct CrossTypeCenterDropTests {
         let ok = manager.performCenterDrop(dragInfo: drag, targetPaneID: termPaneID)
 
         #expect(ok)
-        // Invariant: there is always at least one editor pane.
-        let editorLeafCount = manager.root.leafCount(ofType: .editor)
-        #expect(editorLeafCount >= 1)
-        // The auto-split actually happened: a new editor pane was created
-        // (so we now have 2 editor leaves — the original and the new one).
+        // The newly created destination replaces the emptied source editor.
         let editorLeaves = manager.root.leafIDs.filter { manager.root.content(for: $0) == .editor }
-        #expect(editorLeaves.count == 2)
-        // The original editor pane still exists (invariant: never destroy
-        // the last editor pane, even if its last tab was moved out).
-        #expect(editorLeaves.contains(editorPaneID))
-        // fileA lives in the new editor pane (not the source).
-        let newEditor = try #require(editorLeaves.first { $0 != editorPaneID })
+        #expect(editorLeaves.count == 1)
+        #expect(!editorLeaves.contains(editorPaneID))
+        let newEditor = try #require(editorLeaves.first)
         let newTM = try #require(manager.tabManager(for: newEditor))
         #expect(newTM.tabs.count == 1)
         #expect(newTM.tabs[0].url == fileA)
-        // Source editor pane has been emptied (its only tab was moved).
+        #expect(newTM.activeTabID == newTM.tabs[0].id)
+        #expect(manager.activePaneID == newEditor)
+        // The detached manager object is empty, and no longer belongs to a pane.
         #expect(editorTM.tabs.isEmpty)
+        #expect(manager.tabManager(for: editorPaneID) == nil)
         // Terminal pane is still alive.
         #expect(manager.terminalState(for: termPaneID) != nil)
         #expect(manager.root.leafCount(ofType: .terminal) == 1)
@@ -271,7 +276,7 @@ struct CrossTypeCenterDropTests {
 
         let drag = TabDragInfo(
             paneID: paneA.id,
-            tabID: UUID(),
+            tabID: try editorTabID(for: fileA, in: paneA, manager: manager),
             fileURL: fileA,
             contentType: .editor
         )
@@ -322,7 +327,7 @@ struct CrossTypeCenterDropTests {
 
         let drag = TabDragInfo(
             paneID: paneA.id,
-            tabID: UUID(),
+            tabID: try editorTabID(for: fileA, in: paneA, manager: manager),
             fileURL: fileA,
             contentType: .editor
         )
@@ -371,7 +376,7 @@ struct CrossTypeCenterDropTests {
 
         let drag = TabDragInfo(
             paneID: editorPaneID.id,
-            tabID: UUID(),
+            tabID: try editorTabID(for: fileA, in: editorPaneID, manager: manager),
             fileURL: fileA,
             contentType: .editor
         )

--- a/PineTests/MaximizedPaneDropSafetyTests.swift
+++ b/PineTests/MaximizedPaneDropSafetyTests.swift
@@ -1,0 +1,207 @@
+//
+//  MaximizedPaneDropSafetyTests.swift
+//  PineTests
+//
+//  Regression coverage for structural drop routing against the temporary
+//  maximized pane tree (issue #1169).
+//
+
+import CoreGraphics
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+@Suite("Maximized Pane Drop Safety")
+@MainActor
+struct MaximizedPaneDropSafetyTests {
+    private let paneSize = CGSize(width: 800, height: 600)
+
+    @Test("Pane tab edge drop is hidden and rejected while maximized")
+    func paneTabEdgeDropIsRejected() throws {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        let tabManager = try #require(manager.tabManager(for: paneID))
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/maximized.swift"),
+            content: "let value = 1",
+            savedContent: "let value = 1"
+        )
+        tabManager.tabs = [tab]
+        tabManager.activeTabID = tab.id
+        _ = try #require(manager.splitPane(paneID, axis: .horizontal))
+        let savedLeafIDs = manager.persistableRoot.leafIDs
+
+        manager.maximize(paneID: paneID)
+        manager.activeDrag = TabDragInfo(
+            paneID: paneID.id,
+            tabID: tab.id,
+            fileURL: tab.url,
+            contentType: .editor
+        )
+        let delegate = paneDelegate(for: paneID, manager: manager)
+
+        let hoverZone = delegate.updateDropZone(
+            for: .paneTab,
+            at: CGPoint(x: paneSize.width - 1, y: paneSize.height / 2)
+        )
+
+        #expect(hoverZone == nil)
+        #expect(manager.dropZones[paneID] == nil)
+        #expect(!delegate.performPaneTabDrop(zone: .right))
+        #expect(manager.isMaximized)
+        #expect(manager.root.leafIDs == [paneID])
+        #expect(manager.persistableRoot.leafIDs == savedLeafIDs)
+        #expect(manager.activeDrag?.tabID == tab.id)
+        #expect(tabManager.tabs.map(\.id) == [tab.id])
+    }
+
+    @Test("All pane tab zones defer to the local tab strip while maximized")
+    func paneTabCenterDropIsRejected() throws {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        _ = try #require(manager.splitPane(paneID, axis: .vertical))
+        manager.maximize(paneID: paneID)
+
+        let delegate = paneDelegate(for: paneID, manager: manager)
+
+        #expect(delegate.routedDropZone(for: .paneTab, proposedZone: .center) == nil)
+        #expect(delegate.routedDropZone(for: .paneTab, proposedZone: .left) == nil)
+    }
+
+    @Test("Sidebar and Finder files are forced to non-structural center drop")
+    func fileDropsAreForcedToCenter() throws {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        _ = try #require(manager.splitPane(paneID, axis: .horizontal))
+        manager.maximize(paneID: paneID)
+        let delegate = paneDelegate(for: paneID, manager: manager)
+
+        #expect(delegate.routedDropZone(for: .sidebarFile, proposedZone: .right) == .center)
+        #expect(delegate.routedDropZone(for: .fileURL, proposedZone: .bottom) == .center)
+        #expect(delegate.updateDropZone(
+            for: .sidebarFile,
+            at: CGPoint(x: paneSize.width - 1, y: paneSize.height / 2)
+        ) == .center)
+        #expect(manager.dropZones[paneID] == .center)
+        #expect(manager.root.leafIDs == [paneID])
+    }
+
+    @Test("Root drop is hidden and rejected while maximized")
+    func rootDropIsRejected() throws {
+        let manager = PaneManager()
+        let terminalPaneID = manager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let terminalState = try #require(manager.terminalState(for: terminalPaneID))
+        let tabID = try #require(terminalState.terminalTabs.first?.id)
+        let savedLeafIDs = manager.persistableRoot.leafIDs
+
+        manager.maximize(paneID: terminalPaneID)
+        manager.activeDrag = TabDragInfo(
+            paneID: terminalPaneID.id,
+            tabID: tabID,
+            contentType: .terminal
+        )
+        let delegate = RootPaneSplitDropDelegate(
+            paneManager: manager,
+            containerSize: paneSize
+        )
+
+        #expect(!delegate.canRouteStructuralDrop)
+        #expect(delegate.updateRootDropZone(at: CGPoint(x: 1, y: 300)) == nil)
+        #expect(manager.rootDropZone == nil)
+
+        // A stale zone must not bypass the perform-time guard.
+        manager.rootDropZone = .left
+        #expect(!delegate.performRootPaneTabDrop(zone: manager.rootDropZone))
+        #expect(manager.rootDropZone == nil)
+        #expect(manager.isMaximized)
+        #expect(manager.root.leafIDs == [terminalPaneID])
+        #expect(manager.persistableRoot.leafIDs == savedLeafIDs)
+        #expect(manager.activeDrag?.tabID == tabID)
+        #expect(terminalState.terminalTabs.map(\.id) == [tabID])
+    }
+
+    @Test("Editor tabs still reorder locally while their pane is maximized")
+    func editorTabsStillReorderLocally() throws {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        let tabManager = try #require(manager.tabManager(for: paneID))
+        let first = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/first.swift"),
+            content: "first",
+            savedContent: "first"
+        )
+        let second = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/second.swift"),
+            content: "second",
+            savedContent: "second"
+        )
+        tabManager.tabs = [first, second]
+        tabManager.activeTabID = first.id
+        _ = try #require(manager.splitPane(paneID, axis: .horizontal))
+        manager.maximize(paneID: paneID)
+        manager.activeDrag = TabDragInfo(
+            paneID: paneID.id,
+            tabID: first.id,
+            fileURL: first.url,
+            contentType: .editor
+        )
+        let delegate = TabDropDelegate(
+            tabManager: tabManager,
+            paneManager: manager,
+            targetPaneID: paneID,
+            targetTabID: second.id,
+            hoverTargetTabID: .constant(nil)
+        )
+
+        let decision = delegate.routingDecision()
+        #expect(decision == .localReorder(draggedTabID: first.id))
+        #expect(delegate.handleDropEntered(decision: decision))
+        #expect(delegate.finishDrop(decision: decision))
+        #expect(tabManager.tabs.map(\.id) == [second.id, first.id])
+        #expect(manager.activeDrag == nil)
+        #expect(manager.isMaximized)
+    }
+
+    @Test("Terminal tabs still reorder locally while their pane is maximized")
+    func terminalTabsStillReorderLocally() throws {
+        let manager = PaneManager()
+        let terminalPaneID = manager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let terminalState = try #require(manager.terminalState(for: terminalPaneID))
+        terminalState.addTab(workingDirectory: nil)
+        let firstID = terminalState.terminalTabs[0].id
+        let secondID = terminalState.terminalTabs[1].id
+        manager.maximize(paneID: terminalPaneID)
+        manager.activeDrag = TabDragInfo(
+            paneID: terminalPaneID.id,
+            tabID: firstID,
+            contentType: .terminal
+        )
+        let delegate = TerminalTabDropDelegate(
+            terminalState: terminalState,
+            targetTabID: secondID,
+            targetPaneID: terminalPaneID,
+            paneManager: manager
+        )
+
+        let decision = delegate.routingDecision()
+        #expect(decision == .localReorder(draggedTabID: firstID))
+        #expect(delegate.handleDropEntered(decision: decision))
+        #expect(delegate.finishDrop(decision: decision))
+        #expect(terminalState.terminalTabs.map(\.id) == [secondID, firstID])
+        #expect(manager.activeDrag == nil)
+        #expect(manager.isMaximized)
+    }
+
+    private func paneDelegate(
+        for paneID: PaneID,
+        manager: PaneManager
+    ) -> PaneSplitDropDelegate {
+        PaneSplitDropDelegate(
+            paneID: paneID,
+            paneManager: manager,
+            paneSize: paneSize
+        )
+    }
+}

--- a/PineTests/PaneManagerRootDropTests.swift
+++ b/PineTests/PaneManagerRootDropTests.swift
@@ -112,6 +112,8 @@ struct PaneManagerRootDropTests {
         let newState = try #require(manager.terminalState(for: newTerminalPanes[0]))
         #expect(newState.terminalTabs.count == 1)
         #expect(newState.terminalTabs[0].id == tabID)
+        #expect(newState.activeTerminalID == tabID)
+        #expect(newState.pendingFocusTabID == tabID)
     }
 
     @Test func wrapRoot_sourcePaneKeptWhenMultipleTabs() throws {

--- a/PineTests/PaneManagerTests.swift
+++ b/PineTests/PaneManagerTests.swift
@@ -367,11 +367,10 @@ struct PaneManagerTests {
         manager.moveTabBetweenPanes(tabURL: ghostURL, from: firstPane, to: secondPane)
         // Source pane retains its tab — ghost URL was a no-op move.
         #expect(manager.tabManager(for: firstPane)?.tabs.count == 1)
-        // The empty destination pane is now collapsed by `pruneEmptyEditorLeaves`,
-        // since `firstPane` still holds a tab and the invariant (≥1 editor leaf
-        // in the tree) is preserved.
-        #expect(manager.tabManager(for: secondPane) == nil)
-        #expect(manager.root.leafCount == 1)
+        // Failed transfers are atomic: unrelated empty panes and focus are
+        // not mutated as a side effect of a missing source tab.
+        #expect(manager.tabManager(for: secondPane)?.tabs.isEmpty == true)
+        #expect(manager.root.leafCount == 2)
     }
 
     @Test func moveTabBetweenPanes_preservesAllTabState() {
@@ -407,6 +406,7 @@ struct PaneManagerTests {
         manager.moveTabBetweenPanes(tabURL: testURL, from: firstPane, to: secondPane)
         let destTab = manager.tabManager(for: secondPane)?.tabs.first(where: { $0.url == testURL })
         #expect(destTab != nil)
+        #expect(destTab?.id == manager.tabManager(for: secondPane)?.activeTabID)
         #expect(destTab?.content == testContent)
         #expect(destTab?.cursorPosition == 42)
         #expect(destTab?.scrollOffset == 123.5)

--- a/PineTests/PaneSplitDropIntegrationTests.swift
+++ b/PineTests/PaneSplitDropIntegrationTests.swift
@@ -77,6 +77,17 @@ struct PaneSplitDropIntegrationTests {
         )
     }
 
+    /// Resolves the exact identity carried by production editor-tab drags.
+    /// URL-only fallback is reserved for legacy callers that omit `tabID`.
+    private func editorTabID(
+        for url: URL,
+        in paneID: PaneID,
+        manager: PaneManager
+    ) throws -> UUID {
+        let tabManager = try #require(manager.tabManager(for: paneID))
+        return try #require(tabManager.tabs.first(where: { $0.url == url })?.id)
+    }
+
     /// Two editor panes side-by-side; each pane owns one tab.
     private func managerWithTwoEditorPanes() throws -> TwoEditorPanes {
         let manager = PaneManager()
@@ -173,23 +184,24 @@ struct PaneSplitDropIntegrationTests {
         let paneB = setup.paneB
         let delegate = delegate(for: paneB, on: manager)
         manager.activeDrag = TabDragInfo(
-            paneID: paneA.id, tabID: UUID(), fileURL: fileA, contentType: .editor
+            paneID: paneA.id,
+            tabID: try editorTabID(for: fileA, in: paneA, manager: manager),
+            fileURL: fileA,
+            contentType: .editor
         )
         let beforeLeafCount = manager.root.leafCount
 
         let ok = delegate.performPaneTabDrop(zone: .right)
 
         #expect(ok)
-        // Tree grew by exactly one new editor leaf.
-        #expect(manager.root.leafCount == beforeLeafCount + 1)
-        #expect(manager.root.leafCount(ofType: .editor) == 3)
-        // The new pane is the active pane and sits horizontally after paneB.
+        // The new leaf replaces the now-empty source pane, so total count is
+        // stable. The destination sits horizontally after paneB.
+        #expect(manager.root.leafCount == beforeLeafCount)
+        #expect(manager.root.leafCount(ofType: .editor) == 2)
         if case .split(let axis, let first, let second, _) = manager.root {
             #expect(axis == .horizontal)
-            // The root split is unchanged (paneA | paneB-tree); the new
-            // horizontal split is nested inside the second child.
-            #expect(first.contains(paneA))
-            #expect(second.contains(paneB))
+            #expect(first.contains(paneB))
+            #expect(!second.contains(paneA))
             #expect(manager.activePaneID != paneA && manager.activePaneID != paneB)
         } else {
             Issue.record("Expected root to remain a split after edge drop")
@@ -210,13 +222,17 @@ struct PaneSplitDropIntegrationTests {
         let paneB = setup.paneB
         let delegate = delegate(for: paneB, on: manager)
         manager.activeDrag = TabDragInfo(
-            paneID: paneA.id, tabID: UUID(), fileURL: fileA, contentType: .editor
+            paneID: paneA.id,
+            tabID: try editorTabID(for: fileA, in: paneA, manager: manager),
+            fileURL: fileA,
+            contentType: .editor
         )
 
         let ok = delegate.performPaneTabDrop(zone: .left)
 
         #expect(ok)
-        #expect(manager.root.leafCount(ofType: .editor) == 3)
+        #expect(manager.root.leafCount(ofType: .editor) == 2)
+        #expect(manager.tabManager(for: paneA) == nil)
         // New pane is active and is the first child of paneB's split.
         let newID = manager.activePaneID
         #expect(newID != paneA && newID != paneB)
@@ -233,22 +249,25 @@ struct PaneSplitDropIntegrationTests {
         let paneB = setup.paneB
         let delegate = delegate(for: paneB, on: manager)
         manager.activeDrag = TabDragInfo(
-            paneID: paneA.id, tabID: UUID(), fileURL: fileA, contentType: .editor
+            paneID: paneA.id,
+            tabID: try editorTabID(for: fileA, in: paneA, manager: manager),
+            fileURL: fileA,
+            contentType: .editor
         )
 
         let ok = delegate.performPaneTabDrop(zone: .bottom)
 
         #expect(ok)
-        #expect(manager.root.leafCount(ofType: .editor) == 3)
+        #expect(manager.root.leafCount(ofType: .editor) == 2)
+        #expect(manager.tabManager(for: paneA) == nil)
         let newID = manager.activePaneID
         let newTM = try #require(manager.tabManager(for: newID))
         #expect(newTM.tabs.contains { $0.url == fileA })
         // paneB's split axis is vertical (top/bottom edge → vertical).
-        if case .split(.horizontal, _, let second, _) = manager.root,
-           case .split(let axis, _, _, _) = second {
+        if case .split(let axis, _, _, _) = manager.root {
             #expect(axis == .vertical)
         } else {
-            Issue.record("Expected vertical split under paneB after bottom drop")
+            Issue.record("Expected vertical split around paneB after bottom drop")
         }
     }
 
@@ -261,13 +280,17 @@ struct PaneSplitDropIntegrationTests {
         let paneB = setup.paneB
         let delegate = delegate(for: paneB, on: manager)
         manager.activeDrag = TabDragInfo(
-            paneID: paneA.id, tabID: UUID(), fileURL: fileA, contentType: .editor
+            paneID: paneA.id,
+            tabID: try editorTabID(for: fileA, in: paneA, manager: manager),
+            fileURL: fileA,
+            contentType: .editor
         )
 
         let ok = delegate.performPaneTabDrop(zone: .top)
 
         #expect(ok)
-        #expect(manager.root.leafCount(ofType: .editor) == 3)
+        #expect(manager.root.leafCount(ofType: .editor) == 2)
+        #expect(manager.tabManager(for: paneA) == nil)
         let newID = manager.activePaneID
         let newTM = try #require(manager.tabManager(for: newID))
         #expect(newTM.tabs.contains { $0.url == fileA })
@@ -380,14 +403,18 @@ struct PaneSplitDropIntegrationTests {
 
         let delegate = delegate(for: termID, on: manager)
         manager.activeDrag = TabDragInfo(
-            paneID: editorID.id, tabID: UUID(), fileURL: fileA, contentType: .editor
+            paneID: editorID.id,
+            tabID: try editorTabID(for: fileA, in: editorID, manager: manager),
+            fileURL: fileA,
+            contentType: .editor
         )
 
         let ok = delegate.performPaneTabDrop(zone: .right)
 
         #expect(ok)
-        // A new editor pane was created adjacent to the terminal target.
-        #expect(manager.root.leafCount(ofType: .editor) == beforeEditorCount + 1)
+        // The new editor pane replaces the emptied source pane.
+        #expect(manager.root.leafCount(ofType: .editor) == beforeEditorCount)
+        #expect(manager.tabManager(for: editorID) == nil)
         let newEditorID = try #require(
             manager.root.leafIDs.first {
                 $0 != editorID && manager.root.content(for: $0) == .editor
@@ -435,7 +462,10 @@ struct PaneSplitDropIntegrationTests {
         let paneB = setup.paneB
         let delegate = delegate(for: paneB, on: manager)
         manager.activeDrag = TabDragInfo(
-            paneID: paneA.id, tabID: UUID(), fileURL: fileA, contentType: .editor
+            paneID: paneA.id,
+            tabID: try editorTabID(for: fileA, in: paneA, manager: manager),
+            fileURL: fileA,
+            contentType: .editor
         )
         let beforeLeafCount = manager.root.leafCount
 
@@ -496,7 +526,10 @@ struct PaneSplitDropIntegrationTests {
 
         let delegate = delegate(for: termID, on: manager)
         manager.activeDrag = TabDragInfo(
-            paneID: editorID.id, tabID: UUID(), fileURL: fileA, contentType: .editor
+            paneID: editorID.id,
+            tabID: try editorTabID(for: fileA, in: editorID, manager: manager),
+            fileURL: fileA,
+            contentType: .editor
         )
 
         let ok = delegate.performPaneTabDrop(zone: .center)
@@ -528,7 +561,10 @@ struct PaneSplitDropIntegrationTests {
         let paneB = setup.paneB
         let delegate = delegate(for: paneB, on: manager)
         manager.activeDrag = TabDragInfo(
-            paneID: paneA.id, tabID: UUID(), fileURL: fileA, contentType: .editor
+            paneID: paneA.id,
+            tabID: try editorTabID(for: fileA, in: paneA, manager: manager),
+            fileURL: fileA,
+            contentType: .editor
         )
         let beforeRoot = manager.root
 
@@ -567,11 +603,10 @@ struct PaneSplitDropIntegrationTests {
         #expect(ok == false)
     }
 
-    @Test("Edge drop of editor tab without fileURL is a no-op but returns true")
-    func editorEdgeDrop_withoutFileURL_isNoOp() throws {
+    @Test("Edge drop of editor tab without fileURL is rejected without consuming drag")
+    func editorEdgeDropWithoutFileURLIsRejected() throws {
         // TabDragInfo.contentType == .editor with fileURL == nil cannot
-        // dispatch to splitPane (which needs a URL). The delegate returns
-        // true (drop accepted) but performs no tree mutation.
+        // dispatch to splitPane (which needs a URL).
         let setup = try managerWithTwoEditorPanes()
         let manager = setup.manager
         let paneA = setup.paneA
@@ -584,10 +619,9 @@ struct PaneSplitDropIntegrationTests {
 
         let ok = delegate.performPaneTabDrop(zone: .right)
 
-        #expect(ok == true)
+        #expect(ok == false)
         #expect(manager.root == beforeRoot)
-        // activeDrag was consumed (cleared) even though no mutation happened.
-        #expect(manager.activeDrag == nil)
+        #expect(manager.activeDrag != nil)
     }
 
     // MARK: - State side-effects
@@ -601,7 +635,10 @@ struct PaneSplitDropIntegrationTests {
         let paneB = setup.paneB
         let delegate = delegate(for: paneB, on: manager)
         manager.activeDrag = TabDragInfo(
-            paneID: paneA.id, tabID: UUID(), fileURL: fileA, contentType: .editor
+            paneID: paneA.id,
+            tabID: try editorTabID(for: fileA, in: paneA, manager: manager),
+            fileURL: fileA,
+            contentType: .editor
         )
 
         _ = delegate.performPaneTabDrop(zone: .right)
@@ -618,7 +655,10 @@ struct PaneSplitDropIntegrationTests {
         let paneB = setup.paneB
         let delegate = delegate(for: paneB, on: manager)
         manager.activeDrag = TabDragInfo(
-            paneID: paneA.id, tabID: UUID(), fileURL: fileA, contentType: .editor
+            paneID: paneA.id,
+            tabID: try editorTabID(for: fileA, in: paneA, manager: manager),
+            fileURL: fileA,
+            contentType: .editor
         )
 
         _ = delegate.performPaneTabDrop(zone: .center)
@@ -665,16 +705,19 @@ struct PaneSplitDropIntegrationTests {
         // Drop fileA from paneA onto the right edge of the deeply nested paneD.
         let delegate = delegate(for: paneD, on: manager)
         manager.activeDrag = TabDragInfo(
-            paneID: paneA.id, tabID: UUID(), fileURL: fileA, contentType: .editor
+            paneID: paneA.id,
+            tabID: try editorTabID(for: fileA, in: paneA, manager: manager),
+            fileURL: fileA,
+            contentType: .editor
         )
 
         let ok = delegate.performPaneTabDrop(zone: .right)
 
         #expect(ok)
-        // One new editor leaf created; original 4 panes all still present.
-        #expect(manager.root.leafCount(ofType: .editor) == beforeEditorCount + 1)
+        // The new editor leaf replaces the now-empty source leaf.
+        #expect(manager.root.leafCount(ofType: .editor) == beforeEditorCount)
         let allLeaves = manager.root.leafIDs
-        #expect(allLeaves.contains(paneA))
+        #expect(!allLeaves.contains(paneA))
         #expect(allLeaves.contains(paneB))
         #expect(allLeaves.contains(paneC))
         #expect(allLeaves.contains(paneD))
@@ -741,7 +784,10 @@ struct PaneSplitDropIntegrationTests {
         let paneB = setup.paneB
         let delegate = delegate(for: paneB, on: manager)
         manager.activeDrag = TabDragInfo(
-            paneID: paneA.id, tabID: UUID(), fileURL: fileA, contentType: .editor
+            paneID: paneA.id,
+            tabID: try editorTabID(for: fileA, in: paneA, manager: manager),
+            fileURL: fileA,
+            contentType: .editor
         )
 
         // Cursor in the right edge → zone should be .right.
@@ -752,14 +798,13 @@ struct PaneSplitDropIntegrationTests {
         #expect(ok)
 
         // Right edge → horizontal split with new pane as the second child.
-        // The root split (paneA horizontal paneB-tree) is preserved; the new
-        // horizontal split is nested inside the second child of the root.
-        guard case .split(.horizontal, _, let second, _) = manager.root,
-              case .split(let nestedAxis, _, _, _) = second else {
-            Issue.record("Expected nested horizontal split under paneB")
+        // The empty source is collapsed, promoting paneB's split to root.
+        guard case .split(let axis, let first, _, _) = manager.root else {
+            Issue.record("Expected horizontal split around paneB")
             return
         }
-        #expect(nestedAxis == .horizontal)
+        #expect(axis == .horizontal)
+        #expect(first.contains(paneB))
     }
 
     @Test("Cursor-to-zone-to-mutation end-to-end: bottom edge produces vertical split")
@@ -771,7 +816,10 @@ struct PaneSplitDropIntegrationTests {
         let paneB = setup.paneB
         let delegate = delegate(for: paneB, on: manager)
         manager.activeDrag = TabDragInfo(
-            paneID: paneA.id, tabID: UUID(), fileURL: fileA, contentType: .editor
+            paneID: paneA.id,
+            tabID: try editorTabID(for: fileA, in: paneA, manager: manager),
+            fileURL: fileA,
+            contentType: .editor
         )
 
         let zone = PaneDropZone.zone(for: Cursor.bottom, in: paneSize)
@@ -780,13 +828,14 @@ struct PaneSplitDropIntegrationTests {
         let ok = delegate.performPaneTabDrop(zone: zone)
         #expect(ok)
 
-        // Bottom edge → vertical split.
-        guard case .split(.horizontal, _, let second, _) = manager.root,
-              case .split(let nestedAxis, _, _, _) = second else {
-            Issue.record("Expected nested vertical split under paneB")
+        // Bottom edge → vertical split. The empty source is collapsed,
+        // promoting paneB's split to root.
+        guard case .split(let axis, let first, _, _) = manager.root else {
+            Issue.record("Expected vertical split around paneB")
             return
         }
-        #expect(nestedAxis == .vertical)
+        #expect(axis == .vertical)
+        #expect(first.contains(paneB))
     }
 
     @Test("Cursor-to-zone-to-mutation end-to-end: center triggers same-type move")
@@ -798,7 +847,10 @@ struct PaneSplitDropIntegrationTests {
         let paneB = setup.paneB
         let delegate = delegate(for: paneB, on: manager)
         manager.activeDrag = TabDragInfo(
-            paneID: paneA.id, tabID: UUID(), fileURL: fileA, contentType: .editor
+            paneID: paneA.id,
+            tabID: try editorTabID(for: fileA, in: paneA, manager: manager),
+            fileURL: fileA,
+            contentType: .editor
         )
         let beforeLeafCount = manager.root.leafCount
 

--- a/PineTests/ProjectManagerTabManagerWiringTests.swift
+++ b/PineTests/ProjectManagerTabManagerWiringTests.swift
@@ -1,0 +1,77 @@
+//
+//  ProjectManagerTabManagerWiringTests.swift
+//  PineTests
+//
+//  Regression coverage for project services on editor groups created after
+//  the primary pane (issue #1169).
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Project Manager TabManager Wiring")
+@MainActor
+struct ProjectManagerTabManagerWiringTests {
+    @Test("Split editor groups inherit context and recovery services")
+    func splitManagersAreConfigured() throws {
+        let project = ProjectManager()
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        project.setupRecovery(projectURL: directory)
+
+        let firstPaneID = project.paneManager.activePaneID
+        let secondPaneID = try #require(
+            project.paneManager.splitPane(firstPaneID, axis: .horizontal)
+        )
+        let secondManager = try #require(
+            project.paneManager.tabManager(for: secondPaneID)
+        )
+
+        #expect(secondManager.recoveryManager === project.recoveryManager)
+        #expect(secondManager.onEditorContextChanged != nil)
+    }
+
+    @Test("Restored editor groups inherit context and recovery services")
+    func restoredManagersAreConfigured() throws {
+        let project = ProjectManager()
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        project.setupRecovery(projectURL: directory)
+
+        let firstPaneID = PaneID()
+        let secondPaneID = PaneID()
+        let layout = PaneNode.split(
+            .horizontal,
+            first: .leaf(firstPaneID, .editor),
+            second: .leaf(secondPaneID, .editor),
+            ratio: 0.5
+        )
+        project.paneManager.restoreLayout(
+            from: layout,
+            activePaneUUID: secondPaneID.id
+        )
+
+        for paneID in [firstPaneID, secondPaneID] {
+            let tabManager = try #require(
+                project.paneManager.tabManager(for: paneID)
+            )
+            #expect(tabManager.recoveryManager === project.recoveryManager)
+            #expect(tabManager.onEditorContextChanged != nil)
+        }
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "ProjectManagerTabManagerWiringTests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        return directory
+    }
+}

--- a/PineTests/TabAutoSaveTests.swift
+++ b/PineTests/TabAutoSaveTests.swift
@@ -79,6 +79,40 @@ struct TabAutoSaveTests {
         #expect(saveCount == 1)
     }
 
+    @Test("different tab keys save independently while each key still debounces")
+    func keyedSchedulesAreIndependent() async throws {
+        let coordinator = TabAutoSave()
+        coordinator.delay = 0.1
+        let firstKey = UUID()
+        let secondKey = UUID()
+        var firstSaveCount = 0
+        var secondSaveCount = 0
+
+        coordinator.schedule(
+            for: firstKey,
+            isStillDirty: { true },
+            saveAction: { firstSaveCount += 1 }
+        )
+        coordinator.schedule(
+            for: secondKey,
+            isStillDirty: { true },
+            saveAction: { secondSaveCount += 1 }
+        )
+        coordinator.schedule(
+            for: firstKey,
+            isStillDirty: { true },
+            saveAction: { firstSaveCount += 1 }
+        )
+
+        #expect(coordinator.hasScheduledSave(for: firstKey))
+        #expect(coordinator.hasScheduledSave(for: secondKey))
+        try await Task.sleep(for: .milliseconds(300))
+
+        #expect(firstSaveCount == 1)
+        #expect(secondSaveCount == 1)
+        #expect(!coordinator.hasScheduledSave)
+    }
+
     @Test("isSaving is true during save action")
     func isSavingDuringAction() async throws {
         let coordinator = TabAutoSave()

--- a/PineTests/TabCloseHelperBulkTests.swift
+++ b/PineTests/TabCloseHelperBulkTests.swift
@@ -1,0 +1,219 @@
+//
+//  TabCloseHelperBulkTests.swift
+//  PineTests
+//
+//  Regression coverage for bulk-close outcomes and pane removal (#1169).
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import Pine
+
+@Suite("TabCloseHelper Bulk Close")
+@MainActor
+struct TabCloseHelperBulkTests {
+    private struct PaneFixture {
+        let paneManager: PaneManager
+        let paneID: PaneID
+        let tabManager: TabManager
+    }
+
+    private func makeDirtyPane(
+        url: URL = URL(fileURLWithPath: "/tmp/pine-bulk-close-\(UUID().uuidString).swift"),
+        content: String = "modified",
+        savedContent: String = "original"
+    ) -> PaneFixture? {
+        let paneManager = PaneManager()
+        let firstPaneID = paneManager.activePaneID
+        guard let paneID = paneManager.splitPane(firstPaneID, axis: .horizontal),
+              let tabManager = paneManager.tabManager(for: paneID) else {
+            Issue.record("Failed to create the pane fixture")
+            return nil
+        }
+
+        let tab = EditorTab(url: url, content: content, savedContent: savedContent)
+        tabManager.tabs = [tab]
+        tabManager.activeTabID = tab.id
+        return PaneFixture(paneManager: paneManager, paneID: paneID, tabManager: tabManager)
+    }
+
+    private func removePaneAfterCompletedClose(_ didClose: Bool, fixture: PaneFixture) {
+        if didClose && fixture.tabManager.tabs.isEmpty {
+            fixture.paneManager.removePane(fixture.paneID)
+        }
+    }
+
+    @Test("Don't Save completes close-all and permits empty-pane removal")
+    func confirmedDiscardRemovesPane() {
+        guard let fixture = makeDirtyPane() else { return }
+        var saveAttempted = false
+
+        let didClose = TabCloseHelper.closeAllTabs(
+            in: fixture.tabManager,
+            gitProvider: GitStatusProvider(),
+            presentAlert: { .alertSecondButtonReturn },
+            saveTab: { _ in
+                saveAttempted = true
+                return false
+            }
+        )
+        removePaneAfterCompletedClose(didClose, fixture: fixture)
+
+        #expect(didClose)
+        #expect(!saveAttempted)
+        #expect(fixture.tabManager.tabs.isEmpty)
+        #expect(fixture.paneManager.tabManager(for: fixture.paneID) == nil)
+        #expect(fixture.paneManager.root.leafCount == 1)
+    }
+
+    @Test("Save All persists changes, completes close-all, and permits pane removal")
+    func saveSuccessRemovesPane() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-bulk-close-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let url = directory.appendingPathComponent("saved.swift")
+        try "original".write(to: url, atomically: true, encoding: .utf8)
+        guard let fixture = makeDirtyPane(url: url) else { return }
+
+        guard let defaults = UserDefaults(
+            suiteName: "TabCloseHelperBulkTests-\(UUID().uuidString)"
+        ) else {
+            Issue.record("Failed to create isolated defaults")
+            return
+        }
+        let settings = EditorSettings(defaults: defaults)
+        settings.insertFinalNewline = false
+        settings.stripTrailingWhitespace = false
+        settings.formatOnSave = false
+        fixture.tabManager.editorSettings = settings
+
+        let didClose = TabCloseHelper.closeAllTabs(
+            in: fixture.tabManager,
+            gitProvider: GitStatusProvider(),
+            presentAlert: { .alertFirstButtonReturn }
+        )
+        removePaneAfterCompletedClose(didClose, fixture: fixture)
+
+        #expect(didClose)
+        #expect(try String(contentsOf: url, encoding: .utf8) == "modified")
+        #expect(fixture.paneManager.tabManager(for: fixture.paneID) == nil)
+        #expect(fixture.paneManager.root.leafCount == 1)
+    }
+
+    @Test("Cancel aborts close-all and keeps the dirty pane accessible")
+    func cancelPreservesPaneAndDirtyTab() {
+        guard let fixture = makeDirtyPane() else { return }
+
+        let didClose = TabCloseHelper.closeAllTabs(
+            in: fixture.tabManager,
+            gitProvider: GitStatusProvider(),
+            presentAlert: { .alertThirdButtonReturn }
+        )
+        removePaneAfterCompletedClose(didClose, fixture: fixture)
+
+        #expect(!didClose)
+        #expect(fixture.paneManager.tabManager(for: fixture.paneID) === fixture.tabManager)
+        #expect(fixture.paneManager.root.leafCount == 2)
+        #expect(fixture.tabManager.tabs.count == 1)
+        #expect(fixture.tabManager.tabs.first?.isDirty == true)
+    }
+
+    @Test("Save failure aborts close-all and keeps every tab accessible")
+    func saveFailurePreservesPaneAndDirtyTabs() {
+        guard let fixture = makeDirtyPane() else { return }
+        let secondTab = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-bulk-close-\(UUID().uuidString).swift"),
+            content: "second modified",
+            savedContent: "second original"
+        )
+        fixture.tabManager.tabs.append(secondTab)
+        var saveAttempts = 0
+
+        let didClose = TabCloseHelper.closeAllTabs(
+            in: fixture.tabManager,
+            gitProvider: GitStatusProvider(),
+            presentAlert: { .alertFirstButtonReturn },
+            saveTab: { index in
+                saveAttempts += 1
+                guard saveAttempts < 2 else { return false }
+                let savedContent = fixture.tabManager.tabs[index].content
+                fixture.tabManager.tabs[index].savedContent = savedContent
+                return true
+            }
+        )
+        removePaneAfterCompletedClose(didClose, fixture: fixture)
+
+        #expect(!didClose)
+        #expect(saveAttempts == 2)
+        #expect(fixture.paneManager.tabManager(for: fixture.paneID) === fixture.tabManager)
+        #expect(fixture.paneManager.root.leafCount == 2)
+        #expect(fixture.tabManager.tabs.count == 2)
+        #expect(fixture.tabManager.tabs[0].isDirty == false)
+        #expect(fixture.tabManager.tabs[1].isDirty == true)
+    }
+
+    @Test("Clean close-all skips the alert and reports completion")
+    func cleanTabsCloseWithoutAlert() {
+        let tabManager = TabManager()
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-clean-close-\(UUID().uuidString).swift"),
+            content: "unchanged",
+            savedContent: "unchanged"
+        )
+        tabManager.tabs = [tab]
+        tabManager.activeTabID = tab.id
+        var alertPresented = false
+
+        let didClose = TabCloseHelper.closeAllTabs(
+            in: tabManager,
+            gitProvider: GitStatusProvider(),
+            presentAlert: {
+                alertPresented = true
+                return .alertThirdButtonReturn
+            }
+        )
+
+        #expect(didClose)
+        #expect(!alertPresented)
+        #expect(tabManager.tabs.isEmpty)
+    }
+
+    @Test("Cancelled Close Others and Close Right report failure without mutation")
+    func cancelledScopedBulkClosesPreserveTabs() {
+        let tabManager = TabManager()
+        let first = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-keep-\(UUID().uuidString).swift"),
+            content: "unchanged",
+            savedContent: "unchanged"
+        )
+        let second = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-dirty-\(UUID().uuidString).swift"),
+            content: "modified",
+            savedContent: "original"
+        )
+        tabManager.tabs = [first, second]
+        tabManager.activeTabID = second.id
+        let provider = GitStatusProvider()
+
+        let closedOthers = TabCloseHelper.closeOtherTabs(
+            keeping: first.id,
+            in: tabManager,
+            gitProvider: provider,
+            presentAlert: { .alertThirdButtonReturn }
+        )
+        let closedRight = TabCloseHelper.closeTabsToTheRight(
+            of: first.id,
+            in: tabManager,
+            gitProvider: provider,
+            presentAlert: { .alertThirdButtonReturn }
+        )
+
+        #expect(!closedOthers)
+        #expect(!closedRight)
+        #expect(tabManager.tabs.map(\.id) == [first.id, second.id])
+        #expect(tabManager.tabs.last?.isDirty == true)
+    }
+}

--- a/PineTests/TabTransferSafetyTests.swift
+++ b/PineTests/TabTransferSafetyTests.swift
@@ -1,0 +1,436 @@
+//
+//  TabTransferSafetyTests.swift
+//  PineTests
+//
+//  Regression coverage for atomic editor-tab transfers between panes (#1169).
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Editor tab transfer safety")
+@MainActor
+struct TabTransferSafetyTests {
+
+    @discardableResult
+    private func appendTab(
+        to manager: TabManager,
+        path: String,
+        content: String = "",
+        savedContent: String = "",
+        isPinned: Bool = false
+    ) -> EditorTab {
+        var tab = EditorTab(
+            url: URL(fileURLWithPath: path),
+            content: content,
+            savedContent: savedContent
+        )
+        tab.isPinned = isPinned
+        manager.tabs.append(tab)
+        manager.activeTabID = tab.id
+        return tab
+    }
+
+    @Test("center transfer preserves identity, dirty state, recovery, and focus")
+    func centerTransferPreservesIdentityDirtyRecoveryAndFocus() throws {
+        let recoveryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-tab-transfer-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: recoveryDirectory) }
+
+        let recovery = RecoveryManager(recoveryDirectory: recoveryDirectory)
+        let paneManager = PaneManager()
+        paneManager.configureEditorTabManager = { $0.recoveryManager = recovery }
+
+        let sourceID = paneManager.activePaneID
+        let source = try #require(paneManager.tabManager(for: sourceID))
+        let moved = appendTab(
+            to: source,
+            path: "/tmp/dirty-transfer.swift",
+            content: "let answer = 42",
+            savedContent: "let answer = 0"
+        )
+        _ = appendTab(to: source, path: "/tmp/source-keeper.swift")
+        source.activeTabID = moved.id
+        recovery.snapshotDirtyTabs(source.tabs)
+        #expect(recovery.pendingRecoveryEntries().contains { $0.0 == moved.id })
+
+        let destinationID = try #require(paneManager.splitPane(sourceID, axis: .horizontal))
+        let didMove = paneManager.moveTabBetweenPanes(
+            tabID: moved.id,
+            tabURL: moved.url,
+            from: sourceID,
+            to: destinationID
+        )
+
+        #expect(didMove)
+        let destination = try #require(paneManager.tabManager(for: destinationID))
+        let transferred = try #require(destination.tabs.first)
+        #expect(transferred.id == moved.id)
+        #expect(transferred.content == moved.content)
+        #expect(transferred.savedContent == moved.savedContent)
+        #expect(transferred.isDirty)
+        #expect(destination.activeTabID == moved.id)
+        #expect(paneManager.activePaneID == destinationID)
+        #expect(!source.tabs.contains { $0.id == moved.id })
+        #expect(recovery.pendingRecoveryEntries().contains { $0.0 == moved.id })
+    }
+
+    @Test("pinned transfer joins destination pinned prefix")
+    func pinnedTransferJoinsDestinationPinnedPrefix() throws {
+        let paneManager = PaneManager()
+        let sourceID = paneManager.activePaneID
+        let source = try #require(paneManager.tabManager(for: sourceID))
+        let moved = appendTab(to: source, path: "/tmp/moved-pinned.swift", isPinned: true)
+        _ = appendTab(to: source, path: "/tmp/source-keeper.swift")
+
+        let destinationID = try #require(paneManager.splitPane(sourceID, axis: .horizontal))
+        let destination = try #require(paneManager.tabManager(for: destinationID))
+        let existingPinned = appendTab(
+            to: destination,
+            path: "/tmp/existing-pinned.swift",
+            isPinned: true
+        )
+        let existingRegular = appendTab(to: destination, path: "/tmp/existing-regular.swift")
+
+        let didMove = paneManager.moveTabBetweenPanes(
+            tabID: moved.id,
+            tabURL: moved.url,
+            from: sourceID,
+            to: destinationID
+        )
+
+        #expect(didMove)
+        #expect(destination.tabs.map(\.id) == [existingPinned.id, moved.id, existingRegular.id])
+        #expect(destination.tabs.prefix(2).allSatisfy { $0.isPinned })
+        #expect(!destination.tabs[2].isPinned)
+        #expect(destination.activeTabID == moved.id)
+    }
+
+    @Test("tab ID wins when the source contains duplicate URLs")
+    func tabIDDisambiguatesDuplicateURLs() throws {
+        let paneManager = PaneManager()
+        let sourceID = paneManager.activePaneID
+        let source = try #require(paneManager.tabManager(for: sourceID))
+        let duplicatePath = "/tmp/duplicate.swift"
+        let first = appendTab(to: source, path: duplicatePath, content: "first")
+        let second = appendTab(to: source, path: duplicatePath, content: "second")
+
+        let destinationID = try #require(paneManager.splitPane(sourceID, axis: .horizontal))
+        let didMove = paneManager.moveTabBetweenPanes(
+            tabID: second.id,
+            tabURL: second.url,
+            from: sourceID,
+            to: destinationID
+        )
+
+        #expect(didMove)
+        #expect(source.tabs.map(\.id) == [first.id])
+        let destination = try #require(paneManager.tabManager(for: destinationID))
+        #expect(destination.tabs.map(\.id) == [second.id])
+        #expect(destination.tabs.first?.content == "second")
+    }
+
+    @Test("moving the sole tab prunes the source pane")
+    func soleTabTransferPrunesSource() throws {
+        let paneManager = PaneManager()
+        let sourceID = paneManager.activePaneID
+        let source = try #require(paneManager.tabManager(for: sourceID))
+        let moved = appendTab(to: source, path: "/tmp/sole.swift")
+
+        let destinationID = try #require(paneManager.splitPane(sourceID, axis: .horizontal))
+        let destination = try #require(paneManager.tabManager(for: destinationID))
+        _ = appendTab(to: destination, path: "/tmp/destination-keeper.swift")
+
+        let didMove = paneManager.moveTabBetweenPanes(
+            tabID: moved.id,
+            tabURL: moved.url,
+            from: sourceID,
+            to: destinationID
+        )
+
+        #expect(didMove)
+        #expect(paneManager.tabManager(for: sourceID) == nil)
+        #expect(paneManager.root.leafCount == 1)
+        #expect(paneManager.activePaneID == destinationID)
+        #expect(destination.activeTabID == moved.id)
+    }
+
+    @Test("edge transfer prunes its empty source and activates the new pane")
+    func edgeTransferPrunesSourceAndActivatesDestination() throws {
+        let paneManager = PaneManager()
+        let sourceID = paneManager.activePaneID
+        let source = try #require(paneManager.tabManager(for: sourceID))
+        let moved = appendTab(to: source, path: "/tmp/edge.swift")
+
+        let targetID = try #require(paneManager.splitPane(sourceID, axis: .horizontal))
+        let target = try #require(paneManager.tabManager(for: targetID))
+        _ = appendTab(to: target, path: "/tmp/target.swift")
+
+        let destinationID = try #require(paneManager.splitPane(
+            targetID,
+            axis: .vertical,
+            tabID: moved.id,
+            tabURL: moved.url,
+            sourcePane: sourceID
+        ))
+
+        #expect(paneManager.tabManager(for: sourceID) == nil)
+        #expect(paneManager.root.leafCount == 2)
+        let destination = try #require(paneManager.tabManager(for: destinationID))
+        #expect(destination.tabs.map(\.id) == [moved.id])
+        #expect(destination.activeTabID == moved.id)
+        #expect(paneManager.activePaneID == destinationID)
+    }
+
+    @Test("failed transfer leaves source, tree, and focus unchanged")
+    func failedTransferIsAtomic() throws {
+        let paneManager = PaneManager()
+        let sourceID = paneManager.activePaneID
+        let source = try #require(paneManager.tabManager(for: sourceID))
+        let sourceTab = appendTab(to: source, path: "/tmp/source.swift")
+        let destinationID = try #require(paneManager.splitPane(sourceID, axis: .horizontal))
+        paneManager.activePaneID = sourceID
+
+        let didMove = paneManager.moveTabBetweenPanes(
+            tabID: UUID(),
+            from: sourceID,
+            to: destinationID
+        )
+
+        #expect(!didMove)
+        #expect(source.tabs.map(\.id) == [sourceTab.id])
+        #expect(paneManager.tabManager(for: destinationID)?.tabs.isEmpty == true)
+        #expect(paneManager.root.leafCount == 2)
+        #expect(paneManager.activePaneID == sourceID)
+
+        let leafCountBeforeFailedSplit = paneManager.root.leafCount
+        let splitResult = paneManager.splitPane(
+            destinationID,
+            axis: .vertical,
+            tabID: UUID(),
+            sourcePane: sourceID
+        )
+        #expect(splitResult == nil)
+        #expect(source.tabs.map(\.id) == [sourceTab.id])
+        #expect(paneManager.root.leafCount == leafCountBeforeFailedSplit)
+        #expect(paneManager.activePaneID == sourceID)
+    }
+
+    @Test("failed insertion can restore exact source order and selection")
+    func extractionRollbackRestoresSourceExactly() throws {
+        let manager = TabManager()
+        let first = appendTab(to: manager, path: "/tmp/rollback-first.swift")
+        let moved = appendTab(to: manager, path: "/tmp/rollback-moved.swift")
+        let last = appendTab(to: manager, path: "/tmp/rollback-last.swift")
+        manager.activeTabID = moved.id
+
+        let extraction = try #require(manager.extractTab(id: moved.id))
+        #expect(manager.tabs.map(\.id) == [first.id, last.id])
+        #expect(manager.activeTabID == last.id)
+
+        manager.restoreExtractedTab(extraction)
+
+        #expect(manager.tabs.map(\.id) == [first.id, moved.id, last.id])
+        #expect(manager.activeTabID == moved.id)
+    }
+
+    @Test("duplicate destination identity rejects transfer without extraction")
+    func duplicateDestinationIdentityLeavesSourceUntouched() throws {
+        let paneManager = PaneManager()
+        let sourceID = paneManager.activePaneID
+        let source = try #require(paneManager.tabManager(for: sourceID))
+        let sourceTab = appendTab(to: source, path: "/tmp/duplicate-id.swift")
+        let destinationID = try #require(paneManager.splitPane(sourceID, axis: .horizontal))
+        let destination = try #require(paneManager.tabManager(for: destinationID))
+        var duplicateIdentity = sourceTab
+        duplicateIdentity.url = URL(fileURLWithPath: "/tmp/other-url.swift")
+        destination.tabs.append(duplicateIdentity)
+        destination.activeTabID = sourceTab.id
+        paneManager.activePaneID = sourceID
+
+        let didMove = paneManager.moveTabBetweenPanes(
+            tabID: sourceTab.id,
+            tabURL: sourceTab.url,
+            from: sourceID,
+            to: destinationID
+        )
+
+        #expect(!didMove)
+        #expect(source.tabs.map(\.id) == [sourceTab.id])
+        #expect(destination.tabs.map(\.id) == [sourceTab.id])
+        #expect(paneManager.activePaneID == sourceID)
+    }
+
+    @Test("duplicate destination URL rejects transfer without extraction")
+    func duplicateDestinationURLLeavesBothManagersUntouched() throws {
+        let paneManager = PaneManager()
+        let sourceID = paneManager.activePaneID
+        let source = try #require(paneManager.tabManager(for: sourceID))
+        let sourceTab = appendTab(to: source, path: "/tmp/same-file.swift", content: "source")
+        let destinationID = try #require(paneManager.splitPane(sourceID, axis: .horizontal))
+        let destination = try #require(paneManager.tabManager(for: destinationID))
+        let destinationTab = appendTab(
+            to: destination,
+            path: "/tmp/./same-file.swift",
+            content: "destination"
+        )
+        paneManager.activePaneID = sourceID
+
+        let didMove = paneManager.moveTabBetweenPanes(
+            tabID: sourceTab.id,
+            tabURL: sourceTab.url,
+            from: sourceID,
+            to: destinationID
+        )
+
+        #expect(!didMove)
+        #expect(source.tabs.map(\.id) == [sourceTab.id])
+        #expect(source.tabs.first?.content == "source")
+        #expect(destination.tabs.map(\.id) == [destinationTab.id])
+        #expect(destination.tabs.first?.content == "destination")
+        #expect(destination.activeTabID == destinationTab.id)
+        #expect(paneManager.activePaneID == sourceID)
+        #expect(paneManager.root.leafCount == 2)
+    }
+
+    @Test("stale tab identity never falls back to a matching URL")
+    func staleTabIdentityDoesNotMoveAnotherTabByURL() throws {
+        let paneManager = PaneManager()
+        let sourceID = paneManager.activePaneID
+        let source = try #require(paneManager.tabManager(for: sourceID))
+        let sourceTab = appendTab(to: source, path: "/tmp/stale-identity.swift")
+        let destinationID = try #require(paneManager.splitPane(sourceID, axis: .horizontal))
+        paneManager.activePaneID = sourceID
+
+        let didMove = paneManager.moveTabBetweenPanes(
+            tabID: UUID(),
+            tabURL: sourceTab.url,
+            from: sourceID,
+            to: destinationID
+        )
+
+        #expect(!didMove)
+        #expect(source.tabs.map(\.id) == [sourceTab.id])
+        #expect(paneManager.tabManager(for: destinationID)?.tabs.isEmpty == true)
+        #expect(paneManager.activePaneID == sourceID)
+        #expect(paneManager.root.leafCount == 2)
+    }
+
+    @Test("source and destination pending auto-saves both survive a transfer")
+    func pendingAutoSavesSurviveTransferIntoNonemptyPane() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-transfer-autosave-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let sourceURL = directory.appendingPathComponent("source.swift")
+        let destinationURL = directory.appendingPathComponent("destination.swift")
+        try "source saved".write(to: sourceURL, atomically: true, encoding: .utf8)
+        try "destination saved".write(to: destinationURL, atomically: true, encoding: .utf8)
+
+        let paneManager = PaneManager()
+        let sourceID = paneManager.activePaneID
+        let source = try #require(paneManager.tabManager(for: sourceID))
+        let moved = appendTab(
+            to: source,
+            path: sourceURL.path,
+            content: "source modified",
+            savedContent: "source saved"
+        )
+        let sourceKeeper = appendTab(
+            to: source,
+            path: directory.appendingPathComponent("keeper.swift").path,
+            content: "keeper",
+            savedContent: "keeper"
+        )
+        let destinationID = try #require(paneManager.splitPane(sourceID, axis: .horizontal))
+        let destination = try #require(paneManager.tabManager(for: destinationID))
+        let destinationTab = appendTab(
+            to: destination,
+            path: destinationURL.path,
+            content: "destination modified",
+            savedContent: "destination saved"
+        )
+        let defaultsSuite = "TabTransferSafetyTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsSuite))
+        defer { defaults.removePersistentDomain(forName: defaultsSuite) }
+        let settings = EditorSettings(defaults: defaults)
+        settings.insertFinalNewline = false
+        settings.stripTrailingWhitespace = false
+        settings.formatOnSave = false
+        destination.editorSettings = settings
+        source.setAutoSaveDelay(0.1)
+        destination.setAutoSaveDelay(0.1)
+        defer {
+            source.cancelAutoSave()
+            destination.cancelAutoSave()
+        }
+
+        source.activeTabID = moved.id
+        source.scheduleAutoSave()
+        // The pending timer belongs to the moved tab even after selection
+        // changes; dragging an inactive tab must transfer that timer too.
+        source.activeTabID = sourceKeeper.id
+        destination.scheduleAutoSave()
+        #expect(source.hasScheduledAutoSave)
+        #expect(destination.hasScheduledAutoSave(for: destinationTab.id))
+
+        let didMove = paneManager.moveTabBetweenPanes(
+            tabID: moved.id,
+            tabURL: moved.url,
+            from: sourceID,
+            to: destinationID
+        )
+
+        #expect(didMove)
+        #expect(!source.hasScheduledAutoSave)
+        #expect(destination.hasScheduledAutoSave)
+        #expect(destination.hasScheduledAutoSave(for: moved.id))
+        #expect(destination.hasScheduledAutoSave(for: destinationTab.id))
+        #expect(destination.activeTabID == moved.id)
+
+        try await Task.sleep(for: .milliseconds(300))
+
+        #expect(!destination.hasScheduledAutoSave)
+        #expect(destination.tabs.first(where: { $0.id == moved.id })?.isDirty == false)
+        #expect(destination.tabs.first(where: { $0.id == destinationTab.id })?.isDirty == false)
+        #expect(try String(contentsOf: sourceURL, encoding: .utf8) == "source modified")
+        #expect(try String(contentsOf: destinationURL, encoding: .utf8) == "destination modified")
+    }
+
+    @Test("TabManager configurator covers existing, split, and restored managers")
+    func tabManagerConfiguratorCoversEveryManager() throws {
+        let paneManager = PaneManager()
+        var configured: [ObjectIdentifier] = []
+        paneManager.configureEditorTabManager = { configured.append(ObjectIdentifier($0)) }
+
+        let initialID = paneManager.activePaneID
+        let initialManager = try #require(paneManager.tabManager(for: initialID))
+        #expect(configured == [ObjectIdentifier(initialManager)])
+
+        let splitID = try #require(paneManager.splitPane(initialID, axis: .horizontal))
+        let splitManager = try #require(paneManager.tabManager(for: splitID))
+        #expect(configured.contains(ObjectIdentifier(splitManager)))
+
+        let restoredA = PaneID()
+        let restoredB = PaneID()
+        let restoredRoot = PaneNode.split(
+            .horizontal,
+            first: .leaf(restoredA, .editor),
+            second: .leaf(restoredB, .editor),
+            ratio: 0.5
+        )
+        paneManager.restoreLayout(from: restoredRoot, activePaneUUID: restoredB.id)
+
+        let restoredManagers = try [
+            #require(paneManager.tabManager(for: restoredA)),
+            #require(paneManager.tabManager(for: restoredB))
+        ]
+        for manager in restoredManagers {
+            #expect(configured.contains(ObjectIdentifier(manager)))
+        }
+        #expect(paneManager.activePaneID == restoredB)
+    }
+}

--- a/PineTests/TerminalTabDragBetweenPanesTests.swift
+++ b/PineTests/TerminalTabDragBetweenPanesTests.swift
@@ -28,6 +28,9 @@ struct TerminalTabDragBetweenPanesTests {
         let newState = try #require(paneManager.terminalState(for: unwrappedNewPaneID))
         #expect(newState.terminalTabs.count == 1)
         #expect(newState.terminalTabs[0].id == tabToMoveID)
+        #expect(newState.activeTerminalID == tabToMoveID)
+        #expect(newState.pendingFocusTabID == tabToMoveID)
+        #expect(paneManager.activePaneID == unwrappedNewPaneID)
         #expect(termState.terminalTabs.count == 1)
     }
 
@@ -62,10 +65,29 @@ struct TerminalTabDragBetweenPanesTests {
         ))
         let tabToMove = pane1State.terminalTabs[0]
 
-        paneManager.moveTerminalTab(tabToMove.id, from: pane1ID, to: pane2ID)
+        let didMove = paneManager.moveTerminalTab(tabToMove.id, from: pane1ID, to: pane2ID)
 
         let pane2State = try #require(paneManager.terminalState(for: pane2ID))
+        #expect(didMove)
         #expect(pane2State.terminalTabs.contains(where: { $0.id == tabToMove.id }))
+        #expect(pane2State.activeTerminalID == tabToMove.id)
+        #expect(pane2State.pendingFocusTabID == tabToMove.id)
+        #expect(paneManager.activePaneID == pane2ID)
         #expect(pane1State.terminalTabs.count == 1)
+    }
+
+    @Test("moveTerminalTab rejects same-pane moves without mutation")
+    func moveTerminalTabRejectsSamePane() throws {
+        let paneManager = PaneManager()
+        let paneID = paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let state = try #require(paneManager.terminalState(for: paneID))
+        let tabID = try #require(state.terminalTabs.first?.id)
+        let beforeIDs = state.terminalTabs.map(\.id)
+
+        let didMove = paneManager.moveTerminalTab(tabID, from: paneID, to: paneID)
+
+        #expect(!didMove)
+        #expect(state.terminalTabs.map(\.id) == beforeIDs)
+        #expect(paneManager.terminalState(for: paneID) === state)
     }
 }


### PR DESCRIPTION
## Summary

- make bulk tab-close transactional so Cancel or a save failure never removes the pane
- preserve editor-tab identity, pinned ordering, dirty/recovery state, pending autosave, and destination focus across pane transfers
- reject stale exact-ID drags instead of falling back to another tab with the same URL
- prune empty source panes consistently after center and edge moves
- block structural pane/root drops while maximized while retaining local reorder and centered file-drop feedback
- give terminal transfer destinations keyboard focus and report failed drops truthfully
- configure every split or restored editor TabManager with project recovery and editor-context services
- support independent per-tab autosave debounce jobs so a transfer cannot cancel another pending save

## Test plan

- SwiftLint on all changed Swift files: 0 violations
- reentrancy guard: passed
- targeted tab, pane, close, drop, and autosave suites: 322 tests passed
- full PineTests: 4,863 tests in 293 suites passed

Closes #1169
Part of #1168