### PR TITLE
fix(lsp): harden streaming transport framing

### DIFF
--- a/Pine/LSP/LSPClient.swift
+++ b/Pine/LSP/LSPClient.swift
@@ -15,6 +15,7 @@
 //  actor — they serialise onto a private background queue.
 //
 
+import Darwin
 import Foundation
 import os
 
@@ -48,23 +49,66 @@ nonisolated enum LSPMessageFraming {
     /// Extracts the `Content-Length` value from a header block.
     /// Returns `nil` if the header is absent or unparseable.
     static func contentLength(from header: String) -> Int? {
-        // Case-insensitive search — servers are inconsistent on casing.
-        guard let range = header.range(of: "Content-Length:", options: .caseInsensitive) else {
-            return nil
+        var parsedLength: Int?
+        for line in header.components(separatedBy: "\r\n") {
+            let fields = line.split(
+                separator: ":",
+                maxSplits: 1,
+                omittingEmptySubsequences: false
+            )
+            guard fields.count == 2 else { continue }
+
+            let name = fields[0].trimmingCharacters(
+                in: .whitespaces
+            )
+            guard name.caseInsensitiveCompare("Content-Length")
+                    == .orderedSame else {
+                continue
+            }
+            // Multiple length fields are ambiguous and must fail closed.
+            guard parsedLength == nil else { return nil }
+
+            let value = fields[1].trimmingCharacters(
+                in: .whitespaces
+            )
+            guard !value.isEmpty,
+                  value.utf8.allSatisfy({ (48...57).contains($0) }),
+                  let length = Int(value) else {
+                return nil
+            }
+            parsedLength = length
         }
-        let afterKey = header[range.upperBound...]
-        // Trim leading whitespace then take digits up to the first non-digit.
-        let trimmed = afterKey.drop(while: { $0.isWhitespace })
-        var digits = ""
-        for char in trimmed {
-            guard char.isNumber else { break }
-            digits.append(char)
-        }
-        return Int(digits)
+        return parsedLength
     }
 }
 
 // MARK: - Transport
+
+/// Why an active stdio transport stopped accepting messages.
+nonisolated enum LSPTransportTermination: Equatable, Sendable {
+    case requested
+    case endOfFile
+    case processExited(status: Int32)
+    case protocolViolation(LSPStreamParserError)
+}
+
+/// Error used to fail pending JSON-RPC continuations when stdio ends.
+nonisolated struct LSPTransportError: LocalizedError, Equatable, Sendable {
+    let termination: LSPTransportTermination
+
+    var errorDescription: String? {
+        switch termination {
+        case .requested:
+            return "LSP transport was terminated by the client"
+        case .endOfFile:
+            return "LSP server closed its stdout stream"
+        case .processExited(let status):
+            return "LSP server exited with status \(status)"
+        case .protocolViolation(let error):
+            return "LSP server sent malformed framing: \(error)"
+        }
+    }
+}
 
 /// A minimal JSON-RPC 2.0 transport over a `Process`'s stdio.
 ///
@@ -77,7 +121,6 @@ nonisolated enum LSPMessageFraming {
 /// `ioQueue`. The only cross-thread surface is the delegate callback, which
 /// hops to the main actor at the call site.
 nonisolated final class LSPTransport: @unchecked Sendable {
-
     /// Receives fully-decoded JSON-RPC messages (notifications and responses).
     weak var delegate: LSPTransportDelegate?
 
@@ -90,8 +133,21 @@ nonisolated final class LSPTransport: @unchecked Sendable {
     /// Private serial queue — all reads/writes of mutable state happen here.
     private let ioQueue = DispatchQueue(label: "com.pine.lsp-transport")
 
-    /// Accumulates the raw stdout bytes until a complete message is framed.
-    private var readBuffer = Data()
+    /// Incremental framing state, confined to `ioQueue`.
+    private var streamParser = LSPMessageStreamParser()
+
+    /// Signalled directly by the Process termination callback so bounded
+    /// termination never waits for work that is itself queued on `ioQueue`.
+    private var processExitSemaphore: DispatchSemaphore?
+
+    /// Ignores stale callbacks from a process that was already replaced.
+    private var processGeneration = 0
+
+    /// Process exit can precede the final stdout readability callback.
+    private var pendingExitStatus: Int32?
+
+    /// EOF and Process.terminationHandler can report the same shutdown.
+    private var didDeliverTermination = true
 
     // MARK: - Lifecycle
 
@@ -103,10 +159,25 @@ nonisolated final class LSPTransport: @unchecked Sendable {
     ///     current process environment is used with common tool paths prepended.
     /// - Returns: `true` if the process launched successfully.
     @discardableResult
-    func start(command: String, arguments: [String], environment: [String: String]? = nil) -> Bool {
+    func start(
+        command: String,
+        arguments: [String],
+        environment: [String: String]? = nil
+    ) -> Bool {
         ioQueue.sync {
             // Already running — refuse to double-start.
             if process?.isRunning == true { return false }
+
+            outPipeCleanup()
+            process = nil
+            stdinPipe = nil
+            processExitSemaphore = nil
+
+            processGeneration &+= 1
+            let generation = processGeneration
+            streamParser = LSPMessageStreamParser()
+            pendingExitStatus = nil
+            didDeliverTermination = false
 
             let proc = Process()
             proc.executableURL = URL(fileURLWithPath: command)
@@ -124,23 +195,56 @@ nonisolated final class LSPTransport: @unchecked Sendable {
             let outPipe = Pipe()
             proc.standardInput = inPipe
             proc.standardOutput = outPipe
-            proc.standardError = Pipe() // discard server stderr for now
+            proc.standardError = FileHandle.nullDevice
+            let stdoutDescriptor = outPipe.fileHandleForReading.fileDescriptor
+            guard Self.configureNonBlocking(
+                descriptor: stdoutDescriptor
+            ) else {
+                didDeliverTermination = true
+                Logger.lsp.error(
+                    "Failed to configure nonblocking LSP stdout"
+                )
+                return false
+            }
+
+            let exitSemaphore = DispatchSemaphore(value: 0)
+            processExitSemaphore = exitSemaphore
 
             // Forward stdout data to the framing reader.
-            outPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
-                let chunk = handle.availableData
-                guard !chunk.isEmpty else { return }
-                self?.ioQueue.async {
-                    self?.appendAndParse(chunk)
+            outPipe.fileHandleForReading.readabilityHandler = { [weak self] _ in
+                self?.ioQueue.async { [weak self] in
+                    self?.drainOutput(
+                        descriptor: stdoutDescriptor,
+                        generation: generation
+                    )
+                }
+            }
+
+            proc.terminationHandler = { [weak self] terminatedProcess in
+                let status = terminatedProcess.terminationStatus
+                exitSemaphore.signal()
+                self?.ioQueue.async { [weak self] in
+                    self?.handleProcessExit(
+                        status: status,
+                        generation: generation,
+                        stdoutDescriptor: stdoutDescriptor
+                    )
                 }
             }
 
             do {
                 try proc.run()
             } catch {
-                Logger.lsp.error("Failed to launch server \(command, privacy: .public): \(String(describing: error), privacy: .public)")
+                outPipe.fileHandleForReading.readabilityHandler = nil
+                proc.terminationHandler = nil
+                didDeliverTermination = true
                 process = nil
                 stdinPipe = nil
+                processExitSemaphore = nil
+                let detail = String(describing: error)
+                Logger.lsp.error(
+                    "Failed to launch server \(command, privacy: .public): \(detail, privacy: .public)"
+                )
                 return false
             }
 
@@ -151,9 +255,34 @@ nonisolated final class LSPTransport: @unchecked Sendable {
         }
     }
 
+    /// Configures a pipe descriptor for nonblocking reads, retrying interrupted
+    /// system calls. Startup fails closed when either operation is rejected.
+    static func configureNonBlocking(descriptor: Int32) -> Bool {
+        var descriptorFlags: Int32
+        repeat {
+            descriptorFlags = Darwin.fcntl(descriptor, F_GETFL)
+        } while descriptorFlags == -1 && errno == EINTR
+        guard descriptorFlags != -1 else { return false }
+
+        var setResult: Int32
+        repeat {
+            setResult = Darwin.fcntl(
+                descriptor,
+                F_SETFL,
+                descriptorFlags | O_NONBLOCK
+            )
+        } while setResult == -1 && errno == EINTR
+        return setResult != -1
+    }
+
     /// Whether the server process is currently running.
     var isRunning: Bool {
         ioQueue.sync { process?.isRunning ?? false }
+    }
+
+    /// Internal observability for process-lifecycle tests.
+    var processIdentifier: pid_t? {
+        ioQueue.sync { process?.processIdentifier }
     }
 
     /// Writes a framed JSON-RPC message to the server's stdin.
@@ -167,7 +296,10 @@ nonisolated final class LSPTransport: @unchecked Sendable {
             do {
                 try pipe.fileHandleForWriting.write(contentsOf: framed)
             } catch {
-                Logger.lsp.error("Failed to write to server stdin: \(String(describing: error), privacy: .public)")
+                let detail = String(describing: error)
+                Logger.lsp.error(
+                    "Failed to write to server stdin: \(detail, privacy: .public)"
+                )
             }
         }
     }
@@ -175,16 +307,42 @@ nonisolated final class LSPTransport: @unchecked Sendable {
     /// Terminates the server process. Sends SIGTERM first, then SIGKILL as a
     /// fallback if the process does not exit within `timeout` seconds.
     func terminate(timeout: TimeInterval = 3.0) {
+        let boundedTimeout = timeout.isFinite ? max(0, timeout) : 3.0
         ioQueue.sync {
             outPipeCleanup()
             guard let proc = process else { return }
+
             if proc.isRunning {
                 proc.terminate()
-                // Give it a moment to exit cleanly.
-                proc.waitUntilExit()
+                let waitResult = processExitSemaphore?.wait(
+                    timeout: .now() + boundedTimeout
+                )
+                if waitResult == .timedOut, proc.isRunning {
+                    let killResult = Darwin.kill(
+                        proc.processIdentifier,
+                        SIGKILL
+                    )
+                    if killResult != 0 {
+                        Logger.lsp.error(
+                            "Failed to SIGKILL unresponsive LSP process"
+                        )
+                    }
+                    _ = processExitSemaphore?.wait(
+                        timeout: .now() + 1.0
+                    )
+                }
             }
-            process = nil
+
+            finishTransport(reason: .requested)
             stdinPipe = nil
+            if proc.isRunning {
+                // Preserve the handle until Process confirms exit. Reporting a
+                // stopped transport must not hide a still-live child.
+                process = proc
+            } else {
+                process = nil
+                processExitSemaphore = nil
+            }
         }
     }
 
@@ -197,57 +355,162 @@ nonisolated final class LSPTransport: @unchecked Sendable {
 
     // MARK: - Framing reader
 
-    /// Appends a stdout chunk and parses as many complete messages as are
-    /// available. Runs on `ioQueue` so the buffer is never accessed
-    /// concurrently.
-    private func appendAndParse(_ chunk: Data) {
-        readBuffer.append(chunk)
+    private func drainOutput(descriptor: Int32, generation: Int) {
+        guard generation == processGeneration,
+              !didDeliverTermination else {
+            return
+        }
 
-        while let (message, consumed) = parseNextMessage() {
-            // Drop the consumed bytes, keeping any partial trailing data.
-            readBuffer.removeFirst(consumed)
-            deliver(message)
+        var storage = [UInt8](repeating: 0, count: 64 * 1024)
+        while !didDeliverTermination {
+            let byteCount = storage.withUnsafeMutableBytes { buffer in
+                Darwin.read(
+                    descriptor,
+                    buffer.baseAddress,
+                    buffer.count
+                )
+            }
+            if byteCount > 0 {
+                appendAndParse(Data(storage.prefix(byteCount)))
+                continue
+            }
+            if byteCount == 0 {
+                handleEndOfFile()
+                return
+            }
+
+            let readError = errno
+            if readError == EINTR {
+                continue
+            }
+            if readError == EAGAIN || readError == EWOULDBLOCK {
+                return
+            }
+
+            Logger.lsp.error(
+                "Failed reading LSP stdout: errno \(readError)"
+            )
+            handleEndOfFile()
+            return
         }
     }
 
-    /// Attempts to parse one complete JSON-RPC message from the head of
-    /// `readBuffer`. Returns the decoded `[String: Any]` and the number of
-    /// bytes consumed (header + payload), or `nil` if more data is needed.
-    private func parseNextMessage() -> (message: [String: Any], consumed: Int)? {
-        // The header is ASCII; look for the `\r\n\r\n` terminator.
-        guard let headerRange = readBuffer.range(of: Data("\r\n\r\n".utf8)) else {
-            return nil // header not yet complete
+    /// Appends a stdout chunk and delivers every complete message in order.
+    private func appendAndParse(_ chunk: Data) {
+        if let error = handleParserEvents(streamParser.append(chunk)) {
+            failTransportForProtocolViolation(error)
+        }
+    }
+
+    @discardableResult
+    private func handleParserEvents(
+        _ events: [LSPStreamParserEvent]
+    ) -> LSPStreamParserError? {
+        for event in events {
+            switch event {
+            case .message(let message):
+                deliver(message)
+            case .malformed(let error):
+                let detail = String(describing: error)
+                Logger.lsp.error(
+                    "Discarded malformed LSP stream input: \(detail, privacy: .public)"
+                )
+                if error.terminatesStream {
+                    return error
+                }
+            }
+        }
+        return nil
+    }
+
+    private func handleProcessExit(
+        status: Int32,
+        generation: Int,
+        stdoutDescriptor: Int32
+    ) {
+        guard generation == processGeneration else { return }
+        pendingExitStatus = status
+        if didDeliverTermination {
+            clearExitedProcess()
+            return
         }
 
-        let headerData = readBuffer[readBuffer.startIndex..<headerRange.lowerBound]
-        guard let header = String(data: headerData, encoding: .utf8) else {
-            // Malformed header — drop everything up to the separator to resync.
-            readBuffer.removeSubrange(readBuffer.startIndex...headerRange.upperBound)
-            return nil
+        // A process can exit before its final readability callback is queued.
+        // Non-blockingly drain bytes already in the pipe before considering
+        // the stream terminated.
+        drainOutput(
+            descriptor: stdoutDescriptor,
+            generation: generation
+        )
+        guard !didDeliverTermination else { return }
+
+        // A descendant may inherit stdout and keep the pipe open after the
+        // server exits. Bound that unusual case without losing available data.
+        ioQueue.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self] in
+            guard let self,
+                  generation == self.processGeneration,
+                  !self.didDeliverTermination else {
+                return
+            }
+            self.finishTransport(reason: .processExited(status: status))
+            self.clearExitedProcess()
+        }
+    }
+
+    private func handleEndOfFile() {
+        let reason = pendingExitStatus.map {
+            LSPTransportTermination.processExited(status: $0)
+        } ?? .endOfFile
+        finishTransport(reason: reason)
+        if process?.isRunning == true {
+            stopRunningProcessWithoutWaiting()
+        } else {
+            clearExitedProcess()
+        }
+    }
+
+    private func finishTransport(reason: LSPTransportTermination) {
+        guard !didDeliverTermination else { return }
+        didDeliverTermination = true
+        outPipeCleanup()
+        handleParserEvents(streamParser.finish())
+        deliverTermination(reason)
+    }
+
+    private func failTransportForProtocolViolation(
+        _ error: LSPStreamParserError
+    ) {
+        guard !didDeliverTermination else { return }
+        finishTransport(reason: .protocolViolation(error))
+        stopRunningProcessWithoutWaiting()
+    }
+
+    private func stopRunningProcessWithoutWaiting() {
+        stdinPipe = nil
+        guard let proc = process else { return }
+        guard proc.isRunning else {
+            clearExitedProcess()
+            return
         }
 
-        guard let length = LSPMessageFraming.contentLength(from: header) else {
-            readBuffer.removeSubrange(readBuffer.startIndex...headerRange.upperBound)
-            return nil
+        proc.terminate()
+        DispatchQueue.global(qos: .utility).asyncAfter(
+            deadline: .now() + 1.0
+        ) {
+            guard proc.isRunning else { return }
+            if Darwin.kill(proc.processIdentifier, SIGKILL) != 0 {
+                Logger.lsp.error(
+                    "Failed to SIGKILL malformed LSP process"
+                )
+            }
         }
+    }
 
-        let bodyStart = headerRange.upperBound
-        // `Data.index(_:offsetBy:)` traps if it would run past endIndex, so
-        // validate available bytes first and return nil (wait for more) instead.
-        let available = readBuffer.distance(from: bodyStart, to: readBuffer.endIndex)
-        guard available >= length else {
-            return nil // payload not yet complete
-        }
-        let bodyEnd = readBuffer.index(bodyStart, offsetBy: length)
-
-        let bodyData = readBuffer.subdata(in: bodyStart..<bodyEnd)
-        let consumed = readBuffer.distance(from: readBuffer.startIndex, to: bodyEnd)
-
-        guard let json = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any] else {
-            Logger.lsp.error("Failed to decode LSP JSON payload")
-            return ([:], consumed) // consume to avoid re-parsing a bad message
-        }
-        return (json, consumed)
+    private func clearExitedProcess() {
+        guard process?.isRunning != true else { return }
+        process = nil
+        stdinPipe = nil
+        processExitSemaphore = nil
     }
 
     /// Delivers a decoded message to the delegate on the main thread — the
@@ -259,6 +522,12 @@ nonisolated final class LSPTransport: @unchecked Sendable {
         let box = SendableJSONBox(message)
         DispatchQueue.main.async { [weak self] in
             self?.delegate?.transport(didReceive: box.value)
+        }
+    }
+
+    private func deliverTermination(_ reason: LSPTransportTermination) {
+        DispatchQueue.main.async { [weak self] in
+            self?.delegate?.transportDidTerminate(reason)
         }
     }
 }
@@ -276,6 +545,9 @@ nonisolated struct SendableJSONBox: @unchecked Sendable {
 protocol LSPTransportDelegate: AnyObject {
     /// Called for every complete JSON-RPC message (notification or response).
     func transport(didReceive message: [String: Any])
+
+    /// Called once when an active process or its stdout stream terminates.
+    func transportDidTerminate(_ reason: LSPTransportTermination)
 }
 
 // MARK: - LSPClient
@@ -312,6 +584,11 @@ final class LSPClient {
 
     /// Pending requests awaiting a server response, keyed by request id.
     private var pending: [Int: (Result<SendableJSONBox, Error>) -> Void] = [:]
+
+    /// Internal observability for deterministic transport-lifecycle tests.
+    var pendingRequestCount: Int {
+        pending.count
+    }
 
     /// The language id this client serves (e.g. "swift", "typescript").
     let language: String
@@ -645,7 +922,6 @@ nonisolated struct LSPError: Error {
 // MARK: - LSPTransportDelegate
 
 extension LSPClient: LSPTransportDelegate {
-
     func transport(didReceive message: [String: Any]) {
         // A server-to-client notification (no "id", has "method").
         if let method = message["method"] as? String {
@@ -659,6 +935,26 @@ extension LSPClient: LSPTransportDelegate {
             let result = message["result"]
             let error = message["error"] as? [String: Any]
             resolveRequest(id: id, result: result, error: error)
+        }
+    }
+
+    func transportDidTerminate(_ reason: LSPTransportTermination) {
+        let transportError = LSPTransportError(termination: reason)
+        let pendingHandlers = Array(pending.values)
+        pending.removeAll()
+        for handler in pendingHandlers {
+            handler(.failure(transportError))
+        }
+
+        switch state {
+        case .shutDown, .exited:
+            state = .exited
+        case .uninitialized:
+            break
+        case .initializing, .initialized:
+            state = .failed
+        case .failed:
+            break
         }
     }
 

--- a/Pine/LSP/LSPMessageStreamParser.swift
+++ b/Pine/LSP/LSPMessageStreamParser.swift
@@ -1,0 +1,182 @@
+//
+//  LSPMessageStreamParser.swift
+//  Pine
+//
+//  Deterministic streaming parser for LSP Content-Length framing.
+//
+
+import Foundation
+
+/// A malformed stream condition that was consumed without emitting a message.
+nonisolated enum LSPStreamParserError: Error, Equatable, Sendable {
+    case headerTooLarge(byteCount: Int)
+    case invalidHeader
+    case payloadTooLarge(byteCount: Int)
+    case invalidJSON
+    case incompleteMessage(bufferedBytes: Int)
+    case inputAfterEOF
+
+    /// Framing errors make the following byte boundary unknowable. Continuing
+    /// could interpret bytes inside a malformed payload as a new LSP message.
+    var terminatesStream: Bool {
+        switch self {
+        case .headerTooLarge, .invalidHeader, .payloadTooLarge, .invalidJSON:
+            return true
+        case .incompleteMessage, .inputAfterEOF:
+            return false
+        }
+    }
+}
+
+/// One parser outcome. Malformed frames are explicit so callers can log them
+/// while continuing to drain later valid frames from the same read.
+nonisolated enum LSPStreamParserEvent {
+    case message([String: Any])
+    case malformed(LSPStreamParserError)
+}
+
+/// Incrementally parses LSP messages from arbitrarily fragmented byte chunks.
+///
+/// The parser owns no process or queue. `LSPTransport` confines one instance
+/// to its serial I/O queue, while tests can feed it synchronously.
+nonisolated struct LSPMessageStreamParser {
+    static let defaultMaximumHeaderSize = 64 * 1024
+    static let defaultMaximumPayloadSize = 16 * 1024 * 1024
+
+    private static let headerSeparator = Data("\r\n\r\n".utf8)
+
+    private let maximumHeaderSize: Int
+    private let maximumPayloadSize: Int
+    private var buffer = Data()
+    private(set) var isFinished = false
+
+    init(
+        maximumHeaderSize: Int = defaultMaximumHeaderSize,
+        maximumPayloadSize: Int = defaultMaximumPayloadSize
+    ) {
+        self.maximumHeaderSize = max(1, maximumHeaderSize)
+        self.maximumPayloadSize = max(1, maximumPayloadSize)
+    }
+
+    var bufferedByteCount: Int {
+        buffer.count
+    }
+
+    /// Appends one stdout chunk and drains every complete frame in order.
+    mutating func append(_ chunk: Data) -> [LSPStreamParserEvent] {
+        guard !isFinished else {
+            return chunk.isEmpty ? [] : [.malformed(.inputAfterEOF)]
+        }
+        guard !chunk.isEmpty else { return [] }
+
+        buffer.append(chunk)
+        return drain()
+    }
+
+    /// Marks the byte stream as complete.
+    ///
+    /// A partial header or body is reported once and discarded. Calling
+    /// `finish()` repeatedly is idempotent.
+    mutating func finish() -> [LSPStreamParserEvent] {
+        guard !isFinished else { return [] }
+        isFinished = true
+        guard !buffer.isEmpty else { return [] }
+
+        let bufferedBytes = buffer.count
+        buffer.removeAll(keepingCapacity: false)
+        return [.malformed(.incompleteMessage(bufferedBytes: bufferedBytes))]
+    }
+
+    private mutating func drain() -> [LSPStreamParserEvent] {
+        var events: [LSPStreamParserEvent] = []
+
+        while !buffer.isEmpty {
+            guard let separatorRange = buffer.range(
+                of: Self.headerSeparator
+            ) else {
+                if buffer.count > maximumHeaderSize {
+                    let byteCount = buffer.count
+                    terminateStream(
+                        with: .headerTooLarge(byteCount: byteCount),
+                        events: &events
+                    )
+                }
+                break
+            }
+
+            let headerByteCount = buffer.distance(
+                from: buffer.startIndex,
+                to: separatorRange.upperBound
+            )
+            let headerData = buffer.subdata(
+                in: buffer.startIndex..<separatorRange.lowerBound
+            )
+            guard headerData.count <= maximumHeaderSize else {
+                terminateStream(
+                    with: .headerTooLarge(byteCount: headerData.count),
+                    events: &events
+                )
+                break
+            }
+
+            guard let header = String(data: headerData, encoding: .ascii),
+                  let payloadLength = LSPMessageFraming.contentLength(
+                      from: header
+                  ) else {
+                terminateStream(with: .invalidHeader, events: &events)
+                break
+            }
+
+            guard payloadLength <= maximumPayloadSize else {
+                terminateStream(
+                    with: .payloadTooLarge(byteCount: payloadLength),
+                    events: &events
+                )
+                break
+            }
+
+            let completeFrameSize = headerByteCount + payloadLength
+            guard buffer.count >= completeFrameSize else {
+                break
+            }
+
+            let bodyStart = buffer.index(
+                buffer.startIndex,
+                offsetBy: headerByteCount
+            )
+            let bodyEnd = buffer.index(
+                bodyStart,
+                offsetBy: payloadLength
+            )
+            let body = buffer.subdata(in: bodyStart..<bodyEnd)
+            consume(completeFrameSize)
+
+            do {
+                let object = try JSONSerialization.jsonObject(with: body)
+                guard let message = object as? [String: Any] else {
+                    terminateStream(with: .invalidJSON, events: &events)
+                    break
+                }
+                events.append(.message(message))
+            } catch {
+                terminateStream(with: .invalidJSON, events: &events)
+                break
+            }
+        }
+
+        return events
+    }
+
+    private mutating func consume(_ byteCount: Int) {
+        buffer.removeFirst(byteCount)
+    }
+
+    private mutating func terminateStream(
+        with error: LSPStreamParserError,
+        events: inout [LSPStreamParserEvent]
+    ) {
+        isFinished = true
+        buffer.removeAll(keepingCapacity: false)
+        events.append(.malformed(error))
+    }
+}

--- a/PineTests/LSPTransportTests.swift
+++ b/PineTests/LSPTransportTests.swift
@@ -1,0 +1,659 @@
+//
+//  LSPTransportTests.swift
+//  PineTests
+//
+//  Deterministic coverage for LSP framing, streaming, and process lifecycle.
+//
+
+import Darwin
+import Foundation
+import Testing
+@testable import Pine
+
+@Suite("LSP Message Framing Tests")
+struct LSPMessageFramingTests {
+    @Test("Frame uses UTF-8 byte length for ASCII and multibyte JSON")
+    func frameUsesUTF8ByteLength() throws {
+        for text in ["plain ASCII", "Привет, Pine 🌲"] {
+            let frame = LSPMessageFraming.frame([
+                "jsonrpc": "2.0",
+                "id": 1,
+                "text": text
+            ])
+            let parts = try splitFrame(frame)
+
+            #expect(
+                LSPMessageFraming.contentLength(from: parts.header)
+                    == parts.body.count
+            )
+            let object = try JSONSerialization.jsonObject(with: parts.body)
+            let message = try #require(object as? [String: Any])
+            #expect(message["text"] as? String == text)
+        }
+    }
+
+    @Test("Content-Length accepts casing and surrounding whitespace")
+    func contentLengthAcceptsCasingAndWhitespace() {
+        let header = [
+            "Content-Type: application/vscode-jsonrpc; charset=utf-8",
+            "  cOnTeNt-LeNgTh \t: \t42  "
+        ].joined(separator: "\r\n")
+
+        #expect(LSPMessageFraming.contentLength(from: header) == 42)
+    }
+
+    @Test("Content-Length rejects ambiguous and malformed values")
+    func contentLengthRejectsMalformedValues() {
+        #expect(
+            LSPMessageFraming.contentLength(
+                from: "X-Content-Length: 12"
+            ) == nil
+        )
+        #expect(
+            LSPMessageFraming.contentLength(
+                from: "Content-Length: 12junk"
+            ) == nil
+        )
+        #expect(
+            LSPMessageFraming.contentLength(
+                from: "Content-Length: -1"
+            ) == nil
+        )
+        #expect(
+            LSPMessageFraming.contentLength(
+                from: "Content-Length:"
+            ) == nil
+        )
+        #expect(
+            LSPMessageFraming.contentLength(
+                from: "Content-Length: 1\r\ncontent-length: 1"
+            ) == nil
+        )
+        #expect(
+            LSPMessageFraming.contentLength(
+                from: "Content-Length: \(String(repeating: "9", count: 100))"
+            ) == nil
+        )
+        #expect(
+            LSPMessageFraming.contentLength(
+                from: "Content-Type: application/json"
+            ) == nil
+        )
+    }
+
+    private func splitFrame(
+        _ frame: Data
+    ) throws -> (header: String, body: Data) {
+        let separator = Data("\r\n\r\n".utf8)
+        let range = try #require(frame.range(of: separator))
+        let headerData = frame.subdata(
+            in: frame.startIndex..<range.lowerBound
+        )
+        let header = try #require(
+            String(data: headerData, encoding: .ascii)
+        )
+        let body = frame.subdata(in: range.upperBound..<frame.endIndex)
+        return (header, body)
+    }
+}
+
+@Suite("LSP Message Stream Parser Tests")
+struct LSPMessageStreamParserTests {
+    @Test("Every header and body split boundary produces one message")
+    func parsesEverySplitBoundary() {
+        let frame = makeFrame(id: 1, text: "Привет 🌲")
+
+        for splitIndex in 0...frame.count {
+            var parser = LSPMessageStreamParser()
+            var events = parser.append(
+                Data(frame.prefix(splitIndex))
+            )
+            events += parser.append(
+                Data(frame.dropFirst(splitIndex))
+            )
+
+            #expect(
+                messageIDs(in: events) == [1],
+                "split index \(splitIndex)"
+            )
+            #expect(
+                parserErrors(in: events).isEmpty,
+                "split index \(splitIndex)"
+            )
+            #expect(parser.bufferedByteCount == 0)
+        }
+    }
+
+    @Test("Byte-by-byte UTF-8 input stays ordered")
+    func parsesByteByByte() {
+        let first = makeFrame(id: 1, text: "один")
+        let second = makeFrame(id: 2, text: "два")
+        var stream = first
+        stream.append(second)
+
+        var parser = LSPMessageStreamParser()
+        var events: [LSPStreamParserEvent] = []
+        for byte in stream {
+            events += parser.append(Data([byte]))
+        }
+
+        #expect(messageIDs(in: events) == [1, 2])
+        #expect(parserErrors(in: events).isEmpty)
+    }
+
+    @Test("Multiple coalesced frames are emitted in wire order")
+    func parsesCoalescedFrames() {
+        var stream = makeFrame(id: 1)
+        stream.append(makeFrame(id: 2))
+        stream.append(makeFrame(id: 3))
+
+        var parser = LSPMessageStreamParser()
+        let events = parser.append(stream)
+
+        #expect(messageIDs(in: events) == [1, 2, 3])
+        #expect(parserErrors(in: events).isEmpty)
+        #expect(parser.bufferedByteCount == 0)
+    }
+
+    @Test("A complete frame precedes one explicit incomplete EOF error")
+    func reportsIncompleteTrailingFrameAtEOF() {
+        let first = makeFrame(id: 1)
+        let partial = Data(makeFrame(id: 2).dropLast(3))
+        var stream = first
+        stream.append(partial)
+
+        var parser = LSPMessageStreamParser()
+        var events = parser.append(stream)
+        #expect(messageIDs(in: events) == [1])
+        #expect(parser.bufferedByteCount == partial.count)
+
+        events += parser.finish()
+        #expect(
+            parserErrors(in: events) == [
+                .incompleteMessage(bufferedBytes: partial.count)
+            ]
+        )
+        #expect(parser.bufferedByteCount == 0)
+        #expect(parser.finish().isEmpty)
+    }
+
+    @Test("Malformed header terminates before a coalesced apparent frame")
+    func malformedHeaderTerminatesStream() {
+        var stream = Data("Content-Length: 12junk\r\n\r\n".utf8)
+        stream.append(makeFrame(id: 7))
+
+        var parser = LSPMessageStreamParser()
+        let events = parser.append(stream)
+
+        #expect(parserErrors(in: events) == [.invalidHeader])
+        #expect(messageIDs(in: events).isEmpty)
+        #expect(parser.isFinished)
+        #expect(parser.bufferedByteCount == 0)
+        #expect(
+            parser.append(makeFrame(id: 8)).errors == [.inputAfterEOF]
+        )
+    }
+
+    @Test("Messages before malformed framing remain ordered")
+    func emitsCompletedMessagesBeforeTerminating() {
+        var stream = makeFrame(id: 1)
+        stream.append(Data("Content-Length: nope\r\n\r\n".utf8))
+        stream.append(makeFrame(id: 2))
+
+        var parser = LSPMessageStreamParser()
+        let events = parser.append(stream)
+
+        #expect(messageIDs(in: events) == [1])
+        #expect(parserErrors(in: events) == [.invalidHeader])
+        #expect(parser.isFinished)
+    }
+
+    @Test("Non-ASCII header terminates before a coalesced apparent frame")
+    func nonASCIIHeaderTerminatesStream() {
+        var stream = Data([0xFF])
+        stream.append(Data("\r\n\r\n".utf8))
+        stream.append(makeFrame(id: 8))
+
+        var parser = LSPMessageStreamParser()
+        let events = parser.append(stream)
+
+        #expect(parserErrors(in: events) == [.invalidHeader])
+        #expect(messageIDs(in: events).isEmpty)
+        #expect(parser.isFinished)
+    }
+
+    @Test("Invalid JSON terminates before a coalesced apparent frame")
+    func invalidJSONTerminatesStream() {
+        var stream = frame(body: Data("{invalid".utf8))
+        stream.append(makeFrame(id: 9))
+
+        var parser = LSPMessageStreamParser()
+        let events = parser.append(stream)
+
+        #expect(parserErrors(in: events) == [.invalidJSON])
+        #expect(messageIDs(in: events).isEmpty)
+        #expect(parser.isFinished)
+    }
+
+    @Test("A non-object JSON payload is malformed")
+    func rejectsNonObjectJSON() {
+        var parser = LSPMessageStreamParser()
+        let events = parser.append(frame(body: Data("[1, 2, 3]".utf8)))
+
+        #expect(messageIDs(in: events).isEmpty)
+        #expect(parserErrors(in: events) == [.invalidJSON])
+        #expect(parser.isFinished)
+    }
+
+    @Test("Missing separator remains buffered until EOF")
+    func reportsHeaderWithoutSeparatorAtEOF() {
+        let header = Data("Content-Length: 10\r\n".utf8)
+        var parser = LSPMessageStreamParser()
+
+        #expect(parser.append(header).isEmpty)
+        #expect(
+            parser.finish().errors == [
+                .incompleteMessage(bufferedBytes: header.count)
+            ]
+        )
+    }
+
+    @Test("Header and payload limits fail predictably")
+    func enforcesSizeLimits() {
+        var headerParser = LSPMessageStreamParser(
+            maximumHeaderSize: 8
+        )
+        #expect(
+            headerParser.append(Data(repeating: 65, count: 9)).errors
+                == [.headerTooLarge(byteCount: 9)]
+        )
+        #expect(headerParser.isFinished)
+
+        var payloadParser = LSPMessageStreamParser(
+            maximumPayloadSize: 4
+        )
+        let oversizedHeader = Data("Content-Length: 5\r\n\r\n".utf8)
+        #expect(
+            payloadParser.append(oversizedHeader).errors
+                == [.payloadTooLarge(byteCount: 5)]
+        )
+        #expect(payloadParser.isFinished)
+        #expect(
+            payloadParser.append(makeFrame(id: 1)).errors
+                == [.inputAfterEOF]
+        )
+    }
+
+    @Test("EOF is idempotent and later input is rejected")
+    func finishIsIdempotent() {
+        var parser = LSPMessageStreamParser()
+
+        #expect(parser.finish().isEmpty)
+        #expect(parser.finish().isEmpty)
+        #expect(
+            parser.append(makeFrame(id: 1)).errors
+                == [.inputAfterEOF]
+        )
+        #expect(parser.bufferedByteCount == 0)
+    }
+
+}
+
+@Suite("LSP Process Transport Tests", .serialized)
+@MainActor
+struct LSPProcessTransportTests {
+    @Test("Stdout descriptor setup succeeds or fails closed")
+    func configuresNonblockingDescriptor() {
+        let pipe = Pipe()
+        let descriptor = pipe.fileHandleForReading.fileDescriptor
+
+        #expect(
+            LSPTransport.configureNonBlocking(descriptor: descriptor)
+        )
+        let flags = Darwin.fcntl(descriptor, F_GETFL)
+        #expect(flags != -1)
+        #expect(flags & O_NONBLOCK != 0)
+        #expect(!LSPTransport.configureNonBlocking(descriptor: -1))
+    }
+
+    @Test(
+        "Echo process preserves callback order and terminates once",
+        .timeLimit(.minutes(1))
+    )
+    func echoProcessPreservesOrder() async {
+        let transport = LSPTransport()
+        let recorder = RecordingLSPTransportDelegate()
+        transport.delegate = recorder
+        defer { transport.terminate(timeout: 0.1) }
+
+        #expect(
+            transport.start(
+                command: "/bin/cat",
+                arguments: [],
+                environment: [:]
+            )
+        )
+        transport.send(["jsonrpc": "2.0", "id": 1])
+        transport.send(["jsonrpc": "2.0", "id": 2])
+        transport.send(["jsonrpc": "2.0", "id": 3])
+
+        #expect(
+            await waitUntil {
+                recorder.messages.count == 3
+            }
+        )
+        #expect(
+            recorder.messages.compactMap { $0["id"] as? Int }
+                == [1, 2, 3]
+        )
+
+        transport.terminate(timeout: 1)
+        #expect(
+            await waitUntil {
+                recorder.terminations.count == 1
+            }
+        )
+        #expect(recorder.terminations == [.requested])
+        #expect(!transport.isRunning)
+    }
+
+    @Test(
+        "Natural process exit reports termination exactly once",
+        .timeLimit(.minutes(1))
+    )
+    func naturalProcessExitIsReportedOnce() async {
+        let transport = LSPTransport()
+        let recorder = RecordingLSPTransportDelegate()
+        transport.delegate = recorder
+
+        #expect(
+            transport.start(
+                command: "/usr/bin/true",
+                arguments: [],
+                environment: [:]
+            )
+        )
+        #expect(
+            await waitUntil {
+                recorder.terminations.count == 1
+            }
+        )
+
+        try? await Task.sleep(for: .milliseconds(200))
+        #expect(recorder.terminations.count == 1)
+        #expect(!transport.isRunning)
+        switch recorder.terminations.first {
+        case .endOfFile, .processExited(status: 0):
+            break
+        default:
+            Issue.record("Unexpected natural-exit reason")
+        }
+    }
+
+    @Test(
+        "Final framed response is delivered before immediate process exit",
+        .timeLimit(.minutes(1))
+    )
+    func finalResponsePrecedesTermination() async throws {
+        let transport = LSPTransport()
+        let recorder = RecordingLSPTransportDelegate()
+        transport.delegate = recorder
+        let frame = try #require(
+            String(bytes: makeFrame(id: 41), encoding: .utf8)
+        )
+
+        #expect(
+            transport.start(
+                command: "/bin/sh",
+                arguments: [
+                    "-c",
+                    "printf '%s' \"$FRAME\""
+                ],
+                environment: ["FRAME": frame]
+            )
+        )
+        #expect(
+            await waitUntil {
+                recorder.terminations.count == 1
+            }
+        )
+
+        #expect(
+            recorder.messages.compactMap { $0["id"] as? Int } == [41]
+        )
+        #expect(recorder.callbackOrder == ["message", "termination"])
+        #expect(!transport.isRunning)
+    }
+
+    @Test(
+        "EOF stops a child that remains alive with stdout closed",
+        .timeLimit(.minutes(1))
+    )
+    func endOfFileStopsLiveProcess() async throws {
+        let transport = LSPTransport()
+        let recorder = RecordingLSPTransportDelegate()
+        transport.delegate = recorder
+        defer { transport.terminate(timeout: 0) }
+
+        #expect(
+            transport.start(
+                command: "/bin/sh",
+                arguments: [
+                    "-c",
+                    "trap '' TERM; exec 1>&-; exec /bin/sleep 30"
+                ],
+                environment: [:]
+            )
+        )
+        let processID = try #require(transport.processIdentifier)
+        #expect(
+            await waitUntil {
+                recorder.terminations == [.endOfFile]
+            }
+        )
+        #expect(
+            await waitUntil {
+                !isProcessAlive(processID)
+            }
+        )
+        #expect(!transport.isRunning)
+        #expect(recorder.terminations.count == 1)
+    }
+
+    @Test(
+        "Pending request fails when transport terminates",
+        .timeLimit(.minutes(1))
+    )
+    func pendingRequestFailsOnTermination() async {
+        let client = LSPClient(language: "test")
+        let request = Task { @MainActor in
+            do {
+                _ = try await client.sendRequest(
+                    "test/request",
+                    params: [:]
+                )
+                return false
+            } catch let error as LSPTransportError {
+                return error.termination
+                    == .processExited(status: 17)
+            } catch {
+                return false
+            }
+        }
+
+        #expect(
+            await waitUntil {
+                client.pendingRequestCount == 1
+            }
+        )
+        client.transportDidTerminate(.processExited(status: 17))
+
+        #expect(await request.value)
+        #expect(client.pendingRequestCount == 0)
+    }
+
+    @Test(
+        "Termination timeout kills an unresponsive child",
+        .timeLimit(.minutes(1))
+    )
+    func terminationTimeoutIsBounded() async {
+        let transport = LSPTransport()
+        defer { transport.terminate(timeout: 0) }
+
+        #expect(
+            transport.start(
+                command: "/bin/sh",
+                arguments: [
+                    "-c",
+                    "trap '' TERM; exec /bin/sleep 30"
+                ],
+                environment: [:]
+            )
+        )
+        let processID = transport.processIdentifier
+        try? await Task.sleep(for: .milliseconds(100))
+
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+        transport.terminate(timeout: 0.1)
+        let elapsed = startedAt.duration(to: clock.now)
+
+        #expect(elapsed < .seconds(2))
+        #expect(!transport.isRunning)
+        if let processID {
+            #expect(!isProcessAlive(processID))
+        }
+    }
+
+    @Test(
+        "Malformed framing terminates the stream and child process",
+        .timeLimit(.minutes(1))
+    )
+    func malformedFramingStopsTransport() async {
+        let transport = LSPTransport()
+        let recorder = RecordingLSPTransportDelegate()
+        transport.delegate = recorder
+        defer { transport.terminate(timeout: 0) }
+
+        #expect(
+            transport.start(
+                command: "/bin/sh",
+                arguments: [
+                    "-c",
+                    """
+                    trap '' TERM
+                    printf 'Content-Length: nope\\r\\n\\r\\n'
+                    exec /bin/sleep 30
+                    """
+                ],
+                environment: [:]
+            )
+        )
+        #expect(
+            await waitUntil {
+                recorder.terminations
+                    == [.protocolViolation(.invalidHeader)]
+            }
+        )
+        #expect(recorder.messages.isEmpty)
+        #expect(
+            await waitUntil {
+                !transport.isRunning
+            }
+        )
+        #expect(recorder.terminations.count == 1)
+    }
+
+    @Test("Invalid executable fails without creating a running transport")
+    func invalidExecutableFailsToStart() {
+        let transport = LSPTransport()
+
+        #expect(
+            !transport.start(
+                command: "/definitely/missing/pine-lsp",
+                arguments: [],
+                environment: [:]
+            )
+        )
+        #expect(!transport.isRunning)
+    }
+}
+
+@MainActor
+private final class RecordingLSPTransportDelegate: LSPTransportDelegate {
+    var messages: [[String: Any]] = []
+    var terminations: [LSPTransportTermination] = []
+    var callbackOrder: [String] = []
+
+    func transport(didReceive message: [String: Any]) {
+        messages.append(message)
+        callbackOrder.append("message")
+    }
+
+    func transportDidTerminate(_ reason: LSPTransportTermination) {
+        terminations.append(reason)
+        callbackOrder.append("termination")
+    }
+}
+
+@MainActor
+private func waitUntil(
+    timeout: Duration = .seconds(2),
+    condition: @MainActor () -> Bool
+) async -> Bool {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while !condition() {
+        guard clock.now < deadline else { return false }
+        try? await Task.sleep(for: .milliseconds(10))
+    }
+    return true
+}
+
+private func isProcessAlive(_ processID: pid_t) -> Bool {
+    if Darwin.kill(processID, 0) == 0 {
+        return true
+    }
+    return errno != ESRCH
+}
+
+private func makeFrame(id: Int, text: String = "") -> Data {
+    var payload: [String: Any] = [
+        "jsonrpc": "2.0",
+        "id": id
+    ]
+    if !text.isEmpty {
+        payload["text"] = text
+    }
+    return LSPMessageFraming.frame(payload)
+}
+
+private func frame(body: Data) -> Data {
+    var framed = Data("Content-Length: \(body.count)\r\n\r\n".utf8)
+    framed.append(body)
+    return framed
+}
+
+private func messageIDs(
+    in events: [LSPStreamParserEvent]
+) -> [Int] {
+    events.compactMap { event in
+        guard case .message(let message) = event else { return nil }
+        return message["id"] as? Int
+    }
+}
+
+private func parserErrors(
+    in events: [LSPStreamParserEvent]
+) -> [LSPStreamParserError] {
+    events.compactMap { event in
+        guard case .malformed(let error) = event else { return nil }
+        return error
+    }
+}
+
+private extension Array where Element == LSPStreamParserEvent {
+    var errors: [LSPStreamParserError] {
+        parserErrors(in: self)
+    }
+}


### PR DESCRIPTION
## Summary

- extract a deterministic incremental parser for LSP Content-Length framing
- fail closed on malformed headers, oversized frames, invalid JSON, and incomplete EOF without emitting partial messages
- preserve final stdout bytes and callback order across process exit, fail pending requests exactly once, and bound TERM-to-KILL cleanup
- cover fragmented, coalesced, UTF-8, malformed, EOF, and real process lifecycle paths without an installed language server or network

## Validation

- Xcode 27 targeted suite: 24 tests, three consecutive final passes
- SwiftLint strict on all changed Swift files: 0 violations
- git diff --check

CI will exercise the same suite on the stable Xcode 26 lane.

Closes #1178