### PR TITLE
docs: choose structural intelligence providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Tests for fail-closed coverage gate
         run: bash scripts/tests/test-check-coverage.sh
 
+      - name: Validate structural-intelligence prototype inputs
+        run: python3 scripts/structural-intelligence/benchmark.py --validate-only
+
   build:
     name: Build for Testing
     runs-on: macos-26

--- a/docs/adr/0001-structural-intelligence-providers.md
+++ b/docs/adr/0001-structural-intelligence-providers.md
@@ -154,14 +154,14 @@ prototype package is not referenced by `Pine.xcodeproj`. Exact raw results are
 in
 [`2026-07-23-xcode-27-beta.json`](../../scripts/structural-intelligence/results/2026-07-23-xcode-27-beta.json).
 
-The baseline used:
+The measured worktree was based on:
 
-- Pine `56e1a19222f2cf041d2f1d4d599e5c465576ba83`;
+- Pine `f71362b036b72925e074cfd4a064d054110cb313`;
 - macOS 27 arm64, Xcode 27 beta `27A5218g`;
 - Apple Swift `6.4 (swiftlang-6.4.0.25.4)`;
 - SourceKit-LSP executable SHA-256
   `7cc11570a25398b677214cddd0463952b3834788de0f33ee4da7911b89b39582`;
-- a 425-byte valid fixture, a 411-byte malformed fixture, and a deterministic
+- a 526-byte valid fixture, a 411-byte malformed fixture, and a deterministic
   644,047-byte/32,005-line fixture.
 
 ### Latency and recovery
@@ -171,15 +171,26 @@ thresholds.
 
 | Fixture | LSP fold first / after edit | LSP symbols first / after edit | Tree-sitter cold / incremental |
 | --- | ---: | ---: | ---: |
-| Valid, 425 B | 59.48 / 1.04 | 2.34 / 0.43 | 0.94 / 0.03 |
-| Malformed, 411 B | 2.59 / 0.56 | 0.50 / 0.33 | 0.29 / 0.10 |
-| Large, 644 KB | 139.10 / 144.25 | 171.03 / 180.94 | 61.62 / 0.03 |
+| Valid, 526 B | 56.20 / 1.02 | 2.53 / 0.35 | 0.89 / 0.03 |
+| Malformed, 411 B | 2.54 / 0.61 | 0.55 / 0.32 | 0.28 / 0.09 |
+| Large, 644 KB | 133.86 / 132.27 | 176.11 / 207.41 | 58.88 / 0.03 |
 
 SourceKit-LSP advertised both capabilities and returned:
 
-- valid: 13 folds and 7 symbols, nested to depth 3;
+- valid: 16 folds and 9 symbols, nested to depth 3;
 - malformed: 8 folds and 6 symbols, nested to depth 3;
 - large: 14,001 folds and 12,001 symbols, nested to depth 4.
+
+The server omitted `positionEncoding`, so the negotiated LSP default was
+UTF-16. The prototype refuses every other encoding and validates all cold and
+post-edit folding ranges, document-symbol ranges, and selection ranges against
+the exact immutable snapshot. It also verifies selection containment and
+parent/child containment and records SHA-256 fingerprints of all canonical
+validated range streams. As concrete non-ASCII evidence, SourceKit-LSP reported
+the `类型🌲` symbol selection at zero-based line 24, UTF-16 characters `7..<11`
+in both runs. The name occupies 10 UTF-8 bytes and 4 UTF-16 code units, so this
+check would reject byte-counted columns or a position inside the emoji's
+surrogate pair.
 
 The raw Tree-sitter walk returned useful structure despite an error root in the
 malformed fixture (4 fold candidates and 2 declaration symbols). Its
@@ -199,8 +210,8 @@ bundle. The measured Xcode toolchain binary itself was 35,848,000 bytes, but
 Pine does not ship it.
 
 The tooling-only Tree-sitter probe produced a 4,463,240-byte release
-executable. A fresh SwiftPM scratch tree occupied 262,154,423 bytes and
-resolved/built in 21.85 seconds with the machine-wide repository cache warm.
+executable. A fresh SwiftPM scratch tree occupied 262,151,094 bytes and
+resolved/built in 19.65 seconds with the machine-wide repository cache warm.
 This is not an exact Pine bundle delta, but it confirms non-trivial build and
 artifact cost that LSP-first avoids.
 

--- a/docs/adr/0001-structural-intelligence-providers.md
+++ b/docs/adr/0001-structural-intelligence-providers.md
@@ -119,7 +119,7 @@ Pine's normalized structural coordinate system is UTF-16 `NSRange`, matching
   `Node.range`. The reviewed Swift binding documents `Node.range` as
   `NSRange`; its encoding-dependent `byteRange` must not escape the adapter.
   `InputEdit` is the sole boundary that converts an `NSRange` to UTF-16LE
-  bytes and Tree-sitter points.
+  bytes and Tree-sitter points (rows plus byte-counted columns).
 - Consumers validate every normalized range against the same snapshot before
   applying it. UI code owns only display conversion (for example, 0-based
   normalized lines to `FoldableRange`'s current 1-based lines).

--- a/docs/adr/0001-structural-intelligence-providers.md
+++ b/docs/adr/0001-structural-intelligence-providers.md
@@ -1,0 +1,300 @@
+# ADR 0001: LSP-first structural intelligence with local fallbacks
+
+- Status: Accepted
+- Date: 2026-07-23
+- Issues: [#1182](https://github.com/batonogov/pine/issues/1182),
+  [#1008](https://github.com/batonogov/pine/issues/1008)
+
+## Context
+
+Pine currently has three unrelated structural heuristics:
+
+- `FoldRangeCalculator` scans bracket pairs and produces UTF-16 character
+  offsets plus 1-based lines.
+- `SymbolParser` uses language-specific regular expressions and returns a flat
+  symbol list.
+- `BracketMatcher` scans around an `NSTextView` UTF-16 caret, excluding the
+  comment/string ranges produced by the regex syntax highlighter.
+
+All three execute synchronously from editor or navigator paths. Pine also has a
+working, per-language LSP client, but it does not yet decode server
+capabilities or request
+[`textDocument/foldingRange`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_foldingRange)
+and
+[`textDocument/documentSymbol`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol).
+
+Adding Tree-sitter to production could provide fast incremental syntax even
+without a language server. It would also add a second language-intelligence
+stack, grammar/query maintenance, binary cost, and a second range model. We
+therefore measured both paths before changing production dependencies.
+
+## Decision
+
+Pine will use a layered model, selected separately per feature:
+
+| Feature | Preferred provider | Fallback | Production dependency change |
+| --- | --- | --- | --- |
+| Folding | LSP `foldingRange` | Existing bracket `FoldRangeCalculator` | None |
+| Document symbols | LSP `documentSymbol` with hierarchy | Existing regex `SymbolParser` | None |
+| Bracket navigation/highlight | Existing bounded `BracketMatcher` with syntax skip ranges | Full-file bounded scan already in place | None |
+
+Tree-sitter is not a production provider in the first implementation sequence.
+It remains the planned offline structural provider if the exit criteria below
+are met. Regex syntax highlighting is unchanged.
+
+### Provider precedence
+
+Each feature chooses exactly one result set for one immutable document
+revision. Results from different providers are never merged:
+
+1. A fresh, valid, non-empty LSP result wins.
+2. A missing capability, missing executable, timeout, cancellation, transport
+   error, invalid range, stale generation, or empty LSP result selects the
+   current local fallback.
+3. The fallback remains visible while an LSP request is pending. Replacing it
+   with an LSP result is one atomic main-actor update.
+
+An empty LSP result deliberately falls back. An empty response can mean “no
+structure”, unsupported syntax, or incomplete recovery; using the local result
+prevents malformed edits from blanking all folding or symbols.
+
+Bracket navigation stays local because LSP defines no bracket-matching
+request. Pulling in a parser solely for this cursor-local operation is not
+justified by the measured Swift-only prototype. The existing bounded scan is
+also immediately available during every edit and for every grammar Pine
+already supports.
+
+### Provider seams
+
+Issue #1008 should introduce data-source-independent seams before adding
+endpoints:
+
+```swift
+nonisolated struct StructuralDocumentSnapshot: Sendable {
+    let identity: UUID
+    let revision: Int
+    let text: String
+    let language: String
+}
+
+nonisolated protocol FoldRangeProviding: Sendable {
+    func foldRanges(
+        for snapshot: StructuralDocumentSnapshot
+    ) async throws -> [StructuralFoldRange]
+}
+
+nonisolated protocol DocumentSymbolProviding: Sendable {
+    func symbols(
+        for snapshot: StructuralDocumentSnapshot
+    ) async throws -> [StructuralSymbol]
+}
+```
+
+`StructuralSymbol` is recursive. Both normalized output models carry validated
+`NSRange` values and the source revision. They do not expose LSP lines,
+Tree-sitter byte ranges, or provider-specific kinds. Existing
+`FoldableRange`/`PineSymbol` become UI adapters rather than provider APIs.
+
+### Range ownership
+
+Pine's normalized structural coordinate system is UTF-16 `NSRange`, matching
+`NSString`, `NSTextStorage`, and `NSTextView`.
+
+- The LSP adapter owns every LSP `Position`/`Range` conversion. It converts
+  against the exact immutable text snapshot used for the request and uses the
+  fail-closed behavior of `LSPPositionConverter.utf16OffsetIfValid`. Negative
+  values, out-of-bounds lines/columns, reversed ranges, positions inside a
+  surrogate pair, and ranges from another revision invalidate the entire
+  provider result.
+- The client advertises only UTF-16 initially. LSP defaults to UTF-16 when
+  `positionEncoding` is absent, as the measured SourceKit-LSP did. A server
+  selecting another encoding is unsupported until that encoding has its own
+  tested adapter; silently interpreting UTF-8/UTF-32 as UTF-16 is forbidden.
+- The LSP adapter expands an omitted folding `startCharacter` to the start of
+  its line and an omitted `endCharacter` to the end of its line, excluding the
+  line terminator. It validates `DocumentSymbol.range` and
+  `DocumentSymbol.selectionRange` independently and requires the selection to
+  be contained by the symbol range.
+- A future Tree-sitter adapter must parse as UTF-16 and expose only
+  `Node.range`. The reviewed Swift binding documents `Node.range` as
+  `NSRange`; its encoding-dependent `byteRange` must not escape the adapter.
+  `InputEdit` is the sole boundary that converts an `NSRange` to UTF-16LE
+  bytes and Tree-sitter points.
+- Consumers validate every normalized range against the same snapshot before
+  applying it. UI code owns only display conversion (for example, 0-based
+  normalized lines to `FoldableRange`'s current 1-based lines).
+
+### Background work, cancellation, and stale results
+
+- The main actor captures document identity, revision, language, and an
+  immutable text snapshot. Request/parse work and range normalization run
+  away from the main thread.
+- Each document has one task per structural feature. A new edit, close,
+  language change, server restart, or provider change cancels its predecessor.
+- LSP cancellation sends
+  [`$/cancelRequest`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#cancelRequest)
+  and cancels the local Swift task. Cancellation is advisory, so application
+  still requires an exact `(identity, revision, providerEpoch)` generation
+  match.
+- Folding and symbols use a 250 ms interactive deadline. The local fallback
+  remains usable after the deadline; a late response is discarded rather than
+  causing visible range churn.
+- A future Tree-sitter provider runs on a dedicated serial utility queue per
+  document, uses parser timeout/cancellation, calls `reset()` after a timeout,
+  and applies a new tree only under the same generation check.
+- Provider errors never clear the last valid local result and never block the
+  main thread.
+
+## Measured prototype
+
+The checked-in
+[`scripts/structural-intelligence`](../../scripts/structural-intelligence/README.md)
+tool runs the installed SourceKit-LSP and a separate SwiftPM executable. The
+prototype package is not referenced by `Pine.xcodeproj`. Exact raw results are
+in
+[`2026-07-23-xcode-27-beta.json`](../../scripts/structural-intelligence/results/2026-07-23-xcode-27-beta.json).
+
+The baseline used:
+
+- Pine `56e1a19222f2cf041d2f1d4d599e5c465576ba83`;
+- macOS 27 arm64, Xcode 27 beta `27A5218g`;
+- Apple Swift `6.4 (swiftlang-6.4.0.25.4)`;
+- SourceKit-LSP executable SHA-256
+  `7cc11570a25398b677214cddd0463952b3834788de0f33ee4da7911b89b39582`;
+- a 425-byte valid fixture, a 411-byte malformed fixture, and a deterministic
+  644,047-byte/32,005-line fixture.
+
+### Latency and recovery
+
+All values are milliseconds from one measured run. They are evidence, not CI
+thresholds.
+
+| Fixture | LSP fold first / after edit | LSP symbols first / after edit | Tree-sitter cold / incremental |
+| --- | ---: | ---: | ---: |
+| Valid, 425 B | 59.48 / 1.04 | 2.34 / 0.43 | 0.94 / 0.03 |
+| Malformed, 411 B | 2.59 / 0.56 | 0.50 / 0.33 | 0.29 / 0.10 |
+| Large, 644 KB | 139.10 / 144.25 | 171.03 / 180.94 | 61.62 / 0.03 |
+
+SourceKit-LSP advertised both capabilities and returned:
+
+- valid: 13 folds and 7 symbols, nested to depth 3;
+- malformed: 8 folds and 6 symbols, nested to depth 3;
+- large: 14,001 folds and 12,001 symbols, nested to depth 4.
+
+The raw Tree-sitter walk returned useful structure despite an error root in the
+malformed fixture (4 fold candidates and 2 declaration symbols). Its
+incremental edit reported exactly one changed range. The simple probe walk is
+not a curated production query, so its counts are not expected to match LSP.
+
+Cancellation was observable in both paths: SourceKit-LSP answered an immediate
+large `documentSymbol` cancellation with JSON-RPC error `-32800`, and every
+Tree-sitter fixture honored a one-microsecond parser timeout and recovered
+after `reset()`.
+
+### Build, binary, and dependency evidence
+
+SourceKit-LSP is external and already resolved by Pine, so the selected first
+sequence adds zero Pine package dependencies and zero bytes to the application
+bundle. The measured Xcode toolchain binary itself was 35,848,000 bytes, but
+Pine does not ship it.
+
+The tooling-only Tree-sitter probe produced a 4,463,240-byte release
+executable. A fresh SwiftPM scratch tree occupied 262,154,423 bytes and
+resolved/built in 21.85 seconds with the machine-wide repository cache warm.
+This is not an exact Pine bundle delta, but it confirms non-trivial build and
+artifact cost that LSP-first avoids.
+
+### Reviewed upstreams
+
+Research date: 2026-07-23. Only primary upstream repositories and the official
+LSP specification were used.
+
+| Component | Reviewed revision/release | License | Maintenance observation |
+| --- | --- | --- | --- |
+| [SourceKit-LSP](https://github.com/swiftlang/sourcekit-lsp/tree/b5d9b039698f52ee417886a8bbec4193b92cd75f) | Xcode toolchain above; upstream `b5d9b03` | [Apache-2.0](https://github.com/swiftlang/sourcekit-lsp/blob/main/LICENSE.txt) | Upstream commit on the research date; bundled with Xcode/Swift toolchains |
+| [SwiftTreeSitter](https://github.com/tree-sitter/swift-tree-sitter/tree/0f40435cdb41673ce4194d731571cf2a2f7c3285) | `0f40435`, 2026-05-26 | [BSD-3-Clause](https://github.com/tree-sitter/swift-tree-sitter/blob/0f40435cdb41673ce4194d731571cf2a2f7c3285/LICENSE) | Active and maintained in the official `tree-sitter` organization |
+| [Tree-sitter runtime 0.25.10](https://github.com/tree-sitter/tree-sitter/tree/da6fe9beb4f7f67beb75914ca8e0d48ae48d6406) | `da6fe9b`, 2025-09-22 | [MIT](https://github.com/tree-sitter/tree-sitter/blob/da6fe9beb4f7f67beb75914ca8e0d48ae48d6406/LICENSE) | Mature runtime with current releases |
+| [Swift grammar generated 0.7.3](https://github.com/alex-pinkus/tree-sitter-swift/tree/31d17fe7e818a2048c808b5c6fdc2dc792f4f5b5) | `31d17fe`, 2026-06-01 | [MIT](https://github.com/alex-pinkus/tree-sitter-swift/blob/31d17fe7e818a2048c808b5c6fdc2dc792f4f5b5/LICENSE) | Active main grammar, but SwiftPM needs its separately maintained generated-source branch |
+
+The grammar's split between current grammar sources and a generated-source
+branch is an additional integration/upgrade cost. All three Tree-sitter
+revisions are pinned in `Package.resolved`; no mutable branch is used.
+
+## Consequences
+
+### Positive
+
+- Pine reuses language intelligence and processes it already owns.
+- Swift gets rich folding, hierarchical symbols, malformed-buffer recovery,
+  and cancellation without increasing the production dependency graph.
+- Unsupported languages and offline environments retain today's behavior.
+- One UTF-16 normalized model prevents provider-specific offsets from leaking
+  into editor state.
+- Provider seams preserve a measured path to Tree-sitter later.
+
+### Negative
+
+- LSP latency is much higher than Tree-sitter incremental parsing on the large
+  fixture, so results must be asynchronous and retain fallbacks.
+- Structural quality initially depends on installed server coverage.
+- Bracket matching remains heuristic and can still miss language-specific
+  constructs outside syntax-highlighter skip ranges.
+- LSP and fallback results can differ after an atomic provider switch; they
+  must never be merged.
+
+## Rejected alternatives
+
+### Tree-sitter for all three features now
+
+Tree-sitter won the incremental-latency measurement and recovered from
+malformed input, but the prototype covers only Swift. Shipping it now would add
+runtime, binding, grammar, generated sources, queries, and a second update
+cadence before Pine has measured other initially supported languages. It also
+does not replace semantic LSP features.
+
+### LSP only, with no fallback
+
+This would blank structure when a binary or capability is missing, violate
+offline/unsupported-language behavior, and cannot implement bracket matching.
+
+### Merge LSP and Tree-sitter ranges
+
+Merging creates ambiguous range ownership and unstable duplicate structure.
+Provider results are snapshots with different recovery rules; deterministic
+precedence is simpler and testable.
+
+## Implementation sequence for #1008
+
+1. Add normalized recursive symbol/fold models, provider protocols, immutable
+   document revisions, and fail-closed UTF-16 conversion tests. Dependency set:
+   Foundation/AppKit only.
+2. Decode initialize capabilities/position encoding and add cancellable
+   `foldingRange`/`documentSymbol` requests to the existing LSP client.
+3. Wire LSP-first folding with the current calculator always available;
+   enforce the 250 ms deadline and generation checks.
+4. Make the Symbol Navigator hierarchical and wire LSP-first symbols with the
+   current regex parser as fallback.
+5. Keep `BracketMatcher` unchanged except for adapting it to the normalized
+   snapshot/generation seam. Do not add Tree-sitter.
+6. Derive supported-language claims from provider/registry capabilities and
+   add valid, malformed, Unicode, CRLF, timeout, cancellation, stale-response,
+   and fallback integration tests.
+
+## Tree-sitter exit strategy
+
+Re-open the production dependency decision only with repository evidence that
+one of these is true:
+
+- a key language lacks a usable LSP folding/symbol capability;
+- p95 LSP structural latency exceeds the 250 ms deadline for representative
+  files;
+- offline structural quality is a documented product requirement; or
+- bracket/syntax recovery defects cannot be fixed within the bounded local
+  scanner.
+
+At that point, extend this prototype to every proposed initial language,
+measure an actual Pine bundle/build delta, review grammar licenses and
+generated-source health again, and implement Tree-sitter behind the same
+provider seams. It may replace the fallback for a feature/language, but it must
+not merge its ranges with LSP output. Removing that provider later requires no
+UI rewrite because provider-specific coordinates remain inside its adapter.

--- a/scripts/structural-intelligence/README.md
+++ b/scripts/structural-intelligence/README.md
@@ -9,8 +9,8 @@ behavior.
 
 ## Inputs
 
-- `fixtures/valid.swift` contains nested declarations, closures, emoji, and CJK
-  text.
+- `fixtures/valid.swift` contains nested declarations, closures, emoji, CJK
+  text, and the representative document symbol `类型🌲`.
 - `fixtures/malformed.swift` deliberately omits closing braces.
 - `benchmark.py` deterministically generates a 644,047-byte fixture with
   2,000 nested declarations. Its SHA-256 is checked before every run.
@@ -47,6 +47,10 @@ The script records:
 
 - toolchain and executable identity, including the `sourcekit-lsp` SHA-256;
 - advertised LSP capabilities and negotiated position encoding;
+- fail-closed validation of every folding range, document-symbol range, and
+  selection range against the exact UTF-16 snapshot, including selection and
+  parent/child containment, with SHA-256 fingerprints of the canonical range
+  streams;
 - first and post-`didChange` folding/symbol request latency;
 - fold count, symbol count, hierarchy depth, malformed-buffer recovery, and
   `$/cancelRequest` behavior;
@@ -63,6 +67,17 @@ prototype stack, not a promised Pine application-size delta.
 
 The reviewed baseline is
 [`results/2026-07-23-xcode-27-beta.json`](results/2026-07-23-xcode-27-beta.json).
+
+The LSP run accepts only negotiated UTF-16. It checks that every reported
+position lands on a real UTF-16 boundary (never inside a surrogate pair), every
+range is ordered and in bounds, each symbol selection is inside its symbol, and
+each child symbol is inside its parent. The representative `类型🌲` selection
+must be exactly zero-based line 24, UTF-16 characters `7..<11`: the name is 10
+UTF-8 bytes but 4 UTF-16 code units. Both the cold and post-edit evidence are
+stored in the baseline JSON, along with fingerprints that cover every validated
+folding range and every hierarchical symbol range/selection pair.
+`--validate-only` also runs a synthetic surrogate-pair and containment
+self-check without starting a language server.
 
 ## Pinned tooling dependencies
 

--- a/scripts/structural-intelligence/README.md
+++ b/scripts/structural-intelligence/README.md
@@ -1,0 +1,76 @@
+# Structural intelligence prototype
+
+This tooling reproduces the evidence for
+[ADR 0001](../../docs/adr/0001-structural-intelligence-providers.md). It
+compares `textDocument/foldingRange` and `textDocument/documentSymbol` from
+the installed `sourcekit-lsp` with a Swift Tree-sitter parse. It does not add
+packages to `Pine.xcodeproj`, link a parser into Pine, or change user-visible
+behavior.
+
+## Inputs
+
+- `fixtures/valid.swift` contains nested declarations, closures, emoji, and CJK
+  text.
+- `fixtures/malformed.swift` deliberately omits closing braces.
+- `benchmark.py` deterministically generates a 644,047-byte fixture with
+  2,000 nested declarations. Its SHA-256 is checked before every run.
+- `tree-sitter-probe/Package.resolved` pins the tooling-only parser stack.
+
+The checked-in fixture hashes and package revisions fail closed under
+`--validate-only`. This validation is also run by CI.
+
+## Run
+
+The full benchmark requires macOS, Xcode with `sourcekit-lsp`, Python 3, and
+network access for SwiftPM on the first run:
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  python3 scripts/structural-intelligence/benchmark.py \
+  --output /tmp/structural-intelligence.json
+```
+
+Use `--sourcekit-lsp /absolute/path/to/sourcekit-lsp` when the active
+toolchain is not discoverable through `xcrun`. Use `--scratch-path <path>` to
+retain or reuse the SwiftPM build. Without it, the script uses and removes a
+fresh scratch directory.
+
+Validate the immutable inputs without Xcode, network access, or a build:
+
+```sh
+python3 scripts/structural-intelligence/benchmark.py --validate-only
+```
+
+## What is measured
+
+The script records:
+
+- toolchain and executable identity, including the `sourcekit-lsp` SHA-256;
+- advertised LSP capabilities and negotiated position encoding;
+- first and post-`didChange` folding/symbol request latency;
+- fold count, symbol count, hierarchy depth, malformed-buffer recovery, and
+  `$/cancelRequest` behavior;
+- Tree-sitter cold parse and incremental reparse latency, changed ranges,
+  hierarchy depth, error recovery, and timeout cancellation;
+- fresh-scratch SwiftPM release-build time, probe executable size, and total
+  scratch-tree size.
+
+Timing values are observations, not pass/fail thresholds. Compare results only
+on equivalent hardware and toolchains. A fresh scratch directory can still use
+SwiftPM's machine-wide repository cache, so the build number is not a
+network-cold download time. The probe executable size is evidence about the
+prototype stack, not a promised Pine application-size delta.
+
+The reviewed baseline is
+[`results/2026-07-23-xcode-27-beta.json`](results/2026-07-23-xcode-27-beta.json).
+
+## Pinned tooling dependencies
+
+| Package | Revision | License |
+| --- | --- | --- |
+| `tree-sitter/swift-tree-sitter` | `0f40435cdb41673ce4194d731571cf2a2f7c3285` | BSD-3-Clause |
+| `tree-sitter/tree-sitter` 0.25.10 | `da6fe9beb4f7f67beb75914ca8e0d48ae48d6406` | MIT |
+| `alex-pinkus/tree-sitter-swift` generated 0.7.3 | `31d17fe7e818a2048c808b5c6fdc2dc792f4f5b5` | MIT |
+
+These packages belong only to the nested prototype package. Production
+dependency selection remains empty under ADR 0001.

--- a/scripts/structural-intelligence/benchmark.py
+++ b/scripts/structural-intelligence/benchmark.py
@@ -1,0 +1,830 @@
+#!/usr/bin/env python3
+"""Reproduce Pine's LSP versus Tree-sitter structural prototype.
+
+The Tree-sitter package is tooling-only and pins every dependency in
+tree-sitter-probe/Package.resolved. Nothing here is linked into Pine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import select
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIRECTORY = Path(__file__).resolve().parent
+REPOSITORY_ROOT = SCRIPT_DIRECTORY.parent.parent
+FIXTURE_DIRECTORY = SCRIPT_DIRECTORY / "fixtures"
+TREE_SITTER_PACKAGE = SCRIPT_DIRECTORY / "tree-sitter-probe"
+BASELINE_RESULT = (
+    SCRIPT_DIRECTORY / "results" / "2026-07-23-xcode-27-beta.json"
+)
+
+PINNED_REVISIONS = {
+    "swift-tree-sitter": "0f40435cdb41673ce4194d731571cf2a2f7c3285",
+    "tree-sitter": "da6fe9beb4f7f67beb75914ca8e0d48ae48d6406",
+    "tree-sitter-swift": "31d17fe7e818a2048c808b5c6fdc2dc792f4f5b5",
+}
+
+FIXTURE_DIGESTS = {
+    "malformed.swift": "5436d2627864fd92e685780372937251326b49209fbbcb70b2908ee985bb1fcc",
+    "valid.swift": "d2ff7a7a27a1e43d4c23dcf092af6d5ae79d8fb72b71b983656934101d02d3fa",
+}
+
+LARGE_FIXTURE_DECLARATIONS = 2_000
+LARGE_FIXTURE_DIGEST = "6f01e70990c9c799a4bb3c50d67297a4dbc65fa8539100805df81a13a013947a"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+class PrototypeError(RuntimeError):
+    """A reproducibility or provider failure."""
+
+
+def sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def generate_large_fixture(declarations: int = LARGE_FIXTURE_DECLARATIONS) -> str:
+    """Create a deterministic, nested Swift buffer above Pine's 50K threshold."""
+    sections = [
+        "import Foundation\n\n",
+        "enum GeneratedNamespace {\n",
+    ]
+    for index in range(declarations):
+        sections.append(
+            f"""    struct Model{index:04d} {{
+        let label = "tree 🌲 {index:04d}"
+
+        enum State {{
+            case ready
+            case waiting
+        }}
+
+        func transform(value: String) -> String {{
+            if value.isEmpty {{
+                return label
+            }}
+            return "\\(label): \\(value)"
+        }}
+    }}
+
+"""
+        )
+    sections.append("}\n")
+    return "".join(sections)
+
+
+def validate_inputs() -> dict[str, Any]:
+    errors: list[str] = []
+    fixture_details: dict[str, Any] = {}
+    for name, expected_digest in sorted(FIXTURE_DIGESTS.items()):
+        path = FIXTURE_DIRECTORY / name
+        if not path.is_file():
+            errors.append(f"missing fixture: {path}")
+            continue
+        content = path.read_bytes()
+        actual_digest = sha256_bytes(content)
+        if actual_digest != expected_digest:
+            errors.append(
+                f"{name} digest changed: expected {expected_digest}, got {actual_digest}"
+            )
+        fixture_details[name] = {
+            "sha256": actual_digest,
+            "utf8_bytes": len(content),
+        }
+
+    resolved_path = TREE_SITTER_PACKAGE / "Package.resolved"
+    if not resolved_path.is_file():
+        errors.append(f"missing lockfile: {resolved_path}")
+    else:
+        resolved = json.loads(resolved_path.read_text(encoding="utf-8"))
+        actual_pins = {
+            pin["identity"]: pin["state"]["revision"] for pin in resolved["pins"]
+        }
+        if actual_pins != PINNED_REVISIONS:
+            errors.append(
+                "Package.resolved pins differ from the reviewed revisions: "
+                f"{actual_pins}"
+            )
+
+    manifest_path = TREE_SITTER_PACKAGE / "Package.swift"
+    if not manifest_path.is_file():
+        errors.append(f"missing package manifest: {manifest_path}")
+    else:
+        manifest = manifest_path.read_text(encoding="utf-8")
+        for identity in ("swift-tree-sitter", "tree-sitter-swift"):
+            revision = PINNED_REVISIONS[identity]
+            if revision not in manifest:
+                errors.append(
+                    f"Package.swift does not pin {identity} at {revision}"
+                )
+
+    large_content = generate_large_fixture().encode("utf-8")
+    large_digest = sha256_bytes(large_content)
+    if LARGE_FIXTURE_DIGEST != "TO_BE_FILLED" and large_digest != LARGE_FIXTURE_DIGEST:
+        errors.append(
+            "generated large fixture digest changed: "
+            f"expected {LARGE_FIXTURE_DIGEST}, got {large_digest}"
+        )
+    fixture_details["large.generated.swift"] = {
+        "sha256": large_digest,
+        "utf8_bytes": len(large_content),
+        "declarations": LARGE_FIXTURE_DECLARATIONS,
+    }
+
+    if not BASELINE_RESULT.is_file():
+        errors.append(f"missing baseline result: {BASELINE_RESULT}")
+    else:
+        baseline = json.loads(BASELINE_RESULT.read_text(encoding="utf-8"))
+        if baseline.get("fixtures") != fixture_details:
+            errors.append("baseline fixture identities do not match current inputs")
+        tree_sitter = baseline.get("tree_sitter", {})
+        if "fresh_scratch_resolution_and_release_build_milliseconds" not in tree_sitter:
+            errors.append("baseline is missing the fresh-scratch build measurement")
+
+    if errors:
+        raise PrototypeError("\n".join(errors))
+    return fixture_details
+
+
+def command_output(
+    command: list[str],
+    *,
+    environment: dict[str, str] | None = None,
+) -> str:
+    result = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    return result.stdout.strip()
+
+
+def developer_environment() -> tuple[dict[str, str], str | None]:
+    environment = os.environ.copy()
+    if environment.get("DEVELOPER_DIR"):
+        return environment, environment["DEVELOPER_DIR"]
+
+    for application in ("Xcode.app", "Xcode-beta.app"):
+        developer_directory = Path("/Applications") / application / "Contents/Developer"
+        if developer_directory.is_dir():
+            environment["DEVELOPER_DIR"] = str(developer_directory)
+            return environment, str(developer_directory)
+
+    return environment, None
+
+
+def resolve_sourcekit_lsp(
+    explicit_path: str | None,
+    environment: dict[str, str],
+) -> Path:
+    if explicit_path:
+        path = Path(explicit_path).expanduser().resolve()
+        if not path.is_file():
+            raise PrototypeError(f"sourcekit-lsp does not exist: {path}")
+        return path
+
+    try:
+        discovered = command_output(
+            ["xcrun", "--find", "sourcekit-lsp"],
+            environment=environment,
+        )
+        return Path(discovered).resolve()
+    except (OSError, subprocess.CalledProcessError):
+        direct = shutil.which("sourcekit-lsp", path=environment.get("PATH"))
+        if direct:
+            return Path(direct).resolve()
+        raise PrototypeError(
+            "sourcekit-lsp was not found; pass --sourcekit-lsp or set DEVELOPER_DIR"
+        )
+
+
+class JSONRPCProcess:
+    """Minimal synchronous JSON-RPC/LSP process with bounded reads."""
+
+    def __init__(
+        self,
+        executable: Path,
+        environment: dict[str, str],
+        timeout_seconds: float,
+    ) -> None:
+        self.process = subprocess.Popen(
+            [str(executable)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            env=environment,
+        )
+        if self.process.stdin is None or self.process.stdout is None:
+            raise PrototypeError("unable to create sourcekit-lsp pipes")
+        self.stdin = self.process.stdin
+        self.stdout = self.process.stdout
+        self.timeout_seconds = timeout_seconds
+        self.buffer = bytearray()
+        self.next_identifier = 0
+
+    def send(self, message: dict[str, Any]) -> None:
+        payload = json.dumps(
+            message,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        frame = f"Content-Length: {len(payload)}\r\n\r\n".encode("ascii") + payload
+        self.stdin.write(frame)
+        self.stdin.flush()
+
+    def notify(self, method: str, parameters: dict[str, Any]) -> None:
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "method": method,
+                "params": parameters,
+            }
+        )
+
+    def begin_request(self, method: str, parameters: dict[str, Any]) -> int:
+        self.next_identifier += 1
+        identifier = self.next_identifier
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": identifier,
+                "method": method,
+                "params": parameters,
+            }
+        )
+        return identifier
+
+    def request(
+        self,
+        method: str,
+        parameters: dict[str, Any],
+    ) -> tuple[Any, float]:
+        start = time.perf_counter()
+        identifier = self.begin_request(method, parameters)
+        response = self.wait_for_response(identifier)
+        elapsed_milliseconds = (time.perf_counter() - start) * 1_000
+        if "error" in response:
+            raise PrototypeError(
+                f"{method} failed: {json.dumps(response['error'], sort_keys=True)}"
+            )
+        return response.get("result"), elapsed_milliseconds
+
+    def read_message(self, timeout_seconds: float | None = None) -> dict[str, Any]:
+        deadline = time.monotonic() + (timeout_seconds or self.timeout_seconds)
+        delimiter = b"\r\n\r\n"
+
+        while True:
+            header_end = self.buffer.find(delimiter)
+            if header_end >= 0:
+                header = bytes(self.buffer[:header_end]).decode("ascii")
+                content_length: int | None = None
+                for line in header.split("\r\n"):
+                    name, separator, value = line.partition(":")
+                    if separator and name.lower() == "content-length":
+                        content_length = int(value.strip())
+                if content_length is None:
+                    raise PrototypeError("sourcekit-lsp frame omitted Content-Length")
+                payload_start = header_end + len(delimiter)
+                payload_end = payload_start + content_length
+                if len(self.buffer) >= payload_end:
+                    payload = bytes(self.buffer[payload_start:payload_end])
+                    del self.buffer[:payload_end]
+                    return json.loads(payload)
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise PrototypeError("timed out waiting for sourcekit-lsp")
+            readable, _, _ = select.select([self.stdout.fileno()], [], [], remaining)
+            if not readable:
+                raise PrototypeError("timed out waiting for sourcekit-lsp")
+            chunk = os.read(self.stdout.fileno(), 64 * 1024)
+            if not chunk:
+                raise PrototypeError(
+                    f"sourcekit-lsp exited with status {self.process.poll()}"
+                )
+            self.buffer.extend(chunk)
+
+    def wait_for_response(
+        self,
+        identifier: int,
+        timeout_seconds: float | None = None,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + (timeout_seconds or self.timeout_seconds)
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise PrototypeError(
+                    f"timed out waiting for sourcekit-lsp request {identifier}"
+                )
+            message = self.read_message(remaining)
+            if message.get("id") == identifier and "method" not in message:
+                return message
+            if "id" in message and "method" in message:
+                self.respond_to_server_request(message)
+
+    def respond_to_server_request(self, message: dict[str, Any]) -> None:
+        method = message.get("method")
+        result: Any = None
+        if method == "workspace/configuration":
+            items = message.get("params", {}).get("items", [])
+            result = [None for _ in items]
+        elif method == "workspace/workspaceFolders":
+            result = []
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": result,
+            }
+        )
+
+    def close(self) -> None:
+        try:
+            if self.process.poll() is None:
+                try:
+                    self.request("shutdown", {})
+                    self.notify("exit", {})
+                except (BrokenPipeError, PrototypeError):
+                    pass
+                try:
+                    self.process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    self.process.terminate()
+                    self.process.wait(timeout=2)
+        finally:
+            if self.process.poll() is None:
+                self.process.kill()
+            self.stdin.close()
+            self.stdout.close()
+
+
+def symbol_metrics(symbols: Any) -> dict[str, Any]:
+    if not isinstance(symbols, list):
+        return {
+            "count": 0,
+            "maximum_depth": 0,
+            "hierarchical": False,
+        }
+
+    count = 0
+    maximum_depth = 0
+    hierarchical = False
+
+    def visit(items: list[Any], depth: int) -> None:
+        nonlocal count, maximum_depth, hierarchical
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            count += 1
+            maximum_depth = max(maximum_depth, depth)
+            children = item.get("children")
+            if isinstance(children, list) and children:
+                hierarchical = True
+                visit(children, depth + 1)
+
+    visit(symbols, 1)
+    return {
+        "count": count,
+        "maximum_depth": maximum_depth,
+        "hierarchical": hierarchical,
+    }
+
+
+def lsp_fixture_measurement(
+    client: JSONRPCProcess,
+    *,
+    name: str,
+    path: Path,
+    source: str,
+    version: int,
+) -> dict[str, Any]:
+    uri = path.resolve().as_uri()
+    client.notify(
+        "textDocument/didOpen",
+        {
+            "textDocument": {
+                "uri": uri,
+                "languageId": "swift",
+                "version": version,
+                "text": source,
+            }
+        },
+    )
+    text_document = {"textDocument": {"uri": uri}}
+    folding_ranges, folding_milliseconds = client.request(
+        "textDocument/foldingRange",
+        text_document,
+    )
+    symbols, symbol_milliseconds = client.request(
+        "textDocument/documentSymbol",
+        text_document,
+    )
+
+    edited_source = source + "\n// incremental edit 🌲\n"
+    version += 1
+    client.notify(
+        "textDocument/didChange",
+        {
+            "textDocument": {"uri": uri, "version": version},
+            "contentChanges": [{"text": edited_source}],
+        },
+    )
+    updated_folding, incremental_folding_milliseconds = client.request(
+        "textDocument/foldingRange",
+        text_document,
+    )
+    updated_symbols, incremental_symbol_milliseconds = client.request(
+        "textDocument/documentSymbol",
+        text_document,
+    )
+    client.notify(
+        "textDocument/didClose",
+        {"textDocument": {"uri": uri}},
+    )
+
+    return {
+        "name": name,
+        "utf8_bytes": len(source.encode("utf-8")),
+        "utf16_units": len(source.encode("utf-16-le")) // 2,
+        "lines": source.count("\n") + 1,
+        "cold_folding_request_milliseconds": folding_milliseconds,
+        "cold_symbol_request_milliseconds": symbol_milliseconds,
+        "incremental_folding_request_milliseconds": incremental_folding_milliseconds,
+        "incremental_symbol_request_milliseconds": incremental_symbol_milliseconds,
+        "fold_count": len(folding_ranges) if isinstance(folding_ranges, list) else 0,
+        "incremental_fold_count": (
+            len(updated_folding) if isinstance(updated_folding, list) else 0
+        ),
+        "symbols": symbol_metrics(symbols),
+        "incremental_symbols": symbol_metrics(updated_symbols),
+    }
+
+
+def measure_lsp(
+    sourcekit_lsp: Path,
+    fixtures: dict[str, tuple[Path, str]],
+    environment: dict[str, str],
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    client = JSONRPCProcess(sourcekit_lsp, environment, timeout_seconds)
+    try:
+        initialization_parameters = {
+            "processId": os.getpid(),
+            "rootUri": REPOSITORY_ROOT.as_uri(),
+            "capabilities": {
+                "general": {"positionEncodings": ["utf-16"]},
+                "textDocument": {
+                    "synchronization": {
+                        "didOpen": True,
+                        "didChange": True,
+                        "didClose": True,
+                    },
+                    "foldingRange": {
+                        "dynamicRegistration": False,
+                        "lineFoldingOnly": False,
+                    },
+                    "documentSymbol": {
+                        "dynamicRegistration": False,
+                        "hierarchicalDocumentSymbolSupport": True,
+                    },
+                },
+                "workspace": {"workspaceFolders": True},
+            },
+            "workspaceFolders": [
+                {
+                    "uri": REPOSITORY_ROOT.as_uri(),
+                    "name": REPOSITORY_ROOT.name,
+                }
+            ],
+        }
+        initialize_result, initialize_milliseconds = client.request(
+            "initialize",
+            initialization_parameters,
+        )
+        client.notify("initialized", {})
+
+        results: list[dict[str, Any]] = []
+        version = 1
+        for name, (path, source) in fixtures.items():
+            results.append(
+                lsp_fixture_measurement(
+                    client,
+                    name=name,
+                    path=path,
+                    source=source,
+                    version=version,
+                )
+            )
+            version += 2
+
+        large_path, large_source = fixtures["large"]
+        large_uri = large_path.resolve().as_uri()
+        client.notify(
+            "textDocument/didOpen",
+            {
+                "textDocument": {
+                    "uri": large_uri,
+                    "languageId": "swift",
+                    "version": version,
+                    "text": large_source,
+                }
+            },
+        )
+        cancellation_identifier = client.begin_request(
+            "textDocument/documentSymbol",
+            {"textDocument": {"uri": large_uri}},
+        )
+        client.notify("$/cancelRequest", {"id": cancellation_identifier})
+        cancellation_response = client.wait_for_response(
+            cancellation_identifier,
+            timeout_seconds,
+        )
+        if "error" in cancellation_response:
+            cancellation_status = {
+                "outcome": "error",
+                "code": cancellation_response["error"].get("code"),
+                "message": cancellation_response["error"].get("message"),
+            }
+        else:
+            cancellation_status = {
+                "outcome": "completed_before_cancel",
+                "symbol_count": symbol_metrics(
+                    cancellation_response.get("result")
+                )["count"],
+            }
+        client.notify(
+            "textDocument/didClose",
+            {"textDocument": {"uri": large_uri}},
+        )
+
+        initialize_dictionary = (
+            initialize_result if isinstance(initialize_result, dict) else {}
+        )
+        capabilities = initialize_dictionary.get("capabilities", {})
+        return {
+            "initialize_milliseconds": initialize_milliseconds,
+            "server_info": initialize_dictionary.get("serverInfo"),
+            "capabilities": {
+                "position_encoding": capabilities.get(
+                    "positionEncoding",
+                    "utf-16 (LSP default)",
+                ),
+                "folding_range_provider": capabilities.get(
+                    "foldingRangeProvider",
+                    False,
+                ),
+                "document_symbol_provider": capabilities.get(
+                    "documentSymbolProvider",
+                    False,
+                ),
+            },
+            "fixtures": results,
+            "cancellation": cancellation_status,
+        }
+    finally:
+        client.close()
+
+
+def directory_size(path: Path) -> int:
+    return sum(
+        item.stat().st_size
+        for item in path.rglob("*")
+        if item.is_file() and not item.is_symlink()
+    )
+
+
+def measure_tree_sitter(
+    fixtures: dict[str, tuple[Path, str]],
+    scratch_path: Path,
+    environment: dict[str, str],
+) -> dict[str, Any]:
+    build_command = [
+        "xcrun",
+        "swift",
+        "build",
+        "--package-path",
+        str(TREE_SITTER_PACKAGE),
+        "--scratch-path",
+        str(scratch_path),
+        "--disable-automatic-resolution",
+        "-c",
+        "release",
+    ]
+    build_start = time.perf_counter()
+    build = subprocess.run(
+        build_command,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    build_milliseconds = (time.perf_counter() - build_start) * 1_000
+    if build.returncode != 0:
+        raise PrototypeError(
+            "Tree-sitter probe build failed:\n"
+            + build.stdout
+            + "\n"
+            + build.stderr
+        )
+
+    binary_candidates = list(scratch_path.rglob("StructuralIntelligenceProbe"))
+    binary_candidates = [
+        candidate
+        for candidate in binary_candidates
+        if candidate.is_file() and os.access(candidate, os.X_OK)
+    ]
+    if not binary_candidates:
+        raise PrototypeError("Tree-sitter probe executable was not produced")
+    binary = max(binary_candidates, key=lambda path: path.stat().st_mtime_ns)
+
+    arguments = [str(binary)]
+    for name, (path, _) in fixtures.items():
+        arguments.append(f"{name}={path}")
+    probe = subprocess.run(
+        arguments,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    return {
+        "fresh_scratch_resolution_and_release_build_milliseconds": build_milliseconds,
+        "probe_binary_bytes": binary.stat().st_size,
+        "scratch_tree_bytes": directory_size(scratch_path),
+        "fixtures": json.loads(probe.stdout),
+    }
+
+
+def toolchain_metadata(
+    sourcekit_lsp: Path,
+    environment: dict[str, str],
+    developer_directory: str | None,
+) -> dict[str, Any]:
+    def optional_output(command: list[str]) -> str | None:
+        try:
+            return command_output(command, environment=environment)
+        except (OSError, subprocess.CalledProcessError):
+            return None
+
+    return {
+        "developer_directory": developer_directory,
+        "xcode": optional_output(["xcodebuild", "-version"]),
+        "swift": optional_output(["xcrun", "swiftc", "--version"]),
+        "sourcekit_lsp_path": str(sourcekit_lsp),
+        "sourcekit_lsp_sha256": sha256_file(sourcekit_lsp),
+        "sourcekit_lsp_binary_bytes": sourcekit_lsp.stat().st_size,
+    }
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sourcekit-lsp",
+        help="absolute sourcekit-lsp path; otherwise discovered with xcrun",
+    )
+    parser.add_argument(
+        "--scratch-path",
+        type=Path,
+        help="Tree-sitter SwiftPM scratch directory (default: temporary)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="write JSON results here instead of stdout",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="per-LSP-request timeout in seconds",
+    )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="verify pinned revisions and fixture hashes without building",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    try:
+        fixture_metadata = validate_inputs()
+        if arguments.validate_only:
+            print(json.dumps(fixture_metadata, indent=2, sort_keys=True))
+            return 0
+
+        environment, developer_directory = developer_environment()
+        sourcekit_lsp = resolve_sourcekit_lsp(
+            arguments.sourcekit_lsp,
+            environment,
+        )
+
+        with tempfile.TemporaryDirectory(prefix="pine-structural-fixtures-") as fixture_tmp:
+            large_path = Path(fixture_tmp) / "large.generated.swift"
+            large_source = generate_large_fixture()
+            large_path.write_text(large_source, encoding="utf-8")
+            fixtures = {
+                "valid": (
+                    FIXTURE_DIRECTORY / "valid.swift",
+                    (FIXTURE_DIRECTORY / "valid.swift").read_text(encoding="utf-8"),
+                ),
+                "malformed": (
+                    FIXTURE_DIRECTORY / "malformed.swift",
+                    (FIXTURE_DIRECTORY / "malformed.swift").read_text(
+                        encoding="utf-8"
+                    ),
+                ),
+                "large": (large_path, large_source),
+            }
+
+            temporary_scratch: tempfile.TemporaryDirectory[str] | None = None
+            if arguments.scratch_path:
+                scratch_path = arguments.scratch_path.resolve()
+                scratch_path.mkdir(parents=True, exist_ok=True)
+            else:
+                temporary_scratch = tempfile.TemporaryDirectory(
+                    prefix="pine-structural-tree-sitter-"
+                )
+                scratch_path = Path(temporary_scratch.name)
+
+            try:
+                result = {
+                    "schema_version": 1,
+                    "measured_at": datetime.now(timezone.utc).isoformat(),
+                    "host": {
+                        "platform": platform.platform(),
+                        "machine": platform.machine(),
+                    },
+                    "repository_commit": optional_repository_commit(),
+                    "fixtures": fixture_metadata,
+                    "toolchain": toolchain_metadata(
+                        sourcekit_lsp,
+                        environment,
+                        developer_directory,
+                    ),
+                    "lsp": measure_lsp(
+                        sourcekit_lsp,
+                        fixtures,
+                        environment,
+                        arguments.timeout,
+                    ),
+                    "tree_sitter": measure_tree_sitter(
+                        fixtures,
+                        scratch_path,
+                        environment,
+                    ),
+                }
+            finally:
+                if temporary_scratch:
+                    temporary_scratch.cleanup()
+
+        output = json.dumps(result, indent=2, sort_keys=True) + "\n"
+        if arguments.output:
+            arguments.output.write_text(output, encoding="utf-8")
+        else:
+            sys.stdout.write(output)
+        return 0
+    except (
+        OSError,
+        PrototypeError,
+        subprocess.CalledProcessError,
+        json.JSONDecodeError,
+    ) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+def optional_repository_commit() -> str | None:
+    try:
+        return command_output(
+            ["git", "rev-parse", "HEAD"],
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/structural-intelligence/benchmark.py
+++ b/scripts/structural-intelligence/benchmark.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import os
 import platform
+import re
 import select
 import shutil
 import subprocess
@@ -39,12 +40,13 @@ PINNED_REVISIONS = {
 
 FIXTURE_DIGESTS = {
     "malformed.swift": "5436d2627864fd92e685780372937251326b49209fbbcb70b2908ee985bb1fcc",
-    "valid.swift": "d2ff7a7a27a1e43d4c23dcf092af6d5ae79d8fb72b71b983656934101d02d3fa",
+    "valid.swift": "fb3ab0c1cae05e2cc9e48fc0f14cd4f11ac9faee25fe4e2f4fda05383d16fb6e",
 }
 
 LARGE_FIXTURE_DECLARATIONS = 2_000
 LARGE_FIXTURE_DIGEST = "6f01e70990c9c799a4bb3c50d67297a4dbc65fa8539100805df81a13a013947a"
 DEFAULT_TIMEOUT_SECONDS = 30.0
+REPRESENTATIVE_UNICODE_SYMBOL = "类型🌲"
 
 
 class PrototypeError(RuntimeError):
@@ -160,6 +162,15 @@ def validate_inputs() -> dict[str, Any]:
         tree_sitter = baseline.get("tree_sitter", {})
         if "fresh_scratch_resolution_and_release_build_milliseconds" not in tree_sitter:
             errors.append("baseline is missing the fresh-scratch build measurement")
+        try:
+            validate_baseline_range_evidence(baseline)
+        except PrototypeError as error:
+            errors.append(f"baseline LSP range evidence is invalid: {error}")
+
+    try:
+        validate_lsp_validator_contract()
+    except PrototypeError as error:
+        errors.append(f"LSP range validator self-check failed: {error}")
 
     if errors:
         raise PrototypeError("\n".join(errors))
@@ -380,6 +391,528 @@ class JSONRPCProcess:
             self.stdout.close()
 
 
+class LSPTextSnapshot:
+    """Exact UTF-16 position boundaries for one immutable document snapshot."""
+
+    def __init__(self, source: str) -> None:
+        self.lines = re.split(r"\r\n|\r|\n", source)
+        self.boundaries: list[set[int]] = []
+        for line in self.lines:
+            offsets = {0}
+            offset = 0
+            for character in line:
+                offset += len(character.encode("utf-16-le")) // 2
+                offsets.add(offset)
+            self.boundaries.append(offsets)
+
+    def position(
+        self,
+        value: Any,
+        *,
+        context: str,
+    ) -> tuple[int, int]:
+        if not isinstance(value, dict):
+            raise PrototypeError(f"{context} is not an LSP Position object")
+        line = value.get("line")
+        character = value.get("character")
+        if (
+            not isinstance(line, int)
+            or isinstance(line, bool)
+            or not isinstance(character, int)
+            or isinstance(character, bool)
+            or line < 0
+            or line >= len(self.lines)
+            or character not in self.boundaries[line]
+        ):
+            raise PrototypeError(
+                f"{context} is not a valid UTF-16 boundary: "
+                f"{json.dumps(value, sort_keys=True)}"
+            )
+        return line, character
+
+    def line_position(
+        self,
+        line: Any,
+        character: Any | None,
+        *,
+        context: str,
+        default_to_line_end: bool,
+    ) -> tuple[int, int]:
+        if (
+            not isinstance(line, int)
+            or isinstance(line, bool)
+            or line < 0
+            or line >= len(self.lines)
+        ):
+            raise PrototypeError(f"{context} has an invalid line: {line!r}")
+        if character is None:
+            resolved_character = (
+                max(self.boundaries[line]) if default_to_line_end else 0
+            )
+        else:
+            if (
+                not isinstance(character, int)
+                or isinstance(character, bool)
+                or character not in self.boundaries[line]
+            ):
+                raise PrototypeError(
+                    f"{context} is not a valid UTF-16 boundary: {character!r}"
+                )
+            resolved_character = character
+        return line, resolved_character
+
+
+def canonical_lsp_range(
+    start: tuple[int, int],
+    end: tuple[int, int],
+) -> dict[str, dict[str, int]]:
+    return {
+        "start": {"line": start[0], "character": start[1]},
+        "end": {"line": end[0], "character": end[1]},
+    }
+
+
+def canonical_json_sha256(value: Any) -> str:
+    content = json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return sha256_bytes(content)
+
+
+def validate_lsp_range(
+    value: Any,
+    snapshot: LSPTextSnapshot,
+    *,
+    context: str,
+) -> tuple[tuple[int, int], tuple[int, int]]:
+    if not isinstance(value, dict):
+        raise PrototypeError(f"{context} is not an LSP Range object")
+    start = snapshot.position(value.get("start"), context=f"{context}.start")
+    end = snapshot.position(value.get("end"), context=f"{context}.end")
+    if end < start:
+        raise PrototypeError(f"{context} is reversed")
+    return start, end
+
+
+def range_contains(
+    outer: tuple[tuple[int, int], tuple[int, int]],
+    inner: tuple[tuple[int, int], tuple[int, int]],
+) -> bool:
+    return outer[0] <= inner[0] and inner[1] <= outer[1]
+
+
+def negotiated_utf16_position_encoding(capabilities: Any) -> str:
+    if not isinstance(capabilities, dict):
+        raise PrototypeError(
+            "sourcekit-lsp initialize result omitted a capabilities object"
+        )
+    if "positionEncoding" not in capabilities:
+        return "utf-16"
+    advertised = capabilities["positionEncoding"]
+    if advertised != "utf-16":
+        raise PrototypeError(
+            "sourcekit-lsp selected unsupported position encoding "
+            f"{advertised!r}; this prototype requires utf-16"
+        )
+    return advertised
+
+
+def validate_folding_ranges(
+    ranges: Any,
+    source: str,
+    *,
+    context: str,
+) -> dict[str, Any]:
+    if not isinstance(ranges, list):
+        raise PrototypeError(f"{context} did not return a FoldingRange array")
+    snapshot = LSPTextSnapshot(source)
+    canonical_ranges: list[dict[str, dict[str, int]]] = []
+    for index, folding_range in enumerate(ranges):
+        item_context = f"{context}[{index}]"
+        if not isinstance(folding_range, dict):
+            raise PrototypeError(f"{item_context} is not an object")
+        start_character = folding_range.get("startCharacter")
+        end_character = folding_range.get("endCharacter")
+        if "startCharacter" in folding_range and start_character is None:
+            raise PrototypeError(f"{item_context}.startCharacter is null")
+        if "endCharacter" in folding_range and end_character is None:
+            raise PrototypeError(f"{item_context}.endCharacter is null")
+        start = snapshot.line_position(
+            folding_range.get("startLine"),
+            start_character,
+            context=f"{item_context}.start",
+            default_to_line_end=False,
+        )
+        end = snapshot.line_position(
+            folding_range.get("endLine"),
+            end_character,
+            context=f"{item_context}.end",
+            default_to_line_end=True,
+        )
+        if end < start:
+            raise PrototypeError(f"{item_context} is reversed")
+        canonical_ranges.append(canonical_lsp_range(start, end))
+    return {
+        "folding_ranges": len(ranges),
+        "folding_ranges_sha256": canonical_json_sha256(canonical_ranges),
+    }
+
+
+def expected_unicode_selection_range(
+    snapshot: LSPTextSnapshot,
+) -> dict[str, dict[str, int]]:
+    matches: list[tuple[int, int]] = []
+    for line_index, line in enumerate(snapshot.lines):
+        search_start = 0
+        while True:
+            character_index = line.find(REPRESENTATIVE_UNICODE_SYMBOL, search_start)
+            if character_index < 0:
+                break
+            prefix = line[:character_index]
+            start_character = len(prefix.encode("utf-16-le")) // 2
+            matches.append((line_index, start_character))
+            search_start = character_index + len(REPRESENTATIVE_UNICODE_SYMBOL)
+    if len(matches) != 1:
+        raise PrototypeError(
+            "expected exactly one representative Unicode symbol in valid.swift, "
+            f"found {len(matches)}"
+        )
+    line, start_character = matches[0]
+    end_character = start_character + (
+        len(REPRESENTATIVE_UNICODE_SYMBOL.encode("utf-16-le")) // 2
+    )
+    return canonical_lsp_range(
+        (line, start_character),
+        (line, end_character),
+    )
+
+
+def validate_document_symbols(
+    symbols: Any,
+    source: str,
+    *,
+    context: str,
+    require_unicode_symbol: bool,
+) -> dict[str, Any]:
+    if not isinstance(symbols, list):
+        raise PrototypeError(f"{context} did not return a DocumentSymbol array")
+    snapshot = LSPTextSnapshot(source)
+    expected_unicode = (
+        expected_unicode_selection_range(snapshot) if require_unicode_symbol else None
+    )
+    symbol_count = 0
+    selection_count = 0
+    unicode_evidence: dict[str, Any] | None = None
+    canonical_ranges: list[dict[str, Any]] = []
+
+    def visit(
+        items: list[Any],
+        parent_range: tuple[tuple[int, int], tuple[int, int]] | None = None,
+        parent_path: tuple[int, ...] = (),
+    ) -> None:
+        nonlocal symbol_count, selection_count, unicode_evidence
+        for index, item in enumerate(items):
+            path = (*parent_path, index)
+            item_context = f"{context}[{'.'.join(str(part) for part in path)}]"
+            if not isinstance(item, dict):
+                raise PrototypeError(f"{item_context} is not an object")
+            name = item.get("name")
+            if not isinstance(name, str) or not name:
+                raise PrototypeError(f"{item_context}.name is invalid")
+            symbol_range = validate_lsp_range(
+                item.get("range"),
+                snapshot,
+                context=f"{item_context}.range",
+            )
+            selection_range = validate_lsp_range(
+                item.get("selectionRange"),
+                snapshot,
+                context=f"{item_context}.selectionRange",
+            )
+            if not range_contains(symbol_range, selection_range):
+                raise PrototypeError(
+                    f"{item_context}.selectionRange is outside its symbol range"
+                )
+            if parent_range is not None and not range_contains(
+                parent_range,
+                symbol_range,
+            ):
+                raise PrototypeError(
+                    f"{item_context}.range is outside its parent symbol range"
+                )
+
+            symbol_count += 1
+            selection_count += 1
+            canonical_ranges.append(
+                {
+                    "path": list(path),
+                    "range": canonical_lsp_range(*symbol_range),
+                    "selection_range": canonical_lsp_range(*selection_range),
+                }
+            )
+            if name == REPRESENTATIVE_UNICODE_SYMBOL:
+                if unicode_evidence is not None:
+                    raise PrototypeError(
+                        "sourcekit-lsp returned the representative Unicode symbol twice"
+                    )
+                actual_selection = canonical_lsp_range(*selection_range)
+                if actual_selection != expected_unicode:
+                    raise PrototypeError(
+                        "representative Unicode selectionRange was not the exact "
+                        f"UTF-16 identifier range: expected {expected_unicode}, "
+                        f"got {actual_selection}"
+                    )
+                unicode_evidence = {
+                    "name": name,
+                    "selection_range": actual_selection,
+                    "utf8_bytes": len(name.encode("utf-8")),
+                    "utf16_units": len(name.encode("utf-16-le")) // 2,
+                }
+
+            children = item.get("children")
+            if children is not None:
+                if not isinstance(children, list):
+                    raise PrototypeError(f"{item_context}.children is not an array")
+                visit(children, symbol_range, path)
+
+    visit(symbols)
+    if require_unicode_symbol and unicode_evidence is None:
+        raise PrototypeError(
+            "sourcekit-lsp omitted the representative Unicode document symbol"
+        )
+
+    result: dict[str, Any] = {
+        "document_symbol_ranges": symbol_count,
+        "document_symbol_selection_ranges": selection_count,
+        "document_symbol_ranges_sha256": canonical_json_sha256(canonical_ranges),
+    }
+    if unicode_evidence is not None:
+        result["representative_unicode_symbol"] = unicode_evidence
+    return result
+
+
+def validate_lsp_validator_contract() -> None:
+    """Keep the offline CI path fail-closed for UTF-16 boundary regressions."""
+
+    snapshot = LSPTextSnapshot("a🌲b\nchild")
+    valid = validate_lsp_range(
+        {
+            "start": {"line": 0, "character": 1},
+            "end": {"line": 0, "character": 3},
+        },
+        snapshot,
+        context="self-check.valid",
+    )
+    if valid != ((0, 1), (0, 3)):
+        raise PrototypeError("valid surrogate-pair range was not preserved")
+
+    try:
+        validate_lsp_range(
+            {
+                "start": {"line": 0, "character": 2},
+                "end": {"line": 0, "character": 3},
+            },
+            snapshot,
+            context="self-check.invalid-surrogate-boundary",
+        )
+    except PrototypeError:
+        pass
+    else:
+        raise PrototypeError("position inside a surrogate pair was accepted")
+
+    if not range_contains(((0, 0), (1, 5)), valid):
+        raise PrototypeError("valid nested range was rejected")
+    if range_contains(valid, ((0, 0), (1, 5))):
+        raise PrototypeError("out-of-parent range was accepted")
+
+    unicode_source = f"struct {REPRESENTATIVE_UNICODE_SYMBOL} {{\n}}\n"
+    unicode_evidence = validate_document_symbols(
+        [
+            {
+                "name": REPRESENTATIVE_UNICODE_SYMBOL,
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 1, "character": 1},
+                },
+                "selectionRange": {
+                    "start": {"line": 0, "character": 7},
+                    "end": {"line": 0, "character": 11},
+                },
+            }
+        ],
+        unicode_source,
+        context="self-check.documentSymbol",
+        require_unicode_symbol=True,
+    )
+    representative = unicode_evidence.get("representative_unicode_symbol")
+    if (
+        not isinstance(representative, dict)
+        or representative.get("selection_range")
+        != canonical_lsp_range((0, 7), (0, 11))
+    ):
+        raise PrototypeError("exact Unicode selection evidence was not preserved")
+
+    try:
+        validate_document_symbols(
+            [
+                {
+                    "name": "parent",
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 6},
+                    },
+                    "selectionRange": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 6},
+                    },
+                    "children": [
+                        {
+                            "name": "child",
+                            "range": {
+                                "start": {"line": 1, "character": 0},
+                                "end": {"line": 1, "character": 5},
+                            },
+                            "selectionRange": {
+                                "start": {"line": 1, "character": 0},
+                                "end": {"line": 1, "character": 5},
+                            },
+                        }
+                    ],
+                }
+            ],
+            "parent\nchild",
+            context="self-check.out-of-parent",
+            require_unicode_symbol=False,
+        )
+    except PrototypeError:
+        pass
+    else:
+        raise PrototypeError("out-of-parent document symbol was accepted")
+
+    if negotiated_utf16_position_encoding({}) != "utf-16":
+        raise PrototypeError("the LSP UTF-16 default was not selected")
+    for unsupported in ("utf-8", "utf-32", None):
+        try:
+            negotiated_utf16_position_encoding(
+                {"positionEncoding": unsupported}
+            )
+        except PrototypeError:
+            pass
+        else:
+            raise PrototypeError(
+                f"unsupported position encoding {unsupported!r} was accepted"
+            )
+
+
+def validate_baseline_range_evidence(baseline: dict[str, Any]) -> None:
+    lsp = baseline.get("lsp")
+    if not isinstance(lsp, dict):
+        raise PrototypeError("missing lsp result")
+    capabilities = lsp.get("capabilities")
+    if (
+        not isinstance(capabilities, dict)
+        or capabilities.get("position_encoding") != "utf-16"
+    ):
+        raise PrototypeError("negotiated position encoding is not utf-16")
+
+    fixture_results = lsp.get("fixtures")
+    if not isinstance(fixture_results, list):
+        raise PrototypeError("missing fixture results")
+    results_by_name = {
+        result.get("name"): result
+        for result in fixture_results
+        if isinstance(result, dict) and isinstance(result.get("name"), str)
+    }
+    if (
+        len(fixture_results) != 3
+        or set(results_by_name) != {"valid", "malformed", "large"}
+    ):
+        raise PrototypeError("fixture result names are incomplete or duplicated")
+
+    fixture_metadata = baseline.get("fixtures")
+    if not isinstance(fixture_metadata, dict):
+        raise PrototypeError("fixture identities are missing")
+    metadata_names = {
+        "valid": "valid.swift",
+        "malformed": "malformed.swift",
+        "large": "large.generated.swift",
+    }
+    for name, result in results_by_name.items():
+        metadata = fixture_metadata.get(metadata_names[name])
+        if (
+            not isinstance(metadata, dict)
+            or result.get("utf8_bytes") != metadata.get("utf8_bytes")
+        ):
+            raise PrototypeError(f"{name} result does not match its fixture identity")
+        validation = result.get("range_validation")
+        if (
+            not isinstance(validation, dict)
+            or validation.get("position_encoding") != "utf-16"
+        ):
+            raise PrototypeError(f"{name} omitted UTF-16 range validation")
+        expected_counts = {
+            "cold": (
+                result.get("fold_count"),
+                result.get("symbols", {}).get("count")
+                if isinstance(result.get("symbols"), dict)
+                else None,
+            ),
+            "incremental": (
+                result.get("incremental_fold_count"),
+                result.get("incremental_symbols", {}).get("count")
+                if isinstance(result.get("incremental_symbols"), dict)
+                else None,
+            ),
+        }
+        for phase, (fold_count, symbol_count) in expected_counts.items():
+            evidence = validation.get(phase)
+            if not isinstance(evidence, dict):
+                raise PrototypeError(f"{name}.{phase} evidence is missing")
+            if evidence.get("folding_ranges") != fold_count:
+                raise PrototypeError(f"{name}.{phase} folding count is inconsistent")
+            if (
+                evidence.get("document_symbol_ranges") != symbol_count
+                or evidence.get("document_symbol_selection_ranges") != symbol_count
+            ):
+                raise PrototypeError(f"{name}.{phase} symbol counts are inconsistent")
+            for digest_name in (
+                "folding_ranges_sha256",
+                "document_symbol_ranges_sha256",
+            ):
+                digest = evidence.get(digest_name)
+                if (
+                    not isinstance(digest, str)
+                    or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+                ):
+                    raise PrototypeError(
+                        f"{name}.{phase}.{digest_name} is not a SHA-256 digest"
+                    )
+
+    valid_source = (FIXTURE_DIRECTORY / "valid.swift").read_text(encoding="utf-8")
+    expected_selection = expected_unicode_selection_range(
+        LSPTextSnapshot(valid_source)
+    )
+    for phase in ("cold", "incremental"):
+        evidence = results_by_name["valid"]["range_validation"][phase].get(
+            "representative_unicode_symbol"
+        )
+        if (
+            not isinstance(evidence, dict)
+            or evidence.get("name") != REPRESENTATIVE_UNICODE_SYMBOL
+            or evidence.get("selection_range") != expected_selection
+            or evidence.get("utf8_bytes")
+            != len(REPRESENTATIVE_UNICODE_SYMBOL.encode("utf-8"))
+            or evidence.get("utf16_units")
+            != len(REPRESENTATIVE_UNICODE_SYMBOL.encode("utf-16-le")) // 2
+        ):
+            raise PrototypeError(
+                f"valid.{phase} representative Unicode evidence is inconsistent"
+            )
+
+
 def symbol_metrics(symbols: Any) -> dict[str, Any]:
     if not isinstance(symbols, list):
         return {
@@ -419,7 +952,13 @@ def lsp_fixture_measurement(
     path: Path,
     source: str,
     version: int,
+    position_encoding: str,
 ) -> dict[str, Any]:
+    if position_encoding != "utf-16":
+        raise PrototypeError(
+            f"{name} cannot validate unsupported position encoding "
+            f"{position_encoding!r}"
+        )
     uri = path.resolve().as_uri()
     client.notify(
         "textDocument/didOpen",
@@ -441,6 +980,19 @@ def lsp_fixture_measurement(
         "textDocument/documentSymbol",
         text_document,
     )
+    cold_range_validation = {
+        **validate_folding_ranges(
+            folding_ranges,
+            source,
+            context=f"{name}.cold.foldingRange",
+        ),
+        **validate_document_symbols(
+            symbols,
+            source,
+            context=f"{name}.cold.documentSymbol",
+            require_unicode_symbol=name == "valid",
+        ),
+    }
 
     edited_source = source + "\n// incremental edit 🌲\n"
     version += 1
@@ -459,6 +1011,19 @@ def lsp_fixture_measurement(
         "textDocument/documentSymbol",
         text_document,
     )
+    incremental_range_validation = {
+        **validate_folding_ranges(
+            updated_folding,
+            edited_source,
+            context=f"{name}.incremental.foldingRange",
+        ),
+        **validate_document_symbols(
+            updated_symbols,
+            edited_source,
+            context=f"{name}.incremental.documentSymbol",
+            require_unicode_symbol=name == "valid",
+        ),
+    }
     client.notify(
         "textDocument/didClose",
         {"textDocument": {"uri": uri}},
@@ -479,6 +1044,11 @@ def lsp_fixture_measurement(
         ),
         "symbols": symbol_metrics(symbols),
         "incremental_symbols": symbol_metrics(updated_symbols),
+        "range_validation": {
+            "position_encoding": position_encoding,
+            "cold": cold_range_validation,
+            "incremental": incremental_range_validation,
+        },
     }
 
 
@@ -524,6 +1094,11 @@ def measure_lsp(
             initialization_parameters,
         )
         client.notify("initialized", {})
+        initialize_dictionary = (
+            initialize_result if isinstance(initialize_result, dict) else {}
+        )
+        capabilities = initialize_dictionary.get("capabilities")
+        position_encoding = negotiated_utf16_position_encoding(capabilities)
 
         results: list[dict[str, Any]] = []
         version = 1
@@ -535,6 +1110,7 @@ def measure_lsp(
                     path=path,
                     source=source,
                     version=version,
+                    position_encoding=position_encoding,
                 )
             )
             version += 2
@@ -579,17 +1155,13 @@ def measure_lsp(
             {"textDocument": {"uri": large_uri}},
         )
 
-        initialize_dictionary = (
-            initialize_result if isinstance(initialize_result, dict) else {}
-        )
-        capabilities = initialize_dictionary.get("capabilities", {})
         return {
             "initialize_milliseconds": initialize_milliseconds,
             "server_info": initialize_dictionary.get("serverInfo"),
             "capabilities": {
                 "position_encoding": capabilities.get(
                     "positionEncoding",
-                    "utf-16 (LSP default)",
+                    position_encoding,
                 ),
                 "folding_range_provider": capabilities.get(
                     "foldingRangeProvider",

--- a/scripts/structural-intelligence/fixtures/malformed.swift
+++ b/scripts/structural-intelligence/fixtures/malformed.swift
@@ -1,0 +1,15 @@
+struct BrokenCatalog {
+    enum State {
+        case ready
+        case waiting
+    }
+
+    func render(value: String) -> String {
+        if value.isEmpty {
+            return "missing"
+        // Intentionally missing the closing braces. Both providers must keep
+        // useful structure instead of blanking the entire document.
+
+    func stillDiscoverable() {
+        print("after malformed region")
+    }

--- a/scripts/structural-intelligence/fixtures/valid.swift
+++ b/scripts/structural-intelligence/fixtures/valid.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct Catalog {
+    let title: String
+
+    enum Status {
+        case draft
+        case published
+    }
+
+    func render(items: [String]) -> String {
+        items.map { item in
+            "\(title): \(item)"
+        }
+        .joined(separator: "\n")
+    }
+}
+
+func greeting(for name: String) -> String {
+    let emoji = "🌲"
+    let localized = "你好, \(name)"
+    return "\(emoji) \(localized)"
+}

--- a/scripts/structural-intelligence/fixtures/valid.swift
+++ b/scripts/structural-intelligence/fixtures/valid.swift
@@ -21,3 +21,9 @@ func greeting(for name: String) -> String {
     let localized = "你好, \(name)"
     return "\(emoji) \(localized)"
 }
+
+struct 类型🌲 { // swiftlint:disable:this type_name
+    func value() -> Int {
+        1
+    }
+}

--- a/scripts/structural-intelligence/results/2026-07-23-xcode-27-beta.json
+++ b/scripts/structural-intelligence/results/2026-07-23-xcode-27-beta.json
@@ -1,0 +1,166 @@
+{
+  "fixtures": {
+    "large.generated.swift": {
+      "declarations": 2000,
+      "sha256": "6f01e70990c9c799a4bb3c50d67297a4dbc65fa8539100805df81a13a013947a",
+      "utf8_bytes": 644047
+    },
+    "malformed.swift": {
+      "sha256": "5436d2627864fd92e685780372937251326b49209fbbcb70b2908ee985bb1fcc",
+      "utf8_bytes": 411
+    },
+    "valid.swift": {
+      "sha256": "d2ff7a7a27a1e43d4c23dcf092af6d5ae79d8fb72b71b983656934101d02d3fa",
+      "utf8_bytes": 425
+    }
+  },
+  "host": {
+    "machine": "arm64",
+    "platform": "macOS-27.0-arm64-arm-64bit"
+  },
+  "lsp": {
+    "cancellation": {
+      "code": -32800,
+      "message": "request cancelled by client",
+      "outcome": "error"
+    },
+    "capabilities": {
+      "document_symbol_provider": true,
+      "folding_range_provider": true,
+      "position_encoding": "utf-16 (LSP default)"
+    },
+    "fixtures": [
+      {
+        "cold_folding_request_milliseconds": 59.48079100000003,
+        "cold_symbol_request_milliseconds": 2.341291999999995,
+        "fold_count": 13,
+        "incremental_fold_count": 14,
+        "incremental_folding_request_milliseconds": 1.0368330000000148,
+        "incremental_symbol_request_milliseconds": 0.4305830000000399,
+        "incremental_symbols": {
+          "count": 7,
+          "hierarchical": true,
+          "maximum_depth": 3
+        },
+        "lines": 24,
+        "name": "valid",
+        "symbols": {
+          "count": 7,
+          "hierarchical": true,
+          "maximum_depth": 3
+        },
+        "utf16_units": 419,
+        "utf8_bytes": 425
+      },
+      {
+        "cold_folding_request_milliseconds": 2.594625000000017,
+        "cold_symbol_request_milliseconds": 0.5010420000000071,
+        "fold_count": 8,
+        "incremental_fold_count": 9,
+        "incremental_folding_request_milliseconds": 0.5622500000000419,
+        "incremental_symbol_request_milliseconds": 0.33041699999997176,
+        "incremental_symbols": {
+          "count": 6,
+          "hierarchical": true,
+          "maximum_depth": 3
+        },
+        "lines": 16,
+        "name": "malformed",
+        "symbols": {
+          "count": 6,
+          "hierarchical": true,
+          "maximum_depth": 3
+        },
+        "utf16_units": 411,
+        "utf8_bytes": 411
+      },
+      {
+        "cold_folding_request_milliseconds": 139.101125,
+        "cold_symbol_request_milliseconds": 171.03191699999996,
+        "fold_count": 14001,
+        "incremental_fold_count": 14002,
+        "incremental_folding_request_milliseconds": 144.25120800000002,
+        "incremental_symbol_request_milliseconds": 180.93925,
+        "incremental_symbols": {
+          "count": 12001,
+          "hierarchical": true,
+          "maximum_depth": 4
+        },
+        "lines": 32005,
+        "name": "large",
+        "symbols": {
+          "count": 12001,
+          "hierarchical": true,
+          "maximum_depth": 4
+        },
+        "utf16_units": 640047,
+        "utf8_bytes": 644047
+      }
+    ],
+    "initialize_milliseconds": 29.44412499999999,
+    "server_info": null
+  },
+  "measured_at": "2026-07-23T12:25:05.034539+00:00",
+  "repository_commit": "56e1a19222f2cf041d2f1d4d599e5c465576ba83",
+  "schema_version": 1,
+  "toolchain": {
+    "developer_directory": "/Applications/Xcode-beta.app/Contents/Developer",
+    "sourcekit_lsp_binary_bytes": 35848000,
+    "sourcekit_lsp_path": "/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/sourcekit-lsp",
+    "sourcekit_lsp_sha256": "7cc11570a25398b677214cddd0463952b3834788de0f33ee4da7911b89b39582",
+    "swift": "Apple Swift version 6.4 (swiftlang-6.4.0.25.4 clang-2100.3.25.1)\nTarget: arm64-apple-macosx27.0.0",
+    "xcode": "Xcode 27.0\nBuild version 27A5218g"
+  },
+  "tree_sitter": {
+    "fresh_scratch_resolution_and_release_build_milliseconds": 21848.7825,
+    "fixtures": [
+      {
+        "changedRangeCount": 1,
+        "coldParseMilliseconds": 0.944666,
+        "foldCandidateCount": 7,
+        "incrementalParseMilliseconds": 0.026416,
+        "lines": 24,
+        "maximumSymbolDepth": 2,
+        "name": "valid",
+        "nodeCount": 93,
+        "rootHasError": false,
+        "symbolCount": 4,
+        "timeoutCancelled": true,
+        "utf16Units": 419,
+        "utf8Bytes": 425
+      },
+      {
+        "changedRangeCount": 1,
+        "coldParseMilliseconds": 0.293917,
+        "foldCandidateCount": 4,
+        "incrementalParseMilliseconds": 0.100208,
+        "lines": 16,
+        "maximumSymbolDepth": 1,
+        "name": "malformed",
+        "nodeCount": 36,
+        "rootHasError": true,
+        "symbolCount": 2,
+        "timeoutCancelled": true,
+        "utf16Units": 411,
+        "utf8Bytes": 411
+      },
+      {
+        "changedRangeCount": 1,
+        "coldParseMilliseconds": 61.615542,
+        "foldCandidateCount": 10001,
+        "incrementalParseMilliseconds": 0.033916,
+        "lines": 32005,
+        "maximumSymbolDepth": 3,
+        "name": "large",
+        "nodeCount": 82007,
+        "rootHasError": false,
+        "symbolCount": 6001,
+        "timeoutCancelled": true,
+        "utf16Units": 640047,
+        "utf8Bytes": 644047
+      }
+    ],
+    "probe_binary_bytes": 4463240,
+    "scratch_tree_bytes": 262154423
+  }
+}

--- a/scripts/structural-intelligence/results/2026-07-23-xcode-27-beta.json
+++ b/scripts/structural-intelligence/results/2026-07-23-xcode-27-beta.json
@@ -10,8 +10,8 @@
       "utf8_bytes": 411
     },
     "valid.swift": {
-      "sha256": "d2ff7a7a27a1e43d4c23dcf092af6d5ae79d8fb72b71b983656934101d02d3fa",
-      "utf8_bytes": 425
+      "sha256": "fb3ab0c1cae05e2cc9e48fc0f14cd4f11ac9faee25fe4e2f4fda05383d16fb6e",
+      "utf8_bytes": 526
     }
   },
   "host": {
@@ -27,38 +27,85 @@
     "capabilities": {
       "document_symbol_provider": true,
       "folding_range_provider": true,
-      "position_encoding": "utf-16 (LSP default)"
+      "position_encoding": "utf-16"
     },
     "fixtures": [
       {
-        "cold_folding_request_milliseconds": 59.48079100000003,
-        "cold_symbol_request_milliseconds": 2.341291999999995,
-        "fold_count": 13,
-        "incremental_fold_count": 14,
-        "incremental_folding_request_milliseconds": 1.0368330000000148,
-        "incremental_symbol_request_milliseconds": 0.4305830000000399,
+        "cold_folding_request_milliseconds": 56.20045900000004,
+        "cold_symbol_request_milliseconds": 2.533500000000022,
+        "fold_count": 16,
+        "incremental_fold_count": 17,
+        "incremental_folding_request_milliseconds": 1.0159170000000328,
+        "incremental_symbol_request_milliseconds": 0.35050000000003134,
         "incremental_symbols": {
-          "count": 7,
+          "count": 9,
           "hierarchical": true,
           "maximum_depth": 3
         },
-        "lines": 24,
+        "lines": 30,
         "name": "valid",
+        "range_validation": {
+          "cold": {
+            "document_symbol_ranges": 9,
+            "document_symbol_ranges_sha256": "e293e1e46f396403893a91ba20c761f3dcb643636ab1e06b2c0bdf36974650f1",
+            "document_symbol_selection_ranges": 9,
+            "folding_ranges": 16,
+            "folding_ranges_sha256": "bd95a7ee66dccedd5eeabe9bf3f14861cc68da536de35dd59a3f8284bf203f19",
+            "representative_unicode_symbol": {
+              "name": "\u7c7b\u578b\ud83c\udf32",
+              "selection_range": {
+                "end": {
+                  "character": 11,
+                  "line": 24
+                },
+                "start": {
+                  "character": 7,
+                  "line": 24
+                }
+              },
+              "utf16_units": 4,
+              "utf8_bytes": 10
+            }
+          },
+          "incremental": {
+            "document_symbol_ranges": 9,
+            "document_symbol_ranges_sha256": "e293e1e46f396403893a91ba20c761f3dcb643636ab1e06b2c0bdf36974650f1",
+            "document_symbol_selection_ranges": 9,
+            "folding_ranges": 17,
+            "folding_ranges_sha256": "1aa87912846faf4e330daf55099013f19da9f5cd420a37e6dd7e8ccfef25d54a",
+            "representative_unicode_symbol": {
+              "name": "\u7c7b\u578b\ud83c\udf32",
+              "selection_range": {
+                "end": {
+                  "character": 11,
+                  "line": 24
+                },
+                "start": {
+                  "character": 7,
+                  "line": 24
+                }
+              },
+              "utf16_units": 4,
+              "utf8_bytes": 10
+            }
+          },
+          "position_encoding": "utf-16"
+        },
         "symbols": {
-          "count": 7,
+          "count": 9,
           "hierarchical": true,
           "maximum_depth": 3
         },
-        "utf16_units": 419,
-        "utf8_bytes": 425
+        "utf16_units": 514,
+        "utf8_bytes": 526
       },
       {
-        "cold_folding_request_milliseconds": 2.594625000000017,
-        "cold_symbol_request_milliseconds": 0.5010420000000071,
+        "cold_folding_request_milliseconds": 2.540040999999993,
+        "cold_symbol_request_milliseconds": 0.5539170000000149,
         "fold_count": 8,
         "incremental_fold_count": 9,
-        "incremental_folding_request_milliseconds": 0.5622500000000419,
-        "incremental_symbol_request_milliseconds": 0.33041699999997176,
+        "incremental_folding_request_milliseconds": 0.6087080000000133,
+        "incremental_symbol_request_milliseconds": 0.32162499999999206,
         "incremental_symbols": {
           "count": 6,
           "hierarchical": true,
@@ -66,6 +113,23 @@
         },
         "lines": 16,
         "name": "malformed",
+        "range_validation": {
+          "cold": {
+            "document_symbol_ranges": 6,
+            "document_symbol_ranges_sha256": "bd00da8409f2976f5d1e8cc6714a5f3627e9de1c01ba86ca30ab9d8499c7e88e",
+            "document_symbol_selection_ranges": 6,
+            "folding_ranges": 8,
+            "folding_ranges_sha256": "6b802766d733ebaefd2e1dfdcd288b38ee7677c0f3b6f91d5266db1453529fbc"
+          },
+          "incremental": {
+            "document_symbol_ranges": 6,
+            "document_symbol_ranges_sha256": "bd00da8409f2976f5d1e8cc6714a5f3627e9de1c01ba86ca30ab9d8499c7e88e",
+            "document_symbol_selection_ranges": 6,
+            "folding_ranges": 9,
+            "folding_ranges_sha256": "22d130b585ba4ca0cb66a671a91cb4f29d2603a891466ae92c77c2e7d1bd5b2d"
+          },
+          "position_encoding": "utf-16"
+        },
         "symbols": {
           "count": 6,
           "hierarchical": true,
@@ -75,12 +139,12 @@
         "utf8_bytes": 411
       },
       {
-        "cold_folding_request_milliseconds": 139.101125,
-        "cold_symbol_request_milliseconds": 171.03191699999996,
+        "cold_folding_request_milliseconds": 133.85654200000002,
+        "cold_symbol_request_milliseconds": 176.11437500000005,
         "fold_count": 14001,
         "incremental_fold_count": 14002,
-        "incremental_folding_request_milliseconds": 144.25120800000002,
-        "incremental_symbol_request_milliseconds": 180.93925,
+        "incremental_folding_request_milliseconds": 132.27233299999997,
+        "incremental_symbol_request_milliseconds": 207.40991600000004,
         "incremental_symbols": {
           "count": 12001,
           "hierarchical": true,
@@ -88,6 +152,23 @@
         },
         "lines": 32005,
         "name": "large",
+        "range_validation": {
+          "cold": {
+            "document_symbol_ranges": 12001,
+            "document_symbol_ranges_sha256": "c7953162a92579359edda2a8fa503a06e7d9e1888e5bc55c3fa4652c09c3fcca",
+            "document_symbol_selection_ranges": 12001,
+            "folding_ranges": 14001,
+            "folding_ranges_sha256": "d81d6e77ea0ba46d4b49379e908d2410557b465a1dd411b5d429c7e6ffd837bd"
+          },
+          "incremental": {
+            "document_symbol_ranges": 12001,
+            "document_symbol_ranges_sha256": "c7953162a92579359edda2a8fa503a06e7d9e1888e5bc55c3fa4652c09c3fcca",
+            "document_symbol_selection_ranges": 12001,
+            "folding_ranges": 14002,
+            "folding_ranges_sha256": "7300d1488828766a5b26a690123f53bc12023eb23e61c4115b5223adf11e265c"
+          },
+          "position_encoding": "utf-16"
+        },
         "symbols": {
           "count": 12001,
           "hierarchical": true,
@@ -97,11 +178,11 @@
         "utf8_bytes": 644047
       }
     ],
-    "initialize_milliseconds": 29.44412499999999,
+    "initialize_milliseconds": 25.382875,
     "server_info": null
   },
-  "measured_at": "2026-07-23T12:25:05.034539+00:00",
-  "repository_commit": "56e1a19222f2cf041d2f1d4d599e5c465576ba83",
+  "measured_at": "2026-07-23T13:07:24.283241+00:00",
+  "repository_commit": "f71362b036b72925e074cfd4a064d054110cb313",
   "schema_version": 1,
   "toolchain": {
     "developer_directory": "/Applications/Xcode-beta.app/Contents/Developer",
@@ -112,28 +193,27 @@
     "xcode": "Xcode 27.0\nBuild version 27A5218g"
   },
   "tree_sitter": {
-    "fresh_scratch_resolution_and_release_build_milliseconds": 21848.7825,
     "fixtures": [
       {
         "changedRangeCount": 1,
-        "coldParseMilliseconds": 0.944666,
-        "foldCandidateCount": 7,
-        "incrementalParseMilliseconds": 0.026416,
-        "lines": 24,
+        "coldParseMilliseconds": 0.888,
+        "foldCandidateCount": 10,
+        "incrementalParseMilliseconds": 0.025,
+        "lines": 30,
         "maximumSymbolDepth": 2,
         "name": "valid",
-        "nodeCount": 93,
+        "nodeCount": 104,
         "rootHasError": false,
-        "symbolCount": 4,
+        "symbolCount": 6,
         "timeoutCancelled": true,
-        "utf16Units": 419,
-        "utf8Bytes": 425
+        "utf16Units": 514,
+        "utf8Bytes": 526
       },
       {
         "changedRangeCount": 1,
-        "coldParseMilliseconds": 0.293917,
+        "coldParseMilliseconds": 0.28025,
         "foldCandidateCount": 4,
-        "incrementalParseMilliseconds": 0.100208,
+        "incrementalParseMilliseconds": 0.09425,
         "lines": 16,
         "maximumSymbolDepth": 1,
         "name": "malformed",
@@ -146,9 +226,9 @@
       },
       {
         "changedRangeCount": 1,
-        "coldParseMilliseconds": 61.615542,
+        "coldParseMilliseconds": 58.879417,
         "foldCandidateCount": 10001,
-        "incrementalParseMilliseconds": 0.033916,
+        "incrementalParseMilliseconds": 0.031917,
         "lines": 32005,
         "maximumSymbolDepth": 3,
         "name": "large",
@@ -160,7 +240,8 @@
         "utf8Bytes": 644047
       }
     ],
+    "fresh_scratch_resolution_and_release_build_milliseconds": 19647.2605,
     "probe_binary_bytes": 4463240,
-    "scratch_tree_bytes": 262154423
+    "scratch_tree_bytes": 262151094
   }
 }

--- a/scripts/structural-intelligence/tree-sitter-probe/Package.resolved
+++ b/scripts/structural-intelligence/tree-sitter-probe/Package.resolved
@@ -1,0 +1,30 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-tree-sitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/swift-tree-sitter",
+      "state" : {
+        "revision" : "0f40435cdb41673ce4194d731571cf2a2f7c3285"
+      }
+    },
+    {
+      "identity" : "tree-sitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter",
+      "state" : {
+        "revision" : "da6fe9beb4f7f67beb75914ca8e0d48ae48d6406",
+        "version" : "0.25.10"
+      }
+    },
+    {
+      "identity" : "tree-sitter-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/alex-pinkus/tree-sitter-swift",
+      "state" : {
+        "revision" : "31d17fe7e818a2048c808b5c6fdc2dc792f4f5b5"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/scripts/structural-intelligence/tree-sitter-probe/Package.swift
+++ b/scripts/structural-intelligence/tree-sitter-probe/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "PineStructuralIntelligenceProbe",
+    platforms: [.macOS(.v13)],
+    dependencies: [
+        .package(
+            url: "https://github.com/tree-sitter/swift-tree-sitter",
+            revision: "0f40435cdb41673ce4194d731571cf2a2f7c3285"
+        ),
+        .package(
+            url: "https://github.com/alex-pinkus/tree-sitter-swift",
+            revision: "31d17fe7e818a2048c808b5c6fdc2dc792f4f5b5"
+        ),
+    ],
+    targets: [
+        .executableTarget(
+            name: "StructuralIntelligenceProbe",
+            dependencies: [
+                .product(
+                    name: "SwiftTreeSitter",
+                    package: "swift-tree-sitter"
+                ),
+                .product(
+                    name: "TreeSitterSwift",
+                    package: "tree-sitter-swift"
+                ),
+            ]
+        ),
+    ]
+)

--- a/scripts/structural-intelligence/tree-sitter-probe/Sources/StructuralIntelligenceProbe/main.swift
+++ b/scripts/structural-intelligence/tree-sitter-probe/Sources/StructuralIntelligenceProbe/main.swift
@@ -1,0 +1,208 @@
+import Foundation
+import SwiftTreeSitter
+import TreeSitterSwift
+
+private struct FixtureResult: Codable {
+    let name: String
+    let utf8Bytes: Int
+    let utf16Units: Int
+    let lines: Int
+    let coldParseMilliseconds: Double
+    let incrementalParseMilliseconds: Double
+    let changedRangeCount: Int
+    let nodeCount: Int
+    let foldCandidateCount: Int
+    let symbolCount: Int
+    let maximumSymbolDepth: Int
+    let rootHasError: Bool
+    let timeoutCancelled: Bool
+}
+
+private enum ProbeError: Error, LocalizedError {
+    case invalidArguments
+    case unableToRead(String)
+    case unableToSetLanguage
+    case parseFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidArguments:
+            "usage: StructuralIntelligenceProbe <name=path> [<name=path> ...]"
+        case .unableToRead(let path):
+            "unable to read fixture at \(path)"
+        case .unableToSetLanguage:
+            "unable to load the pinned Swift grammar"
+        case .parseFailed(let name):
+            "Tree-sitter failed to parse fixture \(name)"
+        }
+    }
+}
+
+private let declarationTypes: Set<String> = [
+    "class_declaration",
+    "enum_declaration",
+    "extension_declaration",
+    "function_declaration",
+    "protocol_declaration",
+    "struct_declaration",
+]
+
+private let foldTypes: Set<String> = [
+    "class_body",
+    "enum_class_body",
+    "function_body",
+    "protocol_body",
+    "statements",
+    "switch_entry",
+]
+
+private func elapsedMilliseconds(_ operation: () throws -> Void) rethrows -> Double {
+    let start = DispatchTime.now().uptimeNanoseconds
+    try operation()
+    let elapsed = DispatchTime.now().uptimeNanoseconds - start
+    return Double(elapsed) / 1_000_000
+}
+
+private func collectMetrics(
+    from node: Node,
+    symbolDepth: Int = 0
+) -> (nodes: Int, folds: Int, symbols: Int, maximumDepth: Int) {
+    let type = node.nodeType ?? ""
+    let isDeclaration = declarationTypes.contains(type)
+    let nextDepth = symbolDepth + (isDeclaration ? 1 : 0)
+
+    var result = (
+        nodes: 1,
+        folds: foldTypes.contains(type)
+            && node.pointRange.lowerBound.row < node.pointRange.upperBound.row ? 1 : 0,
+        symbols: isDeclaration ? 1 : 0,
+        maximumDepth: isDeclaration ? nextDepth : symbolDepth
+    )
+
+    for index in 0..<node.namedChildCount {
+        guard let child = node.namedChild(at: index) else { continue }
+        let childMetrics = collectMetrics(from: child, symbolDepth: nextDepth)
+        result.nodes += childMetrics.nodes
+        result.folds += childMetrics.folds
+        result.symbols += childMetrics.symbols
+        result.maximumDepth = max(result.maximumDepth, childMetrics.maximumDepth)
+    }
+
+    return result
+}
+
+private func point(atUTF16Offset offset: Int, in source: NSString) -> Point {
+    let clampedOffset = max(0, min(offset, source.length))
+    let prefix = source.substring(to: clampedOffset) as NSString
+    let row = prefix.components(separatedBy: "\n").count - 1
+    let lastNewline = prefix.range(
+        of: "\n",
+        options: .backwards
+    )
+    let lineStart = lastNewline.location == NSNotFound
+        ? 0
+        : NSMaxRange(lastNewline)
+    return Point(row: row, column: clampedOffset - lineStart)
+}
+
+private func measureFixture(
+    name: String,
+    source: String,
+    parser: Parser
+) throws -> FixtureResult {
+    var initialTree: MutableTree?
+    let coldMilliseconds = try elapsedMilliseconds {
+        initialTree = parser.parse(source)
+        guard initialTree != nil else { throw ProbeError.parseFailed(name) }
+    }
+    guard let initialTree, let root = initialTree.rootNode else {
+        throw ProbeError.parseFailed(name)
+    }
+
+    let marker = "\n// incremental edit 🌲\n"
+    let editedSource = source + marker
+    let sourceNSString = source as NSString
+    let oldEnd = sourceNSString.length
+    let oldEndPoint = point(atUTF16Offset: oldEnd, in: sourceNSString)
+    let newEnd = oldEnd + (marker as NSString).length
+    let editedNSString = editedSource as NSString
+    let newEndPoint = point(atUTF16Offset: newEnd, in: editedNSString)
+    let edit = InputEdit(
+        startByte: oldEnd * 2,
+        oldEndByte: oldEnd * 2,
+        newEndByte: newEnd * 2,
+        startPoint: oldEndPoint,
+        oldEndPoint: oldEndPoint,
+        newEndPoint: newEndPoint
+    )
+    initialTree.edit(edit)
+
+    var updatedTree: MutableTree?
+    let incrementalMilliseconds = try elapsedMilliseconds {
+        updatedTree = parser.parse(tree: initialTree, string: editedSource)
+        guard updatedTree != nil else { throw ProbeError.parseFailed(name) }
+    }
+    guard let updatedTree else { throw ProbeError.parseFailed(name) }
+
+    let changedRanges = initialTree.changedRanges(from: updatedTree)
+    let metrics = collectMetrics(from: root)
+
+    parser.timeout = 0.000_001
+    let cancelledTree = parser.parse(source)
+    let timeoutCancelled = cancelledTree == nil
+    parser.reset()
+    parser.timeout = 0
+
+    return FixtureResult(
+        name: name,
+        utf8Bytes: source.utf8.count,
+        utf16Units: source.utf16.count,
+        lines: source.components(separatedBy: "\n").count,
+        coldParseMilliseconds: coldMilliseconds,
+        incrementalParseMilliseconds: incrementalMilliseconds,
+        changedRangeCount: changedRanges.count,
+        nodeCount: metrics.nodes,
+        foldCandidateCount: metrics.folds,
+        symbolCount: metrics.symbols,
+        maximumSymbolDepth: metrics.maximumDepth,
+        rootHasError: root.hasError,
+        timeoutCancelled: timeoutCancelled
+    )
+}
+
+private func run() throws {
+    let arguments = Array(CommandLine.arguments.dropFirst())
+    guard !arguments.isEmpty else { throw ProbeError.invalidArguments }
+
+    let parser = Parser()
+    do {
+        try parser.setLanguage(Language(language: tree_sitter_swift()))
+    } catch {
+        throw ProbeError.unableToSetLanguage
+    }
+
+    var results: [FixtureResult] = []
+    for argument in arguments {
+        let parts = argument.split(separator: "=", maxSplits: 1)
+        guard parts.count == 2 else { throw ProbeError.invalidArguments }
+        let name = String(parts[0])
+        let path = String(parts[1])
+        guard let source = try? String(contentsOfFile: path, encoding: .utf8) else {
+            throw ProbeError.unableToRead(path)
+        }
+        results.append(try measureFixture(name: name, source: source, parser: parser))
+    }
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(results)
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+}
+
+do {
+    try run()
+} catch {
+    FileHandle.standardError.write(Data("\(error.localizedDescription)\n".utf8))
+    exit(EXIT_FAILURE)
+}

--- a/scripts/structural-intelligence/tree-sitter-probe/Sources/StructuralIntelligenceProbe/main.swift
+++ b/scripts/structural-intelligence/tree-sitter-probe/Sources/StructuralIntelligenceProbe/main.swift
@@ -118,6 +118,10 @@ private func measureFixture(
     guard let initialTree, let root = initialTree.rootNode else {
         throw ProbeError.parseFailed(name)
     }
+    // Nodes are invalid after their tree is edited. Capture all full-parse
+    // structure before applying the incremental edit below.
+    let metrics = collectMetrics(from: root)
+    let rootHasError = root.hasError
 
     let marker = "\n// incremental edit 🌲\n"
     let editedSource = source + marker
@@ -145,7 +149,6 @@ private func measureFixture(
     guard let updatedTree else { throw ProbeError.parseFailed(name) }
 
     let changedRanges = initialTree.changedRanges(from: updatedTree)
-    let metrics = collectMetrics(from: root)
 
     parser.timeout = 0.000_001
     let cancelledTree = parser.parse(source)
@@ -165,7 +168,7 @@ private func measureFixture(
         foldCandidateCount: metrics.folds,
         symbolCount: metrics.symbols,
         maximumSymbolDepth: metrics.maximumDepth,
-        rootHasError: root.hasError,
+        rootHasError: rootHasError,
         timeoutCancelled: timeoutCancelled
     )
 }

--- a/scripts/structural-intelligence/tree-sitter-probe/Sources/StructuralIntelligenceProbe/main.swift
+++ b/scripts/structural-intelligence/tree-sitter-probe/Sources/StructuralIntelligenceProbe/main.swift
@@ -102,7 +102,9 @@ private func point(atUTF16Offset offset: Int, in source: NSString) -> Point {
     let lineStart = lastNewline.location == NSNotFound
         ? 0
         : NSMaxRange(lastNewline)
-    return Point(row: row, column: clampedOffset - lineStart)
+    // Tree-sitter Point columns are bytes even when the input encoding is
+    // UTF-16LE, so each Foundation UTF-16 code unit occupies two columns.
+    return Point(row: row, column: (clampedOffset - lineStart) * 2)
 }
 
 private func measureFixture(
@@ -124,19 +126,22 @@ private func measureFixture(
     let rootHasError = root.hasError
 
     let marker = "\n// incremental edit 🌲\n"
-    let editedSource = source + marker
     let sourceNSString = source as NSString
-    let oldEnd = sourceNSString.length
-    let oldEndPoint = point(atUTF16Offset: oldEnd, in: sourceNSString)
-    let newEnd = oldEnd + (marker as NSString).length
+    let insertionOffset = sourceNSString.length
+    let editedSource = source + marker
+    let insertionPoint = point(
+        atUTF16Offset: insertionOffset,
+        in: sourceNSString
+    )
+    let newEnd = insertionOffset + (marker as NSString).length
     let editedNSString = editedSource as NSString
     let newEndPoint = point(atUTF16Offset: newEnd, in: editedNSString)
     let edit = InputEdit(
-        startByte: oldEnd * 2,
-        oldEndByte: oldEnd * 2,
+        startByte: insertionOffset * 2,
+        oldEndByte: insertionOffset * 2,
         newEndByte: newEnd * 2,
-        startPoint: oldEndPoint,
-        oldEndPoint: oldEndPoint,
+        startPoint: insertionPoint,
+        oldEndPoint: insertionPoint,
         newEndPoint: newEndPoint
     )
     initialTree.edit(edit)


### PR DESCRIPTION
## Summary

- record ADR 0001 selecting LSP-first folding and hierarchical document symbols with Pine's current local fallbacks
- keep bracket navigation local and add no production parser dependency
- add a reproducible SourceKit-LSP versus pinned Swift Tree-sitter benchmark with valid, malformed, Unicode, and deterministic 644 KB fixtures
- fail closed unless UTF-16 is negotiated, validate every folding/document-symbol range against the exact snapshot, and verify symbol selection plus parent/child containment
- persist canonical range-stream SHA-256 fingerprints and exact `类型🌲` UTF-16 selection evidence for cold and post-edit responses
- check in the Xcode 27 beta baseline, exact upstream revisions/licenses, cancellation evidence, range ownership, concurrency, generation, timeout, fallback, and exit policies
- validate fixture identities and tooling-only dependency pins in CI

## Decision

| Feature | Preferred | Fallback |
| --- | --- | --- |
| Folding | LSP `textDocument/foldingRange` | current bracket calculator |
| Symbols | hierarchical LSP `textDocument/documentSymbol` | current regex parser |
| Brackets | current bounded matcher + syntax skip ranges | current bounded full-file scan |

Tree-sitter remains an exit-path provider behind the proposed seams; the first #1008 implementation sequence adds no production dependency.

## Measured baseline

- SourceKit-LSP advertised both endpoints, returned useful structure for malformed Swift, and honored `$/cancelRequest` with `-32800`
- 644 KB fixture: LSP folding/symbols were ~133.86/176.11 ms; Tree-sitter full/incremental parse was ~58.88/0.032 ms
- tooling-only Tree-sitter release probe: 4.46 MB executable, 262 MB fresh scratch tree, 19.65 s build with the repository cache warm
- the representative `类型🌲` selection was line 24, UTF-16 characters `7..<11` in both cold and post-edit responses
- exact raw results, fixture/package SHA-256 values, and canonical range-stream fingerprints are checked in

## Validation

- `python3 scripts/structural-intelligence/benchmark.py --validate-only`
- full benchmark against Xcode 27 beta SourceKit-LSP and a fresh SwiftPM scratch path
- pinned Tree-sitter probe release build and execution
- strict SwiftLint: 0 violations in all new Swift files
- Swift fixture type-check against the Xcode 27 beta SDK
- Python byte-compilation and `git diff --check`

Closes #1182
