### PR TITLE
refactor(agent): define verified undo authority contract

### DIFF
--- a/Pine/Agent/AgentHistoryChangeSet.swift
+++ b/Pine/Agent/AgentHistoryChangeSet.swift
@@ -1,0 +1,246 @@
+//
+//  AgentHistoryChangeSet.swift
+//  Pine
+//
+//  Versioned, content-free contract for a future verified Agent History undo
+//  pipeline (#1183). The project log stores identities and an opaque payload
+//  reference only; inverse patches/content must live in owner-only
+//  Application Support storage, never in `.pine/agent-log.json`.
+//
+
+import Foundation
+
+/// Binds a verified change set to an owner-private workspace record and exact
+/// Git state without persisting machine-specific paths in the project log.
+///
+/// The Application Support authority record owns the canonical root, worktree
+/// git-dir/common-dir, and filesystem resource identity. The opaque ID here is
+/// only a lookup/binding key and is never sufficient to authorize mutation.
+nonisolated struct AgentHistoryWorkspaceIdentity: Codable, Equatable, Sendable {
+    let privateWorkspaceID: UUID
+    /// Exact HEAD object ID (SHA-1 or SHA-256 repository format).
+    let headOID: String
+    /// SHA-256 of the exact Git index bytes captured with the change set.
+    let indexSHA256: String
+}
+
+/// Explicit writer provenance supplied by a future trusted agent integration.
+///
+/// File-system observation cannot manufacture this value: it must come from a
+/// writer-specific event stream whose monotonically increasing sequence range
+/// is bound to one process generation and one Agent History session.
+nonisolated struct AgentHistoryWriterProvenance: Codable, Equatable, Sendable {
+    let sessionID: UUID
+    let writerInstanceID: UUID
+    let processIdentifier: Int32
+    let processGeneration: UInt64
+    let firstEventSequence: UInt64
+    let lastEventSequence: UInt64
+}
+
+/// File kind recorded without following links. Only regular files are eligible
+/// for the first checked-undo implementation; all other values fail closed.
+nonisolated enum AgentHistoryRecordedFileKind: Equatable, Sendable {
+    case regularFile
+    case symbolicLink
+    case directory
+    case unsupported(String)
+
+    private var persistedValue: String {
+        switch self {
+        case .regularFile: "regularFile"
+        case .symbolicLink: "symbolicLink"
+        case .directory: "directory"
+        case .unsupported(let value): value
+        }
+    }
+}
+
+nonisolated extension AgentHistoryRecordedFileKind: Codable {
+    init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        switch value {
+        case "regularFile": self = .regularFile
+        case "symbolicLink": self = .symbolicLink
+        case "directory": self = .directory
+        default: self = .unsupported(value)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        if case .unsupported(let value) = self,
+           ["regularFile", "symbolicLink", "directory"].contains(value) {
+            throw EncodingError.invalidValue(
+                self,
+                EncodingError.Context(
+                    codingPath: encoder.codingPath,
+                    debugDescription: "Unsupported file kind aliases a trusted value"
+                )
+            )
+        }
+        var container = encoder.singleValueContainer()
+        try container.encode(persistedValue)
+    }
+}
+
+/// Exact identity of one side of a recorded file change.
+nonisolated struct AgentHistoryRecordedFileState: Codable, Equatable, Sendable {
+    let kind: AgentHistoryRecordedFileKind
+    /// SHA-256 of the exact file bytes, without text decoding or newline
+    /// normalization.
+    let contentSHA256: String
+    let byteCount: UInt64
+    /// POSIX permission bits only, without file-type bits.
+    let permissions: UInt16
+}
+
+/// Operation represented by a recorded change.
+///
+/// Rename and symlink values are persisted explicitly so they produce a typed
+/// refusal instead of being misinterpreted as regular-file edits. Unknown
+/// future values also decode without granting mutation permission.
+nonisolated enum AgentHistoryFileOperation: Equatable, Sendable {
+    case modify
+    case create
+    case delete
+    case rename
+    case symlink
+    case unsupported(String)
+
+    var persistedValue: String {
+        switch self {
+        case .modify: "modify"
+        case .create: "create"
+        case .delete: "delete"
+        case .rename: "rename"
+        case .symlink: "symlink"
+        case .unsupported(let value): value
+        }
+    }
+}
+
+nonisolated extension AgentHistoryFileOperation: Codable {
+    init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        switch value {
+        case "modify": self = .modify
+        case "create": self = .create
+        case "delete": self = .delete
+        case "rename": self = .rename
+        case "symlink": self = .symlink
+        default: self = .unsupported(value)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        if case .unsupported(let value) = self,
+           ["modify", "create", "delete", "rename", "symlink"].contains(value) {
+            throw EncodingError.invalidValue(
+                self,
+                EncodingError.Context(
+                    codingPath: encoder.codingPath,
+                    debugDescription: "Unsupported operation aliases a trusted value"
+                )
+            )
+        }
+        var container = encoder.singleValueContainer()
+        try container.encode(persistedValue)
+    }
+}
+
+/// One exact before/after identity pair in a verified change set.
+nonisolated struct AgentHistoryRecordedFileChange: Codable, Equatable, Sendable {
+    let relativePath: String
+    let operation: AgentHistoryFileOperation
+    let before: AgentHistoryRecordedFileState?
+    let after: AgentHistoryRecordedFileState?
+}
+
+/// Storage class for private Agent History authority and inverse-payload data.
+///
+/// The persisted contract intentionally has no arbitrary path case. A future
+/// resolver derives locations from opaque IDs underneath Pine's owner-only
+/// Application Support directory.
+nonisolated enum AgentHistoryPrivateStorage: Equatable, Sendable {
+    case applicationSupport
+    case unsupported(String)
+
+    private var persistedValue: String {
+        switch self {
+        case .applicationSupport: "applicationSupport"
+        case .unsupported(let value): value
+        }
+    }
+}
+
+nonisolated extension AgentHistoryPrivateStorage: Codable {
+    init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        switch value {
+        case "applicationSupport": self = .applicationSupport
+        default: self = .unsupported(value)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        if case .unsupported("applicationSupport") = self {
+            throw EncodingError.invalidValue(
+                self,
+                EncodingError.Context(
+                    codingPath: encoder.codingPath,
+                    debugDescription: "Unsupported storage aliases a trusted value"
+                )
+            )
+        }
+        var container = encoder.singleValueContainer()
+        try container.encode(persistedValue)
+    }
+}
+
+/// Lookup key for the owner-private record that is the actual authorization
+/// source. `.pine/agent-log.json` is only a display/index projection and may be
+/// edited by project contents, so the future engine must load this record,
+/// compare the complete canonical projection, and honor private consumed/
+/// in-flight state before performing any runtime validation.
+nonisolated struct AgentHistoryPrivateAuthorityReference: Codable, Equatable, Sendable {
+    static let currentManifestFormatVersion = 1
+
+    let storage: AgentHistoryPrivateStorage
+    let recordID: UUID
+    let manifestFormatVersion: Int
+    /// SHA-256 of the canonical change-set projection excluding this digest.
+    /// This is an integrity cross-check, not an authentication primitive; the
+    /// owner-private manifest remains the source of authority.
+    let canonicalContractSHA256: String
+}
+
+/// Content-free reference to an inverse payload stored outside the project.
+nonisolated struct AgentHistoryInversePayloadReference: Codable, Equatable, Sendable {
+    static let currentFormatVersion = 1
+
+    let storage: AgentHistoryPrivateStorage
+    let blobID: UUID
+    let formatVersion: Int
+    let byteCount: UInt64
+    let sha256: String
+}
+
+/// Exact, versioned input contract for a future checked inverse operation.
+///
+/// This type deliberately contains no patch bytes or source text. The payload
+/// reference is integrity-bound, and the before/after identities let the
+/// eventual engine reject divergence before applying anything.
+nonisolated struct VerifiedAgentChangeSet: Codable, Equatable, Sendable {
+    static let currentSchemaVersion = 1
+
+    let id: UUID
+    /// Entry identity bound into the owner-private authority manifest.
+    let historyEntryID: UUID
+    let schemaVersion: Int
+    let capturedAt: Date
+    let provenance: AgentHistoryWriterProvenance
+    let workspace: AgentHistoryWorkspaceIdentity
+    let changes: [AgentHistoryRecordedFileChange]
+    let authority: AgentHistoryPrivateAuthorityReference
+    let inversePayload: AgentHistoryInversePayloadReference
+}

--- a/Pine/Agent/AgentHistoryEntry.swift
+++ b/Pine/Agent/AgentHistoryEntry.swift
@@ -21,7 +21,7 @@ import Foundation
 /// undo: a safe inverse also requires an exact before/after change set and a
 /// divergence check, neither of which the current history format stores
 /// (#1183).
-enum AgentHistoryAttribution: String, Codable, Sendable {
+nonisolated enum AgentHistoryAttribution: String, Codable, Sendable {
     /// Pine inferred the paths from process/file-system activity.
     case heuristic
     /// More than one session or writer could have produced the changes.
@@ -41,14 +41,16 @@ enum AgentHistoryAttribution: String, Codable, Sendable {
 }
 
 /// Why an Agent History entry cannot currently be undone safely.
-enum AgentHistoryUndoUnavailableReason: Sendable, Equatable {
+nonisolated enum AgentHistoryUndoUnavailableReason: Sendable, Equatable {
     case heuristicAttribution
     case ambiguousAttribution
     case missingVerifiedReversibleChangeSet
+    case invalidVerifiedReversibleChangeSet
+    case checkedUndoEngineUnavailable
 }
 
 /// Fail-closed decision used by both the UI and the mutation boundary.
-enum AgentHistoryUndoAvailability: Sendable, Equatable {
+nonisolated enum AgentHistoryUndoAvailability: Sendable, Equatable {
     /// Reserved for a future entry format that carries a checked inverse
     /// change set. No entry in the current format returns this case.
     case available
@@ -63,7 +65,7 @@ enum AgentHistoryUndoAvailability: Sendable, Equatable {
 /// never leaks file contents. Decoding is forward-compatible: an unknown
 /// `agentTypeRaw` decodes into a generic entry instead of throwing, because the
 /// log file outlives individual app versions.
-struct AgentHistoryEntry: Codable, Identifiable, Equatable, Sendable {
+nonisolated struct AgentHistoryEntry: Codable, Identifiable, Equatable, Sendable {
     /// Stable identifier for this log entry.
     let id: UUID
     /// Identifier of the `AgentSession` this entry records. Lets the UI and
@@ -82,6 +84,10 @@ struct AgentHistoryEntry: Codable, Identifiable, Equatable, Sendable {
     /// Confidence of the association between this session and `affectedFiles`.
     /// Legacy entries decode as `.heuristic`.
     let attribution: AgentHistoryAttribution
+    /// Content-free, versioned contract from a trusted provenance pipeline.
+    /// Current heuristic recording never supplies one. Patch/content bytes
+    /// live outside the project and are referenced opaquely by this value.
+    let verifiedChangeSet: VerifiedAgentChangeSet?
     /// Human-readable summary, e.g. "5 files, +142/-38 lines".
     let summary: String
     /// Whether the entry's changes have been reverted via `AgentHistoryStore.revert`.
@@ -95,6 +101,7 @@ struct AgentHistoryEntry: Codable, Identifiable, Equatable, Sendable {
         endedAt: Date? = nil,
         affectedFiles: [String],
         attribution: AgentHistoryAttribution = .heuristic,
+        verifiedChangeSet: VerifiedAgentChangeSet? = nil,
         summary: String,
         reverted: Bool = false
     ) {
@@ -105,22 +112,31 @@ struct AgentHistoryEntry: Codable, Identifiable, Equatable, Sendable {
         self.endedAt = endedAt
         self.affectedFiles = affectedFiles
         self.attribution = attribution
+        self.verifiedChangeSet = verifiedChangeSet
         self.summary = summary
         self.reverted = reverted
     }
 
-    /// The current history format has no exact before/after patch or content
-    /// identity. Consequently no entry can authorize a working-tree mutation:
-    /// heuristic/ambiguous attribution is unsafe by definition, and verified
-    /// attribution still lacks a checked reversible change set.
+    /// No current entry can authorize a working-tree mutation. Heuristic and
+    /// ambiguous attribution are unsafe by definition. Verified entries must
+    /// pass the pure change-set preflight, and even structurally complete
+    /// records remain locked until runtime divergence checks and a checked,
+    /// atomic apply engine exist.
     var undoAvailability: AgentHistoryUndoAvailability {
         switch attribution {
         case .heuristic:
-            .unavailable(.heuristicAttribution)
+            return .unavailable(.heuristicAttribution)
         case .ambiguous:
-            .unavailable(.ambiguousAttribution)
+            return .unavailable(.ambiguousAttribution)
         case .verified:
-            .unavailable(.missingVerifiedReversibleChangeSet)
+            switch AgentHistoryUndoPreflight.evaluate(self) {
+            case .readyForPrivateAuthorityValidation:
+                return .unavailable(.checkedUndoEngineUnavailable)
+            case .blocked(.missingChangeSet):
+                return .unavailable(.missingVerifiedReversibleChangeSet)
+            case .blocked:
+                return .unavailable(.invalidVerifiedReversibleChangeSet)
+            }
         }
     }
 
@@ -145,6 +161,12 @@ struct AgentHistoryEntry: Codable, Identifiable, Equatable, Sendable {
             AgentHistoryAttribution.self,
             forKey: .attribution
         )) ?? .heuristic
+        // Missing/invalid future contracts fail closed without making the
+        // entire long-lived history log unreadable.
+        verifiedChangeSet = try? container.decodeIfPresent(
+            VerifiedAgentChangeSet.self,
+            forKey: .verifiedChangeSet
+        )
         summary = try container.decodeIfPresent(String.self, forKey: .summary) ?? ""
         reverted = try container.decodeIfPresent(Bool.self, forKey: .reverted) ?? false
     }

--- a/Pine/Agent/AgentHistoryStore.swift
+++ b/Pine/Agent/AgentHistoryStore.swift
@@ -107,7 +107,8 @@ final class AgentHistoryStore {
             let data = try Data(contentsOf: logURL)
             // Tolerate an empty file (treat as no entries).
             guard !data.isEmpty else { return }
-            entries = try Self.makeDecoder().decode([AgentHistoryEntry].self, from: data)
+            let decoded = try Self.makeDecoder().decode([AgentHistoryEntry].self, from: data)
+            entries = Self.quarantiningDuplicateIdentities(decoded)
             loggedSessionIDs = Set(entries.map(\.sessionID))
         } catch {
             // Corrupt or unreadable log: never crash — start empty and log.
@@ -137,7 +138,6 @@ final class AgentHistoryStore {
     ) {
         // Avoid double-logging a session finalized twice (detection + termination).
         guard !loggedSessionIDs.contains(session.id) else { return }
-        loggedSessionIDs.insert(session.id)
 
         let safePaths = affectedRelativePaths.filter(Self.isValidRelativePath)
         let entry = AgentHistoryEntry(
@@ -157,12 +157,34 @@ final class AgentHistoryStore {
     /// Appends an entry directly (used by tests and restore), trims to
     /// `maxEntries`, and schedules an asynchronous persist.
     func append(_ entry: AgentHistoryEntry) {
+        guard !loggedSessionIDs.contains(entry.sessionID),
+              !entries.contains(where: { $0.id == entry.id }),
+              !hasPrivateIdentityCollision(entry) else {
+            NSLog("AgentHistoryStore: quarantined duplicate history identity")
+            return
+        }
+
+        loggedSessionIDs.insert(entry.sessionID)
         entries.append(entry)
         if entries.count > maxEntries {
             let surplus = entries.count - maxEntries
             entries.removeFirst(surplus)
         }
         persist()
+    }
+
+    /// Rejects duplicate private identities at append time. A private authority
+    /// record and inverse blob are single-use capabilities; sharing either
+    /// across rows would make a row selection ambiguous at the future mutation
+    /// boundary.
+    private func hasPrivateIdentityCollision(_ candidate: AgentHistoryEntry) -> Bool {
+        guard let changeSet = candidate.verifiedChangeSet else { return false }
+        return entries.contains { existing in
+            guard let existingChangeSet = existing.verifiedChangeSet else { return false }
+            return existingChangeSet.id == changeSet.id
+                || existingChangeSet.authority.recordID == changeSet.authority.recordID
+                || existingChangeSet.inversePayload.blobID == changeSet.inversePayload.blobID
+        }
     }
 
     // MARK: - Revert
@@ -190,10 +212,10 @@ final class AgentHistoryStore {
         let reason: AgentHistoryUndoUnavailableReason
         switch entries[index].undoAvailability {
         case .available:
-            // `.available` is reserved for a future exact inverse-change-set
-            // format. Until its checked apply operation exists, even that
-            // state must fail closed instead of falling back to whole-file git.
-            reason = .missingVerifiedReversibleChangeSet
+            // Until the checked apply operation exists, even an accidentally
+            // exposed future state must fail closed instead of falling back to
+            // whole-file git.
+            reason = .checkedUndoEngineUnavailable
         case .unavailable(let unavailableReason):
             reason = unavailableReason
         }
@@ -239,6 +261,50 @@ final class AgentHistoryStore {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
         return encoder
+    }
+
+    // MARK: - Identity quarantine
+
+    /// Removes every row participating in an identity collision. Keeping the
+    /// first row would make project-controlled JSON ordering an authority
+    /// decision; quarantining the complete collision set stays fail-closed.
+    private static func quarantiningDuplicateIdentities(
+        _ decoded: [AgentHistoryEntry]
+    ) -> [AgentHistoryEntry] {
+        let changeSets = decoded.compactMap(\.verifiedChangeSet)
+        let duplicateEntryIDs = duplicateValues(decoded.map(\.id))
+        let duplicateSessionIDs = duplicateValues(decoded.map(\.sessionID))
+        let duplicateChangeSetIDs = duplicateValues(changeSets.map(\.id))
+        let duplicateAuthorityIDs = duplicateValues(changeSets.map(\.authority.recordID))
+        let duplicatePayloadIDs = duplicateValues(changeSets.map(\.inversePayload.blobID))
+
+        let filtered = decoded.filter { entry in
+            guard !duplicateEntryIDs.contains(entry.id),
+                  !duplicateSessionIDs.contains(entry.sessionID) else {
+                return false
+            }
+            guard let changeSet = entry.verifiedChangeSet else { return true }
+            return !duplicateChangeSetIDs.contains(changeSet.id)
+                && !duplicateAuthorityIDs.contains(changeSet.authority.recordID)
+                && !duplicatePayloadIDs.contains(changeSet.inversePayload.blobID)
+        }
+
+        if filtered.count != decoded.count {
+            NSLog(
+                "AgentHistoryStore: quarantined \(decoded.count - filtered.count) "
+                    + "entries with duplicate identities"
+            )
+        }
+        return filtered
+    }
+
+    private static func duplicateValues<Value: Hashable>(_ values: [Value]) -> Set<Value> {
+        var seen: Set<Value> = []
+        var duplicates: Set<Value> = []
+        for value in values where !seen.insert(value).inserted {
+            duplicates.insert(value)
+        }
+        return duplicates
     }
 
     // MARK: - Path safety

--- a/Pine/Agent/AgentHistoryUndoPreflight.swift
+++ b/Pine/Agent/AgentHistoryUndoPreflight.swift
@@ -1,0 +1,237 @@
+//
+//  AgentHistoryUndoPreflight.swift
+//  Pine
+//
+//  Pure, fail-closed validation for the verified Agent History change-set
+//  contract (#1183). This validates the project-log projection only; a future
+//  undo engine must treat the owner-private manifest as authority, resolve the
+//  current workspace, lstat every path, re-hash content/index state, preview
+//  the inverse, and apply atomically.
+//
+
+import Foundation
+
+/// Why a stored entry is not eligible to reach the future checked-undo engine.
+nonisolated enum AgentHistoryUndoPreflightFailure: Equatable, Sendable {
+    case attributionNotVerified(AgentHistoryAttribution)
+    case missingChangeSet
+    case unsupportedSchemaVersion(Int)
+    case invalidChangeSetIdentity
+    case entryIdentityMismatch
+    case sessionMismatch
+    case invalidProvenance
+    case invalidPrivateAuthority
+    case invalidWorkspaceIdentity
+    case invalidInversePayload
+    case emptyChangeSet
+    case affectedFilesMismatch
+    case invalidRelativePath(String)
+    case duplicatePath(String)
+    case unsupportedOperation(String)
+    case invalidFileState(String)
+}
+
+/// Result of validating the immutable, persisted undo contract.
+nonisolated enum AgentHistoryUndoPreflightDecision: Equatable, Sendable {
+    /// The contract is structurally complete. This does not authorize mutation:
+    /// private-authority lookup, runtime divergence checks, and a checked apply
+    /// engine are still required.
+    case readyForPrivateAuthorityValidation
+    case blocked(AgentHistoryUndoPreflightFailure)
+}
+
+/// Structural validation shared by the history model and the future mutation
+/// boundary. It is pure so malformed/legacy/future records can be tested
+/// exhaustively without touching the file system.
+nonisolated enum AgentHistoryUndoPreflight {
+    static func evaluate(_ entry: AgentHistoryEntry) -> AgentHistoryUndoPreflightDecision {
+        guard entry.attribution == .verified else {
+            return .blocked(.attributionNotVerified(entry.attribution))
+        }
+        guard let changeSet = entry.verifiedChangeSet else {
+            return .blocked(.missingChangeSet)
+        }
+        guard changeSet.schemaVersion == VerifiedAgentChangeSet.currentSchemaVersion else {
+            return .blocked(.unsupportedSchemaVersion(changeSet.schemaVersion))
+        }
+        guard changeSet.id != zeroUUID,
+              changeSet.historyEntryID != zeroUUID,
+              changeSet.capturedAt.timeIntervalSinceReferenceDate.isFinite else {
+            return .blocked(.invalidChangeSetIdentity)
+        }
+        guard changeSet.historyEntryID == entry.id else {
+            return .blocked(.entryIdentityMismatch)
+        }
+        guard changeSet.provenance.sessionID == entry.sessionID else {
+            return .blocked(.sessionMismatch)
+        }
+        guard isValid(changeSet.provenance) else {
+            return .blocked(.invalidProvenance)
+        }
+        guard isValid(changeSet.authority) else {
+            return .blocked(.invalidPrivateAuthority)
+        }
+        guard isValid(changeSet.workspace) else {
+            return .blocked(.invalidWorkspaceIdentity)
+        }
+        guard isValid(changeSet.inversePayload) else {
+            return .blocked(.invalidInversePayload)
+        }
+        guard !changeSet.changes.isEmpty else {
+            return .blocked(.emptyChangeSet)
+        }
+
+        let recordedPaths = changeSet.changes.map(\.relativePath)
+        guard recordedPaths == entry.affectedFiles else {
+            return .blocked(.affectedFilesMismatch)
+        }
+
+        var canonicalPathKeys: Set<String> = []
+        for change in changeSet.changes {
+            guard isCanonicalRelativePath(change.relativePath) else {
+                return .blocked(.invalidRelativePath(change.relativePath))
+            }
+
+            let pathKey = conservativePathKey(change.relativePath)
+            guard canonicalPathKeys.insert(pathKey).inserted else {
+                return .blocked(.duplicatePath(change.relativePath))
+            }
+
+            if let failure = validateChange(change) {
+                return .blocked(failure)
+            }
+        }
+
+        return .readyForPrivateAuthorityValidation
+    }
+
+    private static func isValid(_ provenance: AgentHistoryWriterProvenance) -> Bool {
+        provenance.sessionID != zeroUUID
+            && provenance.writerInstanceID != zeroUUID
+            && provenance.processIdentifier > 0
+            && provenance.processGeneration > 0
+            && provenance.firstEventSequence <= provenance.lastEventSequence
+    }
+
+    private static func isValid(_ workspace: AgentHistoryWorkspaceIdentity) -> Bool {
+        workspace.privateWorkspaceID != zeroUUID
+            && isGitObjectID(workspace.headOID)
+            && isCanonicalSHA256(workspace.indexSHA256)
+    }
+
+    private static func isValid(_ authority: AgentHistoryPrivateAuthorityReference) -> Bool {
+        guard case .applicationSupport = authority.storage else { return false }
+        return authority.recordID != zeroUUID
+            && authority.manifestFormatVersion
+                == AgentHistoryPrivateAuthorityReference.currentManifestFormatVersion
+            && isCanonicalSHA256(authority.canonicalContractSHA256)
+    }
+
+    private static func isValid(_ payload: AgentHistoryInversePayloadReference) -> Bool {
+        guard case .applicationSupport = payload.storage else { return false }
+        return payload.formatVersion == AgentHistoryInversePayloadReference.currentFormatVersion
+            && payload.blobID != zeroUUID
+            && payload.byteCount > 0
+            && isCanonicalSHA256(payload.sha256)
+    }
+
+    private static func validateChange(
+        _ change: AgentHistoryRecordedFileChange
+    ) -> AgentHistoryUndoPreflightFailure? {
+        switch change.operation {
+        case .modify:
+            guard let before = change.before,
+                  let after = change.after,
+                  isValid(before),
+                  isValid(after),
+                  before != after else {
+                return .invalidFileState(change.relativePath)
+            }
+        case .create:
+            guard change.before == nil,
+                  let after = change.after,
+                  isValid(after) else {
+                return .invalidFileState(change.relativePath)
+            }
+        case .delete:
+            guard let before = change.before,
+                  isValid(before),
+                  change.after == nil else {
+                return .invalidFileState(change.relativePath)
+            }
+        case .rename, .symlink:
+            return .unsupportedOperation(change.operation.persistedValue)
+        case .unsupported(let value):
+            return .unsupportedOperation(value)
+        }
+        return nil
+    }
+
+    private static func isValid(_ state: AgentHistoryRecordedFileState) -> Bool {
+        guard case .regularFile = state.kind else { return false }
+        return isCanonicalSHA256(state.contentSHA256)
+            && state.permissions <= 0o7777
+    }
+
+    /// Requires an NFC-normalized, unambiguous relative POSIX path and refuses
+    /// Git metadata or Pine's own history log. Runtime validation must still
+    /// resolve beneath a root directory descriptor without following links,
+    /// compare device/inode/link-count identities, and revalidate immediately
+    /// before the atomic apply.
+    private static func isCanonicalRelativePath(_ path: String) -> Bool {
+        let normalizedPath = path.precomposedStringWithCanonicalMapping
+        guard !path.isEmpty,
+              path.utf8.elementsEqual(normalizedPath.utf8),
+              !path.hasPrefix("/"),
+              !path.utf8.contains(0) else {
+            return false
+        }
+
+        let components = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard components.allSatisfy({ component in
+            !component.isEmpty && component != "." && component != ".."
+        }) else {
+            return false
+        }
+
+        let componentKeys = components.map { conservativePathKey(String($0)) }
+        guard !componentKeys.contains(".git") else { return false }
+        guard componentKeys.count >= 2 else { return true }
+        return !(0..<(componentKeys.count - 1)).contains { index in
+            componentKeys[index] == ".pine"
+                && componentKeys[index + 1] == "agent-log.json"
+        }
+    }
+
+    /// Rejects aliases conservatively across case-insensitive and
+    /// normalization-insensitive volumes. Refusing two legitimate paths on a
+    /// case-sensitive volume is safer than applying an inverse to the wrong
+    /// object after a project moves to a different volume.
+    private static func conservativePathKey(_ path: String) -> String {
+        path.precomposedStringWithCanonicalMapping.folding(
+            options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+            locale: Locale(identifier: "en_US_POSIX")
+        )
+    }
+
+    private static func isCanonicalSHA256(_ value: String) -> Bool {
+        isLowercaseHex(value, lengths: [64])
+    }
+
+    private static func isGitObjectID(_ value: String) -> Bool {
+        // Git repositories may use SHA-1 or SHA-256 object formats.
+        isLowercaseHex(value, lengths: [40, 64])
+            && value.utf8.contains(where: { $0 != 48 })
+    }
+
+    private static func isLowercaseHex(_ value: String, lengths: Set<Int>) -> Bool {
+        guard lengths.contains(value.utf8.count) else { return false }
+        return value.utf8.allSatisfy { byte in
+            (48...57).contains(byte) || (97...102).contains(byte)
+        }
+    }
+
+    private static let zeroUUID = UUID(
+        uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    )
+}

--- a/PineTests/AgentHistoryChangeSetTests.swift
+++ b/PineTests/AgentHistoryChangeSetTests.swift
@@ -1,0 +1,213 @@
+//
+//  AgentHistoryChangeSetTests.swift
+//  PineTests
+//
+//  Persistence and privacy tests for the verified undo contract (#1183).
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Agent History Verified Change Set")
+struct AgentHistoryChangeSetTests {
+
+    @Test("A verified change set round-trips through the project log")
+    func roundTrip() throws {
+        let entry = AgentHistoryChangeSetFixtures.entry()
+
+        let data = try AgentHistoryStore.makeEncoder().encode(entry)
+        let decoded = try AgentHistoryStore.makeDecoder().decode(
+            AgentHistoryEntry.self,
+            from: data
+        )
+
+        #expect(decoded == entry)
+        #expect(decoded.verifiedChangeSet == entry.verifiedChangeSet)
+    }
+
+    @Test("The project log stores no patch bytes or machine-specific paths")
+    func projectLogContainsOnlyOpaquePayloadReference() throws {
+        let entry = AgentHistoryChangeSetFixtures.entry()
+        let data = try AgentHistoryStore.makeEncoder().encode(entry)
+        let json = try #require(String(data: data, encoding: .utf8))
+
+        #expect(!json.contains("private source that must not enter git"))
+        #expect(!json.contains("/Users/example/private-project"))
+        #expect(!json.contains("unifiedDiff"))
+        #expect(!json.contains("patchContents"))
+        #expect(json.contains(entry.verifiedChangeSet?.inversePayload.blobID.uuidString ?? "missing"))
+        #expect(json.contains("\"storage\" : \"applicationSupport\""))
+    }
+
+    @Test("Unknown operation and storage values decode without becoming trusted")
+    func unknownValuesDecodeFailClosed() throws {
+        let operation = try JSONDecoder().decode(
+            AgentHistoryFileOperation.self,
+            from: Data("\"futureOperation\"".utf8)
+        )
+        let storage = try JSONDecoder().decode(
+            AgentHistoryPrivateStorage.self,
+            from: Data("\"projectRelativeFile\"".utf8)
+        )
+
+        #expect(operation == .unsupported("futureOperation"))
+        #expect(storage == .unsupported("projectRelativeFile"))
+    }
+
+    @Test("Unsupported enum cases cannot encode aliases of trusted values")
+    func unsupportedAliasesCannotRoundTripAsTrusted() {
+        #expect(throws: (any Error).self) {
+            try JSONEncoder().encode(
+                AgentHistoryFileOperation.unsupported("modify")
+            )
+        }
+        #expect(throws: (any Error).self) {
+            try JSONEncoder().encode(
+                AgentHistoryRecordedFileKind.unsupported("regularFile")
+            )
+        }
+        #expect(throws: (any Error).self) {
+            try JSONEncoder().encode(
+                AgentHistoryPrivateStorage.unsupported("applicationSupport")
+            )
+        }
+    }
+
+    @Test("A malformed optional change set does not make the history log unreadable")
+    func malformedOptionalContractFailsClosed() throws {
+        let data = Data("""
+        {
+          "id": "00000000-0000-0000-0000-000000000301",
+          "sessionID": "00000000-0000-0000-0000-000000000302",
+          "agentTypeRaw": "codex",
+          "startedAt": 1000,
+          "affectedFiles": ["tracked.txt"],
+          "attribution": "verified",
+          "verifiedChangeSet": "malformed",
+          "summary": "1 file"
+        }
+        """.utf8)
+
+        let entry = try JSONDecoder().decode(AgentHistoryEntry.self, from: data)
+
+        #expect(entry.verifiedChangeSet == nil)
+        #expect(entry.undoAvailability == .unavailable(.missingVerifiedReversibleChangeSet))
+    }
+}
+
+enum AgentHistoryChangeSetFixtures {
+    static let digestA = String(repeating: "a", count: 64)
+    static let digestB = String(repeating: "b", count: 64)
+    static let digestC = String(repeating: "c", count: 64)
+    static let digestD = String(repeating: "d", count: 64)
+    static let digestE = String(repeating: "e", count: 64)
+    static let headOID = String(repeating: "1", count: 40)
+
+    static func fileState(
+        digest: String = digestA,
+        byteCount: UInt64 = 12,
+        permissions: UInt16 = 0o644,
+        kind: AgentHistoryRecordedFileKind = .regularFile
+    ) -> AgentHistoryRecordedFileState {
+        AgentHistoryRecordedFileState(
+            kind: kind,
+            contentSHA256: digest,
+            byteCount: byteCount,
+            permissions: permissions
+        )
+    }
+
+    static func modifyChange(path: String = "Sources/App.swift") -> AgentHistoryRecordedFileChange {
+        AgentHistoryRecordedFileChange(
+            relativePath: path,
+            operation: .modify,
+            before: fileState(digest: digestA),
+            after: fileState(digest: digestB, byteCount: 20)
+        )
+    }
+
+    static func changeSet(
+        id: UUID = UUID(),
+        historyEntryID: UUID = UUID(),
+        sessionID: UUID,
+        schemaVersion: Int = VerifiedAgentChangeSet.currentSchemaVersion,
+        provenance: AgentHistoryWriterProvenance? = nil,
+        workspace: AgentHistoryWorkspaceIdentity? = nil,
+        changes: [AgentHistoryRecordedFileChange]? = nil,
+        authority: AgentHistoryPrivateAuthorityReference? = nil,
+        authorityRecordID: UUID = UUID(),
+        inversePayload: AgentHistoryInversePayloadReference? = nil,
+        payloadBlobID: UUID = UUID()
+    ) -> VerifiedAgentChangeSet {
+        VerifiedAgentChangeSet(
+            id: id,
+            historyEntryID: historyEntryID,
+            schemaVersion: schemaVersion,
+            capturedAt: Date(timeIntervalSince1970: 1_000),
+            provenance: provenance ?? AgentHistoryWriterProvenance(
+                sessionID: sessionID,
+                writerInstanceID: UUID(),
+                processIdentifier: 42,
+                processGeneration: 3,
+                firstEventSequence: 10,
+                lastEventSequence: 12
+            ),
+            workspace: workspace ?? AgentHistoryWorkspaceIdentity(
+                privateWorkspaceID: UUID(),
+                headOID: headOID,
+                indexSHA256: digestD
+            ),
+            changes: changes ?? [modifyChange()],
+            authority: authority ?? AgentHistoryPrivateAuthorityReference(
+                storage: .applicationSupport,
+                recordID: authorityRecordID,
+                manifestFormatVersion:
+                    AgentHistoryPrivateAuthorityReference.currentManifestFormatVersion,
+                canonicalContractSHA256: digestC
+            ),
+            inversePayload: inversePayload ?? AgentHistoryInversePayloadReference(
+                storage: .applicationSupport,
+                blobID: payloadBlobID,
+                formatVersion: AgentHistoryInversePayloadReference.currentFormatVersion,
+                byteCount: 256,
+                sha256: digestE
+            )
+        )
+    }
+
+    static func entry(
+        id: UUID = UUID(),
+        attribution: AgentHistoryAttribution = .verified,
+        sessionID: UUID = UUID(),
+        changes: [AgentHistoryRecordedFileChange]? = nil,
+        changeSetID: UUID = UUID(),
+        authorityRecordID: UUID = UUID(),
+        payloadBlobID: UUID = UUID(),
+        changeSetTransform: ((VerifiedAgentChangeSet) -> VerifiedAgentChangeSet)? = nil
+    ) -> AgentHistoryEntry {
+        let entryID = id
+        let resolvedChanges = changes ?? [modifyChange()]
+        let originalChangeSet = changeSet(
+            id: changeSetID,
+            historyEntryID: entryID,
+            sessionID: sessionID,
+            changes: resolvedChanges,
+            authorityRecordID: authorityRecordID,
+            payloadBlobID: payloadBlobID
+        )
+        let resolvedChangeSet = changeSetTransform?(originalChangeSet) ?? originalChangeSet
+        return AgentHistoryEntry(
+            id: entryID,
+            sessionID: sessionID,
+            agentTypeRaw: "codex",
+            startedAt: Date(timeIntervalSince1970: 900),
+            endedAt: Date(timeIntervalSince1970: 1_100),
+            affectedFiles: resolvedChanges.map(\.relativePath),
+            attribution: attribution,
+            verifiedChangeSet: resolvedChangeSet,
+            summary: "\(resolvedChanges.count) files"
+        )
+    }
+}

--- a/PineTests/AgentHistoryStoreTests.swift
+++ b/PineTests/AgentHistoryStoreTests.swift
@@ -227,6 +227,67 @@ struct AgentHistoryStoreTests {
         #expect(reloaded.entries.last?.summary == "entry \(count - 1)")
     }
 
+    // MARK: - Identity quarantine
+
+    @Test("Loading quarantines every row in an identity collision")
+    func loadQuarantinesDuplicateIdentities() throws {
+        let temp = try makeTempProject()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let duplicateEntryID = UUID()
+        let duplicateSessionID = UUID()
+        let duplicateChangeSetID = UUID()
+        let duplicateAuthorityID = UUID()
+        let duplicatePayloadID = UUID()
+        let entries = [
+            AgentHistoryChangeSetFixtures.entry(id: duplicateEntryID),
+            AgentHistoryChangeSetFixtures.entry(id: duplicateEntryID),
+            AgentHistoryChangeSetFixtures.entry(sessionID: duplicateSessionID),
+            AgentHistoryChangeSetFixtures.entry(sessionID: duplicateSessionID),
+            AgentHistoryChangeSetFixtures.entry(changeSetID: duplicateChangeSetID),
+            AgentHistoryChangeSetFixtures.entry(changeSetID: duplicateChangeSetID),
+            AgentHistoryChangeSetFixtures.entry(authorityRecordID: duplicateAuthorityID),
+            AgentHistoryChangeSetFixtures.entry(authorityRecordID: duplicateAuthorityID),
+            AgentHistoryChangeSetFixtures.entry(payloadBlobID: duplicatePayloadID),
+            AgentHistoryChangeSetFixtures.entry(payloadBlobID: duplicatePayloadID),
+        ]
+        let safeEntry = AgentHistoryChangeSetFixtures.entry()
+        let data = try AgentHistoryStore.makeEncoder().encode(entries + [safeEntry])
+        try writeLog(in: temp, contents: data)
+
+        let store = AgentHistoryStore(projectRoot: temp)
+
+        #expect(store.entries == [safeEntry])
+    }
+
+    @Test("Appending rejects entry, session, and private-capability collisions")
+    func appendRejectsDuplicateIdentities() throws {
+        let store = AgentHistoryStore(projectRoot: nil)
+        let first = AgentHistoryChangeSetFixtures.entry()
+        let changeSet = try #require(first.verifiedChangeSet)
+        store.append(first)
+
+        store.append(AgentHistoryChangeSetFixtures.entry(id: first.id))
+        store.append(AgentHistoryChangeSetFixtures.entry(sessionID: first.sessionID))
+        store.append(
+            AgentHistoryChangeSetFixtures.entry(
+                changeSetID: changeSet.id
+            )
+        )
+        store.append(
+            AgentHistoryChangeSetFixtures.entry(
+                authorityRecordID: changeSet.authority.recordID
+            )
+        )
+        store.append(
+            AgentHistoryChangeSetFixtures.entry(
+                payloadBlobID: changeSet.inversePayload.blobID
+            )
+        )
+
+        #expect(store.entries == [first])
+    }
+
     // MARK: - Revert integration (store → GitFileRevert → real git repo)
 
     @Test("store.revert refuses heuristic entries in a real git repo")

--- a/PineTests/AgentHistoryUndoPreflightTests.swift
+++ b/PineTests/AgentHistoryUndoPreflightTests.swift
@@ -1,0 +1,388 @@
+//
+//  AgentHistoryUndoPreflightTests.swift
+//  PineTests
+//
+//  Pure fail-closed validation tests for durable Agent History undo (#1183).
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Agent History Undo Preflight")
+struct AgentHistoryUndoPreflightTests {
+
+    @Test("A complete contract advances only to private-authority validation")
+    func completeContractIsStructurallyReady() {
+        let entry = AgentHistoryChangeSetFixtures.entry()
+
+        #expect(
+            AgentHistoryUndoPreflight.evaluate(entry)
+                == .readyForPrivateAuthorityValidation
+        )
+        #expect(entry.undoAvailability == .unavailable(.checkedUndoEngineUnavailable))
+    }
+
+    @Test("Heuristic and ambiguous attribution cannot borrow a change set")
+    func unverifiedAttributionIsBlocked() {
+        for attribution in [AgentHistoryAttribution.heuristic, .ambiguous] {
+            let entry = AgentHistoryChangeSetFixtures.entry(attribution: attribution)
+            #expect(
+                AgentHistoryUndoPreflight.evaluate(entry)
+                    == .blocked(.attributionNotVerified(attribution))
+            )
+        }
+    }
+
+    @Test("Verified attribution without a change set remains read-only")
+    func missingChangeSetIsBlocked() {
+        let entry = makeEntry(changeSet: nil)
+
+        #expect(AgentHistoryUndoPreflight.evaluate(entry) == .blocked(.missingChangeSet))
+        #expect(entry.undoAvailability == .unavailable(.missingVerifiedReversibleChangeSet))
+    }
+
+    @Test("Unknown schema versions fail closed")
+    func futureSchemaIsBlocked() {
+        let sessionID = UUID()
+        let changeSet = AgentHistoryChangeSetFixtures.changeSet(
+            sessionID: sessionID,
+            schemaVersion: 99
+        )
+        let entry = makeEntry(sessionID: sessionID, changeSet: changeSet)
+
+        #expect(
+            AgentHistoryUndoPreflight.evaluate(entry)
+                == .blocked(.unsupportedSchemaVersion(99))
+        )
+    }
+
+    @Test("The change-set identifier must be nonzero")
+    func invalidChangeSetIdentityIsBlocked() {
+        let sessionID = UUID()
+        let original = AgentHistoryChangeSetFixtures.changeSet(sessionID: sessionID)
+        let changeSet = VerifiedAgentChangeSet(
+            id: UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)),
+            historyEntryID: original.historyEntryID,
+            schemaVersion: original.schemaVersion,
+            capturedAt: original.capturedAt,
+            provenance: original.provenance,
+            workspace: original.workspace,
+            changes: original.changes,
+            authority: original.authority,
+            inversePayload: original.inversePayload
+        )
+        let entry = makeEntry(sessionID: sessionID, changeSet: changeSet)
+
+        #expect(
+            AgentHistoryUndoPreflight.evaluate(entry)
+                == .blocked(.invalidChangeSetIdentity)
+        )
+    }
+
+    @Test("The private authority must bind the exact stored entry")
+    func entryIdentityMismatchIsBlocked() {
+        let sessionID = UUID()
+        let changeSet = AgentHistoryChangeSetFixtures.changeSet(sessionID: sessionID)
+        let entry = makeEntry(
+            entryID: UUID(),
+            sessionID: sessionID,
+            changeSet: changeSet
+        )
+
+        #expect(
+            AgentHistoryUndoPreflight.evaluate(entry)
+                == .blocked(.entryIdentityMismatch)
+        )
+    }
+
+    @Test("The change set must belong to the stored session")
+    func sessionMismatchIsBlocked() {
+        let entry = makeEntry(
+            sessionID: UUID(),
+            changeSet: AgentHistoryChangeSetFixtures.changeSet(sessionID: UUID())
+        )
+
+        #expect(AgentHistoryUndoPreflight.evaluate(entry) == .blocked(.sessionMismatch))
+    }
+
+    @Test("Writer process generation and event cursor must be valid")
+    func invalidProvenanceIsBlocked() {
+        let sessionID = UUID()
+        let changeSet = AgentHistoryChangeSetFixtures.changeSet(
+            sessionID: sessionID,
+            provenance: AgentHistoryWriterProvenance(
+                sessionID: sessionID,
+                writerInstanceID: UUID(),
+                processIdentifier: 0,
+                processGeneration: 0,
+                firstEventSequence: 4,
+                lastEventSequence: 3
+            )
+        )
+        let entry = makeEntry(sessionID: sessionID, changeSet: changeSet)
+
+        #expect(AgentHistoryUndoPreflight.evaluate(entry) == .blocked(.invalidProvenance))
+    }
+
+    @Test("Workspace identity requires an opaque private ID and Git state")
+    func invalidWorkspaceIsBlocked() {
+        let sessionID = UUID()
+        let changeSet = AgentHistoryChangeSetFixtures.changeSet(
+            sessionID: sessionID,
+            workspace: AgentHistoryWorkspaceIdentity(
+                privateWorkspaceID: UUID(
+                    uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+                ),
+                headOID: "not-an-object-id",
+                indexSHA256: AgentHistoryChangeSetFixtures.digestD
+            )
+        )
+        let entry = makeEntry(sessionID: sessionID, changeSet: changeSet)
+
+        #expect(
+            AgentHistoryUndoPreflight.evaluate(entry)
+                == .blocked(.invalidWorkspaceIdentity)
+        )
+    }
+
+    @Test("Project-log data cannot replace the owner-private authority record")
+    func invalidPrivateAuthorityIsBlocked() {
+        let sessionID = UUID()
+        let changeSet = AgentHistoryChangeSetFixtures.changeSet(
+            sessionID: sessionID,
+            authority: AgentHistoryPrivateAuthorityReference(
+                storage: .unsupported("projectLog"),
+                recordID: UUID(),
+                manifestFormatVersion: 99,
+                canonicalContractSHA256: "BAD"
+            )
+        )
+        let entry = makeEntry(sessionID: sessionID, changeSet: changeSet)
+
+        #expect(
+            AgentHistoryUndoPreflight.evaluate(entry)
+                == .blocked(.invalidPrivateAuthority)
+        )
+    }
+
+    @Test("Inverse payload must be owner-private, integrity-bound, and non-empty")
+    func invalidInversePayloadIsBlocked() {
+        let sessionID = UUID()
+        let changeSet = AgentHistoryChangeSetFixtures.changeSet(
+            sessionID: sessionID,
+            inversePayload: AgentHistoryInversePayloadReference(
+                storage: .unsupported("projectFile"),
+                blobID: UUID(),
+                formatVersion: 2,
+                byteCount: 0,
+                sha256: "BAD"
+            )
+        )
+        let entry = makeEntry(sessionID: sessionID, changeSet: changeSet)
+
+        #expect(
+            AgentHistoryUndoPreflight.evaluate(entry)
+                == .blocked(.invalidInversePayload)
+        )
+    }
+
+    @Test("Empty and affected-file-mismatched change sets fail closed")
+    func emptyOrMismatchedChangesAreBlocked() {
+        let sessionID = UUID()
+        let empty = AgentHistoryChangeSetFixtures.changeSet(
+            sessionID: sessionID,
+            changes: []
+        )
+        #expect(
+            AgentHistoryUndoPreflight.evaluate(
+                makeEntry(sessionID: sessionID, affectedFiles: [], changeSet: empty)
+            ) == .blocked(.emptyChangeSet)
+        )
+
+        let nonempty = AgentHistoryChangeSetFixtures.changeSet(sessionID: sessionID)
+        #expect(
+            AgentHistoryUndoPreflight.evaluate(
+                makeEntry(
+                    sessionID: sessionID,
+                    affectedFiles: ["different.swift"],
+                    changeSet: nonempty
+                )
+            ) == .blocked(.affectedFilesMismatch)
+        )
+    }
+
+    @Test("Traversal, absolute, noncanonical, and ambiguous paths fail closed")
+    func unsafePathsAreBlocked() {
+        let invalidPaths = [
+            "../escape.swift",
+            "/absolute.swift",
+            "Sources/./App.swift",
+            "Sources//App.swift",
+            "Cafe\u{301}.swift",
+            "bad\u{0000}name.swift",
+            ".git/config",
+            "nested/.GIT/index",
+            ".pine/agent-log.json",
+            "nested/.PINE/AGENT-LOG.JSON",
+        ]
+
+        for path in invalidPaths {
+            let change = AgentHistoryChangeSetFixtures.modifyChange(path: path)
+            let entry = entryWithChanges([change])
+            #expect(
+                AgentHistoryUndoPreflight.evaluate(entry)
+                    == .blocked(.invalidRelativePath(path))
+            )
+        }
+
+        let aliases = [
+            AgentHistoryChangeSetFixtures.modifyChange(path: "Sources/App.swift"),
+            AgentHistoryChangeSetFixtures.modifyChange(path: "sources/app.swift"),
+        ]
+        let aliasedEntry = entryWithChanges(aliases)
+        #expect(
+            AgentHistoryUndoPreflight.evaluate(aliasedEntry)
+                == .blocked(.duplicatePath("sources/app.swift"))
+        )
+    }
+
+    @Test("Rename, symlink, and unknown operations have explicit refusal")
+    func unsupportedOperationsAreBlocked() {
+        let operations: [AgentHistoryFileOperation] = [
+            .rename,
+            .symlink,
+            .unsupported("futureOperation"),
+        ]
+
+        for operation in operations {
+            let change = AgentHistoryRecordedFileChange(
+                relativePath: "Sources/App.swift",
+                operation: operation,
+                before: AgentHistoryChangeSetFixtures.fileState(),
+                after: AgentHistoryChangeSetFixtures.fileState(
+                    digest: AgentHistoryChangeSetFixtures.digestB
+                )
+            )
+            let entry = entryWithChanges([change])
+            #expect(
+                AgentHistoryUndoPreflight.evaluate(entry)
+                    == .blocked(.unsupportedOperation(operation.persistedValue))
+            )
+        }
+    }
+
+    @Test("Modify, create, and delete require exact before/after shapes")
+    func operationStateShapesAreValidated() {
+        let invalidChanges = [
+            AgentHistoryRecordedFileChange(
+                relativePath: "modify.swift",
+                operation: .modify,
+                before: AgentHistoryChangeSetFixtures.fileState(),
+                after: AgentHistoryChangeSetFixtures.fileState()
+            ),
+            AgentHistoryRecordedFileChange(
+                relativePath: "create.swift",
+                operation: .create,
+                before: AgentHistoryChangeSetFixtures.fileState(),
+                after: AgentHistoryChangeSetFixtures.fileState()
+            ),
+            AgentHistoryRecordedFileChange(
+                relativePath: "delete.swift",
+                operation: .delete,
+                before: AgentHistoryChangeSetFixtures.fileState(),
+                after: AgentHistoryChangeSetFixtures.fileState()
+            ),
+        ]
+
+        for change in invalidChanges {
+            let entry = entryWithChanges([change])
+            #expect(
+                AgentHistoryUndoPreflight.evaluate(entry)
+                    == .blocked(.invalidFileState(change.relativePath))
+            )
+        }
+    }
+
+    @Test("Non-regular file states and noncanonical digests are refused")
+    func invalidFileIdentityIsBlocked() {
+        let invalidStates = [
+            AgentHistoryChangeSetFixtures.fileState(
+                kind: .symbolicLink
+            ),
+            AgentHistoryChangeSetFixtures.fileState(
+                digest: String(repeating: "A", count: 64)
+            ),
+        ]
+
+        for state in invalidStates {
+            let change = AgentHistoryRecordedFileChange(
+                relativePath: "Sources/App.swift",
+                operation: .create,
+                before: nil,
+                after: state
+            )
+            let entry = entryWithChanges([change])
+            #expect(
+                AgentHistoryUndoPreflight.evaluate(entry)
+                    == .blocked(.invalidFileState(change.relativePath))
+            )
+        }
+    }
+
+    @Test("Valid create and delete contracts reach private-authority validation")
+    func supportedOperationShapesAreReady() {
+        let changes = [
+            AgentHistoryRecordedFileChange(
+                relativePath: "created.swift",
+                operation: .create,
+                before: nil,
+                after: AgentHistoryChangeSetFixtures.fileState()
+            ),
+            AgentHistoryRecordedFileChange(
+                relativePath: "deleted.swift",
+                operation: .delete,
+                before: AgentHistoryChangeSetFixtures.fileState(),
+                after: nil
+            ),
+        ]
+
+        #expect(
+            AgentHistoryUndoPreflight.evaluate(entryWithChanges(changes))
+                == .readyForPrivateAuthorityValidation
+        )
+    }
+
+    private func entryWithChanges(
+        _ changes: [AgentHistoryRecordedFileChange]
+    ) -> AgentHistoryEntry {
+        let sessionID = UUID()
+        return makeEntry(
+            sessionID: sessionID,
+            affectedFiles: changes.map(\.relativePath),
+            changeSet: AgentHistoryChangeSetFixtures.changeSet(
+                sessionID: sessionID,
+                changes: changes
+            )
+        )
+    }
+
+    private func makeEntry(
+        entryID: UUID? = nil,
+        sessionID: UUID = UUID(),
+        affectedFiles: [String] = ["Sources/App.swift"],
+        changeSet: VerifiedAgentChangeSet?
+    ) -> AgentHistoryEntry {
+        AgentHistoryEntry(
+            id: entryID ?? changeSet?.historyEntryID ?? UUID(),
+            sessionID: sessionID,
+            agentTypeRaw: "codex",
+            startedAt: Date(timeIntervalSince1970: 900),
+            affectedFiles: affectedFiles,
+            attribution: .verified,
+            verifiedChangeSet: changeSet,
+            summary: "\(affectedFiles.count) files"
+        )
+    }
+}

--- a/PineTests/AgentHistoryUndoSafetyTests.swift
+++ b/PineTests/AgentHistoryUndoSafetyTests.swift
@@ -169,11 +169,64 @@ struct AgentHistoryUndoSafetyTests {
             startedAt: storedEntry.startedAt,
             affectedFiles: storedEntry.affectedFiles,
             attribution: .verified,
+            verifiedChangeSet: AgentHistoryChangeSetFixtures.changeSet(
+                historyEntryID: storedEntry.id,
+                sessionID: storedEntry.sessionID,
+                changes: [
+                    AgentHistoryChangeSetFixtures.modifyChange(path: "tracked.txt"),
+                ]
+            ),
             summary: storedEntry.summary
         )
         let result = await store.revert(entry: callerCopy)
 
         #expect(result.blockedReason == .heuristicAttribution)
+        #expect(try readFromRepo(repo, file: "tracked.txt") == unrelatedWork)
+    }
+
+    @Test("A structurally complete contract stays locked until checked apply exists")
+    func completeContractCannotMutateWorkingTreeYet() async throws {
+        let repo = try makeTempGitRepo()
+        defer { try? FileManager.default.removeItem(at: repo) }
+        try writeToRepo(repo, file: "tracked.txt", contents: "committed\n")
+        try gitInRepo(repo, ["add", "tracked.txt"])
+        try gitInRepo(repo, ["commit", "-m", "initial"])
+        let unrelatedWork = "committed\nnew human edit\n"
+        try writeToRepo(repo, file: "tracked.txt", contents: unrelatedWork)
+
+        let sessionID = UUID()
+        let entryID = UUID()
+        let change = AgentHistoryChangeSetFixtures.modifyChange(path: "tracked.txt")
+        let entry = AgentHistoryEntry(
+            id: entryID,
+            sessionID: sessionID,
+            agentTypeRaw: "codex",
+            startedAt: Date(),
+            affectedFiles: ["tracked.txt"],
+            attribution: .verified,
+            verifiedChangeSet: AgentHistoryChangeSetFixtures.changeSet(
+                historyEntryID: entryID,
+                sessionID: sessionID,
+                changes: [change]
+            ),
+            summary: "1 file"
+        )
+        let store = AgentHistoryStore(projectRoot: repo)
+        store.append(entry)
+        store.flush()
+
+        #expect(
+            AgentHistoryUndoPreflight.evaluate(entry)
+                == .readyForPrivateAuthorityValidation
+        )
+        #expect(entry.undoAvailability == .unavailable(.checkedUndoEngineUnavailable))
+
+        let result = await store.revert(entry: entry)
+
+        #expect(!result.allSucceeded)
+        #expect(result.fileResults.isEmpty)
+        #expect(result.blockedReason == .checkedUndoEngineUnavailable)
+        #expect(store.entries.first?.reverted == false)
         #expect(try readFromRepo(repo, file: "tracked.txt") == unrelatedWork)
     }
 


### PR DESCRIPTION
## Summary

- add a versioned, content-free verified change-set contract for Agent History
- keep inverse payloads and canonical workspace identity in owner-private Application Support storage
- treat `.pine/agent-log.json` as an untrusted projection, never as mutation authority
- validate provenance, Git state, file identities, operations, paths, and capability bindings fail-closed
- quarantine every history row involved in duplicate entry, session, change-set, authority, or payload identities

## Safety boundary

This PR does not add a mutation or undo engine. Heuristic and ambiguous entries remain read-only. Even a structurally complete verified contract only advances to private-authority validation and stays blocked with `checkedUndoEngineUnavailable`.

A future implementation must load and match the owner-private authority manifest, resolve beneath a root directory descriptor without following links, revalidate Git and file identities immediately before apply, preview the inverse, and apply atomically.

## Verification

- 53 focused Agent History tests passed
- strict SwiftLint: 0 violations across all 8 touched files
- post-rebase range-diff is exact against `main`

Refs #1183