### PR TITLE
ci: fail closed when coverage is unavailable

### DIFF
--- a/.github/scripts/check_coverage.py
+++ b/.github/scripts/check_coverage.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Extract and enforce Pine's logic-only code-coverage threshold.
+
+The check is deliberately fail-closed. Missing result bundles, xccov
+failures, malformed reports, missing application coverage, and reports with
+zero executable logic lines are infrastructure failures rather than a reason
+to skip the coverage gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+THRESHOLD_FAILURE = 1
+INFRASTRUCTURE_FAILURE = 2
+TRANSIENT_XCCOV_DIAGNOSTICS = ("no coverage data in result bundle",)
+
+# Pure SwiftUI/AppKit presentation files are exercised by the UI-test shards
+# and intentionally remain outside the logic-only unit-test threshold.
+EXCLUDED_VIEWS = frozenset(
+    {
+        "AccessibilityIdentifiers.swift",
+        "BranchSubtitleClickHandler.swift",
+        "BranchSwitcherView.swift",
+        "CodeEditorView.swift",
+        "ContentView.swift",
+        "ContentView+Helpers.swift",
+        "EditorTabBar.swift",
+        "FileNodeRow.swift",
+        "GitAndNotificationObserver.swift",
+        "MarkdownPreviewView.swift",
+        "PaneLeafView.swift",
+        "PaneTreeView.swift",
+        "QuickLookPreviewView.swift",
+        "QuickOpenView.swift",
+        "RecoveryDialogView.swift",
+        "RepresentedFileTracker.swift",
+        "SearchResultsView.swift",
+        "SidebarFileTree.swift",
+        "SidebarView.swift",
+        "StatusBarView.swift",
+        "TerminalBarView.swift",
+        "TerminalPaneContent.swift",
+        "TerminalPaneTabBar.swift",
+        "TerminalSearchBar.swift",
+        "WelcomeView.swift",
+    }
+)
+
+
+class CoverageError(Exception):
+    """Raised when coverage cannot be proven from the current result bundle."""
+
+
+@dataclass(frozen=True)
+class FileCoverage:
+    """Line coverage for one source file."""
+
+    name: str
+    covered_lines: int
+    executable_lines: int
+
+    @property
+    def percentage(self) -> float:
+        if self.executable_lines == 0:
+            return 0.0
+        return self.covered_lines / self.executable_lines * 100
+
+
+@dataclass(frozen=True)
+class CoverageSummary:
+    """Validated logic-only coverage totals and per-file details."""
+
+    covered_lines: int
+    executable_lines: int
+    included_files: tuple[FileCoverage, ...]
+    excluded_files: tuple[FileCoverage, ...]
+
+    @property
+    def percentage(self) -> float:
+        return self.covered_lines / self.executable_lines * 100
+
+
+def _nonnegative_line_count(value: Any, field: str, filename: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise CoverageError(
+            f"{filename} has invalid {field}: expected a non-negative integer"
+        )
+    return value
+
+
+def summarize_coverage(
+    report: Any,
+    target_name: str = "Pine.app",
+) -> CoverageSummary:
+    """Validate an xccov JSON report and calculate logic-only totals."""
+    if not isinstance(report, dict):
+        raise CoverageError("xccov returned a non-object JSON root")
+
+    targets = report.get("targets")
+    if not isinstance(targets, list) or not targets:
+        raise CoverageError("xccov report contains no coverage targets")
+
+    matching_targets = [
+        target
+        for target in targets
+        if isinstance(target, dict) and target.get("name") == target_name
+    ]
+    if not matching_targets:
+        raise CoverageError(f"xccov report is missing target {target_name}")
+    if len(matching_targets) > 1:
+        raise CoverageError(f"xccov report contains duplicate target {target_name}")
+
+    files = matching_targets[0].get("files")
+    if not isinstance(files, list) or not files:
+        raise CoverageError(f"target {target_name} contains no file coverage")
+
+    included: list[FileCoverage] = []
+    excluded: list[FileCoverage] = []
+    for index, file_report in enumerate(files):
+        if not isinstance(file_report, dict):
+            raise CoverageError(
+                f"target {target_name} contains a non-object file entry "
+                f"at index {index}"
+            )
+
+        raw_name = file_report.get("name")
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            raise CoverageError(
+                f"target {target_name} contains a file entry without a name"
+            )
+        name = Path(raw_name).name
+        covered = _nonnegative_line_count(
+            file_report.get("coveredLines"),
+            "coveredLines",
+            name,
+        )
+        executable = _nonnegative_line_count(
+            file_report.get("executableLines"),
+            "executableLines",
+            name,
+        )
+        if covered > executable:
+            raise CoverageError(
+                f"{name} reports more covered lines than executable lines"
+            )
+
+        file_coverage = FileCoverage(name, covered, executable)
+        if name in EXCLUDED_VIEWS:
+            excluded.append(file_coverage)
+        else:
+            included.append(file_coverage)
+
+    covered_lines = sum(file.covered_lines for file in included)
+    executable_lines = sum(file.executable_lines for file in included)
+    if executable_lines == 0:
+        raise CoverageError(
+            f"target {target_name} reports zero executable logic lines"
+        )
+
+    return CoverageSummary(
+        covered_lines=covered_lines,
+        executable_lines=executable_lines,
+        included_files=tuple(included),
+        excluded_files=tuple(excluded),
+    )
+
+
+def _is_transient_xccov_failure(diagnostic: str) -> bool:
+    lowered = diagnostic.lower()
+    return any(
+        marker in lowered for marker in TRANSIENT_XCCOV_DIAGNOSTICS
+    )
+
+
+def load_coverage_report(
+    result_bundle: Path,
+    attempts: int,
+    retry_delay: float,
+    timeout: float,
+) -> Any:
+    """Run xccov with bounded retries for its known transient diagnostic."""
+    if not result_bundle.is_dir():
+        raise CoverageError(f"result bundle does not exist: {result_bundle}")
+
+    last_diagnostic = "no diagnostic output"
+    for attempt in range(1, attempts + 1):
+        try:
+            process = subprocess.run(
+                [
+                    "xcrun",
+                    "xccov",
+                    "view",
+                    "--report",
+                    "--json",
+                    str(result_bundle),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise CoverageError(
+                f"xccov timed out after {format_percentage(timeout)} seconds"
+            ) from error
+        except OSError as error:
+            raise CoverageError(f"unable to launch xccov: {error}") from error
+
+        if process.returncode == 0:
+            try:
+                return json.loads(process.stdout)
+            except json.JSONDecodeError as error:
+                raise CoverageError(
+                    f"xccov returned malformed JSON: {error}"
+                ) from error
+
+        last_diagnostic = (
+            process.stderr.strip()
+            or process.stdout.strip()
+            or "no diagnostic output"
+        )
+        should_retry = (
+            attempt < attempts
+            and _is_transient_xccov_failure(last_diagnostic)
+        )
+        if not should_retry:
+            raise CoverageError(
+                f"xccov exited with code {process.returncode}: "
+                f"{last_diagnostic}"
+            )
+        if retry_delay:
+            time.sleep(retry_delay)
+
+    raise CoverageError(
+        f"xccov failed after {attempts} attempts: {last_diagnostic}"
+    )
+
+
+def format_percentage(value: float) -> str:
+    """Render enough precision to keep threshold-edge results unambiguous."""
+    rendered = f"{value:.4f}".rstrip("0").rstrip(".")
+    return rendered if "." in rendered else f"{rendered}.0"
+
+
+def _single_line(value: str) -> str:
+    return " ".join(value.splitlines()).strip()
+
+
+def append_github_output(path: Path, values: dict[str, str]) -> None:
+    """Append single-line step outputs for later workflow steps."""
+    with path.open("a", encoding="utf-8") as output:
+        for key, value in values.items():
+            output.write(f"{key}={_single_line(value)}\n")
+
+
+def _coverage_markdown(
+    summary: CoverageSummary,
+    threshold: float,
+    passed: bool,
+) -> str:
+    percentage = format_percentage(summary.percentage)
+    icon = "✅" if passed else "❌"
+    lines = [
+        f"## {icon} Code Coverage: {percentage}%",
+        "",
+        (
+            f"Logic-only coverage: **{summary.covered_lines} / "
+            f"{summary.executable_lines} lines**"
+        ),
+        f"Required threshold: **{format_percentage(threshold)}%**",
+        "",
+    ]
+
+    measurable = [
+        file for file in summary.included_files if file.executable_lines > 0
+    ]
+    measurable.sort(key=lambda file: (file.percentage, file.name))
+    if measurable:
+        lines.extend(
+            [
+                "### Lowest Coverage Files (logic only)",
+                "",
+                "| File | Coverage | Lines |",
+                "|------|---------:|------:|",
+            ]
+        )
+        for file in measurable[:10]:
+            lines.append(
+                f"| {file.name} | {format_percentage(file.percentage)}% | "
+                f"{file.covered_lines}/{file.executable_lines} |"
+            )
+
+        lines.extend(
+            [
+                "",
+                "### Highest Coverage Files",
+                "",
+                "| File | Coverage | Lines |",
+                "|------|---------:|------:|",
+            ]
+        )
+        for file in measurable[-10:]:
+            lines.append(
+                f"| {file.name} | {format_percentage(file.percentage)}% | "
+                f"{file.covered_lines}/{file.executable_lines} |"
+            )
+
+    if summary.excluded_files:
+        excluded_lines = sum(
+            file.executable_lines for file in summary.excluded_files
+        )
+        lines.extend(
+            [
+                "",
+                (
+                    f"_Excluded from threshold: {len(summary.excluded_files)} "
+                    "pure SwiftUI/AppKit presentation files "
+                    f"({excluded_lines} lines), covered by UI tests._"
+                ),
+            ]
+        )
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def append_summary(path: Path, markdown: str) -> None:
+    with path.open("a", encoding="utf-8") as summary_file:
+        summary_file.write(markdown)
+
+
+def _publish_error(args: argparse.Namespace, message: str) -> None:
+    values = {
+        "status": "error",
+        "coverage": "",
+        "covered-lines": "",
+        "executable-lines": "",
+        "message": message,
+    }
+    if args.github_output:
+        try:
+            append_github_output(args.github_output, values)
+        except OSError as error:
+            print(f"::warning::Unable to write GITHUB_OUTPUT: {error}")
+
+    if args.github_summary:
+        markdown = "\n".join(
+            [
+                "## ❌ Code Coverage unavailable",
+                "",
+                f"Coverage infrastructure failure: {_single_line(message)}",
+                "",
+                "The coverage gate failed closed; no passing result was reported.",
+                "",
+            ]
+        )
+        try:
+            append_summary(args.github_summary, markdown)
+        except OSError as error:
+            print(f"::warning::Unable to write GITHUB_STEP_SUMMARY: {error}")
+
+
+def _positive_integer(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def _nonnegative_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError(
+            "must be a finite non-negative number"
+        )
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError(
+            "must be a finite number greater than zero"
+        )
+    return parsed
+
+
+def _threshold(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or not 0 <= parsed <= 100:
+        raise argparse.ArgumentTypeError("must be between 0 and 100")
+    return parsed
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("result_bundle", type=Path)
+    parser.add_argument("--threshold", type=_threshold, required=True)
+    parser.add_argument("--target", default="Pine.app")
+    parser.add_argument("--attempts", type=_positive_integer, default=3)
+    parser.add_argument(
+        "--retry-delay",
+        type=_nonnegative_float,
+        default=1.0,
+    )
+    parser.add_argument(
+        "--timeout",
+        type=_positive_float,
+        default=60.0,
+        help="Maximum seconds for one xccov attempt.",
+    )
+    parser.add_argument("--github-output", type=Path)
+    parser.add_argument("--github-summary", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        report = load_coverage_report(
+            args.result_bundle,
+            attempts=args.attempts,
+            retry_delay=args.retry_delay,
+            timeout=args.timeout,
+        )
+        summary = summarize_coverage(report, target_name=args.target)
+    except CoverageError as error:
+        message = str(error)
+        _publish_error(args, message)
+        print(f"::error::Coverage infrastructure failure: {message}")
+        return INFRASTRUCTURE_FAILURE
+
+    passed = summary.percentage >= args.threshold
+    percentage = format_percentage(summary.percentage)
+    status = "pass" if passed else "below-threshold"
+    message = (
+        "Coverage is at or above the required threshold."
+        if passed
+        else "Coverage is below the required threshold."
+    )
+    outputs = {
+        "status": status,
+        "coverage": percentage,
+        "covered-lines": str(summary.covered_lines),
+        "executable-lines": str(summary.executable_lines),
+        "message": message,
+    }
+    if args.github_output:
+        try:
+            append_github_output(args.github_output, outputs)
+        except OSError as error:
+            _publish_error(args, f"unable to write GITHUB_OUTPUT: {error}")
+            print(f"::error::Unable to publish coverage outputs: {error}")
+            return INFRASTRUCTURE_FAILURE
+
+    if args.github_summary:
+        try:
+            append_summary(
+                args.github_summary,
+                _coverage_markdown(summary, args.threshold, passed),
+            )
+        except OSError as error:
+            print(f"::warning::Unable to write GITHUB_STEP_SUMMARY: {error}")
+
+    print(
+        f"Coverage: {percentage}% "
+        f"({summary.covered_lines}/{summary.executable_lines} logic lines); "
+        f"threshold: {format_percentage(args.threshold)}%"
+    )
+    if not passed:
+        print(
+            f"::error::Coverage {percentage}% is below "
+            f"{format_percentage(args.threshold)}% threshold"
+        )
+        return THRESHOLD_FAILURE
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
             -skip-testing:PineTests/FuzzConfigValidatorTests \
             -skip-testing:PineTests/FuzzGoToLineParserTests \
             -retry-tests-on-failure \
-            -test-timeouts-enabled \
+            -test-timeouts-enabled YES \
             -enableCodeCoverage YES \
             -resultBundlePath TestResults.xcresult \
             CODE_SIGN_IDENTITY=- \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Tests for inout-post reentrancy guard
         run: bash scripts/tests/test-check-no-post-under-inout.sh
 
+      - name: Tests for fail-closed coverage gate
+        run: bash scripts/tests/test-check-coverage.sh
+
   build:
     name: Build for Testing
     runs-on: macos-26
@@ -267,172 +270,48 @@ jobs:
           python3 .github/scripts/detect_flaky_tests.py \
             TestResults.xcresult --github-summary
 
-      - name: Extract Coverage Report
+      - name: Check Coverage Threshold
         if: success() || failure()
         id: coverage
-        continue-on-error: true
         run: |
-          XCRESULT="TestResults.xcresult"
-          if [ ! -d "$XCRESULT" ]; then
-            echo "No .xcresult bundle found"
-            exit 0
-          fi
-
-          # Get JSON coverage report
-          # On macos-26 / Xcode 26 RC runners, xccov sometimes fails with
-          # "No coverage data in result bundle" even when tests pass (#1060).
-          # Coverage is informational — never block the PR on this.
-          if ! xcrun xccov view --report --json "$XCRESULT" > coverage.json 2>/dev/null; then
-            echo "::warning::Could not extract coverage data from result bundle — skipping coverage check"
-            exit 0
-          fi
-
-          # Extract coverage for Pine target, excluding pure SwiftUI view files
-          # (views are covered by UI tests separately)
-          COVERAGE=$(python3 -c "
-          import json, sys
-          EXCLUDED_VIEWS = {
-              'AccessibilityIdentifiers.swift',
-              'BranchSubtitleClickHandler.swift',
-              'BranchSwitcherView.swift',
-              'CodeEditorView.swift',
-              'ContentView.swift',
-              'ContentView+Helpers.swift',
-              'PaneLeafView.swift',
-              'EditorTabBar.swift',
-              'FileNodeRow.swift',
-              'GitAndNotificationObserver.swift',
-              'MarkdownPreviewView.swift',
-              'QuickLookPreviewView.swift',
-              'QuickOpenView.swift',
-              'RecoveryDialogView.swift',
-              'RepresentedFileTracker.swift',
-              'SearchResultsView.swift',
-              'SidebarView.swift',
-              'SidebarFileTree.swift',
-              'StatusBarView.swift',
-              'PaneTreeView.swift',
-              'TerminalBarView.swift',
-              'TerminalPaneContent.swift',
-              'TerminalPaneTabBar.swift',
-              'TerminalSearchBar.swift',
-              'WelcomeView.swift',
-          }
-          with open('coverage.json') as f:
-              data = json.load(f)
-          for target in data.get('targets', []):
-              if target['name'] == 'Pine.app':
-                  covered = 0
-                  total = 0
-                  for f in target.get('files', []):
-                      if f['name'] in EXCLUDED_VIEWS:
-                          continue
-                      covered += f.get('coveredLines', 0)
-                      total += f.get('executableLines', 0)
-                  pct = (covered / total * 100) if total > 0 else 0
-                  print(f'{pct:.1f}')
-                  sys.exit(0)
-          print('0.0')
-          ")
-
-          echo "coverage=$COVERAGE" >> "$GITHUB_OUTPUT"
-          echo "## Code Coverage: ${COVERAGE}%" >> "$GITHUB_STEP_SUMMARY"
-
-          # Generate per-file breakdown for top/bottom files
-          python3 -c "
-          import json
-          EXCLUDED_VIEWS = {
-              'AccessibilityIdentifiers.swift',
-              'BranchSubtitleClickHandler.swift',
-              'BranchSwitcherView.swift',
-              'CodeEditorView.swift',
-              'ContentView.swift',
-              'ContentView+Helpers.swift',
-              'PaneLeafView.swift',
-              'EditorTabBar.swift',
-              'FileNodeRow.swift',
-              'GitAndNotificationObserver.swift',
-              'MarkdownPreviewView.swift',
-              'QuickLookPreviewView.swift',
-              'QuickOpenView.swift',
-              'RecoveryDialogView.swift',
-              'RepresentedFileTracker.swift',
-              'PaneTreeView.swift',
-              'SearchResultsView.swift',
-              'SidebarView.swift',
-              'SidebarFileTree.swift',
-              'StatusBarView.swift',
-              'TerminalBarView.swift',
-              'TerminalPaneContent.swift',
-              'TerminalPaneTabBar.swift',
-              'TerminalSearchBar.swift',
-              'WelcomeView.swift',
-          }
-          with open('coverage.json') as f:
-              data = json.load(f)
-          for target in data.get('targets', []):
-              if target['name'] != 'Pine.app':
-                  continue
-              files = []
-              excluded = []
-              for f in target.get('files', []):
-                  name = f['name']
-                  pct = f['lineCoverage'] * 100
-                  entry = (name, pct, f.get('coveredLines', 0), f.get('executableLines', 0))
-                  if name in EXCLUDED_VIEWS:
-                      excluded.append(entry)
-                  else:
-                      files.append(entry)
-              files.sort(key=lambda x: x[1])
-
-              print('### Lowest Coverage Files (logic only)')
-              print('| File | Coverage | Lines |')
-              print('|------|----------|-------|')
-              for name, pct, covered, total in files[:10]:
-                  if total > 0:
-                      print(f'| {name} | {pct:.1f}% | {covered}/{total} |')
-
-              print()
-              print('### Highest Coverage Files')
-              print('| File | Coverage | Lines |')
-              print('|------|----------|-------|')
-              for name, pct, covered, total in files[-10:]:
-                  if total > 0:
-                      print(f'| {name} | {pct:.1f}% | {covered}/{total} |')
-
-              if excluded:
-                  excluded_lines = sum(t for _, _, _, t in excluded)
-                  print()
-                  print(f'_Excluded from threshold: {len(excluded)} pure SwiftUI view files ({excluded_lines} lines) — covered by UI tests._')
-          " >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Check Coverage Threshold
-        if: (success() || failure()) && steps.coverage.outputs.coverage != ''
-        run: |
-          COVERAGE="${{ steps.coverage.outputs.coverage }}"
-          THRESHOLD="${{ env.COVERAGE_THRESHOLD }}"
-          echo "Coverage: ${COVERAGE}%, threshold: ${THRESHOLD}%"
-          if python3 -c "exit(0 if float('$COVERAGE') >= float('$THRESHOLD') else 1)"; then
-            echo "✅ Coverage is above threshold"
-          else
-            echo "::error::Coverage ${COVERAGE}% is below ${THRESHOLD}% threshold"
-            exit 1
-          fi
+          python3 .github/scripts/check_coverage.py \
+            TestResults.xcresult \
+            --threshold "$COVERAGE_THRESHOLD" \
+            --github-output "$GITHUB_OUTPUT" \
+            --github-summary "$GITHUB_STEP_SUMMARY"
 
       - name: Comment Coverage on PR
-        if: (success() || failure()) && github.event_name == 'pull_request' && steps.coverage.outputs.coverage != ''
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         env:
+          COVERAGE_STATUS: ${{ steps.coverage.outputs.status }}
           COVERAGE_VALUE: ${{ steps.coverage.outputs.coverage }}
+          COVERED_LINES: ${{ steps.coverage.outputs.covered-lines }}
+          EXECUTABLE_LINES: ${{ steps.coverage.outputs.executable-lines }}
+          COVERAGE_MESSAGE: ${{ steps.coverage.outputs.message }}
           COVERAGE_MIN: ${{ env.COVERAGE_THRESHOLD }}
           FLAKY_COUNT: ${{ steps.flaky.outputs.flaky-count }}
           FLAKY_TESTS: ${{ steps.flaky.outputs.flaky-tests }}
         with:
           script: |
-            const coverage = process.env.COVERAGE_VALUE;
+            const status = process.env.COVERAGE_STATUS;
+            const coverage = process.env.COVERAGE_VALUE || '';
             const threshold = parseFloat(process.env.COVERAGE_MIN);
-            const passing = parseFloat(coverage) >= threshold;
+            const coveredLines = process.env.COVERED_LINES || '';
+            const executableLines = process.env.EXECUTABLE_LINES || '';
+            const publishedDiagnostic = (process.env.COVERAGE_MESSAGE || '')
+              .replaceAll('`', "'");
+            const passing = status === 'pass';
+            const available = ['pass', 'below-threshold'].includes(status);
+            const diagnostic = publishedDiagnostic || (
+              available
+                ? 'Coverage checker did not publish a diagnostic.'
+                : 'Coverage checker did not publish a valid result.'
+            );
             const icon = passing ? '✅' : '❌';
+            const heading = available
+              ? `${icon} Code Coverage: ${coverage}%`
+              : '❌ Code Coverage unavailable';
 
             const flakyCount = parseInt(process.env.FLAKY_COUNT || '0', 10);
             // FLAKY_TESTS is JSON-encoded by the detection script
@@ -440,11 +319,16 @@ jobs:
             try { flakyTests = JSON.parse(process.env.FLAKY_TESTS || '""'); } catch (e) { flakyTests = process.env.FLAKY_TESTS || ''; }
 
             const lines = [
-              `## ${icon} Code Coverage: ${coverage}%`,
+              '<!-- pine-coverage-report -->',
+              `## ${heading}`,
               '',
               `Threshold: ${threshold}%`,
               '',
-              `${passing ? 'Coverage is above the minimum threshold.' : '**Coverage is below the minimum threshold. This is a blocking check — the PR cannot be merged.**'}`,
+              available
+                ? `Logic-only lines: ${coveredLines}/${executableLines}`
+                : '**Coverage extraction failed. The gate failed closed and did not report a passing result.**',
+              '',
+              diagnostic,
             ];
 
             if (flakyCount > 0) {
@@ -463,7 +347,10 @@ jobs:
               issue_number: context.issue.number,
             });
             const botComment = comments.find(c =>
-              c.user.type === 'Bot' && c.body.includes('Code Coverage:')
+              c.user.type === 'Bot' && (
+                c.body.includes('<!-- pine-coverage-report -->') ||
+                c.body.includes('Code Coverage:')
+              )
             );
 
             if (botComment) {

--- a/PineTests/CompletionEndpointTests.swift
+++ b/PineTests/CompletionEndpointTests.swift
@@ -1,0 +1,191 @@
+//
+//  CompletionEndpointTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("CompletionEndpoint", .serialized)
+@MainActor
+struct CompletionEndpointTests {
+
+    @Test func returnsEmptyListWithoutAHandler() async {
+        let endpoint = CompletionEndpoint.shared
+        endpoint.handler = nil
+
+        let result = await endpoint.completion(
+            url: URL(fileURLWithPath: "/tmp/example.swift"),
+            offset: 4,
+            text: "prin"
+        )
+
+        #expect(result.isEmpty)
+        #expect(!result.isIncomplete)
+    }
+
+    @Test func forwardsTheRequestAndReturnsTheHandlerResult() async {
+        let endpoint = CompletionEndpoint.shared
+        let expectedURL = URL(fileURLWithPath: "/tmp/example.swift")
+        let expected = LSPCompletionList(
+            items: [LSPCompletionItem(label: "print")],
+            isIncomplete: true
+        )
+        var receivedURL: URL?
+        var receivedOffset: Int?
+        var receivedText: String?
+        endpoint.handler = { url, offset, text in
+            receivedURL = url
+            receivedOffset = offset
+            receivedText = text
+            return expected
+        }
+        defer { endpoint.handler = nil }
+
+        let result = await endpoint.completion(
+            url: expectedURL,
+            offset: 4,
+            text: "prin"
+        )
+
+        #expect(result == expected)
+        #expect(receivedURL == expectedURL)
+        #expect(receivedOffset == 4)
+        #expect(receivedText == "prin")
+    }
+
+    @Test func evaluatesIdentifierAndTriggerCharacterInsertions() {
+        let identifier = CompletionTrigger.evaluate(
+            editedRange: NSRange(location: 2, length: 0),
+            cursor: 3,
+            source: "foo" as NSString
+        )
+        #expect(identifier.shouldTrigger)
+        #expect(!identifier.fireImmediately)
+        #expect(identifier.prefix == "foo")
+
+        let trigger = CompletionTrigger.evaluate(
+            editedRange: NSRange(location: 6, length: 1),
+            cursor: 7,
+            source: "object." as NSString
+        )
+        #expect(trigger.shouldTrigger)
+        #expect(trigger.fireImmediately)
+        #expect(trigger.prefix.isEmpty)
+
+        let multiCharacterTrigger = CompletionTrigger.evaluate(
+            editedRange: NSRange(location: 5, length: 2),
+            cursor: 7,
+            source: "value->" as NSString
+        )
+        #expect(multiCharacterTrigger.shouldTrigger)
+        #expect(multiCharacterTrigger.fireImmediately)
+        #expect(multiCharacterTrigger.prefix.isEmpty)
+    }
+
+    @Test func rejectsMissingInvalidAndNonIdentifierEdits() {
+        let source = "value " as NSString
+        let decisions = [
+            CompletionTrigger.evaluate(
+                editedRange: nil,
+                cursor: source.length,
+                source: source
+            ),
+            CompletionTrigger.evaluate(
+                editedRange: NSRange(location: source.length, length: 0),
+                cursor: source.length,
+                source: source
+            ),
+            CompletionTrigger.evaluate(
+                editedRange: NSRange(location: source.length, length: 2),
+                cursor: source.length,
+                source: source
+            ),
+            CompletionTrigger.evaluate(
+                editedRange: NSRange(location: source.length - 1, length: 1),
+                cursor: source.length,
+                source: source
+            )
+        ]
+
+        for decision in decisions {
+            #expect(!decision.shouldTrigger)
+            #expect(!decision.fireImmediately)
+            #expect(decision.prefix.isEmpty)
+        }
+    }
+
+    @Test func handlesUnicodeCodeUnitsWithoutInventingACompletion() {
+        let source = "😀" as NSString
+        let decision = CompletionTrigger.evaluate(
+            editedRange: NSRange(location: 0, length: 0),
+            cursor: source.length,
+            source: source
+        )
+
+        #expect(!decision.shouldTrigger)
+        #expect(!decision.fireImmediately)
+        #expect(decision.prefix.isEmpty)
+        #expect(CompletionTrigger.wordPrefix(at: source.length, in: source).isEmpty)
+    }
+
+    @Test func extractsAndClampsIdentifierPrefixes() {
+        let source = "let foo42_bar" as NSString
+
+        #expect(CompletionTrigger.wordPrefix(at: -10, in: source).isEmpty)
+        #expect(CompletionTrigger.wordPrefix(at: 7, in: source) == "foo")
+        #expect(CompletionTrigger.wordPrefix(at: 10_000, in: source) == "foo42_bar")
+        #expect(CompletionTrigger.wordPrefix(at: 4, in: source).isEmpty)
+
+        #expect(CompletionTrigger.isIdentifierChar("A"))
+        #expect(CompletionTrigger.isIdentifierChar("7"))
+        #expect(CompletionTrigger.isIdentifierChar("_"))
+        #expect(!CompletionTrigger.isIdentifierChar("-"))
+
+        #expect(CompletionTrigger.defaultTriggerCharacters == [".", "->", "::", ":"])
+        #expect(CompletionTrigger.defaultTriggerCharsScalar == [".", "-", ">", ":"])
+    }
+
+    @Test func buildsInsertionsForPlainTextAndSnippets() {
+        let plain = CompletionInsertion.fromSnippet(LSPSnippet("😀 value"))
+        #expect(plain == CompletionInsertion(
+            text: "😀 value",
+            finalCursorOffset: 8
+        ))
+
+        let snippet = CompletionInsertion.fromSnippet(
+            LSPSnippet("func ${1:name}() {$0}")
+        )
+        #expect(snippet.text == "func name() {}")
+        #expect(snippet.finalCursorOffset == 5)
+    }
+
+    @Test func computesClampedIdentifierReplacementRanges() {
+        let source = "let foo42_bar." as NSString
+
+        #expect(CompletionInsertion.wordRange(
+            endingAt: -1,
+            in: source
+        ) == NSRange(location: 0, length: 0))
+        #expect(CompletionInsertion.wordRange(
+            endingAt: 7,
+            in: source
+        ) == NSRange(location: 4, length: 3))
+        #expect(CompletionInsertion.wordRange(
+            endingAt: 10_000,
+            in: source
+        ) == NSRange(location: source.length, length: 0))
+        #expect(CompletionInsertion.wordRange(
+            endingAt: source.length - 1,
+            in: source
+        ) == NSRange(location: 4, length: 9))
+
+        let emoji = "😀name" as NSString
+        #expect(CompletionInsertion.wordRange(
+            endingAt: emoji.length,
+            in: emoji
+        ) == NSRange(location: 2, length: 4))
+    }
+}

--- a/PineTests/HoverMarkdownRendererTests.swift
+++ b/PineTests/HoverMarkdownRendererTests.swift
@@ -1,0 +1,168 @@
+//
+//  HoverMarkdownRendererTests.swift
+//  PineTests
+//
+
+import AppKit
+import Testing
+
+@testable import Pine
+
+@Suite("HoverMarkdownRenderer")
+@MainActor
+struct HoverMarkdownRendererTests {
+
+    @Test func rendersPlainTextVerbatimWithMonospacedStyle() {
+        let content = "func pine() -> Bool"
+
+        let result = HoverMarkdownRenderer.render(content, isMarkdown: false)
+
+        #expect(result.string == content)
+        #expect(font(at: 0, in: result) == NSFont.monospacedSystemFont(
+            ofSize: 11,
+            weight: .regular
+        ))
+        #expect(foregroundColor(at: 0, in: result) == NSColor.labelColor)
+        #expect(backgroundColor(at: 0, in: result) == nil)
+    }
+
+    @Test func rendersCommonMarkdownConstructsWithExpectedStyles() {
+        let markdown = """
+        ## Signature
+        ---
+          ```swift
+        func pine() -> Bool
+          ```
+        Use **safe** and `fast`.
+        """
+
+        let result = HoverMarkdownRenderer.render(markdown, isMarkdown: true)
+
+        let separator = String(repeating: "\u{2014}", count: 40)
+        #expect(result.string == """
+        Signature
+        \(separator)
+        func pine() -> Bool
+        Use safe and fast.
+
+        """)
+
+        let headingOffset = offset(of: "Signature", in: result)
+        #expect(font(at: headingOffset, in: result) == NSFont.boldSystemFont(ofSize: 13))
+        #expect(foregroundColor(at: headingOffset, in: result) == NSColor.labelColor)
+
+        let separatorOffset = offset(of: separator, in: result)
+        #expect(font(at: separatorOffset, in: result) == NSFont.systemFont(ofSize: 12))
+        #expect(foregroundColor(at: separatorOffset, in: result) == NSColor.secondaryLabelColor)
+
+        let blockOffset = offset(of: "func pine", in: result)
+        assertCodeStyle(at: blockOffset, in: result)
+
+        let bodyOffset = offset(of: "Use ", in: result)
+        #expect(font(at: bodyOffset, in: result) == NSFont.systemFont(ofSize: 12))
+        #expect(foregroundColor(at: bodyOffset, in: result) == NSColor.labelColor)
+
+        let boldOffset = offset(of: "safe", in: result)
+        #expect(font(at: boldOffset, in: result) == NSFont.boldSystemFont(ofSize: 12))
+        #expect(foregroundColor(at: boldOffset, in: result) == NSColor.labelColor)
+
+        let inlineCodeOffset = offset(of: "fast", in: result)
+        assertCodeStyle(at: inlineCodeOffset, in: result)
+    }
+
+    @Test func handlesEmptyAndUnterminatedFencedCodeBlocks() {
+        let empty = HoverMarkdownRenderer.render(
+            "  ```swift\n  ```",
+            isMarkdown: true
+        )
+        #expect(empty.length == 0)
+
+        let unterminated = HoverMarkdownRenderer.render(
+            "```swift\nlet value = 1\nreturn value",
+            isMarkdown: true
+        )
+        #expect(unterminated.string == "let value = 1\nreturn value\n")
+        assertCodeStyle(at: offset(of: "let value", in: unterminated), in: unterminated)
+        assertCodeStyle(at: offset(of: "return value", in: unterminated), in: unterminated)
+    }
+
+    @Test func preservesUnmatchedInlineMarkupAsLiteralText() {
+        let result = HoverMarkdownRenderer.render(
+            "`closed` then `open\n**still open",
+            isMarkdown: true
+        )
+
+        #expect(result.string == "closed then `open\n**still open\n")
+        assertCodeStyle(at: offset(of: "closed", in: result), in: result)
+
+        let backtickOffset = offset(of: "`open", in: result)
+        #expect(font(at: backtickOffset, in: result) == NSFont.systemFont(ofSize: 12))
+        #expect(backgroundColor(at: backtickOffset, in: result) == nil)
+
+        let unmatchedBoldOffset = offset(of: "**still open", in: result)
+        #expect(font(at: unmatchedBoldOffset, in: result) == NSFont.systemFont(ofSize: 12))
+        #expect(backgroundColor(at: unmatchedBoldOffset, in: result) == nil)
+    }
+
+    @Test func acceptsOnlyHeadingLevelsOneThroughSixWithRequiredSpacing() {
+        let result = HoverMarkdownRenderer.render(
+            "#\n###### Six\n####### Seven\n##NoSpace\n # Indented",
+            isMarkdown: true
+        )
+
+        #expect(result.string == "Six\n####### Seven\n##NoSpace\n # Indented\n")
+
+        let validHeadingOffset = offset(of: "Six", in: result)
+        #expect(font(at: validHeadingOffset, in: result) == NSFont.boldSystemFont(ofSize: 13))
+
+        for literal in ["####### Seven", "##NoSpace", "# Indented"] {
+            let literalOffset = offset(of: literal, in: result)
+            #expect(font(at: literalOffset, in: result) == NSFont.systemFont(ofSize: 12))
+        }
+    }
+
+    private func assertCodeStyle(
+        at offset: Int,
+        in result: NSAttributedString
+    ) {
+        #expect(font(at: offset, in: result) == NSFont.monospacedSystemFont(
+            ofSize: 11,
+            weight: .regular
+        ))
+        #expect(foregroundColor(at: offset, in: result) == NSColor.labelColor)
+        #expect(backgroundColor(at: offset, in: result) == NSColor.textBackgroundColor)
+    }
+
+    private func offset(
+        of substring: String,
+        in result: NSAttributedString
+    ) -> Int {
+        let range = (result.string as NSString).range(of: substring)
+        guard range.location != NSNotFound else {
+            Issue.record("Expected rendered output to contain '\(substring)'")
+            return 0
+        }
+        return range.location
+    }
+
+    private func font(
+        at offset: Int,
+        in result: NSAttributedString
+    ) -> NSFont? {
+        result.attribute(.font, at: offset, effectiveRange: nil) as? NSFont
+    }
+
+    private func foregroundColor(
+        at offset: Int,
+        in result: NSAttributedString
+    ) -> NSColor? {
+        result.attribute(.foregroundColor, at: offset, effectiveRange: nil) as? NSColor
+    }
+
+    private func backgroundColor(
+        at offset: Int,
+        in result: NSAttributedString
+    ) -> NSColor? {
+        result.attribute(.backgroundColor, at: offset, effectiveRange: nil) as? NSColor
+    }
+}

--- a/scripts/tests/test-check-coverage.sh
+++ b/scripts/tests/test-check-coverage.sh
@@ -374,6 +374,17 @@ if grep -qF "continue-on-error: true" <<< "$coverage_step" || \
 fi
 echo "✓ workflow wires the coverage checker as a blocking step"
 
+unit_test_step="$(
+    sed -n \
+        '/- name: Unit Tests/,/- name: Detect Flaky Tests/p' \
+        "$WORKFLOW"
+)"
+if ! grep -qF -- "-test-timeouts-enabled YES" <<< "$unit_test_step"; then
+    echo "✗ unit test timeout flag is missing its required boolean value"
+    exit 1
+fi
+echo "✓ unit test timeout flag cannot consume the coverage option"
+
 comment_step="$(
     sed -n \
         '/- name: Comment Coverage on PR/,/^  [a-zA-Z0-9_-]*:/p' \

--- a/scripts/tests/test-check-coverage.sh
+++ b/scripts/tests/test-check-coverage.sh
@@ -1,0 +1,392 @@
+#!/bin/bash
+# Process-level regression tests for the fail-closed coverage gate.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CHECKER="$REPO_ROOT/.github/scripts/check_coverage.py"
+WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "$TEST_ROOT/bin"
+
+cat > "$TEST_ROOT/bin/xcrun" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -lt 5 ] || \
+    [ "$1" != "xccov" ] || \
+    [ "$2" != "view" ] || \
+    [ "$3" != "--report" ] || \
+    [ "$4" != "--json" ]; then
+    echo "unexpected xcrun invocation: $*" >&2
+    exit 64
+fi
+
+counter_file="${FAKE_XCCOV_COUNTER:?}"
+count=0
+if [ -f "$counter_file" ]; then
+    count="$(tr -d '[:space:]' < "$counter_file")"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$counter_file"
+
+case "${FAKE_XCCOV_MODE:-success}" in
+    success)
+        cat "${FAKE_COVERAGE_JSON:?}"
+        ;;
+    malformed)
+        echo "this is not JSON"
+        ;;
+    permanent-failure)
+        echo "synthetic permanent xccov failure" >&2
+        exit 9
+        ;;
+    transient-then-success)
+        if [ "$count" -lt 3 ]; then
+            echo "No coverage data in result bundle" >&2
+            exit 1
+        fi
+        cat "${FAKE_COVERAGE_JSON:?}"
+        ;;
+    hang)
+        exec sleep 5
+        ;;
+    *)
+        echo "unknown fake mode: ${FAKE_XCCOV_MODE}" >&2
+        exit 64
+        ;;
+esac
+EOF
+chmod +x "$TEST_ROOT/bin/xcrun"
+
+cat > "$TEST_ROOT/at-threshold.json" <<'EOF'
+{
+  "targets": [
+    {
+      "name": "Pine.app",
+      "files": [
+        {
+          "name": "/checkout/Pine/Logic.swift",
+          "coveredLines": 7,
+          "executableLines": 10
+        },
+        {
+          "name": "ContentView.swift",
+          "coveredLines": 100,
+          "executableLines": 100
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+cat > "$TEST_ROOT/below-threshold.json" <<'EOF'
+{
+  "targets": [
+    {
+      "name": "Pine.app",
+      "files": [
+        {
+          "name": "Logic.swift",
+          "coveredLines": 69,
+          "executableLines": 100
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+cat > "$TEST_ROOT/missing-payload.json" <<'EOF'
+{"actions": []}
+EOF
+
+cat > "$TEST_ROOT/missing-target.json" <<'EOF'
+{
+  "targets": [
+    {
+      "name": "PineTests.xctest",
+      "files": [
+        {
+          "name": "Tests.swift",
+          "coveredLines": 10,
+          "executableLines": 10
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+cat > "$TEST_ROOT/zero-lines.json" <<'EOF'
+{
+  "targets": [
+    {
+      "name": "Pine.app",
+      "files": [
+        {
+          "name": "Logic.swift",
+          "coveredLines": 0,
+          "executableLines": 0
+        },
+        {
+          "name": "ContentView.swift",
+          "coveredLines": 10,
+          "executableLines": 10
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+cat > "$TEST_ROOT/invalid-lines.json" <<'EOF'
+{
+  "targets": [
+    {
+      "name": "Pine.app",
+      "files": [
+        {
+          "name": "Logic.swift",
+          "coveredLines": "7",
+          "executableLines": 10
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+run_checker() {
+    local expected_exit="$1"
+    local label="$2"
+    shift 2
+
+    set +e
+    CHECK_OUTPUT="$("$@" 2>&1)"
+    CHECK_STATUS=$?
+    set -e
+
+    if [ "$CHECK_STATUS" -ne "$expected_exit" ]; then
+        echo "✗ $label: expected exit $expected_exit, got $CHECK_STATUS"
+        echo "$CHECK_OUTPUT"
+        exit 1
+    fi
+    echo "✓ $label"
+}
+
+new_counter() {
+    COUNTER_FILE="$TEST_ROOT/counter-$1"
+}
+
+fresh_bundle="$TEST_ROOT/TestResults.xcresult"
+mkdir "$fresh_bundle"
+
+new_counter "threshold"
+threshold_output="$TEST_ROOT/threshold-output"
+threshold_summary="$TEST_ROOT/threshold-summary"
+run_checker 0 "coverage at the threshold passes" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCCOV_COUNTER="$COUNTER_FILE" \
+    FAKE_COVERAGE_JSON="$TEST_ROOT/at-threshold.json" \
+    python3 "$CHECKER" "$fresh_bundle" \
+    --threshold 70 \
+    --attempts 1 \
+    --github-output "$threshold_output" \
+    --github-summary "$threshold_summary"
+grep -qF "status=pass" "$threshold_output"
+grep -qF "coverage=70.0" "$threshold_output"
+grep -qF "covered-lines=7" "$threshold_output"
+grep -qF "executable-lines=10" "$threshold_output"
+grep -qF "7 / 10 lines" "$threshold_summary"
+grep -qF "1 pure SwiftUI/AppKit presentation files (100 lines)" \
+    "$threshold_summary"
+echo "✓ excluded views do not inflate the logic-only total"
+
+new_counter "above"
+run_checker 0 "coverage above the threshold passes" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCCOV_COUNTER="$COUNTER_FILE" \
+    FAKE_COVERAGE_JSON="$TEST_ROOT/at-threshold.json" \
+    python3 "$CHECKER" "$fresh_bundle" \
+    --threshold 69 \
+    --attempts 1
+
+new_counter "below"
+below_output="$TEST_ROOT/below-output"
+below_summary="$TEST_ROOT/below-summary"
+run_checker 1 "coverage below the threshold blocks the job" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCCOV_COUNTER="$COUNTER_FILE" \
+    FAKE_COVERAGE_JSON="$TEST_ROOT/below-threshold.json" \
+    python3 "$CHECKER" "$fresh_bundle" \
+    --threshold 70 \
+    --attempts 1 \
+    --github-output "$below_output" \
+    --github-summary "$below_summary"
+grep -qF "status=below-threshold" "$below_output"
+grep -qF "coverage=69.0" "$below_output"
+grep -qF "## ❌ Code Coverage: 69.0%" "$below_summary"
+echo "✓ below-threshold output is explicit and comment-ready"
+
+missing_output="$TEST_ROOT/missing-output"
+missing_summary="$TEST_ROOT/missing-summary"
+new_counter "missing"
+run_checker 2 "missing result bundle fails closed" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCCOV_COUNTER="$COUNTER_FILE" \
+    FAKE_COVERAGE_JSON="$TEST_ROOT/at-threshold.json" \
+    python3 "$CHECKER" "$TEST_ROOT/missing.xcresult" \
+    --threshold 70 \
+    --github-output "$missing_output" \
+    --github-summary "$missing_summary"
+grep -qF "status=error" "$missing_output"
+grep -qF "coverage=" "$missing_output"
+grep -qF "Code Coverage unavailable" "$missing_summary"
+grep -qF "no passing result was reported" "$missing_summary"
+echo "✓ infrastructure errors publish a failing status"
+
+new_counter "permanent"
+run_checker 2 "permanent xccov failure fails without retrying" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCCOV_COUNTER="$COUNTER_FILE" \
+    FAKE_XCCOV_MODE="permanent-failure" \
+    FAKE_COVERAGE_JSON="$TEST_ROOT/at-threshold.json" \
+    python3 "$CHECKER" "$fresh_bundle" \
+    --threshold 70 \
+    --retry-delay 0
+if [ "$(tr -d '[:space:]' < "$COUNTER_FILE")" -ne 1 ]; then
+    echo "✗ permanent xccov failure was retried"
+    exit 1
+fi
+echo "✓ permanent xccov failure is not retried"
+
+new_counter "transient"
+run_checker 0 "known transient xccov failure retries with a bound" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCCOV_COUNTER="$COUNTER_FILE" \
+    FAKE_XCCOV_MODE="transient-then-success" \
+    FAKE_COVERAGE_JSON="$TEST_ROOT/at-threshold.json" \
+    python3 "$CHECKER" "$fresh_bundle" \
+    --threshold 70 \
+    --attempts 3 \
+    --retry-delay 0
+if [ "$(tr -d '[:space:]' < "$COUNTER_FILE")" -ne 3 ]; then
+    echo "✗ transient xccov failure did not stop at the retry bound"
+    exit 1
+fi
+echo "✓ known transient xccov failure retries exactly to the bound"
+
+new_counter "timeout"
+run_checker 2 "a hung xccov attempt fails at its own timeout" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCCOV_COUNTER="$COUNTER_FILE" \
+    FAKE_XCCOV_MODE="hang" \
+    FAKE_COVERAGE_JSON="$TEST_ROOT/at-threshold.json" \
+    python3 "$CHECKER" "$fresh_bundle" \
+    --threshold 70 \
+    --timeout 0.1
+if [ "$(tr -d '[:space:]' < "$COUNTER_FILE")" -ne 1 ]; then
+    echo "✗ timed-out xccov attempt was retried"
+    exit 1
+fi
+echo "✓ xccov timeout is bounded and not retried"
+
+run_checker 2 "a non-finite timeout is rejected" \
+    python3 "$CHECKER" "$fresh_bundle" \
+    --threshold 70 \
+    --timeout nan
+
+run_checker 2 "a non-finite retry delay is rejected" \
+    python3 "$CHECKER" "$fresh_bundle" \
+    --threshold 70 \
+    --retry-delay inf
+
+new_counter "malformed"
+run_checker 2 "malformed xccov JSON fails closed" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCCOV_COUNTER="$COUNTER_FILE" \
+    FAKE_XCCOV_MODE="malformed" \
+    FAKE_COVERAGE_JSON="$TEST_ROOT/at-threshold.json" \
+    python3 "$CHECKER" "$fresh_bundle" \
+    --threshold 70 \
+    --attempts 1
+
+new_counter "payload"
+run_checker 2 "missing coverage payload fails closed" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCCOV_COUNTER="$COUNTER_FILE" \
+    FAKE_COVERAGE_JSON="$TEST_ROOT/missing-payload.json" \
+    python3 "$CHECKER" "$fresh_bundle" \
+    --threshold 70 \
+    --attempts 1
+
+new_counter "target"
+run_checker 2 "missing Pine.app coverage fails closed" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCCOV_COUNTER="$COUNTER_FILE" \
+    FAKE_COVERAGE_JSON="$TEST_ROOT/missing-target.json" \
+    python3 "$CHECKER" "$fresh_bundle" \
+    --threshold 70 \
+    --attempts 1
+
+new_counter "zero"
+run_checker 2 "zero executable logic lines fail closed" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCCOV_COUNTER="$COUNTER_FILE" \
+    FAKE_COVERAGE_JSON="$TEST_ROOT/zero-lines.json" \
+    python3 "$CHECKER" "$fresh_bundle" \
+    --threshold 70 \
+    --attempts 1
+
+new_counter "invalid"
+run_checker 2 "malformed line counts fail closed" \
+    env \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    FAKE_XCCOV_COUNTER="$COUNTER_FILE" \
+    FAKE_COVERAGE_JSON="$TEST_ROOT/invalid-lines.json" \
+    python3 "$CHECKER" "$fresh_bundle" \
+    --threshold 70 \
+    --attempts 1
+
+coverage_step="$(
+    sed -n \
+        '/- name: Check Coverage Threshold/,/- name: Comment Coverage on PR/p' \
+        "$WORKFLOW"
+)"
+if grep -qF "continue-on-error: true" <<< "$coverage_step" || \
+    ! grep -qF ".github/scripts/check_coverage.py" <<< "$coverage_step"; then
+    echo "✗ workflow does not wire the coverage checker as a blocking step"
+    exit 1
+fi
+echo "✓ workflow wires the coverage checker as a blocking step"
+
+comment_step="$(
+    sed -n \
+        '/- name: Comment Coverage on PR/,/^  [a-zA-Z0-9_-]*:/p' \
+        "$WORKFLOW"
+)"
+if ! grep -qF "if: always() && github.event_name == 'pull_request'" \
+    <<< "$comment_step" || \
+    ! grep -qF "Code Coverage unavailable" <<< "$comment_step" || \
+    ! grep -qF "did not report a passing result" <<< "$comment_step" || \
+    ! grep -qF "did not publish a valid result" <<< "$comment_step"; then
+    echo "✗ PR comment can leave a missing report described as passing"
+    exit 1
+fi
+echo "✓ PR comment reports missing coverage as a failing gate"
+
+echo "All coverage gate regression tests passed."


### PR DESCRIPTION
## Summary

- replace the permissive inline `xccov` parsing with a tested fail-closed checker
- validate the result bundle, coverage payload, `Pine.app` target, line counts, and executable totals before publishing a result
- retry only the known transient missing-coverage diagnostic, with bounded attempts and per-attempt timeouts
- keep the existing logic-only exclusions and publish explicit pass, below-threshold, or infrastructure-error output
- add deterministic tests for previously uncovered completion and hover-rendering logic so the enforced 70% gate starts with a real safety margin

## Coverage

- measured baseline: `20,165 / 29,005 = 69.5225%`
- new focused coverage: `CompletionEndpoint.swift 88/88`, `HoverMarkdownRenderer.swift 198/198`
- expected full logic-only result: `20,451 / 29,005 = 70.5085%`

## Verification

- `bash scripts/tests/test-check-coverage.sh`
- `bash -n scripts/tests/test-check-coverage.sh`
- `python3 -m py_compile .github/scripts/check_coverage.py`
- strict SwiftLint on both new Swift test files: 0 violations
- 13 focused Swift tests passed under Xcode 27 beta with code coverage enabled
- independent review: no blocker/high/medium findings

Closes #1180
