### PR TITLE
ci: fail closed and add Xcode 27 compatibility coverage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,231 @@
+name: Bug report
+description: Report a reproducible problem in Pine
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Pine. Please include exact version and build numbers so we can distinguish macOS 26 issues from macOS 27 beta regressions.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the problem and its visible impact.
+      placeholder: A concise description of what is broken.
+    validations:
+      required: true
+
+  - type: input
+    id: pine_version
+    attributes:
+      label: Pine version
+      description: The version shown in Pine > About Pine, or the commit SHA for a source build.
+      placeholder: "1.34.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: pine_source
+    attributes:
+      label: Installation source
+      description: Where this Pine build came from.
+      options:
+        - GitHub release
+        - Homebrew
+        - Built from source
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: macos_version
+    attributes:
+      label: macOS version and build
+      description: Paste the complete output of `sw_vers`.
+      placeholder: |
+        ProductName:            macOS
+        ProductVersion:         27.0
+        BuildVersion:           26A5378n
+    validations:
+      required: true
+
+  - type: dropdown
+    id: macos_channel
+    attributes:
+      label: macOS release channel
+      options:
+        - Stable
+        - Developer beta
+        - Public beta
+        - Release candidate
+        - Other or unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: development_toolchain
+    attributes:
+      label: Xcode and macOS SDK
+      description: For source builds or SDK-specific bugs, paste `xcodebuild -version`, `xcrun --sdk macosx --show-sdk-version`, and `xcrun --sdk macosx --show-sdk-build-version`. For a release build with no local Xcode, write "Not applicable — release build".
+      placeholder: |
+        Xcode 27.0
+        Build version 27A5218g
+        macOS SDK: 27.0 (26A5378i)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: architecture
+    attributes:
+      label: Architecture
+      options:
+        - Apple silicon (arm64)
+        - Intel (x86_64)
+        - Other or unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: hardware_displays
+    attributes:
+      label: Hardware and displays
+      description: Include the Mac model, chip, memory, and every relevant built-in or external display, resolution/scaling, refresh rate, and HDR setting.
+      placeholder: |
+        MacBook Pro (14-inch, M4 Pro, 24 GB)
+        Built-in Liquid Retina XDR, 3024x1964, ProMotion, HDR enabled
+        External Studio Display, 5120x2880, default scaling, 60 Hz
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Terminal
+        - Code editor or code rendering
+        - Both terminal and code editor
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Start from launching Pine and list the smallest reliable sequence that triggers the bug.
+      placeholder: |
+        1. Open Pine...
+        2. Open...
+        3. Observe...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: Describe what should happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: Describe what happens instead, including any visible artifacts or error messages.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Explain how the bug affects your workflow, data, readability, or ability to use Pine.
+      placeholder: Why this problem matters in day-to-day use.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: Frequency
+      options:
+        - Every time
+        - Often
+        - Intermittently
+        - Happened once
+    validations:
+      required: true
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Regression
+      description: Did the same workflow work correctly on an older Pine or macOS version?
+      options:
+        - "Yes"
+        - "No"
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: last_known_good
+    attributes:
+      label: Last known working version
+      description: If this is a regression, provide the last working Pine version and macOS version/build.
+      placeholder: "Pine 1.33.4 on macOS 26.5 (25F90)"
+
+  - type: textarea
+    id: terminal_environment
+    attributes:
+      label: Terminal environment
+      description: Required for terminal bugs. Include the shell and version, `$TERM`, the command or TUI application, and whether the session is local, SSH, or another environment.
+      placeholder: |
+        Shell: /bin/zsh 5.9
+        TERM: xterm-256color
+        Command/TUI: vim 9.1
+        Session: local
+
+  - type: textarea
+    id: renderer_comparison
+    attributes:
+      label: Metal and CoreGraphics comparison
+      description: For terminal bugs, reproduce once through the default path (Metal when available; note any fallback log) and once with `--disable-metal` or `PINE_DISABLE_METAL=1` (forced CoreGraphics). If you cannot run one mode, say why.
+      placeholder: |
+        Default path (effective renderer + fallback log):
+        Forced CoreGraphics (--disable-metal):
+        Difference between modes:
+
+  - type: textarea
+    id: implementation_ideas
+    attributes:
+      label: Implementation ideas
+      description: Optional technical clues, suspected causes, or possible fixes.
+      placeholder: Leave blank if you do not have implementation suggestions.
+
+  - type: textarea
+    id: media_logs
+    attributes:
+      label: Screenshots, recordings, and logs
+      description: Drag in screenshots or a screen recording and paste relevant Console output, crash reports, or logs. Remove secrets and personal data first.
+      placeholder: Attach media and logs here, or write "None".
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Final checks
+      options:
+        - label: I searched for an existing issue that describes this problem.
+          required: true
+        - label: I removed passwords, tokens, private paths, and other sensitive information from the report.
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        Maintainers: add the appropriate area and priority labels and assign the issue to the active milestone before implementation begins.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,36 @@
 
 <!-- What does this PR do? 1-3 bullet points -->
 
+## Related issue
+
+<!-- Closes #1234 -->
+
 ## Test plan
 
 - [ ] Unit tests added/updated
 - [ ] UI tests added/updated (if applicable)
+
+## Compatibility matrix
+
+<!-- Use Tested, Not tested, or N/A. For tested rows, include the exact version and build. -->
+<!-- For compatibility-sensitive changes, paste the complete output of:
+     sw_vers
+     xcodebuild -version
+     xcrun --sdk macosx --show-sdk-version
+     xcrun --sdk macosx --show-sdk-build-version
+-->
+
+- macOS 26: <!-- Tested / Not tested / N/A — version + build -->
+- macOS 27 beta: <!-- Tested / Not tested / N/A — version + build + Developer/Public beta/RC channel -->
+- Xcode: <!-- version + build, or Not tested / N/A -->
+- macOS SDK: <!-- version + build, or Not tested / N/A -->
+
+### Terminal renderer coverage
+
+<!-- Complete for terminal-related changes. Use Tested, Not tested, or N/A. -->
+
+- Default path (Metal when available): <!-- Tested / Not tested / N/A — effective renderer, fallback log, result -->
+- CoreGraphics (`--disable-metal`): <!-- Tested / Not tested / N/A — result -->
 
 ## Manual testing checklist
 

--- a/.github/scripts/validate_test_results.py
+++ b/.github/scripts/validate_test_results.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Validate that an xcodebuild invocation really executed and passed tests.
+
+The validator is deliberately fail-closed. A successful validation requires:
+
+* a result bundle created during the current invocation;
+* xcresulttool output that can be parsed;
+* at least one executed test with a recognized terminal result;
+* no final test failures; and
+* a zero xcodebuild exit status.
+
+When xcodebuild fails, its original exit status is preserved even if the
+result bundle contains no final test failures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+VALIDATION_ERROR = 2
+
+
+class ResultValidationError(Exception):
+    """Raised when an xcresult bundle cannot prove a successful test run."""
+
+
+@dataclass(frozen=True)
+class TestSummary:
+    """Terminal test-case counts from an xcresult test tree."""
+
+    executed: int = 0
+    passed: int = 0
+    failed: int = 0
+    skipped: int = 0
+    retried: int = 0
+    unknown: int = 0
+
+    def __add__(self, other: "TestSummary") -> "TestSummary":
+        return TestSummary(
+            executed=self.executed + other.executed,
+            passed=self.passed + other.passed,
+            failed=self.failed + other.failed,
+            skipped=self.skipped + other.skipped,
+            retried=self.retried + other.retried,
+            unknown=self.unknown + other.unknown,
+        )
+
+
+def summarize_test_results(node: Any) -> TestSummary:
+    """Recursively summarize test cases without counting retry attempts twice."""
+    if isinstance(node, list):
+        summary = TestSummary()
+        for child in node:
+            summary += summarize_test_results(child)
+        return summary
+
+    if not isinstance(node, dict):
+        return TestSummary()
+
+    if node.get("nodeType") == "Test Case":
+        result = node.get("result")
+        repetitions = [
+            child
+            for child in node.get("children", [])
+            if isinstance(child, dict)
+            and child.get("nodeType") == "Repetition"
+        ]
+        retried = int(len(repetitions) > 1)
+
+        if result in {"Passed", "Expected Failure"}:
+            return TestSummary(executed=1, passed=1, retried=retried)
+        if result == "Failed":
+            return TestSummary(executed=1, failed=1, retried=retried)
+        if result == "Skipped":
+            return TestSummary(skipped=1, retried=retried)
+        return TestSummary(executed=1, retried=retried, unknown=1)
+
+    summary = TestSummary()
+    for key in ("children", "testNodes"):
+        children = node.get(key, [])
+        if isinstance(children, list):
+            summary += summarize_test_results(children)
+    return summary
+
+
+def load_test_results(result_bundle: Path) -> dict[str, Any]:
+    """Run xcresulttool and return the parsed test tree."""
+    process = subprocess.run(
+        [
+            "xcrun",
+            "xcresulttool",
+            "get",
+            "test-results",
+            "tests",
+            "--path",
+            str(result_bundle),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if process.returncode != 0:
+        detail = process.stderr.strip() or "no diagnostic output"
+        raise ResultValidationError(
+            f"xcresulttool exited with code {process.returncode}: {detail}"
+        )
+
+    try:
+        data = json.loads(process.stdout)
+    except json.JSONDecodeError as error:
+        raise ResultValidationError(
+            f"xcresulttool returned invalid JSON: {error}"
+        ) from error
+
+    if not isinstance(data, dict):
+        raise ResultValidationError("xcresulttool returned a non-object root")
+    return data
+
+
+def validate_bundle(
+    result_bundle: Path,
+    started_at: float,
+) -> TestSummary:
+    """Validate bundle freshness and terminal test results."""
+    if not result_bundle.is_dir():
+        raise ResultValidationError(
+            f"result bundle does not exist: {result_bundle}"
+        )
+
+    modified_at = result_bundle.stat().st_mtime
+    if modified_at < started_at:
+        raise ResultValidationError(
+            "result bundle predates the current xcodebuild invocation "
+            f"(mtime={modified_at:.6f}, started_at={started_at:.6f})"
+        )
+
+    summary = summarize_test_results(load_test_results(result_bundle))
+    if summary.executed == 0:
+        raise ResultValidationError("result bundle reports zero executed tests")
+    if summary.unknown:
+        raise ResultValidationError(
+            f"result bundle contains {summary.unknown} test(s) "
+            "with an unrecognized terminal result"
+        )
+    return summary
+
+
+def format_summary(summary: TestSummary) -> str:
+    """Return a compact, log-friendly result summary."""
+    return (
+        f"executed={summary.executed} "
+        f"passed={summary.passed} "
+        f"failed={summary.failed} "
+        f"skipped={summary.skipped} "
+        f"retried={summary.retried}"
+    )
+
+
+def append_github_summary(summary: TestSummary) -> None:
+    """Append a stable Markdown table when GitHub exposes a summary file."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+
+    rows = [
+        "### Unit test results",
+        "",
+        "| Executed | Passed | Failed | Skipped | Retried |",
+        "|---------:|-------:|-------:|--------:|--------:|",
+        (
+            f"| {summary.executed} | {summary.passed} | "
+            f"{summary.failed} | {summary.skipped} | {summary.retried} |"
+        ),
+        "",
+    ]
+    try:
+        with open(summary_path, "a", encoding="utf-8") as summary_file:
+            summary_file.write("\n".join(rows))
+    except OSError as error:
+        # Reporting must never replace the xcodebuild/validation exit status.
+        print(f"::warning::Unable to write GITHUB_STEP_SUMMARY: {error}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("result_bundle", type=Path)
+    parser.add_argument(
+        "--xcodebuild-exit",
+        type=int,
+        required=True,
+        help="Original xcodebuild exit status (0-255).",
+    )
+    parser.add_argument(
+        "--started-at",
+        type=float,
+        required=True,
+        help="Unix timestamp captured immediately before xcodebuild.",
+    )
+    parser.add_argument(
+        "--github-summary",
+        action="store_true",
+        help="Append counts to GITHUB_STEP_SUMMARY when it is set.",
+    )
+    args = parser.parse_args()
+    if not 0 <= args.xcodebuild_exit <= 255:
+        parser.error("--xcodebuild-exit must be between 0 and 255")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        summary = validate_bundle(args.result_bundle, args.started_at)
+    except (OSError, ResultValidationError) as error:
+        print(f"::error::Unable to validate unit-test execution: {error}")
+        return args.xcodebuild_exit or VALIDATION_ERROR
+
+    print(f"Unit test summary: {format_summary(summary)}")
+    if args.github_summary:
+        append_github_summary(summary)
+
+    if args.xcodebuild_exit:
+        print(
+            "::error::xcodebuild exited with code "
+            f"{args.xcodebuild_exit}; preserving the original failure"
+        )
+        return args.xcodebuild_exit
+
+    if summary.failed:
+        print(
+            f"::error::Result bundle contains {summary.failed} "
+            "final test failure(s)"
+        )
+        return VALIDATION_ERROR
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,7 @@ jobs:
             -skip-testing:PineTests/FuzzConfigValidatorTests \
             -skip-testing:PineTests/FuzzGoToLineParserTests \
             -retry-tests-on-failure \
+            -parallel-testing-enabled NO \
             -test-timeouts-enabled YES \
             -resultBundlePath "$RESULT_BUNDLE" \
             CODE_SIGN_IDENTITY=- \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,15 @@ jobs:
       - name: Tests for inout-post reentrancy guard
         run: bash scripts/tests/test-check-no-post-under-inout.sh
 
+      - name: Tests for Metal toolchain installer
+        run: bash scripts/tests/test-ensure-metal-toolchain.sh
+
+      - name: Tests for unit-test result validation
+        run: bash scripts/tests/test-validate-test-results.sh
+
+      - name: Tests for xcodebuild CLI options
+        run: bash scripts/tests/test-xcodebuild-cli-options.sh
+
   build:
     name: Build for Testing
     runs-on: macos-26
@@ -75,12 +84,8 @@ jobs:
       - name: Select Xcode
         uses: ./.github/actions/select-xcode
 
-      - name: Download Metal Toolchain
-        run: |
-          # SwiftTerm 1.13+ ships Metal shaders. Xcode 26 beta images on
-          # GitHub Actions runners do not bundle the Metal Toolchain by
-          # default, causing `cannot execute tool 'metal'` build errors.
-          xcodebuild -downloadComponent MetalToolchain
+      - name: Ensure Metal Toolchain
+        run: bash scripts/ensure-metal-toolchain.sh
 
       - name: Cache SPM Dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -156,6 +161,138 @@ jobs:
           retention-days: 1
           compression-level: 0
 
+  # Compiler/SDK compatibility lane for the Xcode 27 preview image. The
+  # hosted runner still uses macOS 26, so runtime coverage on macOS 27 must
+  # continue on real hardware. Keep this non-blocking while the image is in
+  # preview; failures should remain visible without becoming required checks.
+  xcode-27-compatibility:
+    name: Xcode 27 Preview Compatibility
+    runs-on: xcode-27
+    continue-on-error: true
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Do not use the stable select-xcode helper here: xcode-27 runners
+      # provide the preview Xcode/SDK pair as their active toolchain.
+      - name: Report Preview Environment
+        run: |
+          sw_vers
+          uname -m
+          xcodebuild -version
+          xcode_version="$(xcodebuild -version | awk 'NR == 1 { print $2 }')"
+          sdk_version="$(xcrun --sdk macosx --show-sdk-version)"
+          echo "macOS SDK version: $sdk_version"
+          echo "macOS SDK build: $(xcrun --sdk macosx --show-sdk-build-version)"
+          echo "macOS SDK path: $(xcrun --sdk macosx --show-sdk-path)"
+
+          case "$xcode_version" in
+            27|27.*) ;;
+            *)
+              echo "::error::The xcode-27 lane resolved Xcode $xcode_version"
+              exit 1
+              ;;
+          esac
+
+          case "$sdk_version" in
+            27|27.*) ;;
+            *)
+              echo "::error::The xcode-27 lane resolved macOS SDK $sdk_version"
+              exit 1
+              ;;
+          esac
+
+      - name: Ensure Metal Toolchain
+        run: bash scripts/ensure-metal-toolchain.sh
+
+      - name: Cache SPM Dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: DerivedData-Xcode27/SourcePackages
+          key: spm-xcode-27-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            spm-xcode-27-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Verify macOS 26 Deployment Target
+        run: |
+          for configuration in Debug Release; do
+            settings="$(
+              xcodebuild \
+                -project Pine.xcodeproj \
+                -alltargets \
+                -configuration "$configuration" \
+                -showBuildSettings \
+                -json
+            )"
+            target_count="$(jq 'length' <<<"$settings")"
+            if [ "$target_count" -eq 0 ]; then
+              echo "::error::No targets resolved for $configuration"
+              exit 1
+            fi
+
+            invalid="$(
+              jq -r '
+                .[]
+                | select(.buildSettings.MACOSX_DEPLOYMENT_TARGET != "26.0")
+                | "\(.target)=\(.buildSettings.MACOSX_DEPLOYMENT_TARGET // "missing")"
+              ' <<<"$settings"
+            )"
+            if [ -n "$invalid" ]; then
+              echo "::error::Expected MACOSX_DEPLOYMENT_TARGET=26.0 for every $configuration target"
+              echo "$invalid"
+              exit 1
+            fi
+
+            echo "Verified $target_count $configuration target settings at MACOSX_DEPLOYMENT_TARGET=26.0"
+          done
+
+      - name: Build App with Xcode 27
+        run: |
+          xcodebuild build \
+            -project Pine.xcodeproj \
+            -scheme Pine \
+            -destination "platform=macOS" \
+            -derivedDataPath DerivedData-Xcode27 \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO
+
+      - name: Unit Tests with Xcode 27
+        run: |
+          RESULT_BUNDLE="Xcode27TestResults.xcresult"
+          rm -rf "$RESULT_BUNDLE"
+          TEST_STARTED_AT="$(date +%s)"
+
+          set +e
+          xcodebuild test \
+            -project Pine.xcodeproj \
+            -scheme Pine \
+            -destination "platform=macOS" \
+            -derivedDataPath DerivedData-Xcode27 \
+            -only-testing:PineTests \
+            -skip-testing:PineTests/FuzzGitDiffParserTests \
+            -skip-testing:PineTests/FuzzGitBlameParserTests \
+            -skip-testing:PineTests/FuzzGitStatusParserTests \
+            -skip-testing:PineTests/FuzzSyntaxHighlighterTests \
+            -skip-testing:PineTests/FuzzQuickOpenProviderTests \
+            -skip-testing:PineTests/FuzzSymbolParserTests \
+            -skip-testing:PineTests/FuzzConfigValidatorTests \
+            -skip-testing:PineTests/FuzzGoToLineParserTests \
+            -retry-tests-on-failure \
+            -test-timeouts-enabled YES \
+            -resultBundlePath "$RESULT_BUNDLE" \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO
+          TEST_EXIT=$?
+          set -e
+
+          python3 .github/scripts/validate_test_results.py \
+            "$RESULT_BUNDLE" \
+            --xcodebuild-exit "$TEST_EXIT" \
+            --started-at "$TEST_STARTED_AT" \
+            --github-summary
+
   unit-tests:
     name: Unit Tests
     runs-on: macos-26
@@ -191,6 +328,10 @@ jobs:
       # and can be triggered on-demand via the `fuzz` label on a PR.
       - name: Unit Tests
         run: |
+          RESULT_BUNDLE="TestResults.xcresult"
+          rm -rf "$RESULT_BUNDLE"
+          TEST_STARTED_AT="$(date +%s)"
+
           set +e
           xcodebuild test-without-building \
             -project Pine.xcodeproj \
@@ -207,58 +348,19 @@ jobs:
             -skip-testing:PineTests/FuzzConfigValidatorTests \
             -skip-testing:PineTests/FuzzGoToLineParserTests \
             -retry-tests-on-failure \
-            -test-timeouts-enabled \
+            -test-timeouts-enabled YES \
             -enableCodeCoverage YES \
-            -resultBundlePath TestResults.xcresult \
+            -resultBundlePath "$RESULT_BUNDLE" \
             CODE_SIGN_IDENTITY=- \
             CODE_SIGNING_ALLOWED=NO
           TEST_EXIT=$?
           set -e
 
-          if [ "$TEST_EXIT" -eq 0 ]; then
-            echo "xcodebuild exited cleanly"
-            exit 0
-          fi
-
-          echo "::warning::xcodebuild exited with code $TEST_EXIT — checking xcresult for actual failures"
-
-          # When the test host crashes on first launch but all tests pass on
-          # retry, xcodebuild still returns exit code 65. Parse the xcresult
-          # to distinguish "real failures" from "crash-then-retry-all-passed".
-          if [ ! -d "TestResults.xcresult" ]; then
-            echo "::error::No xcresult bundle found and xcodebuild failed"
-            exit "$TEST_EXIT"
-          fi
-
-          FAILED_TESTS=$(xcrun xcresulttool get test-results tests \
-            --path TestResults.xcresult \
-            | python3 -c "
-          import json, sys
-
-          def count_failures(node):
-              node_type = node.get('nodeType', '')
-              result = node.get('result', '')
-              children = node.get('children', [])
-
-              if node_type == 'Test Case':
-                  # A test case that ultimately failed (not retried-and-passed)
-                  return 1 if result == 'Failed' else 0
-
-              return sum(count_failures(c) for c in children)
-
-          data = json.load(sys.stdin)
-          print(count_failures(data))
-          ")
-
-          echo "Failed tests (after retries): $FAILED_TESTS"
-
-          if [ "$FAILED_TESTS" -eq 0 ]; then
-            echo "All tests passed after retries — treating as success despite exit code $TEST_EXIT"
-            exit 0
-          else
-            echo "::error::$FAILED_TESTS test(s) still failing after retries"
-            exit "$TEST_EXIT"
-          fi
+          python3 .github/scripts/validate_test_results.py \
+            "$RESULT_BUNDLE" \
+            --xcodebuild-exit "$TEST_EXIT" \
+            --started-at "$TEST_STARTED_AT" \
+            --github-summary
 
       - name: Detect Flaky Tests
         if: success() || failure()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for AI coding agents (Claude Code, pi, and others) working in this repo
 
 ## Project Overview
 
-Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Targets macOS 26 (Tahoe) with Liquid Glass UI.
+Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Its minimum deployment target is macOS 26.0 (Tahoe), and compatibility work must cover both macOS 26 and the current macOS 27 beta.
 
 **Dependencies** (via Xcode SPM):
 - [SwiftTerm](https://github.com/migueldeicaza/SwiftTerm) — terminal emulator
@@ -13,7 +13,9 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Targets 
 
 ## Build & Run
 
-- **Xcode 26+** required, macOS 26+ deployment target
+- **Xcode 26+** required. Keep `MACOSX_DEPLOYMENT_TARGET` at `26.0`; macOS 27 is an additional compatibility target, not a new minimum requirement
+- Test compatibility-sensitive changes on both macOS 26 and the current macOS 27 beta when those runtimes are available. Do not fix a macOS 27 regression by breaking or raising the macOS 26 baseline
+- For OS- or SDK-specific reports, include the complete output of `sw_vers`, `xcodebuild -version`, `xcrun --sdk macosx --show-sdk-version`, and `xcrun --sdk macosx --show-sdk-build-version`; labels such as "macOS 27" or "Xcode beta" are not precise enough
 - Open `Pine.xcodeproj` in Xcode, build and run (Cmd+R)
 - CLI build: `xcodebuild -project Pine.xcodeproj -scheme Pine build` (requires `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`)
 - Type-check a single file (no sudo needed): `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -typecheck -target arm64-apple-macos26.0 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk <file.swift>`
@@ -38,6 +40,7 @@ Pine is a minimal native macOS code editor built with SwiftUI + AppKit. Targets 
 - **Quick terminal:** a system-wide ⌃⌥Space hotkey (`Carbon RegisterEventHotKey`, no Accessibility permission required, works in the App Sandbox) toggles a floating drop-down terminal over any application (#1113). The session is keep-alive — scrollback survives toggles; Esc and ⌘W hide it. The working directory resolves to an open Pine project (current implementation picks `openProjects.keys.first` — Dictionary order, not the key window; key-window resolution is a follow-up), else the most-recent project, else `$HOME`. Disable with `--disable-quick-terminal` or `PINE_DISABLE_QUICK_TERMINAL` (used by UI tests). Agent detection (#950) does NOT cover the quick-terminal tab (it lives outside the pane tree) — a follow-up wires it in. A menu item, Settings UI (custom hotkey, screen edge, height), and per-pane quick terminals are follow-ups — v1 ships the hotkey + window only.
 - **Known issue:** XCUITest launch arguments (`-key YES`) store values as strings in NSArgumentDomain. `UserDefaults.object(forKey:) as? Bool` returns nil for strings. To set boolean UserDefaults for UI tests, use `defaults write <bundle-id> <key> -bool YES` via `Process` in setUp, and `defaults delete` in tearDown
 - **Known issue:** Pine's terminal opts into SwiftTerm's Metal renderer (`setUseMetal(true)`) once the view lands in a window, replacing the layer-backed CoreGraphics raster with a GPU swapchain and eliminating the entire black-screen class (#64, #661, #871, #918, #923, #966, #1094, #1108). On failure (headless CI VM, old GPU, virtual display without a Metal device) it silently falls back to CoreGraphics. UI tests pass `--disable-metal` to pin CoreGraphics on macOS-26 virtual displays; production users can opt out with `--disable-metal` or `PINE_DISABLE_METAL`.
+- **Terminal rendering compatibility:** manually reproduce rendering bugs once through the default path (Metal when available; record any fallback-to-CoreGraphics log) and once after relaunching with `--disable-metal` or `PINE_DISABLE_METAL=1` to force CoreGraphics. Record the effective renderer, Mac model/chip, display configuration, and whether the result differs on macOS 26 versus the current macOS 27 beta
 - To interact with menu items in UI tests, use `app.menuBars.menuBarItems["File"].click()` then `app.menuItems["Item Name"].click()` with English names (locale is forced to `en`)
 - Accessibility identifiers defined in `Pine/AccessibilityIdentifiers.swift` — used by both app views and UI tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,27 @@ xcodebuild -project Pine.xcodeproj -scheme Pine build
 
 New `.swift` files placed in `Pine/`, `PineTests/`, or `PineUITests/` are automatically picked up by Xcode (the project uses `PBXFileSystemSynchronizedRootGroup`). No manual `project.pbxproj` edits needed.
 
+## macOS Compatibility
+
+Pine's minimum deployment target remains macOS 26.0. The current macOS 27 beta is an additional compatibility target, so compatibility fixes must preserve macOS 26 support rather than raising the deployment target.
+
+For OS-, SDK-, or rendering-specific bug reports and pull requests, capture the exact environment:
+
+```bash
+sw_vers
+xcodebuild -version
+xcrun --sdk macosx --show-sdk-version
+xcrun --sdk macosx --show-sdk-build-version
+```
+
+Include the complete output, the Mac model/chip, and the display configuration. When both runtimes are available, state the result separately for macOS 26 and the current macOS 27 beta; use `not tested` where a runtime was unavailable.
+
+For terminal rendering bugs, perform a manual comparison after each code change:
+
+1. Launch normally to exercise the default path (Metal when available), and note any fallback-to-CoreGraphics message in Console.
+2. Quit Pine completely, then relaunch with the `--disable-metal` argument or `PINE_DISABLE_METAL=1` environment variable to force CoreGraphics.
+3. Report the effective renderer that reproduces the problem and whether behavior differs between macOS 26 and macOS 27 beta.
+
 ## Running Tests
 
 ### Unit tests

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ brew install --cask pine-editor
 ## Build from Source
 
 Requires macOS 26+ and Xcode 26+.
+Pine keeps a macOS 26.0 deployment target while also checking source compatibility with the current macOS 27 beta SDK.
 
 ```bash
 git clone https://github.com/batonogov/pine.git

--- a/scripts/ensure-metal-toolchain.sh
+++ b/scripts/ensure-metal-toolchain.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Install Xcode's separately distributed Metal toolchain when it is absent.
+# `xcodebuild -showComponent` can exit successfully while reporting
+# `{"status":"uninstalled"}`, so the JSON status is authoritative.
+set -euo pipefail
+
+MAX_ATTEMPTS="${METAL_TOOLCHAIN_MAX_ATTEMPTS:-3}"
+RETRY_DELAY_SECONDS="${METAL_TOOLCHAIN_RETRY_DELAY_SECONDS:-10}"
+
+case "$MAX_ATTEMPTS" in
+    [1-9]|[1-9][0-9]*)
+        ;;
+    *)
+        echo "::error::METAL_TOOLCHAIN_MAX_ATTEMPTS must be a positive integer"
+        exit 2
+        ;;
+esac
+
+case "$RETRY_DELAY_SECONDS" in
+    0|[1-9]|[1-9][0-9]*)
+        ;;
+    *)
+        echo "::error::METAL_TOOLCHAIN_RETRY_DELAY_SECONDS must be a non-negative integer"
+        exit 2
+        ;;
+esac
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "::error::jq is required to inspect the Metal Toolchain status"
+    exit 2
+fi
+
+metal_toolchain_status() {
+    local component_json
+    local component_status
+
+    if ! component_json="$(xcodebuild -showComponent MetalToolchain -json 2>/dev/null)"; then
+        echo "unknown"
+        return
+    fi
+
+    if component_status="$(
+        printf '%s\n' "$component_json" \
+            | jq -er '.status | select(type == "string")' 2>/dev/null
+    )" && [ -n "$component_status" ]; then
+        echo "$component_status"
+    else
+        echo "unknown"
+    fi
+}
+
+metal_toolchain_is_installed() {
+    case "$1" in
+        installed|installedUpdateAvailable)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+status="$(metal_toolchain_status)"
+# IDEFoundation treats both statuses as usable installed components.
+if metal_toolchain_is_installed "$status"; then
+    echo "Metal Toolchain is already installed"
+    exit 0
+fi
+
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    echo "Downloading Metal Toolchain (attempt $attempt of $MAX_ATTEMPTS; current status: $status)"
+
+    if xcodebuild -downloadComponent MetalToolchain; then
+        download_succeeded=true
+    else
+        download_succeeded=false
+    fi
+
+    # The component may be installed even if xcodebuild reports a late error,
+    # so query the authoritative status after every attempt, including the last.
+    status="$(metal_toolchain_status)"
+    if metal_toolchain_is_installed "$status"; then
+        echo "Metal Toolchain installed successfully"
+        exit 0
+    fi
+
+    if [ "$download_succeeded" = true ]; then
+        echo "::warning::Metal Toolchain download completed but status is '$status'"
+    else
+        echo "::warning::Metal Toolchain download command failed; status is '$status'"
+    fi
+
+    if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+        echo "Retrying in $RETRY_DELAY_SECONDS seconds"
+        sleep "$RETRY_DELAY_SECONDS"
+        status="$(metal_toolchain_status)"
+        if metal_toolchain_is_installed "$status"; then
+            echo "Metal Toolchain installed successfully"
+            exit 0
+        fi
+    fi
+done
+
+echo "::error::Metal Toolchain is not installed after $MAX_ATTEMPTS attempts (status: $status)"
+exit 1

--- a/scripts/tests/test-ensure-metal-toolchain.sh
+++ b/scripts/tests/test-ensure-metal-toolchain.sh
@@ -1,0 +1,280 @@
+#!/bin/bash
+# Regression tests for ensure-metal-toolchain.sh. The fake xcodebuild models
+# Xcode 27's surprising contract: `-showComponent` may exit 0 while returning
+# `{"status":"uninstalled"}`.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/ensure-metal-toolchain.sh"
+PASS=0
+FAIL=0
+TEST_ROOT=""
+
+cleanup() {
+    [ -n "$TEST_ROOT" ] && rm -rf "$TEST_ROOT"
+    TEST_ROOT=""
+}
+trap cleanup EXIT
+
+pass() {
+    echo "  ✓ $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "  ✗ $1"
+    FAIL=$((FAIL + 1))
+}
+
+setup_fake_xcodebuild() {
+    TEST_ROOT="$(mktemp -d)"
+    mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/state"
+
+    cat > "$TEST_ROOT/bin/xcodebuild" <<'FAKE_XCODEBUILD'
+#!/bin/bash
+set -euo pipefail
+
+scenario="${TEST_SCENARIO:?}"
+state_dir="${TEST_STATE_DIR:?}"
+
+if [ "$#" -eq 3 ] \
+    && [ "$1" = "-showComponent" ] \
+    && [ "$2" = "MetalToolchain" ] \
+    && [ "$3" = "-json" ]; then
+    action="show"
+elif [ "$#" -eq 2 ] \
+    && [ "$1" = "-downloadComponent" ] \
+    && [ "$2" = "MetalToolchain" ]; then
+    action="download"
+else
+    echo "unexpected xcodebuild arguments: $*" >&2
+    exit 64
+fi
+
+case "$action" in
+    show)
+        case "$scenario" in
+            already_installed)
+                status="installed"
+                ;;
+            show_error_then_installed)
+                if [ ! -f "$state_dir/downloaded" ]; then
+                    exit 70
+                fi
+                status="installed"
+                ;;
+            malformed_then_installed)
+                if [ ! -f "$state_dir/downloaded" ]; then
+                    echo "not-json"
+                    exit 0
+                fi
+                status="installed"
+                ;;
+            uninstalled_then_installed|download_errors_after_install)
+                if [ -f "$state_dir/downloaded" ]; then
+                    status="installed"
+                else
+                    status="uninstalled"
+                fi
+                ;;
+            update_available_then_installed)
+                if [ -f "$state_dir/downloaded" ]; then
+                    status="installed"
+                else
+                    status="installedUpdateAvailable"
+                fi
+                ;;
+            delayed_install)
+                if [ ! -f "$state_dir/downloaded" ]; then
+                    status="uninstalled"
+                elif [ -f "$state_dir/post-download-status-seen" ]; then
+                    status="installed"
+                else
+                    touch "$state_dir/post-download-status-seen"
+                    status="uninstalled"
+                fi
+                ;;
+            uninstalled_forever|download_fails)
+                status="uninstalled"
+                ;;
+            *)
+                echo "unknown test scenario: $scenario" >&2
+                exit 64
+                ;;
+        esac
+
+        printf '{"buildVersion":"test","status":"%s"}\n' "$status"
+        ;;
+    download)
+        count=0
+        if [ -f "$state_dir/download-count" ]; then
+            count="$(cat "$state_dir/download-count")"
+        fi
+        echo "$((count + 1))" > "$state_dir/download-count"
+
+        if [ "$scenario" = "download_fails" ]; then
+            exit 1
+        fi
+
+        touch "$state_dir/downloaded"
+        if [ "$scenario" = "download_errors_after_install" ]; then
+            exit 1
+        fi
+        ;;
+esac
+FAKE_XCODEBUILD
+    chmod +x "$TEST_ROOT/bin/xcodebuild"
+}
+
+run_installer() {
+    PATH="$TEST_ROOT/bin:$PATH" \
+        TEST_SCENARIO="$1" \
+        TEST_STATE_DIR="$TEST_ROOT/state" \
+        METAL_TOOLCHAIN_MAX_ATTEMPTS=3 \
+        METAL_TOOLCHAIN_RETRY_DELAY_SECONDS=0 \
+        bash "$SCRIPT"
+}
+
+run_installer_with_limits() {
+    PATH="$TEST_ROOT/bin:$PATH" \
+        TEST_SCENARIO="$1" \
+        TEST_STATE_DIR="$TEST_ROOT/state" \
+        METAL_TOOLCHAIN_MAX_ATTEMPTS="$2" \
+        METAL_TOOLCHAIN_RETRY_DELAY_SECONDS="$3" \
+        bash "$SCRIPT"
+}
+
+download_count() {
+    if [ -f "$TEST_ROOT/state/download-count" ]; then
+        cat "$TEST_ROOT/state/download-count"
+    else
+        echo 0
+    fi
+}
+
+echo "Test 1: installed status skips the download"
+setup_fake_xcodebuild
+if run_installer already_installed >/dev/null 2>&1 && [ "$(download_count)" -eq 0 ]; then
+    pass "already-installed component accepted"
+else
+    fail "installed component should not be downloaded"
+fi
+cleanup
+
+echo "Test 2: uninstalled status with exit 0 triggers the download"
+setup_fake_xcodebuild
+if run_installer uninstalled_then_installed >/dev/null 2>&1 && [ "$(download_count)" -eq 1 ]; then
+    pass "uninstalled JSON status rejected and installed"
+else
+    fail "uninstalled status was treated as installed"
+fi
+cleanup
+
+echo "Test 3: failed status query triggers the download"
+setup_fake_xcodebuild
+if run_installer show_error_then_installed >/dev/null 2>&1 && [ "$(download_count)" -eq 1 ]; then
+    pass "failed status query recovered"
+else
+    fail "failed status query did not recover"
+fi
+cleanup
+
+echo "Test 4: malformed status JSON triggers the download"
+setup_fake_xcodebuild
+if run_installer malformed_then_installed >/dev/null 2>&1 && [ "$(download_count)" -eq 1 ]; then
+    pass "malformed status response recovered"
+else
+    fail "malformed status response did not recover"
+fi
+cleanup
+
+echo "Test 5: successful downloads without installed status exhaust retries"
+setup_fake_xcodebuild
+if run_installer uninstalled_forever >/dev/null 2>&1; then
+    fail "uninstalled status should fail after retries"
+elif [ "$(download_count)" -eq 3 ]; then
+    pass "uninstalled status exhausted all retries"
+else
+    fail "unexpected retry count for uninstalled status"
+fi
+cleanup
+
+echo "Test 6: installed component with an update available remains usable"
+setup_fake_xcodebuild
+if run_installer update_available_then_installed >/dev/null 2>&1 && [ "$(download_count)" -eq 0 ]; then
+    pass "installedUpdateAvailable status accepted"
+else
+    fail "usable installed component was downloaded again"
+fi
+cleanup
+
+echo "Test 7: delayed installed status avoids a duplicate download"
+setup_fake_xcodebuild
+if run_installer delayed_install >/dev/null 2>&1 && [ "$(download_count)" -eq 1 ]; then
+    pass "delayed installed status accepted after retry delay"
+else
+    fail "delayed installed status caused a duplicate download"
+fi
+cleanup
+
+echo "Test 8: installed status wins over a late download error"
+setup_fake_xcodebuild
+if run_installer download_errors_after_install >/dev/null 2>&1 && [ "$(download_count)" -eq 1 ]; then
+    pass "installed component accepted after download command error"
+else
+    fail "late download error masked the installed status"
+fi
+cleanup
+
+echo "Test 9: failed downloads exhaust retries"
+setup_fake_xcodebuild
+if run_installer download_fails >/dev/null 2>&1; then
+    fail "failed downloads should return non-zero"
+elif [ "$(download_count)" -eq 3 ]; then
+    pass "failed downloads exhausted all retries"
+else
+    fail "unexpected retry count for failed downloads"
+fi
+cleanup
+
+echo "Test 10: invalid attempt counts fail before invoking xcodebuild"
+invalid_attempts_rejected=true
+for value in 0 00 08 -1 abc; do
+    setup_fake_xcodebuild
+    set +e
+    run_installer_with_limits already_installed "$value" 0 >/dev/null 2>&1
+    result=$?
+    set -e
+    if [ "$result" -ne 2 ] || [ "$(download_count)" -ne 0 ]; then
+        invalid_attempts_rejected=false
+    fi
+    cleanup
+done
+if [ "$invalid_attempts_rejected" = true ]; then
+    pass "invalid and leading-zero attempt counts rejected"
+else
+    fail "an invalid attempt count was accepted"
+fi
+
+echo "Test 11: invalid retry delays fail before invoking xcodebuild"
+invalid_delays_rejected=true
+for value in 00 08 -1 abc; do
+    setup_fake_xcodebuild
+    set +e
+    run_installer_with_limits already_installed 1 "$value" >/dev/null 2>&1
+    result=$?
+    set -e
+    if [ "$result" -ne 2 ] || [ "$(download_count)" -ne 0 ]; then
+        invalid_delays_rejected=false
+    fi
+    cleanup
+done
+if [ "$invalid_delays_rejected" = true ]; then
+    pass "invalid and leading-zero retry delays rejected"
+else
+    fail "an invalid retry delay was accepted"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/tests/test-validate-test-results.sh
+++ b/scripts/tests/test-validate-test-results.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+# Process-level regression tests for validate_test_results.py.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+VALIDATOR="$REPO_ROOT/.github/scripts/validate_test_results.py"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "$TEST_ROOT/bin"
+
+cat > "$TEST_ROOT/bin/xcrun" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+if [ "${FAKE_XCRESULTTOOL_MODE:-success}" = "failure" ]; then
+    echo "synthetic xcresulttool failure" >&2
+    exit 9
+fi
+
+cat "$FAKE_XCRESULT_JSON"
+EOF
+chmod +x "$TEST_ROOT/bin/xcrun"
+
+cat > "$TEST_ROOT/passing.json" <<'EOF'
+{
+  "nodeType": "Test Plan",
+  "testNodes": [
+    {
+      "nodeType": "Test Suite",
+      "name": "PineTests",
+      "children": [
+        {
+          "nodeType": "Test Case",
+          "name": "passes",
+          "result": "Passed",
+          "children": []
+        },
+        {
+          "nodeType": "Test Case",
+          "name": "skips",
+          "result": "Skipped",
+          "children": []
+        },
+        {
+          "nodeType": "Test Case",
+          "name": "passesOnRetry",
+          "result": "Passed",
+          "children": [
+            {
+              "nodeType": "Repetition",
+              "name": "Run 1",
+              "result": "Failed"
+            },
+            {
+              "nodeType": "Repetition",
+              "name": "Run 2",
+              "result": "Passed"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+cat > "$TEST_ROOT/all-skipped.json" <<'EOF'
+{
+  "nodeType": "Test Plan",
+  "testNodes": [
+    {
+      "nodeType": "Test Case",
+      "name": "skipped",
+      "result": "Skipped",
+      "children": []
+    }
+  ]
+}
+EOF
+
+cat > "$TEST_ROOT/unknown-result.json" <<'EOF'
+{
+  "nodeType": "Test Plan",
+  "testNodes": [
+    {
+      "nodeType": "Test Case",
+      "name": "unknown",
+      "result": "Not Run",
+      "children": []
+    }
+  ]
+}
+EOF
+
+cat > "$TEST_ROOT/empty.json" <<'EOF'
+{"nodeType": "Test Plan", "children": []}
+EOF
+
+cat > "$TEST_ROOT/invalid.json" <<'EOF'
+this is not JSON
+EOF
+
+cat > "$TEST_ROOT/failing.json" <<'EOF'
+{
+  "nodeType": "Test Plan",
+  "children": [
+    {
+      "nodeType": "Test Case",
+      "name": "fails",
+      "result": "Failed",
+      "children": []
+    }
+  ]
+}
+EOF
+
+run_validator() {
+    local expected_exit="$1"
+    local label="$2"
+    shift 2
+
+    set +e
+    output="$("$@" 2>&1)"
+    status=$?
+    set -e
+
+    if [ "$status" -ne "$expected_exit" ]; then
+        echo "✗ $label: expected exit $expected_exit, got $status"
+        echo "$output"
+        exit 1
+    fi
+    echo "✓ $label"
+}
+
+fresh_bundle="$TEST_ROOT/fresh.xcresult"
+start_time="$(date +%s)"
+mkdir "$fresh_bundle"
+
+run_validator 0 "successful run reports every result category" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCRESULT_JSON="$TEST_ROOT/passing.json" \
+    python3 "$VALIDATOR" "$fresh_bundle" \
+    --xcodebuild-exit 0 \
+    --started-at "$start_time"
+
+set +e
+summary_output="$(
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCRESULT_JSON="$TEST_ROOT/passing.json" \
+    python3 "$VALIDATOR" "$fresh_bundle" \
+    --xcodebuild-exit 0 \
+    --started-at "$start_time" 2>&1
+)"
+summary_status=$?
+set -e
+if [ "$summary_status" -ne 0 ] || \
+    ! grep -qF \
+        "executed=2 passed=2 failed=0 skipped=1 retried=1" \
+        <<< "$summary_output"; then
+    echo "✗ successful run did not emit the expected explicit summary"
+    echo "$summary_output"
+    exit 1
+fi
+echo "✓ successful run emits an explicit summary"
+
+github_summary="$TEST_ROOT/github-summary.md"
+run_validator 0 "GitHub summary output succeeds" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCRESULT_JSON="$TEST_ROOT/passing.json" \
+    GITHUB_STEP_SUMMARY="$github_summary" \
+    python3 "$VALIDATOR" "$fresh_bundle" \
+    --xcodebuild-exit 0 \
+    --started-at "$start_time" \
+    --github-summary
+if ! grep -qF "| 2 | 2 | 0 | 1 | 1 |" "$github_summary"; then
+    echo "✗ GitHub summary did not contain the expected counts"
+    cat "$github_summary"
+    exit 1
+fi
+echo "✓ GitHub summary contains every result category"
+
+run_validator 65 "summary write failure does not mask xcodebuild failure" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCRESULT_JSON="$TEST_ROOT/passing.json" \
+    GITHUB_STEP_SUMMARY="$TEST_ROOT" \
+    python3 "$VALIDATOR" "$fresh_bundle" \
+    --xcodebuild-exit 65 \
+    --started-at "$start_time" \
+    --github-summary
+
+run_validator 65 "xcodebuild failure is preserved despite zero final failures" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCRESULT_JSON="$TEST_ROOT/passing.json" \
+    python3 "$VALIDATOR" "$fresh_bundle" \
+    --xcodebuild-exit 65 \
+    --started-at "$start_time"
+
+run_validator 2 "missing result bundle fails closed" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCRESULT_JSON="$TEST_ROOT/passing.json" \
+    python3 "$VALIDATOR" "$TEST_ROOT/missing.xcresult" \
+    --xcodebuild-exit 0 \
+    --started-at "$start_time"
+
+run_validator 2 "empty result bundle fails closed" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCRESULT_JSON="$TEST_ROOT/empty.json" \
+    python3 "$VALIDATOR" "$fresh_bundle" \
+    --xcodebuild-exit 0 \
+    --started-at "$start_time"
+
+run_validator 2 "all-skipped bundle fails closed" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCRESULT_JSON="$TEST_ROOT/all-skipped.json" \
+    python3 "$VALIDATOR" "$fresh_bundle" \
+    --xcodebuild-exit 0 \
+    --started-at "$start_time"
+
+run_validator 2 "unknown terminal result fails closed" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCRESULT_JSON="$TEST_ROOT/unknown-result.json" \
+    python3 "$VALIDATOR" "$fresh_bundle" \
+    --xcodebuild-exit 0 \
+    --started-at "$start_time"
+
+run_validator 2 "xcresulttool failure fails closed" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCRESULTTOOL_MODE=failure \
+    FAKE_XCRESULT_JSON="$TEST_ROOT/passing.json" \
+    python3 "$VALIDATOR" "$fresh_bundle" \
+    --xcodebuild-exit 0 \
+    --started-at "$start_time"
+
+run_validator 2 "malformed xcresulttool JSON fails closed" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCRESULT_JSON="$TEST_ROOT/invalid.json" \
+    python3 "$VALIDATOR" "$fresh_bundle" \
+    --xcodebuild-exit 0 \
+    --started-at "$start_time"
+
+run_validator 2 "final test failure fails closed" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCRESULT_JSON="$TEST_ROOT/failing.json" \
+    python3 "$VALIDATOR" "$fresh_bundle" \
+    --xcodebuild-exit 0 \
+    --started-at "$start_time"
+
+future_start="$((start_time + 3600))"
+run_validator 2 "stale result bundle fails closed" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCRESULT_JSON="$TEST_ROOT/passing.json" \
+    python3 "$VALIDATOR" "$fresh_bundle" \
+    --xcodebuild-exit 0 \
+    --started-at "$future_start"
+
+echo "All validate_test_results.py regression tests passed."

--- a/scripts/tests/test-xcodebuild-cli-options.sh
+++ b/scripts/tests/test-xcodebuild-cli-options.sh
@@ -29,3 +29,28 @@ if [ -n "$invalid_lines" ]; then
 fi
 
 echo "✓ All xcodebuild test-timeout options pass an explicit YES value"
+
+xcode_27_block="$(
+    sed -n \
+        '/- name: Unit Tests with Xcode 27/,/^  unit-tests:/p' \
+        "$CI_WORKFLOW"
+)"
+all_parallel_lines="$(
+    grep -nF -- '-parallel-testing-enabled' "$CI_WORKFLOW" || true
+)"
+xcode_27_parallel_lines="$(
+    printf '%s\n' "$xcode_27_block" \
+        | grep -F -- '-parallel-testing-enabled' \
+        || true
+)"
+
+if [ "$(printf '%s\n' "$all_parallel_lines" | grep -c . || true)" -ne 1 ] \
+    || [ "$(printf '%s\n' "$xcode_27_parallel_lines" | grep -c . || true)" -ne 1 ] \
+    || ! printf '%s\n' "$xcode_27_parallel_lines" \
+        | grep -qF -- '-parallel-testing-enabled NO'; then
+    echo "✗ The Xcode 27 unit-test lane must be the only serialized lane and pass an explicit NO value"
+    echo "$all_parallel_lines"
+    exit 1
+fi
+
+echo "✓ Only the Xcode 27 unit-test lane disables parallel testing"

--- a/scripts/tests/test-xcodebuild-cli-options.sh
+++ b/scripts/tests/test-xcodebuild-cli-options.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Guard xcodebuild options whose missing values can shift every later token.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CI_WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
+
+timeout_lines="$(
+    grep -nF -- '-test-timeouts-enabled' "$CI_WORKFLOW" \
+        | grep -vE '^[0-9]+:[[:space:]]*#' \
+        || true
+)"
+
+if [ -z "$timeout_lines" ]; then
+    echo "✗ CI workflow no longer enables per-test timeouts"
+    exit 1
+fi
+
+invalid_lines="$(
+    printf '%s\n' "$timeout_lines" \
+        | grep -vE -- '-test-timeouts-enabled[[:space:]]+YES([[:space:]]|$)' \
+        || true
+)"
+
+if [ -n "$invalid_lines" ]; then
+    echo "✗ Every -test-timeouts-enabled option must pass an explicit YES value:"
+    echo "$invalid_lines"
+    exit 1
+fi
+
+echo "✓ All xcodebuild test-timeout options pass an explicit YES value"


### PR DESCRIPTION
## Summary

- replace permissive test-result post-processing with a fail-closed xcresult validator
- preserve the original xcodebuild exit status and require a fresh bundle with executed tests
- add a non-blocking Xcode 27 and SDK 27 compatibility lane while preserving the macOS 26.0 deployment target
- serialize only the preview lane to contain Xcode 27 runner resource contention while stable CI stays parallel
- add compatibility reporting templates, documentation, and a bounded Metal toolchain installer

## Correctness guarantees

- every test-timeout option has an explicit value
- stale, missing, malformed, empty, all-skipped, or failing result bundles cannot produce a green check
- stable CI remains required and parallel while the Xcode 27 preview lane is non-blocking and serialized
- every Debug and Release target must resolve MACOSX_DEPLOYMENT_TARGET=26.0
- coverage extraction remains separate work tracked by #1180

## Test plan

- [x] fail-closed validator regression suite: 14 cases
- [x] xcodebuild option guard, including preview-only serialization
- [x] Metal toolchain installer regression suite: 11 cases
- [x] workflow and issue-form YAML validation
- [x] shell and Python syntax validation
- [x] deployment-target checks for all targets in Debug and Release

## Stack

This PR is stacked on #1184 so the newly enforced full PineTests run includes the cooperative-executor starvation fix.

Fixes #1158
Closes #1132
Refs #1180

Replaces #1134.