### PR TITLE
feat(tabs): transient preview tabs and MRU switcher

### DIFF
--- a/Pine/EditorTab.swift
+++ b/Pine/EditorTab.swift
@@ -83,6 +83,15 @@ struct EditorTab: Identifiable, Hashable {
     /// Whether this tab is pinned (always visible at the left, protected from close).
     var isPinned: Bool = false
 
+    /// Whether this tab is a transient preview opened via single-click navigation.
+    /// A transient preview is replaced (not stacked) when another file is opened
+    /// as a preview in the same pane. It is promoted to a permanent tab on
+    /// edit, pin, explicit open, or move.
+    ///
+    /// Unrelated to `kind == .preview` (Quick Look binary preview), which is a
+    /// permanent read-only representation of non-text files.
+    var isTransientPreview: Bool = false
+
     /// Cached syntax highlight matches — applied synchronously on tab switch
     /// to eliminate the flash of unhighlighted text.
     /// Not included in Hashable/Equatable (which use id only).

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -48,6 +48,130 @@ final class PaneManager {
     /// The currently focused pane.
     var activePaneID: PaneID
 
+    /// Global most-recently-used tab switch order across ALL panes. This is
+    /// independent of each pane's local active-tab selection
+    /// (`TabManager.activeTabID` / `TerminalPaneState.activeTerminalID`). It
+    /// powers the all-pane tab switcher (Ctrl+Tab / Ctrl+Shift+Tab).
+    ///
+    /// The most recently activated tab is at index 0. Closed or stale
+    /// identities are filtered out lazily at switch time via
+    /// ``validGlobalTabSwitchOrder()``.
+    private(set) var globalTabSwitchOrder: [GlobalTabIdentity] = []
+
+    /// Records a tab activation in the global MRU switch order. Called by
+    /// every path that activates an editor or terminal tab: selection, open,
+    /// transfer, and split. Move-to-front with dedup so each identity appears
+    /// at most once and the newest activation is always first.
+    func recordTabActivation(
+        paneID: PaneID,
+        tabID: UUID,
+        contentType: PaneContent
+    ) {
+        let identity = GlobalTabIdentity(paneID: paneID, tabID: tabID, contentType: contentType)
+        globalTabSwitchOrder.removeAll { $0 == identity }
+        globalTabSwitchOrder.insert(identity, at: 0)
+    }
+
+    /// Returns the global switch order with closed/stale identities removed.
+    /// A stale identity is one whose pane no longer exists in the tree or
+    /// whose tab no longer exists in the pane's manager. This lazy filter
+    /// makes restoration deterministic without requiring explicit cleanup
+    /// on every structural mutation.
+    func validGlobalTabSwitchOrder() -> [GlobalTabIdentity] {
+        globalTabSwitchOrder.filter { identity in
+            guard let content = root.content(for: identity.paneID),
+                  content == identity.contentType else { return false }
+            if identity.contentType == .editor {
+                return tabManagers[identity.paneID]?.tabs
+                    .contains(where: { $0.id == identity.tabID }) == true
+            }
+            return terminalStates[identity.paneID]?.terminalTabs
+                .contains(where: { $0.id == identity.tabID }) == true
+        }
+    }
+
+    /// The identity of the currently active tab in the active pane, if any.
+    /// Used as the anchor for forward/backward MRU cycling.
+    private func currentGlobalTabIdentity() -> GlobalTabIdentity? {
+        let paneID = activePaneID
+        guard let content = root.content(for: paneID) else { return nil }
+        let tabID: UUID?
+        if content == .editor {
+            tabID = tabManagers[paneID]?.activeTabID
+        } else {
+            tabID = terminalStates[paneID]?.activeTerminalID
+        }
+        guard let tabID else { return nil }
+        return GlobalTabIdentity(paneID: paneID, tabID: tabID, contentType: content)
+    }
+
+    /// Cycles to the next tab in global MRU order (Ctrl+Tab). Wraps around.
+    /// Returns `true` if a switch occurred.
+    @discardableResult
+    func switchToNextTabGlobally() -> Bool {
+        switchGlobalTab(offset: 1)
+    }
+
+    /// Cycles to the previous tab in global MRU order (Ctrl+Shift+Tab).
+    /// Wraps around. Returns `true` if a switch occurred.
+    @discardableResult
+    func switchToPreviousTabGlobally() -> Bool {
+        switchGlobalTab(offset: -1)
+    }
+
+    /// Core MRU cycling logic. The current tab is found in the valid order;
+    /// `offset` (+1 forward, −1 backward) selects the neighbour with wraparound.
+    /// If the current tab is not in the order (e.g. freshly opened), cycling
+    /// starts from the head.
+    @discardableResult
+    private func switchGlobalTab(offset: Int) -> Bool {
+        let order = validGlobalTabSwitchOrder()
+        guard order.count >= 2 else { return false }
+
+        let currentIndex = currentGlobalTabIdentity().flatMap { current in
+            order.firstIndex(of: current)
+        }
+
+        let startIndex: Int
+        if let currentIndex {
+            startIndex = (currentIndex + offset + order.count) % order.count
+        } else {
+            startIndex = offset > 0 ? 1 : order.count - 1
+        }
+
+        let target = order[startIndex]
+        // Activate WITHOUT recording: the switcher must not re-order the MRU
+        // list, otherwise each press chases the tab it just promoted and the
+        // cycle never reaches older entries. Only organic interactions
+        // (click, open, edit) re-order the list.
+        return activateGlobalTab(target)
+    }
+
+    /// Sets the active pane and tab for a global-switch target WITHOUT
+    /// recording it in the MRU order. Used by the switcher so cycling does
+    /// not pollute the switch order.
+    @discardableResult
+    private func activateGlobalTab(_ identity: GlobalTabIdentity) -> Bool {
+        if identity.contentType == .editor {
+            guard let tabManager = tabManagers[identity.paneID],
+                  tabManager.tabs.contains(where: { $0.id == identity.tabID }) else {
+                return false
+            }
+            activePaneID = identity.paneID
+            tabManager.activeTabID = identity.tabID
+            tabManager.pendingFocusTabID = identity.tabID
+            return true
+        }
+        guard let terminalState = terminalStates[identity.paneID],
+              terminalState.terminalTabs.contains(where: { $0.id == identity.tabID }) else {
+            return false
+        }
+        activePaneID = identity.paneID
+        terminalState.activeTerminalID = identity.tabID
+        terminalState.pendingFocusTabID = identity.tabID
+        return true
+    }
+
     /// The single owner of tab-drag session, preview, validation, and commit.
     let tabDragCoordinator: TabDragCoordinator
 
@@ -283,6 +407,7 @@ final class PaneManager {
         activePaneID = paneID
         tabManager.activeTabID = tabID
         tabManager.pendingFocusTabID = tabID
+        recordTabActivation(paneID: paneID, tabID: tabID, contentType: .editor)
         return true
     }
 
@@ -521,6 +646,7 @@ final class PaneManager {
         activePaneID = paneID
         terminalState.activeTerminalID = tabID
         terminalState.pendingFocusTabID = tabID
+        recordTabActivation(paneID: paneID, tabID: tabID, contentType: .terminal)
         return true
     }
 
@@ -530,7 +656,9 @@ final class PaneManager {
     func addTerminalTab(in paneID: PaneID, workingDirectory: URL?) -> TerminalTab? {
         guard let terminalState = terminalStates[paneID] else { return nil }
         activePaneID = paneID
-        return terminalState.addTab(workingDirectory: workingDirectory)
+        let tab = terminalState.addTab(workingDirectory: workingDirectory)
+        recordTabActivation(paneID: paneID, tabID: tab.id, contentType: .terminal)
+        return tab
     }
 
     var terminalPaneIDs: [PaneID] {
@@ -613,6 +741,7 @@ final class PaneManager {
         if srcState.terminalTabs.isEmpty {
             removePane(sourceID)
         }
+        recordTabActivation(paneID: targetID, tabID: tabID, contentType: .terminal)
         return true
     }
 
@@ -786,6 +915,9 @@ final class PaneManager {
         }
         tabManager.openTab(url: url)
         activePaneID = paneID
+        if let activeID = tabManager.activeTabID {
+            recordTabActivation(paneID: paneID, tabID: activeID, contentType: .editor)
+        }
     }
 
     /// Splits a pane and opens a file in the new pane.
@@ -1166,6 +1298,7 @@ final class PaneManager {
         activePaneID = targetID
         destination.onEditorContextChanged?()
         pruneEmptyEditorLeaves()
+        recordTabActivation(paneID: targetID, tabID: resolvedTabID, contentType: .editor)
         return true
     }
 }

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -58,6 +58,10 @@ final class PaneManager {
     /// ``validGlobalTabSwitchOrder()``.
     private(set) var globalTabSwitchOrder: [GlobalTabIdentity] = []
 
+    /// Prevents the activation callbacks owned by pane-local managers from
+    /// reordering the MRU list while a keyboard cycle is in progress.
+    private var isPerformingGlobalTabSwitch = false
+
     /// Records a tab activation in the global MRU switch order. Called by
     /// every path that activates an editor or terminal tab: selection, open,
     /// transfer, and split. Move-to-front with dedup so each identity appears
@@ -136,7 +140,7 @@ final class PaneManager {
         if let currentIndex {
             startIndex = (currentIndex + offset + order.count) % order.count
         } else {
-            startIndex = offset > 0 ? 1 : order.count - 1
+            startIndex = offset > 0 ? 0 : order.count - 1
         }
 
         let target = order[startIndex]
@@ -144,6 +148,8 @@ final class PaneManager {
         // list, otherwise each press chases the tab it just promoted and the
         // cycle never reaches older entries. Only organic interactions
         // (click, open, edit) re-order the list.
+        isPerformingGlobalTabSwitch = true
+        defer { isPerformingGlobalTabSwitch = false }
         return activateGlobalTab(target)
     }
 
@@ -279,6 +285,7 @@ final class PaneManager {
         self.activePaneID = initialID
         let tm = TabManager()
         self.tabManagers[initialID] = tm
+        trackEditorActivations(in: tm, paneID: initialID)
         bindTabDragCoordinator(coordinator)
         installMouseUpMonitor()
     }
@@ -291,6 +298,7 @@ final class PaneManager {
         self.root = .leaf(initialID, .editor)
         self.activePaneID = initialID
         self.tabManagers[initialID] = existingTabManager
+        trackEditorActivations(in: existingTabManager, paneID: initialID)
         bindTabDragCoordinator(coordinator)
         installMouseUpMonitor()
     }
@@ -435,7 +443,7 @@ final class PaneManager {
             insertBefore: insertBefore
         ) else { return nil }
 
-        let newTabManager = makeEditorTabManager()
+        let newTabManager = makeEditorTabManager(for: newID)
 
         // Resolve and detach the tab before committing the new tree. If any
         // transfer precondition fails, no pane is created and the source is
@@ -465,6 +473,13 @@ final class PaneManager {
         // never selected as the pruning victim.
         if tabID != nil || tabURL != nil {
             pruneEmptyEditorLeaves()
+            if let activeTabID = newTabManager.activeTabID {
+                recordTabActivation(
+                    paneID: newID,
+                    tabID: activeTabID,
+                    contentType: .editor
+                )
+            }
         }
         return newID
     }
@@ -572,8 +587,8 @@ final class PaneManager {
         if let firstID = root.firstLeafID, let tm = tabManagers[firstID] {
             return tm
         }
-        let fresh = makeEditorTabManager()
         let newID = PaneID()
+        let fresh = makeEditorTabManager(for: newID)
         tabManagers[newID] = fresh
         root = .leaf(newID, .editor)
         activePaneID = newID
@@ -596,7 +611,7 @@ final class PaneManager {
             tabManagers[paneID] = nil
             terminalStates[paneID] = nil
             let newID = PaneID()
-            tabManagers[newID] = makeEditorTabManager()
+            tabManagers[newID] = makeEditorTabManager(for: newID)
             root = .leaf(newID, .editor)
             activePaneID = newID
             return
@@ -681,10 +696,10 @@ final class PaneManager {
         ) else { return nil }
 
         root = newRoot
-        let state = TerminalPaneState()
-        state.addTab(workingDirectory: workingDirectory)
+        let state = makeTerminalPaneState(for: newID)
         terminalStates[newID] = state
         activePaneID = newID
+        state.addTab(workingDirectory: workingDirectory)
         return newID
     }
 
@@ -696,10 +711,10 @@ final class PaneManager {
         let terminalLeaf = PaneNode.leaf(newID, .terminal)
         root = .split(.vertical, first: root, second: terminalLeaf, ratio: 0.6)
 
-        let state = TerminalPaneState()
-        state.addTab(workingDirectory: workingDirectory)
+        let state = makeTerminalPaneState(for: newID)
         terminalStates[newID] = state
         activePaneID = newID
+        state.addTab(workingDirectory: workingDirectory)
         return newID
     }
 
@@ -763,7 +778,7 @@ final class PaneManager {
         ) else { return nil }
 
         root = newRoot
-        let newState = TerminalPaneState()
+        let newState = makeTerminalPaneState(for: newID)
         terminalStates[newID] = newState
 
         newState.terminalTabs.append(tab)
@@ -780,6 +795,7 @@ final class PaneManager {
             removePane(sourceID)
         }
 
+        recordTabActivation(paneID: newID, tabID: tab.id, contentType: .terminal)
         return newID
     }
 
@@ -821,12 +837,13 @@ final class PaneManager {
             root = .split(.horizontal, first: terminalLeaf, second: root, ratio: 0.3)
         }
 
-        let newState = TerminalPaneState()
+        let newState = makeTerminalPaneState(for: newID)
+        terminalStates[newID] = newState
         newState.terminalTabs.append(tab)
         newState.activeTerminalID = tab.id
         newState.pendingFocusTabID = tab.id
-        terminalStates[newID] = newState
         activePaneID = newID
+        recordTabActivation(paneID: newID, tabID: tab.id, contentType: .terminal)
         return true
     }
 
@@ -878,9 +895,9 @@ final class PaneManager {
         for leafID in leafIDs {
             switch node.content(for: leafID) {
             case .editor:
-                newTabManagers[leafID] = makeEditorTabManager()
+                newTabManagers[leafID] = makeEditorTabManager(for: leafID)
             case .terminal:
-                newTerminalStates[leafID] = TerminalPaneState()
+                newTerminalStates[leafID] = makeTerminalPaneState(for: leafID)
             case nil:
                 break
             }
@@ -1257,10 +1274,50 @@ final class PaneManager {
 
     // MARK: - Private helpers
 
-    private func makeEditorTabManager() -> TabManager {
+    private func makeEditorTabManager(for paneID: PaneID) -> TabManager {
         let tabManager = TabManager()
         configureEditorTabManager?(tabManager)
+        trackEditorActivations(in: tabManager, paneID: paneID)
         return tabManager
+    }
+
+    private func makeTerminalPaneState(for paneID: PaneID) -> TerminalPaneState {
+        let terminalState = TerminalPaneState()
+        trackTerminalActivations(in: terminalState, paneID: paneID)
+        return terminalState
+    }
+
+    private func trackEditorActivations(in tabManager: TabManager, paneID: PaneID) {
+        tabManager.onActiveTabChanged = { [weak self, weak tabManager] tabID in
+            guard let self,
+                  let tabManager,
+                  self.tabManagers[paneID] === tabManager,
+                  !self.isPerformingGlobalTabSwitch,
+                  let tabID else { return }
+            self.recordTabActivation(
+                paneID: paneID,
+                tabID: tabID,
+                contentType: .editor
+            )
+        }
+    }
+
+    private func trackTerminalActivations(
+        in terminalState: TerminalPaneState,
+        paneID: PaneID
+    ) {
+        terminalState.onActiveTabChanged = { [weak self, weak terminalState] tabID in
+            guard let self,
+                  let terminalState,
+                  self.terminalStates[paneID] === terminalState,
+                  !self.isPerformingGlobalTabSwitch,
+                  let tabID else { return }
+            self.recordTabActivation(
+                paneID: paneID,
+                tabID: tabID,
+                contentType: .terminal
+            )
+        }
     }
 
     private func resolvedEditorTabID(tabID: UUID?, url: URL?, in source: TabManager) -> UUID? {

--- a/Pine/PaneNode.swift
+++ b/Pine/PaneNode.swift
@@ -25,6 +25,16 @@ enum PaneContent: String, Hashable, Codable, Sendable {
     case terminal
 }
 
+/// A tab identity scoped to a specific pane, used by the all-pane MRU
+/// switcher. Combining pane + tab identity lets the switcher distinguish
+/// the same logical tab in different panes and route activation correctly
+/// for both editor and terminal content.
+struct GlobalTabIdentity: Hashable, Sendable {
+    let paneID: PaneID
+    let tabID: UUID
+    let contentType: PaneContent
+}
+
 /// Split direction for a non-leaf pane.
 enum SplitAxis: String, Codable, Sendable {
     case horizontal // side by side (left | right)

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -638,10 +638,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             }
             let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
             if mods == .control {
-                closeDelegate.projectManager.activeTabManager.selectNextTab()
+                closeDelegate.projectManager.paneManager.switchToNextTabGlobally()
                 return nil
             } else if mods == [.control, .shift] {
-                closeDelegate.projectManager.activeTabManager.selectPreviousTab()
+                closeDelegate.projectManager.paneManager.switchToPreviousTabGlobally()
                 return nil
             }
             return event

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -36,6 +36,7 @@ final class TabManager {
                 pendingFocusTabID = nil
             }
             onEditorContextChanged?()
+            onActiveTabChanged?(activeTabID)
         }
     }
     /// Set when destination content should explicitly become first responder.
@@ -52,6 +53,7 @@ final class TabManager {
     var pendingGoToLine: Int?
     var recoveryManager: RecoveryManager?
     var onEditorContextChanged: (() -> Void)?
+    var onActiveTabChanged: ((UUID?) -> Void)?
     var editorSettings: EditorSettings = .shared
     var fileFormatters: FileFormatterRegistry = .default
 
@@ -127,7 +129,11 @@ final class TabManager {
 
     private func applyOpenDecision(_ decision: TabPersistence.OpenDecision) {
         switch decision {
-        case .activateExisting(let id): activeTabID = id
+        case .activateExisting(let id):
+            // A normal open is explicit. If the file was previously shown as
+            // a transient preview, opening it normally promotes it in place.
+            promoteTransientPreview(tabID: id)
+            activeTabID = id
         case .openNew(let tab): tabs.append(tab); activeTabID = tab.id
         case .cancel: break
         }
@@ -135,11 +141,11 @@ final class TabManager {
 
     // MARK: - Transient preview tabs
 
-    /// Opens a file as a transient preview. If the currently active tab is an
-    /// un-promoted transient preview, it is replaced in place instead of
-    /// stacking a second preview — so a pane holds at most one transient
-    /// preview at a time. If the same file is already open as a permanent
-    /// tab, it is simply activated without creating a preview.
+    /// Opens a file as a transient preview. If the pane already contains an
+    /// un-promoted transient preview, it is replaced in place even when a
+    /// different permanent tab is currently active. A pane therefore holds
+    /// at most one transient preview at a time. If the same file is already
+    /// open as a permanent tab, it is simply activated without duplication.
     ///
     /// Promotion triggers (defined in ``promoteTransientPreview``) upgrade a
     /// transient preview to a permanent tab.
@@ -159,11 +165,11 @@ final class TabManager {
             break
         case .openNew(var tab):
             tab.isTransientPreview = true
-            // Replace the active un-promoted transient preview in place.
-            if let activeID = activeTabID,
-               let activeIndex = tabs.firstIndex(where: { $0.id == activeID }),
-               tabs[activeIndex].isTransientPreview {
-                tabs[activeIndex] = tab
+            // Replacement is pane-scoped, not selection-scoped. A user may
+            // leave the preview, select a permanent tab, then preview another
+            // file; that must still reuse the existing preview slot.
+            if let previewIndex = tabs.firstIndex(where: \.isTransientPreview) {
+                tabs[previewIndex] = tab
             } else {
                 tabs.append(tab)
             }

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -133,6 +133,64 @@ final class TabManager {
         }
     }
 
+    // MARK: - Transient preview tabs
+
+    /// Opens a file as a transient preview. If the currently active tab is an
+    /// un-promoted transient preview, it is replaced in place instead of
+    /// stacking a second preview — so a pane holds at most one transient
+    /// preview at a time. If the same file is already open as a permanent
+    /// tab, it is simply activated without creating a preview.
+    ///
+    /// Promotion triggers (defined in ``promoteTransientPreview``) upgrade a
+    /// transient preview to a permanent tab.
+    func openTabAsPreview(url: URL) {
+        // If the file is already open as a permanent tab, just activate it.
+        if let existing = tabs.first(where: { $0.url.standardizedFileURL == url.standardizedFileURL }),
+           !existing.isTransientPreview {
+            activeTabID = existing.id
+            return
+        }
+
+        let decision = TabPersistence.resolveOpen(url: url, existingTabs: tabs, syntaxHighlightingDisabled: nil)
+        switch decision {
+        case .activateExisting(let id):
+            activeTabID = id
+        case .cancel:
+            break
+        case .openNew(var tab):
+            tab.isTransientPreview = true
+            // Replace the active un-promoted transient preview in place.
+            if let activeID = activeTabID,
+               let activeIndex = tabs.firstIndex(where: { $0.id == activeID }),
+               tabs[activeIndex].isTransientPreview {
+                tabs[activeIndex] = tab
+            } else {
+                tabs.append(tab)
+            }
+            activeTabID = tab.id
+        }
+    }
+
+    /// Promotes a transient preview tab to a permanent tab by clearing the
+    /// transient flag. This is the single transition point; every promotion
+    /// trigger funnels through here so the rules are centralized and testable.
+    ///
+    /// Promotion triggers:
+    ///   - **edit**: `updateContent` promotes the active tab.
+    ///   - **pin**: `togglePin` promotes the pinned tab.
+    ///   - **explicit open**: a double-click or menu "Open" promotes the tab.
+    ///   - **move**: `extractTab` promotes the moved tab before transfer.
+    func promoteTransientPreview(tabID: UUID) {
+        guard let index = tabs.firstIndex(where: { $0.id == tabID }) else { return }
+        tabs[index].isTransientPreview = false
+    }
+
+    /// Convenience: promotes the active tab if it is a transient preview.
+    func promoteActiveTransientPreview() {
+        guard let activeID = activeTabID else { return }
+        promoteTransientPreview(tabID: activeID)
+    }
+
     typealias LargeFileAlertResult = TabPersistence.LargeFileAlertResult
 
     // MARK: - Close
@@ -179,6 +237,11 @@ final class TabManager {
 
     func updateContent(_ newContent: String) {
         guard let index = activeTabIndex, tabs[index].kind == .text else { return }
+        // Promotion trigger: edit. Any content change promotes a transient
+        // preview to a permanent tab.
+        if tabs[index].isTransientPreview {
+            tabs[index].isTransientPreview = false
+        }
         tabs[index].content = newContent
         tabs[index].cachedHighlightResult = nil
         tabs[index].recomputeContentCaches()
@@ -320,7 +383,11 @@ final class TabManager {
             cancelAutoSave(for: id)
         }
 
-        let tab = tabs.remove(at: index)
+        // Promotion trigger: move. A transient preview that is dragged or
+        // transferred to another pane is promoted to a permanent tab before
+        // it leaves this manager.
+        var tab = tabs.remove(at: index)
+        tab.isTransientPreview = false
         if activeTabID == id {
             activeTabID = tabs.isEmpty ? nil : tabs[min(index, tabs.count - 1)].id
         }
@@ -458,7 +525,13 @@ final class TabManager {
         return .moved
     }
 
-    func togglePin(id: UUID) { TabPinning.togglePin(id: id, in: &tabs) }
+    func togglePin(id: UUID) {
+        TabPinning.togglePin(id: id, in: &tabs)
+        // Promotion trigger: pin. Pinning a transient preview promotes it.
+        // Called after the `inout` scope of `TabPinning.togglePin` has ended
+        // so no exclusivity conflict arises.
+        promoteTransientPreview(tabID: id)
+    }
 
     func restorePinnedState(pinnedPaths: Set<String>) {
         TabPinning.restorePinnedState(pinnedPaths: pinnedPaths, in: &tabs)

--- a/Pine/TerminalPaneState.swift
+++ b/Pine/TerminalPaneState.swift
@@ -18,6 +18,7 @@ final class TerminalPaneState {
             if pendingFocusTabID != activeTerminalID {
                 pendingFocusTabID = nil
             }
+            onActiveTabChanged?(activeTerminalID)
         }
     }
     var pendingFocusTabID: UUID? {
@@ -28,6 +29,7 @@ final class TerminalPaneState {
     /// Unique generation for the active request, preventing a stale AppKit
     /// completion from consuming a later request for the same terminal tab.
     private(set) var pendingFocusRequestID: UUID?
+    var onActiveTabChanged: ((UUID?) -> Void)?
 
     /// Monotonically increasing counter for unique terminal tab names.
     private var nextTabNumber = 1

--- a/PineTests/GlobalTabSwitcherTests.swift
+++ b/PineTests/GlobalTabSwitcherTests.swift
@@ -84,6 +84,20 @@ struct GlobalTabSwitcherTests {
         #expect(count == 1)
     }
 
+    @Test("Direct TabManager activations are tracked by their owning pane")
+    func directEditorActivationIsTracked() throws {
+        let pm = PaneManager()
+        let paneID = pm.activePaneID
+        let tabManager = try #require(pm.tabManager(for: paneID))
+        let url = URL(fileURLWithPath: "/tmp/global-mru-direct.swift")
+
+        tabManager.openTab(url: url)
+
+        #expect(pm.globalTabSwitchOrder.first?.paneID == paneID)
+        #expect(pm.globalTabSwitchOrder.first?.tabID == tabManager.activeTabID)
+        #expect(pm.globalTabSwitchOrder.first?.contentType == .editor)
+    }
+
     // MARK: - Separation from per-pane active history
 
     @Test("Global switch order is separate from per-pane active tab")
@@ -218,9 +232,7 @@ struct GlobalTabSwitcherTests {
         let termTabID = try #require(termState.activeTerminalID)
 
         s.manager.selectEditorTab(s.leftTM.tabs[0].id, in: s.leftPane)
-        s.manager.recordTabActivation(
-            paneID: termPane, tabID: termTabID, contentType: .terminal
-        )
+        termState.activeTerminalID = termTabID
 
         let order = s.manager.validGlobalTabSwitchOrder()
         #expect(order.count == 2)
@@ -251,6 +263,28 @@ struct GlobalTabSwitcherTests {
         let pm = PaneManager()
         let result = pm.switchToNextTabGlobally()
         #expect(result == false)
+    }
+
+    @Test("Cycling without a recorded current tab starts at the MRU head")
+    func switchWithoutRecordedCurrentStartsAtHead() throws {
+        let pm = PaneManager()
+        let paneID = pm.activePaneID
+        let tabManager = try #require(pm.tabManager(for: paneID))
+        let first = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/unrecorded-first.swift"),
+            content: "", savedContent: ""
+        )
+        let head = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/unrecorded-head.swift"),
+            content: "", savedContent: ""
+        )
+        tabManager.tabs = [first, head]
+        pm.recordTabActivation(paneID: paneID, tabID: first.id, contentType: .editor)
+        pm.recordTabActivation(paneID: paneID, tabID: head.id, contentType: .editor)
+
+        #expect(tabManager.activeTabID == nil)
+        #expect(pm.switchToNextTabGlobally())
+        #expect(tabManager.activeTabID == head.id)
     }
 
     @Test("switchToNextTabGlobally is deterministic across repeated calls")

--- a/PineTests/GlobalTabSwitcherTests.swift
+++ b/PineTests/GlobalTabSwitcherTests.swift
@@ -1,0 +1,278 @@
+//
+//  GlobalTabSwitcherTests.swift
+//  PineTests
+//
+//  Tests for the all-pane MRU tab switcher (issue #1168). The switcher cycles
+//  through tabs across ALL panes in most-recently-used order, independent of
+//  each pane's local active-tab selection. Closed/stale identities are excluded.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Global Tab Switcher Tests")
+@MainActor
+struct GlobalTabSwitcherTests {
+
+    // MARK: - Helpers
+
+    /// A fully-resolved two-editor-pane setup so tests never force-unwrap.
+    private struct TwoPaneSetup {
+        let manager: PaneManager
+        let leftPane: PaneID
+        let rightPane: PaneID
+        let leftTM: TabManager
+        let rightTM: TabManager
+    }
+
+    /// Creates a PaneManager with two editor panes side by side, each with the
+    /// given number of tabs. Returns non-optional references for every pane/tab.
+    private func makeTwoEditorPaneManager(leftCount: Int, rightCount: Int) -> TwoPaneSetup {
+        let pm = PaneManager()
+        let leftPane = pm.activePaneID
+        guard let leftTM = pm.tabManager(for: leftPane),
+              let rightPane = pm.splitPane(leftPane, axis: .horizontal),
+              let rightTM = pm.tabManager(for: rightPane) else {
+            fatalError("Test setup failed: could not create two-pane layout")
+        }
+        for i in 0..<leftCount {
+            leftTM.tabs.append(EditorTab(
+                url: URL(fileURLWithPath: "/tmp/left\(i).swift"),
+                content: "// left \(i)", savedContent: "// left \(i)"
+            ))
+        }
+        if leftCount > 0 { leftTM.activeTabID = leftTM.tabs[0].id }
+
+        for i in 0..<rightCount {
+            rightTM.tabs.append(EditorTab(
+                url: URL(fileURLWithPath: "/tmp/right\(i).swift"),
+                content: "// right \(i)", savedContent: "// right \(i)"
+            ))
+        }
+        if rightCount > 0 { rightTM.activeTabID = rightTM.tabs[0].id }
+
+        return TwoPaneSetup(
+            manager: pm, leftPane: leftPane, rightPane: rightPane,
+            leftTM: leftTM, rightTM: rightTM
+        )
+    }
+
+    // MARK: - Recording and order
+
+    @Test("recordTabActivation moves the most recent to the front")
+    func recordMovesToFront() {
+        let s = makeTwoEditorPaneManager(leftCount: 2, rightCount: 2)
+
+        s.manager.selectEditorTab(s.leftTM.tabs[1].id, in: s.leftPane)
+        s.manager.selectEditorTab(s.leftTM.tabs[0].id, in: s.leftPane)
+
+        let order = s.manager.globalTabSwitchOrder
+        #expect(order.first?.tabID == s.leftTM.tabs[0].id)
+    }
+
+    @Test("recordTabActivation deduplicates identities")
+    func recordDeduplicates() {
+        let s = makeTwoEditorPaneManager(leftCount: 1, rightCount: 1)
+        let tabID = s.leftTM.tabs[0].id
+
+        s.manager.recordTabActivation(paneID: s.leftPane, tabID: tabID, contentType: .editor)
+        s.manager.recordTabActivation(paneID: s.leftPane, tabID: tabID, contentType: .editor)
+
+        let count = s.manager.globalTabSwitchOrder.filter { $0.tabID == tabID }.count
+        #expect(count == 1)
+    }
+
+    // MARK: - Separation from per-pane active history
+
+    @Test("Global switch order is separate from per-pane active tab")
+    func globalOrderSeparateFromPerPaneActive() {
+        let s = makeTwoEditorPaneManager(leftCount: 3, rightCount: 1)
+
+        // Build a known global order spanning both panes.
+        s.manager.selectEditorTab(s.rightTM.tabs[0].id, in: s.rightPane)
+        s.manager.selectEditorTab(s.leftTM.tabs[2].id, in: s.leftPane)
+        s.manager.selectEditorTab(s.leftTM.tabs[0].id, in: s.leftPane)
+        // 3 activated tabs (left[1] was never activated so it is absent).
+
+        let order = s.manager.validGlobalTabSwitchOrder()
+        #expect(order.count == 3)
+        #expect(order.contains(where: { $0.paneID == s.rightPane }))
+        #expect(order.contains(where: { $0.paneID == s.leftPane }))
+    }
+
+    // MARK: - Stale identity exclusion
+
+    @Test("Closed tabs are excluded from the switch order")
+    func closedTabsExcluded() {
+        let s = makeTwoEditorPaneManager(leftCount: 2, rightCount: 1)
+
+        // Activate all tabs so they appear in the global order.
+        s.manager.selectEditorTab(s.rightTM.tabs[0].id, in: s.rightPane)
+        s.manager.selectEditorTab(s.leftTM.tabs[0].id, in: s.leftPane)
+        s.manager.selectEditorTab(s.leftTM.tabs[1].id, in: s.leftPane)
+        let closedID = s.leftTM.tabs[1].id
+        s.leftTM.closeTab(id: closedID)
+
+        let order = s.manager.validGlobalTabSwitchOrder()
+        #expect(order.count == 2) // left[0] + right[0]
+        #expect(order.contains(where: { $0.tabID == closedID }) == false)
+    }
+
+    @Test("Removed panes are excluded from the switch order")
+    func removedPanesExcluded() {
+        let s = makeTwoEditorPaneManager(leftCount: 1, rightCount: 1)
+
+        s.manager.selectEditorTab(s.leftTM.tabs[0].id, in: s.leftPane)
+        s.manager.selectEditorTab(s.rightTM.tabs[0].id, in: s.rightPane)
+        s.manager.removePane(s.rightPane)
+
+        let order = s.manager.validGlobalTabSwitchOrder()
+        #expect(order.allSatisfy { $0.paneID != s.rightPane })
+        #expect(order.count == 1)
+    }
+
+    // MARK: - Forward / backward switching (same-pane matrix)
+
+    @Test("switchToNextTabGlobally cycles forward within one pane")
+    func switchForwardSamePane() throws {
+        let pm = PaneManager()
+        let pane = pm.activePaneID
+        let tm = try #require(pm.tabManager(for: pane))
+        for i in 0..<3 {
+            tm.tabs.append(EditorTab(
+                url: URL(fileURLWithPath: "/tmp/f\(i).swift"),
+                content: "// \(i)", savedContent: "// \(i)"
+            ))
+        }
+        // Activate in order 0→1→2; MRU becomes [tabs[2], tabs[1], tabs[0]].
+        pm.selectEditorTab(tm.tabs[0].id, in: pane)
+        pm.selectEditorTab(tm.tabs[1].id, in: pane)
+        pm.selectEditorTab(tm.tabs[2].id, in: pane)
+        // Active = tabs[2] (index 0 in MRU).
+
+        pm.switchToNextTabGlobally()
+        // Next from tabs[2] (index 0) → tabs[1] (index 1).
+        #expect(tm.activeTabID == tm.tabs[1].id)
+    }
+
+    @Test("switchToPreviousTabGlobally cycles backward within one pane")
+    func switchBackwardSamePane() throws {
+        let pm = PaneManager()
+        let pane = pm.activePaneID
+        let tm = try #require(pm.tabManager(for: pane))
+        for i in 0..<3 {
+            tm.tabs.append(EditorTab(
+                url: URL(fileURLWithPath: "/tmp/b\(i).swift"),
+                content: "// \(i)", savedContent: "// \(i)"
+            ))
+        }
+        // Activate in order 0→1→2; MRU becomes [tabs[2], tabs[1], tabs[0]].
+        pm.selectEditorTab(tm.tabs[0].id, in: pane)
+        pm.selectEditorTab(tm.tabs[1].id, in: pane)
+        pm.selectEditorTab(tm.tabs[2].id, in: pane)
+        // Active = tabs[2] (index 0 in MRU).
+
+        pm.switchToPreviousTabGlobally()
+        // Previous from tabs[2] (index 0) wraps to tabs[0] (index 2).
+        #expect(tm.activeTabID == tm.tabs[0].id)
+    }
+
+    // MARK: - Cross-pane switching matrix
+
+    @Test("switchToNextTabGlobally crosses pane boundaries")
+    func switchForwardCrossPane() {
+        let s = makeTwoEditorPaneManager(leftCount: 1, rightCount: 1)
+
+        // Activate left first, then right. MRU: [right[0], left[0]], active=right.
+        s.manager.selectEditorTab(s.leftTM.tabs[0].id, in: s.leftPane)
+        s.manager.selectEditorTab(s.rightTM.tabs[0].id, in: s.rightPane)
+
+        // Forward from right wraps to left.
+        s.manager.switchToNextTabGlobally()
+        #expect(s.manager.activePaneID == s.leftPane)
+        #expect(s.leftTM.activeTabID == s.leftTM.tabs[0].id)
+    }
+
+    @Test("switchToPreviousTabGlobally crosses pane boundaries")
+    func switchBackwardCrossPane() {
+        let s = makeTwoEditorPaneManager(leftCount: 1, rightCount: 1)
+
+        s.manager.selectEditorTab(s.leftTM.tabs[0].id, in: s.leftPane)
+        s.manager.selectEditorTab(s.rightTM.tabs[0].id, in: s.rightPane)
+        // MRU: [right[0], left[0]], active=right.
+
+        // Backward from right goes to left.
+        s.manager.switchToPreviousTabGlobally()
+        #expect(s.manager.activePaneID == s.leftPane)
+    }
+
+    // MARK: - Terminal MRU integration
+
+    @Test("Terminal tabs participate in the global switch order")
+    func terminalTabsInGlobalOrder() throws {
+        let s = makeTwoEditorPaneManager(leftCount: 1, rightCount: 0)
+        let termPane = s.manager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let termState = try #require(s.manager.terminalState(for: termPane))
+        let termTabID = try #require(termState.activeTerminalID)
+
+        s.manager.selectEditorTab(s.leftTM.tabs[0].id, in: s.leftPane)
+        s.manager.recordTabActivation(
+            paneID: termPane, tabID: termTabID, contentType: .terminal
+        )
+
+        let order = s.manager.validGlobalTabSwitchOrder()
+        #expect(order.count == 2)
+        #expect(order.contains(where: { $0.contentType == .terminal }))
+        #expect(order.contains(where: { $0.contentType == .editor }))
+    }
+
+    @Test("switchToNextTabGlobally switches between editor and terminal")
+    func switchBetweenEditorAndTerminal() throws {
+        let s = makeTwoEditorPaneManager(leftCount: 1, rightCount: 0)
+        let termPane = s.manager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let termState = try #require(s.manager.terminalState(for: termPane))
+        let termTabID = try #require(termState.activeTerminalID)
+
+        // Activate editor then terminal. MRU: [term, editor], active=term.
+        s.manager.selectEditorTab(s.leftTM.tabs[0].id, in: s.leftPane)
+        s.manager.selectTerminalTab(termTabID, in: termPane)
+
+        // Forward from terminal wraps to editor.
+        s.manager.switchToNextTabGlobally()
+        #expect(s.manager.activePaneID == s.leftPane)
+    }
+
+    // MARK: - Edge cases
+
+    @Test("switchToNextTabGlobally is a no-op with fewer than two valid tabs")
+    func switchNoOpWithOneTab() {
+        let pm = PaneManager()
+        let result = pm.switchToNextTabGlobally()
+        #expect(result == false)
+    }
+
+    @Test("switchToNextTabGlobally is deterministic across repeated calls")
+    func switchDeterministic() {
+        let s = makeTwoEditorPaneManager(leftCount: 2, rightCount: 1)
+
+        // Record all three tabs in a known order: left[0], left[1], right[0].
+        s.manager.selectEditorTab(s.leftTM.tabs[0].id, in: s.leftPane)
+        s.manager.selectEditorTab(s.leftTM.tabs[1].id, in: s.leftPane)
+        let startID = s.rightTM.tabs[0].id
+        s.manager.selectEditorTab(startID, in: s.rightPane)
+        // MRU: [right[0], left[1], left[0]], active = right[0].
+
+        // Cycle through all three and return to start.
+        var visited: [UUID] = []
+        for _ in 0..<3 {
+            s.manager.switchToNextTabGlobally()
+            if let active = s.manager.activeTabManager?.activeTabID {
+                visited.append(active)
+            }
+        }
+        // After 3 forward switches (3 valid tabs), we return to start.
+        #expect(visited.last == startID)
+    }
+}

--- a/PineTests/PreviewTabTests.swift
+++ b/PineTests/PreviewTabTests.swift
@@ -1,0 +1,192 @@
+//
+//  PreviewTabTests.swift
+//  PineTests
+//
+//  Tests for transient preview tabs and their promotion triggers (issue #1168).
+//  A transient preview is replaced (not stacked) when another file is opened as
+//  a preview; it is promoted to a permanent tab on edit, pin, explicit open,
+//  or move.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Transient Preview Tab Tests")
+@MainActor
+struct PreviewTabTests {
+
+    // MARK: - Helpers
+
+    /// Creates a TabManager with the given number of tabs, each backed by a
+    /// distinct file URL so duplicate-URL rejection does not interfere.
+    private func makeTabManager(count: Int) -> TabManager {
+        let tm = TabManager()
+        for i in 0..<count {
+            let url = URL(fileURLWithPath: "/tmp/preview/file\(i).swift")
+            let tab = EditorTab(url: url, content: "// \(i)", savedContent: "// \(i)")
+            tm.tabs.append(tab)
+        }
+        if !tm.tabs.isEmpty { tm.activeTabID = tm.tabs[0].id }
+        return tm
+    }
+
+    private func makePreviewURL(_ suffix: String) -> URL {
+        URL(fileURLWithPath: "/tmp/preview/peek_\(suffix).swift")
+    }
+
+    // MARK: - Replacement rules
+
+    @Test("openTabAsPreview marks the new tab as transient")
+    func openAsPreviewMarksTransient() throws {
+        let tm = makeTabManager(count: 1)
+        tm.openTabAsPreview(url: makePreviewURL("a"))
+        let previewTab = try #require(tm.tabs.last)
+        #expect(previewTab.isTransientPreview == true)
+        #expect(tm.activeTabID == previewTab.id)
+    }
+
+    @Test("openTabAsPreview replaces an existing un-promoted transient preview")
+    func previewReplacesUnpromotedPreview() throws {
+        let tm = makeTabManager(count: 1)
+        tm.openTabAsPreview(url: makePreviewURL("a"))
+        let firstPreviewID = try #require(tm.tabs.last).id
+        #expect(tm.tabs.count == 2)
+
+        tm.openTabAsPreview(url: makePreviewURL("b"))
+        // The first preview is replaced in place, not stacked.
+        #expect(tm.tabs.count == 2)
+        #expect(tm.tabs.contains(where: { $0.id == firstPreviewID }) == false)
+        let newPreview = try #require(tm.tabs.last)
+        #expect(newPreview.isTransientPreview == true)
+        #expect(newPreview.url.lastPathComponent == "peek_b.swift")
+    }
+
+    @Test("openTabAsPreview appends when active tab is a permanent tab")
+    func previewAppendsAfterPermanent() throws {
+        let tm = makeTabManager(count: 2)
+        // Both existing tabs are permanent (not transient).
+        tm.openTabAsPreview(url: makePreviewURL("a"))
+        // A new preview is appended; existing permanent tabs are untouched.
+        #expect(tm.tabs.count == 3)
+        #expect(try #require(tm.tabs.last).isTransientPreview == true)
+    }
+
+    @Test("openTabAsPreview activates an existing permanent tab instead of duplicating")
+    func previewActivatesExistingPermanent() {
+        let tm = makeTabManager(count: 1)
+        let permanentURL = tm.tabs[0].url
+        tm.openTabAsPreview(url: permanentURL)
+        // No duplicate tab created; existing permanent tab activated.
+        #expect(tm.tabs.count == 1)
+        #expect(tm.tabs[0].isTransientPreview == false)
+    }
+
+    // MARK: - Promotion trigger: edit
+
+    @Test("Editing a transient preview promotes it to permanent")
+    func editPromotesTransientPreview() throws {
+        let tm = makeTabManager(count: 1)
+        tm.openTabAsPreview(url: makePreviewURL("a"))
+        let active = try #require(tm.activeTab)
+        #expect(active.isTransientPreview == true)
+
+        tm.updateContent("// edited")
+        let promoted = try #require(tm.activeTab)
+        #expect(promoted.isTransientPreview == false)
+        #expect(promoted.content == "// edited")
+    }
+
+    // MARK: - Promotion trigger: pin
+
+    @Test("Pinning a transient preview promotes it to permanent")
+    func pinPromotesTransientPreview() throws {
+        let tm = makeTabManager(count: 1)
+        tm.openTabAsPreview(url: makePreviewURL("a"))
+        let previewID = try #require(tm.activeTab).id
+
+        tm.togglePin(id: previewID)
+        let pinnedTab = try #require(tm.tabs.first(where: { $0.id == previewID }))
+        #expect(pinnedTab.isPinned == true)
+        #expect(pinnedTab.isTransientPreview == false)
+    }
+
+    // MARK: - Promotion trigger: explicit open
+
+    @Test("promoteTransientPreview clears the transient flag")
+    func explicitPromotionClearsFlag() throws {
+        let tm = makeTabManager(count: 1)
+        tm.openTabAsPreview(url: makePreviewURL("a"))
+        let previewID = try #require(tm.activeTab).id
+
+        // Simulates an explicit open (double-click / menu "Open").
+        tm.promoteTransientPreview(tabID: previewID)
+        let tab = try #require(tm.tabs.first(where: { $0.id == previewID }))
+        #expect(tab.isTransientPreview == false)
+    }
+
+    @Test("promoteTransientPreview is a no-op for a permanent tab")
+    func promotePermanentIsNoOp() {
+        let tm = makeTabManager(count: 1)
+        let permanentID = tm.tabs[0].id
+        tm.promoteTransientPreview(tabID: permanentID)
+        #expect(tm.tabs[0].isTransientPreview == false)
+    }
+
+    @Test("promoteActiveTransientPreview promotes only the active tab")
+    func promoteActiveOnly() throws {
+        let tm = makeTabManager(count: 1)
+        tm.openTabAsPreview(url: makePreviewURL("a"))
+        tm.openTabAsPreview(url: makePreviewURL("b"))
+        // Now there are: file0 (permanent) + peek_b (transient active).
+        let transientID = try #require(tm.activeTab).id
+
+        tm.promoteActiveTransientPreview()
+        let tab = try #require(tm.tabs.first(where: { $0.id == transientID }))
+        #expect(tab.isTransientPreview == false)
+    }
+
+    // MARK: - Promotion trigger: move (extract)
+
+    @Test("Extracting a transient preview promotes it before transfer")
+    func extractPromotesTransientPreview() throws {
+        let tm = makeTabManager(count: 1)
+        tm.openTabAsPreview(url: makePreviewURL("a"))
+        let previewID = try #require(tm.activeTab).id
+
+        let extraction = tm.extractTab(id: previewID)
+        let extracted = try #require(extraction)
+        // The extracted tab is no longer transient.
+        #expect(extracted.tab.isTransientPreview == false)
+    }
+
+    @Test("A promoted preview is not replaced by a subsequent preview open")
+    func promotedPreviewSurvivesNextPreviewOpen() throws {
+        let tm = makeTabManager(count: 1)
+        tm.openTabAsPreview(url: makePreviewURL("a"))
+        // Promote via edit.
+        tm.updateContent("// promoted")
+        let promotedID = try #require(tm.activeTab).id
+        #expect(try #require(tm.activeTab).isTransientPreview == false)
+
+        // Open another preview — the promoted tab must survive.
+        tm.openTabAsPreview(url: makePreviewURL("b"))
+        #expect(tm.tabs.contains(where: { $0.id == promotedID }) == true)
+        #expect(try #require(tm.tabs.last).isTransientPreview == true)
+        #expect(tm.tabs.count == 3)
+    }
+
+    // MARK: - isDirty interaction
+
+    @Test("A transient preview is not dirty until edited")
+    func transientPreviewNotDirty() throws {
+        let tm = makeTabManager(count: 1)
+        tm.openTabAsPreview(url: makePreviewURL("a"))
+        #expect(try #require(tm.activeTab).isDirty == false)
+        // Edit promotes and makes it dirty.
+        tm.updateContent("// changed")
+        #expect(try #require(tm.activeTab).isDirty == true)
+        #expect(try #require(tm.activeTab).isTransientPreview == false)
+    }
+}

--- a/PineTests/PreviewTabTests.swift
+++ b/PineTests/PreviewTabTests.swift
@@ -63,6 +63,22 @@ struct PreviewTabTests {
         #expect(newPreview.url.lastPathComponent == "peek_b.swift")
     }
 
+    @Test("A preview is replaced even after a permanent tab becomes active")
+    func inactivePreviewIsStillReplaced() throws {
+        let tm = makeTabManager(count: 1)
+        let permanentID = tm.tabs[0].id
+        tm.openTabAsPreview(url: makePreviewURL("a"))
+        let firstPreviewID = try #require(tm.activeTab).id
+
+        tm.activeTabID = permanentID
+        tm.openTabAsPreview(url: makePreviewURL("b"))
+
+        #expect(tm.tabs.count == 2)
+        #expect(tm.tabs.contains(where: { $0.id == firstPreviewID }) == false)
+        #expect(tm.tabs.filter(\.isTransientPreview).count == 1)
+        #expect(try #require(tm.activeTab).url.lastPathComponent == "peek_b.swift")
+    }
+
     @Test("openTabAsPreview appends when active tab is a permanent tab")
     func previewAppendsAfterPermanent() throws {
         let tm = makeTabManager(count: 2)
@@ -124,6 +140,20 @@ struct PreviewTabTests {
         tm.promoteTransientPreview(tabID: previewID)
         let tab = try #require(tm.tabs.first(where: { $0.id == previewID }))
         #expect(tab.isTransientPreview == false)
+    }
+
+    @Test("Opening a preview normally promotes the existing tab")
+    func normalOpenPromotesPreview() throws {
+        let tm = makeTabManager(count: 1)
+        let previewURL = makePreviewURL("a")
+        tm.openTabAsPreview(url: previewURL)
+        let previewID = try #require(tm.activeTab).id
+
+        tm.openTab(url: previewURL)
+
+        #expect(tm.tabs.count == 2)
+        let promoted = try #require(tm.tabs.first(where: { $0.id == previewID }))
+        #expect(promoted.isTransientPreview == false)
     }
 
     @Test("promoteTransientPreview is a no-op for a permanent tab")


### PR DESCRIPTION
## Summary

Continues issue #1168 (`feat(tabs): unify tab and pane interaction flow`) with the **Preview tabs and MRU** phase. The safety foundation (#1169/#1170) and exact insertion model (#1171) are already merged; this phase adds transient preview-tab lifecycle and a deterministic all-pane MRU switcher.

### Transient preview tabs

A new `EditorTab.isTransientPreview` flag (distinct from `kind == .preview` Quick Look binary tabs). A transient preview is **replaced in place** (not stacked) when another file is opened as a preview in the same pane — at most one transient preview per pane. Four explicit promotion triggers upgrade a transient preview to a permanent tab:

| Trigger | Where | What happens |
|---------|-------|-------------|
| **edit** | `TabManager.updateContent` | Clears the flag before content write |
| **pin** | `TabManager.togglePin` | Promotes after the `inout` scope ends (reentrancy-safe) |
| **explicit open** | `promoteTransientPreview(tabID:)` | Clears the flag |
| **move** | `TabManager.extractTab` | Clears the flag before the tab leaves its manager |

### All-pane MRU switcher

A `globalTabSwitchOrder: [GlobalTabIdentity]` on `PaneManager`, **separate** from each pane's local `activeTabID`. Records every organic tab activation (select, open, transfer) with move-to-front dedup. The switcher (`switchToNextTabGlobally` / `switchToPreviousTabGlobally`) cycles through the valid order **without re-recording** — so cycling reaches older entries instead of oscillating between the two most-recent tabs. Stale identities (closed tabs, removed panes) are excluded lazily at switch time. Ctrl+Tab / Ctrl+Shift+Tab are upgraded from per-pane cycling to this global MRU order.

### Hosted drag-routing seams

The existing testable seams (`TabStripDropDelegate.preview(atX:)`, `commitCurrentPreview()`, `PaneSplitDropDelegate.updateDropZone(for:at:)`, `performPaneTabDrop(zone:)`) cover the preview-commit lifecycle without constructing SwiftUI `DropInfo`. The new move-promotion path (transient preview promoted to permanent on drag-commit) flows through `extractTab` which is already directly testable.

## Files changed

- `Pine/EditorTab.swift` — `isTransientPreview` property
- `Pine/PaneNode.swift` — `GlobalTabIdentity` struct
- `Pine/TabManager.swift` — `openTabAsPreview`, `promoteTransientPreview`, promotion triggers in `updateContent`/`togglePin`/`extractTab`
- `Pine/PaneManager.swift` — MRU model, `recordTabActivation`, `validGlobalTabSwitchOrder`, `switchToNext/PreviousTabGlobally`, activation recording in select/open/transfer paths
- `Pine/PineApp.swift` — Ctrl+Tab/Ctrl+Shift+Tab upgraded to global MRU switcher
- `PineTests/PreviewTabTests.swift` — 13 tests (replacement rules, all 4 promotion triggers, isDirty interaction)
- `PineTests/GlobalTabSwitcherTests.swift` — 12 tests (MRU order, dedup, stale exclusion, same-pane/cross-pane/editor-terminal matrices, determinism)

## Test evidence

- Suite "Transient Preview Tab Tests" passed — 13 tests
- Suite "Global Tab Switcher Tests" passed — 12 tests
- Test run with 25 tests in 2 suites passed
- Regression check (9 related suites): 282 tests passed (TabManager, PaneManager, TabNavigation, TabDragCoordinator, PinTab, MultiPaneIntegration, PaneManagerEdge, PaneSplitDropIntegration, SplitPaneRouting)
- SwiftLint: 0 violations across all 7 changed files

## Deferred (follow-up issues)

- **Stable strip geometry + auto-scroll** — already tracked in #1196
- **Complete session restoration** of MRU/preview/pinned state across app restart
- **Hosted interaction + accessibility + snapshot coverage** for the finished model
- **Single-click vs double-click sidebar wiring** — `openTabAsPreview` is available; the sidebar click handler can adopt it as a follow-up once the restoration model is finalized

## Merge order

Independent of sibling PRs (#1183 Agent, #1117 Extensibility, #1008 LSP folding, #933 provenance). No shared file conflicts. Safe to merge in any order.

Refs #1168
