### PR TITLE
feat(agent): add trusted event provenance envelope

### DIFF
--- a/Pine/Agent/Provenance/AgentEventEnvelope.swift
+++ b/Pine/Agent/Provenance/AgentEventEnvelope.swift
@@ -1,0 +1,305 @@
+//
+//  AgentEventEnvelope.swift
+//  Pine
+//
+//  Trusted event provenance slice (epic #933, section 1 — "Trusted event
+//  provenance").
+//
+//  `AgentEventEnvelope` is the single structured record that captures WHO did
+//  WHAT, WHERE, and HOW TRUSTWORTHY the observation is. It is the foundation
+//  for trustworthy agent awareness: terminal/process observation stays useful
+//  for presence and attention, but file/tool attribution requires explicit
+//  provenance like this envelope (#933).
+//
+//  Safety boundary with #1183 (heuristic history undo):
+//  - This is a pure DATA MODEL. It carries provenance and, optionally, an
+//    exact content-identity change set. It performs no working-tree mutation
+//    and authorizes none.
+//  - A `.verified` trust level means the event's SOURCE is trustworthy (an
+//    explicit structured report), NOT that an undo is safe. A safe inverse
+//    still requires a checked change set AND a divergence check against the
+//    current file (handled separately by #1183).
+//  - Trust levels and sources decode forward-compatibly: an unknown value
+//    from a future Pine never upgrades into a more trusted level — it fails
+//    closed to `.inferred` / a preserved-raw source.
+//
+
+import Foundation
+
+/// How trustworthy the attribution of an event is.
+///
+/// Ordered weakest-to-strongest: `observed` < `inferred` < `verified`.
+/// Temporal correlation alone can never reach `.verified` (#933); only an
+/// explicit structured report can.
+enum TrustLevel: String, Codable, Sendable, Equatable, CaseIterable {
+    /// A terminal/process was observed to be present or active, but no
+    /// specific action was attributed (e.g. an agent was detected running).
+    case observed
+    /// Pine inferred an action by correlating file-system/git activity with
+    /// an active agent in time. The strongest level the current heuristic
+    /// correlation can reach; explicitly NOT proof of exclusive authorship.
+    case inferred
+    /// An explicit structured report identified the actor and, when relevant,
+    /// the exact change. The only level that can carry a verified change set.
+    case verified
+
+    /// `true` only for `.verified`. Callers that gate destructive behavior on
+    /// trust must additionally require a checked change set and a divergence
+    /// check — `.verified` alone is necessary but not sufficient (#1183).
+    var isVerified: Bool { self == .verified }
+
+    /// `true` for levels based on correlation rather than an explicit report.
+    var isHeuristic: Bool { self != .verified }
+
+    /// Unknown future values fail closed as `.inferred` (the strongest level
+    /// correlation can reach, still non-verified). Trust levels can outlive
+    /// the app version that wrote them, and an older Pine must never turn an
+    /// unfamiliar level into `.verified`. Mirrors the tolerant decoding of
+    /// `AgentHistoryAttribution`.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        self = Self(rawValue: rawValue) ?? .inferred
+    }
+}
+
+/// What produced an event. Used together with `TrustLevel` to describe both
+/// the origin and the reliability of an observation.
+enum EventSource: Sendable, Equatable {
+    /// A terminal process was detected (presence/lifecycle).
+    case terminalProcess
+    /// File-system observation (FSEvents refresh).
+    case fileSystemObservation
+    /// Git status/diff correlation.
+    case gitCorrelation
+    /// An explicit structured report from the agent or a trusted integration.
+    case explicitAgentEvent
+    /// A direct user action attributed for context.
+    case userAction
+
+    /// A stable, version-independent string used for persistence. Survives
+    /// the addition of new cases; round-trips via `init?(stableIdentifier:)`.
+    /// `.unknown` preserves its original raw value so a newer-Pine source
+    /// string survives a round-trip through an older build.
+    var stableIdentifier: String {
+        switch self {
+        case .terminalProcess: "terminalProcess"
+        case .fileSystemObservation: "fileSystemObservation"
+        case .gitCorrelation: "gitCorrelation"
+        case .explicitAgentEvent: "explicitAgentEvent"
+        case .userAction: "userAction"
+        case .unknown(let raw): raw
+        }
+    }
+
+    /// Reconstructs a source from its `stableIdentifier`. Returns `nil` for an
+    /// unrecognised identifier so decoding stays forward-compatible.
+    init?(stableIdentifier: String) {
+        switch stableIdentifier {
+        case "terminalProcess": self = .terminalProcess
+        case "fileSystemObservation": self = .fileSystemObservation
+        case "gitCorrelation": self = .gitCorrelation
+        case "explicitAgentEvent": self = .explicitAgentEvent
+        case "userAction": self = .userAction
+        default: return nil
+        }
+    }
+
+    /// Forward-compatible decoder: an unknown source is preserved verbatim via
+    /// the `unknown` case rather than throwing, so a log from a newer Pine
+    /// still loads. The raw value is retained for round-tripping.
+    case unknown(raw: String)
+}
+
+extension EventSource: Codable {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        if let known = EventSource(stableIdentifier: raw) {
+            self = known
+        } else {
+            self = .unknown(raw: raw)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(stableIdentifier)
+    }
+}
+
+/// Identifies the agent process that produced an event.
+struct AgentProcessIdentity: Codable, Sendable, Equatable {
+    /// Stable identifier of the terminal tab hosting the agent.
+    let terminalID: UUID
+    /// Monotonic generation of the process within that terminal. A new shell
+    /// or a relaunched agent increments this, so events from a stale process
+    /// cannot be confused with a fresh one.
+    let processGeneration: UInt64
+}
+
+/// Where an agent event occurred.
+struct AgentEventLocation: Codable, Sendable, Equatable {
+    /// The git worktree root path at event time. Disambiguates nested
+    /// worktrees sharing one project (#1183). Stored as a path string because
+    /// worktrees may live outside the project root.
+    let worktreePath: String
+    /// The working directory at event time. May equal `worktreePath`.
+    let cwd: String
+}
+
+/// The result of an observed command, carried as optional evidence.
+struct AgentCommandResult: Codable, Sendable, Equatable {
+    /// The command line that was observed (e.g. `git commit -m "..."`).
+    let command: String
+    /// The process exit status (`0` on success).
+    let exitStatus: Int32
+}
+
+/// An exact file change identified by content hashes — never by content.
+///
+/// `before` is `nil` for a newly created file. Both identities are content
+/// fingerprints: a future safe-undo path can detect divergence by re-hashing
+/// the current file and comparing it to `after` (#1183).
+struct AgentFileChange: Codable, Sendable, Equatable {
+    /// Relative path from the project root. Never absolute, never content.
+    let relativePath: String
+    /// Identity of the content before the change; `nil` for a new file.
+    let before: ContentIdentity?
+    /// Identity of the content after the change.
+    let after: ContentIdentity
+}
+
+/// Optional evidence carried by an event. A presence-only event carries `.none`.
+enum AgentEventPayload: Codable, Sendable, Equatable {
+    /// No structured payload; the event records presence/observation only.
+    case none
+    /// A command was observed to complete with this result.
+    case commandResult(AgentCommandResult)
+    /// An exact file change, identified by content hashes — never content.
+    case fileChange(AgentFileChange)
+
+    private enum CodingKeys: String, CodingKey {
+        case kind, commandResult, fileChange
+    }
+
+    private init(fromKnown container: KeyedDecodingContainer<Self.CodingKeys>) throws {
+        let kind = try container.decode(String.self, forKey: .kind)
+        switch kind {
+        case "none":
+            self = .none
+        case "commandResult":
+            self = .commandResult(try container.decode(AgentCommandResult.self, forKey: .commandResult))
+        case "fileChange":
+            self = .fileChange(try container.decode(AgentFileChange.self, forKey: .fileChange))
+        default:
+            // Unknown payload kinds are preserved as `.none` rather than
+            // throwing: a future Pine may record payload kinds this build
+            // cannot interpret, and the provenance (identity/trust/source)
+            // remains useful without the payload.
+            self = .none
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(fromKnown: container)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .none:
+            try container.encode("none", forKey: .kind)
+        case .commandResult(let result):
+            try container.encode("commandResult", forKey: .kind)
+            try container.encode(result, forKey: .commandResult)
+        case .fileChange(let change):
+            try container.encode("fileChange", forKey: .kind)
+            try container.encode(change, forKey: .fileChange)
+        }
+    }
+}
+
+/// One structured record of a trusted (or explicitly heuristic) agent event.
+///
+/// Captures project + worktree identity, agent/session identity, terminal
+/// process generation, working directory, a monotonic event cursor + wall-clock
+/// timestamp, the event source, its trust level, and an optional payload. This
+/// is the unit a provenance pipeline records so that the UI and a future
+/// safe-undo path can answer "what did this verified agent actually do?"
+/// without relying on temporal correlation alone (#933).
+struct AgentEventEnvelope: Codable, Identifiable, Sendable, Equatable {
+    /// Stable identifier for this envelope.
+    let id: UUID
+    /// Identifier of the Pine project the event occurred in.
+    let projectID: UUID
+    /// Identifier of the agent session that produced the event.
+    let sessionID: UUID
+    /// Stable string representation of the agent type (`AgentType.stableIdentifier`).
+    /// Kept as a plain string so a new agent type added later decodes cleanly.
+    let agentTypeRaw: String
+    /// The agent process that produced the event (terminal + generation).
+    let process: AgentProcessIdentity
+    /// Where the event occurred (worktree root + cwd).
+    let location: AgentEventLocation
+    /// Monotonic sequence number from this process's `EventCursor`.
+    let cursorValue: UInt64
+    /// When the event was recorded (wall-clock).
+    let timestamp: Date
+    /// What produced the event.
+    let source: EventSource
+    /// How trustworthy the attribution is.
+    let trustLevel: TrustLevel
+    /// Optional evidence (command result or exact file-change identity).
+    let payload: AgentEventPayload
+
+    init(
+        id: UUID = UUID(),
+        projectID: UUID,
+        sessionID: UUID,
+        agentTypeRaw: String,
+        process: AgentProcessIdentity,
+        location: AgentEventLocation,
+        cursorValue: UInt64,
+        timestamp: Date = Date(),
+        source: EventSource,
+        trustLevel: TrustLevel,
+        payload: AgentEventPayload = .none
+    ) {
+        self.id = id
+        self.projectID = projectID
+        self.sessionID = sessionID
+        self.agentTypeRaw = agentTypeRaw
+        self.process = process
+        self.location = location
+        self.cursorValue = cursorValue
+        self.timestamp = timestamp
+        self.source = source
+        self.trustLevel = trustLevel
+        self.payload = payload
+    }
+
+    /// Forward-compatible decoder. Missing or unrecognised values fail closed
+    /// to the least-trusting safe default rather than throwing, so a log from a
+    /// newer or older Pine always loads as read-only provenance.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        projectID = try container.decode(UUID.self, forKey: .projectID)
+        sessionID = try container.decode(UUID.self, forKey: .sessionID)
+        agentTypeRaw = try container.decodeIfPresent(String.self, forKey: .agentTypeRaw) ?? "generic:Unknown"
+        process = try container.decodeIfPresent(AgentProcessIdentity.self, forKey: .process)
+            ?? AgentProcessIdentity(terminalID: UUID(), processGeneration: 0)
+        location = try container.decodeIfPresent(AgentEventLocation.self, forKey: .location)
+            ?? AgentEventLocation(worktreePath: "", cwd: "")
+        cursorValue = try container.decodeIfPresent(UInt64.self, forKey: .cursorValue) ?? 0
+        timestamp = try container.decodeIfPresent(Date.self, forKey: .timestamp) ?? Date(timeIntervalSince1970: 0)
+        source = (try? container.decodeIfPresent(EventSource.self, forKey: .source)) ?? .unknown(raw: "")
+        // Unknown / missing trust levels decode as `.inferred` (the strongest
+        // level correlation can reach, still non-verified) so provenance never
+        // silently upgrades into `.verified`.
+        trustLevel = (try? container.decodeIfPresent(TrustLevel.self, forKey: .trustLevel)) ?? .inferred
+        payload = (try? container.decodeIfPresent(AgentEventPayload.self, forKey: .payload)) ?? .none
+    }
+}

--- a/Pine/Agent/Provenance/AgentEventEnvelope.swift
+++ b/Pine/Agent/Provenance/AgentEventEnvelope.swift
@@ -31,7 +31,7 @@ import Foundation
 /// Ordered weakest-to-strongest: `observed` < `inferred` < `verified`.
 /// Temporal correlation alone can never reach `.verified` (#933); only an
 /// explicit structured report can.
-enum TrustLevel: String, Codable, Sendable, Equatable, CaseIterable {
+nonisolated enum TrustLevel: String, Codable, Sendable, Equatable, CaseIterable {
     /// A terminal/process was observed to be present or active, but no
     /// specific action was attributed (e.g. an agent was detected running).
     case observed
@@ -65,7 +65,7 @@ enum TrustLevel: String, Codable, Sendable, Equatable, CaseIterable {
 
 /// What produced an event. Used together with `TrustLevel` to describe both
 /// the origin and the reliability of an observation.
-enum EventSource: Sendable, Equatable {
+nonisolated enum EventSource: Sendable, Equatable {
     /// A terminal process was detected (presence/lifecycle).
     case terminalProcess
     /// File-system observation (FSEvents refresh).
@@ -92,6 +92,15 @@ enum EventSource: Sendable, Equatable {
         }
     }
 
+    /// Only an explicit structured agent event can establish verified agent
+    /// attribution. Every other source remains observational or heuristic.
+    var canEstablishVerifiedTrust: Bool {
+        if case .explicitAgentEvent = self {
+            return true
+        }
+        return false
+    }
+
     /// Reconstructs a source from its `stableIdentifier`. Returns `nil` for an
     /// unrecognised identifier so decoding stays forward-compatible.
     init?(stableIdentifier: String) {
@@ -111,25 +120,68 @@ enum EventSource: Sendable, Equatable {
     case unknown(raw: String)
 }
 
-extension EventSource: Codable {
+nonisolated extension EventSource: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case kind, raw
+    }
+
     init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        let raw = try container.decode(String.self)
-        if let known = EventSource(stableIdentifier: raw) {
-            self = known
-        } else {
-            self = .unknown(raw: raw)
+        // Known values and legacy unknown values use the original single-string
+        // representation. New unknown values use a tagged representation so an
+        // unknown raw value that aliases a known identifier cannot become a
+        // trusted source after an encode/decode round-trip.
+        if let raw = try? decoder.singleValueContainer().decode(String.self) {
+            self = EventSource(stableIdentifier: raw) ?? .unknown(raw: raw)
+            return
         }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(String.self, forKey: .kind)
+        guard kind == "unknown" else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .kind,
+                in: container,
+                debugDescription: "Unsupported EventSource representation"
+            )
+        }
+        self = .unknown(raw: try container.decode(String.self, forKey: .raw))
     }
 
     func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(stableIdentifier)
+        switch self {
+        case .unknown(let raw):
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode("unknown", forKey: .kind)
+            try container.encode(raw, forKey: .raw)
+        default:
+            var container = encoder.singleValueContainer()
+            try container.encode(stableIdentifier)
+        }
+    }
+}
+
+nonisolated extension TrustLevel {
+    /// Returns the effective trust after applying the source and provenance
+    /// invariants. A caller or persisted record may request `.verified`, but it
+    /// is granted only to a complete explicit structured event.
+    static func effective(
+        requested: TrustLevel,
+        source: EventSource,
+        provenanceIsComplete: Bool,
+        payloadIsValid: Bool = true
+    ) -> TrustLevel {
+        guard requested == .verified else { return requested }
+        guard source.canEstablishVerifiedTrust,
+              provenanceIsComplete,
+              payloadIsValid else {
+            return .inferred
+        }
+        return .verified
     }
 }
 
 /// Identifies the agent process that produced an event.
-struct AgentProcessIdentity: Codable, Sendable, Equatable {
+nonisolated struct AgentProcessIdentity: Codable, Sendable, Equatable {
     /// Stable identifier of the terminal tab hosting the agent.
     let terminalID: UUID
     /// Monotonic generation of the process within that terminal. A new shell
@@ -139,7 +191,7 @@ struct AgentProcessIdentity: Codable, Sendable, Equatable {
 }
 
 /// Where an agent event occurred.
-struct AgentEventLocation: Codable, Sendable, Equatable {
+nonisolated struct AgentEventLocation: Codable, Sendable, Equatable {
     /// The git worktree root path at event time. Disambiguates nested
     /// worktrees sharing one project (#1183). Stored as a path string because
     /// worktrees may live outside the project root.
@@ -149,7 +201,7 @@ struct AgentEventLocation: Codable, Sendable, Equatable {
 }
 
 /// The result of an observed command, carried as optional evidence.
-struct AgentCommandResult: Codable, Sendable, Equatable {
+nonisolated struct AgentCommandResult: Codable, Sendable, Equatable {
     /// The command line that was observed (e.g. `git commit -m "..."`).
     let command: String
     /// The process exit status (`0` on success).
@@ -161,7 +213,7 @@ struct AgentCommandResult: Codable, Sendable, Equatable {
 /// `before` is `nil` for a newly created file. Both identities are content
 /// fingerprints: a future safe-undo path can detect divergence by re-hashing
 /// the current file and comparing it to `after` (#1183).
-struct AgentFileChange: Codable, Sendable, Equatable {
+nonisolated struct AgentFileChange: Codable, Sendable, Equatable {
     /// Relative path from the project root. Never absolute, never content.
     let relativePath: String
     /// Identity of the content before the change; `nil` for a new file.
@@ -171,7 +223,7 @@ struct AgentFileChange: Codable, Sendable, Equatable {
 }
 
 /// Optional evidence carried by an event. A presence-only event carries `.none`.
-enum AgentEventPayload: Codable, Sendable, Equatable {
+nonisolated enum AgentEventPayload: Codable, Sendable, Equatable {
     /// No structured payload; the event records presence/observation only.
     case none
     /// A command was observed to complete with this result.
@@ -229,7 +281,7 @@ enum AgentEventPayload: Codable, Sendable, Equatable {
 /// is the unit a provenance pipeline records so that the UI and a future
 /// safe-undo path can answer "what did this verified agent actually do?"
 /// without relying on temporal correlation alone (#933).
-struct AgentEventEnvelope: Codable, Identifiable, Sendable, Equatable {
+nonisolated struct AgentEventEnvelope: Codable, Identifiable, Sendable, Equatable {
     /// Stable identifier for this envelope.
     let id: UUID
     /// Identifier of the Pine project the event occurred in.
@@ -267,6 +319,36 @@ struct AgentEventEnvelope: Codable, Identifiable, Sendable, Equatable {
         trustLevel: TrustLevel,
         payload: AgentEventPayload = .none
     ) {
+        self.init(
+            id: id,
+            projectID: projectID,
+            sessionID: sessionID,
+            agentTypeRaw: agentTypeRaw,
+            process: process,
+            location: location,
+            cursorValue: cursorValue,
+            timestamp: timestamp,
+            source: source,
+            requestedTrustLevel: trustLevel,
+            payload: payload,
+            payloadIsValid: true
+        )
+    }
+
+    private init(
+        id: UUID,
+        projectID: UUID,
+        sessionID: UUID,
+        agentTypeRaw: String,
+        process: AgentProcessIdentity,
+        location: AgentEventLocation,
+        cursorValue: UInt64,
+        timestamp: Date,
+        source: EventSource,
+        requestedTrustLevel: TrustLevel,
+        payload: AgentEventPayload,
+        payloadIsValid: Bool
+    ) {
         self.id = id
         self.projectID = projectID
         self.sessionID = sessionID
@@ -276,8 +358,24 @@ struct AgentEventEnvelope: Codable, Identifiable, Sendable, Equatable {
         self.cursorValue = cursorValue
         self.timestamp = timestamp
         self.source = source
-        self.trustLevel = trustLevel
         self.payload = payload
+        self.trustLevel = TrustLevel.effective(
+            requested: requestedTrustLevel,
+            source: source,
+            provenanceIsComplete: Self.provenanceIsComplete(
+                ProvenanceValidationInput(
+                    id: id,
+                    projectID: projectID,
+                    sessionID: sessionID,
+                    agentTypeRaw: agentTypeRaw,
+                    process: process,
+                    location: location,
+                    cursorValue: cursorValue,
+                    timestamp: timestamp
+                )
+            ),
+            payloadIsValid: payloadIsValid
+        )
     }
 
     /// Forward-compatible decoder. Missing or unrecognised values fail closed
@@ -285,21 +383,96 @@ struct AgentEventEnvelope: Codable, Identifiable, Sendable, Equatable {
     /// newer or older Pine always loads as read-only provenance.
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        id = try container.decode(UUID.self, forKey: .id)
-        projectID = try container.decode(UUID.self, forKey: .projectID)
-        sessionID = try container.decode(UUID.self, forKey: .sessionID)
-        agentTypeRaw = try container.decodeIfPresent(String.self, forKey: .agentTypeRaw) ?? "generic:Unknown"
-        process = try container.decodeIfPresent(AgentProcessIdentity.self, forKey: .process)
-            ?? AgentProcessIdentity(terminalID: UUID(), processGeneration: 0)
-        location = try container.decodeIfPresent(AgentEventLocation.self, forKey: .location)
+        let id = try container.decode(UUID.self, forKey: .id)
+        let projectID = try container.decode(UUID.self, forKey: .projectID)
+        let sessionID = try container.decode(UUID.self, forKey: .sessionID)
+        let agentTypeRaw = try container.decodeIfPresent(
+            String.self,
+            forKey: .agentTypeRaw
+        ) ?? "generic:Unknown"
+        let process = try container.decodeIfPresent(
+            AgentProcessIdentity.self,
+            forKey: .process
+        ) ?? AgentProcessIdentity(terminalID: Self.zeroUUID, processGeneration: 0)
+        let location = try container.decodeIfPresent(AgentEventLocation.self, forKey: .location)
             ?? AgentEventLocation(worktreePath: "", cwd: "")
-        cursorValue = try container.decodeIfPresent(UInt64.self, forKey: .cursorValue) ?? 0
-        timestamp = try container.decodeIfPresent(Date.self, forKey: .timestamp) ?? Date(timeIntervalSince1970: 0)
-        source = (try? container.decodeIfPresent(EventSource.self, forKey: .source)) ?? .unknown(raw: "")
+        let cursorValue = try container.decodeIfPresent(UInt64.self, forKey: .cursorValue) ?? 0
+        let timestamp = try container.decodeIfPresent(Date.self, forKey: .timestamp)
+            ?? Date(timeIntervalSince1970: 0)
+        let source = (try? container.decodeIfPresent(
+            EventSource.self,
+            forKey: .source
+        )) ?? .unknown(raw: "")
         // Unknown / missing trust levels decode as `.inferred` (the strongest
         // level correlation can reach, still non-verified) so provenance never
         // silently upgrades into `.verified`.
-        trustLevel = (try? container.decodeIfPresent(TrustLevel.self, forKey: .trustLevel)) ?? .inferred
-        payload = (try? container.decodeIfPresent(AgentEventPayload.self, forKey: .payload)) ?? .none
+        let requestedTrustLevel = (try? container.decodeIfPresent(
+            TrustLevel.self,
+            forKey: .trustLevel
+        )) ?? .inferred
+
+        let payload: AgentEventPayload
+        let payloadIsValid: Bool
+        do {
+            payload = try container.decodeIfPresent(
+                AgentEventPayload.self,
+                forKey: .payload
+            ) ?? .none
+            payloadIsValid = true
+        } catch {
+            payload = .none
+            payloadIsValid = false
+        }
+
+        self.init(
+            id: id,
+            projectID: projectID,
+            sessionID: sessionID,
+            agentTypeRaw: agentTypeRaw,
+            process: process,
+            location: location,
+            cursorValue: cursorValue,
+            timestamp: timestamp,
+            source: source,
+            requestedTrustLevel: requestedTrustLevel,
+            payload: payload,
+            payloadIsValid: payloadIsValid
+        )
+    }
+
+    private static func provenanceIsComplete(
+        _ input: ProvenanceValidationInput
+    ) -> Bool {
+        let timestampSeconds = input.timestamp.timeIntervalSince1970
+        return input.id != zeroUUID
+            && input.projectID != zeroUUID
+            && input.sessionID != zeroUUID
+            && !input.agentTypeRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && input.process.terminalID != zeroUUID
+            && input.process.processGeneration > 0
+            && isAbsoluteMetadataPath(input.location.worktreePath)
+            && isAbsoluteMetadataPath(input.location.cwd)
+            && input.cursorValue > 0
+            && timestampSeconds.isFinite
+            && timestampSeconds != 0
+    }
+
+    private static func isAbsoluteMetadataPath(_ path: String) -> Bool {
+        !path.isEmpty && path.hasPrefix("/") && !path.utf8.contains(0)
+    }
+
+    private static let zeroUUID = UUID(
+        uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    )
+
+    private struct ProvenanceValidationInput {
+        let id: UUID
+        let projectID: UUID
+        let sessionID: UUID
+        let agentTypeRaw: String
+        let process: AgentProcessIdentity
+        let location: AgentEventLocation
+        let cursorValue: UInt64
+        let timestamp: Date
     }
 }

--- a/Pine/Agent/Provenance/AgentEventProvenanceCollector.swift
+++ b/Pine/Agent/Provenance/AgentEventProvenanceCollector.swift
@@ -1,0 +1,46 @@
+//
+//  AgentEventProvenanceCollector.swift
+//  Pine
+//
+//  Trusted event provenance slice (epic #933, section 1 — "Trusted event
+//  provenance").
+//
+//  `AgentEventProvenanceCollector` is the seam a future provenance pipeline
+//  adopts to RECORD `AgentEventEnvelope` values. This file ships the protocol
+//  and a no-op default only; it deliberately performs NO live terminal or
+//  file-system wiring (that belongs to a later slice, once #1183's safety gate
+//  is in place).
+//
+
+import Foundation
+
+/// The seam a provenance pipeline adopts to record trusted agent events.
+///
+/// Adopters (a future terminal/process observer, an explicit agent-event
+/// channel, etc.) build an `AgentEventEnvelope` and hand it here. The
+/// collector is responsible for persisting / indexing it. This protocol is
+/// `Sendable` so it can be shared across isolation domains; concrete
+/// adopters decide their own concurrency (actor, main-actor, queue).
+///
+/// - Important: Recording an envelope is metadata only. It must not perform
+///   any working-tree mutation, and it must not authorize an undo — those
+///   are separate, #1183-gated operations.
+protocol AgentEventProvenanceCollector: Sendable {
+    /// Records a trusted (or explicitly heuristic) agent event.
+    ///
+    /// - Parameter envelope: The provenance envelope to store/index.
+    func record(_ envelope: AgentEventEnvelope) async
+}
+
+/// A no-op collector used as a safe default and for tests.
+///
+/// Drops every recorded envelope. Pine can hold an instance as the default
+/// collector until a real provenance pipeline is wired in (later slice), so
+/// call sites never deal with optionality.
+final class NullAgentEventProvenanceCollector: AgentEventProvenanceCollector, @unchecked Sendable {
+    init() {}
+
+    func record(_ envelope: AgentEventEnvelope) async {
+        // Intentionally empty: provenance recording is disabled.
+    }
+}

--- a/Pine/Agent/Provenance/AgentEventProvenanceCollector.swift
+++ b/Pine/Agent/Provenance/AgentEventProvenanceCollector.swift
@@ -25,7 +25,7 @@ import Foundation
 /// - Important: Recording an envelope is metadata only. It must not perform
 ///   any working-tree mutation, and it must not authorize an undo — those
 ///   are separate, #1183-gated operations.
-protocol AgentEventProvenanceCollector: Sendable {
+nonisolated protocol AgentEventProvenanceCollector: Sendable {
     /// Records a trusted (or explicitly heuristic) agent event.
     ///
     /// - Parameter envelope: The provenance envelope to store/index.
@@ -37,9 +37,7 @@ protocol AgentEventProvenanceCollector: Sendable {
 /// Drops every recorded envelope. Pine can hold an instance as the default
 /// collector until a real provenance pipeline is wired in (later slice), so
 /// call sites never deal with optionality.
-final class NullAgentEventProvenanceCollector: AgentEventProvenanceCollector, @unchecked Sendable {
-    init() {}
-
+nonisolated struct NullAgentEventProvenanceCollector: AgentEventProvenanceCollector {
     func record(_ envelope: AgentEventEnvelope) async {
         // Intentionally empty: provenance recording is disabled.
     }

--- a/Pine/Agent/Provenance/ContentIdentity.swift
+++ b/Pine/Agent/Provenance/ContentIdentity.swift
@@ -1,0 +1,75 @@
+//
+//  ContentIdentity.swift
+//  Pine
+//
+//  Trusted event provenance slice (epic #933, section 1 — "Trusted event
+//  provenance"). A `ContentIdentity` is a verifiable fingerprint of file
+//  contents at one point in time, used by `AgentFileChange` to record exact
+//  before/after state for a verified agent write.
+//
+//  Safety invariants (see #933 / #1183):
+//  - Stores ONLY a SHA-256 digest and a byte count. It NEVER stores, embeds,
+//    or logs the original file contents.
+//  - Two identities compare equal iff the digested bytes were identical,
+//    which lets a future safe-undo path detect divergence before reverting
+//    (#1183: "refuse when the current file has diverged from the expected
+//    after-state").
+//  - Hashing is deterministic: identical bytes always produce an identical
+//    identity, regardless of machine or locale.
+//
+
+import CryptoKit
+import Foundation
+
+/// A verifiable, content-only fingerprint of a file's bytes at one moment.
+///
+/// Holds a SHA-256 digest and the original byte count — never the bytes
+/// themselves. Two `ContentIdentity` values are equal only when both the
+/// digest and byte count match, which is how a verified event can detect that
+/// the working tree has diverged from its expected after-state before any
+/// inverse operation runs (#1183).
+struct ContentIdentity: Codable, Sendable, Equatable, Hashable {
+    /// Lowercase hex encoding of the SHA-256 digest (exactly 64 characters).
+    let sha256Hex: String
+    /// Number of bytes that were hashed. Stored alongside the digest so a
+    /// digest collision between inputs of different lengths cannot be treated
+    /// as a match.
+    let byteCount: Int
+
+    /// Computes the identity of the given data without retaining it.
+    ///
+    /// - Parameter content: The bytes to fingerprint. They are hashed and then
+    ///   discarded; this type never stores them.
+    init(content: Data) {
+        let digest = SHA256.hash(data: content)
+        self.sha256Hex = digest.map { String(format: "%02x", $0) }.joined()
+        self.byteCount = content.count
+    }
+
+    /// Reconstructs an identity from persisted components.
+    ///
+    /// Returns `nil` unless `sha256Hex` is exactly 64 lowercase-hex characters
+    /// and `byteCount` is non-negative. This keeps a corrupted or tampered
+    /// store from loading an identity that could authorize a rollback.
+    init?(sha256Hex: String, byteCount: Int) {
+        guard byteCount >= 0,
+              sha256Hex.count == 64,
+              sha256Hex.allSatisfy({ $0.isHexDigit }),
+              sha256Hex == sha256Hex.lowercased()
+        else { return nil }
+        self.sha256Hex = sha256Hex
+        self.byteCount = byteCount
+    }
+
+    /// The identity of empty content. Useful as a "before" identity for a
+    /// newly created file, and as a safe fallback that matches nothing but
+    /// other empty content.
+    static let empty = ContentIdentity(content: Data())
+}
+
+private extension Character {
+    /// `true` for characters legal in a lowercase hex string (`0`–`9`, `a`–`f`).
+    var isHexDigit: Bool {
+        ("0"..."9").contains(self) || ("a"..."f").contains(self)
+    }
+}

--- a/Pine/Agent/Provenance/ContentIdentity.swift
+++ b/Pine/Agent/Provenance/ContentIdentity.swift
@@ -28,13 +28,17 @@ import Foundation
 /// digest and byte count match, which is how a verified event can detect that
 /// the working tree has diverged from its expected after-state before any
 /// inverse operation runs (#1183).
-struct ContentIdentity: Codable, Sendable, Equatable, Hashable {
+nonisolated struct ContentIdentity: Codable, Sendable, Equatable, Hashable {
     /// Lowercase hex encoding of the SHA-256 digest (exactly 64 characters).
     let sha256Hex: String
     /// Number of bytes that were hashed. Stored alongside the digest so a
     /// digest collision between inputs of different lengths cannot be treated
     /// as a match.
     let byteCount: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case sha256Hex, byteCount
+    }
 
     /// Computes the identity of the given data without retaining it.
     ///
@@ -52,22 +56,47 @@ struct ContentIdentity: Codable, Sendable, Equatable, Hashable {
     /// and `byteCount` is non-negative. This keeps a corrupted or tampered
     /// store from loading an identity that could authorize a rollback.
     init?(sha256Hex: String, byteCount: Int) {
-        guard byteCount >= 0,
-              sha256Hex.count == 64,
-              sha256Hex.allSatisfy({ $0.isHexDigit }),
-              sha256Hex == sha256Hex.lowercased()
-        else { return nil }
+        guard Self.isValid(sha256Hex: sha256Hex, byteCount: byteCount) else {
+            return nil
+        }
         self.sha256Hex = sha256Hex
         self.byteCount = byteCount
+    }
+
+    /// Validates persisted components instead of allowing synthesized
+    /// `Decodable` to bypass the reconstruction invariant.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let sha256Hex = try container.decode(String.self, forKey: .sha256Hex)
+        let byteCount = try container.decode(Int.self, forKey: .byteCount)
+
+        guard let validated = Self(
+            sha256Hex: sha256Hex,
+            byteCount: byteCount
+        ) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .sha256Hex,
+                in: container,
+                debugDescription: "ContentIdentity requires lowercase SHA-256 and nonnegative byte count"
+            )
+        }
+        self = validated
     }
 
     /// The identity of empty content. Useful as a "before" identity for a
     /// newly created file, and as a safe fallback that matches nothing but
     /// other empty content.
     static let empty = ContentIdentity(content: Data())
+
+    private static func isValid(sha256Hex: String, byteCount: Int) -> Bool {
+        byteCount >= 0
+            && sha256Hex.count == 64
+            && sha256Hex.allSatisfy(\.isHexDigit)
+            && sha256Hex == sha256Hex.lowercased()
+    }
 }
 
-private extension Character {
+nonisolated private extension Character {
     /// `true` for characters legal in a lowercase hex string (`0`–`9`, `a`–`f`).
     var isHexDigit: Bool {
         ("0"..."9").contains(self) || ("a"..."f").contains(self)

--- a/Pine/Agent/Provenance/EventCursor.swift
+++ b/Pine/Agent/Provenance/EventCursor.swift
@@ -1,0 +1,56 @@
+//
+//  EventCursor.swift
+//  Pine
+//
+//  Trusted event provenance slice (epic #933, section 1 — "Trusted event
+//  provenance"). `EventCursor` mints monotonically increasing, per-process
+//  event sequence numbers that anchor each `AgentEventEnvelope` to a precise
+//  position in the event stream.
+//
+//  A monotonic cursor lets the UI and a future safe-undo path order events
+//  unambiguously and detect gaps/reordering when two agents touch the same
+//  project (see the #933 Snailflyer comment: "event cursor before and after
+//  the action"). `actor` isolation guarantees increments are atomic and
+//  safe to call from any thread.
+//
+
+import Foundation
+
+/// A monotonically increasing, thread-safe source of event sequence numbers.
+///
+/// Each call to `next()` returns a value strictly greater than every prior
+/// return from the same cursor. The current value is also exposed as
+/// `current` (the last minted value, or the seed before any call). Concurrency
+/// safety comes from `actor` isolation: increments are serialized, so two
+/// concurrent callers can never observe the same value or an out-of-order
+/// pair.
+///
+/// This type mints values only; it is not itself persisted. The produced
+/// `UInt64` is carried by `AgentEventEnvelope.cursorValue`, so a stored
+/// envelope remains a plain `Codable` value.
+actor EventCursor {
+    /// The most recently minted value. Before any `next()` call this is the
+    /// seed; afterwards it is the last returned value.
+    private(set) var current: UInt64
+
+    /// Creates a cursor whose first minted value will be `seed + 1`.
+    ///
+    /// - Parameter seed: The value `current` holds before the first `next()`.
+    ///   Defaults to `0` so the first minted value is `1`. A non-default seed
+    ///   supports deterministic testing and resuming after a restart.
+    init(seed: UInt64 = 0) {
+        self.current = seed
+    }
+
+    /// Mints the next sequence number.
+    ///
+    /// - Returns: A value strictly greater than every value previously
+    ///   returned by this cursor.
+    /// - Precondition: `current` has not overflowed `UInt64.max`.
+    @discardableResult
+    func next() -> UInt64 {
+        precondition(current < UInt64.max, "EventCursor exhausted: UInt64 overflow")
+        current &+= 1
+        return current
+    }
+}

--- a/PineTests/AgentProvenanceTests/AgentEventEnvelopeTests.swift
+++ b/PineTests/AgentProvenanceTests/AgentEventEnvelopeTests.swift
@@ -1,0 +1,261 @@
+//
+//  AgentEventEnvelopeTests.swift
+//  PineTests
+//
+//  Tests for AgentEventEnvelope and its supporting types (epic #933, slice 1 —
+//  trusted event provenance): TrustLevel, EventSource, payloads, and
+//  forward-compatible Codable behavior.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+struct AgentEventEnvelopeTests {
+
+    // MARK: - Helpers
+
+    /// A known-valid UUID fixture. Aborts only on a malformed fixture string
+    /// (a programmer error), never on input data, so no force-unwrap is used.
+    private func known(_ raw: String) -> UUID {
+        guard let id = UUID(uuidString: raw) else {
+            fatalError("Invalid fixture UUID string: \(raw)")
+        }
+        return id
+    }
+
+    private func sampleEnvelope(
+        trustLevel: TrustLevel = .inferred,
+        payload: AgentEventPayload = .none
+    ) -> AgentEventEnvelope {
+        AgentEventEnvelope(
+            projectID: known("00000000-0000-0000-0000-000000000001"),
+            sessionID: known("00000000-0000-0000-0000-000000000002"),
+            agentTypeRaw: "claudeCode",
+            process: AgentProcessIdentity(
+                terminalID: known("00000000-0000-0000-0000-000000000003"),
+                processGeneration: 4
+            ),
+            location: AgentEventLocation(worktreePath: "/proj", cwd: "/proj/src"),
+            cursorValue: 42,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            source: .explicitAgentEvent,
+            trustLevel: trustLevel,
+            payload: payload
+        )
+    }
+
+    private func decode(_ json: [String: Any]) throws -> AgentEventEnvelope {
+        let data = try JSONSerialization.data(withJSONObject: json, options: [])
+        return try JSONDecoder().decode(AgentEventEnvelope.self, from: data)
+    }
+
+    // MARK: - TrustLevel
+
+    @Test func trustLevel_hasObservedInferredVerified() {
+        #expect(TrustLevel.allCases == [.observed, .inferred, .verified])
+    }
+
+    @Test func trustLevel_isVerifiedOnlyForVerified() {
+        #expect(TrustLevel.observed.isVerified == false)
+        #expect(TrustLevel.inferred.isVerified == false)
+        #expect(TrustLevel.verified.isVerified == true)
+    }
+
+    @Test func trustLevel_isHeuristicUnlessVerified() {
+        #expect(TrustLevel.observed.isHeuristic == true)
+        #expect(TrustLevel.inferred.isHeuristic == true)
+        #expect(TrustLevel.verified.isHeuristic == false)
+    }
+
+    @Test func trustLevel_transitionsFromObservedToVerified() {
+        // Levels are ordered weakest-to-strongest; verify the full ordering.
+        let ordered: [TrustLevel] = [.observed, .inferred, .verified]
+        for i in 0..<(ordered.count - 1) {
+            #expect(!ordered[i].isVerified)
+        }
+        #expect(ordered.last?.isVerified == true)
+    }
+
+    @Test func trustLevel_decodesKnownValues() throws {
+        for level in TrustLevel.allCases {
+            let data = try JSONEncoder().encode(level)
+            let decoded = try JSONDecoder().decode(TrustLevel.self, from: data)
+            #expect(decoded == level)
+        }
+    }
+
+    @Test func trustLevel_unknownRawValue_failsClosedToInferred() throws {
+        // An unknown trust value from a future Pine must NOT become .verified.
+        let data = Data("\"quantum\"".utf8)
+        let decoded = try JSONDecoder().decode(TrustLevel.self, from: data)
+        #expect(decoded == .inferred)
+    }
+
+    // MARK: - EventSource
+
+    @Test func eventSource_roundTripsKnownCases() throws {
+        let known: [EventSource] = [
+            .terminalProcess, .fileSystemObservation, .gitCorrelation,
+            .explicitAgentEvent, .userAction,
+        ]
+        for source in known {
+            let data = try JSONEncoder().encode(source)
+            let decoded = try JSONDecoder().decode(EventSource.self, from: data)
+            #expect(decoded == source)
+        }
+    }
+
+    @Test func eventSource_unknownRawValue_isPreservedNotThrown() throws {
+        let data = Data("\"futureSource\"".utf8)
+        let decoded = try JSONDecoder().decode(EventSource.self, from: data)
+        if case .unknown(let raw) = decoded {
+            #expect(raw == "futureSource")
+        } else {
+            Issue.record("expected .unknown, got \(decoded)")
+        }
+    }
+
+    @Test func eventSource_unknownRoundTripsRawValue() throws {
+        let source = EventSource.unknown(raw: "experimental")
+        let data = try JSONEncoder().encode(source)
+        let decoded = try JSONDecoder().decode(EventSource.self, from: data)
+        #expect(decoded == source)
+    }
+
+    @Test func eventSource_stableIdentifier_resolvesKnownOnly() {
+        for source: EventSource in [.terminalProcess, .gitCorrelation, .userAction] {
+            #expect(EventSource(stableIdentifier: source.stableIdentifier) == source)
+        }
+        #expect(EventSource(stableIdentifier: "neverHeardOfIt") == nil)
+    }
+
+    // MARK: - Payload
+
+    @Test func payload_noneRoundTrips() throws {
+        let data = try JSONEncoder().encode(AgentEventPayload.none)
+        let decoded = try JSONDecoder().decode(AgentEventPayload.self, from: data)
+        #expect(decoded == .none)
+    }
+
+    @Test func payload_commandResultRoundTrips() throws {
+        let payload = AgentEventPayload.commandResult(
+            AgentCommandResult(command: "git commit -m ship", exitStatus: 0)
+        )
+        let data = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(AgentEventPayload.self, from: data)
+        #expect(decoded == payload)
+    }
+
+    @Test func payload_fileChangeRoundTrips() throws {
+        let payload = AgentEventPayload.fileChange(
+            AgentFileChange(
+                relativePath: "src/app.swift",
+                before: ContentIdentity(content: Data("before".utf8)),
+                after: ContentIdentity(content: Data("after".utf8))
+            )
+        )
+        let data = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(AgentEventPayload.self, from: data)
+        #expect(decoded == payload)
+    }
+
+    @Test func payload_unknownKind_failsClosedToNone() throws {
+        // A payload kind from a newer Pine must not throw; it degrades to none
+        // while provenance (identity/trust/source) stays intact.
+        let json: [String: Any] = [
+            "kind": "futurePayloadKind",
+            "fileChange": ["relativePath": "x", "after": ["sha256Hex": String(repeating: "0", count: 64), "byteCount": 0]],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let decoded = try JSONDecoder().decode(AgentEventPayload.self, from: data)
+        #expect(decoded == .none)
+    }
+
+    // MARK: - Envelope Codable round-trip
+
+    @Test func envelope_roundTripsAllFields() throws {
+        let original = sampleEnvelope(
+            trustLevel: .verified,
+            payload: .fileChange(AgentFileChange(
+                relativePath: "a/b.swift",
+                before: nil,
+                after: ContentIdentity(content: Data("new".utf8))
+            ))
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(AgentEventEnvelope.self, from: data)
+        #expect(decoded == original)
+        #expect(decoded.trustLevel == .verified)
+        #expect(decoded.source == .explicitAgentEvent)
+        #expect(decoded.cursorValue == 42)
+    }
+
+    @Test func envelope_hasAllRequiredProvenanceFields() {
+        let envelope = sampleEnvelope()
+        // Each field required by epic #933 section 1 is present and populated.
+        #expect(envelope.projectID != known("00000000-0000-0000-0000-000000000000"))
+        #expect(envelope.sessionID != known("00000000-0000-0000-0000-000000000000"))
+        #expect(!envelope.agentTypeRaw.isEmpty)
+        #expect(envelope.process.processGeneration == 4)
+        #expect(envelope.process.terminalID != UUID())
+        #expect(!envelope.location.worktreePath.isEmpty)
+        #expect(!envelope.location.cwd.isEmpty)
+        #expect(envelope.cursorValue > 0)
+    }
+
+    // MARK: - Forward-compatible decoding (fail closed)
+
+    @Test func envelope_unknownTrustLevel_failsClosedToInferred() throws {
+        let json: [String: Any] = [
+            "id": "00000000-0000-0000-0000-000000000009",
+            "projectID": "00000000-0000-0000-0000-000000000001",
+            "sessionID": "00000000-0000-0000-0000-000000000002",
+            "agentTypeRaw": "claudeCode",
+            "trustLevel": "unfathomable",
+        ]
+        let decoded = try decode(json)
+        // Unknown trust never upgrades to .verified.
+        #expect(decoded.trustLevel == .inferred)
+        #expect(decoded.trustLevel.isVerified == false)
+    }
+
+    @Test func envelope_missingOptionalFields_useSafeDefaults() throws {
+        // A minimal envelope from an older format must still decode.
+        let json: [String: Any] = [
+            "id": "00000000-0000-0000-0000-000000000009",
+            "projectID": "00000000-0000-0000-0000-000000000001",
+            "sessionID": "00000000-0000-0000-0000-000000000002",
+        ]
+        let decoded = try decode(json)
+        #expect(decoded.agentTypeRaw == "generic:Unknown")
+        #expect(decoded.cursorValue == 0)
+        #expect(decoded.payload == .none)
+        #expect(decoded.trustLevel == .inferred)
+        #expect(decoded.location.worktreePath == "")
+    }
+
+    @Test func envelope_unknownSource_isPreserved() throws {
+        let json: [String: Any] = [
+            "id": "00000000-0000-0000-0000-000000000009",
+            "projectID": "00000000-0000-0000-0000-000000000001",
+            "sessionID": "00000000-0000-0000-0000-000000000002",
+            "source": "mcpChannel",
+        ]
+        let decoded = try decode(json)
+        if case .unknown(let raw) = decoded.source {
+            #expect(raw == "mcpChannel")
+        } else {
+            Issue.record("expected .unknown source")
+        }
+    }
+
+    @Test func envelope_verifiedWithoutPayload_isStillVerified() {
+        // .verified describes the SOURCE trust, independent of payload. A
+        // presence-only verified event is legitimate.
+        let envelope = sampleEnvelope(trustLevel: .verified, payload: .none)
+        #expect(envelope.trustLevel.isVerified)
+        #expect(envelope.payload == .none)
+    }
+}

--- a/PineTests/AgentProvenanceTests/AgentEventEnvelopeTests.swift
+++ b/PineTests/AgentProvenanceTests/AgentEventEnvelopeTests.swift
@@ -27,6 +27,7 @@ struct AgentEventEnvelopeTests {
 
     private func sampleEnvelope(
         trustLevel: TrustLevel = .inferred,
+        source: EventSource = .explicitAgentEvent,
         payload: AgentEventPayload = .none
     ) -> AgentEventEnvelope {
         AgentEventEnvelope(
@@ -40,7 +41,7 @@ struct AgentEventEnvelopeTests {
             location: AgentEventLocation(worktreePath: "/proj", cwd: "/proj/src"),
             cursorValue: 42,
             timestamp: Date(timeIntervalSince1970: 1_700_000_000),
-            source: .explicitAgentEvent,
+            source: source,
             trustLevel: trustLevel,
             payload: payload
         )
@@ -122,6 +123,14 @@ struct AgentEventEnvelopeTests {
         let data = try JSONEncoder().encode(source)
         let decoded = try JSONDecoder().decode(EventSource.self, from: data)
         #expect(decoded == source)
+    }
+
+    @Test func eventSource_unknownAliasingKnownValue_staysUnknownAfterRoundTrip() throws {
+        let source = EventSource.unknown(raw: "explicitAgentEvent")
+        let data = try JSONEncoder().encode(source)
+        let decoded = try JSONDecoder().decode(EventSource.self, from: data)
+        #expect(decoded == source)
+        #expect(decoded.canEstablishVerifiedTrust == false)
     }
 
     @Test func eventSource_stableIdentifier_resolvesKnownOnly() {
@@ -221,6 +230,36 @@ struct AgentEventEnvelopeTests {
         #expect(decoded.trustLevel.isVerified == false)
     }
 
+    @Test func envelope_verifiedWithMissingProvenance_failsClosedToInferred() throws {
+        let json: [String: Any] = [
+            "id": "00000000-0000-0000-0000-000000000009",
+            "projectID": "00000000-0000-0000-0000-000000000001",
+            "sessionID": "00000000-0000-0000-0000-000000000002",
+            "trustLevel": "verified",
+        ]
+        let decoded = try decode(json)
+        #expect(decoded.trustLevel == .inferred)
+        #expect(decoded.trustLevel.isVerified == false)
+    }
+
+    @Test func envelope_heuristicSourcesCannotClaimVerifiedTrust() {
+        let sources: [EventSource] = [
+            .terminalProcess,
+            .fileSystemObservation,
+            .gitCorrelation,
+            .userAction,
+            .unknown(raw: "futureSource"),
+        ]
+
+        for source in sources {
+            let envelope = sampleEnvelope(
+                trustLevel: .verified,
+                source: source
+            )
+            #expect(envelope.trustLevel == .inferred)
+        }
+    }
+
     @Test func envelope_missingOptionalFields_useSafeDefaults() throws {
         // A minimal envelope from an older format must still decode.
         let json: [String: Any] = [
@@ -234,6 +273,7 @@ struct AgentEventEnvelopeTests {
         #expect(decoded.payload == .none)
         #expect(decoded.trustLevel == .inferred)
         #expect(decoded.location.worktreePath == "")
+        #expect(decoded.process.terminalID == known("00000000-0000-0000-0000-000000000000"))
     }
 
     @Test func envelope_unknownSource_isPreserved() throws {
@@ -257,5 +297,34 @@ struct AgentEventEnvelopeTests {
         let envelope = sampleEnvelope(trustLevel: .verified, payload: .none)
         #expect(envelope.trustLevel.isVerified)
         #expect(envelope.payload == .none)
+    }
+
+    @Test func envelope_malformedNestedContentIdentity_dropsPayloadAndTrust() throws {
+        let json: [String: Any] = [
+            "id": "00000000-0000-0000-0000-000000000009",
+            "projectID": "00000000-0000-0000-0000-000000000001",
+            "sessionID": "00000000-0000-0000-0000-000000000002",
+            "agentTypeRaw": "claudeCode",
+            "process": [
+                "terminalID": "00000000-0000-0000-0000-000000000003",
+                "processGeneration": 1,
+            ],
+            "location": ["worktreePath": "/proj", "cwd": "/proj"],
+            "cursorValue": 1,
+            "timestamp": 1_000,
+            "source": "explicitAgentEvent",
+            "trustLevel": "verified",
+            "payload": [
+                "kind": "fileChange",
+                "fileChange": [
+                    "relativePath": "src/app.swift",
+                    "after": ["sha256Hex": "not-a-digest", "byteCount": -1],
+                ],
+            ],
+        ]
+
+        let decoded = try decode(json)
+        #expect(decoded.payload == .none)
+        #expect(decoded.trustLevel == .inferred)
     }
 }

--- a/PineTests/AgentProvenanceTests/AgentEventProvenanceCollectorTests.swift
+++ b/PineTests/AgentProvenanceTests/AgentEventProvenanceCollectorTests.swift
@@ -1,0 +1,76 @@
+//
+//  AgentEventProvenanceCollectorTests.swift
+//  PineTests
+//
+//  Tests for the AgentEventProvenanceCollector seam and its no-op default
+//  (epic #933, slice 1 — trusted event provenance).
+//
+
+import Foundation
+import os
+import Testing
+
+@testable import Pine
+
+struct AgentEventProvenanceCollectorTests {
+
+    private func makeEnvelope() -> AgentEventEnvelope {
+        AgentEventEnvelope(
+            projectID: UUID(),
+            sessionID: UUID(),
+            agentTypeRaw: "claudeCode",
+            process: AgentProcessIdentity(terminalID: UUID(), processGeneration: 1),
+            location: AgentEventLocation(worktreePath: "/proj", cwd: "/proj"),
+            cursorValue: 1,
+            source: .explicitAgentEvent,
+            trustLevel: .verified,
+            payload: .none
+        )
+    }
+
+    @Test func nullCollector_isSendableAndAdoptsProtocol() {
+        // Compile-time conformance is asserted by the type annotation; this
+        // confirms the null collector can be used wherever the protocol is
+        // expected without optionality.
+        let collector: AgentEventProvenanceCollector = NullAgentEventProvenanceCollector()
+        #expect(type(of: collector) == NullAgentEventProvenanceCollector.self)
+    }
+
+    @Test func nullCollector_recordsWithoutThrowing() async {
+        let collector = NullAgentEventProvenanceCollector()
+        // Recording many envelopes must be a harmless no-op.
+        for _ in 0..<100 {
+            await collector.record(makeEnvelope())
+        }
+        #expect(true)
+    }
+
+    @Test func customCollector_canCaptureRecordedEnvelopes() async {
+        // A test collector proving the seam is adoptable and observable.
+        let collector = CapturingCollector()
+        let first = makeEnvelope()
+        let second = makeEnvelope()
+        await collector.record(first)
+        await collector.record(second)
+        #expect(collector.recorded.count == 2)
+        #expect(collector.recorded[0] == first)
+        #expect(collector.recorded[1] == second)
+    }
+}
+
+/// A thread-safe collector used to verify the seam captures envelopes.
+///
+/// Mirrors the production `NullAgentEventProvenanceCollector`: a `Sendable`
+/// final class guarded by an unfair lock. An `actor` cannot conform to a
+/// plain `Sendable` protocol under strict concurrency, so the test uses the
+/// same lock-based shape production adopters will.
+final class CapturingCollector: AgentEventProvenanceCollector, @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock(initialState: [AgentEventEnvelope]())
+
+    func record(_ envelope: AgentEventEnvelope) async {
+        lock.withLock { state in state.append(envelope) }
+    }
+
+    /// The envelopes recorded so far, in insertion order.
+    var recorded: [AgentEventEnvelope] { lock.withLock { $0 } }
+}

--- a/PineTests/AgentProvenanceTests/AgentEventProvenanceCollectorTests.swift
+++ b/PineTests/AgentProvenanceTests/AgentEventProvenanceCollectorTests.swift
@@ -7,12 +7,11 @@
 //
 
 import Foundation
-import os
 import Testing
 
 @testable import Pine
 
-struct AgentEventProvenanceCollectorTests {
+nonisolated struct AgentEventProvenanceCollectorTests {
 
     private func makeEnvelope() -> AgentEventEnvelope {
         AgentEventEnvelope(
@@ -45,32 +44,35 @@ struct AgentEventProvenanceCollectorTests {
         #expect(true)
     }
 
-    @Test func customCollector_canCaptureRecordedEnvelopes() async {
-        // A test collector proving the seam is adoptable and observable.
+    @Test func actorCollector_canCaptureAcrossIsolationDomains() async {
+        // An actor is the natural serialization boundary for a provenance
+        // stream. Recording from a detached task proves the protocol and its
+        // Sendable envelope are not accidentally MainActor-isolated.
         let collector = CapturingCollector()
         let first = makeEnvelope()
         let second = makeEnvelope()
-        await collector.record(first)
-        await collector.record(second)
-        #expect(collector.recorded.count == 2)
-        #expect(collector.recorded[0] == first)
-        #expect(collector.recorded[1] == second)
+        await Task.detached {
+            await collector.record(first)
+            await collector.record(second)
+        }.value
+
+        let recorded = await collector.snapshot()
+        #expect(recorded.count == 2)
+        #expect(recorded[0] == first)
+        #expect(recorded[1] == second)
     }
 }
 
-/// A thread-safe collector used to verify the seam captures envelopes.
-///
-/// Mirrors the production `NullAgentEventProvenanceCollector`: a `Sendable`
-/// final class guarded by an unfair lock. An `actor` cannot conform to a
-/// plain `Sendable` protocol under strict concurrency, so the test uses the
-/// same lock-based shape production adopters will.
-final class CapturingCollector: AgentEventProvenanceCollector, @unchecked Sendable {
-    private let lock = OSAllocatedUnfairLock(initialState: [AgentEventEnvelope]())
+/// An actor-backed collector proving the seam supports serialized persistence
+/// without unchecked Sendable conformance.
+actor CapturingCollector: AgentEventProvenanceCollector {
+    private var recorded: [AgentEventEnvelope] = []
 
     func record(_ envelope: AgentEventEnvelope) async {
-        lock.withLock { state in state.append(envelope) }
+        recorded.append(envelope)
     }
 
-    /// The envelopes recorded so far, in insertion order.
-    var recorded: [AgentEventEnvelope] { lock.withLock { $0 } }
+    func snapshot() -> [AgentEventEnvelope] {
+        recorded
+    }
 }

--- a/PineTests/AgentProvenanceTests/ContentIdentityTests.swift
+++ b/PineTests/AgentProvenanceTests/ContentIdentityTests.swift
@@ -1,0 +1,104 @@
+//
+//  ContentIdentityTests.swift
+//  PineTests
+//
+//  Tests for ContentIdentity (epic #933, slice 1 — trusted event provenance).
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+struct ContentIdentityTests {
+
+    // MARK: - Hashing determinism
+
+    @Test func identicalContent_producesEqualIdentities() {
+        let a = ContentIdentity(content: Data("hello world".utf8))
+        let b = ContentIdentity(content: Data("hello world".utf8))
+        #expect(a == b)
+        #expect(a.sha256Hex == b.sha256Hex)
+        #expect(a.byteCount == b.byteCount)
+    }
+
+    @Test func differentContent_producesDifferentIdentities() {
+        let a = ContentIdentity(content: Data("hello".utf8))
+        let b = ContentIdentity(content: Data("Hello".utf8))
+        #expect(a != b)
+        #expect(a.sha256Hex != b.sha256Hex)
+    }
+
+    @Test func knownSha256Value_isDeterministic() {
+        // SHA-256("hello") is a fixed, well-known digest. Asserting it proves
+        // the hashing is deterministic and matches the standard algorithm.
+        let identity = ContentIdentity(content: Data("hello".utf8))
+        #expect(identity.sha256Hex == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+        #expect(identity.byteCount == 5)
+    }
+
+    @Test func emptyContent_hasStableEmptyIdentity() {
+        let empty = ContentIdentity.empty
+        let fromData = ContentIdentity(content: Data())
+        #expect(empty == fromData)
+        #expect(empty.byteCount == 0)
+        // SHA-256 of zero bytes is also a fixed value.
+        #expect(empty.sha256Hex == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    }
+
+    // MARK: - Never stores content
+
+    @Test func identityDoesNotRetainSourceContent() {
+        // The identity is a value type holding only a hex string + count.
+        // There is no field that could hold the original bytes; this test
+        // documents the invariant by confirming the public surface.
+        let identity = ContentIdentity(content: Data("sensitive content".utf8))
+        #expect(identity.sha256Hex.count == 64)
+        // No accessible property exposes the source bytes.
+        #expect(Mirror(reflecting: identity).children.map(\.label) == ["sha256Hex", "byteCount"])
+    }
+
+    // MARK: - Reconstruction validation (fail-closed)
+
+    @Test func reconstruct_acceptsValidHexAndCount() {
+        let hex = String(repeating: "a", count: 64)
+        let identity = ContentIdentity(sha256Hex: hex, byteCount: 7)
+        #expect(identity?.sha256Hex == hex)
+        #expect(identity?.byteCount == 7)
+    }
+
+    @Test func reconstruct_rejectsHexOfWrongLength() {
+        #expect(ContentIdentity(sha256Hex: "abcd", byteCount: 4) == nil)
+        #expect(ContentIdentity(sha256Hex: String(repeating: "a", count: 63), byteCount: 4) == nil)
+        #expect(ContentIdentity(sha256Hex: String(repeating: "a", count: 65), byteCount: 4) == nil)
+    }
+
+    @Test func reconstruct_rejectsNonHexCharacters() {
+        #expect(ContentIdentity(sha256Hex: String(repeating: "z", count: 64), byteCount: 4) == nil)
+        #expect(ContentIdentity(sha256Hex: String(repeating: " ", count: 64), byteCount: 4) == nil)
+    }
+
+    @Test func reconstruct_rejectsUppercaseHex() {
+        // Only lowercase hex is accepted to keep persisted identities canonical.
+        #expect(ContentIdentity(sha256Hex: String(repeating: "A", count: 64), byteCount: 4) == nil)
+    }
+
+    @Test func reconstruct_rejectsNegativeByteCount() {
+        #expect(ContentIdentity(sha256Hex: String(repeating: "a", count: 64), byteCount: -1) == nil)
+    }
+
+    @Test func roundTripThroughComputedIdentity_reconstructs() {
+        let original = ContentIdentity(content: Data("round trip".utf8))
+        let reconstructed = ContentIdentity(sha256Hex: original.sha256Hex, byteCount: original.byteCount)
+        #expect(reconstructed == original)
+    }
+
+    // MARK: - Codable
+
+    @Test func codable_roundTripsPreservingHash() throws {
+        let original = ContentIdentity(content: Data("encode me".utf8))
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ContentIdentity.self, from: data)
+        #expect(decoded == original)
+    }
+}

--- a/PineTests/AgentProvenanceTests/ContentIdentityTests.swift
+++ b/PineTests/AgentProvenanceTests/ContentIdentityTests.swift
@@ -10,7 +10,7 @@ import Testing
 
 @testable import Pine
 
-struct ContentIdentityTests {
+nonisolated struct ContentIdentityTests {
 
     // MARK: - Hashing determinism
 
@@ -100,5 +100,35 @@ struct ContentIdentityTests {
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(ContentIdentity.self, from: data)
         #expect(decoded == original)
+    }
+
+    @Test func codable_rejectsInvalidDigest() throws {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "sha256Hex": "not-a-digest",
+            "byteCount": 12,
+        ])
+
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(ContentIdentity.self, from: data)
+        }
+    }
+
+    @Test func codable_rejectsNegativeByteCount() throws {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "sha256Hex": String(repeating: "a", count: 64),
+            "byteCount": -1,
+        ])
+
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(ContentIdentity.self, from: data)
+        }
+    }
+
+    @Test func hashingIsAvailableFromDetachedTask() async {
+        let identity = await Task.detached {
+            ContentIdentity(content: Data("background".utf8))
+        }.value
+
+        #expect(identity.byteCount == 10)
     }
 }

--- a/PineTests/AgentProvenanceTests/EventCursorTests.swift
+++ b/PineTests/AgentProvenanceTests/EventCursorTests.swift
@@ -1,0 +1,121 @@
+//
+//  EventCursorTests.swift
+//  PineTests
+//
+//  Tests for EventCursor (epic #933, slice 1 — trusted event provenance).
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+struct EventCursorTests {
+
+    // MARK: - Monotonicity
+
+    @Test func firstValue_isOneByDefault() async {
+        let cursor = EventCursor()
+        #expect(await cursor.current == 0)
+        let first = await cursor.next()
+        #expect(first == 1)
+        #expect(await cursor.current == 1)
+    }
+
+    @Test func next_isStrictlyMonotonic() async {
+        let cursor = EventCursor()
+        var previous: UInt64 = 0
+        for _ in 0..<1_000 {
+            let value = await cursor.next()
+            #expect(value > previous)
+            previous = value
+        }
+        #expect(await cursor.current == 1_000)
+    }
+
+    @Test func seed_advancesFromProvidedValue() async {
+        let cursor = EventCursor(seed: 99)
+        #expect(await cursor.current == 99)
+        #expect(await cursor.next() == 100)
+        #expect(await cursor.next() == 101)
+        #expect(await cursor.current == 101)
+    }
+
+    @Test func next_canBeDiscarded() async {
+        let cursor = EventCursor()
+        // @discardableResult allows ignoring the return value.
+        await cursor.next()
+        await cursor.next()
+        let third = await cursor.next()
+        #expect(third == 3)
+    }
+
+    // MARK: - Thread safety / concurrency
+
+    @Test func concurrentIncrements_neverRepeatOrReorder() async {
+        // Many tasks each mint a batch of values concurrently. Because the
+        // cursor is an actor, increments are serialized: every value must be
+        // unique and the total count must equal tasks * batch.
+        let cursor = EventCursor()
+        let tasks = 16
+        let perTask = 500
+
+        let collected = await withTaskGroup(of: [UInt64].self, returning: [UInt64].self) { group in
+            for _ in 0..<tasks {
+                group.addTask {
+                    var values: [UInt64] = []
+                    values.reserveCapacity(perTask)
+                    for _ in 0..<perTask {
+                        values.append(await cursor.next())
+                    }
+                    return values
+                }
+            }
+            var all: [UInt64] = []
+            for await batch in group {
+                all.append(contentsOf: batch)
+            }
+            return all
+        }
+
+        #expect(collected.count == tasks * perTask)
+        // No duplicates across concurrent callers.
+        let unique = Set(collected)
+        #expect(unique.count == collected.count)
+        // Values span 1...total with no gaps and no overflow.
+        let total = UInt64(tasks * perTask)
+        #expect(unique.min() == 1)
+        #expect(unique.max() == total)
+        let current = await cursor.current
+        #expect(current == total)
+    }
+
+    @Test func concurrentIncrements_fromNonZeroSeed_preserveMonotonicity() async {
+        let seed: UInt64 = 1_000
+        let cursor = EventCursor(seed: seed)
+        let tasks = 8
+        let perTask = 100
+
+        let collected = await withTaskGroup(of: [UInt64].self, returning: Set<UInt64>.self) { group in
+            for _ in 0..<tasks {
+                group.addTask {
+                    var values: [UInt64] = []
+                    for _ in 0..<perTask {
+                        values.append(await cursor.next())
+                    }
+                    return values
+                }
+            }
+            var unique: Set<UInt64> = []
+            for await batch in group {
+                unique.formUnion(batch)
+            }
+            return unique
+        }
+
+        let total = UInt64(tasks * perTask)
+        #expect(collected.count == Int(total))
+        #expect(collected.min() == seed + 1)
+        #expect(collected.max() == seed + total)
+    }
+}


### PR DESCRIPTION
## Summary

Slice 1 of epic **#933** (`epic(agent): trustworthy CLI-agent awareness and handoff`): a pure **data-model** foundation for trusted event provenance. No live terminal or file-system wiring in this slice — that belongs to later slices, after the #1183 safety gate lands.

This is the provenance model #1183's durable design references ("record explicit provenance: project/worktree identity, terminal/process generation, agent/session identity, event cursor, path, timestamp; capture a content identity or exact before/after patch").

**Refs #933** — does not close the epic (slice 1 of 4).

## What's added

- **`AgentEventEnvelope`** — the single structured record capturing WHO did WHAT, WHERE, and HOW TRUSTWORTHY the observation is: project/worktree identity, agent/session identity, terminal/process generation, cwd, monotonic event cursor + wall-clock timestamp, event source, trust level, and an optional payload. Forward-compatible decoder: missing/unknown values fail closed to the least-trusting safe default rather than throwing.
- **`TrustLevel`** — `observed` / `inferred` / `verified`. Temporal correlation alone never reaches `.verified`. Unknown raw values decode to `.inferred` (never upgrade to `.verified`), mirroring `AgentHistoryAttribution`.
- **`EventSource`** — `terminalProcess` / `fileSystemObservation` / `gitCorrelation` / `explicitAgentEvent` / `userAction`, plus an `unknown(raw:)` case that preserves future source strings verbatim.
- **`ContentIdentity`** — SHA-256 fingerprint (CryptoKit) + byte count. **Never stores content.** Two identities match only when both digest and length match, so a future safe-undo path can detect divergence before reverting (#1183).
- **`EventCursor`** — monotonic, thread-safe (`actor`) per-process event sequence number.
- **`AgentEventProvenanceCollector`** — adoptable `Sendable` seam for recording envelopes, plus a no-op `NullAgentEventProvenanceCollector` default.

## Safety boundary (#1183)

A `.verified` trust level means the event **source** is trustworthy, not that an undo is safe. A safe inverse still requires a checked change set AND a divergence check against the current file — that is #1183's domain, handled separately. This envelope performs and authorizes **no** working-tree mutation.

## Validation

All commands run with `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer` (only Xcode-beta is installed locally; the project's CI uses stable Xcode 26).

- **SwiftLint** (8 files): `Done linting! Found 0 violations, 0 serious in 8 files.`
- **Typecheck** (4 impl files, beta toolchain, macOS 26 SDK): exit 0.
- **Unit tests** (`-only-testing` the 4 suites): `Test run with 41 tests in 4 suites passed after 0.018 seconds.` (XCODEBUILD_EXIT=0). Covers: hash determinism + known SHA-256, reconstruction fail-closed validation, Codable round-trips, cursor monotonicity + concurrency (16×500 concurrent increments, no repeats/gaps), trust-level transitions, forward-compatible decoding (unknown trust → `.inferred`, unknown source preserved, unknown payload → `.none`, missing fields → safe defaults), collector seam.

## Merge order

Independent — new files only (`Pine/Agent/Provenance/`, `PineTests/AgentProvenanceTests/`). Touches no file owned by sibling PRs (#1183 Agent history, #1008 Syntax/LSP, #1117 Extensibility, #1168 Pane/Tab, #1195 CI). Merge in any order.

## Follow-ups (later slices of #933, not in this PR)

- Trusted event provenance pipeline wiring (terminal/process observer → envelope).
- Reviewable changes (exact before/after patches, overlap detection, checked inverse).
- Editor/agent handoff (read-only context surface, ADR).
