### PR TITLE
feat(tabs): add exact cross-pane insertion targets

### DIFF
--- a/Pine/AppKitFocusRequestCoordinator.swift
+++ b/Pine/AppKitFocusRequestCoordinator.swift
@@ -1,0 +1,115 @@
+//
+//  AppKitFocusRequestCoordinator.swift
+//  Pine
+//
+//  Retains destination-focus requests until AppKit confirms first responder.
+//
+
+import AppKit
+
+/// Bridges an observable tab-focus request to an AppKit view lifecycle.
+///
+/// SwiftUI may call `updateNSView` before a newly split destination is attached
+/// to a window. The request therefore remains pending after a failed attempt
+/// and is retried when the host view moves into a window.
+@MainActor
+final class AppKitFocusRequestCoordinator {
+    private(set) var pendingRequestID: UUID?
+
+    private weak var hostView: NSView?
+    private weak var targetView: NSView?
+    private var canAttempt: ((UUID) -> Bool)?
+    private var onResult: ((UUID, Bool) -> Void)?
+    private var attemptScheduled = false
+    private var scheduledTransientRetry = false
+
+    func update(
+        requestID: UUID?,
+        hostView: NSView,
+        targetView: NSView?,
+        canAttempt: ((UUID) -> Bool)? = nil,
+        onResult: ((UUID, Bool) -> Void)?
+    ) {
+        self.hostView = hostView
+        self.targetView = targetView
+        self.canAttempt = canAttempt
+        self.onResult = onResult
+
+        guard let requestID else {
+            cancel()
+            return
+        }
+        if pendingRequestID != requestID {
+            pendingRequestID = requestID
+            scheduledTransientRetry = false
+        }
+        scheduleAttempt()
+    }
+
+    func hostDidMoveToWindow(_ hostView: NSView) {
+        self.hostView = hostView
+        guard hostView.window != nil else { return }
+        scheduleAttempt()
+    }
+
+    func cancel() {
+        pendingRequestID = nil
+        targetView = nil
+        canAttempt = nil
+        onResult = nil
+        scheduledTransientRetry = false
+    }
+
+    /// Synchronous seam used by lifecycle callbacks and regression tests.
+    @discardableResult
+    func attemptNow() -> Bool {
+        guard let requestID = pendingRequestID else { return false }
+        guard canAttempt?(requestID) != false else {
+            pendingRequestID = nil
+            scheduledTransientRetry = false
+            onResult?(requestID, false)
+            return false
+        }
+        guard
+              let hostView,
+              let targetView,
+              let window = hostView.window,
+              targetView.window === window else {
+            onResult?(requestID, false)
+            return false
+        }
+
+        let accepted = window.makeFirstResponder(targetView)
+        let responderMatchesTarget = if window.firstResponder === targetView {
+            true
+        } else if let responderView = window.firstResponder as? NSView {
+            responderView.isDescendant(of: targetView)
+        } else {
+            false
+        }
+        let succeeded = accepted && responderMatchesTarget
+        onResult?(requestID, succeeded)
+
+        if succeeded {
+            pendingRequestID = nil
+            scheduledTransientRetry = false
+        } else if !scheduledTransientRetry {
+            // AppKit can briefly reject a responder while SwiftUI finishes
+            // reparenting. Retry once on the next runloop; later view updates
+            // and `viewDidMoveToWindow` remain additional retry opportunities.
+            scheduledTransientRetry = true
+            scheduleAttempt()
+        }
+        return succeeded
+    }
+
+    private func scheduleAttempt() {
+        guard pendingRequestID != nil, !attemptScheduled else { return }
+        attemptScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.attemptScheduled = false
+            self.attemptNow()
+        }
+    }
+}

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -68,6 +68,10 @@ struct CodeEditorView: NSViewRepresentable {
     var cachedHighlightResult: HighlightMatchResult?
     /// When non-nil, the editor scrolls to this offset. The `id` ensures each request is unique.
     var goToOffset: GoToRequest?
+    /// Set by a committed tab drop to explicitly focus the destination editor.
+    var focusRequestTabID: UUID?
+    var canAttemptFocusRequest: ((UUID) -> Bool)?
+    var onFocusRequestResult: ((UUID, Bool) -> Void)?
     /// Indentation style detected for the current file, used for indent guide rendering.
     var indentStyle: IndentationStyle = .spaces(4)
 
@@ -332,6 +336,15 @@ struct CodeEditorView: NSViewRepresentable {
         context.coordinator.parent = self
 
         guard let editorContainer = container as? EditorContainerView else { return }
+
+        let focusTarget = context.coordinator.scrollView?.documentView as? GutterTextView
+        editorContainer.destinationFocusCoordinator.update(
+            requestID: focusRequestTabID,
+            hostView: editorContainer,
+            targetView: focusTarget,
+            canAttempt: canAttemptFocusRequest,
+            onResult: onFocusRequestResult
+        )
 
         // Minimap visibility — triggers relayout via needsLayout
         if let minimapView = context.coordinator.minimapView {

--- a/Pine/EditorContainerViews.swift
+++ b/Pine/EditorContainerViews.swift
@@ -74,6 +74,12 @@ final class EditorContainerView: NSView {
     // Match NSScrollView's flipped coordinate system for correct find bar clipping
     override var isFlipped: Bool { true }
     var minimapWidth: CGFloat = 0
+    let destinationFocusCoordinator = AppKitFocusRequestCoordinator()
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        destinationFocusCoordinator.hostDidMoveToWindow(self)
+    }
 
     override func layout() {
         super.layout()

--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -53,7 +53,7 @@ struct EditorTabBar: View {
     @Environment(PaneManager.self) private var paneManager
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    @State private var hoverTargetTabID: UUID?
+    @State private var tabFrames: [UUID: CGRect] = [:]
 
     /// Minimum tab width before scrolling kicks in.
     static let minTabWidth: CGFloat = 80
@@ -70,6 +70,21 @@ struct EditorTabBar: View {
 
     /// Width for pinned tabs — compact, icon-focused.
     static let pinnedTabWidth: CGFloat = 40
+
+    private var paneID: PaneID { overridePaneID ?? paneManager.activePaneID }
+    private var coordinateSpaceName: String { "editor-tab-strip-\(paneID.id.uuidString)" }
+
+    private var insertionIndicatorX: CGFloat? {
+        guard let intent = paneManager.tabDragCoordinator.previewIntent,
+              intent.destinationPaneID == paneID,
+              intent.drag.contentType == .editor,
+              let insertionIndex = intent.insertionIndex else { return nil }
+        return TabStripInsertionGeometry.indicatorX(
+            for: insertionIndex,
+            orderedTabIDs: tabManager.tabs.map(\.id),
+            frames: tabFrames
+        )
+    }
 
     /// Computes tab widths: active tab stays at full width, inactive tabs share the rest.
     /// Pinned tabs always use `pinnedTabWidth` and are excluded from the dynamic calculation.
@@ -98,7 +113,6 @@ struct EditorTabBar: View {
                                 pinnedCount: pinnedCount
                             )
                             ForEach(tabManager.tabs) { tab in
-                                let paneID = overridePaneID ?? paneManager.activePaneID
                                 let isActive = tab.id == tabManager.activeTabID
                                 let isDragged = paneManager.activeDrag.map { drag in
                                     drag.paneID == paneID.id
@@ -154,24 +168,19 @@ struct EditorTabBar: View {
                                 .scaleEffect(isDragged ? 0.95 : 1.0)
                                 .transaction { $0.animation = nil }
                                 .id(tab.id)
+                                .reportTabStripFrame(
+                                    tabID: tab.id,
+                                    coordinateSpace: coordinateSpaceName
+                                )
                                 .onDrag {
-                                    let info = TabDragInfo(
-                                        paneID: paneID.id,
+                                    let info = paneManager.beginTabDrag(
+                                        paneID: paneID,
                                         tabID: tab.id,
-                                        fileURL: tab.url
+                                        fileURL: tab.url,
+                                        contentType: .editor
                                     )
-                                    // Store in shared state for synchronous access by drop delegates
-                                    paneManager.activeDrag = info
                                     return info.itemProvider()
                                 }
-                                .onDrop(of: [.paneTabDrag], delegate: TabDropDelegate(
-                                    tabManager: tabManager,
-                                    paneManager: paneManager,
-                                    targetPaneID: paneID,
-                                    targetTabID: tab.id,
-                                    hoverTargetTabID: $hoverTargetTabID,
-                                    onReorder: onReorder
-                                ))
                             }
 
                         }
@@ -179,6 +188,22 @@ struct EditorTabBar: View {
                         .padding(.trailing, 8)
                     }
                     .frame(maxHeight: .infinity, alignment: .center)
+                    .contentShape(Rectangle())
+                    .coordinateSpace(name: coordinateSpaceName)
+                    .onPreferenceChange(TabStripFramePreferenceKey.self) { tabFrames = $0 }
+                    .overlay(alignment: .topLeading) {
+                        if let insertionIndicatorX {
+                            TabInsertionIndicator(x: insertionIndicatorX)
+                        }
+                    }
+                    .onDrop(of: [.paneTabDrag], delegate: TabStripDropDelegate(
+                        paneID: paneID,
+                        contentType: .editor,
+                        orderedTabIDs: tabManager.tabs.map(\.id),
+                        frames: tabFrames,
+                        paneManager: paneManager,
+                        onCommit: onReorder
+                    ))
                     .onAppear {
                         if let activeID = tabManager.activeTabID {
                             proxy.scrollTo(activeID, anchor: .center)
@@ -265,79 +290,6 @@ struct EditorTabBar: View {
         // propagate to inline buttons (e.g. `markdownPreviewToggle`).
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier(AccessibilityID.editorTabBar)
-    }
-}
-
-/// Handles drag-to-reorder for editor tabs.
-/// Provides visual feedback via `hoverTargetTabID` and smooth spring animations.
-struct TabDropDelegate: DropDelegate {
-    let tabManager: TabManager
-    let paneManager: PaneManager
-    let targetPaneID: PaneID
-    let targetTabID: UUID
-    @Binding var hoverTargetTabID: UUID?
-    var onReorder: (() -> Void)?
-
-    /// Spring animation matching Safari's tab reordering feel.
-    private static let reorderAnimation: Animation = .spring(response: 0.3, dampingFraction: 0.8)
-
-    /// Resolves whether this item-level delegate should reorder locally or
-    /// leave the drag for the enclosing pane drop delegate.
-    func routingDecision() -> TabItemDropDecision {
-        TabItemDropRouter.decide(
-            drag: paneManager.activeDrag,
-            targetPaneID: targetPaneID,
-            targetContent: .editor
-        )
-    }
-
-    func validateDrop(info: DropInfo) -> Bool {
-        guard info.hasItemsConforming(to: [.paneTabDrag]) else { return false }
-        guard case .localReorder = routingDecision() else { return false }
-        return true
-    }
-
-    /// Applies the local reorder path without requiring a synthetic DropInfo.
-    /// Kept internal so routing and state cleanup can be covered by unit tests.
-    @discardableResult
-    func handleDropEntered(decision: TabItemDropDecision) -> Bool {
-        guard case .localReorder(let draggedTabID) = decision else { return false }
-        guard draggedTabID != targetTabID else { return true }
-        hoverTargetTabID = targetTabID
-        withAnimation(Self.reorderAnimation) {
-            tabManager.reorderTab(draggedID: draggedTabID, targetID: targetTabID)
-        }
-        return true
-    }
-
-    /// Completes a local item-level drop. Deferred pane drops must retain the
-    /// shared drag payload for the enclosing pane delegate.
-    @discardableResult
-    func finishDrop(decision: TabItemDropDecision) -> Bool {
-        guard case .localReorder = decision else { return false }
-        withAnimation(Self.reorderAnimation) {
-            hoverTargetTabID = nil
-        }
-        paneManager.activeDrag = nil
-        onReorder?()
-        return true
-    }
-
-    func performDrop(info: DropInfo) -> Bool {
-        finishDrop(decision: routingDecision())
-    }
-
-    func dropEntered(info: DropInfo) {
-        handleDropEntered(decision: routingDecision())
-    }
-
-    func dropExited(info: DropInfo) {
-        hoverTargetTabID = nil
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        guard case .localReorder = routingDecision() else { return nil }
-        return DropProposal(operation: .move)
     }
 }
 

--- a/Pine/MarkdownPreviewView.swift
+++ b/Pine/MarkdownPreviewView.swift
@@ -8,9 +8,12 @@ import SwiftUI
 /// Renders Markdown content as a read-only attributed string in a scrollable NSTextView.
 struct MarkdownPreviewView: NSViewRepresentable {
     let content: String
+    var focusRequestTabID: UUID?
+    var canAttemptFocusRequest: ((UUID) -> Bool)?
+    var onFocusRequestResult: ((UUID, Bool) -> Void)?
 
-    func makeNSView(context: Context) -> NSScrollView {
-        let scrollView = NSScrollView()
+    func makeNSView(context: Context) -> MarkdownPreviewScrollView {
+        let scrollView = MarkdownPreviewScrollView()
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = false
         scrollView.autohidesScrollers = true
@@ -32,12 +35,26 @@ struct MarkdownPreviewView: NSViewRepresentable {
         scrollView.documentView = textView
         context.coordinator.textView = textView
         context.coordinator.scheduleRender(content: content)
+        scrollView.destinationFocusCoordinator.update(
+            requestID: focusRequestTabID,
+            hostView: scrollView,
+            targetView: textView,
+            canAttempt: canAttemptFocusRequest,
+            onResult: onFocusRequestResult
+        )
 
         return scrollView
     }
 
-    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+    func updateNSView(_ scrollView: MarkdownPreviewScrollView, context: Context) {
         context.coordinator.scheduleRender(content: content)
+        scrollView.destinationFocusCoordinator.update(
+            requestID: focusRequestTabID,
+            hostView: scrollView,
+            targetView: context.coordinator.textView,
+            canAttempt: canAttemptFocusRequest,
+            onResult: onFocusRequestResult
+        )
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -61,5 +78,14 @@ struct MarkdownPreviewView: NSViewRepresentable {
             renderWorkItem = workItem
             DispatchQueue.main.asyncAfter(deadline: .now() + UITimings.Delay.standard, execute: workItem)
         }
+    }
+}
+
+final class MarkdownPreviewScrollView: NSScrollView {
+    let destinationFocusCoordinator = AppKitFocusRequestCoordinator()
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        destinationFocusCoordinator.hostDidMoveToWindow(self)
     }
 }

--- a/Pine/PaneDropZone.swift
+++ b/Pine/PaneDropZone.swift
@@ -119,9 +119,14 @@ struct PaneSplitDropDelegate: DropDelegate {
     let paneManager: PaneManager
     /// Actual pane size from GeometryReader, used for percentage-based drop zone detection.
     let paneSize: CGSize
+    /// Tab strips own this band and pane-body routing must not compete with it.
+    var excludedTopInset: CGFloat = 0
 
     func validateDrop(info: DropInfo) -> Bool {
         guard let payload = payload(for: info) else { return false }
+        if payload == .paneTab, info.location.y < excludedTopInset {
+            return false
+        }
         return routedDropZone(for: payload, proposedZone: .center) != nil
     }
 
@@ -135,6 +140,9 @@ struct PaneSplitDropDelegate: DropDelegate {
               routedDropZone(for: payload, proposedZone: .center) != nil else {
             return nil
         }
+        if payload == .paneTab, paneManager.dropZones[paneID] == nil {
+            return nil
+        }
         let operation: DropOperation = payload == .paneTab ? .move : .copy
         return DropProposal(operation: operation)
     }
@@ -146,14 +154,16 @@ struct PaneSplitDropDelegate: DropDelegate {
     func performDrop(info: DropInfo) -> Bool {
         guard let payload = payload(for: info) else { return false }
 
-        // Snapshot zone and clear ALL overlays before tree mutations.
+        // Snapshot the visual zone. Tab intents must commit before overlays
+        // are cleared because the coordinator owns the preview transaction.
         let savedZone = paneManager.dropZones[paneID]
-        paneManager.clearAllDropZones()
 
         // Pane tab drag takes priority
         if payload == .paneTab {
             return handlePaneTabDrop(zone: savedZone)
         }
+
+        paneManager.clearAllDropZones()
 
         // Sidebar file drag — decode from item providers async
         if payload == .sidebarFile {
@@ -209,54 +219,15 @@ struct PaneSplitDropDelegate: DropDelegate {
         guard let zone = routedDropZone(for: .paneTab, proposedZone: zone) else {
             return false
         }
-
-        // Use synchronous shared drag state instead of async NSItemProvider
-        guard let dragInfo = paneManager.activeDrag else { return false }
-
-        let sourcePaneID = PaneID(id: dragInfo.paneID)
-        let didPerformDrop: Bool
-
-        switch zone {
-        case .left, .right, .top, .bottom:
-            // Edge drop always creates a new pane of matching type
-            let axis: SplitAxis = (zone == .left || zone == .right) ? .horizontal : .vertical
-            let before = (zone == .left || zone == .top)
-            if dragInfo.contentType == .terminal {
-                didPerformDrop = paneManager.splitAndMoveTerminalTab(
-                    tabID: dragInfo.tabID,
-                    from: sourcePaneID,
-                    relativeTo: paneID,
-                    axis: axis,
-                    insertBefore: before
-                ) != nil
-            } else if let fileURL = dragInfo.fileURL {
-                didPerformDrop = paneManager.splitPane(
-                    paneID,
-                    axis: axis,
-                    tabID: dragInfo.tabID,
-                    tabURL: fileURL,
-                    sourcePane: sourcePaneID,
-                    insertBefore: before
-                ) != nil
-            } else {
-                didPerformDrop = false
-            }
-        case .center:
-            // Center drop: same-type moves into the pane;
-            // cross-type triggers an auto-split (issue #714).
-            didPerformDrop = paneManager.performCenterDrop(
-                dragInfo: dragInfo,
-                targetPaneID: paneID
-            )
+        guard paneManager.previewPaneDrop(
+            destinationPaneID: paneID,
+            proposedZone: zone
+        ) != nil else { return false }
+        let didCommit = paneManager.tabDragCoordinator.commitPreview()
+        if didCommit {
+            paneManager.clearAllDropZones()
         }
-
-        // Preserve the shared payload when this delegate rejects the drop so
-        // an ancestor/root target can still handle it. Consume it only after
-        // the corresponding model mutation has actually committed.
-        if didPerformDrop {
-            paneManager.activeDrag = nil
-        }
-        return didPerformDrop
+        return didCommit
     }
 
     private func handleFileDrop(providers: [NSItemProvider]) {
@@ -321,8 +292,22 @@ extension PaneSplitDropDelegate {
         for payload: PaneDropPayload,
         at location: CGPoint
     ) -> PaneDropZone? {
+        if payload == .paneTab, location.y < excludedTopInset {
+            paneManager.dropZones[paneID] = nil
+            paneManager.tabDragCoordinator.clearPreview(destinationPaneID: paneID)
+            return nil
+        }
         let proposedZone = PaneDropZone.zone(for: location, in: paneSize)
-        let zone = routedDropZone(for: payload, proposedZone: proposedZone)
+        let routedZone = routedDropZone(for: payload, proposedZone: proposedZone)
+        let zone: PaneDropZone?
+        if payload == .paneTab, let routedZone {
+            zone = paneManager.previewPaneDrop(
+                destinationPaneID: paneID,
+                proposedZone: routedZone
+            )
+        } else {
+            zone = routedZone
+        }
         paneManager.dropZones[paneID] = zone
         if zone != nil {
             paneManager.startStaleDropPollingIfNeeded()

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -8,6 +8,64 @@
 import SwiftUI
 import UniformTypeIdentifiers
 
+/// Presentation routing also determines which AppKit content view owns a
+/// pending destination-focus request after a tab drag commits.
+enum EditorContentPresentation: Equatable {
+    case codeEditor
+    case quickLook
+    case markdownPreview
+    case markdownSplit
+
+    static func resolve(for tab: EditorTab) -> EditorContentPresentation {
+        switch tab.kind {
+        case .preview:
+            return .quickLook
+        case .text where tab.isMarkdownFile:
+            switch tab.previewMode {
+            case .source:
+                return .codeEditor
+            case .preview:
+                return .markdownPreview
+            case .split:
+                return .markdownSplit
+            }
+        case .text:
+            return .codeEditor
+        }
+    }
+}
+
+/// Keeps pane-body routing consistent with whether a real tab strip exists.
+/// An optional count distinguishes missing backing state from a valid empty
+/// strip: zero tabs still expose the single N=0 insertion gap.
+nonisolated enum PaneLeafTabStripComposition {
+    static func rendersStrip(
+        content: PaneContent,
+        editorTabCount: Int?,
+        terminalTabCount: Int?
+    ) -> Bool {
+        switch content {
+        case .editor:
+            editorTabCount != nil
+        case .terminal:
+            terminalTabCount != nil
+        }
+    }
+
+    static func excludedTopInset(
+        content: PaneContent,
+        editorTabCount: Int?,
+        terminalTabCount: Int?,
+        tabBarHeight: CGFloat
+    ) -> CGFloat {
+        rendersStrip(
+            content: content,
+            editorTabCount: editorTabCount,
+            terminalTabCount: terminalTabCount
+        ) ? tabBarHeight : 0
+    }
+}
+
 /// A single leaf pane showing the editor area with its own tab bar.
 struct PaneLeafView: View {
     let paneID: PaneID
@@ -45,6 +103,14 @@ struct PaneLeafView: View {
     private var tabManager: TabManager? { paneManager.tabManager(for: paneID) }
     private var terminalState: TerminalPaneState? { paneManager.terminalState(for: paneID) }
     private var isActive: Bool { paneManager.activePaneID == paneID }
+    private var tabStripExcludedTopInset: CGFloat {
+        PaneLeafTabStripComposition.excludedTopInset(
+            content: content,
+            editorTabCount: tabManager?.tabs.count,
+            terminalTabCount: terminalState?.terminalTabs.count,
+            tabBarHeight: LayoutMetrics.tabBarHeight
+        )
+    }
 
     var body: some View {
         Group {
@@ -71,7 +137,8 @@ struct PaneLeafView: View {
         .onDrop(of: [.paneTabDrag, .sidebarFileDrag, .fileURL], delegate: PaneSplitDropDelegate(
             paneID: paneID,
             paneManager: paneManager,
-            paneSize: paneSize
+            paneSize: paneSize,
+            excludedTopInset: tabStripExcludedTopInset
         ))
         .border(
             isActive && paneManager.root.leafCount > 1
@@ -182,29 +249,29 @@ struct PaneLeafView: View {
     @ViewBuilder
     private func editorPaneContent(tabManager: TabManager) -> some View {
         VStack(spacing: 0) {
-            if !tabManager.tabs.isEmpty {
-                EditorTabBar(
-                    tabManager: tabManager,
-                    onCloseTab: { tab in
-                        closeTabWithConfirmation(tab, tabManager: tabManager)
-                    },
-                    onCloseOtherTabs: { tabID in
-                        closeOtherTabsWithConfirmation(keeping: tabID, tabManager: tabManager)
-                    },
-                    onCloseTabsToTheRight: { tabID in
-                        closeTabsToTheRightWithConfirmation(of: tabID, tabManager: tabManager)
-                    },
-                    onCloseAllTabs: {
-                        closeAllTabsWithConfirmation(tabManager: tabManager)
-                    },
-                    isMarkdownFile: tabManager.activeTab?.isMarkdownFile ?? false,
-                    previewMode: tabManager.activeTab?.previewMode ?? .source,
-                    onTogglePreview: {
-                        tabManager.togglePreviewMode()
-                    },
-                    overridePaneID: paneID
-                )
-            }
+            // Keep the strip visible at N=0: its full-width surface is the
+            // one valid insertion gap for a tab dragged from another pane.
+            EditorTabBar(
+                tabManager: tabManager,
+                onCloseTab: { tab in
+                    closeTabWithConfirmation(tab, tabManager: tabManager)
+                },
+                onCloseOtherTabs: { tabID in
+                    closeOtherTabsWithConfirmation(keeping: tabID, tabManager: tabManager)
+                },
+                onCloseTabsToTheRight: { tabID in
+                    closeTabsToTheRightWithConfirmation(of: tabID, tabManager: tabManager)
+                },
+                onCloseAllTabs: {
+                    closeAllTabsWithConfirmation(tabManager: tabManager)
+                },
+                isMarkdownFile: tabManager.activeTab?.isMarkdownFile ?? false,
+                previewMode: tabManager.activeTab?.previewMode ?? .source,
+                onTogglePreview: {
+                    tabManager.togglePreviewMode()
+                },
+                overridePaneID: paneID
+            )
 
             if let tab = tabManager.activeTab, let rootURL = workspace.rootURL {
                 BreadcrumbPathBar(
@@ -216,26 +283,49 @@ struct PaneLeafView: View {
 
             if let tab = tabManager.activeTab {
                 Group {
-                    if tab.kind == .preview {
-                        QuickLookPreviewView(url: tab.url)
+                    let focusRequestID = tabManager.pendingFocusTabID == tab.id ? tab.id : nil
+                    switch EditorContentPresentation.resolve(for: tab) {
+                    case .quickLook:
+                        QuickLookPreviewView(
+                            url: tab.url,
+                            focusRequestTabID: focusRequestID,
+                            canAttemptFocusRequest: { tabID in
+                                tabManager.activeTabID == tabID
+                                    && tabManager.pendingFocusTabID == tabID
+                            },
+                            onFocusRequestResult: { tabID, succeeded in
+                                tabManager.acknowledgeFocusRequest(
+                                    for: tabID,
+                                    succeeded: succeeded
+                                )
+                            }
+                        )
                             .accessibilityIdentifier(AccessibilityID.quickLookPreview)
-                    } else if tab.isMarkdownFile {
-                        switch tab.previewMode {
-                        case .source:
+                    case .markdownPreview:
+                        MarkdownPreviewView(
+                            content: tab.content,
+                            focusRequestTabID: focusRequestID,
+                            canAttemptFocusRequest: { tabID in
+                                tabManager.activeTabID == tabID
+                                    && tabManager.pendingFocusTabID == tabID
+                            },
+                            onFocusRequestResult: { tabID, succeeded in
+                                tabManager.acknowledgeFocusRequest(
+                                    for: tabID,
+                                    succeeded: succeeded
+                                )
+                            }
+                        )
+                        .accessibilityIdentifier(AccessibilityID.markdownPreviewView)
+                    case .markdownSplit:
+                        HSplitView {
                             codeEditorView(for: tab, tabManager: tabManager)
-                        case .preview:
+                                .frame(minWidth: 200)
                             MarkdownPreviewView(content: tab.content)
                                 .accessibilityIdentifier(AccessibilityID.markdownPreviewView)
-                        case .split:
-                            HSplitView {
-                                codeEditorView(for: tab, tabManager: tabManager)
-                                    .frame(minWidth: 200)
-                                MarkdownPreviewView(content: tab.content)
-                                    .accessibilityIdentifier(AccessibilityID.markdownPreviewView)
-                                    .frame(minWidth: 200)
-                            }
+                                .frame(minWidth: 200)
                         }
-                    } else {
+                    case .codeEditor:
                         codeEditorView(for: tab, tabManager: tabManager)
                     }
                 }
@@ -295,6 +385,14 @@ struct PaneLeafView: View {
             },
             cachedHighlightResult: tab.cachedHighlightResult,
             goToOffset: goToLineOffset,
+            focusRequestTabID: tabManager.pendingFocusTabID == tab.id ? tab.id : nil,
+            canAttemptFocusRequest: { tabID in
+                tabManager.activeTabID == tabID
+                    && tabManager.pendingFocusTabID == tabID
+            },
+            onFocusRequestResult: { tabID, succeeded in
+                tabManager.acknowledgeFocusRequest(for: tabID, succeeded: succeeded)
+            },
             indentStyle: tab.cachedIndentation,
             fontSize: FontSizeSettings.shared.fontSize
         )

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -48,10 +48,21 @@ final class PaneManager {
     /// The currently focused pane.
     var activePaneID: PaneID
 
-    /// Shared drag state for synchronous tab drag between panes.
-    /// Set by editor and terminal tab drag sources, read by drop delegates.
-    /// Using shared state avoids unreliable async NSItemProvider loading.
-    var activeDrag: TabDragInfo?
+    /// The single owner of tab-drag session, preview, validation, and commit.
+    let tabDragCoordinator: TabDragCoordinator
+
+    /// Compatibility facade for existing cleanup and diagnostics. New drop
+    /// destinations submit intents through `tabDragCoordinator`.
+    var activeDrag: TabDragInfo? {
+        get { tabDragCoordinator.activeDrag }
+        set {
+            if let newValue {
+                tabDragCoordinator.begin(newValue)
+            } else {
+                tabDragCoordinator.cancel()
+            }
+        }
+    }
 
     /// Active drop zone per pane — centralized to avoid stale @State/@Binding issues.
     var dropZones: [PaneID: PaneDropZone] = [:]
@@ -84,6 +95,7 @@ final class PaneManager {
     func clearAllDropZones() {
         dropZones.removeAll()
         rootDropZone = nil
+        tabDragCoordinator.clearPreview()
     }
 
     /// Clears leaf-level drop zone overlays without touching rootDropZone.
@@ -137,19 +149,25 @@ final class PaneManager {
     /// Creates a PaneManager with a single editor pane.
     init() {
         let initialID = PaneID()
+        let coordinator = TabDragCoordinator()
+        self.tabDragCoordinator = coordinator
         self.root = .leaf(initialID, .editor)
         self.activePaneID = initialID
         let tm = TabManager()
         self.tabManagers[initialID] = tm
+        bindTabDragCoordinator(coordinator)
         installMouseUpMonitor()
     }
 
     /// Creates a PaneManager with an existing TabManager (for migration from single-pane).
     init(existingTabManager: TabManager) {
         let initialID = PaneID()
+        let coordinator = TabDragCoordinator()
+        self.tabDragCoordinator = coordinator
         self.root = .leaf(initialID, .editor)
         self.activePaneID = initialID
         self.tabManagers[initialID] = existingTabManager
+        bindTabDragCoordinator(coordinator)
         installMouseUpMonitor()
     }
 
@@ -329,6 +347,24 @@ final class PaneManager {
         transferEditorTab(tabID: tabID, url: tabURL, from: sourceID, to: targetID)
     }
 
+    /// Indexed cross-pane transfer used by an editor strip insertion intent.
+    @discardableResult
+    func moveTabBetweenPanes(
+        tabID: UUID,
+        tabURL: URL? = nil,
+        from sourceID: PaneID,
+        to targetID: PaneID,
+        at insertionIndex: Int
+    ) -> Bool {
+        transferEditorTab(
+            tabID: tabID,
+            url: tabURL,
+            from: sourceID,
+            to: targetID,
+            insertionIndex: insertionIndex
+        )
+    }
+
     // MARK: - Empty editor leaf pruning
 
     /// Removes any editor leaf whose TabManager has no tabs, collapsing the
@@ -503,13 +539,32 @@ final class PaneManager {
 
     @discardableResult
     func moveTerminalTab(_ tabID: UUID, from sourceID: PaneID, to targetID: PaneID) -> Bool {
+        guard let destination = terminalStates[targetID] else { return false }
+        return moveTerminalTab(
+            tabID,
+            from: sourceID,
+            to: targetID,
+            at: destination.terminalTabs.count
+        )
+    }
+
+    /// Atomically inserts a terminal tab at an exact destination gap. Every
+    /// precondition is checked before either source or destination changes.
+    @discardableResult
+    func moveTerminalTab(
+        _ tabID: UUID,
+        from sourceID: PaneID,
+        to targetID: PaneID,
+        at insertionIndex: Int
+    ) -> Bool {
         guard sourceID != targetID,
               let srcState = terminalStates[sourceID],
               let dstState = terminalStates[targetID],
+              (0...dstState.terminalTabs.count).contains(insertionIndex),
               !dstState.terminalTabs.contains(where: { $0.id == tabID }),
               let tab = srcState.terminalTabs.first(where: { $0.id == tabID }) else { return false }
 
-        dstState.terminalTabs.append(tab)
+        dstState.terminalTabs.insert(tab, at: insertionIndex)
         dstState.activeTerminalID = tab.id
         dstState.pendingFocusTabID = tab.id
         srcState.terminalTabs.removeAll { $0.id == tabID }
@@ -710,6 +765,260 @@ final class PaneManager {
         return newPaneID
     }
 
+    // MARK: - Transactional tab drag
+
+    /// Starts a drag and returns the payload stored in the item provider.
+    @discardableResult
+    func beginTabDrag(
+        paneID: PaneID,
+        tabID: UUID,
+        fileURL: URL?,
+        contentType: PaneContent
+    ) -> TabDragInfo {
+        let drag = TabDragInfo(
+            paneID: paneID.id,
+            tabID: tabID,
+            fileURL: fileURL,
+            contentType: contentType
+        )
+        tabDragCoordinator.begin(drag)
+        return drag
+    }
+
+    /// Builds the typed intent for a same-type strip. Cross-type payloads are
+    /// deliberately rejected here so the strip and pane body never compete.
+    func tabStripIntent(
+        destinationPaneID: PaneID,
+        contentType: PaneContent,
+        insertionIndex: Int
+    ) -> TabDropIntent? {
+        guard let drag = activeDrag,
+              drag.contentType == contentType,
+              root.content(for: destinationPaneID) == contentType else { return nil }
+        let key = TabDragKey(drag)
+        if key.sourcePaneID == destinationPaneID {
+            return .reorder(
+                drag: key,
+                destinationPaneID: destinationPaneID,
+                insertionIndex: insertionIndex
+            )
+        }
+        return .insert(
+            drag: key,
+            destinationPaneID: destinationPaneID,
+            insertionIndex: insertionIndex
+        )
+    }
+
+    /// Previews a pane-body destination and returns the zone that should be
+    /// drawn. A cross-type center drop is represented as the bottom split it
+    /// will actually commit, keeping feedback and mutation identical.
+    @discardableResult
+    func previewPaneDrop(
+        destinationPaneID: PaneID,
+        proposedZone: PaneDropZone
+    ) -> PaneDropZone? {
+        guard let drag = activeDrag,
+              let targetContent = root.content(for: destinationPaneID) else {
+            tabDragCoordinator.clearPreview(destinationPaneID: destinationPaneID)
+            return nil
+        }
+
+        let key = TabDragKey(drag)
+        let intent: TabDropIntent
+        let visualZone: PaneDropZone
+        if proposedZone == .center {
+            if drag.contentType == targetContent {
+                intent = .merge(drag: key, destinationPaneID: destinationPaneID)
+                visualZone = .center
+            } else {
+                intent = .leafSplit(
+                    drag: key,
+                    destinationPaneID: destinationPaneID,
+                    zone: .bottom
+                )
+                visualZone = .bottom
+            }
+        } else {
+            intent = .leafSplit(
+                drag: key,
+                destinationPaneID: destinationPaneID,
+                zone: proposedZone
+            )
+            visualZone = proposedZone
+        }
+
+        return tabDragCoordinator.preview(intent) ? visualZone : nil
+    }
+
+    @discardableResult
+    func previewRootDrop(zone: RootDropZone) -> Bool {
+        guard let drag = activeDrag else { return false }
+        return tabDragCoordinator.preview(.rootSplit(drag: TabDragKey(drag), zone: zone))
+    }
+
+    private func bindTabDragCoordinator(_ coordinator: TabDragCoordinator) {
+        coordinator.validateIntent = { [weak self] intent in
+            self?.canCommitTabDrop(intent) == true
+        }
+        coordinator.commitIntent = { [weak self] intent in
+            self?.commitTabDrop(intent) == true
+        }
+    }
+
+    private func canCommitTabDrop(_ intent: TabDropIntent) -> Bool {
+        let key = intent.drag
+        guard root.content(for: key.sourcePaneID) == key.contentType,
+              sourceContainsDraggedTab(key) else { return false }
+
+        switch intent {
+        case .reorder(_, let destinationPaneID, let insertionIndex):
+            guard destinationPaneID == key.sourcePaneID,
+                  root.content(for: destinationPaneID) == key.contentType else { return false }
+            if key.contentType == .editor {
+                return tabManagers[destinationPaneID]?
+                    .canMoveTab(id: key.tabID, toInsertionIndex: insertionIndex)
+                    .accepted == true
+            }
+            return terminalStates[destinationPaneID]?
+                .canMoveTab(id: key.tabID, toInsertionIndex: insertionIndex)
+                .accepted == true
+
+        case .insert(_, let destinationPaneID, let insertionIndex):
+            guard !isMaximized,
+                  destinationPaneID != key.sourcePaneID,
+                  root.content(for: destinationPaneID) == key.contentType else { return false }
+            if key.contentType == .editor {
+                guard let tab = tabManagers[key.sourcePaneID]?.tabs
+                    .first(where: { $0.id == key.tabID }) else { return false }
+                return tabManagers[destinationPaneID]?
+                    .canInsertTransferredTab(tab, at: insertionIndex) == true
+            }
+            guard let destination = terminalStates[destinationPaneID] else { return false }
+            return (0...destination.terminalTabs.count).contains(insertionIndex)
+                && !destination.terminalTabs.contains(where: { $0.id == key.tabID })
+
+        case .merge(_, let destinationPaneID):
+            guard !isMaximized,
+                  destinationPaneID != key.sourcePaneID,
+                  root.content(for: destinationPaneID) == key.contentType else { return false }
+            if key.contentType == .editor {
+                guard let tab = tabManagers[key.sourcePaneID]?.tabs
+                    .first(where: { $0.id == key.tabID }) else { return false }
+                let destination = tabManagers[destinationPaneID]
+                let index = tab.isPinned
+                    ? destination?.pinnedTabCount
+                    : destination?.tabs.count
+                guard let destination, let index else { return false }
+                return destination.canInsertTransferredTab(tab, at: index)
+            }
+            return terminalStates[destinationPaneID]?
+                .terminalTabs.contains(where: { $0.id == key.tabID }) == false
+
+        case .leafSplit(_, let destinationPaneID, let zone):
+            return !isMaximized
+                && zone != .center
+                && root.content(for: destinationPaneID) != nil
+
+        case .rootSplit:
+            return !isMaximized
+                && root.leafCount > 1
+                && key.contentType == .terminal
+        }
+    }
+
+    private func sourceContainsDraggedTab(_ key: TabDragKey) -> Bool {
+        if key.contentType == .editor {
+            return tabManagers[key.sourcePaneID]?.tabs
+                .contains(where: { $0.id == key.tabID }) == true
+        }
+        return terminalStates[key.sourcePaneID]?.terminalTabs
+            .contains(where: { $0.id == key.tabID }) == true
+    }
+
+    private func commitTabDrop(_ intent: TabDropIntent) -> Bool {
+        guard canCommitTabDrop(intent) else { return false }
+        let key = intent.drag
+
+        switch intent {
+        case .reorder(_, let destinationPaneID, let insertionIndex):
+            let result: TabInsertionResult
+            if key.contentType == .editor {
+                result = tabManagers[destinationPaneID]?.moveTab(
+                    id: key.tabID,
+                    toInsertionIndex: insertionIndex
+                ) ?? .rejected
+            } else {
+                result = terminalStates[destinationPaneID]?.moveTab(
+                    id: key.tabID,
+                    toInsertionIndex: insertionIndex
+                ) ?? .rejected
+            }
+            if result.accepted {
+                activePaneID = destinationPaneID
+            }
+            return result.accepted
+
+        case .insert(_, let destinationPaneID, let insertionIndex):
+            if key.contentType == .editor {
+                return moveTabBetweenPanes(
+                    tabID: key.tabID,
+                    from: key.sourcePaneID,
+                    to: destinationPaneID,
+                    at: insertionIndex
+                )
+            }
+            return moveTerminalTab(
+                key.tabID,
+                from: key.sourcePaneID,
+                to: destinationPaneID,
+                at: insertionIndex
+            )
+
+        case .merge(_, let destinationPaneID):
+            if key.contentType == .editor {
+                return moveTabBetweenPanes(
+                    tabID: key.tabID,
+                    from: key.sourcePaneID,
+                    to: destinationPaneID
+                )
+            }
+            return moveTerminalTab(key.tabID, from: key.sourcePaneID, to: destinationPaneID)
+
+        case .leafSplit(_, let destinationPaneID, let zone):
+            let axis: SplitAxis = (zone == .left || zone == .right)
+                ? .horizontal
+                : .vertical
+            let insertBefore = zone == .left || zone == .top
+            if key.contentType == .editor {
+                guard let tab = tabManagers[key.sourcePaneID]?.tabs
+                    .first(where: { $0.id == key.tabID }) else { return false }
+                return splitPane(
+                    destinationPaneID,
+                    axis: axis,
+                    tabID: key.tabID,
+                    tabURL: tab.url,
+                    sourcePane: key.sourcePaneID,
+                    insertBefore: insertBefore
+                ) != nil
+            }
+            return splitAndMoveTerminalTab(
+                tabID: key.tabID,
+                from: key.sourcePaneID,
+                relativeTo: destinationPaneID,
+                axis: axis,
+                insertBefore: insertBefore
+            ) != nil
+
+        case .rootSplit(_, let zone):
+            return wrapRootWithTerminal(
+                at: zone,
+                from: key.sourcePaneID,
+                tabID: key.tabID
+            )
+        }
+    }
+
     // MARK: - Center drop
 
     /// Handles a center-zone tab drop on `targetPaneID`.
@@ -797,17 +1106,21 @@ final class PaneManager {
         tabID: UUID?,
         url: URL?,
         from sourceID: PaneID,
-        to targetID: PaneID
+        to targetID: PaneID,
+        insertionIndex: Int? = nil
     ) -> Bool {
         guard sourceID != targetID,
               let source = tabManagers[sourceID],
               let destination = tabManagers[targetID],
               let resolvedTabID = resolvedEditorTabID(tabID: tabID, url: url, in: source),
-              let tab = source.tabs.first(where: { $0.id == resolvedTabID }),
-              destination.canInsertTransferredTab(tab),
+              let tab = source.tabs.first(where: { $0.id == resolvedTabID }) else { return false }
+
+        let resolvedInsertionIndex = insertionIndex
+            ?? (tab.isPinned ? destination.pinnedTabCount : destination.tabs.count)
+        guard destination.canInsertTransferredTab(tab, at: resolvedInsertionIndex),
               let extraction = source.extractTab(id: resolvedTabID) else { return false }
 
-        guard destination.insertTransferredTab(extraction) else {
+        guard destination.insertTransferredTab(extraction, at: resolvedInsertionIndex) else {
             source.restoreExtractedTab(extraction)
             return false
         }

--- a/Pine/PaneTreeView.swift
+++ b/Pine/PaneTreeView.swift
@@ -13,10 +13,19 @@ import SwiftUI
 /// Recursively renders the PaneNode tree as nested split views.
 struct PaneTreeView: View {
     let node: PaneNode
+    var isRoot = true
     @Environment(PaneManager.self) private var paneManager
     @State private var containerSize: CGSize = .zero
 
     var body: some View {
+        if isRoot {
+            rootDropTarget
+        } else {
+            nodeContent
+        }
+    }
+
+    private var rootDropTarget: some View {
         nodeContent
             .overlay {
                 GeometryReader { geometry in
@@ -73,7 +82,7 @@ struct PaneSplitView: View {
 
             if axis == .horizontal {
                 HStack(spacing: 0) {
-                    PaneTreeView(node: first)
+                    PaneTreeView(node: first, isRoot: false)
                         .frame(width: clampedFirstSize)
 
                     PaneDividerView(
@@ -88,12 +97,12 @@ struct PaneSplitView: View {
                         }
                     )
 
-                    PaneTreeView(node: second)
+                    PaneTreeView(node: second, isRoot: false)
                         .frame(maxWidth: .infinity)
                 }
             } else {
                 VStack(spacing: 0) {
-                    PaneTreeView(node: first)
+                    PaneTreeView(node: first, isRoot: false)
                         .frame(height: clampedFirstSize)
 
                     PaneDividerView(
@@ -108,7 +117,7 @@ struct PaneSplitView: View {
                         }
                     )
 
-                    PaneTreeView(node: second)
+                    PaneTreeView(node: second, isRoot: false)
                         .frame(maxHeight: .infinity)
                 }
             }

--- a/Pine/QuickLookPreviewView.swift
+++ b/Pine/QuickLookPreviewView.swift
@@ -17,15 +17,25 @@ import SwiftUI
 /// embedding the view.
 struct QuickLookPreviewView: NSViewRepresentable {
     let url: URL
+    var focusRequestTabID: UUID?
+    var canAttemptFocusRequest: ((UUID) -> Bool)?
+    var onFocusRequestResult: ((UUID, Bool) -> Void)?
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
     }
 
-    func makeNSView(context: Context) -> QLPreviewView {
+    func makeNSView(context: Context) -> FocusableQuickLookPreviewView {
         // swiftlint:disable:next force_unwrapping
-        let view = QLPreviewView(frame: .zero, style: .normal)!
+        let view = FocusableQuickLookPreviewView(frame: .zero, style: .normal)!
         context.coordinator.currentURL = url
+        view.destinationFocusCoordinator.update(
+            requestID: focusRequestTabID,
+            hostView: view,
+            targetView: view,
+            canAttempt: canAttemptFocusRequest,
+            onResult: onFocusRequestResult
+        )
         // Defer previewItem assignment to the next runloop iteration so the view
         // is fully embedded in the window hierarchy before QuickLookUI attempts
         // its internal overlay/border update (#673).
@@ -38,7 +48,14 @@ struct QuickLookPreviewView: NSViewRepresentable {
         return view
     }
 
-    func updateNSView(_ nsView: QLPreviewView, context: Context) {
+    func updateNSView(_ nsView: FocusableQuickLookPreviewView, context: Context) {
+        nsView.destinationFocusCoordinator.update(
+            requestID: focusRequestTabID,
+            hostView: nsView,
+            targetView: nsView,
+            canAttempt: canAttemptFocusRequest,
+            onResult: onFocusRequestResult
+        )
         // Guard against updating a QLPreviewView that has been closed/deactivated
         // or when the preview item would be nil — prevents crash on tab switching (#618)
         guard nsView.window != nil else { return }
@@ -59,10 +76,27 @@ struct QuickLookPreviewView: NSViewRepresentable {
         }
     }
 
+    static func dismantleNSView(
+        _ nsView: FocusableQuickLookPreviewView,
+        coordinator: Coordinator
+    ) {
+        dismantlePreviewView(nsView, coordinator: coordinator)
+    }
+
+    /// Compatibility overload retained for direct QuickLook lifecycle tests.
     static func dismantleNSView(_ nsView: QLPreviewView, coordinator: Coordinator) {
+        dismantlePreviewView(nsView, coordinator: coordinator)
+    }
+
+    private static func dismantlePreviewView(
+        _ nsView: QLPreviewView,
+        coordinator: Coordinator
+    ) {
         // Increment generation so any pending async blocks from makeNSView/updateNSView
         // see a mismatch and skip the stale previewItem assignment.
         coordinator.generation += 1
+        (nsView as? FocusableQuickLookPreviewView)?
+            .destinationFocusCoordinator.cancel()
         // Clear the preview item before the view is torn down to prevent
         // QuickLookUI from accessing stale internal state during deallocation (#673).
         nsView.previewItem = nil
@@ -75,6 +109,17 @@ struct QuickLookPreviewView: NSViewRepresentable {
     final class Coordinator {
         var currentURL: URL?
         var generation: Int = 0
+    }
+}
+
+final class FocusableQuickLookPreviewView: QLPreviewView {
+    let destinationFocusCoordinator = AppKitFocusRequestCoordinator()
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        destinationFocusCoordinator.hostDidMoveToWindow(self)
     }
 }
 

--- a/Pine/RootDropZone.swift
+++ b/Pine/RootDropZone.swift
@@ -127,6 +127,9 @@ struct RootPaneSplitDropDelegate: DropDelegate {
 
     func dropExited(info: DropInfo) {
         paneManager.rootDropZone = nil
+        if case .rootSplit? = paneManager.tabDragCoordinator.previewIntent {
+            paneManager.tabDragCoordinator.clearPreview()
+        }
     }
 
     func performDrop(info: DropInfo) -> Bool {
@@ -154,9 +157,12 @@ extension RootPaneSplitDropDelegate {
     /// Testable counterpart of the root delegate's hover routing.
     @discardableResult
     func updateRootDropZone(at location: CGPoint) -> RootDropZone? {
-        let zone = canRouteStructuralDrop
+        let detectedZone = canRouteStructuralDrop
             ? RootDropZone.detect(location: location, in: containerSize)
             : nil
+        let zone = detectedZone.flatMap { candidate in
+            paneManager.previewRootDrop(zone: candidate) ? candidate : nil
+        }
         paneManager.rootDropZone = zone
         if zone != nil {
             paneManager.startStaleDropPollingIfNeeded()
@@ -167,21 +173,15 @@ extension RootPaneSplitDropDelegate {
     /// Testable counterpart of `performDrop(info:)`.
     @discardableResult
     func performRootPaneTabDrop(zone: RootDropZone?) -> Bool {
-        paneManager.clearAllDropZones()
         guard canRouteStructuralDrop,
               let zone,
-              let dragInfo = paneManager.activeDrag else {
+              paneManager.previewRootDrop(zone: zone) else {
+            paneManager.rootDropZone = nil
             return false
         }
-
-        let sourcePaneID = PaneID(id: dragInfo.paneID)
-        let didPerformDrop = paneManager.wrapRootWithTerminal(
-            at: zone,
-            from: sourcePaneID,
-            tabID: dragInfo.tabID
-        )
+        let didPerformDrop = paneManager.tabDragCoordinator.commitPreview()
         if didPerformDrop {
-            paneManager.activeDrag = nil
+            paneManager.clearAllDropZones()
         }
         return didPerformDrop
     }

--- a/Pine/TabDragCoordinator.swift
+++ b/Pine/TabDragCoordinator.swift
@@ -1,0 +1,163 @@
+//
+//  TabDragCoordinator.swift
+//  Pine
+//
+//  Transactional intent model shared by editor and terminal tab drags.
+//
+
+import SwiftUI
+
+/// The outcome of moving a tab to an insertion gap.
+enum TabInsertionResult: Equatable, Sendable {
+    case moved
+    case noOp
+    case rejected
+
+    var accepted: Bool { self != .rejected }
+}
+
+/// Stable identity copied from the active drag into every preview intent.
+/// The coordinator rejects intents left behind by an older drag gesture.
+struct TabDragKey: Equatable, Sendable {
+    let dragID: UUID
+    let sourcePaneID: PaneID
+    let tabID: UUID
+    let contentType: PaneContent
+
+    init(_ drag: TabDragInfo) {
+        dragID = drag.dragID
+        sourcePaneID = PaneID(id: drag.paneID)
+        tabID = drag.tabID
+        contentType = drag.contentType
+    }
+}
+
+/// A complete, revalidatable description of the mutation that a drop would
+/// perform. Hover only updates this value; model state changes in `commit`.
+enum TabDropIntent: Equatable, Sendable {
+    /// Move within one strip. `insertionIndex` is one of the N+1 gaps in the
+    /// pre-removal tab array.
+    case reorder(
+        drag: TabDragKey,
+        destinationPaneID: PaneID,
+        insertionIndex: Int
+    )
+    /// Insert into another strip at one of its N+1 gaps.
+    case insert(
+        drag: TabDragKey,
+        destinationPaneID: PaneID,
+        insertionIndex: Int
+    )
+    /// Merge into a pane body using the destination type's default end gap.
+    case merge(drag: TabDragKey, destinationPaneID: PaneID)
+    /// Split one leaf and place the dragged tab in the new pane.
+    case leafSplit(
+        drag: TabDragKey,
+        destinationPaneID: PaneID,
+        zone: PaneDropZone
+    )
+    /// Wrap the complete pane tree at a window edge.
+    case rootSplit(drag: TabDragKey, zone: RootDropZone)
+
+    var drag: TabDragKey {
+        switch self {
+        case .reorder(let drag, _, _),
+             .insert(let drag, _, _),
+             .merge(let drag, _),
+             .leafSplit(let drag, _, _),
+             .rootSplit(let drag, _):
+            drag
+        }
+    }
+}
+
+/// One coordinator owns the full drag session. Drop destinations submit
+/// preview intents; only `commitPreview` may mutate pane/tab models.
+@MainActor
+@Observable
+final class TabDragCoordinator {
+    private(set) var activeDrag: TabDragInfo?
+    private(set) var previewIntent: TabDropIntent?
+
+    @ObservationIgnored
+    var validateIntent: ((TabDropIntent) -> Bool)?
+    @ObservationIgnored
+    var commitIntent: ((TabDropIntent) -> Bool)?
+
+    func begin(_ drag: TabDragInfo) {
+        activeDrag = drag
+        previewIntent = nil
+    }
+
+    @discardableResult
+    func preview(_ intent: TabDropIntent) -> Bool {
+        guard intentBelongsToActiveDrag(intent),
+              validateIntent?(intent) == true else {
+            if previewIntent?.drag.dragID == intent.drag.dragID {
+                previewIntent = nil
+            }
+            return false
+        }
+        previewIntent = intent
+        return true
+    }
+
+    func clearPreview() {
+        previewIntent = nil
+    }
+
+    func clearPreview(destinationPaneID: PaneID) {
+        guard previewIntent?.destinationPaneID == destinationPaneID else { return }
+        previewIntent = nil
+    }
+
+    @discardableResult
+    func commitPreview() -> Bool {
+        guard let intent = previewIntent,
+              intentBelongsToActiveDrag(intent),
+              validateIntent?(intent) == true,
+              commitIntent?(intent) == true else {
+            previewIntent = nil
+            return false
+        }
+        cancel()
+        return true
+    }
+
+    func cancel() {
+        activeDrag = nil
+        previewIntent = nil
+    }
+
+    private func intentBelongsToActiveDrag(_ intent: TabDropIntent) -> Bool {
+        guard let activeDrag else { return false }
+        let key = intent.drag
+        return key.dragID == activeDrag.dragID
+            && key.sourcePaneID.id == activeDrag.paneID
+            && key.tabID == activeDrag.tabID
+            && key.contentType == activeDrag.contentType
+    }
+}
+
+extension TabDropIntent {
+    var destinationPaneID: PaneID? {
+        switch self {
+        case .reorder(_, let destinationPaneID, _),
+             .insert(_, let destinationPaneID, _),
+             .merge(_, let destinationPaneID),
+             .leafSplit(_, let destinationPaneID, _):
+            destinationPaneID
+        case .rootSplit:
+            nil
+        }
+    }
+
+    var insertionIndex: Int? {
+        switch self {
+        case .reorder(_, _, let index), .insert(_, _, let index):
+            index
+        case .merge, .leafSplit, .rootSplit:
+            nil
+        }
+    }
+}

--- a/Pine/TabDragInfo.swift
+++ b/Pine/TabDragInfo.swift
@@ -16,7 +16,10 @@ extension UTType {
 
 /// Information about a tab being dragged between panes.
 /// JSON-encoded for NSItemProvider transport via custom UTType.
-struct TabDragInfo: Codable, Sendable {
+struct TabDragInfo: Codable, Equatable, Sendable {
+    /// Identifies one drag gesture. A fresh value prevents a delayed hover or
+    /// drop callback from committing a newer drag of the same tab.
+    let dragID: UUID
     let paneID: UUID
     let tabID: UUID
     let fileURL: URL?
@@ -54,7 +57,14 @@ struct TabDragInfo: Codable, Sendable {
         return provider
     }
 
-    init(paneID: UUID, tabID: UUID, fileURL: URL? = nil, contentType: PaneContent = .editor) {
+    init(
+        dragID: UUID = UUID(),
+        paneID: UUID,
+        tabID: UUID,
+        fileURL: URL? = nil,
+        contentType: PaneContent = .editor
+    ) {
+        self.dragID = dragID
         self.paneID = paneID
         self.tabID = tabID
         self.fileURL = fileURL
@@ -62,6 +72,7 @@ struct TabDragInfo: Codable, Sendable {
     }
 
     enum CodingKeys: String, CodingKey {
+        case dragID
         case paneID
         case tabID
         case fileURL
@@ -70,39 +81,10 @@ struct TabDragInfo: Codable, Sendable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        dragID = try container.decodeIfPresent(UUID.self, forKey: .dragID) ?? UUID()
         paneID = try container.decode(UUID.self, forKey: .paneID)
         tabID = try container.decode(UUID.self, forKey: .tabID)
         fileURL = try container.decodeIfPresent(URL.self, forKey: .fileURL)
         contentType = try container.decodeIfPresent(PaneContent.self, forKey: .contentType) ?? .editor
-    }
-}
-
-/// Routing decision for the drop destination attached to an individual tab.
-/// Cross-pane drags must bypass that nested destination so the surrounding
-/// pane can handle moving or splitting the tab.
-enum TabItemDropDecision: Equatable {
-    case localReorder(draggedTabID: UUID)
-    case deferToPane
-    case reject
-}
-
-/// Pure routing shared by editor and terminal tab drop delegates.
-nonisolated enum TabItemDropRouter {
-    static func decide(
-        drag: TabDragInfo?,
-        targetPaneID: PaneID,
-        targetContent: PaneContent
-    ) -> TabItemDropDecision {
-        guard let drag else { return .reject }
-
-        guard drag.paneID == targetPaneID.id else {
-            return .deferToPane
-        }
-
-        guard drag.contentType == targetContent else {
-            return .reject
-        }
-
-        return .localReorder(draggedTabID: drag.tabID)
     }
 }

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -30,8 +30,17 @@ final class TabManager {
 
     var tabs: [EditorTab] = []
     var activeTabID: UUID? {
-        didSet { if activeTabID != oldValue { onEditorContextChanged?() } }
+        didSet {
+            guard activeTabID != oldValue else { return }
+            if pendingFocusTabID != activeTabID {
+                pendingFocusTabID = nil
+            }
+            onEditorContextChanged?()
+        }
     }
+    /// Set after a drag commit so the destination content can become first
+    /// responder. It remains pending until AppKit confirms the responder.
+    var pendingFocusTabID: UUID?
     var pendingGoToLine: Int?
     var recoveryManager: RecoveryManager?
     var onEditorContextChanged: (() -> Void)?
@@ -60,6 +69,21 @@ final class TabManager {
     var dirtyTabs: [EditorTab] { TabCollection.dirtyTabs(in: tabs) }
     var isAutoSaveEnabled: Bool { UserDefaults.standard.bool(forKey: Self.autoSaveKey) }
     var pinnedTabCount: Int { TabPinning.pinnedTabCount(in: tabs) }
+
+    /// Acknowledges an AppKit focus attempt for the active destination tab.
+    /// Failed, stale, and off-screen attempts deliberately retain the request
+    /// so a later view update or window-attachment callback can retry it.
+    @discardableResult
+    func acknowledgeFocusRequest(for tabID: UUID, succeeded: Bool) -> Bool {
+        guard pendingFocusTabID == tabID else { return false }
+        guard activeTabID == tabID else {
+            pendingFocusTabID = nil
+            return false
+        }
+        guard succeeded else { return false }
+        pendingFocusTabID = nil
+        return true
+    }
 
     /// A tab temporarily detached from this manager while it is transferred
     /// to another editor pane. The original position and selection make a
@@ -299,7 +323,19 @@ final class TabManager {
     /// Duplicate identities and file URLs are rejected so each pane keeps
     /// the same one-file/one-tab invariant as ``openTab(url:)``.
     func canInsertTransferredTab(_ tab: EditorTab) -> Bool {
-        !tabs.contains { existing in
+        canInsertTransferredTab(tab, at: tab.isPinned ? pinnedTabCount : tabs.count)
+    }
+
+    /// Validates an exact destination gap without changing either manager.
+    /// Pinned tabs may only enter the pinned prefix; regular tabs may only
+    /// enter at or after the shared pinned/unpinned boundary.
+    func canInsertTransferredTab(_ tab: EditorTab, at insertionIndex: Int) -> Bool {
+        guard (0...tabs.count).contains(insertionIndex) else { return false }
+        let respectsPinnedBoundary = tab.isPinned
+            ? insertionIndex <= pinnedTabCount
+            : insertionIndex >= pinnedTabCount
+        guard respectsPinnedBoundary else { return false }
+        return !tabs.contains { existing in
             existing.id == tab.id
                 || existing.url.standardizedFileURL == tab.url.standardizedFileURL
         }
@@ -309,15 +345,17 @@ final class TabManager {
     /// of the pinned prefix; regular tabs are appended after that prefix.
     @discardableResult
     func insertTransferredTab(_ tab: EditorTab) -> Bool {
-        guard canInsertTransferredTab(tab) else { return false }
+        let insertionIndex = tab.isPinned ? pinnedTabCount : tabs.count
+        return insertTransferredTab(tab, at: insertionIndex)
+    }
 
-        if tab.isPinned {
-            let firstUnpinned = tabs.firstIndex(where: { !$0.isPinned }) ?? tabs.endIndex
-            tabs.insert(tab, at: firstUnpinned)
-        } else {
-            tabs.append(tab)
-        }
+    /// Inserts at an exact N+1 gap and activates/focuses the transferred tab.
+    @discardableResult
+    func insertTransferredTab(_ tab: EditorTab, at insertionIndex: Int) -> Bool {
+        guard canInsertTransferredTab(tab, at: insertionIndex) else { return false }
+        tabs.insert(tab, at: insertionIndex)
         activeTabID = tab.id
+        pendingFocusTabID = tab.id
         return true
     }
 
@@ -326,7 +364,14 @@ final class TabManager {
     /// the callback resolves the tab in the manager that now contains it.
     @discardableResult
     func insertTransferredTab(_ extraction: ExtractedTab) -> Bool {
-        guard insertTransferredTab(extraction.tab) else { return false }
+        let insertionIndex = extraction.tab.isPinned ? pinnedTabCount : tabs.count
+        return insertTransferredTab(extraction, at: insertionIndex)
+    }
+
+    /// Indexed counterpart used by cross-pane strip drops.
+    @discardableResult
+    func insertTransferredTab(_ extraction: ExtractedTab, at insertionIndex: Int) -> Bool {
+        guard insertTransferredTab(extraction.tab, at: insertionIndex) else { return false }
         if extraction.shouldResumeAutoSave {
             scheduleAutoSave(for: extraction.tab.id)
         }
@@ -352,6 +397,51 @@ final class TabManager {
 
     func reorderTab(draggedID: UUID, targetID: UUID) {
         TabCollection.reorderTab(draggedID: draggedID, targetID: targetID, in: &tabs)
+    }
+
+    /// Moves a tab to one of the strip's N+1 pre-removal gaps.
+    ///
+    /// Gaps immediately before and after the dragged tab are both no-ops.
+    /// Invalid indices and pinned-boundary crossings are rejected.
+    func canMoveTab(id: UUID, toInsertionIndex insertionIndex: Int) -> TabInsertionResult {
+        guard (0...tabs.count).contains(insertionIndex),
+              let sourceIndex = tabs.firstIndex(where: { $0.id == id }) else {
+            return .rejected
+        }
+
+        let tab = tabs[sourceIndex]
+        let respectsPinnedBoundary = tab.isPinned
+            ? insertionIndex <= pinnedTabCount
+            : insertionIndex >= pinnedTabCount
+        guard respectsPinnedBoundary else { return .rejected }
+
+        let destinationIndex = insertionIndex > sourceIndex
+            ? insertionIndex - 1
+            : insertionIndex
+        return destinationIndex == sourceIndex ? .noOp : .moved
+    }
+
+    @discardableResult
+    func moveTab(id: UUID, toInsertionIndex insertionIndex: Int) -> TabInsertionResult {
+        let validation = canMoveTab(id: id, toInsertionIndex: insertionIndex)
+        guard validation != .rejected,
+              let sourceIndex = tabs.firstIndex(where: { $0.id == id }) else {
+            return .rejected
+        }
+        let destinationIndex = insertionIndex > sourceIndex
+            ? insertionIndex - 1
+            : insertionIndex
+        guard validation == .moved else {
+            activeTabID = id
+            pendingFocusTabID = id
+            return .noOp
+        }
+
+        let movedTab = tabs.remove(at: sourceIndex)
+        tabs.insert(movedTab, at: destinationIndex)
+        activeTabID = id
+        pendingFocusTabID = id
+        return .moved
     }
 
     func togglePin(id: UUID) { TabPinning.togglePin(id: id, in: &tabs) }

--- a/Pine/TabStripDropTarget.swift
+++ b/Pine/TabStripDropTarget.swift
@@ -1,0 +1,141 @@
+//
+//  TabStripDropTarget.swift
+//  Pine
+//
+//  Shared N+1 insertion-gap routing for editor and terminal tab strips.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct TabStripFramePreferenceKey: PreferenceKey {
+    static var defaultValue: [UUID: CGRect] = [:]
+
+    static func reduce(value: inout [UUID: CGRect], nextValue: () -> [UUID: CGRect]) {
+        value.merge(nextValue(), uniquingKeysWith: { _, latest in latest })
+    }
+}
+
+/// Pure geometry used by both strips and unit tests.
+nonisolated enum TabStripInsertionGeometry {
+    static func insertionIndex(
+        atX locationX: CGFloat,
+        orderedTabIDs: [UUID],
+        frames: [UUID: CGRect]
+    ) -> Int? {
+        guard !orderedTabIDs.isEmpty else { return 0 }
+        for (index, tabID) in orderedTabIDs.enumerated() {
+            guard let frame = frames[tabID] else { return nil }
+            if locationX < frame.midX {
+                return index
+            }
+        }
+        return orderedTabIDs.count
+    }
+
+    static func indicatorX(
+        for insertionIndex: Int,
+        orderedTabIDs: [UUID],
+        frames: [UUID: CGRect],
+        emptyLeadingX: CGFloat = 4
+    ) -> CGFloat? {
+        guard (0...orderedTabIDs.count).contains(insertionIndex) else { return nil }
+        guard !orderedTabIDs.isEmpty else { return emptyLeadingX }
+        if insertionIndex == 0 {
+            return frames[orderedTabIDs[0]]?.minX
+        }
+        if insertionIndex == orderedTabIDs.count {
+            return frames[orderedTabIDs[insertionIndex - 1]]?.maxX
+        }
+        guard let previous = frames[orderedTabIDs[insertionIndex - 1]],
+              let next = frames[orderedTabIDs[insertionIndex]] else { return nil }
+        return (previous.maxX + next.minX) / 2
+    }
+}
+
+extension View {
+    func reportTabStripFrame(tabID: UUID, coordinateSpace: String) -> some View {
+        background {
+            GeometryReader { geometry in
+                Color.clear.preference(
+                    key: TabStripFramePreferenceKey.self,
+                    value: [tabID: geometry.frame(in: .named(coordinateSpace))]
+                )
+            }
+        }
+    }
+}
+
+/// A single drop target spans a complete tab strip. Cursor geometry resolves
+/// one of N+1 gaps; hover records only a preview intent.
+struct TabStripDropDelegate: DropDelegate {
+    let paneID: PaneID
+    let contentType: PaneContent
+    let orderedTabIDs: [UUID]
+    let frames: [UUID: CGRect]
+    let paneManager: PaneManager
+    var onCommit: (() -> Void)?
+
+    func validateDrop(info: DropInfo) -> Bool {
+        info.hasItemsConforming(to: [.paneTabDrag])
+            && paneManager.activeDrag?.contentType == contentType
+    }
+
+    func dropEntered(info: DropInfo) {
+        _ = preview(atX: info.location.x)
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        preview(atX: info.location.x)
+            ? DropProposal(operation: .move)
+            : nil
+    }
+
+    func dropExited(info: DropInfo) {
+        paneManager.tabDragCoordinator.clearPreview(destinationPaneID: paneID)
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        guard preview(atX: info.location.x) else { return false }
+        let committed = paneManager.tabDragCoordinator.commitPreview()
+        if committed {
+            paneManager.clearAllDropZones()
+            onCommit?()
+        }
+        return committed
+    }
+
+    /// Testable counterpart of hover callbacks.
+    @discardableResult
+    func preview(atX locationX: CGFloat) -> Bool {
+        guard let insertionIndex = TabStripInsertionGeometry.insertionIndex(
+            atX: locationX,
+            orderedTabIDs: orderedTabIDs,
+            frames: frames
+        ), let intent = paneManager.tabStripIntent(
+            destinationPaneID: paneID,
+            contentType: contentType,
+            insertionIndex: insertionIndex
+        ), paneManager.tabDragCoordinator.preview(intent) else {
+            paneManager.tabDragCoordinator.clearPreview(destinationPaneID: paneID)
+            return false
+        }
+        paneManager.clearLeafDropZones()
+        paneManager.rootDropZone = nil
+        return true
+    }
+}
+
+/// The only mutation feedback rendered by tab strips.
+struct TabInsertionIndicator: View {
+    let x: CGFloat
+
+    var body: some View {
+        Capsule()
+            .fill(Color.accentColor)
+            .frame(width: 3, height: LayoutMetrics.tabBarHeight - 6)
+            .position(x: x, y: LayoutMetrics.tabBarHeight / 2)
+            .allowsHitTesting(false)
+            .accessibilityIdentifier("tabInsertionIndicator")
+    }
+}

--- a/Pine/TerminalPaneState.swift
+++ b/Pine/TerminalPaneState.swift
@@ -12,7 +12,14 @@ import SwiftUI
 @Observable
 final class TerminalPaneState {
     var terminalTabs: [TerminalTab] = []
-    var activeTerminalID: UUID?
+    var activeTerminalID: UUID? {
+        didSet {
+            guard activeTerminalID != oldValue else { return }
+            if pendingFocusTabID != activeTerminalID {
+                pendingFocusTabID = nil
+            }
+        }
+    }
     var pendingFocusTabID: UUID?
 
     /// Monotonically increasing counter for unique terminal tab names.
@@ -28,6 +35,20 @@ final class TerminalPaneState {
     }
 
     var tabCount: Int { terminalTabs.count }
+
+    /// Clears a focus request only after AppKit confirms that the active
+    /// terminal view became first responder.
+    @discardableResult
+    func acknowledgeFocusRequest(for tabID: UUID, succeeded: Bool) -> Bool {
+        guard pendingFocusTabID == tabID else { return false }
+        guard activeTerminalID == tabID else {
+            pendingFocusTabID = nil
+            return false
+        }
+        guard succeeded else { return false }
+        pendingFocusTabID = nil
+        return true
+    }
 
     @discardableResult
     func addTab(workingDirectory: URL?) -> TerminalTab {
@@ -58,6 +79,42 @@ final class TerminalPaneState {
             fromOffsets: IndexSet(integer: fromIndex),
             toOffset: toIndex > fromIndex ? toIndex + 1 : toIndex
         )
+    }
+
+    /// Moves a terminal tab to one of the strip's N+1 pre-removal gaps.
+    func canMoveTab(id: UUID, toInsertionIndex insertionIndex: Int) -> TabInsertionResult {
+        guard (0...terminalTabs.count).contains(insertionIndex),
+              let sourceIndex = terminalTabs.firstIndex(where: { $0.id == id }) else {
+            return .rejected
+        }
+        let destinationIndex = insertionIndex > sourceIndex
+            ? insertionIndex - 1
+            : insertionIndex
+        return destinationIndex == sourceIndex ? .noOp : .moved
+    }
+
+    @discardableResult
+    func moveTab(id: UUID, toInsertionIndex insertionIndex: Int) -> TabInsertionResult {
+        let validation = canMoveTab(id: id, toInsertionIndex: insertionIndex)
+        guard validation != .rejected,
+              let sourceIndex = terminalTabs.firstIndex(where: { $0.id == id }) else {
+            return .rejected
+        }
+
+        let destinationIndex = insertionIndex > sourceIndex
+            ? insertionIndex - 1
+            : insertionIndex
+        guard validation == .moved else {
+            activeTerminalID = id
+            pendingFocusTabID = id
+            return .noOp
+        }
+
+        let tab = terminalTabs.remove(at: sourceIndex)
+        terminalTabs.insert(tab, at: destinationIndex)
+        activeTerminalID = id
+        pendingFocusTabID = id
+        return .moved
     }
 
     func startTabs(workingDirectory: URL?) {

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -14,6 +14,21 @@ struct TerminalPaneTabBar: View {
     let terminalState: TerminalPaneState
     var workingDirectory: URL?
     @Environment(PaneManager.self) private var paneManager
+    @State private var tabFrames: [UUID: CGRect] = [:]
+
+    private var coordinateSpaceName: String { "terminal-tab-strip-\(paneID.id.uuidString)" }
+
+    private var insertionIndicatorX: CGFloat? {
+        guard let intent = paneManager.tabDragCoordinator.previewIntent,
+              intent.destinationPaneID == paneID,
+              intent.drag.contentType == .terminal,
+              let insertionIndex = intent.insertionIndex else { return nil }
+        return TabStripInsertionGeometry.indicatorX(
+            for: insertionIndex,
+            orderedTabIDs: terminalState.terminalTabs.map(\.id),
+            frames: tabFrames
+        )
+    }
 
     private func closeTerminalTabWithConfirmation(_ tab: TerminalTab) {
         guard TabCloseHelper.confirmTerminalProcessStop(tabs: [tab]) else { return }
@@ -26,64 +41,79 @@ struct TerminalPaneTabBar: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 2) {
-                    ForEach(terminalState.terminalTabs) { tab in
-                        let isActive = tab.id == terminalState.activeTerminalID
-                        let isDragged = paneManager.activeDrag.map { drag in
-                            drag.paneID == paneID.id
-                                && drag.tabID == tab.id
-                                && drag.contentType == .terminal
-                        } ?? false
-                        TerminalNativeTabItem(
-                            tab: tab,
-                            isActive: isActive,
-                            canClose: true,
-                            onSelect: {
-                                terminalState.activeTerminalID = tab.id
-                                terminalState.pendingFocusTabID = tab.id
-                            },
-                            onClose: { closeTerminalTabWithConfirmation(tab) }
-                        )
-                        .opacity(isDragged ? 0.4 : 1.0)
-                        .scaleEffect(isDragged ? 0.95 : 1.0)
-                        .transaction { $0.animation = nil }
-                        .onDrag {
-                            let info = TabDragInfo(
-                                paneID: paneID.id,
-                                tabID: tab.id,
-                                fileURL: nil,
-                                contentType: .terminal
+            HStack(spacing: 0) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 2) {
+                        ForEach(terminalState.terminalTabs) { tab in
+                            let isActive = tab.id == terminalState.activeTerminalID
+                            let isDragged = paneManager.activeDrag.map { drag in
+                                drag.paneID == paneID.id
+                                    && drag.tabID == tab.id
+                                    && drag.contentType == .terminal
+                            } ?? false
+                            TerminalNativeTabItem(
+                                tab: tab,
+                                isActive: isActive,
+                                canClose: true,
+                                onSelect: {
+                                    terminalState.activeTerminalID = tab.id
+                                    terminalState.pendingFocusTabID = tab.id
+                                },
+                                onClose: { closeTerminalTabWithConfirmation(tab) }
                             )
-                            paneManager.activeDrag = info
-                            return info.itemProvider()
+                            .opacity(isDragged ? 0.4 : 1.0)
+                            .scaleEffect(isDragged ? 0.95 : 1.0)
+                            .transaction { $0.animation = nil }
+                            .reportTabStripFrame(
+                                tabID: tab.id,
+                                coordinateSpace: coordinateSpaceName
+                            )
+                            .onDrag {
+                                let info = paneManager.beginTabDrag(
+                                    paneID: paneID,
+                                    tabID: tab.id,
+                                    fileURL: nil,
+                                    contentType: .terminal
+                                )
+                                return info.itemProvider()
+                            }
                         }
-                        .onDrop(of: [.paneTabDrag], delegate: TerminalTabDropDelegate(
-                            terminalState: terminalState,
-                            targetTabID: tab.id,
-                            targetPaneID: paneID,
-                            paneManager: paneManager
-                        ))
                     }
+                    .padding(.horizontal, 4)
                 }
-                .padding(.horizontal, 4)
-            }
 
-            // New terminal tab button
-            Button {
-                terminalState.addTab(workingDirectory: workingDirectory)
-            } label: {
-                Image(systemName: "plus")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 24, height: 24)
-            }
-            .buttonStyle(.plain)
-            .help(Strings.newTerminal)
-            .accessibilityIdentifier(AccessibilityID.newTerminalButton)
-            .accessibilityAddTraits(.isButton)
+                // New terminal tab button
+                Button {
+                    terminalState.addTab(workingDirectory: workingDirectory)
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 24, height: 24)
+                }
+                .buttonStyle(.plain)
+                .help(Strings.newTerminal)
+                .accessibilityIdentifier(AccessibilityID.newTerminalButton)
+                .accessibilityAddTraits(.isButton)
 
-            Spacer()
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .contentShape(Rectangle())
+            .coordinateSpace(name: coordinateSpaceName)
+            .onPreferenceChange(TabStripFramePreferenceKey.self) { tabFrames = $0 }
+            .overlay(alignment: .topLeading) {
+                if let insertionIndicatorX {
+                    TabInsertionIndicator(x: insertionIndicatorX)
+                }
+            }
+            .onDrop(of: [.paneTabDrag], delegate: TabStripDropDelegate(
+                paneID: paneID,
+                contentType: .terminal,
+                orderedTabIDs: terminalState.terminalTabs.map(\.id),
+                frames: tabFrames,
+                paneManager: paneManager
+            ))
 
             // Maximize / restore terminal pane
             Button {
@@ -133,65 +163,5 @@ struct TerminalPaneTabBar: View {
         .background(.bar)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier(AccessibilityID.terminalTabBar)
-    }
-}
-
-/// Handles drag-to-reorder for terminal tabs within a pane.
-struct TerminalTabDropDelegate: DropDelegate {
-    let terminalState: TerminalPaneState
-    let targetTabID: UUID
-    let targetPaneID: PaneID
-    let paneManager: PaneManager
-
-    private static let reorderAnimation: Animation = .spring(response: 0.3, dampingFraction: 0.8)
-
-    func validateDrop(info: DropInfo) -> Bool {
-        guard info.hasItemsConforming(to: [.paneTabDrag]) else { return false }
-        guard case .localReorder = routingDecision() else { return false }
-        return true
-    }
-
-    func performDrop(info: DropInfo) -> Bool {
-        finishDrop(decision: routingDecision())
-    }
-
-    func dropEntered(info: DropInfo) {
-        _ = handleDropEntered(decision: routingDecision())
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        guard case .localReorder = routingDecision() else { return nil }
-        return DropProposal(operation: .move)
-    }
-
-    /// Returns whether this tab-local destination should reorder, defer to the
-    /// surrounding pane, or reject the drag entirely.
-    func routingDecision() -> TabItemDropDecision {
-        TabItemDropRouter.decide(
-            drag: paneManager.activeDrag,
-            targetPaneID: targetPaneID,
-            targetContent: .terminal
-        )
-    }
-
-    /// Testable mutation seam for `dropEntered(info:)`.
-    @discardableResult
-    func handleDropEntered(decision: TabItemDropDecision) -> Bool {
-        guard case .localReorder(let draggedTabID) = decision else { return false }
-        guard draggedTabID != targetTabID else { return true }
-        withAnimation(Self.reorderAnimation) {
-            terminalState.reorderTab(draggedID: draggedTabID, targetID: targetTabID)
-        }
-        return true
-    }
-
-    /// Testable completion seam for `performDrop(info:)`.
-    /// Deferred and rejected drops must leave the shared payload untouched so
-    /// an ancestor pane destination can finish the operation.
-    @discardableResult
-    func finishDrop(decision: TabItemDropDecision) -> Bool {
-        guard case .localReorder = decision else { return false }
-        paneManager.activeDrag = nil
-        return true
     }
 }

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -722,6 +722,7 @@ class TerminalContainerView: NSView {
 
     var terminalPaneState: TerminalPaneState?
     private var currentTabID: UUID?
+    let destinationFocusCoordinator = AppKitFocusRequestCoordinator()
     private let scrollInterceptor = TerminalScrollInterceptor()
     private var scrollMonitor: Any?
     private var accumulatedScrollDelta: CGFloat = 0
@@ -777,6 +778,7 @@ class TerminalContainerView: NSView {
             scrollInterceptor.handleActiveTabChange()
             subviews.forEach { $0.removeFromSuperview() }
             currentTabID = nil
+            destinationFocusCoordinator.cancel()
             scrollInterceptor.terminalView = nil
             scrollInterceptor.workingDirectory = nil
             return
@@ -830,11 +832,24 @@ class TerminalContainerView: NSView {
 
         installScrollMonitor()
 
-        // Focus the terminal view when requested by TerminalPaneState
-        if let pending = terminalPaneState?.pendingFocusTabID, pending == tab.id {
-            terminalPaneState?.pendingFocusTabID = nil
-            focusTerminalView(tab.terminalView)
-        }
+        let focusRequestID = terminalPaneState?.pendingFocusTabID == tab.id
+            ? tab.id
+            : nil
+        destinationFocusCoordinator.update(
+            requestID: focusRequestID,
+            hostView: self,
+            targetView: tab.terminalView,
+            canAttempt: { [weak state = terminalPaneState] tabID in
+                state?.activeTerminalID == tabID
+                    && state?.pendingFocusTabID == tabID
+            },
+            onResult: { [weak state = terminalPaneState] tabID, succeeded in
+                state?.acknowledgeFocusRequest(
+                    for: tabID,
+                    succeeded: succeeded
+                )
+            }
+        )
     }
 
     // MARK: - Scroll event monitor for TUI mouse reporting
@@ -1087,20 +1102,9 @@ class TerminalContainerView: NSView {
         recoveryDebouncer?.schedule()
     }
 
-    /// Requests first responder on the terminal view.
-    /// Always deferred via async dispatch so that the focus request lands
-    /// *after* SwiftUI finishes its layout pass — otherwise SwiftUI can
-    /// restore first-responder to the editor's GutterTextView, undoing
-    /// the terminal focus requested by Cmd+T / Cmd+`.
-    private func focusTerminalView(_ terminalView: LocalProcessTerminalView) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            self.window?.makeFirstResponder(terminalView)
-        }
-    }
-
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
+        destinationFocusCoordinator.hostDidMoveToWindow(self)
         // AppKit may call this method multiple times for the same window —
         // skip the observer dance when nothing has actually changed.
         guard window !== observedWindow else { return }

--- a/PineTests/MaximizedPaneDropSafetyTests.swift
+++ b/PineTests/MaximizedPaneDropSafetyTests.swift
@@ -147,18 +147,14 @@ struct MaximizedPaneDropSafetyTests {
             fileURL: first.url,
             contentType: .editor
         )
-        let delegate = TabDropDelegate(
-            tabManager: tabManager,
-            paneManager: manager,
-            targetPaneID: paneID,
-            targetTabID: second.id,
-            hoverTargetTabID: .constant(nil)
-        )
-
-        let decision = delegate.routingDecision()
-        #expect(decision == .localReorder(draggedTabID: first.id))
-        #expect(delegate.handleDropEntered(decision: decision))
-        #expect(delegate.finishDrop(decision: decision))
+        let intent = try #require(manager.tabStripIntent(
+            destinationPaneID: paneID,
+            contentType: .editor,
+            insertionIndex: 2
+        ))
+        #expect(manager.tabDragCoordinator.preview(intent))
+        #expect(tabManager.tabs.map(\.id) == [first.id, second.id])
+        #expect(manager.tabDragCoordinator.commitPreview())
         #expect(tabManager.tabs.map(\.id) == [second.id, first.id])
         #expect(manager.activeDrag == nil)
         #expect(manager.isMaximized)
@@ -178,17 +174,14 @@ struct MaximizedPaneDropSafetyTests {
             tabID: firstID,
             contentType: .terminal
         )
-        let delegate = TerminalTabDropDelegate(
-            terminalState: terminalState,
-            targetTabID: secondID,
-            targetPaneID: terminalPaneID,
-            paneManager: manager
-        )
-
-        let decision = delegate.routingDecision()
-        #expect(decision == .localReorder(draggedTabID: firstID))
-        #expect(delegate.handleDropEntered(decision: decision))
-        #expect(delegate.finishDrop(decision: decision))
+        let intent = try #require(manager.tabStripIntent(
+            destinationPaneID: terminalPaneID,
+            contentType: .terminal,
+            insertionIndex: 2
+        ))
+        #expect(manager.tabDragCoordinator.preview(intent))
+        #expect(terminalState.terminalTabs.map(\.id) == [firstID, secondID])
+        #expect(manager.tabDragCoordinator.commitPreview())
         #expect(terminalState.terminalTabs.map(\.id) == [secondID, firstID])
         #expect(manager.activeDrag == nil)
         #expect(manager.isMaximized)

--- a/PineTests/TabDestinationFocusTests.swift
+++ b/PineTests/TabDestinationFocusTests.swift
@@ -1,0 +1,164 @@
+//
+//  TabDestinationFocusTests.swift
+//  PineTests
+//
+//  Destination presentation and AppKit focus acknowledgement regressions.
+//
+
+import AppKit
+import Foundation
+import QuickLookUI
+import Testing
+
+@testable import Pine
+
+@Suite("Tab Destination Focus")
+@MainActor
+struct TabDestinationFocusTests {
+    @Test("Presentation routing covers Quick Look and rendered Markdown")
+    func previewPresentationRouting() {
+        let quickLook = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/image.png"),
+            kind: .preview
+        )
+        var markdown = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/readme.md"),
+            content: "# Pine",
+            savedContent: "# Pine"
+        )
+
+        #expect(EditorContentPresentation.resolve(for: quickLook) == .quickLook)
+        markdown.previewMode = .preview
+        #expect(EditorContentPresentation.resolve(for: markdown) == .markdownPreview)
+        markdown.previewMode = .split
+        #expect(EditorContentPresentation.resolve(for: markdown) == .markdownSplit)
+        markdown.previewMode = .source
+        #expect(EditorContentPresentation.resolve(for: markdown) == .codeEditor)
+    }
+
+    @Test("Failed attempts retry while switching tabs cancels stale focus")
+    func failedAttemptsRetryAndTabSwitchCancelsStaleFocus() {
+        let manager = TabManager()
+        let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/image.png"), kind: .preview)
+        manager.tabs = [tab]
+        manager.activeTabID = tab.id
+        manager.pendingFocusTabID = tab.id
+
+        #expect(!manager.acknowledgeFocusRequest(for: tab.id, succeeded: false))
+        #expect(manager.pendingFocusTabID == tab.id)
+        #expect(!manager.acknowledgeFocusRequest(for: UUID(), succeeded: true))
+        #expect(manager.pendingFocusTabID == tab.id)
+
+        manager.activeTabID = nil
+        #expect(manager.pendingFocusTabID == nil)
+        #expect(!manager.acknowledgeFocusRequest(for: tab.id, succeeded: true))
+        #expect(manager.pendingFocusTabID == nil)
+    }
+
+    @Test("Detached AppKit destination retries and acknowledges after attachment")
+    func detachedDestinationRetriesAfterWindowAttachment() {
+        let manager = TabManager()
+        let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/readme.md"))
+        manager.tabs = [tab]
+        manager.activeTabID = tab.id
+        manager.pendingFocusTabID = tab.id
+
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let target = FocusAcceptingTestView(frame: host.bounds)
+        host.addSubview(target)
+        let coordinator = AppKitFocusRequestCoordinator()
+        coordinator.update(
+            requestID: tab.id,
+            hostView: host,
+            targetView: target,
+            onResult: { tabID, succeeded in
+                manager.acknowledgeFocusRequest(for: tabID, succeeded: succeeded)
+            }
+        )
+
+        #expect(!coordinator.attemptNow())
+        #expect(coordinator.pendingRequestID == tab.id)
+        #expect(manager.pendingFocusTabID == tab.id)
+
+        let window = NSWindow(
+            contentRect: host.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+
+        #expect(coordinator.attemptNow())
+        #expect(window.firstResponder === target)
+        #expect(coordinator.pendingRequestID == nil)
+        #expect(manager.pendingFocusTabID == nil)
+    }
+
+    @Test("Stale request is cancelled before AppKit can steal focus")
+    func staleRequestDoesNotChangeFirstResponder() {
+        let manager = TabManager()
+        let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/readme.md"))
+        manager.tabs = [tab]
+        manager.activeTabID = tab.id
+        manager.pendingFocusTabID = tab.id
+
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let target = FocusAcceptingTestView(frame: host.bounds)
+        host.addSubview(target)
+        let window = NSWindow(
+            contentRect: host.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        let originalResponder = window.firstResponder
+        let coordinator = AppKitFocusRequestCoordinator()
+        coordinator.update(
+            requestID: tab.id,
+            hostView: host,
+            targetView: target,
+            canAttempt: { tabID in
+                manager.activeTabID == tabID
+                    && manager.pendingFocusTabID == tabID
+            },
+            onResult: { tabID, succeeded in
+                manager.acknowledgeFocusRequest(for: tabID, succeeded: succeeded)
+            }
+        )
+
+        manager.activeTabID = nil
+        #expect(!coordinator.attemptNow())
+        #expect(coordinator.pendingRequestID == nil)
+        #expect(window.firstResponder === originalResponder)
+        #expect(window.firstResponder !== target)
+    }
+
+    @Test("Quick Look focus target is an explicit first responder")
+    func quickLookAcceptsDestinationFocus() throws {
+        let view = try #require(FocusableQuickLookPreviewView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 300),
+            style: .normal
+        ))
+        #expect(view.acceptsFirstResponder)
+    }
+
+    @Test("Terminal focus acknowledgement retries and cancels on active switch")
+    func terminalAcknowledgementRetryAndCancellation() {
+        let state = TerminalPaneState()
+        let first = state.addTab(workingDirectory: nil)
+
+        #expect(!state.acknowledgeFocusRequest(for: first.id, succeeded: false))
+        #expect(state.pendingFocusTabID == first.id)
+
+        let second = state.addTab(workingDirectory: nil)
+        #expect(state.pendingFocusTabID == second.id)
+        state.activeTerminalID = first.id
+        #expect(state.pendingFocusTabID == nil)
+        #expect(!state.acknowledgeFocusRequest(for: second.id, succeeded: true))
+    }
+}
+
+private final class FocusAcceptingTestView: NSView {
+    override var acceptsFirstResponder: Bool { true }
+}

--- a/PineTests/TabDragCoordinatorTests.swift
+++ b/PineTests/TabDragCoordinatorTests.swift
@@ -1,0 +1,564 @@
+//
+//  TabDragCoordinatorTests.swift
+//  PineTests
+//
+//  Transaction, boundary, routing, and focus coverage for issue #1171.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Tab Drag Coordinator")
+@MainActor
+struct TabDragCoordinatorTests {
+    @Test("Editor strip hover is preview-only and commit moves to the last gap")
+    func editorPreviewThenCommit() throws {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        let tabs = [makeEditorTab("a.swift"), makeEditorTab("b.swift"), makeEditorTab("c.swift")]
+        let tabManager = try #require(manager.tabManager(for: paneID))
+        tabManager.tabs = tabs
+        tabManager.activeTabID = tabs[0].id
+        _ = manager.beginTabDrag(
+            paneID: paneID,
+            tabID: tabs[0].id,
+            fileURL: tabs[0].url,
+            contentType: .editor
+        )
+
+        let intent = try #require(manager.tabStripIntent(
+            destinationPaneID: paneID,
+            contentType: .editor,
+            insertionIndex: 3
+        ))
+        #expect(manager.tabDragCoordinator.preview(intent))
+        #expect(tabManager.tabs.map(\.id) == tabs.map(\.id))
+
+        #expect(manager.tabDragCoordinator.commitPreview())
+        #expect(tabManager.tabs.map(\.id) == [tabs[1].id, tabs[2].id, tabs[0].id])
+        #expect(tabManager.activeTabID == tabs[0].id)
+        #expect(tabManager.pendingFocusTabID == tabs[0].id)
+        #expect(manager.activeDrag == nil)
+        #expect(manager.tabDragCoordinator.previewIntent == nil)
+    }
+
+    @Test("Both adjacent gaps are accepted no-ops")
+    func adjacentGapsAreNoOps() throws {
+        for gap in [1, 2] {
+            let manager = PaneManager()
+            let paneID = manager.activePaneID
+            let tabs = [makeEditorTab("a.swift"), makeEditorTab("b.swift"), makeEditorTab("c.swift")]
+            let tabManager = try #require(manager.tabManager(for: paneID))
+            tabManager.tabs = tabs
+            _ = manager.beginTabDrag(
+                paneID: paneID,
+                tabID: tabs[1].id,
+                fileURL: tabs[1].url,
+                contentType: .editor
+            )
+            let intent = try #require(manager.tabStripIntent(
+                destinationPaneID: paneID,
+                contentType: .editor,
+                insertionIndex: gap
+            ))
+
+            #expect(manager.tabDragCoordinator.preview(intent))
+            #expect(manager.tabDragCoordinator.commitPreview())
+            #expect(tabManager.tabs.map(\.id) == tabs.map(\.id))
+            #expect(tabManager.pendingFocusTabID == tabs[1].id)
+        }
+    }
+
+    @Test("Cross-pane editor inserts at first, middle, and last gaps")
+    func editorCrossPaneExactGaps() throws {
+        for insertionIndex in 0...2 {
+            let setup = try makeEditorPanePair()
+            let dragged = setup.source.tabs[0]
+            let kept = setup.source.tabs[1]
+            let originalTarget = setup.target.tabs
+            _ = setup.manager.beginTabDrag(
+                paneID: setup.sourcePaneID,
+                tabID: dragged.id,
+                fileURL: dragged.url,
+                contentType: .editor
+            )
+            let intent = try #require(setup.manager.tabStripIntent(
+                destinationPaneID: setup.targetPaneID,
+                contentType: .editor,
+                insertionIndex: insertionIndex
+            ))
+
+            #expect(setup.manager.tabDragCoordinator.preview(intent))
+            #expect(setup.source.tabs.map(\.id) == [dragged.id, kept.id])
+            #expect(setup.target.tabs.map(\.id) == originalTarget.map(\.id))
+            #expect(setup.manager.tabDragCoordinator.commitPreview())
+
+            var expected = originalTarget.map(\.id)
+            expected.insert(dragged.id, at: insertionIndex)
+            #expect(setup.target.tabs.map(\.id) == expected)
+            #expect(setup.source.tabs.map(\.id) == [kept.id])
+            #expect(setup.target.activeTabID == dragged.id)
+            #expect(setup.target.pendingFocusTabID == dragged.id)
+            #expect(setup.manager.activePaneID == setup.targetPaneID)
+        }
+    }
+
+    @Test("Pinned and regular tabs cannot cross their boundary")
+    func pinnedBoundaryRejectsInvalidGaps() throws {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        let pinnedA = makeEditorTab("pinned-a.swift", pinned: true)
+        let pinnedB = makeEditorTab("pinned-b.swift", pinned: true)
+        let regularA = makeEditorTab("regular-a.swift")
+        let regularB = makeEditorTab("regular-b.swift")
+        let tabManager = try #require(manager.tabManager(for: paneID))
+        tabManager.tabs = [pinnedA, pinnedB, regularA, regularB]
+
+        _ = manager.beginTabDrag(
+            paneID: paneID,
+            tabID: pinnedA.id,
+            fileURL: pinnedA.url,
+            contentType: .editor
+        )
+        let pinnedIntent = try #require(manager.tabStripIntent(
+            destinationPaneID: paneID,
+            contentType: .editor,
+            insertionIndex: 3
+        ))
+        #expect(!manager.tabDragCoordinator.preview(pinnedIntent))
+
+        _ = manager.beginTabDrag(
+            paneID: paneID,
+            tabID: regularB.id,
+            fileURL: regularB.url,
+            contentType: .editor
+        )
+        let regularIntent = try #require(manager.tabStripIntent(
+            destinationPaneID: paneID,
+            contentType: .editor,
+            insertionIndex: 1
+        ))
+        #expect(!manager.tabDragCoordinator.preview(regularIntent))
+        #expect(tabManager.tabs.map(\.id) == [pinnedA.id, pinnedB.id, regularA.id, regularB.id])
+    }
+
+    @Test("Shared pinned boundary accepts either tab class")
+    func pinnedBoundaryAcceptsBothClasses() throws {
+        do {
+            let setup = try makeEditorPanePair(
+                sourceTabs: [
+                    makeEditorTab("dragged-pinned.swift", pinned: true),
+                    makeEditorTab("kept.swift")
+                ],
+                targetTabs: [
+                    makeEditorTab("target-pinned.swift", pinned: true),
+                    makeEditorTab("target.swift")
+                ]
+            )
+            let dragged = setup.source.tabs[0]
+            let targetPinned = setup.target.tabs[0]
+            let targetRegular = setup.target.tabs[1]
+            try previewAndCommitEditorInsert(setup: setup, dragged: dragged, insertionIndex: 1)
+            #expect(setup.target.tabs.map(\.id) == [
+                targetPinned.id, dragged.id, targetRegular.id
+            ])
+        }
+
+        do {
+            let setup = try makeEditorPanePair(
+                sourceTabs: [
+                    makeEditorTab("kept-pinned.swift", pinned: true),
+                    makeEditorTab("dragged.swift")
+                ],
+                targetTabs: [
+                    makeEditorTab("target-pinned.swift", pinned: true),
+                    makeEditorTab("target.swift")
+                ]
+            )
+            let dragged = setup.source.tabs[1]
+            let targetPinned = setup.target.tabs[0]
+            let targetRegular = setup.target.tabs[1]
+            try previewAndCommitEditorInsert(setup: setup, dragged: dragged, insertionIndex: 1)
+            #expect(setup.target.tabs.map(\.id) == [
+                targetPinned.id, dragged.id, targetRegular.id
+            ])
+        }
+    }
+
+    @Test("A new drag invalidates an old intent with the same tab identity")
+    func staleDragIDIsRejected() throws {
+        let manager = PaneManager()
+        let paneID = manager.activePaneID
+        let tabs = [makeEditorTab("a.swift"), makeEditorTab("b.swift")]
+        let tabManager = try #require(manager.tabManager(for: paneID))
+        tabManager.tabs = tabs
+        _ = manager.beginTabDrag(
+            paneID: paneID,
+            tabID: tabs[0].id,
+            fileURL: tabs[0].url,
+            contentType: .editor
+        )
+        let staleIntent = try #require(manager.tabStripIntent(
+            destinationPaneID: paneID,
+            contentType: .editor,
+            insertionIndex: 2
+        ))
+        #expect(manager.tabDragCoordinator.preview(staleIntent))
+
+        let newDrag = manager.beginTabDrag(
+            paneID: paneID,
+            tabID: tabs[0].id,
+            fileURL: tabs[0].url,
+            contentType: .editor
+        )
+        #expect(!manager.tabDragCoordinator.preview(staleIntent))
+        #expect(!manager.tabDragCoordinator.commitPreview())
+        #expect(manager.activeDrag?.dragID == newDrag.dragID)
+        #expect(tabManager.tabs.map(\.id) == tabs.map(\.id))
+    }
+
+    @Test("Commit revalidates destination and never extracts on failure")
+    func atomicCommitRevalidation() throws {
+        let setup = try makeEditorPanePair()
+        let dragged = setup.source.tabs[0]
+        _ = setup.manager.beginTabDrag(
+            paneID: setup.sourcePaneID,
+            tabID: dragged.id,
+            fileURL: dragged.url,
+            contentType: .editor
+        )
+        let intent = try #require(setup.manager.tabStripIntent(
+            destinationPaneID: setup.targetPaneID,
+            contentType: .editor,
+            insertionIndex: 0
+        ))
+        #expect(setup.manager.tabDragCoordinator.preview(intent))
+
+        setup.target.tabs.insert(
+            EditorTab(url: dragged.url, content: "duplicate", savedContent: "duplicate"),
+            at: 0
+        )
+        let sourceBeforeCommit = setup.source.tabs.map(\.id)
+        let targetBeforeCommit = setup.target.tabs.map(\.id)
+        #expect(!setup.manager.tabDragCoordinator.commitPreview())
+        #expect(setup.source.tabs.map(\.id) == sourceBeforeCommit)
+        #expect(setup.target.tabs.map(\.id) == targetBeforeCommit)
+        #expect(setup.manager.activeDrag?.tabID == dragged.id)
+    }
+
+    @Test("Terminal strips use the same preview and indexed commit path")
+    func terminalPreviewAndIndexedCommit() throws {
+        let manager = PaneManager()
+        let sourcePaneID = manager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let source = try #require(manager.terminalState(for: sourcePaneID))
+        let dragged = try #require(source.terminalTabs.first)
+        let kept = source.addTab(workingDirectory: nil)
+        let targetPaneID = try #require(manager.createTerminalPane(
+            relativeTo: sourcePaneID,
+            axis: .horizontal,
+            workingDirectory: nil
+        ))
+        let target = try #require(manager.terminalState(for: targetPaneID))
+        let originalTarget = try #require(target.terminalTabs.first)
+
+        _ = manager.beginTabDrag(
+            paneID: sourcePaneID,
+            tabID: dragged.id,
+            fileURL: nil,
+            contentType: .terminal
+        )
+        let intent = try #require(manager.tabStripIntent(
+            destinationPaneID: targetPaneID,
+            contentType: .terminal,
+            insertionIndex: 0
+        ))
+        #expect(manager.tabDragCoordinator.preview(intent))
+        #expect(source.terminalTabs.map(\.id) == [dragged.id, kept.id])
+        #expect(target.terminalTabs.map(\.id) == [originalTarget.id])
+
+        #expect(manager.tabDragCoordinator.commitPreview())
+        #expect(source.terminalTabs.map(\.id) == [kept.id])
+        #expect(target.terminalTabs.map(\.id) == [dragged.id, originalTarget.id])
+        #expect(target.activeTerminalID == dragged.id)
+        #expect(target.pendingFocusTabID == dragged.id)
+    }
+
+    @Test("Cross-type center preview shows and commits the actual bottom split")
+    func crossTypeCenterMatchesPreview() throws {
+        let manager = PaneManager()
+        let sourcePaneID = manager.activePaneID
+        let source = try #require(manager.tabManager(for: sourcePaneID))
+        let dragged = makeEditorTab("dragged.swift")
+        let kept = makeEditorTab("kept.swift")
+        source.tabs = [dragged, kept]
+        let terminalPaneID = manager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let leafCountBefore = manager.root.leafCount
+
+        _ = manager.beginTabDrag(
+            paneID: sourcePaneID,
+            tabID: dragged.id,
+            fileURL: dragged.url,
+            contentType: .editor
+        )
+        #expect(manager.previewPaneDrop(
+            destinationPaneID: terminalPaneID,
+            proposedZone: .center
+        ) == .bottom)
+        guard case .leafSplit(_, let previewTarget, let previewZone)? =
+            manager.tabDragCoordinator.previewIntent else {
+            Issue.record("Expected leaf split preview")
+            return
+        }
+        #expect(previewTarget == terminalPaneID)
+        #expect(previewZone == .bottom)
+        #expect(manager.root.leafCount == leafCountBefore)
+        #expect(source.tabs.map(\.id) == [dragged.id, kept.id])
+
+        #expect(manager.tabDragCoordinator.commitPreview())
+        #expect(manager.root.leafCount == leafCountBefore + 1)
+        let destinationPaneID = manager.activePaneID
+        let destination = try #require(manager.tabManager(for: destinationPaneID))
+        #expect(destination.tabs.map(\.id) == [dragged.id])
+        #expect(destination.pendingFocusTabID == dragged.id)
+        #expect(source.tabs.map(\.id) == [kept.id])
+    }
+
+    @Test("Pane body excludes the tab strip routing band")
+    func stripAndBodyRoutingDoNotOverlap() throws {
+        let setup = try makeEditorPanePair()
+        let dragged = setup.source.tabs[0]
+        _ = setup.manager.beginTabDrag(
+            paneID: setup.sourcePaneID,
+            tabID: dragged.id,
+            fileURL: dragged.url,
+            contentType: .editor
+        )
+        let delegate = PaneSplitDropDelegate(
+            paneID: setup.targetPaneID,
+            paneManager: setup.manager,
+            paneSize: CGSize(width: 400, height: 300),
+            excludedTopInset: 30
+        )
+
+        #expect(delegate.updateDropZone(
+            for: .paneTab,
+            at: CGPoint(x: 200, y: 10)
+        ) == nil)
+        #expect(setup.manager.tabDragCoordinator.previewIntent == nil)
+        #expect(delegate.updateDropZone(
+            for: .paneTab,
+            at: CGPoint(x: 200, y: 150)
+        ) == .center)
+        #expect(setup.source.tabs.count == 2)
+        #expect(setup.target.tabs.count == 2)
+    }
+
+    @Test("Empty editor pane exposes and commits its single strip gap")
+    func emptyEditorPaneInsertionGap() throws {
+        let manager = PaneManager()
+        let sourcePaneID = manager.activePaneID
+        let source = try #require(manager.tabManager(for: sourcePaneID))
+        let dragged = makeEditorTab("dragged.swift")
+        let kept = makeEditorTab("kept.swift")
+        source.tabs = [dragged, kept]
+        source.activeTabID = dragged.id
+
+        let targetPaneID = try #require(manager.splitPane(sourcePaneID, axis: .horizontal))
+        let target = try #require(manager.tabManager(for: targetPaneID))
+        #expect(target.tabs.isEmpty)
+        #expect(PaneLeafTabStripComposition.rendersStrip(
+            content: .editor,
+            editorTabCount: target.tabs.count,
+            terminalTabCount: nil
+        ))
+        #expect(PaneLeafTabStripComposition.excludedTopInset(
+            content: .editor,
+            editorTabCount: target.tabs.count,
+            terminalTabCount: nil,
+            tabBarHeight: 30
+        ) == 30)
+
+        let insertionIndex = try #require(TabStripInsertionGeometry.insertionIndex(
+            atX: 200,
+            orderedTabIDs: [],
+            frames: [:]
+        ))
+        #expect(insertionIndex == 0)
+        _ = manager.beginTabDrag(
+            paneID: sourcePaneID,
+            tabID: dragged.id,
+            fileURL: dragged.url,
+            contentType: .editor
+        )
+        let bodyDelegate = PaneSplitDropDelegate(
+            paneID: targetPaneID,
+            paneManager: manager,
+            paneSize: CGSize(width: 400, height: 300),
+            excludedTopInset: 30
+        )
+        #expect(bodyDelegate.updateDropZone(
+            for: .paneTab,
+            at: CGPoint(x: 200, y: 10)
+        ) == nil)
+        let stripDelegate = TabStripDropDelegate(
+            paneID: targetPaneID,
+            contentType: .editor,
+            orderedTabIDs: [],
+            frames: [:],
+            paneManager: manager
+        )
+
+        #expect(stripDelegate.preview(atX: 200))
+        #expect(manager.tabDragCoordinator.previewIntent?.insertionIndex == insertionIndex)
+        #expect(target.tabs.isEmpty)
+        #expect(manager.tabDragCoordinator.commitPreview())
+        #expect(target.tabs.map(\.id) == [dragged.id])
+        #expect(source.tabs.map(\.id) == [kept.id])
+    }
+
+    @Test("Empty terminal pane exposes and commits its single strip gap")
+    func emptyTerminalPaneInsertionGap() throws {
+        let manager = PaneManager()
+        let sourcePaneID = manager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let source = try #require(manager.terminalState(for: sourcePaneID))
+        let dragged = try #require(source.terminalTabs.first)
+        let kept = source.addTab(workingDirectory: nil)
+        let targetPaneID = try #require(manager.createTerminalPane(
+            relativeTo: sourcePaneID,
+            axis: .horizontal,
+            workingDirectory: nil
+        ))
+        let target = try #require(manager.terminalState(for: targetPaneID))
+        target.terminalTabs.removeAll()
+        target.activeTerminalID = nil
+
+        #expect(PaneLeafTabStripComposition.rendersStrip(
+            content: .terminal,
+            editorTabCount: nil,
+            terminalTabCount: target.terminalTabs.count
+        ))
+        #expect(PaneLeafTabStripComposition.excludedTopInset(
+            content: .terminal,
+            editorTabCount: nil,
+            terminalTabCount: target.terminalTabs.count,
+            tabBarHeight: 30
+        ) == 30)
+
+        _ = manager.beginTabDrag(
+            paneID: sourcePaneID,
+            tabID: dragged.id,
+            fileURL: nil,
+            contentType: .terminal
+        )
+        let bodyDelegate = PaneSplitDropDelegate(
+            paneID: targetPaneID,
+            paneManager: manager,
+            paneSize: CGSize(width: 400, height: 300),
+            excludedTopInset: 30
+        )
+        #expect(bodyDelegate.updateDropZone(
+            for: .paneTab,
+            at: CGPoint(x: 200, y: 10)
+        ) == nil)
+        let stripDelegate = TabStripDropDelegate(
+            paneID: targetPaneID,
+            contentType: .terminal,
+            orderedTabIDs: [],
+            frames: [:],
+            paneManager: manager
+        )
+
+        #expect(stripDelegate.preview(atX: 200))
+        #expect(manager.tabDragCoordinator.previewIntent?.insertionIndex == 0)
+        #expect(target.terminalTabs.isEmpty)
+        #expect(manager.tabDragCoordinator.commitPreview())
+        #expect(target.terminalTabs.map(\.id) == [dragged.id])
+        #expect(source.terminalTabs.map(\.id) == [kept.id])
+    }
+
+    @Test("Missing backing state does not reserve a dead strip band")
+    func missingBackingStateHasNoExcludedInset() {
+        #expect(!PaneLeafTabStripComposition.rendersStrip(
+            content: .editor,
+            editorTabCount: nil,
+            terminalTabCount: nil
+        ))
+        #expect(PaneLeafTabStripComposition.excludedTopInset(
+            content: .editor,
+            editorTabCount: nil,
+            terminalTabCount: nil,
+            tabBarHeight: 30
+        ) == 0)
+    }
+
+    private struct EditorPanePair {
+        let manager: PaneManager
+        let sourcePaneID: PaneID
+        let targetPaneID: PaneID
+        let source: TabManager
+        let target: TabManager
+    }
+
+    private func makeEditorPanePair(
+        sourceTabs: [EditorTab]? = nil,
+        targetTabs: [EditorTab]? = nil
+    ) throws -> EditorPanePair {
+        let resolvedSourceTabs = sourceTabs ?? [
+            makeEditorTab("source.swift"),
+            makeEditorTab("kept.swift")
+        ]
+        let resolvedTargetTabs = targetTabs ?? [
+            makeEditorTab("target-a.swift"),
+            makeEditorTab("target-b.swift")
+        ]
+        let manager = PaneManager()
+        let sourcePaneID = manager.activePaneID
+        let source = try #require(manager.tabManager(for: sourcePaneID))
+        source.tabs = resolvedSourceTabs
+        source.activeTabID = resolvedSourceTabs.first?.id
+        let targetPaneID = try #require(manager.splitPane(sourcePaneID, axis: .horizontal))
+        let target = try #require(manager.tabManager(for: targetPaneID))
+        target.tabs = resolvedTargetTabs
+        target.activeTabID = resolvedTargetTabs.first?.id
+        return EditorPanePair(
+            manager: manager,
+            sourcePaneID: sourcePaneID,
+            targetPaneID: targetPaneID,
+            source: source,
+            target: target
+        )
+    }
+
+    private func previewAndCommitEditorInsert(
+        setup: EditorPanePair,
+        dragged: EditorTab,
+        insertionIndex: Int
+    ) throws {
+        _ = setup.manager.beginTabDrag(
+            paneID: setup.sourcePaneID,
+            tabID: dragged.id,
+            fileURL: dragged.url,
+            contentType: .editor
+        )
+        let intent = try #require(setup.manager.tabStripIntent(
+            destinationPaneID: setup.targetPaneID,
+            contentType: .editor,
+            insertionIndex: insertionIndex
+        ))
+        #expect(setup.manager.tabDragCoordinator.preview(intent))
+        #expect(setup.manager.tabDragCoordinator.commitPreview())
+    }
+
+    private func makeEditorTab(_ name: String, pinned: Bool = false) -> EditorTab {
+        var tab = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/\(UUID().uuidString)-\(name)"),
+            content: name,
+            savedContent: name
+        )
+        tab.isPinned = pinned
+        return tab
+    }
+}

--- a/PineTests/TabDragInteractionTests.swift
+++ b/PineTests/TabDragInteractionTests.swift
@@ -2,12 +2,11 @@
 //  TabDragInteractionTests.swift
 //  PineTests
 //
-//  Deterministic coverage for tab hit geometry and nested drop routing.
+//  Deterministic coverage for tab hit and insertion-gap geometry.
 //
 
 import CoreGraphics
 import Foundation
-import SwiftUI
 import Testing
 
 @testable import Pine
@@ -18,7 +17,7 @@ struct TabSlotHitTestingTests {
     private let epsilon: CGFloat = 0.001
     private let glyphFrame = CGRect(x: 58, y: 8, width: 14, height: 14)
 
-    @Test("Close target expands the visible glyph by the configured hit slop")
+    @Test("Close target expands the glyph by configured hit slop")
     func closeTargetUsesConfiguredGeometry() {
         let rect = TabSlotHitTesting.closeRect(for: glyphFrame)
         let expectedHitSize = TabSlotHitTesting.closeGlyphSize
@@ -33,7 +32,7 @@ struct TabSlotHitTestingTests {
         #expect(rect.height == expectedHitSize)
     }
 
-    @Test("Close target follows the measured glyph anywhere in a flexible tab")
+    @Test("Close target follows measured glyph in flexible tabs")
     func closeTargetFollowsMeasuredGlyph() {
         let frames = [
             CGRect(x: 10, y: 8, width: 14, height: 14),
@@ -48,7 +47,7 @@ struct TabSlotHitTestingTests {
         }
     }
 
-    @Test("Points immediately inside every close-target boundary close the tab")
+    @Test("Points immediately inside every close boundary close")
     func insideCloseTargetBoundariesClose() {
         let rect = TabSlotHitTesting.closeRect(for: glyphFrame)
         let points = [
@@ -69,7 +68,7 @@ struct TabSlotHitTestingTests {
         }
     }
 
-    @Test("Points immediately outside every close-target boundary select the tab")
+    @Test("Points immediately outside every close boundary select")
     func outsideCloseTargetBoundariesSelect() {
         let rect = TabSlotHitTesting.closeRect(for: glyphFrame)
         let points = [
@@ -88,7 +87,7 @@ struct TabSlotHitTestingTests {
         }
     }
 
-    @Test("Upper, lower, and trailing slot padding select the tab")
+    @Test("Upper, lower, and trailing slot padding select")
     func slotPaddingSelects() {
         let closeRect = TabSlotHitTesting.closeRect(for: glyphFrame)
         let points = [
@@ -106,7 +105,7 @@ struct TabSlotHitTestingTests {
         }
     }
 
-    @Test("Tabs that cannot close always select, including over the close target")
+    @Test("Tabs that cannot close always select")
     func cannotCloseAlwaysSelects() {
         let rect = TabSlotHitTesting.closeRect(for: glyphFrame)
         let points = [
@@ -124,7 +123,7 @@ struct TabSlotHitTestingTests {
         }
     }
 
-    @Test("Missing glyph measurement cannot accidentally close a tab")
+    @Test("Missing glyph measurement cannot close a tab")
     func missingGlyphMeasurementSelects() {
         #expect(TabSlotHitTesting.target(
             at: CGPoint(x: 10, y: slotHeight / 2),
@@ -134,408 +133,79 @@ struct TabSlotHitTestingTests {
     }
 }
 
-@Suite("Tab Item Drop Routing")
-struct TabItemDropRouterTests {
-    @Test("Missing shared drag state is rejected")
-    func missingDragIsRejected() {
-        let decision = TabItemDropRouter.decide(
-            drag: nil,
-            targetPaneID: PaneID(),
-            targetContent: .editor
-        )
+@Suite("Tab Strip N+1 Geometry")
+struct TabStripInsertionGeometryTests {
+    private let ids = [UUID(), UUID(), UUID()]
 
-        #expect(decision == .reject)
+    private var frames: [UUID: CGRect] {
+        [
+            ids[0]: CGRect(x: 4, y: 0, width: 80, height: 30),
+            ids[1]: CGRect(x: 86, y: 0, width: 120, height: 30),
+            ids[2]: CGRect(x: 208, y: 0, width: 60, height: 30)
+        ]
     }
 
-    @Test("Editor drag in its source editor pane reorders locally")
-    func localEditorDragReorders() {
-        let paneID = PaneID()
-        let tabID = UUID()
-        let drag = makeDrag(paneID: paneID, tabID: tabID, content: .editor)
-
-        let decision = TabItemDropRouter.decide(
-            drag: drag,
-            targetPaneID: paneID,
-            targetContent: .editor
-        )
-
-        #expect(decision == .localReorder(draggedTabID: tabID))
+    @Test("Empty strip has exactly one insertion gap")
+    func emptyStrip() {
+        #expect(TabStripInsertionGeometry.insertionIndex(
+            atX: 500,
+            orderedTabIDs: [],
+            frames: [:]
+        ) == 0)
+        #expect(TabStripInsertionGeometry.indicatorX(
+            for: 0,
+            orderedTabIDs: [],
+            frames: [:]
+        ) == 4)
     }
 
-    @Test("Terminal drag in its source terminal pane reorders locally")
-    func localTerminalDragReorders() {
-        let paneID = PaneID()
-        let tabID = UUID()
-        let drag = makeDrag(paneID: paneID, tabID: tabID, content: .terminal)
-
-        let decision = TabItemDropRouter.decide(
-            drag: drag,
-            targetPaneID: paneID,
-            targetContent: .terminal
-        )
-
-        #expect(decision == .localReorder(draggedTabID: tabID))
+    @Test(
+        "Cursor resolves first, middle, and last gaps",
+        arguments: [
+            (CGFloat(0), 0),
+            (CGFloat(60), 1),
+            (CGFloat(150), 2),
+            (CGFloat(500), 3)
+        ]
+    )
+    func gapResolution(locationX: CGFloat, expectedIndex: Int) {
+        #expect(TabStripInsertionGeometry.insertionIndex(
+            atX: locationX,
+            orderedTabIDs: ids,
+            frames: frames
+        ) == expectedIndex)
     }
 
-    @Test("Editor drag targeting another editor pane defers to the pane delegate")
-    func crossPaneEditorDragDefers() {
-        let drag = makeDrag(paneID: PaneID(), content: .editor)
-
-        let decision = TabItemDropRouter.decide(
-            drag: drag,
-            targetPaneID: PaneID(),
-            targetContent: .editor
-        )
-
-        #expect(decision == .deferToPane)
+    @Test("Indicator uses tab edges and spacing midpoints")
+    func indicatorPositions() {
+        #expect(TabStripInsertionGeometry.indicatorX(
+            for: 0,
+            orderedTabIDs: ids,
+            frames: frames
+        ) == 4)
+        #expect(TabStripInsertionGeometry.indicatorX(
+            for: 1,
+            orderedTabIDs: ids,
+            frames: frames
+        ) == 85)
+        #expect(TabStripInsertionGeometry.indicatorX(
+            for: 3,
+            orderedTabIDs: ids,
+            frames: frames
+        ) == 268)
     }
 
-    @Test("Terminal drag targeting another terminal pane defers to the pane delegate")
-    func crossPaneTerminalDragDefers() {
-        let drag = makeDrag(paneID: PaneID(), content: .terminal)
-
-        let decision = TabItemDropRouter.decide(
-            drag: drag,
-            targetPaneID: PaneID(),
-            targetContent: .terminal
-        )
-
-        #expect(decision == .deferToPane)
-    }
-
-    @Test("Editor drag targeting a terminal pane defers to cross-type pane handling")
-    func crossPaneEditorToTerminalDefers() {
-        let drag = makeDrag(paneID: PaneID(), content: .editor)
-
-        let decision = TabItemDropRouter.decide(
-            drag: drag,
-            targetPaneID: PaneID(),
-            targetContent: .terminal
-        )
-
-        #expect(decision == .deferToPane)
-    }
-
-    @Test("Terminal drag targeting an editor pane defers to cross-type pane handling")
-    func crossPaneTerminalToEditorDefers() {
-        let drag = makeDrag(paneID: PaneID(), content: .terminal)
-
-        let decision = TabItemDropRouter.decide(
-            drag: drag,
-            targetPaneID: PaneID(),
-            targetContent: .editor
-        )
-
-        #expect(decision == .deferToPane)
-    }
-
-    @Test("Editor payload claiming its source is a terminal pane is rejected")
-    func samePaneEditorToTerminalIsRejected() {
-        let paneID = PaneID()
-        let drag = makeDrag(paneID: paneID, content: .editor)
-
-        let decision = TabItemDropRouter.decide(
-            drag: drag,
-            targetPaneID: paneID,
-            targetContent: .terminal
-        )
-
-        #expect(decision == .reject)
-    }
-
-    @Test("Terminal payload claiming its source is an editor pane is rejected")
-    func samePaneTerminalToEditorIsRejected() {
-        let paneID = PaneID()
-        let drag = makeDrag(paneID: paneID, content: .terminal)
-
-        let decision = TabItemDropRouter.decide(
-            drag: drag,
-            targetPaneID: paneID,
-            targetContent: .editor
-        )
-
-        #expect(decision == .reject)
-    }
-
-    private func makeDrag(
-        paneID: PaneID,
-        tabID: UUID = UUID(),
-        content: PaneContent
-    ) -> TabDragInfo {
-        TabDragInfo(
-            paneID: paneID.id,
-            tabID: tabID,
-            fileURL: content == .editor ? URL(fileURLWithPath: "/tmp/test.swift") : nil,
-            contentType: content
-        )
-    }
-}
-
-@Suite("Editor Tab Drop Delegate Routing")
-@MainActor
-struct EditorTabDropDelegateRoutingTests {
-    @Test("Local editor drop reorders, consumes payload, and reports completion")
-    func localDropCompletes() {
-        let paneManager = PaneManager()
-        let paneID = paneManager.activePaneID
-        guard let tabManager = paneManager.tabManager(for: paneID) else {
-            Issue.record("Missing initial editor tab manager")
-            return
-        }
-        let first = EditorTab(
-            url: URL(fileURLWithPath: "/tmp/first.swift"),
-            content: "",
-            savedContent: ""
-        )
-        let second = EditorTab(
-            url: URL(fileURLWithPath: "/tmp/second.swift"),
-            content: "",
-            savedContent: ""
-        )
-        tabManager.tabs = [first, second]
-        paneManager.activeDrag = TabDragInfo(
-            paneID: paneID.id,
-            tabID: first.id,
-            fileURL: first.url
-        )
-        var completionCount = 0
-        let delegate = TabDropDelegate(
-            tabManager: tabManager,
-            paneManager: paneManager,
-            targetPaneID: paneID,
-            targetTabID: second.id,
-            hoverTargetTabID: .constant(nil),
-            onReorder: { completionCount += 1 }
-        )
-
-        let decision = delegate.routingDecision()
-        #expect(decision == .localReorder(draggedTabID: first.id))
-        #expect(delegate.handleDropEntered(decision: decision))
-        #expect(tabManager.tabs.map(\.id) == [second.id, first.id])
-        #expect(delegate.finishDrop(decision: decision))
-        #expect(paneManager.activeDrag == nil)
-        #expect(completionCount == 1)
-    }
-
-    @Test("Cross-pane editor drop leaves payload and order for the pane delegate")
-    func crossPaneDropDefers() {
-        let paneManager = PaneManager()
-        let targetPaneID = paneManager.activePaneID
-        guard let tabManager = paneManager.tabManager(for: targetPaneID) else {
-            Issue.record("Missing initial editor tab manager")
-            return
-        }
-        let tab = EditorTab(
-            url: URL(fileURLWithPath: "/tmp/target.swift"),
-            content: "",
-            savedContent: ""
-        )
-        tabManager.tabs = [tab]
-        let drag = TabDragInfo(
-            paneID: PaneID().id,
-            tabID: UUID(),
-            fileURL: URL(fileURLWithPath: "/tmp/source.swift")
-        )
-        paneManager.activeDrag = drag
-        let delegate = TabDropDelegate(
-            tabManager: tabManager,
-            paneManager: paneManager,
-            targetPaneID: targetPaneID,
-            targetTabID: tab.id,
-            hoverTargetTabID: .constant(nil)
-        )
-
-        let decision = delegate.routingDecision()
-        #expect(decision == .deferToPane)
-        #expect(!delegate.handleDropEntered(decision: decision))
-        #expect(!delegate.finishDrop(decision: decision))
-        #expect(tabManager.tabs.map(\.id) == [tab.id])
-        #expect(paneManager.activeDrag?.tabID == drag.tabID)
-    }
-}
-
-@Suite("Terminal Tab Drop Delegate Routing")
-@MainActor
-struct TerminalTabDropDelegateRoutingTests {
-    @Test("Local terminal drop reorders and consumes the shared payload")
-    func localDropCompletes() {
-        let paneManager = PaneManager()
-        let paneID = PaneID()
-        let state = TerminalPaneState()
-        let first = TerminalTab(name: "Terminal 1")
-        let second = TerminalTab(name: "Terminal 2")
-        state.terminalTabs = [first, second]
-        paneManager.activeDrag = TabDragInfo(
-            paneID: paneID.id,
-            tabID: first.id,
-            contentType: .terminal
-        )
-        let delegate = TerminalTabDropDelegate(
-            terminalState: state,
-            targetTabID: second.id,
-            targetPaneID: paneID,
-            paneManager: paneManager
-        )
-
-        let decision = delegate.routingDecision()
-        #expect(decision == .localReorder(draggedTabID: first.id))
-        #expect(delegate.handleDropEntered(decision: decision))
-        #expect(state.terminalTabs.map(\.id) == [second.id, first.id])
-        #expect(delegate.finishDrop(decision: decision))
-        #expect(paneManager.activeDrag == nil)
-    }
-
-    @Test("Cross-pane terminal drop leaves payload and order for the pane delegate")
-    func crossPaneDropDefers() {
-        let paneManager = PaneManager()
-        let targetPaneID = PaneID()
-        let state = TerminalPaneState()
-        let tab = TerminalTab(name: "Terminal 1")
-        state.terminalTabs = [tab]
-        let drag = TabDragInfo(
-            paneID: PaneID().id,
-            tabID: UUID(),
-            contentType: .terminal
-        )
-        paneManager.activeDrag = drag
-        let delegate = TerminalTabDropDelegate(
-            terminalState: state,
-            targetTabID: tab.id,
-            targetPaneID: targetPaneID,
-            paneManager: paneManager
-        )
-
-        let decision = delegate.routingDecision()
-        #expect(decision == .deferToPane)
-        #expect(!delegate.handleDropEntered(decision: decision))
-        #expect(!delegate.finishDrop(decision: decision))
-        #expect(state.terminalTabs.map(\.id) == [tab.id])
-        #expect(paneManager.activeDrag?.tabID == drag.tabID)
-    }
-}
-
-@Suite("Nested Tab-to-Pane Drop Integration")
-@MainActor
-struct NestedTabToPaneDropIntegrationTests {
-    @Test("Deferred editor item drop is completed by the target pane")
-    func deferredEditorDropMovesThroughPaneDelegate() throws {
-        let paneManager = PaneManager()
-        let sourcePaneID = paneManager.activePaneID
-        let sourceTabManager = try #require(paneManager.tabManager(for: sourcePaneID))
-        let sourceTab = EditorTab(
-            url: URL(fileURLWithPath: "/tmp/source.swift"),
-            content: "source",
-            savedContent: "source"
-        )
-        sourceTabManager.tabs = [sourceTab]
-        sourceTabManager.activeTabID = sourceTab.id
-
-        let targetPaneID = try #require(
-            paneManager.splitPane(sourcePaneID, axis: .horizontal)
-        )
-        let targetTabManager = try #require(paneManager.tabManager(for: targetPaneID))
-        let targetTab = EditorTab(
-            url: URL(fileURLWithPath: "/tmp/target.swift"),
-            content: "target",
-            savedContent: "target"
-        )
-        targetTabManager.tabs = [targetTab]
-        targetTabManager.activeTabID = targetTab.id
-
-        let drag = TabDragInfo(
-            paneID: sourcePaneID.id,
-            tabID: sourceTab.id,
-            fileURL: sourceTab.url,
-            contentType: .editor
-        )
-        paneManager.activeDrag = drag
-        let itemDelegate = TabDropDelegate(
-            tabManager: targetTabManager,
-            paneManager: paneManager,
-            targetPaneID: targetPaneID,
-            targetTabID: targetTab.id,
-            hoverTargetTabID: .constant(nil)
-        )
-
-        let decision = itemDelegate.routingDecision()
-        #expect(decision == .deferToPane)
-        #expect(!itemDelegate.handleDropEntered(decision: decision))
-        #expect(!itemDelegate.finishDrop(decision: decision))
-        #expect(paneManager.activeDrag?.paneID == drag.paneID)
-        #expect(paneManager.activeDrag?.tabID == drag.tabID)
-        #expect(paneManager.activeDrag?.fileURL == drag.fileURL)
-        #expect(paneManager.activeDrag?.contentType == drag.contentType)
-        #expect(targetTabManager.tabs.map(\.id) == [targetTab.id])
-        #expect(sourceTabManager.tabs.map(\.id) == [sourceTab.id])
-
-        let paneDelegate = PaneSplitDropDelegate(
-            paneID: targetPaneID,
-            paneManager: paneManager,
-            paneSize: CGSize(width: 400, height: 300)
-        )
-
-        #expect(paneDelegate.performPaneTabDrop(zone: .center))
-        #expect(paneManager.activeDrag == nil)
-        #expect(targetTabManager.tabs.contains { $0.id == targetTab.id })
-        #expect(targetTabManager.tabs.contains { $0.url == sourceTab.url })
-        #expect(targetTabManager.tabs.count == 2)
-        #expect(paneManager.tabManager(for: sourcePaneID) == nil)
-        #expect(paneManager.root.content(for: sourcePaneID) == nil)
-        #expect(paneManager.root.content(for: targetPaneID) == .editor)
-    }
-
-    @Test("Deferred terminal item drop is completed by the target pane")
-    func deferredTerminalDropMovesThroughPaneDelegate() throws {
-        let paneManager = PaneManager()
-        let sourcePaneID = paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
-        let sourceState = try #require(paneManager.terminalState(for: sourcePaneID))
-        let sourceTab = try #require(sourceState.terminalTabs.first)
-
-        let targetPaneID = try #require(paneManager.createTerminalPane(
-            relativeTo: sourcePaneID,
-            axis: .horizontal,
-            workingDirectory: nil
-        ))
-        let targetState = try #require(paneManager.terminalState(for: targetPaneID))
-        let targetTab = try #require(targetState.terminalTabs.first)
-
-        let drag = TabDragInfo(
-            paneID: sourcePaneID.id,
-            tabID: sourceTab.id,
-            contentType: .terminal
-        )
-        paneManager.activeDrag = drag
-        let itemDelegate = TerminalTabDropDelegate(
-            terminalState: targetState,
-            targetTabID: targetTab.id,
-            targetPaneID: targetPaneID,
-            paneManager: paneManager
-        )
-
-        let decision = itemDelegate.routingDecision()
-        #expect(decision == .deferToPane)
-        #expect(!itemDelegate.handleDropEntered(decision: decision))
-        #expect(!itemDelegate.finishDrop(decision: decision))
-        #expect(paneManager.activeDrag?.paneID == drag.paneID)
-        #expect(paneManager.activeDrag?.tabID == drag.tabID)
-        #expect(paneManager.activeDrag?.fileURL == drag.fileURL)
-        #expect(paneManager.activeDrag?.contentType == drag.contentType)
-        #expect(targetState.terminalTabs.map(\.id) == [targetTab.id])
-        #expect(sourceState.terminalTabs.map(\.id) == [sourceTab.id])
-
-        let paneDelegate = PaneSplitDropDelegate(
-            paneID: targetPaneID,
-            paneManager: paneManager,
-            paneSize: CGSize(width: 400, height: 300)
-        )
-
-        #expect(paneDelegate.performPaneTabDrop(zone: .center))
-        #expect(paneManager.activeDrag == nil)
-        #expect(targetState.terminalTabs.map(\.id).contains(targetTab.id))
-        #expect(targetState.terminalTabs.map(\.id).contains(sourceTab.id))
-        #expect(targetState.terminalTabs.count == 2)
-        #expect(paneManager.terminalState(for: sourcePaneID) == nil)
-        #expect(paneManager.root.content(for: sourcePaneID) == nil)
-        #expect(paneManager.root.content(for: targetPaneID) == .terminal)
+    @Test("Missing frames and out-of-range gaps are rejected")
+    func invalidGeometry() {
+        #expect(TabStripInsertionGeometry.insertionIndex(
+            atX: 10,
+            orderedTabIDs: ids,
+            frames: [:]
+        ) == nil)
+        #expect(TabStripInsertionGeometry.indicatorX(
+            for: 4,
+            orderedTabIDs: ids,
+            frames: frames
+        ) == nil)
     }
 }

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -388,10 +388,11 @@ struct TerminalTabTests {
         container.showTab(state.activeTab)
         let window = makeWindow(contentView: container)
 
-        // Add tab2 and consume pendingFocus
+        // Add tab2 and confirm focus only after AppKit accepts it.
         let tab2 = state.addTab(workingDirectory: nil)
         container.showTab(state.activeTab)
-        // pendingFocusTabID was consumed by showTab
+        #expect(state.pendingFocusTabID == tab2.id)
+        #expect(container.destinationFocusCoordinator.attemptNow())
         #expect(state.pendingFocusTabID == nil)
 
         // Now switch back to tab1 via activeTerminalID (simulating tab bar click)
@@ -413,7 +414,7 @@ struct TerminalTabTests {
 
     // MARK: - pendingFocusTabID consumption
 
-    @Test @MainActor func showTabConsumesPendingFocus() throws {
+    @Test @MainActor func showTabRetainsFocusUntilResponderIsConfirmed() throws {
         let state = TerminalPaneState()
         state.addTab(workingDirectory: nil)
         state.startTabs(workingDirectory: nil)
@@ -424,6 +425,13 @@ struct TerminalTabTests {
         container.terminalPaneState = state
         container.showTab(newTab)
 
+        #expect(state.pendingFocusTabID == newTab.id)
+        #expect(!container.destinationFocusCoordinator.attemptNow())
+        #expect(state.pendingFocusTabID == newTab.id)
+
+        let window = makeWindow(contentView: container)
+        #expect(container.destinationFocusCoordinator.attemptNow())
+        #expect(window.firstResponder === newTab.terminalView)
         #expect(state.pendingFocusTabID == nil)
     }
 


### PR DESCRIPTION
## Summary

- introduce one coordinator and stable identity for editor and terminal tab drags
- expose N+1 insertion gaps, including empty strips and before or after edge positions
- use the same exact-index model for same-pane reorder and cross-pane transfer
- keep hover preview-only and commit one revalidated atomic mutation
- keep strip insertion, pane-body split, and root split routing disjoint
- focus usable editor, preview, Markdown, or terminal content after a successful move

## Safety invariants

- stale and cross-type payloads are rejected
- failed transfers roll back without losing tab state
- maximized panes cannot receive hidden structural mutations
- pinned boundaries remain valid
- the committed index matches the visible insertion indicator

## Test plan

- [x] first, middle, last, and empty-strip insertion
- [x] same-pane no-op and cross-pane transfer
- [x] pinned boundaries and stale payloads
- [x] editor, preview, Markdown, and terminal focus routing
- [x] maximized-pane and close-hit boundary regressions
- [x] 248 targeted tests in 9 suites
- [x] SwiftLint on all 23 changed Swift files

Closes #1171
Refs #1168

Built on #1170.