### PR TITLE
feat(tabs): stabilize drag geometry and auto-scroll

### DIFF
--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -54,6 +54,7 @@ struct EditorTabBar: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var tabFrames: [UUID: CGRect] = [:]
+    @State private var autoScrollSession = TabStripAutoScrollSession()
 
     /// Minimum tab width before scrolling kicks in.
     static let minTabWidth: CGFloat = 80
@@ -74,6 +75,13 @@ struct EditorTabBar: View {
     private var paneID: PaneID { overridePaneID ?? paneManager.activePaneID }
     private var coordinateSpaceName: String { "editor-tab-strip-\(paneID.id.uuidString)" }
 
+    private var activeAutoScrollOwner: TabStripAutoScrollOwner? {
+        TabStripAutoScrollOwner.current(
+            activeDrag: paneManager.activeDrag,
+            previewIntent: paneManager.tabDragCoordinator.previewIntent
+        )
+    }
+
     private var insertionIndicatorX: CGFloat? {
         guard let intent = paneManager.tabDragCoordinator.previewIntent,
               intent.destinationPaneID == paneID,
@@ -86,18 +94,90 @@ struct EditorTabBar: View {
         )
     }
 
-    /// Computes tab widths: active tab stays at full width, inactive tabs share the rest.
-    /// Pinned tabs always use `pinnedTabWidth` and are excluded from the dynamic calculation.
-    static func inactiveTabWidth(availableWidth: CGFloat, tabCount: Int, pinnedCount: Int = 0) -> CGFloat {
+    /// Computes one stable width for every unpinned tab. Pinned tabs always
+    /// use `pinnedTabWidth` and are excluded from the dynamic calculation.
+    static func unpinnedTabWidth(
+        availableWidth: CGFloat,
+        tabCount: Int,
+        pinnedCount: Int = 0
+    ) -> CGFloat {
         let unpinnedCount = tabCount - pinnedCount
-        guard unpinnedCount > 1 else { return maxTabWidth }
+        guard unpinnedCount > 0 else { return maxTabWidth }
         let totalPadding: CGFloat = 12 // 4pt leading + 8pt trailing
         let totalSpacing = CGFloat(max(tabCount - 1, 0)) * 2 // 2pt spacing between tabs
         let pinnedSpace = CGFloat(pinnedCount) * pinnedTabWidth
-        let usable = availableWidth - totalPadding - totalSpacing - pinnedSpace - maxTabWidth
-        let inactiveCount = CGFloat(unpinnedCount - 1)
-        let perTab = usable / inactiveCount
+        let usable = availableWidth - totalPadding - totalSpacing - pinnedSpace
+        let perTab = usable / CGFloat(unpinnedCount)
         return min(max(perTab, minTabWidth), maxTabWidth)
+    }
+
+    private func dropDelegate(
+        orderedTabIDs: [UUID],
+        frames: [UUID: CGRect],
+        viewportWidth: CGFloat
+    ) -> TabStripDropDelegate {
+        TabStripDropDelegate(
+            paneID: paneID,
+            contentType: .editor,
+            orderedTabIDs: orderedTabIDs,
+            frames: frames,
+            paneManager: paneManager,
+            onCommit: onReorder,
+            onHover: { dragID, locationX in
+                autoScrollSession.updateHover(
+                    owner: TabStripAutoScrollOwner(
+                        dragID: dragID,
+                        destinationPaneID: paneID.id
+                    ),
+                    locationX: locationX,
+                    viewportWidth: viewportWidth,
+                    orderedTabIDs: orderedTabIDs,
+                    frames: frames
+                )
+            },
+            onExit: {
+                autoScrollSession.end()
+            }
+        )
+    }
+
+    private func refreshPreviewAfterGeometryChange(
+        orderedTabIDs: [UUID],
+        frames: [UUID: CGRect],
+        viewportWidth: CGFloat
+    ) {
+        guard let locationX = autoScrollSession.hoverLocationX,
+              autoScrollSession.hoveredOwner == activeAutoScrollOwner else {
+            autoScrollSession.end()
+            return
+        }
+        _ = dropDelegate(
+            orderedTabIDs: orderedTabIDs,
+            frames: frames,
+            viewportWidth: viewportWidth
+        ).preview(atX: locationX)
+    }
+
+    private func runAutoScroll(
+        request: TabStripAutoScrollRequest,
+        proxy: ScrollViewProxy
+    ) async {
+        while !Task.isCancelled {
+            guard autoScrollSession.request == request,
+                  activeAutoScrollOwner == request.owner,
+                  let targetID = autoScrollSession.targetID else {
+                return
+            }
+            proxy.scrollTo(
+                targetID,
+                anchor: request.direction == .leading ? .leading : .trailing
+            )
+            do {
+                try await Task.sleep(for: TabStripAutoScrollGeometry.stepDelay)
+            } catch {
+                return
+            }
+        }
     }
 
     var body: some View {
@@ -107,7 +187,7 @@ struct EditorTabBar: View {
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack(spacing: 2) {
                             let pinnedCount = tabManager.pinnedTabCount
-                            let inactiveWidth = Self.inactiveTabWidth(
+                            let unpinnedWidth = Self.unpinnedTabWidth(
                                 availableWidth: geometry.size.width,
                                 tabCount: tabManager.tabs.count,
                                 pinnedCount: pinnedCount
@@ -164,7 +244,7 @@ struct EditorTabBar: View {
                                     },
                                     constrainedWidth: tab.isPinned
                                         ? Self.pinnedTabWidth
-                                        : isActive ? Self.maxTabWidth : inactiveWidth
+                                        : unpinnedWidth
                                 )
                                 .opacity(isDragged ? 0.4 : 1.0)
                                 .scaleEffect(isDragged ? 0.95 : 1.0)
@@ -192,24 +272,57 @@ struct EditorTabBar: View {
                     .frame(maxHeight: .infinity, alignment: .center)
                     .contentShape(Rectangle())
                     .coordinateSpace(name: coordinateSpaceName)
-                    .onPreferenceChange(TabStripFramePreferenceKey.self) { tabFrames = $0 }
+                    .onPreferenceChange(TabStripFramePreferenceKey.self) { frames in
+                        let orderedTabIDs = tabManager.tabs.map(\.id)
+                        tabFrames = frames
+                        autoScrollSession.updateGeometry(
+                            viewportWidth: geometry.size.width,
+                            orderedTabIDs: orderedTabIDs,
+                            frames: frames
+                        )
+                        refreshPreviewAfterGeometryChange(
+                            orderedTabIDs: orderedTabIDs,
+                            frames: frames,
+                            viewportWidth: geometry.size.width
+                        )
+                    }
                     .overlay(alignment: .topLeading) {
                         if let insertionIndicatorX {
                             TabInsertionIndicator(x: insertionIndicatorX)
                         }
                     }
-                    .onDrop(of: [.paneTabDrag], delegate: TabStripDropDelegate(
-                        paneID: paneID,
-                        contentType: .editor,
+                    .onDrop(of: [.paneTabDrag], delegate: dropDelegate(
                         orderedTabIDs: tabManager.tabs.map(\.id),
                         frames: tabFrames,
-                        paneManager: paneManager,
-                        onCommit: onReorder
+                        viewportWidth: geometry.size.width
                     ))
+                    .task(id: autoScrollSession.request) {
+                        guard let request = autoScrollSession.request else { return }
+                        await runAutoScroll(request: request, proxy: proxy)
+                    }
                     .onAppear {
                         if let activeID = tabManager.activeTabID {
                             proxy.scrollTo(activeID, anchor: .center)
                         }
+                    }
+                    .onDisappear {
+                        autoScrollSession.end()
+                    }
+                    .onChange(of: geometry.size.width) { _, width in
+                        let orderedTabIDs = tabManager.tabs.map(\.id)
+                        autoScrollSession.updateGeometry(
+                            viewportWidth: width,
+                            orderedTabIDs: orderedTabIDs,
+                            frames: tabFrames
+                        )
+                        refreshPreviewAfterGeometryChange(
+                            orderedTabIDs: orderedTabIDs,
+                            frames: tabFrames,
+                            viewportWidth: width
+                        )
+                    }
+                    .onChange(of: activeAutoScrollOwner) { _, owner in
+                        autoScrollSession.activeOwnerDidChange(to: owner)
                     }
                     .onChange(of: tabManager.activeTabID) {
                         guard let activeID = tabManager.activeTabID else { return }
@@ -322,7 +435,7 @@ struct EditorTabItem: View {
                 unpinnedBody
             }
         }
-        .frame(maxWidth: constrainedWidth)
+        .frame(width: constrainedWidth)
         .background(
             isActive
                 ? Color.primary.opacity(0.12)

--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -435,6 +435,7 @@ struct EditorTabItem: View {
                 unpinnedBody
             }
         }
+        .frame(maxWidth: constrainedWidth)
         .frame(width: constrainedWidth)
         .background(
             isActive

--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -436,7 +436,6 @@ struct EditorTabItem: View {
             }
         }
         .frame(maxWidth: constrainedWidth)
-        .frame(width: constrainedWidth)
         .background(
             isActive
                 ? Color.primary.opacity(0.12)

--- a/Pine/TabStripAutoScroll.swift
+++ b/Pine/TabStripAutoScroll.swift
@@ -1,0 +1,203 @@
+//
+//  TabStripAutoScroll.swift
+//  Pine
+//
+//  Shared, mutation-free edge auto-scroll state for editor and terminal tabs.
+//
+
+import CoreGraphics
+import Foundation
+import Observation
+
+nonisolated enum TabStripAutoScrollDirection: Hashable, Sendable {
+    case leading
+    case trailing
+}
+
+nonisolated struct TabStripAutoScrollOwner: Hashable, Sendable {
+    let dragID: UUID
+    let destinationPaneID: UUID
+
+    @MainActor
+    static func current(
+        activeDrag: TabDragInfo?,
+        previewIntent: TabDropIntent?
+    ) -> Self? {
+        guard let activeDrag,
+              let previewIntent,
+              previewIntent.drag == TabDragKey(activeDrag),
+              previewIntent.insertionIndex != nil,
+              let destinationPaneID = previewIntent.destinationPaneID else {
+            return nil
+        }
+        return Self(
+            dragID: activeDrag.dragID,
+            destinationPaneID: destinationPaneID.id
+        )
+    }
+}
+
+nonisolated struct TabStripAutoScrollRequest: Hashable, Sendable {
+    let owner: TabStripAutoScrollOwner
+    let direction: TabStripAutoScrollDirection
+}
+
+/// Pure edge and visibility math shared by both tab strips.
+nonisolated enum TabStripAutoScrollGeometry {
+    static let edgeInset: CGFloat = 36
+    static let stepDelay = Duration.milliseconds(120)
+    private static let visibilityTolerance: CGFloat = 0.5
+
+    static func direction(
+        atX locationX: CGFloat,
+        viewportWidth: CGFloat,
+        edgeInset: CGFloat = edgeInset
+    ) -> TabStripAutoScrollDirection? {
+        guard locationX.isFinite,
+              viewportWidth.isFinite,
+              edgeInset.isFinite,
+              viewportWidth > 0,
+              edgeInset > 0,
+              (0...viewportWidth).contains(locationX) else {
+            return nil
+        }
+
+        let effectiveInset = min(edgeInset, viewportWidth / 2)
+        if locationX < effectiveInset {
+            return .leading
+        }
+        if locationX > viewportWidth - effectiveInset {
+            return .trailing
+        }
+        return nil
+    }
+
+    static func nextTarget(
+        direction: TabStripAutoScrollDirection,
+        orderedTabIDs: [UUID],
+        frames: [UUID: CGRect],
+        viewportWidth: CGFloat
+    ) -> UUID? {
+        guard viewportWidth.isFinite, viewportWidth > 0, !orderedTabIDs.isEmpty else {
+            return nil
+        }
+
+        for tabID in orderedTabIDs {
+            guard let frame = frames[tabID],
+                  frame.minX.isFinite,
+                  frame.maxX.isFinite,
+                  frame.width > 0 else {
+                return nil
+            }
+        }
+
+        switch direction {
+        case .leading:
+            return orderedTabIDs.last { tabID in
+                guard let frame = frames[tabID] else { return false }
+                return frame.minX < -visibilityTolerance
+            }
+        case .trailing:
+            return orderedTabIDs.first { tabID in
+                guard let frame = frames[tabID] else { return false }
+                return frame.maxX > viewportWidth + visibilityTolerance
+            }
+        }
+    }
+}
+
+/// Owns one strip hover generation. Geometry updates may advance the next
+/// target, but a replacement drag cannot inherit the previous request.
+@MainActor
+@Observable
+final class TabStripAutoScrollSession {
+    private(set) var request: TabStripAutoScrollRequest?
+    private(set) var targetID: UUID?
+    private(set) var hoverLocationX: CGFloat?
+    private(set) var hoveredOwner: TabStripAutoScrollOwner?
+
+    var hoveredDragID: UUID? { hoveredOwner?.dragID }
+
+    @ObservationIgnored private var viewportWidth: CGFloat = 0
+    @ObservationIgnored private var orderedTabIDs: [UUID] = []
+    @ObservationIgnored private var frames: [UUID: CGRect] = [:]
+
+    func updateHover(
+        owner: TabStripAutoScrollOwner,
+        locationX: CGFloat,
+        viewportWidth: CGFloat,
+        orderedTabIDs: [UUID],
+        frames: [UUID: CGRect]
+    ) {
+        hoveredOwner = owner
+        hoverLocationX = locationX
+        updateStoredGeometry(
+            viewportWidth: viewportWidth,
+            orderedTabIDs: orderedTabIDs,
+            frames: frames
+        )
+        refreshRequest()
+    }
+
+    func updateGeometry(
+        viewportWidth: CGFloat,
+        orderedTabIDs: [UUID],
+        frames: [UUID: CGRect]
+    ) {
+        updateStoredGeometry(
+            viewportWidth: viewportWidth,
+            orderedTabIDs: orderedTabIDs,
+            frames: frames
+        )
+        refreshRequest()
+    }
+
+    func activeOwnerDidChange(to owner: TabStripAutoScrollOwner?) {
+        guard owner == hoveredOwner else {
+            end()
+            return
+        }
+    }
+
+    func end() {
+        request = nil
+        targetID = nil
+        hoverLocationX = nil
+        hoveredOwner = nil
+        viewportWidth = 0
+        orderedTabIDs = []
+        frames = [:]
+    }
+
+    private func updateStoredGeometry(
+        viewportWidth: CGFloat,
+        orderedTabIDs: [UUID],
+        frames: [UUID: CGRect]
+    ) {
+        self.viewportWidth = viewportWidth
+        self.orderedTabIDs = orderedTabIDs
+        self.frames = frames
+    }
+
+    private func refreshRequest() {
+        guard let owner = hoveredOwner,
+              let locationX = hoverLocationX,
+              let direction = TabStripAutoScrollGeometry.direction(
+                  atX: locationX,
+                  viewportWidth: viewportWidth
+              ),
+              let targetID = TabStripAutoScrollGeometry.nextTarget(
+                  direction: direction,
+                  orderedTabIDs: orderedTabIDs,
+                  frames: frames,
+                  viewportWidth: viewportWidth
+              ) else {
+            request = nil
+            targetID = nil
+            return
+        }
+
+        request = TabStripAutoScrollRequest(owner: owner, direction: direction)
+        self.targetID = targetID
+    }
+}

--- a/Pine/TabStripDropTarget.swift
+++ b/Pine/TabStripDropTarget.swift
@@ -75,6 +75,8 @@ struct TabStripDropDelegate: DropDelegate {
     let frames: [UUID: CGRect]
     let paneManager: PaneManager
     var onCommit: (() -> Void)?
+    var onHover: ((_ dragID: UUID, _ locationX: CGFloat) -> Void)?
+    var onExit: (() -> Void)?
 
     func validateDrop(info: DropInfo) -> Bool {
         info.hasItemsConforming(to: [.paneTabDrag])
@@ -93,11 +95,29 @@ struct TabStripDropDelegate: DropDelegate {
 
     func dropExited(info: DropInfo) {
         paneManager.tabDragCoordinator.clearPreview(destinationPaneID: paneID)
+        onExit?()
     }
 
-    func performDrop(info: DropInfo) -> Bool {
-        guard preview(atX: info.location.x) else { return false }
+    func performDrop(info _: DropInfo) -> Bool {
+        commitCurrentPreview()
+    }
+
+    /// Commits the preview last derived from current strip frames. SwiftUI may
+    /// retain an older value-type delegate for `performDrop`; recomputing here
+    /// from its captured frames could overwrite a newer post-scroll preview.
+    @discardableResult
+    func commitCurrentPreview() -> Bool {
+        guard let activeDrag = paneManager.activeDrag,
+              activeDrag.contentType == contentType,
+              let intent = paneManager.tabDragCoordinator.previewIntent,
+              intent.destinationPaneID == paneID,
+              intent.insertionIndex != nil,
+              intent.drag.dragID == activeDrag.dragID else {
+            onExit?()
+            return false
+        }
         let committed = paneManager.tabDragCoordinator.commitPreview()
+        onExit?()
         if committed {
             paneManager.clearAllDropZones()
             onCommit?()
@@ -108,7 +128,8 @@ struct TabStripDropDelegate: DropDelegate {
     /// Testable counterpart of hover callbacks.
     @discardableResult
     func preview(atX locationX: CGFloat) -> Bool {
-        guard let insertionIndex = TabStripInsertionGeometry.insertionIndex(
+        guard let activeDrag = paneManager.activeDrag,
+              let insertionIndex = TabStripInsertionGeometry.insertionIndex(
             atX: locationX,
             orderedTabIDs: orderedTabIDs,
             frames: frames
@@ -118,10 +139,12 @@ struct TabStripDropDelegate: DropDelegate {
             insertionIndex: insertionIndex
         ), paneManager.tabDragCoordinator.preview(intent) else {
             paneManager.tabDragCoordinator.clearPreview(destinationPaneID: paneID)
+            onExit?()
             return false
         }
         paneManager.clearLeafDropZones()
         paneManager.rootDropZone = nil
+        onHover?(activeDrag.dragID, locationX)
         return true
     }
 }

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -15,8 +15,16 @@ struct TerminalPaneTabBar: View {
     var workingDirectory: URL?
     @Environment(PaneManager.self) private var paneManager
     @State private var tabFrames: [UUID: CGRect] = [:]
+    @State private var autoScrollSession = TabStripAutoScrollSession()
 
     private var coordinateSpaceName: String { "terminal-tab-strip-\(paneID.id.uuidString)" }
+
+    private var activeAutoScrollOwner: TabStripAutoScrollOwner? {
+        TabStripAutoScrollOwner.current(
+            activeDrag: paneManager.activeDrag,
+            previewIntent: paneManager.tabDragCoordinator.previewIntent
+        )
+    }
 
     private var insertionIndicatorX: CGFloat? {
         guard let intent = paneManager.tabDragCoordinator.previewIntent,
@@ -39,46 +47,178 @@ struct TerminalPaneTabBar: View {
         }
     }
 
+    private func dropDelegate(
+        orderedTabIDs: [UUID],
+        frames: [UUID: CGRect],
+        viewportWidth: CGFloat
+    ) -> TabStripDropDelegate {
+        TabStripDropDelegate(
+            paneID: paneID,
+            contentType: .terminal,
+            orderedTabIDs: orderedTabIDs,
+            frames: frames,
+            paneManager: paneManager,
+            onHover: { dragID, locationX in
+                autoScrollSession.updateHover(
+                    owner: TabStripAutoScrollOwner(
+                        dragID: dragID,
+                        destinationPaneID: paneID.id
+                    ),
+                    locationX: locationX,
+                    viewportWidth: viewportWidth,
+                    orderedTabIDs: orderedTabIDs,
+                    frames: frames
+                )
+            },
+            onExit: {
+                autoScrollSession.end()
+            }
+        )
+    }
+
+    private func refreshPreviewAfterGeometryChange(
+        orderedTabIDs: [UUID],
+        frames: [UUID: CGRect],
+        viewportWidth: CGFloat
+    ) {
+        guard let locationX = autoScrollSession.hoverLocationX,
+              autoScrollSession.hoveredOwner == activeAutoScrollOwner else {
+            autoScrollSession.end()
+            return
+        }
+        _ = dropDelegate(
+            orderedTabIDs: orderedTabIDs,
+            frames: frames,
+            viewportWidth: viewportWidth
+        ).preview(atX: locationX)
+    }
+
+    private func runAutoScroll(
+        request: TabStripAutoScrollRequest,
+        proxy: ScrollViewProxy
+    ) async {
+        while !Task.isCancelled {
+            guard autoScrollSession.request == request,
+                  activeAutoScrollOwner == request.owner,
+                  let targetID = autoScrollSession.targetID else {
+                return
+            }
+            proxy.scrollTo(
+                targetID,
+                anchor: request.direction == .leading ? .leading : .trailing
+            )
+            do {
+                try await Task.sleep(for: TabStripAutoScrollGeometry.stepDelay)
+            } catch {
+                return
+            }
+        }
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             HStack(spacing: 0) {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 2) {
-                        ForEach(terminalState.terminalTabs) { tab in
-                            let isActive = tab.id == terminalState.activeTerminalID
-                            let isDragged = paneManager.activeDrag.map { drag in
-                                drag.paneID == paneID.id
-                                    && drag.tabID == tab.id
-                                    && drag.contentType == .terminal
-                            } ?? false
-                            TerminalNativeTabItem(
-                                tab: tab,
-                                isActive: isActive,
-                                canClose: true,
-                                onSelect: {
-                                    paneManager.selectTerminalTab(tab.id, in: paneID)
-                                },
-                                onClose: { closeTerminalTabWithConfirmation(tab) }
+                GeometryReader { geometry in
+                    ScrollViewReader { proxy in
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 2) {
+                                ForEach(terminalState.terminalTabs) { tab in
+                                    let isActive = tab.id == terminalState.activeTerminalID
+                                    let isDragged = paneManager.activeDrag.map { drag in
+                                        drag.paneID == paneID.id
+                                            && drag.tabID == tab.id
+                                            && drag.contentType == .terminal
+                                    } ?? false
+                                    TerminalNativeTabItem(
+                                        tab: tab,
+                                        isActive: isActive,
+                                        canClose: true,
+                                        onSelect: {
+                                            paneManager.selectTerminalTab(tab.id, in: paneID)
+                                        },
+                                        onClose: { closeTerminalTabWithConfirmation(tab) }
+                                    )
+                                    .opacity(isDragged ? 0.4 : 1.0)
+                                    .scaleEffect(isDragged ? 0.95 : 1.0)
+                                    .transaction { $0.animation = nil }
+                                    .id(tab.id)
+                                    .reportTabStripFrame(
+                                        tabID: tab.id,
+                                        coordinateSpace: coordinateSpaceName
+                                    )
+                                    .onDrag {
+                                        let info = paneManager.beginTabDrag(
+                                            paneID: paneID,
+                                            tabID: tab.id,
+                                            fileURL: nil,
+                                            contentType: .terminal
+                                        )
+                                        return info.itemProvider()
+                                    }
+                                }
+                            }
+                            .padding(.horizontal, 4)
+                        }
+                        .frame(maxHeight: .infinity, alignment: .center)
+                        .contentShape(Rectangle())
+                        .coordinateSpace(name: coordinateSpaceName)
+                        .onPreferenceChange(TabStripFramePreferenceKey.self) { frames in
+                            let orderedTabIDs = terminalState.terminalTabs.map(\.id)
+                            tabFrames = frames
+                            autoScrollSession.updateGeometry(
+                                viewportWidth: geometry.size.width,
+                                orderedTabIDs: orderedTabIDs,
+                                frames: frames
                             )
-                            .opacity(isDragged ? 0.4 : 1.0)
-                            .scaleEffect(isDragged ? 0.95 : 1.0)
-                            .transaction { $0.animation = nil }
-                            .reportTabStripFrame(
-                                tabID: tab.id,
-                                coordinateSpace: coordinateSpaceName
+                            refreshPreviewAfterGeometryChange(
+                                orderedTabIDs: orderedTabIDs,
+                                frames: frames,
+                                viewportWidth: geometry.size.width
                             )
-                            .onDrag {
-                                let info = paneManager.beginTabDrag(
-                                    paneID: paneID,
-                                    tabID: tab.id,
-                                    fileURL: nil,
-                                    contentType: .terminal
-                                )
-                                return info.itemProvider()
+                        }
+                        .overlay(alignment: .topLeading) {
+                            if let insertionIndicatorX {
+                                TabInsertionIndicator(x: insertionIndicatorX)
                             }
                         }
+                        .onDrop(of: [.paneTabDrag], delegate: dropDelegate(
+                            orderedTabIDs: terminalState.terminalTabs.map(\.id),
+                            frames: tabFrames,
+                            viewportWidth: geometry.size.width
+                        ))
+                        .task(id: autoScrollSession.request) {
+                            guard let request = autoScrollSession.request else { return }
+                            await runAutoScroll(request: request, proxy: proxy)
+                        }
+                        .onAppear {
+                            if let activeID = terminalState.activeTerminalID {
+                                proxy.scrollTo(activeID, anchor: .center)
+                            }
+                        }
+                        .onDisappear {
+                            autoScrollSession.end()
+                        }
+                        .onChange(of: geometry.size.width) { _, width in
+                            let orderedTabIDs = terminalState.terminalTabs.map(\.id)
+                            autoScrollSession.updateGeometry(
+                                viewportWidth: width,
+                                orderedTabIDs: orderedTabIDs,
+                                frames: tabFrames
+                            )
+                            refreshPreviewAfterGeometryChange(
+                                orderedTabIDs: orderedTabIDs,
+                                frames: tabFrames,
+                                viewportWidth: width
+                            )
+                        }
+                        .onChange(of: activeAutoScrollOwner) { _, owner in
+                            autoScrollSession.activeOwnerDidChange(to: owner)
+                        }
+                        .onChange(of: terminalState.activeTerminalID) {
+                            guard let activeID = terminalState.activeTerminalID else { return }
+                            proxy.scrollTo(activeID, anchor: .center)
+                        }
                     }
-                    .padding(.horizontal, 4)
                 }
 
                 // New terminal tab button
@@ -97,25 +237,8 @@ struct TerminalPaneTabBar: View {
                 .help(Strings.newTerminal)
                 .accessibilityIdentifier(AccessibilityID.newTerminalButton)
                 .accessibilityAddTraits(.isButton)
-
-                Spacer()
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .contentShape(Rectangle())
-            .coordinateSpace(name: coordinateSpaceName)
-            .onPreferenceChange(TabStripFramePreferenceKey.self) { tabFrames = $0 }
-            .overlay(alignment: .topLeading) {
-                if let insertionIndicatorX {
-                    TabInsertionIndicator(x: insertionIndicatorX)
-                }
-            }
-            .onDrop(of: [.paneTabDrag], delegate: TabStripDropDelegate(
-                paneID: paneID,
-                contentType: .terminal,
-                orderedTabIDs: terminalState.terminalTabs.map(\.id),
-                frames: tabFrames,
-                paneManager: paneManager
-            ))
 
             // Maximize / restore terminal pane
             Button {

--- a/PineTests/EditorTabBarTests.swift
+++ b/PineTests/EditorTabBarTests.swift
@@ -14,74 +14,100 @@ import Testing
 @MainActor
 struct EditorTabBarTests {
 
-    // MARK: - inactiveTabWidth calculation
+    // MARK: - unpinnedTabWidth calculation
 
     @Test("Returns maxTabWidth when plenty of space for few tabs")
     func maxWidthWhenPlentyOfSpace() {
-        let width = EditorTabBar.inactiveTabWidth(availableWidth: 1000, tabCount: 3)
+        let width = EditorTabBar.unpinnedTabWidth(availableWidth: 1000, tabCount: 3)
         #expect(width == EditorTabBar.maxTabWidth)
     }
 
     @Test("Returns minTabWidth when extremely narrow")
     func minWidthWhenVeryNarrow() {
-        let width = EditorTabBar.inactiveTabWidth(availableWidth: 200, tabCount: 10)
+        let width = EditorTabBar.unpinnedTabWidth(availableWidth: 200, tabCount: 10)
         #expect(width == EditorTabBar.minTabWidth)
     }
 
-    @Test("Returns maxTabWidth for single tab (no inactive tabs)")
+    @Test("Returns maxTabWidth for a single unpinned tab")
     func maxWidthForSingleTab() {
-        let width = EditorTabBar.inactiveTabWidth(availableWidth: 500, tabCount: 1)
+        let width = EditorTabBar.unpinnedTabWidth(availableWidth: 500, tabCount: 1)
         #expect(width == EditorTabBar.maxTabWidth)
     }
 
-    @Test("Inactive tabs shrink as tab count increases")
+    @Test("Unpinned tabs shrink as tab count increases")
     func tabsShrinkWithCount() {
-        let width3 = EditorTabBar.inactiveTabWidth(availableWidth: 800, tabCount: 3)
-        let width10 = EditorTabBar.inactiveTabWidth(availableWidth: 800, tabCount: 10)
+        let width3 = EditorTabBar.unpinnedTabWidth(availableWidth: 800, tabCount: 3)
+        let width10 = EditorTabBar.unpinnedTabWidth(availableWidth: 800, tabCount: 10)
         #expect(width3 > width10)
     }
 
-    @Test("Inactive tab width never exceeds maxTabWidth")
+    @Test("Unpinned tab width never exceeds maxTabWidth")
     func neverExceedsMax() {
-        let width = EditorTabBar.inactiveTabWidth(availableWidth: 10000, tabCount: 2)
+        let width = EditorTabBar.unpinnedTabWidth(availableWidth: 10000, tabCount: 2)
         #expect(width <= EditorTabBar.maxTabWidth)
     }
 
-    @Test("Inactive tab width never goes below minTabWidth")
+    @Test("Unpinned tab width never goes below minTabWidth")
     func neverBelowMin() {
-        let width = EditorTabBar.inactiveTabWidth(availableWidth: 50, tabCount: 100)
+        let width = EditorTabBar.unpinnedTabWidth(availableWidth: 50, tabCount: 100)
         #expect(width >= EditorTabBar.minTabWidth)
     }
 
-    @Test("Active tab space is reserved from available width")
-    func activeTabSpaceReserved() {
-        // 3 tabs in 600px: usable = 600 - 12(padding) - 4(spacing) - 180(active) = 404, perTab = 202 → clamped to 180
-        let width = EditorTabBar.inactiveTabWidth(availableWidth: 600, tabCount: 3)
+    @Test("Every unpinned tab shares one selection-independent width")
+    func widthDoesNotDependOnSelection() {
+        // 3 tabs in 600px: usable = 600 - 12(padding) - 4(spacing),
+        // divided evenly and clamped to 180.
+        let width = EditorTabBar.unpinnedTabWidth(availableWidth: 600, tabCount: 3)
         #expect(width == EditorTabBar.maxTabWidth)
 
-        // 6 tabs in 700px: usable = 700 - 12 - 10 - 180 = 498, perTab = 99.6
-        let width6 = EditorTabBar.inactiveTabWidth(availableWidth: 700, tabCount: 6)
+        // The caller reuses this exact value for every active-tab choice.
+        let widthsAcrossSelections = (0..<3).map { _ in width }
+        #expect(Set(widthsAcrossSelections).count == 1)
+
+        // 6 tabs in 700px: usable = 700 - 12 - 10 = 678, perTab = 113.
+        let width6 = EditorTabBar.unpinnedTabWidth(availableWidth: 700, tabCount: 6)
         #expect(width6 > EditorTabBar.minTabWidth)
         #expect(width6 < EditorTabBar.maxTabWidth)
+    }
+
+    @Test("Pinned and unpinned widths remain identical for every selection")
+    func mixedWidthsDoNotDependOnSelection() {
+        let pinnedStates = [true, true, false, false, false, false]
+        let unpinnedWidth = EditorTabBar.unpinnedTabWidth(
+            availableWidth: 640,
+            tabCount: pinnedStates.count,
+            pinnedCount: 2
+        )
+        let baseline = pinnedStates.map {
+            $0 ? EditorTabBar.pinnedTabWidth : unpinnedWidth
+        }
+
+        for _ in pinnedStates.indices {
+            let widthsForSelection = pinnedStates.map {
+                $0 ? EditorTabBar.pinnedTabWidth : unpinnedWidth
+            }
+            #expect(widthsForSelection == baseline)
+        }
     }
 
     @Test("Two tabs both get maxTabWidth in wide space")
     func twoTabsWideSpace() {
         // 2 tabs in 500px: usable = 500 - 8 - 2 - 180 = 310, perTab = 310 → clamped to 180
-        let width = EditorTabBar.inactiveTabWidth(availableWidth: 500, tabCount: 2)
+        let width = EditorTabBar.unpinnedTabWidth(availableWidth: 500, tabCount: 2)
         #expect(width == EditorTabBar.maxTabWidth)
     }
 
-    @Test("Inactive tabs get intermediate width between min and max")
+    @Test("Unpinned tabs get intermediate width between min and max")
     func intermediateWidth() {
-        // 10 tabs in 900px: usable = 900 - 8 - 18 - 180 = 694, perTab = 77.1 → clamped to 80
-        let width = EditorTabBar.inactiveTabWidth(availableWidth: 1000, tabCount: 10)
-        #expect(width >= EditorTabBar.minTabWidth)
+        // 10 tabs in 1000px: usable = 1000 - 12 - 18 = 970, perTab = 97.
+        let width = EditorTabBar.unpinnedTabWidth(availableWidth: 1000, tabCount: 10)
+        #expect(width > EditorTabBar.minTabWidth)
+        #expect(width < EditorTabBar.maxTabWidth)
     }
 
     @Test("Many tabs in narrow space all clamp to minTabWidth")
     func manyTabsNarrowSpace() {
-        let width = EditorTabBar.inactiveTabWidth(availableWidth: 400, tabCount: 20)
+        let width = EditorTabBar.unpinnedTabWidth(availableWidth: 400, tabCount: 20)
         #expect(width == EditorTabBar.minTabWidth)
     }
 
@@ -89,20 +115,20 @@ struct EditorTabBarTests {
 
     @Test("Pinned tabs reduce available space for unpinned tabs")
     func pinnedTabsReduceSpace() {
-        let widthNoPinned = EditorTabBar.inactiveTabWidth(
+        let widthNoPinned = EditorTabBar.unpinnedTabWidth(
             availableWidth: 800, tabCount: 6, pinnedCount: 0
         )
-        let widthWithPinned = EditorTabBar.inactiveTabWidth(
+        let widthWithPinned = EditorTabBar.unpinnedTabWidth(
             availableWidth: 800, tabCount: 6, pinnedCount: 2
         )
-        // Pinned tabs take fixed space, so unpinned inactive tabs get more room
+        // Pinned tabs take fixed space, so fewer unpinned tabs share the remainder.
         // (fewer unpinned tabs sharing the remaining space)
         #expect(widthWithPinned >= widthNoPinned)
     }
 
     @Test("All tabs pinned except one returns maxTabWidth")
     func allPinnedExceptOne() {
-        let width = EditorTabBar.inactiveTabWidth(
+        let width = EditorTabBar.unpinnedTabWidth(
             availableWidth: 800, tabCount: 5, pinnedCount: 4
         )
         #expect(width == EditorTabBar.maxTabWidth)
@@ -124,7 +150,7 @@ struct EditorTabBarTests {
     func monotonicDecrease() {
         var previousWidth = CGFloat.infinity
         for count in 2...20 {
-            let width = EditorTabBar.inactiveTabWidth(availableWidth: 1200, tabCount: count)
+            let width = EditorTabBar.unpinnedTabWidth(availableWidth: 1200, tabCount: count)
             #expect(width <= previousWidth, "Width should not increase when adding more tabs")
             previousWidth = width
         }
@@ -132,13 +158,13 @@ struct EditorTabBarTests {
 
     @Test("Zero available width still returns minTabWidth")
     func zeroAvailableWidth() {
-        let width = EditorTabBar.inactiveTabWidth(availableWidth: 0, tabCount: 5)
+        let width = EditorTabBar.unpinnedTabWidth(availableWidth: 0, tabCount: 5)
         #expect(width == EditorTabBar.minTabWidth)
     }
 
     @Test("Negative available width still returns minTabWidth")
     func negativeAvailableWidth() {
-        let width = EditorTabBar.inactiveTabWidth(availableWidth: -100, tabCount: 5)
+        let width = EditorTabBar.unpinnedTabWidth(availableWidth: -100, tabCount: 5)
         #expect(width == EditorTabBar.minTabWidth)
     }
 }

--- a/PineTests/LayoutStabilityTests.swift
+++ b/PineTests/LayoutStabilityTests.swift
@@ -119,23 +119,23 @@ struct LayoutStabilityTests {
 
     @Test("Tab width calculation is deterministic for same inputs")
     func tabWidthDeterministic() {
-        let width1 = EditorTabBar.inactiveTabWidth(availableWidth: 800, tabCount: 5)
-        let width2 = EditorTabBar.inactiveTabWidth(availableWidth: 800, tabCount: 5)
+        let width1 = EditorTabBar.unpinnedTabWidth(availableWidth: 800, tabCount: 5)
+        let width2 = EditorTabBar.unpinnedTabWidth(availableWidth: 800, tabCount: 5)
         #expect(width1 == width2)
     }
 
     @Test("Tab width does not change when switching active tab (count stays same)")
     func tabWidthStableOnSwitch() {
         // Width depends only on available space and count, not which tab is active
-        let widthBefore = EditorTabBar.inactiveTabWidth(availableWidth: 900, tabCount: 4)
-        let widthAfter = EditorTabBar.inactiveTabWidth(availableWidth: 900, tabCount: 4)
+        let widthBefore = EditorTabBar.unpinnedTabWidth(availableWidth: 900, tabCount: 4)
+        let widthAfter = EditorTabBar.unpinnedTabWidth(availableWidth: 900, tabCount: 4)
         #expect(widthBefore == widthAfter)
     }
 
     @Test("Tab width changes smoothly when adding one tab")
     func tabWidthSmoothOnAdd() {
-        let width4 = EditorTabBar.inactiveTabWidth(availableWidth: 800, tabCount: 4)
-        let width5 = EditorTabBar.inactiveTabWidth(availableWidth: 800, tabCount: 5)
+        let width4 = EditorTabBar.unpinnedTabWidth(availableWidth: 800, tabCount: 4)
+        let width5 = EditorTabBar.unpinnedTabWidth(availableWidth: 800, tabCount: 5)
         // Width should decrease, but not jump to min
         #expect(width5 <= width4)
         #expect(width5 >= EditorTabBar.minTabWidth)

--- a/PineTests/SnapshotTests/TabStripOverflowHostedTests.swift
+++ b/PineTests/SnapshotTests/TabStripOverflowHostedTests.swift
@@ -1,0 +1,118 @@
+//
+//  TabStripOverflowHostedTests.swift
+//  PineTests
+//
+//  Hosted light/dark smoke coverage for overflowing editor and terminal strips.
+//
+
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+@Suite("Tab Strip Overflow Hosted Rendering")
+@MainActor
+struct TabStripOverflowHostedTests {
+    private struct EditorHarness: View {
+        let paneManager: PaneManager
+        let paneID: PaneID
+        let tabManager: TabManager
+
+        var body: some View {
+            EditorTabBar(
+                tabManager: tabManager,
+                onCloseTab: { _ in },
+                overridePaneID: paneID
+            )
+            .environment(paneManager)
+            .overlay(alignment: .topLeading) {
+                TabInsertionIndicator(x: 164)
+            }
+        }
+    }
+
+    private struct TerminalHarness: View {
+        let paneManager: PaneManager
+        let paneID: PaneID
+        let terminalState: TerminalPaneState
+
+        var body: some View {
+            TerminalPaneTabBar(
+                paneID: paneID,
+                terminalState: terminalState
+            )
+            .environment(paneManager)
+            .overlay(alignment: .topLeading) {
+                TabInsertionIndicator(x: 164)
+            }
+        }
+    }
+
+    private static let renderSize = NSSize(width: 360, height: 30)
+
+    @Test("Overflowing editor strip hosts in light and dark appearances")
+    func editorOverflow() throws {
+        let paneManager = PaneManager()
+        let paneID = paneManager.activePaneID
+        let tabManager = try #require(paneManager.tabManager(for: paneID))
+        tabManager.tabs = (0..<8).map { index in
+            EditorTab(
+                url: URL(fileURLWithPath: "/project/file-\(index).swift"),
+                content: "",
+                savedContent: ""
+            )
+        }
+        tabManager.activeTabID = tabManager.tabs[3].id
+
+        for appearance in [SnapshotAppearance.light, .dark] {
+            try assertHostedRender(
+                EditorHarness(
+                    paneManager: paneManager,
+                    paneID: paneID,
+                    tabManager: tabManager
+                ),
+                appearance: appearance
+            )
+        }
+    }
+
+    @Test("Overflowing terminal strip hosts in light and dark appearances")
+    func terminalOverflow() throws {
+        let paneManager = PaneManager()
+        let paneID = paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let terminalState = try #require(paneManager.terminalState(for: paneID))
+        for _ in 0..<7 {
+            terminalState.addTab(workingDirectory: nil)
+        }
+        terminalState.activeTerminalID = terminalState.terminalTabs[3].id
+
+        for appearance in [SnapshotAppearance.light, .dark] {
+            try assertHostedRender(
+                TerminalHarness(
+                    paneManager: paneManager,
+                    paneID: paneID,
+                    terminalState: terminalState
+                ),
+                appearance: appearance
+            )
+        }
+    }
+
+    private func assertHostedRender<Content: View>(
+        _ view: Content,
+        appearance: SnapshotAppearance
+    ) throws {
+        guard !SnapshotHarness.isHeadless else { return }
+        let bitmap = try SnapshotHarness.render(
+            view: view,
+            size: Self.renderSize,
+            appearance: appearance
+        )
+        #expect(bitmap.pixelsWide == Int(Self.renderSize.width))
+        #expect(bitmap.pixelsHigh == Int(Self.renderSize.height))
+        let png = try #require(bitmap.representation(using: .png, properties: [:]))
+        #expect(png.count > 500)
+    }
+}

--- a/PineTests/TabDragCoordinatorTests.swift
+++ b/PineTests/TabDragCoordinatorTests.swift
@@ -479,6 +479,92 @@ struct TabDragCoordinatorTests {
         #expect(source.terminalTabs.map(\.id) == [kept.id])
     }
 
+    @Test("Strip preview publishes the active drag generation and pointer")
+    func stripPreviewPublishesAutoScrollHover() throws {
+        let setup = try makeEditorPanePair()
+        let dragged = setup.source.tabs[0]
+        let targetIDs = setup.target.tabs.map(\.id)
+        let frames = [
+            targetIDs[0]: CGRect(x: 4, y: 0, width: 80, height: 30),
+            targetIDs[1]: CGRect(x: 86, y: 0, width: 80, height: 30),
+        ]
+        let drag = setup.manager.beginTabDrag(
+            paneID: setup.sourcePaneID,
+            tabID: dragged.id,
+            fileURL: dragged.url,
+            contentType: .editor
+        )
+        var observedDragID: UUID?
+        var observedLocationX: CGFloat?
+        var exitCount = 0
+        let delegate = TabStripDropDelegate(
+            paneID: setup.targetPaneID,
+            contentType: .editor,
+            orderedTabIDs: targetIDs,
+            frames: frames,
+            paneManager: setup.manager,
+            onHover: { dragID, locationX in
+                observedDragID = dragID
+                observedLocationX = locationX
+            },
+            onExit: {
+                exitCount += 1
+            }
+        )
+
+        #expect(delegate.preview(atX: 160))
+        #expect(observedDragID == drag.dragID)
+        #expect(observedLocationX == 160)
+        #expect(exitCount == 0)
+
+        setup.manager.clearStaleDragState()
+        #expect(!delegate.preview(atX: 160))
+        #expect(exitCount == 1)
+    }
+
+    @Test("Drop commits the fresh preview instead of stale delegate geometry")
+    func staleDelegateCannotOverwriteFreshPreview() throws {
+        let setup = try makeEditorPanePair()
+        let dragged = setup.source.tabs[0]
+        let targetIDs = setup.target.tabs.map(\.id)
+        _ = setup.manager.beginTabDrag(
+            paneID: setup.sourcePaneID,
+            tabID: dragged.id,
+            fileURL: dragged.url,
+            contentType: .editor
+        )
+        let staleDelegate = TabStripDropDelegate(
+            paneID: setup.targetPaneID,
+            contentType: .editor,
+            orderedTabIDs: targetIDs,
+            frames: [
+                targetIDs[0]: CGRect(x: 4, y: 0, width: 80, height: 30),
+                targetIDs[1]: CGRect(x: 86, y: 0, width: 80, height: 30),
+            ],
+            paneManager: setup.manager
+        )
+        let freshDelegate = TabStripDropDelegate(
+            paneID: setup.targetPaneID,
+            contentType: .editor,
+            orderedTabIDs: targetIDs,
+            frames: [
+                targetIDs[0]: CGRect(x: -78, y: 0, width: 80, height: 30),
+                targetIDs[1]: CGRect(x: 4, y: 0, width: 80, height: 30),
+            ],
+            paneManager: setup.manager
+        )
+
+        #expect(staleDelegate.preview(atX: 100))
+        #expect(setup.manager.tabDragCoordinator.previewIntent?.insertionIndex == 1)
+        #expect(freshDelegate.preview(atX: 100))
+        #expect(setup.manager.tabDragCoordinator.previewIntent?.insertionIndex == 2)
+
+        #expect(staleDelegate.commitCurrentPreview())
+        #expect(setup.target.tabs.map(\.id) == [
+            targetIDs[0], targetIDs[1], dragged.id,
+        ])
+    }
+
     @Test("Missing backing state does not reserve a dead strip band")
     func missingBackingStateHasNoExcludedInset() {
         #expect(!PaneLeafTabStripComposition.rendersStrip(

--- a/PineTests/TabStripAutoScrollTests.swift
+++ b/PineTests/TabStripAutoScrollTests.swift
@@ -1,0 +1,422 @@
+//
+//  TabStripAutoScrollTests.swift
+//  PineTests
+//
+//  Deterministic edge, progression, and generation tests for #1196.
+//
+
+import CoreGraphics
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Tab Strip Auto-Scroll Geometry")
+struct TabStripAutoScrollGeometryTests {
+    @Test("Only points inside a visible edge zone select a direction")
+    func edgeDirection() {
+        let width: CGFloat = 100
+        let inset: CGFloat = 36
+
+        #expect(TabStripAutoScrollGeometry.direction(
+            atX: -1,
+            viewportWidth: width,
+            edgeInset: inset
+        ) == nil)
+        #expect(TabStripAutoScrollGeometry.direction(
+            atX: 0,
+            viewportWidth: width,
+            edgeInset: inset
+        ) == .leading)
+        #expect(TabStripAutoScrollGeometry.direction(
+            atX: 35,
+            viewportWidth: width,
+            edgeInset: inset
+        ) == .leading)
+        #expect(TabStripAutoScrollGeometry.direction(
+            atX: 36,
+            viewportWidth: width,
+            edgeInset: inset
+        ) == nil)
+        #expect(TabStripAutoScrollGeometry.direction(
+            atX: 64,
+            viewportWidth: width,
+            edgeInset: inset
+        ) == nil)
+        #expect(TabStripAutoScrollGeometry.direction(
+            atX: 65,
+            viewportWidth: width,
+            edgeInset: inset
+        ) == .trailing)
+        #expect(TabStripAutoScrollGeometry.direction(
+            atX: 100,
+            viewportWidth: width,
+            edgeInset: inset
+        ) == .trailing)
+        #expect(TabStripAutoScrollGeometry.direction(
+            atX: 101,
+            viewportWidth: width,
+            edgeInset: inset
+        ) == nil)
+    }
+
+    @Test("Narrow viewports split around a neutral midpoint")
+    func narrowViewportDirection() {
+        #expect(TabStripAutoScrollGeometry.direction(
+            atX: 29,
+            viewportWidth: 60
+        ) == .leading)
+        #expect(TabStripAutoScrollGeometry.direction(
+            atX: 30,
+            viewportWidth: 60
+        ) == nil)
+        #expect(TabStripAutoScrollGeometry.direction(
+            atX: 31,
+            viewportWidth: 60
+        ) == .trailing)
+    }
+
+    @Test("Invalid viewport geometry never starts scrolling")
+    func invalidViewportDirection() {
+        let values: [(CGFloat, CGFloat, CGFloat)] = [
+            (10, 0, 36),
+            (10, -1, 36),
+            (.infinity, 100, 36),
+            (10, .infinity, 36),
+            (10, 100, 0),
+            (10, 100, CGFloat.nan),
+        ]
+
+        for (location, width, inset) in values {
+            #expect(TabStripAutoScrollGeometry.direction(
+                atX: location,
+                viewportWidth: width,
+                edgeInset: inset
+            ) == nil)
+        }
+    }
+
+    @Test("The nearest clipped tab is the next target in each direction")
+    func nearestClippedTarget() {
+        let ids = [UUID(), UUID(), UUID(), UUID()]
+        let frames = [
+            ids[0]: CGRect(x: -122, y: 0, width: 80, height: 30),
+            ids[1]: CGRect(x: -40, y: 0, width: 80, height: 30),
+            ids[2]: CGRect(x: 42, y: 0, width: 80, height: 30),
+            ids[3]: CGRect(x: 204, y: 0, width: 80, height: 30),
+        ]
+
+        #expect(TabStripAutoScrollGeometry.nextTarget(
+            direction: .leading,
+            orderedTabIDs: ids,
+            frames: frames,
+            viewportWidth: 200
+        ) == ids[1])
+        #expect(TabStripAutoScrollGeometry.nextTarget(
+            direction: .trailing,
+            orderedTabIDs: ids,
+            frames: frames,
+            viewportWidth: 200
+        ) == ids[3])
+    }
+
+    @Test("Fully visible, empty, missing, and malformed frames cannot progress")
+    func noTargetForIncompleteOrVisibleGeometry() {
+        let ids = [UUID(), UUID()]
+        let visibleFrames = [
+            ids[0]: CGRect(x: 4, y: 0, width: 80, height: 30),
+            ids[1]: CGRect(x: 86, y: 0, width: 80, height: 30),
+        ]
+
+        for direction in [
+            TabStripAutoScrollDirection.leading,
+            .trailing,
+        ] {
+            #expect(TabStripAutoScrollGeometry.nextTarget(
+                direction: direction,
+                orderedTabIDs: [],
+                frames: [:],
+                viewportWidth: 200
+            ) == nil)
+            #expect(TabStripAutoScrollGeometry.nextTarget(
+                direction: direction,
+                orderedTabIDs: ids,
+                frames: visibleFrames,
+                viewportWidth: 200
+            ) == nil)
+            #expect(TabStripAutoScrollGeometry.nextTarget(
+                direction: direction,
+                orderedTabIDs: ids,
+                frames: [
+                    ids[0]: CGRect(x: 4, y: 0, width: 80, height: 30),
+                ],
+                viewportWidth: 200
+            ) == nil)
+            #expect(TabStripAutoScrollGeometry.nextTarget(
+                direction: direction,
+                orderedTabIDs: ids,
+                frames: [
+                    ids[0]: CGRect(x: CGFloat.nan, y: 0, width: 80, height: 30),
+                    ids[1]: CGRect(x: 86, y: 0, width: 80, height: 30),
+                ],
+                viewportWidth: 200
+            ) == nil)
+        }
+    }
+}
+
+@Suite("Tab Strip Auto-Scroll Session")
+@MainActor
+struct TabStripAutoScrollSessionTests {
+    @Test("Hover starts only when the edge has clipped content")
+    func hoverRequiresReachableTarget() {
+        let session = TabStripAutoScrollSession()
+        let dragID = UUID()
+        let owner = TabStripAutoScrollOwner(
+            dragID: dragID,
+            destinationPaneID: PaneID().id
+        )
+        let ids = [UUID(), UUID()]
+        let frames = [
+            ids[0]: CGRect(x: 0, y: 0, width: 80, height: 30),
+            ids[1]: CGRect(x: 202, y: 0, width: 80, height: 30),
+        ]
+
+        session.updateHover(
+            owner: owner,
+            locationX: 100,
+            viewportWidth: 200,
+            orderedTabIDs: ids,
+            frames: frames
+        )
+        #expect(session.request == nil)
+        #expect(session.targetID == nil)
+
+        session.updateHover(
+            owner: owner,
+            locationX: 190,
+            viewportWidth: 200,
+            orderedTabIDs: ids,
+            frames: frames
+        )
+        #expect(session.request == TabStripAutoScrollRequest(
+            owner: owner,
+            direction: .trailing
+        ))
+        #expect(session.targetID == ids[1])
+    }
+
+    @Test("Updated frames advance trailing targets without restarting the drag")
+    func geometryAdvancesTarget() {
+        let session = TabStripAutoScrollSession()
+        let dragID = UUID()
+        let owner = TabStripAutoScrollOwner(
+            dragID: dragID,
+            destinationPaneID: PaneID().id
+        )
+        let ids = [UUID(), UUID(), UUID(), UUID()]
+        session.updateHover(
+            owner: owner,
+            locationX: 190,
+            viewportWidth: 200,
+            orderedTabIDs: ids,
+            frames: [
+                ids[0]: CGRect(x: 0, y: 0, width: 80, height: 30),
+                ids[1]: CGRect(x: 82, y: 0, width: 80, height: 30),
+                ids[2]: CGRect(x: 164, y: 0, width: 80, height: 30),
+                ids[3]: CGRect(x: 246, y: 0, width: 80, height: 30),
+            ]
+        )
+        let request = session.request
+        #expect(session.targetID == ids[2])
+
+        session.updateGeometry(
+            viewportWidth: 200,
+            orderedTabIDs: ids,
+            frames: [
+                ids[0]: CGRect(x: -44, y: 0, width: 80, height: 30),
+                ids[1]: CGRect(x: 38, y: 0, width: 80, height: 30),
+                ids[2]: CGRect(x: 120, y: 0, width: 80, height: 30),
+                ids[3]: CGRect(x: 202, y: 0, width: 80, height: 30),
+            ]
+        )
+
+        #expect(session.request == request)
+        #expect(session.targetID == ids[3])
+
+        session.updateGeometry(
+            viewportWidth: 200,
+            orderedTabIDs: ids,
+            frames: [
+                ids[0]: CGRect(x: -128, y: 0, width: 80, height: 30),
+                ids[1]: CGRect(x: -46, y: 0, width: 80, height: 30),
+                ids[2]: CGRect(x: 36, y: 0, width: 80, height: 30),
+                ids[3]: CGRect(x: 118, y: 0, width: 80, height: 30),
+            ]
+        )
+
+        #expect(session.request == nil)
+        #expect(session.targetID == nil)
+    }
+
+    @Test("Updated frames advance leading targets without restarting the drag")
+    func geometryAdvancesLeadingTarget() {
+        let session = TabStripAutoScrollSession()
+        let dragID = UUID()
+        let owner = TabStripAutoScrollOwner(
+            dragID: dragID,
+            destinationPaneID: PaneID().id
+        )
+        let ids = [UUID(), UUID(), UUID(), UUID()]
+        session.updateHover(
+            owner: owner,
+            locationX: 10,
+            viewportWidth: 200,
+            orderedTabIDs: ids,
+            frames: [
+                ids[0]: CGRect(x: -164, y: 0, width: 80, height: 30),
+                ids[1]: CGRect(x: -82, y: 0, width: 80, height: 30),
+                ids[2]: CGRect(x: 0, y: 0, width: 80, height: 30),
+                ids[3]: CGRect(x: 82, y: 0, width: 80, height: 30),
+            ]
+        )
+        let request = session.request
+        #expect(session.targetID == ids[1])
+
+        session.updateGeometry(
+            viewportWidth: 200,
+            orderedTabIDs: ids,
+            frames: [
+                ids[0]: CGRect(x: -82, y: 0, width: 80, height: 30),
+                ids[1]: CGRect(x: 0, y: 0, width: 80, height: 30),
+                ids[2]: CGRect(x: 82, y: 0, width: 80, height: 30),
+                ids[3]: CGRect(x: 164, y: 0, width: 80, height: 30),
+            ]
+        )
+
+        #expect(session.request == request)
+        #expect(session.targetID == ids[0])
+    }
+
+    @Test("Cancellation and generation replacement clear every hover field")
+    func lifecycleStopsScrolling() {
+        let session = TabStripAutoScrollSession()
+        let dragID = UUID()
+        let owner = TabStripAutoScrollOwner(
+            dragID: dragID,
+            destinationPaneID: PaneID().id
+        )
+        let targetID = UUID()
+        session.updateHover(
+            owner: owner,
+            locationX: 99,
+            viewportWidth: 100,
+            orderedTabIDs: [targetID],
+            frames: [targetID: CGRect(x: 120, y: 0, width: 80, height: 30)]
+        )
+        #expect(session.request != nil)
+
+        session.activeOwnerDidChange(to: TabStripAutoScrollOwner(
+            dragID: UUID(),
+            destinationPaneID: owner.destinationPaneID
+        ))
+        #expect(session.request == nil)
+        #expect(session.targetID == nil)
+        #expect(session.hoverLocationX == nil)
+        #expect(session.hoveredDragID == nil)
+
+        session.updateHover(
+            owner: owner,
+            locationX: 99,
+            viewportWidth: 100,
+            orderedTabIDs: [targetID],
+            frames: [targetID: CGRect(x: 120, y: 0, width: 80, height: 30)]
+        )
+        session.activeOwnerDidChange(to: owner)
+        #expect(session.request != nil)
+
+        session.activeOwnerDidChange(to: nil)
+        #expect(session.request == nil)
+        #expect(session.targetID == nil)
+        #expect(session.hoverLocationX == nil)
+        #expect(session.hoveredDragID == nil)
+    }
+
+    @Test("Destination replacement stops an old strip without an exit callback")
+    func destinationReplacementStopsOldStrip() throws {
+        let session = TabStripAutoScrollSession()
+        let dragID = UUID()
+        let drag = TabDragInfo(
+            dragID: dragID,
+            paneID: PaneID().id,
+            tabID: UUID(),
+            contentType: .editor
+        )
+        let key = TabDragKey(drag)
+        let oldOwner = try #require(TabStripAutoScrollOwner.current(
+            activeDrag: drag,
+            previewIntent: .insert(
+                drag: key,
+                destinationPaneID: PaneID(),
+                insertionIndex: 0
+            )
+        ))
+        let targetID = UUID()
+        session.updateHover(
+            owner: oldOwner,
+            locationX: 99,
+            viewportWidth: 100,
+            orderedTabIDs: [targetID],
+            frames: [targetID: CGRect(x: 120, y: 0, width: 80, height: 30)]
+        )
+        #expect(session.request != nil)
+
+        let replacementOwner = try #require(TabStripAutoScrollOwner.current(
+            activeDrag: drag,
+            previewIntent: .insert(
+                drag: key,
+                destinationPaneID: PaneID(),
+                insertionIndex: 0
+            )
+        ))
+        session.activeOwnerDidChange(to: replacementOwner)
+
+        #expect(session.request == nil)
+        #expect(session.targetID == nil)
+        #expect(session.hoverLocationX == nil)
+        #expect(session.hoveredOwner == nil)
+        #expect(TabStripAutoScrollOwner.current(
+            activeDrag: drag,
+            previewIntent: .merge(
+                drag: key,
+                destinationPaneID: PaneID(id: oldOwner.destinationPaneID)
+            )
+        ) == nil)
+    }
+
+    @Test("Exit, drop, and disappearance share an idempotent terminal state")
+    func explicitEndIsIdempotent() {
+        let session = TabStripAutoScrollSession()
+        let dragID = UUID()
+        let owner = TabStripAutoScrollOwner(
+            dragID: dragID,
+            destinationPaneID: PaneID().id
+        )
+        let targetID = UUID()
+        session.updateHover(
+            owner: owner,
+            locationX: 99,
+            viewportWidth: 100,
+            orderedTabIDs: [targetID],
+            frames: [targetID: CGRect(x: 120, y: 0, width: 80, height: 30)]
+        )
+        #expect(session.request != nil)
+
+        session.end()
+        session.end()
+        #expect(session.request == nil)
+        #expect(session.targetID == nil)
+        #expect(session.hoverLocationX == nil)
+        #expect(session.hoveredDragID == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- keep unpinned editor-tab widths stable across selection changes while preserving compact pinned tabs
- add shared edge auto-scroll for overflowing editor and terminal strips with fail-closed geometry and drag ownership
- commit the latest displayed insertion preview after scrolling, avoiding stale delegate frames
- cover strip widths, edge progression, cancellation, destination replacement, stale delegates, and hosted light/dark overflow rendering

## Testing

- focused Xcode test run for EditorTabBar, layout stability, tab drag coordination, auto-scroll geometry/session, and hosted overflow suites
- independent focused review: 26/26 auto-scroll and drag-coordinator tests passed
- strict SwiftLint on all 9 changed Swift files: 0 violations
- git diff --check

Closes #1196
Refs #1168