### PR TITLE
fix(syntax): avoid cooperative-executor starvation during highlighting

### DIFF
--- a/Pine/Syntax/SyntaxHighlightAsync.swift
+++ b/Pine/Syntax/SyntaxHighlightAsync.swift
@@ -67,8 +67,8 @@ nonisolated final class SyntaxHighlightAsync: @unchecked Sendable {
     /// - `textStorage` is exclusively mutated on the main thread.
     /// - `NSFont` is immutable.
     /// - `SyntaxHighlightEngine` is already `@unchecked Sendable`.
-    /// - The box is stack-local and never escapes beyond a single synchronous
-    ///   main-thread call.
+    /// - The box is local to one async hop and only escapes into its single
+    ///   `MainActor.run` operation.
     private struct MainHopBox: @unchecked Sendable {
         let textStorage: NSTextStorage
         let font: NSFont
@@ -124,11 +124,15 @@ nonisolated final class SyntaxHighlightAsync: @unchecked Sendable {
         if let generation, generation.current != gen { return nil }
 
         if let result {
-            self.applyMatchesOnMain(result, to: textStorage, font: font)
+            await self.applyMatchesOnMain(result, to: textStorage, font: font)
             multilineCache.update(key: ObjectIdentifier(textStorage), fingerprint: result.multilineFingerprint)
             return result
         } else {
-            self.resetAttributesOnMain(textStorage: textStorage, range: fullRange, font: font)
+            await self.resetAttributesOnMain(
+                textStorage: textStorage,
+                range: fullRange,
+                font: font
+            )
             return nil
         }
     }
@@ -191,10 +195,14 @@ nonisolated final class SyntaxHighlightAsync: @unchecked Sendable {
 
         let (result, _) = bgResult
         if let result {
-            self.applyMatchesOnMain(result, to: textStorage, font: font)
+            await self.applyMatchesOnMain(result, to: textStorage, font: font)
             multilineCache.update(key: key, fingerprint: result.multilineFingerprint)
         } else {
-            self.resetAttributesOnMain(textStorage: textStorage, range: fullRange, font: font)
+            await self.resetAttributesOnMain(
+                textStorage: textStorage,
+                range: fullRange,
+                font: font
+            )
         }
     }
 
@@ -238,10 +246,14 @@ nonisolated final class SyntaxHighlightAsync: @unchecked Sendable {
         if let generation, generation.current != gen { return }
 
         if let result {
-            self.applyMatchesOnMain(result, to: textStorage, font: font)
+            await self.applyMatchesOnMain(result, to: textStorage, font: font)
             multilineCache.setIfNil(key: key, fingerprint: result.multilineFingerprint)
         } else {
-            self.resetAttributesOnMain(textStorage: textStorage, range: visibleCharRange, font: font)
+            await self.resetAttributesOnMain(
+                textStorage: textStorage,
+                range: visibleCharRange,
+                font: font
+            )
         }
     }
 
@@ -276,47 +288,33 @@ nonisolated final class SyntaxHighlightAsync: @unchecked Sendable {
         return rules
     }
 
-    /// Hops to the main thread (synchronously) to call `applyMatches`.
+    /// Suspends on the main actor to call `applyMatches`.
     ///
     /// Used by the async entry points. `NSTextStorage` and `NSFont` are not
-    /// `Sendable`, so we avoid `MainActor.run { }` (which requires Sendable
-    /// captures under strict concurrency) and instead route through
-    /// `DispatchQueue.main.sync` — classic Apple pattern for bridging
-    /// background GCD work to the main-thread UI.
-    ///
-    /// Safe to call from any non-main thread; falls through directly when
-    /// already on main to avoid a redundant hop.
+    /// `Sendable`, so `MainHopBox` provides an explicit isolation boundary.
+    /// Awaiting `MainActor.run` keeps AppKit mutation on the main thread
+    /// without blocking a cooperative-executor thread while the actor is busy.
     private func applyMatchesOnMain(
         _ result: HighlightMatchResult,
         to textStorage: NSTextStorage,
         font: NSFont
-    ) {
+    ) async {
         let box = MainHopBox(textStorage: textStorage, font: font, engine: engine)
-        if Thread.isMainThread {
+        await MainActor.run {
             box.engine.applyMatches(result, to: box.textStorage, font: box.font)
-        } else {
-            DispatchQueue.main.sync {
-                box.engine.applyMatches(result, to: box.textStorage, font: box.font)
-            }
         }
     }
 
-    /// Hops to the main thread (synchronously) to call `resetAttributes`.
+    /// Suspends on the main actor to call `resetAttributes`.
     /// See `applyMatchesOnMain` for rationale.
     private func resetAttributesOnMain(
         textStorage: NSTextStorage,
         range: NSRange,
         font: NSFont
-    ) {
+    ) async {
         let box = MainHopBox(textStorage: textStorage, font: font, engine: engine)
-        if Thread.isMainThread {
+        await MainActor.run {
             box.engine.resetAttributes(textStorage: box.textStorage, range: range, font: box.font)
-        } else {
-            DispatchQueue.main.sync {
-                box.engine.resetAttributes(
-                    textStorage: box.textStorage, range: range, font: box.font
-                )
-            }
         }
     }
 }

--- a/PineTests/SyntaxHighlighterMainHopTests.swift
+++ b/PineTests/SyntaxHighlighterMainHopTests.swift
@@ -8,9 +8,9 @@
 //  `-[__NSDictionaryM setObject:forKey:]` when multiple tabs highlighted
 //  concurrently and NSTextStorage was mutated from a background thread.
 //
-//  The fix routes `applyMatches`/`resetAttributes` through the main thread
-//  via `DispatchQueue.main.sync`. These tests exercise the hop from
-//  deliberately non-main contexts to verify no crash and correct colors.
+//  The fix routes `applyMatches`/`resetAttributes` through the main actor.
+//  These tests exercise the hop from deliberately non-main contexts to
+//  verify no crash, no cooperative-executor starvation, and correct colors.
 //
 
 import Testing
@@ -31,6 +31,29 @@ private final class StorageBox: @unchecked Sendable {
     init(storage: NSTextStorage, font: NSFont) {
         self.storage = storage
         self.font = font
+    }
+}
+
+/// Thread-safe ownership for detached tasks created while the main thread is
+/// deliberately occupied by the starvation regression.
+private final class HighlightTaskStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var tasks: [Task<Void, Never>] = []
+
+    func replace(with tasks: [Task<Void, Never>]) {
+        lock.withLock {
+            self.tasks = tasks
+        }
+    }
+
+    func append(_ task: Task<Void, Never>) {
+        lock.withLock {
+            tasks.append(task)
+        }
+    }
+
+    func snapshot() -> [Task<Void, Never>] {
+        lock.withLock { tasks }
     }
 }
 
@@ -277,5 +300,74 @@ struct SyntaxHighlighterMainHopTests {
         }.value
 
         #expect(foregroundColor(in: box.storage, at: 0) == keywordColor)
+    }
+
+    // MARK: - 7. Main-actor contention does not starve cooperative tasks
+
+    /// Reproduces issue #1159 without leaving a permanently blocked test
+    /// process. The old `DispatchQueue.main.sync` hop occupied cooperative
+    /// executor threads while the main thread was busy. Enough detached
+    /// highlights could then prevent an unrelated cooperative task from
+    /// running at all.
+    ///
+    /// The main-thread hold and probe wait are both bounded. With an async
+    /// MainActor hop, highlight tasks suspend instead of blocking executor
+    /// threads, so the independent probe completes during the hold.
+    @Test(
+        "Busy main actor does not starve the cooperative executor",
+        .timeLimit(.minutes(1))
+    )
+    @MainActor
+    func busyMainActorDoesNotStarveCooperativeExecutor() async {
+        register()
+        let highlighter = SyntaxHighlighter.shared
+        let taskCount = min(
+            256,
+            max(64, ProcessInfo.processInfo.activeProcessorCount * 4)
+        )
+        let boxes = (0..<taskCount).map { index in
+            StorageBox(
+                storage: NSTextStorage(string: "func contention\(index)() {}"),
+                font: Self.font
+            )
+        }
+        let probeSignal = DispatchSemaphore(value: 0)
+        let taskStore = HighlightTaskStore()
+
+        let probeCompleted: Bool = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            DispatchQueue.main.async {
+                let highlightTasks = boxes.map { box in
+                    Task.detached(priority: .high) {
+                        _ = await highlighter.highlightAsync(
+                            textStorage: box.storage,
+                            language: "mhtestswift",
+                            font: box.font
+                        )
+                    }
+                }
+                taskStore.replace(with: highlightTasks)
+
+                // Keep the main thread busy long enough for the detached
+                // highlights to reach their main-actor application step.
+                Thread.sleep(forTimeInterval: 1)
+
+                let probeTask = Task.detached(priority: .high) {
+                    _ = probeSignal.signal()
+                }
+                taskStore.append(probeTask)
+
+                let result = probeSignal.wait(timeout: .now() + 2)
+                continuation.resume(returning: result == .success)
+            }
+        }
+
+        for task in taskStore.snapshot() {
+            await task.value
+        }
+
+        #expect(
+            probeCompleted,
+            "A synchronous main hop starved an unrelated cooperative task"
+        )
     }
 }


### PR DESCRIPTION
## Summary

- replace blocking main-queue syntax-application hops with suspending `MainActor` hops
- await apply and reset at every async highlighting call site while preserving completion ordering
- add a bounded saturation regression that fails quickly instead of hanging the test host

## Root cause

Detached highlighting tasks could occupy cooperative-executor threads while synchronously waiting for the main queue. Under full-suite contention, enough blocked workers could starve unrelated cooperative work. The last thread-safety-suite progress marker was incidental rather than the lock owner.

This branch is now a single syntax fix on current `main`. CI/Xcode 27 hardening is inherited from `main`, including the fail-closed coverage gate from #1191; this PR carries no CI changes.

## Test plan

- [x] `SyntaxHighlighterMainHopTests`: 7/7 passed under Xcode 27
- [x] bounded starvation regression passed in 1.002 seconds
- [x] changed-file SwiftLint: 0 violations
- [x] coverage gate regression suite
- [x] nonisolated and reentrancy guards plus their regression suites
- [x] `git diff --check`
- [ ] full CI on rebased head

Fixes #1159
Refs #1180
