### PR TITLE
fix(concurrency): clear residual Xcode warnings

### DIFF
--- a/Pine/Agent/AgentStatusBarItem.swift
+++ b/Pine/Agent/AgentStatusBarItem.swift
@@ -138,9 +138,11 @@ struct AgentStatusBarItem: View {
     /// "N agent[s] active" with correct singular/plural form.
     private var countLabel: Text {
         if summaries.count == 1 {
-            Text(verbatim: "1 ") + Text(Strings.statusbarAgentActive)
+            Text("\(Text(verbatim: "1 "))\(Text(Strings.statusbarAgentActive))")
         } else {
-            Text(verbatim: "\(summaries.count) ") + Text(Strings.statusbarAgentsActive)
+            Text(
+                "\(Text(verbatim: "\(summaries.count) "))\(Text(Strings.statusbarAgentsActive))"
+            )
         }
     }
 

--- a/Pine/LSP/CompletionProvider.swift
+++ b/Pine/LSP/CompletionProvider.swift
@@ -368,7 +368,7 @@ nonisolated struct LSPSnippet: Equatable, Sendable {
                 }
 
                 // `$n` — simple tab stop with no placeholder.
-                if let digit = next.wholeNumberValue {
+                if next.wholeNumberValue != nil {
                     let start = output.count
                     // Look ahead for more digits: `$10` is tab stop 10.
                     var j = i + 1

--- a/Pine/Syntax/CompiledGrammar.swift
+++ b/Pine/Syntax/CompiledGrammar.swift
@@ -36,7 +36,7 @@ nonisolated final class CompiledGrammarCache: @unchecked Sendable {
 
     /// Removes compiled rules for a grammar name.
     func removeRules(for grammarName: String) {
-        lock.withLock { compiledRules.removeValue(forKey: grammarName) }
+        lock.withLock { _ = compiledRules.removeValue(forKey: grammarName) }
     }
 }
 

--- a/Pine/Syntax/SyntaxHighlightAsync.swift
+++ b/Pine/Syntax/SyntaxHighlightAsync.swift
@@ -29,7 +29,7 @@ nonisolated final class MultilineMatchCache: @unchecked Sendable {
     }
 
     func remove(key: ObjectIdentifier) {
-        lock.withLock { cache.removeValue(forKey: key) }
+        lock.withLock { _ = cache.removeValue(forKey: key) }
     }
 
     func removeAll() {

--- a/Pine/Syntax/SyntaxHighlightEngine.swift
+++ b/Pine/Syntax/SyntaxHighlightEngine.swift
@@ -54,6 +54,17 @@ struct SyncContext: Sendable {
 /// Thread safety: `computeMatches`/`computeMatchesWithRules` are pure computation
 /// (thread-safe). `applyMatches`/`resetAttributes` MUST be called on the main thread.
 nonisolated final class SyntaxHighlightEngine: @unchecked Sendable {
+    /// Carries AppKit values across the compiler's nonisolated-to-main-actor
+    /// boundary without claiming that the values are generally thread-safe.
+    ///
+    /// The box is created and consumed synchronously by methods whose public
+    /// contract requires the main thread. `MainActor.assumeIsolated` validates
+    /// that contract before either value is accessed.
+    private struct MainActorMutationBox: @unchecked Sendable {
+        let textStorage: NSTextStorage
+        let font: NSFont
+    }
+
     /// Number of context lines around edited region for incremental highlighting.
     let contextLines = 20
 
@@ -339,59 +350,65 @@ nonisolated final class SyntaxHighlightEngine: @unchecked Sendable {
         to textStorage: NSTextStorage,
         font: NSFont
     ) {
-        let currentLength = textStorage.length
-        guard result.repaintRange.location + result.repaintRange.length <= currentLength else {
-            return
+        let box = MainActorMutationBox(textStorage: textStorage, font: font)
+        MainActor.assumeIsolated {
+            let currentLength = box.textStorage.length
+            guard result.repaintRange.location + result.repaintRange.length <= currentLength else {
+                return
+            }
+
+            let undoManager = box.textStorage.layoutManagers.first?.firstTextView?.undoManager
+
+            if undoManager?.isUndoing == true || undoManager?.isRedoing == true {
+                return
+            }
+
+            undoManager?.disableUndoRegistration()
+            defer { undoManager?.enableUndoRegistration() }
+
+            box.textStorage.beginEditing()
+            box.textStorage.addAttributes([
+                .foregroundColor: NSColor.textColor,
+                .font: box.font
+            ], range: result.repaintRange)
+
+            for match in result.matches {
+                guard match.range.location + match.range.length <= currentLength else { continue }
+                guard let color = theme.color(for: match.scope) else { continue }
+                box.textStorage.addAttribute(.foregroundColor, value: color, range: match.range)
+            }
+
+            box.textStorage.endEditing()
         }
-
-        let undoManager = textStorage.layoutManagers.first?.firstTextView?.undoManager
-
-        if undoManager?.isUndoing == true || undoManager?.isRedoing == true {
-            return
-        }
-
-        undoManager?.disableUndoRegistration()
-        defer { undoManager?.enableUndoRegistration() }
-
-        textStorage.beginEditing()
-        textStorage.addAttributes([
-            .foregroundColor: NSColor.textColor,
-            .font: font
-        ], range: result.repaintRange)
-
-        for match in result.matches {
-            guard match.range.location + match.range.length <= currentLength else { continue }
-            guard let color = theme.color(for: match.scope) else { continue }
-            textStorage.addAttribute(.foregroundColor, value: color, range: match.range)
-        }
-
-        textStorage.endEditing()
     }
 
     /// Resets attributes to base style (no grammar). Main thread only.
     func resetAttributes(textStorage: NSTextStorage, range: NSRange, font: NSFont) {
-        let currentLength = textStorage.length
-        guard currentLength > 0 else { return }
-        let safeRange = NSRange(
-            location: min(range.location, currentLength),
-            length: min(range.length, currentLength - min(range.location, currentLength))
-        )
-        guard safeRange.length > 0 else { return }
+        let box = MainActorMutationBox(textStorage: textStorage, font: font)
+        MainActor.assumeIsolated {
+            let currentLength = box.textStorage.length
+            guard currentLength > 0 else { return }
+            let safeRange = NSRange(
+                location: min(range.location, currentLength),
+                length: min(range.length, currentLength - min(range.location, currentLength))
+            )
+            guard safeRange.length > 0 else { return }
 
-        let undoManager = textStorage.layoutManagers.first?.firstTextView?.undoManager
+            let undoManager = box.textStorage.layoutManagers.first?.firstTextView?.undoManager
 
-        if undoManager?.isUndoing == true || undoManager?.isRedoing == true {
-            return
+            if undoManager?.isUndoing == true || undoManager?.isRedoing == true {
+                return
+            }
+
+            undoManager?.disableUndoRegistration()
+            defer { undoManager?.enableUndoRegistration() }
+            box.textStorage.beginEditing()
+            box.textStorage.addAttributes([
+                .foregroundColor: NSColor.textColor,
+                .font: box.font
+            ], range: safeRange)
+            box.textStorage.endEditing()
         }
-
-        undoManager?.disableUndoRegistration()
-        defer { undoManager?.enableUndoRegistration() }
-        textStorage.beginEditing()
-        textStorage.addAttributes([
-            .foregroundColor: NSColor.textColor,
-            .font: font
-        ], range: safeRange)
-        textStorage.endEditing()
     }
 
     // MARK: - Range helpers

--- a/PineTests/SyntaxHighlightEngineTests.swift
+++ b/PineTests/SyntaxHighlightEngineTests.swift
@@ -149,7 +149,7 @@ struct SyntaxHighlightEngineTests {
         #expect(color != keywordColor)
     }
 
-    @Test func applyMatches_doesNotRegisterUndoActions() {
+    @Test func applyAndReset_doNotRegisterUndoActionsAndRestoreRegistration() {
         let text = "func hello() /* comment */"
         let storage = NSTextStorage(string: text)
         let layoutManager = NSLayoutManager()
@@ -182,11 +182,25 @@ struct SyntaxHighlightEngineTests {
         )
 
         #expect(textView.undoManager?.canUndo == false)
+        #expect(textView.undoManager?.isUndoRegistrationEnabled == true)
 
         engine.applyMatches(result, to: storage, font: font)
 
         #expect(textView.undoManager?.canUndo == false,
                 "applyMatches must not register undo actions")
+        #expect(textView.undoManager?.isUndoRegistrationEnabled == true,
+                "applyMatches must restore undo registration")
+
+        engine.resetAttributes(
+            textStorage: storage,
+            range: NSRange(location: 0, length: storage.length),
+            font: font
+        )
+
+        #expect(textView.undoManager?.canUndo == false,
+                "resetAttributes must not register undo actions")
+        #expect(textView.undoManager?.isUndoRegistrationEnabled == true,
+                "resetAttributes must restore undo registration")
     }
 
     // MARK: - resetAttributes


### PR DESCRIPTION
## Summary

- replace deprecated `Text + Text` composition while preserving localized snapshot output
- remove the residual unused-value diagnostics in snippet parsing and the two locked caches
- keep `NSTextStorage` mutation on the main actor through a narrow, synchronously consumed boundary and verify undo registration is restored

## Dependency and merge order

This is the final residual slice for #1197. **Do not merge it before #1205.** The remaining catalogued sites on `main` are already owned by open work and intentionally excluded here:

- #1205: `CodeEditorView+Coordinator`, `GoToLineView`, `PineApp`, `PineAppMenuCommands`, `ProjectManager`, `RecoveryManager`, `TerminalSession`, and `WorkspaceManager`
- #1206: `LSPClient`
- #1207: `AgentHistoryStore`
- #1210: `PaneManager` and `EditorTabBar`
- #1211 (stacked on #1203): `UserTaskRunner`

`Fixes #1197` is conditional on those owners landing first and the final stable-Xcode-26 plus Xcode-27 inventory being zero. If any catalogued diagnostic remains, keep this PR blocked and update the inventory before merging.

## Validation

- Xcode 27.0 beta (27A5218g): clean app build succeeded; zero diagnostics in all five targeted app files
- 68 targeted unit/snapshot tests passed across 7 suites
- strict SwiftLint on all changed files: 0 violations
- full strict SwiftLint across 542 files: one pre-existing `Pine/AboutInfo.swift:37` `superfluous_disable_command`, unchanged from `origin/main` and outside the #1197 compiler-warning inventory
- `scripts/check-no-post-under-inout.py Pine PineTests`
- stable Xcode 26 is not installed locally; its compatibility lane remains the authoritative final gate

Fixes #1197