### PR TITLE
feat(agent): add secure provenance event store

### DIFF
--- a/Pine/Agent/Provenance/AgentEventProvenanceStore.swift
+++ b/Pine/Agent/Provenance/AgentEventProvenanceStore.swift
@@ -1,0 +1,642 @@
+//
+//  AgentEventProvenanceStore.swift
+//  Pine
+//
+//  Owner-private append-only storage for trusted agent-event provenance
+//  (epic #933, storage slice).
+//
+//  This actor is deliberately not wired into terminal observation, Agent
+//  Activity, Agent History, or undo. It is a persistence and query boundary
+//  only. Recording metadata here never authorizes a working-tree mutation.
+//
+
+import CryptoKit
+import Foundation
+
+/// Project/worktree identity that owns one provenance journal.
+///
+/// The worktree path is canonicalized once when the scope is created. Every
+/// appended envelope is checked against both fields, so copying a valid record
+/// into another project's journal cannot make it authoritative there.
+nonisolated struct AgentEventStoreScope: Sendable, Equatable {
+    let projectID: UUID
+    let worktreePath: String
+
+    init(projectID: UUID, worktreeURL: URL) throws {
+        guard projectID != Self.zeroUUID,
+              worktreeURL.isFileURL,
+              Self.isSafeAbsolutePath(worktreeURL.path) else {
+            throw AgentEventStoreError.invalidScope
+        }
+        let canonicalPath = Self.canonicalPath(worktreeURL.path)
+        guard Self.isSafeAbsolutePath(canonicalPath) else {
+            throw AgentEventStoreError.invalidScope
+        }
+        self.projectID = projectID
+        self.worktreePath = canonicalPath
+    }
+
+    static func canonicalPath(_ path: String) -> String {
+        URL(fileURLWithPath: path)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+            .path
+    }
+
+    static func isSafeAbsolutePath(_ path: String) -> Bool {
+        !path.isEmpty
+            && path.hasPrefix("/")
+            && !path.utf8.contains(0)
+            && path.utf8.count <= AgentEventStoreLimits.maximumPathBytes
+    }
+
+    static let zeroUUID = UUID(
+        uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    )
+}
+
+/// Bounded storage and input limits for one journal.
+nonisolated struct AgentEventStoreLimits: Sendable, Equatable {
+    static let maximumPathBytes = 4_096
+    private static let maximumRecords = 100_000
+    private static let maximumLogBytes = 256 * 1_024 * 1_024
+    private static let maximumRecordBytes = 8 * 1_024 * 1_024
+    private static let maximumDedupeEntries = 200_000
+    private static let maximumTrackedStreams = 100_000
+    private static let maximumQueryResults = 10_000
+    private static let maximumMetadataBytes = 4_096
+    private static let maximumCommandBytes = 1 * 1_024 * 1_024
+    private static let maximumQuarantineFiles = 64
+    private static let maximumQuarantineBytes = 16 * 1_024 * 1_024
+
+    let maxRecords: Int
+    let maxLogBytes: Int
+    let maxRecordBytes: Int
+    let maxDedupeEntries: Int
+    let maxTrackedStreams: Int
+    let maxQueryResults: Int
+    let maxAgentTypeBytes: Int
+    let maxSourceBytes: Int
+    let maxCommandBytes: Int
+    let maxQuarantineFiles: Int
+    let maxQuarantineBytes: Int
+
+    init(
+        maxRecords: Int = 2_000,
+        maxLogBytes: Int = 8 * 1_024 * 1_024,
+        maxRecordBytes: Int = 128 * 1_024,
+        maxDedupeEntries: Int = 4_000,
+        maxTrackedStreams: Int = 1_024,
+        maxQueryResults: Int = 1_000,
+        maxAgentTypeBytes: Int = 256,
+        maxSourceBytes: Int = 256,
+        maxCommandBytes: Int = 32 * 1_024,
+        maxQuarantineFiles: Int = 4,
+        maxQuarantineBytes: Int = 1 * 1_024 * 1_024
+    ) throws {
+        guard maxRecords > 0,
+              maxRecords <= Self.maximumRecords,
+              maxLogBytes >= 4_096,
+              maxLogBytes <= Self.maximumLogBytes,
+              maxRecordBytes > 0,
+              maxRecordBytes <= Self.maximumRecordBytes,
+              maxRecordBytes < maxLogBytes,
+              maxDedupeEntries > 0,
+              maxDedupeEntries <= Self.maximumDedupeEntries,
+              maxTrackedStreams > 0,
+              maxTrackedStreams <= Self.maximumTrackedStreams,
+              maxQueryResults > 0,
+              maxQueryResults <= Self.maximumQueryResults,
+              maxAgentTypeBytes > 0,
+              maxAgentTypeBytes <= Self.maximumMetadataBytes,
+              maxSourceBytes > 0,
+              maxSourceBytes <= Self.maximumMetadataBytes,
+              maxCommandBytes > 0,
+              maxCommandBytes <= Self.maximumCommandBytes,
+              maxQuarantineFiles > 0,
+              maxQuarantineFiles <= Self.maximumQuarantineFiles,
+              maxQuarantineBytes > 0,
+              maxQuarantineBytes <= Self.maximumQuarantineBytes else {
+            throw AgentEventStoreError.invalidLimits
+        }
+        self.maxRecords = maxRecords
+        self.maxLogBytes = maxLogBytes
+        self.maxRecordBytes = maxRecordBytes
+        self.maxDedupeEntries = maxDedupeEntries
+        self.maxTrackedStreams = maxTrackedStreams
+        self.maxQueryResults = maxQueryResults
+        self.maxAgentTypeBytes = maxAgentTypeBytes
+        self.maxSourceBytes = maxSourceBytes
+        self.maxCommandBytes = maxCommandBytes
+        self.maxQuarantineFiles = maxQuarantineFiles
+        self.maxQuarantineBytes = maxQuarantineBytes
+    }
+
+    static var `default`: AgentEventStoreLimits {
+        // These constants are validated above and cannot fail.
+        do {
+            return try AgentEventStoreLimits()
+        } catch {
+            preconditionFailure("Invalid built-in AgentEventStoreLimits")
+        }
+    }
+}
+
+/// Opening or operating the secure journal failed.
+nonisolated enum AgentEventStoreError: Error, Sendable, Equatable {
+    case invalidScope
+    case invalidLimits
+    case unsafeStorage(AgentEventStorageFailure)
+}
+
+/// Fail-closed storage failure categories. Raw errno/path details are not
+/// exposed because callers only need to know that the journal lost authority.
+nonisolated enum AgentEventStorageFailure: String, Error, Codable, Sendable, Equatable {
+    case createDirectory
+    case openDirectory
+    case unsafeDirectory
+    case openJournal
+    case unsafeJournal
+    case pathReplaced
+    case read
+    case write
+    case synchronize
+    case compact
+    case quarantine
+    case storageLimit
+}
+
+/// Why an otherwise structured envelope was refused.
+nonisolated enum AgentEventAppendRejection: Error, Sendable, Equatable {
+    case wrongProject
+    case wrongWorktree
+    case invalidProvenance
+    case invalidPayload
+    case oversizedRecord
+    case identityCollision
+    case nonMonotonicCursor
+    case streamLimitReached
+    case sequenceExhausted
+    case storage(AgentEventStorageFailure)
+}
+
+/// Typed result for callers that need to distinguish a durable append from a
+/// retained-window duplicate or a fail-closed rejection.
+nonisolated enum AgentEventAppendOutcome: Sendable, Equatable {
+    case appended(sequence: UInt64)
+    case duplicate(existingSequence: UInt64)
+    case rejected(AgentEventAppendRejection)
+}
+
+/// One durable journal row. `sequence` is global within this scoped store;
+/// `envelope.cursorValue` remains monotonic within its process stream.
+nonisolated struct StoredAgentEvent: Codable, Sendable, Equatable {
+    let sequence: UInt64
+    let envelope: AgentEventEnvelope
+}
+
+/// Integrity condition observed while opening the current journal.
+nonisolated enum AgentEventStoreIntegrity: Sendable, Equatable {
+    case healthy
+    case recovered(AgentEventCorruptionReport)
+    case unavailable(AgentEventStorageFailure)
+}
+
+/// Typed evidence that an invalid suffix was quarantined before recovery.
+nonisolated struct AgentEventCorruptionReport: Sendable, Equatable {
+    enum Kind: String, Codable, Sendable, Equatable {
+        case truncatedFrame
+        case invalidMagic
+        case oversizedFrame
+        case checksumMismatch
+        case decodeFailure
+        case scopeMismatch
+        case invalidCheckpoint
+        case tooManyRecords
+        case oversizedJournal
+    }
+
+    let kind: Kind
+    let retainedRecordCount: Int
+    let discardedByteCount: Int
+    let quarantinedByteCount: Int
+    let quarantineFileName: String
+}
+
+/// Value-type snapshot for read-only consumers.
+nonisolated struct AgentEventStoreSnapshot: Sendable, Equatable {
+    let scope: AgentEventStoreScope
+    let integrity: AgentEventStoreIntegrity
+    let lastSequence: UInt64
+    let records: [StoredAgentEvent]
+
+    var verified: [StoredAgentEvent] {
+        records.filter { $0.envelope.trustLevel == .verified }
+    }
+
+    var inferred: [StoredAgentEvent] {
+        records.filter { $0.envelope.trustLevel == .inferred }
+    }
+
+    var observed: [StoredAgentEvent] {
+        records.filter { $0.envelope.trustLevel == .observed }
+    }
+}
+
+/// Bounded read-only filter. Nil fields match every value.
+nonisolated struct AgentEventQuery: Sendable, Equatable {
+    let sessionID: UUID?
+    let terminalID: UUID?
+    let trustLevel: TrustLevel?
+    let source: EventSource?
+    let sequenceAfter: UInt64?
+    let sequenceThrough: UInt64?
+    let limit: Int?
+
+    init(
+        sessionID: UUID? = nil,
+        terminalID: UUID? = nil,
+        trustLevel: TrustLevel? = nil,
+        source: EventSource? = nil,
+        sequenceAfter: UInt64? = nil,
+        sequenceThrough: UInt64? = nil,
+        limit: Int? = nil
+    ) {
+        self.sessionID = sessionID
+        self.terminalID = terminalID
+        self.trustLevel = trustLevel
+        self.source = source
+        self.sequenceAfter = sequenceAfter
+        self.sequenceThrough = sequenceThrough
+        self.limit = limit
+    }
+}
+
+/// Typed query response that never separates rows from the journal integrity
+/// state under which they were read.
+nonisolated struct AgentEventQueryResult: Sendable, Equatable {
+    let scope: AgentEventStoreScope
+    let integrity: AgentEventStoreIntegrity
+    let records: [StoredAgentEvent]
+
+    var verified: [StoredAgentEvent] {
+        records.filter { $0.envelope.trustLevel == .verified }
+    }
+
+    var inferred: [StoredAgentEvent] {
+        records.filter { $0.envelope.trustLevel == .inferred }
+    }
+
+    var observed: [StoredAgentEvent] {
+        records.filter { $0.envelope.trustLevel == .observed }
+    }
+}
+
+/// Stream identity used for cursor monotonicity across restarts.
+nonisolated struct AgentEventStreamIdentity: Codable, Hashable, Sendable {
+    let sessionID: UUID
+    let terminalID: UUID
+    let processGeneration: UInt64
+
+    init(envelope: AgentEventEnvelope) {
+        self.sessionID = envelope.sessionID
+        self.terminalID = envelope.process.terminalID
+        self.processGeneration = envelope.process.processGeneration
+    }
+}
+
+/// Persisted dedupe identity. The digest detects UUID reuse with different
+/// content instead of silently treating the collision as a duplicate.
+nonisolated struct AgentEventRecentIdentity: Codable, Sendable, Equatable {
+    let id: UUID
+    let digest: String
+    let sequence: UInt64
+}
+
+/// Metadata included whenever retention compacts the event suffix.
+nonisolated struct AgentEventJournalCheckpoint: Codable, Sendable, Equatable {
+    let projectID: UUID
+    let worktreePath: String
+    let lastSequence: UInt64
+    let streamWatermarks: [AgentEventStreamIdentity: UInt64]
+    let recentIdentities: [AgentEventRecentIdentity]
+}
+
+/// Serialized, owner-private provenance collector and query store.
+///
+/// Actor isolation is the single mutation boundary. The secure journal itself
+/// performs synchronous POSIX I/O, but is private to this actor and is never
+/// called from the main actor by this slice.
+actor AgentEventProvenanceStore: AgentEventProvenanceCollector {
+    private let scope: AgentEventStoreScope
+    private let limits: AgentEventStoreLimits
+    private let journal: SecureAgentEventJournal
+
+    private var records: [StoredAgentEvent]
+    private var lastSequence: UInt64
+    private var streamWatermarks: [AgentEventStreamIdentity: UInt64]
+    private var recentIdentities: [UUID: AgentEventRecentIdentity]
+    private var recentIdentityOrder: [UUID]
+    private var integrity: AgentEventStoreIntegrity
+
+    init(
+        scope: AgentEventStoreScope,
+        storageRoot: URL = AgentEventProvenanceStore.defaultStorageRoot,
+        limits: AgentEventStoreLimits = .default
+    ) throws {
+        let opened: SecureAgentEventJournal.Opened
+        do {
+            opened = try SecureAgentEventJournal.open(
+                scope: scope,
+                storageRoot: storageRoot,
+                limits: limits
+            )
+        } catch let failure as AgentEventStorageFailure {
+            throw AgentEventStoreError.unsafeStorage(failure)
+        }
+
+        self.scope = scope
+        self.limits = limits
+        self.journal = opened.journal
+        self.records = opened.state.records
+        self.lastSequence = opened.state.lastSequence
+        self.streamWatermarks = opened.state.streamWatermarks
+        self.recentIdentityOrder = opened.state.recentIdentities.map(\.id)
+        self.recentIdentities = Dictionary(
+            uniqueKeysWithValues: opened.state.recentIdentities.map { ($0.id, $0) }
+        )
+        self.integrity = opened.integrity
+    }
+
+    /// Safe protocol adapter. Callers that require typed refusal information
+    /// use `append(_:)`; the original #1204 collector seam remains source
+    /// compatible and fail-closed.
+    func record(_ envelope: AgentEventEnvelope) async {
+        _ = append(envelope)
+    }
+
+    /// Validates, deduplicates, durably appends, and only then publishes the
+    /// record to in-memory queries.
+    @discardableResult
+    func append(_ envelope: AgentEventEnvelope) -> AgentEventAppendOutcome {
+        if case .unavailable(let failure) = integrity {
+            return .rejected(.storage(failure))
+        }
+
+        let normalized: AgentEventEnvelope
+        do {
+            normalized = try AgentEventEnvelopeNormalizer.normalize(
+                envelope,
+                scope: scope,
+                limits: limits
+            )
+        } catch let rejection as AgentEventAppendRejection {
+            return .rejected(rejection)
+        } catch {
+            return .rejected(.invalidProvenance)
+        }
+
+        let digest: String
+        do {
+            digest = try SecureAgentEventJournal.digest(of: normalized)
+        } catch {
+            return .rejected(.oversizedRecord)
+        }
+
+        if let existing = recentIdentities[normalized.id] {
+            if existing.digest == digest {
+                return .duplicate(existingSequence: existing.sequence)
+            }
+            return .rejected(.identityCollision)
+        }
+        if let retained = records.first(where: { $0.envelope.id == normalized.id }) {
+            guard let retainedDigest = try? SecureAgentEventJournal.digest(
+                of: retained.envelope
+            ) else {
+                return .rejected(.identityCollision)
+            }
+            if retainedDigest == digest {
+                return .duplicate(existingSequence: retained.sequence)
+            }
+            return .rejected(.identityCollision)
+        }
+
+        let stream = AgentEventStreamIdentity(envelope: normalized)
+        if let watermark = streamWatermarks[stream],
+           normalized.cursorValue <= watermark {
+            return .rejected(.nonMonotonicCursor)
+        }
+        if streamWatermarks[stream] == nil,
+           streamWatermarks.count >= limits.maxTrackedStreams {
+            return .rejected(.streamLimitReached)
+        }
+        guard lastSequence < UInt64.max else {
+            return .rejected(.sequenceExhausted)
+        }
+
+        let sequence = lastSequence + 1
+        let record = StoredAgentEvent(sequence: sequence, envelope: normalized)
+        guard SecureAgentEventJournal.encodedEventSize(record) <= limits.maxRecordBytes else {
+            return .rejected(.oversizedRecord)
+        }
+
+        var nextRecords = records
+        nextRecords.append(record)
+
+        var nextWatermarks = streamWatermarks
+        nextWatermarks[stream] = normalized.cursorValue
+
+        var nextIdentityOrder = recentIdentityOrder.filter { $0 != normalized.id }
+        nextIdentityOrder.append(normalized.id)
+        if nextIdentityOrder.count > limits.maxDedupeEntries {
+            nextIdentityOrder.removeFirst(nextIdentityOrder.count - limits.maxDedupeEntries)
+        }
+
+        var nextIdentities = recentIdentities
+        nextIdentities[normalized.id] = AgentEventRecentIdentity(
+            id: normalized.id,
+            digest: digest,
+            sequence: sequence
+        )
+        let retainedIdentityIDs = Set(nextIdentityOrder)
+        nextIdentities = nextIdentities.filter { retainedIdentityIDs.contains($0.key) }
+
+        let checkpoint = AgentEventJournalCheckpoint(
+            projectID: scope.projectID,
+            worktreePath: scope.worktreePath,
+            lastSequence: sequence,
+            streamWatermarks: nextWatermarks,
+            recentIdentities: nextIdentityOrder.compactMap { nextIdentities[$0] }
+        )
+
+        let retained: [StoredAgentEvent]
+        do {
+            retained = try journal.persist(
+                appended: record,
+                prospectiveRecords: nextRecords,
+                checkpoint: checkpoint
+            )
+        } catch let failure as AgentEventStorageFailure {
+            integrity = .unavailable(failure)
+            return .rejected(.storage(failure))
+        } catch {
+            integrity = .unavailable(.write)
+            return .rejected(.storage(.write))
+        }
+
+        records = retained
+        lastSequence = sequence
+        streamWatermarks = nextWatermarks
+        recentIdentityOrder = nextIdentityOrder
+        recentIdentities = nextIdentities
+        return .appended(sequence: sequence)
+    }
+
+    /// Full retained suffix plus typed recovery state.
+    func snapshot() -> AgentEventStoreSnapshot {
+        AgentEventStoreSnapshot(
+            scope: scope,
+            integrity: integrity,
+            lastSequence: lastSequence,
+            records: records
+        )
+    }
+
+    /// Chronological, bounded read-only query with inseparable integrity state.
+    func query(_ query: AgentEventQuery = AgentEventQuery()) -> AgentEventQueryResult {
+        let requestedLimit = query.limit ?? limits.maxQueryResults
+        let safeLimit = max(0, min(requestedLimit, limits.maxQueryResults))
+        let matches: [StoredAgentEvent]
+        if safeLimit == 0 {
+            matches = []
+        } else {
+            matches = Array(records.lazy.filter { record in
+                let envelope = record.envelope
+                return (query.sessionID == nil || envelope.sessionID == query.sessionID)
+                    && (query.terminalID == nil
+                        || envelope.process.terminalID == query.terminalID)
+                    && (query.trustLevel == nil || envelope.trustLevel == query.trustLevel)
+                    && (query.source == nil || envelope.source == query.source)
+                    && (query.sequenceAfter.map { record.sequence > $0 } ?? true)
+                    && (query.sequenceThrough.map { record.sequence <= $0 } ?? true)
+            }.prefix(safeLimit))
+        }
+        return AgentEventQueryResult(
+            scope: scope,
+            integrity: integrity,
+            records: matches
+        )
+    }
+
+    /// Stable paths are exposed for diagnostics/tests only; callers must never
+    /// mutate them. Runtime I/O remains descriptor-relative.
+    func storageLocations() -> (scopeDirectory: URL, journal: URL) {
+        (journal.scopeDirectoryURL, journal.journalURL)
+    }
+
+    nonisolated static var defaultStorageRoot: URL {
+        FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Pine", isDirectory: true)
+            .appendingPathComponent("AgentProvenance", isDirectory: true)
+    }
+}
+
+/// Shared fail-closed normalization used for both live appends and decoded
+/// journal frames. Keeping one implementation prevents a hand-crafted,
+/// checksummed on-disk record from bypassing the live collector's rules.
+nonisolated enum AgentEventEnvelopeNormalizer {
+    static func normalize(
+        _ envelope: AgentEventEnvelope,
+        scope: AgentEventStoreScope,
+        limits: AgentEventStoreLimits
+    ) throws -> AgentEventEnvelope {
+        guard envelope.projectID == scope.projectID else {
+            throw AgentEventAppendRejection.wrongProject
+        }
+
+        guard AgentEventStoreScope.isSafeAbsolutePath(envelope.location.worktreePath),
+              AgentEventStoreScope.isSafeAbsolutePath(envelope.location.cwd) else {
+            throw AgentEventAppendRejection.invalidProvenance
+        }
+        let eventWorktree = AgentEventStoreScope.canonicalPath(envelope.location.worktreePath)
+        guard eventWorktree == scope.worktreePath else {
+            throw AgentEventAppendRejection.wrongWorktree
+        }
+
+        let canonicalCWD = AgentEventStoreScope.canonicalPath(envelope.location.cwd)
+        guard AgentEventStoreScope.isSafeAbsolutePath(canonicalCWD),
+              isWithinScope(canonicalCWD, root: scope.worktreePath),
+              envelope.id != AgentEventStoreScope.zeroUUID,
+              envelope.cursorValue > 0,
+              envelope.sessionID != AgentEventStoreScope.zeroUUID,
+              envelope.process.terminalID != AgentEventStoreScope.zeroUUID,
+              envelope.process.processGeneration > 0,
+              envelope.agentTypeRaw.utf8.count <= limits.maxAgentTypeBytes,
+              !envelope.agentTypeRaw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !envelope.agentTypeRaw.utf8.contains(0),
+              envelope.source.stableIdentifier.utf8.count <= limits.maxSourceBytes,
+              !envelope.source.stableIdentifier
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !envelope.source.stableIdentifier.utf8.contains(0),
+              envelope.timestamp.timeIntervalSince1970.isFinite,
+              envelope.timestamp.timeIntervalSince1970 != 0 else {
+            throw AgentEventAppendRejection.invalidProvenance
+        }
+
+        guard isSafePayload(envelope.payload, limits: limits) else {
+            throw AgentEventAppendRejection.invalidPayload
+        }
+
+        // Reconstructing is intentional: the #1204 initializer recomputes the
+        // effective trust level. A malformed/incomplete caller can never
+        // preserve `.verified` merely because it arrived as an in-memory value.
+        return AgentEventEnvelope(
+            id: envelope.id,
+            projectID: envelope.projectID,
+            sessionID: envelope.sessionID,
+            agentTypeRaw: envelope.agentTypeRaw,
+            process: envelope.process,
+            location: AgentEventLocation(
+                worktreePath: scope.worktreePath,
+                cwd: canonicalCWD
+            ),
+            cursorValue: envelope.cursorValue,
+            timestamp: envelope.timestamp,
+            source: envelope.source,
+            trustLevel: envelope.trustLevel,
+            payload: envelope.payload
+        )
+    }
+
+    private static func isWithinScope(_ path: String, root: String) -> Bool {
+        path == root || path.hasPrefix(root.hasSuffix("/") ? root : root + "/")
+    }
+
+    private static func isSafePayload(
+        _ payload: AgentEventPayload,
+        limits: AgentEventStoreLimits
+    ) -> Bool {
+        switch payload {
+        case .none:
+            return true
+        case .commandResult(let result):
+            return !result.command.utf8.contains(0)
+                && result.command.utf8.count <= limits.maxCommandBytes
+        case .fileChange(let change):
+            return isSafeRelativePath(change.relativePath)
+        }
+    }
+
+    private static func isSafeRelativePath(_ path: String) -> Bool {
+        guard !path.isEmpty,
+              path.utf8.count <= AgentEventStoreLimits.maximumPathBytes,
+              !path.hasPrefix("/"),
+              !path.utf8.contains(0) else {
+            return false
+        }
+        let components = path.split(separator: "/", omittingEmptySubsequences: false)
+        return !components.isEmpty
+            && components.allSatisfy { !$0.isEmpty && $0 != "." && $0 != ".." }
+    }
+}

--- a/Pine/Agent/Provenance/SecureAgentEventJournal.swift
+++ b/Pine/Agent/Provenance/SecureAgentEventJournal.swift
@@ -1,0 +1,1157 @@
+//
+//  SecureAgentEventJournal.swift
+//  Pine
+//
+//  Descriptor-relative, owner-private journal used only by
+//  AgentEventProvenanceStore (epic #933, storage slice).
+//
+
+import CryptoKit
+import Darwin
+import Foundation
+
+nonisolated struct AgentEventJournalLoadedState: Sendable {
+    let records: [StoredAgentEvent]
+    let lastSequence: UInt64
+    let streamWatermarks: [AgentEventStreamIdentity: UInt64]
+    let recentIdentities: [AgentEventRecentIdentity]
+}
+
+/// Low-level file-descriptor owner.
+///
+/// The unchecked conformance is intentionally narrow: one
+/// `AgentEventProvenanceStore` actor creates and exclusively owns this object.
+/// No descriptor or mutable state escapes that actor.
+nonisolated final class SecureAgentEventJournal: @unchecked Sendable {
+    struct Opened {
+        let journal: SecureAgentEventJournal
+        let state: AgentEventJournalLoadedState
+        let integrity: AgentEventStoreIntegrity
+    }
+
+    static let journalFileName = "events.pinejournal"
+    static let frameMagic = Data([0x50, 0x4E, 0x45, 0x56]) // "PNEV"
+
+    let scopeDirectoryURL: URL
+    let journalURL: URL
+
+    private let scope: AgentEventStoreScope
+    private let limits: AgentEventStoreLimits
+    private let storageRoot: URL
+    private let scopeDirectoryName: String
+
+    private var rootDescriptor: Int32
+    private var scopeDescriptor: Int32
+    private var journalDescriptor: Int32
+    private var rootIdentity: FileIdentity
+    private var scopeIdentity: FileIdentity
+    private var journalIdentity: FileIdentity
+    private var journalByteCount: Int
+    private var persistedRecordCount: Int
+
+    deinit {
+        Darwin.close(journalDescriptor)
+        Darwin.close(scopeDescriptor)
+        Darwin.close(rootDescriptor)
+    }
+
+    static func open(
+        scope: AgentEventStoreScope,
+        storageRoot: URL,
+        limits: AgentEventStoreLimits
+    ) throws -> Opened {
+        guard storageRoot.isFileURL,
+              AgentEventStoreScope.isSafeAbsolutePath(storageRoot.path) else {
+            throw AgentEventStorageFailure.unsafeDirectory
+        }
+        try createStorageRootIfNeeded(storageRoot)
+
+        let root = try openDirectory(path: storageRoot.path)
+        let rootDescriptor = root.descriptor
+        var scopeDescriptor: Int32 = -1
+        var journalDescriptor: Int32 = -1
+        var shouldClose = true
+        defer {
+            if shouldClose {
+                if journalDescriptor >= 0 { Darwin.close(journalDescriptor) }
+                if scopeDescriptor >= 0 { Darwin.close(scopeDescriptor) }
+                Darwin.close(rootDescriptor)
+            }
+        }
+
+        let scopeName = scopeDirectoryName(for: scope)
+        let createdScope: Bool
+        if Darwin.mkdirat(rootDescriptor, scopeName, mode_t(0o700)) == 0 {
+            createdScope = true
+        } else if errno == EEXIST {
+            createdScope = false
+        } else {
+            throw AgentEventStorageFailure.createDirectory
+        }
+
+        scopeDescriptor = Darwin.openat(
+            rootDescriptor,
+            scopeName,
+            O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW
+        )
+        guard scopeDescriptor >= 0 else {
+            throw AgentEventStorageFailure.openDirectory
+        }
+        let scopeInfo = try checkedDirectory(
+            descriptor: scopeDescriptor,
+            parentDescriptor: rootDescriptor,
+            name: scopeName
+        )
+        let scopeMode = try fileInfo(descriptor: scopeDescriptor).st_mode
+        let scopeModeNeedsSync = scopeMode & mode_t(0o777) != mode_t(0o700)
+        guard Darwin.fchmod(scopeDescriptor, mode_t(0o700)) == 0 else {
+            throw AgentEventStorageFailure.unsafeDirectory
+        }
+        if scopeModeNeedsSync {
+            try synchronizeDirectory(scopeDescriptor)
+        }
+        if createdScope {
+            try synchronizeDirectory(rootDescriptor)
+        }
+
+        var createdJournal = false
+        journalDescriptor = Darwin.openat(
+            scopeDescriptor,
+            journalFileName,
+            O_RDWR | O_APPEND | O_CLOEXEC | O_NOFOLLOW | O_CREAT | O_EXCL,
+            mode_t(0o600)
+        )
+        if journalDescriptor >= 0 {
+            createdJournal = true
+        } else if errno == EEXIST {
+            journalDescriptor = Darwin.openat(
+                scopeDescriptor,
+                journalFileName,
+                O_RDWR | O_APPEND | O_CLOEXEC | O_NOFOLLOW
+            )
+        }
+        guard journalDescriptor >= 0 else {
+            throw AgentEventStorageFailure.openJournal
+        }
+        let journalInfo = try checkedJournal(
+            descriptor: journalDescriptor,
+            directoryDescriptor: scopeDescriptor
+        )
+        guard Darwin.fchmod(journalDescriptor, mode_t(0o600)) == 0 else {
+            throw AgentEventStorageFailure.unsafeJournal
+        }
+        if createdJournal {
+            try synchronizeDirectory(scopeDescriptor)
+        }
+
+        let scopeURL = storageRoot.appendingPathComponent(scopeName, isDirectory: true)
+        let instance = SecureAgentEventJournal(
+            scope: scope,
+            limits: limits,
+            storageRoot: storageRoot,
+            scopeDirectoryName: scopeName,
+            scopeDirectoryURL: scopeURL,
+            journalURL: scopeURL.appendingPathComponent(journalFileName),
+            rootDescriptor: rootDescriptor,
+            scopeDescriptor: scopeDescriptor,
+            journalDescriptor: journalDescriptor,
+            rootIdentity: root.identity,
+            scopeIdentity: scopeInfo,
+            journalIdentity: journalInfo.identity,
+            journalByteCount: journalInfo.byteCount,
+            persistedRecordCount: 0
+        )
+        shouldClose = false
+
+        let loaded = try instance.load()
+        instance.persistedRecordCount = loaded.state.records.count
+        return Opened(
+            journal: instance,
+            state: loaded.state,
+            integrity: loaded.integrity
+        )
+    }
+
+    /// Persists one append. A normal record is written with `O_APPEND`; when
+    /// retention would be crossed, the immutable retained suffix is rewritten
+    /// to a temp inode and atomically renamed over the active path.
+    func persist(
+        appended record: StoredAgentEvent,
+        prospectiveRecords: [StoredAgentEvent],
+        checkpoint: AgentEventJournalCheckpoint
+    ) throws -> [StoredAgentEvent] {
+        try verifyLivePaths()
+        let eventFrame = try Self.frame(for: .event(record))
+        guard eventFrame.count <= limits.maxRecordBytes + Self.frameOverhead else {
+            throw AgentEventStorageFailure.storageLimit
+        }
+
+        if persistedRecordCount + 1 <= limits.maxRecords,
+           journalByteCount + eventFrame.count <= limits.maxLogBytes {
+            let originalSize = journalByteCount
+            do {
+                try writeAll(eventFrame, to: journalDescriptor)
+                try Self.synchronizeFile(journalDescriptor)
+            } catch {
+                _ = Darwin.ftruncate(journalDescriptor, off_t(originalSize))
+                _ = Self.synchronizeFileBestEffort(journalDescriptor)
+                throw AgentEventStorageFailure.write
+            }
+            journalByteCount += eventFrame.count
+            persistedRecordCount += 1
+            return prospectiveRecords
+        }
+
+        return try compact(
+            prospectiveRecords: prospectiveRecords,
+            checkpoint: checkpoint
+        )
+    }
+
+    static func digest(of envelope: AgentEventEnvelope) throws -> String {
+        let data = try codecEncoder().encode(envelope)
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func encodedEventSize(_ record: StoredAgentEvent) -> Int {
+        guard let data = try? codecEncoder().encode(DiskEntry.event(record)) else {
+            return Int.max
+        }
+        return data.count
+    }
+
+    static func scopeDirectoryURL(
+        storageRoot: URL,
+        scope: AgentEventStoreScope
+    ) -> URL {
+        storageRoot.appendingPathComponent(scopeDirectoryName(for: scope), isDirectory: true)
+    }
+
+    // MARK: - Opening and recovery
+
+    private init(
+        scope: AgentEventStoreScope,
+        limits: AgentEventStoreLimits,
+        storageRoot: URL,
+        scopeDirectoryName: String,
+        scopeDirectoryURL: URL,
+        journalURL: URL,
+        rootDescriptor: Int32,
+        scopeDescriptor: Int32,
+        journalDescriptor: Int32,
+        rootIdentity: FileIdentity,
+        scopeIdentity: FileIdentity,
+        journalIdentity: FileIdentity,
+        journalByteCount: Int,
+        persistedRecordCount: Int
+    ) {
+        self.scope = scope
+        self.limits = limits
+        self.storageRoot = storageRoot
+        self.scopeDirectoryName = scopeDirectoryName
+        self.scopeDirectoryURL = scopeDirectoryURL
+        self.journalURL = journalURL
+        self.rootDescriptor = rootDescriptor
+        self.scopeDescriptor = scopeDescriptor
+        self.journalDescriptor = journalDescriptor
+        self.rootIdentity = rootIdentity
+        self.scopeIdentity = scopeIdentity
+        self.journalIdentity = journalIdentity
+        self.journalByteCount = journalByteCount
+        self.persistedRecordCount = persistedRecordCount
+    }
+
+    private func load() throws -> (
+        state: AgentEventJournalLoadedState,
+        integrity: AgentEventStoreIntegrity
+    ) {
+        try verifyLivePaths()
+        guard journalByteCount > 0 else {
+            return (.empty, .healthy)
+        }
+
+        let hardReadLimit = limits.maxLogBytes + limits.maxRecordBytes + Self.frameOverhead
+        if journalByteCount > hardReadLimit {
+            let report = try quarantineAndRecover(
+                validPrefixByteCount: 0,
+                kind: .oversizedJournal,
+                state: .empty
+            )
+            return (.empty, .recovered(report))
+        }
+
+        let bytes = try readExactly(
+            descriptor: journalDescriptor,
+            byteCount: journalByteCount,
+            offset: 0
+        )
+        let parsed = parse(bytes)
+        if let corruption = parsed.corruption {
+            let report = try quarantineAndRecover(
+                validPrefixByteCount: parsed.validPrefixByteCount,
+                kind: corruption,
+                state: parsed.state
+            )
+            return (parsed.state, .recovered(report))
+        }
+        return (parsed.state, .healthy)
+    }
+
+    private func parse(_ data: Data) -> ParseResult {
+        var offset = 0
+        var records: [StoredAgentEvent] = []
+        var checkpoint: AgentEventJournalCheckpoint?
+        var checkpointFrameSeen = false
+        var lastSequence: UInt64 = 0
+        var streamWatermarks: [AgentEventStreamIdentity: UInt64] = [:]
+        var localRecordWatermarks: [AgentEventStreamIdentity: UInt64] = [:]
+        var checkpointRecordWatermarks: [AgentEventStreamIdentity: UInt64] = [:]
+        var recentIdentities: [AgentEventRecentIdentity] = []
+        var seenRecordIDs: Set<UUID> = []
+        var sawCheckpointLastRecord = false
+        var enteredPostCheckpointRecords = false
+
+        func result(
+            corruption: AgentEventCorruptionReport.Kind?,
+            validPrefix: Int
+        ) -> ParseResult {
+            if checkpointFrameSeen,
+               !sawCheckpointLastRecord,
+               corruption != nil {
+                return ParseResult(
+                    state: .empty,
+                    validPrefixByteCount: 0,
+                    corruption: .invalidCheckpoint
+                )
+            }
+            return ParseResult(
+                state: AgentEventJournalLoadedState(
+                    records: records,
+                    lastSequence: lastSequence,
+                    streamWatermarks: streamWatermarks,
+                    recentIdentities: recentIdentities
+                ),
+                validPrefixByteCount: validPrefix,
+                corruption: corruption
+            )
+        }
+
+        while offset < data.count {
+            let frameStart = offset
+            guard data.count - offset >= Self.headerByteCount else {
+                return result(corruption: .truncatedFrame, validPrefix: frameStart)
+            }
+            guard data[offset..<(offset + 4)].elementsEqual(Self.frameMagic) else {
+                return result(corruption: .invalidMagic, validPrefix: frameStart)
+            }
+
+            let payloadLength = Self.decodeLength(data, at: offset + 4)
+            guard payloadLength > 0,
+                  payloadLength <= limits.maxLogBytes else {
+                return result(corruption: .oversizedFrame, validPrefix: frameStart)
+            }
+            let totalLength = Self.headerByteCount + payloadLength + Self.digestByteCount
+            guard data.count - offset >= totalLength else {
+                return result(corruption: .truncatedFrame, validPrefix: frameStart)
+            }
+
+            let payloadStart = offset + Self.headerByteCount
+            let payloadEnd = payloadStart + payloadLength
+            let payload = Data(data[payloadStart..<payloadEnd])
+            let expectedDigest = Data(data[payloadEnd..<(payloadEnd + Self.digestByteCount)])
+            let actualDigest = Data(SHA256.hash(data: payload))
+            guard expectedDigest == actualDigest else {
+                return result(corruption: .checksumMismatch, validPrefix: frameStart)
+            }
+
+            let entry: DiskEntry
+            do {
+                entry = try Self.codecDecoder().decode(DiskEntry.self, from: payload)
+            } catch {
+                return result(corruption: .decodeFailure, validPrefix: frameStart)
+            }
+
+            switch entry {
+            case .checkpoint(let loadedCheckpoint):
+                guard !checkpointFrameSeen,
+                      records.isEmpty,
+                      loadedCheckpoint.projectID == scope.projectID,
+                      loadedCheckpoint.worktreePath == scope.worktreePath else {
+                    return result(corruption: .invalidCheckpoint, validPrefix: frameStart)
+                }
+                guard loadedCheckpoint.streamWatermarks.count <= limits.maxTrackedStreams,
+                      loadedCheckpoint.recentIdentities.count <= limits.maxDedupeEntries,
+                      Self.validCheckpoint(loadedCheckpoint) else {
+                    return result(corruption: .invalidCheckpoint, validPrefix: frameStart)
+                }
+                checkpointFrameSeen = true
+                checkpoint = loadedCheckpoint
+                lastSequence = loadedCheckpoint.lastSequence
+                streamWatermarks = loadedCheckpoint.streamWatermarks
+                recentIdentities = loadedCheckpoint.recentIdentities
+
+            case .event(let persistedRecord):
+                guard totalLength <= limits.maxRecordBytes + Self.frameOverhead else {
+                    return result(corruption: .oversizedFrame, validPrefix: frameStart)
+                }
+                let normalizedEnvelope: AgentEventEnvelope
+                do {
+                    normalizedEnvelope = try AgentEventEnvelopeNormalizer.normalize(
+                        persistedRecord.envelope,
+                        scope: scope,
+                        limits: limits
+                    )
+                } catch AgentEventAppendRejection.wrongProject,
+                        AgentEventAppendRejection.wrongWorktree {
+                    return result(corruption: .scopeMismatch, validPrefix: frameStart)
+                } catch {
+                    return result(corruption: .decodeFailure, validPrefix: frameStart)
+                }
+                guard normalizedEnvelope == persistedRecord.envelope,
+                      persistedRecord.sequence > 0 else {
+                    return result(corruption: .decodeFailure, validPrefix: frameStart)
+                }
+                let record = StoredAgentEvent(
+                    sequence: persistedRecord.sequence,
+                    envelope: normalizedEnvelope
+                )
+                guard !seenRecordIDs.contains(record.envelope.id) else {
+                    return result(corruption: .decodeFailure, validPrefix: frameStart)
+                }
+                if let previousSequence = records.last?.sequence {
+                    guard previousSequence < UInt64.max,
+                          record.sequence == previousSequence + 1 else {
+                        return result(corruption: .decodeFailure, validPrefix: frameStart)
+                    }
+                } else if checkpoint == nil, record.sequence != 1 {
+                    return result(corruption: .decodeFailure, validPrefix: frameStart)
+                }
+                let stream = AgentEventStreamIdentity(envelope: record.envelope)
+                if let prior = localRecordWatermarks[stream],
+                   record.envelope.cursorValue <= prior {
+                    return result(corruption: .decodeFailure, validPrefix: frameStart)
+                }
+                localRecordWatermarks[stream] = record.envelope.cursorValue
+                seenRecordIDs.insert(record.envelope.id)
+                records.append(record)
+                guard records.count <= limits.maxRecords else {
+                    records.removeLast()
+                    return result(corruption: .tooManyRecords, validPrefix: frameStart)
+                }
+
+                // Retained frames covered by a compaction checkpoint are query
+                // history only. Frames appended afterwards advance state.
+                let coveredByCheckpoint = checkpoint.map {
+                    record.sequence <= $0.lastSequence
+                } ?? false
+                if let checkpoint {
+                    if coveredByCheckpoint {
+                        guard !enteredPostCheckpointRecords else {
+                            return result(
+                                corruption: .invalidCheckpoint,
+                                validPrefix: frameStart
+                            )
+                        }
+                        checkpointRecordWatermarks[stream] = record.envelope.cursorValue
+                        if record.sequence == checkpoint.lastSequence {
+                            guard Self.checkpoint(
+                                checkpoint,
+                                matches: records,
+                                recordWatermarks: checkpointRecordWatermarks
+                            ) else {
+                                return ParseResult(
+                                    state: .empty,
+                                    validPrefixByteCount: 0,
+                                    corruption: .invalidCheckpoint
+                                )
+                            }
+                            sawCheckpointLastRecord = true
+                        }
+                    } else {
+                        guard sawCheckpointLastRecord else {
+                            return ParseResult(
+                                state: .empty,
+                                validPrefixByteCount: 0,
+                                corruption: .invalidCheckpoint
+                            )
+                        }
+                        enteredPostCheckpointRecords = true
+                    }
+                }
+                if !coveredByCheckpoint {
+                    guard record.sequence > lastSequence,
+                          streamWatermarks.count < limits.maxTrackedStreams
+                            || streamWatermarks[stream] != nil,
+                          streamWatermarks[stream].map({
+                              record.envelope.cursorValue > $0
+                          }) ?? true else {
+                        return result(corruption: .decodeFailure, validPrefix: frameStart)
+                    }
+                    lastSequence = record.sequence
+                    streamWatermarks[stream] = record.envelope.cursorValue
+                    guard let digest = try? Self.digest(of: record.envelope) else {
+                        return result(corruption: .decodeFailure, validPrefix: frameStart)
+                    }
+                    let identity = AgentEventRecentIdentity(
+                        id: record.envelope.id,
+                        digest: digest,
+                        sequence: record.sequence
+                    )
+                    recentIdentities.removeAll { $0.id == identity.id }
+                    recentIdentities.append(identity)
+                    if recentIdentities.count > limits.maxDedupeEntries {
+                        recentIdentities.removeFirst()
+                    }
+                }
+            }
+
+            offset += totalLength
+        }
+
+        // A checkpoint is authoritative only after its retained suffix proves
+        // the final sequence, stream watermarks, and recent identity digest.
+        if checkpoint == nil {
+            lastSequence = records.last?.sequence ?? 0
+        } else if let checkpoint {
+            guard sawCheckpointLastRecord,
+                  Self.checkpoint(
+                      checkpoint,
+                      matches: records,
+                      recordWatermarks: checkpointRecordWatermarks
+                  ) else {
+                return ParseResult(
+                    state: .empty,
+                    validPrefixByteCount: 0,
+                    corruption: .invalidCheckpoint
+                )
+            }
+        }
+        return result(corruption: nil, validPrefix: offset)
+    }
+
+    private func quarantineAndRecover(
+        validPrefixByteCount: Int,
+        kind: AgentEventCorruptionReport.Kind,
+        state: AgentEventJournalLoadedState
+    ) throws -> AgentEventCorruptionReport {
+        try verifyLivePaths()
+        let discarded = max(0, journalByteCount - validPrefixByteCount)
+        let quarantineName = Self.quarantineFileName()
+        let quarantineDescriptor = Darwin.openat(
+            scopeDescriptor,
+            quarantineName,
+            O_WRONLY | O_CLOEXEC | O_NOFOLLOW | O_CREAT | O_EXCL,
+            mode_t(0o600)
+        )
+        guard quarantineDescriptor >= 0 else {
+            throw AgentEventStorageFailure.quarantine
+        }
+        var quarantineSucceeded = false
+        defer {
+            Darwin.close(quarantineDescriptor)
+            if !quarantineSucceeded {
+                _ = Darwin.unlinkat(scopeDescriptor, quarantineName, 0)
+            }
+        }
+
+        let capturedCount = min(discarded, limits.maxQuarantineBytes)
+        do {
+            var copied = 0
+            let chunkSize = 64 * 1_024
+            while copied < capturedCount {
+                let count = min(chunkSize, capturedCount - copied)
+                let chunk = try readExactly(
+                    descriptor: journalDescriptor,
+                    byteCount: count,
+                    offset: validPrefixByteCount + copied
+                )
+                try Self.writeAll(chunk, to: quarantineDescriptor)
+                copied += count
+            }
+            guard Darwin.fchmod(quarantineDescriptor, mode_t(0o600)) == 0 else {
+                throw AgentEventStorageFailure.quarantine
+            }
+            let quarantineInfo = try Self.fileInfo(descriptor: quarantineDescriptor)
+            guard Self.isSafeRegularFile(quarantineInfo),
+                  quarantineInfo.st_nlink == 1 else {
+                throw AgentEventStorageFailure.quarantine
+            }
+            try Self.synchronizeFile(quarantineDescriptor)
+            try Self.synchronizeDirectory(scopeDescriptor)
+            quarantineSucceeded = true
+        } catch {
+            throw AgentEventStorageFailure.quarantine
+        }
+
+        // Evidence is durable before the active journal is repaired.
+        guard Darwin.ftruncate(journalDescriptor, off_t(validPrefixByteCount)) == 0 else {
+            throw AgentEventStorageFailure.write
+        }
+        try Self.synchronizeFile(journalDescriptor)
+        journalByteCount = validPrefixByteCount
+        persistedRecordCount = state.records.count
+        try pruneQuarantineFiles()
+
+        return AgentEventCorruptionReport(
+            kind: kind,
+            retainedRecordCount: state.records.count,
+            discardedByteCount: discarded,
+            quarantinedByteCount: capturedCount,
+            quarantineFileName: quarantineName
+        )
+    }
+
+    // MARK: - Append and compaction
+
+    private func compact(
+        prospectiveRecords: [StoredAgentEvent],
+        checkpoint: AgentEventJournalCheckpoint
+    ) throws -> [StoredAgentEvent] {
+        let checkpointFrame = try Self.frame(for: .checkpoint(checkpoint))
+        guard checkpointFrame.count < limits.maxLogBytes else {
+            throw AgentEventStorageFailure.storageLimit
+        }
+
+        var retained = Array(prospectiveRecords.suffix(limits.maxRecords))
+        var eventFrames = try retained.map { try Self.frame(for: .event($0)) }
+        var total = checkpointFrame.count + eventFrames.reduce(0) { $0 + $1.count }
+        while total > limits.maxLogBytes, retained.count > 1 {
+            total -= eventFrames.removeFirst().count
+            retained.removeFirst()
+        }
+        guard total <= limits.maxLogBytes,
+              retained.last?.sequence == prospectiveRecords.last?.sequence else {
+            throw AgentEventStorageFailure.storageLimit
+        }
+
+        let temporaryName = ".events-\(UUID().uuidString).tmp"
+        let temporaryDescriptor = Darwin.openat(
+            scopeDescriptor,
+            temporaryName,
+            O_WRONLY | O_CLOEXEC | O_NOFOLLOW | O_CREAT | O_EXCL,
+            mode_t(0o600)
+        )
+        guard temporaryDescriptor >= 0 else {
+            throw AgentEventStorageFailure.compact
+        }
+
+        var renamed = false
+        defer {
+            Darwin.close(temporaryDescriptor)
+            if !renamed {
+                _ = Darwin.unlinkat(scopeDescriptor, temporaryName, 0)
+            }
+        }
+
+        do {
+            try Self.writeAll(checkpointFrame, to: temporaryDescriptor)
+            for frame in eventFrames {
+                try Self.writeAll(frame, to: temporaryDescriptor)
+            }
+            guard Darwin.fchmod(temporaryDescriptor, mode_t(0o600)) == 0 else {
+                throw AgentEventStorageFailure.compact
+            }
+            let temporaryInfo = try Self.fileInfo(descriptor: temporaryDescriptor)
+            guard Self.isSafeRegularFile(temporaryInfo),
+                  temporaryInfo.st_nlink == 1 else {
+                throw AgentEventStorageFailure.compact
+            }
+            try Self.synchronizeFile(temporaryDescriptor)
+            try verifyLivePaths()
+            guard Darwin.renameat(
+                scopeDescriptor,
+                temporaryName,
+                scopeDescriptor,
+                Self.journalFileName
+            ) == 0 else {
+                throw AgentEventStorageFailure.compact
+            }
+            renamed = true
+            try Self.synchronizeDirectory(scopeDescriptor)
+        } catch let failure as AgentEventStorageFailure {
+            throw failure
+        } catch {
+            throw AgentEventStorageFailure.compact
+        }
+
+        let replacementDescriptor = Darwin.openat(
+            scopeDescriptor,
+            Self.journalFileName,
+            O_RDWR | O_APPEND | O_CLOEXEC | O_NOFOLLOW
+        )
+        guard replacementDescriptor >= 0 else {
+            throw AgentEventStorageFailure.openJournal
+        }
+        let replacement: (identity: FileIdentity, byteCount: Int)
+        do {
+            replacement = try Self.checkedJournal(
+                descriptor: replacementDescriptor,
+                directoryDescriptor: scopeDescriptor
+            )
+        } catch {
+            Darwin.close(replacementDescriptor)
+            throw AgentEventStorageFailure.unsafeJournal
+        }
+
+        Darwin.close(journalDescriptor)
+        journalDescriptor = replacementDescriptor
+        journalIdentity = replacement.identity
+        journalByteCount = replacement.byteCount
+        persistedRecordCount = retained.count
+        return retained
+    }
+
+    // MARK: - Descriptor security
+
+    private func verifyLivePaths() throws {
+        let rootPathInfo = try Self.pathInfo(path: storageRoot.path)
+        let rootFDInfo = try Self.fileInfo(descriptor: rootDescriptor)
+        guard Self.identity(rootPathInfo) == rootIdentity,
+              Self.identity(rootFDInfo) == rootIdentity,
+              Self.isSafeDirectory(rootFDInfo) else {
+            throw AgentEventStorageFailure.pathReplaced
+        }
+
+        let scopePathInfo = try Self.pathInfo(
+            parentDescriptor: rootDescriptor,
+            name: scopeDirectoryName
+        )
+        let scopeFDInfo = try Self.fileInfo(descriptor: scopeDescriptor)
+        guard Self.identity(scopePathInfo) == scopeIdentity,
+              Self.identity(scopeFDInfo) == scopeIdentity,
+              Self.isSafeDirectory(scopeFDInfo) else {
+            throw AgentEventStorageFailure.pathReplaced
+        }
+
+        let journalPathInfo = try Self.pathInfo(
+            parentDescriptor: scopeDescriptor,
+            name: Self.journalFileName
+        )
+        let journalFDInfo = try Self.fileInfo(descriptor: journalDescriptor)
+        guard Self.identity(journalPathInfo) == journalIdentity,
+              Self.identity(journalFDInfo) == journalIdentity else {
+            throw AgentEventStorageFailure.pathReplaced
+        }
+        guard Self.isSafeRegularFile(journalFDInfo),
+              journalFDInfo.st_nlink == 1,
+              journalFDInfo.st_size == off_t(journalByteCount) else {
+            throw AgentEventStorageFailure.unsafeJournal
+        }
+    }
+
+    private static func createStorageRootIfNeeded(_ url: URL) throws {
+        do {
+            try FileManager.default.createDirectory(
+                at: url,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: NSNumber(value: 0o700)]
+            )
+        } catch {
+            throw AgentEventStorageFailure.createDirectory
+        }
+    }
+
+    private static func openDirectory(path: String) throws -> (
+        descriptor: Int32,
+        identity: FileIdentity
+    ) {
+        let pathBefore = try pathInfo(path: path)
+        guard isDirectory(pathBefore), pathBefore.st_uid == geteuid() else {
+            throw AgentEventStorageFailure.unsafeDirectory
+        }
+        let descriptor = Darwin.open(
+            path,
+            O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW
+        )
+        guard descriptor >= 0 else {
+            throw AgentEventStorageFailure.openDirectory
+        }
+        do {
+            let descriptorInfo = try fileInfo(descriptor: descriptor)
+            guard identity(pathBefore) == identity(descriptorInfo),
+                  isDirectory(descriptorInfo),
+                  descriptorInfo.st_uid == geteuid(),
+                  Darwin.fchmod(descriptor, mode_t(0o700)) == 0 else {
+                throw AgentEventStorageFailure.unsafeDirectory
+            }
+            if descriptorInfo.st_mode & mode_t(0o777) != mode_t(0o700) {
+                try synchronizeDirectory(descriptor)
+            }
+            return (descriptor, identity(descriptorInfo))
+        } catch {
+            Darwin.close(descriptor)
+            throw error
+        }
+    }
+
+    private static func checkedDirectory(
+        descriptor: Int32,
+        parentDescriptor: Int32,
+        name: String
+    ) throws -> FileIdentity {
+        let path = try pathInfo(parentDescriptor: parentDescriptor, name: name)
+        let opened = try fileInfo(descriptor: descriptor)
+        guard identity(path) == identity(opened),
+              isSafeDirectory(opened) else {
+            throw AgentEventStorageFailure.unsafeDirectory
+        }
+        return identity(opened)
+    }
+
+    private static func checkedJournal(
+        descriptor: Int32,
+        directoryDescriptor: Int32
+    ) throws -> (identity: FileIdentity, byteCount: Int) {
+        let path = try pathInfo(
+            parentDescriptor: directoryDescriptor,
+            name: journalFileName
+        )
+        let opened = try fileInfo(descriptor: descriptor)
+        guard identity(path) == identity(opened),
+              isSafeRegularFile(opened),
+              opened.st_nlink == 1,
+              opened.st_size >= 0,
+              opened.st_size <= off_t(Int.max) else {
+            throw AgentEventStorageFailure.unsafeJournal
+        }
+        return (identity(opened), Int(opened.st_size))
+    }
+
+    private static func isSafeDirectory(_ info: stat) -> Bool {
+        isDirectory(info)
+            && info.st_uid == geteuid()
+            && (info.st_mode & mode_t(0o077)) == 0
+    }
+
+    private static func isSafeRegularFile(_ info: stat) -> Bool {
+        (info.st_mode & S_IFMT) == S_IFREG
+            && info.st_uid == geteuid()
+            && (info.st_mode & mode_t(0o077)) == 0
+    }
+
+    private static func isDirectory(_ info: stat) -> Bool {
+        (info.st_mode & S_IFMT) == S_IFDIR
+    }
+
+    private static func identity(_ info: stat) -> FileIdentity {
+        FileIdentity(device: info.st_dev, inode: info.st_ino)
+    }
+
+    private static func fileInfo(descriptor: Int32) throws -> stat {
+        var info = stat()
+        guard Darwin.fstat(descriptor, &info) == 0 else {
+            throw AgentEventStorageFailure.read
+        }
+        return info
+    }
+
+    private static func pathInfo(path: String) throws -> stat {
+        var info = stat()
+        guard Darwin.lstat(path, &info) == 0 else {
+            throw AgentEventStorageFailure.read
+        }
+        return info
+    }
+
+    private static func pathInfo(
+        parentDescriptor: Int32,
+        name: String
+    ) throws -> stat {
+        var info = stat()
+        guard Darwin.fstatat(
+            parentDescriptor,
+            name,
+            &info,
+            AT_SYMLINK_NOFOLLOW
+        ) == 0 else {
+            throw AgentEventStorageFailure.pathReplaced
+        }
+        return info
+    }
+
+    // MARK: - Framing and I/O
+
+    private static let headerByteCount = 8
+    private static let digestByteCount = 32
+    private static let frameOverhead = headerByteCount + digestByteCount
+
+    private static func frame(for entry: DiskEntry) throws -> Data {
+        let payload = try codecEncoder().encode(entry)
+        guard payload.count <= Int(UInt32.max) else {
+            throw AgentEventStorageFailure.storageLimit
+        }
+        var frame = frameMagic
+        var length = UInt32(payload.count).bigEndian
+        withUnsafeBytes(of: &length) { frame.append(contentsOf: $0) }
+        frame.append(payload)
+        frame.append(contentsOf: SHA256.hash(data: payload))
+        return frame
+    }
+
+    private static func decodeLength(_ data: Data, at offset: Int) -> Int {
+        var value: UInt32 = 0
+        _ = withUnsafeMutableBytes(of: &value) { destination in
+            data.copyBytes(
+                to: destination,
+                from: offset..<(offset + MemoryLayout<UInt32>.size)
+            )
+        }
+        return Int(UInt32(bigEndian: value))
+    }
+
+    private static func codecEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+
+    private static func codecDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    private static func writeAll(_ data: Data, to descriptor: Int32) throws {
+        try data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return }
+            var written = 0
+            while written < rawBuffer.count {
+                let result = Darwin.write(
+                    descriptor,
+                    baseAddress.advanced(by: written),
+                    rawBuffer.count - written
+                )
+                if result < 0, errno == EINTR { continue }
+                guard result > 0 else {
+                    throw AgentEventStorageFailure.write
+                }
+                written += result
+            }
+        }
+    }
+
+    private func writeAll(_ data: Data, to descriptor: Int32) throws {
+        try Self.writeAll(data, to: descriptor)
+    }
+
+    private func readExactly(
+        descriptor: Int32,
+        byteCount: Int,
+        offset: Int
+    ) throws -> Data {
+        guard byteCount >= 0, offset >= 0 else {
+            throw AgentEventStorageFailure.read
+        }
+        var output = Data(count: byteCount)
+        try output.withUnsafeMutableBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return }
+            var consumed = 0
+            while consumed < byteCount {
+                let result = Darwin.pread(
+                    descriptor,
+                    baseAddress.advanced(by: consumed),
+                    byteCount - consumed,
+                    off_t(offset + consumed)
+                )
+                if result < 0, errno == EINTR { continue }
+                guard result > 0 else {
+                    throw AgentEventStorageFailure.read
+                }
+                consumed += result
+            }
+        }
+        return output
+    }
+
+    private static func synchronizeFile(_ descriptor: Int32) throws {
+        if Darwin.fcntl(descriptor, F_FULLFSYNC) == 0 {
+            return
+        }
+        guard Darwin.fsync(descriptor) == 0 else {
+            throw AgentEventStorageFailure.synchronize
+        }
+    }
+
+    private static func synchronizeFileBestEffort(_ descriptor: Int32) -> Bool {
+        (Darwin.fcntl(descriptor, F_FULLFSYNC) == 0) || (Darwin.fsync(descriptor) == 0)
+    }
+
+    private static func synchronizeDirectory(_ descriptor: Int32) throws {
+        guard Darwin.fsync(descriptor) == 0 else {
+            throw AgentEventStorageFailure.synchronize
+        }
+    }
+
+    private func pruneQuarantineFiles() throws {
+        let duplicate = Darwin.dup(scopeDescriptor)
+        guard duplicate >= 0, let directory = fdopendir(duplicate) else {
+            if duplicate >= 0 { Darwin.close(duplicate) }
+            throw AgentEventStorageFailure.quarantine
+        }
+        defer { closedir(directory) }
+
+        var names: [String] = []
+        while let entry = readdir(directory) {
+            let name = withUnsafePointer(to: &entry.pointee.d_name) { pointer in
+                pointer.withMemoryRebound(to: CChar.self, capacity: Int(MAXNAMLEN) + 1) {
+                    String(cString: $0)
+                }
+            }
+            if name.hasPrefix("quarantine-"), name.hasSuffix(".bin") {
+                names.append(name)
+            }
+        }
+        names.sort()
+        let surplus = names.count - limits.maxQuarantineFiles
+        guard surplus > 0 else { return }
+        for name in names.prefix(surplus) {
+            guard Darwin.unlinkat(scopeDescriptor, name, 0) == 0 else {
+                throw AgentEventStorageFailure.quarantine
+            }
+        }
+        try Self.synchronizeDirectory(scopeDescriptor)
+    }
+
+    private static func quarantineFileName() -> String {
+        let milliseconds = UInt64(max(0, Date().timeIntervalSince1970 * 1_000))
+        return String(format: "quarantine-%020llu-%@.bin", milliseconds, UUID().uuidString)
+    }
+
+    private static func scopeDirectoryName(for scope: AgentEventStoreScope) -> String {
+        let material = "\(scope.projectID.uuidString.lowercased())\u{0}\(scope.worktreePath)"
+        let digest = SHA256.hash(data: Data(material.utf8))
+        let suffix = digest.prefix(20).map { String(format: "%02x", $0) }.joined()
+        return "scope-\(suffix)"
+    }
+
+    private static func validCheckpoint(
+        _ checkpoint: AgentEventJournalCheckpoint
+    ) -> Bool {
+        let identities = checkpoint.recentIdentities
+        let sequences = identities.map(\.sequence)
+        return Set(identities.map(\.id)).count == identities.count
+            && zip(sequences, sequences.dropFirst()).allSatisfy {
+                $0.0 < $0.1
+            }
+            && identities.allSatisfy {
+                $0.sequence > 0
+                    && $0.sequence <= checkpoint.lastSequence
+                    && $0.digest.count == 64
+                    && $0.digest.allSatisfy { character in
+                        ("0"..."9").contains(character) || ("a"..."f").contains(character)
+                    }
+            }
+            && checkpoint.lastSequence > 0
+            && checkpoint.streamWatermarks.allSatisfy { stream, cursor in
+                stream.sessionID != AgentEventStoreScope.zeroUUID
+                    && stream.terminalID != AgentEventStoreScope.zeroUUID
+                    && stream.processGeneration > 0
+                    && cursor > 0
+            }
+    }
+
+    private static func checkpoint(
+        _ checkpoint: AgentEventJournalCheckpoint,
+        matches records: [StoredAgentEvent],
+        recordWatermarks: [AgentEventStreamIdentity: UInt64]
+    ) -> Bool {
+        guard recordWatermarks.allSatisfy({
+            checkpoint.streamWatermarks[$0.key] == $0.value
+        }),
+        let finalRecord = records.first(where: {
+            $0.sequence == checkpoint.lastSequence
+        }),
+        let finalIdentity = checkpoint.recentIdentities.last,
+        finalIdentity.id == finalRecord.envelope.id,
+        finalIdentity.sequence == finalRecord.sequence else {
+            return false
+        }
+
+        let recordsByID = Dictionary(
+            uniqueKeysWithValues: records.map { ($0.envelope.id, $0) }
+        )
+        return checkpoint.recentIdentities.allSatisfy { identity in
+            guard let record = recordsByID[identity.id] else { return true }
+            guard record.sequence == identity.sequence,
+                  let digest = try? digest(of: record.envelope) else {
+                return false
+            }
+            return digest == identity.digest
+        }
+    }
+}
+
+nonisolated private extension AgentEventJournalLoadedState {
+    static let empty = AgentEventJournalLoadedState(
+        records: [],
+        lastSequence: 0,
+        streamWatermarks: [:],
+        recentIdentities: []
+    )
+}
+
+nonisolated private extension SecureAgentEventJournal {
+    struct FileIdentity: Equatable {
+        let device: dev_t
+        let inode: ino_t
+    }
+
+    struct ParseResult {
+        let state: AgentEventJournalLoadedState
+        let validPrefixByteCount: Int
+        let corruption: AgentEventCorruptionReport.Kind?
+    }
+
+    enum DiskEntry: Codable {
+        case checkpoint(AgentEventJournalCheckpoint)
+        case event(StoredAgentEvent)
+
+        private enum CodingKeys: String, CodingKey {
+            case version, kind, checkpoint, event
+        }
+
+        private enum Kind: String, Codable {
+            case checkpoint
+            case event
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let version = try container.decode(Int.self, forKey: .version)
+            guard version == 1 else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .version,
+                    in: container,
+                    debugDescription: "Unsupported provenance journal version"
+                )
+            }
+            switch try container.decode(Kind.self, forKey: .kind) {
+            case .checkpoint:
+                self = .checkpoint(
+                    try container.decode(
+                        AgentEventJournalCheckpoint.self,
+                        forKey: .checkpoint
+                    )
+                )
+            case .event:
+                self = .event(
+                    try container.decode(StoredAgentEvent.self, forKey: .event)
+                )
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(1, forKey: .version)
+            switch self {
+            case .checkpoint(let checkpoint):
+                try container.encode(Kind.checkpoint, forKey: .kind)
+                try container.encode(checkpoint, forKey: .checkpoint)
+            case .event(let event):
+                try container.encode(Kind.event, forKey: .kind)
+                try container.encode(event, forKey: .event)
+            }
+        }
+    }
+}

--- a/PineTests/AgentProvenanceTests/AgentEventProvenanceStoreTests.swift
+++ b/PineTests/AgentProvenanceTests/AgentEventProvenanceStoreTests.swift
@@ -1,0 +1,1339 @@
+//
+//  AgentEventProvenanceStoreTests.swift
+//  PineTests
+//
+//  Security, durability, retention, and query coverage for epic #933's
+//  owner-private provenance storage slice.
+//
+
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import Pine
+
+struct AgentEventProvenanceStoreTests {
+    private struct Fixture {
+        let root: URL
+        let storageRoot: URL
+        let worktree: URL
+        let scope: AgentEventStoreScope
+    }
+
+    private func fixture() throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-provenance-\(UUID().uuidString)", isDirectory: true)
+        let worktree = root.appendingPathComponent("worktree", isDirectory: true)
+        let storageRoot = root.appendingPathComponent("private-store", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: worktree,
+            withIntermediateDirectories: true
+        )
+        let scope = try AgentEventStoreScope(projectID: UUID(), worktreeURL: worktree)
+        return Fixture(
+            root: root,
+            storageRoot: storageRoot,
+            worktree: worktree,
+            scope: scope
+        )
+    }
+
+    private func envelope(
+        _ fixture: Fixture,
+        id: UUID = UUID(),
+        projectID: UUID? = nil,
+        sessionID: UUID = UUID(),
+        terminalID: UUID = UUID(),
+        generation: UInt64 = 1,
+        worktreePath: String? = nil,
+        cwd: String? = nil,
+        cursor: UInt64,
+        source: EventSource = .explicitAgentEvent,
+        trust: TrustLevel = .verified,
+        payload: AgentEventPayload = .none,
+        agentTypeRaw: String = "claudeCode"
+    ) -> AgentEventEnvelope {
+        AgentEventEnvelope(
+            id: id,
+            projectID: projectID ?? fixture.scope.projectID,
+            sessionID: sessionID,
+            agentTypeRaw: agentTypeRaw,
+            process: AgentProcessIdentity(
+                terminalID: terminalID,
+                processGeneration: generation
+            ),
+            location: AgentEventLocation(
+                worktreePath: worktreePath ?? fixture.scope.worktreePath,
+                cwd: cwd ?? fixture.scope.worktreePath
+            ),
+            cursorValue: cursor,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000 + Double(cursor)),
+            source: source,
+            trustLevel: trust,
+            payload: payload
+        )
+    }
+
+    private func mode(at url: URL) throws -> UInt16 {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        guard let permissions = attributes[.posixPermissions] as? NSNumber else {
+            Issue.record("Missing POSIX permissions for \(url.path)")
+            return 0
+        }
+        return permissions.uint16Value & 0o777
+    }
+
+    private func frameLength(in data: Data, at offset: Int) -> Int {
+        guard data.count - offset >= 8 else { return 0 }
+        let length = data[(offset + 4)..<(offset + 8)].reduce(UInt32(0)) {
+            ($0 << 8) | UInt32($1)
+        }
+        return 8 + Int(length) + 32
+    }
+
+    private func journalFrame(payload: Data) -> Data {
+        var frame = SecureAgentEventJournal.frameMagic
+        var length = UInt32(payload.count).bigEndian
+        withUnsafeBytes(of: &length) { frame.append(contentsOf: $0) }
+        frame.append(payload)
+        frame.append(contentsOf: SHA256.hash(data: payload))
+        return frame
+    }
+
+    private func recoveredReport(
+        _ snapshot: AgentEventStoreSnapshot
+    ) -> AgentEventCorruptionReport? {
+        if case .recovered(let report) = snapshot.integrity {
+            return report
+        }
+        return nil
+    }
+
+    // MARK: - Durable append and restart
+
+    @Test func durableAppendSurvivesRestartAndProtocolAdapter() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        let first = envelope(fixture, cursor: 1)
+        let collector: AgentEventProvenanceCollector = store
+        await collector.record(first)
+
+        let restarted = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        let snapshot = await restarted.snapshot()
+        #expect(snapshot.integrity == .healthy)
+        #expect(snapshot.lastSequence == 1)
+        #expect(snapshot.records.map(\.envelope) == [first])
+    }
+
+    @Test func restartPreservesCursorAndDedupeCheckpointAfterRetention() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let limits = try AgentEventStoreLimits(
+            maxRecords: 2,
+            maxLogBytes: 32 * 1_024,
+            maxRecordBytes: 4 * 1_024,
+            maxDedupeEntries: 4
+        )
+        let session = UUID()
+        let terminal = UUID()
+        let ids = (0..<6).map { _ in UUID() }
+
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot,
+            limits: limits
+        )
+        for cursor in 1...5 {
+            let event = envelope(
+                fixture,
+                id: ids[cursor],
+                sessionID: session,
+                terminalID: terminal,
+                cursor: UInt64(cursor)
+            )
+            #expect(await store.append(event) == .appended(sequence: UInt64(cursor)))
+        }
+
+        let restarted = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot,
+            limits: limits
+        )
+        let retained = await restarted.snapshot()
+        #expect(retained.records.map(\.sequence) == [4, 5])
+        #expect(retained.lastSequence == 5)
+
+        let retainedDuplicate = envelope(
+            fixture,
+            id: ids[5],
+            sessionID: session,
+            terminalID: terminal,
+            cursor: 5
+        )
+        #expect(
+            await restarted.append(retainedDuplicate)
+                == .duplicate(existingSequence: 5)
+        )
+
+        let evictedCursor = envelope(
+            fixture,
+            id: ids[0],
+            sessionID: session,
+            terminalID: terminal,
+            cursor: 1
+        )
+        #expect(
+            await restarted.append(evictedCursor)
+                == .rejected(.nonMonotonicCursor)
+        )
+
+        let next = envelope(
+            fixture,
+            id: ids[0],
+            sessionID: session,
+            terminalID: terminal,
+            cursor: 6
+        )
+        #expect(await restarted.append(next) == .appended(sequence: 6))
+    }
+
+    // MARK: - Concurrency, dedupe, monotonicity
+
+    @Test func concurrentStreamsReceiveUniqueGlobalMonotonicSequences() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        let events = (0..<64).map { _ in
+            envelope(fixture, cursor: 1)
+        }
+
+        let outcomes = await withTaskGroup(
+            of: AgentEventAppendOutcome.self,
+            returning: [AgentEventAppendOutcome].self
+        ) { group in
+            for event in events {
+                group.addTask {
+                    await store.append(event)
+                }
+            }
+            var collected: [AgentEventAppendOutcome] = []
+            for await outcome in group {
+                collected.append(outcome)
+            }
+            return collected
+        }
+
+        let sequences = outcomes.compactMap { outcome -> UInt64? in
+            guard case .appended(let sequence) = outcome else { return nil }
+            return sequence
+        }.sorted()
+        #expect(sequences == Array(1...64).map(UInt64.init))
+        #expect(await store.snapshot().records.count == 64)
+    }
+
+    @Test func concurrentDuplicateHasExactlyOneDurableAppend() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        let event = envelope(fixture, cursor: 1)
+
+        let outcomes = await withTaskGroup(
+            of: AgentEventAppendOutcome.self,
+            returning: [AgentEventAppendOutcome].self
+        ) { group in
+            for _ in 0..<32 {
+                group.addTask {
+                    await store.append(event)
+                }
+            }
+            var collected: [AgentEventAppendOutcome] = []
+            for await outcome in group {
+                collected.append(outcome)
+            }
+            return collected
+        }
+
+        #expect(outcomes.filter { $0 == .appended(sequence: 1) }.count == 1)
+        #expect(outcomes.filter { $0 == .duplicate(existingSequence: 1) }.count == 31)
+        #expect(await store.snapshot().records.count == 1)
+    }
+
+    @Test func cursorMustIncreaseWithinProcessStream() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        let session = UUID()
+        let terminal = UUID()
+
+        #expect(
+            await store.append(
+                envelope(
+                    fixture,
+                    sessionID: session,
+                    terminalID: terminal,
+                    cursor: 2
+                )
+            ) == .appended(sequence: 1)
+        )
+        #expect(
+            await store.append(
+                envelope(
+                    fixture,
+                    sessionID: session,
+                    terminalID: terminal,
+                    cursor: 1
+                )
+            ) == .rejected(.nonMonotonicCursor)
+        )
+    }
+
+    @Test func reusedEventIdentityWithDifferentContentIsRejected() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        let id = UUID()
+        let session = UUID()
+        let terminal = UUID()
+        let original = envelope(
+            fixture,
+            id: id,
+            sessionID: session,
+            terminalID: terminal,
+            cursor: 1
+        )
+        let collision = envelope(
+            fixture,
+            id: id,
+            sessionID: session,
+            terminalID: terminal,
+            cursor: 2,
+            payload: .commandResult(
+                AgentCommandResult(command: "git status", exitStatus: 0)
+            )
+        )
+
+        #expect(await store.append(original) == .appended(sequence: 1))
+        #expect(await store.append(collision) == .rejected(.identityCollision))
+    }
+
+    @Test func trackedStreamCountIsBounded() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let limits = try AgentEventStoreLimits(maxTrackedStreams: 2)
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot,
+            limits: limits
+        )
+
+        #expect(await store.append(envelope(fixture, cursor: 1)) == .appended(sequence: 1))
+        #expect(await store.append(envelope(fixture, cursor: 1)) == .appended(sequence: 2))
+        #expect(
+            await store.append(envelope(fixture, cursor: 1))
+                == .rejected(.streamLimitReached)
+        )
+    }
+
+    // MARK: - Scope and fail-closed normalization
+
+    @Test func wrongProjectAndWorktreeAreRejectedWithoutWriting() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let otherWorktree = fixture.root.appendingPathComponent("other")
+        try FileManager.default.createDirectory(at: otherWorktree, withIntermediateDirectories: true)
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+
+        #expect(
+            await store.append(
+                envelope(fixture, projectID: UUID(), cursor: 1)
+            ) == .rejected(.wrongProject)
+        )
+        #expect(
+            await store.append(
+                envelope(
+                    fixture,
+                    worktreePath: otherWorktree.path,
+                    cwd: otherWorktree.path,
+                    cursor: 1
+                )
+            ) == .rejected(.wrongWorktree)
+        )
+        #expect(await store.snapshot().records.isEmpty)
+    }
+
+    @Test func cwdOutsideWorktreeAndInvalidPayloadPathsFailClosed() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+
+        #expect(
+            await store.append(
+                envelope(fixture, cwd: fixture.root.path, cursor: 1)
+            ) == .rejected(.invalidProvenance)
+        )
+        let invalidChange = AgentFileChange(
+            relativePath: "../outside.swift",
+            before: nil,
+            after: .empty
+        )
+        #expect(
+            await store.append(
+                envelope(
+                    fixture,
+                    cursor: 1,
+                    payload: .fileChange(invalidChange)
+                )
+            ) == .rejected(.invalidPayload)
+        )
+    }
+
+    @Test func canonicalPathsAreStoredAndTrustCannotBeUpgraded() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let sourceDirectory = fixture.worktree.appendingPathComponent("Sources")
+        try FileManager.default.createDirectory(at: sourceDirectory, withIntermediateDirectories: true)
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        let event = envelope(
+            fixture,
+            worktreePath: fixture.worktree.appendingPathComponent(".").path,
+            cwd: sourceDirectory.appendingPathComponent("..").appendingPathComponent("Sources").path,
+            cursor: 1,
+            source: .gitCorrelation,
+            trust: .verified
+        )
+
+        #expect(await store.append(event) == .appended(sequence: 1))
+        let stored = await store.snapshot().records.first?.envelope
+        #expect(stored?.location.worktreePath == fixture.scope.worktreePath)
+        #expect(stored?.location.cwd == sourceDirectory.resolvingSymlinksInPath().path)
+        #expect(stored?.trustLevel == .inferred)
+    }
+
+    @Test func oversizedAgentTypeCommandPayloadAndFrameAreRejected() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let limits = try AgentEventStoreLimits(
+            maxLogBytes: 8 * 1_024,
+            maxRecordBytes: 512,
+            maxAgentTypeBytes: 16,
+            maxSourceBytes: 18,
+            maxCommandBytes: 128
+        )
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot,
+            limits: limits
+        )
+
+        #expect(
+            await store.append(
+                envelope(
+                    fixture,
+                    cursor: 1,
+                    agentTypeRaw: String(repeating: "a", count: 17)
+                )
+            ) == .rejected(.invalidProvenance)
+        )
+        #expect(
+            await store.append(
+                envelope(
+                    fixture,
+                    cursor: 1,
+                    source: .unknown(raw: "   "),
+                    trust: .inferred
+                )
+            ) == .rejected(.invalidProvenance)
+        )
+        #expect(
+            await store.append(
+                envelope(
+                    fixture,
+                    cursor: 1,
+                    source: .unknown(raw: String(repeating: "s", count: 19)),
+                    trust: .inferred
+                )
+            ) == .rejected(.invalidProvenance)
+        )
+        #expect(
+            await store.append(
+                envelope(
+                    fixture,
+                    cursor: 1,
+                    payload: .commandResult(
+                        AgentCommandResult(
+                            command: String(repeating: "c", count: 129),
+                            exitStatus: 0
+                        )
+                    )
+                )
+            ) == .rejected(.invalidPayload)
+        )
+
+        let frameLimitedStore = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.root.appendingPathComponent("frame-store"),
+            limits: try AgentEventStoreLimits(
+                maxLogBytes: 8 * 1_024,
+                maxRecordBytes: 512,
+                maxCommandBytes: 4 * 1_024
+            )
+        )
+        #expect(
+            await frameLimitedStore.append(
+                envelope(
+                    fixture,
+                    cursor: 1,
+                    payload: .commandResult(
+                        AgentCommandResult(
+                            command: String(repeating: "x", count: 1_024),
+                            exitStatus: 0
+                        )
+                    )
+                )
+            ) == .rejected(.oversizedRecord)
+        )
+    }
+
+    @Test func oversizedRelativePathAndInvalidLimitsAreRejected() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        let longPath = String(repeating: "a", count: AgentEventStoreLimits.maximumPathBytes + 1)
+        let change = AgentFileChange(relativePath: longPath, before: nil, after: .empty)
+        #expect(
+            await store.append(
+                envelope(fixture, cursor: 1, payload: .fileChange(change))
+            ) == .rejected(.invalidPayload)
+        )
+        #expect(
+            await store.append(
+                envelope(
+                    fixture,
+                    cwd: "/" + longPath,
+                    cursor: 1
+                )
+            ) == .rejected(.invalidProvenance)
+        )
+        #expect(throws: AgentEventStoreError.invalidLimits) {
+            _ = try AgentEventStoreLimits(maxRecords: 0)
+        }
+        #expect(throws: AgentEventStoreError.invalidLimits) {
+            _ = try AgentEventStoreLimits(maxLogBytes: 1_024, maxRecordBytes: 2_048)
+        }
+        #expect(throws: AgentEventStoreError.invalidLimits) {
+            _ = try AgentEventStoreLimits(maxRecords: Int.max)
+        }
+        #expect(throws: AgentEventStoreError.invalidLimits) {
+            _ = try AgentEventStoreLimits(maxLogBytes: Int.max)
+        }
+        #expect(throws: AgentEventStoreError.invalidLimits) {
+            _ = try AgentEventStoreLimits(maxCommandBytes: Int.max)
+        }
+        #expect(throws: AgentEventStoreError.invalidLimits) {
+            _ = try AgentEventStoreLimits(maxQuarantineBytes: Int.max)
+        }
+    }
+
+    // MARK: - Retention and read-only queries
+
+    @Test func countRetentionKeepsNewestSuffixAndGlobalSequence() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let limits = try AgentEventStoreLimits(
+            maxRecords: 3,
+            maxDedupeEntries: 6
+        )
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot,
+            limits: limits
+        )
+        let session = UUID()
+        let terminal = UUID()
+        for cursor in 1...10 {
+            #expect(
+                await store.append(
+                    envelope(
+                        fixture,
+                        sessionID: session,
+                        terminalID: terminal,
+                        cursor: UInt64(cursor)
+                    )
+                ) == .appended(sequence: UInt64(cursor))
+            )
+        }
+
+        let snapshot = await store.snapshot()
+        #expect(snapshot.records.map(\.sequence) == [8, 9, 10])
+        #expect(snapshot.lastSequence == 10)
+
+        let restarted = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot,
+            limits: limits
+        )
+        #expect(await restarted.snapshot().records.map(\.sequence) == [8, 9, 10])
+    }
+
+    @Test func byteRetentionStaysBoundedAndKeepsLatestRecord() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let limits = try AgentEventStoreLimits(
+            maxRecords: 100,
+            maxLogBytes: 4 * 1_024,
+            maxRecordBytes: 2 * 1_024,
+            maxDedupeEntries: 5,
+            maxTrackedStreams: 2,
+            maxCommandBytes: 800
+        )
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot,
+            limits: limits
+        )
+        let session = UUID()
+        let terminal = UUID()
+        for cursor in 1...12 {
+            let outcome = await store.append(
+                envelope(
+                    fixture,
+                    sessionID: session,
+                    terminalID: terminal,
+                    cursor: UInt64(cursor),
+                    payload: .commandResult(
+                        AgentCommandResult(
+                            command: String(repeating: "x", count: 400),
+                            exitStatus: 0
+                        )
+                    )
+                )
+            )
+            #expect(outcome == .appended(sequence: UInt64(cursor)))
+        }
+
+        let locations = await store.storageLocations()
+        let attributes = try FileManager.default.attributesOfItem(atPath: locations.journal.path)
+        let size = (attributes[.size] as? NSNumber)?.intValue
+        #expect(size != nil)
+        #expect((size ?? Int.max) <= limits.maxLogBytes)
+        #expect(await store.snapshot().records.last?.sequence == 12)
+    }
+
+    @Test func trustAndSequenceQueriesAreExplicitAndBounded() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let limits = try AgentEventStoreLimits(maxQueryResults: 2)
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot,
+            limits: limits
+        )
+
+        let verified = envelope(fixture, cursor: 1)
+        let inferred = envelope(
+            fixture,
+            cursor: 1,
+            source: .gitCorrelation,
+            trust: .inferred
+        )
+        let observed = envelope(
+            fixture,
+            cursor: 1,
+            source: .terminalProcess,
+            trust: .observed
+        )
+        #expect(await store.append(verified) == .appended(sequence: 1))
+        #expect(await store.append(inferred) == .appended(sequence: 2))
+        #expect(await store.append(observed) == .appended(sequence: 3))
+
+        let snapshot = await store.snapshot()
+        #expect(snapshot.verified.map(\.sequence) == [1])
+        #expect(snapshot.inferred.map(\.sequence) == [2])
+        #expect(snapshot.observed.map(\.sequence) == [3])
+        let inferredResult = await store.query(
+            AgentEventQuery(trustLevel: .inferred)
+        )
+        #expect(inferredResult.integrity == .healthy)
+        #expect(inferredResult.verified.isEmpty)
+        #expect(inferredResult.inferred.map(\.sequence) == [2])
+        #expect(inferredResult.observed.isEmpty)
+        #expect(
+            await store.query(
+                AgentEventQuery(sequenceAfter: 1, limit: 99)
+            ).records.map(\.sequence) == [2, 3]
+        )
+        #expect(
+            await store.query(
+                AgentEventQuery(sequenceThrough: 2)
+            ).records.map(\.sequence) == [1, 2]
+        )
+    }
+
+    // MARK: - Owner-private descriptor safety
+
+    @Test func storageDirectoriesAndJournalAreOwnerPrivate() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        #expect(await store.append(envelope(fixture, cursor: 1)) == .appended(sequence: 1))
+        let locations = await store.storageLocations()
+
+        #expect(try mode(at: fixture.storageRoot) == 0o700)
+        #expect(try mode(at: locations.scopeDirectory) == 0o700)
+        #expect(try mode(at: locations.journal) == 0o600)
+    }
+
+    @Test func symlinkStorageRootAndScopeDirectoryAreRefused() throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let realRoot = fixture.root.appendingPathComponent("real-root")
+        try FileManager.default.createDirectory(
+            at: realRoot,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: NSNumber(value: 0o700)]
+        )
+        let linkedRoot = fixture.root.appendingPathComponent("linked-root")
+        try FileManager.default.createSymbolicLink(
+            at: linkedRoot,
+            withDestinationURL: realRoot
+        )
+        #expect(throws: AgentEventStoreError.self) {
+            _ = try AgentEventProvenanceStore(
+                scope: fixture.scope,
+                storageRoot: linkedRoot
+            )
+        }
+
+        let storageRoot = fixture.root.appendingPathComponent("scope-root")
+        try FileManager.default.createDirectory(
+            at: storageRoot,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: NSNumber(value: 0o700)]
+        )
+        let scopeDirectory = SecureAgentEventJournal.scopeDirectoryURL(
+            storageRoot: storageRoot,
+            scope: fixture.scope
+        )
+        try FileManager.default.createSymbolicLink(
+            at: scopeDirectory,
+            withDestinationURL: realRoot
+        )
+        #expect(throws: AgentEventStoreError.self) {
+            _ = try AgentEventProvenanceStore(
+                scope: fixture.scope,
+                storageRoot: storageRoot
+            )
+        }
+    }
+
+    @Test func symlinkJournalIsRefusedWithoutTouchingTarget() throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        try FileManager.default.createDirectory(
+            at: fixture.storageRoot,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: NSNumber(value: 0o700)]
+        )
+        let scopeDirectory = SecureAgentEventJournal.scopeDirectoryURL(
+            storageRoot: fixture.storageRoot,
+            scope: fixture.scope
+        )
+        try FileManager.default.createDirectory(
+            at: scopeDirectory,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: NSNumber(value: 0o700)]
+        )
+        let target = fixture.root.appendingPathComponent("target")
+        let marker = Data("do not touch".utf8)
+        try marker.write(to: target)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o600)],
+            ofItemAtPath: target.path
+        )
+        let journal = scopeDirectory.appendingPathComponent(
+            SecureAgentEventJournal.journalFileName
+        )
+        try FileManager.default.createSymbolicLink(at: journal, withDestinationURL: target)
+
+        #expect(throws: AgentEventStoreError.self) {
+            _ = try AgentEventProvenanceStore(
+                scope: fixture.scope,
+                storageRoot: fixture.storageRoot
+            )
+        }
+        #expect(try Data(contentsOf: target) == marker)
+    }
+
+    @Test func hardlinkedJournalIsRefused() throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        try FileManager.default.createDirectory(
+            at: fixture.storageRoot,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: NSNumber(value: 0o700)]
+        )
+        let scopeDirectory = SecureAgentEventJournal.scopeDirectoryURL(
+            storageRoot: fixture.storageRoot,
+            scope: fixture.scope
+        )
+        try FileManager.default.createDirectory(
+            at: scopeDirectory,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: NSNumber(value: 0o700)]
+        )
+        let external = fixture.root.appendingPathComponent("external-journal")
+        try Data().write(to: external)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o600)],
+            ofItemAtPath: external.path
+        )
+        let journal = scopeDirectory.appendingPathComponent(
+            SecureAgentEventJournal.journalFileName
+        )
+        try FileManager.default.linkItem(at: external, to: journal)
+
+        #expect(throws: AgentEventStoreError.self) {
+            _ = try AgentEventProvenanceStore(
+                scope: fixture.scope,
+                storageRoot: fixture.storageRoot
+            )
+        }
+    }
+
+    @Test func directoryPathSwapFailsClosedBeforeNextAppend() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        #expect(await store.append(envelope(fixture, cursor: 1)) == .appended(sequence: 1))
+        let locations = await store.storageLocations()
+        let displaced = fixture.root.appendingPathComponent("displaced-scope")
+        try FileManager.default.moveItem(at: locations.scopeDirectory, to: displaced)
+        try FileManager.default.createDirectory(
+            at: locations.scopeDirectory,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: NSNumber(value: 0o700)]
+        )
+
+        let outcome = await store.append(envelope(fixture, cursor: 1))
+        #expect(outcome == .rejected(.storage(.pathReplaced)))
+
+        let replacement = fixture.root.appendingPathComponent("replacement-scope")
+        try FileManager.default.moveItem(at: locations.scopeDirectory, to: replacement)
+        try FileManager.default.moveItem(at: displaced, to: locations.scopeDirectory)
+        #expect(
+            await store.append(envelope(fixture, cursor: 1))
+                == .rejected(.storage(.pathReplaced))
+        )
+        #expect(await store.snapshot().records.count == 1)
+        #expect(await store.snapshot().integrity == .unavailable(.pathReplaced))
+    }
+
+    @Test func journalPathSwapToHardlinkFailsClosed() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        #expect(await store.append(envelope(fixture, cursor: 1)) == .appended(sequence: 1))
+        let locations = await store.storageLocations()
+        let displaced = locations.scopeDirectory.appendingPathComponent("old-journal")
+        try FileManager.default.moveItem(at: locations.journal, to: displaced)
+        let external = fixture.root.appendingPathComponent("external")
+        try Data("external".utf8).write(to: external)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o600)],
+            ofItemAtPath: external.path
+        )
+        try FileManager.default.linkItem(at: external, to: locations.journal)
+
+        let outcome = await store.append(envelope(fixture, cursor: 1))
+        #expect(outcome == .rejected(.storage(.pathReplaced)))
+        #expect(try Data(contentsOf: external) == Data("external".utf8))
+    }
+
+    @Test func addingASecondHardlinkToLiveJournalFailsClosed() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        #expect(await store.append(envelope(fixture, cursor: 1)) == .appended(sequence: 1))
+        let locations = await store.storageLocations()
+        let secondLink = fixture.root.appendingPathComponent("journal-hardlink")
+        try FileManager.default.linkItem(at: locations.journal, to: secondLink)
+
+        let outcome = await store.append(envelope(fixture, cursor: 1))
+        #expect(outcome == .rejected(.storage(.unsafeJournal)))
+        #expect(await store.snapshot().records.count == 1)
+        #expect(await store.snapshot().integrity == .unavailable(.unsafeJournal))
+    }
+
+    @Test func storageRootPathSwapFailsClosedBeforeNextAppend() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        #expect(await store.append(envelope(fixture, cursor: 1)) == .appended(sequence: 1))
+        let displaced = fixture.root.appendingPathComponent("displaced-root")
+        try FileManager.default.moveItem(at: fixture.storageRoot, to: displaced)
+        try FileManager.default.createDirectory(
+            at: fixture.storageRoot,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: NSNumber(value: 0o700)]
+        )
+
+        #expect(
+            await store.append(envelope(fixture, cursor: 1))
+                == .rejected(.storage(.pathReplaced))
+        )
+    }
+
+    @Test func groupReadablePreexistingJournalIsRefused() throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        try FileManager.default.createDirectory(
+            at: fixture.storageRoot,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: NSNumber(value: 0o700)]
+        )
+        let scopeDirectory = SecureAgentEventJournal.scopeDirectoryURL(
+            storageRoot: fixture.storageRoot,
+            scope: fixture.scope
+        )
+        try FileManager.default.createDirectory(
+            at: scopeDirectory,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: NSNumber(value: 0o700)]
+        )
+        let journal = scopeDirectory.appendingPathComponent(
+            SecureAgentEventJournal.journalFileName
+        )
+        try Data().write(to: journal)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o640)],
+            ofItemAtPath: journal.path
+        )
+
+        #expect(throws: AgentEventStoreError.self) {
+            _ = try AgentEventProvenanceStore(
+                scope: fixture.scope,
+                storageRoot: fixture.storageRoot
+            )
+        }
+    }
+
+    // MARK: - Corruption quarantine and recovery
+
+    @Test func truncatedTailIsQuarantinedThenValidPrefixLoads() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        #expect(await store.append(envelope(fixture, cursor: 1)) == .appended(sequence: 1))
+        let locations = await store.storageLocations()
+        let suffix = Data([0x50, 0x4E, 0x45])
+        let handle = try FileHandle(forWritingTo: locations.journal)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: suffix)
+        try handle.close()
+
+        let restarted = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        let snapshot = await restarted.snapshot()
+        let report = recoveredReport(snapshot)
+        #expect(report?.kind == .truncatedFrame)
+        #expect(report?.discardedByteCount == suffix.count)
+        #expect(report?.quarantinedByteCount == suffix.count)
+        #expect(snapshot.records.count == 1)
+        #expect(await restarted.query().integrity == snapshot.integrity)
+
+        guard let report else { return }
+        let quarantine = locations.scopeDirectory
+            .appendingPathComponent(report.quarantineFileName)
+        #expect(try Data(contentsOf: quarantine) == suffix)
+        #expect(try mode(at: quarantine) == 0o600)
+
+        let cleanRestart = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        #expect(await cleanRestart.snapshot().integrity == .healthy)
+        #expect(await cleanRestart.snapshot().records.count == 1)
+    }
+
+    @Test func checksumCorruptionQuarantinesCorruptFrameAndFollowingSuffix() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        for cursor in 1...3 {
+            #expect(
+                await store.append(envelope(fixture, cursor: UInt64(cursor)))
+                    == .appended(sequence: UInt64(cursor))
+            )
+        }
+        let locations = await store.storageLocations()
+        let bytes = try Data(contentsOf: locations.journal)
+        let firstLength = frameLength(in: bytes, at: 0)
+        #expect(firstLength > 8)
+        let mutationOffset = firstLength + 12
+        let handle = try FileHandle(forWritingTo: locations.journal)
+        try handle.seek(toOffset: UInt64(mutationOffset))
+        try handle.write(contentsOf: Data([bytes[mutationOffset] ^ 0x01]))
+        try handle.close()
+
+        let restarted = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        let snapshot = await restarted.snapshot()
+        let report = recoveredReport(snapshot)
+        #expect(report?.kind == .checksumMismatch)
+        #expect(report?.retainedRecordCount == 1)
+        #expect(report?.discardedByteCount == bytes.count - firstLength)
+        #expect(snapshot.records.map(\.sequence) == [1])
+    }
+
+    @Test func semanticCheckpointTamperIsQuarantinedWithValidChecksum() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let limits = try AgentEventStoreLimits(
+            maxRecords: 2,
+            maxDedupeEntries: 4
+        )
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot,
+            limits: limits
+        )
+        for cursor in 1...3 {
+            #expect(
+                await store.append(envelope(fixture, cursor: UInt64(cursor)))
+                    == .appended(sequence: UInt64(cursor))
+            )
+        }
+
+        let locations = await store.storageLocations()
+        let bytes = try Data(contentsOf: locations.journal)
+        let firstLength = frameLength(in: bytes, at: 0)
+        let payloadLength = firstLength - 8 - 32
+        guard firstLength > 8 + 32,
+              firstLength <= bytes.count else {
+            Issue.record("Expected a checkpoint frame")
+            return
+        }
+
+        let payload = Data(bytes[8..<(8 + payloadLength)])
+        guard var root = try JSONSerialization.jsonObject(with: payload) as? [String: Any],
+              var checkpoint = root["checkpoint"] as? [String: Any],
+              var identities = checkpoint["recentIdentities"] as? [[String: Any]],
+              var finalIdentity = identities.last else {
+            Issue.record("Expected checkpoint identity metadata")
+            return
+        }
+        finalIdentity["digest"] = String(repeating: "0", count: 64)
+        identities[identities.count - 1] = finalIdentity
+        checkpoint["recentIdentities"] = identities
+        root["checkpoint"] = checkpoint
+
+        let tamperedPayload = try JSONSerialization.data(
+            withJSONObject: root,
+            options: [.sortedKeys]
+        )
+        var tamperedBytes = journalFrame(payload: tamperedPayload)
+        tamperedBytes.append(bytes[firstLength...])
+        try tamperedBytes.write(to: locations.journal)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o600)],
+            ofItemAtPath: locations.journal.path
+        )
+
+        let restarted = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot,
+            limits: limits
+        )
+        let snapshot = await restarted.snapshot()
+        let report = recoveredReport(snapshot)
+        #expect(report?.kind == .invalidCheckpoint)
+        #expect(report?.discardedByteCount == tamperedBytes.count)
+        #expect(report?.quarantinedByteCount == tamperedBytes.count)
+        #expect(snapshot.records.isEmpty)
+    }
+
+    @Test func physicallyTruncatedLastFrameKeepsEarlierFrames() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        #expect(await store.append(envelope(fixture, cursor: 1)) == .appended(sequence: 1))
+        #expect(await store.append(envelope(fixture, cursor: 1)) == .appended(sequence: 2))
+        let locations = await store.storageLocations()
+        let bytes = try Data(contentsOf: locations.journal)
+        let handle = try FileHandle(forWritingTo: locations.journal)
+        try handle.truncate(atOffset: UInt64(bytes.count - 7))
+        try handle.close()
+        #expect(
+            await store.append(envelope(fixture, cursor: 1))
+                == .rejected(.storage(.unsafeJournal))
+        )
+
+        let restarted = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        let snapshot = await restarted.snapshot()
+        #expect(recoveredReport(snapshot)?.kind == .truncatedFrame)
+        #expect(snapshot.records.map(\.sequence) == [1])
+    }
+
+    @Test func oversizedFrameHeaderIsQuarantinedWithoutAllocation() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        let locations = await store.storageLocations()
+        var oversized = SecureAgentEventJournal.frameMagic
+        var length = UInt32.max.bigEndian
+        withUnsafeBytes(of: &length) { oversized.append(contentsOf: $0) }
+        try oversized.write(to: locations.journal)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o600)],
+            ofItemAtPath: locations.journal.path
+        )
+
+        let restarted = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        let snapshot = await restarted.snapshot()
+        #expect(recoveredReport(snapshot)?.kind == .oversizedFrame)
+        #expect(snapshot.records.isEmpty)
+    }
+
+    @Test func stricterRestartCountLimitQuarantinesOverflowFrames() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let generous = try AgentEventStoreLimits(
+            maxRecords: 4,
+            maxDedupeEntries: 4
+        )
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot,
+            limits: generous
+        )
+        for cursor in 1...3 {
+            #expect(
+                await store.append(envelope(fixture, cursor: UInt64(cursor)))
+                    == .appended(sequence: UInt64(cursor))
+            )
+        }
+
+        let strict = try AgentEventStoreLimits(
+            maxRecords: 2,
+            maxDedupeEntries: 2
+        )
+        let restarted = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot,
+            limits: strict
+        )
+        let snapshot = await restarted.snapshot()
+        #expect(recoveredReport(snapshot)?.kind == .tooManyRecords)
+        #expect(snapshot.records.map(\.sequence) == [1, 2])
+    }
+
+    @Test func oversizedJournalQuarantineCaptureIsBounded() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let limits = try AgentEventStoreLimits(
+            maxLogBytes: 4 * 1_024,
+            maxRecordBytes: 1_024,
+            maxQuarantineBytes: 128
+        )
+        let store = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot,
+            limits: limits
+        )
+        let locations = await store.storageLocations()
+        let oversized = Data(repeating: 0xA5, count: 6 * 1_024)
+        try oversized.write(to: locations.journal)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o600)],
+            ofItemAtPath: locations.journal.path
+        )
+
+        let restarted = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot,
+            limits: limits
+        )
+        let snapshot = await restarted.snapshot()
+        let report = recoveredReport(snapshot)
+        #expect(report?.kind == .oversizedJournal)
+        #expect(report?.discardedByteCount == oversized.count)
+        #expect(report?.quarantinedByteCount == limits.maxQuarantineBytes)
+        guard let report else { return }
+        let quarantine = locations.scopeDirectory
+            .appendingPathComponent(report.quarantineFileName)
+        #expect(try Data(contentsOf: quarantine).count == limits.maxQuarantineBytes)
+    }
+
+    @Test func copiedJournalFromWrongProjectOrWorktreeIsQuarantined() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let originalStore = try AgentEventProvenanceStore(
+            scope: fixture.scope,
+            storageRoot: fixture.storageRoot
+        )
+        #expect(
+            await originalStore.append(envelope(fixture, cursor: 1))
+                == .appended(sequence: 1)
+        )
+        let originalLocations = await originalStore.storageLocations()
+        let originalBytes = try Data(contentsOf: originalLocations.journal)
+
+        let otherProjectScope = try AgentEventStoreScope(
+            projectID: UUID(),
+            worktreeURL: fixture.worktree
+        )
+        let otherProjectStore = try AgentEventProvenanceStore(
+            scope: otherProjectScope,
+            storageRoot: fixture.storageRoot
+        )
+        let otherProjectLocations = await otherProjectStore.storageLocations()
+        try originalBytes.write(to: otherProjectLocations.journal)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o600)],
+            ofItemAtPath: otherProjectLocations.journal.path
+        )
+        let otherProjectRestart = try AgentEventProvenanceStore(
+            scope: otherProjectScope,
+            storageRoot: fixture.storageRoot
+        )
+        let projectSnapshot = await otherProjectRestart.snapshot()
+        #expect(recoveredReport(projectSnapshot)?.kind == .scopeMismatch)
+        #expect(projectSnapshot.records.isEmpty)
+
+        let otherWorktree = fixture.root.appendingPathComponent("other-worktree")
+        try FileManager.default.createDirectory(
+            at: otherWorktree,
+            withIntermediateDirectories: true
+        )
+        let otherWorktreeScope = try AgentEventStoreScope(
+            projectID: fixture.scope.projectID,
+            worktreeURL: otherWorktree
+        )
+        let otherWorktreeStore = try AgentEventProvenanceStore(
+            scope: otherWorktreeScope,
+            storageRoot: fixture.storageRoot
+        )
+        let otherWorktreeLocations = await otherWorktreeStore.storageLocations()
+        try originalBytes.write(to: otherWorktreeLocations.journal)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o600)],
+            ofItemAtPath: otherWorktreeLocations.journal.path
+        )
+        let otherWorktreeRestart = try AgentEventProvenanceStore(
+            scope: otherWorktreeScope,
+            storageRoot: fixture.storageRoot
+        )
+        let worktreeSnapshot = await otherWorktreeRestart.snapshot()
+        #expect(recoveredReport(worktreeSnapshot)?.kind == .scopeMismatch)
+        #expect(worktreeSnapshot.records.isEmpty)
+    }
+
+    @Test func quarantineFileRetentionIsBounded() async throws {
+        let fixture = try fixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let limits = try AgentEventStoreLimits(maxQuarantineFiles: 2)
+
+        var scopeDirectory: URL?
+        for marker in 0..<5 {
+            let store = try AgentEventProvenanceStore(
+                scope: fixture.scope,
+                storageRoot: fixture.storageRoot,
+                limits: limits
+            )
+            let locations = await store.storageLocations()
+            scopeDirectory = locations.scopeDirectory
+            let handle = try FileHandle(forWritingTo: locations.journal)
+            try handle.seekToEnd()
+            try handle.write(contentsOf: Data([UInt8(marker)]))
+            try handle.close()
+
+            let recovered = try AgentEventProvenanceStore(
+                scope: fixture.scope,
+                storageRoot: fixture.storageRoot,
+                limits: limits
+            )
+            #expect(recoveredReport(await recovered.snapshot()) != nil)
+        }
+
+        guard let scopeDirectory else {
+            Issue.record("Missing scope directory")
+            return
+        }
+        let names = try FileManager.default.contentsOfDirectory(
+            atPath: scopeDirectory.path
+        ).filter {
+            $0.hasPrefix("quarantine-") && $0.hasSuffix(".bin")
+        }
+        #expect(names.count == limits.maxQuarantineFiles)
+    }
+}


### PR DESCRIPTION
## Summary

- add an actor-isolated, append-only provenance collector/store scoped by project identity and canonical worktree
- persist checksummed frames with global monotonic sequence, per-stream cursor watermarks, identity/digest deduplication, bounded retention, and read-only filtered queries
- fail closed on malformed or cross-scope provenance while keeping verified, inferred, and observed results explicitly separated
- harden owner-private storage with 0700/0600 permissions, descriptor-relative and O_NOFOLLOW opens, owner/type/link/inode/path-swap checks, durable append/compaction, and bounded corruption quarantine evidence
- include the shared deterministic AgentActivity ambiguity-test fix from 33bd03a

## Scope

This is deliberately a storage/collector slice of #933 and builds on the envelope/collector foundation from #1204.

Refs #933

It does not close #933 and intentionally does not add UI, live authenticated ingress, TerminalSession wiring, Activity/History projection, or undo orchestration.

The exact event-to-before/after bridge still needs:

- authenticated transport and trusted source identity
- TerminalSession/tool/agent ingress wiring
- canonical project/worktree binding at ingestion
- preimage and postimage capture with content identities
- exact reversible patch/change-set persistence and multi-file atomic grouping
- current-content/divergence preflight plus confirmation and undo policy
- mapping only verified events into AgentActivity and AgentHistory

## Recovery and bounds

- restart restores retained records, cursor watermarks, and dedupe state
- corrupt or truncated suffixes are durably copied to owner-private quarantine before active-log truncation
- typed query results surface healthy, recovered, or unavailable integrity state and never detach rows from that state
- frame, file, record count, query, path, payload, metadata, command, stream, dedupe, and quarantine limits are capped

## Validation

- AgentEventProvenanceStoreTests: 33/33 passed, including post-rebase run
- relevant provenance/identity/cursor/undo suites: 109/109 passed
- post-cherry-pick store + AgentActivity suites: 55/55 passed
- strict SwiftLint on all changed Swift files: 0 violations
- Swift 6 standalone provenance typecheck: passed
- reentrancy guard and git diff check: passed
- repository-wide strict SwiftLint reports the existing Pine/AboutInfo.swift:37 superfluous_disable_command baseline; no changed file violates SwiftLint