### PR TITLE
fix: synchronize YAML fold rendering

### DIFF
--- a/Pine/CodeEditorView+Coordinator.swift
+++ b/Pine/CodeEditorView+Coordinator.swift
@@ -33,6 +33,17 @@ extension CodeEditorView {
         /// Cached foldable ranges for the current text.
         var foldableRanges: [FoldableRange] = []
 
+        /// Fold state currently used by AppKit's glyph/layout delegates.
+        ///
+        /// `PaneLeafView` builds the binding getter from an `EditorTab` value
+        /// captured during the current SwiftUI render. After the binding
+        /// setter writes a new state to `TabManager`, that captured getter
+        /// remains one render behind until `updateNSView` replaces `parent`.
+        /// Reading `parent.foldState` while invalidating layout therefore
+        /// makes the text rendering lag the gutter by one click. Keep the
+        /// state applied to AppKit synchronously in the coordinator instead.
+        private(set) var renderedFoldState: FoldState
+
         /// Snapshot adapter around Pine's bounded bracket matcher (#1008).
         private let bracketProvider = BoundedBracketProvider()
         private var bracketRevision = 0
@@ -206,6 +217,7 @@ extension CodeEditorView {
 
         init(parent: CodeEditorView) {
             self.parent = parent
+            self.renderedFoldState = parent.foldState
             self.lastLSPFoldRefreshGeneration =
                 parent.lspFoldRefreshGeneration
             // Initialize language/fileName to match the initial view,
@@ -226,6 +238,15 @@ extension CodeEditorView {
                 name: .tabReloadedFromDisk,
                 object: nil
             )
+        }
+
+        /// Adopts the latest SwiftUI value before any update path can force
+        /// TextKit layout. On a tab switch, `updateContentIfNeeded` restores
+        /// scroll position synchronously, so its layout delegate must already
+        /// use the destination tab's fold state rather than the previous one.
+        func prepareForViewUpdate(_ parent: CodeEditorView) {
+            self.parent = parent
+            synchronizeFoldState(parent.foldState)
         }
 
         /// Handles `.tabReloadedFromDisk` notification — if the URL matches
@@ -1199,8 +1220,9 @@ extension CodeEditorView {
 
         /// Handles fold toggle from gutter click.
         func handleFoldToggle(_ foldable: FoldableRange) {
-            parent.foldState.toggle(foldable)
-            applyFoldState()
+            var state = renderedFoldState
+            state.toggle(foldable)
+            commitFoldState(state)
         }
 
         /// Toggles inline diff expansion for a hunk when user clicks a gutter diff marker.
@@ -1228,8 +1250,8 @@ extension CodeEditorView {
         /// `.onReceive` path) and #1047 (which closed the AppKit
         /// `reportStateChange` path), on the one AppKit-observer path that
         /// #1051 did not audit: the keyboard-driven `.foldCode` observer.
-        /// `applyFoldState()` is deferred alongside the mutation because it
-        /// reads `parent.foldState` and must observe the just-applied change.
+        /// AppKit layout invalidation is deferred alongside the mutation so
+        /// the glyph and line-fragment delegates observe the committed state.
         ///
         /// The defer lives in ``scheduleFoldAction`` (not inline here) so the
         /// deferral contract is unit-testable — see
@@ -1257,11 +1279,11 @@ extension CodeEditorView {
             }
         }
 
-        /// Applies a fold action to `parent.foldState`. Extracted and internal
-        /// so the reentrancy deferral contract in ``handleFoldCode`` is
-        /// unit-testable (the deferral lives in the caller, the fold logic
-        /// here is the deferred body), and so the fold logic itself can be
-        /// exercised without a key window.
+        /// Applies a fold action to persistent and rendered fold state.
+        /// Extracted and internal so the reentrancy deferral contract in
+        /// ``handleFoldCode`` is unit-testable (the deferral lives in the
+        /// caller, the fold logic here is the deferred body), and so the fold
+        /// logic itself can be exercised without a key window.
         func performFoldAction(_ action: String) {
             switch action {
             case "fold":
@@ -1269,11 +1291,13 @@ extension CodeEditorView {
             case "unfold":
                 unfoldAtCursor()
             case "foldAll":
-                parent.foldState.foldAll(foldableRanges)
-                applyFoldState()
+                var state = renderedFoldState
+                state.foldAll(foldableRanges)
+                commitFoldState(state)
             case "unfoldAll":
-                parent.foldState.unfoldAll()
-                applyFoldState()
+                var state = renderedFoldState
+                state.unfoldAll()
+                commitFoldState(state)
             default:
                 break
             }
@@ -1292,12 +1316,13 @@ extension CodeEditorView {
             // Find innermost unfoldable range at cursor line
             let candidates = foldableRanges.filter {
                 cursorLine >= $0.startLine && cursorLine <= $0.endLine
-                    && !parent.foldState.isFolded($0)
+                    && !renderedFoldState.isFolded($0)
             }
             // Pick the innermost (smallest span)
             if let best = candidates.min(by: { ($0.endLine - $0.startLine) < ($1.endLine - $1.startLine) }) {
-                parent.foldState.fold(best)
-                applyFoldState()
+                var state = renderedFoldState
+                state.fold(best)
+                commitFoldState(state)
             }
         }
 
@@ -1312,20 +1337,49 @@ extension CodeEditorView {
             let cursorLine = cache.lineNumber(at: cursorLocation)
 
             // Find folded range whose startLine matches cursor line
-            if let folded = parent.foldState.foldedRanges.first(where: { $0.startLine == cursorLine }) {
-                parent.foldState.unfold(folded)
-                applyFoldState()
+            if let folded = renderedFoldState.foldedRanges.first(
+                where: { $0.startLine == cursorLine }
+            ) {
+                var state = renderedFoldState
+                state.unfold(folded)
+                commitFoldState(state)
             }
         }
 
-        /// Applies the current fold state to the layout manager and redraws.
-        private func applyFoldState() {
+        /// Synchronizes fold state supplied by a later SwiftUI render.
+        ///
+        /// Gutter/menu actions already update `renderedFoldState`
+        /// synchronously. The equality check avoids invalidating the complete
+        /// document again when that same state comes back through
+        /// `updateNSView`.
+        func synchronizeFoldState(_ state: FoldState) {
+            guard state != renderedFoldState else {
+                lineNumberView?.foldState = state
+                return
+            }
+            renderedFoldState = state
+            invalidateFoldLayout()
+        }
+
+        /// Commits a user action to both persistent SwiftUI state and the
+        /// synchronous AppKit rendering state.
+        private func commitFoldState(_ state: FoldState) {
+            // Set this before writing the binding. Its setter can trigger a
+            // synchronous updateNSView, which must already observe the state
+            // that the layout delegate will render.
+            renderedFoldState = state
+            parent.foldState = state
+            invalidateFoldLayout()
+        }
+
+        /// Invalidates glyphs/layout using `renderedFoldState` and redraws.
+        private func invalidateFoldLayout() {
             guard let sv = scrollView,
                   let textView = sv.documentView as? NSTextView,
                   let layoutManager = textView.layoutManager else { return }
 
             let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
-            lineNumberView?.foldState = parent.foldState
+            lineNumberView?.foldState = renderedFoldState
             // Invalidate glyphs so shouldGenerateGlyphs re-evaluates hidden lines,
             // then invalidate layout so shouldSetLineFragmentRect collapses heights.
             layoutManager.invalidateGlyphs(forCharacterRange: fullRange, changeInLength: 0, actualCharacterRange: nil)
@@ -1346,7 +1400,7 @@ extension CodeEditorView {
             font aFont: NSFont,
             forGlyphRange glyphRange: NSRange
         ) -> Int {
-            guard !parent.foldState.foldedRanges.isEmpty,
+            guard !renderedFoldState.foldedRanges.isEmpty,
                   let cache = lineStartsCache else { return 0 }
 
             let count = glyphRange.length
@@ -1366,7 +1420,7 @@ extension CodeEditorView {
                     isHidden = prevHidden
                 } else {
                     let line = cache.lineNumber(at: charIndex)
-                    isHidden = parent.foldState.isLineHidden(line)
+                    isHidden = renderedFoldState.isLineHidden(line)
                     prevCharIndex = charIndex
                     prevHidden = isHidden
                 }
@@ -1397,7 +1451,7 @@ extension CodeEditorView {
             in textContainer: NSTextContainer,
             forGlyphRange glyphRange: NSRange
         ) -> Bool {
-            guard !parent.foldState.foldedRanges.isEmpty else { return false }
+            guard !renderedFoldState.foldedRanges.isEmpty else { return false }
             let charRange = layoutManager.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
 
             // Use cached line starts for O(log n) lookup
@@ -1405,7 +1459,7 @@ extension CodeEditorView {
             let line = cache.lineNumber(at: charRange.location)
 
             // If this line is hidden (inside a folded region), collapse it to zero height
-            if parent.foldState.isLineHidden(line) {
+            if renderedFoldState.isLineHidden(line) {
                 lineFragmentRect.pointee.size.height = 0
                 lineFragmentUsedRect.pointee.size.height = 0
                 baselineOffset.pointee = 0

--- a/Pine/CodeEditorView.swift
+++ b/Pine/CodeEditorView.swift
@@ -367,8 +367,9 @@ struct CodeEditorView: NSViewRepresentable {
     }
 
     func updateNSView(_ container: NSView, context: Context) {
-        // Обновляем parent, чтобы binding в coordinator был актуальным
-        context.coordinator.parent = self
+        // Adopt the new tab's fold state before content synchronization can
+        // force TextKit layout for cursor/scroll restoration.
+        context.coordinator.prepareForViewUpdate(self)
 
         guard let editorContainer = container as? EditorContainerView else { return }
 
@@ -465,7 +466,6 @@ struct CodeEditorView: NSViewRepresentable {
             lineNumberView.lineDiffs = lineDiffs
             lineNumberView.diffHunks = diffHunks
             lineNumberView.validationDiagnostics = validationDiagnostics
-            lineNumberView.foldState = foldState
         }
         if let minimapView = context.coordinator.minimapView {
             minimapView.lineDiffs = lineDiffs

--- a/Pine/FoldState.swift
+++ b/Pine/FoldState.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// Управляет состоянием свёрнутых регионов кода для одного таба.
-struct FoldState {
+struct FoldState: Equatable {
     /// Текущие свёрнутые регионы.
     private(set) var foldedRanges: [FoldableRange] = []
 

--- a/PineTests/CoordinatorExtendedTests.swift
+++ b/PineTests/CoordinatorExtendedTests.swift
@@ -243,6 +243,212 @@ struct CoordinatorExtendedTests {
         #expect(foldState.isFolded(range))
     }
 
+    @Test("YAML fold renders on the first click with a snapshot binding getter")
+    func handleFoldToggle_rendersSnapshotBindingImmediately() throws {
+        let text = """
+        disabled_rules:
+          - trailing_comma
+          - todo
+        opt_in_rules:
+        """
+        let initialState = FoldState()
+        var persistedState = initialState
+        let editorView = CodeEditorView(
+            text: .constant(text),
+            contentVersion: 0,
+            language: "yaml",
+            fileName: ".swiftlint.yml",
+            foldState: .init(
+                // PaneLeafView captures an EditorTab value in exactly this
+                // shape: the getter remains on the previous render's
+                // snapshot even after the setter persists the new state.
+                get: { initialState },
+                set: { persistedState = $0 }
+            )
+        )
+        let (scrollView, textView) = makeTextStack(text: text)
+        let coordinator = CodeEditorView.Coordinator(parent: editorView)
+        coordinator.scrollView = scrollView
+        coordinator.lineStartsCache = LineStartsCache(text: text)
+        textView.layoutManager?.delegate = coordinator
+
+        let lineNumberView = LineNumberView(
+            textView: textView,
+            clipView: scrollView.contentView
+        )
+        coordinator.lineNumberView = lineNumberView
+
+        let range = try #require(
+            YAMLIndentationFoldCalculator.calculate(text: text).first {
+                $0.kind == .indentation && $0.startLine == 1
+            }
+        )
+        let layoutManager = try #require(textView.layoutManager)
+        let textContainer = try #require(textView.textContainer)
+        layoutManager.ensureLayout(for: textContainer)
+
+        let hiddenCharacter = (text as NSString).range(
+            of: "trailing_comma"
+        ).location
+        var hiddenGlyph = layoutManager.glyphIndexForCharacter(
+            at: hiddenCharacter
+        )
+        #expect(
+            !layoutManager.propertyForGlyph(at: hiddenGlyph).contains(.null)
+        )
+
+        coordinator.handleFoldToggle(range)
+        layoutManager.ensureLayout(for: textContainer)
+        hiddenGlyph = layoutManager.glyphIndexForCharacter(
+            at: hiddenCharacter
+        )
+
+        #expect(persistedState.isFolded(range))
+        #expect(coordinator.renderedFoldState.isFolded(range))
+        #expect(lineNumberView.foldState.isFolded(range))
+        #expect(
+            layoutManager.propertyForGlyph(at: hiddenGlyph).contains(.null),
+            "The first click must suppress YAML body glyphs immediately"
+        )
+
+        coordinator.handleFoldToggle(range)
+        layoutManager.ensureLayout(for: textContainer)
+        hiddenGlyph = layoutManager.glyphIndexForCharacter(
+            at: hiddenCharacter
+        )
+
+        #expect(!persistedState.isFolded(range))
+        #expect(!coordinator.renderedFoldState.isFolded(range))
+        #expect(!lineNumberView.foldState.isFolded(range))
+        #expect(
+            !layoutManager.propertyForGlyph(at: hiddenGlyph).contains(.null),
+            "The second click must reveal the YAML body, not apply the first click"
+        )
+    }
+
+    @Test("A later SwiftUI fold-state update resynchronizes AppKit rendering")
+    func synchronizeFoldState_appliesExternalState() throws {
+        let text = "root:\n  child: value\nsibling: value"
+        let (coordinator, scrollView, textView) = makeCoordinator(
+            text: text,
+            language: "yaml",
+            fileName: "test.yaml"
+        )
+        textView.layoutManager?.delegate = coordinator
+        coordinator.lineStartsCache = LineStartsCache(text: text)
+        coordinator.lineNumberView = LineNumberView(
+            textView: textView,
+            clipView: scrollView.contentView
+        )
+        let layoutManager = try #require(textView.layoutManager)
+        let textContainer = try #require(textView.textContainer)
+        layoutManager.ensureLayout(for: textContainer)
+
+        let range = try #require(
+            YAMLIndentationFoldCalculator.calculate(text: text).first
+        )
+        let hiddenCharacter = (text as NSString).range(
+            of: "child"
+        ).location
+        var hiddenGlyph = layoutManager.glyphIndexForCharacter(
+            at: hiddenCharacter
+        )
+        #expect(
+            !layoutManager.propertyForGlyph(at: hiddenGlyph).contains(.null)
+        )
+        var restoredState = FoldState()
+        restoredState.fold(range)
+
+        coordinator.synchronizeFoldState(restoredState)
+        layoutManager.ensureLayout(for: textContainer)
+        hiddenGlyph = layoutManager.glyphIndexForCharacter(
+            at: hiddenCharacter
+        )
+
+        #expect(coordinator.renderedFoldState.isFolded(range))
+        #expect(coordinator.lineNumberView?.foldState.isFolded(range) == true)
+        #expect(
+            layoutManager.propertyForGlyph(at: hiddenGlyph).contains(.null)
+        )
+    }
+
+    @Test("Tab switch adopts its fold state before restoring content and scroll")
+    func prepareForViewUpdate_unfoldsBeforeTabLayout() throws {
+        let oldLines = (1...240).map { "  - old_rule_\($0)" }
+        let oldText = (["disabled_rules:"] + oldLines).joined(separator: "\n")
+        let oldRange = FoldableRange(
+            startLine: 1,
+            endLine: 241,
+            startCharIndex: 0,
+            endCharIndex: (oldText as NSString).length,
+            kind: .indentation
+        )
+        var oldState = FoldState()
+        oldState.fold(oldRange)
+
+        let oldView = CodeEditorView(
+            text: .constant(oldText),
+            contentVersion: 0,
+            language: "yaml",
+            fileName: "old.yaml",
+            foldState: .constant(oldState)
+        )
+        let (scrollView, textView) = makeTextStack(text: oldText)
+        textView.isVerticallyResizable = true
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        let coordinator = CodeEditorView.Coordinator(parent: oldView)
+        coordinator.scrollView = scrollView
+        coordinator.lineStartsCache = LineStartsCache(text: oldText)
+        coordinator.syncContentVersion()
+        textView.layoutManager?.delegate = coordinator
+
+        let newLines = (1...240).map { "new_rule_\($0): enabled" }
+        let newText = newLines.joined(separator: "\n")
+        let savedOffset: CGFloat = 600
+        let newView = CodeEditorView(
+            text: .constant(newText),
+            contentVersion: 1,
+            language: "yaml",
+            fileName: "new.yaml",
+            foldState: .constant(FoldState()),
+            initialScrollOffset: savedOffset
+        )
+
+        // This is the production updateNSView order: destination state first,
+        // then the content path that synchronously lays out and restores scroll.
+        coordinator.prepareForViewUpdate(newView)
+        coordinator.updateContentIfNeeded(
+            text: newText,
+            language: "yaml",
+            fileName: "new.yaml",
+            font: font13
+        )
+
+        #expect(coordinator.parent.fileName == "new.yaml")
+        let layoutManager = try #require(textView.layoutManager)
+        let textContainer = try #require(textView.textContainer)
+        layoutManager.ensureLayout(for: textContainer)
+        let visibleCharacter = (newText as NSString).range(
+            of: "new_rule_200"
+        ).location
+        let visibleGlyph = layoutManager.glyphIndexForCharacter(
+            at: visibleCharacter
+        )
+
+        #expect(coordinator.renderedFoldState == FoldState())
+        #expect(
+            !layoutManager.propertyForGlyph(at: visibleGlyph).contains(.null),
+            "The destination document must not inherit hidden lines from the previous tab"
+        )
+        #expect(
+            scrollView.contentView.bounds.origin.y > 0,
+            "Scroll restoration must use the destination tab's unfolded layout"
+        )
+    }
+
     private func waitForFoldCalculation(
         _ coordinator: CodeEditorView.Coordinator
     ) async {


### PR DESCRIPTION
## Summary

- Keep the AppKit-rendered fold state synchronous with SwiftUI binding writes.
- Apply the destination tab fold state before TextKit lays out content for cursor and scroll restoration.
- Add TextKit regressions for the first and second YAML gutter clicks, external state restoration, and tab switching.

## Related issue

Closes #1231

## Test plan

- [x] Unit tests added/updated
- [x] UI tests N/A — the regression is covered directly through the TextKit layout manager and glyph properties
- [x] 77 tests passed across CoordinatorExtendedTests, FoldObserverReentrancyTests, FoldStateTests, and YAMLIndentationFoldTests
- [x] Strict SwiftLint passed with 0 violations in all changed Swift files

## Compatibility matrix

- macOS 26: Not tested — runtime unavailable locally; the tested build kept the arm64-apple-macos26.0 deployment target
- macOS 27 beta: Tested — macOS 27.0, build 26A5388g; beta channel is not reported by sw_vers
- Xcode: Xcode 27.0, build 27A5218g
- macOS SDK: 27.0, build 26A5378i

### Terminal renderer coverage

- Default path (Metal when available): N/A — editor-only change
- CoreGraphics (`--disable-metal`): N/A — editor-only change

## Manual testing checklist

- [ ] Verified the change works as expected — automated TextKit regression used because no macOS 26 runtime is available locally
- [x] No regressions in related features — all 77 related tests passed

Ready to merge when all required CI checks are green.
