### PR TITLE
fix(terminal): prevent black panes after terminal reparent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,7 +519,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Shard 1 — Terminal (26 tests)
+          # Shard 1 — Terminal (27 tests)
           - shard-name: "Terminal"
             test-classes: >-
               -only-testing:PineUITests/TerminalTests

--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -58,6 +58,7 @@ nonisolated enum AccessibilityID {
     // MARK: - Terminal
     static let terminalTabBar = "terminalTabBar"
     static func terminalTab(_ name: String) -> String { "terminalTab_\(name)" }
+    static let terminalSurface = "terminalSurface"
     static let newTerminalButton = "newTerminalButton"
     static let maximizeTerminalButton = "maximizeTerminalButton"
     static let hideTerminalButton = "hideTerminalButton"

--- a/Pine/QuickTerminal/QuickTerminalController.swift
+++ b/Pine/QuickTerminal/QuickTerminalController.swift
@@ -95,7 +95,7 @@ final class QuickTerminalController {
         // as contentView triggers `viewDidMoveToWindow` → observer install +
         // `layout()` → `showTab(activeTab)` → `startIfNeeded()`.
         let container = TerminalContainerView(frame: rect)
-        container.terminalPaneState = paneState
+        container.bind(to: paneState)
         win.contentView = container
         // Explicit `showTab` matches the in-window pattern
         // (`TerminalContentView.updateNSView`) and makes the PTY-spawn path

--- a/Pine/TerminalPaneState.swift
+++ b/Pine/TerminalPaneState.swift
@@ -12,6 +12,14 @@ import SwiftUI
 @Observable
 final class TerminalPaneState {
     var terminalTabs: [TerminalTab] = []
+    /// The AppKit host currently presenting this pane's active terminal.
+    ///
+    /// SwiftUI may temporarily keep outgoing and incoming representables
+    /// alive during structural pane updates. A pane-wide lease prevents the
+    /// stale host from reclaiming a newly selected tab after the incoming host
+    /// has taken over. This is presentation plumbing, not observable state.
+    @ObservationIgnored
+    weak var presentationOwner: TerminalContainerView?
     var activeTerminalID: UUID? {
         didSet {
             guard activeTerminalID != oldValue else { return }

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -294,12 +294,15 @@ struct TerminalPaneTabBar: View {
 
             // Maximize / restore terminal pane
             Button {
-                withAnimation(PineAnimation.quick) {
-                    if paneManager.isMaximized {
-                        paneManager.restoreFromMaximize()
-                    } else {
-                        paneManager.maximize(paneID: paneID)
-                    }
+                // This structurally replaces the pane tree while preserving a
+                // model-owned AppKit terminal view. An animated transition
+                // keeps the outgoing and incoming representables alive at
+                // once, so both can contend for the single NSView. Swap
+                // atomically; the native terminal surface remains continuous.
+                if paneManager.isMaximized {
+                    paneManager.restoreFromMaximize()
+                } else {
+                    paneManager.maximize(paneID: paneID)
                 }
             } label: {
                 Image(systemName: paneManager.maximizedPaneID == paneID

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -25,6 +25,24 @@ import os
 final class PineTerminalView: LocalProcessTerminalView {
     private var redrawBackgroundColor: CGColor?
     private var initialMetalRedrawWorkItems: [DispatchWorkItem] = []
+    #if DEBUG
+    /// Per-view seam for exercising the production CoreGraphics fallback
+    /// without mutating process-wide launch arguments or environment.
+    var metalRendererDisabledForTesting = false
+    #endif
+    /// SwiftTerm 1.15 rebuilds its nested `MTKView` only when the `NSWindow`
+    /// identity changes. Pine also reparents a terminal between AppKit hosts
+    /// inside the same project window (pane maximize/restore and tab moves).
+    /// That can leave the old `CAMetalLayer` bound to a retired presentation
+    /// host even though the window pointer is unchanged.
+    ///
+    /// TerminalContainerView owns the presentation generation because AppKit
+    /// can move either this view, the whole container, or an ancestor subtree.
+    /// Immediate-superview/window identity alone misses at least one of those
+    /// paths. Recreate only after the generation actually changes; ordinary
+    /// resize, focus, and tab hide/show keep the same renderer and glyph atlas.
+    private var presentationHostGeneration: UUID?
+    private var metalRendererNeedsRecreationOnAttach = false
     /// The attachment retry batch can finish before a slow interactive shell
     /// emits its first prompt. Re-arm it once, after the first PTY chunk that
     /// actually changes visible buffer content, so an earlier OSC title does
@@ -89,6 +107,9 @@ final class PineTerminalView: LocalProcessTerminalView {
     /// `MetalError.deviceUnavailable` is thrown; SwiftTerm keeps using
     /// CoreGraphics and Pine records the concrete failure for diagnostics.
     func enableMetalRendererIfNeeded() {
+        #if DEBUG
+        guard !metalRendererDisabledForTesting else { return }
+        #endif
         guard !Self.isMetalExplicitlyDisabled else { return }
         guard window != nil else { return }
         guard !isUsingMetalRenderer else { return }
@@ -112,6 +133,21 @@ final class PineTerminalView: LocalProcessTerminalView {
             || ProcessInfo.processInfo.environment["PINE_DISABLE_METAL"] != nil
     }
 
+    /// Binds the renderer to one committed AppKit presentation generation.
+    ///
+    /// The first binding records identity only. Later generations rebuild the
+    /// nested MTKView while preserving the Terminal, PTY, display buffer, and
+    /// scrollback. If the hierarchy is temporarily detached, the pending
+    /// rebuild runs after the next real window attachment.
+    func bindPresentationHost(generation: UUID) {
+        guard presentationHostGeneration != generation else { return }
+        if presentationHostGeneration != nil, isUsingMetalRenderer {
+            metalRendererNeedsRecreationOnAttach = true
+        }
+        presentationHostGeneration = generation
+        recreateMetalRendererAfterHostChangeIfNeeded()
+    }
+
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         guard window != nil else {
@@ -124,6 +160,7 @@ final class PineTerminalView: LocalProcessTerminalView {
         // fires `viewDidMoveToWindow` again, but `enableMetalRendererIfNeeded`
         // is idempotent, so the second call is a cheap no-op.
         enableMetalRendererIfNeeded()
+        recreateMetalRendererAfterHostChangeIfNeeded()
 
         // `MTKView` is on-demand (`isPaused = true`) and its CAMetalLayer may
         // not have a drawable during the first display request. SwiftTerm
@@ -136,6 +173,44 @@ final class PineTerminalView: LocalProcessTerminalView {
         // cancelled on the next detach (issue #1128).
         if isUsingMetalRenderer {
             scheduleInitialMetalRedrawRetries()
+        }
+    }
+
+    /// Recreates SwiftTerm's renderer after an AppKit presentation-generation
+    /// change, including whole-container or ancestor detach/reattach inside
+    /// the same `NSWindow`.
+    ///
+    /// SwiftTerm exposes no public rebind API in 1.15, so the supported
+    /// `setUseMetal(false/true)` pair is the narrow compatibility bridge.
+    /// It replaces only the nested `MTKView` and renderer; `Terminal` and the
+    /// local process stay alive. Ordinary resize/focus/occlusion redraws never
+    /// enter this path because they do not move the view between hosts.
+    private func recreateMetalRendererAfterHostChangeIfNeeded() {
+        guard metalRendererNeedsRecreationOnAttach,
+              superview != nil,
+              window != nil else { return }
+        metalRendererNeedsRecreationOnAttach = false
+        guard isUsingMetalRenderer else { return }
+
+        do {
+            try setUseMetal(false)
+            try setUseMetal(true)
+        } catch {
+            Logger.terminal.error(
+                "SwiftTerm Metal renderer recreation after host reparent failed: \(String(describing: error), privacy: .public)"
+            )
+        }
+
+        if isUsingMetalRenderer {
+            // Reuse the bounded first-draw recovery window for the newly
+            // created CAMetalLayer. viewDidMoveToWindow may immediately
+            // schedule the same batch again; the helper cancels/restarts it,
+            // so a host transition never creates parallel retry loops.
+            scheduleInitialMetalRedrawRetries()
+        } else {
+            // Enabling Metal failed after the old renderer was removed.
+            // Repaint synchronously through the CoreGraphics fallback.
+            requestRendererDisplay()
         }
     }
 
@@ -703,15 +778,29 @@ struct TerminalContentView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> TerminalContainerView {
         let container = TerminalContainerView()
-        container.terminalPaneState = terminalPaneState
+        let didRebind = container.bind(to: terminalPaneState)
         container.canAttemptFocusRequest = canAttemptFocusRequest
-        container.showTab(terminalPaneState.activeTab)
+        container.showTab(
+            terminalPaneState.activeTab,
+            forcePresentationClaim: didRebind && container.window != nil
+        )
         return container
     }
 
     func updateNSView(_ container: TerminalContainerView, context: Context) {
+        let didRebind = container.bind(to: terminalPaneState)
         container.canAttemptFocusRequest = canAttemptFocusRequest
-        container.showTab(terminalPaneState.activeTab)
+        container.showTab(
+            terminalPaneState.activeTab,
+            forcePresentationClaim: didRebind && container.window != nil
+        )
+    }
+
+    static func dismantleNSView(
+        _ container: TerminalContainerView,
+        coordinator: Coordinator
+    ) {
+        container.prepareForDismantle()
     }
 }
 
@@ -727,9 +816,23 @@ class TerminalContainerView: NSView {
     /// is not blank when it first appears. The real size replaces this in `layout()`.
     static let defaultTerminalFrame = NSRect(x: 0, y: 0, width: 800, height: 300)
 
+    /// Changes only when the actual AppKit presentation host changes. Every
+    /// active PineTerminalView binds to this token, covering direct terminal
+    /// moves, whole-container reparenting, and ancestor detach/reattach while
+    /// keeping ordinary tab switches and resizes renderer-stable.
+    private var presentationGeneration = UUID()
+    /// Full AppKit ancestry of this container, excluding the container itself.
+    /// A direct move of an ancestor within the same window leaves both this
+    /// view's immediate superview and NSWindow unchanged, but AppKit still
+    /// calls `viewDidMoveToWindow()` on descendants. Comparing the complete
+    /// chain there catches that otherwise invisible presentation-host change.
+    private var presentationAncestorChain: [ObjectIdentifier] = []
+    private var hasAttachedToWindow = false
+    private var isAttachedToWindow = false
     var terminalPaneState: TerminalPaneState?
     var canAttemptFocusRequest: ((UUID) -> Bool)?
     private var currentTabID: UUID?
+    private weak var currentTab: TerminalTab?
     let destinationFocusCoordinator = AppKitFocusRequestCoordinator()
     private let scrollInterceptor = TerminalScrollInterceptor()
     private var scrollMonitor: Any?
@@ -779,26 +882,57 @@ class TerminalContainerView: NSView {
     /// and `UITimings.Debounce.terminalRecovery`.
     private var recoveryDebouncer: Debouncer?
 
-    func showTab(_ tab: TerminalTab?) {
+    /// Associates this AppKit host with one pane state. SwiftUI can reuse an
+    /// NSViewRepresentable at the same structural position for a different
+    /// pane, so release the old pane/tab leases before switching models.
+    @discardableResult
+    func bind(to paneState: TerminalPaneState) -> Bool {
+        guard terminalPaneState !== paneState else { return false }
+        showTab(nil)
+        terminalPaneState = paneState
+        return true
+    }
+
+    func showTab(
+        _ tab: TerminalTab?,
+        forcePresentationClaim: Bool = false
+    ) {
         guard let tab else {
             // Tab cleared (terminal pane closed) — kill any in-flight
             // auto-scroll so it cannot tick against a now-detached view.
             scrollInterceptor.handleActiveTabChange()
+            releaseTabPresentationOwnershipIfNeeded()
+            releasePanePresentationOwnershipIfNeeded()
             subviews.forEach { $0.removeFromSuperview() }
             currentTabID = nil
+            currentTab = nil
             destinationFocusCoordinator.cancel()
             scrollInterceptor.terminalView = nil
             scrollInterceptor.workingDirectory = nil
             return
         }
+
+        // A structural SwiftUI transition can temporarily keep two
+        // TerminalContainerViews for the same pane alive. The newly attached
+        // host claims explicitly from viewDidMoveToWindow; ordinary
+        // update/layout passes must not let an outgoing host steal the single
+        // model-owned NSView back.
+        guard canClaimPresentation(of: tab, force: forcePresentationClaim) else {
+            suspendPresentationWhileOwnedElsewhere()
+            return
+        }
+
         let tabChanged = tab.id != currentTabID || tab.terminalView.superview !== self
         if tabChanged {
             // Auto-scroll started against the *outgoing* tab — stop it before
             // we swap the underlying terminalView so the next tick cannot
             // scroll the freshly-installed tab using stale coordinates.
             scrollInterceptor.handleActiveTabChange()
+            releaseTabPresentationOwnershipIfNeeded()
             subviews.forEach { $0.removeFromSuperview() }
             currentTabID = tab.id
+            currentTab = tab
+            tab.presentationOwner = self
             let effectiveBounds = bounds.size.width > 0 && bounds.size.height > 0
                 ? bounds : Self.defaultTerminalFrame
             tab.terminalView.frame = effectiveBounds
@@ -832,9 +966,19 @@ class TerminalContainerView: NSView {
             self.needsLayout = true
             self.needsDisplay = true
 
-            // Force a synchronous full repaint from the SwiftTerm display
-            // buffer (and raise SIGWINCH on alternate-screen TUIs so the
-            // child itself redraws — see `refreshAfterReparent` docs).
+        } else if tab.presentationOwner !== self {
+            // Repair a stale lease without touching the already-correct view
+            // hierarchy (for example after an interrupted transition).
+            currentTab = tab
+            tab.presentationOwner = self
+        }
+
+        if let pineTerminalView = tab.terminalView as? PineTerminalView {
+            pineTerminalView.bindPresentationHost(generation: presentationGeneration)
+        }
+        if tabChanged {
+            // Bind the new presentation generation before repainting so the
+            // redraw targets the replacement MTKView, not a retired layer.
             tab.refreshAfterReparent()
         }
 
@@ -862,6 +1006,93 @@ class TerminalContainerView: NSView {
                 )
             }
         )
+    }
+
+    /// Returns whether this container may present the pane without stealing
+    /// it from another live host. The lease belongs to the pane rather than
+    /// the active tab: otherwise a stale outgoing host could reclaim the next
+    /// tab when both representables observe an active-tab change.
+    ///
+    /// A force claim is reserved for a container that has just attached or
+    /// moved to a new presentation host. Detached incoming representables
+    /// cannot take the terminal away from a visible owner before SwiftUI
+    /// commits their attachment.
+    private func canClaimPresentation(
+        of tab: TerminalTab,
+        force: Bool
+    ) -> Bool {
+        guard let terminalPaneState else {
+            guard let owner = tab.presentationOwner else { return true }
+            return owner === self
+                || (window != nil && (force || owner.window == nil))
+        }
+
+        if terminalPaneState.presentationOwner === self {
+            return true
+        }
+
+        // An off-window representable is not yet a committed presentation
+        // host. It may claim an entirely unowned initial pane, but must not
+        // pull a moved tab or pane away from a live/detached predecessor.
+        if window == nil {
+            guard terminalPaneState.presentationOwner == nil,
+                  tab.presentationOwner == nil else { return false }
+            terminalPaneState.presentationOwner = self
+            return true
+        }
+
+        let displacedPaneOwner = terminalPaneState.presentationOwner
+        if let paneOwner = displacedPaneOwner,
+           paneOwner !== self,
+           !force,
+           paneOwner.window != nil {
+            return false
+        }
+
+        if let tabOwner = tab.presentationOwner,
+           tabOwner !== self,
+           !force,
+           tabOwner.window != nil,
+           tabOwner.terminalPaneState?.activeTab?.id == tab.id {
+            return false
+        }
+
+        terminalPaneState.presentationOwner = self
+        if let displacedPaneOwner, displacedPaneOwner !== self {
+            displacedPaneOwner.suspendPresentationWhileOwnedElsewhere()
+        }
+        return true
+    }
+
+    private func releaseTabPresentationOwnershipIfNeeded() {
+        guard let currentTab, currentTab.presentationOwner === self else { return }
+        currentTab.presentationOwner = nil
+    }
+
+    private func releasePanePresentationOwnershipIfNeeded() {
+        guard terminalPaneState?.presentationOwner === self else { return }
+        terminalPaneState?.presentationOwner = nil
+    }
+
+    /// Tears down event/focus plumbing in an outgoing host after another live
+    /// container has claimed the terminal. Keep `currentTabID` intact so late
+    /// update/layout callbacks remain identifiable as stale and cannot turn
+    /// into a fresh-tab claim.
+    private func suspendPresentationWhileOwnedElsewhere() {
+        scrollInterceptor.handleActiveTabChange()
+        subviews.forEach { $0.removeFromSuperview() }
+        destinationFocusCoordinator.cancel()
+        scrollInterceptor.terminalView = nil
+        scrollInterceptor.workingDirectory = nil
+        removeScrollMonitor()
+    }
+
+    /// Releases the presentation lease and AppKit resources owned by this
+    /// representable. The PTY and TerminalTab intentionally remain alive.
+    func prepareForDismantle() {
+        showTab(nil)
+        removeScrollMonitor()
+        removeWindowObservers()
     }
 
     // MARK: - Scroll event monitor for TUI mouse reporting
@@ -1048,9 +1279,48 @@ class TerminalContainerView: NSView {
     }
 
     override func removeFromSuperview() {
-        removeScrollMonitor()
-        removeWindowObservers()
+        prepareForDismantle()
         super.removeFromSuperview()
+    }
+
+    override func viewDidMoveToSuperview() {
+        super.viewDidMoveToSuperview()
+        guard superview != nil else { return }
+        let newAncestorChain = currentPresentationAncestorChain()
+        let movedDirectlyInsideWindow = isAttachedToWindow
+            && !presentationAncestorChain.isEmpty
+            && presentationAncestorChain != newAncestorChain
+        presentationAncestorChain = newAncestorChain
+        if movedDirectlyInsideWindow {
+            advancePresentationGeneration()
+        }
+        guard window != nil,
+              let activeTab = terminalPaneState?.activeTab else { return }
+        // AppKit can move an existing view directly between two parents in
+        // the same NSWindow without calling our removeFromSuperview override.
+        // viewDidMoveToWindow then sees the same observed window and returns
+        // early, so claim at the actual superview boundary as well.
+        showTab(activeTab, forcePresentationClaim: true)
+        if movedDirectlyInsideWindow {
+            // CoreGraphics also loses presentation state on this boundary.
+            // Metal recreation schedules its own frame, but the shared redraw
+            // keeps both renderer paths correct and preserves the fallback.
+            refreshActiveTerminalAfterReparent()
+        }
+    }
+
+    private func advancePresentationGeneration() {
+        presentationGeneration = UUID()
+    }
+
+    private func currentPresentationAncestorChain() -> [ObjectIdentifier] {
+        var chain: [ObjectIdentifier] = []
+        var ancestor = superview
+        while let view = ancestor {
+            chain.append(ObjectIdentifier(view))
+            ancestor = view.superview
+        }
+        return chain
     }
 
     /// Tears down every window/app-level notification observer registered in
@@ -1116,7 +1386,35 @@ class TerminalContainerView: NSView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
+        let isNowAttached = window != nil
+        let reattachedAfterHierarchyDetach = isNowAttached
+            && hasAttachedToWindow
+            && !isAttachedToWindow
+        let newAncestorChain = isNowAttached
+            ? currentPresentationAncestorChain()
+            : presentationAncestorChain
+        let ancestorMovedInsideWindow = isNowAttached
+            && isAttachedToWindow
+            && !presentationAncestorChain.isEmpty
+            && presentationAncestorChain != newAncestorChain
+        isAttachedToWindow = isNowAttached
+        if isNowAttached {
+            presentationAncestorChain = newAncestorChain
+            if reattachedAfterHierarchyDetach || ancestorMovedInsideWindow {
+                advancePresentationGeneration()
+            }
+            hasAttachedToWindow = true
+        }
         destinationFocusCoordinator.hostDidMoveToWindow(self)
+        if ancestorMovedInsideWindow,
+           let activeTab = terminalPaneState?.activeTab {
+            // AppKit reports a direct ancestor-subtree move with the same
+            // non-nil NSWindow. Reclaim before the same-window observer fast
+            // path below; otherwise an outgoing representable can keep the
+            // model-owned terminal view in a retired presentation subtree.
+            showTab(activeTab, forcePresentationClaim: true)
+            refreshActiveTerminalAfterReparent()
+        }
         // AppKit may call this method multiple times for the same window —
         // skip the observer dance when nothing has actually changed.
         guard window !== observedWindow else { return }
@@ -1189,6 +1487,13 @@ class TerminalContainerView: NSView {
             }
         }
         observedWindow = win
+        if let activeTab = terminalPaneState?.activeTab {
+            // This container has just become a real presentation host. It may
+            // legitimately reclaim the model-owned view from an outgoing
+            // maximize/restore container; later ordinary update/layout calls
+            // cannot steal it back while this lease remains live.
+            showTab(activeTab, forcePresentationClaim: true)
+        }
         // First repaint after attaching to the window — `displayIfNeeded`
         // inside `showTab` is a no-op when the container had no window yet,
         // so this is the first chance to actually paint the SwiftTerm view.
@@ -1300,6 +1605,15 @@ final class TerminalTab: Identifiable, Hashable {
     let stableLabel: String
     let terminalView: LocalProcessTerminalView
     fileprivate(set) var isTerminated = false
+    /// The AppKit container currently presenting `terminalView`.
+    ///
+    /// A pane maximize/restore can keep outgoing and incoming SwiftUI
+    /// representables alive in the same animation transaction. Since an
+    /// `NSView` can have only one superview, stale containers must not steal
+    /// the model-owned terminal view back from the newly attached host.
+    /// Presentation ownership is UI plumbing, not observable tab state.
+    @ObservationIgnored
+    weak var presentationOwner: TerminalContainerView?
 
     // MARK: - Agent tracking (#951)
 
@@ -1338,6 +1652,9 @@ final class TerminalTab: Identifiable, Hashable {
         self.shellSettings = shellSettings
         self.agentHandoffSettings = agentHandoffSettings
         self.terminalView = PineTerminalView(frame: TerminalContainerView.defaultTerminalFrame)
+        self.terminalView.setAccessibilityElement(true)
+        self.terminalView.setAccessibilityRole(.textArea)
+        self.terminalView.setAccessibilityIdentifier(AccessibilityID.terminalSurface)
         self.delegate = TerminalTabDelegate()
         self.delegate.tab = self
         self.terminalView.processDelegate = self.delegate

--- a/PineTests/TerminalMetalRendererTests.swift
+++ b/PineTests/TerminalMetalRendererTests.swift
@@ -168,6 +168,11 @@ struct TerminalMetalRendererTests {
             window.contentView = nil
             return
         }
+        guard let originalMetalView = firstMetalView(in: view) else {
+            Issue.record("Attached terminal has no Metal view")
+            window.contentView = nil
+            return
+        }
 
         // Cancel the first batch before the main queue can deliver it, then
         // reattach to the same window. A fresh batch is required because the
@@ -178,6 +183,250 @@ struct TerminalMetalRendererTests {
         try? await Task.sleep(for: .milliseconds(450))
 
         #expect(redrawRequests == UITimings.Render.terminalFirstFrameRetryDelays.count)
+        guard let reattachedMetalView = firstMetalView(in: view) else {
+            Issue.record("Reattached terminal lost its Metal view")
+            window.contentView = nil
+            return
+        }
+        #expect(reattachedMetalView === originalMetalView)
+        window.contentView = nil
+    }
+
+    @Test("Switching away and back to the same host keeps Metal renderer")
+    func sameHostReattachKeepsMetalView() {
+        guard MTLCreateSystemDefaultDevice() != nil else { return }
+        let state = TerminalPaneState()
+        let firstTab = state.addTab(workingDirectory: nil)
+        let secondTab = state.addTab(workingDirectory: nil)
+        state.activeTerminalID = firstTab.id
+        let container = TerminalContainerView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 300)
+        )
+        container.bind(to: state)
+        let window = makeWindow(containing: container)
+        defer {
+            firstTab.stop()
+            secondTab.stop()
+            window.contentView = nil
+        }
+        guard let view = firstTab.terminalView as? PineTerminalView else {
+            Issue.record("Terminal tab does not use PineTerminalView")
+            return
+        }
+        guard view.isUsingMetalRenderer,
+              let originalMetalView = firstMetalView(in: view) else {
+            return
+        }
+
+        state.activeTerminalID = secondTab.id
+        container.showTab(secondTab)
+        state.activeTerminalID = firstTab.id
+        container.showTab(firstTab)
+
+        #expect(firstMetalView(in: view) === originalMetalView)
+        #expect(view.superview === container)
+        #expect(view.isUsingMetalRenderer)
+    }
+
+    @Test("Repeated same-window container reparent recreates only Metal presentation")
+    func repeatedSameWindowContainerReparentRecreatesMetalView() {
+        guard MTLCreateSystemDefaultDevice() != nil else { return }
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        let container = TerminalContainerView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 300)
+        )
+        container.bind(to: state)
+        let firstHost = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let secondHost = NSView(frame: NSRect(x: 400, y: 0, width: 400, height: 300))
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        root.addSubview(firstHost)
+        root.addSubview(secondHost)
+        firstHost.addSubview(container)
+
+        let window = makeWindow(containing: root)
+        defer {
+            tab.stop()
+            window.contentView = nil
+        }
+        guard let view = tab.terminalView as? PineTerminalView else {
+            Issue.record("Terminal tab does not use PineTerminalView")
+            return
+        }
+        guard view.isUsingMetalRenderer,
+              var previousMetalView = firstMetalView(in: view) else {
+            return
+        }
+        let originalTerminal = view.getTerminal()
+
+        // Direct same-window moves keep both the terminal view's immediate
+        // superview and its NSWindow unchanged. Exercise both directions
+        // repeatedly: this is the maximize/restore presentation boundary.
+        for index in 0..<20 {
+            let destination = index.isMultiple(of: 2) ? secondHost : firstHost
+            destination.addSubview(container)
+            guard let recreatedMetalView = firstMetalView(in: view) else {
+                Issue.record("Reparented terminal lost its Metal view")
+                return
+            }
+            #expect(recreatedMetalView !== previousMetalView)
+            #expect(view.getTerminal() === originalTerminal)
+            #expect(view.superview === container)
+            #expect(container.superview === destination)
+            #expect(view.isUsingMetalRenderer)
+            previousMetalView = recreatedMetalView
+        }
+    }
+
+    @Test("Ancestor detach and same-window reattach recreates Metal presentation")
+    func ancestorDetachReattachRecreatesMetalView() {
+        guard MTLCreateSystemDefaultDevice() != nil else { return }
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        let container = TerminalContainerView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 300)
+        )
+        container.bind(to: state)
+        let root = NSView(frame: container.bounds)
+        root.addSubview(container)
+        let window = makeWindow(containing: root)
+        defer {
+            tab.stop()
+            window.contentView = nil
+        }
+        guard let view = tab.terminalView as? PineTerminalView else {
+            Issue.record("Terminal tab does not use PineTerminalView")
+            return
+        }
+        guard view.isUsingMetalRenderer,
+              let originalMetalView = firstMetalView(in: view) else { return }
+        let originalTerminal = view.getTerminal()
+
+        // Neither the terminal nor its container changes immediate superview;
+        // only the ancestor presentation subtree leaves and re-enters window.
+        window.contentView = nil
+        window.contentView = root
+
+        guard let recreatedMetalView = firstMetalView(in: view) else {
+            Issue.record("Reattached terminal lost its Metal view")
+            return
+        }
+        #expect(recreatedMetalView !== originalMetalView)
+        #expect(view.getTerminal() === originalTerminal)
+        #expect(view.superview === container)
+        #expect(container.superview === root)
+        #expect(view.isUsingMetalRenderer)
+    }
+
+    @Test("Direct same-window ancestor move recreates Metal presentation")
+    func directSameWindowAncestorMoveRecreatesMetalView() {
+        guard MTLCreateSystemDefaultDevice() != nil else { return }
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        let container = TerminalContainerView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 300)
+        )
+        container.bind(to: state)
+        let ancestor = NSView(frame: container.bounds)
+        ancestor.addSubview(container)
+        let firstHost = NSView(frame: ancestor.bounds)
+        let secondHost = NSView(frame: ancestor.bounds)
+        firstHost.addSubview(ancestor)
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        root.addSubview(firstHost)
+        root.addSubview(secondHost)
+        let window = makeWindow(containing: root)
+        defer {
+            tab.stop()
+            window.contentView = nil
+        }
+        guard let view = tab.terminalView as? PineTerminalView else {
+            Issue.record("Terminal tab does not use PineTerminalView")
+            return
+        }
+        guard view.isUsingMetalRenderer,
+              let originalMetalView = firstMetalView(in: view) else { return }
+        let originalTerminal = view.getTerminal()
+
+        // Moving the ancestor directly within one window leaves both the
+        // terminal and container immediate superviews unchanged. AppKit only
+        // reports the presentation-subtree change through the descendant's
+        // same-window viewDidMoveToWindow callback.
+        secondHost.addSubview(ancestor)
+
+        guard let recreatedMetalView = firstMetalView(in: view) else {
+            Issue.record("Ancestor-reparented terminal lost its Metal view")
+            return
+        }
+        #expect(recreatedMetalView !== originalMetalView)
+        #expect(view.getTerminal() === originalTerminal)
+        #expect(view.superview === container)
+        #expect(container.superview === ancestor)
+        #expect(ancestor.superview === secondHost)
+        #expect(view.isUsingMetalRenderer)
+    }
+
+    @Test("CoreGraphics redraws after direct same-window ancestor move")
+    func coreGraphicsAncestorMovePreservesTerminalAndRedraws() throws {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        let container = TerminalContainerView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 300)
+        )
+        container.bind(to: state)
+        let ancestor = NSView(frame: container.bounds)
+        ancestor.addSubview(container)
+        let firstHost = NSView(frame: ancestor.bounds)
+        let secondHost = NSView(frame: ancestor.bounds)
+        firstHost.addSubview(ancestor)
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        root.addSubview(firstHost)
+        root.addSubview(secondHost)
+        let window = makeWindow(containing: root)
+        defer {
+            tab.stop()
+            window.contentView = nil
+        }
+        guard let view = tab.terminalView as? PineTerminalView else {
+            Issue.record("Terminal tab does not use PineTerminalView")
+            return
+        }
+        view.metalRendererDisabledForTesting = true
+        if view.isUsingMetalRenderer {
+            try view.setUseMetal(false)
+        }
+        let originalTerminal = view.getTerminal()
+        feed("core-graphics-probe", to: view)
+        var redrawRequests = 0
+        view.backendRedrawRequestObserver = { redrawRequests += 1 }
+
+        secondHost.addSubview(ancestor)
+
+        #expect(!view.isUsingMetalRenderer)
+        #expect(view.getTerminal() === originalTerminal)
+        #expect(view.superview === container)
+        #expect(container.superview === ancestor)
+        #expect(ancestor.superview === secondHost)
+        #expect(redrawRequests >= 1)
+    }
+
+    @Test("Ordinary resize does not recreate Metal view")
+    func resizeKeepsMetalRenderer() {
+        guard MTLCreateSystemDefaultDevice() != nil else { return }
+        let view = PineTerminalView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        let window = makeWindow(containing: view)
+        guard view.isUsingMetalRenderer,
+              let originalMetalView = firstMetalView(in: view) else {
+            window.contentView = nil
+            return
+        }
+
+        view.setFrameSize(NSSize(width: 640, height: 240))
+        view.layoutSubtreeIfNeeded()
+        view.requestRendererDisplay()
+
+        #expect(firstMetalView(in: view) === originalMetalView)
+        #expect(view.isUsingMetalRenderer)
         window.contentView = nil
     }
 

--- a/PineTests/TerminalMetalRendererTests.swift
+++ b/PineTests/TerminalMetalRendererTests.swift
@@ -278,6 +278,80 @@ struct TerminalMetalRendererTests {
         }
     }
 
+    @Test("Cross-pane tab move recreates Metal presentation and preserves terminal")
+    func crossPaneTabMoveRecreatesMetalPresentation() {
+        guard MTLCreateSystemDefaultDevice() != nil else { return }
+        let sourceState = TerminalPaneState()
+        let movedTab = sourceState.addTab(workingDirectory: nil)
+        let remainingTab = sourceState.addTab(workingDirectory: nil)
+        sourceState.activeTerminalID = movedTab.id
+        let destinationState = TerminalPaneState()
+        let destinationExistingTab = destinationState.addTab(workingDirectory: nil)
+
+        let source = TerminalContainerView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 300)
+        )
+        let destination = TerminalContainerView(
+            frame: NSRect(x: 400, y: 0, width: 400, height: 300)
+        )
+        source.bind(to: sourceState)
+        destination.bind(to: destinationState)
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        root.addSubview(source)
+        root.addSubview(destination)
+
+        let window = makeWindow(containing: root)
+        defer {
+            source.prepareForDismantle()
+            destination.prepareForDismantle()
+            movedTab.stop()
+            remainingTab.stop()
+            destinationExistingTab.stop()
+            window.contentView = nil
+        }
+        #expect(source.window === window)
+        #expect(destination.window === window)
+        #expect(movedTab.terminalView.superview === source)
+        #expect(movedTab.presentationOwner === source)
+        #expect(destinationExistingTab.terminalView.superview === destination)
+        #expect(destinationExistingTab.presentationOwner === destination)
+        guard let view = movedTab.terminalView as? PineTerminalView else {
+            Issue.record("Terminal tab does not use PineTerminalView")
+            return
+        }
+        guard view.isUsingMetalRenderer,
+              let originalMetalView = firstMetalView(in: view) else {
+            return
+        }
+        let originalTerminal = view.getTerminal()
+
+        // Mirror PaneManager's add-before-remove transfer while both pane
+        // hosts are already committed to the same window. The destination
+        // must replace only the renderer presentation, never the session.
+        destinationState.terminalTabs.append(movedTab)
+        destinationState.activeTerminalID = movedTab.id
+        sourceState.terminalTabs.removeAll { $0.id == movedTab.id }
+        sourceState.activeTerminalID = remainingTab.id
+        destination.showTab(movedTab)
+        source.showTab(remainingTab)
+
+        guard let recreatedMetalView = firstMetalView(in: view) else {
+            Issue.record("Cross-pane terminal move lost its Metal view")
+            return
+        }
+        #expect(recreatedMetalView !== originalMetalView)
+        #expect(view.getTerminal() === originalTerminal)
+        #expect(view.isUsingMetalRenderer)
+        #expect(view.superview === destination)
+        #expect(destinationState.presentationOwner === destination)
+        #expect(movedTab.presentationOwner === destination)
+        #expect(remainingTab.terminalView.superview === source)
+        #expect(sourceState.presentationOwner === source)
+        #expect(remainingTab.presentationOwner === source)
+        #expect(destinationExistingTab.terminalView.superview == nil)
+        #expect(destinationExistingTab.presentationOwner == nil)
+    }
+
     @Test("Ancestor detach and same-window reattach recreates Metal presentation")
     func ancestorDetachReattachRecreatesMetalView() {
         guard MTLCreateSystemDefaultDevice() != nil else { return }

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -107,6 +107,363 @@ struct TerminalTabTests {
         #expect(!container.subviews.contains(tab1.terminalView))
     }
 
+    @Test @MainActor func staleContainerCannotReclaimTabFromLiveOwner() {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        let first = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let second = TerminalContainerView(frame: NSRect(x: 400, y: 0, width: 400, height: 300))
+        first.terminalPaneState = state
+        second.terminalPaneState = state
+
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        let window = NSWindow(
+            contentRect: host.bounds,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        host.addSubview(first)
+        host.addSubview(second)
+        defer {
+            tab.stop()
+            window.contentView = nil
+        }
+
+        first.showTab(tab)
+        second.showTab(tab)
+        #expect(tab.presentationOwner === second)
+        #expect(tab.terminalView.superview === second)
+
+        // Models the outgoing maximize/restore representable receiving late
+        // updateNSView and layout callbacks during a structural transition.
+        first.showTab(tab)
+        first.layout()
+
+        #expect(tab.presentationOwner === second)
+        #expect(tab.terminalView.superview === second)
+    }
+
+    @Test @MainActor func newlyAttachedContainerCanReclaimPresentationLease() {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        let first = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let second = TerminalContainerView(frame: NSRect(x: 400, y: 0, width: 400, height: 300))
+        first.terminalPaneState = state
+        second.terminalPaneState = state
+
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        let window = NSWindow(
+            contentRect: host.bounds,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        host.addSubview(first)
+        host.addSubview(second)
+        defer {
+            tab.stop()
+            window.contentView = nil
+        }
+
+        first.showTab(tab)
+        second.showTab(tab)
+        #expect(tab.presentationOwner === second)
+
+        // Reattaching the previously used split container models restore.
+        // Its window-attachment callback is the one legitimate force claim.
+        first.removeFromSuperview()
+        host.addSubview(first)
+
+        #expect(tab.presentationOwner === first)
+        #expect(tab.terminalView.superview === first)
+
+        // The older live host can no longer steal the view back.
+        second.showTab(tab)
+        second.layout()
+        #expect(tab.presentationOwner === first)
+        #expect(tab.terminalView.superview === first)
+    }
+
+    @Test @MainActor func detachedContainerCannotStealFromLivePaneOwner() {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        let live = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let incoming = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        live.terminalPaneState = state
+        incoming.terminalPaneState = state
+
+        let host = NSView(frame: live.bounds)
+        let window = NSWindow(
+            contentRect: host.bounds,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        host.addSubview(live)
+        defer {
+            tab.stop()
+            window.contentView = nil
+        }
+
+        live.showTab(tab)
+        incoming.showTab(tab)
+
+        #expect(state.presentationOwner === live)
+        #expect(tab.presentationOwner === live)
+        #expect(tab.terminalView.superview === live)
+
+        host.addSubview(incoming)
+
+        #expect(state.presentationOwner === incoming)
+        #expect(tab.presentationOwner === incoming)
+        #expect(tab.terminalView.superview === incoming)
+    }
+
+    @Test @MainActor func staleContainerCannotStealNewlySelectedTab() {
+        let state = TerminalPaneState()
+        let firstTab = state.addTab(workingDirectory: nil)
+        let secondTab = state.addTab(workingDirectory: nil)
+        state.activeTerminalID = firstTab.id
+        let stale = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let live = TerminalContainerView(frame: NSRect(x: 400, y: 0, width: 400, height: 300))
+        stale.terminalPaneState = state
+        live.terminalPaneState = state
+
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        let window = NSWindow(
+            contentRect: host.bounds,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        host.addSubview(stale)
+        host.addSubview(live)
+        defer {
+            firstTab.stop()
+            secondTab.stop()
+            window.contentView = nil
+        }
+
+        #expect(state.presentationOwner === live)
+        #expect(firstTab.presentationOwner === live)
+
+        state.activeTerminalID = secondTab.id
+        live.showTab(secondTab)
+        stale.showTab(secondTab)
+        stale.layout()
+
+        #expect(state.presentationOwner === live)
+        #expect(secondTab.presentationOwner === live)
+        #expect(secondTab.terminalView.superview === live)
+    }
+
+    @Test @MainActor func sameWindowContainerReparentReclaimsPaneLease() {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        let moving = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let competing = TerminalContainerView(frame: NSRect(x: 400, y: 0, width: 400, height: 300))
+        moving.terminalPaneState = state
+        competing.terminalPaneState = state
+
+        let firstHost = NSView(frame: moving.bounds)
+        let secondHost = NSView(frame: competing.bounds)
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        root.addSubview(firstHost)
+        root.addSubview(secondHost)
+        let window = NSWindow(
+            contentRect: root.bounds,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = root
+        firstHost.addSubview(moving)
+        secondHost.addSubview(competing)
+        defer {
+            tab.stop()
+            window.contentView = nil
+        }
+
+        #expect(state.presentationOwner === competing)
+        #expect(tab.terminalView.superview === competing)
+
+        // Direct addSubview reparents without calling moving.removeFromSuperview().
+        secondHost.addSubview(moving)
+
+        #expect(state.presentationOwner === moving)
+        #expect(tab.presentationOwner === moving)
+        #expect(tab.terminalView.superview === moving)
+
+        competing.showTab(tab)
+        competing.layout()
+        #expect(state.presentationOwner === moving)
+        #expect(tab.presentationOwner === moving)
+        #expect(tab.terminalView.superview === moving)
+    }
+
+    @Test @MainActor func sameWindowAncestorReparentReclaimsPaneLease() {
+        let state = TerminalPaneState()
+        let tab = state.addTab(workingDirectory: nil)
+        let reclaiming = TerminalContainerView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 300)
+        )
+        let outgoing = TerminalContainerView(
+            frame: NSRect(x: 400, y: 0, width: 400, height: 300)
+        )
+        reclaiming.bind(to: state)
+        outgoing.bind(to: state)
+
+        let movingAncestor = NSView(frame: reclaiming.bounds)
+        movingAncestor.addSubview(reclaiming)
+        let firstHost = NSView(frame: reclaiming.bounds)
+        let secondHost = NSView(frame: outgoing.bounds)
+        firstHost.addSubview(movingAncestor)
+        secondHost.addSubview(outgoing)
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        root.addSubview(firstHost)
+        root.addSubview(secondHost)
+        let window = NSWindow(
+            contentRect: root.bounds,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = root
+        defer {
+            tab.stop()
+            window.contentView = nil
+        }
+
+        outgoing.showTab(tab, forcePresentationClaim: true)
+        #expect(state.presentationOwner === outgoing)
+        #expect(tab.terminalView.superview === outgoing)
+
+        // The container itself keeps the same immediate superview. AppKit
+        // reports only a same-window descendant callback when its ancestor is
+        // moved directly to another presentation subtree.
+        secondHost.addSubview(movingAncestor)
+
+        #expect(state.presentationOwner === reclaiming)
+        #expect(tab.presentationOwner === reclaiming)
+        #expect(tab.terminalView.superview === reclaiming)
+        #expect(reclaiming.superview === movingAncestor)
+        #expect(movingAncestor.superview === secondHost)
+
+        outgoing.showTab(tab)
+        outgoing.layout()
+        #expect(state.presentationOwner === reclaiming)
+        #expect(tab.presentationOwner === reclaiming)
+        #expect(tab.terminalView.superview === reclaiming)
+    }
+
+    @Test @MainActor func detachedDestinationWaitsToClaimMovedTabUntilAttach() {
+        let sourceState = TerminalPaneState()
+        let movedTab = sourceState.addTab(workingDirectory: nil)
+        let remainingTab = sourceState.addTab(workingDirectory: nil)
+        sourceState.activeTerminalID = movedTab.id
+        let destinationState = TerminalPaneState()
+        let source = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let destination = TerminalContainerView(frame: NSRect(x: 400, y: 0, width: 400, height: 300))
+        source.bind(to: sourceState)
+        destination.bind(to: destinationState)
+
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        let window = NSWindow(
+            contentRect: host.bounds,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        host.addSubview(source)
+        defer {
+            movedTab.stop()
+            remainingTab.stop()
+            window.contentView = nil
+        }
+
+        #expect(sourceState.presentationOwner === source)
+        #expect(movedTab.presentationOwner === source)
+
+        destinationState.terminalTabs.append(movedTab)
+        destinationState.activeTerminalID = movedTab.id
+        sourceState.terminalTabs.removeAll { $0.id == movedTab.id }
+        sourceState.activeTerminalID = remainingTab.id
+
+        destination.showTab(movedTab)
+        #expect(destinationState.presentationOwner == nil)
+        #expect(movedTab.presentationOwner === source)
+        #expect(movedTab.terminalView.superview === source)
+
+        host.addSubview(destination)
+        source.showTab(sourceState.activeTab)
+
+        #expect(destinationState.presentationOwner === destination)
+        #expect(movedTab.presentationOwner === destination)
+        #expect(movedTab.terminalView.superview === destination)
+        #expect(sourceState.presentationOwner === source)
+        #expect(remainingTab.presentationOwner === source)
+        #expect(remainingTab.terminalView.superview === source)
+    }
+
+    @Test @MainActor func rebindingContainerReleasesPreviousPaneLease() {
+        let firstState = TerminalPaneState()
+        let firstTab = firstState.addTab(workingDirectory: nil)
+        let secondState = TerminalPaneState()
+        let secondTab = secondState.addTab(workingDirectory: nil)
+        let container = TerminalContainerView(
+            frame: NSRect(x: 0, y: 0, width: 400, height: 300)
+        )
+        let outgoingSecondOwner = TerminalContainerView(
+            frame: NSRect(x: 400, y: 0, width: 400, height: 300)
+        )
+        container.bind(to: firstState)
+        outgoingSecondOwner.bind(to: secondState)
+
+        let host = NSView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
+        let window = NSWindow(
+            contentRect: host.bounds,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        host.addSubview(container)
+        host.addSubview(outgoingSecondOwner)
+        defer {
+            firstTab.stop()
+            secondTab.stop()
+            window.contentView = nil
+        }
+
+        #expect(firstState.presentationOwner === container)
+        #expect(firstTab.presentationOwner === container)
+        #expect(secondState.presentationOwner === outgoingSecondOwner)
+        #expect(secondTab.presentationOwner === outgoingSecondOwner)
+
+        let didRebind = container.bind(to: secondState)
+        container.showTab(
+            secondState.activeTab,
+            forcePresentationClaim: didRebind && container.window != nil
+        )
+
+        #expect(firstState.presentationOwner == nil)
+        #expect(firstTab.presentationOwner == nil)
+        #expect(secondState.presentationOwner === container)
+        #expect(secondTab.presentationOwner === container)
+        #expect(secondTab.terminalView.superview === container)
+
+        outgoingSecondOwner.showTab(secondState.activeTab)
+        outgoingSecondOwner.layout()
+        #expect(secondState.presentationOwner === container)
+        #expect(secondTab.presentationOwner === container)
+        #expect(secondTab.terminalView.superview === container)
+    }
+
     // MARK: - TerminalContainerView scroll monitor lifecycle
 
     @Test @MainActor func showTabNilClearsScrollInterceptorTerminalView() {

--- a/PineUITests/TerminalTests.swift
+++ b/PineUITests/TerminalTests.swift
@@ -33,6 +33,10 @@ final class TerminalTests: PineUITestCase {
         app.descendants(matching: .any)["terminalTabBar"].firstMatch
     }
 
+    private var terminalSurface: XCUIElement {
+        app.descendants(matching: .any)["terminalSurface"].firstMatch
+    }
+
     private var newTerminalButton: XCUIElement {
         app.descendants(matching: .any)["newTerminalButton"].firstMatch
     }
@@ -256,6 +260,89 @@ final class TerminalTests: PineUITestCase {
             waitForExistence(restoredTab, timeout: 5),
             "Editor area (with main.swift tab) should be visible after restore"
         )
+    }
+
+    /// Repeated structural replacement must keep all model-owned AppKit
+    /// terminal surfaces inside the live SwiftUI host. Exercise both the
+    /// production renderer selection and the forced CoreGraphics fallback in
+    /// one method so the Terminal CI shard gains only one test.
+    func testRepeatedMaximizeRestoreKeepsTerminalSurfacesAttachedAcrossRenderers() throws {
+        app.launchArguments.removeAll { $0 == "--disable-metal" }
+        assertRepeatedMaximizeRestoreKeepsTerminalSurfaceAttached(renderer: "Production")
+
+        // The black-terminal family predates Metal, so relaunch with the
+        // legacy renderer under the exact same structural stress.
+        app.terminate()
+        app.launchArguments.append("--disable-metal")
+        assertRepeatedMaximizeRestoreKeepsTerminalSurfaceAttached(renderer: "CoreGraphics")
+    }
+
+    private func assertRepeatedMaximizeRestoreKeepsTerminalSurfaceAttached(renderer: String) {
+        launchAndWaitForLoad()
+        openMainSwiftFromSidebar()
+        createTerminalViaMenu()
+        let terminalNames = ["Terminal 1", "Terminal 2", "Terminal 3"]
+        XCTAssertTrue(
+            waitForExistence(terminalTab(terminalNames[0]), timeout: 10),
+            "First terminal should exist before creating stress sessions"
+        )
+        XCTAssertTrue(
+            waitForExistence(newTerminalButton, timeout: 5),
+            "New terminal button should exist"
+        )
+        for name in terminalNames.dropFirst() {
+            newTerminalButton.click()
+            XCTAssertTrue(
+                waitForExistence(terminalTab(name), timeout: 10),
+                "\(name) should exist before maximize/restore stress"
+            )
+        }
+
+        XCTAssertTrue(
+            waitForExistence(terminalSurface, timeout: 10),
+            "Terminal surface should be attached before maximize/restore stress"
+        )
+        let divider = app.descendants(matching: .any)["paneDivider"].firstMatch
+
+        for iteration in 1...12 {
+            maximizeButton.click()
+            let disappearDeadline = Date().addingTimeInterval(5)
+            while divider.exists && Date() < disappearDeadline {
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+            XCTAssertFalse(
+                divider.exists,
+                "\(renderer) cycle \(iteration): divider should disappear"
+            )
+
+            let maximizedSurface = terminalSurface
+            XCTAssertTrue(
+                waitForExistence(maximizedSurface, timeout: 5),
+                "\(renderer) cycle \(iteration): terminal surface should remain attached when maximized"
+            )
+            XCTAssertGreaterThan(maximizedSurface.frame.width, 100)
+            XCTAssertGreaterThan(maximizedSurface.frame.height, 100)
+
+            maximizeButton.click()
+            XCTAssertTrue(
+                waitForExistence(divider, timeout: 5),
+                "\(renderer) cycle \(iteration): divider should return after restore"
+            )
+
+            let restoredSurface = terminalSurface
+            XCTAssertTrue(
+                waitForExistence(restoredSurface, timeout: 5),
+                "\(renderer) cycle \(iteration): terminal surface should remain attached after restore"
+            )
+            XCTAssertGreaterThan(restoredSurface.frame.width, 100)
+            XCTAssertGreaterThan(restoredSurface.frame.height, 100)
+            for name in terminalNames {
+                XCTAssertTrue(
+                    terminalTab(name).exists,
+                    "\(renderer) cycle \(iteration): \(name) session should survive"
+                )
+            }
+        }
     }
 
     /// Click hide/close button removes the terminal pane entirely.


### PR DESCRIPTION
## Summary

- make terminal maximize/restore an atomic structural swap instead of an animated overlap
- give each terminal pane and tab one committed AppKit presentation owner so stale SwiftUI representables cannot steal the model-owned SwiftTerm view
- detect direct view moves, whole-container moves, detach/reattach, and ancestor-subtree moves inside the same window
- refresh CoreGraphics after a real host change and recreate only SwiftTerm's nested Metal renderer when its presentation generation changes
- preserve the long-lived `TerminalTab`, SwiftTerm view, terminal model, and process; fall back to CoreGraphics if Metal recreation fails
- route Quick Terminal through the same binding lifecycle

The presentation-ownership race exists independently of renderer choice. Historical CoreGraphics black-surface reports keep that path in regression coverage; Metal additionally needs its nested `MTKView` presentation recreated after a real same-window host change.

## Regression coverage

- 101 focused terminal lifecycle/renderer unit tests passed
- hosted cross-pane test moves a live terminal between two attached pane containers, verifies a new `MTKView`, preserves the same `Terminal`, transfers both ownership leases, and cleans up the displaced tab
- combined structural UI stress passed: three independent live terminal tabs, switching across all three, 12 maximize/restore cycles through the production renderer path, app relaunch, then 12 more cycles with forced CoreGraphics
- the UI stress is an accessibility/frame/attachment oracle, not a pixel sampler; hosted AppKit tests cover renderer recreation, terminal identity, and redraw routing
- UI test build passed
- SwiftLint strict: 0 violations
- `git diff --check` passed
- full local unit run reached 5,544 tests with one unrelated `SymbolCoordinatorTests.staleResultIsDiscarded` timing failure; the complete 17-test `SymbolCoordinatorTests` class passed on isolated rerun

## Compatibility

Local compatibility-sensitive verification:

- macOS 27.0 (26A5388g)
- Xcode 27.0 (27A5218g)
- macOS SDK 27.0 (26A5378i)
- MacBook Pro Mac16,7, M4 Pro, built-in 3456×2234 Retina display
- SwiftTerm 1.15.0, Sparkle 2.9.4, swift-markdown/cmark 0.8.0, swift-argument-parser 1.8.2 (unchanged)

The deployment target remains macOS 26.0. This machine has no macOS 26/Xcode 26 runtime, so the protected CI macOS 26 jobs provide the baseline verification.

Closes #1229
