### PR TITLE
feat(extensibility): complete command palette and registry (#1117)

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -88,6 +88,14 @@ nonisolated enum AccessibilityID {
     static let quickOpenResultsList = "quickOpenResultsList"
     static func quickOpenItem(_ name: String) -> String { "quickOpenItem_\(name)" }
 
+    // MARK: - Command Palette
+    static let commandPaletteOverlay = "commandPaletteOverlay"
+    static let commandPaletteSearchField = "commandPaletteSearchField"
+    static let commandPaletteResultsList = "commandPaletteResultsList"
+    static func commandPaletteItem(_ id: String) -> String {
+        "commandPaletteItem_\(id)"
+    }
+
     // MARK: - Symbol Navigator
     static let symbolNavigatorOverlay = "symbolNavigatorOverlay"
     static let symbolSearchField = "symbolSearchField"

--- a/Pine/CommandPaletteView.swift
+++ b/Pine/CommandPaletteView.swift
@@ -1,0 +1,185 @@
+//
+//  CommandPaletteView.swift
+//  Pine
+//
+//  Searchable built-in command + user task palette (issue #1117).
+//
+
+import SwiftUI
+
+struct CommandPaletteView: View {
+    @Binding var isPresented: Bool
+    let items: [CommandPaletteItem]
+    let onInvoke: (CommandPaletteItem) -> Void
+
+    @State private var searchText = ""
+    @State private var selectedIndex = 0
+
+    private var filteredItems: [CommandPaletteItem] {
+        CommandPaletteSearch.filter(items, query: searchText)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            QuickOpenSearchField(
+                text: $searchText,
+                placeholder: String(localized: "commandPalette.placeholder"),
+                onArrowUp: { moveSelection(by: -1) },
+                onArrowDown: { moveSelection(by: 1) },
+                onReturn: { invokeSelected() },
+                onEscape: { isPresented = false }
+            )
+            .accessibilityIdentifier(AccessibilityID.commandPaletteSearchField)
+            .padding(10)
+
+            Divider()
+            resultsList
+        }
+        .frame(width: 560, height: 400)
+        .onChange(of: searchText) { _, _ in
+            selectedIndex = 0
+        }
+        .onChange(of: filteredItems.map(\.id)) { _, newIDs in
+            if newIDs.isEmpty {
+                selectedIndex = 0
+            } else {
+                selectedIndex = min(selectedIndex, newIDs.count - 1)
+            }
+        }
+        .accessibilityIdentifier(AccessibilityID.commandPaletteOverlay)
+    }
+
+    private var resultsList: some View {
+        Group {
+            if filteredItems.isEmpty {
+                VStack {
+                    Spacer()
+                    Text("commandPalette.noResults")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 0) {
+                            ForEach(Array(filteredItems.enumerated()), id: \.element.id) { index, item in
+                                row(item, isSelected: index == selectedIndex)
+                                    .id(index)
+                                    .onTapGesture {
+                                        guard item.isEnabled else { return }
+                                        selectedIndex = index
+                                        invoke(item)
+                                    }
+                            }
+                        }
+                    }
+                    .onChange(of: selectedIndex) { _, newIndex in
+                        proxy.scrollTo(newIndex, anchor: .center)
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier(AccessibilityID.commandPaletteResultsList)
+    }
+
+    private func row(
+        _ item: CommandPaletteItem,
+        isSelected: Bool
+    ) -> some View {
+        HStack(spacing: 9) {
+            Image(systemName: item.iconName)
+                .font(.system(size: 14))
+                .foregroundStyle(item.isTask ? Color.orange : Color.accentColor)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(item.title)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Text(item.subtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 8)
+
+            shortcutState(for: item.shortcut.state)
+
+            if let shortcut = item.shortcut.displayText {
+                Text(shortcut)
+                    .font(.system(size: 12, design: .rounded))
+                    .foregroundStyle(
+                        item.shortcut.state == .shadowed
+                            ? AnyShapeStyle(.tertiary)
+                            : AnyShapeStyle(.secondary)
+                    )
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(isSelected ? Color.accentColor.opacity(0.2) : Color.clear)
+        .contentShape(Rectangle())
+        .opacity(item.isEnabled ? 1 : 0.48)
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier(AccessibilityID.commandPaletteItem(item.id.accessibilityToken))
+    }
+
+    @ViewBuilder
+    private func shortcutState(
+        for state: CommandShortcutState
+    ) -> some View {
+        switch state {
+        case .userOverride:
+            Text("commandPalette.shortcutOverride")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(.quaternary, in: Capsule())
+        case .shadowed:
+            Text("commandPalette.shortcutConflict")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.orange)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(Color.orange.opacity(0.12), in: Capsule())
+        case .builtIn, .none:
+            EmptyView()
+        }
+    }
+
+    private func moveSelection(by delta: Int) {
+        selectedIndex = CommandPaletteNavigation.movedIndex(
+            from: selectedIndex,
+            by: delta,
+            itemCount: filteredItems.count
+        )
+    }
+
+    private func invokeSelected() {
+        guard filteredItems.indices.contains(selectedIndex) else { return }
+        let item = filteredItems[selectedIndex]
+        guard item.isEnabled else { return }
+        invoke(item)
+    }
+
+    private func invoke(_ item: CommandPaletteItem) {
+        isPresented = false
+        onInvoke(item)
+    }
+}
+
+nonisolated private extension CommandPaletteItemID {
+    var accessibilityToken: String {
+        switch self {
+        case .builtIn(let command):
+            "command_\(command.rawValue)"
+        case .task(let id):
+            "task_\(id)"
+        }
+    }
+}

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -41,6 +41,7 @@ struct ContentView: View {
     @State var showRecoveryDialog = false
     @State var isDragTargeted = false
     @State var isQuickOpenPresented = false
+    @State var isCommandPalettePresented = false
     @State var isSymbolNavigatorPresented = false
     @State var isBranchSwitcherPresented = false
     @State var showGoToLine = false
@@ -132,6 +133,29 @@ struct ContentView: View {
             // exclusivity abort.
             DispatchQueue.main.async {
                 isQuickOpenPresented = true
+            }
+        }
+        .sheet(isPresented: $isCommandPalettePresented) {
+            CommandPaletteView(
+                isPresented: $isCommandPalettePresented,
+                items: CommandPaletteCatalog.makeItems(
+                    tasks: ExtensibilityManager.shared.tasks.tasks,
+                    keybindings: ExtensibilityManager.shared.keybindings,
+                    context: UserCommandInvocationRouter.context(
+                        for: projectManager
+                    )
+                ),
+                onInvoke: invokeCommandPaletteItem
+            )
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: .showCommandPalette)
+        ) { _ in
+            // Notification delivery is synchronous. Defer the @State write
+            // to avoid re-entering SwiftUI storage from a menu/keybinding
+            // dispatch call stack (the #1051 exclusivity-abort family).
+            DispatchQueue.main.async {
+                isCommandPalettePresented = true
             }
         }
         .sheet(isPresented: $isSymbolNavigatorPresented) {
@@ -352,6 +376,24 @@ struct ContentView: View {
         guard let notificationObject else { return isKeyWindow }
         guard let targetProject = notificationObject as? ProjectManager else { return false }
         return targetProject === currentProject
+    }
+
+    private func invokeCommandPaletteItem(_ item: CommandPaletteItem) {
+        switch item.id {
+        case .builtIn(let command):
+            UserCommandInvocationRouter.dispatch(
+                command,
+                projectManager: projectManager
+            )
+        case .task(let id):
+            guard let task = ExtensibilityManager.shared.tasks.task(forID: id) else {
+                return
+            }
+            UserTaskInvocationController.invoke(
+                task,
+                projectManager: projectManager
+            )
+        }
     }
 
     // MARK: - Subview builders

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -135,29 +135,12 @@ struct ContentView: View {
                 isQuickOpenPresented = true
             }
         }
-        .sheet(isPresented: $isCommandPalettePresented) {
-            CommandPaletteView(
-                isPresented: $isCommandPalettePresented,
-                items: CommandPaletteCatalog.makeItems(
-                    tasks: ExtensibilityManager.shared.tasks.tasks,
-                    keybindings: ExtensibilityManager.shared.keybindings,
-                    context: UserCommandInvocationRouter.context(
-                        for: projectManager
-                    )
-                ),
-                onInvoke: invokeCommandPaletteItem
-            )
-        }
-        .onReceive(
-            NotificationCenter.default.publisher(for: .showCommandPalette)
-        ) { _ in
-            // Notification delivery is synchronous. Defer the @State write
-            // to avoid re-entering SwiftUI storage from a menu/keybinding
-            // dispatch call stack (the #1051 exclusivity-abort family).
-            DispatchQueue.main.async {
-                isCommandPalettePresented = true
-            }
-        }
+        .modifier(CommandPalettePresenter(
+            isPresented: $isCommandPalettePresented,
+            projectManager: projectManager,
+            isKeyWindow: controlActiveState == .key,
+            onInvoke: invokeCommandPaletteItem
+        ))
         .sheet(isPresented: $isSymbolNavigatorPresented) {
             SymbolNavigatorView(isPresented: $isSymbolNavigatorPresented)
                 .environment(projectManager)
@@ -378,6 +361,18 @@ struct ContentView: View {
         return targetProject === currentProject
     }
 
+    static func shouldHandleTargetedCommand(
+        notificationObject: Any?,
+        currentProject: ProjectManager,
+        isKeyWindow: Bool
+    ) -> Bool {
+        guard let notificationObject else { return isKeyWindow }
+        guard let targetProject = notificationObject as? ProjectManager else {
+            return false
+        }
+        return targetProject === currentProject
+    }
+
     private func invokeCommandPaletteItem(_ item: CommandPaletteItem) {
         switch item.id {
         case .builtIn(let command):
@@ -403,6 +398,49 @@ struct ContentView: View {
         PaneTreeView(node: paneManager.root)
     }
 
+}
+
+private struct CommandPalettePresenter: ViewModifier {
+    @Binding var isPresented: Bool
+    let projectManager: ProjectManager
+    let isKeyWindow: Bool
+    let onInvoke: (CommandPaletteItem) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(isPresented: $isPresented) {
+                CommandPaletteView(
+                    isPresented: $isPresented,
+                    items: CommandPaletteCatalog.makeItems(
+                        tasks: ExtensibilityManager.shared.tasks.tasks,
+                        keybindings: ExtensibilityManager.shared.keybindings,
+                        context: UserCommandInvocationRouter.context(
+                            for: projectManager
+                        )
+                    ),
+                    onInvoke: onInvoke
+                )
+            }
+            .onReceive(
+                NotificationCenter.default.publisher(
+                    for: .showCommandPalette
+                )
+            ) { notification in
+                guard ContentView.shouldHandleTargetedCommand(
+                    notificationObject: notification.object,
+                    currentProject: projectManager,
+                    isKeyWindow: isKeyWindow
+                ) else {
+                    return
+                }
+                // Notification delivery is synchronous. Defer the @State
+                // write to avoid re-entering SwiftUI storage from a
+                // menu/keybinding dispatch call stack (#1051 family).
+                DispatchQueue.main.async {
+                    isPresented = true
+                }
+            }
+    }
 }
 
 // MARK: - Preview

--- a/Pine/Extensibility/CommandPaletteModel.swift
+++ b/Pine/Extensibility/CommandPaletteModel.swift
@@ -1,0 +1,326 @@
+//
+//  CommandPaletteModel.swift
+//  Pine
+//
+//  Unified searchable catalog for Pine's built-in commands and user tasks
+//  (issue #1117). The model is independent from SwiftUI so fuzzy ranking,
+//  shortcut precedence, availability, and keyboard navigation remain
+//  deterministic and directly testable.
+//
+
+import AppKit
+import Foundation
+
+nonisolated enum CommandPaletteCategory: String, Sendable, CaseIterable {
+    case file
+    case edit
+    case view
+    case git
+    case terminal
+    case tasks
+
+    var localizedTitle: String {
+        switch self {
+        case .file:
+            String(localized: "commandPalette.category.file")
+        case .edit:
+            String(localized: "commandPalette.category.edit")
+        case .view:
+            String(localized: "commandPalette.category.view")
+        case .git:
+            String(localized: "menu.git")
+        case .terminal:
+            String(localized: "menu.terminal")
+        case .tasks:
+            String(localized: "menu.tasks")
+        }
+    }
+}
+
+nonisolated enum CommandAvailabilityRequirement: Sendable {
+    case always
+    case project
+    case activeFile
+    case gitRepository
+    case terminal
+}
+
+nonisolated struct CommandPaletteContext: Sendable, Equatable {
+    let hasProject: Bool
+    let hasActiveFile: Bool
+    let isGitRepository: Bool
+    let hasTerminal: Bool
+
+    static let unavailable = CommandPaletteContext(
+        hasProject: false,
+        hasActiveFile: false,
+        isGitRepository: false,
+        hasTerminal: false
+    )
+
+    func satisfies(_ requirement: CommandAvailabilityRequirement) -> Bool {
+        switch requirement {
+        case .always:
+            true
+        case .project:
+            hasProject
+        case .activeFile:
+            hasActiveFile
+        case .gitRepository:
+            isGitRepository
+        case .terminal:
+            hasTerminal
+        }
+    }
+}
+
+nonisolated enum CommandPaletteItemID: Hashable, Sendable {
+    case builtIn(UserCommand)
+    case task(String)
+}
+
+nonisolated enum CommandShortcutState: Sendable, Equatable {
+    /// The built-in key equivalent is effective.
+    case builtIn
+    /// A user binding replaces the command's built-in key equivalent.
+    case userOverride
+    /// Another user binding claims this command's built-in key equivalent.
+    case shadowed
+    /// The command or task has no shortcut.
+    case none
+}
+
+nonisolated struct CommandShortcutPresentation: Sendable, Equatable {
+    let chord: ParsedKeyChord?
+    let state: CommandShortcutState
+
+    var displayText: String? {
+        chord?.displayText
+    }
+}
+
+nonisolated struct CommandPaletteItem: Identifiable, Sendable, Equatable {
+    let id: CommandPaletteItemID
+    let title: String
+    let subtitle: String
+    let searchTerms: [String]
+    let iconName: String
+    let shortcut: CommandShortcutPresentation
+    let isEnabled: Bool
+
+    var isTask: Bool {
+        if case .task = id {
+            return true
+        }
+        return false
+    }
+
+    var searchableText: String {
+        ([title, subtitle] + searchTerms).joined(separator: " ").lowercased()
+    }
+}
+
+@MainActor
+enum CommandPaletteCatalog {
+    static func makeItems(
+        tasks: [UserTask],
+        keybindings: UserKeybindingRegistry,
+        context: CommandPaletteContext
+    ) -> [CommandPaletteItem] {
+        let userEntries = keybindings.entries
+        let entryByCommand = Dictionary(
+            uniqueKeysWithValues: userEntries.map { ($0.command, $0.chord) }
+        )
+        let commandByClaimedChord = Dictionary(
+            uniqueKeysWithValues: userEntries.map { ($0.chord, $0.command) }
+        )
+
+        let builtIns = UserCommand.allCases.map { command in
+            let shortcut = shortcutPresentation(
+                for: command,
+                entryByCommand: entryByCommand,
+                commandByClaimedChord: commandByClaimedChord
+            )
+            return CommandPaletteItem(
+                id: .builtIn(command),
+                title: command.localizedTitle,
+                subtitle: command.category.localizedTitle,
+                searchTerms: [command.rawValue],
+                iconName: command.iconName,
+                shortcut: shortcut,
+                isEnabled: context.satisfies(command.availabilityRequirement)
+            )
+        }
+
+        let taskItems = tasks.map { task in
+            let isEnabled: Bool
+            switch task.scope {
+            case .activeFile:
+                isEnabled = context.hasActiveFile
+            case .project:
+                isEnabled = context.hasProject
+            }
+            return CommandPaletteItem(
+                id: .task(task.id),
+                title: task.label,
+                subtitle: CommandPaletteCategory.tasks.localizedTitle,
+                searchTerms: [task.id, task.command],
+                iconName: MenuIcons.tasks,
+                shortcut: CommandShortcutPresentation(chord: nil, state: .none),
+                isEnabled: isEnabled
+            )
+        }
+
+        return builtIns + taskItems
+    }
+
+    private static func shortcutPresentation(
+        for command: UserCommand,
+        entryByCommand: [UserCommand: ParsedKeyChord],
+        commandByClaimedChord: [ParsedKeyChord: UserCommand]
+    ) -> CommandShortcutPresentation {
+        if let userChord = entryByCommand[command] {
+            return CommandShortcutPresentation(
+                chord: userChord,
+                state: .userOverride
+            )
+        }
+        guard let builtInChord = command.defaultChord else {
+            return CommandShortcutPresentation(chord: nil, state: .none)
+        }
+        if let claimant = commandByClaimedChord[builtInChord],
+           claimant != command {
+            return CommandShortcutPresentation(
+                chord: builtInChord,
+                state: .shadowed
+            )
+        }
+        return CommandShortcutPresentation(
+            chord: builtInChord,
+            state: .builtIn
+        )
+    }
+}
+
+nonisolated enum CommandPaletteSearch {
+    static func filter(
+        _ items: [CommandPaletteItem],
+        query: String
+    ) -> [CommandPaletteItem] {
+        let tokens = query
+            .lowercased()
+            .split(whereSeparator: \.isWhitespace)
+            .map(String.init)
+        guard !tokens.isEmpty else { return items }
+
+        return items.enumerated()
+            .compactMap { index, item -> (CommandPaletteItem, Int, Int)? in
+                var totalScore = 0
+                for token in tokens {
+                    guard let score = score(token: token, item: item) else {
+                        return nil
+                    }
+                    totalScore += score
+                }
+                return (item, totalScore, index)
+            }
+            .sorted { lhs, rhs in
+                if lhs.1 != rhs.1 {
+                    return lhs.1 > rhs.1
+                }
+                return lhs.2 < rhs.2
+            }
+            .map(\.0)
+    }
+
+    private static func score(
+        token: String,
+        item: CommandPaletteItem
+    ) -> Int? {
+        let title = item.title.lowercased()
+        let terms = item.searchTerms.map { $0.lowercased() }
+
+        if title == token {
+            return 1_000
+        }
+        if title.hasPrefix(token) {
+            return 800 - title.count
+        }
+        if title.contains(token) {
+            return 600 - title.count
+        }
+        if terms.contains(token) {
+            return 550
+        }
+        if let term = terms.first(where: { $0.hasPrefix(token) }) {
+            return 500 - term.count
+        }
+        if isSubsequence(token, of: title) {
+            return 300 - title.count
+        }
+        if isSubsequence(token, of: item.searchableText) {
+            return 100 - item.searchableText.count
+        }
+        return nil
+    }
+
+    private static func isSubsequence(_ query: String, of target: String) -> Bool {
+        var queryIndex = query.startIndex
+        var targetIndex = target.startIndex
+        while queryIndex < query.endIndex, targetIndex < target.endIndex {
+            if query[queryIndex] == target[targetIndex] {
+                query.formIndex(after: &queryIndex)
+            }
+            target.formIndex(after: &targetIndex)
+        }
+        return queryIndex == query.endIndex
+    }
+}
+
+nonisolated enum CommandPaletteNavigation {
+    static func movedIndex(
+        from currentIndex: Int,
+        by delta: Int,
+        itemCount: Int
+    ) -> Int {
+        guard itemCount > 0 else { return 0 }
+        let normalized = min(max(currentIndex, 0), itemCount - 1)
+        let remainder = (normalized + delta) % itemCount
+        return remainder >= 0 ? remainder : remainder + itemCount
+    }
+}
+
+nonisolated extension ParsedKeyChord {
+    var displayText: String {
+        var result = ""
+        if modifiers.contains(.control) {
+            result += "⌃"
+        }
+        if modifiers.contains(.option) {
+            result += "⌥"
+        }
+        if modifiers.contains(.shift) {
+            result += "⇧"
+        }
+        if modifiers.contains(.command) {
+            result += "⌘"
+        }
+        result += Self.displayKey(key)
+        return result
+    }
+
+    private static func displayKey(_ key: String) -> String {
+        switch key {
+        case "return": "↩"
+        case "tab": "⇥"
+        case "delete": "⌫"
+        case "esc": "⎋"
+        case "space": "Space"
+        case "up": "↑"
+        case "down": "↓"
+        case "left": "←"
+        case "right": "→"
+        default: key.uppercased()
+        }
+    }
+}

--- a/Pine/Extensibility/CommandPaletteModel.swift
+++ b/Pine/Extensibility/CommandPaletteModel.swift
@@ -26,7 +26,7 @@ nonisolated enum CommandPaletteCategory: String, Sendable, CaseIterable {
         case .edit:
             String(localized: "commandPalette.category.edit")
         case .view:
-            String(localized: "commandPalette.category.view")
+            String(localized: "menu.view")
         case .git:
             String(localized: "menu.git")
         case .terminal:
@@ -41,6 +41,7 @@ nonisolated enum CommandAvailabilityRequirement: Sendable {
     case always
     case project
     case activeFile
+    case activeFileAndTerminal
     case gitRepository
     case terminal
 }
@@ -66,6 +67,8 @@ nonisolated struct CommandPaletteContext: Sendable, Equatable {
             hasProject
         case .activeFile:
             hasActiveFile
+        case .activeFileAndTerminal:
+            hasActiveFile && hasTerminal
         case .gitRepository:
             isGitRepository
         case .terminal:
@@ -128,12 +131,16 @@ enum CommandPaletteCatalog {
         context: CommandPaletteContext
     ) -> [CommandPaletteItem] {
         let userEntries = keybindings.entries
-        let entryByCommand = Dictionary(
-            uniqueKeysWithValues: userEntries.map { ($0.command, $0.chord) }
-        )
-        let commandByClaimedChord = Dictionary(
-            uniqueKeysWithValues: userEntries.map { ($0.chord, $0.command) }
-        )
+        var entryByCommand: [UserCommand: ParsedKeyChord] = [:]
+        var commandByClaimedChord: [ParsedKeyChord: UserCommand] = [:]
+        for entry in userEntries {
+            if entryByCommand[entry.command] == nil {
+                entryByCommand[entry.command] = entry.chord
+            }
+            if commandByClaimedChord[entry.chord] == nil {
+                commandByClaimedChord[entry.chord] = entry.command
+            }
+        }
 
         let builtIns = UserCommand.allCases.map { command in
             let shortcut = shortcutPresentation(

--- a/Pine/Extensibility/UserCommand+Palette.swift
+++ b/Pine/Extensibility/UserCommand+Palette.swift
@@ -8,11 +8,26 @@
 //  keybinding precedence logic from drifting apart.
 //
 
+import AppKit
 import Foundation
 
 nonisolated extension UserCommand {
     var localizedTitle: String {
         switch self {
+        case .save:
+            String(localized: "menu.save")
+        case .saveAll:
+            String(localized: "menu.saveAll")
+        case .saveAs:
+            String(localized: "menu.saveAs")
+        case .duplicate:
+            String(localized: "menu.duplicate")
+        case .toggleAutoSave:
+            String(localized: "menu.autoSave")
+        case .toggleFormatOnSave:
+            String(localized: "menu.formatOnSave")
+        case .toggleSmartListContinuation:
+            String(localized: "menu.smartListContinuation")
         case .toggleComment:
             String(localized: "menu.toggleComment")
         case .findInFile:
@@ -23,10 +38,32 @@ nonisolated extension UserCommand {
             String(localized: "menu.findNext")
         case .findPrevious:
             String(localized: "menu.findPrevious")
+        case .useSelectionForFind:
+            String(localized: "menu.useSelectionForFind")
         case .findInProject:
             String(localized: "menu.findInProject")
         case .goToLine:
             String(localized: "menu.goToLine")
+        case .nextChange:
+            String(localized: "menu.nextChange")
+        case .previousChange:
+            String(localized: "menu.previousChange")
+        case .acceptChange:
+            String(localized: "menu.acceptChange")
+        case .revertChange:
+            String(localized: "menu.revertChange")
+        case .acceptAllChanges:
+            String(localized: "menu.acceptAllChanges")
+        case .revertAllChanges:
+            String(localized: "menu.revertAllChanges")
+        case .foldCode:
+            String(localized: "menu.foldCode")
+        case .unfoldCode:
+            String(localized: "menu.unfoldCode")
+        case .foldAll:
+            String(localized: "menu.foldAll")
+        case .unfoldAll:
+            String(localized: "menu.unfoldAll")
         case .symbolNavigator:
             String(localized: "menu.symbolNavigator")
         case .quickOpen:
@@ -37,6 +74,12 @@ nonisolated extension UserCommand {
             String(localized: "menu.openFolder")
         case .showBranchSwitcher:
             String(localized: "menu.switchBranch")
+        case .increaseFontSize:
+            String(localized: "menu.increaseFontSize")
+        case .decreaseFontSize:
+            String(localized: "menu.decreaseFontSize")
+        case .resetFontSize:
+            String(localized: "menu.resetFontSize")
         case .toggleWordWrap:
             String(localized: "menu.toggleWordWrap")
         case .toggleMinimap:
@@ -45,41 +88,109 @@ nonisolated extension UserCommand {
             String(localized: "menu.toggleBlame")
         case .togglePreview:
             String(localized: "menu.togglePreview")
+        case .revealFileInFinder:
+            String(localized: "menu.revealFileInFinder")
+        case .revealProjectInFinder:
+            String(localized: "menu.revealProjectInFinder")
+        case .showAgentActivity:
+            String(localized: "menu.agentActivity")
+        case .showAgentHistory:
+            String(localized: "menu.agentHistory")
         case .toggleTerminal:
             String(localized: "terminal.toggle")
         case .newTerminalTab:
             String(localized: "menu.newTerminalTab")
+        case .findInTerminal:
+            String(localized: "menu.findInTerminal")
+        case .sendToTerminal:
+            String(localized: "menu.sendToTerminal")
+        case .toggleTerminalZoom:
+            String(localized: "menu.toggleTerminalZoom")
+        case .editKeybindings:
+            String(localized: "menu.editKeybindings")
+        case .editTasks:
+            String(localized: "menu.editTasks")
+        case .reloadUserConfiguration:
+            String(localized: "menu.reloadUserConfiguration")
         }
     }
 
     var category: CommandPaletteCategory {
         switch self {
-        case .openFolder, .quickOpen, .symbolNavigator, .commandPalette:
+        case .save, .saveAll, .saveAs, .duplicate, .toggleAutoSave,
+             .toggleFormatOnSave, .toggleSmartListContinuation,
+             .openFolder, .quickOpen, .symbolNavigator, .commandPalette:
             .file
         case .toggleComment, .findInFile, .findAndReplace,
-             .findNext, .findPrevious, .findInProject, .goToLine:
+             .findNext, .findPrevious, .useSelectionForFind,
+             .findInProject, .goToLine, .nextChange, .previousChange,
+             .acceptChange, .revertChange, .acceptAllChanges,
+             .revertAllChanges, .foldCode, .unfoldCode, .foldAll,
+             .unfoldAll:
             .edit
-        case .toggleWordWrap, .toggleMinimap, .toggleBlame, .togglePreview:
+        case .increaseFontSize, .decreaseFontSize, .resetFontSize,
+             .toggleWordWrap, .toggleMinimap, .toggleBlame, .togglePreview,
+             .revealFileInFinder, .revealProjectInFinder,
+             .showAgentActivity, .showAgentHistory:
             .view
         case .showBranchSwitcher:
             .git
-        case .toggleTerminal, .newTerminalTab:
+        case .toggleTerminal, .newTerminalTab, .findInTerminal,
+             .sendToTerminal, .toggleTerminalZoom:
             .terminal
+        case .editKeybindings, .editTasks, .reloadUserConfiguration:
+            .tasks
         }
     }
 
     var iconName: String {
         switch self {
+        case .save:
+            MenuIcons.save
+        case .saveAll:
+            MenuIcons.saveAll
+        case .saveAs:
+            MenuIcons.saveAs
+        case .duplicate:
+            MenuIcons.duplicate
+        case .toggleAutoSave:
+            MenuIcons.autoSave
+        case .toggleFormatOnSave:
+            MenuIcons.formatOnSave
+        case .toggleSmartListContinuation:
+            MenuIcons.smartListContinuation
         case .toggleComment:
             MenuIcons.toggleComment
         case .findInFile, .findNext, .findPrevious:
             MenuIcons.find
         case .findAndReplace:
             MenuIcons.findAndReplace
+        case .useSelectionForFind:
+            MenuIcons.find
         case .findInProject:
             MenuIcons.findInProject
         case .goToLine:
             MenuIcons.goToLine
+        case .nextChange:
+            MenuIcons.nextChange
+        case .previousChange:
+            MenuIcons.previousChange
+        case .acceptChange:
+            MenuIcons.acceptChange
+        case .revertChange:
+            MenuIcons.revertChange
+        case .acceptAllChanges:
+            MenuIcons.acceptAllChanges
+        case .revertAllChanges:
+            MenuIcons.revertAllChanges
+        case .foldCode:
+            MenuIcons.foldCode
+        case .unfoldCode:
+            MenuIcons.unfoldCode
+        case .foldAll:
+            MenuIcons.foldAll
+        case .unfoldAll:
+            MenuIcons.unfoldAll
         case .symbolNavigator:
             MenuIcons.symbolNavigator
         case .quickOpen:
@@ -90,6 +201,12 @@ nonisolated extension UserCommand {
             MenuIcons.openFolder
         case .showBranchSwitcher:
             MenuIcons.switchBranch
+        case .increaseFontSize:
+            MenuIcons.increaseFontSize
+        case .decreaseFontSize:
+            MenuIcons.decreaseFontSize
+        case .resetFontSize:
+            MenuIcons.resetFontSize
         case .toggleWordWrap:
             MenuIcons.toggleWordWrap
         case .toggleMinimap:
@@ -98,35 +215,79 @@ nonisolated extension UserCommand {
             MenuIcons.toggleBlame
         case .togglePreview:
             MenuIcons.togglePreview
+        case .revealFileInFinder:
+            MenuIcons.revealFileInFinder
+        case .revealProjectInFinder:
+            MenuIcons.revealProjectInFinder
+        case .showAgentActivity:
+            MenuIcons.agentActivity
+        case .showAgentHistory:
+            MenuIcons.agentHistory
         case .toggleTerminal:
             MenuIcons.toggleTerminal
         case .newTerminalTab:
             MenuIcons.newTerminalTab
+        case .findInTerminal:
+            MenuIcons.find
+        case .sendToTerminal:
+            MenuIcons.sendToTerminal
+        case .toggleTerminalZoom:
+            MenuIcons.maximizeTerminal
+        case .editKeybindings:
+            MenuIcons.editKeybindings
+        case .editTasks:
+            MenuIcons.editTasks
+        case .reloadUserConfiguration:
+            MenuIcons.reloadUserConfiguration
         }
     }
 
     var availabilityRequirement: CommandAvailabilityRequirement {
         switch self {
-        case .openFolder:
+        case .openFolder, .increaseFontSize, .decreaseFontSize,
+             .resetFontSize, .editKeybindings, .editTasks,
+             .reloadUserConfiguration:
             .always
-        case .quickOpen, .commandPalette:
+        case .quickOpen, .commandPalette, .saveAll, .toggleAutoSave,
+             .toggleFormatOnSave, .toggleSmartListContinuation,
+             .findInProject, .toggleTerminal, .newTerminalTab,
+             .toggleMinimap, .toggleBlame, .toggleWordWrap,
+             .revealProjectInFinder, .showAgentActivity, .showAgentHistory:
             .project
         case .showBranchSwitcher:
             .gitRepository
-        case .toggleTerminal, .newTerminalTab:
-            .project
-        case .toggleMinimap, .toggleBlame, .toggleWordWrap:
-            .project
-        case .toggleComment, .findInFile, .findAndReplace,
-             .findNext, .findPrevious, .findInProject, .goToLine,
-             .symbolNavigator, .togglePreview:
+        case .findInTerminal, .toggleTerminalZoom:
+            .terminal
+        case .sendToTerminal:
+            .activeFileAndTerminal
+        case .save, .saveAs, .duplicate, .toggleComment, .findInFile,
+             .findAndReplace, .findNext, .findPrevious,
+             .useSelectionForFind, .goToLine, .nextChange,
+             .previousChange, .acceptChange, .revertChange,
+             .acceptAllChanges, .revertAllChanges, .foldCode,
+             .unfoldCode, .foldAll, .unfoldAll, .symbolNavigator,
+             .togglePreview, .revealFileInFinder:
             .activeFile
         }
     }
 
     var defaultChord: ParsedKeyChord? {
+        if self == .increaseFontSize {
+            return ParsedKeyChord(modifiers: .command, key: "+")
+        }
         let value: String?
         switch self {
+        case .save:
+            value = "cmd+s"
+        case .saveAll:
+            value = "cmd+option+s"
+        case .saveAs:
+            value = "cmd+shift+s"
+        case .duplicate:
+            value = "cmd+shift+d"
+        case .toggleAutoSave, .toggleFormatOnSave,
+             .toggleSmartListContinuation:
+            value = nil
         case .toggleComment:
             value = "cmd+/"
         case .findInFile:
@@ -137,10 +298,30 @@ nonisolated extension UserCommand {
             value = "cmd+g"
         case .findPrevious:
             value = "cmd+shift+g"
+        case .useSelectionForFind:
+            value = "cmd+e"
         case .findInProject:
             value = "cmd+shift+f"
         case .goToLine:
             value = "cmd+l"
+        case .nextChange:
+            value = "ctrl+option+down"
+        case .previousChange:
+            value = "ctrl+option+up"
+        case .acceptChange:
+            value = "ctrl+option+return"
+        case .revertChange:
+            value = "ctrl+option+delete"
+        case .acceptAllChanges, .revertAllChanges:
+            value = nil
+        case .foldCode:
+            value = "cmd+option+left"
+        case .unfoldCode:
+            value = "cmd+option+right"
+        case .foldAll:
+            value = "cmd+option+shift+left"
+        case .unfoldAll:
+            value = "cmd+option+shift+right"
         case .symbolNavigator:
             value = "cmd+r"
         case .quickOpen:
@@ -151,6 +332,12 @@ nonisolated extension UserCommand {
             value = "cmd+shift+o"
         case .showBranchSwitcher:
             value = "cmd+shift+b"
+        case .increaseFontSize:
+            value = nil
+        case .decreaseFontSize:
+            value = "cmd+-"
+        case .resetFontSize:
+            value = "cmd+0"
         case .toggleWordWrap:
             value = "option+z"
         case .toggleMinimap:
@@ -159,10 +346,23 @@ nonisolated extension UserCommand {
             value = "cmd+control+b"
         case .togglePreview:
             value = "cmd+shift+p"
+        case .revealFileInFinder:
+            value = "cmd+shift+r"
+        case .revealProjectInFinder, .showAgentActivity,
+             .showAgentHistory:
+            value = nil
         case .toggleTerminal:
             value = "cmd+`"
         case .newTerminalTab:
             value = "cmd+t"
+        case .findInTerminal:
+            value = nil
+        case .sendToTerminal:
+            value = "cmd+shift+return"
+        case .toggleTerminalZoom:
+            value = "cmd+option+return"
+        case .editKeybindings, .editTasks, .reloadUserConfiguration:
+            value = nil
         }
         return value.flatMap(UserKeybindingRegistry.parse)
     }

--- a/Pine/Extensibility/UserCommand+Palette.swift
+++ b/Pine/Extensibility/UserCommand+Palette.swift
@@ -1,0 +1,169 @@
+//
+//  UserCommand+Palette.swift
+//  Pine
+//
+//  Discoverability metadata shared by user keybindings and the command
+//  palette. Keeping the title, category, icon, availability requirement, and
+//  default shortcut beside the stable command id prevents the palette and
+//  keybinding precedence logic from drifting apart.
+//
+
+import Foundation
+
+nonisolated extension UserCommand {
+    var localizedTitle: String {
+        switch self {
+        case .toggleComment:
+            String(localized: "menu.toggleComment")
+        case .findInFile:
+            String(localized: "menu.find")
+        case .findAndReplace:
+            String(localized: "menu.findAndReplace")
+        case .findNext:
+            String(localized: "menu.findNext")
+        case .findPrevious:
+            String(localized: "menu.findPrevious")
+        case .findInProject:
+            String(localized: "menu.findInProject")
+        case .goToLine:
+            String(localized: "menu.goToLine")
+        case .symbolNavigator:
+            String(localized: "menu.symbolNavigator")
+        case .quickOpen:
+            String(localized: "menu.quickOpen")
+        case .commandPalette:
+            String(localized: "menu.commandPalette")
+        case .openFolder:
+            String(localized: "menu.openFolder")
+        case .showBranchSwitcher:
+            String(localized: "menu.switchBranch")
+        case .toggleWordWrap:
+            String(localized: "menu.toggleWordWrap")
+        case .toggleMinimap:
+            String(localized: "menu.toggleMinimap")
+        case .toggleBlame:
+            String(localized: "menu.toggleBlame")
+        case .togglePreview:
+            String(localized: "menu.togglePreview")
+        case .toggleTerminal:
+            String(localized: "terminal.toggle")
+        case .newTerminalTab:
+            String(localized: "menu.newTerminalTab")
+        }
+    }
+
+    var category: CommandPaletteCategory {
+        switch self {
+        case .openFolder, .quickOpen, .symbolNavigator, .commandPalette:
+            .file
+        case .toggleComment, .findInFile, .findAndReplace,
+             .findNext, .findPrevious, .findInProject, .goToLine:
+            .edit
+        case .toggleWordWrap, .toggleMinimap, .toggleBlame, .togglePreview:
+            .view
+        case .showBranchSwitcher:
+            .git
+        case .toggleTerminal, .newTerminalTab:
+            .terminal
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .toggleComment:
+            MenuIcons.toggleComment
+        case .findInFile, .findNext, .findPrevious:
+            MenuIcons.find
+        case .findAndReplace:
+            MenuIcons.findAndReplace
+        case .findInProject:
+            MenuIcons.findInProject
+        case .goToLine:
+            MenuIcons.goToLine
+        case .symbolNavigator:
+            MenuIcons.symbolNavigator
+        case .quickOpen:
+            MenuIcons.quickOpen
+        case .commandPalette:
+            MenuIcons.commandPalette
+        case .openFolder:
+            MenuIcons.openFolder
+        case .showBranchSwitcher:
+            MenuIcons.switchBranch
+        case .toggleWordWrap:
+            MenuIcons.toggleWordWrap
+        case .toggleMinimap:
+            MenuIcons.toggleMinimap
+        case .toggleBlame:
+            MenuIcons.toggleBlame
+        case .togglePreview:
+            MenuIcons.togglePreview
+        case .toggleTerminal:
+            MenuIcons.toggleTerminal
+        case .newTerminalTab:
+            MenuIcons.newTerminalTab
+        }
+    }
+
+    var availabilityRequirement: CommandAvailabilityRequirement {
+        switch self {
+        case .openFolder:
+            .always
+        case .quickOpen, .commandPalette:
+            .project
+        case .showBranchSwitcher:
+            .gitRepository
+        case .toggleTerminal, .newTerminalTab:
+            .project
+        case .toggleMinimap, .toggleBlame, .toggleWordWrap:
+            .project
+        case .toggleComment, .findInFile, .findAndReplace,
+             .findNext, .findPrevious, .findInProject, .goToLine,
+             .symbolNavigator, .togglePreview:
+            .activeFile
+        }
+    }
+
+    var defaultChord: ParsedKeyChord? {
+        let value: String?
+        switch self {
+        case .toggleComment:
+            value = "cmd+/"
+        case .findInFile:
+            value = "cmd+f"
+        case .findAndReplace:
+            value = "cmd+option+f"
+        case .findNext:
+            value = "cmd+g"
+        case .findPrevious:
+            value = "cmd+shift+g"
+        case .findInProject:
+            value = "cmd+shift+f"
+        case .goToLine:
+            value = "cmd+l"
+        case .symbolNavigator:
+            value = "cmd+r"
+        case .quickOpen:
+            value = "cmd+p"
+        case .commandPalette:
+            value = "cmd+option+p"
+        case .openFolder:
+            value = "cmd+shift+o"
+        case .showBranchSwitcher:
+            value = "cmd+shift+b"
+        case .toggleWordWrap:
+            value = "option+z"
+        case .toggleMinimap:
+            value = "cmd+shift+m"
+        case .toggleBlame:
+            value = "cmd+control+b"
+        case .togglePreview:
+            value = "cmd+shift+p"
+        case .toggleTerminal:
+            value = "cmd+`"
+        case .newTerminalTab:
+            value = "cmd+t"
+        }
+        return value.flatMap(UserKeybindingRegistry.parse)
+    }
+}

--- a/Pine/Extensibility/UserCommandInvocationRouter.swift
+++ b/Pine/Extensibility/UserCommandInvocationRouter.swift
@@ -7,6 +7,7 @@
 //  cannot drift between the two extensibility surfaces (issue #1117).
 //
 
+import AppKit
 import Foundation
 
 @MainActor
@@ -22,13 +23,73 @@ enum UserCommandInvocationRouter {
         }
 
         switch command {
+        case .save:
+            projectManager?.saveActiveTabFromMenu()
+
+        case .saveAll:
+            projectManager?.saveAllTabsFromMenu()
+
+        case .saveAs:
+            guard let projectManager else { return }
+            saveAs(projectManager: projectManager)
+
+        case .duplicate:
+            guard let projectManager else { return }
+            projectManager.activeTabManager.duplicateActiveTab(
+                projectRoot: projectManager.workspace.rootURL
+            )
+
+        case .toggleAutoSave:
+            let defaults = UserDefaults.standard
+            let key = TabManager.autoSaveKey
+            defaults.set(!defaults.bool(forKey: key), forKey: key)
+
+        case .toggleFormatOnSave:
+            let settings = EditorSettings.shared
+            settings.formatOnSave.toggle()
+
+        case .toggleSmartListContinuation:
+            let settings = EditorSettings.shared
+            settings.smartListContinuation.toggle()
+
         case .toggleComment, .findInFile, .findAndReplace,
-             .findNext, .findPrevious, .findInProject, .goToLine,
-             .symbolNavigator, .quickOpen, .commandPalette, .openFolder,
-             .toggleWordWrap:
+             .findNext, .findPrevious, .useSelectionForFind,
+             .findInProject, .goToLine,
+             .symbolNavigator, .quickOpen, .openFolder,
+             .toggleWordWrap, .showAgentActivity, .showAgentHistory,
+             .findInTerminal, .sendToTerminal:
             notificationCenter.post(
                 name: Notification.Name(command.notificationKey),
                 object: nil
+            )
+
+        case .commandPalette:
+            notificationCenter.post(
+                name: .showCommandPalette,
+                object: projectManager
+            )
+
+        case .nextChange, .previousChange:
+            let direction = command == .nextChange ? "next" : "previous"
+            notificationCenter.post(
+                name: .navigateChange,
+                object: nil,
+                userInfo: ["direction": direction]
+            )
+
+        case .acceptChange, .revertChange,
+             .acceptAllChanges, .revertAllChanges:
+            notificationCenter.post(
+                name: .inlineDiffAction,
+                object: nil,
+                userInfo: ["action": command.inlineDiffAction]
+            )
+
+        case .foldCode, .unfoldCode, .foldAll, .unfoldAll:
+            notificationCenter.post(
+                name: .foldCode,
+                object: nil,
+                userInfo: ["action": command.foldAction]
             )
 
         case .showBranchSwitcher:
@@ -36,6 +97,15 @@ enum UserCommandInvocationRouter {
                 name: .showBranchSwitcher,
                 object: projectManager
             )
+
+        case .increaseFontSize:
+            FontSizeSettings.shared.increase()
+
+        case .decreaseFontSize:
+            FontSizeSettings.shared.decrease()
+
+        case .resetFontSize:
+            FontSizeSettings.shared.reset()
 
         case .toggleMinimap:
             MinimapSettings.toggle()
@@ -47,6 +117,16 @@ enum UserCommandInvocationRouter {
 
         case .togglePreview:
             projectManager?.activeTabManager.togglePreviewMode()
+
+        case .revealFileInFinder:
+            guard let url = projectManager?.activeTabManager.activeTab?.url else {
+                return
+            }
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+
+        case .revealProjectInFinder:
+            guard let url = projectManager?.workspace.rootURL else { return }
+            NSWorkspace.shared.activateFileViewerSelecting([url])
 
         case .toggleTerminal:
             guard let projectManager else { return }
@@ -61,6 +141,25 @@ enum UserCommandInvocationRouter {
                 relativeTo: projectManager.paneManager.activePaneID,
                 workingDirectory: projectManager.workspace.rootURL
             )
+
+        case .toggleTerminalZoom:
+            projectManager?.paneManager.toggleMaximizeOnActiveTerminalPane()
+
+        case .editKeybindings:
+            Task { @MainActor in
+                await UserConfigurationEditor.openKeybindings()
+            }
+
+        case .editTasks:
+            Task { @MainActor in
+                await UserConfigurationEditor.openTasks()
+            }
+
+        case .reloadUserConfiguration:
+            Task { @MainActor in
+                await PineAppMenuCommands
+                    .reloadAndPresentConfigurationDiagnostics()
+            }
         }
     }
 
@@ -76,5 +175,68 @@ enum UserCommandInvocationRouter {
             isGitRepository: projectManager.workspace.gitProvider.isGitRepository,
             hasTerminal: projectManager.hasTerminalPanes
         )
+    }
+
+    private static func saveAs(projectManager: ProjectManager) {
+        let tabManager = projectManager.activeTabManager
+        guard let activeTab = tabManager.activeTab else { return }
+
+        let panel = NSSavePanel()
+        panel.title = Strings.saveAsPanelTitle
+        panel.nameFieldStringValue = activeTab.fileName
+        panel.directoryURL = activeTab.url.deletingLastPathComponent()
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        // Keep the file mutation outside the originating menu/key-event
+        // call stack to avoid the #1058 Swift exclusivity-abort family.
+        DispatchQueue.main.async {
+            do {
+                try tabManager.saveActiveTabAs(to: url)
+                Task {
+                    await projectManager.workspace.gitProvider.refreshAsync()
+                    NotificationCenter.default.post(
+                        name: .refreshLineDiffs,
+                        object: nil
+                    )
+                }
+            } catch {
+                AlertTemplate.fileOperationErrorCritical.runModal(
+                    messageText: Strings.fileOperationErrorTitle,
+                    informativeText: error.localizedDescription
+                )
+            }
+        }
+    }
+}
+
+nonisolated private extension UserCommand {
+    var inlineDiffAction: InlineDiffAction {
+        switch self {
+        case .acceptChange:
+            .accept
+        case .revertChange:
+            .revert
+        case .acceptAllChanges:
+            .acceptAll
+        case .revertAllChanges:
+            .revertAll
+        default:
+            preconditionFailure("Command does not represent an inline-diff action")
+        }
+    }
+
+    var foldAction: String {
+        switch self {
+        case .foldCode:
+            "fold"
+        case .unfoldCode:
+            "unfold"
+        case .foldAll:
+            "foldAll"
+        case .unfoldAll:
+            "unfoldAll"
+        default:
+            preconditionFailure("Command does not represent a fold action")
+        }
     }
 }

--- a/Pine/Extensibility/UserCommandInvocationRouter.swift
+++ b/Pine/Extensibility/UserCommandInvocationRouter.swift
@@ -1,0 +1,80 @@
+//
+//  UserCommandInvocationRouter.swift
+//  Pine
+//
+//  Single execution path for registered commands. User keybindings and the
+//  command palette both enter here, so availability checks and side effects
+//  cannot drift between the two extensibility surfaces (issue #1117).
+//
+
+import Foundation
+
+@MainActor
+enum UserCommandInvocationRouter {
+    static func dispatch(
+        _ command: UserCommand,
+        projectManager: ProjectManager?,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        let context = context(for: projectManager)
+        guard context.satisfies(command.availabilityRequirement) else {
+            return
+        }
+
+        switch command {
+        case .toggleComment, .findInFile, .findAndReplace,
+             .findNext, .findPrevious, .findInProject, .goToLine,
+             .symbolNavigator, .quickOpen, .commandPalette, .openFolder,
+             .toggleWordWrap:
+            notificationCenter.post(
+                name: Notification.Name(command.notificationKey),
+                object: nil
+            )
+
+        case .showBranchSwitcher:
+            notificationCenter.post(
+                name: .showBranchSwitcher,
+                object: projectManager
+            )
+
+        case .toggleMinimap:
+            MinimapSettings.toggle()
+
+        case .toggleBlame:
+            let key = BlameConstants.storageKey
+            let defaults = UserDefaults.standard
+            defaults.set(!defaults.bool(forKey: key), forKey: key)
+
+        case .togglePreview:
+            projectManager?.activeTabManager.togglePreviewMode()
+
+        case .toggleTerminal:
+            guard let projectManager else { return }
+            projectManager.terminal.focusOrCreateTerminal(
+                relativeTo: projectManager.paneManager.activePaneID,
+                workingDirectory: projectManager.workspace.rootURL
+            )
+
+        case .newTerminalTab:
+            guard let projectManager else { return }
+            projectManager.terminal.createTerminalTab(
+                relativeTo: projectManager.paneManager.activePaneID,
+                workingDirectory: projectManager.workspace.rootURL
+            )
+        }
+    }
+
+    static func context(
+        for projectManager: ProjectManager?
+    ) -> CommandPaletteContext {
+        guard let projectManager else {
+            return .unavailable
+        }
+        return CommandPaletteContext(
+            hasProject: projectManager.workspace.rootURL != nil,
+            hasActiveFile: projectManager.activeTabManager.activeTab != nil,
+            isGitRepository: projectManager.workspace.gitProvider.isGitRepository,
+            hasTerminal: projectManager.hasTerminalPanes
+        )
+    }
+}

--- a/Pine/Extensibility/UserConfigurationDiagnostic+Localized.swift
+++ b/Pine/Extensibility/UserConfigurationDiagnostic+Localized.swift
@@ -53,6 +53,11 @@ extension UserConfigurationDiagnosticReason {
                 localized: "userConfig.diagnostic.duplicateChord",
                 defaultValue: "“\(value)” duplicates entry \(firstEntryNumber)."
             )
+        case .duplicateCommand(let id, let firstEntryNumber):
+            String(
+                localized: "userConfig.diagnostic.duplicateCommand",
+                defaultValue: "Command id “\(id)” duplicates entry \(firstEntryNumber)."
+            )
         case .duplicateTaskID(let id, let firstEntryNumber):
             String(
                 localized: "userConfig.diagnostic.duplicateTaskID",

--- a/Pine/Extensibility/UserConfigurationDiagnostic.swift
+++ b/Pine/Extensibility/UserConfigurationDiagnostic.swift
@@ -25,6 +25,7 @@ nonisolated enum UserConfigurationDiagnosticReason: Sendable, Equatable {
     case textInputChord(value: String)
     case reservedSystemChord(value: String)
     case duplicateChord(value: String, firstEntryNumber: Int)
+    case duplicateCommand(id: String, firstEntryNumber: Int)
     case duplicateTaskID(id: String, firstEntryNumber: Int)
     case emptyTaskID
     case emptyTaskLabel
@@ -49,6 +50,8 @@ nonisolated enum UserConfigurationDiagnosticReason: Sendable, Equatable {
             "key chord '\(value)' is reserved by macOS or text editing"
         case .duplicateChord(let value, let firstEntryNumber):
             "key chord '\(value)' duplicates entry \(firstEntryNumber)"
+        case .duplicateCommand(let id, let firstEntryNumber):
+            "command id '\(id)' duplicates entry \(firstEntryNumber)"
         case .duplicateTaskID(let id, let firstEntryNumber):
             "task id '\(id)' duplicates entry \(firstEntryNumber)"
         case .emptyTaskID:

--- a/Pine/Extensibility/UserConfigurationEditor.swift
+++ b/Pine/Extensibility/UserConfigurationEditor.swift
@@ -265,20 +265,22 @@ enum UserConfigurationEditor {
     }
 
     nonisolated private static var keybindingsComment: String {
-        String(
+        let guidance = String(
             localized: "userConfig.starter.keybindingsComment",
             defaultValue: """
             Pine keybindings. Add entries to the "keybindings" array below. \
-            Each entry maps a command id to a key chord. Command ids: \
-            quickOpen, findInFile, findAndReplace, findNext, findPrevious, \
-            findInProject, goToLine, symbolNavigator, toggleComment, \
-            toggleWordWrap, openFolder, showBranchSwitcher. Chords use \
-            lowercase modifiers joined by '+': cmd (or command), shift, alt \
-            (or option/opt), ctrl (or control), plus one key (for example \
-            'f', 'return', or 'up'). A dispatch modifier (cmd or ctrl) is \
-            required. Reserved system chords and plain text input are rejected.
+            Each entry maps a command id to a key chord. Supported command \
+            ids are listed after this guidance. Chords use lowercase modifiers \
+            joined by '+': cmd (or command), shift, alt (or option/opt), ctrl \
+            (or control), plus one key (for example 'f', 'return', or 'up'). \
+            A dispatch modifier (cmd or ctrl) is required. Reserved system \
+            chords and plain text input are rejected.
             """
         )
+        let commandIDs = UserCommand.allCases
+            .map(\.rawValue)
+            .joined(separator: ", ")
+        return "\(guidance) \(commandIDs)."
     }
 
     nonisolated private static var tasksComment: String {
@@ -289,10 +291,10 @@ enum UserConfigurationEditor {
             a shell command. Fields: id (unique), label (menu text), command \
             (shell string), scope (activeFile or project; default activeFile), \
             replaces_file_content (default false; when true in activeFile \
-            scope, Pine sends the current file content to stdin; stdout does \
-            not currently replace the file), require_confirmation (default \
-            auto; destructive commands such as rm, chmod, dd, and diskutil \
-            prompt for confirmation).
+            scope, Pine sends the current file content to stdin and applies \
+            stdout only if the same editor buffer is still unchanged), \
+            require_confirmation (default auto; destructive commands such as \
+            rm, chmod, dd, and diskutil prompt for confirmation).
             """
         )
     }

--- a/Pine/Extensibility/UserKeybinding.swift
+++ b/Pine/Extensibility/UserKeybinding.swift
@@ -38,47 +38,104 @@ nonisolated struct UserKeybindingsDocument: Codable, Sendable, Equatable {
 /// pressed. This keeps the keybinding surface fully decoupled from the rest
 /// of the app — no protocol surface to maintain.
 nonisolated enum UserCommand: String, Sendable, CaseIterable {
+    case save
+    case saveAll
+    case saveAs
+    case duplicate
+    case toggleAutoSave
+    case toggleFormatOnSave
+    case toggleSmartListContinuation
     case toggleComment
     case findInFile
     case findAndReplace
     case findNext
     case findPrevious
+    case useSelectionForFind
     case findInProject
     case goToLine
+    case nextChange
+    case previousChange
+    case acceptChange
+    case revertChange
+    case acceptAllChanges
+    case revertAllChanges
+    case foldCode
+    case unfoldCode
+    case foldAll
+    case unfoldAll
     case symbolNavigator
     case quickOpen
     case commandPalette
     case openFolder
     case showBranchSwitcher
+    case increaseFontSize
+    case decreaseFontSize
+    case resetFontSize
     case toggleWordWrap
     case toggleMinimap
     case toggleBlame
     case togglePreview
+    case revealFileInFinder
+    case revealProjectInFinder
+    case showAgentActivity
+    case showAgentHistory
     case toggleTerminal
     case newTerminalTab
+    case findInTerminal
+    case sendToTerminal
+    case toggleTerminalZoom
+    case editKeybindings
+    case editTasks
+    case reloadUserConfiguration
 
     /// The string key for the `Notification.Name` posted when this command fires.
     /// Use `Notification.Name(rawValue:)` on the MainActor side to convert.
     var notificationKey: String {
         switch self {
+        case .save: "user.save"
+        case .saveAll: "user.saveAll"
+        case .saveAs: "user.saveAs"
+        case .duplicate: "user.duplicate"
+        case .toggleAutoSave: "user.toggleAutoSave"
+        case .toggleFormatOnSave: "user.toggleFormatOnSave"
+        case .toggleSmartListContinuation: "user.toggleSmartListContinuation"
         case .toggleComment: "toggleComment"
         case .findInFile: "findInFile"
         case .findAndReplace: "findAndReplace"
         case .findNext: "findNext"
         case .findPrevious: "findPrevious"
+        case .useSelectionForFind: "useSelectionForFind"
         case .findInProject: "showProjectSearch"
         case .goToLine: "goToLine"
+        case .nextChange, .previousChange: "navigateChange"
+        case .acceptChange, .revertChange,
+             .acceptAllChanges, .revertAllChanges:
+            "inlineDiffAction"
+        case .foldCode, .unfoldCode, .foldAll, .unfoldAll: "foldCode"
         case .symbolNavigator: "showSymbolNavigator"
         case .quickOpen: "showQuickOpen"
         case .commandPalette: "showCommandPalette"
         case .openFolder: "openFolder"
         case .showBranchSwitcher: "showBranchSwitcher"
+        case .increaseFontSize: "user.increaseFontSize"
+        case .decreaseFontSize: "user.decreaseFontSize"
+        case .resetFontSize: "user.resetFontSize"
         case .toggleWordWrap: "toggleWordWrap"
         case .toggleMinimap: "user.toggleMinimap"
         case .toggleBlame: "user.toggleBlame"
         case .togglePreview: "user.togglePreview"
+        case .revealFileInFinder: "user.revealFileInFinder"
+        case .revealProjectInFinder: "user.revealProjectInFinder"
+        case .showAgentActivity: "showAgentActivity"
+        case .showAgentHistory: "showAgentHistory"
         case .toggleTerminal: "user.toggleTerminal"
         case .newTerminalTab: "user.newTerminalTab"
+        case .findInTerminal: "findInTerminal"
+        case .sendToTerminal: "sendToTerminal"
+        case .toggleTerminalZoom: "user.toggleTerminalZoom"
+        case .editKeybindings: "user.editKeybindings"
+        case .editTasks: "user.editTasks"
+        case .reloadUserConfiguration: "user.reloadUserConfiguration"
         }
     }
 
@@ -207,6 +264,7 @@ final class UserKeybindingRegistry {
         var parsed: [ResolvedUserKeybinding] = []
         var diagnostics: [UserConfigurationDiagnostic] = []
         var firstEntryForChord: [ParsedKeyChord: Int] = [:]
+        var firstEntryForCommand: [UserCommand: Int] = [:]
         for (index, entry) in raw.enumerated() {
             let entryNumber = index + 1
             let command = UserCommand.from(entry.command)
@@ -254,6 +312,20 @@ final class UserKeybindingRegistry {
                 continue
             }
 
+            if let firstEntryNumber = firstEntryForCommand[command] {
+                diagnostics.append(UserConfigurationDiagnostic(
+                    file: .keybindings,
+                    fileURL: url,
+                    entryNumber: entryNumber,
+                    reason: .duplicateCommand(
+                        id: command.rawValue,
+                        firstEntryNumber: firstEntryNumber
+                    )
+                ))
+            } else {
+                firstEntryForCommand[command] = entryNumber
+            }
+
             if let firstEntryNumber = firstEntryForChord[chord] {
                 diagnostics.append(UserConfigurationDiagnostic(
                     file: .keybindings,
@@ -279,17 +351,27 @@ final class UserKeybindingRegistry {
 
     /// Looks up the command matching a key event, if any.
     func command(for event: NSEvent) -> UserCommand? {
-        let mods = event.modifierFlags.intersection(Self.dispatchModifierMask)
-        guard let key = Self.keyToken(
-            keyCode: event.keyCode,
-            charactersIgnoringModifiers: event.charactersIgnoringModifiers
-        ) else {
-            return nil
-        }
-        for entry in entries where entry.chord.modifiers == mods && entry.chord.key == key {
+        guard let chord = Self.chord(for: event) else { return nil }
+        for entry in entries where entry.chord == chord {
             return entry.command
         }
         return nil
+    }
+
+    /// Whether a user entry replaces `command`'s built-in shortcut.
+    func hasOverride(for command: UserCommand) -> Bool {
+        entries.contains { $0.command == command }
+    }
+
+    /// Returns `true` when `event` is the old built-in shortcut of a command
+    /// that has been rebound by the user. The unified event router consumes
+    /// such an event before NSMenu sees it, making a user binding a true
+    /// replacement instead of an additional shortcut.
+    func suppressesBuiltInShortcut(for event: NSEvent) -> Bool {
+        guard let chord = Self.chord(for: event) else { return false }
+        return UserCommand.allCases.contains { command in
+            command.defaultChord == chord && hasOverride(for: command)
+        }
     }
 
     init() {}
@@ -320,6 +402,21 @@ final class UserKeybindingRegistry {
         .option,
         .shift,
     ]
+
+    nonisolated private static func chord(
+        for event: NSEvent
+    ) -> ParsedKeyChord? {
+        guard let key = keyToken(
+            keyCode: event.keyCode,
+            charactersIgnoringModifiers: event.charactersIgnoringModifiers
+        ) else {
+            return nil
+        }
+        return ParsedKeyChord(
+            modifiers: event.modifierFlags.intersection(dispatchModifierMask),
+            key: key
+        )
+    }
 
     nonisolated private static let reservedChords: Set<ParsedKeyChord> = Set(
         [

--- a/Pine/Extensibility/UserKeybinding.swift
+++ b/Pine/Extensibility/UserKeybinding.swift
@@ -47,6 +47,7 @@ nonisolated enum UserCommand: String, Sendable, CaseIterable {
     case goToLine
     case symbolNavigator
     case quickOpen
+    case commandPalette
     case openFolder
     case showBranchSwitcher
     case toggleWordWrap
@@ -69,6 +70,7 @@ nonisolated enum UserCommand: String, Sendable, CaseIterable {
         case .goToLine: "goToLine"
         case .symbolNavigator: "showSymbolNavigator"
         case .quickOpen: "showQuickOpen"
+        case .commandPalette: "showCommandPalette"
         case .openFolder: "openFolder"
         case .showBranchSwitcher: "showBranchSwitcher"
         case .toggleWordWrap: "toggleWordWrap"
@@ -83,11 +85,7 @@ nonisolated enum UserCommand: String, Sendable, CaseIterable {
     /// Whether this command currently has a production notification observer.
     var isAvailableForUserKeybinding: Bool {
         switch self {
-        case .toggleMinimap, .toggleBlame, .togglePreview,
-             .toggleTerminal, .newTerminalTab:
-            false
-        default:
-            true
+        default: true
         }
     }
 

--- a/Pine/Extensibility/UserKeybindingDispatcher.swift
+++ b/Pine/Extensibility/UserKeybindingDispatcher.swift
@@ -54,6 +54,11 @@ enum UserKeybindingDispatcher {
             dispatchUserCommand(userCommand)
             return nil
         }
+        // A user override replaces the built-in key equivalent; its former
+        // chord must not leak through to NSMenu as a second active shortcut.
+        if registry.suppressesBuiltInShortcut(for: event) {
+            return nil
+        }
         if dispatchBuiltIn(event) {
             return nil
         }

--- a/Pine/Extensibility/UserTaskInvocationController.swift
+++ b/Pine/Extensibility/UserTaskInvocationController.swift
@@ -1,0 +1,98 @@
+//
+//  UserTaskInvocationController.swift
+//  Pine
+//
+//  One safety-preserving task invocation path shared by the Tasks menu and
+//  command palette (issue #1117). Shell text always comes directly from the
+//  validated task definition; editor selections, terminal output, and
+//  OSC-derived paths are never interpolated into it.
+//
+
+import AppKit
+import Foundation
+import os
+
+@MainActor
+enum UserTaskInvocationController {
+    static func invoke(
+        _ task: UserTask,
+        projectManager: ProjectManager
+    ) {
+        if task.effectiveRequireConfirmation(),
+           !presentConfirmation(for: task) {
+            return
+        }
+
+        let tabManager = projectManager.activeTabManager
+        let activeTab = tabManager.activeTab
+        let capturedTabID = activeTab?.id
+        let capturedContent = activeTab?.content
+
+        UserTaskRunner.shared.run(
+            task: task,
+            fileURL: activeTab?.url,
+            projectRootURL: projectManager.workspace.rootURL,
+            fileContent: capturedContent
+        ) { outcome in
+            presentOutcome(
+                outcome,
+                task: task,
+                projectManager: projectManager,
+                capturedTabID: capturedTabID,
+                capturedContent: capturedContent
+            )
+        }
+    }
+
+    private static func presentConfirmation(for task: UserTask) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = Strings.userTaskConfirmationTitle(task.label)
+        alert.informativeText = Strings.userTaskConfirmationMessage(task.command)
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: Strings.userTaskRun)
+        alert.addButton(withTitle: Strings.dialogCancel)
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    private static func presentOutcome(
+        _ outcome: UserTaskOutcome,
+        task: UserTask,
+        projectManager: ProjectManager,
+        capturedTabID: UUID?,
+        capturedContent: String?
+    ) {
+        guard outcome.succeeded else {
+            Logger.extensibility.error(
+                "Task '\(task.label)' failed (exit \(outcome.exitCode)): \(outcome.stderr)"
+            )
+            return
+        }
+
+        Logger.extensibility.info(
+            "Task '\(task.label)' completed successfully"
+        )
+        guard task.replacesFileContent else { return }
+
+        // Fail closed if the user switched tabs or edited the file while the
+        // process ran. Applying stdout to a different/newer buffer would lose
+        // unrelated work and violate the task's active-file contract.
+        let tabManager = projectManager.activeTabManager
+        guard let capturedTabID,
+              let capturedContent,
+              tabManager.activeTab?.id == capturedTabID,
+              tabManager.activeTab?.content == capturedContent else {
+            presentReplacementConflict()
+            return
+        }
+        tabManager.updateContent(outcome.stdout)
+    }
+
+    private static func presentReplacementConflict() {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = Strings.userTaskOutputConflictTitle
+        alert.informativeText = Strings.userTaskOutputConflictMessage
+        alert.addButton(withTitle: Strings.dialogOK)
+        alert.runModal()
+    }
+}

--- a/Pine/Extensibility/UserTaskInvocationController.swift
+++ b/Pine/Extensibility/UserTaskInvocationController.swift
@@ -18,13 +18,18 @@ enum UserTaskInvocationController {
         _ task: UserTask,
         projectManager: ProjectManager
     ) {
+        let tabManager = projectManager.activeTabManager
+        let activeTab = tabManager.activeTab
+        if task.scope == .activeFile, activeTab == nil {
+            presentMissingActiveFile()
+            return
+        }
+
         if task.effectiveRequireConfirmation(),
            !presentConfirmation(for: task) {
             return
         }
 
-        let tabManager = projectManager.activeTabManager
-        let activeTab = tabManager.activeTab
         let capturedTabID = activeTab?.id
         let capturedContent = activeTab?.content
 
@@ -34,13 +39,15 @@ enum UserTaskInvocationController {
             projectRootURL: projectManager.workspace.rootURL,
             fileContent: capturedContent
         ) { outcome in
-            presentOutcome(
-                outcome,
-                task: task,
-                projectManager: projectManager,
-                capturedTabID: capturedTabID,
-                capturedContent: capturedContent
-            )
+            Task { @MainActor in
+                presentOutcome(
+                    outcome,
+                    task: task,
+                    projectManager: projectManager,
+                    capturedTabID: capturedTabID,
+                    capturedContent: capturedContent
+                )
+            }
         }
     }
 
@@ -77,14 +84,27 @@ enum UserTaskInvocationController {
         // process ran. Applying stdout to a different/newer buffer would lose
         // unrelated work and violate the task's active-file contract.
         let tabManager = projectManager.activeTabManager
-        guard let capturedTabID,
-              let capturedContent,
-              tabManager.activeTab?.id == capturedTabID,
-              tabManager.activeTab?.content == capturedContent else {
+        guard canApplyReplacement(
+            capturedTabID: capturedTabID,
+            capturedContent: capturedContent,
+            currentTabID: tabManager.activeTab?.id,
+            currentContent: tabManager.activeTab?.content
+        ) else {
             presentReplacementConflict()
             return
         }
         tabManager.updateContent(outcome.stdout)
+    }
+
+    nonisolated static func canApplyReplacement(
+        capturedTabID: UUID?,
+        capturedContent: String?,
+        currentTabID: UUID?,
+        currentContent: String?
+    ) -> Bool {
+        guard let capturedTabID, let capturedContent else { return false }
+        return currentTabID == capturedTabID
+            && currentContent == capturedContent
     }
 
     private static func presentReplacementConflict() {
@@ -92,6 +112,15 @@ enum UserTaskInvocationController {
         alert.alertStyle = .warning
         alert.messageText = Strings.userTaskOutputConflictTitle
         alert.informativeText = Strings.userTaskOutputConflictMessage
+        alert.addButton(withTitle: Strings.dialogOK)
+        alert.runModal()
+    }
+
+    private static func presentMissingActiveFile() {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = Strings.userTaskMissingFileTitle
+        alert.informativeText = Strings.userTaskMissingFileMessage
         alert.addButton(withTitle: Strings.dialogOK)
         alert.runModal()
     }

--- a/Pine/Extensibility/UserTaskRunner.swift
+++ b/Pine/Extensibility/UserTaskRunner.swift
@@ -12,7 +12,7 @@ import Foundation
 import os
 
 /// Outcome of running a user task.
-struct UserTaskOutcome: Sendable, Equatable {
+nonisolated struct UserTaskOutcome: Sendable, Equatable {
     let taskID: String
     /// Captured stdout (UTF-8). Empty on error or no output.
     let stdout: String

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -15650,55 +15650,55 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine-Tastaturkurzbefehle. Fügen Sie unten Einträge zum Array \"keybindings\" hinzu. Jeder Eintrag ordnet eine Befehlskennung einer Tastenkombination zu. Befehlskennungen: quickOpen, findInFile, findAndReplace, findNext, findPrevious, findInProject, goToLine, symbolNavigator, toggleComment, toggleWordWrap, openFolder, showBranchSwitcher. Tastenkombinationen verwenden kleingeschriebene, durch '+' verbundene Modifikatoren: cmd (oder command), shift, alt (oder option/opt), ctrl (oder control) und eine Taste (zum Beispiel 'f', 'return' oder 'up'). Ein Dispatch-Modifikator (cmd oder ctrl) ist erforderlich. Reservierte Systemkombinationen und normale Texteingaben werden abgelehnt."
+            "value": "Pine-Tastaturkurzbefehle. Fügen Sie unten Einträge zum Array \"keybindings\" hinzu. Jeder Eintrag ordnet eine Befehlskennung einer Tastenkombination zu. Die unterstützten Befehlskennungen folgen nach diesem Hinweis. Tastenkombinationen verwenden kleingeschriebene, durch '+' verbundene Modifikatoren: cmd (oder command), shift, alt (oder option/opt), ctrl (oder control) und eine Taste (zum Beispiel 'f', 'return' oder 'up'). Ein Dispatch-Modifikator (cmd oder ctrl) ist erforderlich. Reservierte Systemkombinationen und normale Texteingaben werden abgelehnt."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine keybindings. Add entries to the \"keybindings\" array below. Each entry maps a command id to a key chord. Command ids: quickOpen, findInFile, findAndReplace, findNext, findPrevious, findInProject, goToLine, symbolNavigator, toggleComment, toggleWordWrap, openFolder, showBranchSwitcher. Chords use lowercase modifiers joined by '+': cmd (or command), shift, alt (or option/opt), ctrl (or control), plus one key (for example 'f', 'return', or 'up'). A dispatch modifier (cmd or ctrl) is required. Reserved system chords and plain text input are rejected."
+            "value": "Pine keybindings. Add entries to the \"keybindings\" array below. Each entry maps a command id to a key chord. Supported command ids are listed after this guidance. Chords use lowercase modifiers joined by '+': cmd (or command), shift, alt (or option/opt), ctrl (or control), plus one key (for example 'f', 'return', or 'up'). A dispatch modifier (cmd or ctrl) is required. Reserved system chords and plain text input are rejected."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atajos de Pine. Añada entradas al array \"keybindings\" de abajo. Cada entrada asocia un id de comando con una combinación de teclas. Id. de comando: quickOpen, findInFile, findAndReplace, findNext, findPrevious, findInProject, goToLine, symbolNavigator, toggleComment, toggleWordWrap, openFolder, showBranchSwitcher. Las combinaciones usan modificadores en minúsculas unidos por '+': cmd (o command), shift, alt (u option/opt), ctrl (o control), más una tecla (por ejemplo, 'f', 'return' o 'up'). Se requiere un modificador de despacho (cmd o ctrl). Se rechazan las combinaciones reservadas del sistema y la entrada de texto normal."
+            "value": "Atajos de Pine. Añada entradas al array \"keybindings\" de abajo. Cada entrada asocia un id de comando con una combinación de teclas. Los id. de comando compatibles aparecen después de esta guía. Las combinaciones usan modificadores en minúsculas unidos por '+': cmd (o command), shift, alt (u option/opt), ctrl (o control), más una tecla (por ejemplo, 'f', 'return' o 'up'). Se requiere un modificador de despacho (cmd o ctrl). Se rechazan las combinaciones reservadas del sistema y la entrada de texto normal."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Raccourcis clavier de Pine. Ajoutez des entrées au tableau \"keybindings\" ci-dessous. Chaque entrée associe un identifiant de commande à une combinaison de touches. Identifiants de commande : quickOpen, findInFile, findAndReplace, findNext, findPrevious, findInProject, goToLine, symbolNavigator, toggleComment, toggleWordWrap, openFolder, showBranchSwitcher. Les combinaisons utilisent des modificateurs en minuscules reliés par '+' : cmd (ou command), shift, alt (ou option/opt), ctrl (ou control), plus une touche (par exemple 'f', 'return' ou 'up'). Un modificateur de répartition (cmd ou ctrl) est requis. Les combinaisons système réservées et la saisie de texte normale sont rejetées."
+            "value": "Raccourcis clavier de Pine. Ajoutez des entrées au tableau \"keybindings\" ci-dessous. Chaque entrée associe un identifiant de commande à une combinaison de touches. Les identifiants pris en charge suivent ces instructions. Les combinaisons utilisent des modificateurs en minuscules reliés par '+' : cmd (ou command), shift, alt (ou option/opt), ctrl (ou control), plus une touche (par exemple 'f', 'return' ou 'up'). Un modificateur de répartition (cmd ou ctrl) est requis. Les combinaisons système réservées et la saisie de texte normale sont rejetées."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine のキーバインド。下の \"keybindings\" 配列にエントリを追加してください。各エントリはコマンド ID をキーの組み合わせに割り当てます。コマンド ID: quickOpen, findInFile, findAndReplace, findNext, findPrevious, findInProject, goToLine, symbolNavigator, toggleComment, toggleWordWrap, openFolder, showBranchSwitcher。キーの組み合わせは小文字の修飾キーを '+' で連結します: cmd (または command)、shift、alt (または option/opt)、ctrl (または control) と 1 つのキー (例: 'f'、'return'、'up')。ディスパッチ修飾キー (cmd または ctrl) が必要です。システムで予約された組み合わせと通常のテキスト入力は拒否されます。"
+            "value": "Pine のキーバインド。下の \"keybindings\" 配列にエントリを追加してください。各エントリはコマンド ID をキーの組み合わせに割り当てます。対応するコマンド ID はこの説明の後に一覧表示されます。キーの組み合わせは小文字の修飾キーを '+' で連結します: cmd (または command)、shift、alt (または option/opt)、ctrl (または control) と 1 つのキー (例: 'f'、'return'、'up')。ディスパッチ修飾キー (cmd または ctrl) が必要です。システムで予約された組み合わせと通常のテキスト入力は拒否されます。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine 단축키. 아래 \"keybindings\" 배열에 항목을 추가하세요. 각 항목은 명령 ID를 키 조합에 연결합니다. 명령 ID: quickOpen, findInFile, findAndReplace, findNext, findPrevious, findInProject, goToLine, symbolNavigator, toggleComment, toggleWordWrap, openFolder, showBranchSwitcher. 키 조합은 소문자 보조 키를 '+'로 연결합니다: cmd(또는 command), shift, alt(또는 option/opt), ctrl(또는 control)과 하나의 키(예: 'f', 'return', 'up'). 디스패치 보조 키(cmd 또는 ctrl)가 필요합니다. 시스템 예약 조합과 일반 텍스트 입력은 거부됩니다."
+            "value": "Pine 단축키. 아래 \"keybindings\" 배열에 항목을 추가하세요. 각 항목은 명령 ID를 키 조합에 연결합니다. 지원되는 명령 ID는 이 안내 뒤에 나열됩니다. 키 조합은 소문자 보조 키를 '+'로 연결합니다: cmd(또는 command), shift, alt(또는 option/opt), ctrl(또는 control)과 하나의 키(예: 'f', 'return', 'up'). 디스패치 보조 키(cmd 또는 ctrl)가 필요합니다. 시스템 예약 조합과 일반 텍스트 입력은 거부됩니다."
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Atalhos de teclado do Pine. Adicione entradas ao array \"keybindings\" abaixo. Cada entrada associa um id de comando a uma combinação de teclas. IDs de comando: quickOpen, findInFile, findAndReplace, findNext, findPrevious, findInProject, goToLine, symbolNavigator, toggleComment, toggleWordWrap, openFolder, showBranchSwitcher. As combinações usam modificadores em minúsculas unidos por '+': cmd (ou command), shift, alt (ou option/opt), ctrl (ou control), mais uma tecla (por exemplo, 'f', 'return' ou 'up'). Um modificador de despacho (cmd ou ctrl) é obrigatório. Combinações reservadas do sistema e entrada de texto normal são rejeitadas."
+            "value": "Atalhos de teclado do Pine. Adicione entradas ao array \"keybindings\" abaixo. Cada entrada associa um id de comando a uma combinação de teclas. Os IDs de comando compatíveis aparecem após estas instruções. As combinações usam modificadores em minúsculas unidos por '+': cmd (ou command), shift, alt (ou option/opt), ctrl (ou control), mais uma tecla (por exemplo, 'f', 'return' ou 'up'). Um modificador de despacho (cmd ou ctrl) é obrigatório. Combinações reservadas do sistema e entrada de texto normal são rejeitadas."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Сочетания клавиш Pine. Добавляйте записи в массив \"keybindings\" ниже. Каждая запись связывает идентификатор команды с сочетанием клавиш. Идентификаторы команд: quickOpen, findInFile, findAndReplace, findNext, findPrevious, findInProject, goToLine, symbolNavigator, toggleComment, toggleWordWrap, openFolder, showBranchSwitcher. В сочетаниях используются строчные модификаторы, соединённые знаком '+': cmd (или command), shift, alt (или option/opt), ctrl (или control) и одна клавиша (например, 'f', 'return' или 'up'). Требуется модификатор диспетчеризации (cmd или ctrl). Зарезервированные системные сочетания и обычный текстовый ввод отклоняются."
+            "value": "Сочетания клавиш Pine. Добавляйте записи в массив \"keybindings\" ниже. Каждая запись связывает идентификатор команды с сочетанием клавиш. Поддерживаемые идентификаторы команд перечислены после этой подсказки. В сочетаниях используются строчные модификаторы, соединённые знаком '+': cmd (или command), shift, alt (или option/opt), ctrl (или control) и одна клавиша (например, 'f', 'return' или 'up'). Требуется модификатор диспетчеризации (cmd или ctrl). Зарезервированные системные сочетания и обычный текстовый ввод отклоняются."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine 快捷键。请在下面的 \"keybindings\" 数组中添加条目。每个条目将命令 ID 映射到按键组合。命令 ID：quickOpen、findInFile、findAndReplace、findNext、findPrevious、findInProject、goToLine、symbolNavigator、toggleComment、toggleWordWrap、openFolder、showBranchSwitcher。按键组合使用以 '+' 连接的小写修饰键：cmd（或 command）、shift、alt（或 option/opt）、ctrl（或 control），再加一个按键（例如 'f'、'return' 或 'up'）。必须包含分派修饰键（cmd 或 ctrl）。系统保留的组合和普通文本输入会被拒绝。"
+            "value": "Pine 快捷键。请在下面的 \"keybindings\" 数组中添加条目。每个条目将命令 ID 映射到按键组合。支持的命令 ID 会列在本说明之后。按键组合使用以 '+' 连接的小写修饰键：cmd（或 command）、shift、alt（或 option/opt）、ctrl（或 control），再加一个按键（例如 'f'、'return' 或 'up'）。必须包含分派修饰键（cmd 或 ctrl）。系统保留的组合和普通文本输入会被拒绝。"
           }
         }
       }
@@ -15709,55 +15709,55 @@
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine-Aufgaben. Fügen Sie unten Einträge zum Array \"tasks\" hinzu. Jede Aufgabe führt einen Shell-Befehl aus. Felder: id (eindeutig), label (Menütext), command (Shell-Zeichenfolge), scope (activeFile oder project; Standard activeFile), replaces_file_content (Standard false; bei true im Bereich activeFile sendet Pine den aktuellen Dateiinhalt an stdin; stdout ersetzt die Datei derzeit nicht), require_confirmation (Standard automatisch; destruktive Befehle wie rm, chmod, dd und diskutil verlangen eine Bestätigung)."
+            "value": "Pine-Aufgaben. Fügen Sie unten Einträge zum Array \"tasks\" hinzu. Jede Aufgabe führt einen Shell-Befehl aus. Felder: id (eindeutig), label (Menütext), command (Shell-Zeichenfolge), scope (activeFile oder project; Standard activeFile), replaces_file_content (Standard false; bei true im Bereich activeFile sendet Pine den aktuellen Dateiinhalt an stdin und übernimmt stdout nur, wenn derselbe Editorpuffer unverändert ist), require_confirmation (Standard automatisch; destruktive Befehle wie rm, chmod, dd und diskutil verlangen eine Bestätigung)."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine tasks. Add entries to the \"tasks\" array below. Each task runs a shell command. Fields: id (unique), label (menu text), command (shell string), scope (activeFile or project; default activeFile), replaces_file_content (default false; when true in activeFile scope, Pine sends the current file content to stdin; stdout does not currently replace the file), require_confirmation (default auto; destructive commands such as rm, chmod, dd, and diskutil prompt for confirmation)."
+            "value": "Pine tasks. Add entries to the \"tasks\" array below. Each task runs a shell command. Fields: id (unique), label (menu text), command (shell string), scope (activeFile or project; default activeFile), replaces_file_content (default false; when true in activeFile scope, Pine sends the current file content to stdin and applies stdout only if the same editor buffer is still unchanged), require_confirmation (default auto; destructive commands such as rm, chmod, dd, and diskutil prompt for confirmation)."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tareas de Pine. Añada entradas al array \"tasks\" de abajo. Cada tarea ejecuta un comando de shell. Campos: id (único), label (texto del menú), command (cadena de shell), scope (activeFile o project; predeterminado activeFile), replaces_file_content (predeterminado false; cuando es true con ámbito activeFile, Pine envía el contenido actual del archivo a stdin; actualmente stdout no reemplaza el archivo), require_confirmation (predeterminado automático; los comandos destructivos como rm, chmod, dd y diskutil solicitan confirmación)."
+            "value": "Tareas de Pine. Añada entradas al array \"tasks\" de abajo. Cada tarea ejecuta un comando de shell. Campos: id (único), label (texto del menú), command (cadena de shell), scope (activeFile o project; predeterminado activeFile), replaces_file_content (predeterminado false; cuando es true con ámbito activeFile, Pine envía el contenido actual a stdin y aplica stdout solo si el mismo búfer sigue sin cambios), require_confirmation (predeterminado automático; los comandos destructivos como rm, chmod, dd y diskutil solicitan confirmación)."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tâches Pine. Ajoutez des entrées au tableau \"tasks\" ci-dessous. Chaque tâche exécute une commande shell. Champs : id (unique), label (texte du menu), command (chaîne shell), scope (activeFile ou project ; activeFile par défaut), replaces_file_content (false par défaut ; avec true et la portée activeFile, Pine envoie le contenu actuel du fichier à stdin ; stdout ne remplace pas encore le fichier), require_confirmation (automatique par défaut ; les commandes destructrices telles que rm, chmod, dd et diskutil demandent une confirmation)."
+            "value": "Tâches Pine. Ajoutez des entrées au tableau \"tasks\" ci-dessous. Chaque tâche exécute une commande shell. Champs : id (unique), label (texte du menu), command (chaîne shell), scope (activeFile ou project ; activeFile par défaut), replaces_file_content (false par défaut ; avec true et la portée activeFile, Pine envoie le contenu actuel à stdin et applique stdout uniquement si le même tampon est resté inchangé), require_confirmation (automatique par défaut ; les commandes destructrices telles que rm, chmod, dd et diskutil demandent une confirmation)."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine のタスク。下の \"tasks\" 配列にエントリを追加してください。各タスクはシェルコマンドを実行します。フィールド: id (一意)、label (メニューのテキスト)、command (シェル文字列)、scope (activeFile または project、デフォルトは activeFile)、replaces_file_content (デフォルトは false。activeFile スコープで true の場合、Pine は現在のファイル内容を stdin に送信します。現在、stdout はファイルを置き換えません)、require_confirmation (デフォルトは自動。rm、chmod、dd、diskutil などの破壊的なコマンドでは確認を求めます)。"
+            "value": "Pine のタスク。下の \"tasks\" 配列にエントリを追加してください。各タスクはシェルコマンドを実行します。フィールド: id (一意)、label (メニューのテキスト)、command (シェル文字列)、scope (activeFile または project、デフォルトは activeFile)、replaces_file_content (デフォルトは false。activeFile スコープで true の場合、現在の内容を stdin に送り、同じエディターバッファーが未変更のときだけ stdout を適用します)、require_confirmation (デフォルトは自動。rm、chmod、dd、diskutil などの破壊的なコマンドでは確認を求めます)。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine 작업. 아래 \"tasks\" 배열에 항목을 추가하세요. 각 작업은 셸 명령을 실행합니다. 필드: id(고유), label(메뉴 텍스트), command(셸 문자열), scope(activeFile 또는 project, 기본값 activeFile), replaces_file_content(기본값 false, activeFile 범위에서 true이면 Pine이 현재 파일 내용을 stdin으로 보내며 현재 stdout은 파일을 바꾸지 않음), require_confirmation(기본값 자동, rm, chmod, dd, diskutil 같은 파괴적 명령은 확인을 요청함)."
+            "value": "Pine 작업. 아래 \"tasks\" 배열에 항목을 추가하세요. 각 작업은 셸 명령을 실행합니다. 필드: id(고유), label(메뉴 텍스트), command(셸 문자열), scope(activeFile 또는 project, 기본값 activeFile), replaces_file_content(기본값 false, activeFile 범위에서 true이면 현재 내용을 stdin으로 보내고 같은 편집기 버퍼가 변경되지 않았을 때만 stdout을 적용함), require_confirmation(기본값 자동, rm, chmod, dd, diskutil 같은 파괴적 명령은 확인을 요청함)."
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tarefas do Pine. Adicione entradas ao array \"tasks\" abaixo. Cada tarefa executa um comando de shell. Campos: id (único), label (texto do menu), command (string de shell), scope (activeFile ou project; padrão activeFile), replaces_file_content (padrão false; quando true no escopo activeFile, o Pine envia o conteúdo atual do arquivo para stdin; atualmente stdout não substitui o arquivo), require_confirmation (padrão automático; comandos destrutivos como rm, chmod, dd e diskutil solicitam confirmação)."
+            "value": "Tarefas do Pine. Adicione entradas ao array \"tasks\" abaixo. Cada tarefa executa um comando de shell. Campos: id (único), label (texto do menu), command (string de shell), scope (activeFile ou project; padrão activeFile), replaces_file_content (padrão false; quando true no escopo activeFile, o Pine envia o conteúdo atual para stdin e aplica stdout apenas se o mesmo buffer continuar inalterado), require_confirmation (padrão automático; comandos destrutivos como rm, chmod, dd e diskutil solicitam confirmação)."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Задачи Pine. Добавляйте записи в массив \"tasks\" ниже. Каждая задача выполняет команду оболочки. Поля: id (уникальный), label (текст меню), command (строка оболочки), scope (activeFile или project; по умолчанию activeFile), replaces_file_content (по умолчанию false; при true и области activeFile Pine передаёт текущее содержимое файла в stdin; в текущей реализации stdout не заменяет файл), require_confirmation (по умолчанию автоматически; разрушительные команды, например rm, chmod, dd и diskutil, требуют подтверждения)."
+            "value": "Задачи Pine. Добавляйте записи в массив \"tasks\" ниже. Каждая задача выполняет команду оболочки. Поля: id (уникальный), label (текст меню), command (строка оболочки), scope (activeFile или project; по умолчанию activeFile), replaces_file_content (по умолчанию false; при true и области activeFile Pine передаёт текущее содержимое в stdin и применяет stdout, только если тот же буфер редактора не изменился), require_confirmation (по умолчанию автоматически; разрушительные команды, например rm, chmod, dd и diskutil, требуют подтверждения)."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine 任务。请在下面的 \"tasks\" 数组中添加条目。每个任务运行一条 shell 命令。字段：id（唯一）、label（菜单文本）、command（shell 字符串）、scope（activeFile 或 project；默认为 activeFile）、replaces_file_content（默认为 false；在 activeFile 范围内设为 true 时，Pine 会将当前文件内容发送到 stdin；stdout 目前不会替换文件）、require_confirmation（默认为自动；rm、chmod、dd 和 diskutil 等破坏性命令会请求确认）。"
+            "value": "Pine 任务。请在下面的 \"tasks\" 数组中添加条目。每个任务运行一条 shell 命令。字段：id（唯一）、label（菜单文本）、command（shell 字符串）、scope（activeFile 或 project；默认为 activeFile）、replaces_file_content（默认为 false；在 activeFile 范围内设为 true 时，将当前内容发送到 stdin，并且仅在同一编辑器缓冲区仍未更改时应用 stdout）、require_confirmation（默认为自动；rm、chmod、dd 和 diskutil 等破坏性命令会请求确认）。"
           }
         }
       }
@@ -16291,6 +16291,231 @@
             "value": "“%1$@” 与条目 %2$lld 重复。"
           }
         }
+      }
+    },
+    "commandPalette.category.file": {
+      "comment": "Command palette category for file and workspace commands.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Datei" } },
+        "en": { "stringUnit": { "state": "translated", "value": "File" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Archivo" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Fichier" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ファイル" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "파일" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Arquivo" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Файл" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "文件" } }
+      }
+    },
+    "commandPalette.category.edit": {
+      "comment": "Command palette category for editor commands.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Bearbeiten" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Edit" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Edición" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Édition" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "編集" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "편집" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Editar" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Правка" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "编辑" } }
+      }
+    },
+    "menu.commandPalette": {
+      "comment": "Menu command that opens the searchable command palette.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Befehlspalette…" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Command Palette…" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Paleta de comandos…" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Palette de commandes…" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "コマンドパレット…" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "명령 팔레트…" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Paleta de comandos…" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Палитра команд…" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "命令面板…" } }
+      }
+    },
+    "commandPalette.placeholder": {
+      "comment": "Placeholder in the command palette search field.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Befehle und Aufgaben suchen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Search commands and tasks" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Buscar comandos y tareas" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Rechercher des commandes et des tâches" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "コマンドとタスクを検索" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "명령 및 작업 검색" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Buscar comandos e tarefas" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Поиск команд и задач" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "搜索命令和任务" } }
+      }
+    },
+    "commandPalette.noResults": {
+      "comment": "Empty state when the command palette search has no matches.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Keine passenden Befehle oder Aufgaben" } },
+        "en": { "stringUnit": { "state": "translated", "value": "No matching commands or tasks" } },
+        "es": { "stringUnit": { "state": "translated", "value": "No hay comandos ni tareas coincidentes" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Aucune commande ou tâche correspondante" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "一致するコマンドまたはタスクはありません" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "일치하는 명령 또는 작업 없음" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Nenhum comando ou tarefa correspondente" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Подходящие команды и задачи не найдены" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "没有匹配的命令或任务" } }
+      }
+    },
+    "commandPalette.shortcutOverride": {
+      "comment": "Badge for a command whose shortcut is a user override.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Benutzerdefiniert" } },
+        "en": { "stringUnit": { "state": "translated", "value": "User override" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Personalizado" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Personnalisé" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ユーザー設定" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "사용자 지정" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Personalizado" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Пользовательское" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "用户覆盖" } }
+      }
+    },
+    "commandPalette.shortcutConflict": {
+      "comment": "Badge for a built-in shortcut shadowed by another user binding.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Belegt" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Overridden" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Reemplazado" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Remplacé" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "上書き済み" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "재정의됨" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Substituído" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Переопределено" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已被覆盖" } }
+      }
+    },
+    "userTask.confirmation.title": {
+      "comment": "Confirmation title before running a task. %@ is the task label.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Aufgabe „%@“ ausführen?" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Run task “%@”?" } },
+        "es": { "stringUnit": { "state": "translated", "value": "¿Ejecutar la tarea «%@»?" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Exécuter la tâche « %@ » ?" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "タスク「%@」を実行しますか？" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "“%@” 작업을 실행할까요?" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Executar a tarefa “%@”?" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Выполнить задачу «%@»?" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "运行任务“%@”吗？" } }
+      }
+    },
+    "userTask.confirmation.message": {
+      "comment": "Confirmation body before running a task. %@ is the exact shell command.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Diese Aufgabe führt den folgenden Befehl aus:\n%@" } },
+        "en": { "stringUnit": { "state": "translated", "value": "This task will execute the following command:\n%@" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Esta tarea ejecutará el siguiente comando:\n%@" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Cette tâche exécutera la commande suivante :\n%@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "このタスクは次のコマンドを実行します:\n%@" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이 작업은 다음 명령을 실행합니다:\n%@" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Esta tarefa executará o seguinte comando:\n%@" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Задача выполнит следующую команду:\n%@" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此任务将执行以下命令：\n%@" } }
+      }
+    },
+    "userTask.run": {
+      "comment": "Button that confirms running a user task.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Ausführen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Run" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Ejecutar" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Exécuter" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "実行" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "실행" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Executar" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Выполнить" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "运行" } }
+      }
+    },
+    "userTask.outputConflict.title": {
+      "comment": "Title shown when task output cannot safely replace an edited buffer.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Aufgabenausgabe nicht angewendet" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Task output wasn’t applied" } },
+        "es": { "stringUnit": { "state": "translated", "value": "No se aplicó la salida de la tarea" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "La sortie de la tâche n’a pas été appliquée" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "タスク出力は適用されませんでした" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "작업 출력을 적용하지 않음" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "A saída da tarefa não foi aplicada" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Вывод задачи не применён" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "未应用任务输出" } }
+      }
+    },
+    "userTask.outputConflict.message": {
+      "comment": "Explains that a task output replacement was blocked to preserve newer edits.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Die aktive Datei oder ihr Inhalt hat sich während der Aufgabe geändert. Die neueren Änderungen wurden beibehalten." } },
+        "en": { "stringUnit": { "state": "translated", "value": "The active file or its content changed while the task was running. Pine preserved the newer edits." } },
+        "es": { "stringUnit": { "state": "translated", "value": "El archivo activo o su contenido cambió durante la tarea. Pine conservó los cambios más recientes." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Le fichier actif ou son contenu a changé pendant la tâche. Pine a conservé les modifications récentes." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "タスクの実行中にアクティブなファイルまたは内容が変更されました。新しい編集内容は保持されました。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "작업 실행 중 활성 파일 또는 내용이 변경되었습니다. Pine이 최신 편집 내용을 유지했습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "O arquivo ativo ou seu conteúdo mudou durante a tarefa. O Pine preservou as edições mais recentes." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Активный файл или его содержимое изменились во время выполнения задачи. Pine сохранил более новые правки." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "任务运行期间，活动文件或其内容已更改。Pine 保留了较新的编辑。" } }
+      }
+    },
+    "userTask.missingFile.title": {
+      "comment": "Title shown when an active-file task has no active file.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Keine aktive Datei" } },
+        "en": { "stringUnit": { "state": "translated", "value": "No active file" } },
+        "es": { "stringUnit": { "state": "translated", "value": "No hay ningún archivo activo" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Aucun fichier actif" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "アクティブなファイルがありません" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "활성 파일 없음" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Nenhum arquivo ativo" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Нет активного файла" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "没有活动文件" } }
+      }
+    },
+    "userTask.missingFile.message": {
+      "comment": "Explains why an active-file task cannot run.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Öffnen Sie eine Datei, bevor Sie diese Aufgabe ausführen." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Open a file before running this task." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Abra un archivo antes de ejecutar esta tarea." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Ouvrez un fichier avant d’exécuter cette tâche." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "このタスクを実行する前にファイルを開いてください。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이 작업을 실행하기 전에 파일을 여세요." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Abra um arquivo antes de executar esta tarefa." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Перед выполнением задачи откройте файл." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "运行此任务前请先打开文件。" } }
+      }
+    },
+    "userConfig.diagnostic.duplicateCommand": {
+      "comment": "Diagnostic: duplicate command id. %1$@ is the id, %2$lld is the first entry number.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Befehlskennung „%1$@“ dupliziert Eintrag %2$lld." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Command id “%1$@” duplicates entry %2$lld." } },
+        "es": { "stringUnit": { "state": "translated", "value": "El id. de comando «%1$@» duplica la entrada %2$lld." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "L’identifiant de commande « %1$@ » duplique l’entrée %2$lld." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "コマンド ID「%1$@」はエントリ %2$lld と重複しています。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "명령 ID “%1$@”이(가) 항목 %2$lld와 중복됩니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "O ID de comando “%1$@” duplica a entrada %2$lld." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Идентификатор команды «%1$@» дублирует запись %2$lld." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "命令 ID“%1$@”与条目 %2$lld 重复。" } }
       }
     },
     "userConfig.diagnostic.duplicateTaskID": {

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -17,6 +17,7 @@ nonisolated enum MenuIcons {
     static let smartListContinuation = "list.bullet"
 
     static let quickOpen = "doc.text.magnifyingglass"
+    static let commandPalette = "command"
     static let installCLI = "terminal"
 
     // MARK: - Edit menu

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -575,15 +575,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // first, followed by Pine's physical-key handlers; NSMenu and the
         // responder chain see only events neither layer consumed. Keeping this
         // in one monitor avoids AppKit's unspecified ordering among monitors.
-        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             let registry = ExtensibilityManager.shared.keybindings
             return UserKeybindingDispatcher.route(
                 event,
                 registry: registry,
                 dispatchUserCommand: { command in
-                    NotificationCenter.default.post(
-                        name: Notification.Name(command.notificationKey),
-                        object: nil
+                    UserCommandInvocationRouter.dispatch(
+                        command,
+                        projectManager: self?.activeProjectManager()
                     )
                 },
                 dispatchBuiltIn: Self.handleBuiltInKeyDown

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -18,7 +18,6 @@
 //
 
 import AppKit
-import os
 import SwiftUI
 
 /// Top-level `Commands` struct containing every `CommandGroup` / `CommandMenu`
@@ -78,6 +77,20 @@ struct PineAppMenuCommands: Commands {
             .disabled(focusedProject?.workspace.rootURL == nil)
 
             Button {
+                NotificationCenter.default.post(
+                    name: .showCommandPalette,
+                    object: focusedProject
+                )
+            } label: {
+                Label(
+                    Strings.menuCommandPalette,
+                    systemImage: MenuIcons.commandPalette
+                )
+            }
+            .keyboardShortcut("p", modifiers: [.command, .option])
+            .disabled(focusedProject?.workspace.rootURL == nil)
+
+            Button {
                 NotificationCenter.default.post(name: .showSymbolNavigator, object: nil)
             } label: {
                 Label(Strings.menuSymbolNavigator, systemImage: MenuIcons.symbolNavigator)
@@ -113,33 +126,10 @@ struct PineAppMenuCommands: Commands {
 
             Button {
                 guard let pm = focusedProject else { return }
-                guard pm.activeTabManager.activeTab != nil else { return }
-                let panel = NSSavePanel()
-                panel.title = Strings.saveAsPanelTitle
-                panel.nameFieldStringValue = pm.activeTabManager.activeTab?.fileName ?? ""
-                if let dir = pm.activeTabManager.activeTab?.url.deletingLastPathComponent() {
-                    panel.directoryURL = dir
-                }
-                guard panel.runModal() == .OK, let url = panel.url else { return }
-                // Defer the save + refresh to break reentrancy (#1058):
-                // saveActiveTabAs mutates @Observable tab state synchronously
-                // when format-on-save changes content; doing that inside the
-                // ButtonAction callstack triggers an exclusivity abort on
-                // macOS 26.5.1. The panel stays synchronous (user interaction).
-                DispatchQueue.main.async {
-                    do {
-                        try pm.activeTabManager.saveActiveTabAs(to: url)
-                        Task {
-                            await pm.workspace.gitProvider.refreshAsync()
-                            NotificationCenter.default.post(name: .refreshLineDiffs, object: nil)
-                        }
-                    } catch {
-                        AlertTemplate.fileOperationErrorCritical.runModal(
-                            messageText: Strings.fileOperationErrorTitle,
-                            informativeText: error.localizedDescription
-                        )
-                    }
-                }
+                UserCommandInvocationRouter.dispatch(
+                    .saveAs,
+                    projectManager: pm
+                )
             } label: {
                 Label(Strings.menuSaveAs, systemImage: MenuIcons.saveAs)
             }
@@ -565,7 +555,7 @@ struct PineAppMenuCommands: Commands {
         // MARK: - Tasks menu (issue #1009)
         // User-defined external commands loaded from tasks.json. Dynamically
         // populated from ExtensibilityManager; each item runs its task via
-        // UserTaskRunner and reports the outcome in a toast.
+        // the shared safety-preserving invocation controller.
         CommandMenu(Strings.menuTasks) {
             let taskList = ExtensibilityManager.shared.tasks.tasks
             if taskList.isEmpty {
@@ -575,29 +565,20 @@ struct PineAppMenuCommands: Commands {
             ForEach(taskList) { task in
                 Button {
                     guard let pm = focusedProject else { return }
-                    let activeTab = pm.activeTabManager.activeTab
-
-                    // Security: require confirmation for destructive commands
-                    // (milestone #1088, item 4).
-                    if task.effectiveRequireConfirmation() {
-                        let alert = NSAlert()
-                        alert.messageText = "Run task \"\(task.label)\"?"
-                        alert.informativeText = """
-                            This task will execute the following command:
-                            \(task.command)
-                            """
-                        alert.alertStyle = .warning
-                        alert.addButton(withTitle: "Run")
-                        alert.addButton(withTitle: "Cancel")
-                        if alert.runModal() == .alertFirstButtonReturn {
-                            Self.runUserTask(task, activeTab: activeTab, projectManager: pm)
-                        }
-                    } else {
-                        Self.runUserTask(task, activeTab: activeTab, projectManager: pm)
-                    }
+                    UserTaskInvocationController.invoke(
+                        task,
+                        projectManager: pm
+                    )
                 } label: {
                     Label(task.label, systemImage: MenuIcons.tasks)
                 }
+                .disabled(
+                    focusedProject == nil
+                        || (
+                            task.scope == .activeFile
+                                && focusedProject?.activeTabManager.activeTab == nil
+                        )
+                )
             }
 
             Divider()
@@ -693,43 +674,4 @@ struct PineAppMenuCommands: Commands {
         )
     }
 
-    /// Runs a user task via `UserTaskRunner` and presents the outcome.
-    /// Extracted so the confirmation alert and the non-confirmation path
-    /// share a single execution point.
-    private static func runUserTask(
-        _ task: UserTask,
-        activeTab: EditorTab?,
-        projectManager: ProjectManager
-    ) {
-        UserTaskRunner.shared.run(
-            task: task,
-            fileURL: activeTab?.url,
-            projectRootURL: projectManager.workspace.rootURL,
-            fileContent: activeTab?.content
-        ) { outcome in
-            // Completion is invoked on the main thread (per UserTaskRunner.run);
-            // assert main actor isolation to cross the @Sendable boundary.
-            MainActor.assumeIsolated {
-                Self.presentTaskOutcome(outcome, task: task, projectManager: projectManager)
-            }
-        }
-    }
-
-    /// Shows a brief toast/alert for a completed user task.
-    private static func presentTaskOutcome(
-        _ outcome: UserTaskOutcome,
-        task: UserTask,
-        projectManager: ProjectManager
-    ) {
-        // For now: log the outcome. A proper toast UI can be added later.
-        if outcome.exitCode == 0 {
-            Logger.extensibility.info(
-                "Task '\(task.label)' completed successfully"
-            )
-        } else {
-            Logger.extensibility.error(
-                "Task '\(task.label)' failed (exit \(outcome.exitCode)): \(outcome.stderr)"
-            )
-        }
-    }
 }

--- a/Pine/PineAppNotifications.swift
+++ b/Pine/PineAppNotifications.swift
@@ -15,6 +15,7 @@ extension Notification.Name {
     static let openFolder = Notification.Name("openFolder")
     static let closeTab = Notification.Name("closeTab")
     static let showQuickOpen = Notification.Name("showQuickOpen")
+    static let showCommandPalette = Notification.Name("showCommandPalette")
     /// userInfo: ["oldURL": URL, "newURL": URL]
     static let fileRenamed = Notification.Name("fileRenamed")
     /// userInfo: ["url": URL]

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -226,10 +226,10 @@ enum Strings {
     static let menuRevealProjectInFinder: LocalizedStringKey = "menu.revealProjectInFinder"
     static let menuTasks: LocalizedStringKey = "menu.tasks"
     static let menuTasksEmpty: LocalizedStringKey = "menu.tasksEmpty"
+    static let menuCommandPalette: LocalizedStringKey = "menu.commandPalette"
     static let menuEditKeybindings: LocalizedStringKey = "menu.editKeybindings"
     static let menuEditTasks: LocalizedStringKey = "menu.editTasks"
     static let menuReloadUserConfiguration: LocalizedStringKey = "menu.reloadUserConfiguration"
-    static let menuCommandPalette: LocalizedStringKey = "menu.commandPalette"
 
     static func userTaskConfirmationTitle(_ label: String) -> String {
         String(
@@ -255,6 +255,14 @@ enum Strings {
 
     static var userTaskOutputConflictMessage: String {
         String(localized: "userTask.outputConflict.message")
+    }
+
+    static var userTaskMissingFileTitle: String {
+        String(localized: "userTask.missingFile.title")
+    }
+
+    static var userTaskMissingFileMessage: String {
+        String(localized: "userTask.missingFile.message")
     }
 
     // MARK: - Quick Open

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -229,6 +229,33 @@ enum Strings {
     static let menuEditKeybindings: LocalizedStringKey = "menu.editKeybindings"
     static let menuEditTasks: LocalizedStringKey = "menu.editTasks"
     static let menuReloadUserConfiguration: LocalizedStringKey = "menu.reloadUserConfiguration"
+    static let menuCommandPalette: LocalizedStringKey = "menu.commandPalette"
+
+    static func userTaskConfirmationTitle(_ label: String) -> String {
+        String(
+            localized: "userTask.confirmation.title",
+            defaultValue: "Run task “\(label)”?"
+        )
+    }
+
+    static func userTaskConfirmationMessage(_ command: String) -> String {
+        String(
+            localized: "userTask.confirmation.message",
+            defaultValue: "This task will execute the following command:\n\(command)"
+        )
+    }
+
+    static var userTaskRun: String {
+        String(localized: "userTask.run")
+    }
+
+    static var userTaskOutputConflictTitle: String {
+        String(localized: "userTask.outputConflict.title")
+    }
+
+    static var userTaskOutputConflictMessage: String {
+        String(localized: "userTask.outputConflict.message")
+    }
 
     // MARK: - Quick Open
 

--- a/PineTests/AgentActivityStoreTests.swift
+++ b/PineTests/AgentActivityStoreTests.swift
@@ -219,12 +219,13 @@ struct AgentActivityStoreTests {
         let action = try #require(store.actions.first)
         #expect(action.sessionID == nil)
         #expect(action.agentType == nil)
+        let expectedCandidates = [
+            candidate(sessionID: sessionA, agentType: .claudeCode),
+            candidate(sessionID: sessionB, agentType: .codex)
+        ].sorted { $0.sessionID.uuidString < $1.sessionID.uuidString }
         #expect(
             action.attribution
-                == .ambiguous(candidates: [
-                    candidate(sessionID: sessionA, agentType: .claudeCode),
-                    candidate(sessionID: sessionB, agentType: .codex)
-                ])
+                == .ambiguous(candidates: expectedCandidates)
         )
         #expect(action.summary == Strings.agentActivityFileChanged("a.swift"))
     }

--- a/PineTests/CommandPaletteHostedInteractionTests.swift
+++ b/PineTests/CommandPaletteHostedInteractionTests.swift
@@ -1,0 +1,164 @@
+//
+//  CommandPaletteHostedInteractionTests.swift
+//  PineTests
+//
+
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import Pine
+
+@Suite("Command palette hosted keyboard interaction")
+@MainActor
+struct CommandPaletteHostedInteractionTests {
+    @Test("Arrow navigation and Return invoke the selected row")
+    func arrowAndReturn() throws {
+        let state = HostedState()
+        let hosted = hostPalette(state: state, items: makeItems())
+        let field = try #require(findTextField(in: hosted))
+        let coordinator = try #require(
+            field.delegate as? QuickOpenSearchField.Coordinator
+        )
+        let editor = NSTextView()
+
+        #expect(coordinator.control(
+            field,
+            textView: editor,
+            doCommandBy: #selector(NSResponder.moveDown(_:))
+        ))
+        #expect(coordinator.control(
+            field,
+            textView: editor,
+            doCommandBy: #selector(NSResponder.insertNewline(_:))
+        ))
+        drainMainRunLoop()
+
+        #expect(state.invoked == [.task("second")])
+        #expect(state.isPresented == false)
+    }
+
+    @Test("Escape dismisses without invoking a command")
+    func escapeDismisses() throws {
+        let state = HostedState()
+        let hosted = hostPalette(state: state, items: makeItems())
+        let field = try #require(findTextField(in: hosted))
+        let coordinator = try #require(
+            field.delegate as? QuickOpenSearchField.Coordinator
+        )
+
+        #expect(coordinator.control(
+            field,
+            textView: NSTextView(),
+            doCommandBy: #selector(NSResponder.cancelOperation(_:))
+        ))
+        drainMainRunLoop()
+
+        #expect(state.isPresented == false)
+        #expect(state.invoked.isEmpty)
+    }
+
+    @Test("Return does not invoke a disabled row")
+    func disabledRowDoesNotInvoke() throws {
+        let state = HostedState()
+        var items = makeItems()
+        items[0] = CommandPaletteItem(
+            id: items[0].id,
+            title: items[0].title,
+            subtitle: items[0].subtitle,
+            searchTerms: items[0].searchTerms,
+            iconName: items[0].iconName,
+            shortcut: items[0].shortcut,
+            isEnabled: false
+        )
+        let hosted = hostPalette(state: state, items: items)
+        let field = try #require(findTextField(in: hosted))
+        let coordinator = try #require(
+            field.delegate as? QuickOpenSearchField.Coordinator
+        )
+
+        #expect(coordinator.control(
+            field,
+            textView: NSTextView(),
+            doCommandBy: #selector(NSResponder.insertNewline(_:))
+        ))
+        drainMainRunLoop()
+
+        #expect(state.isPresented)
+        #expect(state.invoked.isEmpty)
+    }
+
+    private func makeItems() -> [CommandPaletteItem] {
+        [
+            makeItem(id: .builtIn(.quickOpen), title: "Quick Open"),
+            makeItem(id: .task("second"), title: "Second Task"),
+            makeItem(id: .builtIn(.findInFile), title: "Find"),
+        ]
+    }
+
+    private func makeItem(
+        id: CommandPaletteItemID,
+        title: String
+    ) -> CommandPaletteItem {
+        CommandPaletteItem(
+            id: id,
+            title: title,
+            subtitle: "Test",
+            searchTerms: [title],
+            iconName: "command",
+            shortcut: CommandShortcutPresentation(chord: nil, state: .none),
+            isEnabled: true
+        )
+    }
+
+    private func hostPalette(
+        state: HostedState,
+        items: [CommandPaletteItem]
+    ) -> NSHostingView<HostedHarness> {
+        let harness = HostedHarness(state: state, items: items)
+        let hosted = NSHostingView(rootView: harness)
+        hosted.frame = NSRect(x: 0, y: 0, width: 560, height: 400)
+        hosted.layoutSubtreeIfNeeded()
+        drainMainRunLoop()
+        hosted.layoutSubtreeIfNeeded()
+        return hosted
+    }
+
+    private func findTextField(in view: NSView) -> NSTextField? {
+        if let field = view as? NSTextField {
+            return field
+        }
+        for subview in view.subviews {
+            if let field = findTextField(in: subview) {
+                return field
+            }
+        }
+        return nil
+    }
+
+    private func drainMainRunLoop() {
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.02))
+    }
+}
+
+@MainActor
+private final class HostedState {
+    var isPresented = true
+    var invoked: [CommandPaletteItemID] = []
+}
+
+private struct HostedHarness: View {
+    let state: HostedState
+    let items: [CommandPaletteItem]
+
+    var body: some View {
+        CommandPaletteView(
+            isPresented: Binding(
+                get: { state.isPresented },
+                set: { state.isPresented = $0 }
+            ),
+            items: items,
+            onInvoke: { state.invoked.append($0.id) }
+        )
+    }
+}

--- a/PineTests/CommandPaletteModelTests.swift
+++ b/PineTests/CommandPaletteModelTests.swift
@@ -1,0 +1,226 @@
+//
+//  CommandPaletteModelTests.swift
+//  PineTests
+//
+
+import AppKit
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Command palette catalog and search")
+@MainActor
+struct CommandPaletteModelTests {
+    private let fullContext = CommandPaletteContext(
+        hasProject: true,
+        hasActiveFile: true,
+        isGitRepository: true,
+        hasTerminal: true
+    )
+
+    @Test("Catalog contains every registered command and every user task")
+    func catalogCompleteness() {
+        let registry = UserKeybindingRegistry()
+        let tasks = [
+            UserTask(
+                id: "lint",
+                label: "Lint Project",
+                command: "swiftlint",
+                scope: .project
+            ),
+            UserTask(
+                id: "format",
+                label: "Format File",
+                command: "swiftformat -",
+                replacesFileContent: true
+            ),
+        ]
+
+        let items = CommandPaletteCatalog.makeItems(
+            tasks: tasks,
+            keybindings: registry,
+            context: fullContext
+        )
+        let commandIDs = Set(items.compactMap { item -> UserCommand? in
+            guard case .builtIn(let command) = item.id else { return nil }
+            return command
+        })
+        let taskIDs = Set(items.compactMap { item -> String? in
+            guard case .task(let id) = item.id else { return nil }
+            return id
+        })
+
+        #expect(commandIDs == Set(UserCommand.allCases))
+        #expect(taskIDs == ["lint", "format"])
+        #expect(items.count == UserCommand.allCases.count + tasks.count)
+        #expect(items.allSatisfy { !$0.title.isEmpty && !$0.iconName.isEmpty })
+    }
+
+    @Test("Catalog exposes effective override and shadowed shortcut states")
+    func shortcutPrecedencePresentation() throws {
+        let registry = UserKeybindingRegistry()
+        _ = registry.apply(
+            .loaded([
+                ResolvedUserKeybinding(
+                    command: .quickOpen,
+                    chord: try #require(UserKeybindingRegistry.parse("cmd+k"))
+                ),
+                ResolvedUserKeybinding(
+                    command: .toggleComment,
+                    chord: try #require(UserKeybindingRegistry.parse("cmd+f"))
+                ),
+            ]),
+            from: URL(fileURLWithPath: "/tmp/keybindings.json")
+        )
+
+        let items = CommandPaletteCatalog.makeItems(
+            tasks: [],
+            keybindings: registry,
+            context: fullContext
+        )
+        let quickOpen = try #require(item(for: .quickOpen, in: items))
+        let find = try #require(item(for: .findInFile, in: items))
+        let toggleComment = try #require(item(for: .toggleComment, in: items))
+
+        #expect(quickOpen.shortcut.state == .userOverride)
+        #expect(quickOpen.shortcut.displayText == "⌘K")
+        #expect(toggleComment.shortcut.state == .userOverride)
+        #expect(toggleComment.shortcut.displayText == "⌘F")
+        #expect(find.shortcut.state == .shadowed)
+        #expect(find.shortcut.displayText == "⌘F")
+    }
+
+    @Test("Context disables commands and tasks without hiding them")
+    func contextualAvailability() throws {
+        let registry = UserKeybindingRegistry()
+        let tasks = [
+            UserTask(
+                id: "file-task",
+                label: "File Task",
+                command: "cat",
+                scope: .activeFile
+            ),
+            UserTask(
+                id: "project-task",
+                label: "Project Task",
+                command: "true",
+                scope: .project
+            ),
+        ]
+        let context = CommandPaletteContext(
+            hasProject: true,
+            hasActiveFile: false,
+            isGitRepository: false,
+            hasTerminal: false
+        )
+
+        let items = CommandPaletteCatalog.makeItems(
+            tasks: tasks,
+            keybindings: registry,
+            context: context
+        )
+
+        #expect(try #require(item(for: .save, in: items)).isEnabled == false)
+        #expect(try #require(item(for: .saveAs, in: items)).isEnabled == false)
+        #expect(try #require(item(for: .quickOpen, in: items)).isEnabled)
+        #expect(
+            try #require(item(forTask: "file-task", in: items)).isEnabled
+                == false
+        )
+        #expect(try #require(item(forTask: "project-task", in: items)).isEnabled)
+    }
+
+    @Test("Fuzzy search matches titles, command ids, and task ids")
+    func fuzzySearch() {
+        let registry = UserKeybindingRegistry()
+        let task = UserTask(
+            id: "terraform-validate",
+            label: "Validate Infrastructure",
+            command: "terraform validate",
+            scope: .project
+        )
+        let items = CommandPaletteCatalog.makeItems(
+            tasks: [task],
+            keybindings: registry,
+            context: fullContext
+        )
+
+        let byCommandID = CommandPaletteSearch.filter(
+            items,
+            query: "qopen"
+        )
+        let byTaskID = CommandPaletteSearch.filter(
+            items,
+            query: "terra val"
+        )
+        let noMatch = CommandPaletteSearch.filter(
+            items,
+            query: "definitely-not-present"
+        )
+
+        #expect(byCommandID.first?.id == .builtIn(.quickOpen))
+        #expect(byTaskID.first?.id == .task("terraform-validate"))
+        #expect(noMatch.isEmpty)
+    }
+
+    @Test("Keyboard navigation wraps and handles empty results")
+    func keyboardNavigation() {
+        #expect(
+            CommandPaletteNavigation.movedIndex(
+                from: 0,
+                by: -1,
+                itemCount: 3
+            ) == 2
+        )
+        #expect(
+            CommandPaletteNavigation.movedIndex(
+                from: 2,
+                by: 1,
+                itemCount: 3
+            ) == 0
+        )
+        #expect(
+            CommandPaletteNavigation.movedIndex(
+                from: 9,
+                by: 1,
+                itemCount: 3
+            ) == 0
+        )
+        #expect(
+            CommandPaletteNavigation.movedIndex(
+                from: 0,
+                by: 1,
+                itemCount: 0
+            ) == 0
+        )
+    }
+
+    @Test("Shortcut formatter covers named keys and modifiers")
+    func shortcutFormatting() throws {
+        #expect(
+            try #require(
+                UserKeybindingRegistry.parse("ctrl+option+shift+cmd+return")
+            ).displayText == "⌃⌥⇧⌘↩"
+        )
+        #expect(
+            try #require(
+                UserKeybindingRegistry.parse("cmd+left")
+            ).displayText == "⌘←"
+        )
+    }
+
+    private func item(
+        for command: UserCommand,
+        in items: [CommandPaletteItem]
+    ) -> CommandPaletteItem? {
+        items.first { $0.id == .builtIn(command) }
+    }
+
+    private func item(
+        forTask id: String,
+        in items: [CommandPaletteItem]
+    ) -> CommandPaletteItem? {
+        items.first { $0.id == .task(id) }
+    }
+}

--- a/PineTests/MenuIconTests.swift
+++ b/PineTests/MenuIconTests.swift
@@ -17,6 +17,7 @@ struct MenuIconTests {
 
     @Test(arguments: [
         (MenuIcons.openFolder, "Open Folder"),
+        (MenuIcons.commandPalette, "Command Palette"),
         (MenuIcons.save, "Save"),
         (MenuIcons.saveAll, "Save All"),
         (MenuIcons.saveAs, "Save As"),

--- a/PineTests/UserCommandInvocationRouterTests.swift
+++ b/PineTests/UserCommandInvocationRouterTests.swift
@@ -1,0 +1,136 @@
+//
+//  UserCommandInvocationRouterTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Registered command invocation router")
+@MainActor
+struct UserCommandInvocationRouterTests {
+    @Test("Application command dispatches exactly one notification")
+    func openFolderDispatch() {
+        let center = NotificationCenter()
+        let probe = NotificationProbe()
+        let token = center.addObserver(
+            forName: .openFolder,
+            object: nil,
+            queue: nil
+        ) { _ in
+            probe.record("openFolder")
+        }
+        defer { center.removeObserver(token) }
+
+        UserCommandInvocationRouter.dispatch(
+            .openFolder,
+            projectManager: nil,
+            notificationCenter: center
+        )
+
+        #expect(probe.values == ["openFolder"])
+    }
+
+    @Test("Structured fold command preserves its action payload")
+    func foldDispatchPayload() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "pine-command-router-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: false
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("main.swift")
+        try Data("func main() {}".utf8).write(to: file)
+
+        let projectManager = ProjectManager()
+        projectManager.activeTabManager.openTab(url: file)
+        let center = NotificationCenter()
+        let probe = NotificationProbe()
+        let token = center.addObserver(
+            forName: .foldCode,
+            object: nil,
+            queue: nil
+        ) { notification in
+            probe.record(notification.userInfo?["action"] as? String ?? "")
+        }
+        defer { center.removeObserver(token) }
+
+        UserCommandInvocationRouter.dispatch(
+            .unfoldAll,
+            projectManager: projectManager,
+            notificationCenter: center
+        )
+
+        #expect(probe.values == ["unfoldAll"])
+    }
+
+    @Test("Unavailable command does not dispatch")
+    func unavailableCommandIsIgnored() {
+        let center = NotificationCenter()
+        let probe = NotificationProbe()
+        let token = center.addObserver(
+            forName: .findInFile,
+            object: nil,
+            queue: nil
+        ) { _ in
+            probe.record("find")
+        }
+        defer { center.removeObserver(token) }
+
+        UserCommandInvocationRouter.dispatch(
+            .findInFile,
+            projectManager: nil,
+            notificationCenter: center
+        )
+
+        #expect(probe.values.isEmpty)
+    }
+
+    @Test("Targeted palette requests only match their owning project")
+    func commandPaletteTargeting() {
+        let currentProject = ProjectManager()
+        let otherProject = ProjectManager()
+
+        #expect(ContentView.shouldHandleTargetedCommand(
+            notificationObject: currentProject,
+            currentProject: currentProject,
+            isKeyWindow: false
+        ))
+        #expect(!ContentView.shouldHandleTargetedCommand(
+            notificationObject: otherProject,
+            currentProject: currentProject,
+            isKeyWindow: true
+        ))
+        #expect(ContentView.shouldHandleTargetedCommand(
+            notificationObject: nil,
+            currentProject: currentProject,
+            isKeyWindow: true
+        ))
+        #expect(!ContentView.shouldHandleTargetedCommand(
+            notificationObject: nil,
+            currentProject: currentProject,
+            isKeyWindow: false
+        ))
+    }
+}
+
+nonisolated private final class NotificationProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    var values: [String] {
+        lock.withLock { storage }
+    }
+
+    func record(_ value: String) {
+        lock.withLock {
+            storage.append(value)
+        }
+    }
+}

--- a/PineTests/UserConfigurationDiagnosticLocalizedTests.swift
+++ b/PineTests/UserConfigurationDiagnosticLocalizedTests.swift
@@ -26,6 +26,7 @@ struct UserConfigDiagnosticLocalizedTests {
             .textInputChord(value: "f"),
             .reservedSystemChord(value: "cmd+c"),
             .duplicateChord(value: "cmd+p", firstEntryNumber: 2),
+            .duplicateCommand(id: "quickOpen", firstEntryNumber: 1),
             .duplicateTaskID(id: "lint", firstEntryNumber: 1),
             .emptyTaskID,
             .emptyTaskLabel,

--- a/PineTests/UserConfigurationEditorTests.swift
+++ b/PineTests/UserConfigurationEditorTests.swift
@@ -24,7 +24,10 @@ nonisolated struct UserConfigurationEditorTests {
         let object = try JSONSerialization.jsonObject(with: data)
         let dict = try #require(object as? [String: Any])
         // ...document guidance lives in a `_comment` field...
-        #expect(dict["_comment"] is String)
+        let comment = try #require(dict["_comment"] as? String)
+        for command in UserCommand.allCases {
+            #expect(comment.contains(command.rawValue))
+        }
         // ...and the `keybindings` array is empty (no accidental bindings).
         let entries = try #require(dict["keybindings"] as? [Any])
         #expect(entries.isEmpty)
@@ -36,7 +39,9 @@ nonisolated struct UserConfigurationEditorTests {
         let data = Data(content.utf8)
         let object = try JSONSerialization.jsonObject(with: data)
         let dict = try #require(object as? [String: Any])
-        #expect(dict["_comment"] is String)
+        let comment = try #require(dict["_comment"] as? String)
+        #expect(comment.contains("replaces_file_content"))
+        #expect(!comment.contains("stdout does not currently replace"))
         let entries = try #require(dict["tasks"] as? [Any])
         #expect(entries.isEmpty)
     }

--- a/PineTests/UserConfigurationReloadTests.swift
+++ b/PineTests/UserConfigurationReloadTests.swift
@@ -100,7 +100,37 @@ struct UserConfigurationReloadTests {
         #expect(registry.entries.map { $0.command } == [.quickOpen])
     }
 
-    @Test func unavailableUnsafeAndReservedBindingsAreRejected() async throws {
+    @Test func duplicateCommandBindingsRejectAtomically() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("keybindings.json")
+        let registry = UserKeybindingRegistry()
+
+        try write(
+            #"[{"command": "findInFile", "key": "cmd+f"}]"#,
+            to: file
+        )
+        #expect((await registry.load(from: file)).outcome == .loaded)
+
+        try write(
+            """
+            [
+              {"command": "quickOpen", "key": "cmd+k"},
+              {"command": "quickOpen", "key": "cmd+option+k"}
+            ]
+            """,
+            to: file
+        )
+        let report = await registry.load(from: file)
+
+        #expect(report.outcome == .rejected)
+        #expect(report.diagnostics.map(\.reason).contains(
+            .duplicateCommand(id: "quickOpen", firstEntryNumber: 1)
+        ))
+        #expect(registry.entries.map(\.command) == [.findInFile])
+    }
+
+    @Test func safeDirectCommandsLoadWhileUnsafeChordsAreRejected() async throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let file = directory.appendingPathComponent("keybindings.json")
@@ -119,7 +149,7 @@ struct UserConfigurationReloadTests {
         let report = await registry.load(from: file)
 
         #expect(report.outcome == .rejected)
-        #expect(report.diagnostics.map(\.reason).contains(
+        #expect(!report.diagnostics.map(\.reason).contains(
             .unavailableCommand(id: "toggleMinimap")
         ))
         #expect(report.diagnostics.map(\.reason).contains(

--- a/PineTests/UserKeybindingDispatcherTests.swift
+++ b/PineTests/UserKeybindingDispatcherTests.swift
@@ -112,6 +112,55 @@ struct UserKeybindingDispatcherTests {
         #expect(builtInCallCount == 1)
     }
 
+    @Test("Rebinding a command suppresses its former built-in shortcut")
+    func reboundCommandSuppressesOldShortcut() async throws {
+        let registry = try await makeRegistry(chords: [
+            ("quickOpen", "cmd+k"),
+        ])
+        let formerShortcut = try makeCmdEvent(key: "p")
+        var userDispatchCount = 0
+        var builtInCallCount = 0
+
+        let routed = UserKeybindingDispatcher.route(
+            formerShortcut,
+            registry: registry,
+            dispatchUserCommand: { _ in userDispatchCount += 1 },
+            dispatchBuiltIn: { _ in
+                builtInCallCount += 1
+                return true
+            }
+        )
+
+        #expect(routed == nil)
+        #expect(userDispatchCount == 0)
+        #expect(builtInCallCount == 0)
+        #expect(registry.suppressesBuiltInShortcut(for: formerShortcut))
+    }
+
+    @Test("A different user command may claim a built-in shortcut")
+    func userCommandClaimsAnotherBuiltInShortcut() async throws {
+        let registry = try await makeRegistry(chords: [
+            ("toggleComment", "cmd+p"),
+        ])
+        let event = try makeCmdEvent(key: "p")
+        var dispatchedCommands: [UserCommand] = []
+        var builtInCallCount = 0
+
+        let routed = UserKeybindingDispatcher.route(
+            event,
+            registry: registry,
+            dispatchUserCommand: { dispatchedCommands.append($0) },
+            dispatchBuiltIn: { _ in
+                builtInCallCount += 1
+                return true
+            }
+        )
+
+        #expect(routed == nil)
+        #expect(dispatchedCommands == [.toggleComment])
+        #expect(builtInCallCount == 0)
+    }
+
     @Test("Unhandled event reaches menu, text, or terminal unchanged")
     func unhandledEventFallsThrough() async throws {
         let registry = try await makeRegistry(chords: [

--- a/PineTests/UserTaskInvocationControllerTests.swift
+++ b/PineTests/UserTaskInvocationControllerTests.swift
@@ -1,0 +1,55 @@
+//
+//  UserTaskInvocationControllerTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("User task invocation safety")
+struct UserTaskInvocationControllerTests {
+    @Test("Output replacement requires the same unchanged editor buffer")
+    func replacementRequiresSameUnchangedBuffer() {
+        let tabID = UUID()
+
+        #expect(UserTaskInvocationController.canApplyReplacement(
+            capturedTabID: tabID,
+            capturedContent: "before",
+            currentTabID: tabID,
+            currentContent: "before"
+        ))
+        #expect(!UserTaskInvocationController.canApplyReplacement(
+            capturedTabID: tabID,
+            capturedContent: "before",
+            currentTabID: UUID(),
+            currentContent: "before"
+        ))
+        #expect(!UserTaskInvocationController.canApplyReplacement(
+            capturedTabID: tabID,
+            capturedContent: "before",
+            currentTabID: tabID,
+            currentContent: "human edit"
+        ))
+    }
+
+    @Test("Missing capture data always fails closed", arguments: [
+        (nil, "before", UUID(), "before"),
+        (UUID(), nil, UUID(), "before"),
+        (nil, nil, nil, nil),
+    ] as [(UUID?, String?, UUID?, String?)])
+    func missingCaptureFailsClosed(
+        capturedTabID: UUID?,
+        capturedContent: String?,
+        currentTabID: UUID?,
+        currentContent: String?
+    ) {
+        #expect(!UserTaskInvocationController.canApplyReplacement(
+            capturedTabID: capturedTabID,
+            capturedContent: capturedContent,
+            currentTabID: currentTabID,
+            currentContent: currentContent
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

Completes #1117 now that the foundation in #1203 has merged. This branch is rebased directly onto `main` and contains only the two command-palette completion commits.

- adds a fuzzy Command Palette containing every `UserCommand` and every loaded user task
- routes palette and keybinding invocation through one typed command dispatcher
- shows effective built-in shortcuts, user overrides, shadowed shortcuts, and contextual availability
- makes user bindings true replacements: the claimed chord and the rebound command's former shortcut cannot double-dispatch
- keeps `keybindings.json` and `tasks.json` as the only configuration formats, with Edit and Reload actions that require no restart
- surfaces localized file/entry/reason diagnostics while atomically retaining the last valid registry
- rejects reserved macOS/text-input chords and duplicate commands/chords
- keeps shell tasks behind the existing validator/confirmation path, never interpolates editor/terminal-derived text into shell commands, and applies replacement output only to the same unchanged editor buffer
- localizes all new UI in all 9 supported languages
- adds unit and hosted-interaction coverage for parsing, precedence, conflicts, reloads, dispatch, task safety, keyboard navigation, and error presentation

## Validation

- Xcode beta targeted unit/hosted run: **98 tests in 15 suites passed**
- SwiftLint strict on all 27 changed Swift files: **0 violations**
- production reentrancy guard: **clean**
- reentrancy guard self-test: **5/5 passed**
- localization audit: every affected key has a non-empty translated value in all 9 locales
- `git diff --check origin/main..HEAD`: **passed**
- range-diff against the pre-rebase completion commits preserves the implementation; the only contextual delta removes the obsolete task execution helper superseded by the shared invocation controller

Fixes #1117
