### PR TITLE
feat(terminal): add selectable terminal themes with light/dark pairs

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -13,6 +13,9 @@ nonisolated enum AccessibilityID {
         "agentHandoffReadOnlyContextToggle"
     static let agentHandoffStatus = "agentHandoffStatus"
 
+    // MARK: - Terminal theme settings
+    static let terminalAppearancePicker = "terminalAppearancePicker"
+
     // MARK: - Welcome window
     static let welcomeOpenFolderButton = "welcomeOpenFolderButton"
     static let welcomeRecentProjectsList = "welcomeRecentProjectsList"

--- a/Pine/Agent/AgentHandoffSettingsView.swift
+++ b/Pine/Agent/AgentHandoffSettingsView.swift
@@ -11,9 +11,28 @@ import SwiftUI
 struct PineSettingsView: View {
     let lspSettings: LSPSettings
     let handoffSettings: AgentHandoffSettings
+    let terminalThemeSettings: TerminalThemeSettings
+
+    init(
+        lspSettings: LSPSettings,
+        handoffSettings: AgentHandoffSettings,
+        terminalThemeSettings: TerminalThemeSettings = .shared
+    ) {
+        self.lspSettings = lspSettings
+        self.handoffSettings = handoffSettings
+        self.terminalThemeSettings = terminalThemeSettings
+    }
 
     var body: some View {
         TabView {
+            TerminalSettingsView(settings: terminalThemeSettings)
+                .tabItem {
+                    Label(
+                        Strings.settingsTerminalTab,
+                        systemImage: "terminal"
+                    )
+                }
+
             LSPSettingsView(settings: lspSettings)
                 .tabItem {
                     Label(

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -11,6 +11,8 @@ enum Strings {
         "settings.tab.languageServers"
     static let settingsAgentHandoffTab: LocalizedStringKey =
         "settings.tab.agentHandoff"
+    static let settingsTerminalTab: LocalizedStringKey =
+        "settings.tab.terminal"
     static let agentHandoffSettingsTitle: LocalizedStringKey =
         "settings.agentHandoff.title"
     static let agentHandoffReadOnlyContext: LocalizedStringKey =
@@ -179,6 +181,21 @@ enum Strings {
     static let hideTerminalShortcut: LocalizedStringKey = "terminal.hideShortcut"
     static let showTerminalShortcut: LocalizedStringKey = "terminal.showShortcut"
     static let toggleTerminal: LocalizedStringKey = "terminal.toggle"
+
+    // MARK: - Terminal theme settings (#1244)
+
+    static let terminalThemeSettingsTitle: LocalizedStringKey =
+        "settings.terminal.theme.title"
+    static let terminalThemeSettingsSubtitle: LocalizedStringKey =
+        "settings.terminal.theme.subtitle"
+    static let terminalThemeSelectionLabel: LocalizedStringKey =
+        "settings.terminal.theme.selectionLabel"
+    static let terminalAppearanceLabel: LocalizedStringKey =
+        "settings.terminal.appearance.label"
+    static let terminalAppearanceHelp: LocalizedStringKey =
+        "settings.terminal.appearance.help"
+    static let terminalThemePreviewLabel: LocalizedStringKey =
+        "settings.terminal.theme.previewLabel"
 
     // MARK: - Status bar (agent awareness, #952)
 

--- a/Pine/TerminalPalette.swift
+++ b/Pine/TerminalPalette.swift
@@ -60,7 +60,7 @@ import SwiftTerm
 /// 8-bit RGB triple used to describe a single ANSI palette entry in
 /// human-readable form. Converted to SwiftTerm's 16-bit `Color` at install
 /// time. Public for unit-testing.
-struct TerminalPaletteEntry: Equatable {
+struct TerminalPaletteEntry: Equatable, Hashable {
     let red: UInt8
     let green: UInt8
     let blue: UInt8

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -1642,15 +1642,26 @@ final class TerminalTab: Identifiable, Hashable {
     /// palette and background when the user switches between light/dark mode.
     private var appearanceObservation: NSKeyValueObservation?
 
+    /// Observer for `terminalThemeChanged` — re-applies the selected theme's
+    /// colors immediately when the user picks a new theme or appearance
+    /// policy in Settings (issue #1244). Lives for the tab's lifetime.
+    private var themeChangeObserver: NSObjectProtocol?
+
+    /// The theme/appearance settings source. Defaults to the shared singleton
+    /// but is injectable so unit tests can drive resolution deterministically.
+    private let themeSettings: TerminalThemeSettings
+
     init(
         name: String,
         shellSettings: ShellSettings = .shared,
-        agentHandoffSettings: AgentHandoffSettings = .shared
+        agentHandoffSettings: AgentHandoffSettings = .shared,
+        themeSettings: TerminalThemeSettings = .shared
     ) {
         self.name = name
         self.stableLabel = name
         self.shellSettings = shellSettings
         self.agentHandoffSettings = agentHandoffSettings
+        self.themeSettings = themeSettings
         self.terminalView = PineTerminalView(frame: TerminalContainerView.defaultTerminalFrame)
         self.terminalView.setAccessibilityElement(true)
         self.terminalView.setAccessibilityRole(.textArea)
@@ -1672,25 +1683,55 @@ final class TerminalTab: Identifiable, Hashable {
         applyCurrentTerminalAppearance(forceRedraw: false)
 
         // Re-apply palette and background when system appearance changes.
+        // Only the "Follow System" policy responds to this; Always Light /
+        // Always Dark are independent of the system appearance (#1244).
         appearanceObservation = NSApp.observe(\.effectiveAppearance, options: .new) { [weak self] _, _ in
+            Task { @MainActor [weak self] in
+                self?.applyCurrentTerminalAppearance(forceRedraw: true)
+            }
+        }
+
+        // Re-apply colors immediately when the user changes the selected
+        // theme or appearance policy in Settings → Terminal (issue #1244).
+        themeChangeObserver = NotificationCenter.default.addObserver(
+            forName: .terminalThemeChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.applyCurrentTerminalAppearance(forceRedraw: true)
             }
         }
     }
 
-    /// Applies Pine's appearance-aware terminal colors and keeps SwiftTerm's
+    deinit {
+        if let themeChangeObserver {
+            NotificationCenter.default.removeObserver(themeChangeObserver)
+        }
+    }
+
+    /// Applies the terminal's appearance-aware colors and keeps SwiftTerm's
     /// layer background in sync with the terminal model. SwiftTerm only sets
     /// `layer.backgroundColor` during initial setup, so Pine must refresh it
     /// when the app moves between light and dark appearances.
+    ///
+    /// Resolves the active color scheme from `TerminalThemeSettings` (the
+    /// selected theme + appearance policy vs. the system's effective
+    /// appearance) and applies every slot: background, foreground, cursor,
+    /// selection, link, and the 16 ANSI colors (issue #1244).
     ///
     /// `internal` (not `private`) so unit tests can pin the invariant that
     /// this method does NOT clear `layer.contents` without a synchronous
     /// repaint (issue #1107).
     internal func applyCurrentTerminalAppearance(forceRedraw: Bool) {
-        let background = TerminalPalette.currentBackgroundColor()
-        terminalView.nativeForegroundColor = .textColor
+        let scheme = themeSettings.currentScheme()
+        let background = scheme.backgroundColor()
+
+        terminalView.nativeForegroundColor = scheme.foregroundColor()
         terminalView.nativeBackgroundColor = background
+        terminalView.caretColor = scheme.cursorColor()
+        terminalView.selectedTextBackgroundColor = scheme.selectionColor()
+
         // Sync the layer's background colour WITHOUT clearing `contents`.
         // `prepareLayerForRedraw()` nils `layer.contents`, which is only safe
         // from `forceFullRedraw()` — where the nil is immediately followed by
@@ -1704,11 +1745,12 @@ final class TerminalTab: Identifiable, Hashable {
         // and redundant on the `forceRedraw == true` path.
         terminalView.layer?.backgroundColor = background.cgColor
 
-        // Apply Pine's terminal palette (issue #816, #931).
-        // Centralised in `TerminalPalette` so it can be unit-tested
-        // independently of the SwiftTerm view and kept as a single source of
-        // truth. The palette adapts to the current system appearance.
-        TerminalPalette.install(on: terminalView)
+        // Install the theme's 16 ANSI colors (issue #816, #931, #1244).
+        // The palette is resolved from the theme so the user's selection
+        // takes effect immediately without restarting the shell or losing
+        // scrollback. True-color `\e[38;2;R;G;Bm` output and TUI-owned colors
+        // are untouched — only the 16 ANSI slots are replaced.
+        TerminalPalette.install(palette: scheme.ansiColors, on: terminalView)
 
         if forceRedraw {
             forceFullRedraw()

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -1645,7 +1645,12 @@ final class TerminalTab: Identifiable, Hashable {
     /// Observer for `terminalThemeChanged` — re-applies the selected theme's
     /// colors immediately when the user picks a new theme or appearance
     /// policy in Settings (issue #1244). Lives for the tab's lifetime.
-    private var themeChangeObserver: NSObjectProtocol?
+    ///
+    /// `nonisolated(unsafe)`: the token is set once during `init` (on the main
+    /// actor) and read only in `deinit`, which is implicitly `nonisolated` and
+    /// therefore cannot touch a MainActor-isolated stored property. The token
+    /// itself is a plain `NSObjectProtocol` value with no actor affinity.
+    nonisolated(unsafe) private var themeChangeObserver: NSObjectProtocol?
 
     /// The theme/appearance settings source. Defaults to the shared singleton
     /// but is injectable so unit tests can drive resolution deterministically.

--- a/Pine/TerminalSettingsView.swift
+++ b/Pine/TerminalSettingsView.swift
@@ -1,0 +1,189 @@
+//
+//  TerminalSettingsView.swift
+//  Pine
+//
+//  Settings pane for terminal themes and appearance policy (#1244).
+//
+//  Shows a theme selector (curated built-in themes), an appearance policy
+//  picker (Follow System / Always Light / Always Dark), and a live preview
+//  swatch grid. All changes apply immediately — the selected theme's colors
+//  are applied to every live terminal session through the
+//  `terminalThemeChanged` notification.
+//
+
+import SwiftUI
+
+@MainActor
+struct TerminalSettingsView: View {
+    let settings: TerminalThemeSettings
+    private let locale: Locale
+
+    init(settings: TerminalThemeSettings, locale: Locale = .current) {
+        self.settings = settings
+        self.locale = locale
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(Strings.terminalThemeSettingsTitle)
+                .font(.title2.weight(.semibold))
+
+            Text(Strings.terminalThemeSettingsSubtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            // MARK: - Appearance policy
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(Strings.terminalAppearanceLabel)
+                    .font(.headline)
+
+                Picker(
+                    Strings.terminalAppearanceLabel,
+                    selection: Binding(
+                        get: { settings.appearancePolicy },
+                        set: { settings.appearancePolicy = $0 }
+                    )
+                ) {
+                    ForEach(
+                        TerminalAppearancePolicy.allCases,
+                        id: \.self
+                    ) { policy in
+                        Text(LocalizedStringKey(policy.nameKey))
+                            .tag(policy)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .accessibilityIdentifier(
+                    AccessibilityID.terminalAppearancePicker
+                )
+
+                Text(Strings.terminalAppearanceHelp)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Divider()
+
+            // MARK: - Theme picker
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(Strings.terminalThemeSelectionLabel)
+                    .font(.headline)
+
+                ScrollView {
+                    VStack(spacing: 6) {
+                        ForEach(
+                            TerminalTheme.builtIn,
+                            id: \.id
+                        ) { theme in
+                            themeRow(theme)
+                        }
+                    }
+                }
+                .background(Color.primary.opacity(0.035))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(20)
+        .frame(width: 720, height: 500)
+        .environment(\.locale, locale)
+    }
+
+    // MARK: - Theme row with preview
+
+    @ViewBuilder
+    private func themeRow(_ theme: TerminalTheme) -> some View {
+        let isSelected = settings.selectedThemeID == theme.id
+        Button {
+            settings.setTheme(id: theme.id)
+        } label: {
+            HStack(spacing: 12) {
+                // Color swatch preview — shows both light and dark variants.
+                swatchPreview(
+                    light: theme.light,
+                    dark: theme.dark
+                )
+                .frame(width: 88, height: 36)
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(LocalizedStringKey(theme.nameKey))
+                        .foregroundStyle(.primary)
+                    Text(Strings.terminalThemePreviewLabel)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.tint)
+                        .accessibilityHidden(true)
+                }
+            }
+            .contentShape(Rectangle())
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background {
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(
+                        isSelected
+                            ? Color.accentColor.opacity(0.16)
+                            : Color.clear
+                    )
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("terminal-theme-row-\(theme.id)")
+    }
+
+    /// A compact two-half swatch: left half renders the dark variant's
+    /// background + foreground accent colors, right half the light variant's.
+    @ViewBuilder
+    private func swatchPreview(
+        light: TerminalColorScheme,
+        dark: TerminalColorScheme
+    ) -> some View {
+        HStack(spacing: 0) {
+            swatchHalf(dark)
+            swatchHalf(light)
+        }
+    }
+
+    @ViewBuilder
+    private func swatchHalf(_ scheme: TerminalColorScheme) -> some View {
+        ZStack {
+            scheme.background.makeNSColor().suColor
+            HStack(spacing: 1) {
+                ForEach(0..<8, id: \.self) { index in
+                    scheme.ansiColors[index]
+                        .makeNSColor()
+                        .suColor
+                }
+            }
+            .padding(1)
+        }
+    }
+}
+
+// MARK: - NSColor → SwiftUI bridge
+
+private extension NSColor {
+    /// Converts to a SwiftUI `Color` in the sRGB color space.
+    var suColor: Color {
+        let resolved = usingColorSpace(.sRGB) ?? self
+        return Color(
+            srgbRed: resolved.redComponent,
+            green: resolved.greenComponent,
+            blue: resolved.blueComponent,
+            opacity: resolved.alphaComponent
+        )
+    }
+}

--- a/Pine/TerminalSettingsView.swift
+++ b/Pine/TerminalSettingsView.swift
@@ -180,7 +180,8 @@ private extension NSColor {
     var suColor: Color {
         let resolved = usingColorSpace(.sRGB) ?? self
         return Color(
-            srgbRed: resolved.redComponent,
+            .sRGB,
+            red: resolved.redComponent,
             green: resolved.greenComponent,
             blue: resolved.blueComponent,
             opacity: resolved.alphaComponent

--- a/Pine/TerminalTheme.swift
+++ b/Pine/TerminalTheme.swift
@@ -28,7 +28,7 @@ import SwiftTerm
 /// `[black, red, green, yellow, blue, magenta, cyan, white,
 ///  brightBlack, brightRed, brightGreen, brightYellow,
 ///  brightBlue, brightMagenta, brightCyan, brightWhite]`.
-struct TerminalColorScheme: Equatable, Sendable {
+struct TerminalColorScheme: Equatable, Hashable, Sendable {
     /// Exactly 16 ANSI color entries.
     let ansiColors: [TerminalPaletteEntry]
     /// Default terminal background.

--- a/Pine/TerminalTheme.swift
+++ b/Pine/TerminalTheme.swift
@@ -1,0 +1,407 @@
+//
+//  TerminalTheme.swift
+//  Pine
+//
+//  Selectable terminal color themes with paired light/dark variants (#1244).
+//
+//  Each built-in theme is modelled as a light/dark pair covering the ANSI 16
+//  colors, the default foreground/background, cursor, selection, and link
+//  treatment. Pine's default theme ("Pine") reproduces the previous fixed
+//  One Dark / Catppuccin Latte palettes bit-for-bit, so existing users see no
+//  visual change unless they pick another theme.
+//
+//  The active variant (light or dark) is resolved by `TerminalThemeSettings`
+//  using the user's Appearance policy (Follow System / Always Light /
+//  Always Dark) combined with `NSApp.effectiveAppearance`.
+//
+
+import AppKit
+import Foundation
+import SwiftTerm
+
+// MARK: - Color scheme (one half of a theme — light OR dark)
+
+/// A complete color scheme for one appearance: the 16 ANSI colors plus the
+/// non-ANSI slots (background, foreground, cursor, selection, link).
+///
+/// `ansiColors` slot order matches the SGR / xterm convention:
+/// `[black, red, green, yellow, blue, magenta, cyan, white,
+///  brightBlack, brightRed, brightGreen, brightYellow,
+///  brightBlue, brightMagenta, brightCyan, brightWhite]`.
+struct TerminalColorScheme: Equatable, Sendable {
+    /// Exactly 16 ANSI color entries.
+    let ansiColors: [TerminalPaletteEntry]
+    /// Default terminal background.
+    let background: TerminalPaletteEntry
+    /// Default terminal foreground (text).
+    let foreground: TerminalPaletteEntry
+    /// Caret / cursor color.
+    let cursor: TerminalPaletteEntry
+    /// Selection highlight background.
+    let selection: TerminalPaletteEntry
+    /// Color used for underlined hyperlinks (OSC 8 / implicit URLs).
+    let link: TerminalPaletteEntry
+
+    init(
+        ansiColors: [TerminalPaletteEntry],
+        background: TerminalPaletteEntry,
+        foreground: TerminalPaletteEntry,
+        cursor: TerminalPaletteEntry,
+        selection: TerminalPaletteEntry,
+        link: TerminalPaletteEntry
+    ) {
+        precondition(
+            ansiColors.count == TerminalPalette.colorCount,
+            "TerminalColorScheme requires exactly \(TerminalPalette.colorCount) ANSI entries"
+        )
+        self.ansiColors = ansiColors
+        self.background = background
+        self.foreground = foreground
+        self.cursor = cursor
+        self.selection = selection
+        self.link = link
+    }
+
+    /// Background as an opaque `NSColor` (sRGB).
+    func backgroundColor() -> NSColor {
+        background.makeNSColor()
+    }
+
+    /// Foreground as an `NSColor` (sRGB).
+    func foregroundColor() -> NSColor {
+        foreground.makeNSColor()
+    }
+
+    /// Cursor as an `NSColor` (sRGB).
+    func cursorColor() -> NSColor {
+        cursor.makeNSColor()
+    }
+
+    /// Selection as an `NSColor` (sRGB).
+    func selectionColor() -> NSColor {
+        selection.makeNSColor()
+    }
+
+    /// Link color as an `NSColor` (sRGB).
+    func linkColor() -> NSColor {
+        link.makeNSColor()
+    }
+
+    /// Builds the SwiftTerm `Color` array for `installColors`.
+    /// Returns `nil` if the entry list does not contain exactly 16 entries.
+    func swiftTermColors() -> [SwiftTerm.Color]? {
+        TerminalPalette.swiftTermColors(from: ansiColors)
+    }
+}
+
+// MARK: - Theme (a light/dark pair)
+
+/// A terminal theme: a stable identifier, a localized display-name key, and
+/// the light/dark color schemes. The active variant is chosen at runtime by
+/// `TerminalThemeSettings` based on the Appearance policy and the system's
+/// effective appearance.
+struct TerminalTheme: Equatable, Hashable, Identifiable, Sendable {
+    /// Stable, non-localized identifier persisted in UserDefaults.
+    let id: String
+    /// Localization key for the human-readable theme name.
+    let nameKey: String
+    /// Light-appearance color scheme.
+    let light: TerminalColorScheme
+    /// Dark-appearance color scheme.
+    let dark: TerminalColorScheme
+
+    /// Returns the scheme matching the given appearance.
+    func scheme(forDarkAppearance isDark: Bool) -> TerminalColorScheme {
+        isDark ? dark : light
+    }
+}
+
+// MARK: - Built-in themes
+
+extension TerminalTheme {
+
+    /// All built-in themes, in display order. The first entry ("pine") is the
+    /// default and reproduces Pine's previous fixed One Dark / Catppuccin
+    /// Latte palettes bit-for-bit.
+    static let builtIn: [TerminalTheme] = [
+        pine,
+        solarized,
+        dracula,
+        nord,
+        github,
+    ]
+
+    /// The default theme identifier.
+    static let defaultID = pine.id
+
+    /// Looks up a built-in theme by identifier, falling back to the default
+    /// ("pine") theme when the id is unknown (e.g. a theme removed in a past
+    /// release). Never returns `nil`.
+    static func theme(forID id: String) -> TerminalTheme {
+        builtIn.first { $0.id == id } ?? pine
+    }
+
+    // MARK: Pine (default — One Dark / Catppuccin Latte)
+
+    /// Pine's signature theme. The dark variant is One Dark (with the
+    /// ghost-text slot-0 override); the light variant is the contrast-adjusted
+    /// Catppuccin Latte palette. Both reproduce the colors Pine shipped before
+    /// themes were user-selectable, so this is a no-op visual change for
+    /// existing users.
+    static let pine = TerminalTheme(
+        id: "pine",
+        nameKey: "terminal.theme.pine.name",
+        light: TerminalColorScheme(
+            ansiColors: TerminalPalette.lightPalette,
+            background: TerminalPalette.lightModeBackgroundReference,
+            foreground: TerminalPaletteEntry(red: 0x4C, green: 0x4F, blue: 0x69),
+            cursor: TerminalPaletteEntry(red: 0xDC, green: 0x8A, blue: 0x78),
+            selection: TerminalPaletteEntry(red: 0xCC, green: 0xD0, blue: 0xE1),
+            link: TerminalPaletteEntry(red: 0x1E, green: 0x66, blue: 0xF5)
+        ),
+        dark: TerminalColorScheme(
+            ansiColors: TerminalPalette.macOSAligned,
+            background: TerminalPalette.darkModeBackgroundReference,
+            foreground: TerminalPaletteEntry(red: 0xAB, green: 0xB2, blue: 0xBF),
+            cursor: TerminalPaletteEntry(red: 0xFF, green: 0xFF, blue: 0xFF),
+            selection: TerminalPaletteEntry(red: 0x3E, green: 0x44, blue: 0x55),
+            link: TerminalPaletteEntry(red: 0x61, green: 0xAF, blue: 0xEF)
+        )
+    )
+
+    // MARK: Solarized
+
+    /// Solarized (Ethan Schoonover). The dark variant uses the Solarized
+    /// "base03" background; the light variant uses "base3". ANSI slots map to
+    /// the canonical Solarized accent colors.
+    static let solarized = TerminalTheme(
+        id: "solarized",
+        nameKey: "terminal.theme.solarized.name",
+        light: TerminalColorScheme(
+            ansiColors: [
+                .init(red: 0xEE, green: 0xE8, blue: 0xD5), // 0  base2 (black)
+                .init(red: 0xDC, green: 0x32, blue: 0x2F), // 1  red
+                .init(red: 0x85, green: 0x99, blue: 0x00), // 2  green
+                .init(red: 0xB5, green: 0x89, blue: 0x00), // 3  yellow
+                .init(red: 0x26, green: 0x8B, blue: 0xD2), // 4  blue
+                .init(red: 0xD3, green: 0x36, blue: 0x82), // 5  magenta
+                .init(red: 0x2A, green: 0xA1, blue: 0x98), // 6  cyan
+                .init(red: 0x07, green: 0x36, blue: 0x42), // 7  base02 (white)
+                .init(red: 0x00, green: 0x2B, blue: 0x36), // 8  base03 (bright black)
+                .init(red: 0xCB, green: 0x4B, blue: 0x16), // 9  orange
+                .init(red: 0x58, green: 0x6E, blue: 0x75), // 10 base01
+                .init(red: 0x82, green: 0x84, blue: 0x00), // 11 base00
+                .init(red: 0x83, green: 0x94, blue: 0x96), // 12 base1
+                .init(red: 0x6C, green: 0x71, blue: 0xC4), // 13 violet
+                .init(red: 0x93, green: 0xA1, blue: 0xA1), // 14 base1
+                .init(red: 0xFD, green: 0xF6, blue: 0xE3), // 15 base3
+            ],
+            background: TerminalPaletteEntry(red: 0xFD, green: 0xF6, blue: 0xE3), // base3
+            foreground: TerminalPaletteEntry(red: 0x65, green: 0x7B, blue: 0x83), // base00
+            cursor: TerminalPaletteEntry(red: 0x65, green: 0x7B, blue: 0x83),
+            selection: TerminalPaletteEntry(red: 0xE8, green: 0xE4, blue: 0xD0), // base2
+            link: TerminalPaletteEntry(red: 0x26, green: 0x8B, blue: 0xD2)
+        ),
+        dark: TerminalColorScheme(
+            ansiColors: [
+                .init(red: 0x07, green: 0x36, blue: 0x42), // 0  base02
+                .init(red: 0xDC, green: 0x32, blue: 0x2F), // 1  red
+                .init(red: 0x85, green: 0x99, blue: 0x00), // 2  green
+                .init(red: 0xB5, green: 0x89, blue: 0x00), // 3  yellow
+                .init(red: 0x26, green: 0x8B, blue: 0xD2), // 4  blue
+                .init(red: 0xD3, green: 0x36, blue: 0x82), // 5  magenta
+                .init(red: 0x2A, green: 0xA1, blue: 0x98), // 6  cyan
+                .init(red: 0xEE, green: 0xE8, blue: 0xD5), // 7  base2
+                .init(red: 0x00, green: 0x2B, blue: 0x36), // 8  base03
+                .init(red: 0xCB, green: 0x4B, blue: 0x16), // 9  orange
+                .init(red: 0x58, green: 0x6E, blue: 0x75), // 10 base01
+                .init(red: 0x82, green: 0x84, blue: 0x00), // 11 base00
+                .init(red: 0x83, green: 0x94, blue: 0x96), // 12 base1
+                .init(red: 0x6C, green: 0x71, blue: 0xC4), // 13 violet
+                .init(red: 0x93, green: 0xA1, blue: 0xA1), // 14 base1
+                .init(red: 0xFD, green: 0xF6, blue: 0xE3), // 15 base3
+            ],
+            background: TerminalPaletteEntry(red: 0x00, green: 0x2B, blue: 0x36), // base03
+            foreground: TerminalPaletteEntry(red: 0x8A, green: 0x99, blue: 0xA5), // base0
+            cursor: TerminalPaletteEntry(red: 0x8A, green: 0x99, blue: 0xA5),
+            selection: TerminalPaletteEntry(red: 0x07, green: 0x36, blue: 0x42), // base02
+            link: TerminalPaletteEntry(red: 0x26, green: 0x8B, blue: 0xD2)
+        )
+    )
+
+    // MARK: Dracula
+
+    /// Dracula — a popular dark theme. The light variant is a softened
+    /// Dracula-on-cream adaptation for light mode.
+    static let dracula = TerminalTheme(
+        id: "dracula",
+        nameKey: "terminal.theme.dracula.name",
+        light: TerminalColorScheme(
+            ansiColors: [
+                .init(red: 0xD5, green: 0xCE, blue: 0xC8), // 0  black (soft)
+                .init(red: 0xC1, green: 0x2C, blue: 0x2C), // 1  red
+                .init(red: 0x1A, green: 0x8B, blue: 0x3B), // 2  green
+                .init(red: 0xB6, green: 0x79, blue: 0x06), // 3  yellow
+                .init(red: 0x1E, green: 0x55, blue: 0xCC), // 4  blue
+                .init(red: 0xA6, green: 0x35, blue: 0xA0), // 5  magenta
+                .init(red: 0x0E, green: 0x8A, blue: 0x8A), // 6  cyan
+                .init(red: 0x3C, green: 0x38, blue: 0x36), // 7  white (dark)
+                .init(red: 0x92, green: 0x83, blue: 0x74), // 8  bright black
+                .init(red: 0xE5, green: 0x44, blue: 0x44), // 9  bright red
+                .init(red: 0x2E, green: 0xC2, blue: 0x7E), // 10 bright green
+                .init(red: 0xE0, green: 0xB0, blue: 0x4A), // 11 bright yellow
+                .init(red: 0x45, green: 0x6C, blue: 0xE8), // 12 bright blue
+                .init(red: 0xC8, green: 0x61, blue: 0xC0), // 13 bright magenta
+                .init(red: 0x2A, green: 0xB7, blue: 0xB7), // 14 bright cyan
+                .init(red: 0x4C, green: 0x49, blue: 0x45), // 15 bright white
+            ],
+            background: TerminalPaletteEntry(red: 0xFB, green: 0xF4, blue: 0xF0),
+            foreground: TerminalPaletteEntry(red: 0x3C, green: 0x38, blue: 0x36),
+            cursor: TerminalPaletteEntry(red: 0xC8, green: 0x61, blue: 0xC0),
+            selection: TerminalPaletteEntry(red: 0xE5, green: 0xD8, blue: 0xD0),
+            link: TerminalPaletteEntry(red: 0x1E, green: 0x55, blue: 0xCC)
+        ),
+        dark: TerminalColorScheme(
+            ansiColors: [
+                .init(red: 0x21, green: 0x29, blue: 0x33), // 0  black
+                .init(red: 0xFF, green: 0x55, blue: 0x55), // 1  red
+                .init(red: 0x50, green: 0xFA, blue: 0x7B), // 2  green
+                .init(red: 0xF1, green: 0xFA, blue: 0x8C), // 3  yellow
+                .init(red: 0xBD, green: 0x93, blue: 0xF9), // 4  blue
+                .init(red: 0xFF, green: 0x79, blue: 0xC6), // 5  magenta
+                .init(red: 0x8B, green: 0xE9, blue: 0xFD), // 6  cyan
+                .init(red: 0xF8, green: 0xF8, blue: 0xF2), // 7  white
+                .init(red: 0x62, green: 0x72, blue: 0xA4), // 8  bright black
+                .init(red: 0xFF, green: 0x6E, blue: 0x6E), // 9  bright red
+                .init(red: 0x69, green: 0xFF, blue: 0x94), // 10 bright green
+                .init(red: 0xFF, green: 0xFF, blue: 0xA5), // 11 bright yellow
+                .init(red: 0xD6, green: 0xAC, blue: 0xFF), // 12 bright blue
+                .init(red: 0xFF, green: 0x92, blue: 0xDF), // 13 bright magenta
+                .init(red: 0xA4, green: 0xFF, blue: 0xFF), // 14 bright cyan
+                .init(red: 0xFF, green: 0xFF, blue: 0xFF), // 15 bright white
+            ],
+            background: TerminalPaletteEntry(red: 0x28, green: 0x2A, blue: 0x36),
+            foreground: TerminalPaletteEntry(red: 0xF8, green: 0xF8, blue: 0xF2),
+            cursor: TerminalPaletteEntry(red: 0xFF, green: 0x79, blue: 0xC6),
+            selection: TerminalPaletteEntry(red: 0x44, green: 0x47, blue: 0x5A),
+            link: TerminalPaletteEntry(red: 0xBD, green: 0x93, blue: 0xF9)
+        )
+    )
+
+    // MARK: Nord
+
+    /// Nord — an arctic, north-bluish color palette. Light variant uses the
+    /// "Snow Storm" neutrals.
+    static let nord = TerminalTheme(
+        id: "nord",
+        nameKey: "terminal.theme.nord.name",
+        light: TerminalColorScheme(
+            ansiColors: [
+                .init(red: 0xEC, green: 0xEF, blue: 0xF4), // 0  snow storm
+                .init(red: 0xBF, green: 0x61, blue: 0x6A), // 1  red (frost)
+                .init(red: 0xA3, green: 0xBE, blue: 0x8C), // 2  green
+                .init(red: 0xEB, green: 0xCB, blue: 0x8B), // 3  yellow
+                .init(red: 0x53, green: 0x7A, blue: 0x9E), // 4  blue (frost)
+                .init(red: 0xB4, green: 0x8E, blue: 0xAD), // 5  magenta
+                .init(red: 0x8F, green: 0xBC, blue: 0xBB), // 6  cyan (frost)
+                .init(red: 0x2E, green: 0x34, blue: 0x40), // 7  white (dark)
+                .init(red: 0xD8, green: 0xDE, blue: 0xE9), // 8  bright black
+                .init(red: 0xBF, green: 0x61, blue: 0x6A), // 9  bright red
+                .init(red: 0xA3, green: 0xBE, blue: 0x8C), // 10 bright green
+                .init(red: 0xEB, green: 0xCB, blue: 0x8B), // 11 bright yellow
+                .init(red: 0x53, green: 0x7A, blue: 0x9E), // 12 bright blue
+                .init(red: 0xB4, green: 0x8E, blue: 0xAD), // 13 bright magenta
+                .init(red: 0x8F, green: 0xBC, blue: 0xBB), // 14 bright cyan
+                .init(red: 0x4C, green: 0x55, blue: 0x6A), // 15 bright white
+            ],
+            background: TerminalPaletteEntry(red: 0xEC, green: 0xEF, blue: 0xF4),
+            foreground: TerminalPaletteEntry(red: 0x2E, green: 0x34, blue: 0x40),
+            cursor: TerminalPaletteEntry(red: 0x2E, green: 0x34, blue: 0x40),
+            selection: TerminalPaletteEntry(red: 0xD8, green: 0xDE, blue: 0xE9),
+            link: TerminalPaletteEntry(red: 0x53, green: 0x7A, blue: 0x9E)
+        ),
+        dark: TerminalColorScheme(
+            ansiColors: [
+                .init(red: 0x3B, green: 0x42, blue: 0x52), // 0  black (polar night)
+                .init(red: 0xBF, green: 0x61, blue: 0x6A), // 1  red
+                .init(red: 0xA3, green: 0xBE, blue: 0x8C), // 2  green
+                .init(red: 0xEB, green: 0xCB, blue: 0x8B), // 3  yellow
+                .init(red: 0x81, green: 0xA1, blue: 0xC1), // 4  blue (frost)
+                .init(red: 0xB4, green: 0x8E, blue: 0xAD), // 5  magenta
+                .init(red: 0x88, green: 0xC0, blue: 0xD0), // 6  cyan (frost)
+                .init(red: 0xE5, green: 0xE9, blue: 0xF0), // 7  white (snow storm)
+                .init(red: 0x4C, green: 0x55, blue: 0x6A), // 8  bright black
+                .init(red: 0xBF, green: 0x61, blue: 0x6A), // 9  bright red
+                .init(red: 0xA3, green: 0xBE, blue: 0x8C), // 10 bright green
+                .init(red: 0xEB, green: 0xCB, blue: 0x8B), // 11 bright yellow
+                .init(red: 0x81, green: 0xA1, blue: 0xC1), // 12 bright blue
+                .init(red: 0xB4, green: 0x8E, blue: 0xAD), // 13 bright magenta
+                .init(red: 0x8F, green: 0xBC, blue: 0xBB), // 14 bright cyan
+                .init(red: 0xEC, green: 0xEF, blue: 0xF4), // 15 bright white
+            ],
+            background: TerminalPaletteEntry(red: 0x2E, green: 0x34, blue: 0x40),
+            foreground: TerminalPaletteEntry(red: 0xD8, green: 0xDE, blue: 0xE9),
+            cursor: TerminalPaletteEntry(red: 0xD8, green: 0xDE, blue: 0xE9),
+            selection: TerminalPaletteEntry(red: 0x43, green: 0x4C, blue: 0x5E),
+            link: TerminalPaletteEntry(red: 0x88, green: 0xC0, blue: 0xD0)
+        )
+    )
+
+    // MARK: GitHub
+
+    /// GitHub — based on GitHub's light and dark default themes.
+    static let github = TerminalTheme(
+        id: "github",
+        nameKey: "terminal.theme.github.name",
+        light: TerminalColorScheme(
+            ansiColors: [
+                .init(red: 0x6E, green: 0x77, blue: 0x83), // 0  black
+                .init(red: 0xCB, green: 0x24, blue: 0x33), // 1  red
+                .init(red: 0x1A, green: 0x7F, blue: 0x37), // 2  green
+                .init(red: 0xBF, green: 0x87, blue: 0x0A), // 3  yellow
+                .init(red: 0x09, green: 0x69, blue: 0xE7), // 4  blue
+                .init(red: 0x82, green: 0x53, blue: 0x9E), // 5  magenta
+                .init(red: 0x1B, green: 0x7C, blue: 0x83), // 6  cyan
+                .init(red: 0x24, green: 0x29, blue: 0x2F), // 7  white
+                .init(red: 0x5C, green: 0x65, blue: 0x70), // 8  bright black
+                .init(red: 0xCB, green: 0x24, blue: 0x33), // 9  bright red
+                .init(red: 0x1A, green: 0x7F, blue: 0x37), // 10 bright green
+                .init(red: 0xBF, green: 0x87, blue: 0x0A), // 11 bright yellow
+                .init(red: 0x09, green: 0x69, blue: 0xE7), // 12 bright blue
+                .init(red: 0x82, green: 0x53, blue: 0x9E), // 13 bright magenta
+                .init(red: 0x1B, green: 0x7C, blue: 0x83), // 14 bright cyan
+                .init(red: 0x57, green: 0x5F, blue: 0x66), // 15 bright white
+            ],
+            background: TerminalPaletteEntry(red: 0xFF, green: 0xFF, blue: 0xFF),
+            foreground: TerminalPaletteEntry(red: 0x24, green: 0x29, blue: 0x2F),
+            cursor: TerminalPaletteEntry(red: 0x24, green: 0x29, blue: 0x2F),
+            selection: TerminalPaletteEntry(red: 0xAE, green: 0xD0, blue: 0xFF),
+            link: TerminalPaletteEntry(red: 0x09, green: 0x69, blue: 0xE7)
+        ),
+        dark: TerminalColorScheme(
+            ansiColors: [
+                .init(red: 0x48, green: 0x4F, blue: 0x58), // 0  black
+                .init(red: 0xFF, green: 0x7B, blue: 0x72), // 1  red
+                .init(red: 0x3F, green: 0xB9, blue: 0x50), // 2  green
+                .init(red: 0xD2, green: 0x9E, blue: 0x22), // 3  yellow
+                .init(red: 0x58, green: 0xA6, blue: 0xFF), // 4  blue
+                .init(red: 0xBC, green: 0x8C, blue: 0xFF), // 5  magenta
+                .init(red: 0x39, green: 0xC5, blue: 0xCF), // 6  cyan
+                .init(red: 0xB1, green: 0xBA, blue: 0xC4), // 7  white
+                .init(red: 0x6E, green: 0x76, blue: 0x81), // 8  bright black
+                .init(red: 0xFF, green: 0x7B, blue: 0x72), // 9  bright red
+                .init(red: 0x3F, green: 0xB9, blue: 0x50), // 10 bright green
+                .init(red: 0xE3, green: 0xB3, blue: 0x41), // 11 bright yellow
+                .init(red: 0x79, green: 0xC0, blue: 0xFF), // 12 bright blue
+                .init(red: 0xD2, green: 0xA8, blue: 0xFF), // 13 bright magenta
+                .init(red: 0x56, green: 0xD4, blue: 0xDD), // 14 bright cyan
+                .init(red: 0xF0, green: 0xF6, blue: 0xFC), // 15 bright white
+            ],
+            background: TerminalPaletteEntry(red: 0x0D, green: 0x11, blue: 0x17),
+            foreground: TerminalPaletteEntry(red: 0xE6, green: 0xED, blue: 0xF3),
+            cursor: TerminalPaletteEntry(red: 0xE6, green: 0xED, blue: 0xF3),
+            selection: TerminalPaletteEntry(red: 0x39, green: 0x35, blue: 0x3F),
+            link: TerminalPaletteEntry(red: 0x58, green: 0xA6, blue: 0xFF)
+        )
+    )
+}

--- a/Pine/TerminalThemeSettings.swift
+++ b/Pine/TerminalThemeSettings.swift
@@ -1,0 +1,173 @@
+//
+//  TerminalThemeSettings.swift
+//  Pine
+//
+//  User-facing terminal theme and appearance preferences (#1244).
+//
+//  Replaces the previous fixed One Dark / Catppuccin Latte switch with a
+//  selectable theme model. The selected theme's active variant (light or
+//  dark) is resolved against the user's Appearance policy and the system's
+//  effective appearance, then applied to every live terminal session.
+//
+//  The settings are persisted in UserDefaults and broadcast via
+//  `Notification.Name.terminalThemeChanged` so existing project terminals and
+//  the Quick Terminal re-apply colors without restarting their shells or
+//  losing scrollback.
+//
+
+import Foundation
+
+/// How the terminal theme responds to the system appearance.
+enum TerminalAppearancePolicy: String, CaseIterable, Sendable {
+    /// Follow the system's effective appearance (default).
+    case followSystem
+    /// Always use the theme's light variant.
+    case alwaysLight
+    /// Always use the theme's dark variant.
+    case alwaysDark
+
+    /// Localization key for the human-readable policy name.
+    var nameKey: String {
+        switch self {
+        case .followSystem:
+            return "terminal.appearance.followSystem"
+        case .alwaysLight:
+            return "terminal.appearance.alwaysLight"
+        case .alwaysDark:
+            return "terminal.appearance.alwaysDark"
+        }
+    }
+}
+
+/// Centralised terminal theme and appearance preferences.
+///
+/// `selectedThemeID` stores the stable identifier of the chosen
+/// `TerminalTheme`; `appearancePolicy` controls which variant (light/dark) is
+/// active. Both are persisted in `UserDefaults` and applied immediately —
+/// `didSet` posts `Notification.Name.terminalThemeChanged` so live terminal
+/// sessions repaint without restarting their shells.
+///
+/// `currentScheme(isDarkAppearance:)` resolves the active color scheme by
+/// combining the policy with the passed-in effective-appearance flag. Callers
+/// pass the system flag so the model stays free of AppKit dependencies (and
+/// unit-testable).
+@MainActor
+@Observable
+final class TerminalThemeSettings {
+    static let shared = TerminalThemeSettings()
+
+    enum Keys {
+        static let themeID = "terminal.theme.id"
+        static let appearancePolicy = "terminal.appearance.policy"
+    }
+
+    private let defaults: UserDefaults
+
+    /// Stable identifier of the selected built-in theme.
+    var selectedThemeID: String {
+        didSet {
+            guard selectedThemeID != oldValue else { return }
+            defaults.set(selectedThemeID, forKey: Keys.themeID)
+            notifyChanged()
+        }
+    }
+
+    /// How the theme variant is chosen.
+    var appearancePolicy: TerminalAppearancePolicy {
+        didSet {
+            guard appearancePolicy != oldValue else { return }
+            defaults.set(appearancePolicy.rawValue, forKey: Keys.appearancePolicy)
+            notifyChanged()
+        }
+    }
+
+    /// The resolved `TerminalTheme` for `selectedThemeID`. Falls back to the
+    /// default ("pine") theme if the stored id is unknown.
+    var selectedTheme: TerminalTheme {
+        TerminalTheme.theme(forID: selectedThemeID)
+    }
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+
+        let storedID = defaults.string(forKey: Keys.themeID)
+        self.selectedThemeID = storedID?.isEmpty == false
+            ? storedID!
+            : TerminalTheme.defaultID
+
+        if let storedPolicy = defaults.string(forKey: Keys.appearancePolicy),
+           let policy = TerminalAppearancePolicy(rawValue: storedPolicy) {
+            self.appearancePolicy = policy
+        } else {
+            self.appearancePolicy = .followSystem
+        }
+    }
+
+    // MARK: - Resolution
+
+    /// Returns the active color scheme for the selected theme, taking the
+    /// appearance policy into account.
+    ///
+    /// - Parameter isDarkAppearance: Whether the system's effective appearance
+    ///   is currently dark. Ignored when the policy is not `followSystem`.
+    /// - Returns: The resolved `TerminalColorScheme` to apply.
+    func currentScheme(isDarkAppearance: Bool) -> TerminalColorScheme {
+        let theme = selectedTheme
+        switch appearancePolicy {
+        case .followSystem:
+            return theme.scheme(forDarkAppearance: isDarkAppearance)
+        case .alwaysLight:
+            return theme.light
+        case .alwaysDark:
+            return theme.dark
+        }
+    }
+
+    /// Convenience overload that queries the live system appearance directly.
+    /// Use only from the main thread / MainActor context where `NSApp` is valid.
+    func currentScheme() -> TerminalColorScheme {
+        currentScheme(isDarkAppearance: TerminalPalette.isDarkMode)
+    }
+
+    /// Whether the terminal should currently present its dark variant, given
+    /// the policy and the passed-in system flag. Used by tests and by the
+    /// preview to decide which variant label to show.
+    func isDarkActive(isDarkAppearance: Bool) -> Bool {
+        switch appearancePolicy {
+        case .followSystem:
+            return isDarkAppearance
+        case .alwaysLight:
+            return false
+        case .alwaysDark:
+            return true
+        }
+    }
+
+    /// Selects a theme by id and broadcasts the change.
+    func setTheme(id: String) {
+        selectedThemeID = id
+    }
+
+    /// Resets both theme and appearance policy to their defaults.
+    func reset() {
+        selectedThemeID = TerminalTheme.defaultID
+        appearancePolicy = .followSystem
+    }
+
+    // MARK: - Broadcasting
+
+    /// Posts the change notification so live terminal sessions repaint.
+    private func notifyChanged() {
+        NotificationCenter.default.post(name: .terminalThemeChanged, object: self)
+    }
+}
+
+// MARK: - Notification
+
+extension Notification.Name {
+    /// Posted after the selected terminal theme or appearance policy changes.
+    /// Observed by `TerminalTab` (project terminals) and the Quick Terminal
+    /// so they re-apply colors without restarting their shells or losing
+    /// scrollback (#1244).
+    static let terminalThemeChanged = Notification.Name("terminalThemeChanged")
+}

--- a/Pine/TerminalThemeSettings.swift
+++ b/Pine/TerminalThemeSettings.swift
@@ -91,9 +91,11 @@ final class TerminalThemeSettings {
         self.defaults = defaults
 
         let storedID = defaults.string(forKey: Keys.themeID)
-        self.selectedThemeID = storedID?.isEmpty == false
-            ? storedID!
-            : TerminalTheme.defaultID
+        if let storedID, !storedID.isEmpty {
+            self.selectedThemeID = storedID
+        } else {
+            self.selectedThemeID = TerminalTheme.defaultID
+        }
 
         if let storedPolicy = defaults.string(forKey: Keys.appearancePolicy),
            let policy = TerminalAppearancePolicy(rawValue: storedPolicy) {


### PR DESCRIPTION
Closes #1244. Adds 5 built-in terminal themes (Pine, Solarized, Dracula, Nord, GitHub) with paired light/dark variants and automatic system-appearance switching. Theme selector in Settings with live preview.