### PR TITLE
fix(tabs): bound destination focus retries

### DIFF
--- a/Pine/AppKitFocusRequestCoordinator.swift
+++ b/Pine/AppKitFocusRequestCoordinator.swift
@@ -11,17 +11,29 @@ import AppKit
 ///
 /// SwiftUI may call `updateNSView` before a newly split destination is attached
 /// to a window. The request therefore remains pending after a failed attempt
-/// and is retried when the host view moves into a window.
+/// and is retried when the host view moves into a window. Once AppKit can
+/// actually evaluate the target, transient responder rejection is retried only
+/// within a fixed budget so repeated SwiftUI updates cannot steal focus later.
 @MainActor
 final class AppKitFocusRequestCoordinator {
+    static let defaultMaximumAttempts = 2
+
     private(set) var pendingRequestID: UUID?
+    private(set) var attemptCount = 0
 
     private weak var hostView: NSView?
     private weak var targetView: NSView?
     private var canAttempt: ((UUID) -> Bool)?
     private var onResult: ((UUID, Bool) -> Void)?
     private var attemptScheduled = false
-    private var scheduledTransientRetry = false
+    private var requestGeneration: UInt64 = 0
+    private var completedRequestID: UUID?
+    private let maximumAttempts: Int
+
+    init(maximumAttempts: Int = defaultMaximumAttempts) {
+        precondition(maximumAttempts > 0)
+        self.maximumAttempts = maximumAttempts
+    }
 
     func update(
         requestID: UUID?,
@@ -39,9 +51,11 @@ final class AppKitFocusRequestCoordinator {
             cancel()
             return
         }
+        guard completedRequestID != requestID else { return }
         if pendingRequestID != requestID {
             pendingRequestID = requestID
-            scheduledTransientRetry = false
+            attemptCount = 0
+            requestGeneration &+= 1
         }
         scheduleAttempt()
     }
@@ -53,11 +67,13 @@ final class AppKitFocusRequestCoordinator {
     }
 
     func cancel() {
+        requestGeneration &+= 1
         pendingRequestID = nil
         targetView = nil
         canAttempt = nil
         onResult = nil
-        scheduledTransientRetry = false
+        attemptCount = 0
+        completedRequestID = nil
     }
 
     /// Synchronous seam used by lifecycle callbacks and regression tests.
@@ -65,9 +81,7 @@ final class AppKitFocusRequestCoordinator {
     func attemptNow() -> Bool {
         guard let requestID = pendingRequestID else { return false }
         guard canAttempt?(requestID) != false else {
-            pendingRequestID = nil
-            scheduledTransientRetry = false
-            onResult?(requestID, false)
+            finish(requestID: requestID, succeeded: false)
             return false
         }
         guard
@@ -75,10 +89,10 @@ final class AppKitFocusRequestCoordinator {
               let targetView,
               let window = hostView.window,
               targetView.window === window else {
-            onResult?(requestID, false)
             return false
         }
 
+        attemptCount += 1
         let accepted = window.makeFirstResponder(targetView)
         let responderMatchesTarget = if window.firstResponder === targetView {
             true
@@ -88,17 +102,16 @@ final class AppKitFocusRequestCoordinator {
             false
         }
         let succeeded = accepted && responderMatchesTarget
-        onResult?(requestID, succeeded)
 
         if succeeded {
-            pendingRequestID = nil
-            scheduledTransientRetry = false
-        } else if !scheduledTransientRetry {
+            finish(requestID: requestID, succeeded: true)
+        } else if attemptCount < maximumAttempts {
             // AppKit can briefly reject a responder while SwiftUI finishes
-            // reparenting. Retry once on the next runloop; later view updates
-            // and `viewDidMoveToWindow` remain additional retry opportunities.
-            scheduledTransientRetry = true
+            // reparenting. The counter spans automatic retries, lifecycle
+            // callbacks, and repeated SwiftUI updates for this request.
             scheduleAttempt()
+        } else {
+            finish(requestID: requestID, succeeded: false)
         }
         return succeeded
     }
@@ -106,10 +119,26 @@ final class AppKitFocusRequestCoordinator {
     private func scheduleAttempt() {
         guard pendingRequestID != nil, !attemptScheduled else { return }
         attemptScheduled = true
+        let generation = requestGeneration
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.attemptScheduled = false
+            guard self.requestGeneration == generation else {
+                // A queued block belongs to a superseded request. Drop it,
+                // then ensure the current generation gets its own attempt.
+                self.scheduleAttempt()
+                return
+            }
             self.attemptNow()
         }
+    }
+
+    private func finish(requestID: UUID, succeeded: Bool) {
+        guard pendingRequestID == requestID else { return }
+        let completion = onResult
+        requestGeneration &+= 1
+        pendingRequestID = nil
+        completedRequestID = requestID
+        completion?(requestID, succeeded)
     }
 }

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -68,10 +68,13 @@ struct CodeEditorView: NSViewRepresentable {
     var cachedHighlightResult: HighlightMatchResult?
     /// When non-nil, the editor scrolls to this offset. The `id` ensures each request is unique.
     var goToOffset: GoToRequest?
-    /// Set by a committed tab drop to explicitly focus the destination editor.
-    var focusRequestTabID: UUID?
+    /// Unique request set when the destination editor should become first responder.
+    var focusRequestID: UUID?
     var canAttemptFocusRequest: ((UUID) -> Bool)?
     var onFocusRequestResult: ((UUID, Bool) -> Void)?
+    /// Revalidates the owning pane and tab before the deferred initial focus
+    /// installed by `makeNSView` is allowed to become first responder.
+    var canBecomeInitialFirstResponder: (() -> Bool)?
     /// Indentation style detected for the current file, used for indent guide rendering.
     var indentStyle: IndentationStyle = .spaces(4)
 
@@ -265,9 +268,13 @@ struct CodeEditorView: NSViewRepresentable {
 
         // Minimap redraw and first responder need the view to be in the window
         // hierarchy, so defer only those non-visual operations.
+        let canBecomeInitialFirstResponder = canBecomeInitialFirstResponder
         DispatchQueue.main.async {
             minimapView.needsDisplay = true
-            textView.window?.makeFirstResponder(textView)
+            Self.attemptInitialFocus(
+                on: textView,
+                canAttempt: canBecomeInitialFirstResponder
+            )
         }
 
         // Observe scroll changes to persist scroll offset.
@@ -331,6 +338,24 @@ struct CodeEditorView: NSViewRepresentable {
         return container
     }
 
+    /// Synchronous seam for the deferred `makeNSView` focus request.
+    ///
+    /// The owning pane/tab can change before the next main-queue turn. Always
+    /// revalidate at execution time so creating a background editor cannot
+    /// bypass `AppKitFocusRequestCoordinator` and steal first responder.
+    @discardableResult
+    static func attemptInitialFocus(
+        on targetView: NSView,
+        canAttempt: (() -> Bool)?
+    ) -> Bool {
+        guard canAttempt?() != false,
+              let window = targetView.window else {
+            return false
+        }
+        return window.makeFirstResponder(targetView)
+            && window.firstResponder === targetView
+    }
+
     func updateNSView(_ container: NSView, context: Context) {
         // Обновляем parent, чтобы binding в coordinator был актуальным
         context.coordinator.parent = self
@@ -339,7 +364,7 @@ struct CodeEditorView: NSViewRepresentable {
 
         let focusTarget = context.coordinator.scrollView?.documentView as? GutterTextView
         editorContainer.destinationFocusCoordinator.update(
-            requestID: focusRequestTabID,
+            requestID: focusRequestID,
             hostView: editorContainer,
             targetView: focusTarget,
             canAttempt: canAttemptFocusRequest,

--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -122,7 +122,9 @@ struct EditorTabBar: View {
                                 EditorTabItem(
                                     tab: tab,
                                     isActive: isActive,
-                                    onSelect: { tabManager.activeTabID = tab.id },
+                                    onSelect: {
+                                        paneManager.selectEditorTab(tab.id, in: paneID)
+                                    },
                                     onClose: { onCloseTab(tab) },
                                     onTogglePin: { tabManager.togglePin(id: tab.id) },
                                     onCloseOtherTabs: {
@@ -227,7 +229,7 @@ struct EditorTabBar: View {
                 Menu {
                     ForEach(tabManager.tabs) { tab in
                         Button {
-                            tabManager.activeTabID = tab.id
+                            paneManager.selectEditorTab(tab.id, in: paneID)
                         } label: {
                             Label {
                                 Text(tab.fileName)

--- a/Pine/MarkdownPreviewView.swift
+++ b/Pine/MarkdownPreviewView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// Renders Markdown content as a read-only attributed string in a scrollable NSTextView.
 struct MarkdownPreviewView: NSViewRepresentable {
     let content: String
-    var focusRequestTabID: UUID?
+    var focusRequestID: UUID?
     var canAttemptFocusRequest: ((UUID) -> Bool)?
     var onFocusRequestResult: ((UUID, Bool) -> Void)?
 
@@ -36,7 +36,7 @@ struct MarkdownPreviewView: NSViewRepresentable {
         context.coordinator.textView = textView
         context.coordinator.scheduleRender(content: content)
         scrollView.destinationFocusCoordinator.update(
-            requestID: focusRequestTabID,
+            requestID: focusRequestID,
             hostView: scrollView,
             targetView: textView,
             canAttempt: canAttemptFocusRequest,
@@ -49,7 +49,7 @@ struct MarkdownPreviewView: NSViewRepresentable {
     func updateNSView(_ scrollView: MarkdownPreviewScrollView, context: Context) {
         context.coordinator.scheduleRender(content: content)
         scrollView.destinationFocusCoordinator.update(
-            requestID: focusRequestTabID,
+            requestID: focusRequestID,
             hostView: scrollView,
             targetView: context.coordinator.textView,
             canAttempt: canAttemptFocusRequest,

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -283,19 +283,24 @@ struct PaneLeafView: View {
 
             if let tab = tabManager.activeTab {
                 Group {
-                    let focusRequestID = tabManager.pendingFocusTabID == tab.id ? tab.id : nil
+                    let focusRequestID = tabManager.pendingFocusTabID == tab.id
+                        ? tabManager.pendingFocusRequestID
+                        : nil
                     switch EditorContentPresentation.resolve(for: tab) {
                     case .quickLook:
                         QuickLookPreviewView(
                             url: tab.url,
-                            focusRequestTabID: focusRequestID,
-                            canAttemptFocusRequest: { tabID in
-                                tabManager.activeTabID == tabID
-                                    && tabManager.pendingFocusTabID == tabID
+                            focusRequestID: focusRequestID,
+                            canAttemptFocusRequest: { requestID in
+                                paneManager.activePaneID == paneID
+                                    && tabManager.activeTabID == tab.id
+                                    && tabManager.pendingFocusTabID == tab.id
+                                    && tabManager.pendingFocusRequestID == requestID
                             },
-                            onFocusRequestResult: { tabID, succeeded in
+                            onFocusRequestResult: { requestID, succeeded in
                                 tabManager.acknowledgeFocusRequest(
-                                    for: tabID,
+                                    requestID: requestID,
+                                    for: tab.id,
                                     succeeded: succeeded
                                 )
                             }
@@ -304,14 +309,17 @@ struct PaneLeafView: View {
                     case .markdownPreview:
                         MarkdownPreviewView(
                             content: tab.content,
-                            focusRequestTabID: focusRequestID,
-                            canAttemptFocusRequest: { tabID in
-                                tabManager.activeTabID == tabID
-                                    && tabManager.pendingFocusTabID == tabID
+                            focusRequestID: focusRequestID,
+                            canAttemptFocusRequest: { requestID in
+                                paneManager.activePaneID == paneID
+                                    && tabManager.activeTabID == tab.id
+                                    && tabManager.pendingFocusTabID == tab.id
+                                    && tabManager.pendingFocusRequestID == requestID
                             },
-                            onFocusRequestResult: { tabID, succeeded in
+                            onFocusRequestResult: { requestID, succeeded in
                                 tabManager.acknowledgeFocusRequest(
-                                    for: tabID,
+                                    requestID: requestID,
+                                    for: tab.id,
                                     succeeded: succeeded
                                 )
                             }
@@ -385,13 +393,25 @@ struct PaneLeafView: View {
             },
             cachedHighlightResult: tab.cachedHighlightResult,
             goToOffset: goToLineOffset,
-            focusRequestTabID: tabManager.pendingFocusTabID == tab.id ? tab.id : nil,
-            canAttemptFocusRequest: { tabID in
-                tabManager.activeTabID == tabID
-                    && tabManager.pendingFocusTabID == tabID
+            focusRequestID: tabManager.pendingFocusTabID == tab.id
+                ? tabManager.pendingFocusRequestID
+                : nil,
+            canAttemptFocusRequest: { requestID in
+                paneManager.activePaneID == paneID
+                    && tabManager.activeTabID == tab.id
+                    && tabManager.pendingFocusTabID == tab.id
+                    && tabManager.pendingFocusRequestID == requestID
             },
-            onFocusRequestResult: { tabID, succeeded in
-                tabManager.acknowledgeFocusRequest(for: tabID, succeeded: succeeded)
+            onFocusRequestResult: { requestID, succeeded in
+                tabManager.acknowledgeFocusRequest(
+                    requestID: requestID,
+                    for: tab.id,
+                    succeeded: succeeded
+                )
+            },
+            canBecomeInitialFirstResponder: {
+                paneManager.activePaneID == paneID
+                    && tabManager.activeTabID == tab.id
             },
             indentStyle: tab.cachedIndentation,
             fontSize: FontSizeSettings.shared.fontSize

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -271,6 +271,21 @@ final class PaneManager {
         Array(tabManagers.values)
     }
 
+    /// Selects an editor tab and makes its owning pane the active focus
+    /// destination. Tab-strip controls use this instead of changing only the
+    /// local selection, which could leave focus routed to another pane.
+    @discardableResult
+    func selectEditorTab(_ tabID: UUID, in paneID: PaneID) -> Bool {
+        guard let tabManager = tabManagers[paneID],
+              tabManager.tabs.contains(where: { $0.id == tabID }) else {
+            return false
+        }
+        activePaneID = paneID
+        tabManager.activeTabID = tabID
+        tabManager.pendingFocusTabID = tabID
+        return true
+    }
+
     // MARK: - Split operations
 
     /// Splits a pane by placing a new pane alongside it.
@@ -493,6 +508,29 @@ final class PaneManager {
 
     func terminalState(for paneID: PaneID) -> TerminalPaneState? {
         terminalStates[paneID]
+    }
+
+    /// Selects a terminal tab, activates its pane, and requests first responder
+    /// for the newly selected terminal content.
+    @discardableResult
+    func selectTerminalTab(_ tabID: UUID, in paneID: PaneID) -> Bool {
+        guard let terminalState = terminalStates[paneID],
+              terminalState.terminalTabs.contains(where: { $0.id == tabID }) else {
+            return false
+        }
+        activePaneID = paneID
+        terminalState.activeTerminalID = tabID
+        terminalState.pendingFocusTabID = tabID
+        return true
+    }
+
+    /// Adds a terminal tab through the pane owner so creation and focus
+    /// routing cannot disagree about the active pane.
+    @discardableResult
+    func addTerminalTab(in paneID: PaneID, workingDirectory: URL?) -> TerminalTab? {
+        guard let terminalState = terminalStates[paneID] else { return nil }
+        activePaneID = paneID
+        return terminalState.addTab(workingDirectory: workingDirectory)
     }
 
     var terminalPaneIDs: [PaneID] {

--- a/Pine/QuickLookPreviewView.swift
+++ b/Pine/QuickLookPreviewView.swift
@@ -17,7 +17,7 @@ import SwiftUI
 /// embedding the view.
 struct QuickLookPreviewView: NSViewRepresentable {
     let url: URL
-    var focusRequestTabID: UUID?
+    var focusRequestID: UUID?
     var canAttemptFocusRequest: ((UUID) -> Bool)?
     var onFocusRequestResult: ((UUID, Bool) -> Void)?
 
@@ -30,7 +30,7 @@ struct QuickLookPreviewView: NSViewRepresentable {
         let view = FocusableQuickLookPreviewView(frame: .zero, style: .normal)!
         context.coordinator.currentURL = url
         view.destinationFocusCoordinator.update(
-            requestID: focusRequestTabID,
+            requestID: focusRequestID,
             hostView: view,
             targetView: view,
             canAttempt: canAttemptFocusRequest,
@@ -50,7 +50,7 @@ struct QuickLookPreviewView: NSViewRepresentable {
 
     func updateNSView(_ nsView: FocusableQuickLookPreviewView, context: Context) {
         nsView.destinationFocusCoordinator.update(
-            requestID: focusRequestTabID,
+            requestID: focusRequestID,
             hostView: nsView,
             targetView: nsView,
             canAttempt: canAttemptFocusRequest,

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -38,9 +38,17 @@ final class TabManager {
             onEditorContextChanged?()
         }
     }
-    /// Set after a drag commit so the destination content can become first
-    /// responder. It remains pending until AppKit confirms the responder.
-    var pendingFocusTabID: UUID?
+    /// Set when destination content should explicitly become first responder.
+    /// It remains pending until the bounded AppKit request finishes.
+    var pendingFocusTabID: UUID? {
+        didSet {
+            pendingFocusRequestID = pendingFocusTabID.map { _ in UUID() }
+        }
+    }
+    /// Unique generation for the current request. A repeated request for the
+    /// same tab receives a fresh identity, so a queued completion from an
+    /// earlier drag cannot consume it.
+    private(set) var pendingFocusRequestID: UUID?
     var pendingGoToLine: Int?
     var recoveryManager: RecoveryManager?
     var onEditorContextChanged: (() -> Void)?
@@ -70,19 +78,25 @@ final class TabManager {
     var isAutoSaveEnabled: Bool { UserDefaults.standard.bool(forKey: Self.autoSaveKey) }
     var pinnedTabCount: Int { TabPinning.pinnedTabCount(in: tabs) }
 
-    /// Acknowledges an AppKit focus attempt for the active destination tab.
-    /// Failed, stale, and off-screen attempts deliberately retain the request
-    /// so a later view update or window-attachment callback can retry it.
+    /// Consumes the terminal result of a bounded AppKit focus request.
+    ///
+    /// Retryable lifecycle states are retained inside
+    /// `AppKitFocusRequestCoordinator` and do not call this method. A `false`
+    /// result therefore means the request was cancelled or exhausted.
     @discardableResult
-    func acknowledgeFocusRequest(for tabID: UUID, succeeded: Bool) -> Bool {
+    func acknowledgeFocusRequest(
+        requestID: UUID,
+        for tabID: UUID,
+        succeeded: Bool
+    ) -> Bool {
         guard pendingFocusTabID == tabID else { return false }
+        guard pendingFocusRequestID == requestID else { return false }
         guard activeTabID == tabID else {
             pendingFocusTabID = nil
             return false
         }
-        guard succeeded else { return false }
         pendingFocusTabID = nil
-        return true
+        return succeeded
     }
 
     /// A tab temporarily detached from this manager while it is transferred

--- a/Pine/TerminalPaneContent.swift
+++ b/Pine/TerminalPaneContent.swift
@@ -23,7 +23,12 @@ struct TerminalPaneContent: View {
                 workingDirectory: workspace.rootURL
             )
             TerminalSearchBarContainer(terminalState: terminalState)
-            TerminalContentView(terminalPaneState: terminalState)
+            TerminalContentView(
+                terminalPaneState: terminalState,
+                canAttemptFocusRequest: { _ in
+                    paneManager.activePaneID == paneID
+                }
+            )
         }
         .background(Color(nsColor: .textBackgroundColor))
         .onAppear {

--- a/Pine/TerminalPaneState.swift
+++ b/Pine/TerminalPaneState.swift
@@ -20,7 +20,14 @@ final class TerminalPaneState {
             }
         }
     }
-    var pendingFocusTabID: UUID?
+    var pendingFocusTabID: UUID? {
+        didSet {
+            pendingFocusRequestID = pendingFocusTabID.map { _ in UUID() }
+        }
+    }
+    /// Unique generation for the active request, preventing a stale AppKit
+    /// completion from consuming a later request for the same terminal tab.
+    private(set) var pendingFocusRequestID: UUID?
 
     /// Monotonically increasing counter for unique terminal tab names.
     private var nextTabNumber = 1
@@ -36,18 +43,24 @@ final class TerminalPaneState {
 
     var tabCount: Int { terminalTabs.count }
 
-    /// Clears a focus request only after AppKit confirms that the active
-    /// terminal view became first responder.
+    /// Consumes the terminal result of a bounded AppKit focus request.
+    ///
+    /// Retryable lifecycle states stay inside `AppKitFocusRequestCoordinator`;
+    /// `false` means the request was cancelled or exhausted.
     @discardableResult
-    func acknowledgeFocusRequest(for tabID: UUID, succeeded: Bool) -> Bool {
+    func acknowledgeFocusRequest(
+        requestID: UUID,
+        for tabID: UUID,
+        succeeded: Bool
+    ) -> Bool {
         guard pendingFocusTabID == tabID else { return false }
+        guard pendingFocusRequestID == requestID else { return false }
         guard activeTerminalID == tabID else {
             pendingFocusTabID = nil
             return false
         }
-        guard succeeded else { return false }
         pendingFocusTabID = nil
-        return true
+        return succeeded
     }
 
     @discardableResult

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -56,8 +56,7 @@ struct TerminalPaneTabBar: View {
                                 isActive: isActive,
                                 canClose: true,
                                 onSelect: {
-                                    terminalState.activeTerminalID = tab.id
-                                    terminalState.pendingFocusTabID = tab.id
+                                    paneManager.selectTerminalTab(tab.id, in: paneID)
                                 },
                                 onClose: { closeTerminalTabWithConfirmation(tab) }
                             )
@@ -84,7 +83,10 @@ struct TerminalPaneTabBar: View {
 
                 // New terminal tab button
                 Button {
-                    terminalState.addTab(workingDirectory: workingDirectory)
+                    paneManager.addTerminalTab(
+                        in: paneID,
+                        workingDirectory: workingDirectory
+                    )
                 } label: {
                     Image(systemName: "plus")
                         .font(.system(size: 11, weight: .medium))

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -695,15 +695,18 @@ class TerminalScrollInterceptor: NSView {
 /// Переключение терминальных табов происходит на уровне AppKit.
 struct TerminalContentView: NSViewRepresentable {
     let terminalPaneState: TerminalPaneState
+    let canAttemptFocusRequest: (UUID) -> Bool
 
     func makeNSView(context: Context) -> TerminalContainerView {
         let container = TerminalContainerView()
         container.terminalPaneState = terminalPaneState
+        container.canAttemptFocusRequest = canAttemptFocusRequest
         container.showTab(terminalPaneState.activeTab)
         return container
     }
 
     func updateNSView(_ container: TerminalContainerView, context: Context) {
+        container.canAttemptFocusRequest = canAttemptFocusRequest
         container.showTab(terminalPaneState.activeTab)
     }
 }
@@ -721,6 +724,7 @@ class TerminalContainerView: NSView {
     static let defaultTerminalFrame = NSRect(x: 0, y: 0, width: 800, height: 300)
 
     var terminalPaneState: TerminalPaneState?
+    var canAttemptFocusRequest: ((UUID) -> Bool)?
     private var currentTabID: UUID?
     let destinationFocusCoordinator = AppKitFocusRequestCoordinator()
     private let scrollInterceptor = TerminalScrollInterceptor()
@@ -832,19 +836,23 @@ class TerminalContainerView: NSView {
 
         installScrollMonitor()
 
-        let focusRequestID = terminalPaneState?.pendingFocusTabID == tab.id
-            ? tab.id
+        let tabID = tab.id
+        let focusRequestID = terminalPaneState?.pendingFocusTabID == tabID
+            ? terminalPaneState?.pendingFocusRequestID
             : nil
         destinationFocusCoordinator.update(
             requestID: focusRequestID,
             hostView: self,
             targetView: tab.terminalView,
-            canAttempt: { [weak state = terminalPaneState] tabID in
+            canAttempt: { [weak self, weak state = terminalPaneState] requestID in
                 state?.activeTerminalID == tabID
                     && state?.pendingFocusTabID == tabID
+                    && state?.pendingFocusRequestID == requestID
+                    && self?.canAttemptFocusRequest?(requestID) != false
             },
-            onResult: { [weak state = terminalPaneState] tabID, succeeded in
+            onResult: { [weak state = terminalPaneState] requestID, succeeded in
                 state?.acknowledgeFocusRequest(
+                    requestID: requestID,
                     for: tabID,
                     succeeded: succeeded
                 )

--- a/PineTests/TabDestinationFocusTests.swift
+++ b/PineTests/TabDestinationFocusTests.swift
@@ -36,48 +36,108 @@ struct TabDestinationFocusTests {
         #expect(EditorContentPresentation.resolve(for: markdown) == .codeEditor)
     }
 
-    @Test("Failed attempts retry while switching tabs cancels stale focus")
-    func failedAttemptsRetryAndTabSwitchCancelsStaleFocus() {
+    @Test("Final focus results consume requests while tab switches cancel stale focus")
+    func finalResultsAndTabSwitchConsumeFocusRequests() throws {
         let manager = TabManager()
         let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/image.png"), kind: .preview)
         manager.tabs = [tab]
         manager.activeTabID = tab.id
         manager.pendingFocusTabID = tab.id
+        let failedRequestID = try #require(manager.pendingFocusRequestID)
 
-        #expect(!manager.acknowledgeFocusRequest(for: tab.id, succeeded: false))
-        #expect(manager.pendingFocusTabID == tab.id)
-        #expect(!manager.acknowledgeFocusRequest(for: UUID(), succeeded: true))
+        #expect(!manager.acknowledgeFocusRequest(
+            requestID: failedRequestID,
+            for: tab.id,
+            succeeded: false
+        ))
+        #expect(manager.pendingFocusTabID == nil)
+
+        manager.pendingFocusTabID = tab.id
+        let pendingRequestID = try #require(manager.pendingFocusRequestID)
+        #expect(!manager.acknowledgeFocusRequest(
+            requestID: pendingRequestID,
+            for: UUID(),
+            succeeded: true
+        ))
         #expect(manager.pendingFocusTabID == tab.id)
 
         manager.activeTabID = nil
         #expect(manager.pendingFocusTabID == nil)
-        #expect(!manager.acknowledgeFocusRequest(for: tab.id, succeeded: true))
+        #expect(!manager.acknowledgeFocusRequest(
+            requestID: pendingRequestID,
+            for: tab.id,
+            succeeded: true
+        ))
         #expect(manager.pendingFocusTabID == nil)
     }
 
-    @Test("Detached AppKit destination retries and acknowledges after attachment")
-    func detachedDestinationRetriesAfterWindowAttachment() {
+    @Test("Repeated requests for one tab receive distinct generations")
+    func repeatedRequestsForSameTabHaveDistinctGenerations() throws {
         let manager = TabManager()
         let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/readme.md"))
         manager.tabs = [tab]
         manager.activeTabID = tab.id
         manager.pendingFocusTabID = tab.id
+        let firstRequestID = try #require(manager.pendingFocusRequestID)
+
+        manager.pendingFocusTabID = tab.id
+        let secondRequestID = try #require(manager.pendingFocusRequestID)
+        #expect(secondRequestID != firstRequestID)
+        #expect(!manager.acknowledgeFocusRequest(
+            requestID: firstRequestID,
+            for: tab.id,
+            succeeded: true
+        ))
+        #expect(manager.pendingFocusRequestID == secondRequestID)
+        #expect(manager.acknowledgeFocusRequest(
+            requestID: secondRequestID,
+            for: tab.id,
+            succeeded: true
+        ))
+        #expect(manager.pendingFocusTabID == nil)
+
+        let terminalState = TerminalPaneState()
+        let terminalTab = terminalState.addTab(workingDirectory: nil)
+        let firstTerminalRequestID = try #require(terminalState.pendingFocusRequestID)
+        terminalState.pendingFocusTabID = terminalTab.id
+        let secondTerminalRequestID = try #require(terminalState.pendingFocusRequestID)
+        #expect(secondTerminalRequestID != firstTerminalRequestID)
+        #expect(!terminalState.acknowledgeFocusRequest(
+            requestID: firstTerminalRequestID,
+            for: terminalTab.id,
+            succeeded: true
+        ))
+        #expect(terminalState.pendingFocusRequestID == secondTerminalRequestID)
+    }
+
+    @Test("Detached AppKit destination retries and acknowledges after attachment")
+    func detachedDestinationRetriesAfterWindowAttachment() throws {
+        let manager = TabManager()
+        let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/readme.md"))
+        manager.tabs = [tab]
+        manager.activeTabID = tab.id
+        manager.pendingFocusTabID = tab.id
+        let requestID = try #require(manager.pendingFocusRequestID)
 
         let host = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
         let target = FocusAcceptingTestView(frame: host.bounds)
         host.addSubview(target)
         let coordinator = AppKitFocusRequestCoordinator()
         coordinator.update(
-            requestID: tab.id,
+            requestID: requestID,
             hostView: host,
             targetView: target,
-            onResult: { tabID, succeeded in
-                manager.acknowledgeFocusRequest(for: tabID, succeeded: succeeded)
+            onResult: { completedRequestID, succeeded in
+                manager.acknowledgeFocusRequest(
+                    requestID: completedRequestID,
+                    for: tab.id,
+                    succeeded: succeeded
+                )
             }
         )
 
         #expect(!coordinator.attemptNow())
-        #expect(coordinator.pendingRequestID == tab.id)
+        #expect(coordinator.pendingRequestID == requestID)
         #expect(manager.pendingFocusTabID == tab.id)
 
         let window = NSWindow(
@@ -95,12 +155,13 @@ struct TabDestinationFocusTests {
     }
 
     @Test("Stale request is cancelled before AppKit can steal focus")
-    func staleRequestDoesNotChangeFirstResponder() {
+    func staleRequestDoesNotChangeFirstResponder() throws {
         let manager = TabManager()
         let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/readme.md"))
         manager.tabs = [tab]
         manager.activeTabID = tab.id
         manager.pendingFocusTabID = tab.id
+        let requestID = try #require(manager.pendingFocusRequestID)
 
         let host = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
         let target = FocusAcceptingTestView(frame: host.bounds)
@@ -115,15 +176,20 @@ struct TabDestinationFocusTests {
         let originalResponder = window.firstResponder
         let coordinator = AppKitFocusRequestCoordinator()
         coordinator.update(
-            requestID: tab.id,
+            requestID: requestID,
             hostView: host,
             targetView: target,
-            canAttempt: { tabID in
-                manager.activeTabID == tabID
-                    && manager.pendingFocusTabID == tabID
+            canAttempt: { candidateRequestID in
+                manager.activeTabID == tab.id
+                    && manager.pendingFocusTabID == tab.id
+                    && manager.pendingFocusRequestID == candidateRequestID
             },
-            onResult: { tabID, succeeded in
-                manager.acknowledgeFocusRequest(for: tabID, succeeded: succeeded)
+            onResult: { completedRequestID, succeeded in
+                manager.acknowledgeFocusRequest(
+                    requestID: completedRequestID,
+                    for: tab.id,
+                    succeeded: succeeded
+                )
             }
         )
 
@@ -132,6 +198,283 @@ struct TabDestinationFocusTests {
         #expect(coordinator.pendingRequestID == nil)
         #expect(window.firstResponder === originalResponder)
         #expect(window.firstResponder !== target)
+    }
+
+    @Test("Responder rejection exhausts one bounded budget across repeated updates")
+    func responderRejectionExhaustsBoundedBudget() async throws {
+        let manager = TabManager()
+        let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/readme.md"))
+        manager.tabs = [tab]
+        manager.activeTabID = tab.id
+        manager.pendingFocusTabID = tab.id
+        let requestID = try #require(manager.pendingFocusRequestID)
+
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let target = FocusAcceptingTestView(frame: host.bounds)
+        host.addSubview(target)
+        let window = FocusRejectingTestWindow(
+            contentRect: host.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        let baselineAttempts = window.focusAttemptCount
+        var terminalResults: [Bool] = []
+        let onResult: (UUID, Bool) -> Void = { completedRequestID, succeeded in
+            terminalResults.append(succeeded)
+            manager.acknowledgeFocusRequest(
+                requestID: completedRequestID,
+                for: tab.id,
+                succeeded: succeeded
+            )
+        }
+        let coordinator = AppKitFocusRequestCoordinator(maximumAttempts: 2)
+        coordinator.update(
+            requestID: requestID,
+            hostView: host,
+            targetView: target,
+            onResult: onResult
+        )
+
+        // Exercise the first attempt synchronously while retaining the queued
+        // retry installed by `update`.
+        #expect(!coordinator.attemptNow())
+        #expect(coordinator.pendingRequestID == requestID)
+        #expect(manager.pendingFocusTabID == tab.id)
+        #expect(window.focusAttemptCount - baselineAttempts == 1)
+        #expect(terminalResults.isEmpty)
+
+        // Repeated SwiftUI updates while the retry is pending must neither
+        // reset the counter nor enqueue parallel attempts.
+        for _ in 0..<3 {
+            coordinator.update(
+                requestID: requestID,
+                hostView: host,
+                targetView: target,
+                onResult: onResult
+            )
+        }
+        await nextMainQueueTurn()
+        #expect(coordinator.pendingRequestID == nil)
+        #expect(manager.pendingFocusTabID == nil)
+        #expect(window.focusAttemptCount - baselineAttempts == 2)
+        #expect(terminalResults == [false])
+
+        // A stale SwiftUI update for the completed request must not restart
+        // the budget or enqueue another responder attempt.
+        coordinator.update(
+            requestID: requestID,
+            hostView: host,
+            targetView: target,
+            onResult: onResult
+        )
+        await nextMainQueueTurn()
+        await nextMainQueueTurn()
+        #expect(window.focusAttemptCount - baselineAttempts == 2)
+        #expect(terminalResults == [false])
+    }
+
+    @Test("Queued attempt from a superseded generation cannot focus its old target")
+    func queuedSupersededGenerationDoesNotRun() async {
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let oldTarget = FocusAcceptingTestView(frame: host.bounds)
+        let currentTarget = FocusAcceptingTestView(frame: host.bounds)
+        host.addSubview(oldTarget)
+        host.addSubview(currentTarget)
+        let window = NSWindow(
+            contentRect: host.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+
+        let oldRequestID = UUID()
+        let currentRequestID = UUID()
+        var completedRequestIDs: [UUID] = []
+        let coordinator = AppKitFocusRequestCoordinator()
+        coordinator.update(
+            requestID: oldRequestID,
+            hostView: host,
+            targetView: oldTarget,
+            onResult: { requestID, _ in completedRequestIDs.append(requestID) }
+        )
+        coordinator.update(
+            requestID: currentRequestID,
+            hostView: host,
+            targetView: currentTarget,
+            onResult: { requestID, _ in completedRequestIDs.append(requestID) }
+        )
+
+        // The first queue turn discards the stale generation and schedules
+        // the current one; the second executes only the current attempt.
+        await nextMainQueueTurn()
+        await nextMainQueueTurn()
+
+        #expect(window.firstResponder === currentTarget)
+        #expect(window.firstResponder !== oldTarget)
+        #expect(completedRequestIDs == [currentRequestID])
+        #expect(coordinator.pendingRequestID == nil)
+    }
+
+    @Test("Pane switch cancels delayed editor focus before AppKit can steal it")
+    func paneSwitchCancelsDelayedEditorFocus() throws {
+        let paneManager = PaneManager()
+        let destinationPaneID = paneManager.activePaneID
+        let tabManager = try #require(paneManager.tabManager(for: destinationPaneID))
+        let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/readme.md"))
+        tabManager.tabs = [tab]
+        tabManager.activeTabID = tab.id
+        tabManager.pendingFocusTabID = tab.id
+        let requestID = try #require(tabManager.pendingFocusRequestID)
+        let otherPaneID = try #require(
+            paneManager.splitPane(destinationPaneID, axis: .horizontal)
+        )
+        #expect(paneManager.activePaneID == otherPaneID)
+
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let target = FocusAcceptingTestView(frame: host.bounds)
+        host.addSubview(target)
+        let window = NSWindow(
+            contentRect: host.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        let originalResponder = window.firstResponder
+        let coordinator = AppKitFocusRequestCoordinator()
+        coordinator.update(
+            requestID: requestID,
+            hostView: host,
+            targetView: target,
+            canAttempt: { candidateRequestID in
+                paneManager.activePaneID == destinationPaneID
+                    && tabManager.activeTabID == tab.id
+                    && tabManager.pendingFocusTabID == tab.id
+                    && tabManager.pendingFocusRequestID == candidateRequestID
+            },
+            onResult: { completedRequestID, succeeded in
+                tabManager.acknowledgeFocusRequest(
+                    requestID: completedRequestID,
+                    for: tab.id,
+                    succeeded: succeeded
+                )
+            }
+        )
+
+        #expect(!coordinator.attemptNow())
+        #expect(coordinator.pendingRequestID == nil)
+        #expect(tabManager.pendingFocusTabID == nil)
+        #expect(window.firstResponder === originalResponder)
+        #expect(window.firstResponder !== target)
+    }
+
+    @Test("Deferred editor creation revalidates its pane before taking focus")
+    func deferredEditorCreationRevalidatesPane() {
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let target = FocusAcceptingTestView(frame: host.bounds)
+        host.addSubview(target)
+        let window = NSWindow(
+            contentRect: host.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        let originalResponder = window.firstResponder
+
+        #expect(!CodeEditorView.attemptInitialFocus(
+            on: target,
+            canAttempt: { false }
+        ))
+        #expect(window.firstResponder === originalResponder)
+        #expect(window.firstResponder !== target)
+
+        #expect(CodeEditorView.attemptInitialFocus(
+            on: target,
+            canAttempt: { true }
+        ))
+        #expect(window.firstResponder === target)
+    }
+
+    @Test("Pane switch cancels delayed terminal focus before AppKit can steal it")
+    func paneSwitchCancelsDelayedTerminalFocus() {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        let container = TerminalContainerView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 300)
+        )
+        container.terminalPaneState = state
+        container.canAttemptFocusRequest = { _ in false }
+        container.showTab(tab)
+        let window = NSWindow(
+            contentRect: container.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+        let originalResponder = window.firstResponder
+
+        #expect(!container.destinationFocusCoordinator.attemptNow())
+        #expect(container.destinationFocusCoordinator.pendingRequestID == nil)
+        #expect(state.pendingFocusTabID == nil)
+        #expect(window.firstResponder === originalResponder)
+        #expect(window.firstResponder !== tab.terminalView)
+    }
+
+    @Test("Tab-strip selection and creation activate the owning pane first")
+    func tabStripActionsActivateOwningPane() throws {
+        let paneManager = PaneManager()
+        let editorPaneID = paneManager.activePaneID
+        let editorManager = try #require(paneManager.tabManager(for: editorPaneID))
+        let firstEditorTab = EditorTab(url: URL(fileURLWithPath: "/tmp/first.swift"))
+        let secondEditorTab = EditorTab(url: URL(fileURLWithPath: "/tmp/second.swift"))
+        editorManager.tabs = [firstEditorTab, secondEditorTab]
+        editorManager.activeTabID = firstEditorTab.id
+
+        let terminalPaneID = try #require(paneManager.createTerminalPane(
+            relativeTo: editorPaneID,
+            axis: .vertical,
+            workingDirectory: nil
+        ))
+        let terminalState = try #require(paneManager.terminalState(for: terminalPaneID))
+        let firstTerminalTab = try #require(terminalState.activeTab)
+        #expect(paneManager.activePaneID == terminalPaneID)
+
+        #expect(paneManager.selectEditorTab(secondEditorTab.id, in: editorPaneID))
+        #expect(paneManager.activePaneID == editorPaneID)
+        #expect(editorManager.activeTabID == secondEditorTab.id)
+        #expect(editorManager.pendingFocusTabID == secondEditorTab.id)
+
+        let firstEditorRequestID = try #require(editorManager.pendingFocusRequestID)
+        paneManager.activePaneID = terminalPaneID
+        #expect(paneManager.selectEditorTab(secondEditorTab.id, in: editorPaneID))
+        #expect(paneManager.activePaneID == editorPaneID)
+        #expect(editorManager.activeTabID == secondEditorTab.id)
+        #expect(editorManager.pendingFocusTabID == secondEditorTab.id)
+        #expect(editorManager.pendingFocusRequestID != firstEditorRequestID)
+
+        let addedTerminalTab = try #require(
+            paneManager.addTerminalTab(in: terminalPaneID, workingDirectory: nil)
+        )
+        #expect(paneManager.activePaneID == terminalPaneID)
+        #expect(terminalState.activeTerminalID == addedTerminalTab.id)
+        #expect(terminalState.pendingFocusTabID == addedTerminalTab.id)
+
+        paneManager.activePaneID = editorPaneID
+        #expect(paneManager.selectTerminalTab(firstTerminalTab.id, in: terminalPaneID))
+        #expect(paneManager.activePaneID == terminalPaneID)
+        #expect(terminalState.activeTerminalID == firstTerminalTab.id)
+        #expect(terminalState.pendingFocusTabID == firstTerminalTab.id)
+
+        let previousRequestID = terminalState.pendingFocusRequestID
+        #expect(!paneManager.selectTerminalTab(UUID(), in: terminalPaneID))
+        #expect(paneManager.activePaneID == terminalPaneID)
+        #expect(terminalState.activeTerminalID == firstTerminalTab.id)
+        #expect(terminalState.pendingFocusRequestID == previousRequestID)
     }
 
     @Test("Quick Look focus target is an explicit first responder")
@@ -143,22 +486,50 @@ struct TabDestinationFocusTests {
         #expect(view.acceptsFirstResponder)
     }
 
-    @Test("Terminal focus acknowledgement retries and cancels on active switch")
-    func terminalAcknowledgementRetryAndCancellation() {
+    @Test("Terminal focus terminal result and active switch both clear pending requests")
+    func terminalResultAndActiveSwitchClearPendingRequests() throws {
         let state = TerminalPaneState()
         let first = state.addTab(workingDirectory: nil)
+        let failedRequestID = try #require(state.pendingFocusRequestID)
 
-        #expect(!state.acknowledgeFocusRequest(for: first.id, succeeded: false))
-        #expect(state.pendingFocusTabID == first.id)
+        #expect(!state.acknowledgeFocusRequest(
+            requestID: failedRequestID,
+            for: first.id,
+            succeeded: false
+        ))
+        #expect(state.pendingFocusTabID == nil)
 
         let second = state.addTab(workingDirectory: nil)
+        let staleRequestID = try #require(state.pendingFocusRequestID)
         #expect(state.pendingFocusTabID == second.id)
         state.activeTerminalID = first.id
         #expect(state.pendingFocusTabID == nil)
-        #expect(!state.acknowledgeFocusRequest(for: second.id, succeeded: true))
+        #expect(!state.acknowledgeFocusRequest(
+            requestID: staleRequestID,
+            for: second.id,
+            succeeded: true
+        ))
     }
 }
 
 private final class FocusAcceptingTestView: NSView {
     override var acceptsFirstResponder: Bool { true }
+}
+
+private final class FocusRejectingTestWindow: NSWindow {
+    private(set) var focusAttemptCount = 0
+
+    override func makeFirstResponder(_ responder: NSResponder?) -> Bool {
+        focusAttemptCount += 1
+        return false
+    }
+}
+
+@MainActor
+private func nextMainQueueTurn() async {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.main.async {
+            continuation.resume()
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- bound AppKit first-responder retries across automatic retries, lifecycle callbacks, and repeated SwiftUI updates
- give every editor and terminal focus request a unique generation so stale completions cannot consume newer requests
- reject delayed focus after pane switches and route editor/terminal tab-strip actions through the owning pane
- revalidate the active pane and tab before the editor's deferred initial focus runs

## Validation

- strict SwiftLint: 0 violations in all 13 changed Swift files
- 167 focused pane, tab, terminal, and destination-focus tests passed
- strengthened 13-test destination-focus suite rebuilt and passed after final review changes
- independent review completed with no remaining blocker/high/medium findings

Refs #1168