### PR TITLE
feat(agent): add verified patch engine

### DIFF
--- a/Pine/Agent/AgentHistoryUndoPreflight.swift
+++ b/Pine/Agent/AgentHistoryUndoPreflight.swift
@@ -178,7 +178,7 @@ nonisolated enum AgentHistoryUndoPreflight {
     /// resolve beneath a root directory descriptor without following links,
     /// compare device/inode/link-count identities, and revalidate immediately
     /// before the atomic apply.
-    private static func isCanonicalRelativePath(_ path: String) -> Bool {
+    static func isCanonicalRelativePath(_ path: String) -> Bool {
         let normalizedPath = path.precomposedStringWithCanonicalMapping
         guard !path.isEmpty,
               path.utf8.elementsEqual(normalizedPath.utf8),
@@ -207,7 +207,7 @@ nonisolated enum AgentHistoryUndoPreflight {
     /// normalization-insensitive volumes. Refusing two legitimate paths on a
     /// case-sensitive volume is safer than applying an inverse to the wrong
     /// object after a project moves to a different volume.
-    private static func conservativePathKey(_ path: String) -> String {
+    static func conservativePathKey(_ path: String) -> String {
         path.precomposedStringWithCanonicalMapping.folding(
             options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
             locale: Locale(identifier: "en_US_POSIX")

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchEngine.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchEngine.swift
@@ -564,6 +564,7 @@ nonisolated enum VerifiedPatchEngine {
 
         var prepared: [VerifiedPreparedInverseOperation] = []
         var aggregateLCSCells = 0
+        var aggregateMappingCells = 0
         for operation in patch.operations {
             if operation.kind == .rename {
                 return .failure(.unsupportedOperation(
@@ -574,7 +575,8 @@ nonisolated enum VerifiedPatchEngine {
             switch prepare(
                 operation,
                 snapshot: currentSnapshot,
-                aggregateLCSCells: &aggregateLCSCells
+                aggregateLCSCells: &aggregateLCSCells,
+                aggregateMappingCells: &aggregateMappingCells
             ) {
             case .success(let value):
                 prepared.append(value)
@@ -671,14 +673,16 @@ nonisolated enum VerifiedPatchEngine {
     private static func prepare(
         _ operation: VerifiedPatchOperation,
         snapshot: VerifiedPatchWorkspaceSnapshot,
-        aggregateLCSCells: inout Int
+        aggregateLCSCells: inout Int,
+        aggregateMappingCells: inout Int
     ) -> Result<VerifiedPreparedInverseOperation, VerifiedPatchConflict> {
         switch operation.kind {
         case .modify:
             return prepareModify(
                 operation,
                 snapshot: snapshot,
-                aggregateLCSCells: &aggregateLCSCells
+                aggregateLCSCells: &aggregateLCSCells,
+                aggregateMappingCells: &aggregateMappingCells
             )
         case .create:
             guard let after = operation.after else {
@@ -732,7 +736,8 @@ nonisolated enum VerifiedPatchEngine {
     private static func prepareModify(
         _ operation: VerifiedPatchOperation,
         snapshot: VerifiedPatchWorkspaceSnapshot,
-        aggregateLCSCells: inout Int
+        aggregateLCSCells: inout Int,
+        aggregateMappingCells: inout Int
     ) -> Result<VerifiedPreparedInverseOperation, VerifiedPatchConflict> {
         guard let before = operation.before,
               let after = operation.after else {
@@ -775,19 +780,36 @@ nonisolated enum VerifiedPatchEngine {
                 estimate
               ),
               newAggregate
-                <= VerifiedPatchLimits.maximumAggregateLCSCellCount else {
+                <= VerifiedPatchLimits.maximumAggregateLCSCellCount,
+              aggregateMappingCells <= VerifiedPatchLimits
+                .maximumAggregateMappingCellCount else {
             return .failure(conflict(operation, .resourceLimitExceeded))
         }
-        aggregateLCSCells = newAggregate
+        let remainingMappingCells = VerifiedPatchLimits
+            .maximumAggregateMappingCellCount - aggregateMappingCells
 
         switch VerifiedTextPatch.prepareInverse(
             hunks: hunks,
             capturedAfter: after.content,
-            current: current.content
+            current: current.content,
+            mappingCellBudget: remainingMappingCells
         ) {
         case .failure(let reason):
             return .failure(conflict(operation, reason))
         case .success(let textResult):
+            guard textResult.lcsCellCount == estimate,
+                  let newMappingAggregate = checkedAdd(
+                    aggregateMappingCells,
+                    textResult.mappingCellCount
+                  ),
+                  newMappingAggregate <= VerifiedPatchLimits
+                    .maximumAggregateMappingCellCount else {
+                return .failure(
+                    conflict(operation, .resourceLimitExceeded)
+                )
+            }
+            aggregateLCSCells = newAggregate
+            aggregateMappingCells = newMappingAggregate
             let merged = VerifiedPatchFileState(
                 content: textResult.content,
                 kind: .regularFile,

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchEngine.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchEngine.swift
@@ -455,7 +455,8 @@ nonisolated enum VerifiedPatchEngine {
     static func makePatch(
         id: UUID,
         receipt: VerifiedPatchIngressReceipt,
-        operations sources: [VerifiedPatchSourceOperation]
+        operations sources: [VerifiedPatchSourceOperation],
+        planningObserver: (() -> Void)? = nil
     ) throws -> VerifiedPatchSet {
         guard id != zeroUUID else {
             throw VerifiedPatchValidationError.invalidPatchID
@@ -512,7 +513,8 @@ nonisolated enum VerifiedPatchEngine {
 
         let collapsed = try collapse(
             validatedSources,
-            patchID: id
+            patchID: id,
+            planningObserver: planningObserver
         )
         guard !collapsed.isEmpty else {
             throw VerifiedPatchValidationError.noOperations
@@ -524,7 +526,7 @@ nonisolated enum VerifiedPatchEngine {
         let patch = VerifiedPatchSet(
             id: id,
             receipt: validatedReceipt,
-            operations: collapsed.sorted(by: operationOrder)
+            operations: collapsed
         )
         try revalidate(patch)
         return patch
@@ -919,7 +921,8 @@ nonisolated enum VerifiedPatchEngine {
 
     private static func collapse(
         _ orderedSources: [OrderedSource],
-        patchID: UUID
+        patchID: UUID,
+        planningObserver: (() -> Void)?
     ) throws -> [VerifiedPatchOperation] {
         let sorted = orderedSources.sorted(by: sourceOrder)
         var groups: [String: [VerifiedPatchSourceOperation]] = [:]
@@ -938,12 +941,21 @@ nonisolated enum VerifiedPatchEngine {
             spellings[key] = source.sourcePath
             groups[key, default: []].append(source)
         }
+        guard groups.count
+                <= VerifiedPatchLimits.maximumOperationCount else {
+            throw VerifiedPatchValidationError.tooManyOperations
+        }
 
         var operations: [VerifiedPatchOperation] = []
         var occupiedPathKeys: Set<String> = []
-        var aggregateLCSCells = 0
-        var aggregateHunks = 0
-        for key in groups.keys.sorted() {
+        var planningBudget = PatchPlanningBudget()
+        let canonicalPaths = spellings.values.sorted(
+            by: canonicalPathOrder
+        )
+        for sourcePath in canonicalPaths {
+            let key = VerifiedPatchIngressCoordinator.conservativePathKey(
+                sourcePath
+            )
             guard let chain = groups[key],
                   let first = chain.first,
                   let last = chain.last else {
@@ -980,8 +992,8 @@ nonisolated enum VerifiedPatchEngine {
                 kind: kind,
                 before: before,
                 after: after,
-                aggregateLCSCells: &aggregateLCSCells,
-                aggregateHunks: &aggregateHunks
+                budget: &planningBudget,
+                planningObserver: planningObserver
             )
             let operation = VerifiedPatchOperation(
                 id: VerifiedPatchOperationID(
@@ -1069,9 +1081,13 @@ nonisolated enum VerifiedPatchEngine {
         var transitionIDs: Set<VerifiedPatchTransitionID> = []
         var pathKeys: Set<String> = []
         var capturedBytes = 0
-        var hunkCount = 0
-        var lcsCells = 0
+        var planningBudget = PatchPlanningBudget()
 
+        guard patch.operations == patch.operations.sorted(
+            by: operationOrder
+        ) else {
+            throw VerifiedPatchValidationError.invalidOperation(nil)
+        }
         for operation in patch.operations {
             guard operation.id.patchID == patch.id,
                   !operation.id.transitionIDs.isEmpty,
@@ -1172,8 +1188,8 @@ nonisolated enum VerifiedPatchEngine {
                 kind: canonicalKind,
                 before: operation.before,
                 after: operation.after,
-                aggregateLCSCells: &lcsCells,
-                aggregateHunks: &hunkCount
+                budget: &planningBudget,
+                planningObserver: nil
             )
             guard operation.strategy == canonical else {
                 throw VerifiedPatchValidationError.invalidOperation(
@@ -1189,11 +1205,6 @@ nonisolated enum VerifiedPatchEngine {
                 throw VerifiedPatchValidationError.unusedTransition(unused)
             }
             throw VerifiedPatchValidationError.invalidReceipt
-        }
-        guard patch.operations == patch.operations.sorted(
-            by: operationOrder
-        ) else {
-            throw VerifiedPatchValidationError.invalidOperation(nil)
         }
     }
 
@@ -1495,11 +1506,13 @@ nonisolated enum VerifiedPatchEngine {
                             && $0 <= VerifiedPatchLimits.maximumLineCount
                       } ?? true),
                       previewHunk.header.utf8.count
-                        <= VerifiedPatchLimits.maximumPathByteCount else {
+                        <= VerifiedPatchLimits.maximumPathByteCount,
+                      previewHunk.lines.count <= VerifiedPatchLimits
+                        .maximumPreviewLineCountPerHunk else {
                     throw VerifiedPatchValidationError.invalidOperation(nil)
                 }
-                try accumulatePreparedLines(
-                    previewHunk.lines.map(\.bytes),
+                try accumulatePreparedPreviewLines(
+                    previewHunk.lines,
                     lineCount: &hunkLineCount,
                     byteCount: &hunkByteCount
                 )
@@ -1812,6 +1825,32 @@ nonisolated enum VerifiedPatchEngine {
         }
     }
 
+    private static func accumulatePreparedPreviewLines(
+        _ lines: [VerifiedInversePreviewLine],
+        lineCount: inout Int,
+        byteCount: inout Int
+    ) throws {
+        guard let updatedLineCount = checkedAdd(lineCount, lines.count),
+              updatedLineCount <= VerifiedPatchLimits
+                .maximumPreparedLineReferenceCount else {
+            throw VerifiedPatchValidationError.invalidOperation(nil)
+        }
+        lineCount = updatedLineCount
+        for line in lines {
+            guard line.bytes.count
+                    <= VerifiedPatchLimits.maximumFileByteCount,
+                  let updatedByteCount = checkedAdd(
+                    byteCount,
+                    line.bytes.count
+                  ),
+                  updatedByteCount <= VerifiedPatchLimits
+                    .maximumPreparedHunkByteCount else {
+                throw VerifiedPatchValidationError.invalidOperation(nil)
+            }
+            byteCount = updatedByteCount
+        }
+    }
+
     private static func validateDurableExpectations(
         _ events: [VerifiedPatchDurableEventExpectation],
         workspace: VerifiedPatchCoordinatorExpectations
@@ -1915,32 +1954,52 @@ nonisolated enum VerifiedPatchEngine {
         kind: VerifiedPatchOperationKind,
         before: VerifiedPatchFileState?,
         after: VerifiedPatchFileState?,
-        aggregateLCSCells: inout Int,
-        aggregateHunks: inout Int
+        budget: inout PatchPlanningBudget,
+        planningObserver: (() -> Void)?
     ) -> VerifiedPatchApplicationStrategy {
         guard kind == .modify,
               let before,
               let after,
               before.content != after.content,
-              let plan = VerifiedTextPatch.plan(
+              let estimate = VerifiedTextPatch.estimatedLCSCellCount(
                 before: before.content,
                 after: after.content
               ),
+              let remainingCells = checkedSubtract(
+                VerifiedPatchLimits.maximumAggregateLCSCellCount,
+                budget.lcsCells
+              ),
+              estimate <= remainingCells,
+              let remainingHunks = checkedSubtract(
+                VerifiedPatchLimits.maximumHunkCount,
+                budget.hunks
+              ),
+              remainingHunks > 0 else {
+            return .exactState
+        }
+        planningObserver?()
+        guard let plan = VerifiedTextPatch.plan(
+                before: before.content,
+                after: after.content,
+                lcsCellBudget: remainingCells,
+                hunkBudget: remainingHunks
+              ),
+              plan.lcsCellCount == estimate,
               let updatedCells = checkedAdd(
-                aggregateLCSCells,
+                budget.lcsCells,
                 plan.lcsCellCount
               ),
               updatedCells
                 <= VerifiedPatchLimits.maximumAggregateLCSCellCount,
               let updatedHunks = checkedAdd(
-                aggregateHunks,
+                budget.hunks,
                 plan.hunks.count
               ),
               updatedHunks <= VerifiedPatchLimits.maximumHunkCount else {
             return .exactState
         }
-        aggregateLCSCells = updatedCells
-        aggregateHunks = updatedHunks
+        budget.lcsCells = updatedCells
+        budget.hunks = updatedHunks
         return .text(
             hunks: plan.hunks,
             lcsCellCount: plan.lcsCellCount
@@ -2056,17 +2115,26 @@ nonisolated enum VerifiedPatchEngine {
         _ rhs: VerifiedPatchOperation
     ) -> Bool {
         if lhs.sourcePath != rhs.sourcePath {
-            return lhs.sourcePath < rhs.sourcePath
+            return canonicalPathOrder(lhs.sourcePath, rhs.sourcePath)
         }
         let lhsDestination = lhs.destinationPath ?? ""
         let rhsDestination = rhs.destinationPath ?? ""
         if lhsDestination != rhsDestination {
-            return lhsDestination < rhsDestination
+            return canonicalPathOrder(lhsDestination, rhsDestination)
         }
-        return transitionIDOrder(
-            lhs.id.transitionIDs[0],
-            rhs.id.transitionIDs[0]
-        )
+        switch (
+            lhs.id.transitionIDs.first,
+            rhs.id.transitionIDs.first
+        ) {
+        case (.none, .none):
+            return false
+        case (.none, .some):
+            return true
+        case (.some, .none):
+            return false
+        case (.some(let lhsID), .some(let rhsID)):
+            return transitionIDOrder(lhsID, rhsID)
+        }
     }
 
     private static func sourceOrder(
@@ -2090,9 +2158,26 @@ nonisolated enum VerifiedPatchEngine {
         return lhs.ordinal < rhs.ordinal
     }
 
+    private static func canonicalPathOrder(
+        _ lhs: String,
+        _ rhs: String
+    ) -> Bool {
+        let lhsKey = VerifiedPatchIngressCoordinator.conservativePathKey(lhs)
+        let rhsKey = VerifiedPatchIngressCoordinator.conservativePathKey(rhs)
+        if lhsKey != rhsKey {
+            return lhsKey < rhsKey
+        }
+        return lhs < rhs
+    }
+
     private struct BoundTransition {
         let cursor: UInt64
         let transition: VerifiedPatchContentTransition
+    }
+
+    private struct PatchPlanningBudget {
+        var lcsCells = 0
+        var hunks = 0
     }
 
     private struct OrderedSource {
@@ -2114,6 +2199,15 @@ nonisolated private func checkedAdd(
 ) -> Int? {
     let result = lhs.addingReportingOverflow(rhs)
     return result.overflow ? nil : result.partialValue
+}
+
+nonisolated private func checkedSubtract(
+    _ lhs: Int,
+    _ rhs: Int
+) -> Int? {
+    let result = lhs.subtractingReportingOverflow(rhs)
+    guard !result.overflow, result.partialValue >= 0 else { return nil }
+    return result.partialValue
 }
 
 nonisolated private let zeroUUID = UUID(

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchEngine.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchEngine.swift
@@ -1067,13 +1067,17 @@ nonisolated enum VerifiedPatchEngine {
         }
     }
 
-    static func revalidate(_ patch: VerifiedPatchSet) throws {
+    static func revalidate(
+        _ patch: VerifiedPatchSet,
+        planningObserver: (() -> Void)? = nil
+    ) throws {
         guard patch.id != zeroUUID,
               !patch.operations.isEmpty,
               patch.operations.count
                 <= VerifiedPatchLimits.maximumOperationCount else {
             throw VerifiedPatchValidationError.invalidPatchID
         }
+        try preflightPatchShape(patch)
         let receipt = try VerifiedPatchIngressCoordinator.revalidate(
             patch.receipt
         )
@@ -1083,9 +1087,7 @@ nonisolated enum VerifiedPatchEngine {
         var capturedBytes = 0
         var planningBudget = PatchPlanningBudget()
 
-        guard patch.operations == patch.operations.sorted(
-            by: operationOrder
-        ) else {
+        guard hasCanonicalOperationOrder(patch.operations) else {
             throw VerifiedPatchValidationError.invalidOperation(nil)
         }
         for operation in patch.operations {
@@ -1189,7 +1191,7 @@ nonisolated enum VerifiedPatchEngine {
                 before: operation.before,
                 after: operation.after,
                 budget: &planningBudget,
-                planningObserver: nil
+                planningObserver: planningObserver
             )
             guard operation.strategy == canonical else {
                 throw VerifiedPatchValidationError.invalidOperation(
@@ -1593,6 +1595,12 @@ nonisolated enum VerifiedPatchEngine {
     private static func preflightPatchShape(
         _ patch: VerifiedPatchSet
     ) throws {
+        guard patch.operations.count
+                <= VerifiedPatchLimits.maximumOperationCount,
+              patch.receipt.events.count
+                <= VerifiedPatchLimits.maximumEventCount else {
+            throw VerifiedPatchValidationError.invalidOperation(nil)
+        }
         var transitionCount = 0
         var receiptTransitionCount = 0
         var receiptPathBytes = 0
@@ -1658,19 +1666,43 @@ nonisolated enum VerifiedPatchEngine {
         var hunkLineCount = 0
         var hunkByteCount = 0
         var capturedBytes = 0
+        var operationPathBytes = 0
+        var lcsCells = 0
         for operation in patch.operations {
-            guard let newTransitionCount = checkedAdd(
-                operationTransitionCount,
-                operation.id.transitionIDs.count
-            ),
-            newTransitionCount
-                <= VerifiedPatchLimits.maximumTransitionCount else {
+            guard !operation.id.transitionIDs.isEmpty,
+                  operation.id.transitionIDs.count
+                    <= VerifiedPatchLimits.maximumTransitionCount,
+                  operation.sourcePath.utf8.count
+                    <= VerifiedPatchLimits.maximumPathByteCount,
+                  (operation.destinationPath?.utf8.count ?? 0)
+                    <= VerifiedPatchLimits.maximumPathByteCount,
+                  operation.destinationPath == nil
+                    || operation.id.transitionIDs.count == 1,
+                  let sourcePathBytes = checkedAdd(
+                    operationPathBytes,
+                    operation.sourcePath.utf8.count
+                  ),
+                  let updatedPathBytes = checkedAdd(
+                    sourcePathBytes,
+                    operation.destinationPath?.utf8.count ?? 0
+                  ),
+                  updatedPathBytes <= VerifiedPatchLimits
+                    .maximumSnapshotPathByteCount,
+                  let newTransitionCount = checkedAdd(
+                    operationTransitionCount,
+                    operation.id.transitionIDs.count
+                  ),
+                  newTransitionCount
+                    <= VerifiedPatchLimits.maximumTransitionCount else {
                 throw VerifiedPatchValidationError.tooManyTransitions
             }
+            operationPathBytes = updatedPathBytes
             operationTransitionCount = newTransitionCount
             for state in [operation.before, operation.after]
                 .compactMap({ $0 }) {
-                guard state.content.count
+                guard state.kind == .regularFile,
+                      state.posixMode <= 0o7777,
+                      state.content.count
                         <= VerifiedPatchLimits.maximumFileByteCount,
                       let updated = checkedAdd(
                         capturedBytes,
@@ -1683,19 +1715,36 @@ nonisolated enum VerifiedPatchEngine {
                 }
                 capturedBytes = updated
             }
-            guard case .text(let hunks, _) = operation.strategy else {
+            guard case .text(let hunks, let declaredCells)
+                    = operation.strategy else {
                 continue
+            }
+            guard declaredCells >= 0,
+                  declaredCells <= VerifiedPatchLimits
+                    .maximumLCSCellCountPerDiff,
+                  let updatedLCSCells = checkedAdd(
+                    lcsCells,
+                    declaredCells
+                  ),
+                  updatedLCSCells <= VerifiedPatchLimits
+                    .maximumAggregateLCSCellCount else {
+                throw VerifiedPatchValidationError.invalidOperation(nil)
             }
             guard let updated = checkedAdd(hunkCount, hunks.count),
                   updated <= VerifiedPatchLimits.maximumHunkCount else {
                 throw VerifiedPatchValidationError.tooManyHunks
             }
+            lcsCells = updatedLCSCells
             hunkCount = updated
             for hunk in hunks {
                 guard hunk.beforeStartLine >= 0,
                       hunk.beforeLineCount >= 0,
                       hunk.afterStartLine >= 0,
                       hunk.afterLineCount >= 0,
+                      hunk.beforeLines.count == hunk.beforeLineCount,
+                      hunk.afterLines.count == hunk.afterLineCount,
+                      hunk.prefixContext.count <= 2,
+                      hunk.suffixContext.count <= 2,
                       let beforeEnd = checkedAdd(
                         hunk.beforeStartLine,
                         hunk.beforeLineCount
@@ -1965,7 +2014,16 @@ nonisolated enum VerifiedPatchEngine {
                 before: before.content,
                 after: after.content
               ),
-              let remainingCells = checkedSubtract(
+              let attemptedCells = checkedAdd(
+                budget.attemptedLCSCells,
+                estimate
+              ),
+              attemptedCells <= VerifiedPatchLimits
+                .maximumAggregateLCSCellCount else {
+            return .exactState
+        }
+        budget.attemptedLCSCells = attemptedCells
+        guard let remainingCells = checkedSubtract(
                 VerifiedPatchLimits.maximumAggregateLCSCellCount,
                 budget.lcsCells
               ),
@@ -2137,6 +2195,20 @@ nonisolated enum VerifiedPatchEngine {
         }
     }
 
+    private static func hasCanonicalOperationOrder(
+        _ operations: [VerifiedPatchOperation]
+    ) -> Bool {
+        for index in operations.indices.dropFirst() {
+            guard operationOrder(
+                operations[index - 1],
+                operations[index]
+            ) else {
+                return false
+            }
+        }
+        return true
+    }
+
     private static func sourceOrder(
         _ lhs: OrderedSource,
         _ rhs: OrderedSource
@@ -2177,6 +2249,7 @@ nonisolated enum VerifiedPatchEngine {
 
     private struct PatchPlanningBudget {
         var lcsCells = 0
+        var attemptedLCSCells = 0
         var hunks = 0
     }
 

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchEngine.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchEngine.swift
@@ -534,14 +534,20 @@ nonisolated enum VerifiedPatchEngine {
     /// not imply the inverse can be applied to a current snapshot.
     static func previewInverse(
         _ patch: VerifiedPatchSet
-    ) -> [VerifiedInverseOperationPreview] {
-        patch.operations.map { operation in
-            preview(
+    ) throws -> [VerifiedInverseOperationPreview] {
+        try revalidate(patch)
+        return try patch.operations.map { operation in
+            guard let operationPreview = preview(
                 operation,
                 expectedCurrent: operation.after,
                 result: operation.before,
                 resolvedHunks: nil
-            )
+            ) else {
+                throw VerifiedPatchValidationError.invalidOperation(
+                    operation.id.transitionIDs.first
+                )
+            }
+            return operationPreview
         }
     }
 
@@ -584,6 +590,16 @@ nonisolated enum VerifiedPatchEngine {
                 return .failure(.conflicts([conflict]))
             }
         }
+        guard projectedSnapshot(
+            from: currentSnapshot,
+            applying: prepared
+        ) != nil else {
+            return .failure(.conflicts([VerifiedPatchConflict(
+                operationID: nil,
+                path: nil,
+                reason: .resourceLimitExceeded
+            )]))
+        }
         let workspace = patch.receipt.workspace
         return .success(PreparedInverse(
             patch: patch,
@@ -594,7 +610,7 @@ nonisolated enum VerifiedPatchEngine {
                 rootInode: workspace.rootInode,
                 capturedHeadOID: workspace.capturedHeadOID,
                 capturedIndexSHA256: workspace.capturedIndexSHA256,
-                durableEvents: patch.receipt.durableEventIdentities,
+                durableEvents: patch.receipt.durableEventExpectations,
                 mediatedWriterReceipts: patch.receipt
                     .mediatedWriterReceipts
             ),
@@ -641,8 +657,20 @@ nonisolated enum VerifiedPatchEngine {
                 transformed[result.path] = result.state
             }
         }
+        let finalSnapshot = VerifiedPatchWorkspaceSnapshot(
+            files: transformed
+        )
+        do {
+            try validateSnapshot(finalSnapshot)
+        } catch {
+            return .conflicted([VerifiedPatchConflict(
+                operationID: nil,
+                path: nil,
+                reason: .resourceLimitExceeded
+            )])
+        }
         return .applied(
-            snapshot: VerifiedPatchWorkspaceSnapshot(files: transformed),
+            snapshot: finalSnapshot,
             previews: prepared.previews
         )
     }
@@ -815,12 +843,19 @@ nonisolated enum VerifiedPatchEngine {
                 kind: .regularFile,
                 posixMode: before.posixMode
             )
-            let operationPreview = preview(
+            guard merged.content.count
+                    <= VerifiedPatchLimits.maximumFileByteCount,
+                  let operationPreview = preview(
                 operation,
                 expectedCurrent: current,
                 result: merged,
                 resolvedHunks: textResult.hunks
-            )
+                  ) else {
+                return .failure(conflict(
+                    operation,
+                    .resourceLimitExceeded
+                ))
+            }
             return .success(VerifiedPreparedInverseOperation(
                 operationID: operation.id,
                 kind: operation.kind,
@@ -863,6 +898,14 @@ nonisolated enum VerifiedPatchEngine {
             }
             resolvedHunks = checkedHunks
         }
+        guard let operationPreview = preview(
+            operation,
+            expectedCurrent: expectations.first?.state,
+            result: results.first?.state,
+            resolvedHunks: resolvedHunks
+        ) else {
+            return nil
+        }
         return VerifiedPreparedInverseOperation(
             operationID: operation.id,
             kind: operation.kind,
@@ -870,12 +913,7 @@ nonisolated enum VerifiedPatchEngine {
             expectations: expectations,
             results: results,
             resolvedTextHunks: resolvedHunks,
-            preview: preview(
-                operation,
-                expectedCurrent: expectations.first?.state,
-                result: results.first?.state,
-                resolvedHunks: resolvedHunks
-            )
+            preview: operationPreview
         )
     }
 
@@ -927,7 +965,7 @@ nonisolated enum VerifiedPatchEngine {
 
             let before = first.before
             let after = last.after
-            guard before != after else {
+            guard first.destinationPath != nil || before != after else {
                 throw VerifiedPatchValidationError.invalidOperation(
                     first.transitionID
                 )
@@ -938,37 +976,13 @@ nonisolated enum VerifiedPatchEngine {
                 after: after,
                 transitionID: first.transitionID
             )
-            var strategy: VerifiedPatchApplicationStrategy = .exactState
-            if kind == .modify,
-               let before,
-               let after,
-               before.content != after.content,
-               let estimate = VerifiedTextPatch.estimatedLCSCellCount(
-                before: before.content,
-                after: after.content
-               ),
-               let estimatedAggregate = checkedAdd(
-                aggregateLCSCells,
-                estimate
-               ),
-               estimatedAggregate
-                <= VerifiedPatchLimits.maximumAggregateLCSCellCount,
-               let plan = VerifiedTextPatch.plan(
-                before: before.content,
-                after: after.content
-               ),
-               let hunkAggregate = checkedAdd(
-                aggregateHunks,
-                plan.hunks.count
-               ),
-               hunkAggregate <= VerifiedPatchLimits.maximumHunkCount {
-                aggregateLCSCells = estimatedAggregate
-                aggregateHunks = hunkAggregate
-                strategy = .text(
-                    hunks: plan.hunks,
-                    lcsCellCount: plan.lcsCellCount
-                )
-            }
+            let strategy = canonicalStrategy(
+                kind: kind,
+                before: before,
+                after: after,
+                aggregateLCSCells: &aggregateLCSCells,
+                aggregateHunks: &aggregateHunks
+            )
             let operation = VerifiedPatchOperation(
                 id: VerifiedPatchOperationID(
                     patchID: patchID,
@@ -1060,7 +1074,9 @@ nonisolated enum VerifiedPatchEngine {
 
         for operation in patch.operations {
             guard operation.id.patchID == patch.id,
-                  !operation.id.transitionIDs.isEmpty else {
+                  !operation.id.transitionIDs.isEmpty,
+                  operation.destinationPath == nil
+                    || operation.id.transitionIDs.count == 1 else {
                 throw VerifiedPatchValidationError.invalidOperation(nil)
             }
             var priorAfter: VerifiedPatchStateIdentity?
@@ -1107,13 +1123,16 @@ nonisolated enum VerifiedPatchEngine {
                 priorCursor = bound.cursor
                 priorOrdinal = transitionID.ordinal
             }
-            guard priorAfter == operation.after?.stateIdentity,
-                  try operationKind(
+            let canonicalKind = try operationKind(
                     destinationPath: operation.destinationPath,
                     before: operation.before,
                     after: operation.after,
                     transitionID: operation.id.transitionIDs[0]
-                  ) == operation.kind else {
+                  )
+            guard priorAfter == operation.after?.stateIdentity,
+                  canonicalKind == operation.kind,
+                  operation.kind != .modify
+                    || operation.before != operation.after else {
                 throw VerifiedPatchValidationError.invalidOperation(
                     operation.id.transitionIDs[0]
                 )
@@ -1149,29 +1168,17 @@ nonisolated enum VerifiedPatchEngine {
                 }
                 capturedBytes = updated
             }
-            switch operation.strategy {
-            case .exactState:
-                break
-            case .text(let hunks, let cells):
-                guard operation.kind == .modify,
-                      let before = operation.before,
-                      let after = operation.after,
-                      let recomputed = VerifiedTextPatch.plan(
-                        before: before.content,
-                        after: after.content
-                      ),
-                      recomputed.hunks == hunks,
-                      recomputed.lcsCellCount == cells,
-                      let newHunks = checkedAdd(hunkCount, hunks.count),
-                      newHunks
-                        <= VerifiedPatchLimits.maximumHunkCount,
-                      let newCells = checkedAdd(lcsCells, cells),
-                      newCells <= VerifiedPatchLimits
-                        .maximumAggregateLCSCellCount else {
-                    throw VerifiedPatchValidationError.lcsBudgetExceeded
-                }
-                hunkCount = newHunks
-                lcsCells = newCells
+            let canonical = canonicalStrategy(
+                kind: canonicalKind,
+                before: operation.before,
+                after: operation.after,
+                aggregateLCSCells: &lcsCells,
+                aggregateHunks: &hunkCount
+            )
+            guard operation.strategy == canonical else {
+                throw VerifiedPatchValidationError.invalidOperation(
+                    operation.id.transitionIDs[0]
+                )
             }
         }
         guard transitionIDs.count == transitions.count else {
@@ -1233,9 +1240,29 @@ nonisolated enum VerifiedPatchEngine {
         }
     }
 
+    private static func projectedSnapshot(
+        from snapshot: VerifiedPatchWorkspaceSnapshot,
+        applying operations: [VerifiedPreparedInverseOperation]
+    ) -> VerifiedPatchWorkspaceSnapshot? {
+        var files = snapshot.files
+        for operation in operations {
+            for result in operation.results {
+                files[result.path] = result.state
+            }
+        }
+        let projected = VerifiedPatchWorkspaceSnapshot(files: files)
+        do {
+            try validateSnapshot(projected)
+            return projected
+        } catch {
+            return nil
+        }
+    }
+
     private static func validatePrepared(
         _ prepared: PreparedInverse
     ) throws {
+        try preflightPreparedShape(prepared)
         try revalidate(prepared.patch)
         let workspace = prepared.patch.receipt.workspace
         let expectedCoordinator = VerifiedPatchCoordinatorExpectations(
@@ -1245,15 +1272,13 @@ nonisolated enum VerifiedPatchEngine {
             rootInode: workspace.rootInode,
             capturedHeadOID: workspace.capturedHeadOID,
             capturedIndexSHA256: workspace.capturedIndexSHA256,
-            durableEvents: prepared.patch.receipt.durableEventIdentities,
+            durableEvents: prepared.patch.receipt
+                .durableEventExpectations,
             mediatedWriterReceipts: prepared.patch.receipt
                 .mediatedWriterReceipts
         )
         guard prepared.patchID != zeroUUID,
               prepared.coordinatorExpectations == expectedCoordinator,
-              !prepared.operations.isEmpty,
-              prepared.operations.count
-                <= VerifiedPatchLimits.maximumOperationCount,
               prepared.previews == prepared.operations.map(\.preview),
               VerifiedPatchIngressCoordinator.isValidWorkspace(
                 VerifiedPatchWorkspaceIdentity(
@@ -1319,8 +1344,476 @@ nonisolated enum VerifiedPatchEngine {
         }
     }
 
+    /// Rejects attacker-shaped DTOs before content hashing, canonical diff
+    /// recomputation, or deep receipt/preview equality.
+    static func preflightPreparedShape(
+        _ prepared: PreparedInverse
+    ) throws {
+        guard prepared.patchID != zeroUUID,
+              !prepared.operations.isEmpty,
+              prepared.operations.count
+                <= VerifiedPatchLimits.maximumOperationCount,
+              prepared.previews.count == prepared.operations.count,
+              prepared.patch.operations.count
+                <= VerifiedPatchLimits.maximumOperationCount,
+              prepared.patch.receipt.events.count
+                <= VerifiedPatchLimits.maximumEventCount,
+              prepared.coordinatorExpectations.durableEvents.count
+                <= VerifiedPatchLimits.maximumEventCount,
+              prepared.coordinatorExpectations.mediatedWriterReceipts.count
+                <= VerifiedPatchLimits.maximumEventCount else {
+            throw VerifiedPatchValidationError.invalidOperation(nil)
+        }
+
+        try preflightPatchShape(prepared.patch)
+        try preflightCoordinatorShape(
+            prepared.coordinatorExpectations,
+            patch: prepared.patch
+        )
+        var expectationBytes = 0
+        var resultBytes = 0
+        var expectationPathBytes = 0
+        var resultPathBytes = 0
+        var hunkCount = 0
+        var hunkLineCount = 0
+        var hunkByteCount = 0
+        var operationTransitionIDCount = 0
+        var previewTransitionIDCount = 0
+
+        for operation in prepared.operations {
+            guard let updatedOperationTransitionIDCount = checkedAdd(
+                operationTransitionIDCount,
+                operation.operationID.transitionIDs.count
+            ),
+            updatedOperationTransitionIDCount
+                <= VerifiedPatchLimits.maximumTransitionCount,
+            let updatedPreviewTransitionIDCount = checkedAdd(
+                previewTransitionIDCount,
+                operation.preview.operationID.transitionIDs.count
+            ),
+            updatedPreviewTransitionIDCount
+                <= VerifiedPatchLimits.maximumTransitionCount else {
+                throw VerifiedPatchValidationError.invalidOperation(nil)
+            }
+            operationTransitionIDCount = updatedOperationTransitionIDCount
+            previewTransitionIDCount = updatedPreviewTransitionIDCount
+
+            guard operation.operationID.patchID == prepared.patchID,
+                  operation.kind != .rename,
+                  operation.expectations.count == 1,
+                  operation.results.count == 1,
+                  operation.resolvedTextHunks.count
+                    <= VerifiedPatchLimits.maximumHunkCount,
+                  operation.preview.operationID == operation.operationID,
+                  operation.preview.hunks.count
+                    == operation.resolvedTextHunks.count,
+                  operation.preview.sourcePath.utf8.count
+                    <= VerifiedPatchLimits.maximumPathByteCount,
+                  (operation.preview.destinationPath?.utf8.count ?? 0)
+                    <= VerifiedPatchLimits.maximumPathByteCount else {
+                throw VerifiedPatchValidationError.invalidOperation(nil)
+            }
+            try preflightPreparedModeShape(operation)
+
+            guard let expectation = operation.expectations.first,
+                  let result = operation.results.first,
+                  expectation.path.utf8.count
+                    <= VerifiedPatchLimits.maximumPathByteCount,
+                  result.path.utf8.count
+                    <= VerifiedPatchLimits.maximumPathByteCount,
+                  expectation.path == result.path,
+                  expectation.path == operation.preview.sourcePath,
+                  let newExpectationPathBytes = checkedAdd(
+                    expectationPathBytes,
+                    expectation.path.utf8.count
+                  ),
+                  newExpectationPathBytes <= VerifiedPatchLimits
+                    .maximumSnapshotPathByteCount,
+                  let newResultPathBytes = checkedAdd(
+                    resultPathBytes,
+                    result.path.utf8.count
+                  ),
+                  newResultPathBytes <= VerifiedPatchLimits
+                    .maximumSnapshotPathByteCount else {
+                throw VerifiedPatchValidationError.invalidOperation(nil)
+            }
+            expectationPathBytes = newExpectationPathBytes
+            resultPathBytes = newResultPathBytes
+
+            if let state = expectation.state {
+                guard state.content.count
+                        <= VerifiedPatchLimits.maximumFileByteCount,
+                      let updated = checkedAdd(
+                    expectationBytes,
+                    state.content.count
+                      ),
+                      updated <= VerifiedPatchLimits
+                        .maximumSnapshotByteCount else {
+                    throw VerifiedPatchValidationError.invalidOperation(nil)
+                }
+                expectationBytes = updated
+            }
+            if let state = result.state {
+                guard state.content.count
+                        <= VerifiedPatchLimits.maximumFileByteCount,
+                      let updated = checkedAdd(
+                    resultBytes,
+                    state.content.count
+                      ),
+                      updated <= VerifiedPatchLimits
+                        .maximumSnapshotByteCount else {
+                    throw VerifiedPatchValidationError.invalidOperation(nil)
+                }
+                resultBytes = updated
+            }
+
+            for (index, hunk) in operation.resolvedTextHunks.enumerated() {
+                guard hunk.capturedAfterRange.lowerBound >= 0,
+                      hunk.capturedAfterRange.upperBound
+                        <= VerifiedPatchLimits.maximumLineCount,
+                      hunk.resolvedCurrentRange.lowerBound >= 0,
+                      hunk.resolvedCurrentRange.upperBound
+                        <= VerifiedPatchLimits.maximumLineCount,
+                      let newHunkCount = checkedAdd(hunkCount, 1),
+                      newHunkCount
+                        <= VerifiedPatchLimits.maximumHunkCount else {
+                    throw VerifiedPatchValidationError.invalidOperation(nil)
+                }
+                hunkCount = newHunkCount
+                try accumulatePreparedLines(
+                    hunk.replacementLines,
+                    lineCount: &hunkLineCount,
+                    byteCount: &hunkByteCount
+                )
+
+                let previewHunk = operation.preview.hunks[index]
+                guard previewHunk.capturedAfterStartLine >= 0,
+                      previewHunk.capturedAfterStartLine
+                        <= VerifiedPatchLimits.maximumLineCount,
+                      (previewHunk.resolvedCurrentStartLine.map {
+                        $0 >= 0
+                            && $0 <= VerifiedPatchLimits.maximumLineCount
+                      } ?? true),
+                      previewHunk.header.utf8.count
+                        <= VerifiedPatchLimits.maximumPathByteCount else {
+                    throw VerifiedPatchValidationError.invalidOperation(nil)
+                }
+                try accumulatePreparedLines(
+                    previewHunk.lines.map(\.bytes),
+                    lineCount: &hunkLineCount,
+                    byteCount: &hunkByteCount
+                )
+            }
+        }
+    }
+
+    private static func preflightCoordinatorShape(
+        _ coordinator: VerifiedPatchCoordinatorExpectations,
+        patch: VerifiedPatchSet
+    ) throws {
+        let expectedWriterCount = patch.receipt.events.reduce(into: 0) {
+            if $1.mediatedWriterReceipt != nil {
+                $0 += 1
+            }
+        }
+        guard coordinator.canonicalRootPath.utf8.count
+                <= VerifiedPatchLimits.maximumPathByteCount,
+              coordinator.capturedHeadOID.utf8.count <= 64,
+              coordinator.capturedIndexSHA256.utf8.count <= 64,
+              coordinator.durableEvents.count
+                == patch.receipt.events.count,
+              coordinator.mediatedWriterReceipts.count
+                == expectedWriterCount else {
+            throw VerifiedPatchValidationError.invalidReceipt
+        }
+
+        var metadataBytes = 0
+        for expectation in coordinator.durableEvents {
+            let envelope = expectation.envelope
+            guard let eventBytes = preparedMetadataByteCount(envelope),
+                  eventBytes <= VerifiedPatchLimits
+                    .maximumEventMetadataByteCount,
+                  expectation.durableIdentity.canonicalWorktreePath
+                    .utf8.count <= VerifiedPatchLimits.maximumPathByteCount,
+                  let updated = checkedAdd(metadataBytes, eventBytes),
+                  updated <= VerifiedPatchLimits
+                    .maximumAggregateEventMetadataByteCount else {
+                throw VerifiedPatchValidationError.eventMetadataTooLarge
+            }
+            metadataBytes = updated
+        }
+
+        var transitionCount = 0
+        var pathBytes = 0
+        for receipt in coordinator.mediatedWriterReceipts {
+            guard receipt.workspace.canonicalRootPath.utf8.count
+                    <= VerifiedPatchLimits.maximumPathByteCount,
+                  receipt.workspace.capturedHeadOID.utf8.count <= 64,
+                  receipt.workspace.capturedIndexSHA256.utf8.count <= 64,
+                  let updatedTransitionCount = checkedAdd(
+                    transitionCount,
+                    receipt.transitions.count
+                  ),
+                  updatedTransitionCount <= VerifiedPatchLimits
+                    .maximumTransitionCount else {
+                throw VerifiedPatchValidationError.tooManyTransitions
+            }
+            transitionCount = updatedTransitionCount
+            for transition in receipt.transitions {
+                guard let sourceBytes = checkedAdd(
+                    pathBytes,
+                    transition.sourcePath.utf8.count
+                ),
+                let destinationBytes = checkedAdd(
+                    sourceBytes,
+                    transition.destinationPath?.utf8.count ?? 0
+                ),
+                destinationBytes <= VerifiedPatchLimits
+                    .maximumSnapshotPathByteCount else {
+                    throw VerifiedPatchValidationError.invalidReceipt
+                }
+                pathBytes = destinationBytes
+            }
+        }
+    }
+
+    private static func preflightPatchShape(
+        _ patch: VerifiedPatchSet
+    ) throws {
+        var transitionCount = 0
+        var receiptTransitionCount = 0
+        var receiptPathBytes = 0
+        var metadataBytes = 0
+        for event in patch.receipt.events {
+            guard let updated = checkedAdd(
+                transitionCount,
+                event.transitions.count
+            ),
+            updated <= VerifiedPatchLimits.maximumTransitionCount else {
+                throw VerifiedPatchValidationError.tooManyTransitions
+            }
+            transitionCount = updated
+
+            guard let eventBytes = preparedMetadataByteCount(
+                event.envelope
+            ),
+            eventBytes <= VerifiedPatchLimits.maximumEventMetadataByteCount,
+            let updatedMetadataBytes = checkedAdd(
+                metadataBytes,
+                eventBytes
+            ),
+            updatedMetadataBytes <= VerifiedPatchLimits
+                .maximumAggregateEventMetadataByteCount else {
+                throw VerifiedPatchValidationError.eventMetadataTooLarge
+            }
+            metadataBytes = updatedMetadataBytes
+
+            if let receipt = event.mediatedWriterReceipt {
+                guard receipt.workspace.canonicalRootPath.utf8.count
+                        <= VerifiedPatchLimits.maximumPathByteCount,
+                      receipt.workspace.capturedHeadOID.utf8.count <= 64,
+                      receipt.workspace.capturedIndexSHA256.utf8.count <= 64,
+                      let updatedReceiptTransitionCount = checkedAdd(
+                        receiptTransitionCount,
+                        receipt.transitions.count
+                      ),
+                      updatedReceiptTransitionCount <= VerifiedPatchLimits
+                        .maximumTransitionCount else {
+                    throw VerifiedPatchValidationError.invalidReceipt
+                }
+                receiptTransitionCount = updatedReceiptTransitionCount
+                for transition in receipt.transitions {
+                    guard let sourceBytes = checkedAdd(
+                        receiptPathBytes,
+                        transition.sourcePath.utf8.count
+                    ),
+                    let destinationBytes = checkedAdd(
+                        sourceBytes,
+                        transition.destinationPath?.utf8.count ?? 0
+                    ),
+                    destinationBytes <= VerifiedPatchLimits
+                        .maximumSnapshotPathByteCount else {
+                        throw VerifiedPatchValidationError.invalidReceipt
+                    }
+                    receiptPathBytes = destinationBytes
+                }
+            }
+        }
+
+        var operationTransitionCount = 0
+        var hunkCount = 0
+        var hunkLineCount = 0
+        var hunkByteCount = 0
+        var capturedBytes = 0
+        for operation in patch.operations {
+            guard let newTransitionCount = checkedAdd(
+                operationTransitionCount,
+                operation.id.transitionIDs.count
+            ),
+            newTransitionCount
+                <= VerifiedPatchLimits.maximumTransitionCount else {
+                throw VerifiedPatchValidationError.tooManyTransitions
+            }
+            operationTransitionCount = newTransitionCount
+            for state in [operation.before, operation.after]
+                .compactMap({ $0 }) {
+                guard state.content.count
+                        <= VerifiedPatchLimits.maximumFileByteCount,
+                      let updated = checkedAdd(
+                        capturedBytes,
+                        state.content.count
+                      ),
+                      updated <= VerifiedPatchLimits
+                        .maximumCapturedByteCount else {
+                    throw VerifiedPatchValidationError
+                        .aggregateContentTooLarge
+                }
+                capturedBytes = updated
+            }
+            guard case .text(let hunks, _) = operation.strategy else {
+                continue
+            }
+            guard let updated = checkedAdd(hunkCount, hunks.count),
+                  updated <= VerifiedPatchLimits.maximumHunkCount else {
+                throw VerifiedPatchValidationError.tooManyHunks
+            }
+            hunkCount = updated
+            for hunk in hunks {
+                guard hunk.beforeStartLine >= 0,
+                      hunk.beforeLineCount >= 0,
+                      hunk.afterStartLine >= 0,
+                      hunk.afterLineCount >= 0,
+                      let beforeEnd = checkedAdd(
+                        hunk.beforeStartLine,
+                        hunk.beforeLineCount
+                      ),
+                      beforeEnd <= VerifiedPatchLimits.maximumLineCount,
+                      let afterEnd = checkedAdd(
+                        hunk.afterStartLine,
+                        hunk.afterLineCount
+                      ),
+                      afterEnd <= VerifiedPatchLimits.maximumLineCount else {
+                    throw VerifiedPatchValidationError.invalidOperation(nil)
+                }
+                try accumulatePreparedLines(
+                    hunk.prefixContext,
+                    lineCount: &hunkLineCount,
+                    byteCount: &hunkByteCount
+                )
+                try accumulatePreparedLines(
+                    hunk.afterLines,
+                    lineCount: &hunkLineCount,
+                    byteCount: &hunkByteCount
+                )
+                try accumulatePreparedLines(
+                    hunk.beforeLines,
+                    lineCount: &hunkLineCount,
+                    byteCount: &hunkByteCount
+                )
+                try accumulatePreparedLines(
+                    hunk.suffixContext,
+                    lineCount: &hunkLineCount,
+                    byteCount: &hunkByteCount
+                )
+            }
+        }
+    }
+
+    private static func preparedMetadataByteCount(
+        _ envelope: AgentEventEnvelope
+    ) -> Int? {
+        let strings: [String] = switch envelope.payload {
+        case .none:
+            [
+                envelope.agentTypeRaw,
+                envelope.location.worktreePath,
+                envelope.location.cwd
+            ]
+        case .commandResult(let result):
+            [
+                envelope.agentTypeRaw,
+                envelope.location.worktreePath,
+                envelope.location.cwd,
+                result.command
+            ]
+        case .fileChange(let change):
+            [
+                envelope.agentTypeRaw,
+                envelope.location.worktreePath,
+                envelope.location.cwd,
+                change.relativePath
+            ]
+        }
+        var result = 0
+        for string in strings {
+            guard let updated = checkedAdd(result, string.utf8.count) else {
+                return nil
+            }
+            result = updated
+        }
+        return result
+    }
+
+    private static func preflightPreparedModeShape(
+        _ operation: VerifiedPreparedInverseOperation
+    ) throws {
+        guard let expectation = operation.expectations.first,
+              let result = operation.results.first else {
+            throw VerifiedPatchValidationError.invalidOperation(nil)
+        }
+        let validStateShape: Bool = switch operation.kind {
+        case .modify:
+            expectation.state != nil && result.state != nil
+        case .create:
+            expectation.state != nil && result.state == nil
+        case .delete:
+            expectation.state == nil && result.state != nil
+        case .rename:
+            false
+        }
+        let validModeShape: Bool = switch operation.mode {
+        case .checkedText:
+            operation.kind == .modify
+                && !operation.resolvedTextHunks.isEmpty
+                && operation.preview.kind == .applyTextHunks
+        case .exactState:
+            operation.resolvedTextHunks.isEmpty
+                == operation.preview.hunks.isEmpty
+        }
+        guard validStateShape, validModeShape else {
+            throw VerifiedPatchValidationError.invalidOperation(nil)
+        }
+    }
+
+    private static func accumulatePreparedLines(
+        _ lines: [Data],
+        lineCount: inout Int,
+        byteCount: inout Int
+    ) throws {
+        guard let updatedLineCount = checkedAdd(lineCount, lines.count),
+              updatedLineCount
+                <= VerifiedPatchLimits
+                    .maximumPreparedLineReferenceCount else {
+            throw VerifiedPatchValidationError.invalidOperation(nil)
+        }
+        lineCount = updatedLineCount
+        for line in lines {
+            guard line.count <= VerifiedPatchLimits.maximumFileByteCount,
+                  let updatedByteCount = checkedAdd(
+                    byteCount,
+                    line.count
+                  ),
+                  updatedByteCount
+                    <= VerifiedPatchLimits
+                        .maximumPreparedHunkByteCount else {
+                throw VerifiedPatchValidationError.invalidOperation(nil)
+            }
+            byteCount = updatedByteCount
+        }
+    }
+
     private static func validateDurableExpectations(
-        _ events: [VerifiedPatchDurableEventIdentity],
+        _ events: [VerifiedPatchDurableEventExpectation],
         workspace: VerifiedPatchCoordinatorExpectations
     ) -> Bool {
         guard !events.isEmpty,
@@ -1330,16 +1823,31 @@ nonisolated enum VerifiedPatchEngine {
         }
         var envelopeIDs: Set<UUID> = []
         var journalSequences: Set<UInt64> = []
-        for (index, event) in events.enumerated() {
-            guard event.projectID == first.projectID,
+        for (index, expectation) in events.enumerated() {
+            let envelope = expectation.envelope
+            let event = expectation.durableIdentity
+            guard event.projectID == first.durableIdentity.projectID,
                   event.canonicalWorktreePath
                     == workspace.canonicalRootPath,
-                  event.sessionID == first.sessionID,
-                  event.terminalID == first.terminalID,
-                  event.processGeneration == first.processGeneration,
+                  event.sessionID == first.durableIdentity.sessionID,
+                  event.terminalID == first.durableIdentity.terminalID,
+                  event.processGeneration
+                    == first.durableIdentity.processGeneration,
                   event.eventCursor > 0,
                   event.envelopeID != zeroUUID,
                   event.journalSequence > 0,
+                  envelope.id == event.envelopeID,
+                  envelope.projectID == event.projectID,
+                  envelope.sessionID == event.sessionID,
+                  envelope.process.terminalID == event.terminalID,
+                  envelope.process.processGeneration
+                    == event.processGeneration,
+                  envelope.location.worktreePath
+                    == event.canonicalWorktreePath,
+                  envelope.cursorValue == event.eventCursor,
+                  envelope.source == .explicitAgentEvent,
+                  envelope.trustLevel == .verified,
+                  envelope.timestamp.timeIntervalSinceReferenceDate.isFinite,
                   envelopeIDs.insert(event.envelopeID).inserted,
                   journalSequences.insert(
                     event.journalSequence
@@ -1347,7 +1855,7 @@ nonisolated enum VerifiedPatchEngine {
                 return false
             }
             guard index > 0 else { continue }
-            let previous = events[index - 1]
+            let previous = events[index - 1].durableIdentity
             guard previous.eventCursor < UInt64.max,
                   event.eventCursor == previous.eventCursor + 1,
                   event.journalSequence > previous.journalSequence else {
@@ -1403,12 +1911,48 @@ nonisolated enum VerifiedPatchEngine {
         }
     }
 
+    private static func canonicalStrategy(
+        kind: VerifiedPatchOperationKind,
+        before: VerifiedPatchFileState?,
+        after: VerifiedPatchFileState?,
+        aggregateLCSCells: inout Int,
+        aggregateHunks: inout Int
+    ) -> VerifiedPatchApplicationStrategy {
+        guard kind == .modify,
+              let before,
+              let after,
+              before.content != after.content,
+              let plan = VerifiedTextPatch.plan(
+                before: before.content,
+                after: after.content
+              ),
+              let updatedCells = checkedAdd(
+                aggregateLCSCells,
+                plan.lcsCellCount
+              ),
+              updatedCells
+                <= VerifiedPatchLimits.maximumAggregateLCSCellCount,
+              let updatedHunks = checkedAdd(
+                aggregateHunks,
+                plan.hunks.count
+              ),
+              updatedHunks <= VerifiedPatchLimits.maximumHunkCount else {
+            return .exactState
+        }
+        aggregateLCSCells = updatedCells
+        aggregateHunks = updatedHunks
+        return .text(
+            hunks: plan.hunks,
+            lcsCellCount: plan.lcsCellCount
+        )
+    }
+
     private static func preview(
         _ operation: VerifiedPatchOperation,
         expectedCurrent: VerifiedPatchFileState?,
         result: VerifiedPatchFileState?,
         resolvedHunks: [VerifiedPreparedTextHunk]?
-    ) -> VerifiedInverseOperationPreview {
+    ) -> VerifiedInverseOperationPreview? {
         let previewKind: VerifiedInversePreviewKind = switch operation.kind {
         case .modify:
             if case .text = operation.strategy {
@@ -1425,12 +1969,17 @@ nonisolated enum VerifiedPatchEngine {
         case .exactState:
             hunkPreviews = []
         case .text(let hunks, _):
-            hunkPreviews = hunks.enumerated().map { index, hunk in
-                hunkPreview(
+            var values: [VerifiedInverseHunkPreview] = []
+            for (index, hunk) in hunks.enumerated() {
+                guard let value = hunkPreview(
                     hunk,
                     resolved: resolvedHunks?[safe: index]
-                )
+                ) else {
+                    return nil
+                }
+                values.append(value)
             }
+            hunkPreviews = values
         }
         return VerifiedInverseOperationPreview(
             operationID: operation.id,
@@ -1446,7 +1995,7 @@ nonisolated enum VerifiedPatchEngine {
     private static func hunkPreview(
         _ hunk: VerifiedTextPatchHunk,
         resolved: VerifiedPreparedTextHunk?
-    ) -> VerifiedInverseHunkPreview {
+    ) -> VerifiedInverseHunkPreview? {
         var lines: [VerifiedInversePreviewLine] = []
         lines.append(contentsOf: hunk.prefixContext.map {
             VerifiedInversePreviewLine(kind: .context, bytes: $0)
@@ -1461,7 +2010,12 @@ nonisolated enum VerifiedPatchEngine {
             VerifiedInversePreviewLine(kind: .context, bytes: $0)
         })
         let currentStart = resolved?.resolvedCurrentRange.lowerBound
-        let headerStart = (currentStart ?? hunk.afterStartLine) + 1
+        guard let headerStart = checkedAdd(
+            currentStart ?? hunk.afterStartLine,
+            1
+        ) else {
+            return nil
+        }
         return VerifiedInverseHunkPreview(
             capturedAfterStartLine: hunk.afterStartLine,
             resolvedCurrentStartLine: currentStart,

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchEngine.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchEngine.swift
@@ -2,312 +2,1428 @@
 //  VerifiedPatchEngine.swift
 //  Pine
 //
-//  Pure construction, preview, and checked inverse application for #933.
+//  Pure ingress, preparation, preview, and rechecked application for #933.
 //
 
 import Foundation
 
-/// Deterministic, side-effect-free verified patch engine.
+/// Pure ingress validation for full provenance envelopes.
 ///
-/// The engine never reads or writes a working tree. Callers provide captured
-/// bytes and an in-memory current snapshot; success returns a new snapshot.
-/// Any conflict returns no partially transformed state.
-nonisolated enum VerifiedPatchEngine {
-    private static let maximumOperationCount = 1_024
-    private static let maximumContentByteCount = 16 * 1_024 * 1_024
+/// The future live coordinator owns where these records came from. This layer
+/// verifies source/trust/scope/cursor/transition consistency but never treats
+/// the resulting receipt as #1207 mutation authority.
+nonisolated enum VerifiedPatchIngressCoordinator {
+    static func accept(
+        receiptID: UUID,
+        workspace: VerifiedPatchWorkspaceIdentity,
+        records: [VerifiedPatchUntrustedEventRecord]
+    ) throws -> VerifiedPatchIngressReceipt {
+        guard receiptID != zeroUUID,
+              isValidWorkspace(workspace) else {
+            throw VerifiedPatchValidationError.invalidWorkspaceIdentity
+        }
+        guard !records.isEmpty else {
+            throw VerifiedPatchValidationError.invalidReceipt
+        }
+        guard records.count <= VerifiedPatchLimits.maximumEventCount else {
+            throw VerifiedPatchValidationError.tooManyEvents
+        }
 
+        let ordered = records.sorted(by: eventOrder)
+        guard let first = ordered.first else {
+            throw VerifiedPatchValidationError.invalidReceipt
+        }
+        let projectID = first.envelope.projectID
+        let sessionID = first.envelope.sessionID
+        let process = first.envelope.process
+        var envelopeIDs: Set<UUID> = []
+        var durableIdentities: Set<VerifiedPatchDurableEventIdentity> = []
+        var journalSequences: Set<UInt64> = []
+        var mediatedState = MediatedReceiptValidationState()
+        var transitionCount = 0
+        var eventMetadataBytes = 0
+        var accepted: [VerifiedPatchAcceptedEvent] = []
+
+        for (index, record) in ordered.enumerated() {
+            let envelope = record.envelope
+            guard envelope.id != zeroUUID,
+                  envelope.projectID == projectID,
+                  envelope.sessionID == sessionID,
+                  envelope.process == process,
+                  envelope.location.worktreePath
+                    == workspace.canonicalRootPath,
+                  envelope.cursorValue > 0,
+                  envelope.timestamp.timeIntervalSinceReferenceDate.isFinite
+            else {
+                throw VerifiedPatchValidationError.invalidEnvelope(
+                    envelope.id
+                )
+            }
+            guard envelope.source == .explicitAgentEvent,
+                  envelope.trustLevel == .verified else {
+                throw VerifiedPatchValidationError.unverifiedEnvelope(
+                    envelope.id
+                )
+            }
+            guard let envelopeMetadataBytes = metadataByteCount(envelope),
+                  envelopeMetadataBytes
+                    <= VerifiedPatchLimits.maximumEventMetadataByteCount,
+                  let aggregateMetadataBytes = checkedAdd(
+                    eventMetadataBytes,
+                    envelopeMetadataBytes
+                  ),
+                  aggregateMetadataBytes <= VerifiedPatchLimits
+                    .maximumAggregateEventMetadataByteCount else {
+                throw VerifiedPatchValidationError.eventMetadataTooLarge
+            }
+            eventMetadataBytes = aggregateMetadataBytes
+            guard envelopeIDs.insert(envelope.id).inserted else {
+                throw VerifiedPatchValidationError.duplicateEnvelope(
+                    envelope.id
+                )
+            }
+            try validateDurableIdentity(
+                record.durableIdentity,
+                envelope: envelope,
+                workspace: workspace
+            )
+            guard durableIdentities.insert(
+                record.durableIdentity
+            ).inserted else {
+                throw VerifiedPatchValidationError.invalidDurableEvent(
+                    envelope.id
+                )
+            }
+            guard journalSequences.insert(
+                record.durableIdentity.journalSequence
+            ).inserted else {
+                throw VerifiedPatchValidationError
+                    .duplicateJournalSequence(
+                        record.durableIdentity.journalSequence
+                    )
+            }
+            guard let updatedTransitionCount = checkedAdd(
+                transitionCount,
+                record.transitions.count
+            ),
+            updatedTransitionCount
+                <= VerifiedPatchLimits.maximumTransitionCount else {
+                throw VerifiedPatchValidationError.tooManyTransitions
+            }
+            transitionCount = updatedTransitionCount
+            for (ordinal, transition) in record.transitions.enumerated() {
+                try validate(
+                    transition,
+                    id: VerifiedPatchTransitionID(
+                        envelopeID: envelope.id,
+                        ordinal: ordinal
+                    )
+                )
+            }
+            try validateMediatedWriterReceipt(
+                record,
+                workspace: workspace,
+                state: &mediatedState
+            )
+            try validatePayloadBinding(record)
+
+            if index > 0 {
+                let previousRecord = ordered[index - 1]
+                let previousCursor = previousRecord.envelope.cursorValue
+                if envelope.cursorValue == previousCursor {
+                    throw VerifiedPatchValidationError.cursorReplay(
+                        previousCursor
+                    )
+                }
+                guard previousCursor < UInt64.max else {
+                    throw VerifiedPatchValidationError.cursorGap(
+                        expected: UInt64.max,
+                        actual: envelope.cursorValue
+                    )
+                }
+                let expected = previousCursor + 1
+                guard envelope.cursorValue == expected else {
+                    throw VerifiedPatchValidationError.cursorGap(
+                        expected: expected,
+                        actual: envelope.cursorValue
+                    )
+                }
+                let previousSequence = previousRecord
+                    .durableIdentity.journalSequence
+                guard previousSequence
+                        < record.durableIdentity.journalSequence else {
+                    throw VerifiedPatchValidationError.journalOrderMismatch(
+                        previous: previousSequence,
+                        actual: record.durableIdentity.journalSequence
+                    )
+                }
+            }
+            accepted.append(VerifiedPatchAcceptedEvent(
+                envelope: envelope,
+                durableIdentity: record.durableIdentity,
+                mediatedWriterReceipt: record.mediatedWriterReceipt,
+                transitions: record.transitions
+            ))
+        }
+
+        return VerifiedPatchIngressReceipt(
+            receiptID: receiptID,
+            workspace: workspace,
+            projectID: projectID,
+            sessionID: sessionID,
+            process: process,
+            events: accepted
+        )
+    }
+
+    /// Revalidates a synthesized or decoded receipt by passing it through the
+    /// same untrusted DTO boundary. No receipt field is trusted by shape.
+    static func revalidate(
+        _ receipt: VerifiedPatchIngressReceipt
+    ) throws -> VerifiedPatchIngressReceipt {
+        let rebuilt = try accept(
+            receiptID: receipt.receiptID,
+            workspace: receipt.workspace,
+            records: receipt.events.map {
+                VerifiedPatchUntrustedEventRecord(
+                    envelope: $0.envelope,
+                    durableIdentity: $0.durableIdentity,
+                    mediatedWriterReceipt: $0.mediatedWriterReceipt,
+                    transitions: $0.transitions
+                )
+            }
+        )
+        guard rebuilt == receipt else {
+            throw VerifiedPatchValidationError.invalidReceipt
+        }
+        return rebuilt
+    }
+
+    static func isAllowedRelativePath(_ path: String) -> Bool {
+        guard path.utf8.count
+                <= VerifiedPatchLimits.maximumPathByteCount,
+              AgentHistoryUndoPreflight.isCanonicalRelativePath(path) else {
+            return false
+        }
+        return !path.split(separator: "/").contains {
+            AgentHistoryUndoPreflight.conservativePathKey(String($0))
+                == ".pine"
+        }
+    }
+
+    static func conservativePathKey(_ path: String) -> String {
+        AgentHistoryUndoPreflight.conservativePathKey(path)
+    }
+
+    private static func validate(
+        _ transition: VerifiedPatchContentTransition,
+        id: VerifiedPatchTransitionID
+    ) throws {
+        guard isAllowedRelativePath(transition.sourcePath) else {
+            throw pathError(transition.sourcePath)
+        }
+        if let destinationPath = transition.destinationPath {
+            guard isAllowedRelativePath(destinationPath) else {
+                throw pathError(destinationPath)
+            }
+            guard conservativePathKey(destinationPath)
+                    != conservativePathKey(transition.sourcePath),
+                  transition.before != nil,
+                  transition.after != nil else {
+                throw VerifiedPatchValidationError.invalidTransition(id)
+            }
+        }
+        guard transition.before != nil || transition.after != nil,
+              transition.before.map(isValidStateIdentity) ?? true,
+              transition.after.map(isValidStateIdentity) ?? true else {
+            throw VerifiedPatchValidationError.invalidTransition(id)
+        }
+    }
+
+    private static func validateDurableIdentity(
+        _ identity: VerifiedPatchDurableEventIdentity,
+        envelope: AgentEventEnvelope,
+        workspace: VerifiedPatchWorkspaceIdentity
+    ) throws {
+        guard identity.projectID == envelope.projectID,
+              identity.canonicalWorktreePath
+                == workspace.canonicalRootPath,
+              identity.canonicalWorktreePath
+                == envelope.location.worktreePath,
+              identity.sessionID == envelope.sessionID,
+              identity.terminalID == envelope.process.terminalID,
+              identity.processGeneration
+                == envelope.process.processGeneration,
+              identity.eventCursor == envelope.cursorValue,
+              identity.envelopeID == envelope.id,
+              identity.journalSequence > 0 else {
+            throw VerifiedPatchValidationError.invalidDurableEvent(
+                envelope.id
+            )
+        }
+    }
+
+    private static func validateMediatedWriterReceipt(
+        _ record: VerifiedPatchUntrustedEventRecord,
+        workspace: VerifiedPatchWorkspaceIdentity,
+        state: inout MediatedReceiptValidationState
+    ) throws {
+        guard !record.transitions.isEmpty else {
+            guard record.mediatedWriterReceipt == nil else {
+                throw VerifiedPatchValidationError
+                    .invalidMediatedWriterReceipt(record.envelope.id)
+            }
+            return
+        }
+        guard let receipt = record.mediatedWriterReceipt else {
+            throw VerifiedPatchValidationError
+                .missingMediatedWriterReceipt(record.envelope.id)
+        }
+        guard receipt.receiptID != zeroUUID,
+              receipt.userApprovalID != zeroUUID,
+              receipt.descriptorTransactionID != zeroUUID,
+              receipt.descriptorCASSequence > 0,
+              receipt.workspace == workspace,
+              receipt.auditEvent == record.durableIdentity,
+              receipt.transitions == record.transitions else {
+            throw VerifiedPatchValidationError
+                .invalidMediatedWriterReceipt(record.envelope.id)
+        }
+        guard state.receiptIDs.insert(receipt.receiptID).inserted,
+              state.transactionIDs.insert(
+                receipt.descriptorTransactionID
+              ).inserted,
+              state.casSequences.insert(
+                receipt.descriptorCASSequence
+              ).inserted else {
+            throw VerifiedPatchValidationError
+                .duplicateMediatedWriterReceipt(receipt.receiptID)
+        }
+        if let lastSequence = state.lastSequence {
+            guard receipt.descriptorCASSequence > lastSequence else {
+                throw VerifiedPatchValidationError
+                    .invalidMediatedWriterReceipt(record.envelope.id)
+            }
+        }
+        state.lastSequence = receipt.descriptorCASSequence
+    }
+
+    private static func validatePayloadBinding(
+        _ record: VerifiedPatchUntrustedEventRecord
+    ) throws {
+        guard case .fileChange(let change) = record.envelope.payload else {
+            return
+        }
+        let matches = record.transitions.filter { transition in
+            transition.destinationPath == nil
+                && transition.sourcePath == change.relativePath
+                && transition.before?.contentIdentity == change.before
+                && transition.after?.contentIdentity == change.after
+        }
+        guard matches.count == 1 else {
+            throw VerifiedPatchValidationError.invalidEnvelope(
+                record.envelope.id
+            )
+        }
+    }
+
+    private static func metadataByteCount(
+        _ envelope: AgentEventEnvelope
+    ) -> Int? {
+        var result = 0
+        let strings: [String]
+        switch envelope.payload {
+        case .none:
+            strings = [
+                envelope.agentTypeRaw,
+                envelope.location.worktreePath,
+                envelope.location.cwd
+            ]
+        case .commandResult(let command):
+            strings = [
+                envelope.agentTypeRaw,
+                envelope.location.worktreePath,
+                envelope.location.cwd,
+                command.command
+            ]
+        case .fileChange(let change):
+            strings = [
+                envelope.agentTypeRaw,
+                envelope.location.worktreePath,
+                envelope.location.cwd,
+                change.relativePath
+            ]
+        }
+        for string in strings {
+            guard let updated = checkedAdd(result, string.utf8.count) else {
+                return nil
+            }
+            result = updated
+        }
+        return result
+    }
+
+    private static func isValidStateIdentity(
+        _ state: VerifiedPatchStateIdentity
+    ) -> Bool {
+        state.kind == .regularFile
+            && state.posixMode <= 0o7777
+    }
+
+    static func isValidWorkspace(
+        _ workspace: VerifiedPatchWorkspaceIdentity
+    ) -> Bool {
+        workspace.privateWorkspaceID != zeroUUID
+            && workspace.rootDevice > 0
+            && workspace.rootInode > 0
+            && isCanonicalAbsolutePath(workspace.canonicalRootPath)
+            && isGitOIDOrEmpty(workspace.capturedHeadOID)
+            && isSHA256OrEmpty(workspace.capturedIndexSHA256)
+    }
+
+    private static func isCanonicalAbsolutePath(_ path: String) -> Bool {
+        let normalized = path.precomposedStringWithCanonicalMapping
+        guard path.hasPrefix("/"),
+              path != "/",
+              path.utf8.elementsEqual(normalized.utf8),
+              !path.utf8.contains(0),
+              path.utf8.count
+                <= VerifiedPatchLimits.maximumPathByteCount else {
+            return false
+        }
+        let components = path.split(
+            separator: "/",
+            omittingEmptySubsequences: false
+        )
+        return components.first?.isEmpty == true
+            && components.dropFirst().allSatisfy {
+                !$0.isEmpty && $0 != "." && $0 != ".."
+            }
+    }
+
+    private static func isGitOIDOrEmpty(_ value: String) -> Bool {
+        value.isEmpty || isLowercaseHex(value, allowedCounts: [40, 64])
+    }
+
+    private static func isSHA256OrEmpty(_ value: String) -> Bool {
+        value.isEmpty || isLowercaseHex(value, allowedCounts: [64])
+    }
+
+    private static func isLowercaseHex(
+        _ value: String,
+        allowedCounts: Set<Int>
+    ) -> Bool {
+        allowedCounts.contains(value.utf8.count)
+            && value.utf8.allSatisfy {
+                (48...57).contains($0) || (97...102).contains($0)
+            }
+    }
+
+    private static func pathError(
+        _ path: String
+    ) -> VerifiedPatchValidationError {
+        let keyComponents = path.split(separator: "/").map {
+            conservativePathKey(String($0))
+        }
+        if keyComponents.contains(".git")
+            || keyComponents.contains(".pine") {
+            return .protectedPath(path)
+        }
+        return .invalidPath(path)
+    }
+
+    private static func eventOrder(
+        _ lhs: VerifiedPatchUntrustedEventRecord,
+        _ rhs: VerifiedPatchUntrustedEventRecord
+    ) -> Bool {
+        if lhs.envelope.cursorValue != rhs.envelope.cursorValue {
+            return lhs.envelope.cursorValue < rhs.envelope.cursorValue
+        }
+        return lhs.envelope.id.uuidString < rhs.envelope.id.uuidString
+    }
+
+    private struct MediatedReceiptValidationState {
+        var receiptIDs: Set<UUID> = []
+        var transactionIDs: Set<UUID> = []
+        var casSequences: Set<UInt64> = []
+        var lastSequence: UInt64?
+    }
+}
+
+/// Deterministic, side-effect-free patch simulation engine.
+nonisolated enum VerifiedPatchEngine {
     static func makePatch(
         id: UUID,
-        binding: VerifiedPatchEventBinding,
-        operations sourceOperations: [VerifiedPatchSourceOperation]
+        receipt: VerifiedPatchIngressReceipt,
+        operations sources: [VerifiedPatchSourceOperation]
     ) throws -> VerifiedPatchSet {
         guard id != zeroUUID else {
             throw VerifiedPatchValidationError.invalidPatchID
         }
-        guard !sourceOperations.isEmpty,
-              sourceOperations.count <= maximumOperationCount else {
+        let validatedReceipt = try VerifiedPatchIngressCoordinator.revalidate(
+            receipt
+        )
+        guard !sources.isEmpty else {
             throw VerifiedPatchValidationError.noOperations
         }
+        guard sources.count
+                <= VerifiedPatchLimits.maximumTransitionCount else {
+            throw VerifiedPatchValidationError.tooManyTransitions
+        }
 
-        var boundTransitions: [BoundTransition: Int] = [:]
-        for event in binding.events {
-            for transition in event.transitions {
-                let key = BoundTransition(
-                    envelopeID: event.envelopeID,
-                    transition: transition
+        let boundTransitions = try transitionMap(validatedReceipt)
+        var seenTransitionIDs: Set<VerifiedPatchTransitionID> = []
+        var validatedSources: [OrderedSource] = []
+        var capturedBytes = 0
+
+        for source in sources {
+            guard seenTransitionIDs.insert(source.transitionID).inserted else {
+                throw VerifiedPatchValidationError.duplicateTransition(
+                    source.transitionID
                 )
-                boundTransitions[key, default: 0] += 1
-                guard boundTransitions[key] == 1 else {
+            }
+            guard let bound = boundTransitions[source.transitionID] else {
+                throw VerifiedPatchValidationError.unboundOperation(
+                    source.transitionID
+                )
+            }
+            try validateSource(source, bound: bound.transition)
+            for state in [source.before, source.after].compactMap({ $0 }) {
+                guard let updated = checkedAdd(
+                    capturedBytes,
+                    state.content.count
+                ),
+                updated
+                    <= VerifiedPatchLimits.maximumCapturedByteCount else {
                     throw VerifiedPatchValidationError
-                        .duplicateBoundTransition
+                        .aggregateContentTooLarge
                 }
+                capturedBytes = updated
             }
+            validatedSources.append(OrderedSource(
+                cursor: bound.cursor,
+                source: source
+            ))
+        }
+        for transitionID in boundTransitions.keys
+        where !seenTransitionIDs.contains(transitionID) {
+            throw VerifiedPatchValidationError.unusedTransition(transitionID)
         }
 
-        var operations: [VerifiedPatchOperation] = []
-        var touchedPaths: Set<String> = []
-        for source in sourceOperations {
-            let operation = try makeOperation(source)
-            for path in operation.touchedPaths {
-                guard touchedPaths.insert(path).inserted else {
-                    throw VerifiedPatchValidationError
-                        .duplicateTouchedPath(path)
-                }
-            }
-
-            let bound = BoundTransition(
-                envelopeID: operation.eventEnvelopeID,
-                transition: operation.transition
-            )
-            guard let count = boundTransitions[bound],
-                  count == 1 else {
-                throw VerifiedPatchValidationError.unboundOperation
-            }
-            boundTransitions[bound] = 0
-            operations.append(operation)
-        }
-
-        guard boundTransitions.values.allSatisfy({ $0 == 0 }) else {
-            throw VerifiedPatchValidationError.unusedBoundTransition
-        }
-        operations.sort(by: operationOrder)
-        return VerifiedPatchSet(
-            id: id,
-            binding: binding,
-            operations: operations
+        let collapsed = try collapse(
+            validatedSources,
+            patchID: id
         )
+        guard !collapsed.isEmpty else {
+            throw VerifiedPatchValidationError.noOperations
+        }
+        guard collapsed.count
+                <= VerifiedPatchLimits.maximumOperationCount else {
+            throw VerifiedPatchValidationError.tooManyOperations
+        }
+        let patch = VerifiedPatchSet(
+            id: id,
+            receipt: validatedReceipt,
+            operations: collapsed.sorted(by: operationOrder)
+        )
+        try revalidate(patch)
+        return patch
     }
 
-    /// Returns one structured preview for every operation, in deterministic
-    /// patch order.
+    /// Nominal preview from captured states only. It is display data and does
+    /// not imply the inverse can be applied to a current snapshot.
     static func previewInverse(
         _ patch: VerifiedPatchSet
     ) -> [VerifiedInverseOperationPreview] {
         patch.operations.map { operation in
-            let previewKind: VerifiedInversePreviewKind
-            switch operation.kind {
-            case .modify:
-                if case .text = operation.strategy {
-                    previewKind = .applyTextHunks
-                } else {
-                    previewKind = .restoreExactBytes
-                }
-            case .create:
-                previewKind = .removeCreatedFile
-            case .delete:
-                previewKind = .restoreDeletedFile
-            case .rename:
-                previewKind = .restoreRenamedFile
-            }
-            let hunkPreviews: [VerifiedInverseHunkPreview]
-            switch operation.strategy {
-            case .text(let hunks):
-                hunkPreviews = hunks.map(preview)
-            case .exactState:
-                hunkPreviews = []
-            }
-            return VerifiedInverseOperationPreview(
-                operationKey: operation.operationKey,
-                eventEnvelopeID: operation.eventEnvelopeID,
-                kind: previewKind,
-                sourcePath: operation.sourcePath,
-                destinationPath: operation.destinationPath,
-                expectedCurrentIdentity: operation.after?.identity,
-                resultIdentity: operation.before?.identity,
-                hunks: hunkPreviews
+            preview(
+                operation,
+                expectedCurrent: operation.after,
+                result: operation.before,
+                resolvedHunks: nil
             )
         }
     }
 
-    static func applyCheckedInverse(
+    /// Resolves all actual current ranges and result bytes without I/O.
+    ///
+    /// Rename remains previewable but is deliberately not preparable because
+    /// #1207's mutation transaction does not authorize rename yet.
+    static func prepareCheckedInverse(
         _ patch: VerifiedPatchSet,
-        to snapshot: VerifiedPatchWorkspaceSnapshot
-    ) -> VerifiedCheckedInverseResult {
-        var transformed = snapshot.files
+        currentSnapshot: VerifiedPatchWorkspaceSnapshot
+    ) -> Result<PreparedInverse, VerifiedPatchPreparationFailure> {
+        do {
+            try revalidate(patch)
+            try validateSnapshot(currentSnapshot)
+        } catch let error as VerifiedPatchValidationError {
+            return .failure(.invalidPatch(error))
+        } catch {
+            return .failure(.invalidPatch(.invalidSnapshot))
+        }
+
+        var prepared: [VerifiedPreparedInverseOperation] = []
+        var aggregateLCSCells = 0
         for operation in patch.operations {
-            if let conflict = apply(operation, files: &transformed) {
-                return .conflicted([conflict])
+            if operation.kind == .rename {
+                return .failure(.unsupportedOperation(
+                    operation.id,
+                    .rename
+                ))
+            }
+            switch prepare(
+                operation,
+                snapshot: currentSnapshot,
+                aggregateLCSCells: &aggregateLCSCells
+            ) {
+            case .success(let value):
+                prepared.append(value)
+            case .failure(let conflict):
+                return .failure(.conflicts([conflict]))
+            }
+        }
+        let workspace = patch.receipt.workspace
+        return .success(PreparedInverse(
+            patch: patch,
+            coordinatorExpectations: VerifiedPatchCoordinatorExpectations(
+                privateWorkspaceID: workspace.privateWorkspaceID,
+                canonicalRootPath: workspace.canonicalRootPath,
+                rootDevice: workspace.rootDevice,
+                rootInode: workspace.rootInode,
+                capturedHeadOID: workspace.capturedHeadOID,
+                capturedIndexSHA256: workspace.capturedIndexSHA256,
+                durableEvents: patch.receipt.durableEventIdentities,
+                mediatedWriterReceipts: patch.receipt
+                    .mediatedWriterReceipts
+            ),
+            operations: prepared
+        ))
+    }
+
+    /// Rechecks exact prepared expectations against a fresh in-memory snapshot.
+    ///
+    /// The final coordinator must still perform the equivalent checks through
+    /// open descriptors and revalidate root/HEAD/index immediately before its
+    /// atomic #1207 transaction.
+    static func applyPrepared(
+        _ prepared: PreparedInverse,
+        currentSnapshot: VerifiedPatchWorkspaceSnapshot
+    ) -> VerifiedCheckedInverseResult {
+        do {
+            try validateSnapshot(currentSnapshot)
+            try validatePrepared(prepared)
+        } catch {
+            return .conflicted([VerifiedPatchConflict(
+                operationID: nil,
+                path: nil,
+                reason: .invalidCurrentSnapshot
+            )])
+        }
+
+        for operation in prepared.operations {
+            for expectation in operation.expectations {
+                guard currentSnapshot.files[expectation.path]
+                        == expectation.state else {
+                    return .conflicted([VerifiedPatchConflict(
+                        operationID: operation.operationID,
+                        path: expectation.path,
+                        reason: .snapshotChangedAfterPreparation
+                    )])
+                }
+            }
+        }
+
+        var transformed = currentSnapshot.files
+        for operation in prepared.operations {
+            for result in operation.results {
+                transformed[result.path] = result.state
             }
         }
         return .applied(
             snapshot: VerifiedPatchWorkspaceSnapshot(files: transformed),
-            previews: previewInverse(patch)
+            previews: prepared.previews
         )
     }
 
-    private static func makeOperation(
-        _ source: VerifiedPatchSourceOperation
-    ) throws -> VerifiedPatchOperation {
-        guard source.eventEnvelopeID != zeroUUID,
-              VerifiedPatchEventBinding.isSafeRelativePath(
-                source.sourcePath
-              ) else {
-            throw VerifiedPatchValidationError.invalidOperation
+    /// Revalidates both authorship and nested journal audit evidence.
+    ///
+    /// Success is still not mutation authority. The caller must continue into
+    /// #1207's descriptor/root/HEAD/index checks and one-shot authority
+    /// consumption. Taking the combined protocol here prevents a
+    /// journal-only receipt from crossing this seam.
+    static func revalidateAuthorityEvidence(
+        _ prepared: PreparedInverse,
+        using revalidator: any PatchAuthorityEvidenceRevalidator
+    ) async throws {
+        try validatePrepared(prepared)
+        let expectations = prepared.coordinatorExpectations
+        guard !expectations.mediatedWriterReceipts.isEmpty else {
+            throw VerifiedPatchValidationError.invalidReceipt
         }
-        guard (source.beforeContent?.count ?? 0)
-                <= maximumContentByteCount,
-              (source.afterContent?.count ?? 0)
-                <= maximumContentByteCount else {
-            throw VerifiedPatchValidationError.contentTooLarge
-        }
-        if let destinationPath = source.destinationPath {
-            guard VerifiedPatchEventBinding.isSafeRelativePath(
-                destinationPath
-            ),
-            destinationPath != source.sourcePath else {
-                throw VerifiedPatchValidationError.invalidPath(
-                    destinationPath
-                )
-            }
-        }
-
-        let before = source.beforeContent.map(VerifiedPatchFileState.init)
-        let after = source.afterContent.map(VerifiedPatchFileState.init)
-        let kind: VerifiedPatchOperationKind
-        switch (
-            source.destinationPath,
-            before != nil,
-            after != nil
-        ) {
-        case (nil, true, true):
-            kind = .modify
-        case (nil, false, true):
-            kind = .create
-        case (nil, true, false):
-            kind = .delete
-        case (.some, true, true):
-            kind = .rename
-        default:
-            throw VerifiedPatchValidationError.invalidOperation
-        }
-        if kind == .modify,
-           before?.identity == after?.identity {
-            throw VerifiedPatchValidationError.invalidOperation
-        }
-
-        let strategy: VerifiedPatchApplicationStrategy
-        if kind == .modify,
-           let beforeContent = source.beforeContent,
-           let afterContent = source.afterContent,
-           VerifiedTextPatch.canDiff(
-            before: beforeContent,
-            after: afterContent
-           ) {
-            let hunks = VerifiedTextPatch.makeHunks(
-                before: beforeContent,
-                after: afterContent
-            )
-            guard !hunks.isEmpty else {
-                throw VerifiedPatchValidationError.invalidOperation
-            }
-            strategy = .text(hunks: hunks)
-        } else {
-            strategy = .exactState
-        }
-
-        return VerifiedPatchOperation(
-            eventEnvelopeID: source.eventEnvelopeID,
-            kind: kind,
-            sourcePath: source.sourcePath,
-            destinationPath: source.destinationPath,
-            before: before,
-            after: after,
-            strategy: strategy
+        try await revalidator.revalidateMediatedWriterReceipts(
+            expectations.mediatedWriterReceipts
+        )
+        try await revalidator.revalidateDurableEvents(
+            expectations.durableEvents
         )
     }
 
-    private static func apply(
+    private static func prepare(
         _ operation: VerifiedPatchOperation,
-        files: inout [String: Data]
-    ) -> VerifiedPatchConflict? {
+        snapshot: VerifiedPatchWorkspaceSnapshot,
+        aggregateLCSCells: inout Int
+    ) -> Result<VerifiedPreparedInverseOperation, VerifiedPatchConflict> {
         switch operation.kind {
         case .modify:
-            return applyModify(operation, files: &files)
+            return prepareModify(
+                operation,
+                snapshot: snapshot,
+                aggregateLCSCells: &aggregateLCSCells
+            )
         case .create:
             guard let after = operation.after else {
-                return conflict(operation, .exactStateDiverged)
+                return .failure(conflict(operation, .exactStateDiverged))
             }
-            guard let current = files[operation.sourcePath] else {
-                return conflict(operation, .expectedFileMissing)
+            guard let current = snapshot.files[operation.sourcePath] else {
+                return .failure(conflict(operation, .expectedFileMissing))
             }
-            guard current == after.content else {
-                return conflict(operation, .exactStateDiverged)
+            guard current == after else {
+                return .failure(conflict(operation, .exactStateDiverged))
             }
-            files.removeValue(forKey: operation.sourcePath)
-            return nil
+            guard let prepared = preparedExact(
+                operation,
+                expectations: [expectation(
+                    operation.sourcePath,
+                    current
+                )],
+                results: [result(operation.sourcePath, nil)]
+            ) else {
+                return .failure(conflict(
+                    operation,
+                    .resourceLimitExceeded
+                ))
+            }
+            return .success(prepared)
         case .delete:
             guard let before = operation.before else {
-                return conflict(operation, .exactStateDiverged)
+                return .failure(conflict(operation, .exactStateDiverged))
             }
-            guard files[operation.sourcePath] == nil else {
-                return conflict(operation, .unexpectedFilePresent)
+            guard snapshot.files[operation.sourcePath] == nil else {
+                return .failure(
+                    conflict(operation, .unexpectedFilePresent)
+                )
             }
-            files[operation.sourcePath] = before.content
-            return nil
+            guard let prepared = preparedExact(
+                operation,
+                expectations: [expectation(operation.sourcePath, nil)],
+                results: [result(operation.sourcePath, before)]
+            ) else {
+                return .failure(conflict(
+                    operation,
+                    .resourceLimitExceeded
+                ))
+            }
+            return .success(prepared)
         case .rename:
-            guard let destinationPath = operation.destinationPath,
-                  let before = operation.before,
-                  let after = operation.after else {
-                return conflict(operation, .exactStateDiverged)
-            }
-            guard files[operation.sourcePath] == nil else {
-                return conflict(operation, .unexpectedFilePresent)
-            }
-            guard let destinationContent = files[destinationPath] else {
-                return conflict(
-                    operation,
-                    .expectedFileMissing,
-                    path: destinationPath
-                )
-            }
-            guard destinationContent == after.content else {
-                return conflict(
-                    operation,
-                    .exactStateDiverged,
-                    path: destinationPath
-                )
-            }
-            files.removeValue(forKey: destinationPath)
-            files[operation.sourcePath] = before.content
-            return nil
+            return .failure(conflict(operation, .exactStateDiverged))
         }
     }
 
-    private static func applyModify(
+    private static func prepareModify(
         _ operation: VerifiedPatchOperation,
-        files: inout [String: Data]
-    ) -> VerifiedPatchConflict? {
+        snapshot: VerifiedPatchWorkspaceSnapshot,
+        aggregateLCSCells: inout Int
+    ) -> Result<VerifiedPreparedInverseOperation, VerifiedPatchConflict> {
         guard let before = operation.before,
               let after = operation.after else {
-            return conflict(operation, .exactStateDiverged)
+            return .failure(conflict(operation, .exactStateDiverged))
         }
-        guard let current = files[operation.sourcePath] else {
-            return conflict(operation, .expectedFileMissing)
+        guard let current = snapshot.files[operation.sourcePath] else {
+            return .failure(conflict(operation, .expectedFileMissing))
         }
-        if current == after.content {
-            files[operation.sourcePath] = before.content
-            return nil
+        guard current.kind == .regularFile else {
+            return .failure(
+                conflict(operation, .unsupportedCurrentFileKind)
+            )
         }
+        if current == after {
+            guard let prepared = preparedExact(
+                operation,
+                expectations: [expectation(
+                    operation.sourcePath,
+                    current
+                )],
+                results: [result(operation.sourcePath, before)]
+            ) else {
+                return .failure(conflict(
+                    operation,
+                    .resourceLimitExceeded
+                ))
+            }
+            return .success(prepared)
+        }
+        guard current.posixMode == after.posixMode else {
+            return .failure(conflict(operation, .exactStateDiverged))
+        }
+        guard case .text(let hunks, _) = operation.strategy,
+              let estimate = VerifiedTextPatch.estimatedLCSCellCount(
+                before: after.content,
+                after: current.content
+              ),
+              let newAggregate = checkedAdd(
+                aggregateLCSCells,
+                estimate
+              ),
+              newAggregate
+                <= VerifiedPatchLimits.maximumAggregateLCSCellCount else {
+            return .failure(conflict(operation, .resourceLimitExceeded))
+        }
+        aggregateLCSCells = newAggregate
 
+        switch VerifiedTextPatch.prepareInverse(
+            hunks: hunks,
+            capturedAfter: after.content,
+            current: current.content
+        ) {
+        case .failure(let reason):
+            return .failure(conflict(operation, reason))
+        case .success(let textResult):
+            let merged = VerifiedPatchFileState(
+                content: textResult.content,
+                kind: .regularFile,
+                posixMode: before.posixMode
+            )
+            let operationPreview = preview(
+                operation,
+                expectedCurrent: current,
+                result: merged,
+                resolvedHunks: textResult.hunks
+            )
+            return .success(VerifiedPreparedInverseOperation(
+                operationID: operation.id,
+                kind: operation.kind,
+                mode: .checkedText,
+                expectations: [expectation(
+                    operation.sourcePath,
+                    current
+                )],
+                results: [result(operation.sourcePath, merged)],
+                resolvedTextHunks: textResult.hunks,
+                preview: operationPreview
+            ))
+        }
+    }
+
+    private static func preparedExact(
+        _ operation: VerifiedPatchOperation,
+        expectations: [VerifiedPreparedPathExpectation],
+        results: [VerifiedPreparedPathResult]
+    ) -> VerifiedPreparedInverseOperation? {
+        let resolvedHunks: [VerifiedPreparedTextHunk]
         switch operation.strategy {
         case .exactState:
-            return conflict(operation, .exactStateDiverged)
-        case .text(let hunks):
-            switch VerifiedTextPatch.applyInverse(
-                hunks: hunks,
-                to: current
-            ) {
-            case .success(let merged):
-                files[operation.sourcePath] = merged
-                return nil
-            case .failure(let reason):
-                return conflict(operation, reason)
+            resolvedHunks = []
+        case .text(let hunks, _):
+            var checkedHunks: [VerifiedPreparedTextHunk] = []
+            for hunk in hunks {
+                guard let end = checkedAdd(
+                    hunk.afterStartLine,
+                    hunk.afterLineCount
+                ) else {
+                    return nil
+                }
+                let range = hunk.afterStartLine..<end
+                checkedHunks.append(VerifiedPreparedTextHunk(
+                    capturedAfterRange: range,
+                    resolvedCurrentRange: range,
+                    replacementLines: hunk.beforeLines
+                ))
             }
+            resolvedHunks = checkedHunks
+        }
+        return VerifiedPreparedInverseOperation(
+            operationID: operation.id,
+            kind: operation.kind,
+            mode: .exactState,
+            expectations: expectations,
+            results: results,
+            resolvedTextHunks: resolvedHunks,
+            preview: preview(
+                operation,
+                expectedCurrent: expectations.first?.state,
+                result: results.first?.state,
+                resolvedHunks: resolvedHunks
+            )
+        )
+    }
+
+    private static func collapse(
+        _ orderedSources: [OrderedSource],
+        patchID: UUID
+    ) throws -> [VerifiedPatchOperation] {
+        let sorted = orderedSources.sorted(by: sourceOrder)
+        var groups: [String: [VerifiedPatchSourceOperation]] = [:]
+        var spellings: [String: String] = [:]
+        for ordered in sorted {
+            let source = ordered.source
+            let key = VerifiedPatchIngressCoordinator.conservativePathKey(
+                source.sourcePath
+            )
+            if let existing = spellings[key],
+               existing != source.sourcePath {
+                throw VerifiedPatchValidationError.aliasedPath(
+                    source.sourcePath
+                )
+            }
+            spellings[key] = source.sourcePath
+            groups[key, default: []].append(source)
+        }
+
+        var operations: [VerifiedPatchOperation] = []
+        var occupiedPathKeys: Set<String> = []
+        var aggregateLCSCells = 0
+        var aggregateHunks = 0
+        for key in groups.keys.sorted() {
+            guard let chain = groups[key],
+                  let first = chain.first,
+                  let last = chain.last else {
+                continue
+            }
+            if chain.contains(where: { $0.destinationPath != nil }) {
+                guard chain.count == 1 else {
+                    throw VerifiedPatchValidationError
+                        .transitionChainMismatch(first.sourcePath)
+                }
+            } else {
+                for index in chain.indices.dropFirst() {
+                    guard chain[index - 1].after == chain[index].before else {
+                        throw VerifiedPatchValidationError
+                            .transitionChainMismatch(first.sourcePath)
+                    }
+                }
+            }
+
+            let before = first.before
+            let after = last.after
+            guard before != after else {
+                throw VerifiedPatchValidationError.invalidOperation(
+                    first.transitionID
+                )
+            }
+            let kind = try operationKind(
+                destinationPath: first.destinationPath,
+                before: before,
+                after: after,
+                transitionID: first.transitionID
+            )
+            var strategy: VerifiedPatchApplicationStrategy = .exactState
+            if kind == .modify,
+               let before,
+               let after,
+               before.content != after.content,
+               let estimate = VerifiedTextPatch.estimatedLCSCellCount(
+                before: before.content,
+                after: after.content
+               ),
+               let estimatedAggregate = checkedAdd(
+                aggregateLCSCells,
+                estimate
+               ),
+               estimatedAggregate
+                <= VerifiedPatchLimits.maximumAggregateLCSCellCount,
+               let plan = VerifiedTextPatch.plan(
+                before: before.content,
+                after: after.content
+               ),
+               let hunkAggregate = checkedAdd(
+                aggregateHunks,
+                plan.hunks.count
+               ),
+               hunkAggregate <= VerifiedPatchLimits.maximumHunkCount {
+                aggregateLCSCells = estimatedAggregate
+                aggregateHunks = hunkAggregate
+                strategy = .text(
+                    hunks: plan.hunks,
+                    lcsCellCount: plan.lcsCellCount
+                )
+            }
+            let operation = VerifiedPatchOperation(
+                id: VerifiedPatchOperationID(
+                    patchID: patchID,
+                    transitionIDs: chain.map(\.transitionID)
+                ),
+                kind: kind,
+                sourcePath: first.sourcePath,
+                destinationPath: first.destinationPath,
+                before: before,
+                after: after,
+                strategy: strategy
+            )
+            for path in operation.touchedPaths {
+                let touchedKey = VerifiedPatchIngressCoordinator
+                    .conservativePathKey(path)
+                guard occupiedPathKeys.insert(touchedKey).inserted else {
+                    throw VerifiedPatchValidationError.aliasedPath(path)
+                }
+            }
+            operations.append(operation)
+        }
+        return operations
+    }
+
+    private static func transitionMap(
+        _ receipt: VerifiedPatchIngressReceipt
+    ) throws -> [VerifiedPatchTransitionID: BoundTransition] {
+        var result: [VerifiedPatchTransitionID: BoundTransition] = [:]
+        for event in receipt.events {
+            for (ordinal, transition) in event.transitions.enumerated() {
+                let id = VerifiedPatchTransitionID(
+                    envelopeID: event.envelope.id,
+                    ordinal: ordinal
+                )
+                guard result[id] == nil else {
+                    throw VerifiedPatchValidationError.duplicateTransition(id)
+                }
+                result[id] = BoundTransition(
+                    cursor: event.envelope.cursorValue,
+                    transition: transition
+                )
+            }
+        }
+        return result
+    }
+
+    private static func validateSource(
+        _ source: VerifiedPatchSourceOperation,
+        bound: VerifiedPatchContentTransition
+    ) throws {
+        guard source.sourcePath == bound.sourcePath,
+              source.destinationPath == bound.destinationPath,
+              source.before?.stateIdentity == bound.before,
+              source.after?.stateIdentity == bound.after else {
+            throw VerifiedPatchValidationError.unboundOperation(
+                source.transitionID
+            )
+        }
+        for state in [source.before, source.after].compactMap({ $0 }) {
+            guard state.kind == .regularFile,
+                  state.posixMode <= 0o7777 else {
+                throw VerifiedPatchValidationError.invalidOperation(
+                    source.transitionID
+                )
+            }
+            guard state.content.count
+                    <= VerifiedPatchLimits.maximumFileByteCount else {
+                throw VerifiedPatchValidationError.contentTooLarge
+            }
+        }
+    }
+
+    static func revalidate(_ patch: VerifiedPatchSet) throws {
+        guard patch.id != zeroUUID,
+              !patch.operations.isEmpty,
+              patch.operations.count
+                <= VerifiedPatchLimits.maximumOperationCount else {
+            throw VerifiedPatchValidationError.invalidPatchID
+        }
+        let receipt = try VerifiedPatchIngressCoordinator.revalidate(
+            patch.receipt
+        )
+        let transitions = try transitionMap(receipt)
+        var transitionIDs: Set<VerifiedPatchTransitionID> = []
+        var pathKeys: Set<String> = []
+        var capturedBytes = 0
+        var hunkCount = 0
+        var lcsCells = 0
+
+        for operation in patch.operations {
+            guard operation.id.patchID == patch.id,
+                  !operation.id.transitionIDs.isEmpty else {
+                throw VerifiedPatchValidationError.invalidOperation(nil)
+            }
+            var priorAfter: VerifiedPatchStateIdentity?
+            var priorCursor: UInt64?
+            var priorOrdinal: Int?
+            for (index, transitionID) in operation.id.transitionIDs
+                .enumerated() {
+                guard transitionIDs.insert(transitionID).inserted,
+                      let bound = transitions[transitionID] else {
+                    throw VerifiedPatchValidationError.unboundOperation(
+                        transitionID
+                    )
+                }
+                if let priorCursor, let priorOrdinal {
+                    guard bound.cursor > priorCursor
+                            || (
+                                bound.cursor == priorCursor
+                                    && transitionID.ordinal > priorOrdinal
+                            ) else {
+                        throw VerifiedPatchValidationError
+                            .transitionChainMismatch(operation.sourcePath)
+                    }
+                }
+                if index == 0 {
+                    guard bound.transition.sourcePath
+                            == operation.sourcePath,
+                          bound.transition.destinationPath
+                            == operation.destinationPath,
+                          bound.transition.before
+                            == operation.before?.stateIdentity else {
+                        throw VerifiedPatchValidationError
+                            .invalidOperation(transitionID)
+                    }
+                } else {
+                    guard bound.transition.sourcePath
+                            == operation.sourcePath,
+                          bound.transition.destinationPath == nil,
+                          bound.transition.before == priorAfter else {
+                        throw VerifiedPatchValidationError
+                            .transitionChainMismatch(operation.sourcePath)
+                    }
+                }
+                priorAfter = bound.transition.after
+                priorCursor = bound.cursor
+                priorOrdinal = transitionID.ordinal
+            }
+            guard priorAfter == operation.after?.stateIdentity,
+                  try operationKind(
+                    destinationPath: operation.destinationPath,
+                    before: operation.before,
+                    after: operation.after,
+                    transitionID: operation.id.transitionIDs[0]
+                  ) == operation.kind else {
+                throw VerifiedPatchValidationError.invalidOperation(
+                    operation.id.transitionIDs[0]
+                )
+            }
+            for path in operation.touchedPaths {
+                guard VerifiedPatchIngressCoordinator
+                    .isAllowedRelativePath(path) else {
+                    throw VerifiedPatchValidationError.invalidPath(path)
+                }
+                let key = VerifiedPatchIngressCoordinator
+                    .conservativePathKey(path)
+                guard pathKeys.insert(key).inserted else {
+                    throw VerifiedPatchValidationError.aliasedPath(path)
+                }
+            }
+            for state in [operation.before, operation.after]
+                .compactMap({ $0 }) {
+                guard state.kind == .regularFile,
+                      state.posixMode <= 0o7777,
+                      state.identity == ContentIdentity(
+                        content: state.content
+                      ),
+                      state.content.count
+                        <= VerifiedPatchLimits.maximumFileByteCount,
+                      let updated = checkedAdd(
+                        capturedBytes,
+                        state.content.count
+                      ),
+                      updated
+                        <= VerifiedPatchLimits.maximumCapturedByteCount else {
+                    throw VerifiedPatchValidationError
+                        .aggregateContentTooLarge
+                }
+                capturedBytes = updated
+            }
+            switch operation.strategy {
+            case .exactState:
+                break
+            case .text(let hunks, let cells):
+                guard operation.kind == .modify,
+                      let before = operation.before,
+                      let after = operation.after,
+                      let recomputed = VerifiedTextPatch.plan(
+                        before: before.content,
+                        after: after.content
+                      ),
+                      recomputed.hunks == hunks,
+                      recomputed.lcsCellCount == cells,
+                      let newHunks = checkedAdd(hunkCount, hunks.count),
+                      newHunks
+                        <= VerifiedPatchLimits.maximumHunkCount,
+                      let newCells = checkedAdd(lcsCells, cells),
+                      newCells <= VerifiedPatchLimits
+                        .maximumAggregateLCSCellCount else {
+                    throw VerifiedPatchValidationError.lcsBudgetExceeded
+                }
+                hunkCount = newHunks
+                lcsCells = newCells
+            }
+        }
+        guard transitionIDs.count == transitions.count else {
+            let unused = transitions.keys.first {
+                !transitionIDs.contains($0)
+            }
+            if let unused {
+                throw VerifiedPatchValidationError.unusedTransition(unused)
+            }
+            throw VerifiedPatchValidationError.invalidReceipt
+        }
+        guard patch.operations == patch.operations.sorted(
+            by: operationOrder
+        ) else {
+            throw VerifiedPatchValidationError.invalidOperation(nil)
+        }
+    }
+
+    private static func validateSnapshot(
+        _ snapshot: VerifiedPatchWorkspaceSnapshot
+    ) throws {
+        guard snapshot.files.count
+                <= VerifiedPatchLimits.maximumSnapshotFileCount else {
+            throw VerifiedPatchValidationError.invalidSnapshot
+        }
+        var byteCount = 0
+        var pathByteCount = 0
+        var keys: Set<String> = []
+        for (path, state) in snapshot.files {
+            guard VerifiedPatchIngressCoordinator
+                    .isAllowedRelativePath(path),
+                  state.posixMode <= 0o7777,
+                  state.content.count
+                    <= VerifiedPatchLimits.maximumFileByteCount,
+                  state.identity == ContentIdentity(
+                    content: state.content
+                  ),
+                  let newBytes = checkedAdd(
+                    byteCount,
+                    state.content.count
+                  ),
+                  newBytes
+                    <= VerifiedPatchLimits.maximumSnapshotByteCount,
+                  let newPathBytes = checkedAdd(
+                    pathByteCount,
+                    path.utf8.count
+                  ),
+                  newPathBytes <= VerifiedPatchLimits
+                    .maximumSnapshotPathByteCount else {
+                throw VerifiedPatchValidationError.invalidSnapshot
+            }
+            let key = VerifiedPatchIngressCoordinator
+                .conservativePathKey(path)
+            guard keys.insert(key).inserted else {
+                throw VerifiedPatchValidationError.aliasedPath(path)
+            }
+            byteCount = newBytes
+            pathByteCount = newPathBytes
+        }
+    }
+
+    private static func validatePrepared(
+        _ prepared: PreparedInverse
+    ) throws {
+        try revalidate(prepared.patch)
+        let workspace = prepared.patch.receipt.workspace
+        let expectedCoordinator = VerifiedPatchCoordinatorExpectations(
+            privateWorkspaceID: workspace.privateWorkspaceID,
+            canonicalRootPath: workspace.canonicalRootPath,
+            rootDevice: workspace.rootDevice,
+            rootInode: workspace.rootInode,
+            capturedHeadOID: workspace.capturedHeadOID,
+            capturedIndexSHA256: workspace.capturedIndexSHA256,
+            durableEvents: prepared.patch.receipt.durableEventIdentities,
+            mediatedWriterReceipts: prepared.patch.receipt
+                .mediatedWriterReceipts
+        )
+        guard prepared.patchID != zeroUUID,
+              prepared.coordinatorExpectations == expectedCoordinator,
+              !prepared.operations.isEmpty,
+              prepared.operations.count
+                <= VerifiedPatchLimits.maximumOperationCount,
+              prepared.previews == prepared.operations.map(\.preview),
+              VerifiedPatchIngressCoordinator.isValidWorkspace(
+                VerifiedPatchWorkspaceIdentity(
+                    privateWorkspaceID: prepared
+                        .coordinatorExpectations.privateWorkspaceID,
+                    canonicalRootPath: prepared
+                        .coordinatorExpectations.canonicalRootPath,
+                    rootDevice: prepared
+                        .coordinatorExpectations.rootDevice,
+                    rootInode: prepared
+                        .coordinatorExpectations.rootInode,
+                    capturedHeadOID: prepared
+                        .coordinatorExpectations.capturedHeadOID,
+                    capturedIndexSHA256: prepared
+                        .coordinatorExpectations.capturedIndexSHA256
+                )
+              ),
+              validateDurableExpectations(
+                prepared.coordinatorExpectations.durableEvents,
+                workspace: prepared.coordinatorExpectations
+              ) else {
+            throw VerifiedPatchValidationError.invalidOperation(nil)
+        }
+        var operationIDs: Set<VerifiedPatchOperationID> = []
+        var pathKeys: Set<String> = []
+        var expectationFiles: [String: VerifiedPatchFileState] = [:]
+        for operation in prepared.operations {
+            guard operation.operationID.patchID == prepared.patchID,
+                  operationIDs.insert(operation.operationID).inserted,
+                  operation.kind != .rename else {
+                throw VerifiedPatchValidationError.invalidOperation(nil)
+            }
+            for expectation in operation.expectations {
+                try validatePreparedPath(
+                    expectation.path,
+                    state: expectation.state,
+                    keys: &pathKeys
+                )
+                if let state = expectation.state {
+                    expectationFiles[expectation.path] = state
+                }
+            }
+            for result in operation.results {
+                guard VerifiedPatchIngressCoordinator
+                    .isAllowedRelativePath(result.path) else {
+                    throw VerifiedPatchValidationError
+                        .invalidPath(result.path)
+                }
+                if let state = result.state {
+                    try validatePreparedState(state)
+                }
+            }
+        }
+        let regenerated = prepareCheckedInverse(
+            prepared.patch,
+            currentSnapshot: VerifiedPatchWorkspaceSnapshot(
+                files: expectationFiles
+            )
+        )
+        guard case .success(let expected) = regenerated,
+              expected == prepared else {
+            throw VerifiedPatchValidationError.invalidOperation(nil)
+        }
+    }
+
+    private static func validateDurableExpectations(
+        _ events: [VerifiedPatchDurableEventIdentity],
+        workspace: VerifiedPatchCoordinatorExpectations
+    ) -> Bool {
+        guard !events.isEmpty,
+              events.count <= VerifiedPatchLimits.maximumEventCount,
+              let first = events.first else {
+            return false
+        }
+        var envelopeIDs: Set<UUID> = []
+        var journalSequences: Set<UInt64> = []
+        for (index, event) in events.enumerated() {
+            guard event.projectID == first.projectID,
+                  event.canonicalWorktreePath
+                    == workspace.canonicalRootPath,
+                  event.sessionID == first.sessionID,
+                  event.terminalID == first.terminalID,
+                  event.processGeneration == first.processGeneration,
+                  event.eventCursor > 0,
+                  event.envelopeID != zeroUUID,
+                  event.journalSequence > 0,
+                  envelopeIDs.insert(event.envelopeID).inserted,
+                  journalSequences.insert(
+                    event.journalSequence
+                  ).inserted else {
+                return false
+            }
+            guard index > 0 else { continue }
+            let previous = events[index - 1]
+            guard previous.eventCursor < UInt64.max,
+                  event.eventCursor == previous.eventCursor + 1,
+                  event.journalSequence > previous.journalSequence else {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func validatePreparedPath(
+        _ path: String,
+        state: VerifiedPatchFileState?,
+        keys: inout Set<String>
+    ) throws {
+        guard VerifiedPatchIngressCoordinator.isAllowedRelativePath(path),
+              keys.insert(
+                VerifiedPatchIngressCoordinator.conservativePathKey(path)
+              ).inserted else {
+            throw VerifiedPatchValidationError.aliasedPath(path)
+        }
+        if let state {
+            try validatePreparedState(state)
+        }
+    }
+
+    private static func validatePreparedState(
+        _ state: VerifiedPatchFileState
+    ) throws {
+        guard state.kind == .regularFile,
+              state.posixMode <= 0o7777,
+              state.content.count
+                <= VerifiedPatchLimits.maximumFileByteCount,
+              state.identity == ContentIdentity(content: state.content) else {
+            throw VerifiedPatchValidationError.invalidOperation(nil)
+        }
+    }
+
+    private static func operationKind(
+        destinationPath: String?,
+        before: VerifiedPatchFileState?,
+        after: VerifiedPatchFileState?,
+        transitionID: VerifiedPatchTransitionID
+    ) throws -> VerifiedPatchOperationKind {
+        return switch (destinationPath, before != nil, after != nil) {
+        case (nil, true, true): .modify
+        case (nil, false, true): .create
+        case (nil, true, false): .delete
+        case (.some, true, true): .rename
+        default:
+            throw VerifiedPatchValidationError.invalidOperation(
+                transitionID
+            )
         }
     }
 
     private static func preview(
-        _ hunk: VerifiedTextPatchHunk
+        _ operation: VerifiedPatchOperation,
+        expectedCurrent: VerifiedPatchFileState?,
+        result: VerifiedPatchFileState?,
+        resolvedHunks: [VerifiedPreparedTextHunk]?
+    ) -> VerifiedInverseOperationPreview {
+        let previewKind: VerifiedInversePreviewKind = switch operation.kind {
+        case .modify:
+            if case .text = operation.strategy {
+                .applyTextHunks
+            } else {
+                .restoreExactFile
+            }
+        case .create: .removeCreatedFile
+        case .delete: .restoreDeletedFile
+        case .rename: .simulateRenamedFile
+        }
+        let hunkPreviews: [VerifiedInverseHunkPreview]
+        switch operation.strategy {
+        case .exactState:
+            hunkPreviews = []
+        case .text(let hunks, _):
+            hunkPreviews = hunks.enumerated().map { index, hunk in
+                hunkPreview(
+                    hunk,
+                    resolved: resolvedHunks?[safe: index]
+                )
+            }
+        }
+        return VerifiedInverseOperationPreview(
+            operationID: operation.id,
+            kind: previewKind,
+            sourcePath: operation.sourcePath,
+            destinationPath: operation.destinationPath,
+            expectedCurrent: expectedCurrent?.stateIdentity,
+            result: result?.stateIdentity,
+            hunks: hunkPreviews
+        )
+    }
+
+    private static func hunkPreview(
+        _ hunk: VerifiedTextPatchHunk,
+        resolved: VerifiedPreparedTextHunk?
     ) -> VerifiedInverseHunkPreview {
         var lines: [VerifiedInversePreviewLine] = []
         lines.append(contentsOf: hunk.prefixContext.map {
@@ -322,11 +1438,29 @@ nonisolated enum VerifiedPatchEngine {
         lines.append(contentsOf: hunk.suffixContext.map {
             VerifiedInversePreviewLine(kind: .context, bytes: $0)
         })
+        let currentStart = resolved?.resolvedCurrentRange.lowerBound
+        let headerStart = (currentStart ?? hunk.afterStartLine) + 1
         return VerifiedInverseHunkPreview(
-            header: "@@ -\(hunk.afterStartLine + 1),\(hunk.afterLineCount) "
-                + "+\(hunk.beforeStartLine + 1),\(hunk.beforeLineCount) @@",
+            capturedAfterStartLine: hunk.afterStartLine,
+            resolvedCurrentStartLine: currentStart,
+            header: "@@ -\(headerStart),\(hunk.afterLineCount) "
+                + "+\(headerStart),\(hunk.beforeLineCount) @@",
             lines: lines
         )
+    }
+
+    private static func expectation(
+        _ path: String,
+        _ state: VerifiedPatchFileState?
+    ) -> VerifiedPreparedPathExpectation {
+        VerifiedPreparedPathExpectation(path: path, state: state)
+    }
+
+    private static func result(
+        _ path: String,
+        _ state: VerifiedPatchFileState?
+    ) -> VerifiedPreparedPathResult {
+        VerifiedPreparedPathResult(path: path, state: state)
     }
 
     private static func conflict(
@@ -335,7 +1469,7 @@ nonisolated enum VerifiedPatchEngine {
         path: String? = nil
     ) -> VerifiedPatchConflict {
         VerifiedPatchConflict(
-            operationKey: operation.operationKey,
+            operationID: operation.id,
             path: path ?? operation.sourcePath,
             reason: reason
         )
@@ -348,19 +1482,64 @@ nonisolated enum VerifiedPatchEngine {
         if lhs.sourcePath != rhs.sourcePath {
             return lhs.sourcePath < rhs.sourcePath
         }
-        if lhs.destinationPath != rhs.destinationPath {
-            return (lhs.destinationPath ?? "") < (rhs.destinationPath ?? "")
+        let lhsDestination = lhs.destinationPath ?? ""
+        let rhsDestination = rhs.destinationPath ?? ""
+        if lhsDestination != rhsDestination {
+            return lhsDestination < rhsDestination
         }
-        return lhs.eventEnvelopeID.uuidString
-            < rhs.eventEnvelopeID.uuidString
+        return transitionIDOrder(
+            lhs.id.transitionIDs[0],
+            rhs.id.transitionIDs[0]
+        )
     }
 
-    private struct BoundTransition: Hashable {
-        let envelopeID: UUID
+    private static func sourceOrder(
+        _ lhs: OrderedSource,
+        _ rhs: OrderedSource
+    ) -> Bool {
+        if lhs.cursor != rhs.cursor {
+            return lhs.cursor < rhs.cursor
+        }
+        return lhs.source.transitionID.ordinal
+            < rhs.source.transitionID.ordinal
+    }
+
+    private static func transitionIDOrder(
+        _ lhs: VerifiedPatchTransitionID,
+        _ rhs: VerifiedPatchTransitionID
+    ) -> Bool {
+        if lhs.envelopeID != rhs.envelopeID {
+            return lhs.envelopeID.uuidString < rhs.envelopeID.uuidString
+        }
+        return lhs.ordinal < rhs.ordinal
+    }
+
+    private struct BoundTransition {
+        let cursor: UInt64
         let transition: VerifiedPatchContentTransition
     }
 
-    private static let zeroUUID = UUID(
-        uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-    )
+    private struct OrderedSource {
+        let cursor: UInt64
+        let source: VerifiedPatchSourceOperation
+    }
+
 }
+
+nonisolated private extension Collection {
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}
+
+nonisolated private func checkedAdd(
+    _ lhs: Int,
+    _ rhs: Int
+) -> Int? {
+    let result = lhs.addingReportingOverflow(rhs)
+    return result.overflow ? nil : result.partialValue
+}
+
+nonisolated private let zeroUUID = UUID(
+    uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+)

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchEngine.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchEngine.swift
@@ -1,0 +1,366 @@
+//
+//  VerifiedPatchEngine.swift
+//  Pine
+//
+//  Pure construction, preview, and checked inverse application for #933.
+//
+
+import Foundation
+
+/// Deterministic, side-effect-free verified patch engine.
+///
+/// The engine never reads or writes a working tree. Callers provide captured
+/// bytes and an in-memory current snapshot; success returns a new snapshot.
+/// Any conflict returns no partially transformed state.
+nonisolated enum VerifiedPatchEngine {
+    private static let maximumOperationCount = 1_024
+    private static let maximumContentByteCount = 16 * 1_024 * 1_024
+
+    static func makePatch(
+        id: UUID,
+        binding: VerifiedPatchEventBinding,
+        operations sourceOperations: [VerifiedPatchSourceOperation]
+    ) throws -> VerifiedPatchSet {
+        guard id != zeroUUID else {
+            throw VerifiedPatchValidationError.invalidPatchID
+        }
+        guard !sourceOperations.isEmpty,
+              sourceOperations.count <= maximumOperationCount else {
+            throw VerifiedPatchValidationError.noOperations
+        }
+
+        var boundTransitions: [BoundTransition: Int] = [:]
+        for event in binding.events {
+            for transition in event.transitions {
+                let key = BoundTransition(
+                    envelopeID: event.envelopeID,
+                    transition: transition
+                )
+                boundTransitions[key, default: 0] += 1
+                guard boundTransitions[key] == 1 else {
+                    throw VerifiedPatchValidationError
+                        .duplicateBoundTransition
+                }
+            }
+        }
+
+        var operations: [VerifiedPatchOperation] = []
+        var touchedPaths: Set<String> = []
+        for source in sourceOperations {
+            let operation = try makeOperation(source)
+            for path in operation.touchedPaths {
+                guard touchedPaths.insert(path).inserted else {
+                    throw VerifiedPatchValidationError
+                        .duplicateTouchedPath(path)
+                }
+            }
+
+            let bound = BoundTransition(
+                envelopeID: operation.eventEnvelopeID,
+                transition: operation.transition
+            )
+            guard let count = boundTransitions[bound],
+                  count == 1 else {
+                throw VerifiedPatchValidationError.unboundOperation
+            }
+            boundTransitions[bound] = 0
+            operations.append(operation)
+        }
+
+        guard boundTransitions.values.allSatisfy({ $0 == 0 }) else {
+            throw VerifiedPatchValidationError.unusedBoundTransition
+        }
+        operations.sort(by: operationOrder)
+        return VerifiedPatchSet(
+            id: id,
+            binding: binding,
+            operations: operations
+        )
+    }
+
+    /// Returns one structured preview for every operation, in deterministic
+    /// patch order.
+    static func previewInverse(
+        _ patch: VerifiedPatchSet
+    ) -> [VerifiedInverseOperationPreview] {
+        patch.operations.map { operation in
+            let previewKind: VerifiedInversePreviewKind
+            switch operation.kind {
+            case .modify:
+                if case .text = operation.strategy {
+                    previewKind = .applyTextHunks
+                } else {
+                    previewKind = .restoreExactBytes
+                }
+            case .create:
+                previewKind = .removeCreatedFile
+            case .delete:
+                previewKind = .restoreDeletedFile
+            case .rename:
+                previewKind = .restoreRenamedFile
+            }
+            let hunkPreviews: [VerifiedInverseHunkPreview]
+            switch operation.strategy {
+            case .text(let hunks):
+                hunkPreviews = hunks.map(preview)
+            case .exactState:
+                hunkPreviews = []
+            }
+            return VerifiedInverseOperationPreview(
+                operationKey: operation.operationKey,
+                eventEnvelopeID: operation.eventEnvelopeID,
+                kind: previewKind,
+                sourcePath: operation.sourcePath,
+                destinationPath: operation.destinationPath,
+                expectedCurrentIdentity: operation.after?.identity,
+                resultIdentity: operation.before?.identity,
+                hunks: hunkPreviews
+            )
+        }
+    }
+
+    static func applyCheckedInverse(
+        _ patch: VerifiedPatchSet,
+        to snapshot: VerifiedPatchWorkspaceSnapshot
+    ) -> VerifiedCheckedInverseResult {
+        var transformed = snapshot.files
+        for operation in patch.operations {
+            if let conflict = apply(operation, files: &transformed) {
+                return .conflicted([conflict])
+            }
+        }
+        return .applied(
+            snapshot: VerifiedPatchWorkspaceSnapshot(files: transformed),
+            previews: previewInverse(patch)
+        )
+    }
+
+    private static func makeOperation(
+        _ source: VerifiedPatchSourceOperation
+    ) throws -> VerifiedPatchOperation {
+        guard source.eventEnvelopeID != zeroUUID,
+              VerifiedPatchEventBinding.isSafeRelativePath(
+                source.sourcePath
+              ) else {
+            throw VerifiedPatchValidationError.invalidOperation
+        }
+        guard (source.beforeContent?.count ?? 0)
+                <= maximumContentByteCount,
+              (source.afterContent?.count ?? 0)
+                <= maximumContentByteCount else {
+            throw VerifiedPatchValidationError.contentTooLarge
+        }
+        if let destinationPath = source.destinationPath {
+            guard VerifiedPatchEventBinding.isSafeRelativePath(
+                destinationPath
+            ),
+            destinationPath != source.sourcePath else {
+                throw VerifiedPatchValidationError.invalidPath(
+                    destinationPath
+                )
+            }
+        }
+
+        let before = source.beforeContent.map(VerifiedPatchFileState.init)
+        let after = source.afterContent.map(VerifiedPatchFileState.init)
+        let kind: VerifiedPatchOperationKind
+        switch (
+            source.destinationPath,
+            before != nil,
+            after != nil
+        ) {
+        case (nil, true, true):
+            kind = .modify
+        case (nil, false, true):
+            kind = .create
+        case (nil, true, false):
+            kind = .delete
+        case (.some, true, true):
+            kind = .rename
+        default:
+            throw VerifiedPatchValidationError.invalidOperation
+        }
+        if kind == .modify,
+           before?.identity == after?.identity {
+            throw VerifiedPatchValidationError.invalidOperation
+        }
+
+        let strategy: VerifiedPatchApplicationStrategy
+        if kind == .modify,
+           let beforeContent = source.beforeContent,
+           let afterContent = source.afterContent,
+           VerifiedTextPatch.canDiff(
+            before: beforeContent,
+            after: afterContent
+           ) {
+            let hunks = VerifiedTextPatch.makeHunks(
+                before: beforeContent,
+                after: afterContent
+            )
+            guard !hunks.isEmpty else {
+                throw VerifiedPatchValidationError.invalidOperation
+            }
+            strategy = .text(hunks: hunks)
+        } else {
+            strategy = .exactState
+        }
+
+        return VerifiedPatchOperation(
+            eventEnvelopeID: source.eventEnvelopeID,
+            kind: kind,
+            sourcePath: source.sourcePath,
+            destinationPath: source.destinationPath,
+            before: before,
+            after: after,
+            strategy: strategy
+        )
+    }
+
+    private static func apply(
+        _ operation: VerifiedPatchOperation,
+        files: inout [String: Data]
+    ) -> VerifiedPatchConflict? {
+        switch operation.kind {
+        case .modify:
+            return applyModify(operation, files: &files)
+        case .create:
+            guard let after = operation.after else {
+                return conflict(operation, .exactStateDiverged)
+            }
+            guard let current = files[operation.sourcePath] else {
+                return conflict(operation, .expectedFileMissing)
+            }
+            guard current == after.content else {
+                return conflict(operation, .exactStateDiverged)
+            }
+            files.removeValue(forKey: operation.sourcePath)
+            return nil
+        case .delete:
+            guard let before = operation.before else {
+                return conflict(operation, .exactStateDiverged)
+            }
+            guard files[operation.sourcePath] == nil else {
+                return conflict(operation, .unexpectedFilePresent)
+            }
+            files[operation.sourcePath] = before.content
+            return nil
+        case .rename:
+            guard let destinationPath = operation.destinationPath,
+                  let before = operation.before,
+                  let after = operation.after else {
+                return conflict(operation, .exactStateDiverged)
+            }
+            guard files[operation.sourcePath] == nil else {
+                return conflict(operation, .unexpectedFilePresent)
+            }
+            guard let destinationContent = files[destinationPath] else {
+                return conflict(
+                    operation,
+                    .expectedFileMissing,
+                    path: destinationPath
+                )
+            }
+            guard destinationContent == after.content else {
+                return conflict(
+                    operation,
+                    .exactStateDiverged,
+                    path: destinationPath
+                )
+            }
+            files.removeValue(forKey: destinationPath)
+            files[operation.sourcePath] = before.content
+            return nil
+        }
+    }
+
+    private static func applyModify(
+        _ operation: VerifiedPatchOperation,
+        files: inout [String: Data]
+    ) -> VerifiedPatchConflict? {
+        guard let before = operation.before,
+              let after = operation.after else {
+            return conflict(operation, .exactStateDiverged)
+        }
+        guard let current = files[operation.sourcePath] else {
+            return conflict(operation, .expectedFileMissing)
+        }
+        if current == after.content {
+            files[operation.sourcePath] = before.content
+            return nil
+        }
+
+        switch operation.strategy {
+        case .exactState:
+            return conflict(operation, .exactStateDiverged)
+        case .text(let hunks):
+            switch VerifiedTextPatch.applyInverse(
+                hunks: hunks,
+                to: current
+            ) {
+            case .success(let merged):
+                files[operation.sourcePath] = merged
+                return nil
+            case .failure(let reason):
+                return conflict(operation, reason)
+            }
+        }
+    }
+
+    private static func preview(
+        _ hunk: VerifiedTextPatchHunk
+    ) -> VerifiedInverseHunkPreview {
+        var lines: [VerifiedInversePreviewLine] = []
+        lines.append(contentsOf: hunk.prefixContext.map {
+            VerifiedInversePreviewLine(kind: .context, bytes: $0)
+        })
+        lines.append(contentsOf: hunk.afterLines.map {
+            VerifiedInversePreviewLine(kind: .remove, bytes: $0)
+        })
+        lines.append(contentsOf: hunk.beforeLines.map {
+            VerifiedInversePreviewLine(kind: .add, bytes: $0)
+        })
+        lines.append(contentsOf: hunk.suffixContext.map {
+            VerifiedInversePreviewLine(kind: .context, bytes: $0)
+        })
+        return VerifiedInverseHunkPreview(
+            header: "@@ -\(hunk.afterStartLine + 1),\(hunk.afterLineCount) "
+                + "+\(hunk.beforeStartLine + 1),\(hunk.beforeLineCount) @@",
+            lines: lines
+        )
+    }
+
+    private static func conflict(
+        _ operation: VerifiedPatchOperation,
+        _ reason: VerifiedPatchConflictReason,
+        path: String? = nil
+    ) -> VerifiedPatchConflict {
+        VerifiedPatchConflict(
+            operationKey: operation.operationKey,
+            path: path ?? operation.sourcePath,
+            reason: reason
+        )
+    }
+
+    private static func operationOrder(
+        _ lhs: VerifiedPatchOperation,
+        _ rhs: VerifiedPatchOperation
+    ) -> Bool {
+        if lhs.sourcePath != rhs.sourcePath {
+            return lhs.sourcePath < rhs.sourcePath
+        }
+        if lhs.destinationPath != rhs.destinationPath {
+            return (lhs.destinationPath ?? "") < (rhs.destinationPath ?? "")
+        }
+        return lhs.eventEnvelopeID.uuidString
+            < rhs.eventEnvelopeID.uuidString
+    }
+
+    private struct BoundTransition: Hashable {
+        let envelopeID: UUID
+        let transition: VerifiedPatchContentTransition
+    }
+
+    private static let zeroUUID = UUID(
+        uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    )
+}

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchModels.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchModels.swift
@@ -39,8 +39,10 @@ nonisolated enum VerifiedPatchLimits {
     static let maximumAggregateMappingCellCount = 8_000_000
     static let maximumHunkCount = 1_024
     static let maximumPathByteCount = 4_096
+    static let maximumPreviewLineCountPerHunk = 2 * maximumLineCount + 4
     static let maximumPreparedHunkByteCount = 64 * 1_024 * 1_024
     static let maximumPreparedLineReferenceCount = 2_097_152
+    static let maximumLineComparisonByteCount = 32 * 1_024 * 1_024
 }
 
 /// Canonical owner-private workspace identity supplied by an ingress receipt.

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchModels.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchModels.swift
@@ -17,7 +17,15 @@ nonisolated enum VerifiedPatchLimits {
     static let maximumTransitionCount = 1_024
     static let maximumOperationCount = 256
     static let maximumVersionPatchCount = 128
+    static let maximumVersionOperationCount = 1_024
     static let maximumVersionNodeCount = 1_024
+    static let maximumVersionEventCount = 4_096
+    static let maximumVersionTransitionCount = 4_096
+    static let maximumVersionCapturedByteCount = 64 * 1_024 * 1_024
+    static let maximumVersionPathByteCount = 4 * 1_024 * 1_024
+    static let maximumVersionEventMetadataByteCount = 4 * 1_024 * 1_024
+    static let maximumVersionLCSCellCount = 8_000_000
+    static let maximumVersionHunkCount = 4_096
     static let maximumFileByteCount = 4 * 1_024 * 1_024
     static let maximumCapturedByteCount = 16 * 1_024 * 1_024
     static let maximumSnapshotFileCount = 4_096
@@ -28,6 +36,7 @@ nonisolated enum VerifiedPatchLimits {
     static let maximumLineCount = 4_096
     static let maximumLCSCellCountPerDiff = 2_000_000
     static let maximumAggregateLCSCellCount = 8_000_000
+    static let maximumAggregateMappingCellCount = 8_000_000
     static let maximumHunkCount = 1_024
     static let maximumPathByteCount = 4_096
 }
@@ -402,6 +411,7 @@ nonisolated enum VerifiedPatchConflictReason: Error, Sendable, Equatable {
     case unsupportedCurrentFileKind
     case currentContentIsNotText
     case humanEditOverlapsAgentRegion(hunkIndex: Int)
+    case ambiguousCurrentMapping(hunkIndex: Int)
     case mappedRegionMismatch(hunkIndex: Int)
     case overlappingResolvedHunks
     case snapshotChangedAfterPreparation

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchModels.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchModels.swift
@@ -2,200 +2,288 @@
 //  VerifiedPatchModels.swift
 //  Pine
 //
-//  Pure, owner-private patch contracts for verified agent events (#933).
-//  These values perform no file-system I/O and grant no mutation authority.
+//  Bounded, pure simulation contracts for verified-change review (#933).
 //
 
 import Foundation
 
-/// One exact content transition reported by a verified event.
+/// Aggregate limits applied at every construction and preparation boundary.
 ///
-/// The transition contains identities only. Patch bytes are supplied
-/// separately to `VerifiedPatchEngine.makePatch` and must match these values.
-nonisolated struct VerifiedPatchContentTransition: Sendable, Equatable, Hashable {
+/// These are correctness limits, not tuning hints. Inputs above a limit fail
+/// closed before allocating a quadratic table or retaining attacker-sized
+/// content. The final descriptor transaction remains owned by #1207.
+nonisolated enum VerifiedPatchLimits {
+    static let maximumEventCount = 512
+    static let maximumTransitionCount = 1_024
+    static let maximumOperationCount = 256
+    static let maximumVersionPatchCount = 128
+    static let maximumVersionNodeCount = 1_024
+    static let maximumFileByteCount = 4 * 1_024 * 1_024
+    static let maximumCapturedByteCount = 16 * 1_024 * 1_024
+    static let maximumSnapshotFileCount = 4_096
+    static let maximumSnapshotByteCount = 32 * 1_024 * 1_024
+    static let maximumSnapshotPathByteCount = 4 * 1_024 * 1_024
+    static let maximumEventMetadataByteCount = 64 * 1_024
+    static let maximumAggregateEventMetadataByteCount = 1 * 1_024 * 1_024
+    static let maximumLineCount = 4_096
+    static let maximumLCSCellCountPerDiff = 2_000_000
+    static let maximumAggregateLCSCellCount = 8_000_000
+    static let maximumHunkCount = 1_024
+    static let maximumPathByteCount = 4_096
+}
+
+/// Canonical owner-private workspace identity supplied by an ingress receipt.
+///
+/// This value is still data, not authority. A final #1207 coordinator must
+/// load it from the owner-private store and recheck root device/inode, HEAD,
+/// and index state through its descriptor transaction.
+nonisolated struct VerifiedPatchWorkspaceIdentity:
+    Sendable,
+    Equatable,
+    Hashable {
+    let privateWorkspaceID: UUID
+    let canonicalRootPath: String
+    let rootDevice: UInt64
+    let rootInode: UInt64
+    let capturedHeadOID: String
+    let capturedIndexSHA256: String
+}
+
+nonisolated enum VerifiedPatchFileKind: String, Sendable, Equatable, Hashable {
+    case regularFile
+    case symbolicLink
+}
+
+/// File bytes plus regular-file metadata used by the pure simulator.
+///
+/// The initializer always recomputes the content identity, so an identity
+/// cannot be paired with different bytes inside this model.
+nonisolated struct VerifiedPatchFileState: Sendable, Equatable {
+    let identity: ContentIdentity
+    let kind: VerifiedPatchFileKind
+    let posixMode: UInt16
+    let content: Data
+
+    init(
+        content: Data,
+        kind: VerifiedPatchFileKind = .regularFile,
+        posixMode: UInt16 = 0o644
+    ) {
+        self.identity = ContentIdentity(content: content)
+        self.kind = kind
+        self.posixMode = posixMode
+        self.content = content
+    }
+
+    var stateIdentity: VerifiedPatchStateIdentity {
+        VerifiedPatchStateIdentity(
+            contentIdentity: identity,
+            kind: kind,
+            posixMode: posixMode
+        )
+    }
+}
+
+/// Content plus metadata identity retained in accepted transition receipts.
+nonisolated struct VerifiedPatchStateIdentity:
+    Sendable,
+    Equatable,
+    Hashable {
+    let contentIdentity: ContentIdentity
+    let kind: VerifiedPatchFileKind
+    let posixMode: UInt16
+}
+
+/// One transition asserted by owner-private capture evidence.
+nonisolated struct VerifiedPatchContentTransition:
+    Sendable,
+    Equatable,
+    Hashable {
     let sourcePath: String
     let destinationPath: String?
-    let beforeIdentity: ContentIdentity?
-    let afterIdentity: ContentIdentity?
+    let before: VerifiedPatchStateIdentity?
+    let after: VerifiedPatchStateIdentity?
 
     init(
         sourcePath: String,
         destinationPath: String? = nil,
-        beforeIdentity: ContentIdentity?,
-        afterIdentity: ContentIdentity?
+        before: VerifiedPatchStateIdentity?,
+        after: VerifiedPatchStateIdentity?
     ) {
         self.sourcePath = sourcePath
         self.destinationPath = destinationPath
-        self.beforeIdentity = beforeIdentity
-        self.afterIdentity = afterIdentity
+        self.before = before
+        self.after = after
     }
 }
 
-/// A verified envelope and the exact file transitions it carries.
-nonisolated struct VerifiedPatchEventReference: Sendable, Equatable {
+/// Collision-free address of one transition in one full event envelope.
+nonisolated struct VerifiedPatchTransitionID:
+    Sendable,
+    Equatable,
+    Hashable {
     let envelopeID: UUID
-    let cursorValue: UInt64
+    let ordinal: Int
+}
+
+/// Durable journal evidence adapted from `AgentEventJournalReceipt`.
+///
+/// The surrounding scope is repeated deliberately. Ingress must prove that
+/// the compact journal receipt belongs to this exact envelope and stream; the
+/// final authority coordinator must query the owner-private journal again
+/// using every field before it may consume #1207 authority.
+nonisolated struct VerifiedPatchDurableEventIdentity:
+    Sendable,
+    Equatable,
+    Hashable {
+    let projectID: UUID
+    let canonicalWorktreePath: String
+    let sessionID: UUID
+    let terminalID: UUID
+    let processGeneration: UInt64
+    let eventCursor: UInt64
+    let envelopeID: UUID
+    let journalSequence: UInt64
+}
+
+/// Owner-private journal seam used by the future authority coordinator.
+///
+/// A conformer must query durable records and compare the complete envelope,
+/// not merely confirm that a sequence number exists.
+nonisolated protocol VerifiedPatchJournalRevalidating: Sendable {
+    func revalidateDurableEvents(
+        _ identities: [VerifiedPatchDurableEventIdentity]
+    ) async throws
+}
+
+/// Owner-private proof that Pine itself applied this exact transition batch.
+///
+/// This is intentionally separate from authenticated agent-event evidence.
+/// The nested durable event is audit context only: file authorship/preimages
+/// come from a Pine-owned descriptor CAS performed after explicit user
+/// approval. Constructed values are still untrusted until the final
+/// coordinator revalidates them against its private writer-receipt store.
+nonisolated struct PineMediatedWriterReceipt: Sendable, Equatable, Hashable {
+    let receiptID: UUID
+    let userApprovalID: UUID
+    let descriptorTransactionID: UUID
+    let descriptorCASSequence: UInt64
+    let workspace: VerifiedPatchWorkspaceIdentity
+    let auditEvent: VerifiedPatchDurableEventIdentity
     let transitions: [VerifiedPatchContentTransition]
 }
 
-/// Complete provenance scope for one patch.
+/// Store seam that establishes mutation authorship for a prepared inverse.
 ///
-/// Events are normalized into cursor order and must form one contiguous,
-/// replay-free range. A future live bridge creates this value only after the
-/// corresponding envelopes have been durably accepted by the provenance
-/// store.
-nonisolated struct VerifiedPatchEventBinding: Sendable, Equatable {
-    let projectID: UUID
-    let worktreePath: String
-    let sessionID: UUID
-    let process: AgentProcessIdentity
-    let events: [VerifiedPatchEventReference]
-
-    var envelopeIDs: [UUID] { events.map(\.envelopeID) }
-    var firstCursorValue: UInt64 { events[0].cursorValue }
-    var lastCursorValue: UInt64 { events[events.count - 1].cursorValue }
-
-    init(
-        projectID: UUID,
-        worktreePath: String,
-        sessionID: UUID,
-        process: AgentProcessIdentity,
-        events: [VerifiedPatchEventReference]
-    ) throws {
-        guard projectID != Self.zeroUUID,
-              sessionID != Self.zeroUUID,
-              process.terminalID != Self.zeroUUID,
-              process.processGeneration > 0,
-              Self.isSafeAbsolutePath(worktreePath),
-              !events.isEmpty else {
-            throw VerifiedPatchValidationError.invalidBinding
-        }
-
-        let ordered = events.sorted {
-            if $0.cursorValue != $1.cursorValue {
-                return $0.cursorValue < $1.cursorValue
-            }
-            return $0.envelopeID.uuidString < $1.envelopeID.uuidString
-        }
-        var seenEnvelopeIDs: Set<UUID> = []
-        for (index, event) in ordered.enumerated() {
-            guard event.envelopeID != Self.zeroUUID,
-                  event.cursorValue > 0,
-                  !event.transitions.isEmpty else {
-                throw VerifiedPatchValidationError.invalidBinding
-            }
-            guard seenEnvelopeIDs.insert(event.envelopeID).inserted else {
-                throw VerifiedPatchValidationError.duplicateEnvelope(
-                    event.envelopeID
-                )
-            }
-            for transition in event.transitions {
-                try Self.validate(transition)
-            }
-            guard index > 0 else { continue }
-            let previous = ordered[index - 1].cursorValue
-            if event.cursorValue == previous {
-                throw VerifiedPatchValidationError.cursorReplay(previous)
-            }
-            guard previous < UInt64.max else {
-                throw VerifiedPatchValidationError.cursorGap(
-                    expected: UInt64.max,
-                    actual: event.cursorValue
-                )
-            }
-            let expected = previous + 1
-            guard event.cursorValue == expected else {
-                throw VerifiedPatchValidationError.cursorGap(
-                    expected: expected,
-                    actual: event.cursorValue
-                )
-            }
-        }
-
-        self.projectID = projectID
-        self.worktreePath = worktreePath
-        self.sessionID = sessionID
-        self.process = process
-        self.events = ordered
-    }
-
-    static func isSafeRelativePath(_ path: String) -> Bool {
-        guard !path.isEmpty,
-              !path.hasPrefix("/"),
-              !path.utf8.contains(0),
-              path.utf8.count <= 4_096 else {
-            return false
-        }
-        let components = path.split(
-            separator: "/",
-            omittingEmptySubsequences: false
-        )
-        return !components.isEmpty
-            && components.allSatisfy {
-                !$0.isEmpty && $0 != "." && $0 != ".."
-            }
-    }
-
-    private static func validate(
-        _ transition: VerifiedPatchContentTransition
-    ) throws {
-        guard isSafeRelativePath(transition.sourcePath),
-              transition.beforeIdentity != nil
-                || transition.afterIdentity != nil else {
-            throw VerifiedPatchValidationError.invalidTransition
-        }
-        if let destinationPath = transition.destinationPath {
-            guard isSafeRelativePath(destinationPath),
-                  destinationPath != transition.sourcePath,
-                  transition.beforeIdentity != nil,
-                  transition.afterIdentity != nil else {
-                throw VerifiedPatchValidationError.invalidTransition
-            }
-        }
-    }
-
-    private static func isSafeAbsolutePath(_ path: String) -> Bool {
-        guard path.hasPrefix("/"),
-              path != "/",
-              !path.utf8.contains(0),
-              path.utf8.count <= 4_096 else {
-            return false
-        }
-        let components = path.split(
-            separator: "/",
-            omittingEmptySubsequences: false
-        )
-        return components.first?.isEmpty == true
-            && components.dropFirst().allSatisfy {
-                !$0.isEmpty && $0 != "." && $0 != ".."
-            }
-    }
-
-    private static let zeroUUID = UUID(
-        uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-    )
+/// Journal revalidation alone is never an implementation of this protocol.
+/// A production conformer must load owner-private receipts created only after
+/// Pine completed the descriptor CAS and bound the user approval.
+nonisolated protocol PineMediatedWriterReceiptRevalidating: Sendable {
+    func revalidateMediatedWriterReceipts(
+        _ receipts: [PineMediatedWriterReceipt]
+    ) async throws
 }
 
-/// Exact bytes supplied by a trusted capture boundary.
-nonisolated struct VerifiedPatchSourceOperation: Sendable, Equatable {
-    let eventEnvelopeID: UUID
-    let sourcePath: String
-    let destinationPath: String?
-    let beforeContent: Data?
-    let afterContent: Data?
+/// Combined read-only authority-evidence seam.
+///
+/// Code preparing a #1207 mutation must use this combined contract, so a
+/// journal-only implementation cannot accidentally satisfy the boundary.
+nonisolated protocol PatchAuthorityEvidenceRevalidator:
+    VerifiedPatchJournalRevalidating,
+    PineMediatedWriterReceiptRevalidating {}
+
+/// Untrusted DTO presented to the ingress coordinator.
+///
+/// It deliberately carries the complete envelope, including source and
+/// effective trust, plus durable journal evidence. All public simulation
+/// boundaries revalidate this DTO even though its value types are constructible
+/// inside the module.
+nonisolated struct VerifiedPatchUntrustedEventRecord: Sendable, Equatable {
+    let envelope: AgentEventEnvelope
+    let durableIdentity: VerifiedPatchDurableEventIdentity
+    let mediatedWriterReceipt: PineMediatedWriterReceipt?
+    let transitions: [VerifiedPatchContentTransition]
+}
+
+/// One accepted envelope retained by a revalidated ingress receipt.
+nonisolated struct VerifiedPatchAcceptedEvent: Sendable, Equatable {
+    let envelope: AgentEventEnvelope
+    let durableIdentity: VerifiedPatchDurableEventIdentity
+    let mediatedWriterReceipt: PineMediatedWriterReceipt?
+    let transitions: [VerifiedPatchContentTransition]
+}
+
+/// Coordinator-issued evidence that full envelopes passed pure ingress checks.
+///
+/// This receipt proves only that the in-memory DTO was internally consistent
+/// with durable audit and Pine-mediated writer receipt fields. It does not
+/// authorize undo. The live coordinator must revalidate the writer receipts
+/// in its private store, query the journal for nested audit identities, source
+/// content from #1207's owner-private store, and perform final root/Git/index
+/// checks.
+nonisolated struct VerifiedPatchIngressReceipt: Sendable, Equatable {
+    let receiptID: UUID
+    let workspace: VerifiedPatchWorkspaceIdentity
+    let projectID: UUID
+    let sessionID: UUID
+    let process: AgentProcessIdentity
+    let events: [VerifiedPatchAcceptedEvent]
+
+    var envelopeIDs: [UUID] { events.map(\.envelope.id) }
+    var durableEventIdentities: [VerifiedPatchDurableEventIdentity] {
+        events.map(\.durableIdentity)
+    }
+    var mediatedWriterReceipts: [PineMediatedWriterReceipt] {
+        events.compactMap(\.mediatedWriterReceipt)
+    }
+    var firstCursorValue: UInt64 { events[0].envelope.cursorValue }
+    var lastCursorValue: UInt64 {
+        events[events.count - 1].envelope.cursorValue
+    }
+    var firstJournalSequence: UInt64 {
+        events[0].durableIdentity.journalSequence
+    }
+    var lastJournalSequence: UInt64 {
+        events[events.count - 1].durableIdentity.journalSequence
+    }
 
     init(
-        eventEnvelopeID: UUID,
+        receiptID: UUID,
+        workspace: VerifiedPatchWorkspaceIdentity,
+        projectID: UUID,
+        sessionID: UUID,
+        process: AgentProcessIdentity,
+        events: [VerifiedPatchAcceptedEvent]
+    ) {
+        self.receiptID = receiptID
+        self.workspace = workspace
+        self.projectID = projectID
+        self.sessionID = sessionID
+        self.process = process
+        self.events = events
+    }
+}
+
+/// Exact captured bytes supplied for one accepted transition.
+nonisolated struct VerifiedPatchSourceOperation: Sendable, Equatable {
+    let transitionID: VerifiedPatchTransitionID
+    let sourcePath: String
+    let destinationPath: String?
+    let before: VerifiedPatchFileState?
+    let after: VerifiedPatchFileState?
+
+    init(
+        transitionID: VerifiedPatchTransitionID,
         sourcePath: String,
         destinationPath: String? = nil,
-        beforeContent: Data?,
-        afterContent: Data?
+        before: VerifiedPatchFileState?,
+        after: VerifiedPatchFileState?
     ) {
-        self.eventEnvelopeID = eventEnvelopeID
+        self.transitionID = transitionID
         self.sourcePath = sourcePath
         self.destinationPath = destinationPath
-        self.beforeContent = beforeContent
-        self.afterContent = afterContent
+        self.before = before
+        self.after = after
     }
 }
 
@@ -206,22 +294,19 @@ nonisolated enum VerifiedPatchOperationKind: String, Sendable, Equatable {
     case rename
 }
 
-/// One exact file state retained only in the owner-private patch payload.
-nonisolated struct VerifiedPatchFileState: Sendable, Equatable {
-    let identity: ContentIdentity
-    let content: Data
-
-    init(content: Data) {
-        self.identity = ContentIdentity(content: content)
-        self.content = content
-    }
+/// Structured operation identity; no delimiter-based path concatenation.
+nonisolated struct VerifiedPatchOperationID:
+    Sendable,
+    Equatable,
+    Hashable {
+    let patchID: UUID
+    let transitionIDs: [VerifiedPatchTransitionID]
 }
 
-/// One deterministic line hunk for a text modification.
+/// Deterministic line hunk from captured before bytes to captured after bytes.
 ///
-/// Lines retain their original newline bytes, including CRLF. Context is
-/// deliberately exact and bounded; inverse application requires a unique
-/// context match in the current text.
+/// Lines include their newline bytes, preserving CRLF and missing final
+/// newlines exactly.
 nonisolated struct VerifiedTextPatchHunk: Sendable, Equatable {
     let beforeStartLine: Int
     let beforeLineCount: Int
@@ -234,39 +319,19 @@ nonisolated struct VerifiedTextPatchHunk: Sendable, Equatable {
 }
 
 nonisolated enum VerifiedPatchApplicationStrategy: Sendable, Equatable {
-    /// Checked, uniquely matched text hunks.
-    case text(hunks: [VerifiedTextPatchHunk])
-    /// Exact-state replacement/removal only.
+    case text(hunks: [VerifiedTextPatchHunk], lcsCellCount: Int)
     case exactState
 }
 
-/// One validated operation in a verified patch set.
+/// One collapsed transition chain in a pure patch simulation.
 nonisolated struct VerifiedPatchOperation: Sendable, Equatable {
-    let eventEnvelopeID: UUID
+    let id: VerifiedPatchOperationID
     let kind: VerifiedPatchOperationKind
     let sourcePath: String
     let destinationPath: String?
     let before: VerifiedPatchFileState?
     let after: VerifiedPatchFileState?
     let strategy: VerifiedPatchApplicationStrategy
-
-    var operationKey: String {
-        [
-            eventEnvelopeID.uuidString,
-            kind.rawValue,
-            sourcePath,
-            destinationPath ?? ""
-        ].joined(separator: ":")
-    }
-
-    var transition: VerifiedPatchContentTransition {
-        VerifiedPatchContentTransition(
-            sourcePath: sourcePath,
-            destinationPath: destinationPath,
-            beforeIdentity: before?.identity,
-            afterIdentity: after?.identity
-        )
-    }
 
     var touchedPaths: [String] {
         if let destinationPath {
@@ -276,19 +341,23 @@ nonisolated struct VerifiedPatchOperation: Sendable, Equatable {
     }
 }
 
-/// A deterministic patch tied to an exact verified event range.
+/// Pure simulation model tied to an accepted ingress receipt.
+///
+/// This type grants no mutation authority. Only #1207's final coordinator may
+/// interpret a prepared result after revalidating private authority, root,
+/// file descriptors, HEAD, index state, and authority consumption.
 nonisolated struct VerifiedPatchSet: Sendable, Equatable, Identifiable {
     let id: UUID
-    let binding: VerifiedPatchEventBinding
+    let receipt: VerifiedPatchIngressReceipt
     let operations: [VerifiedPatchOperation]
 }
 
 nonisolated enum VerifiedInversePreviewKind: String, Sendable, Equatable {
     case applyTextHunks
-    case restoreExactBytes
+    case restoreExactFile
     case removeCreatedFile
     case restoreDeletedFile
-    case restoreRenamedFile
+    case simulateRenamedFile
 }
 
 nonisolated enum VerifiedInversePreviewLineKind: String, Sendable, Equatable {
@@ -303,44 +372,134 @@ nonisolated struct VerifiedInversePreviewLine: Sendable, Equatable {
 }
 
 nonisolated struct VerifiedInverseHunkPreview: Sendable, Equatable {
+    let capturedAfterStartLine: Int
+    let resolvedCurrentStartLine: Int?
     let header: String
     let lines: [VerifiedInversePreviewLine]
 }
 
-/// Structured, deterministic preview for every inverse operation.
+/// Structured preview. Prepared previews describe resolved current ranges;
+/// nominal previews have `resolvedCurrentStartLine == nil`.
 nonisolated struct VerifiedInverseOperationPreview: Sendable, Equatable {
-    let operationKey: String
-    let eventEnvelopeID: UUID
+    let operationID: VerifiedPatchOperationID
     let kind: VerifiedInversePreviewKind
     let sourcePath: String
     let destinationPath: String?
-    let expectedCurrentIdentity: ContentIdentity?
-    let resultIdentity: ContentIdentity?
+    let expectedCurrent: VerifiedPatchStateIdentity?
+    let result: VerifiedPatchStateIdentity?
     let hunks: [VerifiedInverseHunkPreview]
 }
 
-/// In-memory workspace state consumed and returned by the pure engine.
+/// In-memory current state supplied by the future descriptor coordinator.
 nonisolated struct VerifiedPatchWorkspaceSnapshot: Sendable, Equatable {
-    let files: [String: Data]
+    let files: [String: VerifiedPatchFileState]
 }
 
 nonisolated enum VerifiedPatchConflictReason: Error, Sendable, Equatable {
     case expectedFileMissing
     case unexpectedFilePresent
     case exactStateDiverged
+    case unsupportedCurrentFileKind
     case currentContentIsNotText
-    case textContextMissing(hunkIndex: Int)
-    case ambiguousTextContext(hunkIndex: Int)
+    case humanEditOverlapsAgentRegion(hunkIndex: Int)
+    case mappedRegionMismatch(hunkIndex: Int)
     case overlappingResolvedHunks
+    case snapshotChangedAfterPreparation
+    case invalidCurrentSnapshot
+    case resourceLimitExceeded
 }
 
-nonisolated struct VerifiedPatchConflict: Sendable, Equatable {
-    let operationKey: String
-    let path: String
+nonisolated struct VerifiedPatchConflict: Error, Sendable, Equatable {
+    let operationID: VerifiedPatchOperationID?
+    let path: String?
     let reason: VerifiedPatchConflictReason
 }
 
-/// Atomic result: conflicts expose no partially transformed snapshot.
+nonisolated enum VerifiedPatchPreparedMode: Sendable, Equatable {
+    case checkedText
+    case exactState
+}
+
+nonisolated struct VerifiedPreparedPathExpectation: Sendable, Equatable {
+    let path: String
+    let state: VerifiedPatchFileState?
+}
+
+nonisolated struct VerifiedPreparedPathResult: Sendable, Equatable {
+    let path: String
+    let state: VerifiedPatchFileState?
+}
+
+nonisolated struct VerifiedPreparedTextHunk: Sendable, Equatable {
+    let capturedAfterRange: Range<Int>
+    let resolvedCurrentRange: Range<Int>
+    let replacementLines: [Data]
+}
+
+nonisolated struct VerifiedPreparedInverseOperation: Sendable, Equatable {
+    let operationID: VerifiedPatchOperationID
+    let kind: VerifiedPatchOperationKind
+    let mode: VerifiedPatchPreparedMode
+    let expectations: [VerifiedPreparedPathExpectation]
+    let results: [VerifiedPreparedPathResult]
+    let resolvedTextHunks: [VerifiedPreparedTextHunk]
+    let preview: VerifiedInverseOperationPreview
+}
+
+/// Values the final coordinator must revalidate before any disk mutation.
+nonisolated struct VerifiedPatchCoordinatorExpectations:
+    Sendable,
+    Equatable {
+    let privateWorkspaceID: UUID
+    let canonicalRootPath: String
+    let rootDevice: UInt64
+    let rootInode: UInt64
+    let capturedHeadOID: String
+    let capturedIndexSHA256: String
+    let durableEvents: [VerifiedPatchDurableEventIdentity]
+    let mediatedWriterReceipts: [PineMediatedWriterReceipt]
+}
+
+/// Fully resolved pure inverse plan.
+///
+/// `applyPrepared` revalidates every value-level expectation, so synthesized or
+/// stale values cannot bypass the prepare/apply boundary. This still grants no
+/// authority: the final coordinator must call
+/// `revalidateAuthorityEvidence`, then perform #1207's
+/// descriptor/root/Git/index checks and consume its separate authority.
+nonisolated struct PreparedInverse: Sendable, Equatable {
+    let patch: VerifiedPatchSet
+    let coordinatorExpectations: VerifiedPatchCoordinatorExpectations
+    let operations: [VerifiedPreparedInverseOperation]
+    let previews: [VerifiedInverseOperationPreview]
+
+    var patchID: UUID { patch.id }
+
+    init(
+        patch: VerifiedPatchSet,
+        coordinatorExpectations: VerifiedPatchCoordinatorExpectations,
+        operations: [VerifiedPreparedInverseOperation]
+    ) {
+        self.patch = patch
+        self.coordinatorExpectations = coordinatorExpectations
+        self.operations = operations
+        self.previews = operations.map(\.preview)
+    }
+}
+
+nonisolated enum VerifiedPatchPreparationFailure:
+    Error,
+    Sendable,
+    Equatable {
+    case invalidPatch(VerifiedPatchValidationError)
+    case conflicts([VerifiedPatchConflict])
+    case unsupportedOperation(
+        VerifiedPatchOperationID,
+        VerifiedPatchOperationKind
+    )
+}
+
+/// Atomic result: a conflict never exposes a partially transformed snapshot.
 nonisolated enum VerifiedCheckedInverseResult: Sendable, Equatable {
     case applied(
         snapshot: VerifiedPatchWorkspaceSnapshot,
@@ -350,18 +509,40 @@ nonisolated enum VerifiedCheckedInverseResult: Sendable, Equatable {
 }
 
 nonisolated enum VerifiedPatchValidationError: Error, Sendable, Equatable {
-    case invalidBinding
+    case invalidWorkspaceIdentity
+    case invalidReceipt
+    case invalidEnvelope(UUID)
+    case eventMetadataTooLarge
+    case unverifiedEnvelope(UUID)
     case duplicateEnvelope(UUID)
+    case invalidDurableEvent(UUID)
+    case duplicateJournalSequence(UInt64)
+    case journalOrderMismatch(previous: UInt64, actual: UInt64)
+    case missingMediatedWriterReceipt(UUID)
+    case invalidMediatedWriterReceipt(UUID)
+    case duplicateMediatedWriterReceipt(UUID)
     case cursorReplay(UInt64)
     case cursorGap(expected: UInt64, actual: UInt64)
-    case invalidTransition
+    case tooManyEvents
+    case tooManyTransitions
+    case invalidTransition(VerifiedPatchTransitionID?)
     case invalidPatchID
     case noOperations
-    case invalidOperation
+    case tooManyOperations
+    case invalidOperation(VerifiedPatchTransitionID?)
     case invalidPath(String)
-    case duplicateTouchedPath(String)
-    case duplicateBoundTransition
-    case unboundOperation
-    case unusedBoundTransition
+    case protectedPath(String)
+    case aliasedPath(String)
+    case duplicateTransition(VerifiedPatchTransitionID)
+    case unboundOperation(VerifiedPatchTransitionID)
+    case unusedTransition(VerifiedPatchTransitionID)
+    case transitionChainMismatch(String)
     case contentTooLarge
+    case aggregateContentTooLarge
+    case tooManyHunks
+    case lcsBudgetExceeded
+    case invalidSnapshot
+    case tooManyVersionPatches
+    case tooManyVersionNodes
+    case duplicatePatchID(UUID)
 }

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchModels.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchModels.swift
@@ -1,0 +1,367 @@
+//
+//  VerifiedPatchModels.swift
+//  Pine
+//
+//  Pure, owner-private patch contracts for verified agent events (#933).
+//  These values perform no file-system I/O and grant no mutation authority.
+//
+
+import Foundation
+
+/// One exact content transition reported by a verified event.
+///
+/// The transition contains identities only. Patch bytes are supplied
+/// separately to `VerifiedPatchEngine.makePatch` and must match these values.
+nonisolated struct VerifiedPatchContentTransition: Sendable, Equatable, Hashable {
+    let sourcePath: String
+    let destinationPath: String?
+    let beforeIdentity: ContentIdentity?
+    let afterIdentity: ContentIdentity?
+
+    init(
+        sourcePath: String,
+        destinationPath: String? = nil,
+        beforeIdentity: ContentIdentity?,
+        afterIdentity: ContentIdentity?
+    ) {
+        self.sourcePath = sourcePath
+        self.destinationPath = destinationPath
+        self.beforeIdentity = beforeIdentity
+        self.afterIdentity = afterIdentity
+    }
+}
+
+/// A verified envelope and the exact file transitions it carries.
+nonisolated struct VerifiedPatchEventReference: Sendable, Equatable {
+    let envelopeID: UUID
+    let cursorValue: UInt64
+    let transitions: [VerifiedPatchContentTransition]
+}
+
+/// Complete provenance scope for one patch.
+///
+/// Events are normalized into cursor order and must form one contiguous,
+/// replay-free range. A future live bridge creates this value only after the
+/// corresponding envelopes have been durably accepted by the provenance
+/// store.
+nonisolated struct VerifiedPatchEventBinding: Sendable, Equatable {
+    let projectID: UUID
+    let worktreePath: String
+    let sessionID: UUID
+    let process: AgentProcessIdentity
+    let events: [VerifiedPatchEventReference]
+
+    var envelopeIDs: [UUID] { events.map(\.envelopeID) }
+    var firstCursorValue: UInt64 { events[0].cursorValue }
+    var lastCursorValue: UInt64 { events[events.count - 1].cursorValue }
+
+    init(
+        projectID: UUID,
+        worktreePath: String,
+        sessionID: UUID,
+        process: AgentProcessIdentity,
+        events: [VerifiedPatchEventReference]
+    ) throws {
+        guard projectID != Self.zeroUUID,
+              sessionID != Self.zeroUUID,
+              process.terminalID != Self.zeroUUID,
+              process.processGeneration > 0,
+              Self.isSafeAbsolutePath(worktreePath),
+              !events.isEmpty else {
+            throw VerifiedPatchValidationError.invalidBinding
+        }
+
+        let ordered = events.sorted {
+            if $0.cursorValue != $1.cursorValue {
+                return $0.cursorValue < $1.cursorValue
+            }
+            return $0.envelopeID.uuidString < $1.envelopeID.uuidString
+        }
+        var seenEnvelopeIDs: Set<UUID> = []
+        for (index, event) in ordered.enumerated() {
+            guard event.envelopeID != Self.zeroUUID,
+                  event.cursorValue > 0,
+                  !event.transitions.isEmpty else {
+                throw VerifiedPatchValidationError.invalidBinding
+            }
+            guard seenEnvelopeIDs.insert(event.envelopeID).inserted else {
+                throw VerifiedPatchValidationError.duplicateEnvelope(
+                    event.envelopeID
+                )
+            }
+            for transition in event.transitions {
+                try Self.validate(transition)
+            }
+            guard index > 0 else { continue }
+            let previous = ordered[index - 1].cursorValue
+            if event.cursorValue == previous {
+                throw VerifiedPatchValidationError.cursorReplay(previous)
+            }
+            guard previous < UInt64.max else {
+                throw VerifiedPatchValidationError.cursorGap(
+                    expected: UInt64.max,
+                    actual: event.cursorValue
+                )
+            }
+            let expected = previous + 1
+            guard event.cursorValue == expected else {
+                throw VerifiedPatchValidationError.cursorGap(
+                    expected: expected,
+                    actual: event.cursorValue
+                )
+            }
+        }
+
+        self.projectID = projectID
+        self.worktreePath = worktreePath
+        self.sessionID = sessionID
+        self.process = process
+        self.events = ordered
+    }
+
+    static func isSafeRelativePath(_ path: String) -> Bool {
+        guard !path.isEmpty,
+              !path.hasPrefix("/"),
+              !path.utf8.contains(0),
+              path.utf8.count <= 4_096 else {
+            return false
+        }
+        let components = path.split(
+            separator: "/",
+            omittingEmptySubsequences: false
+        )
+        return !components.isEmpty
+            && components.allSatisfy {
+                !$0.isEmpty && $0 != "." && $0 != ".."
+            }
+    }
+
+    private static func validate(
+        _ transition: VerifiedPatchContentTransition
+    ) throws {
+        guard isSafeRelativePath(transition.sourcePath),
+              transition.beforeIdentity != nil
+                || transition.afterIdentity != nil else {
+            throw VerifiedPatchValidationError.invalidTransition
+        }
+        if let destinationPath = transition.destinationPath {
+            guard isSafeRelativePath(destinationPath),
+                  destinationPath != transition.sourcePath,
+                  transition.beforeIdentity != nil,
+                  transition.afterIdentity != nil else {
+                throw VerifiedPatchValidationError.invalidTransition
+            }
+        }
+    }
+
+    private static func isSafeAbsolutePath(_ path: String) -> Bool {
+        guard path.hasPrefix("/"),
+              path != "/",
+              !path.utf8.contains(0),
+              path.utf8.count <= 4_096 else {
+            return false
+        }
+        let components = path.split(
+            separator: "/",
+            omittingEmptySubsequences: false
+        )
+        return components.first?.isEmpty == true
+            && components.dropFirst().allSatisfy {
+                !$0.isEmpty && $0 != "." && $0 != ".."
+            }
+    }
+
+    private static let zeroUUID = UUID(
+        uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    )
+}
+
+/// Exact bytes supplied by a trusted capture boundary.
+nonisolated struct VerifiedPatchSourceOperation: Sendable, Equatable {
+    let eventEnvelopeID: UUID
+    let sourcePath: String
+    let destinationPath: String?
+    let beforeContent: Data?
+    let afterContent: Data?
+
+    init(
+        eventEnvelopeID: UUID,
+        sourcePath: String,
+        destinationPath: String? = nil,
+        beforeContent: Data?,
+        afterContent: Data?
+    ) {
+        self.eventEnvelopeID = eventEnvelopeID
+        self.sourcePath = sourcePath
+        self.destinationPath = destinationPath
+        self.beforeContent = beforeContent
+        self.afterContent = afterContent
+    }
+}
+
+nonisolated enum VerifiedPatchOperationKind: String, Sendable, Equatable {
+    case modify
+    case create
+    case delete
+    case rename
+}
+
+/// One exact file state retained only in the owner-private patch payload.
+nonisolated struct VerifiedPatchFileState: Sendable, Equatable {
+    let identity: ContentIdentity
+    let content: Data
+
+    init(content: Data) {
+        self.identity = ContentIdentity(content: content)
+        self.content = content
+    }
+}
+
+/// One deterministic line hunk for a text modification.
+///
+/// Lines retain their original newline bytes, including CRLF. Context is
+/// deliberately exact and bounded; inverse application requires a unique
+/// context match in the current text.
+nonisolated struct VerifiedTextPatchHunk: Sendable, Equatable {
+    let beforeStartLine: Int
+    let beforeLineCount: Int
+    let afterStartLine: Int
+    let afterLineCount: Int
+    let prefixContext: [Data]
+    let afterLines: [Data]
+    let beforeLines: [Data]
+    let suffixContext: [Data]
+}
+
+nonisolated enum VerifiedPatchApplicationStrategy: Sendable, Equatable {
+    /// Checked, uniquely matched text hunks.
+    case text(hunks: [VerifiedTextPatchHunk])
+    /// Exact-state replacement/removal only.
+    case exactState
+}
+
+/// One validated operation in a verified patch set.
+nonisolated struct VerifiedPatchOperation: Sendable, Equatable {
+    let eventEnvelopeID: UUID
+    let kind: VerifiedPatchOperationKind
+    let sourcePath: String
+    let destinationPath: String?
+    let before: VerifiedPatchFileState?
+    let after: VerifiedPatchFileState?
+    let strategy: VerifiedPatchApplicationStrategy
+
+    var operationKey: String {
+        [
+            eventEnvelopeID.uuidString,
+            kind.rawValue,
+            sourcePath,
+            destinationPath ?? ""
+        ].joined(separator: ":")
+    }
+
+    var transition: VerifiedPatchContentTransition {
+        VerifiedPatchContentTransition(
+            sourcePath: sourcePath,
+            destinationPath: destinationPath,
+            beforeIdentity: before?.identity,
+            afterIdentity: after?.identity
+        )
+    }
+
+    var touchedPaths: [String] {
+        if let destinationPath {
+            return [sourcePath, destinationPath]
+        }
+        return [sourcePath]
+    }
+}
+
+/// A deterministic patch tied to an exact verified event range.
+nonisolated struct VerifiedPatchSet: Sendable, Equatable, Identifiable {
+    let id: UUID
+    let binding: VerifiedPatchEventBinding
+    let operations: [VerifiedPatchOperation]
+}
+
+nonisolated enum VerifiedInversePreviewKind: String, Sendable, Equatable {
+    case applyTextHunks
+    case restoreExactBytes
+    case removeCreatedFile
+    case restoreDeletedFile
+    case restoreRenamedFile
+}
+
+nonisolated enum VerifiedInversePreviewLineKind: String, Sendable, Equatable {
+    case context
+    case remove
+    case add
+}
+
+nonisolated struct VerifiedInversePreviewLine: Sendable, Equatable {
+    let kind: VerifiedInversePreviewLineKind
+    let bytes: Data
+}
+
+nonisolated struct VerifiedInverseHunkPreview: Sendable, Equatable {
+    let header: String
+    let lines: [VerifiedInversePreviewLine]
+}
+
+/// Structured, deterministic preview for every inverse operation.
+nonisolated struct VerifiedInverseOperationPreview: Sendable, Equatable {
+    let operationKey: String
+    let eventEnvelopeID: UUID
+    let kind: VerifiedInversePreviewKind
+    let sourcePath: String
+    let destinationPath: String?
+    let expectedCurrentIdentity: ContentIdentity?
+    let resultIdentity: ContentIdentity?
+    let hunks: [VerifiedInverseHunkPreview]
+}
+
+/// In-memory workspace state consumed and returned by the pure engine.
+nonisolated struct VerifiedPatchWorkspaceSnapshot: Sendable, Equatable {
+    let files: [String: Data]
+}
+
+nonisolated enum VerifiedPatchConflictReason: Error, Sendable, Equatable {
+    case expectedFileMissing
+    case unexpectedFilePresent
+    case exactStateDiverged
+    case currentContentIsNotText
+    case textContextMissing(hunkIndex: Int)
+    case ambiguousTextContext(hunkIndex: Int)
+    case overlappingResolvedHunks
+}
+
+nonisolated struct VerifiedPatchConflict: Sendable, Equatable {
+    let operationKey: String
+    let path: String
+    let reason: VerifiedPatchConflictReason
+}
+
+/// Atomic result: conflicts expose no partially transformed snapshot.
+nonisolated enum VerifiedCheckedInverseResult: Sendable, Equatable {
+    case applied(
+        snapshot: VerifiedPatchWorkspaceSnapshot,
+        previews: [VerifiedInverseOperationPreview]
+    )
+    case conflicted([VerifiedPatchConflict])
+}
+
+nonisolated enum VerifiedPatchValidationError: Error, Sendable, Equatable {
+    case invalidBinding
+    case duplicateEnvelope(UUID)
+    case cursorReplay(UInt64)
+    case cursorGap(expected: UInt64, actual: UInt64)
+    case invalidTransition
+    case invalidPatchID
+    case noOperations
+    case invalidOperation
+    case invalidPath(String)
+    case duplicateTouchedPath(String)
+    case duplicateBoundTransition
+    case unboundOperation
+    case unusedBoundTransition
+    case contentTooLarge
+}

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchModels.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchModels.swift
@@ -39,6 +39,8 @@ nonisolated enum VerifiedPatchLimits {
     static let maximumAggregateMappingCellCount = 8_000_000
     static let maximumHunkCount = 1_024
     static let maximumPathByteCount = 4_096
+    static let maximumPreparedHunkByteCount = 64 * 1_024 * 1_024
+    static let maximumPreparedLineReferenceCount = 2_097_152
 }
 
 /// Canonical owner-private workspace identity supplied by an ingress receipt.
@@ -161,8 +163,21 @@ nonisolated struct VerifiedPatchDurableEventIdentity:
 /// not merely confirm that a sequence number exists.
 nonisolated protocol VerifiedPatchJournalRevalidating: Sendable {
     func revalidateDurableEvents(
-        _ identities: [VerifiedPatchDurableEventIdentity]
+        _ expectations: [VerifiedPatchDurableEventExpectation]
     ) async throws
+}
+
+/// Complete record a journal verifier must match against durable storage.
+///
+/// A compact identity is not enough to establish that the journal retained
+/// the expected source, trust, cwd, timestamp, payload, or agent type. Keeping
+/// the full envelope at this boundary lets a store compare every attribution
+/// field before the event is used as nested audit evidence.
+nonisolated struct VerifiedPatchDurableEventExpectation:
+    Sendable,
+    Equatable {
+    let envelope: AgentEventEnvelope
+    let durableIdentity: VerifiedPatchDurableEventIdentity
 }
 
 /// Owner-private proof that Pine itself applied this exact transition batch.
@@ -242,18 +257,28 @@ nonisolated struct VerifiedPatchIngressReceipt: Sendable, Equatable {
     var durableEventIdentities: [VerifiedPatchDurableEventIdentity] {
         events.map(\.durableIdentity)
     }
+    var durableEventExpectations: [VerifiedPatchDurableEventExpectation] {
+        events.map {
+            VerifiedPatchDurableEventExpectation(
+                envelope: $0.envelope,
+                durableIdentity: $0.durableIdentity
+            )
+        }
+    }
     var mediatedWriterReceipts: [PineMediatedWriterReceipt] {
         events.compactMap(\.mediatedWriterReceipt)
     }
-    var firstCursorValue: UInt64 { events[0].envelope.cursorValue }
+    var firstCursorValue: UInt64 {
+        events.first?.envelope.cursorValue ?? 0
+    }
     var lastCursorValue: UInt64 {
-        events[events.count - 1].envelope.cursorValue
+        events.last?.envelope.cursorValue ?? 0
     }
     var firstJournalSequence: UInt64 {
-        events[0].durableIdentity.journalSequence
+        events.first?.durableIdentity.journalSequence ?? 0
     }
     var lastJournalSequence: UInt64 {
-        events[events.count - 1].durableIdentity.journalSequence
+        events.last?.durableIdentity.journalSequence ?? 0
     }
 
     init(
@@ -466,7 +491,7 @@ nonisolated struct VerifiedPatchCoordinatorExpectations:
     let rootInode: UInt64
     let capturedHeadOID: String
     let capturedIndexSHA256: String
-    let durableEvents: [VerifiedPatchDurableEventIdentity]
+    let durableEvents: [VerifiedPatchDurableEventExpectation]
     let mediatedWriterReceipts: [PineMediatedWriterReceipt]
 }
 

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchVersionChain.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchVersionChain.swift
@@ -1,0 +1,386 @@
+//
+//  VerifiedPatchVersionChain.swift
+//  Pine
+//
+//  Pure overlap and version-chain analysis for verified agent patches (#933).
+//
+
+import Foundation
+
+nonisolated enum VerifiedPatchVersionConflictReason: Sendable, Equatable {
+    case replayedEnvelope(UUID)
+    case cursorOverlap
+    case cursorGap(expected: UInt64, actual: UInt64)
+    case ambiguousVersionChain
+    case cursorOrderMismatch
+}
+
+nonisolated struct VerifiedPatchPathScope: Sendable, Equatable, Hashable {
+    let projectID: UUID
+    let worktreePath: String
+    let relativePath: String
+}
+
+nonisolated struct VerifiedPatchVersionConflict: Sendable, Equatable {
+    let pathScope: VerifiedPatchPathScope?
+    let patchIDs: [UUID]
+    let sessionIDs: [UUID]
+    let reason: VerifiedPatchVersionConflictReason
+
+    var path: String? { pathScope?.relativePath }
+}
+
+nonisolated struct VerifiedPatchVersionChainReport: Sendable, Equatable {
+    /// Exact identity order for every scoped path touched more than once.
+    let orderedPatchIDsByPath: [VerifiedPatchPathScope: [UUID]]
+}
+
+nonisolated enum VerifiedPatchVersionChainResult: Sendable, Equatable {
+    case valid(VerifiedPatchVersionChainReport)
+    case conflicted([VerifiedPatchVersionConflict])
+}
+
+/// Detects cursor replay/gaps and divergent multi-agent file versions.
+nonisolated enum VerifiedPatchVersionChainDetector {
+    static func analyze(
+        _ patches: [VerifiedPatchSet]
+    ) -> VerifiedPatchVersionChainResult {
+        let orderedPatches = patches.sorted {
+            $0.id.uuidString < $1.id.uuidString
+        }
+        var conflicts: [VerifiedPatchVersionConflict] = []
+        detectEnvelopeReplay(orderedPatches, conflicts: &conflicts)
+        detectCursorConflicts(orderedPatches, conflicts: &conflicts)
+
+        let nodesByPath = makeNodesByPath(orderedPatches)
+        var chains: [VerifiedPatchPathScope: [UUID]] = [:]
+        for pathScope in nodesByPath.keys.sorted(by: pathScopeOrder) {
+            guard let nodes = nodesByPath[pathScope],
+                  nodes.count > 1 else {
+                continue
+            }
+            switch linearChain(nodes) {
+            case .success(let orderedNodes):
+                if cursorOrderConflicts(orderedNodes) {
+                    conflicts.append(makeConflict(
+                        pathScope: pathScope,
+                        nodes: orderedNodes,
+                        reason: .cursorOrderMismatch
+                    ))
+                } else {
+                    chains[pathScope] = orderedNodes.map(\.patchID)
+                }
+            case .failure:
+                conflicts.append(makeConflict(
+                    pathScope: pathScope,
+                    nodes: nodes,
+                    reason: .ambiguousVersionChain
+                ))
+            }
+        }
+
+        if conflicts.isEmpty {
+            return .valid(VerifiedPatchVersionChainReport(
+                orderedPatchIDsByPath: chains
+            ))
+        }
+        return .conflicted(conflicts)
+    }
+
+    private static func detectEnvelopeReplay(
+        _ patches: [VerifiedPatchSet],
+        conflicts: inout [VerifiedPatchVersionConflict]
+    ) {
+        var owners: [UUID: VerifiedPatchSet] = [:]
+        for patch in patches {
+            for envelopeID in patch.binding.envelopeIDs {
+                if let existing = owners[envelopeID] {
+                    conflicts.append(VerifiedPatchVersionConflict(
+                        pathScope: nil,
+                        patchIDs: sortedUUIDs([existing.id, patch.id]),
+                        sessionIDs: sortedUUIDs([
+                            existing.binding.sessionID,
+                            patch.binding.sessionID
+                        ]),
+                        reason: .replayedEnvelope(envelopeID)
+                    ))
+                } else {
+                    owners[envelopeID] = patch
+                }
+            }
+        }
+    }
+
+    private static func detectCursorConflicts(
+        _ patches: [VerifiedPatchSet],
+        conflicts: inout [VerifiedPatchVersionConflict]
+    ) {
+        let groups = Dictionary(grouping: patches, by: StreamIdentity.init)
+        for stream in groups.keys.sorted(by: streamOrder) {
+            guard let group = groups[stream],
+                  group.count > 1 else {
+                continue
+            }
+            let ordered = group.sorted {
+                if $0.binding.firstCursorValue
+                    != $1.binding.firstCursorValue {
+                    return $0.binding.firstCursorValue
+                        < $1.binding.firstCursorValue
+                }
+                return $0.id.uuidString < $1.id.uuidString
+            }
+            for index in ordered.indices.dropFirst() {
+                let previous = ordered[index - 1]
+                let current = ordered[index]
+                if current.binding.firstCursorValue
+                    <= previous.binding.lastCursorValue {
+                    conflicts.append(VerifiedPatchVersionConflict(
+                        pathScope: nil,
+                        patchIDs: [previous.id, current.id],
+                        sessionIDs: sortedUUIDs([
+                            previous.binding.sessionID,
+                            current.binding.sessionID
+                        ]),
+                        reason: .cursorOverlap
+                    ))
+                    continue
+                }
+                guard previous.binding.lastCursorValue < UInt64.max else {
+                    conflicts.append(VerifiedPatchVersionConflict(
+                        pathScope: nil,
+                        patchIDs: [previous.id, current.id],
+                        sessionIDs: [current.binding.sessionID],
+                        reason: .cursorGap(
+                            expected: UInt64.max,
+                            actual: current.binding.firstCursorValue
+                        )
+                    ))
+                    continue
+                }
+                let expected = previous.binding.lastCursorValue + 1
+                if current.binding.firstCursorValue != expected {
+                    conflicts.append(VerifiedPatchVersionConflict(
+                        pathScope: nil,
+                        patchIDs: [previous.id, current.id],
+                        sessionIDs: [current.binding.sessionID],
+                        reason: .cursorGap(
+                            expected: expected,
+                            actual: current.binding.firstCursorValue
+                        )
+                    ))
+                }
+            }
+        }
+    }
+
+    private static func makeNodesByPath(
+        _ patches: [VerifiedPatchSet]
+    ) -> [VerifiedPatchPathScope: [VersionNode]] {
+        var result: [VerifiedPatchPathScope: [VersionNode]] = [:]
+        for patch in patches {
+            for operation in patch.operations {
+                let common = (
+                    patchID: patch.id,
+                    sessionID: patch.binding.sessionID,
+                    stream: StreamIdentity(patch),
+                    firstCursor: patch.binding.firstCursorValue
+                )
+                if operation.kind == .rename,
+                   let destinationPath = operation.destinationPath {
+                    let sourceScope = pathScope(
+                        patch,
+                        relativePath: operation.sourcePath
+                    )
+                    let destinationScope = pathScope(
+                        patch,
+                        relativePath: destinationPath
+                    )
+                    result[sourceScope, default: []].append(
+                        VersionNode(
+                            patchID: common.patchID,
+                            sessionID: common.sessionID,
+                            stream: common.stream,
+                            firstCursor: common.firstCursor,
+                            before: operation.before?.identity,
+                            after: nil
+                        )
+                    )
+                    result[destinationScope, default: []].append(
+                        VersionNode(
+                            patchID: common.patchID,
+                            sessionID: common.sessionID,
+                            stream: common.stream,
+                            firstCursor: common.firstCursor,
+                            before: nil,
+                            after: operation.after?.identity
+                        )
+                    )
+                } else {
+                    let scope = pathScope(
+                        patch,
+                        relativePath: operation.sourcePath
+                    )
+                    result[scope, default: []].append(
+                        VersionNode(
+                            patchID: common.patchID,
+                            sessionID: common.sessionID,
+                            stream: common.stream,
+                            firstCursor: common.firstCursor,
+                            before: operation.before?.identity,
+                            after: operation.after?.identity
+                        )
+                    )
+                }
+            }
+        }
+        return result
+    }
+
+    private static func linearChain(
+        _ nodes: [VersionNode]
+    ) -> Result<[VersionNode], ChainFailure> {
+        var predecessors: [Int: [Int]] = [:]
+        var successors: [Int: [Int]] = [:]
+        for lhsIndex in nodes.indices {
+            guard let after = nodes[lhsIndex].after else { continue }
+            for rhsIndex in nodes.indices where lhsIndex != rhsIndex {
+                if nodes[rhsIndex].before == after {
+                    successors[lhsIndex, default: []].append(rhsIndex)
+                    predecessors[rhsIndex, default: []].append(lhsIndex)
+                }
+            }
+        }
+
+        guard successors.values.allSatisfy({ $0.count <= 1 }),
+              predecessors.values.allSatisfy({ $0.count <= 1 }) else {
+            return .failure(.ambiguous)
+        }
+        let roots = nodes.indices.filter {
+            predecessors[$0, default: []].isEmpty
+        }
+        guard roots.count == 1,
+              let root = roots.first else {
+            return .failure(.ambiguous)
+        }
+
+        var result: [VersionNode] = []
+        var visited: Set<Int> = []
+        var current: Int? = root
+        while let index = current {
+            guard visited.insert(index).inserted else {
+                return .failure(.ambiguous)
+            }
+            result.append(nodes[index])
+            current = successors[index, default: []].first
+        }
+        guard result.count == nodes.count else {
+            return .failure(.ambiguous)
+        }
+        return .success(result)
+    }
+
+    private static func cursorOrderConflicts(
+        _ nodes: [VersionNode]
+    ) -> Bool {
+        for index in nodes.indices.dropFirst() {
+            let previous = nodes[index - 1]
+            let current = nodes[index]
+            if previous.stream == current.stream,
+               previous.firstCursor >= current.firstCursor {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func makeConflict(
+        pathScope: VerifiedPatchPathScope,
+        nodes: [VersionNode],
+        reason: VerifiedPatchVersionConflictReason
+    ) -> VerifiedPatchVersionConflict {
+        VerifiedPatchVersionConflict(
+            pathScope: pathScope,
+            patchIDs: sortedUUIDs(nodes.map(\.patchID)),
+            sessionIDs: sortedUUIDs(nodes.map(\.sessionID)),
+            reason: reason
+        )
+    }
+
+    private static func sortedUUIDs(_ values: [UUID]) -> [UUID] {
+        Array(Set(values)).sorted {
+            $0.uuidString < $1.uuidString
+        }
+    }
+
+    private static func streamOrder(
+        _ lhs: StreamIdentity,
+        _ rhs: StreamIdentity
+    ) -> Bool {
+        if lhs.projectID != rhs.projectID {
+            return lhs.projectID.uuidString < rhs.projectID.uuidString
+        }
+        if lhs.worktreePath != rhs.worktreePath {
+            return lhs.worktreePath < rhs.worktreePath
+        }
+        if lhs.sessionID != rhs.sessionID {
+            return lhs.sessionID.uuidString < rhs.sessionID.uuidString
+        }
+        if lhs.terminalID != rhs.terminalID {
+            return lhs.terminalID.uuidString < rhs.terminalID.uuidString
+        }
+        return lhs.processGeneration < rhs.processGeneration
+    }
+
+    private static func pathScope(
+        _ patch: VerifiedPatchSet,
+        relativePath: String
+    ) -> VerifiedPatchPathScope {
+        VerifiedPatchPathScope(
+            projectID: patch.binding.projectID,
+            worktreePath: patch.binding.worktreePath,
+            relativePath: relativePath
+        )
+    }
+
+    private static func pathScopeOrder(
+        _ lhs: VerifiedPatchPathScope,
+        _ rhs: VerifiedPatchPathScope
+    ) -> Bool {
+        if lhs.projectID != rhs.projectID {
+            return lhs.projectID.uuidString < rhs.projectID.uuidString
+        }
+        if lhs.worktreePath != rhs.worktreePath {
+            return lhs.worktreePath < rhs.worktreePath
+        }
+        return lhs.relativePath < rhs.relativePath
+    }
+
+    private struct StreamIdentity: Hashable {
+        let projectID: UUID
+        let worktreePath: String
+        let sessionID: UUID
+        let terminalID: UUID
+        let processGeneration: UInt64
+
+        init(_ patch: VerifiedPatchSet) {
+            projectID = patch.binding.projectID
+            worktreePath = patch.binding.worktreePath
+            sessionID = patch.binding.sessionID
+            terminalID = patch.binding.process.terminalID
+            processGeneration = patch.binding.process.processGeneration
+        }
+    }
+
+    private struct VersionNode {
+        let patchID: UUID
+        let sessionID: UUID
+        let stream: StreamIdentity
+        let firstCursor: UInt64
+        let before: ContentIdentity?
+        let after: ContentIdentity?
+    }
+
+    private enum ChainFailure: Error {
+        case ambiguous
+    }
+}

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchVersionChain.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchVersionChain.swift
@@ -13,6 +13,8 @@ nonisolated enum VerifiedPatchVersionConflictReason: Sendable, Equatable {
     case resourceLimitExceeded
     case replayedEnvelope(UUID)
     case journalSequenceCollision(UInt64)
+    case writerReceiptReplay(UUID)
+    case descriptorTransactionReplay(UUID)
     case descriptorCASSequenceCollision(UInt64)
     case journalOrderMismatch(previous: UInt64, actual: UInt64)
     case descriptorCASOrderMismatch(previous: UInt64, actual: UInt64)
@@ -115,7 +117,7 @@ nonisolated enum VerifiedPatchVersionChainDetector {
         var conflicts: [VerifiedPatchVersionConflict] = []
         detectEnvelopeReplay(orderedPatches, conflicts: &conflicts)
         detectJournalReplay(orderedPatches, conflicts: &conflicts)
-        detectDescriptorCASReplay(orderedPatches, conflicts: &conflicts)
+        detectMediatedWriterReplay(orderedPatches, conflicts: &conflicts)
         detectCursorConflicts(orderedPatches, conflicts: &conflicts)
 
         guard let nodesByPath = makeNodesByPath(orderedPatches) else {
@@ -566,37 +568,86 @@ nonisolated enum VerifiedPatchVersionChainDetector {
         }
     }
 
-    private static func detectDescriptorCASReplay(
+    private static func detectMediatedWriterReplay(
         _ patches: [VerifiedPatchSet],
         conflicts: inout [VerifiedPatchVersionConflict]
     ) {
-        var owners: [DescriptorCASSequenceScope: VerifiedPatchSet] = [:]
+        var receiptOwners: [WorkspaceUUIDScope: VerifiedPatchSet] = [:]
+        var transactionOwners: [WorkspaceUUIDScope: VerifiedPatchSet] = [:]
+        var sequenceOwners: [WorkspaceSequenceScope: VerifiedPatchSet] = [:]
+
         for patch in patches {
             let workspace = patch.receipt.workspace
             for receipt in patch.receipt.mediatedWriterReceipts {
-                let scope = DescriptorCASSequenceScope(
+                let receiptScope = WorkspaceUUIDScope(
                     privateWorkspaceID: workspace.privateWorkspaceID,
                     rootDevice: workspace.rootDevice,
                     rootInode: workspace.rootInode,
-                    sequence: receipt.descriptorCASSequence
+                    value: receipt.receiptID
                 )
-                if let existing = owners[scope] {
-                    conflicts.append(VerifiedPatchVersionConflict(
-                        pathScope: nil,
-                        patchIDs: sortedUUIDs([existing.id, patch.id]),
-                        sessionIDs: sortedUUIDs([
-                            existing.receipt.sessionID,
-                            patch.receipt.sessionID
-                        ]),
+                if let existing = receiptOwners[receiptScope] {
+                    conflicts.append(replayConflict(
+                        existing: existing,
+                        current: patch,
+                        reason: .writerReceiptReplay(receipt.receiptID)
+                    ))
+                } else {
+                    receiptOwners[receiptScope] = patch
+                }
+
+                let transactionScope = WorkspaceUUIDScope(
+                    privateWorkspaceID: workspace.privateWorkspaceID,
+                    rootDevice: workspace.rootDevice,
+                    rootInode: workspace.rootInode,
+                    value: receipt.descriptorTransactionID
+                )
+                if let existing = transactionOwners[transactionScope] {
+                    conflicts.append(replayConflict(
+                        existing: existing,
+                        current: patch,
+                        reason: .descriptorTransactionReplay(
+                            receipt.descriptorTransactionID
+                        )
+                    ))
+                } else {
+                    transactionOwners[transactionScope] = patch
+                }
+
+                let sequenceScope = WorkspaceSequenceScope(
+                    privateWorkspaceID: workspace.privateWorkspaceID,
+                    rootDevice: workspace.rootDevice,
+                    rootInode: workspace.rootInode,
+                    value: receipt.descriptorCASSequence
+                )
+                if let existing = sequenceOwners[sequenceScope] {
+                    conflicts.append(replayConflict(
+                        existing: existing,
+                        current: patch,
                         reason: .descriptorCASSequenceCollision(
                             receipt.descriptorCASSequence
                         )
                     ))
                 } else {
-                    owners[scope] = patch
+                    sequenceOwners[sequenceScope] = patch
                 }
             }
         }
+    }
+
+    private static func replayConflict(
+        existing: VerifiedPatchSet,
+        current: VerifiedPatchSet,
+        reason: VerifiedPatchVersionConflictReason
+    ) -> VerifiedPatchVersionConflict {
+        VerifiedPatchVersionConflict(
+            pathScope: nil,
+            patchIDs: sortedUUIDs([existing.id, current.id]),
+            sessionIDs: sortedUUIDs([
+                existing.receipt.sessionID,
+                current.receipt.sessionID
+            ]),
+            reason: reason
+        )
     }
 
     private static func makeNodesByPath(
@@ -949,13 +1000,6 @@ nonisolated enum VerifiedPatchVersionChainDetector {
         let journalSequence: UInt64
     }
 
-    private struct DescriptorCASSequenceScope: Hashable {
-        let privateWorkspaceID: UUID
-        let rootDevice: UInt64
-        let rootInode: UInt64
-        let sequence: UInt64
-    }
-
     private struct PhysicalRoot: Hashable {
         let device: UInt64
         let inode: UInt64
@@ -980,6 +1024,20 @@ nonisolated enum VerifiedPatchVersionChainDetector {
         var lastJournalSequence: UInt64
         var firstDescriptorCASSequence: UInt64
         var lastDescriptorCASSequence: UInt64
+    }
+
+    private struct WorkspaceUUIDScope: Hashable {
+        let privateWorkspaceID: UUID
+        let rootDevice: UInt64
+        let rootInode: UInt64
+        let value: UUID
+    }
+
+    private struct WorkspaceSequenceScope: Hashable {
+        let privateWorkspaceID: UUID
+        let rootDevice: UInt64
+        let rootInode: UInt64
+        let value: UInt64
     }
 
     private struct VersionNode {

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchVersionChain.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchVersionChain.swift
@@ -76,7 +76,8 @@ nonisolated enum VerifiedPatchVersionChainResult: Sendable, Equatable {
 
 nonisolated enum VerifiedPatchVersionChainDetector {
     static func analyze(
-        _ patches: [VerifiedPatchSet]
+        _ patches: [VerifiedPatchSet],
+        planningObserver: (() -> Void)? = nil
     ) -> VerifiedPatchVersionChainResult {
         guard patches.count
                 <= VerifiedPatchLimits.maximumVersionPatchCount else {
@@ -97,7 +98,10 @@ nonisolated enum VerifiedPatchVersionChainDetector {
                 )])
             }
             do {
-                try VerifiedPatchEngine.revalidate(patch)
+                try VerifiedPatchEngine.revalidate(
+                    patch,
+                    planningObserver: planningObserver
+                )
             } catch {
                 return .conflicted([VerifiedPatchVersionConflict(
                     pathScope: nil,
@@ -180,6 +184,7 @@ nonisolated enum VerifiedPatchVersionChainDetector {
         var pathBytes = 0
         var eventMetadataBytes = 0
         var lcsCells = 0
+        var attemptedPlanningCells = 0
         var hunkCount = 0
 
         for patch in patches {
@@ -223,7 +228,9 @@ nonisolated enum VerifiedPatchVersionChainDetector {
                 }
                 for state in [operation.before, operation.after]
                     .compactMap({ $0 }) {
-                    guard accumulate(
+                    guard state.content.count <= VerifiedPatchLimits
+                            .maximumFileByteCount,
+                          accumulate(
                         state.content.count,
                         into: &capturedBytes,
                         maximum: VerifiedPatchLimits
@@ -231,6 +238,22 @@ nonisolated enum VerifiedPatchVersionChainDetector {
                     ) else {
                         return false
                     }
+                }
+                if operation.kind == .modify,
+                   let before = operation.before,
+                   let after = operation.after,
+                   before.content != after.content,
+                   let estimate = VerifiedTextPatch.estimatedLCSCellCount(
+                        before: before.content,
+                        after: after.content
+                    ),
+                   !accumulate(
+                    estimate,
+                    into: &attemptedPlanningCells,
+                    maximum: VerifiedPatchLimits
+                        .maximumVersionLCSCellCount
+                   ) {
+                    return false
                 }
                 if case .text(let hunks, let declaredCells)
                         = operation.strategy {

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchVersionChain.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchVersionChain.swift
@@ -507,6 +507,20 @@ nonisolated enum VerifiedPatchVersionChainDetector {
                     ))
                     continue
                 }
+                if let previousRange = descriptorCASRange(previous),
+                   let currentRange = descriptorCASRange(current),
+                   currentRange.lowerBound <= previousRange.upperBound {
+                    conflicts.append(VerifiedPatchVersionConflict(
+                        pathScope: nil,
+                        patchIDs: [previous.id, current.id],
+                        sessionIDs: [current.receipt.sessionID],
+                        reason: .descriptorCASOrderMismatch(
+                            previous: previousRange.upperBound,
+                            actual: currentRange.lowerBound
+                        )
+                    ))
+                    continue
+                }
                 guard previous.receipt.lastCursorValue < UInt64.max else {
                     conflicts.append(VerifiedPatchVersionConflict(
                         pathScope: nil,
@@ -533,6 +547,22 @@ nonisolated enum VerifiedPatchVersionChainDetector {
                 }
             }
         }
+    }
+
+    private static func descriptorCASRange(
+        _ patch: VerifiedPatchSet
+    ) -> ClosedRange<UInt64>? {
+        let receipts = patch.receipt.mediatedWriterReceipts
+        guard let first = receipts.first else {
+            return nil
+        }
+        var lowerBound = first.descriptorCASSequence
+        var upperBound = first.descriptorCASSequence
+        for receipt in receipts.dropFirst() {
+            lowerBound = min(lowerBound, receipt.descriptorCASSequence)
+            upperBound = max(upperBound, receipt.descriptorCASSequence)
+        }
+        return lowerBound...upperBound
     }
 
     private static func detectJournalReplay(

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchVersionChain.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchVersionChain.swift
@@ -13,9 +13,12 @@ nonisolated enum VerifiedPatchVersionConflictReason: Sendable, Equatable {
     case resourceLimitExceeded
     case replayedEnvelope(UUID)
     case journalSequenceCollision(UInt64)
+    case descriptorCASSequenceCollision(UInt64)
     case journalOrderMismatch(previous: UInt64, actual: UInt64)
+    case descriptorCASOrderMismatch(previous: UInt64, actual: UInt64)
     case cursorOverlap
     case cursorGap(expected: UInt64, actual: UInt64)
+    case workspaceIdentityMismatch
     case ambiguousVersionChain
     case cursorOrderMismatch
 }
@@ -75,12 +78,10 @@ nonisolated enum VerifiedPatchVersionChainDetector {
     ) -> VerifiedPatchVersionChainResult {
         guard patches.count
                 <= VerifiedPatchLimits.maximumVersionPatchCount else {
-            return .conflicted([VerifiedPatchVersionConflict(
-                pathScope: nil,
-                patchIDs: [],
-                sessionIDs: [],
-                reason: .resourceLimitExceeded
-            )])
+            return resourceLimitConflict()
+        }
+        guard isWithinAnalysisBudget(patches) else {
+            return resourceLimitConflict()
         }
 
         var seenPatchIDs: Set<UUID> = []
@@ -108,9 +109,13 @@ nonisolated enum VerifiedPatchVersionChainDetector {
         let orderedPatches = patches.sorted {
             $0.id.uuidString < $1.id.uuidString
         }
+        if let conflict = workspaceIdentityConflict(orderedPatches) {
+            return .conflicted([conflict])
+        }
         var conflicts: [VerifiedPatchVersionConflict] = []
         detectEnvelopeReplay(orderedPatches, conflicts: &conflicts)
         detectJournalReplay(orderedPatches, conflicts: &conflicts)
+        detectDescriptorCASReplay(orderedPatches, conflicts: &conflicts)
         detectCursorConflicts(orderedPatches, conflicts: &conflicts)
 
         guard let nodesByPath = makeNodesByPath(orderedPatches) else {
@@ -130,11 +135,11 @@ nonisolated enum VerifiedPatchVersionChainDetector {
             }
             switch linearChain(nodes) {
             case .success(let orderedNodes):
-                if cursorOrderConflicts(orderedNodes) {
+                if let reason = evidenceOrderConflict(orderedNodes) {
                     conflicts.append(makeConflict(
                         pathScope: pathScope,
                         nodes: orderedNodes,
-                        reason: .cursorOrderMismatch
+                        reason: reason
                     ))
                 } else {
                     chains[pathScope] = orderedNodes.map(\.patchID)
@@ -154,6 +159,279 @@ nonisolated enum VerifiedPatchVersionChainDetector {
             ))
         }
         return .conflicted(conflicts)
+    }
+
+    /// Rejects aggregate work before any patch can trigger LCS recomputation.
+    ///
+    /// All fields are untrusted at this boundary. Declared costs are only a
+    /// cheap upper gate; `VerifiedPatchEngine.revalidate` still recomputes and
+    /// verifies every accepted value after the whole batch fits this budget.
+    private static func isWithinAnalysisBudget(
+        _ patches: [VerifiedPatchSet]
+    ) -> Bool {
+        var operationCount = 0
+        var nodeCount = 0
+        var eventCount = 0
+        var transitionCount = 0
+        var transitionReferenceCount = 0
+        var capturedBytes = 0
+        var pathBytes = 0
+        var eventMetadataBytes = 0
+        var lcsCells = 0
+        var hunkCount = 0
+
+        for patch in patches {
+            guard accumulate(
+                patch.operations.count,
+                into: &operationCount,
+                maximum: VerifiedPatchLimits.maximumVersionOperationCount
+            ),
+            accumulate(
+                patch.receipt.events.count,
+                into: &eventCount,
+                maximum: VerifiedPatchLimits.maximumVersionEventCount
+            ),
+            consumePath(
+                patch.receipt.workspace.canonicalRootPath,
+                total: &pathBytes
+            ) else {
+                return false
+            }
+
+            for operation in patch.operations {
+                let addedNodes = operation.kind == .rename ? 2 : 1
+                guard accumulate(
+                    addedNodes,
+                    into: &nodeCount,
+                    maximum: VerifiedPatchLimits.maximumVersionNodeCount
+                ),
+                accumulate(
+                    operation.id.transitionIDs.count,
+                    into: &transitionReferenceCount,
+                    maximum: VerifiedPatchLimits
+                        .maximumVersionTransitionCount
+                ),
+                consumePath(operation.sourcePath, total: &pathBytes)
+                else {
+                    return false
+                }
+                if let destinationPath = operation.destinationPath,
+                   !consumePath(destinationPath, total: &pathBytes) {
+                    return false
+                }
+                for state in [operation.before, operation.after]
+                    .compactMap({ $0 }) {
+                    guard accumulate(
+                        state.content.count,
+                        into: &capturedBytes,
+                        maximum: VerifiedPatchLimits
+                            .maximumVersionCapturedByteCount
+                    ) else {
+                        return false
+                    }
+                }
+                if case .text(let hunks, let declaredCells)
+                        = operation.strategy {
+                    guard declaredCells >= 0,
+                          accumulate(
+                            declaredCells,
+                            into: &lcsCells,
+                            maximum: VerifiedPatchLimits
+                                .maximumVersionLCSCellCount
+                          ),
+                          accumulate(
+                            hunks.count,
+                            into: &hunkCount,
+                            maximum: VerifiedPatchLimits
+                                .maximumVersionHunkCount
+                          ) else {
+                        return false
+                    }
+                }
+            }
+
+            for event in patch.receipt.events {
+                guard let metadataCount = eventMetadataByteCount(
+                    event.envelope
+                ),
+                accumulate(
+                    metadataCount,
+                    into: &eventMetadataBytes,
+                    maximum: VerifiedPatchLimits
+                        .maximumVersionEventMetadataByteCount
+                ),
+                accumulate(
+                    event.transitions.count,
+                    into: &transitionCount,
+                    maximum: VerifiedPatchLimits
+                        .maximumVersionTransitionCount
+                ),
+                consumePath(
+                    event.durableIdentity.canonicalWorktreePath,
+                    total: &pathBytes
+                ),
+                consumeTransitionPaths(
+                    event.transitions,
+                    total: &pathBytes
+                ) else {
+                    return false
+                }
+                if let writer = event.mediatedWriterReceipt {
+                    guard writer.transitions.count
+                            == event.transitions.count,
+                          consumePath(
+                            writer.workspace.canonicalRootPath,
+                            total: &pathBytes
+                          ),
+                          consumePath(
+                            writer.auditEvent.canonicalWorktreePath,
+                            total: &pathBytes
+                          ),
+                          consumeTransitionPaths(
+                            writer.transitions,
+                            total: &pathBytes
+                          ) else {
+                        return false
+                    }
+                }
+            }
+        }
+        return true
+    }
+
+    private static func workspaceIdentityConflict(
+        _ patches: [VerifiedPatchSet]
+    ) -> VerifiedPatchVersionConflict? {
+        var privateOwners: [UUID: WorkspaceOwner] = [:]
+        var physicalOwners: [PhysicalRoot: WorkspaceOwner] = [:]
+        for patch in patches {
+            let workspace = patch.receipt.workspace
+            let physical = PhysicalRoot(
+                device: workspace.rootDevice,
+                inode: workspace.rootInode
+            )
+            if let existing = privateOwners[workspace.privateWorkspaceID],
+               existing.physicalRoot != physical {
+                return workspaceConflict(existing.patch, patch)
+            }
+            if let existing = physicalOwners[physical],
+               existing.privateWorkspaceID
+                    != workspace.privateWorkspaceID {
+                return workspaceConflict(existing.patch, patch)
+            }
+            let owner = WorkspaceOwner(
+                privateWorkspaceID: workspace.privateWorkspaceID,
+                physicalRoot: physical,
+                patch: patch
+            )
+            privateOwners[workspace.privateWorkspaceID] = owner
+            physicalOwners[physical] = owner
+        }
+        return nil
+    }
+
+    private static func workspaceConflict(
+        _ lhs: VerifiedPatchSet,
+        _ rhs: VerifiedPatchSet
+    ) -> VerifiedPatchVersionConflict {
+        VerifiedPatchVersionConflict(
+            pathScope: nil,
+            patchIDs: sortedUUIDs([lhs.id, rhs.id]),
+            sessionIDs: sortedUUIDs([
+                lhs.receipt.sessionID,
+                rhs.receipt.sessionID
+            ]),
+            reason: .workspaceIdentityMismatch
+        )
+    }
+
+    private static func resourceLimitConflict()
+        -> VerifiedPatchVersionChainResult {
+        .conflicted([VerifiedPatchVersionConflict(
+            pathScope: nil,
+            patchIDs: [],
+            sessionIDs: [],
+            reason: .resourceLimitExceeded
+        )])
+    }
+
+    private static func accumulate(
+        _ value: Int,
+        into total: inout Int,
+        maximum: Int
+    ) -> Bool {
+        guard value >= 0 else { return false }
+        let result = total.addingReportingOverflow(value)
+        guard !result.overflow,
+              result.partialValue <= maximum else {
+            return false
+        }
+        total = result.partialValue
+        return true
+    }
+
+    private static func consumePath(
+        _ path: String,
+        total: inout Int
+    ) -> Bool {
+        accumulate(
+            path.utf8.count,
+            into: &total,
+            maximum: VerifiedPatchLimits.maximumVersionPathByteCount
+        )
+    }
+
+    private static func consumeTransitionPaths(
+        _ transitions: [VerifiedPatchContentTransition],
+        total: inout Int
+    ) -> Bool {
+        for transition in transitions {
+            guard consumePath(transition.sourcePath, total: &total) else {
+                return false
+            }
+            if let destinationPath = transition.destinationPath,
+               !consumePath(destinationPath, total: &total) {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func eventMetadataByteCount(
+        _ envelope: AgentEventEnvelope
+    ) -> Int? {
+        let strings: [String]
+        switch envelope.payload {
+        case .none:
+            strings = [
+                envelope.agentTypeRaw,
+                envelope.location.worktreePath,
+                envelope.location.cwd
+            ]
+        case .commandResult(let command):
+            strings = [
+                envelope.agentTypeRaw,
+                envelope.location.worktreePath,
+                envelope.location.cwd,
+                command.command
+            ]
+        case .fileChange(let change):
+            strings = [
+                envelope.agentTypeRaw,
+                envelope.location.worktreePath,
+                envelope.location.cwd,
+                change.relativePath
+            ]
+        }
+        var result = 0
+        for string in strings {
+            let updated = result.addingReportingOverflow(
+                string.utf8.count
+            )
+            guard !updated.overflow else { return nil }
+            result = updated.partialValue
+        }
+        return result
     }
 
     private static func detectEnvelopeReplay(
@@ -288,18 +566,61 @@ nonisolated enum VerifiedPatchVersionChainDetector {
         }
     }
 
+    private static func detectDescriptorCASReplay(
+        _ patches: [VerifiedPatchSet],
+        conflicts: inout [VerifiedPatchVersionConflict]
+    ) {
+        var owners: [DescriptorCASSequenceScope: VerifiedPatchSet] = [:]
+        for patch in patches {
+            let workspace = patch.receipt.workspace
+            for receipt in patch.receipt.mediatedWriterReceipts {
+                let scope = DescriptorCASSequenceScope(
+                    privateWorkspaceID: workspace.privateWorkspaceID,
+                    rootDevice: workspace.rootDevice,
+                    rootInode: workspace.rootInode,
+                    sequence: receipt.descriptorCASSequence
+                )
+                if let existing = owners[scope] {
+                    conflicts.append(VerifiedPatchVersionConflict(
+                        pathScope: nil,
+                        patchIDs: sortedUUIDs([existing.id, patch.id]),
+                        sessionIDs: sortedUUIDs([
+                            existing.receipt.sessionID,
+                            patch.receipt.sessionID
+                        ]),
+                        reason: .descriptorCASSequenceCollision(
+                            receipt.descriptorCASSequence
+                        )
+                    ))
+                } else {
+                    owners[scope] = patch
+                }
+            }
+        }
+    }
+
     private static func makeNodesByPath(
         _ patches: [VerifiedPatchSet]
     ) -> [VerifiedPatchPathScope: [VersionNode]]? {
         var result: [VerifiedPatchPathScope: [VersionNode]] = [:]
         var nodeCount = 0
         for patch in patches {
+            guard let evidenceByTransition = transitionEvidence(in: patch)
+            else {
+                return nil
+            }
             for operation in patch.operations {
+                guard let evidence = evidenceRange(
+                    for: operation.id.transitionIDs,
+                    evidence: evidenceByTransition
+                ) else {
+                    return nil
+                }
                 let common = (
                     patchID: patch.id,
                     sessionID: patch.receipt.sessionID,
                     stream: StreamIdentity(patch),
-                    firstCursor: patch.receipt.firstCursorValue
+                    evidence: evidence
                 )
                 if operation.kind == .rename,
                    let destinationPath = operation.destinationPath {
@@ -308,7 +629,7 @@ nonisolated enum VerifiedPatchVersionChainDetector {
                             patchID: common.patchID,
                             sessionID: common.sessionID,
                             stream: common.stream,
-                            firstCursor: common.firstCursor,
+                            evidence: common.evidence,
                             before: operation.before?.stateIdentity,
                             after: nil
                         ),
@@ -324,7 +645,7 @@ nonisolated enum VerifiedPatchVersionChainDetector {
                             patchID: common.patchID,
                             sessionID: common.sessionID,
                             stream: common.stream,
-                            firstCursor: common.firstCursor,
+                            evidence: common.evidence,
                             before: nil,
                             after: operation.after?.stateIdentity
                         ),
@@ -343,7 +664,7 @@ nonisolated enum VerifiedPatchVersionChainDetector {
                             patchID: common.patchID,
                             sessionID: common.sessionID,
                             stream: common.stream,
-                            firstCursor: common.firstCursor,
+                            evidence: common.evidence,
                             before: operation.before?.stateIdentity,
                             after: operation.after?.stateIdentity
                         ),
@@ -358,6 +679,76 @@ nonisolated enum VerifiedPatchVersionChainDetector {
                     }
                 }
             }
+        }
+        return result
+    }
+
+    private static func transitionEvidence(
+        in patch: VerifiedPatchSet
+    ) -> [VerifiedPatchTransitionID: TransitionEvidence]? {
+        var result: [VerifiedPatchTransitionID: TransitionEvidence] = [:]
+        for event in patch.receipt.events {
+            guard event.transitions.isEmpty
+                    || event.mediatedWriterReceipt != nil else {
+                return nil
+            }
+            for ordinal in event.transitions.indices {
+                guard let receipt = event.mediatedWriterReceipt else {
+                    return nil
+                }
+                let id = VerifiedPatchTransitionID(
+                    envelopeID: event.envelope.id,
+                    ordinal: ordinal
+                )
+                let evidence = TransitionEvidence(
+                    cursor: event.envelope.cursorValue,
+                    journalSequence: event.durableIdentity.journalSequence,
+                    descriptorCASSequence: receipt.descriptorCASSequence
+                )
+                guard result.updateValue(evidence, forKey: id) == nil else {
+                    return nil
+                }
+            }
+        }
+        return result
+    }
+
+    private static func evidenceRange(
+        for transitionIDs: [VerifiedPatchTransitionID],
+        evidence: [VerifiedPatchTransitionID: TransitionEvidence]
+    ) -> TransitionEvidenceRange? {
+        guard let firstID = transitionIDs.first,
+              let first = evidence[firstID] else {
+            return nil
+        }
+        var result = TransitionEvidenceRange(
+            firstCursor: first.cursor,
+            lastCursor: first.cursor,
+            firstJournalSequence: first.journalSequence,
+            lastJournalSequence: first.journalSequence,
+            firstDescriptorCASSequence: first.descriptorCASSequence,
+            lastDescriptorCASSequence: first.descriptorCASSequence
+        )
+        for id in transitionIDs.dropFirst() {
+            guard let value = evidence[id] else { return nil }
+            result.firstCursor = min(result.firstCursor, value.cursor)
+            result.lastCursor = max(result.lastCursor, value.cursor)
+            result.firstJournalSequence = min(
+                result.firstJournalSequence,
+                value.journalSequence
+            )
+            result.lastJournalSequence = max(
+                result.lastJournalSequence,
+                value.journalSequence
+            )
+            result.firstDescriptorCASSequence = min(
+                result.firstDescriptorCASSequence,
+                value.descriptorCASSequence
+            )
+            result.lastDescriptorCASSequence = max(
+                result.lastDescriptorCASSequence,
+                value.descriptorCASSequence
+            )
         }
         return result
     }
@@ -421,18 +812,36 @@ nonisolated enum VerifiedPatchVersionChainDetector {
         return .success(result)
     }
 
-    private static func cursorOrderConflicts(
+    private static func evidenceOrderConflict(
         _ nodes: [VersionNode]
-    ) -> Bool {
+    ) -> VerifiedPatchVersionConflictReason? {
+        var lastCursorByStream: [StreamIdentity: UInt64] = [:]
+        for node in nodes {
+            if let lastCursor = lastCursorByStream[node.stream],
+               node.evidence.firstCursor <= lastCursor {
+                return .cursorOrderMismatch
+            }
+            lastCursorByStream[node.stream] = node.evidence.lastCursor
+        }
         for index in nodes.indices.dropFirst() {
-            let previous = nodes[index - 1]
-            let current = nodes[index]
-            if previous.stream == current.stream,
-               previous.firstCursor >= current.firstCursor {
-                return true
+            let previous = nodes[index - 1].evidence
+            let current = nodes[index].evidence
+            if current.firstJournalSequence
+                <= previous.lastJournalSequence {
+                return .journalOrderMismatch(
+                    previous: previous.lastJournalSequence,
+                    actual: current.firstJournalSequence
+                )
+            }
+            if current.firstDescriptorCASSequence
+                <= previous.lastDescriptorCASSequence {
+                return .descriptorCASOrderMismatch(
+                    previous: previous.lastDescriptorCASSequence,
+                    actual: current.firstDescriptorCASSequence
+                )
             }
         }
-        return false
+        return nil
     }
 
     private static func makeConflict(
@@ -540,11 +949,44 @@ nonisolated enum VerifiedPatchVersionChainDetector {
         let journalSequence: UInt64
     }
 
+    private struct DescriptorCASSequenceScope: Hashable {
+        let privateWorkspaceID: UUID
+        let rootDevice: UInt64
+        let rootInode: UInt64
+        let sequence: UInt64
+    }
+
+    private struct PhysicalRoot: Hashable {
+        let device: UInt64
+        let inode: UInt64
+    }
+
+    private struct WorkspaceOwner {
+        let privateWorkspaceID: UUID
+        let physicalRoot: PhysicalRoot
+        let patch: VerifiedPatchSet
+    }
+
+    private struct TransitionEvidence {
+        let cursor: UInt64
+        let journalSequence: UInt64
+        let descriptorCASSequence: UInt64
+    }
+
+    private struct TransitionEvidenceRange {
+        var firstCursor: UInt64
+        var lastCursor: UInt64
+        var firstJournalSequence: UInt64
+        var lastJournalSequence: UInt64
+        var firstDescriptorCASSequence: UInt64
+        var lastDescriptorCASSequence: UInt64
+    }
+
     private struct VersionNode {
         let patchID: UUID
         let sessionID: UUID
         let stream: StreamIdentity
-        let firstCursor: UInt64
+        let evidence: TransitionEvidenceRange
         let before: VerifiedPatchStateIdentity?
         let after: VerifiedPatchStateIdentity?
     }

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchVersionChain.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchVersionChain.swift
@@ -2,23 +2,53 @@
 //  VerifiedPatchVersionChain.swift
 //  Pine
 //
-//  Pure overlap and version-chain analysis for verified agent patches (#933).
+//  Bounded multi-agent overlap and exact content-chain analysis (#933).
 //
 
 import Foundation
 
 nonisolated enum VerifiedPatchVersionConflictReason: Sendable, Equatable {
+    case invalidPatch(UUID)
+    case duplicatePatchID(UUID)
+    case resourceLimitExceeded
     case replayedEnvelope(UUID)
+    case journalSequenceCollision(UInt64)
+    case journalOrderMismatch(previous: UInt64, actual: UInt64)
     case cursorOverlap
     case cursorGap(expected: UInt64, actual: UInt64)
     case ambiguousVersionChain
     case cursorOrderMismatch
 }
 
-nonisolated struct VerifiedPatchPathScope: Sendable, Equatable, Hashable {
-    let projectID: UUID
-    let worktreePath: String
-    let relativePath: String
+/// Workspace identity plus a conservative normalization/case alias key.
+///
+/// Equality deliberately ignores display spelling, so `File.swift`,
+/// `file.swift`, and canonically equivalent spellings cannot split overlap
+/// analysis even if the current volume happens to be case-sensitive.
+nonisolated struct VerifiedPatchPathScope: Sendable, Hashable {
+    let privateWorkspaceID: UUID
+    let rootDevice: UInt64
+    let rootInode: UInt64
+    let conservativeRelativePath: String
+    let displayRelativePath: String
+
+    static func == (
+        lhs: VerifiedPatchPathScope,
+        rhs: VerifiedPatchPathScope
+    ) -> Bool {
+        lhs.privateWorkspaceID == rhs.privateWorkspaceID
+            && lhs.rootDevice == rhs.rootDevice
+            && lhs.rootInode == rhs.rootInode
+            && lhs.conservativeRelativePath
+                == rhs.conservativeRelativePath
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(privateWorkspaceID)
+        hasher.combine(rootDevice)
+        hasher.combine(rootInode)
+        hasher.combine(conservativeRelativePath)
+    }
 }
 
 nonisolated struct VerifiedPatchVersionConflict: Sendable, Equatable {
@@ -27,11 +57,10 @@ nonisolated struct VerifiedPatchVersionConflict: Sendable, Equatable {
     let sessionIDs: [UUID]
     let reason: VerifiedPatchVersionConflictReason
 
-    var path: String? { pathScope?.relativePath }
+    var path: String? { pathScope?.displayRelativePath }
 }
 
 nonisolated struct VerifiedPatchVersionChainReport: Sendable, Equatable {
-    /// Exact identity order for every scoped path touched more than once.
     let orderedPatchIDsByPath: [VerifiedPatchPathScope: [UUID]]
 }
 
@@ -40,19 +69,59 @@ nonisolated enum VerifiedPatchVersionChainResult: Sendable, Equatable {
     case conflicted([VerifiedPatchVersionConflict])
 }
 
-/// Detects cursor replay/gaps and divergent multi-agent file versions.
 nonisolated enum VerifiedPatchVersionChainDetector {
     static func analyze(
         _ patches: [VerifiedPatchSet]
     ) -> VerifiedPatchVersionChainResult {
+        guard patches.count
+                <= VerifiedPatchLimits.maximumVersionPatchCount else {
+            return .conflicted([VerifiedPatchVersionConflict(
+                pathScope: nil,
+                patchIDs: [],
+                sessionIDs: [],
+                reason: .resourceLimitExceeded
+            )])
+        }
+
+        var seenPatchIDs: Set<UUID> = []
+        for patch in patches {
+            guard seenPatchIDs.insert(patch.id).inserted else {
+                return .conflicted([VerifiedPatchVersionConflict(
+                    pathScope: nil,
+                    patchIDs: [patch.id],
+                    sessionIDs: [patch.receipt.sessionID],
+                    reason: .duplicatePatchID(patch.id)
+                )])
+            }
+            do {
+                try VerifiedPatchEngine.revalidate(patch)
+            } catch {
+                return .conflicted([VerifiedPatchVersionConflict(
+                    pathScope: nil,
+                    patchIDs: [patch.id],
+                    sessionIDs: [patch.receipt.sessionID],
+                    reason: .invalidPatch(patch.id)
+                )])
+            }
+        }
+
         let orderedPatches = patches.sorted {
             $0.id.uuidString < $1.id.uuidString
         }
         var conflicts: [VerifiedPatchVersionConflict] = []
         detectEnvelopeReplay(orderedPatches, conflicts: &conflicts)
+        detectJournalReplay(orderedPatches, conflicts: &conflicts)
         detectCursorConflicts(orderedPatches, conflicts: &conflicts)
 
-        let nodesByPath = makeNodesByPath(orderedPatches)
+        guard let nodesByPath = makeNodesByPath(orderedPatches) else {
+            conflicts.append(VerifiedPatchVersionConflict(
+                pathScope: nil,
+                patchIDs: [],
+                sessionIDs: [],
+                reason: .resourceLimitExceeded
+            ))
+            return .conflicted(conflicts)
+        }
         var chains: [VerifiedPatchPathScope: [UUID]] = [:]
         for pathScope in nodesByPath.keys.sorted(by: pathScopeOrder) {
             guard let nodes = nodesByPath[pathScope],
@@ -93,14 +162,14 @@ nonisolated enum VerifiedPatchVersionChainDetector {
     ) {
         var owners: [UUID: VerifiedPatchSet] = [:]
         for patch in patches {
-            for envelopeID in patch.binding.envelopeIDs {
+            for envelopeID in patch.receipt.envelopeIDs {
                 if let existing = owners[envelopeID] {
                     conflicts.append(VerifiedPatchVersionConflict(
                         pathScope: nil,
                         patchIDs: sortedUUIDs([existing.id, patch.id]),
                         sessionIDs: sortedUUIDs([
-                            existing.binding.sessionID,
-                            patch.binding.sessionID
+                            existing.receipt.sessionID,
+                            patch.receipt.sessionID
                         ]),
                         reason: .replayedEnvelope(envelopeID)
                     ))
@@ -122,50 +191,63 @@ nonisolated enum VerifiedPatchVersionChainDetector {
                 continue
             }
             let ordered = group.sorted {
-                if $0.binding.firstCursorValue
-                    != $1.binding.firstCursorValue {
-                    return $0.binding.firstCursorValue
-                        < $1.binding.firstCursorValue
+                if $0.receipt.firstCursorValue
+                    != $1.receipt.firstCursorValue {
+                    return $0.receipt.firstCursorValue
+                        < $1.receipt.firstCursorValue
                 }
                 return $0.id.uuidString < $1.id.uuidString
             }
             for index in ordered.indices.dropFirst() {
                 let previous = ordered[index - 1]
                 let current = ordered[index]
-                if current.binding.firstCursorValue
-                    <= previous.binding.lastCursorValue {
+                if current.receipt.firstCursorValue
+                    <= previous.receipt.lastCursorValue {
                     conflicts.append(VerifiedPatchVersionConflict(
                         pathScope: nil,
                         patchIDs: [previous.id, current.id],
                         sessionIDs: sortedUUIDs([
-                            previous.binding.sessionID,
-                            current.binding.sessionID
+                            previous.receipt.sessionID,
+                            current.receipt.sessionID
                         ]),
                         reason: .cursorOverlap
                     ))
                     continue
                 }
-                guard previous.binding.lastCursorValue < UInt64.max else {
+                if current.receipt.firstJournalSequence
+                    <= previous.receipt.lastJournalSequence {
                     conflicts.append(VerifiedPatchVersionConflict(
                         pathScope: nil,
                         patchIDs: [previous.id, current.id],
-                        sessionIDs: [current.binding.sessionID],
-                        reason: .cursorGap(
-                            expected: UInt64.max,
-                            actual: current.binding.firstCursorValue
+                        sessionIDs: [current.receipt.sessionID],
+                        reason: .journalOrderMismatch(
+                            previous: previous.receipt.lastJournalSequence,
+                            actual: current.receipt.firstJournalSequence
                         )
                     ))
                     continue
                 }
-                let expected = previous.binding.lastCursorValue + 1
-                if current.binding.firstCursorValue != expected {
+                guard previous.receipt.lastCursorValue < UInt64.max else {
                     conflicts.append(VerifiedPatchVersionConflict(
                         pathScope: nil,
                         patchIDs: [previous.id, current.id],
-                        sessionIDs: [current.binding.sessionID],
+                        sessionIDs: [current.receipt.sessionID],
+                        reason: .cursorGap(
+                            expected: UInt64.max,
+                            actual: current.receipt.firstCursorValue
+                        )
+                    ))
+                    continue
+                }
+                let expected = previous.receipt.lastCursorValue + 1
+                if current.receipt.firstCursorValue != expected {
+                    conflicts.append(VerifiedPatchVersionConflict(
+                        pathScope: nil,
+                        patchIDs: [previous.id, current.id],
+                        sessionIDs: [current.receipt.sessionID],
                         reason: .cursorGap(
                             expected: expected,
-                            actual: current.binding.firstCursorValue
+                            actual: current.receipt.firstCursorValue
                         )
                     ))
                 }
@@ -173,67 +255,128 @@ nonisolated enum VerifiedPatchVersionChainDetector {
         }
     }
 
+    private static func detectJournalReplay(
+        _ patches: [VerifiedPatchSet],
+        conflicts: inout [VerifiedPatchVersionConflict]
+    ) {
+        var owners: [JournalSequenceScope: VerifiedPatchSet] = [:]
+        for patch in patches {
+            let workspace = patch.receipt.workspace
+            for event in patch.receipt.durableEventIdentities {
+                let scope = JournalSequenceScope(
+                    privateWorkspaceID: workspace.privateWorkspaceID,
+                    rootDevice: workspace.rootDevice,
+                    rootInode: workspace.rootInode,
+                    journalSequence: event.journalSequence
+                )
+                if let existing = owners[scope] {
+                    conflicts.append(VerifiedPatchVersionConflict(
+                        pathScope: nil,
+                        patchIDs: sortedUUIDs([existing.id, patch.id]),
+                        sessionIDs: sortedUUIDs([
+                            existing.receipt.sessionID,
+                            patch.receipt.sessionID
+                        ]),
+                        reason: .journalSequenceCollision(
+                            event.journalSequence
+                        )
+                    ))
+                } else {
+                    owners[scope] = patch
+                }
+            }
+        }
+    }
+
     private static func makeNodesByPath(
         _ patches: [VerifiedPatchSet]
-    ) -> [VerifiedPatchPathScope: [VersionNode]] {
+    ) -> [VerifiedPatchPathScope: [VersionNode]]? {
         var result: [VerifiedPatchPathScope: [VersionNode]] = [:]
+        var nodeCount = 0
         for patch in patches {
             for operation in patch.operations {
                 let common = (
                     patchID: patch.id,
-                    sessionID: patch.binding.sessionID,
+                    sessionID: patch.receipt.sessionID,
                     stream: StreamIdentity(patch),
-                    firstCursor: patch.binding.firstCursorValue
+                    firstCursor: patch.receipt.firstCursorValue
                 )
                 if operation.kind == .rename,
                    let destinationPath = operation.destinationPath {
-                    let sourceScope = pathScope(
-                        patch,
-                        relativePath: operation.sourcePath
-                    )
-                    let destinationScope = pathScope(
-                        patch,
-                        relativePath: destinationPath
-                    )
-                    result[sourceScope, default: []].append(
+                    guard appendNode(
                         VersionNode(
                             patchID: common.patchID,
                             sessionID: common.sessionID,
                             stream: common.stream,
                             firstCursor: common.firstCursor,
-                            before: operation.before?.identity,
+                            before: operation.before?.stateIdentity,
                             after: nil
-                        )
-                    )
-                    result[destinationScope, default: []].append(
+                        ),
+                        scope: pathScope(
+                            patch,
+                            relativePath: operation.sourcePath
+                        ),
+                        result: &result,
+                        count: &nodeCount
+                    ),
+                    appendNode(
                         VersionNode(
                             patchID: common.patchID,
                             sessionID: common.sessionID,
                             stream: common.stream,
                             firstCursor: common.firstCursor,
                             before: nil,
-                            after: operation.after?.identity
-                        )
-                    )
+                            after: operation.after?.stateIdentity
+                        ),
+                        scope: pathScope(
+                            patch,
+                            relativePath: destinationPath
+                        ),
+                        result: &result,
+                        count: &nodeCount
+                    ) else {
+                        return nil
+                    }
                 } else {
-                    let scope = pathScope(
-                        patch,
-                        relativePath: operation.sourcePath
-                    )
-                    result[scope, default: []].append(
+                    guard appendNode(
                         VersionNode(
                             patchID: common.patchID,
                             sessionID: common.sessionID,
                             stream: common.stream,
                             firstCursor: common.firstCursor,
-                            before: operation.before?.identity,
-                            after: operation.after?.identity
-                        )
-                    )
+                            before: operation.before?.stateIdentity,
+                            after: operation.after?.stateIdentity
+                        ),
+                        scope: pathScope(
+                            patch,
+                            relativePath: operation.sourcePath
+                        ),
+                        result: &result,
+                        count: &nodeCount
+                    ) else {
+                        return nil
+                    }
                 }
             }
         }
         return result
+    }
+
+    private static func appendNode(
+        _ node: VersionNode,
+        scope: VerifiedPatchPathScope,
+        result: inout [VerifiedPatchPathScope: [VersionNode]],
+        count: inout Int
+    ) -> Bool {
+        let updated = count.addingReportingOverflow(1)
+        guard !updated.overflow,
+              updated.partialValue
+                <= VerifiedPatchLimits.maximumVersionNodeCount else {
+            return false
+        }
+        count = updated.partialValue
+        result[scope, default: []].append(node)
+        return true
     }
 
     private static func linearChain(
@@ -250,7 +393,6 @@ nonisolated enum VerifiedPatchVersionChainDetector {
                 }
             }
         }
-
         guard successors.values.allSatisfy({ $0.count <= 1 }),
               predecessors.values.allSatisfy({ $0.count <= 1 }) else {
             return .failure(.ambiguous)
@@ -312,15 +454,55 @@ nonisolated enum VerifiedPatchVersionChainDetector {
         }
     }
 
+    private static func pathScope(
+        _ patch: VerifiedPatchSet,
+        relativePath: String
+    ) -> VerifiedPatchPathScope {
+        let workspace = patch.receipt.workspace
+        return VerifiedPatchPathScope(
+            privateWorkspaceID: workspace.privateWorkspaceID,
+            rootDevice: workspace.rootDevice,
+            rootInode: workspace.rootInode,
+            conservativeRelativePath: VerifiedPatchIngressCoordinator
+                .conservativePathKey(relativePath),
+            displayRelativePath: relativePath
+        )
+    }
+
+    private static func pathScopeOrder(
+        _ lhs: VerifiedPatchPathScope,
+        _ rhs: VerifiedPatchPathScope
+    ) -> Bool {
+        if lhs.privateWorkspaceID != rhs.privateWorkspaceID {
+            return lhs.privateWorkspaceID.uuidString
+                < rhs.privateWorkspaceID.uuidString
+        }
+        if lhs.rootDevice != rhs.rootDevice {
+            return lhs.rootDevice < rhs.rootDevice
+        }
+        if lhs.rootInode != rhs.rootInode {
+            return lhs.rootInode < rhs.rootInode
+        }
+        return lhs.conservativeRelativePath
+            < rhs.conservativeRelativePath
+    }
+
     private static func streamOrder(
         _ lhs: StreamIdentity,
         _ rhs: StreamIdentity
     ) -> Bool {
+        if lhs.privateWorkspaceID != rhs.privateWorkspaceID {
+            return lhs.privateWorkspaceID.uuidString
+                < rhs.privateWorkspaceID.uuidString
+        }
+        if lhs.rootDevice != rhs.rootDevice {
+            return lhs.rootDevice < rhs.rootDevice
+        }
+        if lhs.rootInode != rhs.rootInode {
+            return lhs.rootInode < rhs.rootInode
+        }
         if lhs.projectID != rhs.projectID {
             return lhs.projectID.uuidString < rhs.projectID.uuidString
-        }
-        if lhs.worktreePath != rhs.worktreePath {
-            return lhs.worktreePath < rhs.worktreePath
         }
         if lhs.sessionID != rhs.sessionID {
             return lhs.sessionID.uuidString < rhs.sessionID.uuidString
@@ -331,44 +513,31 @@ nonisolated enum VerifiedPatchVersionChainDetector {
         return lhs.processGeneration < rhs.processGeneration
     }
 
-    private static func pathScope(
-        _ patch: VerifiedPatchSet,
-        relativePath: String
-    ) -> VerifiedPatchPathScope {
-        VerifiedPatchPathScope(
-            projectID: patch.binding.projectID,
-            worktreePath: patch.binding.worktreePath,
-            relativePath: relativePath
-        )
-    }
-
-    private static func pathScopeOrder(
-        _ lhs: VerifiedPatchPathScope,
-        _ rhs: VerifiedPatchPathScope
-    ) -> Bool {
-        if lhs.projectID != rhs.projectID {
-            return lhs.projectID.uuidString < rhs.projectID.uuidString
-        }
-        if lhs.worktreePath != rhs.worktreePath {
-            return lhs.worktreePath < rhs.worktreePath
-        }
-        return lhs.relativePath < rhs.relativePath
-    }
-
     private struct StreamIdentity: Hashable {
+        let privateWorkspaceID: UUID
+        let rootDevice: UInt64
+        let rootInode: UInt64
         let projectID: UUID
-        let worktreePath: String
         let sessionID: UUID
         let terminalID: UUID
         let processGeneration: UInt64
 
         init(_ patch: VerifiedPatchSet) {
-            projectID = patch.binding.projectID
-            worktreePath = patch.binding.worktreePath
-            sessionID = patch.binding.sessionID
-            terminalID = patch.binding.process.terminalID
-            processGeneration = patch.binding.process.processGeneration
+            privateWorkspaceID = patch.receipt.workspace.privateWorkspaceID
+            rootDevice = patch.receipt.workspace.rootDevice
+            rootInode = patch.receipt.workspace.rootInode
+            projectID = patch.receipt.projectID
+            sessionID = patch.receipt.sessionID
+            terminalID = patch.receipt.process.terminalID
+            processGeneration = patch.receipt.process.processGeneration
         }
+    }
+
+    private struct JournalSequenceScope: Hashable {
+        let privateWorkspaceID: UUID
+        let rootDevice: UInt64
+        let rootInode: UInt64
+        let journalSequence: UInt64
     }
 
     private struct VersionNode {
@@ -376,8 +545,8 @@ nonisolated enum VerifiedPatchVersionChainDetector {
         let sessionID: UUID
         let stream: StreamIdentity
         let firstCursor: UInt64
-        let before: ContentIdentity?
-        let after: ContentIdentity?
+        let before: VerifiedPatchStateIdentity?
+        let after: VerifiedPatchStateIdentity?
     }
 
     private enum ChainFailure: Error {

--- a/Pine/Agent/VerifiedChanges/VerifiedTextPatch.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedTextPatch.swift
@@ -2,40 +2,244 @@
 //  VerifiedTextPatch.swift
 //  Pine
 //
-//  Deterministic line diff and checked inverse-hunk application for #933.
+//  Bounded deterministic diff and conservative positional three-way merge.
 //
 
 import Foundation
 
+nonisolated struct VerifiedTextPatchPlan: Sendable, Equatable {
+    let hunks: [VerifiedTextPatchHunk]
+    let lcsCellCount: Int
+}
+
+nonisolated struct VerifiedPreparedTextResult: Sendable, Equatable {
+    let content: Data
+    let hunks: [VerifiedPreparedTextHunk]
+    let lcsCellCount: Int
+}
+
+/// Text patching never searches globally for a matching block.
+///
+/// Preparation diffs the captured after-state against the supplied current
+/// state, rejects any human edit intersecting a captured hunk plus two exact
+/// guard lines, and maps the original range only by the bounded edit deltas
+/// before it. It then verifies the complete guarded region at that resolved
+/// position. A deleted/moved original block therefore conflicts even if
+/// identical bytes appear elsewhere.
 nonisolated enum VerifiedTextPatch {
-    static let maximumLineCount = 4_096
-    static let maximumDiffCellCount = 4_000_000
     private static let contextLineCount = 2
 
-    static func canDiff(before: Data, after: Data) -> Bool {
-        guard isText(before),
-              isText(after) else {
-            return false
-        }
-        let beforeLines = lines(in: before)
-        let afterLines = lines(in: after)
-        guard beforeLines.count <= maximumLineCount,
-              afterLines.count <= maximumLineCount else {
-            return false
-        }
-        let cellCount = (beforeLines.count + 1)
-            .multipliedReportingOverflow(by: afterLines.count + 1)
-        return !cellCount.overflow
-            && cellCount.partialValue <= maximumDiffCellCount
-    }
-
-    static func makeHunks(
+    static func plan(
         before: Data,
         after: Data
-    ) -> [VerifiedTextPatchHunk] {
+    ) -> VerifiedTextPatchPlan? {
+        guard isText(before), isText(after) else {
+            return nil
+        }
         let beforeLines = lines(in: before)
         let afterLines = lines(in: after)
+        guard let cellCount = lcsCellCount(
+            lhsCount: beforeLines.count,
+            rhsCount: afterLines.count
+        ) else {
+            return nil
+        }
         let steps = diffSteps(before: beforeLines, after: afterLines)
+        let hunks = makeHunks(
+            steps: steps,
+            afterLines: afterLines
+        )
+        guard !hunks.isEmpty,
+              hunks.count <= VerifiedPatchLimits.maximumHunkCount else {
+            return nil
+        }
+        return VerifiedTextPatchPlan(
+            hunks: hunks,
+            lcsCellCount: cellCount
+        )
+    }
+
+    static func estimatedLCSCellCount(
+        before: Data,
+        after: Data
+    ) -> Int? {
+        guard isText(before),
+              isText(after) else {
+            return nil
+        }
+        return lcsCellCount(
+            lhsCount: lines(in: before).count,
+            rhsCount: lines(in: after).count
+        )
+    }
+
+    static func prepareInverse(
+        hunks: [VerifiedTextPatchHunk],
+        capturedAfter: Data,
+        current: Data
+    ) -> Result<VerifiedPreparedTextResult, VerifiedPatchConflictReason> {
+        guard isText(capturedAfter),
+              isText(current) else {
+            return .failure(.currentContentIsNotText)
+        }
+        guard hunks.count <= VerifiedPatchLimits.maximumHunkCount else {
+            return .failure(.resourceLimitExceeded)
+        }
+
+        let afterLines = lines(in: capturedAfter)
+        let currentLines = lines(in: current)
+        guard let cellCount = lcsCellCount(
+            lhsCount: afterLines.count,
+            rhsCount: currentLines.count
+        ) else {
+            return .failure(.resourceLimitExceeded)
+        }
+        let humanEdits = lineEdits(
+            from: afterLines,
+            to: currentLines
+        )
+        var resolved: [VerifiedPreparedTextHunk] = []
+
+        for (index, hunk) in hunks.enumerated() {
+            guard let capturedRange = checkedRange(
+                start: hunk.afterStartLine,
+                count: hunk.afterLineCount,
+                upperBound: afterLines.count
+            ) else {
+                return .failure(.mappedRegionMismatch(hunkIndex: index))
+            }
+            let guardStart = hunk.afterStartLine
+                - hunk.prefixContext.count
+            guard guardStart >= 0,
+                  let coreAndSuffixCount = checkedAdd(
+                    hunk.afterLineCount,
+                    hunk.suffixContext.count
+                  ),
+                  let guardEnd = checkedAdd(
+                    hunk.afterStartLine,
+                    coreAndSuffixCount
+                  ),
+                  guardEnd <= afterLines.count else {
+                return .failure(.mappedRegionMismatch(hunkIndex: index))
+            }
+            let guardedRange = guardStart..<guardEnd
+            guard !humanEdits.contains(where: {
+                touches($0, guardedRange: guardedRange)
+            }) else {
+                return .failure(
+                    .humanEditOverlapsAgentRegion(hunkIndex: index)
+                )
+            }
+
+            guard let delta = positionalDelta(
+                before: guardStart,
+                edits: humanEdits
+            ),
+            let resolvedGuardStart = checkedOffset(
+                guardStart,
+                by: delta
+            ),
+            let resolvedCoreStart = checkedOffset(
+                hunk.afterStartLine,
+                by: delta
+            ),
+            let resolvedGuardEnd = checkedAdd(
+                resolvedGuardStart,
+                guardedRange.count
+            ),
+            resolvedGuardStart >= 0,
+            resolvedGuardEnd <= currentLines.count,
+            let resolvedCoreRange = checkedRange(
+                start: resolvedCoreStart,
+                count: capturedRange.count,
+                upperBound: currentLines.count
+            ) else {
+                return .failure(.mappedRegionMismatch(hunkIndex: index))
+            }
+
+            let expectedGuard = Array(afterLines[guardedRange])
+            let actualGuard = Array(
+                currentLines[resolvedGuardStart..<resolvedGuardEnd]
+            )
+            guard expectedGuard == actualGuard else {
+                return .failure(.mappedRegionMismatch(hunkIndex: index))
+            }
+            resolved.append(VerifiedPreparedTextHunk(
+                capturedAfterRange: capturedRange,
+                resolvedCurrentRange: resolvedCoreRange,
+                replacementLines: hunk.beforeLines
+            ))
+        }
+
+        guard !hasOverlap(resolved) else {
+            return .failure(.overlappingResolvedHunks)
+        }
+        var result = currentLines
+        for hunk in resolved.sorted(by: descendingOrder) {
+            result.replaceSubrange(
+                hunk.resolvedCurrentRange,
+                with: hunk.replacementLines
+            )
+        }
+        return .success(VerifiedPreparedTextResult(
+            content: result.reduce(into: Data()) { $0.append($1) },
+            hunks: resolved,
+            lcsCellCount: cellCount
+        ))
+    }
+
+    static func isText(_ data: Data) -> Bool {
+        !data.contains(0) && String(data: data, encoding: .utf8) != nil
+    }
+
+    static func lines(in data: Data) -> [Data] {
+        guard !data.isEmpty else { return [] }
+        var result: [Data] = []
+        var lineStart = data.startIndex
+        var index = lineStart
+        while index < data.endIndex {
+            if data[index] == 0x0A {
+                let next = data.index(after: index)
+                result.append(Data(data[lineStart..<next]))
+                lineStart = next
+            }
+            index = data.index(after: index)
+        }
+        if lineStart < data.endIndex {
+            result.append(Data(data[lineStart..<data.endIndex]))
+        }
+        return result
+    }
+
+    private static func lcsCellCount(
+        lhsCount: Int,
+        rhsCount: Int
+    ) -> Int? {
+        guard lhsCount <= VerifiedPatchLimits.maximumLineCount,
+              rhsCount <= VerifiedPatchLimits.maximumLineCount else {
+            return nil
+        }
+        let lhs = lhsCount.addingReportingOverflow(1)
+        let rhs = rhsCount.addingReportingOverflow(1)
+        guard !lhs.overflow,
+              !rhs.overflow else {
+            return nil
+        }
+        let cells = lhs.partialValue.multipliedReportingOverflow(
+            by: rhs.partialValue
+        )
+        guard !cells.overflow,
+              cells.partialValue
+                <= VerifiedPatchLimits.maximumLCSCellCountPerDiff else {
+            return nil
+        }
+        return cells.partialValue
+    }
+
+    private static func makeHunks(
+        steps: [DiffStep],
+        afterLines: [Data]
+    ) -> [VerifiedTextPatchHunk] {
         var hunks: [VerifiedTextPatchHunk] = []
         var beforeIndex = 0
         var afterIndex = 0
@@ -97,78 +301,44 @@ nonisolated enum VerifiedTextPatch {
         return hunks
     }
 
-    static func applyInverse(
-        hunks: [VerifiedTextPatchHunk],
-        to current: Data
-    ) -> Result<Data, VerifiedPatchConflictReason> {
-        guard isText(current) else {
-            return .failure(.currentContentIsNotText)
-        }
-        let currentLines = lines(in: current)
-        var resolutions: [ResolvedHunk] = []
+    private static func lineEdits(
+        from before: [Data],
+        to after: [Data]
+    ) -> [LineEdit] {
+        let steps = diffSteps(before: before, after: after)
+        var edits: [LineEdit] = []
+        var beforeIndex = 0
+        var activeStart: Int?
+        var removedCount = 0
+        var replacement: [Data] = []
 
-        for (index, hunk) in hunks.enumerated() {
-            let pattern = hunk.prefixContext
-                + hunk.afterLines
-                + hunk.suffixContext
-            guard !pattern.isEmpty else {
-                return .failure(.ambiguousTextContext(hunkIndex: index))
-            }
-            let occurrences = occurrenceStarts(
-                of: pattern,
-                in: currentLines
-            )
-            guard !occurrences.isEmpty else {
-                return .failure(.textContextMissing(hunkIndex: index))
-            }
-            guard occurrences.count == 1,
-                  let occurrence = occurrences.first else {
-                return .failure(.ambiguousTextContext(hunkIndex: index))
-            }
-            let coreStart = occurrence + hunk.prefixContext.count
-            let coreEnd = coreStart + hunk.afterLines.count
-            resolutions.append(ResolvedHunk(
-                originalIndex: index,
-                range: coreStart..<coreEnd,
-                replacement: hunk.beforeLines
+        func finishEdit() {
+            guard let start = activeStart else { return }
+            edits.append(LineEdit(
+                baseRange: start..<(start + removedCount),
+                replacement: replacement
             ))
+            activeStart = nil
+            removedCount = 0
+            replacement = []
         }
 
-        guard !hasOverlap(resolutions) else {
-            return .failure(.overlappingResolvedHunks)
-        }
-
-        var result = currentLines
-        for resolution in resolutions.sorted(by: descendingResolutionOrder) {
-            result.replaceSubrange(
-                resolution.range,
-                with: resolution.replacement
-            )
-        }
-        return .success(result.reduce(into: Data()) { $0.append($1) })
-    }
-
-    static func isText(_ data: Data) -> Bool {
-        !data.contains(0) && String(data: data, encoding: .utf8) != nil
-    }
-
-    static func lines(in data: Data) -> [Data] {
-        guard !data.isEmpty else { return [] }
-        var result: [Data] = []
-        var lineStart = data.startIndex
-        var index = lineStart
-        while index < data.endIndex {
-            if data[index] == 0x0A {
-                let next = data.index(after: index)
-                result.append(Data(data[lineStart..<next]))
-                lineStart = next
+        for step in steps {
+            switch step {
+            case .equal:
+                finishEdit()
+                beforeIndex += 1
+            case .remove:
+                if activeStart == nil { activeStart = beforeIndex }
+                removedCount += 1
+                beforeIndex += 1
+            case .add(let line):
+                if activeStart == nil { activeStart = beforeIndex }
+                replacement.append(line)
             }
-            index = data.index(after: index)
         }
-        if lineStart < data.endIndex {
-            result.append(Data(data[lineStart..<data.endIndex]))
-        }
-        return result
+        finishEdit()
+        return edits
     }
 
     private static func diffSteps(
@@ -236,15 +406,12 @@ nonisolated enum VerifiedTextPatch {
                 beforeIndex += 1
                 continue
             }
-
             let removeLength = lengths[
                 (beforeIndex + 1) * columnCount + afterIndex
             ]
             let addLength = lengths[
                 beforeIndex * columnCount + afterIndex + 1
             ]
-            // Stable tie-break: removals precede additions. This makes patch
-            // bytes independent of dictionary order, locale, or hash seeds.
             if removeLength >= addLength {
                 steps.append(.remove(before[beforeIndex]))
                 beforeIndex += 1
@@ -256,37 +423,67 @@ nonisolated enum VerifiedTextPatch {
         return steps
     }
 
-    private static func occurrenceStarts(
-        of pattern: [Data],
-        in lines: [Data]
-    ) -> [Int] {
-        guard pattern.count <= lines.count else { return [] }
-        if pattern.isEmpty {
-            return Array(0...lines.count)
+    private static func touches(
+        _ edit: LineEdit,
+        guardedRange: Range<Int>
+    ) -> Bool {
+        if edit.baseRange.isEmpty {
+            return edit.baseRange.lowerBound >= guardedRange.lowerBound
+                && edit.baseRange.lowerBound <= guardedRange.upperBound
         }
-        var result: [Int] = []
-        for start in 0...(lines.count - pattern.count)
-        where Array(lines[start..<(start + pattern.count)]) == pattern {
-            result.append(start)
-            if result.count > 1 {
-                return result
-            }
+        return edit.baseRange.overlaps(guardedRange)
+    }
+
+    private static func positionalDelta(
+        before position: Int,
+        edits: [LineEdit]
+    ) -> Int? {
+        var result = 0
+        for edit in edits where edit.baseRange.upperBound <= position {
+            let delta = edit.replacement.count
+                .subtractingReportingOverflow(edit.baseRange.count)
+            guard !delta.overflow else { return nil }
+            let sum = result.addingReportingOverflow(delta.partialValue)
+            guard !sum.overflow else { return nil }
+            result = sum.partialValue
         }
         return result
     }
 
-    private static func hasOverlap(_ resolutions: [ResolvedHunk]) -> Bool {
-        let ordered = resolutions.sorted {
-            if $0.range.lowerBound != $1.range.lowerBound {
-                return $0.range.lowerBound < $1.range.lowerBound
-            }
-            return $0.originalIndex < $1.originalIndex
+    private static func checkedRange(
+        start: Int,
+        count: Int,
+        upperBound: Int
+    ) -> Range<Int>? {
+        guard start >= 0,
+              count >= 0,
+              let end = checkedAdd(start, count),
+              end <= upperBound else {
+            return nil
         }
-        for lhsIndex in ordered.indices {
-            for rhsIndex in ordered.indices where rhsIndex > lhsIndex {
+        return start..<end
+    }
+
+    private static func checkedAdd(_ lhs: Int, _ rhs: Int) -> Int? {
+        let result = lhs.addingReportingOverflow(rhs)
+        return result.overflow ? nil : result.partialValue
+    }
+
+    private static func checkedOffset(
+        _ value: Int,
+        by offset: Int
+    ) -> Int? {
+        checkedAdd(value, offset)
+    }
+
+    private static func hasOverlap(
+        _ hunks: [VerifiedPreparedTextHunk]
+    ) -> Bool {
+        for lhsIndex in hunks.indices {
+            for rhsIndex in hunks.indices where rhsIndex > lhsIndex {
                 if rangesOverlap(
-                    ordered[lhsIndex].range,
-                    ordered[rhsIndex].range
+                    hunks[lhsIndex].resolvedCurrentRange,
+                    hunks[rhsIndex].resolvedCurrentRange
                 ) {
                     return true
                 }
@@ -313,14 +510,12 @@ nonisolated enum VerifiedTextPatch {
         return lhs.overlaps(rhs)
     }
 
-    private static func descendingResolutionOrder(
-        _ lhs: ResolvedHunk,
-        _ rhs: ResolvedHunk
+    private static func descendingOrder(
+        _ lhs: VerifiedPreparedTextHunk,
+        _ rhs: VerifiedPreparedTextHunk
     ) -> Bool {
-        if lhs.range.lowerBound != rhs.range.lowerBound {
-            return lhs.range.lowerBound > rhs.range.lowerBound
-        }
-        return lhs.originalIndex > rhs.originalIndex
+        lhs.resolvedCurrentRange.lowerBound
+            > rhs.resolvedCurrentRange.lowerBound
     }
 
     private enum DiffStep {
@@ -329,9 +524,8 @@ nonisolated enum VerifiedTextPatch {
         case add(Data)
     }
 
-    private struct ResolvedHunk {
-        let originalIndex: Int
-        let range: Range<Int>
+    private struct LineEdit {
+        let baseRange: Range<Int>
         let replacement: [Data]
     }
 }

--- a/Pine/Agent/VerifiedChanges/VerifiedTextPatch.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedTextPatch.swift
@@ -1,0 +1,337 @@
+//
+//  VerifiedTextPatch.swift
+//  Pine
+//
+//  Deterministic line diff and checked inverse-hunk application for #933.
+//
+
+import Foundation
+
+nonisolated enum VerifiedTextPatch {
+    static let maximumLineCount = 4_096
+    static let maximumDiffCellCount = 4_000_000
+    private static let contextLineCount = 2
+
+    static func canDiff(before: Data, after: Data) -> Bool {
+        guard isText(before),
+              isText(after) else {
+            return false
+        }
+        let beforeLines = lines(in: before)
+        let afterLines = lines(in: after)
+        guard beforeLines.count <= maximumLineCount,
+              afterLines.count <= maximumLineCount else {
+            return false
+        }
+        let cellCount = (beforeLines.count + 1)
+            .multipliedReportingOverflow(by: afterLines.count + 1)
+        return !cellCount.overflow
+            && cellCount.partialValue <= maximumDiffCellCount
+    }
+
+    static func makeHunks(
+        before: Data,
+        after: Data
+    ) -> [VerifiedTextPatchHunk] {
+        let beforeLines = lines(in: before)
+        let afterLines = lines(in: after)
+        let steps = diffSteps(before: beforeLines, after: afterLines)
+        var hunks: [VerifiedTextPatchHunk] = []
+        var beforeIndex = 0
+        var afterIndex = 0
+        var activeBeforeStart: Int?
+        var activeAfterStart: Int?
+        var removed: [Data] = []
+        var added: [Data] = []
+
+        func finishHunk() {
+            guard let beforeStart = activeBeforeStart,
+                  let afterStart = activeAfterStart else {
+                return
+            }
+            let prefixStart = max(0, afterStart - contextLineCount)
+            let suffixStart = afterStart + added.count
+            let suffixEnd = min(
+                afterLines.count,
+                suffixStart + contextLineCount
+            )
+            hunks.append(VerifiedTextPatchHunk(
+                beforeStartLine: beforeStart,
+                beforeLineCount: removed.count,
+                afterStartLine: afterStart,
+                afterLineCount: added.count,
+                prefixContext: Array(afterLines[prefixStart..<afterStart]),
+                afterLines: added,
+                beforeLines: removed,
+                suffixContext: Array(afterLines[suffixStart..<suffixEnd])
+            ))
+            activeBeforeStart = nil
+            activeAfterStart = nil
+            removed = []
+            added = []
+        }
+
+        for step in steps {
+            switch step {
+            case .equal:
+                finishHunk()
+                beforeIndex += 1
+                afterIndex += 1
+            case .remove(let line):
+                if activeBeforeStart == nil {
+                    activeBeforeStart = beforeIndex
+                    activeAfterStart = afterIndex
+                }
+                removed.append(line)
+                beforeIndex += 1
+            case .add(let line):
+                if activeBeforeStart == nil {
+                    activeBeforeStart = beforeIndex
+                    activeAfterStart = afterIndex
+                }
+                added.append(line)
+                afterIndex += 1
+            }
+        }
+        finishHunk()
+        return hunks
+    }
+
+    static func applyInverse(
+        hunks: [VerifiedTextPatchHunk],
+        to current: Data
+    ) -> Result<Data, VerifiedPatchConflictReason> {
+        guard isText(current) else {
+            return .failure(.currentContentIsNotText)
+        }
+        let currentLines = lines(in: current)
+        var resolutions: [ResolvedHunk] = []
+
+        for (index, hunk) in hunks.enumerated() {
+            let pattern = hunk.prefixContext
+                + hunk.afterLines
+                + hunk.suffixContext
+            guard !pattern.isEmpty else {
+                return .failure(.ambiguousTextContext(hunkIndex: index))
+            }
+            let occurrences = occurrenceStarts(
+                of: pattern,
+                in: currentLines
+            )
+            guard !occurrences.isEmpty else {
+                return .failure(.textContextMissing(hunkIndex: index))
+            }
+            guard occurrences.count == 1,
+                  let occurrence = occurrences.first else {
+                return .failure(.ambiguousTextContext(hunkIndex: index))
+            }
+            let coreStart = occurrence + hunk.prefixContext.count
+            let coreEnd = coreStart + hunk.afterLines.count
+            resolutions.append(ResolvedHunk(
+                originalIndex: index,
+                range: coreStart..<coreEnd,
+                replacement: hunk.beforeLines
+            ))
+        }
+
+        guard !hasOverlap(resolutions) else {
+            return .failure(.overlappingResolvedHunks)
+        }
+
+        var result = currentLines
+        for resolution in resolutions.sorted(by: descendingResolutionOrder) {
+            result.replaceSubrange(
+                resolution.range,
+                with: resolution.replacement
+            )
+        }
+        return .success(result.reduce(into: Data()) { $0.append($1) })
+    }
+
+    static func isText(_ data: Data) -> Bool {
+        !data.contains(0) && String(data: data, encoding: .utf8) != nil
+    }
+
+    static func lines(in data: Data) -> [Data] {
+        guard !data.isEmpty else { return [] }
+        var result: [Data] = []
+        var lineStart = data.startIndex
+        var index = lineStart
+        while index < data.endIndex {
+            if data[index] == 0x0A {
+                let next = data.index(after: index)
+                result.append(Data(data[lineStart..<next]))
+                lineStart = next
+            }
+            index = data.index(after: index)
+        }
+        if lineStart < data.endIndex {
+            result.append(Data(data[lineStart..<data.endIndex]))
+        }
+        return result
+    }
+
+    private static func diffSteps(
+        before: [Data],
+        after: [Data]
+    ) -> [DiffStep] {
+        let columnCount = after.count + 1
+        var lengths = [Int](
+            repeating: 0,
+            count: (before.count + 1) * columnCount
+        )
+        if !before.isEmpty, !after.isEmpty {
+            for beforeIndex in stride(
+                from: before.count - 1,
+                through: 0,
+                by: -1
+            ) {
+                for afterIndex in stride(
+                    from: after.count - 1,
+                    through: 0,
+                    by: -1
+                ) {
+                    let offset = beforeIndex * columnCount + afterIndex
+                    if before[beforeIndex] == after[afterIndex] {
+                        lengths[offset] = 1
+                            + lengths[
+                                (beforeIndex + 1) * columnCount
+                                    + afterIndex + 1
+                            ]
+                    } else {
+                        lengths[offset] = max(
+                            lengths[
+                                (beforeIndex + 1) * columnCount
+                                    + afterIndex
+                            ],
+                            lengths[
+                                beforeIndex * columnCount
+                                    + afterIndex + 1
+                            ]
+                        )
+                    }
+                }
+            }
+        }
+
+        var steps: [DiffStep] = []
+        var beforeIndex = 0
+        var afterIndex = 0
+        while beforeIndex < before.count || afterIndex < after.count {
+            if beforeIndex < before.count,
+               afterIndex < after.count,
+               before[beforeIndex] == after[afterIndex] {
+                steps.append(.equal)
+                beforeIndex += 1
+                afterIndex += 1
+                continue
+            }
+            if beforeIndex == before.count {
+                steps.append(.add(after[afterIndex]))
+                afterIndex += 1
+                continue
+            }
+            if afterIndex == after.count {
+                steps.append(.remove(before[beforeIndex]))
+                beforeIndex += 1
+                continue
+            }
+
+            let removeLength = lengths[
+                (beforeIndex + 1) * columnCount + afterIndex
+            ]
+            let addLength = lengths[
+                beforeIndex * columnCount + afterIndex + 1
+            ]
+            // Stable tie-break: removals precede additions. This makes patch
+            // bytes independent of dictionary order, locale, or hash seeds.
+            if removeLength >= addLength {
+                steps.append(.remove(before[beforeIndex]))
+                beforeIndex += 1
+            } else {
+                steps.append(.add(after[afterIndex]))
+                afterIndex += 1
+            }
+        }
+        return steps
+    }
+
+    private static func occurrenceStarts(
+        of pattern: [Data],
+        in lines: [Data]
+    ) -> [Int] {
+        guard pattern.count <= lines.count else { return [] }
+        if pattern.isEmpty {
+            return Array(0...lines.count)
+        }
+        var result: [Int] = []
+        for start in 0...(lines.count - pattern.count)
+        where Array(lines[start..<(start + pattern.count)]) == pattern {
+            result.append(start)
+            if result.count > 1 {
+                return result
+            }
+        }
+        return result
+    }
+
+    private static func hasOverlap(_ resolutions: [ResolvedHunk]) -> Bool {
+        let ordered = resolutions.sorted {
+            if $0.range.lowerBound != $1.range.lowerBound {
+                return $0.range.lowerBound < $1.range.lowerBound
+            }
+            return $0.originalIndex < $1.originalIndex
+        }
+        for lhsIndex in ordered.indices {
+            for rhsIndex in ordered.indices where rhsIndex > lhsIndex {
+                if rangesOverlap(
+                    ordered[lhsIndex].range,
+                    ordered[rhsIndex].range
+                ) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private static func rangesOverlap(
+        _ lhs: Range<Int>,
+        _ rhs: Range<Int>
+    ) -> Bool {
+        if lhs.isEmpty, rhs.isEmpty {
+            return lhs.lowerBound == rhs.lowerBound
+        }
+        if lhs.isEmpty {
+            return lhs.lowerBound >= rhs.lowerBound
+                && lhs.lowerBound <= rhs.upperBound
+        }
+        if rhs.isEmpty {
+            return rhs.lowerBound >= lhs.lowerBound
+                && rhs.lowerBound <= lhs.upperBound
+        }
+        return lhs.overlaps(rhs)
+    }
+
+    private static func descendingResolutionOrder(
+        _ lhs: ResolvedHunk,
+        _ rhs: ResolvedHunk
+    ) -> Bool {
+        if lhs.range.lowerBound != rhs.range.lowerBound {
+            return lhs.range.lowerBound > rhs.range.lowerBound
+        }
+        return lhs.originalIndex > rhs.originalIndex
+    }
+
+    private enum DiffStep {
+        case equal
+        case remove(Data)
+        case add(Data)
+    }
+
+    private struct ResolvedHunk {
+        let originalIndex: Int
+        let range: Range<Int>
+        let replacement: [Data]
+    }
+}

--- a/Pine/Agent/VerifiedChanges/VerifiedTextPatch.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedTextPatch.swift
@@ -16,16 +16,18 @@ nonisolated struct VerifiedPreparedTextResult: Sendable, Equatable {
     let content: Data
     let hunks: [VerifiedPreparedTextHunk]
     let lcsCellCount: Int
+    let mappingCellCount: Int
 }
 
 /// Text patching never searches globally for a matching block.
 ///
 /// Preparation diffs the captured after-state against the supplied current
-/// state, rejects any human edit intersecting a captured hunk plus two exact
-/// guard lines, and maps the original range only by the bounded edit deltas
-/// before it. It then verifies the complete guarded region at that resolved
-/// position. A deleted/moved original block therefore conflicts even if
-/// identical bytes appear elsewhere.
+/// state and rejects any human edit intersecting a captured hunk plus two exact
+/// guard lines. It accepts a resolved range only when every optimal LCS
+/// alignment preserves that guarded region contiguously at one identical
+/// current position. A deleted, moved, reordered, or duplicated block
+/// therefore conflicts instead of letting one deterministic LCS tie-break
+/// select unrelated equal bytes.
 nonisolated enum VerifiedTextPatch {
     private static let contextLineCount = 2
 
@@ -38,13 +40,17 @@ nonisolated enum VerifiedTextPatch {
         }
         let beforeLines = lines(in: before)
         let afterLines = lines(in: after)
-        guard let cellCount = lcsCellCount(
-            lhsCount: beforeLines.count,
-            rhsCount: afterLines.count
+        guard let table = makeLCSTable(
+            before: beforeLines,
+            after: afterLines
         ) else {
             return nil
         }
-        let steps = diffSteps(before: beforeLines, after: afterLines)
+        let steps = diffSteps(
+            before: beforeLines,
+            after: afterLines,
+            table: table
+        )
         let hunks = makeHunks(
             steps: steps,
             afterLines: afterLines
@@ -55,7 +61,7 @@ nonisolated enum VerifiedTextPatch {
         }
         return VerifiedTextPatchPlan(
             hunks: hunks,
-            lcsCellCount: cellCount
+            lcsCellCount: table.cellCount
         )
     }
 
@@ -76,7 +82,8 @@ nonisolated enum VerifiedTextPatch {
     static func prepareInverse(
         hunks: [VerifiedTextPatchHunk],
         capturedAfter: Data,
-        current: Data
+        current: Data,
+        mappingCellBudget: Int
     ) -> Result<VerifiedPreparedTextResult, VerifiedPatchConflictReason> {
         guard isText(capturedAfter),
               isText(current) else {
@@ -88,16 +95,26 @@ nonisolated enum VerifiedTextPatch {
 
         let afterLines = lines(in: capturedAfter)
         let currentLines = lines(in: current)
-        guard let cellCount = lcsCellCount(
-            lhsCount: afterLines.count,
-            rhsCount: currentLines.count
-        ) else {
+        guard mappingCellBudget >= 0,
+              let table = makeLCSTable(
+                before: afterLines,
+                after: currentLines
+              ) else {
             return .failure(.resourceLimitExceeded)
         }
-        let humanEdits = lineEdits(
-            from: afterLines,
-            to: currentLines
+        let mappingCells = table.cellCount.multipliedReportingOverflow(
+            by: hunks.count
         )
+        guard !mappingCells.overflow,
+              mappingCells.partialValue <= mappingCellBudget else {
+            return .failure(.resourceLimitExceeded)
+        }
+        let steps = diffSteps(
+            before: afterLines,
+            after: currentLines,
+            table: table
+        )
+        let humanEdits = lineEdits(steps: steps)
         var resolved: [VerifiedPreparedTextHunk] = []
 
         for (index, hunk) in hunks.enumerated() {
@@ -123,6 +140,11 @@ nonisolated enum VerifiedTextPatch {
                 return .failure(.mappedRegionMismatch(hunkIndex: index))
             }
             let guardedRange = guardStart..<guardEnd
+            guard !guardedRange.isEmpty else {
+                return .failure(
+                    .ambiguousCurrentMapping(hunkIndex: index)
+                )
+            }
             guard !humanEdits.contains(where: {
                 touches($0, guardedRange: guardedRange)
             }) else {
@@ -130,18 +152,21 @@ nonisolated enum VerifiedTextPatch {
                     .humanEditOverlapsAgentRegion(hunkIndex: index)
                 )
             }
+            let expectedGuard = Array(afterLines[guardedRange])
 
-            guard let delta = positionalDelta(
-                before: guardStart,
-                edits: humanEdits
-            ),
-            let resolvedGuardStart = checkedOffset(
-                guardStart,
-                by: delta
-            ),
-            let resolvedCoreStart = checkedOffset(
-                hunk.afterStartLine,
-                by: delta
+            guard let resolvedGuardStart = uniqueOptimalMapping(
+                guardedRange: guardedRange,
+                before: afterLines,
+                after: currentLines,
+                table: table
+            ) else {
+                return .failure(
+                    .ambiguousCurrentMapping(hunkIndex: index)
+                )
+            }
+            guard let resolvedCoreStart = checkedAdd(
+                resolvedGuardStart,
+                hunk.prefixContext.count
             ),
             let resolvedGuardEnd = checkedAdd(
                 resolvedGuardStart,
@@ -157,7 +182,17 @@ nonisolated enum VerifiedTextPatch {
                 return .failure(.mappedRegionMismatch(hunkIndex: index))
             }
 
-            let expectedGuard = Array(afterLines[guardedRange])
+            guard duplicateMappingIsStable(
+                capturedRange: guardedRange,
+                resolvedStart: resolvedGuardStart,
+                capturedLines: afterLines,
+                currentLines: currentLines,
+                humanEdits: humanEdits
+            ) else {
+                return .failure(
+                    .ambiguousCurrentMapping(hunkIndex: index)
+                )
+            }
             let actualGuard = Array(
                 currentLines[resolvedGuardStart..<resolvedGuardEnd]
             )
@@ -184,7 +219,8 @@ nonisolated enum VerifiedTextPatch {
         return .success(VerifiedPreparedTextResult(
             content: result.reduce(into: Data()) { $0.append($1) },
             hunks: resolved,
-            lcsCellCount: cellCount
+            lcsCellCount: table.cellCount,
+            mappingCellCount: mappingCells.partialValue
         ))
     }
 
@@ -302,10 +338,8 @@ nonisolated enum VerifiedTextPatch {
     }
 
     private static func lineEdits(
-        from before: [Data],
-        to after: [Data]
+        steps: [DiffStep]
     ) -> [LineEdit] {
-        let steps = diffSteps(before: before, after: after)
         var edits: [LineEdit] = []
         var beforeIndex = 0
         var activeStart: Int?
@@ -341,15 +375,18 @@ nonisolated enum VerifiedTextPatch {
         return edits
     }
 
-    private static func diffSteps(
+    private static func makeLCSTable(
         before: [Data],
         after: [Data]
-    ) -> [DiffStep] {
+    ) -> LCSTable? {
+        guard let cellCount = lcsCellCount(
+            lhsCount: before.count,
+            rhsCount: after.count
+        ) else {
+            return nil
+        }
         let columnCount = after.count + 1
-        var lengths = [Int](
-            repeating: 0,
-            count: (before.count + 1) * columnCount
-        )
+        var lengths = [Int](repeating: 0, count: cellCount)
         if !before.isEmpty, !after.isEmpty {
             for beforeIndex in stride(
                 from: before.count - 1,
@@ -383,7 +420,17 @@ nonisolated enum VerifiedTextPatch {
                 }
             }
         }
+        return LCSTable(
+            lengths: lengths,
+            columnCount: columnCount
+        )
+    }
 
+    private static func diffSteps(
+        before: [Data],
+        after: [Data],
+        table: LCSTable
+    ) -> [DiffStep] {
         var steps: [DiffStep] = []
         var beforeIndex = 0
         var afterIndex = 0
@@ -406,12 +453,14 @@ nonisolated enum VerifiedTextPatch {
                 beforeIndex += 1
                 continue
             }
-            let removeLength = lengths[
-                (beforeIndex + 1) * columnCount + afterIndex
-            ]
-            let addLength = lengths[
-                beforeIndex * columnCount + afterIndex + 1
-            ]
+            let removeLength = table.value(
+                beforeIndex: beforeIndex + 1,
+                afterIndex: afterIndex
+            )
+            let addLength = table.value(
+                beforeIndex: beforeIndex,
+                afterIndex: afterIndex + 1
+            )
             if removeLength >= addLength {
                 steps.append(.remove(before[beforeIndex]))
                 beforeIndex += 1
@@ -423,31 +472,238 @@ nonisolated enum VerifiedTextPatch {
         return steps
     }
 
+    /// Returns a current start only when every optimal LCS alignment preserves
+    /// the guarded region contiguously at that same start.
+    ///
+    /// This walks the optimal-alignment DAG with two rolling rows. `bad`
+    /// tracks any optimal path that skips/reorders a guarded line; min/max
+    /// track all starts used by paths that preserve the whole guard.
+    private static func uniqueOptimalMapping(
+        guardedRange: Range<Int>,
+        before: [Data],
+        after: [Data],
+        table: LCSTable
+    ) -> Int? {
+        guard !guardedRange.isEmpty,
+              guardedRange.lowerBound >= 0,
+              guardedRange.upperBound <= before.count else {
+            return nil
+        }
+        var current = [MappingState](
+            repeating: .unreachable,
+            count: after.count + 1
+        )
+        current[0] = .initial
+
+        for beforeIndex in 0...before.count {
+            var next = [MappingState](
+                repeating: .unreachable,
+                count: after.count + 1
+            )
+            for afterIndex in 0...after.count {
+                let state = current[afterIndex]
+                guard state.isReachable else { continue }
+                let optimum = table.value(
+                    beforeIndex: beforeIndex,
+                    afterIndex: afterIndex
+                )
+                if afterIndex < after.count,
+                   table.value(
+                    beforeIndex: beforeIndex,
+                    afterIndex: afterIndex + 1
+                   ) == optimum {
+                    current[afterIndex + 1].merge(advance(
+                        state,
+                        action: .skipAfter,
+                        beforeIndex: beforeIndex,
+                        afterIndex: afterIndex,
+                        guardedRange: guardedRange
+                    ))
+                }
+                guard beforeIndex < before.count else { continue }
+                if table.value(
+                    beforeIndex: beforeIndex + 1,
+                    afterIndex: afterIndex
+                ) == optimum {
+                    next[afterIndex].merge(advance(
+                        state,
+                        action: .skipBefore,
+                        beforeIndex: beforeIndex,
+                        afterIndex: afterIndex,
+                        guardedRange: guardedRange
+                    ))
+                }
+                if afterIndex < after.count,
+                   before[beforeIndex] == after[afterIndex],
+                   table.value(
+                    beforeIndex: beforeIndex + 1,
+                    afterIndex: afterIndex + 1
+                   ) + 1 == optimum {
+                    next[afterIndex + 1].merge(advance(
+                        state,
+                        action: .match,
+                        beforeIndex: beforeIndex,
+                        afterIndex: afterIndex,
+                        guardedRange: guardedRange
+                    ))
+                }
+            }
+            if beforeIndex == before.count {
+                let result = current[after.count]
+                guard result.goodReachable,
+                      !result.badReachable,
+                      let minimum = result.minimumStart,
+                      minimum == result.maximumStart else {
+                    return nil
+                }
+                return minimum
+            }
+            current = next
+        }
+        return nil
+    }
+
+    private static func advance(
+        _ state: MappingState,
+        action: AlignmentAction,
+        beforeIndex: Int,
+        afterIndex: Int,
+        guardedRange: Range<Int>
+    ) -> MappingState {
+        var result = MappingState.unreachable
+        result.badReachable = state.badReachable
+        guard state.goodReachable else { return result }
+
+        if beforeIndex < guardedRange.lowerBound
+            || beforeIndex >= guardedRange.upperBound {
+            result.includeGood(from: state)
+            return result
+        }
+        if beforeIndex == guardedRange.lowerBound {
+            switch action {
+            case .skipAfter:
+                result.includeGood(start: nil)
+            case .match:
+                result.includeGood(start: afterIndex)
+            case .skipBefore:
+                result.badReachable = true
+            }
+            return result
+        }
+        guard action == .match else {
+            result.badReachable = true
+            return result
+        }
+        result.includeGood(from: state)
+        return result
+    }
+
+    /// Equal guarded blocks have no intrinsic identity. When more than one
+    /// occurrence exists, preparation accepts only a uniform positional shift
+    /// with every human edit outside the complete duplicate envelope.
+    ///
+    /// This rejects a delete/move/reorder that a unique LCS can otherwise
+    /// misinterpret by pairing equal occurrences in their new ordinal order.
+    private static func duplicateMappingIsStable(
+        capturedRange: Range<Int>,
+        resolvedStart: Int,
+        capturedLines: [Data],
+        currentLines: [Data],
+        humanEdits: [LineEdit]
+    ) -> Bool {
+        let pattern = Array(capturedLines[capturedRange])
+        let capturedOccurrences = occurrenceStarts(
+            of: pattern,
+            in: capturedLines
+        )
+        let currentOccurrences = occurrenceStarts(
+            of: pattern,
+            in: currentLines
+        )
+        guard let capturedOrdinal = capturedOccurrences.firstIndex(
+            of: capturedRange.lowerBound
+        ),
+        let currentOrdinal = currentOccurrences.firstIndex(
+            of: resolvedStart
+        ) else {
+            return false
+        }
+        guard capturedOccurrences.count > 1
+                || currentOccurrences.count > 1 else {
+            return true
+        }
+        guard capturedOccurrences.count == currentOccurrences.count,
+              capturedOrdinal == currentOrdinal,
+              let firstCaptured = capturedOccurrences.first,
+              let lastCaptured = capturedOccurrences.last,
+              let firstCurrent = currentOccurrences.first else {
+            return false
+        }
+        let delta = firstCurrent - firstCaptured
+        for index in capturedOccurrences.indices {
+            guard currentOccurrences[index] - capturedOccurrences[index]
+                    == delta else {
+                return false
+            }
+        }
+        let envelopeEnd = lastCaptured + pattern.count
+        let duplicateEnvelope = firstCaptured..<envelopeEnd
+        return !humanEdits.contains {
+            touches($0, guardedRange: duplicateEnvelope)
+        }
+    }
+
+    private static func occurrenceStarts(
+        of pattern: [Data],
+        in lines: [Data]
+    ) -> [Int] {
+        guard !pattern.isEmpty,
+              pattern.count <= lines.count else {
+            return []
+        }
+        var prefixLengths = [Int](
+            repeating: 0,
+            count: pattern.count
+        )
+        var prefixLength = 0
+        for index in pattern.indices.dropFirst() {
+            while prefixLength > 0,
+                  pattern[index] != pattern[prefixLength] {
+                prefixLength = prefixLengths[prefixLength - 1]
+            }
+            if pattern[index] == pattern[prefixLength] {
+                prefixLength += 1
+            }
+            prefixLengths[index] = prefixLength
+        }
+
+        var result: [Int] = []
+        var matched = 0
+        for index in lines.indices {
+            while matched > 0,
+                  lines[index] != pattern[matched] {
+                matched = prefixLengths[matched - 1]
+            }
+            if lines[index] == pattern[matched] {
+                matched += 1
+            }
+            if matched == pattern.count {
+                result.append(index - pattern.count + 1)
+                matched = prefixLengths[matched - 1]
+            }
+        }
+        return result
+    }
+
     private static func touches(
         _ edit: LineEdit,
         guardedRange: Range<Int>
     ) -> Bool {
         if edit.baseRange.isEmpty {
-            return edit.baseRange.lowerBound >= guardedRange.lowerBound
-                && edit.baseRange.lowerBound <= guardedRange.upperBound
+            return edit.baseRange.lowerBound > guardedRange.lowerBound
+                && edit.baseRange.lowerBound < guardedRange.upperBound
         }
         return edit.baseRange.overlaps(guardedRange)
-    }
-
-    private static func positionalDelta(
-        before position: Int,
-        edits: [LineEdit]
-    ) -> Int? {
-        var result = 0
-        for edit in edits where edit.baseRange.upperBound <= position {
-            let delta = edit.replacement.count
-                .subtractingReportingOverflow(edit.baseRange.count)
-            guard !delta.overflow else { return nil }
-            let sum = result.addingReportingOverflow(delta.partialValue)
-            guard !sum.overflow else { return nil }
-            result = sum.partialValue
-        }
-        return result
     }
 
     private static func checkedRange(
@@ -467,13 +723,6 @@ nonisolated enum VerifiedTextPatch {
     private static func checkedAdd(_ lhs: Int, _ rhs: Int) -> Int? {
         let result = lhs.addingReportingOverflow(rhs)
         return result.overflow ? nil : result.partialValue
-    }
-
-    private static func checkedOffset(
-        _ value: Int,
-        by offset: Int
-    ) -> Int? {
-        checkedAdd(value, offset)
     }
 
     private static func hasOverlap(
@@ -527,5 +776,75 @@ nonisolated enum VerifiedTextPatch {
     private struct LineEdit {
         let baseRange: Range<Int>
         let replacement: [Data]
+    }
+
+    private struct LCSTable {
+        let lengths: [Int]
+        let columnCount: Int
+
+        var cellCount: Int {
+            lengths.count
+        }
+
+        func value(
+            beforeIndex: Int,
+            afterIndex: Int
+        ) -> Int {
+            lengths[beforeIndex * columnCount + afterIndex]
+        }
+    }
+
+    private enum AlignmentAction: Equatable {
+        case skipBefore
+        case skipAfter
+        case match
+    }
+
+    private struct MappingState {
+        var goodReachable: Bool
+        var badReachable: Bool
+        var minimumStart: Int?
+        var maximumStart: Int?
+
+        static let unreachable = MappingState(
+            goodReachable: false,
+            badReachable: false,
+            minimumStart: nil,
+            maximumStart: nil
+        )
+
+        static let initial = MappingState(
+            goodReachable: true,
+            badReachable: false,
+            minimumStart: nil,
+            maximumStart: nil
+        )
+
+        var isReachable: Bool {
+            goodReachable || badReachable
+        }
+
+        mutating func includeGood(start: Int?) {
+            goodReachable = true
+            guard let start else { return }
+            minimumStart = min(minimumStart ?? start, start)
+            maximumStart = max(maximumStart ?? start, start)
+        }
+
+        mutating func includeGood(from other: MappingState) {
+            guard other.goodReachable else { return }
+            goodReachable = true
+            if let minimum = other.minimumStart {
+                minimumStart = min(minimumStart ?? minimum, minimum)
+            }
+            if let maximum = other.maximumStart {
+                maximumStart = max(maximumStart ?? maximum, maximum)
+            }
+        }
+
+        mutating func merge(_ other: MappingState) {
+            badReachable = badReachable || other.badReachable
+            includeGood(from: other)
+        }
     }
 }

--- a/Pine/Agent/VerifiedChanges/VerifiedTextPatch.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedTextPatch.swift
@@ -33,22 +33,57 @@ nonisolated enum VerifiedTextPatch {
 
     static func plan(
         before: Data,
-        after: Data
+        after: Data,
+        lcsCellBudget: Int = VerifiedPatchLimits.maximumLCSCellCountPerDiff,
+        hunkBudget: Int = VerifiedPatchLimits.maximumHunkCount
     ) -> VerifiedTextPatchPlan? {
-        guard isText(before), isText(after) else {
+        plan(
+            before: before,
+            after: after,
+            lcsCellBudget: lcsCellBudget,
+            hunkBudget: hunkBudget,
+            lineIdentityProvider: { ContentIdentity(content: $0) }
+        )
+    }
+
+    static func plan(
+        before: Data,
+        after: Data,
+        lcsCellBudget: Int,
+        hunkBudget: Int,
+        lineIdentityProvider: @escaping (Data) -> ContentIdentity
+    ) -> VerifiedTextPatchPlan? {
+        guard before != after,
+              isText(before),
+              isText(after) else {
             return nil
         }
         let beforeLines = lines(in: before)
         let afterLines = lines(in: after)
-        guard let table = makeLCSTable(
-            before: beforeLines,
-            after: afterLines
-        ) else {
+        guard lcsCellBudget >= 0,
+              hunkBudget > 0,
+              let estimate = lcsCellCount(
+                lhsCount: beforeLines.count,
+                rhsCount: afterLines.count
+              ),
+              estimate <= lcsCellBudget,
+              let interned = internLines(
+                before: beforeLines,
+                after: afterLines,
+                lineIdentityProvider: lineIdentityProvider
+              ) else {
             return nil
         }
+        let table = makeLCSTable(
+            before: interned.before,
+            after: interned.after,
+            cellCount: estimate
+        )
         let steps = diffSteps(
             before: beforeLines,
             after: afterLines,
+            beforeTokens: interned.before,
+            afterTokens: interned.after,
             table: table
         )
         let hunks = makeHunks(
@@ -56,7 +91,9 @@ nonisolated enum VerifiedTextPatch {
             afterLines: afterLines
         )
         guard !hunks.isEmpty,
-              hunks.count <= VerifiedPatchLimits.maximumHunkCount else {
+              hunks.count <= hunkBudget,
+              hunks.count <= VerifiedPatchLimits.maximumHunkCount,
+              table.cellCount == estimate else {
             return nil
         }
         return VerifiedTextPatchPlan(
@@ -96,22 +133,36 @@ nonisolated enum VerifiedTextPatch {
         let afterLines = lines(in: capturedAfter)
         let currentLines = lines(in: current)
         guard mappingCellBudget >= 0,
-              let table = makeLCSTable(
-                before: afterLines,
-                after: currentLines
+              let estimate = lcsCellCount(
+                lhsCount: afterLines.count,
+                rhsCount: currentLines.count
               ) else {
             return .failure(.resourceLimitExceeded)
         }
-        let mappingCells = table.cellCount.multipliedReportingOverflow(
+        let mappingCells = estimate.multipliedReportingOverflow(
             by: hunks.count
         )
         guard !mappingCells.overflow,
-              mappingCells.partialValue <= mappingCellBudget else {
+              mappingCells.partialValue <= mappingCellBudget,
+              let interned = internLines(
+                before: afterLines,
+                after: currentLines,
+                lineIdentityProvider: {
+                    ContentIdentity(content: $0)
+                }
+              ) else {
             return .failure(.resourceLimitExceeded)
         }
+        let table = makeLCSTable(
+            before: interned.before,
+            after: interned.after,
+            cellCount: estimate
+        )
         let steps = diffSteps(
             before: afterLines,
             after: currentLines,
+            beforeTokens: interned.before,
+            afterTokens: interned.after,
             table: table
         )
         let humanEdits = lineEdits(steps: steps)
@@ -152,12 +203,12 @@ nonisolated enum VerifiedTextPatch {
                     .humanEditOverlapsAgentRegion(hunkIndex: index)
                 )
             }
-            let expectedGuard = Array(afterLines[guardedRange])
+            let expectedGuard = Array(interned.before[guardedRange])
 
             guard let resolvedGuardStart = uniqueOptimalMapping(
                 guardedRange: guardedRange,
-                before: afterLines,
-                after: currentLines,
+                before: interned.before,
+                after: interned.after,
                 table: table
             ) else {
                 return .failure(
@@ -185,8 +236,8 @@ nonisolated enum VerifiedTextPatch {
             guard duplicateMappingIsStable(
                 capturedRange: guardedRange,
                 resolvedStart: resolvedGuardStart,
-                capturedLines: afterLines,
-                currentLines: currentLines,
+                capturedLines: interned.before,
+                currentLines: interned.after,
                 humanEdits: humanEdits
             ) else {
                 return .failure(
@@ -194,7 +245,7 @@ nonisolated enum VerifiedTextPatch {
                 )
             }
             let actualGuard = Array(
-                currentLines[resolvedGuardStart..<resolvedGuardEnd]
+                interned.after[resolvedGuardStart..<resolvedGuardEnd]
             )
             guard expectedGuard == actualGuard else {
                 return .failure(.mappedRegionMismatch(hunkIndex: index))
@@ -270,6 +321,36 @@ nonisolated enum VerifiedTextPatch {
             return nil
         }
         return cells.partialValue
+    }
+
+    private static func internLines(
+        before: [Data],
+        after: [Data],
+        lineIdentityProvider: @escaping (Data) -> ContentIdentity
+    ) -> InternedLinePair? {
+        var interner = LineInterner(
+            identityProvider: lineIdentityProvider
+        )
+        var beforeTokens: [Int] = []
+        beforeTokens.reserveCapacity(before.count)
+        for line in before {
+            guard let token = interner.intern(line) else {
+                return nil
+            }
+            beforeTokens.append(token)
+        }
+        var afterTokens: [Int] = []
+        afterTokens.reserveCapacity(after.count)
+        for line in after {
+            guard let token = interner.intern(line) else {
+                return nil
+            }
+            afterTokens.append(token)
+        }
+        return InternedLinePair(
+            before: beforeTokens,
+            after: afterTokens
+        )
     }
 
     private static func makeHunks(
@@ -376,15 +457,10 @@ nonisolated enum VerifiedTextPatch {
     }
 
     private static func makeLCSTable(
-        before: [Data],
-        after: [Data]
-    ) -> LCSTable? {
-        guard let cellCount = lcsCellCount(
-            lhsCount: before.count,
-            rhsCount: after.count
-        ) else {
-            return nil
-        }
+        before: [Int],
+        after: [Int],
+        cellCount: Int
+    ) -> LCSTable {
         let columnCount = after.count + 1
         var lengths = [Int](repeating: 0, count: cellCount)
         if !before.isEmpty, !after.isEmpty {
@@ -429,6 +505,8 @@ nonisolated enum VerifiedTextPatch {
     private static func diffSteps(
         before: [Data],
         after: [Data],
+        beforeTokens: [Int],
+        afterTokens: [Int],
         table: LCSTable
     ) -> [DiffStep] {
         var steps: [DiffStep] = []
@@ -437,7 +515,7 @@ nonisolated enum VerifiedTextPatch {
         while beforeIndex < before.count || afterIndex < after.count {
             if beforeIndex < before.count,
                afterIndex < after.count,
-               before[beforeIndex] == after[afterIndex] {
+               beforeTokens[beforeIndex] == afterTokens[afterIndex] {
                 steps.append(.equal)
                 beforeIndex += 1
                 afterIndex += 1
@@ -480,8 +558,8 @@ nonisolated enum VerifiedTextPatch {
     /// track all starts used by paths that preserve the whole guard.
     private static func uniqueOptimalMapping(
         guardedRange: Range<Int>,
-        before: [Data],
-        after: [Data],
+        before: [Int],
+        after: [Int],
         table: LCSTable
     ) -> Int? {
         guard !guardedRange.isEmpty,
@@ -607,8 +685,8 @@ nonisolated enum VerifiedTextPatch {
     private static func duplicateMappingIsStable(
         capturedRange: Range<Int>,
         resolvedStart: Int,
-        capturedLines: [Data],
-        currentLines: [Data],
+        capturedLines: [Int],
+        currentLines: [Int],
         humanEdits: [LineEdit]
     ) -> Bool {
         let pattern = Array(capturedLines[capturedRange])
@@ -654,8 +732,8 @@ nonisolated enum VerifiedTextPatch {
     }
 
     private static func occurrenceStarts(
-        of pattern: [Data],
-        in lines: [Data]
+        of pattern: [Int],
+        in lines: [Int]
     ) -> [Int] {
         guard !pattern.isEmpty,
               pattern.count <= lines.count else {
@@ -765,6 +843,71 @@ nonisolated enum VerifiedTextPatch {
     ) -> Bool {
         lhs.resolvedCurrentRange.lowerBound
             > rhs.resolvedCurrentRange.lowerBound
+    }
+
+    private struct InternedLinePair {
+        let before: [Int]
+        let after: [Int]
+    }
+
+    private struct LineBucketKey: Hashable {
+        let identity: ContentIdentity
+        let byteCount: Int
+    }
+
+    private struct InternedLine {
+        let bytes: Data
+        let token: Int
+    }
+
+    private struct LineInterner {
+        var buckets: [LineBucketKey: [InternedLine]] = [:]
+        var nextToken = 0
+        var byteWork = 0
+        let identityProvider: (Data) -> ContentIdentity
+
+        mutating func intern(_ line: Data) -> Int? {
+            guard consumeByteWork(line.count) else {
+                return nil
+            }
+            let key = LineBucketKey(
+                identity: identityProvider(line),
+                byteCount: line.count
+            )
+            if let candidates = buckets[key] {
+                for candidate in candidates {
+                    guard consumeByteWork(line.count) else {
+                        return nil
+                    }
+                    if candidate.bytes == line {
+                        return candidate.token
+                    }
+                }
+            }
+            let token = nextToken
+            let incremented = nextToken.addingReportingOverflow(1)
+            guard !incremented.overflow else {
+                return nil
+            }
+            nextToken = incremented.partialValue
+            buckets[key, default: []].append(InternedLine(
+                bytes: line,
+                token: token
+            ))
+            return token
+        }
+
+        private mutating func consumeByteWork(_ count: Int) -> Bool {
+            guard count >= 0 else { return false }
+            let updated = byteWork.addingReportingOverflow(count)
+            guard !updated.overflow,
+                  updated.partialValue <= VerifiedPatchLimits
+                    .maximumLineComparisonByteCount else {
+                return false
+            }
+            byteWork = updated.partialValue
+            return true
+        }
     }
 
     private enum DiffStep {

--- a/PineTests/VerifiedChanges/VerifiedPatchEngineTests.swift
+++ b/PineTests/VerifiedChanges/VerifiedPatchEngineTests.swift
@@ -1176,6 +1176,106 @@ struct VerifiedPatchBudgetTests {
         }
     }
 
+    @Test("Failed hunk plans still consume the attempted cell budget")
+    func attemptedPlanningBudget() throws {
+        var planningCount = 0
+        let patch = try hunkExhaustionPatch(
+            patchID: id(11_600),
+            envelopeSeed: 11_610,
+            candidateCount: 20,
+            planningObserver: {
+                planningCount += 1
+            }
+        )
+        let textHunkCount = patch.operations.reduce(into: 0) {
+            if case .text(let hunks, _) = $1.strategy {
+                $0 += hunks.count
+            }
+        }
+        let exactCount = patch.operations.filter {
+            $0.strategy == .exactState
+        }.count
+
+        #expect(textHunkCount == 1_023)
+        #expect(exactCount == 20)
+        #expect(planningCount == 5)
+    }
+
+    @Test("Revalidation preflights sorted oversized paths and hunks")
+    func revalidationShapePreflight() throws {
+        let state = file("x")
+        let records = ["a.txt", "b.txt"].enumerated().map { index, path in
+            record(
+                envelopeID: id(11_700 + index),
+                cursor: UInt64(index + 1),
+                journalSequence: UInt64(index + 1),
+                changes: [change(path, nil, state)]
+            )
+        }
+        let patch = try makePatch(
+            patchID: id(11_710),
+            receipt: try receipt(records),
+            sources: records.map {
+                source($0, ordinal: 0, before: nil, after: state)
+            }
+        )
+        let first = patch.operations[0]
+        let second = patch.operations[1]
+        let oversizedPath = String(
+            repeating: "z",
+            count: VerifiedPatchLimits.maximumPathByteCount + 1
+        )
+        let pathOperation = VerifiedPatchOperation(
+            id: second.id,
+            kind: second.kind,
+            sourcePath: oversizedPath,
+            destinationPath: second.destinationPath,
+            before: second.before,
+            after: second.after,
+            strategy: second.strategy
+        )
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try VerifiedPatchEngine.revalidate(VerifiedPatchSet(
+                id: patch.id,
+                receipt: patch.receipt,
+                operations: [first, pathOperation]
+            ))
+        }
+
+        let emptyHunk = VerifiedTextPatchHunk(
+            beforeStartLine: 0,
+            beforeLineCount: 0,
+            afterStartLine: 0,
+            afterLineCount: 0,
+            prefixContext: [],
+            afterLines: [],
+            beforeLines: [],
+            suffixContext: []
+        )
+        let hunkOperation = VerifiedPatchOperation(
+            id: second.id,
+            kind: second.kind,
+            sourcePath: second.sourcePath,
+            destinationPath: second.destinationPath,
+            before: second.before,
+            after: second.after,
+            strategy: .text(
+                hunks: Array(
+                    repeating: emptyHunk,
+                    count: VerifiedPatchLimits.maximumHunkCount + 1
+                ),
+                lcsCellCount: 1
+            )
+        )
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try VerifiedPatchEngine.revalidate(VerifiedPatchSet(
+                id: patch.id,
+                receipt: patch.receipt,
+                operations: [first, hunkOperation]
+            ))
+        }
+    }
+
     @Test("Snapshot file-count limit accepts limit and rejects +1")
     func snapshotFileLimit() throws {
         let after = file("after")
@@ -1946,6 +2046,47 @@ struct VerifiedPatchVersionChainTests {
         } == true)
     }
 
+    @Test("Version budget rejects prospective plans before revalidation")
+    func versionProspectivePlanningBudget() throws {
+        let base = try hunkExhaustionPatch(
+            patchID: id(15_100),
+            envelopeSeed: 15_110,
+            candidateCount: 1
+        )
+        let patches = (0..<3).map { index in
+            let patchID = id(15_120 + index)
+            return VerifiedPatchSet(
+                id: patchID,
+                receipt: base.receipt,
+                operations: base.operations.map { operation in
+                    VerifiedPatchOperation(
+                        id: VerifiedPatchOperationID(
+                            patchID: patchID,
+                            transitionIDs: operation.id.transitionIDs
+                        ),
+                        kind: operation.kind,
+                        sourcePath: operation.sourcePath,
+                        destinationPath: operation.destinationPath,
+                        before: operation.before,
+                        after: operation.after,
+                        strategy: operation.strategy
+                    )
+                }
+            )
+        }
+        var planningCount = 0
+
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze(
+                patches,
+                planningObserver: {
+                    planningCount += 1
+                }
+            )
+        )?.first?.reason == .resourceLimitExceeded)
+        #expect(planningCount == 0)
+    }
+
     @Test("Private workspace and physical root identities are bijective")
     func workspaceIdentityBijection() throws {
         let before = file("base")
@@ -2343,6 +2484,89 @@ private func makePatch(
     )
 }
 
+private func hunkExhaustionPatch(
+    patchID: UUID,
+    envelopeSeed: Int,
+    candidateCount: Int,
+    planningObserver: (() -> Void)? = nil
+) throws -> VerifiedPatchSet {
+    var states: [(
+        path: String,
+        before: VerifiedPatchFileState,
+        after: VerifiedPatchFileState
+    )] = []
+    for (index, hunkCount) in [512, 511].enumerated() {
+        let contents = separatedInsertionContents(
+            hunkCount: hunkCount
+        )
+        states.append((
+            path: "budget/0\(index)-hunks.txt",
+            before: file(contents.before),
+            after: file(contents.after)
+        ))
+    }
+    let candidateBefore = file(editedStableLines(
+        count: 1_413,
+        replacements: [:]
+    ))
+    let candidateAfter = file(editedStableLines(
+        count: 1_413,
+        replacements: [
+            400: "agent-first",
+            1_000: "agent-second"
+        ]
+    ))
+    for index in 0..<candidateCount {
+        states.append((
+            path: "budget/1-candidate-\(index).txt",
+            before: candidateBefore,
+            after: candidateAfter
+        ))
+    }
+    let records = states.enumerated().map { index, value in
+        record(
+            envelopeID: id(envelopeSeed + index),
+            cursor: UInt64(index + 1),
+            journalSequence: UInt64(index + 1),
+            changes: [change(
+                value.path,
+                value.before,
+                value.after
+            )]
+        )
+    }
+    return try makePatch(
+        patchID: patchID,
+        receipt: try receipt(records),
+        sources: records.enumerated().map { index, value in
+            source(
+                value,
+                ordinal: 0,
+                before: states[index].before,
+                after: states[index].after
+            )
+        },
+        planningObserver: planningObserver
+    )
+}
+
+private func separatedInsertionContents(
+    hunkCount: Int
+) -> (before: Data, after: Data) {
+    precondition(hunkCount > 0)
+    var before = ""
+    var after = ""
+    for index in 0..<hunkCount {
+        after += "agent-\(index)\n"
+        if index < hunkCount - 1 {
+            let stable = "stable-\(index)\n"
+            before += stable
+            after += stable
+        }
+    }
+    return (Data(before.utf8), Data(after.utf8))
+}
+
 private func receipt(
     _ records: [VerifiedPatchUntrustedEventRecord],
     workspace: VerifiedPatchWorkspaceIdentity = workspace()
@@ -2666,6 +2890,16 @@ private func singleEditLines(
             return "\(replacement)\n"
         }
         return "stable-\(index)\n"
+    }.joined()
+    return Data(value.utf8)
+}
+
+private func editedStableLines(
+    count: Int,
+    replacements: [Int: String]
+) -> Data {
+    let value = (0..<count).map { index in
+        "\(replacements[index] ?? "stable-\(index)")\n"
     }.joined()
     return Data(value.utf8)
 }

--- a/PineTests/VerifiedChanges/VerifiedPatchEngineTests.swift
+++ b/PineTests/VerifiedChanges/VerifiedPatchEngineTests.swift
@@ -281,6 +281,30 @@ struct VerifiedPatchIngressTests {
             try receipt([overLimit])
         }
     }
+
+    @Test("Synthesized empty receipt accessors fail safely")
+    func emptyReceiptAccessors() {
+        let empty = VerifiedPatchIngressReceipt(
+            receiptID: id(1),
+            workspace: workspace(),
+            projectID: id(2),
+            sessionID: id(3),
+            process: AgentProcessIdentity(
+                terminalID: id(4),
+                processGeneration: 1
+            ),
+            events: []
+        )
+
+        #expect(empty.firstCursorValue == 0)
+        #expect(empty.lastCursorValue == 0)
+        #expect(empty.firstJournalSequence == 0)
+        #expect(empty.lastJournalSequence == 0)
+        #expect(empty.durableEventExpectations.isEmpty)
+        #expect(throws: VerifiedPatchValidationError.invalidReceipt) {
+            try VerifiedPatchIngressCoordinator.revalidate(empty)
+        }
+    }
 }
 
 @Suite("Verified Patch Preparation")
@@ -310,7 +334,7 @@ struct VerifiedPatchPreparationTests {
         #expect(preview.expectedCurrent == current.stateIdentity)
         #expect(
             prepared.coordinatorExpectations.durableEvents
-                == patch.receipt.durableEventIdentities
+                == patch.receipt.durableEventExpectations
         )
         #expect(
             prepared.coordinatorExpectations.capturedHeadOID
@@ -523,6 +547,20 @@ struct VerifiedPatchPreparationTests {
         let counts = await revalidator.counts()
         #expect(counts.writer == 1)
         #expect(counts.audit == 1)
+        let auditExpectations = await revalidator.auditExpectations()
+        let journalExpectation = try #require(auditExpectations.first)
+        #expect(journalExpectation.envelope == patch.receipt.events[0].envelope)
+        #expect(
+            journalExpectation.durableIdentity
+                == patch.receipt.events[0].durableIdentity
+        )
+        #expect(journalExpectation.envelope.agentTypeRaw == "generic:test")
+        #expect(
+            journalExpectation.envelope.location.cwd
+                == "/private/tmp/project"
+        )
+        #expect(journalExpectation.envelope.source == .explicitAgentEvent)
+        #expect(journalExpectation.envelope.trustLevel == .verified)
     }
 
     @Test("Same-path chains collapse while retaining every durable reference")
@@ -679,7 +717,7 @@ struct VerifiedPatchPreparationTests {
             )]
         )
 
-        #expect(VerifiedPatchEngine.previewInverse(patch).first?.kind
+        #expect(try VerifiedPatchEngine.previewInverse(patch).first?.kind
             == .simulateRenamedFile)
         let preparation = VerifiedPatchEngine.prepareCheckedInverse(
             patch,
@@ -691,6 +729,177 @@ struct VerifiedPatchPreparationTests {
             return
         }
         #expect(operationID == patch.operations[0].id)
+    }
+
+    @Test("Content-preserving rename is valid but no-op modify is rejected")
+    func contentPreservingRenameAndNoOpModify() throws {
+        let state = file("same")
+        let noOp = record(
+            envelopeID: id(10),
+            cursor: 1,
+            journalSequence: 1,
+            changes: [change("same.txt", state, state)]
+        )
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try makePatch(
+                patchID: id(11),
+                receipt: try receipt([noOp]),
+                sources: [source(
+                    noOp,
+                    ordinal: 0,
+                    before: state,
+                    after: state
+                )]
+            )
+        }
+
+        let rename = record(
+            envelopeID: id(12),
+            cursor: 1,
+            journalSequence: 2,
+            changes: [change(
+                "old.txt",
+                state,
+                state,
+                destination: "new.txt"
+            )]
+        )
+        let patch = try makePatch(
+            patchID: id(13),
+            receipt: try receipt([rename]),
+            sources: [source(
+                rename,
+                ordinal: 0,
+                before: state,
+                after: state
+            )]
+        )
+        let preview = try #require(
+            try VerifiedPatchEngine.previewInverse(patch).first
+        )
+        #expect(patch.operations[0].kind == .rename)
+        #expect(preview.kind == .simulateRenamedFile)
+        #expect(preview.sourcePath == "old.txt")
+        #expect(preview.destinationPath == "new.txt")
+        #expect(preview.expectedCurrent == state.stateIdentity)
+        #expect(preview.result == state.stateIdentity)
+    }
+
+    @Test("Rename cannot smuggle a same-source transition chain")
+    func renameChainParity() throws {
+        let before = file("before")
+        let middle = file("middle")
+        let after = file("after")
+        let rename = record(
+            envelopeID: id(30),
+            cursor: 1,
+            journalSequence: 30,
+            changes: [change(
+                "old.txt",
+                before,
+                middle,
+                destination: "new.txt"
+            )]
+        )
+        let followup = record(
+            envelopeID: id(31),
+            cursor: 2,
+            journalSequence: 31,
+            changes: [change("old.txt", middle, after)]
+        )
+        let accepted = try receipt([rename, followup])
+        let sources = [
+            source(rename, ordinal: 0, before: before, after: middle),
+            source(followup, ordinal: 0, before: middle, after: after)
+        ]
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try makePatch(
+                patchID: id(32),
+                receipt: accepted,
+                sources: sources
+            )
+        }
+
+        let forged = VerifiedPatchSet(
+            id: id(33),
+            receipt: accepted,
+            operations: [VerifiedPatchOperation(
+                id: VerifiedPatchOperationID(
+                    patchID: id(33),
+                    transitionIDs: [
+                        transitionID(rename, 0),
+                        transitionID(followup, 0)
+                    ]
+                ),
+                kind: .rename,
+                sourcePath: "old.txt",
+                destinationPath: "new.txt",
+                before: before,
+                after: after,
+                strategy: .exactState
+            )]
+        )
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try VerifiedPatchEngine.revalidate(forged)
+        }
+    }
+
+    @Test("Nominal preview revalidates canonical strategy and arithmetic")
+    func previewRejectsForgedStrategyAndRanges() throws {
+        let patch = try singlePatch(
+            before: file("a\nold\n"),
+            after: file("a\nagent\n")
+        )
+        let original = patch.operations[0]
+        guard case .text(let hunks, let cells) = original.strategy,
+              let firstHunk = hunks.first else {
+            Issue.record("Fixture must produce a canonical text patch")
+            return
+        }
+
+        let downgraded = VerifiedPatchSet(
+            id: patch.id,
+            receipt: patch.receipt,
+            operations: [VerifiedPatchOperation(
+                id: original.id,
+                kind: original.kind,
+                sourcePath: original.sourcePath,
+                destinationPath: original.destinationPath,
+                before: original.before,
+                after: original.after,
+                strategy: .exactState
+            )]
+        )
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try VerifiedPatchEngine.previewInverse(downgraded)
+        }
+
+        let malformed = VerifiedTextPatchHunk(
+            beforeStartLine: firstHunk.beforeStartLine,
+            beforeLineCount: firstHunk.beforeLineCount,
+            afterStartLine: Int.max,
+            afterLineCount: firstHunk.afterLineCount,
+            prefixContext: firstHunk.prefixContext,
+            afterLines: firstHunk.afterLines,
+            beforeLines: firstHunk.beforeLines,
+            suffixContext: firstHunk.suffixContext
+        )
+        let forgedRange = VerifiedPatchSet(
+            id: patch.id,
+            receipt: patch.receipt,
+            operations: [VerifiedPatchOperation(
+                id: original.id,
+                kind: original.kind,
+                sourcePath: original.sourcePath,
+                destinationPath: original.destinationPath,
+                before: original.before,
+                after: original.after,
+                strategy: .text(hunks: [malformed], lcsCellCount: cells)
+            )]
+        )
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try VerifiedPatchEngine.previewInverse(forgedRange)
+        }
     }
 
     @Test("Synthesized patch and prepared values are revalidated")
@@ -953,6 +1162,213 @@ struct VerifiedPatchBudgetTests {
         )
         #expect(preparationConflicts(outcome) != nil)
     }
+
+    @Test("Prepared DTO preflight enforces shape, arithmetic, and aggregates")
+    func preparedDTOPreflight() throws {
+        let patch = try singlePatch(before: file("before"), after: nil)
+        let prepared = try requirePrepared(patch, files: [:])
+        let maximumState = file(Data(
+            repeating: 0x61,
+            count: VerifiedPatchLimits.maximumFileByteCount
+        ))
+
+        let boundaryOperations = (0..<8).map {
+            shapedDeleteOperation(
+                patchID: patch.id,
+                ordinal: $0,
+                path: "restored-\($0).txt",
+                result: maximumState
+            )
+        }
+        let boundary = PreparedInverse(
+            patch: patch,
+            coordinatorExpectations: prepared.coordinatorExpectations,
+            operations: boundaryOperations
+        )
+        try VerifiedPatchEngine.preflightPreparedShape(boundary)
+
+        let aggregateOverflow = PreparedInverse(
+            patch: patch,
+            coordinatorExpectations: prepared.coordinatorExpectations,
+            operations: boundaryOperations + [shapedDeleteOperation(
+                patchID: patch.id,
+                ordinal: 8,
+                path: "overflow.txt",
+                result: file("x")
+            )]
+        )
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try VerifiedPatchEngine.preflightPreparedShape(aggregateOverflow)
+        }
+
+        let original = try #require(prepared.operations.first)
+        let duplicateExpectation = VerifiedPreparedInverseOperation(
+            operationID: original.operationID,
+            kind: original.kind,
+            mode: original.mode,
+            expectations: original.expectations + original.expectations,
+            results: original.results,
+            resolvedTextHunks: original.resolvedTextHunks,
+            preview: original.preview
+        )
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try VerifiedPatchEngine.preflightPreparedShape(PreparedInverse(
+                patch: patch,
+                coordinatorExpectations: prepared.coordinatorExpectations,
+                operations: [duplicateExpectation]
+            ))
+        }
+
+        let textPatch = try singlePatch(
+            patchID: id(20),
+            envelopeID: id(21),
+            before: file("old\n"),
+            after: file("agent\n")
+        )
+        let textPrepared = try requirePrepared(
+            textPatch,
+            files: ["file.txt": file("agent\n")]
+        )
+        let textOperation = try #require(textPrepared.operations.first)
+        let textHunk = try #require(textOperation.resolvedTextHunks.first)
+        let previewHunk = try #require(textOperation.preview.hunks.first)
+        let overflowHunk = VerifiedPreparedTextHunk(
+            capturedAfterRange: Int.max..<Int.max,
+            resolvedCurrentRange: Int.max..<Int.max,
+            replacementLines: textHunk.replacementLines
+        )
+        let overflowPreviewHunk = VerifiedInverseHunkPreview(
+            capturedAfterStartLine: Int.max,
+            resolvedCurrentStartLine: Int.max,
+            header: previewHunk.header,
+            lines: previewHunk.lines
+        )
+        let arithmeticOverflow = VerifiedPreparedInverseOperation(
+            operationID: textOperation.operationID,
+            kind: textOperation.kind,
+            mode: textOperation.mode,
+            expectations: textOperation.expectations,
+            results: textOperation.results,
+            resolvedTextHunks: [overflowHunk],
+            preview: VerifiedInverseOperationPreview(
+                operationID: textOperation.preview.operationID,
+                kind: textOperation.preview.kind,
+                sourcePath: textOperation.preview.sourcePath,
+                destinationPath: textOperation.preview.destinationPath,
+                expectedCurrent: textOperation.preview.expectedCurrent,
+                result: textOperation.preview.result,
+                hunks: [overflowPreviewHunk]
+            )
+        )
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try VerifiedPatchEngine.preflightPreparedShape(PreparedInverse(
+                patch: textPatch,
+                coordinatorExpectations: textPrepared
+                    .coordinatorExpectations,
+                operations: [arithmeticOverflow]
+            ))
+        }
+    }
+
+    @Test("Projected and final snapshots enforce all aggregate limits")
+    func projectedAndFinalSnapshotLimits() throws {
+        let restored = file("x")
+        let patch = try singlePatch(before: restored, after: nil)
+
+        let byteBoundaryFiles = byteSizedSnapshotFiles(
+            totalBytes: VerifiedPatchLimits.maximumSnapshotByteCount - 1
+        )
+        _ = try requirePrepared(patch, files: byteBoundaryFiles)
+
+        let byteOverflowFiles = byteSizedSnapshotFiles(
+            totalBytes: VerifiedPatchLimits.maximumSnapshotByteCount
+        )
+        #expect(
+            preparationConflicts(
+                VerifiedPatchEngine.prepareCheckedInverse(
+                    patch,
+                    currentSnapshot: snapshot(byteOverflowFiles)
+                )
+            )?.first?.reason == .resourceLimitExceeded
+        )
+
+        var fileBoundary: [String: VerifiedPatchFileState] = [:]
+        for index in 0..<(VerifiedPatchLimits.maximumSnapshotFileCount - 1) {
+            fileBoundary["empty/\(index)"] = file(Data())
+        }
+        _ = try requirePrepared(patch, files: fileBoundary)
+        fileBoundary["empty/overflow"] = file(Data())
+        #expect(
+            preparationConflicts(
+                VerifiedPatchEngine.prepareCheckedInverse(
+                    patch,
+                    currentSnapshot: snapshot(fileBoundary)
+                )
+            )?.first?.reason == .resourceLimitExceeded
+        )
+
+        let pathBoundary = pathSizedSnapshotFiles(
+            totalPathBytes: VerifiedPatchLimits
+                .maximumSnapshotPathByteCount - "file.txt".utf8.count
+        )
+        _ = try requirePrepared(patch, files: pathBoundary)
+        var pathOverflow = pathBoundary
+        pathOverflow["z"] = file(Data())
+        #expect(
+            preparationConflicts(
+                VerifiedPatchEngine.prepareCheckedInverse(
+                    patch,
+                    currentSnapshot: snapshot(pathOverflow)
+                )
+            )?.first?.reason == .resourceLimitExceeded
+        )
+
+        let prepared = try requirePrepared(patch, files: [:])
+        let finalOverflow = VerifiedPatchEngine.applyPrepared(
+            prepared,
+            currentSnapshot: snapshot(byteOverflowFiles)
+        )
+        #expect(conflicts(finalOverflow)?.first?.reason
+            == .resourceLimitExceeded)
+    }
+
+    @Test("Merged text respects per-file boundary and rejects +1")
+    func projectedMergedFileLimit() throws {
+        let stableSuffix = "\ns1\ns2\ns3\n"
+        let beforePayloadCount = 2 * 1_024 * 1_024
+            - stableSuffix.utf8.count
+        let beforeText = String(repeating: "b", count: beforePayloadCount)
+            + stableSuffix
+        let afterText = "agent" + stableSuffix
+        let patch = try singlePatch(
+            before: file(beforeText),
+            after: file(afterText)
+        )
+        let boundaryHumanBytes = VerifiedPatchLimits.maximumFileByteCount
+            - beforeText.utf8.count
+        let boundaryCurrent = file(
+            afterText + String(repeating: "h", count: boundaryHumanBytes)
+        )
+        _ = try requirePrepared(
+            patch,
+            files: ["file.txt": boundaryCurrent]
+        )
+
+        let overflowCurrent = file(
+            afterText
+                + String(repeating: "h", count: boundaryHumanBytes + 1)
+        )
+        #expect(
+            preparationConflicts(
+                VerifiedPatchEngine.prepareCheckedInverse(
+                    patch,
+                    currentSnapshot: snapshot([
+                        "file.txt": overflowCurrent
+                    ])
+                )
+            )?.first?.reason == .resourceLimitExceeded
+        )
+    }
 }
 
 @Suite("Verified Patch Version Chains")
@@ -1033,6 +1449,98 @@ struct VerifiedPatchVersionChainTests {
         #expect(versionConflicts(
             VerifiedPatchVersionChainDetector.analyze([first, second])
         )?.contains { $0.reason == .journalSequenceCollision(10) } == true)
+    }
+
+    @Test("Writer authority replay is workspace-scoped across disjoint paths")
+    func mediatedWriterReplayAcrossPaths() throws {
+        let writerID = id(501)
+        let transactionID = id(502)
+        let casSequence: UInt64 = 900
+        let firstRecord = record(
+            envelopeID: id(510),
+            cursor: 1,
+            journalSequence: 10,
+            sessionID: id(511),
+            terminalID: id(512),
+            writerReceiptID: writerID,
+            descriptorTransactionID: transactionID,
+            descriptorCASSequence: casSequence,
+            changes: [change("one.txt", file("a"), file("b"))]
+        )
+        let secondRecord = record(
+            envelopeID: id(520),
+            cursor: 1,
+            journalSequence: 20,
+            sessionID: id(521),
+            terminalID: id(522),
+            writerReceiptID: writerID,
+            descriptorTransactionID: transactionID,
+            descriptorCASSequence: casSequence,
+            changes: [change("two.txt", file("c"), file("d"))]
+        )
+        let first = try makePatch(
+            patchID: id(530),
+            receipt: try receipt([firstRecord]),
+            sources: [source(
+                firstRecord,
+                ordinal: 0,
+                before: file("a"),
+                after: file("b")
+            )]
+        )
+        let second = try makePatch(
+            patchID: id(531),
+            receipt: try receipt([secondRecord]),
+            sources: [source(
+                secondRecord,
+                ordinal: 0,
+                before: file("c"),
+                after: file("d")
+            )]
+        )
+
+        let reasons = versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([first, second])
+        )?.map(\.reason) ?? []
+        #expect(reasons.contains(.writerReceiptReplay(writerID)))
+        #expect(reasons.contains(.descriptorTransactionReplay(transactionID)))
+        #expect(
+            reasons.contains(.descriptorCASSequenceCollision(casSequence))
+        )
+
+        let otherWorkspace = workspace(
+            privateID: id(540),
+            rootDevice: 33,
+            rootInode: 44
+        )
+        let otherRecord = record(
+            envelopeID: id(541),
+            cursor: 1,
+            journalSequence: 30,
+            sessionID: id(542),
+            terminalID: id(543),
+            writerReceiptID: writerID,
+            descriptorTransactionID: transactionID,
+            descriptorCASSequence: casSequence,
+            writerWorkspace: otherWorkspace,
+            changes: [change("three.txt", file("e"), file("f"))]
+        )
+        let other = try makePatch(
+            patchID: id(544),
+            receipt: try receipt([otherRecord], workspace: otherWorkspace),
+            sources: [source(
+                otherRecord,
+                ordinal: 0,
+                before: file("e"),
+                after: file("f")
+            )]
+        )
+        guard case .valid =
+                VerifiedPatchVersionChainDetector.analyze([first, other])
+        else {
+            Issue.record("Distinct private workspaces may reuse local IDs")
+            return
+        }
     }
 
     @Test("Root path aliases cannot split a shared private workspace")
@@ -1587,10 +2095,13 @@ private func record(
     projectID: UUID = id(400),
     rootPath: String = "/private/tmp/project",
     workspaceIdentity: VerifiedPatchWorkspaceIdentity? = nil,
-    descriptorCASSequence: UInt64? = nil,
     source eventSource: EventSource = .explicitAgentEvent,
     payload: AgentEventPayload? = nil,
     mediatedByPine: Bool = true,
+    writerReceiptID: UUID? = nil,
+    descriptorTransactionID: UUID? = nil,
+    descriptorCASSequence: UInt64? = nil,
+    writerWorkspace: VerifiedPatchWorkspaceIdentity? = nil,
     changes: [VerifiedPatchContentTransition]
 ) -> VerifiedPatchUntrustedEventRecord {
     let selectedWorkspace = workspaceIdentity
@@ -1636,12 +2147,12 @@ private func record(
     let writerReceipt: PineMediatedWriterReceipt?
     if mediatedByPine, !changes.isEmpty {
         writerReceipt = PineMediatedWriterReceipt(
-            receiptID: UUID(),
+            receiptID: writerReceiptID ?? UUID(),
             userApprovalID: UUID(),
-            descriptorTransactionID: UUID(),
+            descriptorTransactionID: descriptorTransactionID ?? UUID(),
             descriptorCASSequence: descriptorCASSequence
                 ?? journalSequence,
-            workspace: selectedWorkspace,
+            workspace: writerWorkspace ?? selectedWorkspace,
             auditEvent: auditIdentity,
             transitions: changes
         )
@@ -1780,6 +2291,90 @@ private func versionConflicts(
     return conflicts
 }
 
+private func shapedDeleteOperation(
+    patchID: UUID,
+    ordinal: Int,
+    path: String,
+    result state: VerifiedPatchFileState
+) -> VerifiedPreparedInverseOperation {
+    let operationID = VerifiedPatchOperationID(
+        patchID: patchID,
+        transitionIDs: [VerifiedPatchTransitionID(
+            envelopeID: id(20_000 + ordinal),
+            ordinal: 0
+        )]
+    )
+    return VerifiedPreparedInverseOperation(
+        operationID: operationID,
+        kind: .delete,
+        mode: .exactState,
+        expectations: [VerifiedPreparedPathExpectation(
+            path: path,
+            state: nil
+        )],
+        results: [VerifiedPreparedPathResult(path: path, state: state)],
+        resolvedTextHunks: [],
+        preview: VerifiedInverseOperationPreview(
+            operationID: operationID,
+            kind: .restoreDeletedFile,
+            sourcePath: path,
+            destinationPath: nil,
+            expectedCurrent: nil,
+            result: state.stateIdentity,
+            hunks: []
+        )
+    )
+}
+
+private func byteSizedSnapshotFiles(
+    totalBytes: Int
+) -> [String: VerifiedPatchFileState] {
+    var files: [String: VerifiedPatchFileState] = [:]
+    var remaining = totalBytes
+    var index = 0
+    let maximumState = file(Data(
+        repeating: 0x62,
+        count: VerifiedPatchLimits.maximumFileByteCount
+    ))
+    while remaining > 0 {
+        let count = min(
+            remaining,
+            VerifiedPatchLimits.maximumFileByteCount
+        )
+        files["bytes-\(index).bin"] = count
+            == VerifiedPatchLimits.maximumFileByteCount
+            ? maximumState
+            : file(Data(repeating: 0x62, count: count))
+        remaining -= count
+        index += 1
+    }
+    return files
+}
+
+private func pathSizedSnapshotFiles(
+    totalPathBytes: Int
+) -> [String: VerifiedPatchFileState] {
+    var files: [String: VerifiedPatchFileState] = [:]
+    var remaining = totalPathBytes
+    var index = 0
+    while remaining > 0 {
+        let length = min(
+            remaining,
+            VerifiedPatchLimits.maximumPathByteCount
+        )
+        let suffix = "-\(index)"
+        precondition(length >= suffix.utf8.count)
+        let path = String(
+            repeating: "p",
+            count: length - suffix.utf8.count
+        ) + suffix
+        files[path] = file(Data())
+        remaining -= length
+        index += 1
+    }
+    return files
+}
+
 private func alternatingLines(
     count: Int,
     replacement: String? = nil
@@ -1841,6 +2436,7 @@ private actor AuthorityEvidenceRecorder:
     PatchAuthorityEvidenceRevalidator {
     private var writerReceiptCount = 0
     private var auditEventCount = 0
+    private var expectations: [VerifiedPatchDurableEventExpectation] = []
 
     func revalidateMediatedWriterReceipts(
         _ receipts: [PineMediatedWriterReceipt]
@@ -1849,12 +2445,17 @@ private actor AuthorityEvidenceRecorder:
     }
 
     func revalidateDurableEvents(
-        _ identities: [VerifiedPatchDurableEventIdentity]
+        _ expectations: [VerifiedPatchDurableEventExpectation]
     ) {
-        auditEventCount += identities.count
+        auditEventCount += expectations.count
+        self.expectations.append(contentsOf: expectations)
     }
 
     func counts() -> (writer: Int, audit: Int) {
         (writerReceiptCount, auditEventCount)
+    }
+
+    func auditExpectations() -> [VerifiedPatchDurableEventExpectation] {
+        expectations
     }
 }

--- a/PineTests/VerifiedChanges/VerifiedPatchEngineTests.swift
+++ b/PineTests/VerifiedChanges/VerifiedPatchEngineTests.swift
@@ -2,7 +2,7 @@
 //  VerifiedPatchEngineTests.swift
 //  PineTests
 //
-//  Pure verified patch, preview, merge, and overlap coverage for #933.
+//  Security, preparation, budget, and multi-agent coverage for #933.
 //
 
 import Foundation
@@ -10,700 +10,1200 @@ import Testing
 
 @testable import Pine
 
-@Suite("Verified Patch Engine")
-struct VerifiedPatchEngineTests {
-    @Test("Patch and preview are deterministic and identity-bound")
-    func deterministicPatchAndPreview() throws {
-        let before = data("header\nold\nfooter\n")
-        let after = data("header\nagent\nfooter\n")
-        let patch = try singlePatch(
-            patchID: id(1),
+@Suite("Verified Patch Ingress")
+struct VerifiedPatchIngressTests {
+    @Test("Full provenance and durable journal scope are mandatory")
+    func provenanceAndJournalBinding() throws {
+        let before = file("before\n")
+        let after = file("after\n")
+        let valid = record(
+            envelopeID: id(1),
+            cursor: 1,
+            journalSequence: 10,
+            changes: [change("file.txt", before, after)]
+        )
+
+        _ = try receipt([valid])
+
+        let inferred = record(
             envelopeID: id(2),
-            before: before,
-            after: after
+            cursor: 1,
+            journalSequence: 11,
+            source: .gitCorrelation,
+            changes: [change("file.txt", before, after)]
         )
-        let duplicate = try singlePatch(
-            patchID: id(1),
-            envelopeID: id(2),
-            before: before,
-            after: after
-        )
-
-        #expect(patch == duplicate)
-        let preview = VerifiedPatchEngine.previewInverse(patch)
-        #expect(preview == VerifiedPatchEngine.previewInverse(duplicate))
-        #expect(preview.count == 1)
-        #expect(preview[0].kind == .applyTextHunks)
-        #expect(preview[0].eventEnvelopeID == id(2))
-        #expect(preview[0].expectedCurrentIdentity == ContentIdentity(content: after))
-        #expect(preview[0].resultIdentity == ContentIdentity(content: before))
-        #expect(preview[0].hunks.count == 1)
-        #expect(preview[0].hunks[0].header == "@@ -2,1 +2,1 @@")
-        #expect(preview[0].hunks[0].lines.contains {
-            $0.kind == .remove && $0.bytes == data("agent\n")
-        })
-        #expect(preview[0].hunks[0].lines.contains {
-            $0.kind == .add && $0.bytes == data("old\n")
-        })
-    }
-
-    @Test("Exact expected text is inverted byte-for-byte")
-    func exactTextInverse() throws {
-        let before = data("before\n")
-        let after = data("after\n")
-        let patch = try singlePatch(
-            before: before,
-            after: after
-        )
-
-        let result = VerifiedPatchEngine.applyCheckedInverse(
-            patch,
-            to: VerifiedPatchWorkspaceSnapshot(
-                files: ["file.txt": after, "unrelated.txt": data("keep")]
-            )
-        )
-
-        let applied = try #require(appliedSnapshot(result))
-        #expect(applied.files["file.txt"] == before)
-        #expect(applied.files["unrelated.txt"] == data("keep"))
-    }
-
-    @Test("Checked text hunks preserve a non-overlapping human edit")
-    func nonOverlappingHumanEditIsPreserved() throws {
-        let before = data(
-            "human-old\nstable-a\nstable-b\nold\nstable-c\nstable-d\n"
-        )
-        let after = data(
-            "human-old\nstable-a\nstable-b\nagent\nstable-c\nstable-d\n"
-        )
-        let current = data(
-            "human-new\nstable-a\nstable-b\nagent\nstable-c\nstable-d\n"
-        )
-        let expected = data(
-            "human-new\nstable-a\nstable-b\nold\nstable-c\nstable-d\n"
-        )
-        let patch = try singlePatch(before: before, after: after)
-
-        let result = VerifiedPatchEngine.applyCheckedInverse(
-            patch,
-            to: VerifiedPatchWorkspaceSnapshot(files: ["file.txt": current])
-        )
-
-        let applied = try #require(appliedSnapshot(result))
-        #expect(applied.files["file.txt"] == expected)
-    }
-
-    @Test("A human edit overlapping an agent hunk fails closed")
-    func overlappingHumanEditConflicts() throws {
-        let before = data("a\nb\nold\nc\nd\n")
-        let after = data("a\nb\nagent\nc\nd\n")
-        let current = data("a\nb\nhuman-overlap\nc\nd\n")
-        let patch = try singlePatch(before: before, after: after)
-
-        let result = VerifiedPatchEngine.applyCheckedInverse(
-            patch,
-            to: VerifiedPatchWorkspaceSnapshot(files: ["file.txt": current])
-        )
-
-        let conflicts = try #require(conflicts(result))
-        #expect(conflicts.count == 1)
-        #expect(conflicts[0].reason == .textContextMissing(hunkIndex: 0))
-    }
-
-    @Test("Duplicate checked context is ambiguous and fails closed")
-    func duplicateContextConflicts() throws {
-        let before = data("a\nb\nold\nc\nd\n")
-        let after = data("a\nb\nagent\nc\nd\n")
-        let current = data(
-            "a\nb\nagent\nc\nd\nhuman\n"
-                + "a\nb\nagent\nc\nd\n"
-        )
-        let patch = try singlePatch(before: before, after: after)
-
-        let result = VerifiedPatchEngine.applyCheckedInverse(
-            patch,
-            to: VerifiedPatchWorkspaceSnapshot(files: ["file.txt": current])
-        )
-
-        let conflicts = try #require(conflicts(result))
-        #expect(conflicts[0].reason == .ambiguousTextContext(hunkIndex: 0))
-    }
-
-    @Test("CRLF and a missing final newline survive hunk application")
-    func crlfAndNoFinalNewline() throws {
-        let before = data(
-            "human-old\r\nstable-a\r\nstable-b\r\nold\r\n"
-                + "stable-c\r\nlast"
-        )
-        let after = data(
-            "human-old\r\nstable-a\r\nstable-b\r\nagent\r\n"
-                + "stable-c\r\nlast"
-        )
-        let current = data(
-            "human-new\r\nstable-a\r\nstable-b\r\nagent\r\n"
-                + "stable-c\r\nlast"
-        )
-        let expected = data(
-            "human-new\r\nstable-a\r\nstable-b\r\nold\r\n"
-                + "stable-c\r\nlast"
-        )
-        let patch = try singlePatch(before: before, after: after)
-
-        let result = VerifiedPatchEngine.applyCheckedInverse(
-            patch,
-            to: VerifiedPatchWorkspaceSnapshot(files: ["file.txt": current])
-        )
-
-        let applied = try #require(appliedSnapshot(result))
-        #expect(applied.files["file.txt"] == expected)
-        let preview = VerifiedPatchEngine.previewInverse(patch)
-        #expect(preview[0].hunks[0].lines.contains {
-            $0.bytes == data("agent\r\n")
-        })
-        #expect(preview[0].hunks[0].lines.last?.bytes == data("last"))
-    }
-
-    @Test("Create and delete use exact-state inverse fallbacks")
-    func createAndDeleteExactFallbacks() throws {
-        let created = data("created")
-        let deleted = data("deleted")
-        let createTransition = transition(
-            path: "created.txt",
-            before: nil,
-            after: created
-        )
-        let deleteTransition = transition(
-            path: "deleted.txt",
-            before: deleted,
-            after: nil
-        )
-        let binding = try makeBinding(events: [
-            VerifiedPatchEventReference(
-                envelopeID: id(2),
-                cursorValue: 1,
-                transitions: [createTransition]
-            ),
-            VerifiedPatchEventReference(
-                envelopeID: id(3),
-                cursorValue: 2,
-                transitions: [deleteTransition]
-            )
-        ])
-        let patch = try VerifiedPatchEngine.makePatch(
-            id: id(1),
-            binding: binding,
-            operations: [
-                VerifiedPatchSourceOperation(
-                    eventEnvelopeID: id(3),
-                    sourcePath: "deleted.txt",
-                    beforeContent: deleted,
-                    afterContent: nil
-                ),
-                VerifiedPatchSourceOperation(
-                    eventEnvelopeID: id(2),
-                    sourcePath: "created.txt",
-                    beforeContent: nil,
-                    afterContent: created
-                )
-            ]
-        )
-
-        let previews = VerifiedPatchEngine.previewInverse(patch)
-        #expect(previews.map(\.kind) == [
-            .removeCreatedFile,
-            .restoreDeletedFile
-        ])
-        let result = VerifiedPatchEngine.applyCheckedInverse(
-            patch,
-            to: VerifiedPatchWorkspaceSnapshot(
-                files: ["created.txt": created]
-            )
-        )
-        let applied = try #require(appliedSnapshot(result))
-        #expect(applied.files["created.txt"] == nil)
-        #expect(applied.files["deleted.txt"] == deleted)
-    }
-
-    @Test("A diverged created file is never removed")
-    func divergedCreateConflicts() throws {
-        let patch = try singlePatch(
-            before: nil,
-            after: data("agent-created")
-        )
-        let result = VerifiedPatchEngine.applyCheckedInverse(
-            patch,
-            to: VerifiedPatchWorkspaceSnapshot(
-                files: ["file.txt": data("human-edited")]
-            )
-        )
-
-        let found = try #require(conflicts(result))
-        #expect(found[0].reason == .exactStateDiverged)
-    }
-
-    @Test("Binary changes require an exact after-state")
-    func binaryExactFallback() throws {
-        let before = Data([0x00, 0x01, 0x02])
-        let after = Data([0x00, 0x03, 0x04])
-        let patch = try singlePatch(before: before, after: after)
-        #expect(VerifiedPatchEngine.previewInverse(patch)[0].kind
-            == .restoreExactBytes)
-
-        let exact = VerifiedPatchEngine.applyCheckedInverse(
-            patch,
-            to: VerifiedPatchWorkspaceSnapshot(files: ["file.txt": after])
-        )
-        #expect(try #require(appliedSnapshot(exact)).files["file.txt"]
-            == before)
-
-        let diverged = VerifiedPatchEngine.applyCheckedInverse(
-            patch,
-            to: VerifiedPatchWorkspaceSnapshot(
-                files: ["file.txt": Data([0x00, 0x03, 0x05])]
-            )
-        )
-        #expect(try #require(conflicts(diverged))[0].reason
-            == .exactStateDiverged)
-    }
-
-    @Test("Rename inversion is exact and preserves unrelated files")
-    func renameExactFallback() throws {
-        let before = data("original")
-        let after = data("renamed")
-        let eventID = id(2)
-        let contentTransition = VerifiedPatchContentTransition(
-            sourcePath: "old.txt",
-            destinationPath: "new.txt",
-            beforeIdentity: ContentIdentity(content: before),
-            afterIdentity: ContentIdentity(content: after)
-        )
-        let binding = try makeBinding(events: [
-            VerifiedPatchEventReference(
-                envelopeID: eventID,
-                cursorValue: 1,
-                transitions: [contentTransition]
-            )
-        ])
-        let patch = try VerifiedPatchEngine.makePatch(
-            id: id(1),
-            binding: binding,
-            operations: [
-                VerifiedPatchSourceOperation(
-                    eventEnvelopeID: eventID,
-                    sourcePath: "old.txt",
-                    destinationPath: "new.txt",
-                    beforeContent: before,
-                    afterContent: after
-                )
-            ]
-        )
-
-        let result = VerifiedPatchEngine.applyCheckedInverse(
-            patch,
-            to: VerifiedPatchWorkspaceSnapshot(files: [
-                "new.txt": after,
-                "keep.txt": data("keep")
-            ])
-        )
-        let applied = try #require(appliedSnapshot(result))
-        #expect(applied.files["new.txt"] == nil)
-        #expect(applied.files["old.txt"] == before)
-        #expect(applied.files["keep.txt"] == data("keep"))
-        #expect(VerifiedPatchEngine.previewInverse(patch)[0].kind
-            == .restoreRenamedFile)
-    }
-
-    @Test("One conflict keeps a multi-operation inverse atomic")
-    func multiOperationConflictIsAtomic() throws {
-        let firstBefore = data("one-before")
-        let firstAfter = data("one-after")
-        let secondBefore = data("two-before")
-        let secondAfter = data("two-after")
-        let binding = try makeBinding(events: [
-            event(
-                id: id(2),
-                cursor: 1,
-                path: "one.bin",
-                before: firstBefore,
-                after: firstAfter
-            ),
-            event(
-                id: id(3),
-                cursor: 2,
-                path: "two.bin",
-                before: secondBefore,
-                after: secondAfter
-            )
-        ])
-        let patch = try VerifiedPatchEngine.makePatch(
-            id: id(1),
-            binding: binding,
-            operations: [
-                source(
-                    eventID: id(2),
-                    path: "one.bin",
-                    before: firstBefore,
-                    after: firstAfter
-                ),
-                source(
-                    eventID: id(3),
-                    path: "two.bin",
-                    before: secondBefore,
-                    after: secondAfter
-                )
-            ]
-        )
-        let original = VerifiedPatchWorkspaceSnapshot(files: [
-            "one.bin": firstAfter,
-            "two.bin": data("human")
-        ])
-
-        let result = VerifiedPatchEngine.applyCheckedInverse(
-            patch,
-            to: original
-        )
-
-        #expect(appliedSnapshot(result) == nil)
-        #expect(try #require(conflicts(result))[0].path == "two.bin")
-        #expect(original.files["one.bin"] == firstAfter)
-    }
-
-    @Test("Cursor replay and gaps are rejected by the binding")
-    func cursorReplayAndGap() throws {
-        let contentTransition = transition(
-            path: "file.txt",
-            before: data("a"),
-            after: data("b")
-        )
-        #expect(throws: VerifiedPatchValidationError.cursorReplay(1)) {
-            try makeBinding(events: [
-                VerifiedPatchEventReference(
-                    envelopeID: id(2),
-                    cursorValue: 1,
-                    transitions: [contentTransition]
-                ),
-                VerifiedPatchEventReference(
-                    envelopeID: id(3),
-                    cursorValue: 1,
-                    transitions: [contentTransition]
-                )
-            ])
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try receipt([inferred])
         }
+
+        let forgedJournal = VerifiedPatchUntrustedEventRecord(
+            envelope: valid.envelope,
+            durableIdentity: durableIdentity(
+                envelope: valid.envelope,
+                journalSequence: 10,
+                eventCursor: 2
+            ),
+            mediatedWriterReceipt: valid.mediatedWriterReceipt,
+            transitions: valid.transitions
+        )
+        #expect(
+            throws: VerifiedPatchValidationError
+                .invalidDurableEvent(valid.envelope.id)
+        ) {
+            try receipt([forgedJournal])
+        }
+    }
+
+    @Test("Authenticated external-write evidence is audit-only")
+    func externalWriteCannotAuthorizePatch() {
+        let external = record(
+            envelopeID: id(20),
+            cursor: 1,
+            journalSequence: 1,
+            mediatedByPine: false,
+            changes: [change(
+                "file.txt",
+                file("before"),
+                file("after")
+            )]
+        )
+
+        #expect(throws: VerifiedPatchValidationError
+            .missingMediatedWriterReceipt(external.envelope.id)) {
+            try receipt([external])
+        }
+    }
+
+    @Test("Several batches retain irrelevant durable cursor records")
+    func severalBatchesAndIrrelevantEvents() throws {
+        let first = record(
+            envelopeID: id(1),
+            cursor: 40,
+            journalSequence: 100,
+            changes: [change(
+                "first.txt",
+                file("one\n"),
+                file("agent-one\n")
+            )]
+        )
+        let irrelevant = record(
+            envelopeID: id(2),
+            cursor: 41,
+            journalSequence: 103,
+            changes: []
+        )
+        let second = record(
+            envelopeID: id(3),
+            cursor: 42,
+            journalSequence: 109,
+            changes: [change(
+                "second.txt",
+                file("two\n"),
+                file("agent-two\n")
+            )]
+        )
+
+        let accepted = try receipt([second, first, irrelevant])
+
+        #expect(accepted.events.map(\.envelope.cursorValue) == [40, 41, 42])
+        #expect(accepted.events[1].transitions.isEmpty)
+        #expect(
+            accepted.durableEventIdentities.map(\.journalSequence)
+                == [100, 103, 109]
+        )
+    }
+
+    @Test("Cursor gaps and journal rollback fail closed")
+    func cursorAndJournalOrder() {
+        let state = file("state")
+        let first = record(
+            envelopeID: id(1),
+            cursor: 1,
+            journalSequence: 10,
+            changes: [change("one.txt", nil, state)]
+        )
+        let gap = record(
+            envelopeID: id(2),
+            cursor: 3,
+            journalSequence: 11,
+            changes: []
+        )
         #expect(throws: VerifiedPatchValidationError.cursorGap(
             expected: 2,
             actual: 3
         )) {
-            try makeBinding(events: [
-                VerifiedPatchEventReference(
-                    envelopeID: id(2),
-                    cursorValue: 1,
-                    transitions: [contentTransition]
-                ),
-                VerifiedPatchEventReference(
-                    envelopeID: id(3),
-                    cursorValue: 3,
-                    transitions: [contentTransition]
-                )
-            ])
+            try receipt([first, gap])
+        }
+
+        let rollback = record(
+            envelopeID: id(3),
+            cursor: 2,
+            journalSequence: 9,
+            changes: []
+        )
+        #expect(throws: VerifiedPatchValidationError.journalOrderMismatch(
+            previous: 10,
+            actual: 9
+        )) {
+            try receipt([first, rollback])
         }
     }
 
-    @Test("Captured bytes must match the event content identities")
-    func eventIdentityMismatchIsRejected() throws {
-        let binding = try makeBinding(events: [
-            event(
-                id: id(2),
-                cursor: 1,
-                path: "file.txt",
-                before: data("before"),
-                after: data("after")
+    @Test("File-change payload must bind exactly one transition")
+    func payloadBinding() {
+        let before = file("before")
+        let after = file("after")
+        let mismatchedPayload = AgentEventPayload.fileChange(
+            AgentFileChange(
+                relativePath: "other.txt",
+                before: before.identity,
+                after: after.identity
             )
-        ])
+        )
+        let value = record(
+            envelopeID: id(1),
+            cursor: 1,
+            journalSequence: 1,
+            payload: mismatchedPayload,
+            changes: [change("file.txt", before, after)]
+        )
 
-        #expect(throws: VerifiedPatchValidationError.unboundOperation) {
-            try VerifiedPatchEngine.makePatch(
-                id: id(1),
-                binding: binding,
-                operations: [
+        #expect(
+            throws: VerifiedPatchValidationError
+                .invalidEnvelope(value.envelope.id)
+        ) {
+            try receipt([value])
+        }
+    }
+
+    @Test("Protected, noncanonical, and alias paths are rejected")
+    func pathPolicy() throws {
+        let state = file("state")
+        for path in [".git/config", ".pine/authority", "../escape"] {
+            let value = record(
+                envelopeID: id(path.count),
+                cursor: 1,
+                journalSequence: 1,
+                changes: [change(path, nil, state)]
+            )
+            #expect(throws: VerifiedPatchValidationError.self) {
+                try receipt([value])
+            }
+        }
+
+        let decomposed = "Cafe\u{301}.txt"
+        let value = record(
+            envelopeID: id(30),
+            cursor: 1,
+            journalSequence: 1,
+            changes: [change(decomposed, nil, state)]
+        )
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try receipt([value])
+        }
+
+        let records = [
+            record(
+                envelopeID: id(40),
+                cursor: 1,
+                journalSequence: 1,
+                changes: [change("File.swift", nil, state)]
+            ),
+            record(
+                envelopeID: id(41),
+                cursor: 2,
+                journalSequence: 2,
+                changes: [change("file.swift", nil, state)]
+            )
+        ]
+        let accepted = try receipt(records)
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try makePatch(
+                patchID: id(42),
+                receipt: accepted,
+                sources: [
                     source(
-                        eventID: id(2),
-                        path: "file.txt",
-                        before: data("different-before"),
-                        after: data("after")
+                        records[0],
+                        ordinal: 0,
+                        before: nil,
+                        after: state
+                    ),
+                    source(
+                        records[1],
+                        ordinal: 0,
+                        before: nil,
+                        after: state
                     )
                 ]
             )
         }
     }
+
+    @Test("Event and transition aggregate limits accept limit and reject +1")
+    func ingressLimits() throws {
+        let events = (0..<VerifiedPatchLimits.maximumEventCount).map {
+            record(
+                envelopeID: id($0 + 1),
+                cursor: UInt64($0 + 1),
+                journalSequence: UInt64($0 + 1),
+                changes: []
+            )
+        }
+        _ = try receipt(events)
+        let extra = record(
+            envelopeID: id(events.count + 1),
+            cursor: UInt64(events.count + 1),
+            journalSequence: UInt64(events.count + 1),
+            changes: []
+        )
+        #expect(throws: VerifiedPatchValidationError.tooManyEvents) {
+            try receipt(events + [extra])
+        }
+
+        let state = file("x")
+        let changes = (0..<VerifiedPatchLimits.maximumTransitionCount).map {
+            change("files/\($0).txt", nil, state)
+        }
+        let atLimit = record(
+            envelopeID: id(2_000),
+            cursor: 1,
+            journalSequence: 1,
+            changes: changes
+        )
+        _ = try receipt([atLimit])
+        let overLimit = record(
+            envelopeID: id(2_001),
+            cursor: 1,
+            journalSequence: 1,
+            changes: changes + [change("extra.txt", nil, state)]
+        )
+        #expect(throws: VerifiedPatchValidationError.tooManyTransitions) {
+            try receipt([overLimit])
+        }
+    }
+}
+
+@Suite("Verified Patch Preparation")
+struct VerifiedPatchPreparationTests {
+    @Test("Prepared inverse exposes resolved ranges and exact coordinator seam")
+    func preparedPreviewAndCoordinatorExpectations() throws {
+        let before = file(
+            "p0\np1\np2\np3\nold\nbottom0\nbottom1\n",
+            mode: 0o600
+        )
+        let after = file(
+            "p0\np1\np2\np3\nagent\nbottom0\nbottom1\n",
+            mode: 0o600
+        )
+        let patch = try singlePatch(before: before, after: after)
+        let current = file("human\n" + text(after), mode: 0o600)
+
+        let prepared = try requirePrepared(
+            patch,
+            files: ["file.txt": current]
+        )
+
+        let preview = try #require(prepared.previews.first)
+        let hunk = try #require(preview.hunks.first)
+        #expect(hunk.capturedAfterStartLine == 4)
+        #expect(hunk.resolvedCurrentStartLine == 5)
+        #expect(preview.expectedCurrent == current.stateIdentity)
+        #expect(
+            prepared.coordinatorExpectations.durableEvents
+                == patch.receipt.durableEventIdentities
+        )
+        #expect(
+            prepared.coordinatorExpectations.capturedHeadOID
+                == String(repeating: "a", count: 40)
+        )
+        #expect(
+            prepared.coordinatorExpectations.capturedIndexSHA256
+                == String(repeating: "b", count: 64)
+        )
+
+        let result = VerifiedPatchEngine.applyPrepared(
+            prepared,
+            currentSnapshot: snapshot(["file.txt": current])
+        )
+        let applied = try #require(appliedSnapshot(result))
+        #expect(text(try #require(applied.files["file.txt"]))
+            == "human\np0\np1\np2\np3\nold\nbottom0\nbottom1\n")
+    }
+
+    @Test("A proven non-overlapping human edit is preserved")
+    func preservesNonOverlap() throws {
+        let before = file(
+            "human-old\nstable-a\nstable-b\nold\nstable-c\nstable-d\n"
+        )
+        let after = file(
+            "human-old\nstable-a\nstable-b\nagent\nstable-c\nstable-d\n"
+        )
+        let current = file(
+            "human-new\nstable-a\nstable-b\nagent\nstable-c\nstable-d\n"
+        )
+        let patch = try singlePatch(before: before, after: after)
+
+        let prepared = try requirePrepared(
+            patch,
+            files: ["file.txt": current]
+        )
+        let result = VerifiedPatchEngine.applyPrepared(
+            prepared,
+            currentSnapshot: snapshot(["file.txt": current])
+        )
+
+        let applied = try #require(appliedSnapshot(result))
+        #expect(
+            text(try #require(applied.files["file.txt"]))
+                == "human-new\nstable-a\nstable-b\nold\nstable-c\nstable-d\n"
+        )
+    }
+
+    @Test("Overlap and moved-region duplicates both conflict")
+    func overlapAndMovedDuplicateConflict() throws {
+        let before = file("a\nb\nold\nc\nd\n")
+        let after = file("a\nb\nagent\nc\nd\n")
+        let patch = try singlePatch(before: before, after: after)
+
+        let overlap = VerifiedPatchEngine.prepareCheckedInverse(
+            patch,
+            currentSnapshot: snapshot([
+                "file.txt": file("a\nb\nhuman\nc\nd\n")
+            ])
+        )
+        #expect(preparationConflicts(overlap)?.first?.reason
+            == .humanEditOverlapsAgentRegion(hunkIndex: 0))
+
+        let moved = VerifiedPatchEngine.prepareCheckedInverse(
+            patch,
+            currentSnapshot: snapshot([
+                "file.txt": file(
+                    "human-replaced-original\n"
+                        + "a\nb\nagent\nc\nd\n"
+                )
+            ])
+        )
+        #expect(preparationConflicts(moved)?.first?.reason
+            == .humanEditOverlapsAgentRegion(hunkIndex: 0))
+    }
+
+    @Test("CRLF and missing final newline survive resolved application")
+    func crlfAndNoFinalNewline() throws {
+        let before = file(
+            "human-old\r\nstable-a\r\nstable-b\r\nold\r\nlast"
+        )
+        let after = file(
+            "human-old\r\nstable-a\r\nstable-b\r\nagent\r\nlast"
+        )
+        let current = file(
+            "human-new\r\nstable-a\r\nstable-b\r\nagent\r\nlast"
+        )
+        let patch = try singlePatch(before: before, after: after)
+        let prepared = try requirePrepared(
+            patch,
+            files: ["file.txt": current]
+        )
+        let result = VerifiedPatchEngine.applyPrepared(
+            prepared,
+            currentSnapshot: snapshot(["file.txt": current])
+        )
+
+        let applied = try #require(appliedSnapshot(result))
+        let restored = try #require(applied.files["file.txt"])
+        #expect(text(restored)
+            == "human-new\r\nstable-a\r\nstable-b\r\nold\r\nlast")
+    }
+
+    @Test("Fresh snapshot is rechecked after preparation")
+    func stalePreparedPlanConflicts() throws {
+        let patch = try singlePatch(
+            before: file("before"),
+            after: file("after")
+        )
+        let prepared = try requirePrepared(
+            patch,
+            files: ["file.txt": file("after")]
+        )
+
+        let result = VerifiedPatchEngine.applyPrepared(
+            prepared,
+            currentSnapshot: snapshot(["file.txt": file("human")])
+        )
+
+        #expect(conflicts(result)?.first?.reason
+            == .snapshotChangedAfterPreparation)
+    }
+
+    @Test("Authority seam revalidates writer proof and journal audit")
+    func combinedAuthorityEvidenceSeam() async throws {
+        let patch = try singlePatch(
+            before: file("before"),
+            after: file("after")
+        )
+        let prepared = try requirePrepared(
+            patch,
+            files: ["file.txt": file("after")]
+        )
+        let revalidator = AuthorityEvidenceRecorder()
+
+        try await VerifiedPatchEngine.revalidateAuthorityEvidence(
+            prepared,
+            using: revalidator
+        )
+
+        let counts = await revalidator.counts()
+        #expect(counts.writer == 1)
+        #expect(counts.audit == 1)
+    }
+
+    @Test("Same-path chains collapse while retaining every durable reference")
+    func transitionChainsCollapse() throws {
+        let middle = file("middle")
+        let final = file("final")
+        let create = record(
+            envelopeID: id(1),
+            cursor: 1,
+            journalSequence: 10,
+            changes: [change("file.txt", nil, middle)]
+        )
+        let modify = record(
+            envelopeID: id(2),
+            cursor: 2,
+            journalSequence: 12,
+            changes: [change("file.txt", middle, final)]
+        )
+        let accepted = try receipt([create, modify])
+        let patch = try makePatch(
+            patchID: id(3),
+            receipt: accepted,
+            sources: [
+                source(create, ordinal: 0, before: nil, after: middle),
+                source(modify, ordinal: 0, before: middle, after: final)
+            ]
+        )
+
+        #expect(patch.operations.count == 1)
+        #expect(patch.operations[0].kind == .create)
+        #expect(patch.operations[0].id.transitionIDs == [
+            transitionID(create, 0),
+            transitionID(modify, 0)
+        ])
+        let prepared = try requirePrepared(
+            patch,
+            files: ["file.txt": final]
+        )
+        let applied = try #require(appliedSnapshot(
+            VerifiedPatchEngine.applyPrepared(
+                prepared,
+                currentSnapshot: snapshot(["file.txt": final])
+            )
+        ))
+        #expect(applied.files["file.txt"] == nil)
+
+        let original = file("original")
+        let changed = file("changed")
+        let first = record(
+            envelopeID: id(4),
+            cursor: 1,
+            journalSequence: 20,
+            changes: [change("gone.txt", original, changed)]
+        )
+        let deletion = record(
+            envelopeID: id(5),
+            cursor: 2,
+            journalSequence: 21,
+            changes: [change("gone.txt", changed, nil)]
+        )
+        let deletionPatch = try makePatch(
+            patchID: id(6),
+            receipt: try receipt([first, deletion]),
+            sources: [
+                source(
+                    first,
+                    ordinal: 0,
+                    before: original,
+                    after: changed
+                ),
+                source(
+                    deletion,
+                    ordinal: 0,
+                    before: changed,
+                    after: nil
+                )
+            ]
+        )
+        #expect(deletionPatch.operations[0].kind == .delete)
+        let restore = try requirePrepared(deletionPatch, files: [:])
+        let restored = try #require(appliedSnapshot(
+            VerifiedPatchEngine.applyPrepared(
+                restore,
+                currentSnapshot: snapshot([:])
+            )
+        ))
+        #expect(restored.files["gone.txt"] == original)
+    }
+
+    @Test("Mode is restored and symlink or mode divergence conflicts")
+    func modeAndFileKind() throws {
+        let before = file("before\n", mode: 0o600)
+        let after = file("after\n", mode: 0o755)
+        let patch = try singlePatch(before: before, after: after)
+
+        let prepared = try requirePrepared(
+            patch,
+            files: ["file.txt": after]
+        )
+        let applied = try #require(appliedSnapshot(
+            VerifiedPatchEngine.applyPrepared(
+                prepared,
+                currentSnapshot: snapshot(["file.txt": after])
+            )
+        ))
+        #expect(applied.files["file.txt"]?.posixMode == 0o600)
+
+        let wrongMode = VerifiedPatchEngine.prepareCheckedInverse(
+            patch,
+            currentSnapshot: snapshot([
+                "file.txt": file("after\n", mode: 0o700)
+            ])
+        )
+        #expect(preparationConflicts(wrongMode)?.first?.reason
+            == .exactStateDiverged)
+
+        let symlink = VerifiedPatchEngine.prepareCheckedInverse(
+            patch,
+            currentSnapshot: snapshot([
+                "file.txt": file(
+                    "after\n",
+                    mode: 0o755,
+                    kind: .symbolicLink
+                )
+            ])
+        )
+        #expect(preparationConflicts(symlink)?.first?.reason
+            == .unsupportedCurrentFileKind)
+    }
+
+    @Test("Rename is previewable but cannot become a prepared authority plan")
+    func renameBlocked() throws {
+        let before = file("old")
+        let after = file("new")
+        let rename = record(
+            envelopeID: id(1),
+            cursor: 1,
+            journalSequence: 1,
+            changes: [change(
+                "old.txt",
+                before,
+                after,
+                destination: "new.txt"
+            )]
+        )
+        let patch = try makePatch(
+            patchID: id(2),
+            receipt: try receipt([rename]),
+            sources: [source(
+                rename,
+                ordinal: 0,
+                before: before,
+                after: after
+            )]
+        )
+
+        #expect(VerifiedPatchEngine.previewInverse(patch).first?.kind
+            == .simulateRenamedFile)
+        let preparation = VerifiedPatchEngine.prepareCheckedInverse(
+            patch,
+            currentSnapshot: snapshot(["new.txt": after])
+        )
+        guard case .failure(.unsupportedOperation(let operationID, .rename))
+                = preparation else {
+            Issue.record("Rename must fail before preparing authority")
+            return
+        }
+        #expect(operationID == patch.operations[0].id)
+    }
+
+    @Test("Synthesized patch and prepared values are revalidated")
+    func synthesizedValuesCannotBypassChecks() throws {
+        let patch = try singlePatch(
+            before: file("before"),
+            after: file("after")
+        )
+        let accepted = patch.receipt.events[0]
+        let forgedEvent = VerifiedPatchAcceptedEvent(
+            envelope: accepted.envelope,
+            durableIdentity: VerifiedPatchDurableEventIdentity(
+                projectID: accepted.durableIdentity.projectID,
+                canonicalWorktreePath: accepted.durableIdentity
+                    .canonicalWorktreePath,
+                sessionID: accepted.durableIdentity.sessionID,
+                terminalID: accepted.durableIdentity.terminalID,
+                processGeneration: accepted.durableIdentity
+                    .processGeneration,
+                eventCursor: accepted.durableIdentity.eventCursor,
+                envelopeID: id(9_999),
+                journalSequence: accepted.durableIdentity.journalSequence
+            ),
+            mediatedWriterReceipt: accepted.mediatedWriterReceipt,
+            transitions: accepted.transitions
+        )
+        let forgedReceipt = VerifiedPatchIngressReceipt(
+            receiptID: patch.receipt.receiptID,
+            workspace: patch.receipt.workspace,
+            projectID: patch.receipt.projectID,
+            sessionID: patch.receipt.sessionID,
+            process: patch.receipt.process,
+            events: [forgedEvent]
+        )
+        let forgedPatch = VerifiedPatchSet(
+            id: patch.id,
+            receipt: forgedReceipt,
+            operations: patch.operations
+        )
+
+        guard case .failure(.invalidPatch) =
+                VerifiedPatchEngine.prepareCheckedInverse(
+                    forgedPatch,
+                    currentSnapshot: snapshot(["file.txt": file("after")])
+                ) else {
+            Issue.record("Forged durable receipt must be rejected")
+            return
+        }
+
+        let prepared = try requirePrepared(
+            patch,
+            files: ["file.txt": file("after")]
+        )
+        let forgedExpectations = VerifiedPatchCoordinatorExpectations(
+            privateWorkspaceID: prepared.coordinatorExpectations
+                .privateWorkspaceID,
+            canonicalRootPath: prepared.coordinatorExpectations
+                .canonicalRootPath,
+            rootDevice: prepared.coordinatorExpectations.rootDevice,
+            rootInode: prepared.coordinatorExpectations.rootInode,
+            capturedHeadOID: prepared.coordinatorExpectations
+                .capturedHeadOID,
+            capturedIndexSHA256: prepared.coordinatorExpectations
+                .capturedIndexSHA256,
+            durableEvents: [],
+            mediatedWriterReceipts: prepared.coordinatorExpectations
+                .mediatedWriterReceipts
+        )
+        let forgedPrepared = PreparedInverse(
+            patch: prepared.patch,
+            coordinatorExpectations: forgedExpectations,
+            operations: prepared.operations
+        )
+        #expect(conflicts(VerifiedPatchEngine.applyPrepared(
+            forgedPrepared,
+            currentSnapshot: snapshot(["file.txt": file("after")])
+        ))?.first?.reason == .invalidCurrentSnapshot)
+
+        let originalOperation = prepared.operations[0]
+        let forgedOperation = VerifiedPreparedInverseOperation(
+            operationID: originalOperation.operationID,
+            kind: originalOperation.kind,
+            mode: originalOperation.mode,
+            expectations: originalOperation.expectations,
+            results: [VerifiedPreparedPathResult(
+                path: "other.txt",
+                state: file("forged")
+            )],
+            resolvedTextHunks: originalOperation.resolvedTextHunks,
+            preview: originalOperation.preview
+        )
+        let forgedResult = PreparedInverse(
+            patch: prepared.patch,
+            coordinatorExpectations: prepared.coordinatorExpectations,
+            operations: [forgedOperation]
+        )
+        #expect(conflicts(VerifiedPatchEngine.applyPrepared(
+            forgedResult,
+            currentSnapshot: snapshot(["file.txt": file("after")])
+        ))?.first?.reason == .invalidCurrentSnapshot)
+    }
+}
+
+@Suite("Verified Patch Budgets")
+struct VerifiedPatchBudgetTests {
+    @Test("Per-file byte limit accepts limit and rejects +1")
+    func fileByteLimit() throws {
+        let maximum = Data(
+            repeating: 0,
+            count: VerifiedPatchLimits.maximumFileByteCount
+        )
+        _ = try singlePatch(before: nil, after: file(maximum))
+
+        let oversized = Data(
+            repeating: 0,
+            count: VerifiedPatchLimits.maximumFileByteCount + 1
+        )
+        #expect(throws: VerifiedPatchValidationError.contentTooLarge) {
+            try singlePatch(before: nil, after: file(oversized))
+        }
+    }
+
+    @Test("Operation limit accepts limit and rejects +1")
+    func operationLimit() throws {
+        let state = file("x")
+        let records = (0..<VerifiedPatchLimits.maximumOperationCount).map {
+            record(
+                envelopeID: id($0 + 1),
+                cursor: UInt64($0 + 1),
+                journalSequence: UInt64($0 + 1),
+                changes: [change("files/\($0).txt", nil, state)]
+            )
+        }
+        let accepted = try receipt(records)
+        _ = try makePatch(
+            patchID: id(5_000),
+            receipt: accepted,
+            sources: records.map {
+                source($0, ordinal: 0, before: nil, after: state)
+            }
+        )
+
+        let extra = record(
+            envelopeID: id(records.count + 1),
+            cursor: UInt64(records.count + 1),
+            journalSequence: UInt64(records.count + 1),
+            changes: [change("extra.txt", nil, state)]
+        )
+        let over = records + [extra]
+        #expect(throws: VerifiedPatchValidationError.tooManyOperations) {
+            try makePatch(
+                patchID: id(5_001),
+                receipt: try receipt(over),
+                sources: over.map {
+                    source($0, ordinal: 0, before: nil, after: state)
+                }
+            )
+        }
+    }
+
+    @Test("Snapshot file-count limit accepts limit and rejects +1")
+    func snapshotFileLimit() throws {
+        let after = file("after")
+        let patch = try singlePatch(before: file("before"), after: after)
+        var files = ["file.txt": after]
+        for index in 1..<VerifiedPatchLimits.maximumSnapshotFileCount {
+            files["snapshot/\(index).txt"] = file(Data())
+        }
+        _ = try requirePrepared(patch, files: files)
+
+        files["snapshot/overflow.txt"] = file(Data())
+        guard case .failure(.invalidPatch(.invalidSnapshot)) =
+                VerifiedPatchEngine.prepareCheckedInverse(
+                    patch,
+                    currentSnapshot: snapshot(files)
+                ) else {
+            Issue.record("Snapshot file-count +1 must fail closed")
+            return
+        }
+    }
+
+    @Test("LCS cell budget accepts boundary and rejects +1")
+    func lcsCellLimit() {
+        let atLimit = alternatingLines(count: 1_413)
+        #expect(VerifiedTextPatch.estimatedLCSCellCount(
+            before: atLimit,
+            after: atLimit
+        ) == 1_999_396)
+
+        let overLimit = alternatingLines(count: 1_414)
+        #expect(VerifiedTextPatch.estimatedLCSCellCount(
+            before: overLimit,
+            after: overLimit
+        ) == nil)
+    }
+
+    @Test("Repeated alternating input remains bounded and conservative")
+    func adversarialRepeatedInput() throws {
+        let before = file(
+            alternatingLines(count: 600, replacement: "old\n")
+        )
+        let after = file(
+            alternatingLines(count: 600, replacement: "agent\n")
+        )
+        let patch = try singlePatch(before: before, after: after)
+        let current = file(
+            "human\n" + text(after) + text(after)
+        )
+
+        let outcome = VerifiedPatchEngine.prepareCheckedInverse(
+            patch,
+            currentSnapshot: snapshot(["file.txt": current])
+        )
+        #expect(preparationConflicts(outcome) != nil)
+    }
 }
 
 @Suite("Verified Patch Version Chains")
 struct VerifiedPatchVersionChainTests {
-    @Test("Two agents branching from one file version conflict")
-    func twoAgentOverlapConflicts() throws {
-        let base = data("base")
+    @Test("Divergent bases conflict and exact chains are ordered")
+    func divergenceAndExactChain() throws {
+        let base = file("base")
+        let middle = file("middle")
         let first = try singlePatch(
             patchID: id(1),
-            envelopeID: id(2),
-            before: base,
-            after: data("agent-a"),
-            sessionID: id(11),
-            terminalID: id(21)
-        )
-        let second = try singlePatch(
-            patchID: id(3),
-            envelopeID: id(4),
-            before: base,
-            after: data("agent-b"),
-            sessionID: id(12),
-            terminalID: id(22)
-        )
-
-        let result = VerifiedPatchVersionChainDetector.analyze([
-            second,
-            first
-        ])
-
-        let found = try #require(versionConflicts(result))
-        #expect(found.contains {
-            $0.path == "file.txt"
-                && $0.reason == .ambiguousVersionChain
-        })
-    }
-
-    @Test("Two agents with an exact content chain are ordered")
-    func exactMultiAgentChainIsAccepted() throws {
-        let base = data("base")
-        let middle = data("agent-a")
-        let final = data("agent-b")
-        let first = try singlePatch(
-            patchID: id(1),
-            envelopeID: id(2),
+            envelopeID: id(11),
+            cursor: 1,
+            journalSequence: 10,
             before: base,
             after: middle,
-            sessionID: id(11),
-            terminalID: id(21)
+            sessionID: id(101),
+            terminalID: id(201)
         )
-        let second = try singlePatch(
-            patchID: id(3),
-            envelopeID: id(4),
-            before: middle,
-            after: final,
-            sessionID: id(12),
-            terminalID: id(22)
-        )
-
-        let result = VerifiedPatchVersionChainDetector.analyze([
-            second,
-            first
-        ])
-
-        guard case .valid(let report) = result else {
-            Issue.record("Expected a valid exact version chain")
-            return
-        }
-        let pathScope = VerifiedPatchPathScope(
-            projectID: id(10),
-            worktreePath: "/tmp/project",
-            relativePath: "file.txt"
-        )
-        #expect(report.orderedPatchIDsByPath[pathScope]
-            == [first.id, second.id])
-    }
-
-    @Test("Identical relative paths in separate worktrees do not overlap")
-    func separateWorktreesDoNotConflict() throws {
-        let first = try singlePatch(
-            patchID: id(1),
-            envelopeID: id(2),
-            before: data("base"),
-            after: data("agent-a"),
-            worktreePath: "/tmp/first"
-        )
-        let second = try singlePatch(
-            patchID: id(3),
-            envelopeID: id(4),
-            before: data("base"),
-            after: data("agent-b"),
-            worktreePath: "/tmp/second"
-        )
-
-        let result = VerifiedPatchVersionChainDetector.analyze([
-            first,
-            second
-        ])
-
-        guard case .valid(let report) = result else {
-            Issue.record("Separate worktrees must not share a version chain")
-            return
-        }
-        #expect(report.orderedPatchIDsByPath.isEmpty)
-    }
-
-    @Test("Separate patches in one process detect cursor gaps")
-    func streamCursorGapConflicts() throws {
-        let first = try singlePatch(
-            patchID: id(1),
-            envelopeID: id(2),
+        let divergent = try singlePatch(
+            patchID: id(2),
+            envelopeID: id(12),
             cursor: 1,
-            path: "one.txt",
-            before: data("a"),
-            after: data("b")
+            journalSequence: 20,
+            before: base,
+            after: file("other"),
+            sessionID: id(102),
+            terminalID: id(202)
         )
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([first, divergent])
+        )?.contains { $0.reason == .ambiguousVersionChain } == true)
+
         let second = try singlePatch(
             patchID: id(3),
-            envelopeID: id(4),
-            cursor: 3,
-            path: "two.txt",
-            before: data("c"),
-            after: data("d")
+            envelopeID: id(13),
+            cursor: 1,
+            journalSequence: 30,
+            before: middle,
+            after: file("final"),
+            sessionID: id(103),
+            terminalID: id(203)
         )
-
-        let result = VerifiedPatchVersionChainDetector.analyze([
-            first,
-            second
-        ])
-
-        let found = try #require(versionConflicts(result))
-        #expect(found.contains {
-            $0.reason == .cursorGap(expected: 2, actual: 3)
-        })
+        guard case .valid(let report) =
+                VerifiedPatchVersionChainDetector.analyze([second, first])
+        else {
+            Issue.record("Exact cross-agent version chain should be valid")
+            return
+        }
+        #expect(report.orderedPatchIDsByPath.values.first == [id(1), id(3)])
     }
 
-    @Test("Envelope replay across patch sets is detected")
-    func envelopeReplayConflicts() throws {
+    @Test("Duplicate patch IDs and journal sequence collisions fail closed")
+    func duplicateAndJournalCollision() throws {
         let first = try singlePatch(
             patchID: id(1),
-            envelopeID: id(2),
+            envelopeID: id(11),
+            cursor: 1,
+            journalSequence: 10,
             path: "one.txt",
-            before: data("a"),
-            after: data("b")
+            before: file("a"),
+            after: file("b")
+        )
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([first, first])
+        )?.contains { $0.reason == .duplicatePatchID(id(1)) } == true)
+
+        let second = try singlePatch(
+            patchID: id(2),
+            envelopeID: id(12),
+            cursor: 1,
+            journalSequence: 10,
+            path: "two.txt",
+            before: file("c"),
+            after: file("d"),
+            sessionID: id(102),
+            terminalID: id(202)
+        )
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([first, second])
+        )?.contains { $0.reason == .journalSequenceCollision(10) } == true)
+    }
+
+    @Test("Root path aliases cannot split a shared private workspace")
+    func rootAliasesShareScope() throws {
+        let first = try singlePatch(
+            patchID: id(1),
+            envelopeID: id(11),
+            path: "File.swift",
+            before: file("base"),
+            after: file("one"),
+            rootPath: "/tmp/project"
         )
         let second = try singlePatch(
-            patchID: id(3),
-            envelopeID: id(2),
-            path: "two.txt",
-            before: data("c"),
-            after: data("d"),
-            sessionID: id(12),
-            terminalID: id(22)
+            patchID: id(2),
+            envelopeID: id(12),
+            path: "file.swift",
+            before: file("base"),
+            after: file("two"),
+            sessionID: id(102),
+            terminalID: id(202),
+            rootPath: "/private/tmp/project"
         )
 
-        let result = VerifiedPatchVersionChainDetector.analyze([
-            first,
-            second
-        ])
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([first, second])
+        )?.contains { $0.reason == .ambiguousVersionChain } == true)
+    }
 
-        let found = try #require(versionConflicts(result))
-        #expect(found.contains {
-            $0.reason == .replayedEnvelope(id(2))
-        })
+    @Test("Version patch-count limit accepts limit and rejects +1")
+    func patchCountLimit() throws {
+        let patches = try (0..<VerifiedPatchLimits.maximumVersionPatchCount)
+            .map { index in
+                try singlePatch(
+                    patchID: id(index + 1),
+                    envelopeID: id(index + 1_000),
+                    cursor: 1,
+                    journalSequence: UInt64(index + 1),
+                    path: "file-\(index).txt",
+                    before: file("before-\(index)"),
+                    after: file("after-\(index)"),
+                    sessionID: id(index + 2_000),
+                    terminalID: id(index + 3_000)
+                )
+            }
+        guard case .valid =
+                VerifiedPatchVersionChainDetector.analyze(patches) else {
+            Issue.record("Patch-count limit should remain valid")
+            return
+        }
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze(
+                patches + [try singlePatch(
+                    patchID: id(9_000),
+                    envelopeID: id(9_001),
+                    path: "overflow.txt",
+                    before: file("before"),
+                    after: file("after"),
+                    sessionID: id(9_002),
+                    terminalID: id(9_003)
+                )]
+            )
+        )?.first?.reason == .resourceLimitExceeded)
     }
 }
 
 private func singlePatch(
-    patchID: UUID = id(1),
-    envelopeID: UUID = id(2),
+    patchID: UUID = id(100),
+    envelopeID: UUID = id(101),
     cursor: UInt64 = 1,
+    journalSequence: UInt64 = 1,
     path: String = "file.txt",
-    before: Data?,
-    after: Data?,
-    sessionID: UUID = id(11),
-    terminalID: UUID = id(21),
-    projectID: UUID = id(10),
-    worktreePath: String = "/tmp/project"
+    before: VerifiedPatchFileState?,
+    after: VerifiedPatchFileState?,
+    sessionID: UUID = id(200),
+    terminalID: UUID = id(300),
+    rootPath: String = "/private/tmp/project"
 ) throws -> VerifiedPatchSet {
-    let binding = try makeBinding(
-        events: [
-            event(
-                id: envelopeID,
-                cursor: cursor,
-                path: path,
-                before: before,
-                after: after
-            )
-        ],
+    let value = record(
+        envelopeID: envelopeID,
+        cursor: cursor,
+        journalSequence: journalSequence,
         sessionID: sessionID,
         terminalID: terminalID,
-        projectID: projectID,
-        worktreePath: worktreePath
+        rootPath: rootPath,
+        changes: [change(path, before, after)]
     )
-    return try VerifiedPatchEngine.makePatch(
-        id: patchID,
-        binding: binding,
-        operations: [
-            source(
-                eventID: envelopeID,
-                path: path,
-                before: before,
-                after: after
-            )
-        ]
+    return try makePatch(
+        patchID: patchID,
+        receipt: try receipt(
+            [value],
+            workspace: workspace(rootPath: rootPath)
+        ),
+        sources: [source(
+            value,
+            ordinal: 0,
+            before: before,
+            after: after
+        )]
     )
 }
 
-private func makeBinding(
-    events: [VerifiedPatchEventReference],
-    sessionID: UUID = id(11),
-    terminalID: UUID = id(21),
-    projectID: UUID = id(10),
-    worktreePath: String = "/tmp/project"
-) throws -> VerifiedPatchEventBinding {
-    try VerifiedPatchEventBinding(
+private func makePatch(
+    patchID: UUID,
+    receipt: VerifiedPatchIngressReceipt,
+    sources: [VerifiedPatchSourceOperation]
+) throws -> VerifiedPatchSet {
+    try VerifiedPatchEngine.makePatch(
+        id: patchID,
+        receipt: receipt,
+        operations: sources
+    )
+}
+
+private func receipt(
+    _ records: [VerifiedPatchUntrustedEventRecord],
+    workspace: VerifiedPatchWorkspaceIdentity = workspace()
+) throws -> VerifiedPatchIngressReceipt {
+    try VerifiedPatchIngressCoordinator.accept(
+        receiptID: id(8_000),
+        workspace: workspace,
+        records: records
+    )
+}
+
+private func record(
+    envelopeID: UUID,
+    cursor: UInt64,
+    journalSequence: UInt64,
+    sessionID: UUID = id(200),
+    terminalID: UUID = id(300),
+    projectID: UUID = id(400),
+    rootPath: String = "/private/tmp/project",
+    source eventSource: EventSource = .explicitAgentEvent,
+    payload: AgentEventPayload? = nil,
+    mediatedByPine: Bool = true,
+    changes: [VerifiedPatchContentTransition]
+) -> VerifiedPatchUntrustedEventRecord {
+    let selectedPayload: AgentEventPayload
+    if let payload {
+        selectedPayload = payload
+    } else if changes.count == 1,
+              changes[0].destinationPath == nil,
+              let after = changes[0].after {
+        selectedPayload = .fileChange(AgentFileChange(
+            relativePath: changes[0].sourcePath,
+            before: changes[0].before?.contentIdentity,
+            after: after.contentIdentity
+        ))
+    } else {
+        selectedPayload = .none
+    }
+    let envelope = AgentEventEnvelope(
+        id: envelopeID,
         projectID: projectID,
-        worktreePath: worktreePath,
         sessionID: sessionID,
+        agentTypeRaw: "generic:test",
         process: AgentProcessIdentity(
             terminalID: terminalID,
             processGeneration: 1
         ),
-        events: events
-    )
-}
-
-private func event(
-    id eventID: UUID,
-    cursor: UInt64,
-    path: String,
-    before: Data?,
-    after: Data?
-) -> VerifiedPatchEventReference {
-    VerifiedPatchEventReference(
-        envelopeID: eventID,
+        location: AgentEventLocation(
+            worktreePath: rootPath,
+            cwd: rootPath
+        ),
         cursorValue: cursor,
-        transitions: [
-            transition(
-                path: path,
-                before: before,
-                after: after
-            )
-        ]
+        timestamp: Date(timeIntervalSince1970: 1_000 + Double(cursor)),
+        source: eventSource,
+        trustLevel: .verified,
+        payload: selectedPayload
+    )
+    let auditIdentity = durableIdentity(
+        envelope: envelope,
+        journalSequence: journalSequence
+    )
+    let writerReceipt: PineMediatedWriterReceipt?
+    if mediatedByPine, !changes.isEmpty {
+        writerReceipt = PineMediatedWriterReceipt(
+            receiptID: UUID(),
+            userApprovalID: UUID(),
+            descriptorTransactionID: UUID(),
+            descriptorCASSequence: journalSequence,
+            workspace: workspace(rootPath: rootPath),
+            auditEvent: auditIdentity,
+            transitions: changes
+        )
+    } else {
+        writerReceipt = nil
+    }
+    return VerifiedPatchUntrustedEventRecord(
+        envelope: envelope,
+        durableIdentity: auditIdentity,
+        mediatedWriterReceipt: writerReceipt,
+        transitions: changes
     )
 }
 
-private func transition(
-    path: String,
-    before: Data?,
-    after: Data?
+private func durableIdentity(
+    envelope: AgentEventEnvelope,
+    journalSequence: UInt64,
+    eventCursor: UInt64? = nil
+) -> VerifiedPatchDurableEventIdentity {
+    VerifiedPatchDurableEventIdentity(
+        projectID: envelope.projectID,
+        canonicalWorktreePath: envelope.location.worktreePath,
+        sessionID: envelope.sessionID,
+        terminalID: envelope.process.terminalID,
+        processGeneration: envelope.process.processGeneration,
+        eventCursor: eventCursor ?? envelope.cursorValue,
+        envelopeID: envelope.id,
+        journalSequence: journalSequence
+    )
+}
+
+private func change(
+    _ path: String,
+    _ before: VerifiedPatchFileState?,
+    _ after: VerifiedPatchFileState?,
+    destination: String? = nil
 ) -> VerifiedPatchContentTransition {
     VerifiedPatchContentTransition(
         sourcePath: path,
-        beforeIdentity: before.map(ContentIdentity.init),
-        afterIdentity: after.map(ContentIdentity.init)
+        destinationPath: destination,
+        before: before?.stateIdentity,
+        after: after?.stateIdentity
     )
 }
 
 private func source(
-    eventID: UUID,
-    path: String,
-    before: Data?,
-    after: Data?
+    _ record: VerifiedPatchUntrustedEventRecord,
+    ordinal: Int,
+    before: VerifiedPatchFileState?,
+    after: VerifiedPatchFileState?
 ) -> VerifiedPatchSourceOperation {
-    VerifiedPatchSourceOperation(
-        eventEnvelopeID: eventID,
-        sourcePath: path,
-        beforeContent: before,
-        afterContent: after
+    let transition = record.transitions[ordinal]
+    return VerifiedPatchSourceOperation(
+        transitionID: transitionID(record, ordinal),
+        sourcePath: transition.sourcePath,
+        destinationPath: transition.destinationPath,
+        before: before,
+        after: after
+    )
+}
+
+private func transitionID(
+    _ record: VerifiedPatchUntrustedEventRecord,
+    _ ordinal: Int
+) -> VerifiedPatchTransitionID {
+    VerifiedPatchTransitionID(
+        envelopeID: record.envelope.id,
+        ordinal: ordinal
+    )
+}
+
+private func requirePrepared(
+    _ patch: VerifiedPatchSet,
+    files: [String: VerifiedPatchFileState]
+) throws -> PreparedInverse {
+    switch VerifiedPatchEngine.prepareCheckedInverse(
+        patch,
+        currentSnapshot: snapshot(files)
+    ) {
+    case .success(let prepared):
+        return prepared
+    case .failure(let failure):
+        throw FixtureError.preparation(failure)
+    }
+}
+
+private func snapshot(
+    _ files: [String: VerifiedPatchFileState]
+) -> VerifiedPatchWorkspaceSnapshot {
+    VerifiedPatchWorkspaceSnapshot(files: files)
+}
+
+private func workspace(
+    rootPath: String = "/private/tmp/project",
+    privateID: UUID = id(700),
+    rootDevice: UInt64 = 11,
+    rootInode: UInt64 = 22
+) -> VerifiedPatchWorkspaceIdentity {
+    VerifiedPatchWorkspaceIdentity(
+        privateWorkspaceID: privateID,
+        canonicalRootPath: rootPath,
+        rootDevice: rootDevice,
+        rootInode: rootInode,
+        capturedHeadOID: String(repeating: "a", count: 40),
+        capturedIndexSHA256: String(repeating: "b", count: 64)
     )
 }
 
@@ -721,6 +1221,15 @@ private func conflicts(
     return conflicts
 }
 
+private func preparationConflicts(
+    _ result: Result<PreparedInverse, VerifiedPatchPreparationFailure>
+) -> [VerifiedPatchConflict]? {
+    guard case .failure(.conflicts(let conflicts)) = result else {
+        return nil
+    }
+    return conflicts
+}
+
 private func versionConflicts(
     _ result: VerifiedPatchVersionChainResult
 ) -> [VerifiedPatchVersionConflict]? {
@@ -728,11 +1237,47 @@ private func versionConflicts(
     return conflicts
 }
 
-private func data(_ value: String) -> Data {
-    Data(value.utf8)
+private func alternatingLines(
+    count: Int,
+    replacement: String? = nil
+) -> Data {
+    let value = (0..<count).map { index in
+        if index.isMultiple(of: 2) {
+            return replacement ?? "a\n"
+        }
+        return "b\n"
+    }.joined()
+    return Data(value.utf8)
 }
 
-private func id(_ value: UInt8) -> UUID {
+private func text(_ state: VerifiedPatchFileState) -> String {
+    guard let value = String(data: state.content, encoding: .utf8) else {
+        preconditionFailure("Fixture content must be UTF-8")
+    }
+    return value
+}
+
+private func file(
+    _ value: String,
+    mode: UInt16 = 0o644,
+    kind: VerifiedPatchFileKind = .regularFile
+) -> VerifiedPatchFileState {
+    file(Data(value.utf8), mode: mode, kind: kind)
+}
+
+private func file(
+    _ value: Data,
+    mode: UInt16 = 0o644,
+    kind: VerifiedPatchFileKind = .regularFile
+) -> VerifiedPatchFileState {
+    VerifiedPatchFileState(
+        content: value,
+        kind: kind,
+        posixMode: mode
+    )
+}
+
+private func id(_ value: Int) -> UUID {
     UUID(uuid: (
         0, 0, 0, 0,
         0, 0,
@@ -740,6 +1285,33 @@ private func id(_ value: UInt8) -> UUID {
         0, 0,
         0, 0,
         0, 0,
-        0, value
+        UInt8((value >> 8) & 0xff),
+        UInt8(value & 0xff)
     ))
+}
+
+private enum FixtureError: Error {
+    case preparation(VerifiedPatchPreparationFailure)
+}
+
+private actor AuthorityEvidenceRecorder:
+    PatchAuthorityEvidenceRevalidator {
+    private var writerReceiptCount = 0
+    private var auditEventCount = 0
+
+    func revalidateMediatedWriterReceipts(
+        _ receipts: [PineMediatedWriterReceipt]
+    ) {
+        writerReceiptCount += receipts.count
+    }
+
+    func revalidateDurableEvents(
+        _ identities: [VerifiedPatchDurableEventIdentity]
+    ) {
+        auditEventCount += identities.count
+    }
+
+    func counts() -> (writer: Int, audit: Int) {
+        (writerReceiptCount, auditEventCount)
+    }
 }

--- a/PineTests/VerifiedChanges/VerifiedPatchEngineTests.swift
+++ b/PineTests/VerifiedChanges/VerifiedPatchEngineTests.swift
@@ -1060,6 +1060,122 @@ struct VerifiedPatchBudgetTests {
         }
     }
 
+    @Test("Operation overflow is rejected before any text planning")
+    func operationOverflowPrecedesPlanning() throws {
+        let before = file(alternatingLines(
+            count: 1_413,
+            replacement: "old\n"
+        ))
+        let after = file(alternatingLines(
+            count: 1_413,
+            replacement: "new\n"
+        ))
+        let records = (0...VerifiedPatchLimits.maximumOperationCount)
+            .map { index in
+                record(
+                    envelopeID: id(index + 10_000),
+                    cursor: UInt64(index + 1),
+                    journalSequence: UInt64(index + 1),
+                    changes: [change(
+                        "adversarial/\(index).txt",
+                        before,
+                        after
+                    )]
+                )
+            }
+        let accepted = try receipt(records)
+        var planningCount = 0
+
+        #expect(throws: VerifiedPatchValidationError.tooManyOperations) {
+            try makePatch(
+                patchID: id(10_500),
+                receipt: accepted,
+                sources: records.map {
+                    source(
+                        $0,
+                        ordinal: 0,
+                        before: before,
+                        after: after
+                    )
+                },
+                planningObserver: {
+                    planningCount += 1
+                }
+            )
+        }
+        #expect(planningCount == 0)
+    }
+
+    @Test("Canonical case ordering controls aggregate planning exhaustion")
+    func canonicalOrderControlsPlanningBudget() throws {
+        let before = file(singleEditLines(
+            count: 1_413,
+            replacementIndex: nil,
+            replacement: ""
+        ))
+        let paths = [
+            "Zeta.txt",
+            "alpha.txt",
+            "Beta.txt",
+            "delta.txt",
+            "charlie.txt"
+        ]
+        let records = paths.enumerated().map { index, path in
+            let after = file(singleEditLines(
+                count: 1_413,
+                replacementIndex: 700,
+                replacement: "agent-\(index)"
+            ))
+            return record(
+                envelopeID: id(index + 11_000),
+                cursor: UInt64(index + 1),
+                journalSequence: UInt64(index + 1),
+                changes: [change(path, before, after)]
+            )
+        }
+        let sources = records.enumerated().map { index, value in
+            source(
+                value,
+                ordinal: 0,
+                before: before,
+                after: file(singleEditLines(
+                    count: 1_413,
+                    replacementIndex: 700,
+                    replacement: "agent-\(index)"
+                ))
+            )
+        }
+        let patch = try makePatch(
+            patchID: id(11_500),
+            receipt: try receipt(records),
+            sources: Array(sources.reversed())
+        )
+
+        #expect(patch.operations.map(\.sourcePath) == [
+            "alpha.txt",
+            "Beta.txt",
+            "charlie.txt",
+            "delta.txt",
+            "Zeta.txt"
+        ])
+        for operation in patch.operations.dropLast() {
+            guard case .text = operation.strategy else {
+                Issue.record("First four canonical operations must use text")
+                return
+            }
+        }
+        #expect(patch.operations.last?.strategy == .exactState)
+
+        let forged = VerifiedPatchSet(
+            id: patch.id,
+            receipt: patch.receipt,
+            operations: Array(patch.operations.reversed())
+        )
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try VerifiedPatchEngine.revalidate(forged)
+        }
+    }
+
     @Test("Snapshot file-count limit accepts limit and rejects +1")
     func snapshotFileLimit() throws {
         let after = file("after")
@@ -1094,6 +1210,56 @@ struct VerifiedPatchBudgetTests {
             before: overLimit,
             after: overLimit
         ) == nil)
+    }
+
+    @Test("Long common-prefix lines use the exact estimated cell budget")
+    func longLineComparisonBudget() throws {
+        let before = longPrefixLines(
+            count: 400,
+            replacementIndex: nil,
+            replacement: ""
+        )
+        let after = longPrefixLines(
+            count: 400,
+            replacementIndex: 200,
+            replacement: "changed"
+        )
+        let estimate = try #require(
+            VerifiedTextPatch.estimatedLCSCellCount(
+                before: before,
+                after: after
+            )
+        )
+        let plan = try #require(VerifiedTextPatch.plan(
+            before: before,
+            after: after
+        ))
+
+        #expect(estimate == 160_801)
+        #expect(plan.lcsCellCount == estimate)
+        #expect(plan.hunks.count == 1)
+    }
+
+    @Test("Digest collisions are split by exact line equality")
+    func lineDigestCollisionSafety() throws {
+        let before = Data("alpha\nbravo\nomega\n".utf8)
+        let after = Data("alpha\ndelta\nomega\n".utf8)
+        let collision = try #require(ContentIdentity(
+            sha256Hex: String(repeating: "0", count: 64),
+            byteCount: 0
+        ))
+        let plan = try #require(VerifiedTextPatch.plan(
+            before: before,
+            after: after,
+            lcsCellBudget: VerifiedPatchLimits
+                .maximumLCSCellCountPerDiff,
+            hunkBudget: VerifiedPatchLimits.maximumHunkCount,
+            lineIdentityProvider: { _ in collision }
+        ))
+        let hunk = try #require(plan.hunks.first)
+
+        #expect(hunk.beforeLines == [Data("bravo\n".utf8)])
+        #expect(hunk.afterLines == [Data("delta\n".utf8)])
     }
 
     @Test("Positional mapping work accepts boundary and rejects +1")
@@ -1266,6 +1432,72 @@ struct VerifiedPatchBudgetTests {
                 coordinatorExpectations: textPrepared
                     .coordinatorExpectations,
                 operations: [arithmeticOverflow]
+            ))
+        }
+
+        func operationWithPreviewLines(
+            _ lines: [VerifiedInversePreviewLine]
+        ) -> VerifiedPreparedInverseOperation {
+            let forgedPreviewHunk = VerifiedInverseHunkPreview(
+                capturedAfterStartLine: previewHunk
+                    .capturedAfterStartLine,
+                resolvedCurrentStartLine: previewHunk
+                    .resolvedCurrentStartLine,
+                header: previewHunk.header,
+                lines: lines
+            )
+            return VerifiedPreparedInverseOperation(
+                operationID: textOperation.operationID,
+                kind: textOperation.kind,
+                mode: textOperation.mode,
+                expectations: textOperation.expectations,
+                results: textOperation.results,
+                resolvedTextHunks: textOperation.resolvedTextHunks,
+                preview: VerifiedInverseOperationPreview(
+                    operationID: textOperation.preview.operationID,
+                    kind: textOperation.preview.kind,
+                    sourcePath: textOperation.preview.sourcePath,
+                    destinationPath: textOperation.preview.destinationPath,
+                    expectedCurrent: textOperation.preview.expectedCurrent,
+                    result: textOperation.preview.result,
+                    hunks: [forgedPreviewHunk]
+                )
+            )
+        }
+
+        let excessiveLineCount = Array(
+            repeating: VerifiedInversePreviewLine(
+                kind: .context,
+                bytes: Data()
+            ),
+            count: VerifiedPatchLimits.maximumPreviewLineCountPerHunk + 1
+        )
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try VerifiedPatchEngine.preflightPreparedShape(PreparedInverse(
+                patch: textPatch,
+                coordinatorExpectations: textPrepared
+                    .coordinatorExpectations,
+                operations: [
+                    operationWithPreviewLines(excessiveLineCount)
+                ]
+            ))
+        }
+
+        let excessiveLineBytes = VerifiedInversePreviewLine(
+            kind: .context,
+            bytes: Data(
+                repeating: 0x61,
+                count: VerifiedPatchLimits.maximumFileByteCount + 1
+            )
+        )
+        #expect(throws: VerifiedPatchValidationError.self) {
+            try VerifiedPatchEngine.preflightPreparedShape(PreparedInverse(
+                patch: textPatch,
+                coordinatorExpectations: textPrepared
+                    .coordinatorExpectations,
+                operations: [
+                    operationWithPreviewLines([excessiveLineBytes])
+                ]
             ))
         }
     }
@@ -1680,6 +1912,40 @@ struct VerifiedPatchVersionChainTests {
         } == true)
     }
 
+    @Test("One stream enforces CAS order across disjoint paths")
+    func streamCASOrderAcrossPaths() throws {
+        let first = try singlePatch(
+            patchID: id(15_001),
+            envelopeID: id(15_011),
+            cursor: 1,
+            journalSequence: 10,
+            path: "one.txt",
+            before: file("one-before"),
+            after: file("one-after"),
+            descriptorCASSequence: 4
+        )
+        let second = try singlePatch(
+            patchID: id(15_002),
+            envelopeID: id(15_012),
+            cursor: 2,
+            journalSequence: 20,
+            path: "two.txt",
+            before: file("two-before"),
+            after: file("two-after"),
+            descriptorCASSequence: 3
+        )
+
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([second, first])
+        )?.contains {
+            $0.pathScope == nil
+                && $0.reason == .descriptorCASOrderMismatch(
+                    previous: 4,
+                    actual: 3
+                )
+        } == true)
+    }
+
     @Test("Private workspace and physical root identities are bijective")
     func workspaceIdentityBijection() throws {
         let before = file("base")
@@ -2066,12 +2332,14 @@ private func singlePatch(
 private func makePatch(
     patchID: UUID,
     receipt: VerifiedPatchIngressReceipt,
-    sources: [VerifiedPatchSourceOperation]
+    sources: [VerifiedPatchSourceOperation],
+    planningObserver: (() -> Void)? = nil
 ) throws -> VerifiedPatchSet {
     try VerifiedPatchEngine.makePatch(
         id: patchID,
         receipt: receipt,
-        operations: sources
+        operations: sources,
+        planningObserver: planningObserver
     )
 }
 
@@ -2384,6 +2652,35 @@ private func alternatingLines(
             return replacement ?? "a\n"
         }
         return "b\n"
+    }.joined()
+    return Data(value.utf8)
+}
+
+private func singleEditLines(
+    count: Int,
+    replacementIndex: Int?,
+    replacement: String
+) -> Data {
+    let value = (0..<count).map { index in
+        if index == replacementIndex {
+            return "\(replacement)\n"
+        }
+        return "stable-\(index)\n"
+    }.joined()
+    return Data(value.utf8)
+}
+
+private func longPrefixLines(
+    count: Int,
+    replacementIndex: Int?,
+    replacement: String
+) -> Data {
+    let prefix = String(repeating: "p", count: 3 * 1_024)
+    let value = (0..<count).map { index in
+        let suffix = index == replacementIndex
+            ? replacement
+            : "stable-\(index)"
+        return "\(prefix)\(suffix)\n"
     }.joined()
     return Data(value.utf8)
 }

--- a/PineTests/VerifiedChanges/VerifiedPatchEngineTests.swift
+++ b/PineTests/VerifiedChanges/VerifiedPatchEngineTests.swift
@@ -359,8 +359,89 @@ struct VerifiedPatchPreparationTests {
         )
     }
 
-    @Test("Overlap and moved-region duplicates both conflict")
-    func overlapAndMovedDuplicateConflict() throws {
+    @Test("Deleting the first of two equal after-blocks is ambiguous")
+    func duplicateAfterBlockDeletionConflicts() throws {
+        let before = file(
+            "p0\np1\nold\ns0\ns1\n"
+                + "p0\np1\nagent\ns0\ns1\n"
+        )
+        let after = file(
+            "p0\np1\nagent\ns0\ns1\n"
+                + "p0\np1\nagent\ns0\ns1\n"
+        )
+        let patch = try singlePatch(before: before, after: after)
+        let outcome = VerifiedPatchEngine.prepareCheckedInverse(
+            patch,
+            currentSnapshot: snapshot([
+                "file.txt": file("p0\np1\nagent\ns0\ns1\n")
+            ])
+        )
+
+        #expect(preparationConflicts(outcome)?.first?.reason
+            == .ambiguousCurrentMapping(hunkIndex: 0))
+    }
+
+    @Test("Moved or reordered duplicate after-blocks conflict")
+    func duplicateAfterBlockMovementConflicts() throws {
+        let block = "p0\np1\nagent\ns0\ns1\n"
+        let before = file(
+            "p0\np1\nold\ns0\ns1\n"
+                + "unique-u\n"
+                + block
+                + "unique-v\n"
+        )
+        let after = file(
+            block
+                + "unique-u\n"
+                + block
+                + "unique-v\n"
+        )
+        let patch = try singlePatch(before: before, after: after)
+        let currentValues = [
+            "unique-u\n" + block + "unique-v\n" + block,
+            block + "unique-v\n" + block + "unique-u\n"
+        ]
+
+        for current in currentValues {
+            let outcome = VerifiedPatchEngine.prepareCheckedInverse(
+                patch,
+                currentSnapshot: snapshot([
+                    "file.txt": file(current)
+                ])
+            )
+            #expect(preparationConflicts(outcome)?.first?.reason
+                == .ambiguousCurrentMapping(hunkIndex: 0))
+        }
+    }
+
+    @Test("Duplicate blocks remain safe with one unique optimal mapping")
+    func duplicateAfterBlocksWithUniqueMapping() throws {
+        let block = "p0\np1\nagent\ns0\ns1\n"
+        let before = file(
+            "p0\np1\nold\ns0\ns1\n"
+                + "unique\n"
+                + block
+        )
+        let after = file(block + "unique\n" + block)
+        let current = file("human\n" + text(after))
+        let patch = try singlePatch(before: before, after: after)
+
+        let prepared = try requirePrepared(
+            patch,
+            files: ["file.txt": current]
+        )
+        let result = VerifiedPatchEngine.applyPrepared(
+            prepared,
+            currentSnapshot: snapshot(["file.txt": current])
+        )
+        let applied = try #require(appliedSnapshot(result))
+
+        #expect(text(try #require(applied.files["file.txt"]))
+            == "human\n" + text(before))
+    }
+
+    @Test("A human edit inside the guarded region conflicts")
+    func overlappingHumanEditConflicts() throws {
         let before = file("a\nb\nold\nc\nd\n")
         let after = file("a\nb\nagent\nc\nd\n")
         let patch = try singlePatch(before: before, after: after)
@@ -372,18 +453,6 @@ struct VerifiedPatchPreparationTests {
             ])
         )
         #expect(preparationConflicts(overlap)?.first?.reason
-            == .humanEditOverlapsAgentRegion(hunkIndex: 0))
-
-        let moved = VerifiedPatchEngine.prepareCheckedInverse(
-            patch,
-            currentSnapshot: snapshot([
-                "file.txt": file(
-                    "human-replaced-original\n"
-                        + "a\nb\nagent\nc\nd\n"
-                )
-            ])
-        )
-        #expect(preparationConflicts(moved)?.first?.reason
             == .humanEditOverlapsAgentRegion(hunkIndex: 0))
     }
 
@@ -818,6 +887,53 @@ struct VerifiedPatchBudgetTests {
         ) == nil)
     }
 
+    @Test("Positional mapping work accepts boundary and rejects +1")
+    func positionalMappingBudget() throws {
+        let before = Data(
+            "human-old\nstable-a\nstable-b\nold\nstable-c\nstable-d\n"
+                .utf8
+        )
+        let after = Data(
+            "human-old\nstable-a\nstable-b\nagent\nstable-c\nstable-d\n"
+                .utf8
+        )
+        let current = Data(
+            "human-new\nstable-a\nstable-b\nagent\nstable-c\nstable-d\n"
+                .utf8
+        )
+        let plan = try #require(VerifiedTextPatch.plan(
+            before: before,
+            after: after
+        ))
+        let tableCells = try #require(
+            VerifiedTextPatch.estimatedLCSCellCount(
+                before: after,
+                after: current
+            )
+        )
+        let mappingCells = tableCells * plan.hunks.count
+
+        guard case .success = VerifiedTextPatch.prepareInverse(
+            hunks: plan.hunks,
+            capturedAfter: after,
+            current: current,
+            mappingCellBudget: mappingCells
+        ) else {
+            Issue.record("Exact mapping budget must be accepted")
+            return
+        }
+        guard case .failure(.resourceLimitExceeded) =
+                VerifiedTextPatch.prepareInverse(
+            hunks: plan.hunks,
+            capturedAfter: after,
+            current: current,
+            mappingCellBudget: mappingCells - 1
+        ) else {
+            Issue.record("Mapping budget +1 must fail closed")
+            return
+        }
+    }
+
     @Test("Repeated alternating input remains bounded and conservative")
     func adversarialRepeatedInput() throws {
         let before = file(
@@ -945,6 +1061,416 @@ struct VerifiedPatchVersionChainTests {
         )?.contains { $0.reason == .ambiguousVersionChain } == true)
     }
 
+    @Test("Interleaved streams cannot hide reverse cursor order")
+    func interleavedStreamCursorOrder() throws {
+        let stateA = file("a")
+        let stateB = file("b")
+        let stateC = file("c")
+        let stateD = file("d")
+        let lateInContent = try singlePatch(
+            patchID: id(1),
+            envelopeID: id(11),
+            cursor: 1,
+            journalSequence: 1,
+            before: stateC,
+            after: stateD,
+            sessionID: id(100),
+            terminalID: id(200)
+        )
+        let middle = try singlePatch(
+            patchID: id(2),
+            envelopeID: id(12),
+            cursor: 1,
+            journalSequence: 2,
+            before: stateB,
+            after: stateC,
+            sessionID: id(101),
+            terminalID: id(201)
+        )
+        let earlyInContent = try singlePatch(
+            patchID: id(3),
+            envelopeID: id(13),
+            cursor: 2,
+            journalSequence: 3,
+            before: stateA,
+            after: stateB,
+            sessionID: id(100),
+            terminalID: id(200)
+        )
+
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([
+                lateInContent,
+                middle,
+                earlyInContent
+            ])
+        )?.contains { $0.reason == .cursorOrderMismatch } == true)
+    }
+
+    @Test("Content chains preserve workspace journal and CAS order")
+    func workspaceEvidenceOrder() throws {
+        let stateA = file("a")
+        let stateB = file("b")
+        let stateC = file("c")
+        let journalLate = try singlePatch(
+            patchID: id(1),
+            envelopeID: id(11),
+            journalSequence: 2,
+            before: stateA,
+            after: stateB,
+            sessionID: id(101),
+            terminalID: id(201)
+        )
+        let journalEarly = try singlePatch(
+            patchID: id(2),
+            envelopeID: id(12),
+            journalSequence: 1,
+            before: stateB,
+            after: stateC,
+            sessionID: id(102),
+            terminalID: id(202)
+        )
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([
+                journalLate,
+                journalEarly
+            ])
+        )?.contains {
+            $0.reason == .journalOrderMismatch(previous: 2, actual: 1)
+        } == true)
+
+        let casLate = try singlePatch(
+            patchID: id(3),
+            envelopeID: id(13),
+            journalSequence: 3,
+            before: stateA,
+            after: stateB,
+            sessionID: id(103),
+            terminalID: id(203),
+            descriptorCASSequence: 4
+        )
+        let casEarly = try singlePatch(
+            patchID: id(4),
+            envelopeID: id(14),
+            journalSequence: 4,
+            before: stateB,
+            after: stateC,
+            sessionID: id(104),
+            terminalID: id(204),
+            descriptorCASSequence: 3
+        )
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([
+                casLate,
+                casEarly
+            ])
+        )?.contains {
+            $0.reason == .descriptorCASOrderMismatch(
+                previous: 4,
+                actual: 3
+            )
+        } == true)
+    }
+
+    @Test("Private workspace and physical root identities are bijective")
+    func workspaceIdentityBijection() throws {
+        let before = file("base")
+        let samePhysicalFirst = try singlePatch(
+            patchID: id(1),
+            envelopeID: id(11),
+            before: before,
+            after: file("one"),
+            privateID: id(700)
+        )
+        let samePhysicalSecond = try singlePatch(
+            patchID: id(2),
+            envelopeID: id(12),
+            journalSequence: 2,
+            before: before,
+            after: file("two"),
+            sessionID: id(201),
+            terminalID: id(301),
+            privateID: id(701)
+        )
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([
+                samePhysicalFirst,
+                samePhysicalSecond
+            ])
+        )?.first?.reason == .workspaceIdentityMismatch)
+
+        let samePrivateFirst = try singlePatch(
+            patchID: id(3),
+            envelopeID: id(13),
+            before: before,
+            after: file("three"),
+            privateID: id(702),
+            rootDevice: 30,
+            rootInode: 40
+        )
+        let samePrivateSecond = try singlePatch(
+            patchID: id(4),
+            envelopeID: id(14),
+            journalSequence: 2,
+            before: before,
+            after: file("four"),
+            sessionID: id(202),
+            terminalID: id(302),
+            privateID: id(702),
+            rootDevice: 31,
+            rootInode: 41
+        )
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([
+                samePrivateFirst,
+                samePrivateSecond
+            ])
+        )?.first?.reason == .workspaceIdentityMismatch)
+    }
+
+    @Test("Version operation and node budget accepts boundary and rejects +1")
+    func versionOperationAndNodeBudget() throws {
+        let base = try singlePatch(
+            before: file("before"),
+            after: file("after")
+        )
+        let operation = try #require(base.operations.first)
+        let atLimit = VerifiedPatchSet(
+            id: base.id,
+            receipt: base.receipt,
+            operations: Array(
+                repeating: operation,
+                count: VerifiedPatchLimits.maximumVersionOperationCount
+            )
+        )
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([atLimit])
+        )?.first?.reason == .invalidPatch(base.id))
+
+        let overLimit = VerifiedPatchSet(
+            id: base.id,
+            receipt: base.receipt,
+            operations: atLimit.operations + [operation]
+        )
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([overLimit])
+        )?.first?.reason == .resourceLimitExceeded)
+    }
+
+    @Test("Version declared LCS budget accepts boundary and rejects +1")
+    func versionDeclaredLCSBudget() throws {
+        let base = try singlePatch(
+            before: file("before\n"),
+            after: file("after\n")
+        )
+        let operation = try #require(base.operations.first)
+        guard case .text(let hunks, _) = operation.strategy else {
+            Issue.record("Fixture must use a text strategy")
+            return
+        }
+        func replacingCells(_ cells: Int) -> VerifiedPatchSet {
+            VerifiedPatchSet(
+                id: base.id,
+                receipt: base.receipt,
+                operations: [VerifiedPatchOperation(
+                    id: operation.id,
+                    kind: operation.kind,
+                    sourcePath: operation.sourcePath,
+                    destinationPath: operation.destinationPath,
+                    before: operation.before,
+                    after: operation.after,
+                    strategy: .text(
+                        hunks: hunks,
+                        lcsCellCount: cells
+                    )
+                )]
+            )
+        }
+
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([
+                replacingCells(
+                    VerifiedPatchLimits.maximumVersionLCSCellCount
+                )
+            ])
+        )?.first?.reason == .invalidPatch(base.id))
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([
+                replacingCells(
+                    VerifiedPatchLimits.maximumVersionLCSCellCount + 1
+                )
+            ])
+        )?.first?.reason == .resourceLimitExceeded)
+    }
+
+    @Test("Version captured-content budget accepts boundary and rejects +1")
+    func versionCapturedContentBudget() throws {
+        let base = try singlePatch(
+            before: file("before"),
+            after: file("after")
+        )
+        let operation = try #require(base.operations.first)
+        let large = file(Data(
+            repeating: 0x61,
+            count: VerifiedPatchLimits.maximumFileByteCount
+        ))
+        let largeOperation = VerifiedPatchOperation(
+            id: operation.id,
+            kind: .modify,
+            sourcePath: operation.sourcePath,
+            destinationPath: nil,
+            before: large,
+            after: large,
+            strategy: .exactState
+        )
+        let statesPerOperation = 2
+        let operationCount = VerifiedPatchLimits
+            .maximumVersionCapturedByteCount
+            / VerifiedPatchLimits.maximumFileByteCount
+            / statesPerOperation
+        let atLimit = VerifiedPatchSet(
+            id: base.id,
+            receipt: base.receipt,
+            operations: Array(
+                repeating: largeOperation,
+                count: operationCount
+            )
+        )
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([atLimit])
+        )?.first?.reason == .invalidPatch(base.id))
+
+        let oneMoreByte = VerifiedPatchOperation(
+            id: operation.id,
+            kind: .delete,
+            sourcePath: operation.sourcePath,
+            destinationPath: nil,
+            before: file("x"),
+            after: nil,
+            strategy: .exactState
+        )
+        let overLimit = VerifiedPatchSet(
+            id: base.id,
+            receipt: base.receipt,
+            operations: atLimit.operations + [oneMoreByte]
+        )
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([overLimit])
+        )?.first?.reason == .resourceLimitExceeded)
+    }
+
+    @Test("Version path budget accepts boundary and rejects +1")
+    func versionPathBudget() throws {
+        let base = try singlePatch(
+            before: file("before"),
+            after: file("after")
+        )
+        let operation = try #require(base.operations.first)
+        let rootByteCount = base.receipt.workspace
+            .canonicalRootPath.utf8.count
+        let transitionPathByteCount = operation.sourcePath.utf8.count
+        let retainedPathByteCount = 4 * rootByteCount
+            + 2 * transitionPathByteCount
+        let boundaryPath = String(
+            repeating: "x",
+            count: VerifiedPatchLimits.maximumVersionPathByteCount
+                - retainedPathByteCount
+        )
+        func replacingPath(_ path: String) -> VerifiedPatchSet {
+            VerifiedPatchSet(
+                id: base.id,
+                receipt: base.receipt,
+                operations: [VerifiedPatchOperation(
+                    id: operation.id,
+                    kind: operation.kind,
+                    sourcePath: path,
+                    destinationPath: operation.destinationPath,
+                    before: operation.before,
+                    after: operation.after,
+                    strategy: operation.strategy
+                )]
+            )
+        }
+
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([
+                replacingPath(boundaryPath)
+            ])
+        )?.first?.reason == .invalidPatch(base.id))
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([
+                replacingPath(boundaryPath + "x")
+            ])
+        )?.first?.reason == .resourceLimitExceeded)
+    }
+
+    @Test("Version event-metadata budget accepts boundary and rejects +1")
+    func versionEventMetadataBudget() throws {
+        let base = try singlePatch(
+            before: file("before"),
+            after: file("after")
+        )
+        let accepted = try #require(base.receipt.events.first)
+        let envelope = accepted.envelope
+        let fixedMetadataBytes = envelope.agentTypeRaw.utf8.count
+            + envelope.location.worktreePath.utf8.count
+            + envelope.location.cwd.utf8.count
+        let command = String(
+            repeating: "x",
+            count: VerifiedPatchLimits
+                .maximumVersionEventMetadataByteCount
+                - fixedMetadataBytes
+        )
+        func replacingCommand(_ value: String) -> VerifiedPatchSet {
+            let forgedEnvelope = AgentEventEnvelope(
+                id: envelope.id,
+                projectID: envelope.projectID,
+                sessionID: envelope.sessionID,
+                agentTypeRaw: envelope.agentTypeRaw,
+                process: envelope.process,
+                location: envelope.location,
+                cursorValue: envelope.cursorValue,
+                timestamp: envelope.timestamp,
+                source: envelope.source,
+                trustLevel: envelope.trustLevel,
+                payload: .commandResult(AgentCommandResult(
+                    command: value,
+                    exitStatus: 0
+                ))
+            )
+            let forgedEvent = VerifiedPatchAcceptedEvent(
+                envelope: forgedEnvelope,
+                durableIdentity: accepted.durableIdentity,
+                mediatedWriterReceipt: accepted.mediatedWriterReceipt,
+                transitions: accepted.transitions
+            )
+            let forgedReceipt = VerifiedPatchIngressReceipt(
+                receiptID: base.receipt.receiptID,
+                workspace: base.receipt.workspace,
+                projectID: base.receipt.projectID,
+                sessionID: base.receipt.sessionID,
+                process: base.receipt.process,
+                events: [forgedEvent]
+            )
+            return VerifiedPatchSet(
+                id: base.id,
+                receipt: forgedReceipt,
+                operations: base.operations
+            )
+        }
+
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([
+                replacingCommand(command)
+            ])
+        )?.first?.reason == .invalidPatch(base.id))
+        #expect(versionConflicts(
+            VerifiedPatchVersionChainDetector.analyze([
+                replacingCommand(command + "x")
+            ])
+        )?.first?.reason == .resourceLimitExceeded)
+    }
+
     @Test("Version patch-count limit accepts limit and rejects +1")
     func patchCountLimit() throws {
         let patches = try (0..<VerifiedPatchLimits.maximumVersionPatchCount)
@@ -992,22 +1518,33 @@ private func singlePatch(
     after: VerifiedPatchFileState?,
     sessionID: UUID = id(200),
     terminalID: UUID = id(300),
-    rootPath: String = "/private/tmp/project"
+    rootPath: String = "/private/tmp/project",
+    privateID: UUID = id(700),
+    rootDevice: UInt64 = 11,
+    rootInode: UInt64 = 22,
+    descriptorCASSequence: UInt64? = nil
 ) throws -> VerifiedPatchSet {
+    let workspaceIdentity = workspace(
+        rootPath: rootPath,
+        privateID: privateID,
+        rootDevice: rootDevice,
+        rootInode: rootInode
+    )
     let value = record(
         envelopeID: envelopeID,
         cursor: cursor,
         journalSequence: journalSequence,
         sessionID: sessionID,
         terminalID: terminalID,
-        rootPath: rootPath,
+        workspaceIdentity: workspaceIdentity,
+        descriptorCASSequence: descriptorCASSequence,
         changes: [change(path, before, after)]
     )
     return try makePatch(
         patchID: patchID,
         receipt: try receipt(
             [value],
-            workspace: workspace(rootPath: rootPath)
+            workspace: workspaceIdentity
         ),
         sources: [source(
             value,
@@ -1049,11 +1586,16 @@ private func record(
     terminalID: UUID = id(300),
     projectID: UUID = id(400),
     rootPath: String = "/private/tmp/project",
+    workspaceIdentity: VerifiedPatchWorkspaceIdentity? = nil,
+    descriptorCASSequence: UInt64? = nil,
     source eventSource: EventSource = .explicitAgentEvent,
     payload: AgentEventPayload? = nil,
     mediatedByPine: Bool = true,
     changes: [VerifiedPatchContentTransition]
 ) -> VerifiedPatchUntrustedEventRecord {
+    let selectedWorkspace = workspaceIdentity
+        ?? workspace(rootPath: rootPath)
+    let selectedRootPath = selectedWorkspace.canonicalRootPath
     let selectedPayload: AgentEventPayload
     if let payload {
         selectedPayload = payload
@@ -1078,8 +1620,8 @@ private func record(
             processGeneration: 1
         ),
         location: AgentEventLocation(
-            worktreePath: rootPath,
-            cwd: rootPath
+            worktreePath: selectedRootPath,
+            cwd: selectedRootPath
         ),
         cursorValue: cursor,
         timestamp: Date(timeIntervalSince1970: 1_000 + Double(cursor)),
@@ -1097,8 +1639,9 @@ private func record(
             receiptID: UUID(),
             userApprovalID: UUID(),
             descriptorTransactionID: UUID(),
-            descriptorCASSequence: journalSequence,
-            workspace: workspace(rootPath: rootPath),
+            descriptorCASSequence: descriptorCASSequence
+                ?? journalSequence,
+            workspace: selectedWorkspace,
             auditEvent: auditIdentity,
             transitions: changes
         )

--- a/PineTests/VerifiedChanges/VerifiedPatchEngineTests.swift
+++ b/PineTests/VerifiedChanges/VerifiedPatchEngineTests.swift
@@ -1,0 +1,745 @@
+//
+//  VerifiedPatchEngineTests.swift
+//  PineTests
+//
+//  Pure verified patch, preview, merge, and overlap coverage for #933.
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Verified Patch Engine")
+struct VerifiedPatchEngineTests {
+    @Test("Patch and preview are deterministic and identity-bound")
+    func deterministicPatchAndPreview() throws {
+        let before = data("header\nold\nfooter\n")
+        let after = data("header\nagent\nfooter\n")
+        let patch = try singlePatch(
+            patchID: id(1),
+            envelopeID: id(2),
+            before: before,
+            after: after
+        )
+        let duplicate = try singlePatch(
+            patchID: id(1),
+            envelopeID: id(2),
+            before: before,
+            after: after
+        )
+
+        #expect(patch == duplicate)
+        let preview = VerifiedPatchEngine.previewInverse(patch)
+        #expect(preview == VerifiedPatchEngine.previewInverse(duplicate))
+        #expect(preview.count == 1)
+        #expect(preview[0].kind == .applyTextHunks)
+        #expect(preview[0].eventEnvelopeID == id(2))
+        #expect(preview[0].expectedCurrentIdentity == ContentIdentity(content: after))
+        #expect(preview[0].resultIdentity == ContentIdentity(content: before))
+        #expect(preview[0].hunks.count == 1)
+        #expect(preview[0].hunks[0].header == "@@ -2,1 +2,1 @@")
+        #expect(preview[0].hunks[0].lines.contains {
+            $0.kind == .remove && $0.bytes == data("agent\n")
+        })
+        #expect(preview[0].hunks[0].lines.contains {
+            $0.kind == .add && $0.bytes == data("old\n")
+        })
+    }
+
+    @Test("Exact expected text is inverted byte-for-byte")
+    func exactTextInverse() throws {
+        let before = data("before\n")
+        let after = data("after\n")
+        let patch = try singlePatch(
+            before: before,
+            after: after
+        )
+
+        let result = VerifiedPatchEngine.applyCheckedInverse(
+            patch,
+            to: VerifiedPatchWorkspaceSnapshot(
+                files: ["file.txt": after, "unrelated.txt": data("keep")]
+            )
+        )
+
+        let applied = try #require(appliedSnapshot(result))
+        #expect(applied.files["file.txt"] == before)
+        #expect(applied.files["unrelated.txt"] == data("keep"))
+    }
+
+    @Test("Checked text hunks preserve a non-overlapping human edit")
+    func nonOverlappingHumanEditIsPreserved() throws {
+        let before = data(
+            "human-old\nstable-a\nstable-b\nold\nstable-c\nstable-d\n"
+        )
+        let after = data(
+            "human-old\nstable-a\nstable-b\nagent\nstable-c\nstable-d\n"
+        )
+        let current = data(
+            "human-new\nstable-a\nstable-b\nagent\nstable-c\nstable-d\n"
+        )
+        let expected = data(
+            "human-new\nstable-a\nstable-b\nold\nstable-c\nstable-d\n"
+        )
+        let patch = try singlePatch(before: before, after: after)
+
+        let result = VerifiedPatchEngine.applyCheckedInverse(
+            patch,
+            to: VerifiedPatchWorkspaceSnapshot(files: ["file.txt": current])
+        )
+
+        let applied = try #require(appliedSnapshot(result))
+        #expect(applied.files["file.txt"] == expected)
+    }
+
+    @Test("A human edit overlapping an agent hunk fails closed")
+    func overlappingHumanEditConflicts() throws {
+        let before = data("a\nb\nold\nc\nd\n")
+        let after = data("a\nb\nagent\nc\nd\n")
+        let current = data("a\nb\nhuman-overlap\nc\nd\n")
+        let patch = try singlePatch(before: before, after: after)
+
+        let result = VerifiedPatchEngine.applyCheckedInverse(
+            patch,
+            to: VerifiedPatchWorkspaceSnapshot(files: ["file.txt": current])
+        )
+
+        let conflicts = try #require(conflicts(result))
+        #expect(conflicts.count == 1)
+        #expect(conflicts[0].reason == .textContextMissing(hunkIndex: 0))
+    }
+
+    @Test("Duplicate checked context is ambiguous and fails closed")
+    func duplicateContextConflicts() throws {
+        let before = data("a\nb\nold\nc\nd\n")
+        let after = data("a\nb\nagent\nc\nd\n")
+        let current = data(
+            "a\nb\nagent\nc\nd\nhuman\n"
+                + "a\nb\nagent\nc\nd\n"
+        )
+        let patch = try singlePatch(before: before, after: after)
+
+        let result = VerifiedPatchEngine.applyCheckedInverse(
+            patch,
+            to: VerifiedPatchWorkspaceSnapshot(files: ["file.txt": current])
+        )
+
+        let conflicts = try #require(conflicts(result))
+        #expect(conflicts[0].reason == .ambiguousTextContext(hunkIndex: 0))
+    }
+
+    @Test("CRLF and a missing final newline survive hunk application")
+    func crlfAndNoFinalNewline() throws {
+        let before = data(
+            "human-old\r\nstable-a\r\nstable-b\r\nold\r\n"
+                + "stable-c\r\nlast"
+        )
+        let after = data(
+            "human-old\r\nstable-a\r\nstable-b\r\nagent\r\n"
+                + "stable-c\r\nlast"
+        )
+        let current = data(
+            "human-new\r\nstable-a\r\nstable-b\r\nagent\r\n"
+                + "stable-c\r\nlast"
+        )
+        let expected = data(
+            "human-new\r\nstable-a\r\nstable-b\r\nold\r\n"
+                + "stable-c\r\nlast"
+        )
+        let patch = try singlePatch(before: before, after: after)
+
+        let result = VerifiedPatchEngine.applyCheckedInverse(
+            patch,
+            to: VerifiedPatchWorkspaceSnapshot(files: ["file.txt": current])
+        )
+
+        let applied = try #require(appliedSnapshot(result))
+        #expect(applied.files["file.txt"] == expected)
+        let preview = VerifiedPatchEngine.previewInverse(patch)
+        #expect(preview[0].hunks[0].lines.contains {
+            $0.bytes == data("agent\r\n")
+        })
+        #expect(preview[0].hunks[0].lines.last?.bytes == data("last"))
+    }
+
+    @Test("Create and delete use exact-state inverse fallbacks")
+    func createAndDeleteExactFallbacks() throws {
+        let created = data("created")
+        let deleted = data("deleted")
+        let createTransition = transition(
+            path: "created.txt",
+            before: nil,
+            after: created
+        )
+        let deleteTransition = transition(
+            path: "deleted.txt",
+            before: deleted,
+            after: nil
+        )
+        let binding = try makeBinding(events: [
+            VerifiedPatchEventReference(
+                envelopeID: id(2),
+                cursorValue: 1,
+                transitions: [createTransition]
+            ),
+            VerifiedPatchEventReference(
+                envelopeID: id(3),
+                cursorValue: 2,
+                transitions: [deleteTransition]
+            )
+        ])
+        let patch = try VerifiedPatchEngine.makePatch(
+            id: id(1),
+            binding: binding,
+            operations: [
+                VerifiedPatchSourceOperation(
+                    eventEnvelopeID: id(3),
+                    sourcePath: "deleted.txt",
+                    beforeContent: deleted,
+                    afterContent: nil
+                ),
+                VerifiedPatchSourceOperation(
+                    eventEnvelopeID: id(2),
+                    sourcePath: "created.txt",
+                    beforeContent: nil,
+                    afterContent: created
+                )
+            ]
+        )
+
+        let previews = VerifiedPatchEngine.previewInverse(patch)
+        #expect(previews.map(\.kind) == [
+            .removeCreatedFile,
+            .restoreDeletedFile
+        ])
+        let result = VerifiedPatchEngine.applyCheckedInverse(
+            patch,
+            to: VerifiedPatchWorkspaceSnapshot(
+                files: ["created.txt": created]
+            )
+        )
+        let applied = try #require(appliedSnapshot(result))
+        #expect(applied.files["created.txt"] == nil)
+        #expect(applied.files["deleted.txt"] == deleted)
+    }
+
+    @Test("A diverged created file is never removed")
+    func divergedCreateConflicts() throws {
+        let patch = try singlePatch(
+            before: nil,
+            after: data("agent-created")
+        )
+        let result = VerifiedPatchEngine.applyCheckedInverse(
+            patch,
+            to: VerifiedPatchWorkspaceSnapshot(
+                files: ["file.txt": data("human-edited")]
+            )
+        )
+
+        let found = try #require(conflicts(result))
+        #expect(found[0].reason == .exactStateDiverged)
+    }
+
+    @Test("Binary changes require an exact after-state")
+    func binaryExactFallback() throws {
+        let before = Data([0x00, 0x01, 0x02])
+        let after = Data([0x00, 0x03, 0x04])
+        let patch = try singlePatch(before: before, after: after)
+        #expect(VerifiedPatchEngine.previewInverse(patch)[0].kind
+            == .restoreExactBytes)
+
+        let exact = VerifiedPatchEngine.applyCheckedInverse(
+            patch,
+            to: VerifiedPatchWorkspaceSnapshot(files: ["file.txt": after])
+        )
+        #expect(try #require(appliedSnapshot(exact)).files["file.txt"]
+            == before)
+
+        let diverged = VerifiedPatchEngine.applyCheckedInverse(
+            patch,
+            to: VerifiedPatchWorkspaceSnapshot(
+                files: ["file.txt": Data([0x00, 0x03, 0x05])]
+            )
+        )
+        #expect(try #require(conflicts(diverged))[0].reason
+            == .exactStateDiverged)
+    }
+
+    @Test("Rename inversion is exact and preserves unrelated files")
+    func renameExactFallback() throws {
+        let before = data("original")
+        let after = data("renamed")
+        let eventID = id(2)
+        let contentTransition = VerifiedPatchContentTransition(
+            sourcePath: "old.txt",
+            destinationPath: "new.txt",
+            beforeIdentity: ContentIdentity(content: before),
+            afterIdentity: ContentIdentity(content: after)
+        )
+        let binding = try makeBinding(events: [
+            VerifiedPatchEventReference(
+                envelopeID: eventID,
+                cursorValue: 1,
+                transitions: [contentTransition]
+            )
+        ])
+        let patch = try VerifiedPatchEngine.makePatch(
+            id: id(1),
+            binding: binding,
+            operations: [
+                VerifiedPatchSourceOperation(
+                    eventEnvelopeID: eventID,
+                    sourcePath: "old.txt",
+                    destinationPath: "new.txt",
+                    beforeContent: before,
+                    afterContent: after
+                )
+            ]
+        )
+
+        let result = VerifiedPatchEngine.applyCheckedInverse(
+            patch,
+            to: VerifiedPatchWorkspaceSnapshot(files: [
+                "new.txt": after,
+                "keep.txt": data("keep")
+            ])
+        )
+        let applied = try #require(appliedSnapshot(result))
+        #expect(applied.files["new.txt"] == nil)
+        #expect(applied.files["old.txt"] == before)
+        #expect(applied.files["keep.txt"] == data("keep"))
+        #expect(VerifiedPatchEngine.previewInverse(patch)[0].kind
+            == .restoreRenamedFile)
+    }
+
+    @Test("One conflict keeps a multi-operation inverse atomic")
+    func multiOperationConflictIsAtomic() throws {
+        let firstBefore = data("one-before")
+        let firstAfter = data("one-after")
+        let secondBefore = data("two-before")
+        let secondAfter = data("two-after")
+        let binding = try makeBinding(events: [
+            event(
+                id: id(2),
+                cursor: 1,
+                path: "one.bin",
+                before: firstBefore,
+                after: firstAfter
+            ),
+            event(
+                id: id(3),
+                cursor: 2,
+                path: "two.bin",
+                before: secondBefore,
+                after: secondAfter
+            )
+        ])
+        let patch = try VerifiedPatchEngine.makePatch(
+            id: id(1),
+            binding: binding,
+            operations: [
+                source(
+                    eventID: id(2),
+                    path: "one.bin",
+                    before: firstBefore,
+                    after: firstAfter
+                ),
+                source(
+                    eventID: id(3),
+                    path: "two.bin",
+                    before: secondBefore,
+                    after: secondAfter
+                )
+            ]
+        )
+        let original = VerifiedPatchWorkspaceSnapshot(files: [
+            "one.bin": firstAfter,
+            "two.bin": data("human")
+        ])
+
+        let result = VerifiedPatchEngine.applyCheckedInverse(
+            patch,
+            to: original
+        )
+
+        #expect(appliedSnapshot(result) == nil)
+        #expect(try #require(conflicts(result))[0].path == "two.bin")
+        #expect(original.files["one.bin"] == firstAfter)
+    }
+
+    @Test("Cursor replay and gaps are rejected by the binding")
+    func cursorReplayAndGap() throws {
+        let contentTransition = transition(
+            path: "file.txt",
+            before: data("a"),
+            after: data("b")
+        )
+        #expect(throws: VerifiedPatchValidationError.cursorReplay(1)) {
+            try makeBinding(events: [
+                VerifiedPatchEventReference(
+                    envelopeID: id(2),
+                    cursorValue: 1,
+                    transitions: [contentTransition]
+                ),
+                VerifiedPatchEventReference(
+                    envelopeID: id(3),
+                    cursorValue: 1,
+                    transitions: [contentTransition]
+                )
+            ])
+        }
+        #expect(throws: VerifiedPatchValidationError.cursorGap(
+            expected: 2,
+            actual: 3
+        )) {
+            try makeBinding(events: [
+                VerifiedPatchEventReference(
+                    envelopeID: id(2),
+                    cursorValue: 1,
+                    transitions: [contentTransition]
+                ),
+                VerifiedPatchEventReference(
+                    envelopeID: id(3),
+                    cursorValue: 3,
+                    transitions: [contentTransition]
+                )
+            ])
+        }
+    }
+
+    @Test("Captured bytes must match the event content identities")
+    func eventIdentityMismatchIsRejected() throws {
+        let binding = try makeBinding(events: [
+            event(
+                id: id(2),
+                cursor: 1,
+                path: "file.txt",
+                before: data("before"),
+                after: data("after")
+            )
+        ])
+
+        #expect(throws: VerifiedPatchValidationError.unboundOperation) {
+            try VerifiedPatchEngine.makePatch(
+                id: id(1),
+                binding: binding,
+                operations: [
+                    source(
+                        eventID: id(2),
+                        path: "file.txt",
+                        before: data("different-before"),
+                        after: data("after")
+                    )
+                ]
+            )
+        }
+    }
+}
+
+@Suite("Verified Patch Version Chains")
+struct VerifiedPatchVersionChainTests {
+    @Test("Two agents branching from one file version conflict")
+    func twoAgentOverlapConflicts() throws {
+        let base = data("base")
+        let first = try singlePatch(
+            patchID: id(1),
+            envelopeID: id(2),
+            before: base,
+            after: data("agent-a"),
+            sessionID: id(11),
+            terminalID: id(21)
+        )
+        let second = try singlePatch(
+            patchID: id(3),
+            envelopeID: id(4),
+            before: base,
+            after: data("agent-b"),
+            sessionID: id(12),
+            terminalID: id(22)
+        )
+
+        let result = VerifiedPatchVersionChainDetector.analyze([
+            second,
+            first
+        ])
+
+        let found = try #require(versionConflicts(result))
+        #expect(found.contains {
+            $0.path == "file.txt"
+                && $0.reason == .ambiguousVersionChain
+        })
+    }
+
+    @Test("Two agents with an exact content chain are ordered")
+    func exactMultiAgentChainIsAccepted() throws {
+        let base = data("base")
+        let middle = data("agent-a")
+        let final = data("agent-b")
+        let first = try singlePatch(
+            patchID: id(1),
+            envelopeID: id(2),
+            before: base,
+            after: middle,
+            sessionID: id(11),
+            terminalID: id(21)
+        )
+        let second = try singlePatch(
+            patchID: id(3),
+            envelopeID: id(4),
+            before: middle,
+            after: final,
+            sessionID: id(12),
+            terminalID: id(22)
+        )
+
+        let result = VerifiedPatchVersionChainDetector.analyze([
+            second,
+            first
+        ])
+
+        guard case .valid(let report) = result else {
+            Issue.record("Expected a valid exact version chain")
+            return
+        }
+        let pathScope = VerifiedPatchPathScope(
+            projectID: id(10),
+            worktreePath: "/tmp/project",
+            relativePath: "file.txt"
+        )
+        #expect(report.orderedPatchIDsByPath[pathScope]
+            == [first.id, second.id])
+    }
+
+    @Test("Identical relative paths in separate worktrees do not overlap")
+    func separateWorktreesDoNotConflict() throws {
+        let first = try singlePatch(
+            patchID: id(1),
+            envelopeID: id(2),
+            before: data("base"),
+            after: data("agent-a"),
+            worktreePath: "/tmp/first"
+        )
+        let second = try singlePatch(
+            patchID: id(3),
+            envelopeID: id(4),
+            before: data("base"),
+            after: data("agent-b"),
+            worktreePath: "/tmp/second"
+        )
+
+        let result = VerifiedPatchVersionChainDetector.analyze([
+            first,
+            second
+        ])
+
+        guard case .valid(let report) = result else {
+            Issue.record("Separate worktrees must not share a version chain")
+            return
+        }
+        #expect(report.orderedPatchIDsByPath.isEmpty)
+    }
+
+    @Test("Separate patches in one process detect cursor gaps")
+    func streamCursorGapConflicts() throws {
+        let first = try singlePatch(
+            patchID: id(1),
+            envelopeID: id(2),
+            cursor: 1,
+            path: "one.txt",
+            before: data("a"),
+            after: data("b")
+        )
+        let second = try singlePatch(
+            patchID: id(3),
+            envelopeID: id(4),
+            cursor: 3,
+            path: "two.txt",
+            before: data("c"),
+            after: data("d")
+        )
+
+        let result = VerifiedPatchVersionChainDetector.analyze([
+            first,
+            second
+        ])
+
+        let found = try #require(versionConflicts(result))
+        #expect(found.contains {
+            $0.reason == .cursorGap(expected: 2, actual: 3)
+        })
+    }
+
+    @Test("Envelope replay across patch sets is detected")
+    func envelopeReplayConflicts() throws {
+        let first = try singlePatch(
+            patchID: id(1),
+            envelopeID: id(2),
+            path: "one.txt",
+            before: data("a"),
+            after: data("b")
+        )
+        let second = try singlePatch(
+            patchID: id(3),
+            envelopeID: id(2),
+            path: "two.txt",
+            before: data("c"),
+            after: data("d"),
+            sessionID: id(12),
+            terminalID: id(22)
+        )
+
+        let result = VerifiedPatchVersionChainDetector.analyze([
+            first,
+            second
+        ])
+
+        let found = try #require(versionConflicts(result))
+        #expect(found.contains {
+            $0.reason == .replayedEnvelope(id(2))
+        })
+    }
+}
+
+private func singlePatch(
+    patchID: UUID = id(1),
+    envelopeID: UUID = id(2),
+    cursor: UInt64 = 1,
+    path: String = "file.txt",
+    before: Data?,
+    after: Data?,
+    sessionID: UUID = id(11),
+    terminalID: UUID = id(21),
+    projectID: UUID = id(10),
+    worktreePath: String = "/tmp/project"
+) throws -> VerifiedPatchSet {
+    let binding = try makeBinding(
+        events: [
+            event(
+                id: envelopeID,
+                cursor: cursor,
+                path: path,
+                before: before,
+                after: after
+            )
+        ],
+        sessionID: sessionID,
+        terminalID: terminalID,
+        projectID: projectID,
+        worktreePath: worktreePath
+    )
+    return try VerifiedPatchEngine.makePatch(
+        id: patchID,
+        binding: binding,
+        operations: [
+            source(
+                eventID: envelopeID,
+                path: path,
+                before: before,
+                after: after
+            )
+        ]
+    )
+}
+
+private func makeBinding(
+    events: [VerifiedPatchEventReference],
+    sessionID: UUID = id(11),
+    terminalID: UUID = id(21),
+    projectID: UUID = id(10),
+    worktreePath: String = "/tmp/project"
+) throws -> VerifiedPatchEventBinding {
+    try VerifiedPatchEventBinding(
+        projectID: projectID,
+        worktreePath: worktreePath,
+        sessionID: sessionID,
+        process: AgentProcessIdentity(
+            terminalID: terminalID,
+            processGeneration: 1
+        ),
+        events: events
+    )
+}
+
+private func event(
+    id eventID: UUID,
+    cursor: UInt64,
+    path: String,
+    before: Data?,
+    after: Data?
+) -> VerifiedPatchEventReference {
+    VerifiedPatchEventReference(
+        envelopeID: eventID,
+        cursorValue: cursor,
+        transitions: [
+            transition(
+                path: path,
+                before: before,
+                after: after
+            )
+        ]
+    )
+}
+
+private func transition(
+    path: String,
+    before: Data?,
+    after: Data?
+) -> VerifiedPatchContentTransition {
+    VerifiedPatchContentTransition(
+        sourcePath: path,
+        beforeIdentity: before.map(ContentIdentity.init),
+        afterIdentity: after.map(ContentIdentity.init)
+    )
+}
+
+private func source(
+    eventID: UUID,
+    path: String,
+    before: Data?,
+    after: Data?
+) -> VerifiedPatchSourceOperation {
+    VerifiedPatchSourceOperation(
+        eventEnvelopeID: eventID,
+        sourcePath: path,
+        beforeContent: before,
+        afterContent: after
+    )
+}
+
+private func appliedSnapshot(
+    _ result: VerifiedCheckedInverseResult
+) -> VerifiedPatchWorkspaceSnapshot? {
+    guard case .applied(let snapshot, _) = result else { return nil }
+    return snapshot
+}
+
+private func conflicts(
+    _ result: VerifiedCheckedInverseResult
+) -> [VerifiedPatchConflict]? {
+    guard case .conflicted(let conflicts) = result else { return nil }
+    return conflicts
+}
+
+private func versionConflicts(
+    _ result: VerifiedPatchVersionChainResult
+) -> [VerifiedPatchVersionConflict]? {
+    guard case .conflicted(let conflicts) = result else { return nil }
+    return conflicts
+}
+
+private func data(_ value: String) -> Data {
+    Data(value.utf8)
+}
+
+private func id(_ value: UInt8) -> UUID {
+    UUID(uuid: (
+        0, 0, 0, 0,
+        0, 0,
+        0, 0,
+        0, 0,
+        0, 0,
+        0, 0,
+        0, value
+    ))
+}


### PR DESCRIPTION
Adds the pure, fail-closed patch preparation and version-analysis core for #933. This is foundation only: it does not enable agent writes, create verified History entries, or close the epic.

Highlights:
- exact create, modify, delete, and bounded text-patch models
- exact preview plus checked prepared inverse application
- unique-LCS mapping that rejects ambiguous duplicate regions
- multi-agent overlap/version-chain analysis with workspace, stream, cursor, journal, receipt, transaction, and CAS ordering
- mediated-writer receipt boundary and full durable-envelope revalidation contracts
- bounded operation, path, snapshot, line, hunk, LCS, comparison, prepared-DTO, and version-analysis work
- collision-safe line interning and fail-closed canonical strategy validation

Verification:
- 54 targeted tests passed across four suites
- production Pine build passed
- strict SwiftLint reported zero violations in changed files
- diff and reentrancy guards passed
- independent adversarial re-review approved exact SHA 6b51f0933b87881a21efe8437447f919a5dde896

Related to #933; does not close it.