### PR TITLE
docs(install): use one-command Homebrew cask installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ Pine keeps CLI agents in the terminal and the code in view. It reflects agent ac
 **Homebrew** (recommended):
 
 ```bash
-brew tap batonogov/tap
-brew install --cask pine-editor
+brew install --cask batonogov/tap/pine-editor
 ```
 
 **Direct download:** grab the latest `.dmg` from [Releases](https://github.com/batonogov/pine/releases/latest).

--- a/docs/index.html
+++ b/docs/index.html
@@ -1041,7 +1041,7 @@
                     </div>
                     <div class="install-strip">
                         <div class="install-strip-label" data-i18n="hero.installLabel">Install in 10 seconds</div>
-                        <code>brew tap batonogov/tap &amp;&amp; brew install --cask pine-editor</code>
+                        <code>brew install --cask batonogov/tap/pine-editor</code>
                     </div>
                 </div>
 
@@ -1228,7 +1228,7 @@
                     </div>
                     <div class="command-shell">
                         <div class="command-shell-label">Homebrew</div>
-                        <pre><code>brew tap batonogov/tap &amp;&amp; brew install --cask pine-editor</code></pre>
+                        <pre><code>brew install --cask batonogov/tap/pine-editor</code></pre>
                         <p data-i18n-html="install.shellNote">Build from source with <code>xcodebuild -project Pine.xcodeproj -scheme Pine build</code> if you want the full native stack on your machine.</p>
                     </div>
                 </div>


### PR DESCRIPTION
Closes #1248.

Replace two-step `brew tap batonogov/tap && brew install --cask pine-editor` with the fully qualified one-command cask install:

```sh
brew install --cask batonogov/tap/pine-editor
```

Homebrew automatically adds the tap and trusts only the requested cask, reducing friction and narrowing trust scope.

**Changed surfaces:**
- `README.md` — install block
- `docs/index.html` — hero CTA (line ~1044) and install section (line ~1231)

All other installation methods (direct download, build from source) are unchanged.