### PR TITLE
ci: disable automatic screenshot updates on release

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -3,8 +3,6 @@ name: Update Screenshots
 
 on:
   workflow_dispatch:
-  release:
-    types: [published]
 
 # contents: write -> the Commit screenshots step creates a branch and pushes
 #   it. pull-requests: write -> the same step opens a PR against main.


### PR DESCRIPTION
## What

Removes the `release: [published]` trigger from the Update Screenshots workflow.

## Why

Screenshot updates should not fire automatically on every release. The workflow stays available for manual runs via `workflow_dispatch`, but will no longer open PRs by itself.

## Changes

- `.github/workflows/screenshots.yml`: removed `release` trigger, kept `workflow_dispatch`