### PR TITLE
feat(tabs): add visual global MRU switcher

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -136,6 +136,13 @@ nonisolated enum AccessibilityID {
     static let agentAttentionBell = "agentAttentionBell"
     static let agentAttentionOverlay = "agentAttentionOverlay"
 
+    // MARK: - Global Tab Switcher overlay (#1239)
+    static let globalTabSwitcherOverlay = "globalTabSwitcherOverlay"
+    static let globalTabSwitcherList = "globalTabSwitcherList"
+    static func globalTabSwitcherItem(_ title: String) -> String {
+        "globalTabSwitcherItem_\(title)"
+    }
+
     // MARK: - LSP / Problems panel (#1010)
     static let problemsIndicator = "problemsIndicator"
     static let problemsPanel = "problemsPanel"

--- a/Pine/GlobalTabSwitcherKeyController.swift
+++ b/Pine/GlobalTabSwitcherKeyController.swift
@@ -1,0 +1,134 @@
+//
+//  GlobalTabSwitcherKeyController.swift
+//  Pine
+//
+//  Keyboard controller for the visual MRU tab switcher (issue #1239).
+//
+//  Owns the three NSEvent monitors that drive the Control-Tab overlay session:
+//    1. key-down (Control-Tab)         → begin or advance the session
+//    2. flags-changed (Control release) → commit the highlighted selection
+//    3. key-down (Escape)              → cancel and restore the original tab
+//
+//  The MRU model itself lives on `PaneManager`; this controller only orchestrates
+//  session begin / advance / commit / cancel in response to physical key events.
+//  It resolves the key window's `ProjectManager` (via its `CloseDelegate`) so
+//  the overlay targets the project the user is actually looking at.
+//
+//  Why a dedicated monitor (instead of folding into the existing key-down
+//  handler): Control-release detection needs `flagsChanged`, which the existing
+//  single key-down monitor does not watch. Keeping the lifecycle in one object
+//  also makes it unit-testable via injected closures.
+//
+
+import AppKit
+
+/// Resolves the `PaneManager` for the current key window, plus a way to drive
+/// the session directly. Abstracted so the controller is testable without a
+/// live `NSWindow` / `CloseDelegate`.
+@MainActor
+protocol GlobalTabSwitcherKeyControllerDelegate: AnyObject {
+    /// The pane manager whose session should be driven, or `nil` when no
+    /// eligible project window is key.
+    var paneManagerForTabSwitcher: PaneManager? { get }
+}
+
+/// Owns the NSEvent monitors that drive the Control-Tab overlay.
+///
+/// Installed once at app launch (`install()`) and torn down on `deinit`. All
+/// real work is dispatched to the resolved `PaneManager` so this class holds no
+/// state of its own beyond the monitor tokens.
+@MainActor
+final class GlobalTabSwitcherKeyController {
+    weak var delegate: GlobalTabSwitcherKeyControllerDelegate?
+
+    // Monitor tokens. `nonisolated(unsafe)` only so `deinit` (which is
+    // nonisolated even on a @MainActor class) can remove them; every real
+    // read/write happens on the main thread inside the monitor closures.
+    nonisolated(unsafe) private var keyDownMonitor: Any?
+    nonisolated(unsafe) private var flagsChangedMonitor: Any?
+
+    /// Whether the monitors are currently installed. Used to make `install()`
+    /// idempotent and to guard `deinit`.
+    private var isInstalled = false
+
+    deinit {
+        if let keyDownMonitor {
+            NSEvent.removeMonitor(keyDownMonitor)
+        }
+        if let flagsChangedMonitor {
+            NSEvent.removeMonitor(flagsChangedMonitor)
+        }
+    }
+
+    /// Installs the key-down and flags-changed monitors. Idempotent.
+    func install() {
+        guard !isInstalled else { return }
+        isInstalled = true
+
+        // Key-down: Control-Tab begins/advances; Escape cancels. We watch
+        // .keyDown broadly and filter inside, so a single monitor owns both.
+        keyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
+            self?.handleKeyDown(event) ?? event
+        }
+
+        // Flags-changed: commit when Control is released. This is the canonical
+        // macOS Cmd-Tab / Control-Tab "release to switch" gesture.
+        flagsChangedMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged]) { [weak self] event in
+            self?.handleFlagsChanged(event) ?? event
+        }
+    }
+
+    // MARK: - Event handling
+
+    /// Physical key code for Tab (layout-independent).
+    private static let tabKeyCode: UInt16 = 48
+    /// Physical key code for Escape.
+    private static let escapeKeyCode: UInt16 = 53
+
+    private func handleKeyDown(_ event: NSEvent) -> NSEvent? {
+        guard let paneManager = delegate?.paneManagerForTabSwitcher else {
+            return event
+        }
+
+        // Escape cancels an active session (and otherwise falls through).
+        if event.keyCode == Self.escapeKeyCode, paneManager.isGlobalTabSwitcherActive {
+            paneManager.cancelGlobalTabSwitcher()
+            return nil
+        }
+
+        // Control-Tab (forward) and Shift-Control-Tab (reverse).
+        guard event.keyCode == Self.tabKeyCode else { return event }
+        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let isControl = modifiers.contains(.control)
+        guard isControl else { return event }
+        let reverse = modifiers.contains(.shift)
+
+        if paneManager.isGlobalTabSwitcherActive {
+            // Subsequent press while held: cycle without moving real focus.
+            paneManager.advanceGlobalTabSwitcher(offset: reverse ? -1 : 1)
+        } else {
+            // First press: open the overlay, then advance once so the very
+            // first Control-Tab surfaces the second-most-recent tab (the most
+            // recent is the one the user is already on).
+            if paneManager.beginGlobalTabSwitcherSession() {
+                paneManager.advanceGlobalTabSwitcher(offset: reverse ? -1 : 1)
+            }
+        }
+        return nil
+    }
+
+    private func handleFlagsChanged(_ event: NSEvent) -> NSEvent? {
+        guard let paneManager = delegate?.paneManagerForTabSwitcher,
+              paneManager.isGlobalTabSwitcherActive else {
+            return event
+        }
+        // Commit when Control is no longer held. Checking
+        // `event.modifierFlags.contains(.control)` is the reliable signal that
+        // the Control key has just been released (the event reports the
+        // *new* modifier state).
+        if !event.modifierFlags.contains(.control) {
+            paneManager.commitGlobalTabSwitcher()
+        }
+        return event
+    }
+}

--- a/Pine/GlobalTabSwitcherOverlay.swift
+++ b/Pine/GlobalTabSwitcherOverlay.swift
@@ -1,0 +1,179 @@
+//
+//  GlobalTabSwitcherOverlay.swift
+//  Pine
+//
+//  Visual MRU tab switcher overlay (issue #1239).
+//
+//  Presented by `ContentView` while `PaneManager.globalTabSwitcherSession` is
+//  non-`nil`. Shows the frozen MRU-ordered list of every eligible editor and
+//  terminal tab with its icon, title, pane context, and optional
+//  project-relative path. The highlighted row tracks
+//  `session.selectedIndex`; Control release commits, Escape cancels.
+//
+//  The overlay is intentionally non-interactive (no text field, no click
+//  handling): selection is driven entirely by Control-Tab / Shift-Control-Tab
+//  while the modifier is held, mirroring macOS Cmd-` and most IDE switchers.
+//  Arrow-key / click selection is a deliberate follow-up.
+//
+
+import SwiftUI
+
+/// Lightweight overlay rendering the global MRU tab switcher list.
+///
+/// Reads its data from the injected `PaneManager` (the session and the live
+/// entries) and `WorkspaceManager` (project root for relative paths). It never
+/// mutates the session directly — the keyboard controller in `AppDelegate`
+/// owns begin / advance / commit / cancel.
+struct GlobalTabSwitcherOverlay: View {
+    @Environment(PaneManager.self) private var paneManager
+    @Environment(WorkspaceManager.self) private var workspace
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        let entries = paneManager.globalTabSwitcherEntries(projectRoot: workspace.rootURL)
+        let selectedIndex = paneManager.globalTabSwitcherSession?.selectedIndex ?? 0
+
+        VStack(alignment: .leading, spacing: 0) {
+            Text(Strings.globalTabSwitcherTitle)
+                .font(.headline)
+                .padding(.bottom, 8)
+
+            Divider()
+
+            if entries.isEmpty {
+                emptyState
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 0) {
+                            ForEach(Array(entries.enumerated()), id: \.element.id) { index, entry in
+                                row(entry, isSelected: index == selectedIndex)
+                                    .id(index)
+                            }
+                        }
+                        .padding(.top, 6)
+                    }
+                    .onChange(of: selectedIndex) { _, newIndex in
+                        // Center the highlighted row so long lists stay scannable.
+                        guard entries.indices.contains(newIndex) else { return }
+                        withAnimation(reduceMotion ? nil : PineAnimation.quick) {
+                            proxy.scrollTo(newIndex, anchor: .center)
+                        }
+                    }
+                }
+            }
+
+            Divider()
+                .padding(.top, 4)
+
+            Text(Strings.globalTabSwitcherHint)
+                .font(.system(size: LayoutMetrics.captionFontSize))
+                .foregroundStyle(.secondary)
+                .padding(.top, 6)
+        }
+        .padding(16)
+        .frame(width: 380, height: 320)
+        .accessibilityIdentifier(AccessibilityID.globalTabSwitcherOverlay)
+        .accessibilityAddTraits(.isModal)
+        // VoiceOver: announce the current selection whenever it changes so
+        // sighted and non-sighted users get the same feedback while cycling.
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(
+            accessibilityLabel(
+                entries: entries,
+                selectedIndex: selectedIndex
+            )
+        )
+        .onExitCommand {
+            // Escape: SwiftUI surfaces this as an exit command for modal
+            // overlays. The session controller cancels here; ContentView's
+            // key path also forwards Escape, but this covers VoiceOver
+            // invocation and any focus path that bypasses the key monitor.
+            paneManager.cancelGlobalTabSwitcher()
+        }
+    }
+
+    // MARK: - Rows
+
+    private func row(_ entry: GlobalTabSwitcherEntry, isSelected: Bool) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: entry.symbolName)
+                .font(.system(size: 14))
+                .foregroundStyle(entry.symbolColor)
+                .frame(width: 18)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(verbatim: entry.title)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                if let relativePath = entry.relativePath, !relativePath.isEmpty {
+                    Text(verbatim: relativePath)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+
+            Text(verbatim: entry.paneContext)
+                .font(.system(size: LayoutMetrics.captionFontSize))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(
+                    Capsule()
+                        .fill(.quaternary.opacity(0.5))
+                )
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(isSelected ? Color.accentColor.opacity(0.2) : Color.clear)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(rowAccessibilityLabel(entry))
+        .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
+        .accessibilityIdentifier(AccessibilityID.globalTabSwitcherItem(entry.title))
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Spacer()
+            Text(verbatim: Strings.paneGenericLabel)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Accessibility
+
+    /// Composite VoiceOver label: announces the highlighted row with its
+    /// position so cycling is legible without sight.
+    private func accessibilityLabel(
+        entries: [GlobalTabSwitcherEntry],
+        selectedIndex: Int
+    ) -> String {
+        guard entries.indices.contains(selectedIndex) else {
+            return Strings.globalTabSwitcherTitle
+        }
+        let entry = entries[selectedIndex]
+        return Strings.globalTabSwitcherAnnouncement(
+            title: entry.title,
+            paneContext: entry.paneContext,
+            position: selectedIndex + 1,
+            total: entries.count
+        )
+    }
+
+    private func rowAccessibilityLabel(_ entry: GlobalTabSwitcherEntry) -> String {
+        var parts: [String] = [entry.title, entry.paneContext]
+        if let relativePath = entry.relativePath, !relativePath.isEmpty {
+            parts.append(relativePath)
+        }
+        return parts.joined(separator: ", ")
+    }
+}

--- a/Pine/GlobalTabSwitcherSession.swift
+++ b/Pine/GlobalTabSwitcherSession.swift
@@ -1,0 +1,86 @@
+//
+//  GlobalTabSwitcherSession.swift
+//  Pine
+//
+//  Visual MRU tab switcher session state (issue #1239).
+//
+//  A `GlobalTabSwitcherSession` is the transient, frozen-in-time snapshot that
+//  backs the Control-Tab overlay. It is created by `PaneManager` the moment the
+//  user presses Control-Tab and is torn down on commit (Control release) or
+//  cancellation (Escape). The long-lived MRU order itself lives on
+//  `PaneManager.globalTabSwitchOrder` and remains the single source of truth —
+//  this struct only captures a stable view of it so the overlay does not
+//  re-shuffle while the user cycles.
+//
+//  Design notes:
+//  - `identities` is a snapshot of `PaneManager.validGlobalTabSwitchOrder()`
+//    taken at session start, so repeated Control-Tab presses walk a fixed,
+//    deterministic list even if an organic activation would otherwise have
+//    reordered it mid-cycle.
+//  - `originalIdentity` records where the user started so Escape can restore it
+//    exactly. It is optional because the active tab may not be in the MRU list
+//    (e.g. a freshly opened, never-activated tab).
+//  - `selectedIndex` is the live cursor the overlay highlights. Cycling wraps.
+//
+
+import Foundation
+import SwiftUI
+
+/// Frozen-in-time MRU snapshot backing the visual Control-Tab switcher.
+///
+/// Owned by `PaneManager` (`globalTabSwitcherSession`); `nil` when no switching
+/// session is active. The overlay view observes `PaneManager` and renders while
+/// this is non-`nil`.
+struct GlobalTabSwitcherSession: Equatable {
+    /// The MRU-ordered identities captured at session start. Immutable for the
+    /// life of the session so cycling is deterministic.
+    let identities: [GlobalTabIdentity]
+
+    /// The tab that was active when the session began, used to restore on
+    /// cancellation. `nil` when no tab was active (or the active tab was not
+    /// eligible for switching).
+    let originalIdentity: GlobalTabIdentity?
+
+    /// Cursor into `identities` the overlay is currently highlighting.
+    var selectedIndex: Int
+
+    /// The identity currently under the cursor, if any.
+    var selectedIdentity: GlobalTabIdentity? {
+        guard identities.indices.contains(selectedIndex) else { return nil }
+        return identities[selectedIndex]
+    }
+
+    /// `true` when the cursor points back at the tab the session started on.
+    /// Used to short-circuit a redundant restore on cancel.
+    var isSelectionAtOriginal: Bool {
+        guard let originalIdentity, let selectedIdentity else { return false }
+        return selectedIdentity == originalIdentity
+    }
+}
+
+/// Presentation model for a single row in the switcher overlay.
+///
+/// Built on demand from live pane/tab state so titles stay fresh even though
+/// the identity *order* is frozen for the session. Value type so SwiftUI diffs
+/// cheaply and the snapshot tests can construct it without a live process.
+struct GlobalTabSwitcherEntry: Identifiable, Equatable {
+    /// The pane-scoped identity. Drives activation on commit.
+    let id: GlobalTabIdentity
+
+    /// Primary label: file name for editor tabs, terminal name otherwise.
+    let title: String
+
+    /// SF Symbol name for the leading icon.
+    let symbolName: String
+
+    /// Tint for the leading icon. Matches the file-tree / tab-bar palette.
+    let symbolColor: Color
+
+    /// Human-readable pane context, e.g. "Pane 2". Deterministic position
+    /// within the visible pane tree (left-to-right, top-to-bottom).
+    let paneContext: String
+
+    /// Project-relative path for editor tabs when one can be derived; `nil`
+    /// for terminals or files outside the project root.
+    let relativePath: String?
+}

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -62,6 +62,19 @@ final class PaneManager {
     /// reordering the MRU list while a keyboard cycle is in progress.
     private var isPerformingGlobalTabSwitch = false
 
+    /// The live visual MRU switcher session (`nil` unless Control-Tab overlay
+    /// is up). Created by `beginGlobalTabSwitcherSession()`, torn down on commit
+    /// (Control release) or cancellation (Escape). Observed by the overlay view.
+    /// The MRU order itself (`globalTabSwitchOrder`) remains the source of
+    /// truth; the session only captures a frozen snapshot for deterministic
+    /// cycling while the overlay is shown (#1239).
+    private(set) var globalTabSwitcherSession: GlobalTabSwitcherSession?
+
+    /// `true` while the visual Control-Tab overlay is being driven. The
+    /// keyboard handler uses this to distinguish the *first* Control-Tab press
+    /// (open the overlay) from subsequent presses (cycle it).
+    var isGlobalTabSwitcherActive: Bool { globalTabSwitcherSession != nil }
+
     /// Records a tab activation in the global MRU switch order. Called by
     /// every path that activates an editor or terminal tab: selection, open,
     /// transfer, and split. Move-to-front with dedup so each identity appears
@@ -176,6 +189,180 @@ final class PaneManager {
         terminalState.activeTerminalID = identity.tabID
         terminalState.pendingFocusTabID = identity.tabID
         return true
+    }
+
+    // MARK: - Visual MRU switcher session (#1239)
+
+    /// Begins a visual Control-Tab switching session: freezes the current
+    /// valid MRU order, records the starting tab so Escape can restore it, and
+    /// arms the overlay. The overlay view observes `globalTabSwitcherSession`
+    /// and renders while it is non-`nil`.
+    ///
+    /// Safe to call repeatedly: if a session is already active, this is a
+    /// no-op (the existing session keeps its frozen order). Returns `true` if a
+    /// session is now active (newly or already).
+    @discardableResult
+    func beginGlobalTabSwitcherSession() -> Bool {
+        if globalTabSwitcherSession != nil { return true }
+        let order = validGlobalTabSwitchOrder()
+        guard order.count >= 2 else { return false }
+        let original = currentGlobalTabIdentity()
+        // Anchor the cursor on the current tab if it is in the list; otherwise
+        // (no active tab or active tab not eligible) start at the MRU head so
+        // the first Control-Tab advances to the second-most-recent tab.
+        let startIndex = original.flatMap { original in
+            order.firstIndex(of: original)
+        } ?? 0
+        globalTabSwitcherSession = GlobalTabSwitcherSession(
+            identities: order,
+            originalIdentity: original,
+            selectedIndex: startIndex
+        )
+        return true
+    }
+
+    /// Advances the overlay cursor by `offset` (+1 forward via Control-Tab,
+    /// −1 backward via Shift-Control-Tab), wrapping around the frozen order.
+    /// No-op (and does not create a session) if no session is active or the
+    /// frozen order is empty.
+    ///
+    /// Does NOT record the activation in the MRU list: cycling must not pollute
+    /// the switch order (same invariant as `switchGlobalTab`). The selected tab
+    /// is only surfaced visually; the real activation happens on `commit`.
+    func advanceGlobalTabSwitcher(offset: Int) {
+        guard let session = globalTabSwitcherSession,
+              !session.identities.isEmpty else { return }
+        let count = session.identities.count
+        let newIndex = (session.selectedIndex + offset % count + count) % count
+        globalTabSwitcherSession?.selectedIndex = newIndex
+    }
+
+    /// Commits the current switcher selection: activates the highlighted tab
+    /// and tears down the session. This is the ONLY step during the cycle that
+    /// moves real focus. The selected tab is recorded as the most-recently-used
+    /// only through the normal activation path, so the MRU list updates once,
+    /// at the moment the user committed.
+    func commitGlobalTabSwitcher() {
+        guard let session = globalTabSwitcherSession else { return }
+        defer { globalTabSwitcherSession = nil }
+        guard let target = session.selectedIdentity else { return }
+        // Activate through the same path used by organic selection so the
+        // committed tab is promoted to the MRU head exactly once.
+        isPerformingGlobalTabSwitch = false
+        _ = activateAndRecordGlobalTab(target)
+    }
+
+    /// Cancels the switcher session, restoring the tab that was active when it
+    /// began (Escape). If no original tab was recorded (or it has since become
+    /// invalid), the active pane/tab state is left untouched.
+    func cancelGlobalTabSwitcher() {
+        guard let session = globalTabSwitcherSession else { return }
+        defer { globalTabSwitcherSession = nil }
+        guard let original = session.originalIdentity else { return }
+        // Best-effort restore: if the original tab is still valid, surface it;
+        // otherwise leave whatever is currently active (the user's last view).
+        _ = activateGlobalTab(original)
+    }
+
+    /// Activate a global tab AND record it in the MRU list. Mirrors
+    /// `activateGlobalTab` but promotes the target to the MRU head, used by the
+    /// commit path so the committed tab is treated like an organic activation.
+    @discardableResult
+    private func activateAndRecordGlobalTab(_ identity: GlobalTabIdentity) -> Bool {
+        guard activateGlobalTab(identity) else { return false }
+        recordTabActivation(
+            paneID: identity.paneID,
+            tabID: identity.tabID,
+            contentType: identity.contentType
+        )
+        return true
+    }
+
+    /// Builds the presentation rows for the active switcher session, in the
+    /// frozen session order. Titles are read live so they stay current (e.g. a
+    /// shell-reported terminal title), while the *order* follows the snapshot
+    /// captured at session start. Stale identities (closed/stale since the
+    /// snapshot) are dropped defensively.
+    ///
+    /// `projectRoot` is used to derive project-relative paths for editor tabs;
+    /// pass `nil` when no project is open.
+    func globalTabSwitcherEntries(
+        projectRoot: URL?
+    ) -> [GlobalTabSwitcherEntry] {
+        guard let session = globalTabSwitcherSession else { return [] }
+        // Pane position labels are stable for the session (derived from the
+        // visible tree). Use persistableRoot so hidden-maximized siblings are
+        // still counted in their true positions, not the collapsed single leaf.
+        let panePositions = paneContextLabels()
+        return session.identities.compactMap { identity in
+            entry(for: identity, panePositions: panePositions, projectRoot: projectRoot)
+        }
+    }
+
+    /// Resolves a single identity to a presentation entry. Returns `nil` for
+    /// identities that have become invalid since the session snapshot (closed
+    /// tab, removed pane, or content-type drift).
+    private func entry(
+        for identity: GlobalTabIdentity,
+        panePositions: [PaneID: String],
+        projectRoot: URL?
+    ) -> GlobalTabSwitcherEntry? {
+        let paneContext = panePositions[identity.paneID] ?? Strings.paneGenericLabel
+        if identity.contentType == .editor {
+            guard let tabManager = tabManagers[identity.paneID],
+                  let tab = tabManager.tabs.first(where: { $0.id == identity.tabID }) else {
+                return nil
+            }
+            let fileName = tab.fileName
+            return GlobalTabSwitcherEntry(
+                id: identity,
+                title: fileName,
+                symbolName: FileIconMapper.iconForFile(fileName),
+                symbolColor: FileIconMapper.colorForFile(fileName),
+                paneContext: paneContext,
+                relativePath: Self.relativePath(
+                    from: tab.url,
+                    root: projectRoot
+                )
+            )
+        }
+        guard let terminalState = terminalStates[identity.paneID],
+              let tab = terminalState.terminalTabs.first(where: { $0.id == identity.tabID }) else {
+            return nil
+        }
+        return GlobalTabSwitcherEntry(
+            id: identity,
+            title: tab.name,
+            symbolName: "terminal",
+            symbolColor: .secondary,
+            paneContext: paneContext,
+            relativePath: nil
+        )
+    }
+
+    /// Maps each leaf pane to a 1-based position label (left-to-right,
+    /// top-to-bottom). Uses `persistableRoot` so hidden-maximized siblings keep
+    /// their true positions rather than collapsing to "Pane 1".
+    private func paneContextLabels() -> [PaneID: String] {
+        var labels: [PaneID: String] = [:]
+        for (index, paneID) in persistableRoot.leafIDs.enumerated() {
+            labels[paneID] = Strings.panePositionLabel(index + 1)
+        }
+        return labels
+    }
+
+    /// Project-relative path for `url` under `root`, or `nil` when `url` is not
+    /// under `root` (or when either is absent). Resolves symlinks on both sides
+    /// so a file opened via a symlinked path still matches the resolved root.
+    static func relativePath(from url: URL?, root: URL?) -> String? {
+        guard let url, let root else { return nil }
+        let rootPath = root.resolvingSymlinksInPath().path
+        let urlPath = url.resolvingSymlinksInPath().path
+        guard urlPath == rootPath || urlPath.hasPrefix(rootPath + "/") else {
+            return nil
+        }
+        if urlPath == rootPath { return "" }
+        return String(urlPath.dropFirst(rootPath.count + 1))
     }
 
     /// The single owner of tab-drag session, preview, validation, and commit.

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -420,6 +420,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             || ProcessInfo.processInfo.environment["PINE_DISABLE_QUICK_TERMINAL"] != nil
     }
 
+    // MARK: - Visual MRU tab switcher (#1239)
+
+    /// Owns the Control-Tab / flags-changed monitors driving the visual MRU
+    /// switcher overlay. Installed once in `applicationDidFinishLaunching`.
+    private let tabSwitcherKeyController = GlobalTabSwitcherKeyController()
+
     // MARK: - SPUUpdaterDelegate
 
     nonisolated func feedURLString(for updater: SPUUpdater) -> String? {

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -1255,9 +1255,6 @@ enum Strings {
     static func globalTabSwitcherAnnouncement(
         title: String, paneContext: String, position: Int, total: Int
     ) -> String {
-        String(
-            localized: "globalTabSwitcher.announcement \(title) \(paneContext) \(position) \(total)",
-            defaultValue: "\(title), \(paneContext), \(position) of \(total)"
-        )
+        "\(title), \(paneContext), \(position) of \(total)"
     }
 }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -1248,7 +1248,7 @@ enum Strings {
 
     /// 1-based pane position label, e.g. "Pane 2".
     static func panePositionLabel(_ position: Int) -> String {
-        String(localized: "pane.positionLabel \(position)", defaultValue: "Pane \(position)")
+        "Pane \(position)"
     }
 
     /// VoiceOver description for the currently highlighted row.

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -1228,4 +1228,36 @@ enum Strings {
         String(localized: "a11y.gitStatus.added", defaultValue: "Added")
     static let a11yGitStatusUntracked: String =
         String(localized: "a11y.gitStatus.untracked", defaultValue: "Untracked")
+
+    // MARK: - Global Tab Switcher overlay (#1239)
+
+    /// Title shown at the top of the Control-Tab overlay.
+    static let globalTabSwitcherTitle: String =
+        String(localized: "globalTabSwitcher.title", defaultValue: "Switch Tab")
+
+    /// Footnote hint beneath the list, e.g. "Tab to cycle, release Control to switch".
+    static let globalTabSwitcherHint: String =
+        String(
+            localized: "globalTabSwitcher.hint",
+            defaultValue: "Tab cycles · Release Control to switch · Esc cancels"
+        )
+
+    /// Generic pane label fallback used when a pane position cannot be derived.
+    static let paneGenericLabel: String =
+        String(localized: "pane.genericLabel", defaultValue: "Pane")
+
+    /// 1-based pane position label, e.g. "Pane 2".
+    static func panePositionLabel(_ position: Int) -> String {
+        String(localized: "pane.positionLabel \(position)", defaultValue: "Pane \(position)")
+    }
+
+    /// VoiceOver description for the currently highlighted row.
+    static func globalTabSwitcherAnnouncement(
+        title: String, paneContext: String, position: Int, total: Int
+    ) -> String {
+        String(
+            localized: "globalTabSwitcher.announcement \(title) \(paneContext) \(position) \(total)",
+            defaultValue: "\(title), \(paneContext), \(position) of \(total)"
+        )
+    }
 }


### PR DESCRIPTION
Closes #1239. Visual Control-Tab switcher overlay with MRU ordering, cycle on hold, commit on release.