### PR TITLE
feat: add YAML indentation folding

### DIFF
--- a/Pine/FoldRangeCalculator.swift
+++ b/Pine/FoldRangeCalculator.swift
@@ -7,9 +7,9 @@ import Foundation
 
 /// Описание складываемого региона кода.
 nonisolated struct FoldableRange: Equatable, Sendable {
-    /// 1-based номер строки с открывающей скобкой
+    /// 1-based номер строки с заголовком или открывающей скобкой.
     let startLine: Int
-    /// 1-based номер строки с закрывающей скобкой
+    /// 1-based номер последней строки региона.
     let endLine: Int
     /// UTF-16 смещение открывающего символа
     let startCharIndex: Int
@@ -24,6 +24,9 @@ nonisolated enum FoldKind: Equatable, Sendable {
     case braces       // { }
     case brackets     // [ ]
     case parentheses  // ( )
+    /// Indentation-delimited body whose final line is content, not a closing
+    /// delimiter. Folding hides this line as well as the lines before it.
+    case indentation
 }
 
 /// Вычисляет складываемые регионы по парным скобкам.

--- a/Pine/FoldState.swift
+++ b/Pine/FoldState.swift
@@ -54,22 +54,33 @@ struct FoldState {
     }
 
     /// Проверяет, скрыта ли строка (попадает ли она внутрь свёрнутого региона).
-    /// Строки startLine и endLine самого fold-а остаются видимыми.
+    /// Заголовок `startLine` остаётся видимым. Для скобочных регионов видима
+    /// также строка с закрывающей скобкой; indentation-регион скрывается до
+    /// своей последней строки включительно.
     /// O(1) через Set lookup.
     func isLineHidden(_ line: Int) -> Bool {
         hiddenLines.contains(line)
     }
 
     /// Количество скрытых строк при сворачивании региона.
-    /// Не зависит от текущего состояния fold — просто разница между start и end.
+    /// Не зависит от текущего состояния fold.
     func hiddenLineCount(for range: FoldableRange) -> Int {
-        max(0, range.endLine - range.startLine - 1)
+        switch range.kind {
+        case .indentation:
+            max(0, range.endLine - range.startLine)
+        case .braces, .brackets, .parentheses:
+            max(0, range.endLine - range.startLine - 1)
+        }
     }
 
     // MARK: - Private
 
     private mutating func addHiddenLines(for range: FoldableRange) {
-        for line in (range.startLine + 1)..<range.endLine {
+        let endExclusive = range.kind == .indentation
+            ? range.endLine + 1
+            : range.endLine
+        guard endExclusive > range.startLine + 1 else { return }
+        for line in (range.startLine + 1)..<endExclusive {
             hiddenLines.insert(line)
         }
     }

--- a/Pine/PerTabEditorState.swift
+++ b/Pine/PerTabEditorState.swift
@@ -90,6 +90,7 @@ struct PerTabEditorState: Codable, Equatable, Sendable {
         case .braces: "braces"
         case .brackets: "brackets"
         case .parentheses: "parentheses"
+        case .indentation: "indentation"
         }
     }
 
@@ -100,6 +101,7 @@ struct PerTabEditorState: Codable, Equatable, Sendable {
         case "braces": return .braces
         case "brackets": return .brackets
         case "parentheses": return .parentheses
+        case "indentation": return .indentation
         default:
             logger.warning("Unknown fold kind '\(string)', defaulting to .braces")
             return .braces

--- a/Pine/Syntax/LocalFoldProvider.swift
+++ b/Pine/Syntax/LocalFoldProvider.swift
@@ -6,18 +6,18 @@
 //
 //  One local provider owns the complete fallback result for a revision:
 //  bracket-pair folding for every language, plus indentation suites for
-//  Python (whose configured Pyright server has no foldingRange capability).
+//  Python and YAML (neither has an available foldingRange provider in Pine).
 //
 
 import Foundation
 
 /// Pine's universal local folding provider.
 ///
-/// The provider is always available. Non-Python languages retain exactly the
-/// existing bracket-pair fallback. Python keeps those bracket folds and adds
-/// declaration/control-flow suites derived from indentation. Combining the
-/// two local algorithms happens inside this single provider, so LSP/local
-/// ownership remains deterministic and provider results are never merged.
+/// The provider is always available. Python adds declaration/control-flow
+/// suites; YAML adds block mapping, sequence, and scalar ranges. Every
+/// language keeps bracket folding. Combining local algorithms happens inside
+/// this provider, so LSP/local ownership remains deterministic and provider
+/// results are never merged.
 ///
 /// Syntax extraction and all scanning run on a detached task against an
 /// immutable snapshot, so the local fallback never blocks AppKit.
@@ -60,10 +60,21 @@ nonisolated struct LocalFoldProvider: FoldRangeProviding {
             let isPython = language == "python"
                 || snapshot.uri.lowercased().hasSuffix(".py")
                 || snapshot.uri.lowercased().hasSuffix(".pyw")
+            let isYAML = language == "yaml"
+                || language == "yml"
+                || snapshot.uri.lowercased().hasSuffix(".yaml")
+                || snapshot.uri.lowercased().hasSuffix(".yml")
             let indentationRanges: [FoldableRange]
             let bracketSkipRanges: [NSRange]
             if isPython {
                 let analysis = PythonIndentationFoldCalculator.analyze(
+                    text: text,
+                    additionalSkipRanges: syntaxSkipRanges
+                )
+                indentationRanges = analysis.ranges
+                bracketSkipRanges = analysis.lexicalSkipRanges
+            } else if isYAML {
+                let analysis = YAMLIndentationFoldCalculator.analyze(
                     text: text,
                     additionalSkipRanges: syntaxSkipRanges
                 )
@@ -84,10 +95,14 @@ nonisolated struct LocalFoldProvider: FoldRangeProviding {
                 skipRanges: bracketSkipRanges
             )
             guard !Task.isCancelled else { return nil }
-            return Self.combinedRanges(
+            let combined = Self.combinedRanges(
                 bracketRanges,
                 indentationRanges
             )
+            return isYAML
+                ? YAMLIndentationFoldCalculator
+                    .canonicalizedForDisplay(combined)
+                : combined
         }
         return await withTaskCancellationHandler {
             await task.value

--- a/Pine/Syntax/LocalFoldProvider.swift
+++ b/Pine/Syntax/LocalFoldProvider.swift
@@ -74,10 +74,12 @@ nonisolated struct LocalFoldProvider: FoldRangeProviding {
                 indentationRanges = analysis.ranges
                 bracketSkipRanges = analysis.lexicalSkipRanges
             } else if isYAML {
-                let analysis = YAMLIndentationFoldCalculator.analyze(
+                guard let analysis = YAMLIndentationFoldCalculator.analyze(
                     text: text,
                     additionalSkipRanges: syntaxSkipRanges
-                )
+                ) else {
+                    return nil
+                }
                 indentationRanges = analysis.ranges
                 bracketSkipRanges = analysis.lexicalSkipRanges
             } else {
@@ -99,10 +101,13 @@ nonisolated struct LocalFoldProvider: FoldRangeProviding {
                 bracketRanges,
                 indentationRanges
             )
-            return isYAML
+            guard !Task.isCancelled else { return nil }
+            let displayRanges = isYAML
                 ? YAMLIndentationFoldCalculator
                     .canonicalizedForDisplay(combined)
                 : combined
+            guard !Task.isCancelled else { return nil }
+            return displayRanges
         }
         return await withTaskCancellationHandler {
             await task.value

--- a/Pine/Syntax/YAMLIndentationFoldCalculator.swift
+++ b/Pine/Syntax/YAMLIndentationFoldCalculator.swift
@@ -1,0 +1,1380 @@
+//
+//  YAMLIndentationFoldCalculator.swift
+//  Pine
+//
+//  Language-aware local folding for YAML indentation blocks (#1225).
+//
+
+import Foundation
+
+/// A tolerant, UTF-16 based YAML indentation-fold calculator.
+///
+/// This is deliberately a bounded structural scanner rather than a complete
+/// YAML parser. It recognizes block mappings, block sequences, and block
+/// scalars while treating quoted scalars and flow collections as opaque for
+/// indentation purposes. Incomplete buffers retain any valid surrounding
+/// structure and never make fold calculation unbounded.
+///
+/// The caller runs this work away from the main actor. All offsets use
+/// `NSString` UTF-16 coordinates to match `NSTextView` and `FoldableRange`.
+nonisolated enum YAMLIndentationFoldCalculator {
+    static let tabWidth = 8
+    static let maxActiveDepth = 500
+
+    struct Analysis: Sendable {
+        let ranges: [FoldableRange]
+        /// Sorted, merged comments, quoted scalars, and block scalar bodies.
+        /// Bracket folding skips these ranges for the same snapshot.
+        let lexicalSkipRanges: [NSRange]
+    }
+
+    private enum LineKind {
+        case blank
+        case comment
+        /// A physical line inside a quoted scalar, flow collection, or block
+        /// scalar. Its indentation is content rather than YAML block scope.
+        case continuation
+        case code
+    }
+
+    private struct Line {
+        let start: Int
+        let contentEnd: Int
+        let indentEnd: Int
+        let indentationColumn: Int
+        let rawIsBlank: Bool
+        var kind: LineKind
+        var isSequenceEntry = false
+        var headers: [HeaderCandidate] = []
+    }
+
+    private struct HeaderCandidate {
+        let startLineIndex: Int
+        let indentationColumn: Int
+        let markerOffset: Int
+        /// YAML permits a block sequence to be indented at the same level as
+        /// the mapping key whose value it supplies (BLOCK-OUT context).
+        let allowsIndentlessSequence: Bool
+    }
+
+    private struct ActiveBlock {
+        let header: HeaderCandidate
+        var lastIncludedLineIndex: Int
+    }
+
+    private struct QuoteState {
+        let character: unichar
+        let start: Int
+    }
+
+    private struct LexicalState {
+        var quote: QuoteState?
+        var flowStack: [unichar] = []
+        /// Whether the next token inside a flow collection may begin a node.
+        /// Plain scalars keep this false across physical line breaks.
+        var nodeMayStart = true
+    }
+
+    private struct ParsedLine {
+        let commentStart: Int?
+        let mappingColon: Int?
+        let sequenceMarker: Int?
+        let explicitKeyMarker: Int?
+        let blockScalar: BlockScalarHeader?
+        let hasCode: Bool
+        let hasTrailingPlainScalar: Bool
+    }
+
+    private struct BlockScalarHeader {
+        let markerOffset: Int
+        let explicitIndent: Int?
+    }
+
+    private struct BlockScalarContext {
+        let headerIndex: Int
+        let scalarIndent: Int
+        let explicitIndent: Int?
+        let lines: [Line]
+    }
+
+    /// Calculates YAML indentation folds and returns the lexical exclusions
+    /// used by bracket folding during the same immutable pass.
+    static func analyze(
+        text: String,
+        additionalSkipRanges: [NSRange] = []
+    ) -> Analysis {
+        let source = text as NSString
+        guard source.length > 0 else {
+            return Analysis(ranges: [], lexicalSkipRanges: [])
+        }
+
+        var lines = makeLines(in: source)
+        var lexicalRanges: [NSRange] = []
+        parseStructure(
+            in: source,
+            lines: &lines,
+            lexicalRanges: &lexicalRanges
+        )
+        let exclusions = normalizedRanges(
+            additionalSkipRanges + lexicalRanges,
+            boundedBy: source.length
+        )
+        return Analysis(
+            ranges: canonicalizedForDisplay(
+                resolveRanges(lines: lines)
+            ),
+            lexicalSkipRanges: exclusions
+        )
+    }
+
+    /// Convenience API for focused calculator tests.
+    static func calculate(
+        text: String,
+        skipRanges: [NSRange] = []
+    ) -> [FoldableRange] {
+        analyze(
+            text: text,
+            additionalSkipRanges: skipRanges
+        ).ranges
+    }
+
+    // MARK: - Physical lines
+
+    private static func makeLines(in source: NSString) -> [Line] {
+        var bounds: [(start: Int, end: Int)] = []
+        var lineStart = 0
+        var index = 0
+
+        while index < source.length {
+            let character = source.character(at: index)
+            if character == ASCII.carriageReturn {
+                bounds.append((lineStart, index))
+                if index + 1 < source.length,
+                   source.character(at: index + 1) == ASCII.newline {
+                    index += 2
+                } else {
+                    index += 1
+                }
+                lineStart = index
+            } else if character == ASCII.newline {
+                bounds.append((lineStart, index))
+                index += 1
+                lineStart = index
+            } else {
+                index += 1
+            }
+        }
+        bounds.append((lineStart, source.length))
+
+        return bounds.map { bound in
+            var cursor = bound.start
+            var column = 0
+            while cursor < bound.end {
+                let character = source.character(at: cursor)
+                if character == YAMLASCII.space {
+                    column += 1
+                    cursor += 1
+                } else if character == YAMLASCII.tab {
+                    // Tabs are invalid YAML indentation, but treating them
+                    // deterministically keeps incomplete buffers safe.
+                    column += tabWidth - (column % tabWidth)
+                    cursor += 1
+                } else {
+                    break
+                }
+            }
+
+            let isBlank = cursor == bound.end
+            return Line(
+                start: bound.start,
+                contentEnd: bound.end,
+                indentEnd: cursor,
+                indentationColumn: column,
+                rawIsBlank: isBlank,
+                kind: isBlank ? .blank : .code
+            )
+        }
+    }
+
+    // MARK: - Lexical and structural scan
+
+    private static func parseStructure(
+        in source: NSString,
+        lines: inout [Line],
+        lexicalRanges: inout [NSRange]
+    ) {
+        var lexicalState = LexicalState()
+        var plainScalarIndentation: Int?
+        var scalarContent = Array(
+            repeating: false,
+            count: lines.count
+        )
+
+        for lineIndex in lines.indices {
+            if scalarContent[lineIndex] {
+                lines[lineIndex].kind = .continuation
+                appendWholeLineRange(
+                    lines[lineIndex],
+                    to: &lexicalRanges
+                )
+                continue
+            }
+
+            let line = lines[lineIndex]
+            if plainScalarIndentation != nil,
+               line.rawIsBlank {
+                lines[lineIndex].kind = .blank
+                continue
+            }
+            if let scalarIndent = plainScalarIndentation {
+                if isCommentOnlyLine(source: source, line: line)
+                    || line.indentationColumn <= scalarIndent {
+                    plainScalarIndentation = nil
+                } else {
+                    lines[lineIndex].kind = .continuation
+                    appendWholeLineRange(
+                        lines[lineIndex],
+                        to: &lexicalRanges
+                    )
+                    continue
+                }
+            }
+
+            if isHardDocumentBoundary(
+                source: source,
+                line: line
+            ) {
+                if let quote = lexicalState.quote {
+                    appendRange(
+                        from: quote.start,
+                        to: line.start,
+                        to: &lexicalRanges
+                    )
+                }
+                lexicalState = LexicalState()
+            }
+
+            let startsInQuote = lexicalState.quote != nil
+            let startsInFlow =
+                !lexicalState.flowStack.isEmpty
+            let parsed = scanLine(
+                source: source,
+                line: line,
+                lexicalState: &lexicalState,
+                lexicalRanges: &lexicalRanges
+            )
+
+            if startsInQuote || startsInFlow {
+                plainScalarIndentation = nil
+                lines[lineIndex].kind = .continuation
+                continue
+            }
+            if line.rawIsBlank {
+                lines[lineIndex].kind = .blank
+                continue
+            }
+            guard parsed.hasCode else {
+                lines[lineIndex].kind = .comment
+                continue
+            }
+
+            lines[lineIndex].kind = .code
+            lines[lineIndex].isSequenceEntry =
+                parsed.sequenceMarker != nil
+            lines[lineIndex].headers = headerCandidates(
+                source: source,
+                line: lines[lineIndex],
+                lineIndex: lineIndex,
+                parsed: parsed
+            )
+
+            if let blockScalar = parsed.blockScalar {
+                markBlockScalarContent(
+                    BlockScalarContext(
+                        headerIndex: lineIndex,
+                        scalarIndent:
+                            nodeIndentationColumn(
+                                source: source,
+                                line: lines[lineIndex],
+                                mappingColon:
+                                    parsed.mappingColon,
+                                sequenceMarker:
+                                    parsed.sequenceMarker
+                            ),
+                        explicitIndent:
+                            blockScalar.explicitIndent,
+                        lines: lines
+                    ),
+                    marked: &scalarContent
+                )
+            }
+
+            plainScalarIndentation =
+                parsed.hasTrailingPlainScalar
+                    ? nodeIndentationColumn(
+                        source: source,
+                        line: lines[lineIndex],
+                        mappingColon: parsed.mappingColon,
+                        sequenceMarker:
+                            parsed.sequenceMarker
+                    )
+                    : nil
+        }
+
+        if let quote = lexicalState.quote {
+            appendRange(
+                from: quote.start,
+                to: source.length,
+                to: &lexicalRanges
+            )
+        }
+    }
+
+    private static func scanLine(
+        source: NSString,
+        line: Line,
+        lexicalState: inout LexicalState,
+        lexicalRanges: inout [NSRange]
+    ) -> ParsedLine {
+        var cursor = line.indentEnd
+        var commentStart: Int?
+        var mappingColon: Int?
+        var hasCode = false
+        var plainScalarActive = false
+        let startedInsideQuote = lexicalState.quote != nil
+        let startedInsideFlow =
+            !lexicalState.flowStack.isEmpty
+        var nodeMayStart = startedInsideFlow
+            ? lexicalState.nodeMayStart
+            : true
+
+        let sequenceMarker: Int? =
+            !startedInsideQuote
+                && !startedInsideFlow
+                && isBlockIndicator(
+                    YAMLASCII.hyphen,
+                    at: line.indentEnd,
+                    source: source,
+                    lineEnd: line.contentEnd
+                )
+            ? line.indentEnd
+            : nil
+        let explicitKeyMarker: Int? =
+            !startedInsideQuote
+                && !startedInsideFlow
+                && isBlockIndicator(
+                    YAMLASCII.questionMark,
+                    at: line.indentEnd,
+                    source: source,
+                    lineEnd: line.contentEnd
+                )
+            ? line.indentEnd
+            : nil
+
+        while cursor < line.contentEnd {
+            if let activeQuote = lexicalState.quote {
+                let character = source.character(at: cursor)
+                if activeQuote.character == YAMLASCII.doubleQuote,
+                   character == YAMLASCII.backslash {
+                    cursor = min(line.contentEnd, cursor + 2)
+                    continue
+                }
+                if character == activeQuote.character {
+                    if activeQuote.character == YAMLASCII.singleQuote,
+                       cursor + 1 < line.contentEnd,
+                       source.character(at: cursor + 1)
+                        == YAMLASCII.singleQuote {
+                        cursor += 2
+                        continue
+                    }
+                    cursor += 1
+                    appendRange(
+                        from: activeQuote.start,
+                        to: cursor,
+                        to: &lexicalRanges
+                    )
+                    lexicalState.quote = nil
+                    nodeMayStart = false
+                    continue
+                }
+                cursor += 1
+                continue
+            }
+
+            let character = source.character(at: cursor)
+            if character == YAMLASCII.numberSign,
+               startsComment(
+                at: cursor,
+                line: line,
+                source: source
+               ) {
+                commentStart = cursor
+                appendRange(
+                    from: cursor,
+                    to: line.contentEnd,
+                    to: &lexicalRanges
+                )
+                plainScalarActive = false
+                break
+            }
+
+            let isFlowExplicitKey =
+                !lexicalState.flowStack.isEmpty
+                    && nodeMayStart
+                    && character == YAMLASCII.questionMark
+                    && isBlockIndicator(
+                        YAMLASCII.questionMark,
+                        at: cursor,
+                        source: source,
+                        lineEnd: line.contentEnd
+                    )
+            let isCompactSequenceMarker =
+                lexicalState.flowStack.isEmpty
+                    && nodeMayStart
+                    && character == YAMLASCII.hyphen
+                    && isBlockIndicator(
+                        YAMLASCII.hyphen,
+                        at: cursor,
+                        source: source,
+                        lineEnd: line.contentEnd
+                    )
+            if cursor == sequenceMarker
+                || cursor == explicitKeyMarker
+                || isFlowExplicitKey
+                || isCompactSequenceMarker {
+                hasCode = true
+                plainScalarActive = false
+                nodeMayStart = true
+                cursor += 1
+                continue
+            }
+
+            if nodeMayStart,
+               isNodePropertyIndicator(character) {
+                hasCode = true
+                plainScalarActive = false
+                cursor = nodePropertyEnd(
+                    at: cursor,
+                    source: source,
+                    lineEnd: line.contentEnd,
+                    inFlow:
+                        !lexicalState.flowStack.isEmpty
+                )
+                continue
+            }
+
+            if nodeMayStart,
+               isQuoteIndicator(character) {
+                plainScalarActive = false
+                lexicalState.quote = QuoteState(
+                    character: character,
+                    start: cursor
+                )
+                hasCode = true
+                cursor += 1
+                continue
+            }
+
+            if !isHorizontalWhitespace(character) {
+                hasCode = true
+            }
+
+            if isFlowOpener(character),
+               nodeMayStart {
+                plainScalarActive = false
+                if lexicalState.flowStack.count
+                    < maxActiveDepth {
+                    lexicalState.flowStack.append(character)
+                }
+                nodeMayStart = true
+            } else if let opener = matchingFlowOpener(
+                for: character
+            ), !lexicalState.flowStack.isEmpty {
+                if lexicalState.flowStack.last == opener {
+                    lexicalState.flowStack.removeLast()
+                }
+                plainScalarActive = false
+                nodeMayStart = false
+            } else if character == YAMLASCII.comma,
+                      !lexicalState.flowStack.isEmpty {
+                plainScalarActive = false
+                nodeMayStart = true
+            } else if character == YAMLASCII.colon,
+                      lexicalState.flowStack.isEmpty,
+                      mappingColon == nil,
+                      isMappingColon(
+                        at: cursor,
+                        source: source,
+                        lineEnd: line.contentEnd
+                      ) {
+                mappingColon = cursor
+                plainScalarActive = false
+                nodeMayStart = true
+            } else if character == YAMLASCII.colon,
+                      !lexicalState.flowStack.isEmpty {
+                plainScalarActive = false
+                nodeMayStart = true
+            } else if !isHorizontalWhitespace(character) {
+                if nodeMayStart {
+                    plainScalarActive =
+                        canStartPlainScalar(character)
+                }
+                nodeMayStart = false
+            }
+            cursor += 1
+        }
+
+        lexicalState.nodeMayStart =
+            lexicalState.flowStack.isEmpty
+                ? true
+                : nodeMayStart
+        let codeEnd = commentStart ?? line.contentEnd
+        let scalar = blockScalarHeader(
+            source: source,
+            line: line,
+            codeEnd: codeEnd,
+            mappingColon: mappingColon,
+            sequenceMarker: sequenceMarker
+        )
+        return ParsedLine(
+            commentStart: commentStart,
+            mappingColon: mappingColon,
+            sequenceMarker: sequenceMarker,
+            explicitKeyMarker: explicitKeyMarker,
+            blockScalar: scalar,
+            hasCode: hasCode,
+            hasTrailingPlainScalar:
+                plainScalarActive
+                    && scalar == nil
+                    && lexicalState.quote == nil
+                    && lexicalState.flowStack.isEmpty
+        )
+    }
+
+    private static func headerCandidates(
+        source: NSString,
+        line: Line,
+        lineIndex: Int,
+        parsed: ParsedLine
+    ) -> [HeaderCandidate] {
+        let codeEnd = parsed.commentStart ?? line.contentEnd
+        guard !isDirectiveOrDocumentMarker(
+            source: source,
+            line: line,
+            codeEnd: codeEnd
+        ) else {
+            return []
+        }
+
+        var headers: [HeaderCandidate] = []
+        if let sequenceMarker = parsed.sequenceMarker {
+            headers.append(
+                HeaderCandidate(
+                    startLineIndex: lineIndex,
+                    indentationColumn: line.indentationColumn,
+                    markerOffset: sequenceMarker,
+                    allowsIndentlessSequence: false
+                )
+            )
+        } else if let explicitKey = parsed.explicitKeyMarker {
+            headers.append(
+                HeaderCandidate(
+                    startLineIndex: lineIndex,
+                    indentationColumn: line.indentationColumn,
+                    markerOffset: explicitKey,
+                    allowsIndentlessSequence: false
+                )
+            )
+        }
+
+        if let colon = parsed.mappingColon {
+            let valueStart = colon + 1
+            if parsed.blockScalar != nil
+                || tailIsEmptyOrProperties(
+                    source: source,
+                    from: valueStart,
+                    to: codeEnd
+                ) {
+                headers.append(
+                    HeaderCandidate(
+                        startLineIndex: lineIndex,
+                        indentationColumn: mappingIndentationColumn(
+                            source: source,
+                            line: line,
+                            sequenceMarker:
+                                parsed.sequenceMarker
+                        ),
+                        markerOffset: colon,
+                        allowsIndentlessSequence:
+                            parsed.blockScalar == nil
+                    )
+                )
+            }
+        } else if let scalar = parsed.blockScalar,
+                  parsed.sequenceMarker == nil {
+            headers.append(
+                HeaderCandidate(
+                    startLineIndex: lineIndex,
+                    indentationColumn: line.indentationColumn,
+                    markerOffset: scalar.markerOffset,
+                    allowsIndentlessSequence: false
+                )
+            )
+        }
+
+        return headers
+    }
+
+    // MARK: - Block scalar detection
+
+    private static func blockScalarHeader(
+        source: NSString,
+        line: Line,
+        codeEnd: Int,
+        mappingColon: Int?,
+        sequenceMarker: Int?
+    ) -> BlockScalarHeader? {
+        let valueStart: Int
+        if let mappingColon {
+            valueStart = mappingColon + 1
+        } else if let sequenceMarker {
+            valueStart = sequenceMarker + 1
+        } else {
+            valueStart = line.indentEnd
+        }
+        guard valueStart <= codeEnd else { return nil }
+
+        let tokenRanges = horizontalTokenRanges(
+            source: source,
+            from: valueStart,
+            to: codeEnd
+        )
+        guard let indicatorRange = tokenRanges.last,
+              let explicitIndent = scalarIndentIndicator(
+                source: source,
+                range: indicatorRange
+              ) else {
+            return nil
+        }
+
+        for propertyRange in tokenRanges.dropLast() {
+            let first = source.character(
+                at: propertyRange.location
+            )
+            let isProperty =
+                first == YAMLASCII.ampersand
+                    || first == YAMLASCII.exclamationMark
+            let isCompactSequenceMarker =
+                mappingColon == nil
+                    && sequenceMarker != nil
+                    && propertyRange.length == 1
+                    && first == YAMLASCII.hyphen
+            guard isProperty || isCompactSequenceMarker else {
+                return nil
+            }
+        }
+
+        return BlockScalarHeader(
+            markerOffset: indicatorRange.location,
+            explicitIndent: explicitIndent
+        )
+    }
+
+    /// `nil` means "not an indicator"; `.some(nil)` represents an implicit
+    /// indentation indicator (`|`, `>-`, and similar).
+    private static func scalarIndentIndicator(
+        source: NSString,
+        range: NSRange
+    ) -> Int?? {
+        guard range.length >= 1,
+              range.length <= 3 else {
+            return nil
+        }
+        let first = source.character(at: range.location)
+        guard first == YAMLASCII.verticalBar
+                || first == YAMLASCII.greaterThan else {
+            return nil
+        }
+
+        var digit: Int?
+        var sawChomping = false
+        if range.length > 1 {
+            for offset in 1..<range.length {
+                let character = source.character(
+                    at: range.location + offset
+                )
+                if character >= YAMLASCII.one
+                    && character <= YAMLASCII.nine {
+                    guard digit == nil else { return nil }
+                    digit = Int(character - YAMLASCII.zero)
+                } else if character == YAMLASCII.plus
+                            || character == YAMLASCII.hyphen {
+                    guard !sawChomping else { return nil }
+                    sawChomping = true
+                } else {
+                    return nil
+                }
+            }
+        }
+        return .some(digit)
+    }
+
+    private static func markBlockScalarContent(
+        _ context: BlockScalarContext,
+        marked: inout [Bool]
+    ) {
+        let headerIndex = context.headerIndex
+        let lines = context.lines
+        guard headerIndex + 1 < lines.count else { return }
+
+        let contentIndent: Int
+        if let explicit = context.explicitIndent {
+            contentIndent = context.scalarIndent + explicit
+        } else {
+            guard let firstContent = lines[
+                (headerIndex + 1)...
+            ].first(where: { !$0.rawIsBlank }),
+            firstContent.indentationColumn
+                > context.scalarIndent else {
+                return
+            }
+            contentIndent = firstContent.indentationColumn
+        }
+
+        var index = headerIndex + 1
+        while index < lines.count {
+            let line = lines[index]
+            if line.rawIsBlank {
+                marked[index] = true
+            } else if line.indentationColumn >= contentIndent {
+                marked[index] = true
+            } else {
+                break
+            }
+            index += 1
+        }
+    }
+
+    // MARK: - Range resolution
+
+    /// The editor exposes one disclosure control per physical line. Keep the
+    /// outermost useful range for that line so gutter clicks, Fold Code, and
+    /// Fold All all address the same region.
+    static func canonicalizedForDisplay(
+        _ ranges: [FoldableRange]
+    ) -> [FoldableRange] {
+        let sorted = ranges.sorted(by: foldOrder)
+        var canonical: [FoldableRange] = []
+        canonical.reserveCapacity(sorted.count)
+
+        for range in sorted {
+            guard let current = canonical.last,
+                  current.startLine == range.startLine else {
+                canonical.append(range)
+                continue
+            }
+            if isPreferredDisplayRange(
+                range,
+                over: current
+            ) {
+                canonical[canonical.count - 1] = range
+            }
+        }
+        return canonical
+    }
+
+    private static func isPreferredDisplayRange(
+        _ candidate: FoldableRange,
+        over current: FoldableRange
+    ) -> Bool {
+        if candidate.endLine != current.endLine {
+            return candidate.endLine > current.endLine
+        }
+        if candidate.kind != current.kind {
+            return candidate.kind == .indentation
+        }
+        if candidate.startCharIndex != current.startCharIndex {
+            return candidate.startCharIndex
+                < current.startCharIndex
+        }
+        return candidate.endCharIndex > current.endCharIndex
+    }
+
+    private static func resolveRanges(
+        lines: [Line]
+    ) -> [FoldableRange] {
+        var awaitingBody: [HeaderCandidate] = []
+        var active: [ActiveBlock] = []
+        var ranges: [FoldableRange] = []
+
+        for (lineIndex, line) in lines.enumerated() {
+            switch line.kind {
+            case .blank:
+                break
+            case .comment:
+                for index in active.indices
+                where commentBelongs(
+                    line,
+                    to: active[index].header
+                ) {
+                    active[index].lastIncludedLineIndex =
+                        lineIndex
+                }
+            case .continuation:
+                if !line.rawIsBlank {
+                    activate(
+                        awaitingBody,
+                        with: line,
+                        at: lineIndex,
+                        active: &active
+                    )
+                    awaitingBody.removeAll(
+                        keepingCapacity: true
+                    )
+                }
+                for index in active.indices {
+                    active[index].lastIncludedLineIndex =
+                        lineIndex
+                }
+            case .code:
+                var remaining: [ActiveBlock] = []
+                remaining.reserveCapacity(active.count)
+                for var block in active {
+                    if lineBelongs(
+                        line,
+                        to: block.header
+                    ) {
+                        block.lastIncludedLineIndex =
+                            lineIndex
+                        remaining.append(block)
+                    } else {
+                        appendRange(
+                            for: block,
+                            lines: lines,
+                            to: &ranges
+                        )
+                    }
+                }
+                active = remaining
+
+                activate(
+                    awaitingBody,
+                    with: line,
+                    at: lineIndex,
+                    active: &active
+                )
+                awaitingBody.removeAll(keepingCapacity: true)
+            }
+
+            if !line.headers.isEmpty {
+                awaitingBody.append(
+                    contentsOf: line.headers
+                )
+            }
+        }
+
+        for block in active {
+            appendRange(
+                for: block,
+                lines: lines,
+                to: &ranges
+            )
+        }
+        ranges.sort(by: foldOrder)
+        return ranges.enumerated().compactMap { index, range in
+            index == 0 || range != ranges[index - 1]
+                ? range
+                : nil
+        }
+    }
+
+    private static func activate(
+        _ headers: [HeaderCandidate],
+        with line: Line,
+        at lineIndex: Int,
+        active: inout [ActiveBlock]
+    ) {
+        for header in headers
+        where lineBelongs(line, to: header)
+            && active.count < maxActiveDepth {
+            active.append(
+                ActiveBlock(
+                    header: header,
+                    lastIncludedLineIndex: lineIndex
+                )
+            )
+        }
+    }
+
+    private static func lineBelongs(
+        _ line: Line,
+        to header: HeaderCandidate
+    ) -> Bool {
+        if line.indentationColumn > header.indentationColumn {
+            return true
+        }
+        return header.allowsIndentlessSequence
+            && line.indentationColumn == header.indentationColumn
+            && line.isSequenceEntry
+    }
+
+    private static func commentBelongs(
+        _ line: Line,
+        to header: HeaderCandidate
+    ) -> Bool {
+        line.indentationColumn > header.indentationColumn
+    }
+
+    private static func appendRange(
+        for block: ActiveBlock,
+        lines: [Line],
+        to ranges: inout [FoldableRange]
+    ) {
+        let startLine = block.header.startLineIndex + 1
+        let endLine = block.lastIncludedLineIndex + 1
+        guard endLine > startLine else { return }
+
+        ranges.append(
+            FoldableRange(
+                startLine: startLine,
+                endLine: endLine,
+                startCharIndex: block.header.markerOffset,
+                endCharIndex:
+                    lines[block.lastIncludedLineIndex].contentEnd,
+                kind: .indentation
+            )
+        )
+    }
+
+    private static func foldOrder(
+        _ lhs: FoldableRange,
+        _ rhs: FoldableRange
+    ) -> Bool {
+        if lhs.startLine != rhs.startLine {
+            return lhs.startLine < rhs.startLine
+        }
+        if lhs.endLine != rhs.endLine {
+            return lhs.endLine < rhs.endLine
+        }
+        if lhs.startCharIndex != rhs.startCharIndex {
+            return lhs.startCharIndex < rhs.startCharIndex
+        }
+        return lhs.endCharIndex < rhs.endCharIndex
+    }
+
+    // MARK: - Token helpers
+
+    private static func isHardDocumentBoundary(
+        source: NSString,
+        line: Line
+    ) -> Bool {
+        guard line.indentationColumn == 0 else { return false }
+        return hasDocumentMarker(
+            source: source,
+            from: line.indentEnd,
+            to: line.contentEnd
+        )
+    }
+
+    private static func isDirectiveOrDocumentMarker(
+        source: NSString,
+        line: Line,
+        codeEnd: Int
+    ) -> Bool {
+        guard line.indentEnd < codeEnd else { return false }
+        if source.character(at: line.indentEnd)
+            == YAMLASCII.percent {
+            return true
+        }
+        return hasDocumentMarker(
+            source: source,
+            from: line.indentEnd,
+            to: codeEnd
+        )
+    }
+
+    private static func hasDocumentMarker(
+        source: NSString,
+        from start: Int,
+        to end: Int
+    ) -> Bool {
+        guard start + 3 <= end else { return false }
+        let marker = source.substring(
+            with: NSRange(location: start, length: 3)
+        )
+        guard marker == "---" || marker == "..." else {
+            return false
+        }
+        return start + 3 == end
+            || isHorizontalWhitespace(
+                source.character(at: start + 3)
+            )
+            || source.character(at: start + 3)
+                == YAMLASCII.numberSign
+    }
+
+    private static func isBlockIndicator(
+        _ indicator: unichar,
+        at location: Int,
+        source: NSString,
+        lineEnd: Int
+    ) -> Bool {
+        guard location < lineEnd,
+              source.character(at: location) == indicator else {
+            return false
+        }
+        return location + 1 == lineEnd
+            || isHorizontalWhitespace(
+                source.character(at: location + 1)
+            )
+    }
+
+    private static func isMappingColon(
+        at location: Int,
+        source: NSString,
+        lineEnd: Int
+    ) -> Bool {
+        location + 1 == lineEnd
+            || isHorizontalWhitespace(
+                source.character(at: location + 1)
+            )
+            || source.character(at: location + 1)
+                == YAMLASCII.numberSign
+    }
+
+    private static func startsComment(
+        at location: Int,
+        line: Line,
+        source: NSString
+    ) -> Bool {
+        location == line.indentEnd
+            || (location > line.start
+                && isHorizontalWhitespace(
+                    source.character(at: location - 1)
+                ))
+    }
+
+    private static func isCommentOnlyLine(
+        source: NSString,
+        line: Line
+    ) -> Bool {
+        line.indentEnd < line.contentEnd
+            && source.character(at: line.indentEnd)
+                == YAMLASCII.numberSign
+    }
+
+    private static func isNodePropertyIndicator(
+        _ character: unichar
+    ) -> Bool {
+        character == YAMLASCII.ampersand
+            || character == YAMLASCII.exclamationMark
+    }
+
+    private static func isQuoteIndicator(
+        _ character: unichar
+    ) -> Bool {
+        character == YAMLASCII.singleQuote
+            || character == YAMLASCII.doubleQuote
+    }
+
+    private static func canStartPlainScalar(
+        _ character: unichar
+    ) -> Bool {
+        character != YAMLASCII.asterisk
+            && character != YAMLASCII.verticalBar
+            && character != YAMLASCII.greaterThan
+    }
+
+    private static func nodePropertyEnd(
+        at location: Int,
+        source: NSString,
+        lineEnd: Int,
+        inFlow: Bool
+    ) -> Int {
+        var cursor = location + 1
+
+        // A verbatim tag URI may contain characters that otherwise delimit
+        // flow tokens, so consume it through its closing angle bracket.
+        if source.character(at: location)
+                == YAMLASCII.exclamationMark,
+           cursor < lineEnd,
+           source.character(at: cursor)
+                == YAMLASCII.lessThan {
+            cursor += 1
+            while cursor < lineEnd {
+                let character = source.character(at: cursor)
+                cursor += 1
+                if character == YAMLASCII.greaterThan {
+                    break
+                }
+            }
+            return cursor
+        }
+
+        while cursor < lineEnd {
+            let character = source.character(at: cursor)
+            if isHorizontalWhitespace(character)
+                || (inFlow
+                    && isFlowTokenDelimiter(character)) {
+                break
+            }
+            cursor += 1
+        }
+        return cursor
+    }
+
+    private static func isFlowOpener(
+        _ character: unichar
+    ) -> Bool {
+        character == YAMLASCII.openBracket
+            || character == YAMLASCII.openBrace
+    }
+
+    private static func isFlowTokenDelimiter(
+        _ character: unichar
+    ) -> Bool {
+        character == YAMLASCII.comma
+            || character == YAMLASCII.openBracket
+            || character == YAMLASCII.closeBracket
+            || character == YAMLASCII.openBrace
+            || character == YAMLASCII.closeBrace
+    }
+
+    private static func matchingFlowOpener(
+        for character: unichar
+    ) -> unichar? {
+        switch character {
+        case YAMLASCII.closeBracket:
+            YAMLASCII.openBracket
+        case YAMLASCII.closeBrace:
+            YAMLASCII.openBrace
+        default:
+            nil
+        }
+    }
+
+    private static func tailIsEmptyOrProperties(
+        source: NSString,
+        from start: Int,
+        to end: Int
+    ) -> Bool {
+        let tokens = horizontalTokenRanges(
+            source: source,
+            from: start,
+            to: end
+        )
+        return tokens.allSatisfy { range in
+            let first = source.character(at: range.location)
+            return first == YAMLASCII.ampersand
+                || first == YAMLASCII.exclamationMark
+        }
+    }
+
+    private static func horizontalTokenRanges(
+        source: NSString,
+        from start: Int,
+        to end: Int
+    ) -> [NSRange] {
+        var ranges: [NSRange] = []
+        var cursor = start
+        while cursor < end {
+            while cursor < end,
+                  isHorizontalWhitespace(
+                    source.character(at: cursor)
+                  ) {
+                cursor += 1
+            }
+            guard cursor < end else { break }
+            let tokenStart = cursor
+            while cursor < end,
+                  !isHorizontalWhitespace(
+                    source.character(at: cursor)
+                  ) {
+                cursor += 1
+            }
+            ranges.append(
+                NSRange(
+                    location: tokenStart,
+                    length: cursor - tokenStart
+                )
+            )
+        }
+        return ranges
+    }
+
+    private static func nodeIndentationColumn(
+        source: NSString,
+        line: Line,
+        mappingColon: Int?,
+        sequenceMarker: Int?
+    ) -> Int {
+        guard let sequenceMarker else {
+            return line.indentationColumn
+        }
+
+        let columns = sequenceIndentationColumns(
+            source: source,
+            line: line,
+            firstMarker: sequenceMarker
+        )
+        return mappingColon == nil
+            ? columns.innermostMarker
+            : columns.node
+    }
+
+    private static func mappingIndentationColumn(
+        source: NSString,
+        line: Line,
+        sequenceMarker: Int?
+    ) -> Int {
+        guard let sequenceMarker else {
+            return line.indentationColumn
+        }
+        return sequenceIndentationColumns(
+            source: source,
+            line: line,
+            firstMarker: sequenceMarker
+        ).node
+    }
+
+    private static func sequenceIndentationColumns(
+        source: NSString,
+        line: Line,
+        firstMarker: Int
+    ) -> (node: Int, innermostMarker: Int) {
+        var cursor = firstMarker
+        var column = line.indentationColumn
+        var innermostMarker = column
+
+        while cursor < line.contentEnd,
+              isBlockIndicator(
+                YAMLASCII.hyphen,
+                at: cursor,
+                source: source,
+                lineEnd: line.contentEnd
+              ) {
+            innermostMarker = column
+            cursor += 1
+            column += 1
+            while cursor < line.contentEnd {
+                let character = source.character(at: cursor)
+                guard isHorizontalWhitespace(character) else {
+                    break
+                }
+                if character == YAMLASCII.space {
+                    column += 1
+                } else {
+                    column += tabWidth - (column % tabWidth)
+                }
+                cursor += 1
+            }
+        }
+        return (column, innermostMarker)
+    }
+
+    private static func isHorizontalWhitespace(
+        _ character: unichar
+    ) -> Bool {
+        character == YAMLASCII.space
+            || character == YAMLASCII.tab
+    }
+
+    // MARK: - Lexical ranges
+
+    private static func appendWholeLineRange(
+        _ line: Line,
+        to ranges: inout [NSRange]
+    ) {
+        appendRange(
+            from: line.start,
+            to: line.contentEnd,
+            to: &ranges
+        )
+    }
+
+    private static func appendRange(
+        from start: Int,
+        to end: Int,
+        to ranges: inout [NSRange]
+    ) {
+        guard end > start else { return }
+        ranges.append(
+            NSRange(location: start, length: end - start)
+        )
+    }
+
+    private static func normalizedRanges(
+        _ ranges: [NSRange],
+        boundedBy length: Int
+    ) -> [NSRange] {
+        let valid = ranges.compactMap { range -> NSRange? in
+            guard range.location >= 0,
+                  range.length > 0,
+                  range.location < length else {
+                return nil
+            }
+            return NSRange(
+                location: range.location,
+                length: min(
+                    range.length,
+                    length - range.location
+                )
+            )
+        }
+        .sorted {
+            if $0.location != $1.location {
+                return $0.location < $1.location
+            }
+            return $0.length < $1.length
+        }
+
+        var merged: [NSRange] = []
+        for range in valid {
+            guard let last = merged.last else {
+                merged.append(range)
+                continue
+            }
+            if range.location <= NSMaxRange(last) {
+                merged[merged.count - 1] = NSRange(
+                    location: last.location,
+                    length:
+                        max(
+                            NSMaxRange(last),
+                            NSMaxRange(range)
+                        ) - last.location
+                )
+            } else {
+                merged.append(range)
+            }
+        }
+        return merged
+    }
+}
+
+nonisolated private enum YAMLASCII {
+    static let tab: unichar = 0x09
+    static let space: unichar = 0x20
+    static let exclamationMark: unichar = 0x21
+    static let doubleQuote: unichar = 0x22
+    static let numberSign: unichar = 0x23
+    static let percent: unichar = 0x25
+    static let ampersand: unichar = 0x26
+    static let singleQuote: unichar = 0x27
+    static let asterisk: unichar = 0x2A
+    static let plus: unichar = 0x2B
+    static let comma: unichar = 0x2C
+    static let hyphen: unichar = 0x2D
+    static let zero: unichar = 0x30
+    static let one: unichar = 0x31
+    static let nine: unichar = 0x39
+    static let colon: unichar = 0x3A
+    static let lessThan: unichar = 0x3C
+    static let greaterThan: unichar = 0x3E
+    static let questionMark: unichar = 0x3F
+    static let openBracket: unichar = 0x5B
+    static let backslash: unichar = 0x5C
+    static let closeBracket: unichar = 0x5D
+    static let openBrace: unichar = 0x7B
+    static let verticalBar: unichar = 0x7C
+    static let closeBrace: unichar = 0x7D
+}

--- a/Pine/Syntax/YAMLIndentationFoldCalculator.swift
+++ b/Pine/Syntax/YAMLIndentationFoldCalculator.swift
@@ -20,10 +20,14 @@ import Foundation
 nonisolated enum YAMLIndentationFoldCalculator {
     static let tabWidth = 8
     static let maxActiveDepth = 500
+    private static let cancellationCharacterStride = 4_096
+    private static let cancellationLineStride = 64
+
+    typealias CancellationCheck = @Sendable () -> Bool
 
     struct Analysis: Sendable {
         let ranges: [FoldableRange]
-        /// Sorted, merged comments, quoted scalars, and block scalar bodies.
+        /// Sorted, merged comments, quoted scalars, and multiline scalars.
         /// Bracket folding skips these ranges for the same snapshot.
         let lexicalSkipRanges: [NSRange]
     }
@@ -40,6 +44,9 @@ nonisolated enum YAMLIndentationFoldCalculator {
     private struct Line {
         let start: Int
         let contentEnd: Int
+        /// Offset after the complete line terminator (`LF`, `CRLF`, or `CR`).
+        /// The final physical line ends at the source length.
+        let fullEnd: Int
         let indentEnd: Int
         let indentationColumn: Int
         let rawIsBlank: Bool
@@ -101,28 +108,46 @@ nonisolated enum YAMLIndentationFoldCalculator {
     /// used by bracket folding during the same immutable pass.
     static func analyze(
         text: String,
-        additionalSkipRanges: [NSRange] = []
-    ) -> Analysis {
+        additionalSkipRanges: [NSRange] = [],
+        isCancelled: CancellationCheck = { Task.isCancelled }
+    ) -> Analysis? {
+        guard !isCancelled() else { return nil }
         let source = text as NSString
         guard source.length > 0 else {
             return Analysis(ranges: [], lexicalSkipRanges: [])
         }
 
-        var lines = makeLines(in: source)
+        guard var lines = makeLines(
+            in: source,
+            isCancelled: isCancelled
+        ) else {
+            return nil
+        }
         var lexicalRanges: [NSRange] = []
-        parseStructure(
+        guard parseStructure(
             in: source,
             lines: &lines,
-            lexicalRanges: &lexicalRanges
-        )
+            lexicalRanges: &lexicalRanges,
+            isCancelled: isCancelled
+        ) else {
+            return nil
+        }
+        guard !isCancelled() else { return nil }
         let exclusions = normalizedRanges(
             additionalSkipRanges + lexicalRanges,
             boundedBy: source.length
         )
+        guard !isCancelled(),
+              let resolvedRanges = resolveRanges(
+                lines: lines,
+                isCancelled: isCancelled
+              ) else {
+            return nil
+        }
+        let ranges = canonicalizedForDisplay(resolvedRanges)
+        guard !isCancelled() else { return nil }
         return Analysis(
-            ranges: canonicalizedForDisplay(
-                resolveRanges(lines: lines)
-            ),
+            ranges: ranges,
             lexicalSkipRanges: exclusions
         )
     }
@@ -135,17 +160,26 @@ nonisolated enum YAMLIndentationFoldCalculator {
         analyze(
             text: text,
             additionalSkipRanges: skipRanges
-        ).ranges
+        )?.ranges ?? []
     }
 
     // MARK: - Physical lines
 
-    private static func makeLines(in source: NSString) -> [Line] {
+    private static func makeLines(
+        in source: NSString,
+        isCancelled: CancellationCheck
+    ) -> [Line]? {
         var bounds: [(start: Int, end: Int)] = []
         var lineStart = 0
         var index = 0
+        var nextCancellationCheck = cancellationCharacterStride
 
         while index < source.length {
+            if index >= nextCancellationCheck {
+                guard !isCancelled() else { return nil }
+                nextCancellationCheck =
+                    index + cancellationCharacterStride
+            }
             let character = source.character(at: index)
             if character == ASCII.carriageReturn {
                 bounds.append((lineStart, index))
@@ -166,10 +200,24 @@ nonisolated enum YAMLIndentationFoldCalculator {
         }
         bounds.append((lineStart, source.length))
 
-        return bounds.map { bound in
+        var lines: [Line] = []
+        lines.reserveCapacity(bounds.count)
+        for (boundIndex, bound) in bounds.enumerated() {
+            if boundIndex.isMultiple(
+                of: cancellationLineStride
+            ), isCancelled() {
+                return nil
+            }
             var cursor = bound.start
             var column = 0
+            var nextIndentCancellationCheck =
+                cursor + cancellationCharacterStride
             while cursor < bound.end {
+                if cursor >= nextIndentCancellationCheck {
+                    guard !isCancelled() else { return nil }
+                    nextIndentCancellationCheck =
+                        cursor + cancellationCharacterStride
+                }
                 let character = source.character(at: cursor)
                 if character == YAMLASCII.space {
                     column += 1
@@ -185,15 +233,19 @@ nonisolated enum YAMLIndentationFoldCalculator {
             }
 
             let isBlank = cursor == bound.end
-            return Line(
+            lines.append(Line(
                 start: bound.start,
                 contentEnd: bound.end,
+                fullEnd: boundIndex + 1 < bounds.count
+                    ? bounds[boundIndex + 1].start
+                    : source.length,
                 indentEnd: cursor,
                 indentationColumn: column,
                 rawIsBlank: isBlank,
                 kind: isBlank ? .blank : .code
-            )
+            ))
         }
+        return lines
     }
 
     // MARK: - Lexical and structural scan
@@ -201,8 +253,9 @@ nonisolated enum YAMLIndentationFoldCalculator {
     private static func parseStructure(
         in source: NSString,
         lines: inout [Line],
-        lexicalRanges: inout [NSRange]
-    ) {
+        lexicalRanges: inout [NSRange],
+        isCancelled: CancellationCheck
+    ) -> Bool {
         var lexicalState = LexicalState()
         var plainScalarIndentation: Int?
         var scalarContent = Array(
@@ -211,6 +264,11 @@ nonisolated enum YAMLIndentationFoldCalculator {
         )
 
         for lineIndex in lines.indices {
+            if lineIndex.isMultiple(
+                of: cancellationLineStride
+            ), isCancelled() {
+                return false
+            }
             if scalarContent[lineIndex] {
                 lines[lineIndex].kind = .continuation
                 appendWholeLineRange(
@@ -224,6 +282,10 @@ nonisolated enum YAMLIndentationFoldCalculator {
             if plainScalarIndentation != nil,
                line.rawIsBlank {
                 lines[lineIndex].kind = .blank
+                appendWholeLineRange(
+                    lines[lineIndex],
+                    to: &lexicalRanges
+                )
                 continue
             }
             if let scalarIndent = plainScalarIndentation {
@@ -257,12 +319,15 @@ nonisolated enum YAMLIndentationFoldCalculator {
             let startsInQuote = lexicalState.quote != nil
             let startsInFlow =
                 !lexicalState.flowStack.isEmpty
-            let parsed = scanLine(
+            guard let parsed = scanLine(
                 source: source,
                 line: line,
                 lexicalState: &lexicalState,
-                lexicalRanges: &lexicalRanges
-            )
+                lexicalRanges: &lexicalRanges,
+                isCancelled: isCancelled
+            ) else {
+                return false
+            }
 
             if startsInQuote || startsInFlow {
                 plainScalarIndentation = nil
@@ -289,24 +354,27 @@ nonisolated enum YAMLIndentationFoldCalculator {
             )
 
             if let blockScalar = parsed.blockScalar {
-                markBlockScalarContent(
+                guard markBlockScalarContent(
                     BlockScalarContext(
                         headerIndex: lineIndex,
                         scalarIndent:
-                            nodeIndentationColumn(
+                            blockScalarIndentationColumn(
                                 source: source,
                                 line: lines[lineIndex],
                                 mappingColon:
                                     parsed.mappingColon,
-                                sequenceMarker:
-                                    parsed.sequenceMarker
+                                markerOffset:
+                                    blockScalar.markerOffset
                             ),
                         explicitIndent:
                             blockScalar.explicitIndent,
                         lines: lines
                     ),
-                    marked: &scalarContent
-                )
+                    marked: &scalarContent,
+                    isCancelled: isCancelled
+                ) else {
+                    return false
+                }
             }
 
             plainScalarIndentation =
@@ -328,15 +396,19 @@ nonisolated enum YAMLIndentationFoldCalculator {
                 to: &lexicalRanges
             )
         }
+        return !isCancelled()
     }
 
     private static func scanLine(
         source: NSString,
         line: Line,
         lexicalState: inout LexicalState,
-        lexicalRanges: inout [NSRange]
-    ) -> ParsedLine {
+        lexicalRanges: inout [NSRange],
+        isCancelled: CancellationCheck
+    ) -> ParsedLine? {
         var cursor = line.indentEnd
+        var nextCancellationCheck =
+            cursor + cancellationCharacterStride
         var commentStart: Int?
         var mappingColon: Int?
         var hasCode = false
@@ -372,6 +444,11 @@ nonisolated enum YAMLIndentationFoldCalculator {
             : nil
 
         while cursor < line.contentEnd {
+            if cursor >= nextCancellationCheck {
+                guard !isCancelled() else { return nil }
+                nextCancellationCheck =
+                    cursor + cancellationCharacterStride
+            }
             if let activeQuote = lexicalState.quote {
                 let character = source.character(at: cursor)
                 if activeQuote.character == YAMLASCII.doubleQuote,
@@ -657,6 +734,7 @@ nonisolated enum YAMLIndentationFoldCalculator {
             return nil
         }
 
+        var isExplicitKey = false
         for propertyRange in tokenRanges.dropLast() {
             let first = source.character(
                 at: propertyRange.location
@@ -666,12 +744,20 @@ nonisolated enum YAMLIndentationFoldCalculator {
                     || first == YAMLASCII.exclamationMark
             let isCompactSequenceMarker =
                 mappingColon == nil
-                    && sequenceMarker != nil
                     && propertyRange.length == 1
                     && first == YAMLASCII.hyphen
-            guard isProperty || isCompactSequenceMarker else {
+            let isExplicitKeyMarker =
+                mappingColon == nil
+                    && propertyRange.length == 1
+                    && first == YAMLASCII.questionMark
+                    && !isExplicitKey
+            guard isProperty
+                    || isCompactSequenceMarker
+                    || isExplicitKeyMarker else {
                 return nil
             }
+            isExplicitKey = isExplicitKey
+                || isExplicitKeyMarker
         }
 
         return BlockScalarHeader(
@@ -721,28 +807,43 @@ nonisolated enum YAMLIndentationFoldCalculator {
 
     private static func markBlockScalarContent(
         _ context: BlockScalarContext,
-        marked: inout [Bool]
-    ) {
+        marked: inout [Bool],
+        isCancelled: CancellationCheck
+    ) -> Bool {
         let headerIndex = context.headerIndex
         let lines = context.lines
-        guard headerIndex + 1 < lines.count else { return }
+        guard headerIndex + 1 < lines.count else { return true }
 
         let contentIndent: Int
         if let explicit = context.explicitIndent {
             contentIndent = context.scalarIndent + explicit
         } else {
-            guard let firstContent = lines[
-                (headerIndex + 1)...
-            ].first(where: { !$0.rawIsBlank }),
-            firstContent.indentationColumn
-                > context.scalarIndent else {
-                return
+            var firstContentIndex = headerIndex + 1
+            while firstContentIndex < lines.count,
+                  lines[firstContentIndex].rawIsBlank {
+                if firstContentIndex.isMultiple(
+                    of: cancellationLineStride
+                ), isCancelled() {
+                    return false
+                }
+                firstContentIndex += 1
             }
-            contentIndent = firstContent.indentationColumn
+            guard firstContentIndex < lines.count,
+                  lines[firstContentIndex].indentationColumn
+                    > context.scalarIndent else {
+                return true
+            }
+            contentIndent =
+                lines[firstContentIndex].indentationColumn
         }
 
         var index = headerIndex + 1
         while index < lines.count {
+            if index.isMultiple(
+                of: cancellationLineStride
+            ), isCancelled() {
+                return false
+            }
             let line = lines[index]
             if line.rawIsBlank {
                 marked[index] = true
@@ -753,6 +854,7 @@ nonisolated enum YAMLIndentationFoldCalculator {
             }
             index += 1
         }
+        return true
     }
 
     // MARK: - Range resolution
@@ -801,13 +903,19 @@ nonisolated enum YAMLIndentationFoldCalculator {
     }
 
     private static func resolveRanges(
-        lines: [Line]
-    ) -> [FoldableRange] {
+        lines: [Line],
+        isCancelled: CancellationCheck
+    ) -> [FoldableRange]? {
         var awaitingBody: [HeaderCandidate] = []
         var active: [ActiveBlock] = []
         var ranges: [FoldableRange] = []
 
         for (lineIndex, line) in lines.enumerated() {
+            if lineIndex.isMultiple(
+                of: cancellationLineStride
+            ), isCancelled() {
+                return nil
+            }
             switch line.kind {
             case .blank:
                 break
@@ -881,6 +989,7 @@ nonisolated enum YAMLIndentationFoldCalculator {
             )
         }
         ranges.sort(by: foldOrder)
+        guard !isCancelled() else { return nil }
         return ranges.enumerated().compactMap { index, range in
             index == 0 || range != ranges[index - 1]
                 ? range
@@ -1009,8 +1118,6 @@ nonisolated enum YAMLIndentationFoldCalculator {
             || isHorizontalWhitespace(
                 source.character(at: start + 3)
             )
-            || source.character(at: start + 3)
-                == YAMLASCII.numberSign
     }
 
     private static func isBlockIndicator(
@@ -1038,8 +1145,6 @@ nonisolated enum YAMLIndentationFoldCalculator {
             || isHorizontalWhitespace(
                 source.character(at: location + 1)
             )
-            || source.character(at: location + 1)
-                == YAMLASCII.numberSign
     }
 
     private static func startsComment(
@@ -1222,6 +1327,67 @@ nonisolated enum YAMLIndentationFoldCalculator {
             : columns.node
     }
 
+    /// Resolves a block scalar's indentation relative to every compact block
+    /// indicator that precedes it. Unlike ordinary sequence parsing, an
+    /// explicit mapping key may introduce a nested sequence on the same line
+    /// (`- ? - |2`), so the first physical `-` is not sufficient.
+    private static func blockScalarIndentationColumn(
+        source: NSString,
+        line: Line,
+        mappingColon: Int?,
+        markerOffset: Int
+    ) -> Int {
+        let columns = blockPrefixIndentationColumns(
+            source: source,
+            line: line,
+            before: mappingColon ?? markerOffset
+        )
+        return mappingColon == nil
+            ? columns.innermostMarker
+            : columns.node
+    }
+
+    private static func blockPrefixIndentationColumns(
+        source: NSString,
+        line: Line,
+        before end: Int
+    ) -> (node: Int, innermostMarker: Int) {
+        var cursor = line.indentEnd
+        var column = line.indentationColumn
+        var innermostMarker = column
+
+        while cursor < end {
+            let character = source.character(at: cursor)
+            guard character == YAMLASCII.hyphen
+                    || character == YAMLASCII.questionMark,
+                  isBlockIndicator(
+                    character,
+                    at: cursor,
+                    source: source,
+                    lineEnd: end
+                  ) else {
+                break
+            }
+
+            innermostMarker = column
+            cursor += 1
+            column += 1
+            while cursor < end {
+                let whitespace = source.character(at: cursor)
+                guard isHorizontalWhitespace(whitespace) else {
+                    break
+                }
+                if whitespace == YAMLASCII.space {
+                    column += 1
+                } else {
+                    column += tabWidth - (column % tabWidth)
+                }
+                cursor += 1
+            }
+        }
+        return (column, innermostMarker)
+    }
+
     private static func mappingIndentationColumn(
         source: NSString,
         line: Line,
@@ -1287,7 +1453,7 @@ nonisolated enum YAMLIndentationFoldCalculator {
     ) {
         appendRange(
             from: line.start,
-            to: line.contentEnd,
+            to: line.fullEnd,
             to: &ranges
         )
     }
@@ -1298,8 +1464,18 @@ nonisolated enum YAMLIndentationFoldCalculator {
         to ranges: inout [NSRange]
     ) {
         guard end > start else { return }
-        ranges.append(
-            NSRange(location: start, length: end - start)
+        guard let last = ranges.last,
+              start <= NSMaxRange(last) else {
+            ranges.append(
+                NSRange(location: start, length: end - start)
+            )
+            return
+        }
+        let mergedStart = min(last.location, start)
+        let mergedEnd = max(NSMaxRange(last), end)
+        ranges[ranges.count - 1] = NSRange(
+            location: mergedStart,
+            length: mergedEnd - mergedStart
         )
     }
 

--- a/PineTests/FoldStateTests.swift
+++ b/PineTests/FoldStateTests.swift
@@ -156,6 +156,25 @@ struct FoldStateTests {
         #expect(state.hiddenLineCount(for: makeFoldable(start: 1, end: 5)) == 3)
     }
 
+    @Test func indentationFoldIncludesItsFinalContentLine() {
+        var state = FoldState()
+        let range = FoldableRange(
+            startLine: 1,
+            endLine: 3,
+            startCharIndex: 4,
+            endCharIndex: 24,
+            kind: .indentation
+        )
+
+        state.fold(range)
+
+        #expect(!state.isLineHidden(1))
+        #expect(state.isLineHidden(2))
+        #expect(state.isLineHidden(3))
+        #expect(!state.isLineHidden(4))
+        #expect(state.hiddenLineCount(for: range) == 2)
+    }
+
     // MARK: - Adjacent folds
 
     @Test func twoAdjacentFoldsHideCorrectLines() {

--- a/PineTests/TabEditorStateTests.swift
+++ b/PineTests/TabEditorStateTests.swift
@@ -81,15 +81,22 @@ struct TabEditorStateTests {
             startCharIndex: 300, endCharIndex: 400,
             kind: .brackets
         ))
+        foldState.fold(FoldableRange(
+            startLine: 30, endLine: 32,
+            startCharIndex: 500, endCharIndex: 550,
+            kind: .indentation
+        ))
 
         let serializable = PerTabEditorState.serializableFoldRanges(from: foldState)
 
-        #expect(serializable.count == 2)
+        #expect(serializable.count == 3)
         #expect(serializable[0].startLine == 5)
         #expect(serializable[0].endLine == 15)
         #expect(serializable[0].kind == "braces")
         #expect(serializable[1].startLine == 20)
         #expect(serializable[1].kind == "brackets")
+        #expect(serializable[2].startLine == 30)
+        #expect(serializable[2].kind == "indentation")
     }
 
     @Test("Serializable fold ranges restore to FoldState")
@@ -104,21 +111,30 @@ struct TabEditorStateTests {
                 startLine: 20, endLine: 25,
                 startCharIndex: 300, endCharIndex: 400,
                 kind: "parentheses"
+            ),
+            PerTabEditorState.SerializableFoldRange(
+                startLine: 30, endLine: 32,
+                startCharIndex: 500, endCharIndex: 550,
+                kind: "indentation"
             )
         ]
 
         let foldState = PerTabEditorState.restoreFoldState(from: ranges)
 
-        #expect(foldState.foldedRanges.count == 2)
+        #expect(foldState.foldedRanges.count == 3)
         #expect(foldState.foldedRanges[0].startLine == 5)
         #expect(foldState.foldedRanges[0].endLine == 15)
         #expect(foldState.foldedRanges[0].kind == .braces)
         #expect(foldState.foldedRanges[1].startLine == 20)
         #expect(foldState.foldedRanges[1].kind == .parentheses)
+        #expect(foldState.foldedRanges[2].startLine == 30)
+        #expect(foldState.foldedRanges[2].kind == .indentation)
         #expect(foldState.isLineHidden(6))
         #expect(foldState.isLineHidden(14))
         #expect(!foldState.isLineHidden(5))
         #expect(!foldState.isLineHidden(15))
+        #expect(foldState.isLineHidden(32))
+        #expect(!foldState.isLineHidden(33))
     }
 
     @Test("Empty fold state produces empty serializable ranges")

--- a/PineTests/YAMLIndentationFoldTests.swift
+++ b/PineTests/YAMLIndentationFoldTests.swift
@@ -1,0 +1,612 @@
+//
+//  YAMLIndentationFoldTests.swift
+//  PineTests
+//
+//  Regression coverage for indentation-based YAML folding (#1225).
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("YAML indentation folding")
+struct YAMLIndentationFoldTests {
+    @Test("GitHub Actions jobs, steps, and script bodies are foldable")
+    func githubActionsWorkflow() async throws {
+        let text = """
+        name: CI
+        jobs:
+          build:
+            runs-on: macos-26
+            steps:
+              - uses: actions/checkout@v4
+              - name: Test
+                run: |
+                  swift test
+                  echo done
+          lint:
+            runs-on: macos-26
+        """
+        let ranges = try #require(
+            await localRanges(text: text, language: "yaml")
+        )
+
+        #expect(indentationSpans(ranges) == [
+            "2...12",
+            "3...10",
+            "5...10",
+            "7...10",
+            "8...10",
+            "11...12"
+        ])
+    }
+
+    @Test("A one-line body is hidden completely by indentation folds")
+    func oneLineBodyUsesInclusiveEnd() throws {
+        let range = try #require(
+            YAMLIndentationFoldCalculator.calculate(
+                text: "job:\n  runs-on: macos-26"
+            ).first
+        )
+        #expect(range.startLine == 1)
+        #expect(range.endLine == 2)
+        #expect(range.kind == .indentation)
+
+        var state = FoldState()
+        state.fold(range)
+        #expect(!state.isLineHidden(1))
+        #expect(state.isLineHidden(2))
+        #expect(state.hiddenLineCount(for: range) == 1)
+    }
+
+    @Test("Sequence items and nested mappings get independent ranges")
+    func sequenceItemsAndNestedMappings() {
+        let text = """
+        items:
+          - name: one
+            value: 1
+          - name: two
+            nested:
+              enabled: true
+          - scalar
+        """
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: text
+        )
+
+        #expect(indentationSpans(ranges) == [
+            "1...7",
+            "2...3",
+            "4...6",
+            "5...6"
+        ])
+    }
+
+    @Test("Indentationless block sequences belong to their mapping value")
+    func indentationlessSequence() {
+        let text = """
+        items:
+        - one
+        - two
+        next: value
+        """
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: text
+        )
+
+        #expect(indentationSpans(ranges) == ["1...3"])
+    }
+
+    @Test("Blank and comment lines do not end a block prematurely")
+    func blanksAndComments() {
+        let text = """
+        root:
+          # leading comment
+          child: value
+
+          # trailing child comment
+        sibling:
+          value: x
+        """
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: text
+        )
+
+        #expect(indentationSpans(ranges) == [
+            "1...5",
+            "6...7"
+        ])
+    }
+
+    @Test("A comment-only pseudo-body does not manufacture a fold")
+    func commentOnlyBody() {
+        let text = """
+        empty:
+          # no YAML node here
+        sibling: value
+        """
+
+        #expect(
+            YAMLIndentationFoldCalculator.calculate(text: text)
+                .isEmpty
+        )
+    }
+
+    @Test("A dedented trailing comment is not hidden with the prior block")
+    func dedentedTrailingComment() {
+        let text = """
+        root:
+          child: value
+        # describes the next key
+        next: value
+        """
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: text
+        )
+
+        #expect(indentationSpans(ranges) == ["1...2"])
+    }
+
+    @Test("Quoted keys fold while URL colons and scalar items do not")
+    func quotedKeysAndScalarIndicators() {
+        let text = """
+        "quoted:key":
+          child: true
+        url: https://example.com:8443/path
+        values:
+          - -42
+          - plain
+        """
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: text
+        )
+
+        #expect(indentationSpans(ranges) == [
+            "1...2",
+            "4...6"
+        ])
+    }
+
+    @Test("Quotes and collection indicators inside plain scalars stay plain")
+    func indicatorsInsidePlainScalars() async throws {
+        let text = """
+        title: a "quote and 'single with [bracket and {brace
+        balanced: use [literal] and {literal}
+        next:
+          child: true
+        """
+        let ranges = try #require(
+            await localRanges(text: text, language: "yaml")
+        )
+
+        #expect(indentationSpans(ranges) == ["3...4"])
+        #expect(bracketSpans(ranges).isEmpty)
+    }
+
+    @Test("Multiline plain scalar continuation stays lexically opaque")
+    func multilinePlainScalar() async throws {
+        let text = """
+        title: plain
+          "unfinished and [bracket with {brace
+        next:
+          child: true
+        """
+        let ranges = try #require(
+            await localRanges(text: text, language: "yaml")
+        )
+
+        #expect(indentationSpans(ranges) == ["3...4"])
+        #expect(bracketSpans(ranges).isEmpty)
+    }
+
+    @Test("A compact mapping sibling is not plain-scalar continuation")
+    func compactMappingSiblingAfterPlainValue() {
+        let text = """
+        - key: value
+          other:
+            nested: true
+        """
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: text
+        )
+
+        #expect(indentationSpans(ranges) == [
+            "1...3",
+            "2...3"
+        ])
+    }
+
+    @Test("Anchors and tags may precede nested nodes, aliases stay scalar")
+    func propertiesAndAliases() {
+        let text = """
+        defaults: &defaults
+          retries: 2
+        tagged: !!map
+          enabled: true
+        copy: *defaults
+        """
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: text
+        )
+
+        #expect(indentationSpans(ranges) == [
+            "1...2",
+            "3...4"
+        ])
+    }
+
+    @Test("Block scalar payload is opaque to YAML and bracket folding")
+    func blockScalarPayloadIsOpaque() async throws {
+        let text = """
+        script: |-
+          echo "{"
+            jobs:
+          echo "}"
+        next: true
+        """
+        let ranges = try #require(
+            await localRanges(text: text, language: "yaml")
+        )
+
+        #expect(indentationSpans(ranges) == ["1...4"])
+        #expect(!ranges.contains { range in
+            range.kind == .braces
+                || range.kind == .brackets
+                || range.kind == .parentheses
+        })
+    }
+
+    @Test("Folded scalar modifiers work in either valid order")
+    func blockScalarModifiers() {
+        let fixtures = [
+            "value: >2-\n  first\n  second\nnext: true",
+            "value: |-2\n  first\n  second\nnext: true",
+            "value: |+\n  first\n  second\nnext: true"
+        ]
+
+        for text in fixtures {
+            #expect(
+                indentationSpans(
+                    YAMLIndentationFoldCalculator.calculate(
+                        text: text
+                    )
+                ) == ["1...3"]
+            )
+        }
+    }
+
+    @Test("Direct sequence block scalars use the sequence indentation level")
+    func directSequenceBlockScalars() async throws {
+        let text = """
+        - |
+          echo "{"
+          fake:
+            child: true
+        - >1-
+         folded [
+        - done
+        """
+        let ranges = try #require(
+            await localRanges(text: text, language: "yaml")
+        )
+
+        #expect(indentationSpans(ranges) == [
+            "1...4",
+            "5...6"
+        ])
+        #expect(bracketSpans(ranges).isEmpty)
+    }
+
+    @Test("Compact nested sequence scalars remain opaque")
+    func compactNestedSequenceScalar() async throws {
+        let text = """
+        - - |2
+            echo "["
+            fake:
+              child: true
+        - done
+        next:
+          child: true
+        """
+        let ranges = try #require(
+            await localRanges(text: text, language: "yaml")
+        )
+
+        #expect(indentationSpans(ranges) == [
+            "1...4",
+            "6...7"
+        ])
+        #expect(bracketSpans(ranges).isEmpty)
+    }
+
+    @Test("A scalar inside a compact sequence item ends before its sibling property")
+    func scalarInsideSequenceItem() {
+        let text = """
+        - run: |
+            echo hello
+          shell: bash
+        - run: echo done
+        """
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: text
+        )
+
+        #expect(indentationSpans(ranges) == ["1...3"])
+    }
+
+    @Test("Provider exposes one canonical fold control per start line")
+    func canonicalRangePerStartLine() async throws {
+        let text = """
+        - [
+            one,
+            two
+          ]
+        """
+        let ranges = try #require(
+            await localRanges(text: text, language: "yaml")
+        )
+        let firstLine = ranges.filter { $0.startLine == 1 }
+        let range = try #require(firstLine.first)
+
+        #expect(firstLine.count == 1)
+        #expect(range.endLine == 4)
+        #expect(range.kind == .indentation)
+    }
+
+    @Test("Multiline flow collections stay owned by bracket folding")
+    func multilineFlowCollections() async throws {
+        let text = """
+        matrix: {
+          os: [
+            macos,
+            linux
+          ]
+        }
+        """
+        let ranges = try #require(
+            await localRanges(text: text, language: "yaml")
+        )
+
+        #expect(indentationSpans(ranges).isEmpty)
+        #expect(bracketSpans(ranges) == [
+            "1...6:braces",
+            "2...5:brackets"
+        ])
+    }
+
+    @Test("Explicit flow keys keep quoted indicators opaque")
+    func explicitFlowKey() async throws {
+        let text = """
+        map: {
+          ? "a, [key" : value
+        }
+        next:
+          child: true
+        """
+        let ranges = try #require(
+            await localRanges(text: text, language: "yaml")
+        )
+
+        #expect(indentationSpans(ranges) == ["4...5"])
+        #expect(bracketSpans(ranges) == ["1...3:braces"])
+    }
+
+    @Test("Multiline quoted scalars cannot manufacture YAML structure")
+    func multilineQuotedScalars() {
+        let text = #"""
+        message: "fake
+          jobs:
+            build:
+        "
+        single: 'also
+          steps:
+        '
+        real:
+          child: true
+        """#
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: text
+        )
+
+        #expect(indentationSpans(ranges) == ["8...9"])
+    }
+
+    @Test("A document marker recovers from an unterminated quote")
+    func documentMarkerRecoversLexicalState() {
+        let text = #"""
+        broken: "unterminated
+          fake:
+        ---
+        real:
+          child: yes
+        """#
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: text
+        )
+
+        #expect(indentationSpans(ranges) == ["4...5"])
+    }
+
+    @Test("Directives and document boundaries never leak fold ranges")
+    func multipleDocuments() {
+        let text = """
+        %YAML 1.2
+        ---
+        one:
+          child: true
+        ...
+        ---
+        two:
+          child: true
+        """
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: text
+        )
+
+        #expect(indentationSpans(ranges) == [
+            "3...4",
+            "7...8"
+        ])
+    }
+
+    @Test("CRLF, Unicode keys, and UTF-16 offsets remain exact")
+    func crlfUnicodeOffsets() throws {
+        let text = "корень:\r\n  子: value\r\nnext: yes"
+        let source = text as NSString
+        let range = try #require(
+            YAMLIndentationFoldCalculator.calculate(
+                text: text
+            ).first
+        )
+
+        #expect(range.startLine == 1)
+        #expect(range.endLine == 2)
+        #expect(
+            source.character(at: range.startCharIndex)
+                == 0x3A
+        )
+        #expect(range.endCharIndex == source.range(of: "\r\nnext").location)
+        #expect(
+            source.character(at: range.endCharIndex - 1)
+                != ASCII.carriageReturn
+        )
+    }
+
+    @Test("Malformed indentation is bounded and cannot cross a document marker")
+    func malformedIndentationIsBounded() {
+        let text = """
+        root:
+        \tchild:
+        \t\tvalue: true
+        ---
+        next:
+          value: true
+        """
+        let sourceLength = (text as NSString).length
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: text
+        )
+
+        #expect(ranges.allSatisfy { range in
+            range.startLine >= 1
+                && range.endLine <= 6
+                && range.startCharIndex >= 0
+                && range.endCharIndex <= sourceLength
+        })
+        #expect(ranges.contains { range in
+            range.startLine == 5 && range.endLine == 6
+        })
+        #expect(!ranges.contains { range in
+            range.startLine < 4 && range.endLine > 3
+        })
+    }
+
+    @Test("Active depth is capped for pathological nesting")
+    func activeDepthIsCapped() {
+        let depth = YAMLIndentationFoldCalculator.maxActiveDepth + 25
+        let lines = (0..<depth).map { index in
+            String(repeating: " ", count: index)
+                + "key\(index):"
+        } + [
+            String(repeating: " ", count: depth)
+                + "value: true"
+        ]
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: lines.joined(separator: "\n")
+        )
+
+        #expect(
+            ranges.count
+                <= YAMLIndentationFoldCalculator.maxActiveDepth
+        )
+    }
+
+    @Test("Provider recognizes yaml, yml, and URI suffix fallback")
+    func providerDetection() async throws {
+        let text = "job:\n  child: true"
+        let fixtures = [
+            (language: "yaml", uri: "file:///test.txt"),
+            (language: "yml", uri: "file:///test.txt"),
+            (language: "plain", uri: "file:///test.yaml"),
+            (language: "plain", uri: "file:///test.yml")
+        ]
+
+        for fixture in fixtures {
+            let ranges = try #require(
+                await localRanges(
+                    text: text,
+                    language: fixture.language,
+                    uri: fixture.uri
+                )
+            )
+            #expect(indentationSpans(ranges) == ["1...2"])
+        }
+    }
+
+    @Test("Non-YAML fallback remains bracket-identical")
+    func nonYAMLFallbackUnchanged() async throws {
+        let text = "value {\n  child\n}"
+        let expected = FoldRangeCalculator.calculate(text: text)
+        let actual = try #require(
+            await localRanges(text: text, language: "plain")
+        )
+
+        #expect(actual == expected)
+    }
+
+    @Test("Empty and single-line YAML have no fold ranges")
+    func trivialInputs() {
+        #expect(
+            YAMLIndentationFoldCalculator.calculate(text: "")
+                .isEmpty
+        )
+        #expect(
+            YAMLIndentationFoldCalculator.calculate(
+                text: "key: value"
+            ).isEmpty
+        )
+    }
+
+    private func localRanges(
+        text: String,
+        language: String,
+        uri: String = "file:///fixture.yaml"
+    ) async -> [FoldableRange]? {
+        await LocalFoldProvider(language: language).foldRanges(
+            for: DocumentSnapshot(
+                uri: uri,
+                text: text,
+                revision: DocumentRevision(1)
+            )
+        )
+    }
+
+    private func indentationSpans(
+        _ ranges: [FoldableRange]
+    ) -> [String] {
+        ranges.compactMap { range in
+            guard range.kind == .indentation else { return nil }
+            return "\(range.startLine)...\(range.endLine)"
+        }
+    }
+
+    private func bracketSpans(
+        _ ranges: [FoldableRange]
+    ) -> [String] {
+        ranges.compactMap { range in
+            let kind: String
+            switch range.kind {
+            case .braces:
+                kind = "braces"
+            case .brackets:
+                kind = "brackets"
+            case .parentheses:
+                kind = "parentheses"
+            case .indentation:
+                return nil
+            }
+            return "\(range.startLine)...\(range.endLine):\(kind)"
+        }
+    }
+}

--- a/PineTests/YAMLIndentationFoldTests.swift
+++ b/PineTests/YAMLIndentationFoldTests.swift
@@ -257,6 +257,119 @@ struct YAMLIndentationFoldTests {
         })
     }
 
+    @Test("Explicit block scalar keys stay opaque")
+    func explicitBlockScalarKeyIsOpaque() async throws {
+        let text = """
+        ? |
+          fake:
+            child: true
+          [
+          ]
+        : value
+        real:
+          child: true
+        """
+        let ranges = try #require(
+            await localRanges(text: text, language: "yaml")
+        )
+
+        #expect(indentationSpans(ranges) == [
+            "1...5",
+            "7...8"
+        ])
+        #expect(bracketSpans(ranges).isEmpty)
+    }
+
+    @Test("Compact explicit scalar keys use mapping indentation")
+    func compactExplicitBlockScalarKey() async throws {
+        let text = """
+        - ? |2
+            fake:
+              child: true
+            [
+            ]
+          : value
+        - done
+        """
+        let ranges = try #require(
+            await localRanges(text: text, language: "yaml")
+        )
+
+        #expect(indentationSpans(ranges) == ["1...6"])
+        #expect(bracketSpans(ranges).isEmpty)
+    }
+
+    @Test("Explicit scalar keys may contain compact block sequences")
+    func explicitScalarKeyWithSequence() async throws {
+        let text = """
+        ? - |
+            fake:
+              child: true
+            [
+            ]
+        : value
+        real:
+          child: true
+        """
+        let ranges = try #require(
+            await localRanges(text: text, language: "yaml")
+        )
+
+        #expect(indentationSpans(ranges) == [
+            "1...5",
+            "7...8"
+        ])
+        #expect(bracketSpans(ranges).isEmpty)
+    }
+
+    @Test("Nested explicit-key scalar indentation stops at its sibling")
+    func compactExplicitScalarSequenceSibling() async throws {
+        let text = """
+        - ? - |2
+              fake:
+                child: true
+              [
+              ]
+            - next:
+                child: true
+          : value
+        - done
+        """
+        let ranges = try #require(
+            await localRanges(text: text, language: "yaml")
+        )
+
+        #expect(indentationSpans(ranges) == [
+            "1...8",
+            "6...7"
+        ])
+        #expect(bracketSpans(ranges).isEmpty)
+    }
+
+    @Test("A mapping inside an explicit key owns its scalar indentation")
+    func compactExplicitMappingScalarSibling() async throws {
+        let text = """
+        - ? key: |2
+              fake:
+                child: true
+              [
+              ]
+            sibling:
+              child: true
+          : value
+        - done
+        """
+        let ranges = try #require(
+            await localRanges(text: text, language: "yaml")
+        )
+
+        #expect(indentationSpans(ranges) == [
+            "1...8",
+            "6...7"
+        ])
+        #expect(bracketSpans(ranges).isEmpty)
+    }
+
     @Test("Folded scalar modifiers work in either valid order")
     func blockScalarModifiers() {
         let fixtures = [
@@ -428,6 +541,25 @@ struct YAMLIndentationFoldTests {
         #expect(indentationSpans(ranges) == ["4...5"])
     }
 
+    @Test("Document marker text without separation stays scalar content")
+    func documentMarkerRequiresSeparation() {
+        let text = #"""
+        value: "first
+        ---#not-a-boundary
+        fake:
+          child: true
+        ...#also-not-a-boundary
+        last"
+        real:
+          child: true
+        """#
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: text
+        )
+
+        #expect(indentationSpans(ranges) == ["7...8"])
+    }
+
     @Test("Directives and document boundaries never leak fold ranges")
     func multipleDocuments() {
         let text = """
@@ -471,6 +603,21 @@ struct YAMLIndentationFoldTests {
             source.character(at: range.endCharIndex - 1)
                 != ASCII.carriageReturn
         )
+    }
+
+    @Test("A colon before an attached hash stays plain scalar content")
+    func mappingColonRequiresSeparation() {
+        let text = """
+        - key:#text
+         - fake
+           next
+        - done
+        """
+        let ranges = YAMLIndentationFoldCalculator.calculate(
+            text: text
+        )
+
+        #expect(indentationSpans(ranges) == ["1...3"])
     }
 
     @Test("Malformed indentation is bounded and cannot cross a document marker")
@@ -520,6 +667,65 @@ struct YAMLIndentationFoldTests {
             ranges.count
                 <= YAMLIndentationFoldCalculator.maxActiveDepth
         )
+    }
+
+    @Test("Large scalar payloads use one contiguous lexical exclusion")
+    func largeScalarPayloadsAreCoalesced() throws {
+        let payloadLineCount = 2_048
+        let neverCancelled:
+            YAMLIndentationFoldCalculator.CancellationCheck = { false }
+        let fixtures = [
+            largeBlockScalarFixture(lineCount: payloadLineCount),
+            largePlainScalarFixture(lineCount: payloadLineCount)
+        ]
+
+        for fixture in fixtures {
+            let source = fixture.text as NSString
+            let result = YAMLIndentationFoldCalculator.analyze(
+                text: fixture.text,
+                isCancelled: neverCancelled
+            )
+            let analysis = try #require(result)
+            let payloadStart = try #require(
+                source.range(of: fixture.firstPayloadLine)
+                    .nonEmptyLocation
+            )
+            let siblingStart = try #require(
+                source.range(of: "next: true").nonEmptyLocation
+            )
+
+            #expect(analysis.lexicalSkipRanges == [
+                NSRange(
+                    location: payloadStart,
+                    length: siblingStart - payloadStart
+                )
+            ])
+            #expect(
+                indentationSpans(analysis.ranges)
+                    == fixture.expectedIndentationSpans
+            )
+            #expect(
+                FoldRangeCalculator.calculate(
+                    text: fixture.text,
+                    skipRanges: analysis.lexicalSkipRanges
+                ).isEmpty
+            )
+        }
+    }
+
+    @Test("YAML analysis stops at cooperative cancellation checkpoints")
+    func analysisHonorsCancellation() {
+        let probe = YAMLCancellationProbe(cancelOnCheck: 2)
+        let text = "root:\n"
+            + String(repeating: "  key: value\n", count: 512)
+
+        let analysis = YAMLIndentationFoldCalculator.analyze(
+            text: text,
+            isCancelled: { probe.check() }
+        )
+
+        #expect(analysis == nil)
+        #expect(probe.checkCount == 2)
     }
 
     @Test("Provider recognizes yaml, yml, and URI suffix fallback")
@@ -608,5 +814,82 @@ struct YAMLIndentationFoldTests {
             }
             return "\(range.startLine)...\(range.endLine):\(kind)"
         }
+    }
+
+    private func largeBlockScalarFixture(
+        lineCount: Int
+    ) -> ScalarFixture {
+        let firstPayloadLine = "  open {"
+        let payload = (0..<lineCount).map { index in
+            if index == 0 {
+                return firstPayloadLine
+            }
+            if index == lineCount - 1 {
+                return "  close }"
+            }
+            return "  line \(index)"
+        }.joined(separator: "\r\n")
+        return ScalarFixture(
+            text: "script: |\r\n\(payload)\r\nnext: true",
+            firstPayloadLine: firstPayloadLine,
+            expectedIndentationSpans: ["1...\(lineCount + 1)"]
+        )
+    }
+
+    private func largePlainScalarFixture(
+        lineCount: Int
+    ) -> ScalarFixture {
+        let firstPayloadLine = "  open {"
+        let payload = (0..<lineCount).map { index in
+            if index == 0 {
+                return firstPayloadLine
+            }
+            if index == lineCount - 1 {
+                return "  close }"
+            }
+            return "  line \(index)"
+        }.joined(separator: "\r\n")
+        return ScalarFixture(
+            text:
+                "description: start\r\n"
+                    + "\(payload)\r\nnext: true",
+            firstPayloadLine: firstPayloadLine,
+            expectedIndentationSpans: []
+        )
+    }
+}
+
+nonisolated private struct ScalarFixture {
+    let text: String
+    let firstPayloadLine: String
+    let expectedIndentationSpans: [String]
+}
+
+nonisolated private final class YAMLCancellationProbe:
+    @unchecked Sendable {
+
+    private let lock = NSLock()
+    private let cancelOnCheck: Int
+    private var storedCheckCount = 0
+
+    init(cancelOnCheck: Int) {
+        self.cancelOnCheck = cancelOnCheck
+    }
+
+    var checkCount: Int {
+        lock.withLock { storedCheckCount }
+    }
+
+    func check() -> Bool {
+        lock.withLock {
+            storedCheckCount += 1
+            return storedCheckCount >= cancelOnCheck
+        }
+    }
+}
+
+nonisolated private extension NSRange {
+    var nonEmptyLocation: Int? {
+        location == NSNotFound ? nil : location
     }
 }


### PR DESCRIPTION
## Summary

- add local indentation-based folding for YAML and YML mappings, sequences, and GitHub Actions workflows
- add inclusive indentation fold semantics so a one-line YAML body collapses completely without hiding the next sibling
- keep block scalars, multiline plain/quoted scalars, comments, and flow syntax lexically safe while preserving bracket folding for flow collections
- canonicalize same-start YAML ranges so gutter clicks, Fold Code, Fold All, and persisted state agree
- handle document boundaries, indentationless sequences, compact nested sequences, CRLF/UTF-16 offsets, and malformed input with bounded depth

## Testing

- 29 YAML folding regression tests passed
- 149 related folding, provider, state, and persistence tests passed
- full PineTests: 5,524 passed, 1 opt-in test skipped, 0 failed
- changed Swift files pass SwiftLint with 0 violations
- git diff --check passed

Closes #1225