### PR TITLE
fix: restore native sidebar keyboard focus

### DIFF
--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -113,7 +113,8 @@ extension ContentView {
     ) {
         paneManager.openFileInActiveEditor(
             url: node.url,
-            asTransientPreview: disposition == .transientPreview
+            asTransientPreview: disposition == .transientPreview,
+            requestFocus: disposition.requestsEditorFocus
         )
     }
 

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -5,6 +5,7 @@
 //  A single leaf pane showing the editor area with its own tab bar.
 //
 
+import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -420,6 +421,11 @@ struct PaneLeafView: View {
             canBecomeInitialFirstResponder: {
                 paneManager.activePaneID == paneID
                     && tabManager.activeTabID == tab.id
+                    && SidebarKeyboardFocusPolicy.allowsEditorInitialFocus(
+                        tabID: tab.id,
+                        pendingFocusTabID: tabManager.pendingFocusTabID,
+                        firstResponder: NSApp.keyWindow?.firstResponder
+                    )
             },
             indentStyle: tab.cachedIndentation,
             fontSize: FontSizeSettings.shared.fontSize

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -1220,6 +1220,27 @@ final class PaneManager {
         globalTabSwitchOrder = result
     }
 
+    /// Invalidates a destination-focus request that predates a source control
+    /// such as the sidebar taking first responder.
+    ///
+    /// Only the active pane can currently pass the AppKit coordinators'
+    /// `canAttempt` guards. Keeping the cancellation scoped to that pane avoids
+    /// discarding unrelated restore or drag requests in background panes.
+    func cancelPendingFocusForActivePane() {
+        switch root.content(for: activePaneID) {
+        case .editor:
+            guard let manager = tabManagers[activePaneID],
+                  manager.pendingFocusTabID != nil else { return }
+            manager.pendingFocusTabID = nil
+        case .terminal:
+            guard let state = terminalStates[activePaneID],
+                  state.pendingFocusTabID != nil else { return }
+            state.pendingFocusTabID = nil
+        case nil:
+            break
+        }
+    }
+
     /// Requests usable content focus for the restored active pane. The normal
     /// bounded AppKit retry coordinator consumes this request once the
     /// destination view has entered a window.

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -403,18 +403,26 @@ final class PaneManager {
         Array(tabManagers.values)
     }
 
-    /// Selects an editor tab and makes its owning pane the active focus
-    /// destination. Tab-strip controls use this instead of changing only the
-    /// local selection, which could leave focus routed to another pane.
+    /// Selects an editor tab and makes its owning pane active.
+    ///
+    /// Tab-strip controls use the default focus request so the destination
+    /// editor becomes first responder. Callers such as sidebar previews can
+    /// opt out to keep keyboard interaction at the source.
     @discardableResult
-    func selectEditorTab(_ tabID: UUID, in paneID: PaneID) -> Bool {
+    func selectEditorTab(
+        _ tabID: UUID,
+        in paneID: PaneID,
+        requestFocus: Bool = true
+    ) -> Bool {
         guard let tabManager = tabManagers[paneID],
               tabManager.tabs.contains(where: { $0.id == tabID }) else {
             return false
         }
         activePaneID = paneID
         tabManager.activeTabID = tabID
-        tabManager.pendingFocusTabID = tabID
+        // Clearing here is intentional: a previously queued AppKit retry for
+        // this same tab must not steal focus after a sidebar preview click.
+        tabManager.pendingFocusTabID = requestFocus ? tabID : nil
         recordTabActivation(paneID: paneID, tabID: tabID, contentType: .editor)
         return true
     }
@@ -602,11 +610,15 @@ final class PaneManager {
     }
 
     /// Opens a file into the usable editor destination and routes pane/tab
-    /// activation plus first-responder focus through the same path as a tab
-    /// click. Sidebar previews, explicit opens, Quick Open, and Activity Panel
-    /// navigation use this instead of mutating a pane-local manager directly.
+    /// activation through the same path as a tab click. Explicit opens, Quick
+    /// Open, and Activity Panel navigation request first-responder focus by
+    /// default; sidebar previews opt out so their keyboard focus is preserved.
     @discardableResult
-    func openFileInActiveEditor(url: URL, asTransientPreview: Bool = false) -> Bool {
+    func openFileInActiveEditor(
+        url: URL,
+        asTransientPreview: Bool = false,
+        requestFocus: Bool = true
+    ) -> Bool {
         let tabManager = ensureEditorPane()
         let paneID = activePaneID
         if asTransientPreview {
@@ -615,7 +627,7 @@ final class PaneManager {
             tabManager.openTab(url: url)
         }
         guard let tabID = tabManager.activeTabID else { return false }
-        return selectEditorTab(tabID, in: paneID)
+        return selectEditorTab(tabID, in: paneID, requestFocus: requestFocus)
     }
 
     /// Removes a pane and promotes its sibling. When the very last leaf in

--- a/Pine/SidebarFileTree.swift
+++ b/Pine/SidebarFileTree.swift
@@ -240,10 +240,10 @@ private struct SidebarFileTreeNode: View {
     private func openFile(_ disposition: SidebarFileOpenDisposition) {
         guard !isRenamingThisNode else { return }
         selection = node
-        onFileOpen(node, disposition)
         if disposition == .transientPreview {
             onKeyboardFocusRequested()
         }
+        onFileOpen(node, disposition)
     }
 
     private func loadDeferredChildrenIfNeeded() {

--- a/Pine/SidebarFileTree.swift
+++ b/Pine/SidebarFileTree.swift
@@ -7,6 +7,7 @@
 //  (which the parent translates into "open tab"). See #739, #763, #778.
 //
 
+import AppKit
 import SwiftUI
 
 /// Sidebar row layout constants.
@@ -37,6 +38,20 @@ enum SidebarRowMetrics {
 enum SidebarFileOpenDisposition: Equatable, Sendable {
     case transientPreview
     case permanent
+
+    /// AppKit reports each click in a multi-click sequence immediately.
+    /// Opening a preview on click one and promoting it on click two avoids
+    /// delaying selection while waiting to rule out a double-click.
+    static func pointerClick(count: Int) -> Self {
+        count >= 2 ? .permanent : .transientPreview
+    }
+
+    /// A preview should leave keyboard focus in the sidebar so Finder-style
+    /// commands such as Return-to-rename keep working. Explicit opens move
+    /// focus into the editor.
+    var requestsEditorFocus: Bool {
+        self == .permanent
+    }
 }
 
 struct SidebarFileTree: View {
@@ -44,6 +59,7 @@ struct SidebarFileTree: View {
     let treeRevision: Int
     @Binding var selection: FileNode?
     let onFileOpen: (FileNode, SidebarFileOpenDisposition) -> Void
+    let onKeyboardFocusRequested: () -> Void
 
     var body: some View {
         ForEach(nodes) { node in
@@ -51,7 +67,8 @@ struct SidebarFileTree: View {
                 node: node,
                 treeRevision: treeRevision,
                 selection: $selection,
-                onFileOpen: onFileOpen
+                onFileOpen: onFileOpen,
+                onKeyboardFocusRequested: onKeyboardFocusRequested
             )
         }
     }
@@ -63,6 +80,7 @@ private struct SidebarFileTreeNode: View {
     let treeRevision: Int
     @Binding var selection: FileNode?
     let onFileOpen: (FileNode, SidebarFileOpenDisposition) -> Void
+    let onKeyboardFocusRequested: () -> Void
     @Environment(SidebarExpansionState.self) private var expansion
     @Environment(SidebarEditState.self) private var editState
     @State private var fontSettings = FontSizeSettings.shared
@@ -97,7 +115,8 @@ private struct SidebarFileTreeNode: View {
                                 node: child,
                                 treeRevision: treeRevision,
                                 selection: $selection,
-                                onFileOpen: onFileOpen
+                                onFileOpen: onFileOpen,
+                                onKeyboardFocusRequested: onKeyboardFocusRequested
                             )
                         }
                     }
@@ -176,11 +195,8 @@ private struct SidebarFileTreeNode: View {
             rowContent
         } else {
             rowContent
-                .onTapGesture(count: 2) {
-                    openFile(.permanent)
-                }
-                .onTapGesture(count: 1) {
-                    openFile(.transientPreview)
+                .onTapGesture {
+                    openFile(.pointerClick(count: NSApp.currentEvent?.clickCount ?? 1))
                 }
                 // Expose one labeled element with a stable identifier.
                 // The default action deliberately gives file rows an
@@ -214,6 +230,7 @@ private struct SidebarFileTreeNode: View {
     private func handleFolderTap() {
         guard !isRenamingThisNode else { return }
         selection = node
+        onKeyboardFocusRequested()
         if !expansion.isExpanded(node.url) {
             loadDeferredChildrenIfNeeded()
         }
@@ -224,6 +241,9 @@ private struct SidebarFileTreeNode: View {
         guard !isRenamingThisNode else { return }
         selection = node
         onFileOpen(node, disposition)
+        if disposition == .transientPreview {
+            onKeyboardFocusRequested()
+        }
     }
 
     private func loadDeferredChildrenIfNeeded() {

--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -181,6 +181,14 @@ final class SidebarKeyboardResponderView: NSView {
         if onKeyDown?(event) == true {
             return
         }
+        if event.keyCode == 48 {
+            if event.modifierFlags.contains(.shift) {
+                window?.selectPreviousKeyView(self)
+            } else {
+                window?.selectNextKeyView(self)
+            }
+            return
+        }
         super.keyDown(with: event)
     }
 }
@@ -209,12 +217,14 @@ struct SidebarView: View {
     @Binding var selectedFile: FileNode?
     let onFileOpen: (FileNode, SidebarFileOpenDisposition) -> Void
     @Environment(WorkspaceManager.self) private var workspace
+    @Environment(PaneManager.self) private var paneManager
     @Environment(ProjectRegistry.self) private var registry
     @Environment(\.openWindow) var openWindow
     @Environment(\.undoManager) private var undoManager
     @State private var editState = SidebarEditState()
     @State private var expansion = SidebarExpansionState()
     @State private var keyboardFocusController = SidebarKeyboardFocusController()
+    @FocusState private var hasSwiftUIKeyboardFocus: Bool
 
     var body: some View {
         Group {
@@ -259,7 +269,7 @@ struct SidebarView: View {
                                 selection: $selectedFile,
                                 onFileOpen: onFileOpen,
                                 onKeyboardFocusRequested: {
-                                    keyboardFocusController.requestFocus()
+                                    claimSidebarKeyboardFocus()
                                 }
                             )
                         }
@@ -274,6 +284,14 @@ struct SidebarView: View {
                         .frame(width: 1, height: 1)
                     }
                     .focusable()
+                    .focused($hasSwiftUIKeyboardFocus)
+                    .onChange(of: hasSwiftUIKeyboardFocus) { _, hasFocus in
+                        guard hasFocus else { return }
+                        // Full Keyboard Access focuses SwiftUI's host first.
+                        // Normalize that path to the AppKit responder so a
+                        // deferred editor-creation focus cannot displace it.
+                        claimSidebarKeyboardFocus()
+                    }
                     .environment(editState)
                     .environment(expansion)
                     .onChange(of: workspace.rootNodesRevision) { _, _ in
@@ -328,6 +346,12 @@ struct SidebarView: View {
                     .navigationTitle(workspace.projectName)
                     .onChange(of: editState.renamingURL) { _, newURL in
                         if newURL != nil {
+                            // Context-menu rename/new/duplicate paths do not
+                            // necessarily pass through a row focus claim.
+                            // Claim the AppKit responder before the inline
+                            // TextField takes focus so both explicit retries
+                            // and implicit editor creation are superseded.
+                            claimSidebarKeyboardFocus()
                             // Defer to avoid modifying state during view update
                             DispatchQueue.main.async {
                                 selectedFile = nil
@@ -355,6 +379,14 @@ struct SidebarView: View {
     private func openNewProject() {
         guard let url = registry.openProjectViaPanel() else { return }
         openWindow(value: url)
+    }
+
+    /// A sidebar action supersedes any older destination-focus request. The
+    /// model is invalidated before AppKit changes first responder so a queued
+    /// editor or terminal retry cannot reclaim focus on the next run loop.
+    private func claimSidebarKeyboardFocus() {
+        paneManager.cancelPendingFocusForActivePane()
+        keyboardFocusController.requestFocus()
     }
 
     /// Handles real AppKit events when the sidebar was focused by a row click.
@@ -392,6 +424,7 @@ struct SidebarView: View {
               let selected = selectedFile else {
             return false
         }
+        paneManager.cancelPendingFocusForActivePane()
         editState.startRename(for: selected)
         return true
     }
@@ -400,11 +433,8 @@ struct SidebarView: View {
         guard let selected = selectedFile, !selected.isDirectory else {
             return false
         }
+        claimSidebarKeyboardFocus()
         onFileOpen(selected, .transientPreview)
-        // Space can arrive through SwiftUI's keyboard-focus path rather than
-        // the AppKit bridge. Normalize both paths to the real sidebar
-        // responder before a newly-created preview gets initial focus.
-        keyboardFocusController.requestFocus()
         return true
     }
 }

--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -5,6 +5,7 @@
 //  Created by Федор Батоногов on 09.03.2026.
 //
 
+import AppKit
 import SwiftUI
 
 // MARK: - Sidebar edit state
@@ -124,6 +125,84 @@ final class SidebarEditState {
     }
 }
 
+// MARK: - Sidebar keyboard focus
+
+/// Owns the AppKit responder used by the plain ScrollView file tree.
+///
+/// `ScrollView.focusable()` is still useful for keyboard traversal, but a
+/// mouse click on one of its gesture-driven rows does not reliably make the
+/// SwiftUI key handler first responder. Keeping a real NSView target gives
+/// row clicks the same synchronous responder semantics as NSOutlineView.
+@MainActor
+final class SidebarKeyboardFocusController {
+    private weak var responderView: SidebarKeyboardResponderView?
+
+    func attach(_ responderView: SidebarKeyboardResponderView) {
+        self.responderView = responderView
+    }
+
+    @discardableResult
+    func requestFocus() -> Bool {
+        guard let responderView, let window = responderView.window else {
+            return false
+        }
+        return window.makeFirstResponder(responderView)
+            && window.firstResponder === responderView
+    }
+}
+
+/// Prevents a newly-created preview editor from displacing the sidebar while
+/// preserving implicit initial focus for non-sidebar open paths.
+enum SidebarKeyboardFocusPolicy {
+    static func allowsEditorInitialFocus(
+        tabID: UUID,
+        pendingFocusTabID: UUID?,
+        firstResponder: NSResponder?
+    ) -> Bool {
+        pendingFocusTabID == tabID
+            || !(firstResponder is SidebarKeyboardResponderView)
+    }
+}
+
+/// Invisible responder embedded in the sidebar hierarchy.
+@MainActor
+final class SidebarKeyboardResponderView: NSView {
+    var onKeyDown: ((NSEvent) -> Bool)?
+
+    override var acceptsFirstResponder: Bool { true }
+
+    /// The responder is focused programmatically by a row click and must not
+    /// intercept pointer hit testing itself.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if onKeyDown?(event) == true {
+            return
+        }
+        super.keyDown(with: event)
+    }
+}
+
+/// Keeps the AppKit responder attached to SwiftUI's sidebar lifecycle.
+struct SidebarKeyboardFocusBridge: NSViewRepresentable {
+    let controller: SidebarKeyboardFocusController
+    let onKeyDown: (NSEvent) -> Bool
+
+    func makeNSView(context: Context) -> SidebarKeyboardResponderView {
+        let view = SidebarKeyboardResponderView()
+        view.onKeyDown = onKeyDown
+        controller.attach(view)
+        return view
+    }
+
+    func updateNSView(_ nsView: SidebarKeyboardResponderView, context: Context) {
+        nsView.onKeyDown = onKeyDown
+        controller.attach(nsView)
+    }
+}
+
 // MARK: - Sidebar
 
 struct SidebarView: View {
@@ -135,6 +214,7 @@ struct SidebarView: View {
     @Environment(\.undoManager) private var undoManager
     @State private var editState = SidebarEditState()
     @State private var expansion = SidebarExpansionState()
+    @State private var keyboardFocusController = SidebarKeyboardFocusController()
 
     var body: some View {
         Group {
@@ -177,12 +257,23 @@ struct SidebarView: View {
                                 nodes: workspace.rootNodes,
                                 treeRevision: workspace.rootNodesRevision,
                                 selection: $selectedFile,
-                                onFileOpen: onFileOpen
+                                onFileOpen: onFileOpen,
+                                onKeyboardFocusRequested: {
+                                    keyboardFocusController.requestFocus()
+                                }
                             )
                         }
                         .padding(.vertical, 4)
                     }
                     .accessibilityIdentifier("sidebar")
+                    .background(alignment: .topLeading) {
+                        SidebarKeyboardFocusBridge(
+                            controller: keyboardFocusController,
+                            onKeyDown: handleSidebarKeyDown
+                        )
+                        .frame(width: 1, height: 1)
+                    }
+                    .focusable()
                     .environment(editState)
                     .environment(expansion)
                     .onChange(of: workspace.rootNodesRevision) { _, _ in
@@ -191,28 +282,13 @@ struct SidebarView: View {
                         expansion.prune(toMatch: workspace.rootNodes)
                     }
                     .onKeyPress(.return, phases: .down) { press in
-                        if press.modifiers.contains(.command),
-                           let selected = selectedFile,
-                           !selected.isDirectory {
-                            onFileOpen(selected, .permanent)
-                            return .handled
-                        }
-                        // Finder-style: Enter on a selected sidebar item starts inline rename.
-                        // No-op (and pass through) if nothing is selected or rename is already in progress.
-                        guard press.modifiers.isEmpty,
-                              editState.renamingURL == nil,
-                              let selected = selectedFile else {
-                            return .ignored
-                        }
-                        editState.startRename(for: selected)
-                        return .handled
+                        handleSidebarReturn(
+                            commandPressed: press.modifiers.contains(.command),
+                            hasAnyModifiers: !press.modifiers.isEmpty
+                        ) ? .handled : .ignored
                     }
                     .onKeyPress(.space) {
-                        guard let selected = selectedFile, !selected.isDirectory else {
-                            return .ignored
-                        }
-                        onFileOpen(selected, .transientPreview)
-                        return .handled
+                        handleSidebarSpace() ? .handled : .ignored
                     }
                     .contextMenu {
                         if let rootURL = workspace.rootURL {
@@ -279,6 +355,57 @@ struct SidebarView: View {
     private func openNewProject() {
         guard let url = registry.openProjectViaPanel() else { return }
         openWindow(value: url)
+    }
+
+    /// Handles real AppKit events when the sidebar was focused by a row click.
+    private func handleSidebarKeyDown(_ event: NSEvent) -> Bool {
+        switch event.keyCode {
+        case 36, 76: // Return and keypad Enter
+            let modifiers = event.modifierFlags.intersection([
+                .command, .option, .control, .shift
+            ])
+            return handleSidebarReturn(
+                commandPressed: modifiers.contains(.command),
+                hasAnyModifiers: !modifiers.isEmpty
+            )
+        case 49: // Space
+            return handleSidebarSpace()
+        default:
+            return false
+        }
+    }
+
+    /// Finder-style Return: rename in place. Command-Return is an explicit
+    /// open and moves focus into the editor.
+    private func handleSidebarReturn(
+        commandPressed: Bool,
+        hasAnyModifiers: Bool
+    ) -> Bool {
+        if commandPressed,
+           let selected = selectedFile,
+           !selected.isDirectory {
+            onFileOpen(selected, .permanent)
+            return true
+        }
+        guard !hasAnyModifiers,
+              editState.renamingURL == nil,
+              let selected = selectedFile else {
+            return false
+        }
+        editState.startRename(for: selected)
+        return true
+    }
+
+    private func handleSidebarSpace() -> Bool {
+        guard let selected = selectedFile, !selected.isDirectory else {
+            return false
+        }
+        onFileOpen(selected, .transientPreview)
+        // Space can arrive through SwiftUI's keyboard-focus path rather than
+        // the AppKit bridge. Normalize both paths to the real sidebar
+        // responder before a newly-created preview gets initial focus.
+        keyboardFocusController.requestFocus()
+        return true
     }
 }
 

--- a/PineTests/TabDestinationFocusTests.swift
+++ b/PineTests/TabDestinationFocusTests.swift
@@ -519,6 +519,160 @@ struct TabDestinationFocusTests {
         #expect(editorManager.pendingFocusTabID == tab.id)
     }
 
+    @Test("Sidebar focus claim invalidates an active editor request only")
+    func sidebarClaimInvalidatesActiveEditorRequest() async throws {
+        let paneManager = PaneManager()
+        let editorPaneID = paneManager.activePaneID
+        let editorManager = try #require(paneManager.tabManager(for: editorPaneID))
+        let editorTab = EditorTab(url: URL(fileURLWithPath: "/tmp/sidebar-editor.swift"))
+        editorManager.tabs = [editorTab]
+        editorManager.activeTabID = editorTab.id
+
+        let terminalPaneID = try #require(paneManager.createTerminalPane(
+            relativeTo: editorPaneID,
+            axis: .vertical,
+            workingDirectory: nil
+        ))
+        let terminalState = try #require(paneManager.terminalState(for: terminalPaneID))
+        let terminalRequestID = try #require(terminalState.pendingFocusRequestID)
+
+        paneManager.activePaneID = editorPaneID
+        editorManager.pendingFocusTabID = editorTab.id
+        let editorRequestID = try #require(editorManager.pendingFocusRequestID)
+
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let destination = FocusAcceptingTestView(frame: host.bounds)
+        let sidebarResponder = SidebarKeyboardResponderView(
+            frame: NSRect(x: 0, y: 0, width: 1, height: 1)
+        )
+        host.addSubview(destination)
+        host.addSubview(sidebarResponder)
+        let window = SidebarFocusRaceTestWindow(
+            contentRect: host.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        window.destinationResponder = destination
+        let focusController = SidebarKeyboardFocusController()
+        focusController.attach(sidebarResponder)
+
+        let coordinator = AppKitFocusRequestCoordinator()
+        coordinator.update(
+            requestID: editorRequestID,
+            hostView: host,
+            targetView: destination,
+            canAttempt: { candidateRequestID in
+                paneManager.activePaneID == editorPaneID
+                    && editorManager.activeTabID == editorTab.id
+                    && editorManager.pendingFocusTabID == editorTab.id
+                    && editorManager.pendingFocusRequestID == candidateRequestID
+            },
+            onResult: { completedRequestID, succeeded in
+                editorManager.acknowledgeFocusRequest(
+                    requestID: completedRequestID,
+                    for: editorTab.id,
+                    succeeded: succeeded
+                )
+            }
+        )
+
+        // Leave the request pending after a real rejected attempt. The retry
+        // queued by update() would accept the destination and steal focus if
+        // clearing the model token did not invalidate canAttempt.
+        #expect(!coordinator.attemptNow())
+        #expect(window.destinationAttemptCount == 1)
+        #expect(coordinator.pendingRequestID == editorRequestID)
+
+        paneManager.cancelPendingFocusForActivePane()
+        #expect(focusController.requestFocus())
+        await nextMainQueueTurn()
+
+        #expect(editorManager.pendingFocusTabID == nil)
+        #expect(editorManager.pendingFocusRequestID == nil)
+        #expect(terminalState.pendingFocusRequestID == terminalRequestID)
+        #expect(coordinator.pendingRequestID == nil)
+        #expect(window.destinationAttemptCount == 1)
+        #expect(window.firstResponder === sidebarResponder)
+        #expect(window.firstResponder !== destination)
+    }
+
+    @Test("Sidebar focus claim invalidates an active terminal request only")
+    func sidebarClaimInvalidatesActiveTerminalRequest() async throws {
+        let paneManager = PaneManager()
+        let editorPaneID = paneManager.activePaneID
+        let editorManager = try #require(paneManager.tabManager(for: editorPaneID))
+        let editorTab = EditorTab(url: URL(fileURLWithPath: "/tmp/sidebar-editor.swift"))
+        editorManager.tabs = [editorTab]
+        editorManager.activeTabID = editorTab.id
+        editorManager.pendingFocusTabID = editorTab.id
+        let editorRequestID = try #require(editorManager.pendingFocusRequestID)
+
+        let terminalPaneID = try #require(paneManager.createTerminalPane(
+            relativeTo: editorPaneID,
+            axis: .vertical,
+            workingDirectory: nil
+        ))
+        let terminalState = try #require(paneManager.terminalState(for: terminalPaneID))
+        let terminalTab = try #require(terminalState.activeTab)
+        let terminalRequestID = try #require(terminalState.pendingFocusRequestID)
+
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let destination = FocusAcceptingTestView(frame: host.bounds)
+        let sidebarResponder = SidebarKeyboardResponderView(
+            frame: NSRect(x: 0, y: 0, width: 1, height: 1)
+        )
+        host.addSubview(destination)
+        host.addSubview(sidebarResponder)
+        let window = SidebarFocusRaceTestWindow(
+            contentRect: host.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        window.destinationResponder = destination
+        let focusController = SidebarKeyboardFocusController()
+        focusController.attach(sidebarResponder)
+
+        let coordinator = AppKitFocusRequestCoordinator()
+        coordinator.update(
+            requestID: terminalRequestID,
+            hostView: host,
+            targetView: destination,
+            canAttempt: { candidateRequestID in
+                paneManager.activePaneID == terminalPaneID
+                    && terminalState.activeTerminalID == terminalTab.id
+                    && terminalState.pendingFocusTabID == terminalTab.id
+                    && terminalState.pendingFocusRequestID == candidateRequestID
+            },
+            onResult: { completedRequestID, succeeded in
+                terminalState.acknowledgeFocusRequest(
+                    requestID: completedRequestID,
+                    for: terminalTab.id,
+                    succeeded: succeeded
+                )
+            }
+        )
+
+        #expect(!coordinator.attemptNow())
+        #expect(window.destinationAttemptCount == 1)
+        #expect(coordinator.pendingRequestID == terminalRequestID)
+
+        paneManager.cancelPendingFocusForActivePane()
+        #expect(focusController.requestFocus())
+        await nextMainQueueTurn()
+
+        #expect(terminalState.pendingFocusTabID == nil)
+        #expect(terminalState.pendingFocusRequestID == nil)
+        #expect(editorManager.pendingFocusRequestID == editorRequestID)
+        #expect(coordinator.pendingRequestID == nil)
+        #expect(window.destinationAttemptCount == 1)
+        #expect(window.firstResponder === sidebarResponder)
+        #expect(window.firstResponder !== destination)
+    }
+
     @Test("Sidebar preview preserves focus while an explicit open targets the editor")
     func sidebarOpenDispositionFocusPolicy() {
         #expect(!SidebarFileOpenDisposition.transientPreview.requestsEditorFocus)
@@ -587,6 +741,97 @@ struct TabDestinationFocusTests {
         #expect(window.firstResponder === responder)
     }
 
+    @Test("Queued implicit editor focus respects a sidebar responder claim")
+    func queuedImplicitEditorFocusRespectsSidebarClaim() async {
+        let controller = SidebarKeyboardFocusController()
+        let responder = SidebarKeyboardResponderView(
+            frame: NSRect(x: 0, y: 0, width: 1, height: 1)
+        )
+        let editor = FocusAcceptingTestView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 300)
+        )
+        let window = NSWindow(
+            contentRect: editor.frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(editor)
+        window.contentView?.addSubview(responder)
+        controller.attach(responder)
+
+        let tabID = UUID()
+        var attemptedInitialFocus = false
+        DispatchQueue.main.async {
+            attemptedInitialFocus = true
+            _ = CodeEditorView.attemptInitialFocus(
+                on: editor,
+                canAttempt: {
+                    SidebarKeyboardFocusPolicy.allowsEditorInitialFocus(
+                        tabID: tabID,
+                        pendingFocusTabID: nil,
+                        firstResponder: window.firstResponder
+                    )
+                }
+            )
+        }
+
+        #expect(controller.requestFocus())
+        #expect(window.firstResponder === responder)
+        await nextMainQueueTurn()
+
+        #expect(attemptedInitialFocus)
+        #expect(window.firstResponder === responder)
+        #expect(window.firstResponder !== editor)
+    }
+
+    @Test("Sidebar AppKit responder advances the FKA key-view loop")
+    func sidebarResponderAdvancesKeyViewLoop() throws {
+        let responder = SidebarKeyboardResponderView(
+            frame: NSRect(x: 0, y: 0, width: 1, height: 1)
+        )
+        let window = FocusTraversalTestWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(responder)
+        #expect(window.makeFirstResponder(responder))
+
+        let tabEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "\t",
+            charactersIgnoringModifiers: "\t",
+            isARepeat: false,
+            keyCode: 48
+        ))
+        responder.keyDown(with: tabEvent)
+        #expect(window.nextSelectionCount == 1)
+        #expect(window.previousSelectionCount == 0)
+
+        let shiftTabEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .shift,
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "\t",
+            charactersIgnoringModifiers: "\t",
+            isARepeat: false,
+            keyCode: 48
+        ))
+        responder.keyDown(with: shiftTabEvent)
+        #expect(window.nextSelectionCount == 1)
+        #expect(window.previousSelectionCount == 1)
+    }
+
     @Test("Quick Look focus target is an explicit first responder")
     func quickLookAcceptsDestinationFocus() throws {
         let view = try #require(FocusableQuickLookPreviewView(
@@ -632,6 +877,34 @@ private final class FocusRejectingTestWindow: NSWindow {
     override func makeFirstResponder(_ responder: NSResponder?) -> Bool {
         focusAttemptCount += 1
         return false
+    }
+}
+
+private final class SidebarFocusRaceTestWindow: NSWindow {
+    weak var destinationResponder: NSResponder?
+    private(set) var destinationAttemptCount = 0
+
+    override func makeFirstResponder(_ responder: NSResponder?) -> Bool {
+        if responder === destinationResponder {
+            destinationAttemptCount += 1
+            if destinationAttemptCount == 1 {
+                return false
+            }
+        }
+        return super.makeFirstResponder(responder)
+    }
+}
+
+private final class FocusTraversalTestWindow: NSWindow {
+    private(set) var nextSelectionCount = 0
+    private(set) var previousSelectionCount = 0
+
+    override func selectNextKeyView(_ sender: Any?) {
+        nextSelectionCount += 1
+    }
+
+    override func selectPreviousKeyView(_ sender: Any?) {
+        previousSelectionCount += 1
     }
 }
 

--- a/PineTests/TabDestinationFocusTests.swift
+++ b/PineTests/TabDestinationFocusTests.swift
@@ -477,6 +477,116 @@ struct TabDestinationFocusTests {
         #expect(terminalState.pendingFocusRequestID == previousRequestID)
     }
 
+    @Test("Selection can preserve source focus and cancels stale AppKit requests")
+    func selectionWithoutDestinationFocusCancelsPendingRequest() throws {
+        let paneManager = PaneManager()
+        let editorPaneID = paneManager.activePaneID
+        let editorManager = try #require(paneManager.tabManager(for: editorPaneID))
+        let tab = EditorTab(url: URL(fileURLWithPath: "/tmp/sidebar-preview.swift"))
+        editorManager.tabs = [tab]
+        editorManager.activeTabID = tab.id
+
+        let terminalPaneID = try #require(paneManager.createTerminalPane(
+            relativeTo: editorPaneID,
+            axis: .vertical,
+            workingDirectory: nil
+        ))
+        #expect(paneManager.activePaneID == terminalPaneID)
+
+        // Seed a request for the already-active tab. Because activeTabID does
+        // not change below, only the explicit no-focus path can cancel it.
+        editorManager.pendingFocusTabID = tab.id
+        #expect(editorManager.pendingFocusRequestID != nil)
+
+        #expect(paneManager.selectEditorTab(
+            tab.id,
+            in: editorPaneID,
+            requestFocus: false
+        ))
+        #expect(paneManager.activePaneID == editorPaneID)
+        #expect(editorManager.activeTabID == tab.id)
+        #expect(editorManager.pendingFocusTabID == nil)
+        #expect(editorManager.pendingFocusRequestID == nil)
+
+        let identity = GlobalTabIdentity(
+            paneID: editorPaneID,
+            tabID: tab.id,
+            contentType: .editor
+        )
+        #expect(paneManager.validGlobalTabSwitchOrder().first == identity)
+
+        #expect(paneManager.selectEditorTab(tab.id, in: editorPaneID))
+        #expect(editorManager.pendingFocusTabID == tab.id)
+    }
+
+    @Test("Sidebar preview preserves focus while an explicit open targets the editor")
+    func sidebarOpenDispositionFocusPolicy() {
+        #expect(!SidebarFileOpenDisposition.transientPreview.requestsEditorFocus)
+        #expect(SidebarFileOpenDisposition.permanent.requestsEditorFocus)
+        #expect(SidebarFileOpenDisposition.pointerClick(count: 0) == .transientPreview)
+        #expect(SidebarFileOpenDisposition.pointerClick(count: 1) == .transientPreview)
+        #expect(SidebarFileOpenDisposition.pointerClick(count: 2) == .permanent)
+        #expect(SidebarFileOpenDisposition.pointerClick(count: 3) == .permanent)
+    }
+
+    @Test("Sidebar AppKit responder takes synchronous first-responder focus")
+    func sidebarResponderTakesFocus() {
+        let controller = SidebarKeyboardFocusController()
+        let responder = SidebarKeyboardResponderView(
+            frame: NSRect(x: 0, y: 0, width: 1, height: 1)
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(responder)
+        controller.attach(responder)
+
+        #expect(controller.requestFocus())
+        #expect(window.firstResponder === responder)
+
+        let tabID = UUID()
+        let editor = FocusAcceptingTestView(frame: window.contentView?.bounds ?? .zero)
+        window.contentView?.addSubview(editor)
+
+        #expect(!CodeEditorView.attemptInitialFocus(
+            on: editor,
+            canAttempt: {
+                SidebarKeyboardFocusPolicy.allowsEditorInitialFocus(
+                    tabID: tabID,
+                    pendingFocusTabID: nil,
+                    firstResponder: window.firstResponder
+                )
+            }
+        ))
+        #expect(window.firstResponder === responder)
+
+        #expect(CodeEditorView.attemptInitialFocus(
+            on: editor,
+            canAttempt: {
+                SidebarKeyboardFocusPolicy.allowsEditorInitialFocus(
+                    tabID: tabID,
+                    pendingFocusTabID: tabID,
+                    firstResponder: window.firstResponder
+                )
+            }
+        ))
+        #expect(window.firstResponder === editor)
+        #expect(SidebarKeyboardFocusPolicy.allowsEditorInitialFocus(
+            tabID: tabID,
+            pendingFocusTabID: nil,
+            firstResponder: window.firstResponder
+        ))
+
+        // Keyboard preview actions can originate from SwiftUI's focusable
+        // host. The controller must be able to normalize that path back to
+        // the sidebar responder after another view held focus.
+        #expect(controller.requestFocus())
+        #expect(window.firstResponder === responder)
+    }
+
     @Test("Quick Look focus target is an explicit first responder")
     func quickLookAcceptsDestinationFocus() throws {
         let view = try #require(FocusableQuickLookPreviewView(

--- a/PineUITests/SidebarRenameTests.swift
+++ b/PineUITests/SidebarRenameTests.swift
@@ -32,17 +32,9 @@ final class SidebarRenameTests: PineUITestCase {
     /// Opens the inline rename editor for the given node via right-click →
     /// "Rename" (the `pencil` context menu item).
     ///
-    /// We intentionally do NOT use the `Enter` key path here: SwiftUI's
-    /// `.onKeyPress(.return)` handler, which wires up the Finder-style
-    /// Enter-to-rename shortcut in `SidebarView`, does not receive XCUITest
-    /// synthetic key events on macOS 26 — the same class of flake documented
-    /// for `NSEvent.addLocalMonitorForEvents` in `AGENTS.md`. Using the
-    /// context-menu trigger keeps the rest of the rename flow under real
-    /// end-to-end coverage (inline editor appears, typing, commit path,
-    /// file-system effects) while sidestepping the synthetic-event race on
-    /// the trigger itself. The Enter-key trigger is exercised by the
-    /// dedicated `testEnterTriggersRename` case below, which degrades
-    /// gracefully when the synthetic `onKeyPress` path does not fire.
+    /// Using the context-menu trigger keeps the rename commit/cancel tests
+    /// independent from the keyboard trigger. Return-to-rename itself has
+    /// strict file and folder coverage in the dedicated tests below.
     private func openRenameViaContextMenu(on nodeID: String) {
         let node = app.sidebarNodes[nodeID]
         XCTAssertTrue(waitForExistence(node, timeout: 10), "Node \(nodeID) should exist")

--- a/PineUITests/SidebarRenameTests.swift
+++ b/PineUITests/SidebarRenameTests.swift
@@ -231,18 +231,10 @@ final class SidebarRenameTests: PineUITestCase {
         )
     }
 
-    // MARK: - Enter key trigger (best-effort due to SwiftUI onKeyPress flake)
+    // MARK: - Enter key trigger
 
     /// Verifies that pressing Enter on a selected sidebar row opens the
     /// inline rename editor — the distinctive UX of #737.
-    ///
-    /// The Enter-trigger path lives in `SidebarView`'s `.onKeyPress(.return)`
-    /// handler, which under XCUITest on macOS 26 does not reliably receive
-    /// synthetic key events (same class of flake as the Cmd+W local event
-    /// monitor documented in `AGENTS.md`). When the trigger fails to fire,
-    /// we `XCTSkip` rather than fail — the commit path itself is covered
-    /// end-to-end by the tests above, and the `startRename` logic is
-    /// covered by unit tests on `SidebarEditState`.
     func testEnterTriggersRename() throws {
         launchWithProject(projectURL)
 
@@ -256,11 +248,33 @@ final class SidebarRenameTests: PineUITestCase {
         app.typeKey(.return, modifierFlags: [])
 
         let textField = app.textFields["inlineRenameTextField"]
-        guard textField.waitForExistence(timeout: 5) else {
-            throw XCTSkip("SwiftUI onKeyPress(.return) does not receive XCUITest synthetic events on macOS 26 (see #737)")
-        }
+        XCTAssertTrue(
+            textField.waitForExistence(timeout: 5),
+            "Return on a selected file should start inline rename"
+        )
         // Inline editor is up — cancel it cleanly so we leave the UI in a
         // known state for tearDown.
+        textField.click()
+        textField.typeKey(.escape, modifierFlags: [])
+    }
+
+    func testEnterOnSelectedFolderTriggersRename() throws {
+        launchWithProject(projectURL)
+
+        let sidebar = app.scrollViews["sidebar"]
+        XCTAssertTrue(waitForExistence(sidebar, timeout: 10))
+
+        let folderNode = app.sidebarNodes["fileNode_docs"]
+        XCTAssertTrue(waitForExistence(folderNode, timeout: 5))
+        folderNode.click()
+
+        app.typeKey(.return, modifierFlags: [])
+
+        let textField = app.textFields["inlineRenameTextField"]
+        XCTAssertTrue(
+            textField.waitForExistence(timeout: 5),
+            "Return on a selected folder should start inline rename"
+        )
         textField.click()
         textField.typeKey(.escape, modifierFlags: [])
     }


### PR DESCRIPTION
## Summary

- give the sidebar a native AppKit first responder for Return, keypad Enter, Space, and Full Keyboard Access
- invalidate stale editor and terminal focus retries before the sidebar or inline rename field takes focus
- keep transient file previews focused in the sidebar while explicit opens focus the editor
- preserve native Tab and Shift-Tab traversal through the sidebar responder
- add deterministic race coverage plus strict file, folder, context-menu, and preview UI coverage

## Testing

- 20 focused unit tests passed
- 6 focused UI tests passed
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swiftlint` (0 errors; 9 pre-existing warnings in AboutInfo and generated build sources)
- `git diff --check`