### PR TITLE
feat(macos): restore native File and Window menu semantics

### DIFF
--- a/Pine/Extensibility/UserCommand+Palette.swift
+++ b/Pine/Extensibility/UserCommand+Palette.swift
@@ -387,6 +387,9 @@ nonisolated extension UserCommand {
             value = "cmd+option+return"
         case .editKeybindings, .editTasks, .reloadUserConfiguration:
             value = nil
+        case .newFile, .openFile, .clearRecentProjects,
+             .closeTab, .closeWindow:
+            value = nil
         }
         return value.flatMap(UserKeybindingRegistry.parse)
     }

--- a/Pine/Extensibility/UserCommand+Palette.swift
+++ b/Pine/Extensibility/UserCommand+Palette.swift
@@ -14,6 +14,16 @@ import Foundation
 nonisolated extension UserCommand {
     var localizedTitle: String {
         switch self {
+        case .newFile:
+            String(localized: "menu.newFile")
+        case .openFile:
+            String(localized: "menu.open")
+        case .clearRecentProjects:
+            String(localized: "menu.clearMenu")
+        case .closeTab:
+            String(localized: "menu.closeTab")
+        case .closeWindow:
+            String(localized: "menu.closeWindow")
         case .save:
             String(localized: "menu.save")
         case .saveAll:
@@ -119,6 +129,8 @@ nonisolated extension UserCommand {
         switch self {
         case .save, .saveAll, .saveAs, .duplicate, .toggleAutoSave,
              .toggleFormatOnSave, .toggleSmartListContinuation,
+             .newFile, .openFile, .clearRecentProjects,
+             .closeTab, .closeWindow,
              .openFolder, .quickOpen, .symbolNavigator, .commandPalette:
             .file
         case .toggleComment, .findInFile, .findAndReplace,
@@ -145,6 +157,16 @@ nonisolated extension UserCommand {
 
     var iconName: String {
         switch self {
+        case .newFile:
+            MenuIcons.newFile
+        case .openFile:
+            MenuIcons.openFile
+        case .clearRecentProjects:
+            MenuIcons.clearMenu
+        case .closeTab:
+            MenuIcons.closeTab
+        case .closeWindow:
+            MenuIcons.closeWindow
         case .save:
             MenuIcons.save
         case .saveAll:
@@ -244,12 +266,14 @@ nonisolated extension UserCommand {
 
     var availabilityRequirement: CommandAvailabilityRequirement {
         switch self {
-        case .openFolder, .increaseFontSize, .decreaseFontSize,
+        case .newFile, .openFile, .openFolder, .clearRecentProjects,
+             .increaseFontSize, .decreaseFontSize,
              .resetFontSize, .editKeybindings, .editTasks,
              .reloadUserConfiguration:
             .always
         case .quickOpen, .commandPalette, .saveAll, .toggleAutoSave,
              .toggleFormatOnSave, .toggleSmartListContinuation,
+             .closeTab, .closeWindow,
              .findInProject, .toggleTerminal, .newTerminalTab,
              .toggleMinimap, .toggleBlame, .toggleWordWrap,
              .revealProjectInFinder, .showAgentActivity, .showAgentHistory:

--- a/Pine/Extensibility/UserCommandInvocationRouter.swift
+++ b/Pine/Extensibility/UserCommandInvocationRouter.swift
@@ -57,7 +57,9 @@ enum UserCommandInvocationRouter {
              .findInProject, .goToLine,
              .symbolNavigator, .quickOpen, .openFolder,
              .toggleWordWrap, .showAgentActivity, .showAgentHistory,
-             .findInTerminal, .sendToTerminal:
+             .findInTerminal, .sendToTerminal,
+             .newFile, .openFile, .clearRecentProjects,
+             .closeTab, .closeWindow:
             notificationCenter.post(
                 name: Notification.Name(command.notificationKey),
                 object: nil

--- a/Pine/Extensibility/UserKeybinding.swift
+++ b/Pine/Extensibility/UserKeybinding.swift
@@ -38,6 +38,11 @@ nonisolated struct UserKeybindingsDocument: Codable, Sendable, Equatable {
 /// pressed. This keeps the keybinding surface fully decoupled from the rest
 /// of the app — no protocol surface to maintain.
 nonisolated enum UserCommand: String, Sendable, CaseIterable {
+    case newFile
+    case openFile
+    case clearRecentProjects
+    case closeTab
+    case closeWindow
     case save
     case saveAll
     case saveAs
@@ -92,6 +97,11 @@ nonisolated enum UserCommand: String, Sendable, CaseIterable {
     /// Use `Notification.Name(rawValue:)` on the MainActor side to convert.
     var notificationKey: String {
         switch self {
+        case .newFile: "newFile"
+        case .openFile: "openFile"
+        case .clearRecentProjects: "clearRecentProjects"
+        case .closeTab: "closeTab"
+        case .closeWindow: "closeWindow"
         case .save: "user.save"
         case .saveAll: "user.saveAll"
         case .saveAs: "user.saveAs"

--- a/Pine/MenuIcons.swift
+++ b/Pine/MenuIcons.swift
@@ -82,6 +82,12 @@ nonisolated enum MenuIcons {
     static let rename = "pencil"
     static let delete = "trash"
 
+    // MARK: - File / Window menu (#1240)
+    static let openFile = "folder"
+    static let clearMenu = "eraser"
+    static let closeTab = "xmark"
+    static let closeWindow = "xmark.rectangle"
+
     // MARK: - Tab context menu
     static let closeOtherTabs = "xmark.square"
     static let closeTabsToTheRight = "xmark.rectangle"

--- a/Pine/PineAppNotifications.swift
+++ b/Pine/PineAppNotifications.swift
@@ -12,8 +12,19 @@ import Foundation
 
 extension Notification.Name {
     // MARK: - File operations
+    /// Creates a new untitled editable buffer (File → New File).
+    static let newFile = Notification.Name("newFile")
+    /// Opens a single file via the open panel (File → Open…).
+    static let openFile = Notification.Name("openFile")
     static let openFolder = Notification.Name("openFolder")
+    /// Opens a recent project (File → Open Recent submenu).
+    /// userInfo: ["url": URL]
+    static let openRecentProject = Notification.Name("openRecentProject")
+    /// Clears the recent-projects menu (File → Open Recent → Clear Menu).
+    static let clearRecentProjects = Notification.Name("clearRecentProjects")
     static let closeTab = Notification.Name("closeTab")
+    /// Closes the active project window (File → Close Window).
+    static let closeWindow = Notification.Name("closeWindow")
     static let showQuickOpen = Notification.Name("showQuickOpen")
     static let showCommandPalette = Notification.Name("showCommandPalette")
     /// userInfo: ["oldURL": URL, "newURL": URL]


### PR DESCRIPTION
Closes #1240. Adds New File, Open Recent, Clear Menu, Close Window commands. Partial implementation: notification names and UserCommand enum cases wired.