### PR TITLE
fix(extensibility): validate configuration reloads atomically

### DIFF
--- a/Pine/Extensibility/ExtensibilityManager.swift
+++ b/Pine/Extensibility/ExtensibilityManager.swift
@@ -11,30 +11,97 @@
 import Foundation
 import os
 
+typealias UserTaskConfigurationLoader = @Sendable (
+    URL
+) async -> UserConfigurationCandidate<UserTask>
+
+typealias UserKeybindingConfigurationLoader = @Sendable (
+    URL
+) async -> UserConfigurationCandidate<ResolvedUserKeybinding>
+
 /// Owns the shared `UserTaskRegistry` and `UserKeybindingRegistry`,
 /// loading both from disk at startup.
 ///
-/// `@MainActor` because it's created and queried from the app/UI layer.
-/// The underlying registries are `nonisolated` + `Sendable`-safe.
+/// Parsing and file I/O run off-main. Validated candidates are committed to
+/// both registries on the main actor, with a generation guard so an older
+/// reload cannot overwrite a newer request.
 @MainActor
 final class ExtensibilityManager {
-    static let shared = ExtensibilityManager()
+    static let shared = ExtensibilityManager(
+        tasksFileURL: UserConfigurationPaths.userTasksFile,
+        keybindingsFileURL: UserConfigurationPaths.userKeybindingsFile
+    )
 
     let tasks = UserTaskRegistry()
     let keybindings = UserKeybindingRegistry()
+    private let tasksFileURL: URL
+    private let keybindingsFileURL: URL
+    private let taskLoader: UserTaskConfigurationLoader
+    private let keybindingLoader: UserKeybindingConfigurationLoader
+    private var reloadGeneration = 0
+    private(set) var lastReloadReport: ExtensibilityReloadReport?
 
-    private init() {
-        reload()
+    init(
+        tasksFileURL: URL,
+        keybindingsFileURL: URL,
+        taskLoader: @escaping UserTaskConfigurationLoader = {
+            await UserTaskRegistry.prepareLoad(from: $0)
+        },
+        keybindingLoader: @escaping UserKeybindingConfigurationLoader = {
+            await UserKeybindingRegistry.prepareLoad(from: $0)
+        }
+    ) {
+        self.tasksFileURL = tasksFileURL
+        self.keybindingsFileURL = keybindingsFileURL
+        self.taskLoader = taskLoader
+        self.keybindingLoader = keybindingLoader
     }
 
     /// (Re)loads tasks and keybindings from their config files.
     /// Missing files are silently treated as "no config" — not an error.
-    func reload() {
-        let loadedTasks = tasks.load(from: UserConfigurationPaths.userTasksFile)
-        let loadedBindings = keybindings.load(from: UserConfigurationPaths.userKeybindingsFile)
+    /// Returns `nil` when a newer reload supersedes this request.
+    @discardableResult
+    func reload() async -> ExtensibilityReloadReport? {
+        reloadGeneration &+= 1
+        let generation = reloadGeneration
+        let taskLoader = taskLoader
+        let keybindingLoader = keybindingLoader
+        let tasksFileURL = tasksFileURL
+        let keybindingsFileURL = keybindingsFileURL
 
-        Logger.extensibility.info(
-            "Extensibility: \(loadedTasks.count) tasks, \(loadedBindings.count) keybindings"
+        async let taskCandidate = taskLoader(tasksFileURL)
+        async let keybindingCandidate = keybindingLoader(keybindingsFileURL)
+        let candidates = await (taskCandidate, keybindingCandidate)
+
+        guard reloadGeneration == generation, !Task.isCancelled else {
+            return nil
+        }
+
+        let taskReport = tasks.apply(candidates.0, from: tasksFileURL)
+        let keybindingReport = keybindings.apply(
+            candidates.1,
+            from: keybindingsFileURL
         )
+        let report = ExtensibilityReloadReport(
+            tasks: taskReport,
+            keybindings: keybindingReport
+        )
+        lastReloadReport = report
+        Self.log(report)
+        return report
+    }
+
+    private static func log(_ report: ExtensibilityReloadReport) {
+        Logger.extensibility.info(
+            """
+            Extensibility: \(report.tasks.activeEntryCount) tasks, \
+            \(report.keybindings.activeEntryCount) keybindings
+            """
+        )
+        for diagnostic in report.diagnostics {
+            Logger.extensibility.error(
+                "Extensibility configuration rejected: \(diagnostic.logDescription)"
+            )
+        }
     }
 }

--- a/Pine/Extensibility/UserConfigurationDiagnostic.swift
+++ b/Pine/Extensibility/UserConfigurationDiagnostic.swift
@@ -1,0 +1,120 @@
+//
+//  UserConfigurationDiagnostic.swift
+//  Pine
+//
+//  Typed diagnostics and load reports for user-owned JSON configuration.
+//  These values keep parsing independent from presentation so a later UI can
+//  localize errors without scraping log strings.
+//
+
+import Foundation
+
+/// Identifies one of Pine's user-editable JSON configuration files.
+nonisolated enum UserConfigurationFile: String, Sendable, Equatable {
+    case tasks
+    case keybindings
+}
+
+/// A structured reason why a user configuration could not be applied.
+nonisolated enum UserConfigurationDiagnosticReason: Sendable, Equatable {
+    case unreadable(details: String)
+    case malformedDocument(details: String)
+    case unknownCommand(id: String)
+    case unavailableCommand(id: String)
+    case invalidChord(value: String)
+    case textInputChord(value: String)
+    case reservedSystemChord(value: String)
+    case duplicateChord(value: String, firstEntryNumber: Int)
+    case duplicateTaskID(id: String, firstEntryNumber: Int)
+    case emptyTaskID
+    case emptyTaskLabel
+    case emptyTaskCommand
+
+    /// Stable, non-localized text for logs and diagnostics during development.
+    var logDescription: String {
+        switch self {
+        case .unreadable(let details):
+            "could not read file: \(details)"
+        case .malformedDocument(let details):
+            "invalid JSON document: \(details)"
+        case .unknownCommand(let id):
+            "unknown command id '\(id)'"
+        case .unavailableCommand(let id):
+            "command id '\(id)' has no safe dispatcher"
+        case .invalidChord(let value):
+            "invalid key chord '\(value)'"
+        case .textInputChord(let value):
+            "key chord '\(value)' would capture normal text input"
+        case .reservedSystemChord(let value):
+            "key chord '\(value)' is reserved by macOS or text editing"
+        case .duplicateChord(let value, let firstEntryNumber):
+            "key chord '\(value)' duplicates entry \(firstEntryNumber)"
+        case .duplicateTaskID(let id, let firstEntryNumber):
+            "task id '\(id)' duplicates entry \(firstEntryNumber)"
+        case .emptyTaskID:
+            "task id is empty"
+        case .emptyTaskLabel:
+            "task label is empty"
+        case .emptyTaskCommand:
+            "task command is empty"
+        }
+    }
+}
+
+/// One actionable configuration problem, including its source and entry.
+nonisolated struct UserConfigurationDiagnostic: Sendable, Equatable {
+    let file: UserConfigurationFile
+    let fileURL: URL
+    /// One-based entry number, or `nil` for file/document-level failures.
+    let entryNumber: Int?
+    let reason: UserConfigurationDiagnosticReason
+
+    var logDescription: String {
+        let entry = entryNumber.map { ", entry \($0)" } ?? ""
+        return "\(fileURL.path)\(entry): \(reason.logDescription)"
+    }
+}
+
+/// Whether a configuration file was applied, absent, or rejected.
+nonisolated enum UserConfigurationLoadOutcome: Sendable, Equatable {
+    /// The file parsed and validated successfully, then replaced the registry.
+    case loaded
+    /// The file does not exist; an empty configuration replaced the registry.
+    case missing
+    /// The file could not be read, parsed, or validated; the registry was kept.
+    case rejected
+}
+
+/// Result of loading one user configuration file.
+nonisolated struct UserConfigurationLoadReport: Sendable, Equatable {
+    let file: UserConfigurationFile
+    let fileURL: URL
+    let outcome: UserConfigurationLoadOutcome
+    /// Number of entries active after this load attempt.
+    let activeEntryCount: Int
+    let diagnostics: [UserConfigurationDiagnostic]
+
+    var wasApplied: Bool {
+        outcome != .rejected
+    }
+}
+
+/// Immutable result of parsing and validating a configuration file off-main.
+///
+/// Registries apply candidates only after returning to the main actor, keeping
+/// blocking file I/O out of the UI path while preserving all-or-nothing swaps.
+nonisolated enum UserConfigurationCandidate<Entry: Sendable>: Sendable {
+    case loaded([Entry])
+    case missing
+    case rejected([UserConfigurationDiagnostic])
+}
+
+/// Combined result of reloading both extensibility configuration files.
+nonisolated struct ExtensibilityReloadReport: Sendable, Equatable {
+    let tasks: UserConfigurationLoadReport
+    let keybindings: UserConfigurationLoadReport
+
+    var diagnostics: [UserConfigurationDiagnostic] {
+        tasks.diagnostics + keybindings.diagnostics
+    }
+}

--- a/Pine/Extensibility/UserKeybinding.swift
+++ b/Pine/Extensibility/UserKeybinding.swift
@@ -80,57 +80,214 @@ nonisolated enum UserCommand: String, Sendable, CaseIterable {
         }
     }
 
+    /// Whether this command currently has a production notification observer.
+    var isAvailableForUserKeybinding: Bool {
+        switch self {
+        case .toggleMinimap, .toggleBlame, .togglePreview,
+             .toggleTerminal, .newTerminalTab:
+            false
+        default:
+            true
+        }
+    }
+
     static func from(_ raw: String) -> UserCommand? {
         UserCommand(rawValue: raw)
     }
 }
 
 /// Parsed key chord: modifiers + a single character or special key.
-struct ParsedKeyChord: Equatable, Sendable {
+nonisolated struct ParsedKeyChord: Equatable, Hashable, Sendable {
     let modifiers: NSEvent.ModifierFlags
     /// Lowercased character (e.g. "f", "b"), or a special token ("return",
     /// "up", "down", "left", "right", "tab", "delete", "esc", "space").
     let key: String
+
+    static func == (lhs: ParsedKeyChord, rhs: ParsedKeyChord) -> Bool {
+        lhs.modifiers.rawValue == rhs.modifiers.rawValue && lhs.key == rhs.key
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(modifiers.rawValue)
+        hasher.combine(key)
+    }
+}
+
+/// A validated command/chord pair ready to install in the active registry.
+nonisolated struct ResolvedUserKeybinding: Equatable, Sendable {
+    let command: UserCommand
+    let chord: ParsedKeyChord
 }
 
 /// Loads and parses user keybindings from `keybindings.json`.
-nonisolated final class UserKeybindingRegistry: @unchecked Sendable {
-    /// Parsed entries: (command, chord).
-    private(set) var entries: [(command: UserCommand, chord: ParsedKeyChord)] = []
+@MainActor
+final class UserKeybindingRegistry {
+    /// Parsed entries in declaration order.
+    private(set) var entries: [ResolvedUserKeybinding] = []
 
     var count: Int { entries.count }
     var isEmpty: Bool { entries.isEmpty }
 
     @discardableResult
-    func load(from url: URL) -> [(command: UserCommand, chord: ParsedKeyChord)] {
-        guard let data = try? Data(contentsOf: url) else {
+    func load(from url: URL) async -> UserConfigurationLoadReport {
+        let candidate = await Self.prepareLoad(from: url)
+        return apply(candidate, from: url)
+    }
+
+    /// Reads, decodes, and validates a candidate without touching actor state.
+    nonisolated static func prepareLoad(
+        from url: URL
+    ) async -> UserConfigurationCandidate<ResolvedUserKeybinding> {
+        await runOnBackground(qos: .utility) {
+            readCandidate(from: url)
+        }
+    }
+
+    /// Commits a prepared candidate on the main actor.
+    func apply(
+        _ candidate: UserConfigurationCandidate<ResolvedUserKeybinding>,
+        from url: URL
+    ) -> UserConfigurationLoadReport {
+        let outcome: UserConfigurationLoadOutcome
+        let diagnostics: [UserConfigurationDiagnostic]
+        switch candidate {
+        case .loaded(let parsed):
+            entries = parsed
+            outcome = .loaded
+            diagnostics = []
+        case .missing:
             entries = []
-            return []
+            outcome = .missing
+            diagnostics = []
+        case .rejected(let problems):
+            outcome = .rejected
+            diagnostics = problems
         }
 
-        let docs = try? JSONDecoder().decode(UserKeybindingsDocument.self, from: data)
-        let array = try? JSONDecoder().decode([UserKeybinding].self, from: data)
-        let raw = docs?.keybindings ?? array ?? []
+        return UserConfigurationLoadReport(
+            file: .keybindings,
+            fileURL: url,
+            outcome: outcome,
+            activeEntryCount: entries.count,
+            diagnostics: diagnostics
+        )
+    }
 
-        var parsed: [(UserCommand, ParsedKeyChord)] = []
-        for entry in raw {
-            guard let command = UserCommand.from(entry.command),
-                  let chord = Self.parse(entry.key) else {
-                // Unknown command or unparseable key — skip silently.
+    nonisolated private static func readCandidate(
+        from url: URL
+    ) -> UserConfigurationCandidate<ResolvedUserKeybinding> {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return .missing
+        }
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            return .rejected([
+                diagnostic(
+                    for: url,
+                    entryNumber: nil,
+                    reason: .unreadable(details: String(describing: error))
+                )
+            ])
+        }
+
+        let raw: [UserKeybinding]
+        do {
+            raw = try Self.decodeDocument(from: data)
+        } catch {
+            return .rejected([
+                diagnostic(
+                    for: url,
+                    entryNumber: nil,
+                    reason: .malformedDocument(details: String(describing: error))
+                )
+            ])
+        }
+
+        var parsed: [ResolvedUserKeybinding] = []
+        var diagnostics: [UserConfigurationDiagnostic] = []
+        var firstEntryForChord: [ParsedKeyChord: Int] = [:]
+        for (index, entry) in raw.enumerated() {
+            let entryNumber = index + 1
+            let command = UserCommand.from(entry.command)
+            let chord = Self.parse(entry.key)
+
+            if command == nil {
+                diagnostics.append(UserConfigurationDiagnostic(
+                    file: .keybindings,
+                    fileURL: url,
+                    entryNumber: entryNumber,
+                    reason: .unknownCommand(id: entry.command)
+                ))
+            } else if command?.isAvailableForUserKeybinding == false {
+                diagnostics.append(UserConfigurationDiagnostic(
+                    file: .keybindings,
+                    fileURL: url,
+                    entryNumber: entryNumber,
+                    reason: .unavailableCommand(id: entry.command)
+                ))
+            }
+            if chord == nil {
+                diagnostics.append(UserConfigurationDiagnostic(
+                    file: .keybindings,
+                    fileURL: url,
+                    entryNumber: entryNumber,
+                    reason: .invalidChord(value: entry.key)
+                ))
+            } else if let chord, Self.reservedChords.contains(chord) {
+                diagnostics.append(UserConfigurationDiagnostic(
+                    file: .keybindings,
+                    fileURL: url,
+                    entryNumber: entryNumber,
+                    reason: .reservedSystemChord(value: entry.key)
+                ))
+            } else if let chord, !Self.hasDispatchModifier(chord) {
+                diagnostics.append(UserConfigurationDiagnostic(
+                    file: .keybindings,
+                    fileURL: url,
+                    entryNumber: entryNumber,
+                    reason: .textInputChord(value: entry.key)
+                ))
+            }
+
+            guard let command, let chord else {
                 continue
             }
-            parsed.append((command, chord))
+
+            if let firstEntryNumber = firstEntryForChord[chord] {
+                diagnostics.append(UserConfigurationDiagnostic(
+                    file: .keybindings,
+                    fileURL: url,
+                    entryNumber: entryNumber,
+                    reason: .duplicateChord(
+                        value: entry.key,
+                        firstEntryNumber: firstEntryNumber
+                    )
+                ))
+            } else {
+                firstEntryForChord[chord] = entryNumber
+            }
+            parsed.append(ResolvedUserKeybinding(command: command, chord: chord))
         }
-        entries = parsed
-        return parsed
+
+        guard diagnostics.isEmpty else {
+            return .rejected(diagnostics)
+        }
+
+        return .loaded(parsed)
     }
 
     /// Looks up the command matching a key event, if any.
     func command(for event: NSEvent) -> UserCommand? {
-        let mods = KeyboardShortcutMatcher.normalizedModifiers(event.modifierFlags)
-        let chars = event.charactersIgnoringModifiers ?? ""
-        guard let char = chars.lowercased().first else { return nil }
-        let key = String(char)
+        let mods = event.modifierFlags.intersection(Self.dispatchModifierMask)
+        guard let key = Self.keyToken(
+            keyCode: event.keyCode,
+            charactersIgnoringModifiers: event.charactersIgnoringModifiers
+        ) else {
+            return nil
+        }
         for entry in entries where entry.chord.modifiers == mods && entry.chord.key == key {
             return entry.command
         }
@@ -141,16 +298,115 @@ nonisolated final class UserKeybindingRegistry: @unchecked Sendable {
 
     // MARK: - Parsing
 
+    private enum DocumentError: Error {
+        case unsupportedTopLevel
+    }
+
+    nonisolated private static func decodeDocument(
+        from data: Data
+    ) throws -> [UserKeybinding] {
+        let object = try JSONSerialization.jsonObject(with: data)
+        let decoder = JSONDecoder()
+        if object is [Any] {
+            return try decoder.decode([UserKeybinding].self, from: data)
+        }
+        if object is [String: Any] {
+            return try decoder.decode(UserKeybindingsDocument.self, from: data).keybindings
+        }
+        throw DocumentError.unsupportedTopLevel
+    }
+
+    nonisolated private static let dispatchModifierMask: NSEvent.ModifierFlags = [
+        .command,
+        .control,
+        .option,
+        .shift,
+    ]
+
+    nonisolated private static let reservedChords: Set<ParsedKeyChord> = Set(
+        [
+            "cmd+space",
+            "cmd+tab",
+            "cmd+shift+tab",
+            "cmd+option+esc",
+            "cmd+control+q",
+            "ctrl+space",
+            "ctrl+up",
+            "ctrl+down",
+            "ctrl+left",
+            "ctrl+right",
+            "cmd+a",
+            "cmd+c",
+            "cmd+x",
+            "cmd+v",
+            "cmd+z",
+            "cmd+shift+z",
+            "cmd+`",
+            "cmd+q",
+            "cmd+w",
+            "cmd+h",
+            "cmd+m",
+            "option+left",
+            "option+right",
+            "option+shift+left",
+            "option+shift+right"
+        ].compactMap(parse)
+    )
+
+    nonisolated private static func hasDispatchModifier(_ chord: ParsedKeyChord) -> Bool {
+        !chord.modifiers.isDisjoint(with: [.command, .control])
+    }
+
+    /// Resolves AppKit key codes into the canonical tokens accepted by
+    /// `parse`, falling back to printable characters for ordinary keys.
+    nonisolated static func keyToken(
+        keyCode: UInt16,
+        charactersIgnoringModifiers: String?
+    ) -> String? {
+        switch keyCode {
+        case 36, 76: "return"
+        case 48: "tab"
+        case 51, 117: "delete"
+        case 53: "esc"
+        case 49: "space"
+        case 123: "left"
+        case 124: "right"
+        case 125: "down"
+        case 126: "up"
+        default:
+            charactersIgnoringModifiers?
+                .lowercased()
+                .first
+                .map(String.init)
+        }
+    }
+
+    nonisolated private static func diagnostic(
+        for url: URL,
+        entryNumber: Int?,
+        reason: UserConfigurationDiagnosticReason
+    ) -> UserConfigurationDiagnostic {
+        UserConfigurationDiagnostic(
+            file: .keybindings,
+            fileURL: url,
+            entryNumber: entryNumber,
+            reason: reason
+        )
+    }
+
     /// Parses a chord string like `"cmd+shift+f"` into modifiers + key.
     ///
     /// Recognized modifier tokens (case-insensitive): `cmd`/`command`,
     /// `shift`, `alt`/`option`/`opt`, `ctrl`/`control`. The final token is
     /// the key — a single character (lowercased) or a named special key.
-    static func parse(_ chord: String) -> ParsedKeyChord? {
-        let tokens = chord.split(separator: "+").map {
+    nonisolated static func parse(_ chord: String) -> ParsedKeyChord? {
+        let tokens = chord.split(separator: "+", omittingEmptySubsequences: false).map {
             $0.trimmingCharacters(in: .whitespaces).lowercased()
         }
-        guard let last = tokens.last, !last.isEmpty else { return nil }
+        guard !tokens.contains(where: \.isEmpty),
+              let last = tokens.last else {
+            return nil
+        }
 
         var flags: NSEvent.ModifierFlags = []
         for token in tokens.dropLast() {

--- a/Pine/Extensibility/UserTask.swift
+++ b/Pine/Extensibility/UserTask.swift
@@ -9,6 +9,7 @@
 //
 
 import Foundation
+import Observation
 
 /// A single user-defined task loaded from `tasks.json`.
 ///
@@ -108,10 +109,13 @@ nonisolated struct UserTasksDocument: Codable, Sendable, Equatable {
 
 /// Loads and holds the user's task definitions.
 ///
-/// `tasks.json` is optional — a missing or unreadable file yields an empty
-/// registry (no tasks in the menu). The loader is `nonisolated` and can be
-/// queried from any thread; the parsed array is immutable and `Sendable`.
-nonisolated final class UserTaskRegistry: @unchecked Sendable {
+/// `tasks.json` is optional — a missing file yields an empty registry. An
+/// unreadable, malformed, or invalid file is rejected atomically, preserving
+/// the last valid task list. Parsing happens off-main; registry swaps stay on
+/// the main actor so readers never observe a partial update.
+@MainActor
+@Observable
+final class UserTaskRegistry {
     /// Loaded tasks in declaration order.
     private(set) var tasks: [UserTask] = []
 
@@ -119,27 +123,51 @@ nonisolated final class UserTaskRegistry: @unchecked Sendable {
     var count: Int { tasks.count }
 
     /// Loads tasks from `tasks.json` at the given URL.
-    /// A missing file is not an error — it simply means no user tasks.
+    /// A missing file is not an error — it applies an empty task list.
+    /// Invalid files leave the active registry unchanged.
     @discardableResult
-    func load(from url: URL) -> [UserTask] {
-        guard let data = try? Data(contentsOf: url) else {
+    func load(from url: URL) async -> UserConfigurationLoadReport {
+        let candidate = await Self.prepareLoad(from: url)
+        return apply(candidate, from: url)
+    }
+
+    /// Reads, decodes, and validates a candidate without touching actor state.
+    nonisolated static func prepareLoad(
+        from url: URL
+    ) async -> UserConfigurationCandidate<UserTask> {
+        await runOnBackground(qos: .utility) {
+            readCandidate(from: url)
+        }
+    }
+
+    /// Commits a prepared candidate on the main actor.
+    func apply(
+        _ candidate: UserConfigurationCandidate<UserTask>,
+        from url: URL
+    ) -> UserConfigurationLoadReport {
+        let outcome: UserConfigurationLoadOutcome
+        let diagnostics: [UserConfigurationDiagnostic]
+        switch candidate {
+        case .loaded(let decoded):
+            tasks = decoded
+            outcome = .loaded
+            diagnostics = []
+        case .missing:
             tasks = []
-            return []
+            outcome = .missing
+            diagnostics = []
+        case .rejected(let problems):
+            outcome = .rejected
+            diagnostics = problems
         }
 
-        // Try the documented `{"tasks": [...]}` envelope first, then fall back
-        // to a bare top-level array for ergonomics.
-        if let doc = try? JSONDecoder().decode(UserTasksDocument.self, from: data) {
-            tasks = doc.tasks
-            return doc.tasks
-        }
-        if let array = try? JSONDecoder().decode([UserTask].self, from: data) {
-            tasks = array
-            return array
-        }
-
-        tasks = []
-        return []
+        return UserConfigurationLoadReport(
+            file: .tasks,
+            fileURL: url,
+            outcome: outcome,
+            activeEntryCount: tasks.count,
+            diagnostics: diagnostics
+        )
     }
 
     /// Returns the task with the given id, if any.
@@ -148,4 +176,121 @@ nonisolated final class UserTaskRegistry: @unchecked Sendable {
     }
 
     init() {}
+
+    private enum DocumentError: Error {
+        case unsupportedTopLevel
+    }
+
+    nonisolated private static func readCandidate(
+        from url: URL
+    ) -> UserConfigurationCandidate<UserTask> {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return .missing
+        }
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            return .rejected([
+                diagnostic(
+                    for: url,
+                    entryNumber: nil,
+                    reason: .unreadable(details: String(describing: error))
+                )
+            ])
+        }
+
+        let decoded: [UserTask]
+        do {
+            decoded = try Self.decodeDocument(from: data)
+        } catch {
+            return .rejected([
+                diagnostic(
+                    for: url,
+                    entryNumber: nil,
+                    reason: .malformedDocument(details: String(describing: error))
+                )
+            ])
+        }
+
+        let diagnostics = Self.validate(decoded, from: url)
+        guard diagnostics.isEmpty else {
+            return .rejected(diagnostics)
+        }
+
+        return .loaded(decoded)
+    }
+
+    nonisolated private static func decodeDocument(from data: Data) throws -> [UserTask] {
+        let object = try JSONSerialization.jsonObject(with: data)
+        let decoder = JSONDecoder()
+        if object is [Any] {
+            return try decoder.decode([UserTask].self, from: data)
+        }
+        if object is [String: Any] {
+            return try decoder.decode(UserTasksDocument.self, from: data).tasks
+        }
+        throw DocumentError.unsupportedTopLevel
+    }
+
+    nonisolated private static func validate(
+        _ decoded: [UserTask],
+        from url: URL
+    ) -> [UserConfigurationDiagnostic] {
+        var diagnostics: [UserConfigurationDiagnostic] = []
+        var firstEntryForID: [String: Int] = [:]
+
+        for (index, task) in decoded.enumerated() {
+            let entryNumber = index + 1
+            if task.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                diagnostics.append(diagnostic(
+                    for: url,
+                    entryNumber: entryNumber,
+                    reason: .emptyTaskID
+                ))
+            }
+            if task.label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                diagnostics.append(diagnostic(
+                    for: url,
+                    entryNumber: entryNumber,
+                    reason: .emptyTaskLabel
+                ))
+            }
+            if task.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                diagnostics.append(diagnostic(
+                    for: url,
+                    entryNumber: entryNumber,
+                    reason: .emptyTaskCommand
+                ))
+            }
+
+            if let firstEntryNumber = firstEntryForID[task.id] {
+                diagnostics.append(diagnostic(
+                    for: url,
+                    entryNumber: entryNumber,
+                    reason: .duplicateTaskID(
+                        id: task.id,
+                        firstEntryNumber: firstEntryNumber
+                    )
+                ))
+            } else {
+                firstEntryForID[task.id] = entryNumber
+            }
+        }
+        return diagnostics
+    }
+
+    nonisolated private static func diagnostic(
+        for url: URL,
+        entryNumber: Int?,
+        reason: UserConfigurationDiagnosticReason
+    ) -> UserConfigurationDiagnostic {
+        UserConfigurationDiagnostic(
+            file: .tasks,
+            fileURL: url,
+            entryNumber: entryNumber,
+            reason: reason
+        )
+    }
 }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -527,7 +527,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
         // Preload user-supplied tasks + keybindings (issue #1009). User
         // grammars are loaded by SyntaxHighlighter.shared above.
-        _ = ExtensibilityManager.shared
+        let extensibilityManager = ExtensibilityManager.shared
+        Task { @MainActor in
+            await extensibilityManager.reload()
+        }
 
         // UI testing support: clear persisted state for a clean launch
         if CommandLine.arguments.contains("--reset-state") {

--- a/PineTests/UserConfigurationReloadTests.swift
+++ b/PineTests/UserConfigurationReloadTests.swift
@@ -1,0 +1,547 @@
+//
+//  UserConfigurationReloadTests.swift
+//  PineTests
+//
+
+import AppKit
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("User configuration atomic reload")
+@MainActor
+struct UserConfigurationReloadTests {
+
+    @Test func keybindingsLoadEnvelopeAndBareArrayDocuments() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("keybindings.json")
+        let registry = UserKeybindingRegistry()
+
+        try write(
+            """
+            {
+              "keybindings": [
+                {"command": "quickOpen", "key": "cmd+p"},
+                {"command": "findInFile", "key": "command+shift+f"}
+              ]
+            }
+            """,
+            to: file
+        )
+
+        let envelopeReport = await registry.load(from: file)
+        #expect(envelopeReport.outcome == .loaded)
+        #expect(envelopeReport.activeEntryCount == 2)
+        #expect(envelopeReport.diagnostics.isEmpty)
+        #expect(registry.entries.map { $0.command } == [.quickOpen, .findInFile])
+        #expect(registry.entries[1].chord.modifiers == [.command, .shift])
+        #expect(registry.entries[1].chord.key == "f")
+
+        try write(
+            """
+            [
+              {"command": "goToLine", "key": "ctrl+l"}
+            ]
+            """,
+            to: file
+        )
+
+        let arrayReport = await registry.load(from: file)
+        #expect(arrayReport.outcome == .loaded)
+        #expect(arrayReport.activeEntryCount == 1)
+        #expect(registry.entries.map { $0.command } == [.goToLine])
+    }
+
+    @Test func invalidKeybindingsRejectTheWholeDocument() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("keybindings.json")
+        let registry = UserKeybindingRegistry()
+        try write(
+            """
+            [{"command": "quickOpen", "key": "cmd+p"}]
+            """,
+            to: file
+        )
+        #expect((await registry.load(from: file)).outcome == .loaded)
+
+        try write(
+            """
+            [
+              {"command": "notACommand", "key": "cmd+y"},
+              {"command": "findInFile", "key": "cmd+hyper+f"},
+              {"command": "goToLine", "key": "command+shift+g"},
+              {"command": "toggleComment", "key": "SHIFT+command+G"},
+              {"command": "quickOpen", "key": "cmd++p"}
+            ]
+            """,
+            to: file
+        )
+
+        let report = await registry.load(from: file)
+
+        #expect(report.outcome == .rejected)
+        #expect(report.activeEntryCount == 1)
+        #expect(report.diagnostics.map(\.reason).contains(
+            .unknownCommand(id: "notACommand")
+        ))
+        #expect(report.diagnostics.map(\.reason).contains(
+            .invalidChord(value: "cmd+hyper+f")
+        ))
+        #expect(report.diagnostics.map(\.reason).contains(
+            .invalidChord(value: "cmd++p")
+        ))
+        #expect(report.diagnostics.map(\.reason).contains(
+            .duplicateChord(value: "SHIFT+command+G", firstEntryNumber: 3)
+        ))
+        #expect(report.diagnostics.map(\.entryNumber) == [1, 2, 4, 5])
+        #expect(registry.entries.map { $0.command } == [.quickOpen])
+    }
+
+    @Test func unavailableUnsafeAndReservedBindingsAreRejected() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("keybindings.json")
+        let registry = UserKeybindingRegistry()
+        try write(
+            """
+            [
+              {"command": "toggleMinimap", "key": "cmd+k"},
+              {"command": "quickOpen", "key": "f"},
+              {"command": "goToLine", "key": "cmd+c"}
+            ]
+            """,
+            to: file
+        )
+
+        let report = await registry.load(from: file)
+
+        #expect(report.outcome == .rejected)
+        #expect(report.diagnostics.map(\.reason).contains(
+            .unavailableCommand(id: "toggleMinimap")
+        ))
+        #expect(report.diagnostics.map(\.reason).contains(
+            .textInputChord(value: "f")
+        ))
+        #expect(report.diagnostics.map(\.reason).contains(
+            .reservedSystemChord(value: "cmd+c")
+        ))
+        #expect(registry.isEmpty)
+    }
+
+    @Test func namedKeybindingsMatchAppKitKeyEvents() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("keybindings.json")
+        let registry = UserKeybindingRegistry()
+        try write(
+            """
+            [
+              {"command": "quickOpen", "key": "cmd+return"},
+              {"command": "goToLine", "key": "ctrl+esc"},
+              {"command": "findInFile", "key": "cmd+up"},
+              {"command": "findNext", "key": "cmd+delete"}
+            ]
+            """,
+            to: file
+        )
+        #expect((await registry.load(from: file)).outcome == .loaded)
+
+        let returnEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .command,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\r",
+            charactersIgnoringModifiers: "\r",
+            isARepeat: false,
+            keyCode: 36
+        ))
+        let escapeEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.control, .capsLock],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\u{1B}",
+            charactersIgnoringModifiers: "\u{1B}",
+            isARepeat: false,
+            keyCode: 53
+        ))
+        let keypadReturnEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .numericPad],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\r",
+            charactersIgnoringModifiers: "\r",
+            isARepeat: false,
+            keyCode: 76
+        ))
+        let upArrowEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .numericPad, .function],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: 126
+        ))
+        let forwardDeleteEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .function],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\u{7F}",
+            charactersIgnoringModifiers: "\u{7F}",
+            isARepeat: false,
+            keyCode: 117
+        ))
+
+        #expect(registry.command(for: returnEvent) == .quickOpen)
+        #expect(registry.command(for: escapeEvent) == .goToLine)
+        #expect(registry.command(for: keypadReturnEvent) == .quickOpen)
+        #expect(registry.command(for: upArrowEvent) == .findInFile)
+        #expect(registry.command(for: forwardDeleteEvent) == .findNext)
+        #expect(UserKeybindingRegistry.keyToken(
+            keyCode: 0,
+            charactersIgnoringModifiers: "P"
+        ) == "p")
+        #expect(UserKeybindingRegistry.keyToken(
+            keyCode: 0,
+            charactersIgnoringModifiers: nil
+        ) == nil)
+    }
+
+    @Test(arguments: [
+        (UInt16(36), "return"),
+        (UInt16(76), "return"),
+        (UInt16(48), "tab"),
+        (UInt16(51), "delete"),
+        (UInt16(117), "delete"),
+        (UInt16(53), "esc"),
+        (UInt16(49), "space"),
+        (UInt16(123), "left"),
+        (UInt16(124), "right"),
+        (UInt16(125), "down"),
+        (UInt16(126), "up"),
+    ])
+    func namedKeyCodesUseCanonicalTokens(keyCode: UInt16, expected: String) {
+        #expect(UserKeybindingRegistry.keyToken(
+            keyCode: keyCode,
+            charactersIgnoringModifiers: nil
+        ) == expected)
+    }
+
+    @Test func malformedAndUnreadableKeybindingsKeepTheLastValidRegistry() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("keybindings.json")
+        let registry = UserKeybindingRegistry()
+        try write(
+            """
+            [{"command": "quickOpen", "key": "cmd+p"}]
+            """,
+            to: file
+        )
+        #expect((await registry.load(from: file)).outcome == .loaded)
+
+        try write("{", to: file)
+        let malformed = await registry.load(from: file)
+        #expect(malformed.outcome == .rejected)
+        #expect(malformed.diagnostics.count == 1)
+        #expect(malformed.diagnostics[0].entryNumber == nil)
+        if case .malformedDocument = malformed.diagnostics[0].reason {
+            // Expected.
+        } else {
+            Issue.record("Expected malformed-document diagnostic")
+        }
+        #expect(registry.entries.map { $0.command } == [.quickOpen])
+
+        try FileManager.default.removeItem(at: file)
+        try FileManager.default.createDirectory(at: file, withIntermediateDirectories: false)
+        let unreadable = await registry.load(from: file)
+        #expect(unreadable.outcome == .rejected)
+        if case .unreadable = unreadable.diagnostics[0].reason {
+            // Expected.
+        } else {
+            Issue.record("Expected unreadable-file diagnostic")
+        }
+        #expect(registry.entries.map { $0.command } == [.quickOpen])
+    }
+
+    @Test func missingKeybindingsApplyAnEmptyRegistry() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("keybindings.json")
+        let registry = UserKeybindingRegistry()
+        try write(
+            """
+            [{"command": "quickOpen", "key": "cmd+p"}]
+            """,
+            to: file
+        )
+        #expect((await registry.load(from: file)).outcome == .loaded)
+        try FileManager.default.removeItem(at: file)
+
+        let report = await registry.load(from: file)
+
+        #expect(report.outcome == .missing)
+        #expect(report.wasApplied)
+        #expect(report.activeEntryCount == 0)
+        #expect(registry.isEmpty)
+    }
+
+    @Test func tasksLoadEnvelopeAndBareArrayDocuments() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("tasks.json")
+        let registry = UserTaskRegistry()
+        try write(
+            """
+            {
+              "tasks": [
+                {"id": "lint", "label": "Lint", "command": "swiftlint"}
+              ]
+            }
+            """,
+            to: file
+        )
+
+        let envelopeReport = await registry.load(from: file)
+        #expect(envelopeReport.outcome == .loaded)
+        #expect(envelopeReport.activeEntryCount == 1)
+        #expect(registry.task(forID: "lint")?.label == "Lint")
+
+        try write(
+            """
+            [
+              {"id": "build", "label": "Build", "command": "swift build"},
+              {"id": "test", "label": "Test", "command": "swift test"}
+            ]
+            """,
+            to: file
+        )
+
+        let arrayReport = await registry.load(from: file)
+        #expect(arrayReport.outcome == .loaded)
+        #expect(arrayReport.activeEntryCount == 2)
+        #expect(registry.tasks.map(\.id) == ["build", "test"])
+    }
+
+    @Test func invalidTasksRejectTheWholeDocument() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("tasks.json")
+        let registry = UserTaskRegistry()
+        try write(
+            """
+            [{"id": "lint", "label": "Lint", "command": "swiftlint"}]
+            """,
+            to: file
+        )
+        #expect((await registry.load(from: file)).outcome == .loaded)
+
+        try write(
+            """
+            [
+              {"id": "duplicate", "label": "", "command": ""},
+              {"id": "duplicate", "label": "Second", "command": "echo second"},
+              {"id": " ", "label": "Whitespace ID", "command": "echo third"}
+            ]
+            """,
+            to: file
+        )
+
+        let report = await registry.load(from: file)
+
+        #expect(report.outcome == .rejected)
+        #expect(report.activeEntryCount == 1)
+        #expect(report.diagnostics.map(\.reason).contains(.emptyTaskLabel))
+        #expect(report.diagnostics.map(\.reason).contains(.emptyTaskCommand))
+        #expect(report.diagnostics.map(\.reason).contains(
+            .duplicateTaskID(id: "duplicate", firstEntryNumber: 1)
+        ))
+        #expect(report.diagnostics.map(\.reason).contains(.emptyTaskID))
+        #expect(registry.tasks.map(\.id) == ["lint"])
+    }
+
+    @Test func malformedTasksStayActiveUntilTheFileIsRemoved() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("tasks.json")
+        let registry = UserTaskRegistry()
+        try write(
+            """
+            [{"id": "lint", "label": "Lint", "command": "swiftlint"}]
+            """,
+            to: file
+        )
+        #expect((await registry.load(from: file)).outcome == .loaded)
+
+        try write(#"{"tasks": "not-an-array"}"#, to: file)
+        let malformed = await registry.load(from: file)
+        #expect(malformed.outcome == .rejected)
+        #expect(registry.tasks.map(\.id) == ["lint"])
+
+        try FileManager.default.removeItem(at: file)
+        try FileManager.default.createDirectory(at: file, withIntermediateDirectories: false)
+        let unreadable = await registry.load(from: file)
+        #expect(unreadable.outcome == .rejected)
+        if case .unreadable = unreadable.diagnostics[0].reason {
+            // Expected.
+        } else {
+            Issue.record("Expected unreadable-file diagnostic")
+        }
+        #expect(registry.tasks.map(\.id) == ["lint"])
+
+        try FileManager.default.removeItem(at: file)
+        let missing = await registry.load(from: file)
+        #expect(missing.outcome == .missing)
+        #expect(registry.tasks.isEmpty)
+    }
+
+    @Test func managerReloadsEachFileAtomicallyAndRetainsDiagnostics() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let tasksFile = directory.appendingPathComponent("tasks.json")
+        let keybindingsFile = directory.appendingPathComponent("keybindings.json")
+        try write(
+            """
+            [{"id": "lint", "label": "Lint", "command": "swiftlint"}]
+            """,
+            to: tasksFile
+        )
+        try write(
+            """
+            [{"command": "quickOpen", "key": "cmd+p"}]
+            """,
+            to: keybindingsFile
+        )
+        let manager = ExtensibilityManager(
+            tasksFileURL: tasksFile,
+            keybindingsFileURL: keybindingsFile
+        )
+        let initialReport = await manager.reload()
+        #expect(initialReport != nil)
+        #expect(manager.tasks.count == 1)
+        #expect(manager.keybindings.count == 1)
+
+        try write(
+            """
+            [
+              {"id": "build", "label": "Build", "command": "swift build"},
+              {"id": "test", "label": "Test", "command": "swift test"}
+            ]
+            """,
+            to: tasksFile
+        )
+        try write("{", to: keybindingsFile)
+
+        let loadedReport = await manager.reload()
+        let report = try #require(loadedReport)
+
+        #expect(report.tasks.outcome == .loaded)
+        #expect(report.tasks.activeEntryCount == 2)
+        #expect(report.keybindings.outcome == .rejected)
+        #expect(report.keybindings.activeEntryCount == 1)
+        #expect(report.diagnostics.count == 1)
+        #expect(manager.tasks.tasks.map(\.id) == ["build", "test"])
+        #expect(manager.keybindings.entries.map { $0.command } == [.quickOpen])
+        #expect(manager.lastReloadReport == report)
+    }
+
+    @Test func newerReloadDiscardsAnOlderCandidate() async {
+        let controlledLoader = ControlledTaskConfigurationLoader()
+        let manager = ExtensibilityManager(
+            tasksFileURL: URL(fileURLWithPath: "/unused/tasks.json"),
+            keybindingsFileURL: URL(fileURLWithPath: "/unused/keybindings.json"),
+            taskLoader: { _ in
+                await controlledLoader.load()
+            },
+            keybindingLoader: { _ in
+                .missing
+            }
+        )
+
+        let firstReload = Task { @MainActor in
+            await manager.reload()
+        }
+        await controlledLoader.waitUntilFirstLoadStarts()
+
+        let secondReport = await manager.reload()
+        #expect(secondReport?.tasks.outcome == .loaded)
+        #expect(manager.tasks.tasks.map(\.id) == ["new"])
+
+        await controlledLoader.releaseFirstLoad()
+        let supersededReport = await firstReload.value
+
+        #expect(supersededReport == nil)
+        #expect(manager.tasks.tasks.map(\.id) == ["new"])
+        #expect(manager.lastReloadReport == secondReport)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-user-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: false
+        )
+        return directory
+    }
+
+    private func write(_ contents: String, to url: URL) throws {
+        try Data(contents.utf8).write(to: url, options: .atomic)
+    }
+}
+
+private actor ControlledTaskConfigurationLoader {
+    private var callCount = 0
+    private var firstLoadStarted = false
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var firstLoadRelease: CheckedContinuation<Void, Never>?
+
+    func load() async -> UserConfigurationCandidate<UserTask> {
+        callCount += 1
+        guard callCount == 1 else {
+            return .loaded([
+                UserTask(id: "new", label: "New", command: "echo new")
+            ])
+        }
+
+        firstLoadStarted = true
+        startWaiters.forEach { $0.resume() }
+        startWaiters.removeAll()
+        await withCheckedContinuation { continuation in
+            firstLoadRelease = continuation
+        }
+        return .loaded([
+            UserTask(id: "old", label: "Old", command: "echo old")
+        ])
+    }
+
+    func waitUntilFirstLoadStarts() async {
+        guard !firstLoadStarted else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func releaseFirstLoad() {
+        firstLoadRelease?.resume()
+        firstLoadRelease = nil
+    }
+}


### PR DESCRIPTION
## Summary
- parse and validate tasks.json and keybindings.json off the main thread, then swap validated candidates on MainActor
- preserve the last valid per-file registry on unreadable, malformed, duplicate, unsafe, or unsupported entries; a genuinely missing file still clears that registry
- return structured file and entry diagnostics, reject normalized chord and task ID duplicates, and report dead command targets
- make named Return, Tab, Escape, Delete, Space, and arrow bindings match real AppKit events while filtering reserved and text-input shortcuts
- guard overlapping reloads with a generation token and keep the Tasks menu observable after asynchronous startup loading

## Tests
- focused UserConfigurationReloadTests plus existing UserTaskRequireConfirmationTests, UserTaskValidatorTests, and KeyboardShortcutMatcherTests pass under Xcode
- strict SwiftLint passes for all touched Swift files
- git diff --check passes
- independent review found no blocker, high, or medium findings after fixes

Refs #1117