### PR TITLE
refactor(macos): scope document dialogs to their project window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,7 @@ jobs:
             -skip-testing:PineTests/FuzzConfigValidatorTests \
             -skip-testing:PineTests/FuzzGoToLineParserTests \
             -retry-tests-on-failure \
+            -parallel-testing-enabled NO \
             -test-timeouts-enabled YES \
             -enableCodeCoverage YES \
             -resultBundlePath "$RESULT_BUNDLE" \

--- a/Pine/AlertTemplate.swift
+++ b/Pine/AlertTemplate.swift
@@ -2,21 +2,18 @@
 //  AlertTemplate.swift
 //  Pine
 //
-//  A single enum + factory that replaces all direct NSAlert() constructions
-//  across the codebase. Each case encodes button labels, alert style,
-//  destructive-button position, and button roles so every call site is one
-//  line.
+//  Shared templates for recurring Pine alerts. Each case encodes button
+//  labels, style, destructive-button position, and button roles so call
+//  sites stay consistent.
 //
-//  Two presentation paths are supported (issue #1241):
-//    • `runSheet(on:)`  — async, attaches the alert as a sheet to an
-//      NSWindow. Only blocks that window; other project windows stay live.
-//    • `runModal(…)`    — synchronous fallback for contexts without a
-//      window (headless tests, background dispatch).
+//  Alerts are presented only as queued, window-owned sheets. A missing or
+//  closed owner returns `.abort`; Pine never falls back to application-modal
+//  UI that can block unrelated project windows.
 //
 
 import AppKit
 
-/// Templates for all NSAlert dialogs used in Pine.
+/// Templates for recurring `NSAlert` dialogs used in Pine.
 ///
 /// Usage (window-scoped sheet, preferred):
 /// ```swift
@@ -27,14 +24,7 @@ import AppKit
 /// )
 /// ```
 ///
-/// Usage (application-modal fallback):
-/// ```swift
-/// let response = AlertTemplate.unsavedChangesSingle.runModal(
-///     messageText: Strings.unsavedChangesTitle,
-///     informativeText: Strings.unsavedChangesMessage
-/// )
-/// ```
-enum AlertTemplate: Sendable {
+enum AlertTemplate: Sendable, Equatable {
     // MARK: - Unsaved changes
 
     /// Save / Don't Save / Cancel  — single file close confirmation.
@@ -80,10 +70,6 @@ enum AlertTemplate: Sendable {
     /// Revert All / Cancel  — confirm reverting all changes in a file.
     case revertAllConfirmation
 
-    // MARK: - CLI Installer
-
-    /// OK only, `.informational` style  — CLI install/uninstall notification.
-    case cliInstallerInfo
 }
 
 // MARK: - Factory
@@ -99,7 +85,7 @@ extension AlertTemplate {
     /// - Parameters:
     ///   - messageText: The primary message (bold title).
     ///   - informativeText: Optional secondary message. Pass `nil` to omit.
-    /// - Returns: A configured `NSAlert` ready for sheet or modal presentation.
+    /// - Returns: A configured `NSAlert` ready for queued sheet presentation.
     @MainActor
     func makeAlert(messageText: String, informativeText: String? = nil) -> NSAlert {
         let alert = NSAlert()
@@ -110,45 +96,48 @@ extension AlertTemplate {
         alert.alertStyle = style
 
         let roles = buttonRoles
+        var buttons: [NSButton] = []
         for (index, buttonTitle) in buttonTitles.enumerated() {
             let role = roles[index]
             let button = alert.addButton(withTitle: buttonTitle)
-            switch role {
-            case .destructive:
+            // `NSAlert` implicitly assigns Return to its first button. Clear
+            // every implicit equivalent first; the semantic roles below are
+            // the only keyboard authority.
+            button.keyEquivalent = ""
+            if role.contains(.destructive) {
                 button.hasDestructiveAction = true
-            case .cancel:
-                button.keyEquivalent = "\u{1b}" // Escape
-            case .default:
-                break
             }
+            if role.contains(.cancel) {
+                button.keyEquivalent = "\u{1b}" // Escape
+            }
+            buttons.append(button)
+        }
+
+        let defaultIndices = roles.indices.filter {
+            roles[$0].contains(.default)
+        }
+        assert(
+            defaultIndices.count == 1,
+            "Every alert template must declare exactly one default button"
+        )
+        if let defaultIndex = defaultIndices.first,
+           buttons.indices.contains(defaultIndex),
+           let defaultCell = buttons[defaultIndex].cell as? NSButtonCell {
+            // `defaultButtonCell` gives Return/Enter native default-button
+            // behavior without stealing Escape from a safe button that is
+            // deliberately both `.default` and `.cancel`.
+            alert.window.defaultButtonCell = defaultCell
         }
 
         return alert
-    }
-
-    /// Creates and runs a modal alert for this template.
-    ///
-    /// Application-modal fallback used when no owning window is available
-    /// (headless tests, background dispatch). Prefer ``runSheet(on:)``
-    /// whenever a project window can be resolved.
-    ///
-    /// - Parameters:
-    ///   - messageText: The primary message (bold title).
-    ///   - informativeText: Optional secondary message.
-    /// - Returns: The modal response from the alert.
-    @discardableResult
-    @MainActor
-    func runModal(messageText: String, informativeText: String? = nil) -> NSApplication.ModalResponse {
-        makeAlert(messageText: messageText, informativeText: informativeText).runModal()
     }
 
     /// Presents this alert as a sheet attached to the window resolved from
     /// `context`. The sheet blocks only that window — other project windows
     /// remain fully interactive (issue #1241).
     ///
-    /// When `context` has no attached window (`.unscoped`), falls back to
-    /// application-modal `runModal()` so behavior is preserved in headless
-    /// contexts (tests, background dispatch without a window).
+    /// When `context` has no live owner, the request fails closed with
+    /// `.abort` and no detached dialog is shown.
     ///
     /// Escape and ⌘-. cancel the sheet, resolving to the cancel-button
     /// response (`.alertThirdButtonReturn` for three-button templates,
@@ -167,24 +156,10 @@ extension AlertTemplate {
         messageText: String,
         informativeText: String? = nil
     ) async -> NSApplication.ModalResponse {
-        let alert = makeAlert(messageText: messageText, informativeText: informativeText)
-
-        // Fall back to application-modal when no owning window is available.
-        guard let window = context.nsWindow else {
-            return alert.runModal()
-        }
-
-        // A closed window mid-flow cannot host a sheet; fall back to modal
-        // so the user still sees the alert instead of silently dropping it.
-        guard window.isVisible else {
-            return alert.runModal()
-        }
-
-        return await withCheckedContinuation { continuation in
-            alert.beginSheetModal(for: window) { response in
-                continuation.resume(returning: response)
-            }
-        }
+        await makeAlert(
+            messageText: messageText,
+            informativeText: informativeText
+        ).runSheet(on: context)
     }
 }
 
@@ -196,8 +171,6 @@ extension AlertTemplate {
         switch self {
         case .fileOperationErrorCritical:
             return .critical
-        case .cliInstallerInfo:
-            return .informational
         case .unsavedChangesSingle, .unsavedChangesBulk,
              .terminalTabCloseWarning, .terminalActiveProcessWarning,
              .externalModifyConflict, .fileDeletedSaveAs,
@@ -234,14 +207,12 @@ extension AlertTemplate {
             return [Strings.branchUncommittedChangesSwitch, Strings.dialogCancel]
         case .revertAllConfirmation:
             return [Strings.revertAllButton, Strings.dialogCancel]
-        case .cliInstallerInfo:
-            return [Strings.dialogOK]
         }
     }
 
     /// Per-button roles, parallel to ``buttonTitles``.
     ///
-    /// `.default`    — the non-destructive primary action (Save, Reload, …).
+    /// `.default`    — the Return/Enter action (Save, Keep, Cancel, …).
     /// `.cancel`     — Escape / ⌘-. target (Cancel, Keep). A single-button
     ///                 OK alert uses `.default` since there is nothing to cancel.
     /// `.destructive`— Don't Save / Discard / Quit — confirmed data loss.
@@ -250,31 +221,34 @@ extension AlertTemplate {
         case .unsavedChangesSingle, .unsavedChangesBulk:
             return [.default, .destructive, .cancel]
         case .terminalTabCloseWarning:
-            return [.destructive, .cancel]
+            return [.destructive, [.default, .cancel]]
         case .terminalActiveProcessWarning:
-            return [.destructive, .cancel]
+            return [.destructive, [.default, .cancel]]
         case .externalModifyConflict:
             // Reload discards local edits (destructive); Keep is the safe default.
-            return [.destructive, .cancel]
+            return [.destructive, [.default, .cancel]]
         case .fileDeletedSaveAs:
             return [.default, .destructive, .cancel]
-        case .fileOperationErrorCritical, .fileOperationErrorWarning, .cliInstallerInfo:
+        case .fileOperationErrorCritical, .fileOperationErrorWarning:
             return [.default]
         case .largeFileWarning:
-            return [.default, .default, .cancel]
+            return [.default, [], .cancel]
         case .branchUncommittedChanges:
-            return [.destructive, .cancel]
+            return [.destructive, [.default, .cancel]]
         case .revertAllConfirmation:
-            return [.destructive, .cancel]
+            return [.destructive, [.default, .cancel]]
         }
     }
 }
 
 // MARK: - Alert button role bridging
 
-/// Semantic role for an alert button.
-enum AlertButtonRole: Sendable, Equatable {
-    case `default`
-    case cancel
-    case destructive
+/// Semantic roles for an alert button. A safe secondary action can be both
+/// the Return default and the Escape cancellation target.
+struct AlertButtonRole: OptionSet, Sendable, Equatable {
+    let rawValue: UInt8
+
+    static let `default` = AlertButtonRole(rawValue: 1 << 0)
+    static let cancel = AlertButtonRole(rawValue: 1 << 1)
+    static let destructive = AlertButtonRole(rawValue: 1 << 2)
 }

--- a/Pine/AlertTemplate.swift
+++ b/Pine/AlertTemplate.swift
@@ -112,12 +112,15 @@ extension AlertTemplate {
         let roles = buttonRoles
         for (index, buttonTitle) in buttonTitles.enumerated() {
             let role = roles[index]
-            let isCancel = role == .cancel
-            alert.addButton(
-                withTitle: buttonTitle,
-                variant: NSAlert.Button.variant(for: role),
-                role: isCancel ? .cancel : (role == .destructive ? .destructive : .default)
-            )
+            let button = alert.addButton(withTitle: buttonTitle)
+            switch role {
+            case .destructive:
+                button.hasDestructiveAction = true
+            case .cancel:
+                button.keyEquivalent = "\u{1b}" // Escape
+            case .default:
+                break
+            }
         }
 
         return alert
@@ -242,7 +245,7 @@ extension AlertTemplate {
     /// `.cancel`     — Escape / ⌘-. target (Cancel, Keep). A single-button
     ///                 OK alert uses `.default` since there is nothing to cancel.
     /// `.destructive`— Don't Save / Discard / Quit — confirmed data loss.
-    private var buttonRoles: [NSAlert.Button.Role] {
+    private var buttonRoles: [AlertButtonRole] {
         switch self {
         case .unsavedChangesSingle, .unsavedChangesBulk:
             return [.default, .destructive, .cancel]
@@ -267,24 +270,22 @@ extension AlertTemplate {
     }
 }
 
-// MARK: - NSAlert.Button role bridging
+// MARK: - Alert button role bridging
 
-extension NSAlert.Button {
-    /// Semantic role for an alert button.
-    enum Role: Sendable, Equatable {
-        case `default`
-        case cancel
-        case destructive
-    }
+/// Semantic role for an alert button.
+enum AlertButtonRole: Sendable, Equatable {
+    case `default`
+    case cancel
+    case destructive
+}
 
-    /// Maps a role to the `NSAlert.Button.Variant` used by
-    /// `addButton(withTitle:variant:role:)`. `.default` → `.standard`,
-    /// `.cancel` → `.cancel`, `.destructive` → `.destructive`.
-    static func variant(for role: Role) -> NSAlert.Button.Variant {
-        switch role {
-        case .default: return .standard
-        case .cancel: return .cancel
-        case .destructive: return .destructive
-        }
+/// Maps a role to the `NSAlert.Button.Variant` used by
+/// `addButton(withTitle:variant:role:)`. `.default` → `.standard`,
+/// `.cancel` → `.cancel`, `.destructive` → `.destructive`.
+func nsAlertVariant(for role: AlertButtonRole) -> NSAlert.Button.Variant {
+    switch role {
+    case .default: return .standard
+    case .cancel: return .cancel
+    case .destructive: return .destructive
     }
 }

--- a/Pine/AlertTemplate.swift
+++ b/Pine/AlertTemplate.swift
@@ -278,14 +278,3 @@ enum AlertButtonRole: Sendable, Equatable {
     case cancel
     case destructive
 }
-
-/// Maps a role to the `NSAlert.Button.Variant` used by
-/// `addButton(withTitle:variant:role:)`. `.default` → `.standard`,
-/// `.cancel` → `.cancel`, `.destructive` → `.destructive`.
-func nsAlertVariant(for role: AlertButtonRole) -> NSAlert.Button.Variant {
-    switch role {
-    case .default: return .standard
-    case .cancel: return .cancel
-    case .destructive: return .destructive
-    }
-}

--- a/Pine/AlertTemplate.swift
+++ b/Pine/AlertTemplate.swift
@@ -107,9 +107,6 @@ extension AlertTemplate {
             if role.contains(.destructive) {
                 button.hasDestructiveAction = true
             }
-            if role.contains(.cancel) {
-                button.keyEquivalent = "\u{1b}" // Escape
-            }
             buttons.append(button)
         }
 
@@ -120,16 +117,70 @@ extension AlertTemplate {
             defaultIndices.count == 1,
             "Every alert template must declare exactly one default button"
         )
+        let cancelIndices = roles.indices.filter {
+            roles[$0].contains(.cancel)
+        }
+        assert(
+            cancelIndices.count <= 1,
+            "Every alert template may declare at most one cancel button"
+        )
+
+        // A single NSButtonCell cannot own both Return and Escape: assigning
+        // either key equivalent makes AppKit remove the other. Keep the
+        // visible safe button as the native default (including its blue
+        // appearance), and install zero-sized semantic proxies for any
+        // additional cancellation shortcuts. The proxies forward the exact
+        // NSAlert response tag and are excluded from accessibility.
         if let defaultIndex = defaultIndices.first,
            buttons.indices.contains(defaultIndex),
            let defaultCell = buttons[defaultIndex].cell as? NSButtonCell {
-            // `defaultButtonCell` gives Return/Enter native default-button
-            // behavior without stealing Escape from a safe button that is
-            // deliberately both `.default` and `.cancel`.
             alert.window.defaultButtonCell = defaultCell
+        }
+        if let cancelIndex = cancelIndices.first,
+           buttons.indices.contains(cancelIndex) {
+            let cancelButton = buttons[cancelIndex]
+            if cancelIndex == defaultIndices.first {
+                installShortcutProxy(
+                    for: cancelButton,
+                    keyEquivalent: "\u{1b}",
+                    modifierMask: [],
+                    in: alert
+                )
+            } else {
+                cancelButton.keyEquivalent = "\u{1b}"
+            }
+            installShortcutProxy(
+                for: cancelButton,
+                keyEquivalent: ".",
+                modifierMask: [.command],
+                in: alert
+            )
         }
 
         return alert
+    }
+
+    /// Adds an invisible keyboard-only button that forwards to an NSAlert
+    /// button. Keeping it outside `alert.buttons` preserves response indices,
+    /// layout, focus order, and VoiceOver output.
+    @MainActor
+    private func installShortcutProxy(
+        for button: NSButton,
+        keyEquivalent: String,
+        modifierMask: NSEvent.ModifierFlags,
+        in alert: NSAlert
+    ) {
+        let proxy = NSButton(frame: .zero)
+        proxy.target = button.target
+        proxy.action = button.action
+        proxy.tag = button.tag
+        proxy.keyEquivalent = keyEquivalent
+        proxy.keyEquivalentModifierMask = modifierMask
+        proxy.isBordered = false
+        proxy.isTransparent = true
+        proxy.focusRingType = .none
+        proxy.setAccessibilityElement(false)
+        alert.window.contentView?.addSubview(proxy)
     }
 
     /// Presents this alert as a sheet attached to the window resolved from
@@ -153,13 +204,17 @@ extension AlertTemplate {
     @MainActor
     func runSheet(
         on context: DialogPresentationContext,
+        deduplicationKey: DialogRequestKey? = nil,
         messageText: String,
         informativeText: String? = nil
     ) async -> NSApplication.ModalResponse {
         await makeAlert(
             messageText: messageText,
             informativeText: informativeText
-        ).runSheet(on: context)
+        ).runSheet(
+            on: context,
+            deduplicationKey: deduplicationKey
+        )
     }
 }
 

--- a/Pine/AlertTemplate.swift
+++ b/Pine/AlertTemplate.swift
@@ -4,14 +4,30 @@
 //
 //  A single enum + factory that replaces all direct NSAlert() constructions
 //  across the codebase. Each case encodes button labels, alert style,
-//  and destructive-button position so every call site is one line.
+//  destructive-button position, and button roles so every call site is one
+//  line.
+//
+//  Two presentation paths are supported (issue #1241):
+//    • `runSheet(on:)`  — async, attaches the alert as a sheet to an
+//      NSWindow. Only blocks that window; other project windows stay live.
+//    • `runModal(…)`    — synchronous fallback for contexts without a
+//      window (headless tests, background dispatch).
 //
 
 import AppKit
 
 /// Templates for all NSAlert dialogs used in Pine.
 ///
-/// Usage:
+/// Usage (window-scoped sheet, preferred):
+/// ```swift
+/// let response = await AlertTemplate.unsavedChangesSingle.runSheet(
+///     on: context,
+///     messageText: Strings.unsavedChangesTitle,
+///     informativeText: Strings.unsavedChangesMessage
+/// )
+/// ```
+///
+/// Usage (application-modal fallback):
 /// ```swift
 /// let response = AlertTemplate.unsavedChangesSingle.runModal(
 ///     messageText: Strings.unsavedChangesTitle,
@@ -75,10 +91,15 @@ enum AlertTemplate: Sendable {
 extension AlertTemplate {
     /// Creates a fully configured `NSAlert` for this template.
     ///
+    /// Each button is tagged with a role (`.default`, `.cancel`, or
+    /// `.destructive`) so VoiceOver announces intent and so Escape / ⌘-.
+    /// cancel to the button carrying `.cancel` (or the sole default when
+    /// no explicit cancel exists).
+    ///
     /// - Parameters:
     ///   - messageText: The primary message (bold title).
     ///   - informativeText: Optional secondary message. Pass `nil` to omit.
-    /// - Returns: A configured `NSAlert` ready for `runModal()`.
+    /// - Returns: A configured `NSAlert` ready for sheet or modal presentation.
     @MainActor
     func makeAlert(messageText: String, informativeText: String? = nil) -> NSAlert {
         let alert = NSAlert()
@@ -88,14 +109,25 @@ extension AlertTemplate {
         }
         alert.alertStyle = style
 
-        for buttonTitle in buttonTitles {
-            alert.addButton(withTitle: buttonTitle)
+        let roles = buttonRoles
+        for (index, buttonTitle) in buttonTitles.enumerated() {
+            let role = roles[index]
+            let isCancel = role == .cancel
+            alert.addButton(
+                withTitle: buttonTitle,
+                variant: NSAlert.Button.variant(for: role),
+                role: isCancel ? .cancel : (role == .destructive ? .destructive : .default)
+            )
         }
 
         return alert
     }
 
     /// Creates and runs a modal alert for this template.
+    ///
+    /// Application-modal fallback used when no owning window is available
+    /// (headless tests, background dispatch). Prefer ``runSheet(on:)``
+    /// whenever a project window can be resolved.
     ///
     /// - Parameters:
     ///   - messageText: The primary message (bold title).
@@ -105,6 +137,51 @@ extension AlertTemplate {
     @MainActor
     func runModal(messageText: String, informativeText: String? = nil) -> NSApplication.ModalResponse {
         makeAlert(messageText: messageText, informativeText: informativeText).runModal()
+    }
+
+    /// Presents this alert as a sheet attached to the window resolved from
+    /// `context`. The sheet blocks only that window — other project windows
+    /// remain fully interactive (issue #1241).
+    ///
+    /// When `context` has no attached window (`.unscoped`), falls back to
+    /// application-modal `runModal()` so behavior is preserved in headless
+    /// contexts (tests, background dispatch without a window).
+    ///
+    /// Escape and ⌘-. cancel the sheet, resolving to the cancel-button
+    /// response (`.alertThirdButtonReturn` for three-button templates,
+    /// `.alertSecondButtonReturn` for two-button templates, or
+    /// `.alertFirstButtonReturn` for single-button OK alerts).
+    ///
+    /// - Parameters:
+    ///   - context: The presentation context carrying the owning window.
+    ///   - messageText: The primary message (bold title).
+    ///   - informativeText: Optional secondary message.
+    /// - Returns: The modal response from the sheet.
+    @discardableResult
+    @MainActor
+    func runSheet(
+        on context: DialogPresentationContext,
+        messageText: String,
+        informativeText: String? = nil
+    ) async -> NSApplication.ModalResponse {
+        let alert = makeAlert(messageText: messageText, informativeText: informativeText)
+
+        // Fall back to application-modal when no owning window is available.
+        guard let window = context.nsWindow else {
+            return alert.runModal()
+        }
+
+        // A closed window mid-flow cannot host a sheet; fall back to modal
+        // so the user still sees the alert instead of silently dropping it.
+        guard window.isVisible else {
+            return alert.runModal()
+        }
+
+        return await withCheckedContinuation { continuation in
+            alert.beginSheetModal(for: window) { response in
+                continuation.resume(returning: response)
+            }
+        }
     }
 }
 
@@ -156,6 +233,58 @@ extension AlertTemplate {
             return [Strings.revertAllButton, Strings.dialogCancel]
         case .cliInstallerInfo:
             return [Strings.dialogOK]
+        }
+    }
+
+    /// Per-button roles, parallel to ``buttonTitles``.
+    ///
+    /// `.default`    — the non-destructive primary action (Save, Reload, …).
+    /// `.cancel`     — Escape / ⌘-. target (Cancel, Keep). A single-button
+    ///                 OK alert uses `.default` since there is nothing to cancel.
+    /// `.destructive`— Don't Save / Discard / Quit — confirmed data loss.
+    private var buttonRoles: [NSAlert.Button.Role] {
+        switch self {
+        case .unsavedChangesSingle, .unsavedChangesBulk:
+            return [.default, .destructive, .cancel]
+        case .terminalTabCloseWarning:
+            return [.destructive, .cancel]
+        case .terminalActiveProcessWarning:
+            return [.destructive, .cancel]
+        case .externalModifyConflict:
+            // Reload discards local edits (destructive); Keep is the safe default.
+            return [.destructive, .cancel]
+        case .fileDeletedSaveAs:
+            return [.default, .destructive, .cancel]
+        case .fileOperationErrorCritical, .fileOperationErrorWarning, .cliInstallerInfo:
+            return [.default]
+        case .largeFileWarning:
+            return [.default, .default, .cancel]
+        case .branchUncommittedChanges:
+            return [.destructive, .cancel]
+        case .revertAllConfirmation:
+            return [.destructive, .cancel]
+        }
+    }
+}
+
+// MARK: - NSAlert.Button role bridging
+
+extension NSAlert.Button {
+    /// Semantic role for an alert button.
+    enum Role: Sendable, Equatable {
+        case `default`
+        case cancel
+        case destructive
+    }
+
+    /// Maps a role to the `NSAlert.Button.Variant` used by
+    /// `addButton(withTitle:variant:role:)`. `.default` → `.standard`,
+    /// `.cancel` → `.cancel`, `.destructive` → `.destructive`.
+    static func variant(for role: Role) -> NSAlert.Button.Variant {
+        switch role {
+        case .default: return .standard
+        case .cancel: return .cancel
+        case .destructive: return .destructive
         }
     }
 }

--- a/Pine/BranchSubtitleClickHandler.swift
+++ b/Pine/BranchSubtitleClickHandler.swift
@@ -13,6 +13,7 @@ import SwiftUI
 struct BranchSubtitleClickHandler: NSViewRepresentable {
     var gitProvider: GitStatusProvider
     var isGitRepository: Bool
+    var projectManager: ProjectManager
 
     final class Coordinator: NSObject, NSPopoverDelegate {
         var parent: BranchSubtitleClickHandler
@@ -41,7 +42,8 @@ struct BranchSubtitleClickHandler: NSViewRepresentable {
 
             let content = BranchSwitcherView(
                 gitProvider: parent.gitProvider,
-                isPresented: isPresented
+                isPresented: isPresented,
+                projectManager: parent.projectManager
             )
 
             let hostingController = NSHostingController(rootView: content)

--- a/Pine/BranchSwitcherView.swift
+++ b/Pine/BranchSwitcherView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct BranchSwitcherView: View {
     var gitProvider: GitStatusProvider
     @Binding var isPresented: Bool
+    var projectManager: ProjectManager? = nil
     @State private var searchText = ""
     @State private var errorMessage = ""
 
@@ -74,14 +75,29 @@ struct BranchSwitcherView: View {
             return
         }
 
+        let context = if let projectManager {
+            DialogPresenter.forProject(projectManager)
+        } else {
+            DialogPresentationContext.unscoped
+        }
         Task { @MainActor in
+            guard context.nsWindow?.isVisible == true else { return }
             if gitProvider.hasUncommittedChanges {
-                let context = DialogPresenter.forKeyProject()
+                // A native alert cannot attach while this switcher itself is
+                // a SwiftUI sheet. Dismiss the switcher first; the per-window
+                // coordinator will start the alert after AppKit reports that
+                // the framework-owned sheet has ended.
+                isPresented = false
                 guard await AlertTemplate.branchUncommittedChanges.runSheet(
                     on: context,
                     messageText: Strings.branchUncommittedChangesTitle,
                     informativeText: Strings.branchUncommittedChangesMessage(branch)
                 ) == .alertFirstButtonReturn else { return }
+                guard context.nsWindow?.isVisible == true else { return }
+            } else {
+                // Keep checkout failures presentable as native sheets without
+                // nesting beneath the switcher's framework-owned sheet.
+                isPresented = false
             }
 
             let result = await gitProvider.checkoutBranchAsync(branch)
@@ -90,6 +106,11 @@ struct BranchSwitcherView: View {
                 isPresented = false
             } else {
                 errorMessage = result.error
+                _ = await AlertTemplate.fileOperationErrorWarning.runSheet(
+                    on: context,
+                    messageText: Strings.branchSwitchErrorTitle,
+                    informativeText: result.error
+                )
             }
         }
     }

--- a/Pine/BranchSwitcherView.swift
+++ b/Pine/BranchSwitcherView.swift
@@ -74,14 +74,16 @@ struct BranchSwitcherView: View {
             return
         }
 
-        if gitProvider.hasUncommittedChanges {
-            guard AlertTemplate.branchUncommittedChanges.runModal(
-                messageText: Strings.branchUncommittedChangesTitle,
-                informativeText: Strings.branchUncommittedChangesMessage(branch)
-            ) == .alertFirstButtonReturn else { return }
-        }
+        Task { @MainActor in
+            if gitProvider.hasUncommittedChanges {
+                let context = DialogPresenter.forKeyProject()
+                guard await AlertTemplate.branchUncommittedChanges.runSheet(
+                    on: context,
+                    messageText: Strings.branchUncommittedChangesTitle,
+                    informativeText: Strings.branchUncommittedChangesMessage(branch)
+                ) == .alertFirstButtonReturn else { return }
+            }
 
-        Task {
             let result = await gitProvider.checkoutBranchAsync(branch)
             if result.success {
                 errorMessage = ""

--- a/Pine/CLIInstaller.swift
+++ b/Pine/CLIInstaller.swift
@@ -33,11 +33,18 @@ enum CLIInstaller {
 
     /// Installs the CLI tool by creating a symlink.
     /// Tries without elevated privileges first; falls back to AppleScript admin prompt if needed.
-    static func install() {
+    @MainActor
+    static func install(projectManager: ProjectManager? = nil) {
+        let context = if let projectManager {
+            DialogPresenter.forProject(projectManager)
+        } else {
+            DialogPresenter.forKeyWindow()
+        }
         guard let scriptPath = bundledScriptPath else {
-            showAlert(
+            showError(
                 title: "Installation Failed",
-                message: "Could not find the pine CLI script in the app bundle."
+                message: "Could not find the pine CLI script in the app bundle.",
+                context: context
             )
             return
         }
@@ -55,9 +62,11 @@ enum CLIInstaller {
                     atPath: defaultInstallPath,
                     withDestinationPath: scriptPath
                 )
-                showAlert(
+                presentSuccess(
                     title: "Command Line Tool Installed",
-                    message: "The 'pine' command is now available.\n\nUsage: pine . or pine file.swift"
+                    message: "The 'pine' command is now available.\n\nUsage: pine . or pine file.swift",
+                    projectManager: projectManager,
+                    context: context
                 )
                 return
             } catch {
@@ -78,15 +87,18 @@ enum CLIInstaller {
             if let error {
                 let message = error[NSAppleScript.errorMessage] as? String ?? "Unknown error"
                 if !message.contains("User canceled") {
-                    showAlert(
+                    showError(
                         title: "Installation Failed",
-                        message: message
+                        message: message,
+                        context: context
                     )
                 }
             } else {
-                showAlert(
+                presentSuccess(
                     title: "Command Line Tool Installed",
-                    message: "The 'pine' command is now available.\n\nUsage: pine . or pine file.swift"
+                    message: "The 'pine' command is now available.\n\nUsage: pine . or pine file.swift",
+                    projectManager: projectManager,
+                    context: context
                 )
             }
         }
@@ -94,14 +106,22 @@ enum CLIInstaller {
 
     /// Uninstalls the CLI tool by removing the symlink.
     /// Tries without elevated privileges first; falls back to AppleScript admin prompt if needed.
-    static func uninstall() {
+    @MainActor
+    static func uninstall(projectManager: ProjectManager? = nil) {
+        let context = if let projectManager {
+            DialogPresenter.forProject(projectManager)
+        } else {
+            DialogPresenter.forKeyWindow()
+        }
         // Try without sudo first
         if FileManager.default.isDeletableFile(atPath: defaultInstallPath) {
             do {
                 try FileManager.default.removeItem(atPath: defaultInstallPath)
-                showAlert(
+                presentSuccess(
                     title: "Command Line Tool Removed",
-                    message: "The 'pine' command has been removed from /usr/local/bin."
+                    message: "The 'pine' command has been removed from /usr/local/bin.",
+                    projectManager: projectManager,
+                    context: context
                 )
                 return
             } catch {
@@ -120,27 +140,62 @@ enum CLIInstaller {
             if let error {
                 let message = error[NSAppleScript.errorMessage] as? String ?? "Unknown error"
                 if !message.contains("User canceled") {
-                    showAlert(
+                    showError(
                         title: "Uninstall Failed",
-                        message: message
+                        message: message,
+                        context: context
                     )
                 }
             } else {
-                showAlert(
+                presentSuccess(
                     title: "Command Line Tool Removed",
-                    message: "The 'pine' command has been removed from /usr/local/bin."
+                    message: "The 'pine' command has been removed from /usr/local/bin.",
+                    projectManager: projectManager,
+                    context: context
                 )
             }
         }
     }
 
-    // MARK: - Private
+    // MARK: - Presentation
 
-    // TODO: Swift 6 — mark CLIInstaller or this method as @MainActor
-    private static func showAlert(title: String, message: String) {
-        AlertTemplate.cliInstallerInfo.runModal(
-            messageText: title,
-            informativeText: message
-        )
+    /// Reports success without taking focus or blocking any project window.
+    /// Internal visibility keeps the no-sheet contract directly testable.
+    @MainActor
+    static func presentSuccess(
+        title: String,
+        message: String,
+        projectManager: ProjectManager?,
+        context: DialogPresentationContext,
+        feedbackPresenter: any WindowNonmodalFeedbackPresenting =
+            WindowNonmodalFeedbackPresenter.shared
+    ) {
+        let announcement = "\(title). \(message)"
+        if let projectManager,
+           let owner = context.nsWindow,
+           owner.isVisible,
+           projectManager.dialogOwnerWindow === owner {
+            projectManager.toastManager.show(ToastItem(message: announcement))
+        } else {
+            feedbackPresenter.present(
+                message: announcement,
+                context: context
+            )
+        }
+    }
+
+    @MainActor
+    private static func showError(
+        title: String,
+        message: String,
+        context: DialogPresentationContext
+    ) {
+        Task { @MainActor in
+            _ = await AlertTemplate.fileOperationErrorCritical.runSheet(
+                on: context,
+                messageText: title,
+                informativeText: message
+            )
+        }
     }
 }

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -173,8 +173,11 @@ extension ContentView {
 extension ContentView {
 
     func openNewProject() {
-        guard let url = registry.openProjectViaPanel() else { return }
-        openWindow(value: url)
+        let context = DialogPresenter.forProject(projectManager)
+        Task { @MainActor in
+            guard let url = await registry.openProjectViaPanel(context: context) else { return }
+            openWindow(value: url)
+        }
     }
 
     func handleFileSelection(
@@ -313,12 +316,25 @@ extension ContentView {
                 await workspace.gitProvider.refreshAsync()
             }
         case .revertAll:
-            Self.confirmRevertAll(fileName: fileURL.lastPathComponent) { confirmed in
+            let confirmedTabID = tab.id
+            let confirmedContent = tab.content
+            confirmRevertAll(fileName: fileURL.lastPathComponent) { confirmed in
                 guard confirmed else { return }
+                guard let currentTab = activeTM.activeTab,
+                      currentTab.id == confirmedTabID,
+                      currentTab.content == confirmedContent else {
+                    return
+                }
+                let contentAtRevertStart = currentTab.content
                 Task {
                     if let newContent = await InlineDiffProvider.revertAllHunks(
                         fileURL: fileURL, repoURL: repoURL
                     ) {
+                        guard let latestTab = activeTM.activeTab,
+                              latestTab.id == confirmedTabID,
+                              latestTab.content == contentAtRevertStart else {
+                            return
+                        }
                         activeTM.updateContent(newContent)
                         activeTM.reloadTab(url: fileURL)
                         await workspace.gitProvider.refreshAsync()
@@ -331,8 +347,8 @@ extension ContentView {
     /// Shows a confirmation dialog before reverting all changes in a file.
     /// Presented as a window-scoped sheet so it does not block other project
     /// windows (issue #1241).
-    static func confirmRevertAll(fileName: String, completion: @escaping (Bool) -> Void) {
-        let context = DialogPresenter.forKeyProject()
+    func confirmRevertAll(fileName: String, completion: @escaping (Bool) -> Void) {
+        let context = DialogPresenter.forProject(projectManager)
         Task { @MainActor in
             let response = await AlertTemplate.revertAllConfirmation.runSheet(
                 on: context,
@@ -349,11 +365,19 @@ extension ContentView {
 extension ContentView {
 
     func closeTabWithConfirmation(_ tab: EditorTab) {
-        let didClose = TabCloseHelper.closeTab(
-            tab, in: activeTabManager, gitProvider: workspace.gitProvider
-        )
-        if didClose && activeTabManager.tabs.isEmpty {
-            paneManager.removePane(paneManager.activePaneID)
+        let context = DialogPresenter.forProject(projectManager)
+        let tabManager = activeTabManager
+        let paneID = paneManager.activePaneID
+        Task { @MainActor in
+            let didClose = await TabCloseHelper.closeTab(
+                tab,
+                in: tabManager,
+                gitProvider: workspace.gitProvider,
+                context: context
+            )
+            if didClose && tabManager.tabs.isEmpty {
+                paneManager.removePane(paneID)
+            }
         }
     }
 
@@ -365,11 +389,34 @@ extension ContentView {
 
         let modified = result.conflicts.filter { $0.kind == .modified }
         let deleted = result.conflicts.filter { $0.kind == .deleted }
+        guard !modified.isEmpty || !deleted.isEmpty else { return }
 
-        if !modified.isEmpty {
-            let names = Array(Set(modified.map(\.url.lastPathComponent))).sorted().joined(separator: ", ")
-            let context = DialogPresenter.forKeyProject()
-            Task { @MainActor [weak projectManager] in
+        let context = DialogPresenter.forProject(projectManager)
+        let projectManager = self.projectManager
+        projectManager.enqueueDialogOperation { @MainActor [weak projectManager] in
+            guard let projectManager else { return }
+            let currentModified = modified.filter { conflict in
+                projectManager.allTabs.contains {
+                    $0.url.standardizedFileURL ==
+                        conflict.url.standardizedFileURL
+                        && $0.isDirty
+                }
+            }
+            if !currentModified.isEmpty {
+                let names = Array(
+                    Set(currentModified.map(\.url.lastPathComponent))
+                )
+                    .sorted()
+                    .joined(separator: ", ")
+                let modifiedURLs = Set(
+                    currentModified.map { $0.url.standardizedFileURL }
+                )
+                let displayedAffectedTabs = projectManager.allTabs.filter {
+                    modifiedURLs.contains($0.url.standardizedFileURL)
+                }
+                let displayedAuthorization = DirtyEditorContentAuthorization(
+                    tabs: displayedAffectedTabs
+                )
                 let response = await AlertTemplate.externalModifyConflict.runSheet(
                     on: context,
                     messageText: Strings.externalModifyTitle,
@@ -377,20 +424,48 @@ extension ContentView {
                 )
 
                 if response == .alertFirstButtonReturn {
-                    guard let projectManager else { return }
-                    for conflict in modified {
-                        projectManager.reloadTabs(url: conflict.url)
+                    let currentDirtyTabs = projectManager.allTabs.filter {
+                        modifiedURLs.contains($0.url.standardizedFileURL)
+                            && $0.isDirty
+                    }
+                    if displayedAuthorization.covers(currentDirtyTabs) {
+                        for conflict in currentModified {
+                            projectManager.reloadTabs(url: conflict.url)
+                        }
                     }
                 }
             }
-        }
 
-        for conflict in deleted {
-            handleFileDeletion(conflict.url)
+            // Preserve the old synchronous ordering: each deletion decision
+            // completes before the next one computes its affected tabs.
+            for conflict in deleted {
+                await Self.resolveFileDeletion(
+                    conflict.url,
+                    projectManager: projectManager,
+                    context: context
+                )
+            }
         }
     }
 
     func handleFileDeletion(_ deletedURL: URL) {
+        let context = DialogPresenter.forProject(projectManager)
+        let projectManager = self.projectManager
+        projectManager.enqueueDialogOperation { @MainActor [weak projectManager] in
+            guard let projectManager else { return }
+            await Self.resolveFileDeletion(
+                deletedURL,
+                projectManager: projectManager,
+                context: context
+            )
+        }
+    }
+
+    private static func resolveFileDeletion(
+        _ deletedURL: URL,
+        projectManager: ProjectManager,
+        context: DialogPresentationContext
+    ) async {
         let affected = projectManager.tabsAffectedByDeletion(url: deletedURL)
         guard !affected.isEmpty else { return }
 
@@ -399,40 +474,70 @@ extension ContentView {
             projectManager.closeTabsForDeletedFile(url: deletedURL)
             return
         }
+        let affectedTabIDs = Set(affected.map(\.id))
+        let displayedDirtyContent = Dictionary(
+            dirtyTabs.map { ($0.id, $0.content) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        var savedContent: [UUID: String] = [:]
 
-        let context = DialogPresenter.forKeyProject()
-        let projectManager = self.projectManager
-        Task { @MainActor in
-            let response = await AlertTemplate.fileDeletedSaveAs.runSheet(
-                on: context,
-                messageText: Strings.fileDeletedTitle,
-                informativeText: Strings.fileDeletedMessage
-            )
-            switch response {
-            case .alertFirstButtonReturn:
-                for tab in dirtyTabs {
-                    let panel = NSSavePanel()
-                    panel.nameFieldStringValue = tab.fileName
-                    _ = await panel.runSheet(on: context)
-                    guard let saveURL = panel.url else { return }
-                    do {
-                        try tab.content.write(to: saveURL, atomically: true, encoding: .utf8)
-                    } catch {
-                        _ = await AlertTemplate.fileOperationErrorWarning.runSheet(
-                            on: context,
-                            messageText: Strings.fileOperationErrorTitle,
-                            informativeText: error.localizedDescription
-                        )
-                        return
-                    }
+        let response = await AlertTemplate.fileDeletedSaveAs.runSheet(
+            on: context,
+            messageText: Strings.fileDeletedTitle,
+            informativeText: Strings.fileDeletedMessage
+        )
+        switch response {
+        case .alertFirstButtonReturn:
+            let dirtyTabIDs = projectManager.allTabs
+                .filter {
+                    affectedTabIDs.contains($0.id) && $0.isDirty
                 }
-            case .alertSecondButtonReturn:
-                break
-            default:
-                return
+                .map(\.id)
+            for tabID in dirtyTabIDs {
+                guard let tab = projectManager.allTabs.first(where: {
+                    $0.id == tabID
+                }) else {
+                    continue
+                }
+                let panel = NSSavePanel()
+                panel.nameFieldStringValue = tab.fileName
+                guard await panel.runSheet(on: context) == .OK,
+                      let saveURL = panel.url else { return }
+                guard let currentTab = projectManager.allTabs.first(where: {
+                    $0.id == tabID
+                }) else {
+                    continue
+                }
+                do {
+                    try currentTab.content.write(
+                        to: saveURL,
+                        atomically: true,
+                        encoding: .utf8
+                    )
+                    savedContent[tabID] = currentTab.content
+                } catch {
+                    _ = await AlertTemplate.fileOperationErrorWarning.runSheet(
+                        on: context,
+                        messageText: Strings.fileOperationErrorTitle,
+                        informativeText: error.localizedDescription
+                    )
+                    return
+                }
             }
-            projectManager.closeTabsForDeletedFile(url: deletedURL)
+        case .alertSecondButtonReturn:
+            savedContent = displayedDirtyContent
+        default:
+            return
         }
+        let currentDirtyTabs = projectManager
+            .tabsAffectedByDeletion(url: deletedURL)
+            .filter(\.isDirty)
+        guard currentDirtyTabs.allSatisfy({
+            savedContent[$0.id] == $0.content
+        }) else {
+            return
+        }
+        projectManager.closeTabsForDeletedFile(url: deletedURL)
     }
 }
 

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -329,9 +329,13 @@ extension ContentView {
     }
 
     /// Shows a confirmation dialog before reverting all changes in a file.
+    /// Presented as a window-scoped sheet so it does not block other project
+    /// windows (issue #1241).
     static func confirmRevertAll(fileName: String, completion: @escaping (Bool) -> Void) {
-        DispatchQueue.main.async {
-            let response = AlertTemplate.revertAllConfirmation.runModal(
+        let context = DialogPresenter.forKeyProject()
+        Task { @MainActor in
+            let response = await AlertTemplate.revertAllConfirmation.runSheet(
+                on: context,
                 messageText: Strings.revertAllTitle,
                 informativeText: Strings.revertAllMessage(fileName)
             )
@@ -345,7 +349,12 @@ extension ContentView {
 extension ContentView {
 
     func closeTabWithConfirmation(_ tab: EditorTab) {
-        TabCloseHelper.closeTab(tab, in: activeTabManager, gitProvider: workspace.gitProvider)
+        let didClose = TabCloseHelper.closeTab(
+            tab, in: activeTabManager, gitProvider: workspace.gitProvider
+        )
+        if didClose && activeTabManager.tabs.isEmpty {
+            paneManager.removePane(paneManager.activePaneID)
+        }
     }
 
     func handleExternalChanges(_ result: TabManager.ExternalChangeResult) {
@@ -359,14 +368,19 @@ extension ContentView {
 
         if !modified.isEmpty {
             let names = Array(Set(modified.map(\.url.lastPathComponent))).sorted().joined(separator: ", ")
-            let response = AlertTemplate.externalModifyConflict.runModal(
-                messageText: Strings.externalModifyTitle,
-                informativeText: Strings.externalModifyMessage(names)
-            )
+            let context = DialogPresenter.forKeyProject()
+            Task { @MainActor [weak projectManager] in
+                let response = await AlertTemplate.externalModifyConflict.runSheet(
+                    on: context,
+                    messageText: Strings.externalModifyTitle,
+                    informativeText: Strings.externalModifyMessage(names)
+                )
 
-            if response == .alertFirstButtonReturn {
-                for conflict in modified {
-                    projectManager.reloadTabs(url: conflict.url)
+                if response == .alertFirstButtonReturn {
+                    guard let projectManager else { return }
+                    for conflict in modified {
+                        projectManager.reloadTabs(url: conflict.url)
+                    }
                 }
             }
         }
@@ -381,8 +395,16 @@ extension ContentView {
         guard !affected.isEmpty else { return }
 
         let dirtyTabs = affected.filter { $0.isDirty }
-        if !dirtyTabs.isEmpty {
-            let response = AlertTemplate.fileDeletedSaveAs.runModal(
+        guard !dirtyTabs.isEmpty else {
+            projectManager.closeTabsForDeletedFile(url: deletedURL)
+            return
+        }
+
+        let context = DialogPresenter.forKeyProject()
+        let projectManager = self.projectManager
+        Task { @MainActor in
+            let response = await AlertTemplate.fileDeletedSaveAs.runSheet(
+                on: context,
                 messageText: Strings.fileDeletedTitle,
                 informativeText: Strings.fileDeletedMessage
             )
@@ -391,11 +413,13 @@ extension ContentView {
                 for tab in dirtyTabs {
                     let panel = NSSavePanel()
                     panel.nameFieldStringValue = tab.fileName
-                    guard panel.runModal() == .OK, let saveURL = panel.url else { return }
+                    _ = panel.runSheet(on: context)
+                    guard let saveURL = panel.url else { return }
                     do {
                         try tab.content.write(to: saveURL, atomically: true, encoding: .utf8)
                     } catch {
-                        AlertTemplate.fileOperationErrorWarning.runModal(
+                        _ = await AlertTemplate.fileOperationErrorWarning.runSheet(
+                            on: context,
                             messageText: Strings.fileOperationErrorTitle,
                             informativeText: error.localizedDescription
                         )
@@ -407,9 +431,8 @@ extension ContentView {
             default:
                 return
             }
+            projectManager.closeTabsForDeletedFile(url: deletedURL)
         }
-
-        projectManager.closeTabsForDeletedFile(url: deletedURL)
     }
 }
 

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -413,7 +413,7 @@ extension ContentView {
                 for tab in dirtyTabs {
                     let panel = NSSavePanel()
                     panel.nameFieldStringValue = tab.fileName
-                    _ = panel.runSheet(on: context)
+                    _ = await panel.runSheet(on: context)
                     guard let saveURL = panel.url else { return }
                     do {
                         try tab.content.write(to: saveURL, atomically: true, encoding: .utf8)

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -132,26 +132,35 @@ extension ContentView {
         // Recover into the focused editor pane (issue #971): the user is
         // looking at the active pane, so recovered tabs should appear there,
         // not in the possibly-orphaned primary TabManager.
-        let target = activeTabManager
-        for (_, entry) in recoveryEntries {
-            guard !entry.originalPath.isEmpty else { continue }
-
-            let url = URL(fileURLWithPath: entry.originalPath)
-            target.openTab(url: url)
-
-            if let index = target.tabs.firstIndex(where: { $0.url == url }) {
-                target.tabs[index].content = entry.content
-                target.tabs[index].encoding = entry.encoding
-                target.tabs[index].recomputeContentCaches()
-            }
+        guard let recoveryManager = projectManager.recoveryManager else {
+            return
         }
-        projectManager.recoveryManager?.deleteAllRecoveryFiles()
+        let target = activeTabManager
+        let entries = recoveryEntries
+        let context = DialogPresenter.forProject(projectManager)
+
+        // Dismiss the SwiftUI recovery sheet before presenting a native
+        // large-file sheet on the same window. The restorer keeps cancelled
+        // snapshots on disk, so closing this list cannot lose their content.
         showRecoveryDialog = false
         recoveryEntries = []
+
+        Task { @MainActor in
+            let retained = await recoveryManager.restorePendingEntries(
+                entries,
+                in: target,
+                context: context
+            )
+            guard !Task.isCancelled else { return }
+            recoveryEntries = retained
+            showRecoveryDialog = !retained.isEmpty
+        }
     }
 
     func discardRecovery() {
-        projectManager.recoveryManager?.deleteAllRecoveryFiles()
+        projectManager.recoveryManager?.deleteRecoveryFiles(
+            for: recoveryEntries.map(\.0)
+        )
         showRecoveryDialog = false
         recoveryEntries = []
     }

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -75,8 +75,11 @@ struct ContentView: View {
             .toolbar {
                 ToolbarItem {
                     Button {
-                        if let url = registry.openProjectViaPanel() {
-                            openWindow(value: url)
+                        let context = DialogPresenter.forProject(projectManager)
+                        Task { @MainActor in
+                            if let url = await registry.openProjectViaPanel(context: context) {
+                                openWindow(value: url)
+                            }
                         }
                     } label: {
                         Image(systemName: "folder.badge.plus")
@@ -100,7 +103,8 @@ struct ContentView: View {
         .background {
             BranchSubtitleClickHandler(
                 gitProvider: workspace.gitProvider,
-                isGitRepository: workspace.gitProvider.isGitRepository
+                isGitRepository: workspace.gitProvider.isGitRepository,
+                projectManager: projectManager
             )
             DocumentEditedTracker(isEdited: projectManager.hasUnsavedChanges)
             RepresentedFileTracker(url: activeTab?.url ?? workspace.rootURL)
@@ -163,7 +167,8 @@ struct ContentView: View {
         .sheet(isPresented: $isBranchSwitcherPresented) {
             BranchSwitcherView(
                 gitProvider: workspace.gitProvider,
-                isPresented: $isBranchSwitcherPresented
+                isPresented: $isBranchSwitcherPresented,
+                projectManager: projectManager
             )
             .padding(12)
         }
@@ -325,12 +330,36 @@ struct ContentView: View {
                     } else {
                         // Warn before stopping tabs with foreground processes.
                         // Presented as a window-scoped sheet (issue #1241).
+                        let context = DialogPresenter.forProject(projectManager)
+                        let targetPaneIDs = Set(paneManager.terminalPaneIDs)
+                        let targetTabs = terminal.allTerminalTabs
+                        let targetTabIDs = Set(targetTabs.map(\.id))
+                        let authorizedForegroundProcesses =
+                            TabCloseHelper.foregroundProcessSnapshot(
+                                for: targetTabs
+                            )
                         Task { @MainActor in
                             guard await TabCloseHelper.confirmTerminalProcessStop(
-                                tabs: terminal.allTerminalTabs
+                                tabs: targetTabs,
+                                context: context
                             ) else { return }
+                            let currentPaneIDs = Set(paneManager.terminalPaneIDs)
+                            let currentTabs = terminal.allTerminalTabs
+                            let currentTabIDs = Set(currentTabs.map(\.id))
+                            let currentForegroundProcesses =
+                                TabCloseHelper.foregroundProcessSnapshot(
+                                    for: currentTabs
+                                )
+                            guard currentPaneIDs.isSubset(of: targetPaneIDs),
+                                  currentTabIDs.isSubset(of: targetTabIDs),
+                                  TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
+                                      currentForegroundProcesses,
+                                      by: authorizedForegroundProcesses
+                                  ) else {
+                                return
+                            }
                             // Hide all terminal panes
-                            for paneID in paneManager.terminalPaneIDs {
+                            for paneID in targetPaneIDs {
                                 if let state = paneManager.terminalState(for: paneID) {
                                     for tab in state.terminalTabs { tab.stop() }
                                 }

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -323,16 +323,19 @@ struct ContentView: View {
                             workingDirectory: workspace.rootURL
                         )
                     } else {
-                        // Warn before stopping tabs with foreground processes
-                        guard TabCloseHelper.confirmTerminalProcessStop(
-                            tabs: terminal.allTerminalTabs
-                        ) else { return }
-                        // Hide all terminal panes
-                        for paneID in paneManager.terminalPaneIDs {
-                            if let state = paneManager.terminalState(for: paneID) {
-                                for tab in state.terminalTabs { tab.stop() }
+                        // Warn before stopping tabs with foreground processes.
+                        // Presented as a window-scoped sheet (issue #1241).
+                        Task { @MainActor in
+                            guard await TabCloseHelper.confirmTerminalProcessStop(
+                                tabs: terminal.allTerminalTabs
+                            ) else { return }
+                            // Hide all terminal panes
+                            for paneID in paneManager.terminalPaneIDs {
+                                if let state = paneManager.terminalState(for: paneID) {
+                                    for tab in state.terminalTabs { tab.stop() }
+                                }
+                                paneManager.removePane(paneID)
                             }
-                            paneManager.removePane(paneID)
                         }
                     }
                 },

--- a/Pine/DialogPresentationContext.swift
+++ b/Pine/DialogPresentationContext.swift
@@ -1,0 +1,121 @@
+//
+//  DialogPresentationContext.swift
+//  Pine
+//
+//  Resolves the NSWindow that owns a document dialog so alerts, open/save
+//  panels, and confirmation sheets attach to a single project window instead
+//  of running application-modal (issue #1241).
+//
+//  Pine is multiwindow: a save failure, unsaved-change decision, or file
+//  picker in one project must not block unrelated project windows. Every
+//  dialog flow resolves a presentation anchor through this type before
+//  showing UI. When no anchor is available (headless tests, background
+//  dispatch), the modal `runModal()` fallback is used so behavior is
+//  preserved without a window.
+//
+
+import AppKit
+
+/// The window (or absence of one) that a dialog should attach to.
+///
+/// Carried through close, save, open, external-change, and task flows so
+/// each dialog is scoped to its originating project window. Sendable so it
+/// can cross actor boundaries safely; the wrapped `NSWindow` is only ever
+/// touched on the main actor.
+struct DialogPresentationContext: Sendable {
+    /// The owning project window. `nil` when no window is available —
+    /// callers fall back to the application-modal path.
+    private let window: NSWindow?
+
+    /// Creates a context bound to the given window. Pass `nil` when the
+    /// initiating window is unknown (tests, background dispatch).
+    init(window: NSWindow?) {
+        self.window = window
+    }
+
+    /// A context with no attached window. Dialogs presented against it
+    /// fall back to application-modal `runModal()`.
+    static let unscoped = DialogPresentationContext(window: nil)
+
+    /// The resolved window, or `nil` if none is attached.
+    var nsWindow: NSWindow? { window }
+}
+
+@MainActor
+enum DialogPresenter {
+    /// Resolves the key project window for the currently focused project.
+    /// Returns `nil` if no project window is key (e.g. only the Welcome
+    /// window or Settings is visible).
+    static func keyProjectWindow() -> NSWindow? {
+        guard let window = NSApp.keyWindow else { return nil }
+        // Only treat actual project windows (those with a CloseDelegate) as
+        // dialog anchors. The Welcome window and Settings panels are excluded
+        // so a dialog never attaches to the wrong surface.
+        guard window.delegate is CloseDelegate else { return nil }
+        return window
+    }
+
+    /// Convenience: a context anchored to the key project window, or
+    /// `.unscoped` if none exists.
+    static func forKeyProject() -> DialogPresentationContext {
+        DialogPresentationContext(window: keyProjectWindow())
+    }
+}
+
+// MARK: - NSAlert + window-scoped sheet
+
+extension NSAlert {
+    /// Presents this ad-hoc `NSAlert` as a sheet attached to the window
+    /// resolved from `context`. Falls back to application-modal `runModal()`
+    /// when no window is available (issue #1241).
+    ///
+    /// Use ``AlertTemplate/runSheet(on:messageText:informativeText:)`` for
+    /// templated alerts; this extension is for the few ad-hoc `NSAlert`
+    /// constructions that do not map to a template (user-task confirmation).
+    @discardableResult
+    func runSheet(on context: DialogPresentationContext) async -> NSApplication.ModalResponse {
+        guard let window = context.nsWindow, window.isVisible else {
+            return runModal()
+        }
+        return await withCheckedContinuation { continuation in
+            beginSheetModal(for: window) { response in
+                continuation.resume(returning: response)
+            }
+        }
+    }
+}
+
+// MARK: - NSSavePanel / NSOpenPanel + window-scoped sheet
+
+extension NSSavePanel {
+    /// Presents this save panel as a sheet attached to the window resolved
+    /// from `context`. Returns `.cancel` if the user cancels or no window is
+    /// available. Falls back to application-modal `runModal()` when the
+    /// context has no window (issue #1241).
+    func runSheet(on context: DialogPresentationContext) async -> NSApplication.ModalResponse {
+        guard let window = context.nsWindow, window.isVisible else {
+            return runModal()
+        }
+        return await withCheckedContinuation { continuation in
+            beginSheetModal(for: window) { response in
+                continuation.resume(returning: response)
+            }
+        }
+    }
+}
+
+extension NSOpenPanel {
+    /// Presents this open panel as a sheet attached to the window resolved
+    /// from `context`. Falls back to application-modal `runModal()` when the
+    /// context has no window (issue #1241).
+    func runSheet(on context: DialogPresentationContext) async -> NSApplication.ModalResponse {
+        guard let window = context.nsWindow, window.isVisible else {
+            return runModal()
+        }
+        return await withCheckedContinuation { continuation in
+            beginSheetModal(for: window) { response in
+                continuation.resume(returning: response)
+            }
+        }
+    }
+}

--- a/Pine/DialogPresentationContext.swift
+++ b/Pine/DialogPresentationContext.swift
@@ -2,104 +2,497 @@
 //  DialogPresentationContext.swift
 //  Pine
 //
-//  Resolves the NSWindow that owns a document dialog so alerts, open/save
-//  panels, and confirmation sheets attach to a single project window instead
-//  of running application-modal (issue #1241).
-//
-//  Pine is multiwindow: a save failure, unsaved-change decision, or file
-//  picker in one project must not block unrelated project windows. Every
-//  dialog flow resolves a presentation anchor through this type before
-//  showing UI. When no anchor is available (headless tests, background
-//  dispatch), the modal `runModal()` fallback is used so behavior is
-//  preserved without a window.
+//  Window-owned, queued presentation for alerts and file panels.
 //
 
 import AppKit
 
-/// The window (or absence of one) that a dialog should attach to.
+/// Serializes every native dialog belonging to one window.
 ///
-/// Carried through close, save, open, external-change, and task flows so
-/// each dialog is scoped to its originating project window. Sendable so it
-/// can cross actor boundaries safely; the wrapped `NSWindow` is only ever
-/// touched on the main actor.
-struct DialogPresentationContext: Sendable {
-    /// The owning project window. `nil` when no window is available —
-    /// callers fall back to the application-modal path.
-    private let window: NSWindow?
+/// AppKit does not permit two sheets on the same window. More importantly,
+/// resolving the owner lazily from `NSApp.keyWindow` can move a confirmation
+/// to a different project while the request is suspended. This coordinator
+/// captures its owner weakly, queues requests in FIFO order, and resolves
+/// every pending request exactly once with `.abort` if the owner closes.
+@MainActor
+final class WindowDialogCoordinator {
+    typealias Start = (
+        _ owner: NSWindow,
+        _ completion: @escaping (NSApplication.ModalResponse) -> Void
+    ) -> Void
+    typealias Cancel = (_ owner: NSWindow) -> Void
 
-    /// Creates a context bound to the given window. Pass `nil` when the
-    /// initiating window is unknown (tests, background dispatch).
-    init(window: NSWindow?) {
-        self.window = window
+    private final class Request {
+        let id: UUID
+        let start: Start
+        let cancel: Cancel
+        var continuation: CheckedContinuation<NSApplication.ModalResponse, Never>?
+        private(set) var isResolved = false
+
+        init(id: UUID, start: @escaping Start, cancel: @escaping Cancel) {
+            self.id = id
+            self.start = start
+            self.cancel = cancel
+        }
+
+        func resolve(_ response: NSApplication.ModalResponse) {
+            guard !isResolved else { return }
+            isResolved = true
+            let continuation = continuation
+            self.continuation = nil
+            continuation?.resume(returning: response)
+        }
     }
 
-    /// A context with no attached window. Dialogs presented against it
-    /// fall back to application-modal `runModal()`.
-    static let unscoped = DialogPresentationContext(window: nil)
+    private weak var ownerWindow: NSWindow?
+    private var queuedRequests: [Request] = []
+    private var activeRequest: Request?
+    private var closeObserver: Any?
+    private var sheetEndObserver: Any?
+    private var activationObserver: Any?
+    private let notificationCenter: NotificationCenter
+    private let onOwnerClose: () -> Void
+    private(set) var isOwnerClosed = false
 
-    /// The resolved window, or `nil` if none is attached.
-    var nsWindow: NSWindow? { window }
+    var pendingRequestCount: Int {
+        queuedRequests.count + (activeRequest == nil ? 0 : 1)
+    }
+
+    init(
+        ownerWindow: NSWindow,
+        notificationCenter: NotificationCenter = .default,
+        onOwnerClose: @escaping () -> Void = {}
+    ) {
+        self.ownerWindow = ownerWindow
+        self.notificationCenter = notificationCenter
+        self.onOwnerClose = onOwnerClose
+        closeObserver = notificationCenter.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let senderIdentifier = (notification.object as AnyObject?)
+                .map(ObjectIdentifier.init)
+            MainActor.assumeIsolated {
+                guard let self,
+                      senderIdentifier == self.ownerWindow.map(ObjectIdentifier.init) else {
+                    return
+                }
+                self.ownerDidClose()
+            }
+        }
+        sheetEndObserver = notificationCenter.addObserver(
+            forName: NSWindow.didEndSheetNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let senderIdentifier = (notification.object as AnyObject?)
+                .map(ObjectIdentifier.init)
+            MainActor.assumeIsolated {
+                guard let self,
+                      senderIdentifier == self.ownerWindow.map(ObjectIdentifier.init) else {
+                    return
+                }
+                self.presentNextIfPossible()
+            }
+        }
+        activationObserver = notificationCenter.addObserver(
+            forName: NSWindow.didBecomeKeyNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let senderIdentifier = (notification.object as AnyObject?)
+                .map(ObjectIdentifier.init)
+            MainActor.assumeIsolated {
+                guard let self,
+                      senderIdentifier == self.ownerWindow.map(ObjectIdentifier.init) else {
+                    return
+                }
+                self.presentNextIfPossible()
+            }
+        }
+    }
+
+    isolated deinit {
+        if let closeObserver {
+            notificationCenter.removeObserver(closeObserver)
+        }
+        if let sheetEndObserver {
+            notificationCenter.removeObserver(sheetEndObserver)
+        }
+        if let activationObserver {
+            notificationCenter.removeObserver(activationObserver)
+        }
+    }
+
+    /// Enqueues a native sheet. Missing/closed owners fail closed with
+    /// `.abort`; a dialog is never promoted to an application-modal window.
+    func present(
+        start: @escaping Start,
+        cancel: @escaping Cancel
+    ) async -> NSApplication.ModalResponse {
+        guard !Task.isCancelled else { return .abort }
+        guard !isOwnerClosed else { return .abort }
+        guard ownerWindow != nil else {
+            ownerDidClose()
+            return .abort
+        }
+
+        let requestID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                let request = Request(
+                    id: requestID,
+                    start: start,
+                    cancel: cancel
+                )
+                request.continuation = continuation
+                queuedRequests.append(request)
+                presentNextIfPossible()
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelRequest(id: requestID)
+            }
+        }
+    }
+
+    /// Public to the module so lifecycle tests can exercise the exact
+    /// once-only cancellation path without actually closing an NSWindow.
+    func ownerDidClose() {
+        guard !isOwnerClosed else { return }
+        isOwnerClosed = true
+
+        if let activeRequest {
+            self.activeRequest = nil
+            if let ownerWindow {
+                activeRequest.cancel(ownerWindow)
+            }
+            activeRequest.resolve(.abort)
+        }
+
+        let queued = queuedRequests
+        queuedRequests.removeAll()
+        for request in queued {
+            request.resolve(.abort)
+        }
+        onOwnerClose()
+    }
+
+    private func cancelRequest(id: UUID) {
+        if let activeRequest, activeRequest.id == id {
+            self.activeRequest = nil
+            if let ownerWindow {
+                activeRequest.cancel(ownerWindow)
+            }
+            activeRequest.resolve(.abort)
+            presentNextIfPossible()
+            return
+        }
+        guard let index = queuedRequests.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let request = queuedRequests.remove(at: index)
+        request.resolve(.abort)
+    }
+
+    private func presentNextIfPossible() {
+        guard activeRequest == nil, !queuedRequests.isEmpty else { return }
+        guard let ownerWindow, !isOwnerClosed else {
+            ownerDidClose()
+            return
+        }
+        // SwiftUI and framework-owned sheets do not enter this coordinator.
+        // Wait for them to finish instead of asking AppKit to attach a second
+        // sheet to the same window.
+        guard ownerWindow.attachedSheet == nil else { return }
+
+        let request = queuedRequests.removeFirst()
+        activeRequest = request
+        request.start(ownerWindow) { [weak self, weak request] response in
+            Task { @MainActor in
+                guard let self, let request else { return }
+                self.finish(request, response: response)
+            }
+        }
+    }
+
+    private func finish(
+        _ request: Request,
+        response: NSApplication.ModalResponse
+    ) {
+        request.resolve(response)
+        if activeRequest === request {
+            activeRequest = nil
+        }
+        guard !isOwnerClosed else { return }
+        // Let AppKit finish detaching the just-ended sheet before consulting
+        // `attachedSheet` for the next request. Some panel completions arrive
+        // one run-loop turn before that relationship is cleared.
+        Task { @MainActor [weak self] in
+            self?.presentNextIfPossible()
+        }
+    }
+}
+
+/// Captured presentation authority for one initiating window.
+///
+/// The context strongly retains only the coordinator. The coordinator keeps
+/// the window weak, so an asynchronous request cannot extend the window's
+/// lifetime or attach itself to whatever window later becomes key.
+@MainActor
+struct DialogPresentationContext {
+    fileprivate let coordinator: WindowDialogCoordinator?
+
+    init(window: NSWindow?) {
+        coordinator = window.map { DialogPresenter.coordinator(for: $0) }
+    }
+
+    fileprivate init(coordinator: WindowDialogCoordinator?) {
+        self.coordinator = coordinator
+    }
+
+    /// A deliberately unavailable owner. Presentation against this context
+    /// returns `.abort` and performs no UI.
+    static var unscoped: DialogPresentationContext {
+        DialogPresentationContext(coordinator: nil)
+    }
+
+    var nsWindow: NSWindow? {
+        coordinator?.ownerWindowForPresentation
+    }
+
+    func present(
+        start: @escaping WindowDialogCoordinator.Start,
+        cancel: @escaping WindowDialogCoordinator.Cancel
+    ) async -> NSApplication.ModalResponse {
+        guard let coordinator else { return .abort }
+        return await coordinator.present(start: start, cancel: cancel)
+    }
+}
+
+private extension WindowDialogCoordinator {
+    var ownerWindowForPresentation: NSWindow? {
+        guard !isOwnerClosed else { return nil }
+        guard let ownerWindow else {
+            ownerDidClose()
+            return nil
+        }
+        return ownerWindow
+    }
 }
 
 @MainActor
 enum DialogPresenter {
-    /// Resolves the key project window for the currently focused project.
-    /// Returns `nil` if no project window is key (e.g. only the Welcome
-    /// window or Settings is visible).
-    static func keyProjectWindow() -> NSWindow? {
-        guard let window = NSApp.keyWindow else { return nil }
-        // Only treat actual project windows (those with a CloseDelegate) as
-        // dialog anchors. The Welcome window and Settings panels are excluded
-        // so a dialog never attaches to the wrong surface.
-        guard window.delegate is CloseDelegate else { return nil }
-        return window
+    private final class ProjectBinding {
+        weak var window: NSWindow?
+        weak var projectManager: ProjectManager?
+
+        init(window: NSWindow, projectManager: ProjectManager) {
+            self.window = window
+            self.projectManager = projectManager
+        }
     }
 
-    /// Convenience: a context anchored to the key project window, or
-    /// `.unscoped` if none exists.
+    private static var coordinators: [ObjectIdentifier: WindowDialogCoordinator] = [:]
+    private static var projectBindings: [ObjectIdentifier: ProjectBinding] = [:]
+
+    static func coordinator(for window: NSWindow) -> WindowDialogCoordinator {
+        let identifier = ObjectIdentifier(window)
+        if let coordinator = coordinators[identifier] {
+            if !coordinator.isOwnerClosed,
+               coordinator.ownerWindowForPresentation === window {
+                return coordinator
+            }
+            coordinator.ownerDidClose()
+        }
+        let coordinator = WindowDialogCoordinator(ownerWindow: window) {
+            coordinators.removeValue(forKey: identifier)
+            if let binding = projectBindings.removeValue(forKey: identifier),
+               let owner = binding.window {
+                binding.projectManager?.unbindDialogOwnerWindow(owner)
+            }
+        }
+        coordinators[identifier] = coordinator
+        return coordinator
+    }
+
+    /// Registers the weak project → window anchor and returns its shared
+    /// per-window presentation context.
+    @discardableResult
+    static func register(
+        window: NSWindow,
+        projectManager: ProjectManager
+    ) -> DialogPresentationContext {
+        // A project owns one document window. SwiftUI can replace that
+        // window during scene restoration, so retire every obsolete binding
+        // (and abort its queued sheets) before installing the new anchor.
+        let obsoleteWindows: [NSWindow] = projectBindings.values.compactMap { binding in
+            guard binding.projectManager === projectManager,
+                  let boundWindow = binding.window,
+                  boundWindow !== window else {
+                return nil
+            }
+            return boundWindow
+        }
+        for obsoleteWindow in obsoleteWindows {
+            ownerDidClose(obsoleteWindow)
+        }
+
+        let identifier = ObjectIdentifier(window)
+        if let previous = projectBindings[identifier],
+           let previousWindow = previous.window,
+           previous.projectManager !== projectManager {
+            // The same NSWindow can be reused for a different project during
+            // scene restoration. A coordinator is presentation authority for
+            // the *binding generation*, not merely the NSWindow identity:
+            // retire it before installing B so active/queued requests captured
+            // by A can never appear over B.
+            if let previousCoordinator = coordinators[identifier] {
+                previousCoordinator.ownerDidClose()
+            } else {
+                projectBindings.removeValue(forKey: identifier)
+                previous.projectManager?.unbindDialogOwnerWindow(previousWindow)
+            }
+        }
+        let coordinator = coordinator(for: window)
+        projectBindings[identifier] = ProjectBinding(
+            window: window,
+            projectManager: projectManager
+        )
+        projectManager.bindDialogOwnerWindow(window)
+        return DialogPresentationContext(coordinator: coordinator)
+    }
+
+    /// Explicit lifecycle hook used by the window delegate and tests. The
+    /// coordinator also observes `willClose`, so duplicate calls are harmless.
+    static func ownerDidClose(_ window: NSWindow) {
+        let identifier = ObjectIdentifier(window)
+        if let coordinator = coordinators[identifier] {
+            coordinator.ownerDidClose()
+            return
+        }
+        if let binding = projectBindings.removeValue(forKey: identifier) {
+            binding.projectManager?.unbindDialogOwnerWindow(window)
+        }
+    }
+
+    static func context(for window: NSWindow?) -> DialogPresentationContext {
+        DialogPresentationContext(window: window)
+    }
+
+    static func forKeyWindow() -> DialogPresentationContext {
+        guard let keyWindow = NSApp.keyWindow else { return .unscoped }
+        return context(for: keyWindow.sheetParent ?? keyWindow)
+    }
+
+    /// Captures a visible application window for app-global decisions such
+    /// as Quit. A background project deliberately has no project owner, but
+    /// its retained terminal still needs a place to ask whether Quit should
+    /// stop it. Prefer the current key/main window, then any visible window;
+    /// if none exists the returned context fails closed.
+    static func forApplicationWindow() -> DialogPresentationContext {
+        var candidates: [NSWindow] = []
+        if let keyWindow = NSApp.keyWindow {
+            candidates.append(keyWindow)
+        }
+        if let mainWindow = NSApp.mainWindow {
+            candidates.append(mainWindow)
+        }
+        candidates.append(contentsOf: NSApp.windows)
+        let owner = candidates
+            .map { $0.sheetParent ?? $0 }
+            .first(where: { isEligibleApplicationOwner($0) })
+        return context(for: owner)
+    }
+
+    static func isEligibleApplicationOwner(_ window: NSWindow) -> Bool {
+        window.isVisible && !window.isMiniaturized
+    }
+
+    /// Captures the current project window. Welcome and Settings windows are
+    /// intentionally excluded from document/project decisions.
     static func forKeyProject() -> DialogPresentationContext {
-        DialogPresentationContext(window: keyProjectWindow())
+        guard let keyWindow = NSApp.keyWindow else { return .unscoped }
+        let window = keyWindow.sheetParent ?? keyWindow
+        if projectManager(for: window) != nil {
+            return context(for: window)
+        }
+        guard let delegate = window.delegate as? CloseDelegate else {
+            return .unscoped
+        }
+        return register(window: window, projectManager: delegate.projectManager)
+    }
+
+    /// Resolves the weak window anchor owned by `projectManager`. This remains
+    /// valid even if SwiftUI temporarily replaces the NSWindow delegate.
+    static func forProject(_ projectManager: ProjectManager) -> DialogPresentationContext {
+        context(for: projectManager.dialogOwnerWindow)
+    }
+
+    static func projectManager(for window: NSWindow?) -> ProjectManager? {
+        guard let window else { return nil }
+        let identifier = ObjectIdentifier(window)
+        guard let binding = projectBindings[identifier] else { return nil }
+        guard binding.window === window else {
+            if let previousWindow = binding.window {
+                binding.projectManager?.unbindDialogOwnerWindow(previousWindow)
+            }
+            projectBindings.removeValue(forKey: identifier)
+            return nil
+        }
+        guard let projectManager = binding.projectManager else {
+            projectBindings.removeValue(forKey: identifier)
+            return nil
+        }
+        return projectManager
     }
 }
 
-// MARK: - NSAlert + window-scoped sheet
+// MARK: - Native sheet adapters
 
 extension NSAlert {
-    /// Presents this ad-hoc `NSAlert` as a sheet attached to the window
-    /// resolved from `context`. Falls back to application-modal `runModal()`
-    /// when no window is available (issue #1241).
-    ///
-    /// Use ``AlertTemplate/runSheet(on:messageText:informativeText:)`` for
-    /// templated alerts; this extension is for the few ad-hoc `NSAlert`
-    /// constructions that do not map to a template (user-task confirmation).
     @discardableResult
     func runSheet(on context: DialogPresentationContext) async -> NSApplication.ModalResponse {
-        guard let window = context.nsWindow, window.isVisible else {
-            return runModal()
+        guard let capturedOwner = context.nsWindow,
+              capturedOwner.isVisible,
+              !capturedOwner.isMiniaturized else {
+            return .abort
         }
-        return await withCheckedContinuation { continuation in
-            beginSheetModal(for: window) { response in
-                continuation.resume(returning: response)
+        return await context.present(
+            start: { owner, completion in
+                guard owner.isVisible, !owner.isMiniaturized else {
+                    completion(.abort)
+                    return
+                }
+                self.beginSheetModal(for: owner, completionHandler: completion)
+            },
+            cancel: { owner in
+                guard self.window.sheetParent === owner else { return }
+                owner.endSheet(self.window, returnCode: .abort)
             }
-        }
+        )
     }
 }
 
-// MARK: - NSSavePanel / NSOpenPanel + window-scoped sheet
-
 extension NSSavePanel {
-    /// Presents this save panel as a sheet attached to the window resolved
-    /// from `context`. Returns `.cancel` if the user cancels or no window is
-    /// available. Falls back to application-modal `runModal()` when the
-    /// context has no window (issue #1241).
     func runSheet(on context: DialogPresentationContext) async -> NSApplication.ModalResponse {
-        guard let window = context.nsWindow, window.isVisible else {
-            return runModal()
+        guard let capturedOwner = context.nsWindow,
+              capturedOwner.isVisible,
+              !capturedOwner.isMiniaturized else {
+            return .abort
         }
-        return await withCheckedContinuation { continuation in
-            beginSheetModal(for: window) { response in
-                continuation.resume(returning: response)
+        return await context.present(
+            start: { owner, completion in
+                guard owner.isVisible, !owner.isMiniaturized else {
+                    completion(.abort)
+                    return
+                }
+                self.beginSheetModal(for: owner, completionHandler: completion)
+            },
+            cancel: { _ in
+                self.cancel(nil)
             }
-        }
+        )
     }
 }

--- a/Pine/DialogPresentationContext.swift
+++ b/Pine/DialogPresentationContext.swift
@@ -7,6 +7,21 @@
 
 import AppKit
 
+/// Identity for an in-flight destructive dialog workflow. A repeated user
+/// gesture with the same key is rejected while the original request is active
+/// or queued, preventing a stale second sheet after the first workflow has
+/// already mutated its target.
+enum DialogRequestKey: Hashable {
+    case editorTabs(
+        tabManager: ObjectIdentifier,
+        tabIDs: Set<UUID>
+    )
+    case terminalTabs(
+        tabIDs: Set<UUID>,
+        foregroundProcesses: Set<TerminalForegroundProcessIdentity>
+    )
+}
+
 /// Serializes every native dialog belonging to one window.
 ///
 /// AppKit does not permit two sheets on the same window. More importantly,
@@ -24,13 +39,20 @@ final class WindowDialogCoordinator {
 
     private final class Request {
         let id: UUID
+        let deduplicationKey: DialogRequestKey?
         let start: Start
         let cancel: Cancel
         var continuation: CheckedContinuation<NSApplication.ModalResponse, Never>?
         private(set) var isResolved = false
 
-        init(id: UUID, start: @escaping Start, cancel: @escaping Cancel) {
+        init(
+            id: UUID,
+            deduplicationKey: DialogRequestKey?,
+            start: @escaping Start,
+            cancel: @escaping Cancel
+        ) {
             self.id = id
+            self.deduplicationKey = deduplicationKey
             self.start = start
             self.cancel = cancel
         }
@@ -128,6 +150,7 @@ final class WindowDialogCoordinator {
     /// Enqueues a native sheet. Missing/closed owners fail closed with
     /// `.abort`; a dialog is never promoted to an application-modal window.
     func present(
+        deduplicationKey: DialogRequestKey? = nil,
         start: @escaping Start,
         cancel: @escaping Cancel
     ) async -> NSApplication.ModalResponse {
@@ -137,12 +160,23 @@ final class WindowDialogCoordinator {
             ownerDidClose()
             return .abort
         }
+        if let deduplicationKey {
+            let isDuplicate = activeRequest?.deduplicationKey
+                == deduplicationKey
+                || queuedRequests.contains(where: {
+                    $0.deduplicationKey == deduplicationKey
+                })
+            if isDuplicate {
+                return .abort
+            }
+        }
 
         let requestID = UUID()
         return await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
                 let request = Request(
                     id: requestID,
+                    deduplicationKey: deduplicationKey,
                     start: start,
                     cancel: cancel
                 )
@@ -263,11 +297,16 @@ struct DialogPresentationContext {
     }
 
     func present(
+        deduplicationKey: DialogRequestKey? = nil,
         start: @escaping WindowDialogCoordinator.Start,
         cancel: @escaping WindowDialogCoordinator.Cancel
     ) async -> NSApplication.ModalResponse {
         guard let coordinator else { return .abort }
-        return await coordinator.present(start: start, cancel: cancel)
+        return await coordinator.present(
+            deduplicationKey: deduplicationKey,
+            start: start,
+            cancel: cancel
+        )
     }
 }
 
@@ -284,6 +323,18 @@ private extension WindowDialogCoordinator {
 
 @MainActor
 enum DialogPresenter {
+    enum ApplicationOwnerState: Equatable {
+        case eligible
+        case miniaturized
+        case unavailable
+    }
+
+    enum ApplicationOwnerPlan: Equatable {
+        case keepExisting
+        case restore(index: Int)
+        case showWelcome
+    }
+
     private final class ProjectBinding {
         weak var window: NSWindow?
         weak var projectManager: ProjectManager?
@@ -407,7 +458,30 @@ enum DialogPresenter {
     }
 
     static func isEligibleApplicationOwner(_ window: NSWindow) -> Bool {
-        window.isVisible && !window.isMiniaturized
+        applicationOwnerState(
+            isVisible: window.isVisible,
+            isMiniaturized: window.isMiniaturized
+        ) == .eligible
+    }
+
+    static func applicationOwnerState(
+        isVisible: Bool,
+        isMiniaturized: Bool
+    ) -> ApplicationOwnerState {
+        guard isVisible else { return .unavailable }
+        return isMiniaturized ? .miniaturized : .eligible
+    }
+
+    static func applicationOwnerPlan(
+        for states: [ApplicationOwnerState]
+    ) -> ApplicationOwnerPlan {
+        if states.contains(.eligible) {
+            return .keepExisting
+        }
+        if let index = states.firstIndex(of: .miniaturized) {
+            return .restore(index: index)
+        }
+        return .showWelcome
     }
 
     /// Captures the current project window. Welcome and Settings windows are
@@ -453,15 +527,18 @@ enum DialogPresenter {
 
 extension NSAlert {
     @discardableResult
-    func runSheet(on context: DialogPresentationContext) async -> NSApplication.ModalResponse {
+    func runSheet(
+        on context: DialogPresentationContext,
+        deduplicationKey: DialogRequestKey? = nil
+    ) async -> NSApplication.ModalResponse {
         guard let capturedOwner = context.nsWindow,
-              capturedOwner.isVisible,
-              !capturedOwner.isMiniaturized else {
+              DialogPresenter.isEligibleApplicationOwner(capturedOwner) else {
             return .abort
         }
         return await context.present(
+            deduplicationKey: deduplicationKey,
             start: { owner, completion in
-                guard owner.isVisible, !owner.isMiniaturized else {
+                guard DialogPresenter.isEligibleApplicationOwner(owner) else {
                     completion(.abort)
                     return
                 }
@@ -476,15 +553,18 @@ extension NSAlert {
 }
 
 extension NSSavePanel {
-    func runSheet(on context: DialogPresentationContext) async -> NSApplication.ModalResponse {
+    func runSheet(
+        on context: DialogPresentationContext,
+        deduplicationKey: DialogRequestKey? = nil
+    ) async -> NSApplication.ModalResponse {
         guard let capturedOwner = context.nsWindow,
-              capturedOwner.isVisible,
-              !capturedOwner.isMiniaturized else {
+              DialogPresenter.isEligibleApplicationOwner(capturedOwner) else {
             return .abort
         }
         return await context.present(
+            deduplicationKey: deduplicationKey,
             start: { owner, completion in
-                guard owner.isVisible, !owner.isMiniaturized else {
+                guard DialogPresenter.isEligibleApplicationOwner(owner) else {
                     completion(.abort)
                     return
                 }

--- a/Pine/DialogPresentationContext.swift
+++ b/Pine/DialogPresentationContext.swift
@@ -103,19 +103,3 @@ extension NSSavePanel {
         }
     }
 }
-
-extension NSOpenPanel {
-    /// Presents this open panel as a sheet attached to the window resolved
-    /// from `context`. Falls back to application-modal `runModal()` when the
-    /// context has no window (issue #1241).
-    func runSheet(on context: DialogPresentationContext) async -> NSApplication.ModalResponse {
-        guard let window = context.nsWindow, window.isVisible else {
-            return runModal()
-        }
-        return await withCheckedContinuation { continuation in
-            beginSheetModal(for: window) { response in
-                continuation.resume(returning: response)
-            }
-        }
-    }
-}

--- a/Pine/Extensibility/UserCommandInvocationRouter.swift
+++ b/Pine/Extensibility/UserCommandInvocationRouter.swift
@@ -36,7 +36,8 @@ enum UserCommandInvocationRouter {
         case .duplicate:
             guard let projectManager else { return }
             projectManager.activeTabManager.duplicateActiveTab(
-                projectRoot: projectManager.workspace.rootURL
+                projectRoot: projectManager.workspace.rootURL,
+                context: DialogPresenter.forProject(projectManager)
             )
 
         case .toggleAutoSave:
@@ -148,19 +149,49 @@ enum UserCommandInvocationRouter {
             projectManager?.paneManager.toggleMaximizeOnActiveTerminalPane()
 
         case .editKeybindings:
+            let presentationContext = if let projectManager {
+                DialogPresenter.forProject(projectManager)
+            } else {
+                DialogPresenter.forKeyWindow()
+            }
+            let presenter = AppKitUserConfigurationAlertPresenter(
+                context: presentationContext
+            )
             Task { @MainActor in
-                await UserConfigurationEditor.openKeybindings()
+                await UserConfigurationEditor.openKeybindings(
+                    alertPresenter: presenter
+                )
             }
 
         case .editTasks:
+            let presentationContext = if let projectManager {
+                DialogPresenter.forProject(projectManager)
+            } else {
+                DialogPresenter.forKeyWindow()
+            }
+            let presenter = AppKitUserConfigurationAlertPresenter(
+                context: presentationContext
+            )
             Task { @MainActor in
-                await UserConfigurationEditor.openTasks()
+                await UserConfigurationEditor.openTasks(
+                    alertPresenter: presenter
+                )
             }
 
         case .reloadUserConfiguration:
+            let presentationContext = if let projectManager {
+                DialogPresenter.forProject(projectManager)
+            } else {
+                DialogPresenter.forKeyWindow()
+            }
+            let presenter = AppKitUserConfigurationAlertPresenter(
+                context: presentationContext
+            )
             Task { @MainActor in
                 await PineAppMenuCommands
-                    .reloadAndPresentConfigurationDiagnostics()
+                    .reloadAndPresentConfigurationDiagnostics(
+                        alertPresenter: presenter
+                    )
             }
 
         case .showProblems:
@@ -200,27 +231,25 @@ enum UserCommandInvocationRouter {
     private static func saveAs(projectManager: ProjectManager) {
         let tabManager = projectManager.activeTabManager
         guard let activeTab = tabManager.activeTab else { return }
-
-        let panel = NSSavePanel()
-        panel.title = Strings.saveAsPanelTitle
-        panel.nameFieldStringValue = activeTab.fileName
-        panel.directoryURL = activeTab.url.deletingLastPathComponent()
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-
-        // Keep the file mutation outside the originating menu/key-event
-        // call stack to avoid the #1058 Swift exclusivity-abort family.
-        DispatchQueue.main.async {
+        let context = DialogPresenter.forProject(projectManager)
+        Task { @MainActor in
+            let panel = NSSavePanel()
+            panel.title = Strings.saveAsPanelTitle
+            panel.nameFieldStringValue = activeTab.fileName
+            panel.directoryURL = activeTab.url.deletingLastPathComponent()
+            guard await panel.runSheet(on: context) == .OK,
+                  let url = panel.url else { return }
+            guard tabManager.activeTabID == activeTab.id else { return }
             do {
                 try tabManager.saveActiveTabAs(to: url)
-                Task {
-                    await projectManager.workspace.gitProvider.refreshAsync()
-                    NotificationCenter.default.post(
-                        name: .refreshLineDiffs,
-                        object: nil
-                    )
-                }
+                await projectManager.workspace.gitProvider.refreshAsync()
+                NotificationCenter.default.post(
+                    name: .refreshLineDiffs,
+                    object: nil
+                )
             } catch {
-                AlertTemplate.fileOperationErrorCritical.runModal(
+                _ = await AlertTemplate.fileOperationErrorCritical.runSheet(
+                    on: context,
                     messageText: Strings.fileOperationErrorTitle,
                     informativeText: error.localizedDescription
                 )

--- a/Pine/Extensibility/UserConfigurationAlertPresenter.swift
+++ b/Pine/Extensibility/UserConfigurationAlertPresenter.swift
@@ -26,25 +26,47 @@ protocol UserConfigurationAlertPresenting {
     @discardableResult
     func present(
         _ descriptor: UserConfigurationAlertDescriptor
-    ) -> NSApplication.ModalResponse
+    ) async -> NSApplication.ModalResponse
 }
 
 @MainActor
 struct AppKitUserConfigurationAlertPresenter: UserConfigurationAlertPresenting {
+    let context: DialogPresentationContext
+    let feedbackPresenter: any WindowNonmodalFeedbackPresenting
+
+    init(
+        context: DialogPresentationContext = .unscoped,
+        feedbackPresenter: any WindowNonmodalFeedbackPresenting =
+            WindowNonmodalFeedbackPresenter.shared
+    ) {
+        self.context = context
+        self.feedbackPresenter = feedbackPresenter
+    }
+
     @discardableResult
     func present(
         _ descriptor: UserConfigurationAlertDescriptor
-    ) -> NSApplication.ModalResponse {
-        let alert = NSAlert()
-        switch descriptor.style {
-        case .informational:
-            alert.alertStyle = .informational
-        case .warning:
-            alert.alertStyle = .warning
+    ) async -> NSApplication.ModalResponse {
+        if descriptor.style == .informational {
+            let announcement = "\(descriptor.messageText). \(descriptor.informativeText)"
+            if let owner = context.nsWindow,
+               owner.isVisible,
+               let projectManager = DialogPresenter.projectManager(for: owner) {
+                projectManager.toastManager.show(ToastItem(message: announcement))
+            } else {
+                feedbackPresenter.present(
+                    message: announcement,
+                    context: context
+                )
+            }
+            return .alertFirstButtonReturn
         }
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
         alert.messageText = descriptor.messageText
         alert.informativeText = descriptor.informativeText
         alert.addButton(withTitle: descriptor.buttonTitle)
-        return alert.runModal()
+        return await alert.runSheet(on: context)
     }
 }

--- a/Pine/Extensibility/UserConfigurationEditor.swift
+++ b/Pine/Extensibility/UserConfigurationEditor.swift
@@ -206,7 +206,7 @@ enum UserConfigurationEditor {
             Logger.extensibility.error(
                 "Could not create starter \(file.rawValue) configuration: \(String(describing: error))"
             )
-            alertPresenter.present(creationFailureAlert(file, error: error))
+            await alertPresenter.present(creationFailureAlert(file, error: error))
             return .creationFailed
         }
 
@@ -214,20 +214,26 @@ enum UserConfigurationEditor {
             Logger.extensibility.error(
                 "Could not open \(file.rawValue) configuration at \(fileURL.path)"
             )
-            alertPresenter.present(openFailureAlert(file))
+            await alertPresenter.present(openFailureAlert(file))
             return .openFailed
         }
         return .opened(createdStarter: createdStarter)
     }
 
     /// Shortcut for the keybindings config file.
-    static func openKeybindings() async {
-        await open(.keybindings)
+    static func openKeybindings(
+        alertPresenter: any UserConfigurationAlertPresenting =
+            AppKitUserConfigurationAlertPresenter()
+    ) async {
+        await open(.keybindings, alertPresenter: alertPresenter)
     }
 
     /// Shortcut for the tasks config file.
-    static func openTasks() async {
-        await open(.tasks)
+    static func openTasks(
+        alertPresenter: any UserConfigurationAlertPresenting =
+            AppKitUserConfigurationAlertPresenter()
+    ) async {
+        await open(.tasks, alertPresenter: alertPresenter)
     }
 
     // MARK: - Paths & templates

--- a/Pine/Extensibility/UserTaskInvocationController.swift
+++ b/Pine/Extensibility/UserTaskInvocationController.swift
@@ -21,44 +21,48 @@ enum UserTaskInvocationController {
         let tabManager = projectManager.activeTabManager
         let activeTab = tabManager.activeTab
         if task.scope == .activeFile, activeTab == nil {
-            presentMissingActiveFile()
+            Task { @MainActor in presentMissingActiveFile() }
             return
         }
 
-        if task.effectiveRequireConfirmation(),
-           !presentConfirmation(for: task) {
-            return
-        }
+        Task { @MainActor in
+            if task.effectiveRequireConfirmation(),
+               !await presentConfirmation(for: task) {
+                return
+            }
 
-        let capturedTabID = activeTab?.id
-        let capturedContent = activeTab?.content
+            let capturedTabID = activeTab?.id
+            let capturedContent = activeTab?.content
 
-        UserTaskRunner.shared.run(
-            task: task,
-            fileURL: activeTab?.url,
-            projectRootURL: projectManager.workspace.rootURL,
-            fileContent: capturedContent
-        ) { outcome in
-            Task { @MainActor in
-                presentOutcome(
-                    outcome,
-                    task: task,
-                    projectManager: projectManager,
-                    capturedTabID: capturedTabID,
-                    capturedContent: capturedContent
-                )
+            UserTaskRunner.shared.run(
+                task: task,
+                fileURL: activeTab?.url,
+                projectRootURL: projectManager.workspace.rootURL,
+                fileContent: capturedContent
+            ) { outcome in
+                Task { @MainActor in
+                    presentOutcome(
+                        outcome,
+                        task: task,
+                        projectManager: projectManager,
+                        capturedTabID: capturedTabID,
+                        capturedContent: capturedContent
+                    )
+                }
             }
         }
     }
 
-    private static func presentConfirmation(for task: UserTask) -> Bool {
+    private static func presentConfirmation(for task: UserTask) async -> Bool {
+        let context = DialogPresenter.forKeyProject()
         let alert = NSAlert()
         alert.messageText = Strings.userTaskConfirmationTitle(task.label)
         alert.informativeText = Strings.userTaskConfirmationMessage(task.command)
         alert.alertStyle = .warning
         alert.addButton(withTitle: Strings.userTaskRun)
-        alert.addButton(withTitle: Strings.dialogCancel)
-        return alert.runModal() == .alertFirstButtonReturn
+        alert.addButton(withTitle: Strings.dialogCancel, role: .cancel)
+        let response = await alert.runSheet(on: context)
+        return response == .alertFirstButtonReturn
     }
 
     private static func presentOutcome(
@@ -108,20 +112,26 @@ enum UserTaskInvocationController {
     }
 
     private static func presentReplacementConflict() {
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = Strings.userTaskOutputConflictTitle
-        alert.informativeText = Strings.userTaskOutputConflictMessage
-        alert.addButton(withTitle: Strings.dialogOK)
-        alert.runModal()
+        let context = DialogPresenter.forKeyProject()
+        Task { @MainActor in
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = Strings.userTaskOutputConflictTitle
+            alert.informativeText = Strings.userTaskOutputConflictMessage
+            alert.addButton(withTitle: Strings.dialogOK)
+            _ = await alert.runSheet(on: context)
+        }
     }
 
     private static func presentMissingActiveFile() {
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = Strings.userTaskMissingFileTitle
-        alert.informativeText = Strings.userTaskMissingFileMessage
-        alert.addButton(withTitle: Strings.dialogOK)
-        alert.runModal()
+        let context = DialogPresenter.forKeyProject()
+        Task { @MainActor in
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = Strings.userTaskMissingFileTitle
+            alert.informativeText = Strings.userTaskMissingFileMessage
+            alert.addButton(withTitle: Strings.dialogOK)
+            _ = await alert.runSheet(on: context)
+        }
     }
 }

--- a/Pine/Extensibility/UserTaskInvocationController.swift
+++ b/Pine/Extensibility/UserTaskInvocationController.swift
@@ -27,8 +27,7 @@ enum UserTaskInvocationController {
 
         Task { @MainActor in
             if task.effectiveRequireConfirmation(),
-               !(await presentConfirmation(for: task))
-            {
+               !(await presentConfirmation(for: task)) {
                 return
             }
 
@@ -61,7 +60,7 @@ enum UserTaskInvocationController {
         alert.informativeText = Strings.userTaskConfirmationMessage(task.command)
         alert.alertStyle = .warning
         alert.addButton(withTitle: Strings.userTaskRun)
-        alert.addButton(withTitle: Strings.dialogCancel, role: .cancel)
+        alert.addButton(withTitle: Strings.dialogCancel)
         let response = await alert.runSheet(on: context)
         return response == .alertFirstButtonReturn
     }

--- a/Pine/Extensibility/UserTaskInvocationController.swift
+++ b/Pine/Extensibility/UserTaskInvocationController.swift
@@ -27,7 +27,7 @@ enum UserTaskInvocationController {
 
         Task { @MainActor in
             if task.effectiveRequireConfirmation(),
-               !await presentConfirmation(for: task) {
+               !(await presentConfirmation(for: task)) {
                 return
             }
 

--- a/Pine/Extensibility/UserTaskInvocationController.swift
+++ b/Pine/Extensibility/UserTaskInvocationController.swift
@@ -14,53 +14,132 @@ import os
 
 @MainActor
 enum UserTaskInvocationController {
+    typealias ConfirmationPresenter = @MainActor (
+        UserTask,
+        DialogPresentationContext
+    ) async -> Bool
+    typealias TaskRunner = @MainActor (
+        UserTask,
+        URL?,
+        URL?,
+        String?,
+        @escaping @Sendable (UserTaskOutcome) -> Void
+    ) -> Void
+
+    private struct InvocationSnapshot {
+        let tabID: UUID?
+        let content: String?
+        let context: DialogPresentationContext
+    }
+
     static func invoke(
         _ task: UserTask,
         projectManager: ProjectManager
     ) {
-        let tabManager = projectManager.activeTabManager
-        let activeTab = tabManager.activeTab
-        if task.scope == .activeFile, activeTab == nil {
-            Task { @MainActor in presentMissingActiveFile() }
-            return
-        }
-
+        let context = DialogPresenter.forProject(projectManager)
         Task { @MainActor in
-            if task.effectiveRequireConfirmation(),
-               !(await presentConfirmation(for: task)) {
-                return
-            }
-
-            let capturedTabID = activeTab?.id
-            let capturedContent = activeTab?.content
-
-            UserTaskRunner.shared.run(
-                task: task,
-                fileURL: activeTab?.url,
-                projectRootURL: projectManager.workspace.rootURL,
-                fileContent: capturedContent
-            ) { outcome in
-                Task { @MainActor in
-                    presentOutcome(
-                        outcome,
+            _ = await invokePrepared(
+                task,
+                projectManager: projectManager,
+                context: context,
+                presentConfirmation: { task, context in
+                    await presentConfirmation(for: task, context: context)
+                },
+                runTask: { task, fileURL, projectRootURL, fileContent, completion in
+                    UserTaskRunner.shared.run(
                         task: task,
-                        projectManager: projectManager,
-                        capturedTabID: capturedTabID,
-                        capturedContent: capturedContent
+                        fileURL: fileURL,
+                        projectRootURL: projectRootURL,
+                        fileContent: fileContent,
+                        completion: completion
                     )
                 }
-            }
+            )
         }
     }
 
-    private static func presentConfirmation(for task: UserTask) async -> Bool {
-        let context = DialogPresenter.forKeyProject()
+    /// Resolves and validates the active-file intent on the MainActor
+    /// immediately before the runner starts. Kept internal so suspension
+    /// races can be tested without spawning a real shell.
+    @discardableResult
+    static func invokePrepared(
+        _ task: UserTask,
+        projectManager: ProjectManager,
+        context: DialogPresentationContext,
+        presentConfirmation: ConfirmationPresenter,
+        runTask: TaskRunner
+    ) async -> Bool {
+        guard let owner = context.nsWindow,
+              owner.isVisible,
+              !owner.isMiniaturized else {
+            return false
+        }
+
+        let initialActiveTab = projectManager.activeTabManager.activeTab
+        if task.scope == .activeFile, initialActiveTab == nil {
+            presentMissingActiveFile(context: context)
+            return false
+        }
+
+        if task.effectiveRequireConfirmation(),
+           !(await presentConfirmation(task, context)) {
+            return false
+        }
+        guard let currentOwner = context.nsWindow,
+              currentOwner === owner,
+              currentOwner.isVisible,
+              !currentOwner.isMiniaturized else {
+            return false
+        }
+
+        let currentActiveTab = projectManager.activeTabManager.activeTab
+        if task.scope == .activeFile {
+            // The confirmation authorized the exact active-file intent that
+            // existed when it appeared. Switching tabs, closing the file, or
+            // editing its buffer while suspended must not retarget the task.
+            guard let initialActiveTab,
+                  let currentActiveTab,
+                  currentActiveTab.id == initialActiveTab.id,
+                  currentActiveTab.url == initialActiveTab.url,
+                  currentActiveTab.content == initialActiveTab.content else {
+                return false
+            }
+        }
+
+        let snapshot = InvocationSnapshot(
+            tabID: currentActiveTab?.id,
+            content: currentActiveTab?.content,
+            context: context
+        )
+        runTask(
+            task,
+            currentActiveTab?.url,
+            projectManager.workspace.rootURL,
+            snapshot.content
+        ) { outcome in
+            Task { @MainActor in
+                presentOutcome(
+                    outcome,
+                    task: task,
+                    projectManager: projectManager,
+                    snapshot: snapshot
+                )
+            }
+        }
+        return true
+    }
+
+    private static func presentConfirmation(
+        for task: UserTask,
+        context: DialogPresentationContext
+    ) async -> Bool {
         let alert = NSAlert()
         alert.messageText = Strings.userTaskConfirmationTitle(task.label)
         alert.informativeText = Strings.userTaskConfirmationMessage(task.command)
         alert.alertStyle = .warning
         alert.addButton(withTitle: Strings.userTaskRun)
-        alert.addButton(withTitle: Strings.dialogCancel)
+        let cancelButton = alert.addButton(withTitle: Strings.dialogCancel)
+        cancelButton.keyEquivalent = "\u{1b}"
         let response = await alert.runSheet(on: context)
         return response == .alertFirstButtonReturn
     }
@@ -69,8 +148,7 @@ enum UserTaskInvocationController {
         _ outcome: UserTaskOutcome,
         task: UserTask,
         projectManager: ProjectManager,
-        capturedTabID: UUID?,
-        capturedContent: String?
+        snapshot: InvocationSnapshot
     ) {
         guard outcome.succeeded else {
             Logger.extensibility.error(
@@ -83,18 +161,23 @@ enum UserTaskInvocationController {
             "Task '\(task.label)' completed successfully"
         )
         guard task.replacesFileContent else { return }
+        guard let owner = snapshot.context.nsWindow,
+              owner.isVisible,
+              !owner.isMiniaturized else {
+            return
+        }
 
         // Fail closed if the user switched tabs or edited the file while the
         // process ran. Applying stdout to a different/newer buffer would lose
         // unrelated work and violate the task's active-file contract.
         let tabManager = projectManager.activeTabManager
         guard canApplyReplacement(
-            capturedTabID: capturedTabID,
-            capturedContent: capturedContent,
+            capturedTabID: snapshot.tabID,
+            capturedContent: snapshot.content,
             currentTabID: tabManager.activeTab?.id,
             currentContent: tabManager.activeTab?.content
         ) else {
-            presentReplacementConflict()
+            presentReplacementConflict(context: snapshot.context)
             return
         }
         tabManager.updateContent(outcome.stdout)
@@ -111,8 +194,9 @@ enum UserTaskInvocationController {
             && currentContent == capturedContent
     }
 
-    private static func presentReplacementConflict() {
-        let context = DialogPresenter.forKeyProject()
+    private static func presentReplacementConflict(
+        context: DialogPresentationContext
+    ) {
         Task { @MainActor in
             let alert = NSAlert()
             alert.alertStyle = .warning
@@ -123,8 +207,9 @@ enum UserTaskInvocationController {
         }
     }
 
-    private static func presentMissingActiveFile() {
-        let context = DialogPresenter.forKeyProject()
+    private static func presentMissingActiveFile(
+        context: DialogPresentationContext
+    ) {
         Task { @MainActor in
             let alert = NSAlert()
             alert.alertStyle = .warning

--- a/Pine/Extensibility/UserTaskInvocationController.swift
+++ b/Pine/Extensibility/UserTaskInvocationController.swift
@@ -27,7 +27,8 @@ enum UserTaskInvocationController {
 
         Task { @MainActor in
             if task.effectiveRequireConfirmation(),
-               !(await presentConfirmation(for: task)) {
+               !(await presentConfirmation(for: task))
+            {
                 return
             }
 

--- a/Pine/FileNodeRow.swift
+++ b/Pine/FileNodeRow.swift
@@ -20,6 +20,7 @@ struct FileNodeRow: View {
     @Environment(WorkspaceManager.self) var workspace
     @Environment(TabManager.self) var tabManager
     @Environment(PaneManager.self) var paneManager
+    @Environment(ProjectManager.self) var projectManager
     @Environment(SidebarEditState.self) var editState
     @Environment(\.undoManager) private var undoManager
     @FocusState private var isTextFieldFocused: Bool
@@ -201,7 +202,8 @@ struct FileNodeRow: View {
             in: node.url,
             isDirectory: isDirectory,
             workspace: workspace,
-            undoManager: undoManager
+            undoManager: undoManager,
+            context: DialogPresenter.forProject(projectManager)
         )
     }
 
@@ -210,7 +212,8 @@ struct FileNodeRow: View {
             at: node.url,
             isDirectory: node.isDirectory,
             workspace: workspace,
-            tabManager: tabManager
+            tabManager: tabManager,
+            context: DialogPresenter.forProject(projectManager)
         )
     }
 
@@ -259,7 +262,10 @@ struct FileNodeRow: View {
             oldURL: oldURL,
             existingNames: siblingNames(of: oldURL)
         ) {
-            SidebarEditState.showFileError(validationError)
+            SidebarEditState.showFileError(
+                validationError,
+                context: DialogPresenter.forProject(projectManager)
+            )
             return
         }
 
@@ -268,7 +274,10 @@ struct FileNodeRow: View {
         if let root = workspace.rootURL,
            !FileNode.isWithinProjectRoot(oldURL, projectRoot: root)
             || !FileNode.isWithinProjectRoot(newURL, projectRoot: root) {
-            SidebarEditState.showFileError(Strings.operationOutsideProject)
+            SidebarEditState.showFileError(
+                Strings.operationOutsideProject,
+                context: DialogPresenter.forProject(projectManager)
+            )
             editState.clear()
             return
         }
@@ -318,7 +327,10 @@ struct FileNodeRow: View {
             }
         } catch {
             // Keep editing so the user can try a different name
-            SidebarEditState.showFileError(error.localizedDescription)
+            SidebarEditState.showFileError(
+                error.localizedDescription,
+                context: DialogPresenter.forProject(projectManager)
+            )
         }
     }
 
@@ -343,7 +355,10 @@ struct FileNodeRow: View {
         let deletedURL = node.url
 
         if let root = workspace.rootURL, !FileNode.isWithinProjectRoot(deletedURL, projectRoot: root) {
-            SidebarEditState.showFileError(Strings.operationOutsideProject)
+            SidebarEditState.showFileError(
+                Strings.operationOutsideProject,
+                context: DialogPresenter.forProject(projectManager)
+            )
             return
         }
 
@@ -360,7 +375,10 @@ struct FileNodeRow: View {
                 userInfo: ["url": deletedURL]
             )
         } catch {
-            SidebarEditState.showFileError(error.localizedDescription)
+            SidebarEditState.showFileError(
+                error.localizedDescription,
+                context: DialogPresenter.forProject(projectManager)
+            )
         }
     }
 }

--- a/Pine/LSP/LSPSettingsView.swift
+++ b/Pine/LSP/LSPSettingsView.swift
@@ -475,7 +475,7 @@ struct LSPSettingsView: View {
             }
         }
         self.executablePicker = picker
-        picker.present()
+        picker.present(context: DialogPresenter.forKeyWindow())
     }
 
     // MARK: - Resolution + display helpers
@@ -557,7 +557,7 @@ private struct LSPSettingsDraft {
 
 /// Presents an `NSOpenPanel` restricted to executable files so the user can
 /// pick a language-server binary without typing an error-prone path. Runs on
-/// the main thread (modal), as AppKit requires. Issue #1242.
+/// the main actor as a sheet owned by the Settings window. Issue #1242.
 @MainActor
 private final class ExecutablePicker: NSObject, NSOpenSavePanelDelegate {
     private let completion: (URL) -> Void
@@ -566,7 +566,7 @@ private final class ExecutablePicker: NSObject, NSOpenSavePanelDelegate {
         self.completion = completion
     }
 
-    func present() {
+    func present(context: DialogPresentationContext) {
         let panel = NSOpenPanel()
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
@@ -577,8 +577,8 @@ private final class ExecutablePicker: NSObject, NSOpenSavePanelDelegate {
         // selections with a sheet-level error.
         panel.delegate = self
         panel.prompt = "Choose"
-        panel.level = .modalPanel
-        panel.begin { [weak self] response in
+        Task { @MainActor [weak self] in
+            let response = await panel.runSheet(on: context)
             guard response == .OK,
                   let url = panel.url else {
                 return

--- a/Pine/PaneDropZone.swift
+++ b/Pine/PaneDropZone.swift
@@ -231,14 +231,17 @@ struct PaneSplitDropDelegate: DropDelegate {
     }
 
     private func handleFileDrop(providers: [NSItemProvider]) {
-        guard let tabManager = paneManager.tabManager(for: paneID) else { return }
+        guard paneManager.tabManager(for: paneID) != nil else { return }
         for provider in providers {
             Task {
                 guard let url = try? await provider.loadItem(
                     forTypeIdentifier: UTType.fileURL.identifier
                 ) as? URL else { return }
                 await MainActor.run {
-                    DropHandler.openFilesAsTabs([url], in: tabManager)
+                    _ = paneManager.openFileInPane(
+                        url: url,
+                        paneID: paneID
+                    )
                 }
             }
         }

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -668,35 +668,51 @@ struct PaneLeafView: View {
     // MARK: - Tab close with dirty confirmation
 
     private func closeTabWithConfirmation(_ tab: EditorTab, tabManager: TabManager) {
-        let didClose = TabCloseHelper.closeTab(
-            tab, in: tabManager, gitProvider: workspace.gitProvider
-        )
-        if didClose && tabManager.tabs.isEmpty {
-            paneManager.removePane(paneID)
+        let context = DialogPresenter.forProject(projectManager)
+        Task { @MainActor in
+            let didClose = await TabCloseHelper.closeTab(
+                tab,
+                in: tabManager,
+                gitProvider: workspace.gitProvider,
+                context: context
+            )
+            if didClose && tabManager.tabs.isEmpty {
+                paneManager.removePane(paneID)
+            }
         }
     }
 
     private func closeOtherTabsWithConfirmation(keeping tabID: UUID, tabManager: TabManager) {
+        let context = DialogPresenter.forProject(projectManager)
         Task { @MainActor in
             _ = await TabCloseHelper.closeOtherTabs(
-                keeping: tabID, in: tabManager, gitProvider: workspace.gitProvider
+                keeping: tabID,
+                in: tabManager,
+                gitProvider: workspace.gitProvider,
+                context: context
             )
         }
     }
 
     private func closeTabsToTheRightWithConfirmation(of tabID: UUID, tabManager: TabManager) {
+        let context = DialogPresenter.forProject(projectManager)
         Task { @MainActor in
             _ = await TabCloseHelper.closeTabsToTheRight(
-                of: tabID, in: tabManager, gitProvider: workspace.gitProvider
+                of: tabID,
+                in: tabManager,
+                gitProvider: workspace.gitProvider,
+                context: context
             )
         }
     }
 
     private func closeAllTabsWithConfirmation(tabManager: TabManager) {
+        let context = DialogPresenter.forProject(projectManager)
         Task { @MainActor in
             let didClose = await TabCloseHelper.closeAllTabs(
                 in: tabManager,
-                gitProvider: workspace.gitProvider
+                gitProvider: workspace.gitProvider,
+                context: context
             )
             if didClose && tabManager.tabs.isEmpty {
                 paneManager.removePane(paneID)

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -524,14 +524,41 @@ struct PaneLeafView: View {
                 workspaceURL: workspace.rootURL
             )
         }
-        LSPUIEndpoint.shared.openFileAtLineHandler = { [weak tabManager] url, line, _ in
-            tabManager?.openTab(url: url)
-            // Navigate to the position after a short delay so the tab content
-            // is loaded. Uses the pendingGoToLine mechanism (1-based line).
-            DispatchQueue.main.async {
-                tabManager?.pendingGoToLine = line + 1
-            }
+        LSPUIEndpoint.shared.openFileAtLineHandler = { [weak tabManager] url, line, character in
+            guard let tabManager else { return }
+            Self.openLSPFile(
+                url: url,
+                line: line,
+                character: character,
+                in: tabManager
+            )
         }
+    }
+
+    /// Routes a 0-based LSP destination through the location-aware open path.
+    /// `TabManager` installs the destination only after a pending large-file
+    /// decision succeeds, so the source tab cannot consume it prematurely.
+    @discardableResult
+    static func openLSPFile(
+        url: URL,
+        line: Int,
+        character: Int,
+        in tabManager: TabManager,
+        completion: TabManager.OpenCompletion? = nil
+    ) -> TabManager.OpenRequestResult {
+        tabManager.openTabAndGoToLocation(
+            url: url,
+            line: oneBasedLSPCoordinate(line),
+            column: oneBasedLSPCoordinate(character),
+            completion: completion
+        )
+    }
+
+    /// Converts an untrusted 0-based LSP coordinate to Pine's 1-based
+    /// coordinate without trapping on a negative or `Int.max` server value.
+    private static func oneBasedLSPCoordinate(_ value: Int) -> Int {
+        guard value > 0 else { return 1 }
+        return value == .max ? .max : value + 1
     }
 
     /// Clears the LSP UI endpoint handlers.

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -668,27 +668,39 @@ struct PaneLeafView: View {
     // MARK: - Tab close with dirty confirmation
 
     private func closeTabWithConfirmation(_ tab: EditorTab, tabManager: TabManager) {
-        TabCloseHelper.closeTab(tab, in: tabManager, gitProvider: workspace.gitProvider)
-        if tabManager.tabs.isEmpty {
+        let didClose = TabCloseHelper.closeTab(
+            tab, in: tabManager, gitProvider: workspace.gitProvider
+        )
+        if didClose && tabManager.tabs.isEmpty {
             paneManager.removePane(paneID)
         }
     }
 
     private func closeOtherTabsWithConfirmation(keeping tabID: UUID, tabManager: TabManager) {
-        TabCloseHelper.closeOtherTabs(keeping: tabID, in: tabManager, gitProvider: workspace.gitProvider)
+        Task { @MainActor in
+            _ = await TabCloseHelper.closeOtherTabs(
+                keeping: tabID, in: tabManager, gitProvider: workspace.gitProvider
+            )
+        }
     }
 
     private func closeTabsToTheRightWithConfirmation(of tabID: UUID, tabManager: TabManager) {
-        TabCloseHelper.closeTabsToTheRight(of: tabID, in: tabManager, gitProvider: workspace.gitProvider)
+        Task { @MainActor in
+            _ = await TabCloseHelper.closeTabsToTheRight(
+                of: tabID, in: tabManager, gitProvider: workspace.gitProvider
+            )
+        }
     }
 
     private func closeAllTabsWithConfirmation(tabManager: TabManager) {
-        let didClose = TabCloseHelper.closeAllTabs(
-            in: tabManager,
-            gitProvider: workspace.gitProvider
-        )
-        if didClose && tabManager.tabs.isEmpty {
-            paneManager.removePane(paneID)
+        Task { @MainActor in
+            let didClose = await TabCloseHelper.closeAllTabs(
+                in: tabManager,
+                gitProvider: workspace.gitProvider
+            )
+            if didClose && tabManager.tabs.isEmpty {
+                paneManager.removePane(paneID)
+            }
         }
     }
 }

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -804,17 +804,41 @@ final class PaneManager {
     func openFileInActiveEditor(
         url: URL,
         asTransientPreview: Bool = false,
-        requestFocus: Bool = true
+        requestFocus: Bool = true,
+        completion: TabManager.OpenCompletion? = nil
     ) -> Bool {
+        let previousActivePaneID = activePaneID
+        let existingEditorPaneIDs = Set(tabManagers.keys)
         let tabManager = ensureEditorPane()
         let paneID = activePaneID
-        if asTransientPreview {
-            tabManager.openTabAsPreview(url: url)
-        } else {
-            tabManager.openTab(url: url)
+        let createdDestination = !existingEditorPaneIDs.contains(paneID)
+        let completion: TabManager.OpenCompletion = { [weak self, weak tabManager] result in
+            if let self, let tabManager {
+                self.finishFileOpen(
+                    result,
+                    in: tabManager,
+                    paneID: paneID,
+                    requestFocus: requestFocus,
+                    previousActivePaneID: previousActivePaneID,
+                    removeEmptyDestinationOnCancel: createdDestination
+                )
+            }
+            completion?(result)
         }
-        guard let tabID = tabManager.activeTabID else { return false }
-        return selectEditorTab(tabID, in: paneID, requestFocus: requestFocus)
+        let result = if asTransientPreview {
+            tabManager.openTabAsPreview(url: url, completion: completion)
+        } else {
+            tabManager.openTab(url: url, completion: completion)
+        }
+
+        // `ensureEditorPane()` must provision a destination before the
+        // large-file sheet can resolve, but a pending decision must not steal
+        // pane focus. The completion activates it only after acceptance.
+        if result == .pending,
+           root.content(for: previousActivePaneID) != nil {
+            activePaneID = previousActivePaneID
+        }
+        return result.wasAccepted
     }
 
     /// Removes a pane and promotes its sibling. When the very last leaf in
@@ -1480,19 +1504,35 @@ final class PaneManager {
     /// Opens a file as a new tab in the specified editor pane.
     /// Does nothing if the pane has no TabManager (e.g., terminal pane)
     /// or if the URL is a directory.
-    func openFileInPane(url: URL, paneID: PaneID) {
-        guard let tabManager = tabManagers[paneID] else { return }
+    @discardableResult
+    func openFileInPane(
+        url: URL,
+        paneID: PaneID,
+        completion: TabManager.OpenCompletion? = nil
+    ) -> Bool {
+        guard let tabManager = tabManagers[paneID] else {
+            completion?(.cancelled)
+            return false
+        }
         // Skip directories — they should not open as editor tabs
         var isDir: ObjCBool = false
         let filePath = url.path(percentEncoded: false)
         if FileManager.default.fileExists(atPath: filePath, isDirectory: &isDir), isDir.boolValue {
-            return
+            completion?(.cancelled)
+            return false
         }
-        tabManager.openTab(url: url)
-        activePaneID = paneID
-        if let activeID = tabManager.activeTabID {
-            recordTabActivation(paneID: paneID, tabID: activeID, contentType: .editor)
+        let result = tabManager.openTab(url: url) { [weak self, weak tabManager] result in
+            if let self, let tabManager {
+                self.finishFileOpen(
+                    result,
+                    in: tabManager,
+                    paneID: paneID,
+                    requestFocus: true
+                )
+            }
+            completion?(result)
         }
+        return result.wasAccepted
     }
 
     /// Splits a pane and opens a file in the new pane.
@@ -1502,12 +1542,43 @@ final class PaneManager {
         url: URL,
         relativeTo targetID: PaneID,
         axis: SplitAxis,
-        insertBefore: Bool = false
+        insertBefore: Bool = false,
+        completion: TabManager.OpenCompletion? = nil
     ) -> PaneID? {
-        guard let newPaneID = splitPane(targetID, axis: axis, insertBefore: insertBefore) else { return nil }
-        guard let newTabManager = tabManagers[newPaneID] else { return nil }
-        newTabManager.openTab(url: url)
-        return newPaneID
+        let previousActivePaneID = activePaneID
+        guard let newPaneID = splitPane(
+            targetID,
+            axis: axis,
+            insertBefore: insertBefore
+        ) else {
+            completion?(.cancelled)
+            return nil
+        }
+        guard let newTabManager = tabManagers[newPaneID] else {
+            completion?(.cancelled)
+            return nil
+        }
+        let result = newTabManager.openTab(url: url) { [weak self, weak newTabManager] result in
+            if let self, let newTabManager {
+                self.finishFileOpen(
+                    result,
+                    in: newTabManager,
+                    paneID: newPaneID,
+                    requestFocus: true,
+                    previousActivePaneID: previousActivePaneID,
+                    removeEmptyDestinationOnCancel: true
+                )
+            }
+            completion?(result)
+        }
+
+        // Creating the split is synchronous, while a large-file decision is
+        // not. Keep the source pane active until acceptance.
+        if result == .pending,
+           root.content(for: previousActivePaneID) != nil {
+            activePaneID = previousActivePaneID
+        }
+        return result.wasAccepted ? newPaneID : nil
     }
 
     // MARK: - Transactional tab drag
@@ -1831,6 +1902,39 @@ final class PaneManager {
     }
 
     // MARK: - Private helpers
+
+    /// Applies the terminal result of a file open to pane-level state. This is
+    /// the only place async large-file opens acquire pane focus and MRU
+    /// position, matching the synchronous open path.
+    private func finishFileOpen(
+        _ result: TabManager.OpenRequestResult,
+        in tabManager: TabManager,
+        paneID: PaneID,
+        requestFocus: Bool,
+        previousActivePaneID: PaneID? = nil,
+        removeEmptyDestinationOnCancel: Bool = false
+    ) {
+        switch result {
+        case .opened(let tabID):
+            guard tabManagers[paneID] === tabManager else { return }
+            selectEditorTab(tabID, in: paneID, requestFocus: requestFocus)
+        case .cancelled:
+            if removeEmptyDestinationOnCancel,
+               tabManagers[paneID] === tabManager,
+               tabManager.tabs.isEmpty,
+               root.leafCount > 1 {
+                removePane(paneID)
+            }
+            if let previousActivePaneID,
+               root.content(for: previousActivePaneID) != nil {
+                activePaneID = previousActivePaneID
+            }
+        case .pending:
+            // Completions are terminal; retaining this case makes the shared
+            // result type exhaustive if a future presenter changes behavior.
+            break
+        }
+    }
 
     private func makeEditorTabManager(for paneID: PaneID) -> TabManager {
         let tabManager = TabManager()

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -155,7 +155,7 @@ private struct ProjectWindowView: View {
 
 /// Installs an NSWindowDelegate on the hosting window to intercept close
 /// and prompt for unsaved changes before the window actually closes.
-private struct WindowCloseInterceptor: NSViewRepresentable {
+struct WindowCloseInterceptor: NSViewRepresentable {
     let projectManager: ProjectManager
     let registry: ProjectRegistry
     let projectURL: URL
@@ -177,9 +177,11 @@ private struct WindowCloseInterceptor: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: InterceptorView, context: Context) {
-        // Install delegate if makeNSView's viewDidMoveToWindow fired before
-        // the coordinator was fully wired (defensive — belt and suspenders).
-        if context.coordinator.closeDelegate == nil, let window = nsView.window {
+        // SwiftUI may replace NSWindow.delegate while keeping the same
+        // representable, or move this sentinel to a replacement NSWindow.
+        // Reconcile identity on every update instead of treating the first
+        // installation as permanent.
+        if let window = nsView.window {
             context.coordinator.installDelegate(
                 on: window,
                 projectManager: projectManager,
@@ -211,23 +213,66 @@ private struct WindowCloseInterceptor: NSViewRepresentable {
         var closeDelegate: CloseDelegate?
         // Strong reference to keep the original delegate alive
         var originalDelegate: (any NSWindowDelegate)?
+        weak var installedWindow: NSWindow?
+        private var lifecycleObservers: [Any] = []
 
         func installDelegate(
             on window: NSWindow,
             projectManager: ProjectManager,
             registry: ProjectRegistry,
             projectURL: URL,
-            appDelegate: AppDelegate
+            appDelegate: AppDelegate,
+            presentAlert: CloseDelegate.CloseAlertPresenter? = nil,
+            saveAll: CloseDelegate.CloseSaveAll? = nil
         ) {
-            // Guard against double installation
-            guard closeDelegate == nil else { return }
-            let original = window.delegate
+            if installedWindow !== window {
+                retireCurrentInstallation(restoringOriginal: true)
+                installedWindow = window
+                observeDelegateLifecycle(
+                    on: window,
+                    projectManager: projectManager,
+                    registry: registry,
+                    projectURL: projectURL,
+                    appDelegate: appDelegate
+                )
+            } else if let closeDelegate,
+                      window.delegate === closeDelegate {
+                return
+            } else if closeDelegate != nil {
+                // Same owner, new delegate generation. Do not restore the old
+                // original over SwiftUI's replacement; retire only our stale
+                // observer/dialog authority before wrapping the live delegate.
+                retireCurrentInstallation(restoringOriginal: false)
+                installedWindow = window
+                observeDelegateLifecycle(
+                    on: window,
+                    projectManager: projectManager,
+                    registry: registry,
+                    projectURL: projectURL,
+                    appDelegate: appDelegate
+                )
+            }
+
+            var original = window.delegate
+            if let existing = original as? CloseDelegate {
+                if existing.projectManager === projectManager {
+                    closeDelegate = existing
+                    originalDelegate = existing.original
+                    existing.observeWindowClose(window)
+                    return
+                }
+                let existingOriginal = existing.original
+                existing.detachFromWindow()
+                original = existingOriginal
+            }
             let delegate = CloseDelegate(
                 projectManager: projectManager,
                 registry: registry,
                 projectURL: projectURL,
                 appDelegate: appDelegate,
-                original: original
+                original: original,
+                presentAlert: presentAlert,
+                saveAll: saveAll
             )
             closeDelegate = delegate
             originalDelegate = original
@@ -235,6 +280,74 @@ private struct WindowCloseInterceptor: NSViewRepresentable {
             // Fallback: observe willCloseNotification in case SwiftUI
             // replaces the window delegate after our installation (#138).
             delegate.observeWindowClose(window)
+        }
+
+        private func observeDelegateLifecycle(
+            on window: NSWindow,
+            projectManager: ProjectManager,
+            registry: ProjectRegistry,
+            projectURL: URL,
+            appDelegate: AppDelegate
+        ) {
+            removeLifecycleObservers()
+            for name in [
+                NSWindow.didBecomeKeyNotification,
+                NSWindow.didBecomeMainNotification,
+                NSWindow.didUpdateNotification,
+            ] {
+                lifecycleObservers.append(
+                    NotificationCenter.default.addObserver(
+                        forName: name,
+                        object: window,
+                        queue: .main
+                    ) { [weak self, weak window, weak projectManager,
+                         weak registry, weak appDelegate] _ in
+                        MainActor.assumeIsolated {
+                            guard let self,
+                                  let window,
+                                  let projectManager,
+                                  let registry,
+                                  let appDelegate else {
+                                return
+                            }
+                            self.installDelegate(
+                                on: window,
+                                projectManager: projectManager,
+                                registry: registry,
+                                projectURL: projectURL,
+                                appDelegate: appDelegate
+                            )
+                        }
+                    }
+                )
+            }
+        }
+
+        private func retireCurrentInstallation(restoringOriginal: Bool) {
+            removeLifecycleObservers()
+            if restoringOriginal,
+               let installedWindow,
+               let closeDelegate,
+               installedWindow.delegate === closeDelegate {
+                installedWindow.delegate = originalDelegate
+            }
+            closeDelegate?.detachFromWindow()
+            closeDelegate = nil
+            originalDelegate = nil
+            installedWindow = nil
+        }
+
+        private func removeLifecycleObservers() {
+            for observer in lifecycleObservers {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            lifecycleObservers.removeAll()
+        }
+
+        deinit {
+            for observer in lifecycleObservers {
+                NotificationCenter.default.removeObserver(observer)
+            }
         }
     }
 
@@ -246,6 +359,17 @@ private struct WindowCloseInterceptor: NSViewRepresentable {
 /// windowShouldClose always closes the entire window (red close button path).
 /// Cmd+W is intercepted earlier by AppDelegate's local event monitor.
 class CloseDelegate: NSObject, NSWindowDelegate {
+    typealias CloseAlertPresenter = @MainActor (
+        AlertTemplate,
+        DialogPresentationContext,
+        String,
+        String
+    ) async -> NSApplication.ModalResponse
+    typealias CloseSaveAll = @MainActor (
+        ProjectManager,
+        DialogPresentationContext
+    ) async -> Bool
+
     let projectManager: ProjectManager
     let registry: ProjectRegistry
     let projectURL: URL
@@ -262,25 +386,55 @@ class CloseDelegate: NSObject, NSWindowDelegate {
     /// nonisolated(unsafe): accessed from deinit (nonisolated) to remove observer.
     /// CloseDelegate is always deallocated on the main thread.
     nonisolated(unsafe) private var closeObserver: Any?
+    private weak var ownerWindow: NSWindow?
+    private(set) var dialogContext = DialogPresentationContext.unscoped
+    private var closeDecisionTask: Task<Void, Never>?
+    private weak var approvedCloseWindow: NSWindow?
+    private let closeAlertPresenter: CloseAlertPresenter?
+    private let closeSaveAll: CloseSaveAll?
+
+    private enum WindowCloseDecision {
+        case cancel
+        case approve(discard: DirtyEditorContentAuthorization?)
+    }
 
     init(
         projectManager: ProjectManager,
         registry: ProjectRegistry,
         projectURL: URL,
         appDelegate: AppDelegate,
-        original: (any NSWindowDelegate)?
+        original: (any NSWindowDelegate)?,
+        presentAlert: CloseAlertPresenter? = nil,
+        saveAll: CloseSaveAll? = nil
     ) {
         self.projectManager = projectManager
         self.registry = registry
         self.projectURL = projectURL
         self.appDelegate = appDelegate
         self.original = original
+        self.closeAlertPresenter = presentAlert
+        self.closeSaveAll = saveAll
         super.init()
     }
 
     /// Installs a NotificationCenter observer as a fallback for windowWillClose.
     /// If SwiftUI later replaces the window delegate, the notification still fires.
     func observeWindowClose(_ window: NSWindow) {
+        if let closeObserver {
+            NotificationCenter.default.removeObserver(closeObserver)
+            self.closeObserver = nil
+        }
+        if let previousWindow = ownerWindow, previousWindow !== window {
+            closeDecisionTask?.cancel()
+            closeDecisionTask = nil
+            approvedCloseWindow = nil
+            DialogPresenter.ownerDidClose(previousWindow)
+        }
+        ownerWindow = window
+        dialogContext = DialogPresenter.register(
+            window: window,
+            projectManager: projectManager
+        )
         closeObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,
             object: window,
@@ -308,8 +462,15 @@ class CloseDelegate: NSObject, NSWindowDelegate {
         case .terminal:
             guard let state = pane.terminalState(for: activePaneID),
                   let tab = state.activeTab else { return }
+            let context = dialogContext
             Task { @MainActor in
-                guard await TabCloseHelper.confirmTerminalProcessStop(tabs: [tab]) else { return }
+                guard await TabCloseHelper.confirmTerminalProcessStop(
+                    tabs: [tab],
+                    context: context
+                ) else { return }
+                guard state.terminalTabs.contains(where: { $0 === tab }) else {
+                    return
+                }
                 state.removeTab(id: tab.id)
                 if state.terminalTabs.isEmpty {
                     pane.removePane(activePaneID)
@@ -319,55 +480,161 @@ class CloseDelegate: NSObject, NSWindowDelegate {
         case .editor, nil:
             let activeTM = projectManager.activeTabManager
             guard let tab = activeTM.activeTab else { return }
-            let closed = TabCloseHelper.closeTab(
-                tab, in: activeTM,
-                gitProvider: projectManager.workspace.gitProvider
-            )
-            if closed && activeTM.tabs.isEmpty {
-                pane.removePane(activePaneID)
+            let context = dialogContext
+            Task { @MainActor in
+                let closed = await TabCloseHelper.closeTab(
+                    tab,
+                    in: activeTM,
+                    gitProvider: projectManager.workspace.gitProvider,
+                    context: context
+                )
+                if closed && activeTM.tabs.isEmpty {
+                    pane.removePane(activePaneID)
+                }
             }
         }
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {
+        // Application-level termination already completed the same dirty-tab
+        // and terminal decisions before setting `isTerminating`.
+        if appDelegate?.isTerminating == true {
+            return true
+        }
+        if approvedCloseWindow === sender {
+            approvedCloseWindow = nil
+            return true
+        }
+
+        guard closeDecisionTask == nil else { return false }
+
         // Forward to original delegate first — respect its veto if any
         if let original, original.responds(to: #selector(NSWindowDelegate.windowShouldClose(_:))) {
             guard original.windowShouldClose?(sender) != false else { return false }
         }
 
-        // 1. Check dirty editor tabs
+        let context = DialogPresenter.context(for: sender)
+        closeDecisionTask = Task { @MainActor [weak self, weak sender] in
+            guard let self else { return }
+            let decision = await confirmWindowClose(context: context)
+            closeDecisionTask = nil
+            guard !Task.isCancelled,
+                  let sender,
+                  !didHandleClose else { return }
+            let discardAuthorization: DirtyEditorContentAuthorization?
+            switch decision {
+            case .cancel:
+                return
+            case .approve(let discard):
+                discardAuthorization = discard
+            }
+            // Commit destructive editor mutation only after every prompt and
+            // terminal revalidation has succeeded.
+            if let discardAuthorization,
+               !projectManager.commitDiscard(
+                   discardAuthorization,
+                   postReloadNotifications: false
+               ) {
+                return
+            }
+            approvedCloseWindow = sender
+            sender.performClose(nil)
+            // `performClose` normally re-enters `windowShouldClose`
+            // synchronously and consumes this approval. If the window became
+            // non-closable while the decision was pending, do not leak an
+            // approval into a later close attempt.
+            if approvedCloseWindow === sender {
+                approvedCloseWindow = nil
+            }
+        }
+        return false
+    }
+
+    private func confirmWindowClose(
+        context: DialogPresentationContext
+    ) async -> WindowCloseDecision {
+        var discardAuthorization: DirtyEditorContentAuthorization?
         let dirty = projectManager.allDirtyTabs
         if !dirty.isEmpty {
             let fileList = dirty.map { "  • \($0.fileName)" }.joined(separator: "\n")
-            let response = AlertTemplate.unsavedChangesBulk.runModal(
-                messageText: Strings.unsavedChangesTitle,
-                informativeText: Strings.unsavedChangesListMessage(fileList)
-            )
+            let message = Strings.unsavedChangesListMessage(fileList)
+            let response = if let closeAlertPresenter {
+                await closeAlertPresenter(
+                    .unsavedChangesBulk,
+                    context,
+                    Strings.unsavedChangesTitle,
+                    message
+                )
+            } else {
+                await AlertTemplate.unsavedChangesBulk.runSheet(
+                    on: context,
+                    messageText: Strings.unsavedChangesTitle,
+                    informativeText: message
+                )
+            }
             switch response {
             case .alertFirstButtonReturn:
-                guard projectManager.saveAllPaneTabs() else {
-                    return false // Save failed — abort close
+                let didSave = if let closeSaveAll {
+                    await closeSaveAll(projectManager, context)
+                } else {
+                    await projectManager.saveAllPaneTabs(context: context)
+                }
+                guard didSave else {
+                    return .cancel
                 }
             case .alertSecondButtonReturn:
-                break // Don't save — allow close
+                discardAuthorization = DirtyEditorContentAuthorization(
+                    tabs: dirty
+                )
             default:
-                return false // Cancel — abort close
+                return .cancel
             }
         }
 
-        // 2. Warn about active terminal processes before closing
-        let terminalTabs = projectManager.terminal.allTerminalTabs
-        if terminalTabs.contains(where: { $0.hasForegroundProcess }) {
-            let response = AlertTemplate.terminalTabCloseWarning.runModal(
-                messageText: Strings.terminalTabCloseWarningTitle,
-                informativeText: Strings.terminalTabCloseWarningMessage
+        let authorizedTerminalProcesses =
+            TabCloseHelper.foregroundProcessSnapshot(
+                for: projectManager.terminal.allTerminalTabs
             )
-            guard response == .alertFirstButtonReturn else {
-                return false
+        if !authorizedTerminalProcesses.isEmpty {
+            let terminalResponse = if let closeAlertPresenter {
+                await closeAlertPresenter(
+                    .terminalTabCloseWarning,
+                    context,
+                    Strings.terminalTabCloseWarningTitle,
+                    Strings.terminalTabCloseWarningMessage
+                )
+            } else {
+                await AlertTemplate.terminalTabCloseWarning.runSheet(
+                    on: context,
+                    messageText: Strings.terminalTabCloseWarningTitle,
+                    informativeText: Strings.terminalTabCloseWarningMessage
+                )
+            }
+            guard terminalResponse == .alertFirstButtonReturn else {
+                return .cancel
             }
         }
 
-        return true
+        let currentDirtyTabs = projectManager.allDirtyTabs
+        let currentTerminalProcesses =
+            TabCloseHelper.foregroundProcessSnapshot(
+                for: projectManager.terminal.allTerminalTabs
+            )
+        guard TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
+            currentTerminalProcesses,
+            by: authorizedTerminalProcesses
+        ) else {
+            return .cancel
+        }
+        if let discardAuthorization {
+            guard discardAuthorization.covers(currentDirtyTabs) else {
+                return .cancel
+            }
+            return .approve(discard: discardAuthorization)
+        }
+        return currentDirtyTabs.isEmpty
+            ? .approve(discard: nil)
+            : .cancel
     }
 
     // Forward other delegate calls to the original
@@ -381,9 +648,32 @@ class CloseDelegate: NSObject, NSWindowDelegate {
     private func handleWindowClose() {
         guard !didHandleClose else { return }
         didHandleClose = true
+        closeDecisionTask?.cancel()
+        closeDecisionTask = nil
+        approvedCloseWindow = nil
+        if let ownerWindow {
+            DialogPresenter.ownerDidClose(ownerWindow)
+        }
         appDelegate?.handleProjectWindowDisappear(
             projectURL: projectURL, registry: registry
         )
+    }
+
+    /// Retires interception without treating the owner as user-closed. Used
+    /// when SwiftUI replaces the delegate or moves the representable.
+    func detachFromWindow() {
+        if let closeObserver {
+            NotificationCenter.default.removeObserver(closeObserver)
+            self.closeObserver = nil
+        }
+        closeDecisionTask?.cancel()
+        closeDecisionTask = nil
+        approvedCloseWindow = nil
+        if let ownerWindow {
+            DialogPresenter.ownerDidClose(ownerWindow)
+        }
+        ownerWindow = nil
+        dialogContext = .unscoped
     }
 
     func windowDidBecomeKey(_ notification: Notification) {
@@ -398,6 +688,16 @@ class CloseDelegate: NSObject, NSWindowDelegate {
 // MARK: - AppDelegate
 
 class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
+    typealias TerminationAlertPresenter = @MainActor (
+        AlertTemplate,
+        DialogPresentationContext,
+        String,
+        String
+    ) async -> NSApplication.ModalResponse
+    typealias TerminationSaveAll = @MainActor (
+        ProjectManager,
+        DialogPresentationContext
+    ) async -> Bool
     /// Sparkle updater controller — `startingUpdater: true` enables automatic
     /// background checks respecting `SUScheduledCheckInterval`.
     lazy var updaterController = SPUStandardUpdaterController(
@@ -445,6 +745,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     /// Set to true once applicationShouldTerminate is called, so onDisappear
     /// handlers know not to clear the saved session during app quit.
     private(set) var isTerminating = false
+    private var terminationDecisionTask: Task<Void, Never>?
 
     /// Closure to open a named SwiftUI window, set by PineApp on launch.
     var openNamedWindow: ((String) -> Void)?
@@ -491,10 +792,78 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         }
     }
 
+    /// Waits for SwiftUI/AppKit to capture a real visible Welcome owner.
+    /// This follows multiple lifecycle turns with a strict bound instead of
+    /// assuming one fixed delay is sufficient on every macOS/CI machine.
+    func awaitVisibleWelcomeWindow(
+        maximumAttempts: Int = 40,
+        waitForNextAttempt: (@MainActor () async -> Void)? = nil
+    ) async -> NSWindow? {
+        let wait = waitForNextAttempt ?? {
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        for _ in 0..<maximumAttempts {
+            if let window = visibleWelcomeWindow() {
+                return window
+            }
+            guard !Task.isCancelled else { return nil }
+            await wait()
+        }
+        return visibleWelcomeWindow()
+    }
+
+    /// No-window Open Folder path. A missing Welcome owner fails closed and
+    /// returns false; the panel is never promoted to an application-modal UI.
+    @discardableResult
+    func openFolderFromWelcomeOwner(
+        maximumAttempts: Int = 40,
+        waitForNextAttempt: (@MainActor () async -> Void)? = nil,
+        presentPanel: (@MainActor (DialogPresentationContext) async -> URL?)? = nil
+    ) async -> Bool {
+        showWelcome()
+        guard let window = await awaitVisibleWelcomeWindow(
+            maximumAttempts: maximumAttempts,
+            waitForNextAttempt: waitForNextAttempt
+        ) else {
+            return false
+        }
+        let context = DialogPresenter.context(for: window)
+        let selectedURL: URL?
+        if let presentPanel {
+            selectedURL = await presentPanel(context)
+        } else {
+            selectedURL = await registry.openProjectViaPanel(context: context)
+        }
+        guard let selectedURL else { return false }
+        openProjectWindow?(selectedURL)
+        return true
+    }
+
+    private func visibleWelcomeWindow() -> NSWindow? {
+        if let welcomeWindow,
+           welcomeWindow.isVisible,
+           !welcomeWindow.isMiniaturized {
+            return welcomeWindow
+        }
+        guard let liveWindow = NSApp.windows.first(where: {
+            $0.identifier?.rawValue == "welcome"
+                && $0.contentView != nil
+                && $0.isVisible
+                && !$0.isMiniaturized
+        }) else {
+            return nil
+        }
+        welcomeWindow = liveWindow
+        return liveWindow
+    }
+
     /// Guarantees the Welcome window is visible, creating it via AppKit if needed.
     private func ensureWelcomeVisible() {
         // Check if any welcome window is already on screen
         if let window = welcomeWindow, window.isVisible {
+            if window.isMiniaturized {
+                window.deminiaturize(nil)
+            }
             window.makeKeyAndOrderFront(nil)
             NSApp.activate()
             return
@@ -505,6 +874,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             $0.identifier?.rawValue == "welcome" && $0.contentView != nil
         }) {
             welcomeWindow = liveWindow
+            if liveWindow.isMiniaturized {
+                liveWindow.deminiaturize(nil)
+            }
             liveWindow.makeKeyAndOrderFront(nil)
             NSApp.activate()
             return
@@ -512,6 +884,32 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
         // Nothing worked — create from scratch via AppKit
         createWelcomeWindowViaAppKit()
+    }
+
+    /// Makes one app-owned window suitable for a native Quit sheet. A
+    /// miniaturized window is visible according to AppKit but cannot provide
+    /// discoverable sheet UI from the Dock, so restore it first.
+    func prepareApplicationDialogOwner(
+        windows suppliedWindows: [NSWindow]? = nil
+    ) {
+        let windows = suppliedWindows ?? NSApp.windows
+        if NSApp.isHidden {
+            NSApp.unhide(nil)
+        }
+        if windows.contains(where: {
+            DialogPresenter.isEligibleApplicationOwner($0)
+        }) {
+            return
+        }
+        if let miniaturized = windows.first(where: {
+            $0.isVisible && $0.isMiniaturized
+        }) {
+            miniaturized.deminiaturize(nil)
+            miniaturized.makeKeyAndOrderFront(nil)
+            NSApp.activate()
+            return
+        }
+        ensureWelcomeVisible()
     }
 
     /// Creates the Welcome window via AppKit when SwiftUI's scene lifecycle
@@ -634,8 +1032,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             MainActor.assumeIsolated {
                 guard NSApp.windows.allSatisfy({ !$0.isVisible }) else { return }
                 guard let self else { return }
-                if let url = self.registry.openProjectViaPanel() {
-                    self.openProjectWindow?(url)
+                Task { @MainActor [weak self] in
+                    _ = await self?.openFolderFromWelcomeOwner()
                 }
             }
         }
@@ -866,44 +1264,195 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        isTerminating = true
+        beginApplicationTermination { shouldTerminate in
+            sender.reply(toApplicationShouldTerminate: shouldTerminate)
+        }
+    }
 
-        // Check for unsaved files
-        for (_, pm) in registry.openProjects {
-            let dirty = pm.allDirtyTabs
+    /// Starts the asynchronous AppKit termination handshake. Kept as a
+    /// separate, internal seam so the `.terminateLater`/single-reply contract
+    /// can be tested without constructing a second `NSApplication` singleton.
+    func beginApplicationTermination(
+        reply: @escaping @MainActor (Bool) -> Void
+    ) -> NSApplication.TerminateReply {
+        if isTerminating { return .terminateNow }
+        guard terminationDecisionTask == nil else { return .terminateLater }
+        terminationDecisionTask = Task { @MainActor [weak self] in
+            guard let self else {
+                reply(false)
+                return
+            }
+            let shouldTerminate = await confirmApplicationTermination()
+            terminationDecisionTask = nil
+            isTerminating = shouldTerminate
+            reply(shouldTerminate)
+        }
+        return .terminateLater
+    }
+
+    /// Runs all quit decisions asynchronously on their owning project
+    /// windows. Background projects fall back to one captured visible
+    /// application window (normally Welcome); with no live owner, native
+    /// presentation returns `.abort` and cancels Quit. Save failures also
+    /// cancel Quit.
+    func confirmApplicationTermination(
+        presentAlert: TerminationAlertPresenter? = nil,
+        saveAll: TerminationSaveAll? = nil,
+        applicationContext: DialogPresentationContext? = nil
+    ) async -> Bool {
+        let projects = registry.openProjects
+            .sorted { $0.key.path.localizedStandardCompare($1.key.path) == .orderedAscending }
+            .map(\.value)
+        let needsNativeDecision = presentAlert == nil
+            && projects.contains {
+                !$0.allDirtyTabs.isEmpty || $0.terminal.hasActiveProcesses
+            }
+        if applicationContext == nil, needsNativeDecision {
+            // Quit can arrive from the Dock while Pine is hidden or every
+            // project is miniaturized. Restore/create a discoverable owner
+            // before capturing the fallback context.
+            prepareApplicationDialogOwner()
+        }
+        let fallbackContext = applicationContext
+            ?? DialogPresenter.forApplicationWindow()
+        var discardAuthorizations: [
+            ObjectIdentifier: DirtyEditorContentAuthorization
+        ] = [:]
+        var authorizedTerminalProcesses: [
+            ObjectIdentifier: Set<TerminalForegroundProcessIdentity>
+        ] = [:]
+
+        for projectManager in projects {
+            guard registry.openProjects.values.contains(where: {
+                $0 === projectManager
+            }) else {
+                continue
+            }
+            let projectContext = DialogPresenter.forProject(projectManager)
+            let hasEligibleProjectOwner = projectContext.nsWindow.map {
+                DialogPresenter.isEligibleApplicationOwner($0)
+            } ?? false
+            let context = hasEligibleProjectOwner
+                ? projectContext
+                : fallbackContext
+            let dirty = projectManager.allDirtyTabs
             guard !dirty.isEmpty else { continue }
 
             let fileList = dirty.map { "  • \($0.fileName)" }.joined(separator: "\n")
-            let response = AlertTemplate.unsavedChangesBulk.runModal(
-                messageText: Strings.unsavedChangesTitle,
-                informativeText: Strings.unsavedChangesListMessage(fileList)
-            )
+            let message = Strings.unsavedChangesListMessage(fileList)
+            let response = if let presentAlert {
+                await presentAlert(
+                    .unsavedChangesBulk,
+                    context,
+                    Strings.unsavedChangesTitle,
+                    message
+                )
+            } else {
+                await AlertTemplate.unsavedChangesBulk.runSheet(
+                    on: context,
+                    messageText: Strings.unsavedChangesTitle,
+                    informativeText: message
+                )
+            }
             switch response {
             case .alertFirstButtonReturn:
-                guard pm.saveAllPaneTabs() else {
-                    isTerminating = false
-                    return .terminateCancel
+                let didSave = if let saveAll {
+                    await saveAll(projectManager, context)
+                } else {
+                    await projectManager.saveAllPaneTabs(context: context)
+                }
+                guard didSave else {
+                    return false
                 }
             case .alertSecondButtonReturn:
+                discardAuthorizations[ObjectIdentifier(projectManager)] =
+                    DirtyEditorContentAuthorization(tabs: dirty)
                 continue
             default:
-                isTerminating = false
-                return .terminateCancel
+                return false
             }
         }
 
-        // Check for active terminal processes
-        let hasActiveProcesses = registry.openProjects.values.contains { $0.terminal.hasActiveProcesses }
-        if hasActiveProcesses {
-            if AlertTemplate.terminalActiveProcessWarning.runModal(
-                messageText: Strings.terminalActiveProcessWarningTitle,
-                informativeText: Strings.terminalActiveProcessWarningMessage
-            ) != .alertFirstButtonReturn {
-                isTerminating = false
-                return .terminateCancel
+        for projectManager in projects where projectManager.terminal.hasActiveProcesses {
+            guard registry.openProjects.values.contains(where: {
+                $0 === projectManager
+            }) else {
+                continue
+            }
+            let activeTerminalProcesses =
+                TabCloseHelper.foregroundProcessSnapshot(
+                    for: projectManager.terminal.allTerminalTabs
+            )
+            let projectContext = DialogPresenter.forProject(projectManager)
+            let hasEligibleProjectOwner = projectContext.nsWindow.map {
+                DialogPresenter.isEligibleApplicationOwner($0)
+            } ?? false
+            let context = hasEligibleProjectOwner
+                ? projectContext
+                : fallbackContext
+            let response = if let presentAlert {
+                await presentAlert(
+                    .terminalActiveProcessWarning,
+                    context,
+                    Strings.terminalActiveProcessWarningTitle,
+                    Strings.terminalActiveProcessWarningMessage
+                )
+            } else {
+                await AlertTemplate.terminalActiveProcessWarning.runSheet(
+                    on: context,
+                    messageText: Strings.terminalActiveProcessWarningTitle,
+                    informativeText: Strings.terminalActiveProcessWarningMessage
+                )
+            }
+            guard response == .alertFirstButtonReturn else {
+                return false
+            }
+            authorizedTerminalProcesses[ObjectIdentifier(projectManager)] =
+                activeTerminalProcesses
+        }
+
+        // Other project windows stay interactive while each sheet is open.
+        // Revalidate every destructive authorization immediately before
+        // committing Quit so no new buffer edit or foreground process is
+        // silently covered by an earlier answer.
+        for projectManager in registry.openProjects.values {
+            let identifier = ObjectIdentifier(projectManager)
+            let currentDirtyTabs = projectManager.allDirtyTabs
+            if let authorization = discardAuthorizations[identifier] {
+                guard authorization.covers(currentDirtyTabs) else {
+                    return false
+                }
+            } else if !currentDirtyTabs.isEmpty {
+                return false
+            }
+
+            let allowedTerminalProcesses =
+                authorizedTerminalProcesses[identifier] ?? []
+            let currentTerminalProcesses =
+                TabCloseHelper.foregroundProcessSnapshot(
+                    for: projectManager.terminal.allTerminalTabs
+                )
+            guard TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
+                currentTerminalProcesses,
+                by: allowedTerminalProcesses
+            ) else {
+                return false
             }
         }
 
-        return .terminateNow
+        // Two-phase destructive commit: no project is mutated until every
+        // project and terminal authorization above has passed.
+        for projectManager in registry.openProjects.values {
+            let identifier = ObjectIdentifier(projectManager)
+            if let authorization = discardAuthorizations[identifier],
+               !projectManager.commitDiscard(
+                   authorization,
+                   postReloadNotifications: false
+               ) {
+                return false
+            }
+        }
+
+        return true
     }
 }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -308,10 +308,12 @@ class CloseDelegate: NSObject, NSWindowDelegate {
         case .terminal:
             guard let state = pane.terminalState(for: activePaneID),
                   let tab = state.activeTab else { return }
-            guard TabCloseHelper.confirmTerminalProcessStop(tabs: [tab]) else { return }
-            state.removeTab(id: tab.id)
-            if state.terminalTabs.isEmpty {
-                pane.removePane(activePaneID)
+            Task { @MainActor in
+                guard await TabCloseHelper.confirmTerminalProcessStop(tabs: [tab]) else { return }
+                state.removeTab(id: tab.id)
+                if state.terminalTabs.isEmpty {
+                    pane.removePane(activePaneID)
+                }
             }
 
         case .editor, nil:
@@ -354,10 +356,15 @@ class CloseDelegate: NSObject, NSWindowDelegate {
         }
 
         // 2. Warn about active terminal processes before closing
-        guard TabCloseHelper.confirmTerminalProcessStop(
-            tabs: projectManager.terminal.allTerminalTabs
-        ) else {
-            return false
+        let terminalTabs = projectManager.terminal.allTerminalTabs
+        if terminalTabs.contains(where: { $0.hasForegroundProcess }) {
+            let response = AlertTemplate.terminalTabCloseWarning.runModal(
+                messageText: Strings.terminalTabCloseWarningTitle,
+                informativeText: Strings.terminalTabCloseWarningMessage
+            )
+            guard response == .alertFirstButtonReturn else {
+                return false
+            }
         }
 
         return true

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -192,6 +192,14 @@ struct WindowCloseInterceptor: NSViewRepresentable {
         }
     }
 
+    static func dismantleNSView(
+        _ nsView: InterceptorView,
+        coordinator: Coordinator
+    ) {
+        nsView.onMovedToWindow = nil
+        coordinator.detach()
+    }
+
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     /// Custom NSView that fires a callback synchronously when added to a window.
@@ -237,6 +245,13 @@ struct WindowCloseInterceptor: NSViewRepresentable {
                 )
             } else if let closeDelegate,
                       window.delegate === closeDelegate {
+                if closeDelegate.didCompleteWindowLifecycle,
+                   registry.isWindowOpen(projectURL),
+                   registry.openProjects[
+                       projectURL.resolvingSymlinksInPath()
+                   ] === projectManager {
+                    closeDelegate.beginNewWindowLifecycle(on: window)
+                }
                 return
             } else if closeDelegate != nil {
                 // Same owner, new delegate generation. Do not restore the old
@@ -258,7 +273,15 @@ struct WindowCloseInterceptor: NSViewRepresentable {
                 if existing.projectManager === projectManager {
                     closeDelegate = existing
                     originalDelegate = existing.original
-                    existing.observeWindowClose(window)
+                    if existing.didCompleteWindowLifecycle,
+                       registry.isWindowOpen(projectURL),
+                       registry.openProjects[
+                           projectURL.resolvingSymlinksInPath()
+                       ] === projectManager {
+                        existing.beginNewWindowLifecycle(on: window)
+                    } else if !existing.didCompleteWindowLifecycle {
+                        existing.observeWindowClose(window)
+                    }
                     return
                 }
                 let existingOriginal = existing.original
@@ -343,10 +366,15 @@ struct WindowCloseInterceptor: NSViewRepresentable {
             lifecycleObservers.removeAll()
         }
 
-        deinit {
-            for observer in lifecycleObservers {
-                NotificationCenter.default.removeObserver(observer)
-            }
+        /// Retires the live representable installation while its NSWindow may
+        /// remain alive. This is intentionally idempotent because SwiftUI
+        /// teardown and coordinator destruction can occur back-to-back.
+        func detach() {
+            retireCurrentInstallation(restoringOriginal: true)
+        }
+
+        isolated deinit {
+            retireCurrentInstallation(restoringOriginal: true)
         }
     }
 
@@ -380,6 +408,7 @@ class CloseDelegate: NSObject, NSWindowDelegate {
     /// Tracks whether windowWillClose has already been handled, to prevent
     /// the NotificationCenter fallback from double-firing.
     private var didHandleClose = false
+    var didCompleteWindowLifecycle: Bool { didHandleClose }
 
     /// NotificationCenter observer token for the willClose fallback.
     /// nonisolated(unsafe): accessed from deinit (nonisolated) to remove observer.
@@ -658,6 +687,16 @@ class CloseDelegate: NSObject, NSWindowDelegate {
         )
     }
 
+    /// Re-arms a retained delegate only after ProjectRegistry has explicitly
+    /// moved the same project out of its background state. Repeated
+    /// representable updates during one live window generation must never
+    /// reset the once-only close guard.
+    func beginNewWindowLifecycle(on window: NSWindow) {
+        guard didHandleClose else { return }
+        didHandleClose = false
+        observeWindowClose(window)
+    }
+
     /// Retires interception without treating the owner as user-closed. Used
     /// when SwiftUI replaces the delegate or moves the representable.
     func detachFromWindow() {
@@ -745,6 +784,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     /// handlers know not to clear the saved session during app quit.
     private(set) var isTerminating = false
     private var terminationDecisionTask: Task<Void, Never>?
+    private var welcomeVisibilityGeneration = 0
+    private var pendingWelcomeEnsureTask: Task<Void, Never>?
 
     /// Closure to open a named SwiftUI window, set by PineApp on launch.
     var openNamedWindow: ((String) -> Void)?
@@ -779,15 +820,53 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         }
     }
 
-    func showWelcome() {
+    func showWelcome(
+        waitBeforeEnsure: (@MainActor () async -> Void)? = nil,
+        ensureVisible: (@MainActor () -> Void)? = nil
+    ) {
+        welcomeVisibilityGeneration &+= 1
+        let generation = welcomeVisibilityGeneration
+        pendingWelcomeEnsureTask?.cancel()
+
         // Try SwiftUI first — may silently fail after repeated dismiss cycles
         // because the captured @Environment(\.openWindow) closure becomes stale.
         openNamedWindow?("welcome")
 
         // Give SwiftUI a moment to process, then verify and fallback via AppKit.
-        DispatchQueue.main.asyncAfter(deadline: .now() + UITimings.Delay.short) { [weak self] in
-            guard let self else { return }
-            self.ensureWelcomeVisible()
+        let wait = waitBeforeEnsure ?? {
+            try? await Task.sleep(for: .seconds(UITimings.Delay.short))
+        }
+        pendingWelcomeEnsureTask = Task { @MainActor [weak self] in
+            await wait()
+            guard let self,
+                  !Task.isCancelled,
+                  self.welcomeVisibilityGeneration == generation else {
+                return
+            }
+            if let ensureVisible {
+                ensureVisible()
+            } else {
+                self.ensureWelcomeVisible()
+            }
+            if self.welcomeVisibilityGeneration == generation {
+                self.pendingWelcomeEnsureTask = nil
+            }
+        }
+    }
+
+    /// Cancels every stale Welcome visibility request before hiding all live
+    /// SwiftUI- and AppKit-owned Welcome windows. All successful project-open
+    /// paths use this helper so a delayed `showWelcome()` fallback cannot
+    /// resurrect the Welcome window over the new project.
+    func hideWelcome() {
+        welcomeVisibilityGeneration &+= 1
+        pendingWelcomeEnsureTask?.cancel()
+        pendingWelcomeEnsureTask = nil
+
+        welcomeWindow?.orderOut(nil)
+        for window in NSApp.windows
+            where window.identifier?.rawValue == "welcome" && window.isVisible {
+            window.orderOut(nil)
         }
     }
 
@@ -796,19 +875,24 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     /// assuming one fixed delay is sufficient on every macOS/CI machine.
     func awaitVisibleWelcomeWindow(
         maximumAttempts: Int = 40,
-        waitForNextAttempt: (@MainActor () async -> Void)? = nil
+        waitForNextAttempt: (@MainActor () async -> Void)? = nil,
+        resolveVisibleWindow: (@MainActor () -> NSWindow?)? = nil
     ) async -> NSWindow? {
         let wait = waitForNextAttempt ?? {
             try? await Task.sleep(for: .milliseconds(25))
         }
-        for _ in 0..<maximumAttempts {
-            if let window = visibleWelcomeWindow() {
+        let resolve = resolveVisibleWindow ?? {
+            self.visibleWelcomeWindow()
+        }
+        for _ in 0..<max(0, maximumAttempts) {
+            guard !Task.isCancelled else { return nil }
+            if let window = resolve() {
                 return window
             }
-            guard !Task.isCancelled else { return nil }
             await wait()
         }
-        return visibleWelcomeWindow()
+        guard !Task.isCancelled else { return nil }
+        return resolve()
     }
 
     /// No-window Open Folder path. A missing Welcome owner fails closed and
@@ -817,12 +901,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     func openFolderFromWelcomeOwner(
         maximumAttempts: Int = 40,
         waitForNextAttempt: (@MainActor () async -> Void)? = nil,
+        resolveVisibleWindow: (@MainActor () -> NSWindow?)? = nil,
         presentPanel: (@MainActor (DialogPresentationContext) async -> URL?)? = nil
     ) async -> Bool {
         showWelcome()
         guard let window = await awaitVisibleWelcomeWindow(
             maximumAttempts: maximumAttempts,
-            waitForNextAttempt: waitForNextAttempt
+            waitForNextAttempt: waitForNextAttempt,
+            resolveVisibleWindow: resolveVisibleWindow
         ) else {
             return false
         }
@@ -834,7 +920,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             selectedURL = await registry.openProjectViaPanel(context: context)
         }
         guard let selectedURL else { return false }
-        openProjectWindow?(selectedURL)
+        guard let openProjectWindow else { return false }
+        openProjectWindow(selectedURL)
+        hideWelcome()
         return true
     }
 
@@ -895,20 +983,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         if NSApp.isHidden {
             NSApp.unhide(nil)
         }
-        if windows.contains(where: {
-            DialogPresenter.isEligibleApplicationOwner($0)
-        }) {
-            return
+        let ownerStates = windows.map {
+            DialogPresenter.applicationOwnerState(
+                isVisible: $0.isVisible,
+                isMiniaturized: $0.isMiniaturized
+            )
         }
-        if let miniaturized = windows.first(where: {
-            $0.isVisible && $0.isMiniaturized
-        }) {
+        switch DialogPresenter.applicationOwnerPlan(for: ownerStates) {
+        case .keepExisting:
+            return
+        case let .restore(index):
+            guard windows.indices.contains(index) else {
+                ensureWelcomeVisible()
+                return
+            }
+            let miniaturized = windows[index]
             miniaturized.deminiaturize(nil)
             miniaturized.makeKeyAndOrderFront(nil)
             NSApp.activate()
-            return
+        case .showWelcome:
+            ensureWelcomeVisible()
         }
-        ensureWelcomeVisible()
     }
 
     /// Creates the Welcome window via AppKit when SwiftUI's scene lifecycle
@@ -1164,22 +1259,30 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             let canonical = dir.resolvingSymlinksInPath()
             guard registry.projectManager(for: canonical) != nil else { continue }
             openProjectWindow?(canonical)
-            welcomeWindow?.orderOut(nil)
+            hideWelcome()
         }
 
         // Open files: if a project window is active, add as tabs; otherwise open parent as project
         if !classified.files.isEmpty {
             if let activeProject = activeProjectManager() {
-                DropHandler.openFilesAsTabs(classified.files, in: activeProject.activeTabManager)
+                for file in classified.files {
+                    activeProject.paneManager.openFileInActiveEditor(url: file)
+                }
             } else if let firstFile = classified.files.first {
                 let projectDir = firstFile.deletingLastPathComponent().resolvingSymlinksInPath()
-                guard registry.projectManager(for: projectDir) != nil else { return }
+                guard let projectManager = registry.projectManager(for: projectDir) else { return }
                 openProjectWindow?(projectDir)
-                welcomeWindow?.orderOut(nil)
-                // Open files after project initializes
-                DispatchQueue.main.asyncAfter(deadline: .now() + UITimings.Delay.standard) { [weak self] in
-                    guard let pm = self?.registry.openProjects[projectDir] else { return }
-                    DropHandler.openFilesAsTabs(classified.files, in: pm.activeTabManager)
+                hideWelcome()
+                Task { @MainActor [weak self, weak projectManager] in
+                    guard let self, let projectManager else { return }
+                    guard let owner = await projectManager.awaitDialogOwnerWindow(),
+                          projectManager.dialogOwnerWindow === owner,
+                          self.registry.openProjects[projectDir] === projectManager else {
+                        return
+                    }
+                    for file in classified.files {
+                        projectManager.paneManager.openFileInActiveEditor(url: file)
+                    }
                 }
             }
         }
@@ -1228,8 +1331,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         }
         guard registry.projectManager(for: canonical) != nil else { return }
         openProjectWindow?(canonical)
-        // Hide Welcome window if visible
-        welcomeWindow?.orderOut(nil)
+        hideWelcome()
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -300,8 +300,7 @@ struct WindowCloseInterceptor: NSViewRepresentable {
                         forName: name,
                         object: window,
                         queue: .main
-                    ) { [weak self, weak window, weak projectManager,
-                         weak registry, weak appDelegate] _ in
+                    ) { [weak self, weak window, weak projectManager, weak registry, weak appDelegate] _ in
                         MainActor.assumeIsolated {
                             guard let self,
                                   let window,

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -45,9 +45,9 @@ struct PineAppMenuCommands: Commands {
 
             Button {
                 if CLIInstaller.isInstalled {
-                    CLIInstaller.uninstall()
+                    CLIInstaller.uninstall(projectManager: focusedProject)
                 } else {
-                    CLIInstaller.install()
+                    CLIInstaller.install(projectManager: focusedProject)
                 }
             } label: {
                 Text(CLIInstaller.isInstalled
@@ -137,7 +137,10 @@ struct PineAppMenuCommands: Commands {
 
             Button {
                 guard let pm = focusedProject else { return }
-                pm.activeTabManager.duplicateActiveTab(projectRoot: pm.workspace.rootURL)
+                pm.activeTabManager.duplicateActiveTab(
+                    projectRoot: pm.workspace.rootURL,
+                    context: DialogPresenter.forProject(pm)
+                )
             } label: {
                 Label(Strings.menuDuplicate, systemImage: MenuIcons.duplicate)
             }
@@ -663,22 +666,52 @@ struct PineAppMenuCommands: Commands {
             // and tasks.json) without restarting Pine. Starter files are
             // created on first open; reload surfaces validation errors.
             Button {
+                let context = if let focusedProject {
+                    DialogPresenter.forProject(focusedProject)
+                } else {
+                    DialogPresenter.forKeyWindow()
+                }
+                let presenter = AppKitUserConfigurationAlertPresenter(
+                    context: context
+                )
                 Task { @MainActor in
-                    await UserConfigurationEditor.openKeybindings()
+                    await UserConfigurationEditor.openKeybindings(
+                        alertPresenter: presenter
+                    )
                 }
             } label: {
                 Label(Strings.menuEditKeybindings, systemImage: MenuIcons.editKeybindings)
             }
             Button {
+                let context = if let focusedProject {
+                    DialogPresenter.forProject(focusedProject)
+                } else {
+                    DialogPresenter.forKeyWindow()
+                }
+                let presenter = AppKitUserConfigurationAlertPresenter(
+                    context: context
+                )
                 Task { @MainActor in
-                    await UserConfigurationEditor.openTasks()
+                    await UserConfigurationEditor.openTasks(
+                        alertPresenter: presenter
+                    )
                 }
             } label: {
                 Label(Strings.menuEditTasks, systemImage: MenuIcons.editTasks)
             }
             Button {
+                let context = if let focusedProject {
+                    DialogPresenter.forProject(focusedProject)
+                } else {
+                    DialogPresenter.forKeyWindow()
+                }
+                let presenter = AppKitUserConfigurationAlertPresenter(
+                    context: context
+                )
                 Task { @MainActor in
-                    await Self.reloadAndPresentConfigurationDiagnostics()
+                    await Self.reloadAndPresentConfigurationDiagnostics(
+                        alertPresenter: presenter
+                    )
                 }
             } label: {
                 Label(Strings.menuReloadUserConfiguration, systemImage: MenuIcons.reloadUserConfiguration)
@@ -704,7 +737,7 @@ struct PineAppMenuCommands: Commands {
     ) async {
         let report = await manager.reload()
         guard let report else { return }
-        alertPresenter.present(reloadAlert(for: report))
+        await alertPresenter.present(reloadAlert(for: report))
     }
 
     static func reloadAlert(

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -5,6 +5,7 @@
 //  Created by Федор Батоногов on 10.03.2026.
 //
 
+import AppKit
 import SwiftUI
 
 /// Thin coordinator that owns the workspace, terminal, and tab managers.
@@ -46,6 +47,17 @@ final class ProjectManager {
     /// Merges LSP diagnostics (read live) with config-validator diagnostics
     /// (revision-guarded). Owned here so every window observes the same truth.
     let problemsController: ProblemsPanelController
+    /// Weak anchor for every native dialog owned by this project.
+    ///
+    /// The window owns the visible project surface; keeping this reference
+    /// weak prevents the project model (which may remain alive in the
+    /// background) from extending the NSWindow lifetime.
+    @ObservationIgnored
+    private(set) weak var dialogOwnerWindow: NSWindow?
+    @ObservationIgnored
+    private var dialogOperationTail: Task<Void, Never>?
+    @ObservationIgnored
+    private var dialogOperationGeneration = 0
     @ObservationIgnored
     private(set) lazy var paneManager = PaneManager(existingTabManager: primaryTabManager)
 
@@ -70,11 +82,61 @@ final class ProjectManager {
         paneManager.tabManagers.values.flatMap(\.dirtyTabs)
     }
 
+    /// Validates an exact dirty-buffer authorization across every editor
+    /// pane. This is intentionally separate from commit so Quit can validate
+    /// every project before mutating any project.
+    func canCommitDiscard(
+        _ authorization: DirtyEditorContentAuthorization
+    ) -> Bool {
+        authorization.covers(allDirtyTabs)
+    }
+
+    /// Commits an already validated "Don't Save" decision across panes.
+    /// There is no suspension between the project-level validation and these
+    /// per-manager commits, so another MainActor mutation cannot interleave.
+    @discardableResult
+    func commitDiscard(
+        _ authorization: DirtyEditorContentAuthorization,
+        postReloadNotifications: Bool = true
+    ) -> Bool {
+        guard canCommitDiscard(authorization) else { return false }
+        let reloads = allDirtyTabs.map {
+            ReloadedTab(url: $0.url, text: $0.savedContent)
+        }
+        for tabManager in paneManager.allTabManagers {
+            guard tabManager.discardChanges(
+                authorizedBy: authorization,
+                postReloads: false
+            ) else {
+                return false
+            }
+        }
+        if postReloadNotifications {
+            for reload in reloads {
+                NotificationCenter.default.post(
+                    name: .tabReloadedFromDisk,
+                    object: nil,
+                    userInfo: ["url": reload.url, "text": reload.text]
+                )
+            }
+        }
+        return true
+    }
+
     /// Saves all tabs across all panes. Returns false if any save fails.
     @discardableResult
     func saveAllPaneTabs() -> Bool {
         for tabMgr in paneManager.tabManagers.values {
             guard tabMgr.saveAllTabs() else { return false }
+        }
+        return true
+    }
+
+    /// Window-scoped save-all used by close and termination decisions.
+    @discardableResult
+    func saveAllPaneTabs(context: DialogPresentationContext) async -> Bool {
+        for tabManager in paneManager.tabManagers.values {
+            guard await tabManager.saveAllTabs(context: context) else { return false }
         }
         return true
     }
@@ -89,32 +151,47 @@ final class ProjectManager {
     /// access and triggered `_swift_reportExclusivityConflict` → `abort()`
     /// on macOS 26.5.1 when format-on-save reformatted the buffer (#1058).
     ///
-    /// Autosave (`TabAutoSave`), close, and quit call
-    /// `activeTabManager.saveActiveTab()` directly — they are not invoked
-    /// from a `ButtonAction`, so there is no transactional exclusive access
-    /// to collide with and no deferral is needed.
+    /// Autosave uses the UI-free throwing primitive directly. Close and quit
+    /// use async, window-scoped save overloads after their sheet decisions;
+    /// neither runs inside a `ButtonAction`.
     ///
     /// The disk write is deferred by ~1 runloop (imperceptible at 60 Hz);
     /// the dirty indicator and git status settle one frame later.
     func saveActiveTabFromMenu() {
-        performMenuSave { [weak self] in self?.activeTabManager.saveActiveTab() ?? false }
+        let context = DialogPresenter.forProject(self)
+        let tabManager = activeTabManager
+        let activeID = tabManager.activeTabID
+        performMenuSave { [weak tabManager] in
+            guard let tabManager,
+                  let activeID,
+                  let index = tabManager.tabs.firstIndex(where: { $0.id == activeID }) else {
+                return false
+            }
+            return await tabManager.saveTab(at: index, context: context)
+        }
     }
 
     /// Cmd+Option+S (Save All) from the File menu. Same reentrancy rationale
     /// as ``saveActiveTabFromMenu`` — Save All can also mutate `@Observable`
     /// per-pane tab state synchronously when format-on-save changes content.
     func saveAllTabsFromMenu() {
-        performMenuSave { [weak self] in self?.saveAllPaneTabs() ?? false }
+        let context = DialogPresenter.forProject(self)
+        performMenuSave { [weak self] in
+            guard let self else { return false }
+            return await saveAllPaneTabs(context: context)
+        }
     }
 
     /// Shared deferral for menu-triggered saves. Runs the save `operation`
     /// on the next runloop (outside any `ButtonAction` callstack), then
     /// refreshes git status + line diffs when it succeeded.
-    private func performMenuSave(_ operation: @escaping () -> Bool) {
+    private func performMenuSave(
+        _ operation: @escaping @MainActor () async -> Bool
+    ) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            guard operation() else { return }
-            Task {
+            Task { @MainActor in
+                guard await operation() else { return }
                 await self.workspace.gitProvider.refreshAsync()
                 NotificationCenter.default.post(name: .refreshLineDiffs, object: nil)
             }
@@ -201,7 +278,40 @@ final class ProjectManager {
         terminal.paneManager = paneManager
     }
 
+    func bindDialogOwnerWindow(_ window: NSWindow) {
+        dialogOwnerWindow = window
+    }
+
+    func unbindDialogOwnerWindow(_ window: NSWindow) {
+        guard dialogOwnerWindow === window else { return }
+        dialogOwnerWindow = nil
+    }
+
+    /// Serializes stateful dialog workflows whose model snapshot must be
+    /// recomputed only after an earlier decision finishes. The native sheet
+    /// coordinator serializes presentation, while this queue prevents two
+    /// filesystem events from taking stale tab snapshots before either sheet
+    /// resolves.
+    func enqueueDialogOperation(
+        _ operation: @escaping @MainActor () async -> Void
+    ) {
+        let previous = dialogOperationTail
+        dialogOperationGeneration &+= 1
+        let generation = dialogOperationGeneration
+        dialogOperationTail = Task { @MainActor [weak self] in
+            if let previous {
+                await previous.value
+            }
+            guard let self, !Task.isCancelled else { return }
+            await operation()
+            if dialogOperationGeneration == generation {
+                dialogOperationTail = nil
+            }
+        }
+    }
+
     isolated deinit {
+        dialogOperationTail?.cancel()
         recoveryManager?.stopPeriodicSnapshots()
     }
 
@@ -227,6 +337,10 @@ final class ProjectManager {
     /// created later by pane splits or session restoration.
     private func configureEditorTabManager(_ tabManager: TabManager) {
         tabManager.recoveryManager = recoveryManager
+        tabManager.dialogContextProvider = { [weak self] in
+            guard let self else { return .unscoped }
+            return DialogPresenter.forProject(self)
+        }
         tabManager.onEditorContextChanged = { [weak self] in
             guard let self else { return }
             self.updateEditorContext()
@@ -454,7 +568,12 @@ final class ProjectManager {
     var rootURL: URL? { workspace.rootURL }
     var gitProvider: GitStatusProvider { workspace.gitProvider }
 
-    func openFolder() { workspace.openFolder() }
+    func openFolder() {
+        let context = DialogPresenter.forProject(self)
+        Task { @MainActor in
+            await workspace.openFolder(context: context)
+        }
+    }
     func loadDirectory(url: URL) {
         workspace.loadDirectory(url: url)
         setupRecovery(projectURL: url)

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -287,6 +287,41 @@ final class ProjectManager {
         dialogOwnerWindow = nil
     }
 
+    /// Waits for the project window to become a valid native dialog owner.
+    /// Project scenes are created asynchronously, so launch/drop flows cannot
+    /// safely assume a fixed delay is enough before opening a large file.
+    ///
+    /// The retry loop is bounded and cancellation-aware. Tests can inject the
+    /// wait and eligibility predicate to exercise delayed binding without
+    /// depending on AppKit timing.
+    func awaitDialogOwnerWindow(
+        maximumAttempts: Int = 80,
+        waitForNextAttempt: (@MainActor () async -> Void)? = nil,
+        isEligible: (@MainActor (NSWindow) -> Bool)? = nil
+    ) async -> NSWindow? {
+        let wait = waitForNextAttempt ?? {
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        let acceptsWindow = isEligible ?? {
+            DialogPresenter.isEligibleApplicationOwner($0)
+        }
+
+        for _ in 0..<max(0, maximumAttempts) {
+            guard !Task.isCancelled else { return nil }
+            if let window = dialogOwnerWindow, acceptsWindow(window) {
+                return window
+            }
+            await wait()
+        }
+
+        guard !Task.isCancelled,
+              let window = dialogOwnerWindow,
+              acceptsWindow(window) else {
+            return nil
+        }
+        return window
+    }
+
     /// Serializes stateful dialog workflows whose model snapshot must be
     /// recomputed only after an earlier decision finishes. The native sheet
     /// coordinator serializes presentation, while this queue prevents two

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -80,7 +80,9 @@ final class ProjectRegistry: LSPSettingsObserver {
 
     /// Opens a project via folder picker. Returns the project URL if opened.
     @discardableResult
-    func openProjectViaPanel() -> URL? {
+    func openProjectViaPanel(
+        context: DialogPresentationContext
+    ) async -> URL? {
         let panel = NSOpenPanel()
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
@@ -88,7 +90,8 @@ final class ProjectRegistry: LSPSettingsObserver {
         panel.message = Strings.openPanelMessage
         panel.prompt = Strings.openPanelPrompt
 
-        guard panel.runModal() == .OK, let url = panel.url else { return nil }
+        guard await panel.runSheet(on: context) == .OK,
+              let url = panel.url else { return nil }
         let canonical = url.resolvingSymlinksInPath()
         guard projectManager(for: canonical) != nil else { return nil }
         return canonical

--- a/Pine/RecoveryManager.swift
+++ b/Pine/RecoveryManager.swift
@@ -39,6 +39,12 @@ final class RecoveryManager {
     private let recoveryDirectory: URL
     private var periodicTimer: Timer?
     private var snapshotDebouncer: Debouncer?
+    /// Old crash IDs whose recovered buffers now live under a runtime tab ID.
+    ///
+    /// A failed write of the runtime snapshot leaves the old file in place
+    /// and records it here. A later successful periodic snapshot, save, or
+    /// close then removes the superseded file as well.
+    private var supersededRecoveryIDsByRuntimeID: [UUID: Set<UUID>] = [:]
 
     /// Tabs provider — set by ProjectManager so periodic snapshots can access current tabs.
     var tabsProvider: (() -> [EditorTab])?
@@ -58,29 +64,11 @@ final class RecoveryManager {
     func snapshotDirtyTabs(_ tabs: [EditorTab]) {
         let dirtyTabs = tabs.filter { $0.isDirty && $0.kind == .text }
         guard !dirtyTabs.isEmpty else { return }
-
-        ensureDirectoryExists()
-
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        guard ensureDirectoryExists() else { return }
+        let encoder = makeRecoveryEncoder()
 
         for tab in dirtyTabs {
-            let entry = RecoveryEntry(
-                originalPath: tab.url.path,
-                content: tab.content,
-                encoding: tab.encoding
-            )
-            do {
-                let data = try encoder.encode(entry)
-                let fileURL = recoveryFileURL(for: tab.id)
-                do {
-                    try data.write(to: fileURL, options: .atomic)
-                } catch {
-                    Self.logger.error("Failed to write recovery file for tab \(tab.url.lastPathComponent): \(error)")
-                }
-            } catch {
-                Self.logger.error("Failed to encode recovery entry for \(tab.url.lastPathComponent): \(error)")
-            }
+            _ = writeRecoverySnapshot(for: tab, encoder: encoder)
         }
     }
 
@@ -88,14 +76,17 @@ final class RecoveryManager {
 
     /// Removes the recovery file for a specific tab (e.g., after save or clean close).
     func deleteRecoveryFile(for tabID: UUID) {
-        let fileURL = recoveryFileURL(for: tabID)
-        do {
-            try FileManager.default.removeItem(at: fileURL)
-        } catch let error as NSError where error.domain == NSCocoaErrorDomain
-            && error.code == NSFileNoSuchFileError {
-            // File already deleted — not an error
-        } catch {
-            Self.logger.error("Failed to delete recovery file \(tabID.uuidString): \(error)")
+        _ = removeRecoveryFileOnly(for: tabID)
+        deleteSupersededRecoveryFiles(for: tabID)
+    }
+
+    /// Removes only the explicitly displayed recovery IDs.
+    ///
+    /// Used by the recovery sheet's Discard action so successfully migrated
+    /// runtime snapshots in the same project directory remain intact.
+    func deleteRecoveryFiles(for tabIDs: [UUID]) {
+        for tabID in Set(tabIDs) where removeRecoveryFileOnly(for: tabID) {
+            forgetSupersededReference(to: tabID)
         }
     }
 
@@ -153,6 +144,125 @@ final class RecoveryManager {
             }
         }
         return results
+    }
+
+    /// Restores crash snapshots into `tabManager`, waiting for any interactive
+    /// large-file decision before applying the recovered content.
+    ///
+    /// A snapshot is deleted only after its tab actually opens and the
+    /// recovered buffer has been installed. Cancelled or otherwise unresolved
+    /// entries stay on disk for a later recovery attempt.
+    ///
+    /// - Returns: Entries that could not be restored.
+    func restorePendingEntries(
+        _ entries: [(UUID, RecoveryEntry)],
+        in tabManager: TabManager,
+        context: DialogPresentationContext
+    ) async -> [(UUID, RecoveryEntry)] {
+        var retainedEntries: [(UUID, RecoveryEntry)] = []
+
+        for (recoveryID, entry) in entries {
+            guard !entry.originalPath.isEmpty else {
+                retainedEntries.append((recoveryID, entry))
+                continue
+            }
+
+            let url = URL(fileURLWithPath: entry.originalPath)
+            guard tabManager.canRestoreRecoveryEntry(for: url) else {
+                retainedEntries.append((recoveryID, entry))
+                continue
+            }
+
+            let result = await withCheckedContinuation { continuation in
+                tabManager.openTab(
+                    url: url,
+                    context: context,
+                    completion: { continuation.resume(returning: $0) }
+                )
+            }
+
+            guard case .opened(let tabID) = result,
+                  tabManager.tabs.contains(where: { $0.id == tabID }) else {
+                retainedEntries.append((recoveryID, entry))
+                continue
+            }
+
+            let recoveredTabID: UUID
+            switch tabManager.appendRecoveredTab(
+                basedOn: tabID,
+                content: entry.content,
+                encoding: entry.encoding
+            ) {
+            case .appended(let tabID):
+                recoveredTabID = tabID
+            case .capacityReached, .sourceMissing:
+                retainedEntries.append((recoveryID, entry))
+                continue
+            }
+
+            guard let recoveredTab = tabManager.tabs.first(where: {
+                $0.id == recoveredTabID
+            }) else {
+                retainedEntries.append((recoveryID, entry))
+                continue
+            }
+
+            // Persist the runtime-ID snapshot before removing the crash-ID
+            // snapshot. On failure the old file remains durable and is linked
+            // to the runtime tab for cleanup after a later snapshot/save.
+            _ = migrateRecoverySnapshot(
+                from: recoveryID,
+                to: recoveredTab
+            )
+        }
+
+        return retainedEntries
+    }
+
+    /// Replaces an old crash-ID snapshot with the restored runtime tab's
+    /// snapshot without creating a durability gap.
+    ///
+    /// - Returns: `true` when the restored state is durably represented under
+    ///   the runtime ID (or is clean and needs no snapshot). `false` means the
+    ///   destination write failed and the old snapshot was intentionally kept.
+    @discardableResult
+    func migrateRecoverySnapshot(
+        from recoveryID: UUID,
+        to restoredTab: EditorTab
+    ) -> Bool {
+        guard restoredTab.isDirty && restoredTab.kind == .text else {
+            if !removeRecoveryFileOnly(for: recoveryID),
+               recoveryID != restoredTab.id {
+                recordSupersededRecoveryID(
+                    recoveryID,
+                    for: restoredTab.id
+                )
+            }
+            return true
+        }
+
+        guard ensureDirectoryExists(),
+              writeRecoverySnapshot(for: restoredTab) else {
+            if recoveryID != restoredTab.id {
+                recordSupersededRecoveryID(
+                    recoveryID,
+                    for: restoredTab.id
+                )
+            }
+            return false
+        }
+
+        // When both identities are the same, the atomic write above replaced
+        // the old contents in place. Deleting here would remove the only new
+        // snapshot.
+        guard recoveryID != restoredTab.id else { return true }
+        if !removeRecoveryFileOnly(for: recoveryID) {
+            recordSupersededRecoveryID(
+                recoveryID,
+                for: restoredTab.id
+            )
+        }
+        return true
     }
 
     /// Whether there are any pending recovery files.
@@ -290,16 +400,115 @@ final class RecoveryManager {
         recoveryDirectory.appendingPathComponent("\(tabID.uuidString).json")
     }
 
-    private func ensureDirectoryExists() {
-        if !FileManager.default.fileExists(atPath: recoveryDirectory.path) {
-            do {
-                try FileManager.default.createDirectory(
-                    at: recoveryDirectory,
-                    withIntermediateDirectories: true
+    /// Atomically writes one runtime snapshot and returns whether it reached
+    /// its destination. Superseded crash IDs are removed only after success.
+    private func writeRecoverySnapshot(for tab: EditorTab) -> Bool {
+        writeRecoverySnapshot(for: tab, encoder: makeRecoveryEncoder())
+    }
+
+    private func writeRecoverySnapshot(
+        for tab: EditorTab,
+        encoder: JSONEncoder
+    ) -> Bool {
+        let entry = RecoveryEntry(
+            originalPath: tab.url.path,
+            content: tab.content,
+            encoding: tab.encoding
+        )
+
+        do {
+            let data = try encoder.encode(entry)
+            try data.write(
+                to: recoveryFileURL(for: tab.id),
+                options: .atomic
+            )
+        } catch {
+            Self.logger.error(
+                "Failed to write recovery file for tab \(tab.url.lastPathComponent): \(error)"
+            )
+            return false
+        }
+
+        deleteSupersededRecoveryFiles(for: tab.id)
+        return true
+    }
+
+    private func makeRecoveryEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    @discardableResult
+    private func removeRecoveryFileOnly(for tabID: UUID) -> Bool {
+        let fileURL = recoveryFileURL(for: tabID)
+        do {
+            try FileManager.default.removeItem(at: fileURL)
+            return true
+        } catch let error as NSError where error.domain == NSCocoaErrorDomain
+            && error.code == NSFileNoSuchFileError {
+            return true
+        } catch {
+            Self.logger.error(
+                "Failed to delete recovery file \(tabID.uuidString): \(error)"
+            )
+            return false
+        }
+    }
+
+    private func recordSupersededRecoveryID(
+        _ recoveryID: UUID,
+        for runtimeID: UUID
+    ) {
+        guard recoveryID != runtimeID else { return }
+        supersededRecoveryIDsByRuntimeID[runtimeID, default: []]
+            .insert(recoveryID)
+    }
+
+    private func deleteSupersededRecoveryFiles(for runtimeID: UUID) {
+        guard let recoveryIDs = supersededRecoveryIDsByRuntimeID[runtimeID] else {
+            return
+        }
+        let failed = Set(recoveryIDs.filter {
+            !removeRecoveryFileOnly(for: $0)
+        })
+        if failed.isEmpty {
+            supersededRecoveryIDsByRuntimeID.removeValue(forKey: runtimeID)
+        } else {
+            supersededRecoveryIDsByRuntimeID[runtimeID] = failed
+        }
+    }
+
+    private func forgetSupersededReference(to recoveryID: UUID) {
+        for runtimeID in Array(supersededRecoveryIDsByRuntimeID.keys) {
+            supersededRecoveryIDsByRuntimeID[runtimeID]?.remove(recoveryID)
+            if supersededRecoveryIDsByRuntimeID[runtimeID]?.isEmpty == true {
+                supersededRecoveryIDsByRuntimeID.removeValue(
+                    forKey: runtimeID
                 )
-            } catch {
-                Self.logger.error("Failed to create recovery directory: \(error)")
             }
+        }
+    }
+
+    @discardableResult
+    private func ensureDirectoryExists() -> Bool {
+        var isDirectory: ObjCBool = false
+        if FileManager.default.fileExists(
+            atPath: recoveryDirectory.path,
+            isDirectory: &isDirectory
+        ) {
+            return isDirectory.boolValue
+        }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: recoveryDirectory,
+                withIntermediateDirectories: true
+            )
+            return true
+        } catch {
+            Self.logger.error("Failed to create recovery directory: \(error)")
+            return false
         }
     }
 

--- a/Pine/Settings/KeyBindingsTasksSettingsView.swift
+++ b/Pine/Settings/KeyBindingsTasksSettingsView.swift
@@ -35,14 +35,32 @@ struct KeyBindingsTasksSettingsView: View {
                 title: Strings.settingsKeyBindingsKeybindings,
                 fileURL: UserConfigurationPaths.userKeybindingsFile,
                 count: ExtensibilityManager.shared.keybindings.count,
-                openAction: { Task { await UserConfigurationEditor.openKeybindings() } }
+                openAction: {
+                    let presenter = AppKitUserConfigurationAlertPresenter(
+                        context: DialogPresenter.forKeyWindow()
+                    )
+                    Task {
+                        await UserConfigurationEditor.openKeybindings(
+                            alertPresenter: presenter
+                        )
+                    }
+                }
             )
 
             configSection(
                 title: Strings.settingsKeyBindingsTasks,
                 fileURL: UserConfigurationPaths.userTasksFile,
                 count: ExtensibilityManager.shared.tasks.count,
-                openAction: { Task { await UserConfigurationEditor.openTasks() } }
+                openAction: {
+                    let presenter = AppKitUserConfigurationAlertPresenter(
+                        context: DialogPresenter.forKeyWindow()
+                    )
+                    Task {
+                        await UserConfigurationEditor.openTasks(
+                            alertPresenter: presenter
+                        )
+                    }
+                }
             )
 
             effectiveBindings

--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -55,10 +55,11 @@ final class SidebarEditState {
         in parentURL: URL,
         isDirectory: Bool,
         workspace: WorkspaceManager,
-        undoManager: UndoManager? = nil
+        undoManager: UndoManager? = nil,
+        context: DialogPresentationContext = .unscoped
     ) {
         if let root = workspace.rootURL, !FileNode.isWithinProjectRoot(parentURL, projectRoot: root) {
-            Self.showFileError(Strings.operationOutsideProject)
+            Self.showFileError(Strings.operationOutsideProject, context: context)
             return
         }
 
@@ -72,14 +73,14 @@ final class SidebarEditState {
             if isDirectory {
                 try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: false)
             } else if !FileManager.default.createFile(atPath: newURL.path, contents: nil) {
-                Self.showFileError(Strings.fileCreateError(name))
+                Self.showFileError(Strings.fileCreateError(name), context: context)
                 return
             }
             workspace.refreshFileTree()
             startNewItem(url: newURL)
             scrollToNodeID = newURL
         } catch {
-            Self.showFileError(error.localizedDescription)
+            Self.showFileError(error.localizedDescription, context: context)
         }
     }
 
@@ -88,10 +89,11 @@ final class SidebarEditState {
         at url: URL,
         isDirectory: Bool,
         workspace: WorkspaceManager,
-        tabManager: TabManager
+        tabManager: TabManager,
+        context: DialogPresentationContext = .unscoped
     ) {
         if let root = workspace.rootURL, !FileNode.isWithinProjectRoot(url, projectRoot: root) {
-            Self.showFileError(Strings.operationOutsideProject)
+            Self.showFileError(Strings.operationOutsideProject, context: context)
             return
         }
 
@@ -110,7 +112,7 @@ final class SidebarEditState {
                 tabManager.openTab(url: copyURL)
             }
         } catch {
-            Self.showFileError(error.localizedDescription)
+            Self.showFileError(error.localizedDescription, context: context)
         }
     }
 
@@ -125,11 +127,17 @@ final class SidebarEditState {
     }
 
     /// Shows an AppKit error alert for file operations.
-    static func showFileError(_ message: String) {
-        AlertTemplate.fileOperationErrorWarning.runModal(
-            messageText: Strings.fileOperationErrorTitle,
-            informativeText: message
-        )
+    static func showFileError(
+        _ message: String,
+        context: DialogPresentationContext = .unscoped
+    ) {
+        Task { @MainActor in
+            _ = await AlertTemplate.fileOperationErrorWarning.runSheet(
+                on: context,
+                messageText: Strings.fileOperationErrorTitle,
+                informativeText: message
+            )
+        }
     }
 }
 
@@ -565,6 +573,7 @@ struct SidebarView: View {
     let onFileOpen: (FileNode, SidebarFileOpenDisposition) -> Void
     @Environment(WorkspaceManager.self) private var workspace
     @Environment(PaneManager.self) private var paneManager
+    @Environment(ProjectManager.self) private var projectManager
     @Environment(ProjectRegistry.self) private var registry
     @Environment(\.openWindow) var openWindow
     @Environment(\.undoManager) private var undoManager
@@ -717,7 +726,8 @@ struct SidebarView: View {
                                     in: rootURL,
                                     isDirectory: false,
                                     workspace: workspace,
-                                    undoManager: undoManager
+                                    undoManager: undoManager,
+                                    context: DialogPresenter.forProject(projectManager)
                                 )
                             } label: {
                                 Label(Strings.contextNewFile, systemImage: MenuIcons.newFile)
@@ -729,7 +739,8 @@ struct SidebarView: View {
                                     in: rootURL,
                                     isDirectory: true,
                                     workspace: workspace,
-                                    undoManager: undoManager
+                                    undoManager: undoManager,
+                                    context: DialogPresenter.forProject(projectManager)
                                 )
                             } label: {
                                 Label(Strings.contextNewFolder, systemImage: MenuIcons.newFolder)
@@ -806,8 +817,11 @@ struct SidebarView: View {
 
     /// Opens a new project via folder picker in a new window.
     private func openNewProject() {
-        guard let url = registry.openProjectViaPanel() else { return }
-        openWindow(value: url)
+        let context = DialogPresenter.forProject(projectManager)
+        Task { @MainActor in
+            guard let url = await registry.openProjectViaPanel(context: context) else { return }
+            openWindow(value: url)
+        }
     }
 
     /// A sidebar action supersedes any older destination-focus request. The

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -29,8 +29,8 @@ enum TabCloseHelper {
         _ tab: EditorTab,
         in tabManager: TabManager,
         gitProvider: GitStatusProvider,
-        context: DialogPresentationContext = .forKeyProject()
-    ) {
+        context: DialogPresentationContext = DialogPresenter.forKeyProject()
+    ) -> Bool {
         guard tab.isDirty else {
             tabManager.closeTab(id: tab.id)
             return true
@@ -45,7 +45,7 @@ enum TabCloseHelper {
             switch response {
             case .alertFirstButtonReturn:
                 guard let index = tabManager.tabs.firstIndex(where: { $0.id == tab.id }) else { return }
-                guard tabManager.saveTab(at: index, context: context) else { return }
+                guard tabManager.saveTabSync(at: index) else { return }
                 Task { await gitProvider.refreshAsync() }
                 tabManager.closeTab(id: tab.id)
             case .alertSecondButtonReturn:
@@ -72,7 +72,7 @@ enum TabCloseHelper {
         dirtyTabs: [EditorTab],
         in tabManager: TabManager,
         gitProvider: GitStatusProvider,
-        context: DialogPresentationContext = .forKeyProject(),
+        context: DialogPresentationContext = DialogPresenter.forKeyProject(),
         presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil,
         saveTab: ((Int) -> Bool)? = nil
     ) async -> Bool {
@@ -93,7 +93,7 @@ enum TabCloseHelper {
         case .alertFirstButtonReturn:
             for tab in dirtyTabs {
                 guard let index = tabManager.tabs.firstIndex(where: { $0.id == tab.id }) else { continue }
-                let didSave = saveTab?(index) ?? tabManager.saveTab(at: index, context: context)
+                let didSave = saveTab?(index) ?? tabManager.saveTabSync(at: index)
                 guard didSave else { return false }
             }
             Task { await gitProvider.refreshAsync() }
@@ -112,7 +112,7 @@ enum TabCloseHelper {
         keeping tabID: UUID,
         in tabManager: TabManager,
         gitProvider: GitStatusProvider,
-        context: DialogPresentationContext = .forKeyProject(),
+        context: DialogPresentationContext = DialogPresenter.forKeyProject(),
         presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil,
         saveTab: ((Int) -> Bool)? = nil
     ) async -> Bool {
@@ -136,7 +136,7 @@ enum TabCloseHelper {
         of tabID: UUID,
         in tabManager: TabManager,
         gitProvider: GitStatusProvider,
-        context: DialogPresentationContext = .forKeyProject(),
+        context: DialogPresentationContext = DialogPresenter.forKeyProject(),
         presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil,
         saveTab: ((Int) -> Bool)? = nil
     ) async -> Bool {
@@ -159,7 +159,7 @@ enum TabCloseHelper {
     static func closeAllTabs(
         in tabManager: TabManager,
         gitProvider: GitStatusProvider,
-        context: DialogPresentationContext = .forKeyProject(),
+        context: DialogPresentationContext = DialogPresenter.forKeyProject(),
         presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil,
         saveTab: ((Int) -> Bool)? = nil
     ) async -> Bool {
@@ -192,7 +192,7 @@ enum TabCloseHelper {
     ///     or the user confirmed. `false` to abort the stop/close.
     static func confirmTerminalStop(
         hasForegroundProcess: Bool,
-        context: DialogPresentationContext = .forKeyProject(),
+        context: DialogPresentationContext = DialogPresenter.forKeyProject(),
         presentAlert: @MainActor () async -> NSApplication.ModalResponse = {
             await AlertTemplate.terminalTabCloseWarning.runSheet(
                 on: DialogPresenter.forKeyProject(),
@@ -217,7 +217,7 @@ enum TabCloseHelper {
     ///     user confirmed. `false` to abort.
     static func confirmTerminalProcessStop(
         tabs: [TerminalTab],
-        context: DialogPresentationContext = .forKeyProject(),
+        context: DialogPresentationContext = DialogPresenter.forKeyProject(),
         presentAlert: @MainActor () async -> NSApplication.ModalResponse = {
             await AlertTemplate.terminalTabCloseWarning.runSheet(
                 on: DialogPresenter.forKeyProject(),

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -6,6 +6,11 @@
 //  Also provides the shared terminal foreground-process confirmation used by
 //  the status bar toggle, window close, tab close, and pane close paths.
 //
+//  Dialogs attach to the owning project window as sheets (issue #1241) so a
+//  close confirmation in one project does not block unrelated project windows.
+//  When no window context is supplied the application-modal `runModal()`
+//  fallback is used, preserving behavior in headless/test contexts.
+//
 
 import AppKit
 
@@ -13,52 +18,73 @@ import AppKit
 enum TabCloseHelper {
 
     /// Closes a single tab with unsaved-changes protection.
-    /// Returns `true` if the tab was actually closed.
+    ///
+    /// When `context` resolves a window, the unsaved-changes alert is
+    /// presented as a sheet on that window (issue #1241). The save-failure
+    /// error alert (if any) is likewise window-scoped.
+    ///
+    /// - Returns: `true` if the tab was actually closed.
     @discardableResult
     static func closeTab(
         _ tab: EditorTab,
         in tabManager: TabManager,
-        gitProvider: GitStatusProvider
-    ) -> Bool {
-        if tab.isDirty {
-            let response = AlertTemplate.unsavedChangesSingle.runModal(
+        gitProvider: GitStatusProvider,
+        context: DialogPresentationContext = .forKeyProject()
+    ) {
+        guard tab.isDirty else {
+            tabManager.closeTab(id: tab.id)
+            return true
+        }
+
+        Task { @MainActor in
+            let response = await AlertTemplate.unsavedChangesSingle.runSheet(
+                on: context,
                 messageText: Strings.unsavedChangesTitle,
                 informativeText: Strings.unsavedChangesMessage
             )
             switch response {
             case .alertFirstButtonReturn:
-                guard let index = tabManager.tabs.firstIndex(where: { $0.id == tab.id }) else { return false }
-                guard tabManager.saveTab(at: index) else { return false }
+                guard let index = tabManager.tabs.firstIndex(where: { $0.id == tab.id }) else { return }
+                guard tabManager.saveTab(at: index, context: context) else { return }
                 Task { await gitProvider.refreshAsync() }
                 tabManager.closeTab(id: tab.id)
             case .alertSecondButtonReturn:
                 tabManager.closeTab(id: tab.id)
             default:
-                return false
+                return
             }
-        } else {
-            tabManager.closeTab(id: tab.id)
         }
         return true
     }
 
     /// Shows a confirmation dialog for bulk close operations when there are dirty tabs.
-    /// Returns `true` if the operation should proceed.
+    ///
+    /// `presentAlert` is invoked to produce the modal response. Production
+    /// callers pass a closure that runs the window-scoped sheet; tests inject
+    /// a synchronous stub. Returns `true` if the operation should proceed.
+    ///
+    /// - Parameters:
+    ///   - presentAlert: Async closure that presents the confirmation alert
+    ///     and returns the modal response. When `nil`, the alert is presented
+    ///     as a window-scoped sheet via `context`.
+    ///   - saveTab: Optional save override for testing.
     static func confirmBulkClose(
         dirtyTabs: [EditorTab],
         in tabManager: TabManager,
         gitProvider: GitStatusProvider,
-        presentAlert: (() -> NSApplication.ModalResponse)? = nil,
+        context: DialogPresentationContext = .forKeyProject(),
+        presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil,
         saveTab: ((Int) -> Bool)? = nil
-    ) -> Bool {
+    ) async -> Bool {
         guard !dirtyTabs.isEmpty else { return true }
 
         let fileList = dirtyTabs.map { "  \u{2022} \($0.fileName)" }.joined(separator: "\n")
         let response: NSApplication.ModalResponse
         if let presentAlert {
-            response = presentAlert()
+            response = await presentAlert()
         } else {
-            response = AlertTemplate.unsavedChangesBulk.runModal(
+            response = await AlertTemplate.unsavedChangesBulk.runSheet(
+                on: context,
                 messageText: Strings.unsavedChangesTitle,
                 informativeText: Strings.unsavedChangesListMessage(fileList)
             )
@@ -67,7 +93,7 @@ enum TabCloseHelper {
         case .alertFirstButtonReturn:
             for tab in dirtyTabs {
                 guard let index = tabManager.tabs.firstIndex(where: { $0.id == tab.id }) else { continue }
-                let didSave = saveTab?(index) ?? tabManager.saveTab(at: index)
+                let didSave = saveTab?(index) ?? tabManager.saveTab(at: index, context: context)
                 guard didSave else { return false }
             }
             Task { await gitProvider.refreshAsync() }
@@ -86,14 +112,16 @@ enum TabCloseHelper {
         keeping tabID: UUID,
         in tabManager: TabManager,
         gitProvider: GitStatusProvider,
-        presentAlert: (() -> NSApplication.ModalResponse)? = nil,
+        context: DialogPresentationContext = .forKeyProject(),
+        presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil,
         saveTab: ((Int) -> Bool)? = nil
-    ) -> Bool {
+    ) async -> Bool {
         let dirty = tabManager.dirtyTabsForCloseOthers(keeping: tabID)
-        guard confirmBulkClose(
+        guard await confirmBulkClose(
             dirtyTabs: dirty,
             in: tabManager,
             gitProvider: gitProvider,
+            context: context,
             presentAlert: presentAlert,
             saveTab: saveTab
         ) else { return false }
@@ -108,14 +136,16 @@ enum TabCloseHelper {
         of tabID: UUID,
         in tabManager: TabManager,
         gitProvider: GitStatusProvider,
-        presentAlert: (() -> NSApplication.ModalResponse)? = nil,
+        context: DialogPresentationContext = .forKeyProject(),
+        presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil,
         saveTab: ((Int) -> Bool)? = nil
-    ) -> Bool {
+    ) async -> Bool {
         let dirty = tabManager.dirtyTabsForCloseRight(of: tabID)
-        guard confirmBulkClose(
+        guard await confirmBulkClose(
             dirtyTabs: dirty,
             in: tabManager,
             gitProvider: gitProvider,
+            context: context,
             presentAlert: presentAlert,
             saveTab: saveTab
         ) else { return false }
@@ -129,14 +159,16 @@ enum TabCloseHelper {
     static func closeAllTabs(
         in tabManager: TabManager,
         gitProvider: GitStatusProvider,
-        presentAlert: (() -> NSApplication.ModalResponse)? = nil,
+        context: DialogPresentationContext = .forKeyProject(),
+        presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil,
         saveTab: ((Int) -> Bool)? = nil
-    ) -> Bool {
+    ) async -> Bool {
         let dirty = tabManager.dirtyTabsForCloseAll()
-        guard confirmBulkClose(
+        guard await confirmBulkClose(
             dirtyTabs: dirty,
             in: tabManager,
             gitProvider: gitProvider,
+            context: context,
             presentAlert: presentAlert,
             saveTab: saveTab
         ) else { return false }
@@ -152,22 +184,25 @@ enum TabCloseHelper {
     /// - Parameters:
     ///   - hasForegroundProcess: Whether any terminal tab in scope has a
     ///     running foreground process.
-    ///   - presentAlert: Closure that presents the confirmation alert and
-    ///     returns the modal response. Injected for testing; defaults to the
-    ///     standard `terminalTabCloseWarning` alert.
+    ///   - context: Presentation context for the window-scoped sheet.
+    ///   - presentAlert: Async closure that presents the confirmation alert
+    ///     and returns the modal response. Injected for testing; defaults to
+    ///     the standard `terminalTabCloseWarning` sheet.
     /// - Returns: `true` if there is no foreground process (no warning needed)
     ///     or the user confirmed. `false` to abort the stop/close.
     static func confirmTerminalStop(
         hasForegroundProcess: Bool,
-        presentAlert: () -> NSApplication.ModalResponse = {
-            AlertTemplate.terminalTabCloseWarning.runModal(
+        context: DialogPresentationContext = .forKeyProject(),
+        presentAlert: @MainActor () async -> NSApplication.ModalResponse = {
+            await AlertTemplate.terminalTabCloseWarning.runSheet(
+                on: DialogPresenter.forKeyProject(),
                 messageText: Strings.terminalTabCloseWarningTitle,
                 informativeText: Strings.terminalTabCloseWarningMessage
             )
         }
-    ) -> Bool {
+    ) async -> Bool {
         guard hasForegroundProcess else { return true }
-        return presentAlert() == .alertFirstButtonReturn
+        return await presentAlert() == .alertFirstButtonReturn
     }
 
     /// Convenience overload that checks the foreground-process predicate on
@@ -175,21 +210,25 @@ enum TabCloseHelper {
     ///
     /// - Parameters:
     ///   - tabs: The terminal tabs to inspect.
-    ///   - presentAlert: Closure that presents the confirmation alert.
-    ///     Injected for testing; defaults to the standard alert.
+    ///   - context: Presentation context for the window-scoped sheet.
+    ///   - presentAlert: Async closure that presents the confirmation alert.
+    ///     Injected for testing; defaults to the standard sheet.
     /// - Returns: `true` if none of the tabs has a foreground process or the
     ///     user confirmed. `false` to abort.
     static func confirmTerminalProcessStop(
         tabs: [TerminalTab],
-        presentAlert: () -> NSApplication.ModalResponse = {
-            AlertTemplate.terminalTabCloseWarning.runModal(
+        context: DialogPresentationContext = .forKeyProject(),
+        presentAlert: @MainActor () async -> NSApplication.ModalResponse = {
+            await AlertTemplate.terminalTabCloseWarning.runSheet(
+                on: DialogPresenter.forKeyProject(),
                 messageText: Strings.terminalTabCloseWarningTitle,
                 informativeText: Strings.terminalTabCloseWarningMessage
             )
         }
-    ) -> Bool {
-        confirmTerminalStop(
+    ) async -> Bool {
+        await confirmTerminalStop(
             hasForegroundProcess: tabs.contains { $0.hasForegroundProcess },
+            context: context,
             presentAlert: presentAlert
         )
     }

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -6,13 +6,20 @@
 //  Also provides the shared terminal foreground-process confirmation used by
 //  the status bar toggle, window close, tab close, and pane close paths.
 //
-//  Dialogs attach to the owning project window as sheets (issue #1241) so a
-//  close confirmation in one project does not block unrelated project windows.
-//  When no window context is supplied the application-modal `runModal()`
-//  fallback is used, preserving behavior in headless/test contexts.
+//  Dialogs attach to a captured owning window and are queued per window.
+//  Missing or closed owners cancel the operation instead of falling back to
+//  a detached application-modal alert.
 //
 
 import AppKit
+
+/// Exact foreground job identity covered by a destructive terminal prompt.
+/// A new process group in the same terminal tab is a new authorization
+/// generation and must not be covered by the previous answer.
+struct TerminalForegroundProcessIdentity: Hashable, Sendable {
+    let tabID: UUID
+    let processGroupID: Int32
+}
 
 @MainActor
 enum TabCloseHelper {
@@ -29,39 +36,82 @@ enum TabCloseHelper {
         _ tab: EditorTab,
         in tabManager: TabManager,
         gitProvider: GitStatusProvider,
-        context: DialogPresentationContext = DialogPresenter.forKeyProject()
-    ) -> Bool {
-        guard tab.isDirty else {
-            tabManager.closeTab(id: tab.id)
+        context: DialogPresentationContext = .unscoped,
+        presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil,
+        saveTab: (@MainActor (Int) async -> Bool)? = nil
+    ) async -> Bool {
+        // Callers commonly create the Task from a SwiftUI value snapshot.
+        // Re-resolve identity at async entry so a clean captured value cannot
+        // bypass a prompt after the live tab becomes dirty (and a disappeared
+        // tab cannot produce a false "closed" result).
+        guard let entryTab = tabManager.tabs.first(where: {
+            $0.id == tab.id
+        }) else {
+            return false
+        }
+        let tabID = entryTab.id
+        let entryContent = entryTab.content
+        guard entryTab.isDirty else {
+            tabManager.closeTab(id: tabID)
             return true
         }
 
-        Task { @MainActor in
-            let response = await AlertTemplate.unsavedChangesSingle.runSheet(
+        let response: NSApplication.ModalResponse
+        if let presentAlert {
+            response = await presentAlert()
+        } else {
+            response = await AlertTemplate.unsavedChangesSingle.runSheet(
                 on: context,
                 messageText: Strings.unsavedChangesTitle,
                 informativeText: Strings.unsavedChangesMessage
             )
-            switch response {
-            case .alertFirstButtonReturn:
-                guard let index = tabManager.tabs.firstIndex(where: { $0.id == tab.id }) else { return }
-                guard tabManager.saveTabSync(at: index) else { return }
-                Task { await gitProvider.refreshAsync() }
-                tabManager.closeTab(id: tab.id)
-            case .alertSecondButtonReturn:
-                tabManager.closeTab(id: tab.id)
-            default:
-                return
-            }
         }
-        return true
+        switch response {
+        case .alertFirstButtonReturn:
+            guard let index = tabManager.tabs.firstIndex(where: { $0.id == tabID }) else {
+                return false
+            }
+            let didSave: Bool
+            if let saveTab {
+                didSave = await saveTab(index)
+            } else {
+                didSave = await tabManager.saveTab(at: index, context: context)
+            }
+            guard didSave else {
+                return false
+            }
+            // An async/injected saver can suspend. Never let the original
+            // Save decision close content dirtied after that save completed.
+            guard let currentTab = tabManager.tabs.first(where: {
+                $0.id == tabID
+            }), !currentTab.isDirty else {
+                return false
+            }
+            Task { await gitProvider.refreshAsync() }
+            tabManager.closeTab(id: tabID)
+            return true
+        case .alertSecondButtonReturn:
+            guard let currentTab = tabManager.tabs.first(where: { $0.id == tabID }) else {
+                return false
+            }
+            // The sheet suspends this task. If background work changed the
+            // dirty buffer while it was visible, the user's earlier discard
+            // decision no longer covers the current content.
+            guard !currentTab.isDirty || currentTab.content == entryContent else {
+                return false
+            }
+            tabManager.closeTab(id: tabID)
+            return true
+        default:
+            return false
+        }
     }
 
     /// Shows a confirmation dialog for bulk close operations when there are dirty tabs.
     ///
     /// `presentAlert` is invoked to produce the modal response. Production
     /// callers pass a closure that runs the window-scoped sheet; tests inject
-    /// a synchronous stub. Returns `true` if the operation should proceed.
+    /// an async stub. Returns `true` if the operation should proceed.
     ///
     /// - Parameters:
     ///   - presentAlert: Async closure that presents the confirmation alert
@@ -72,12 +122,18 @@ enum TabCloseHelper {
         dirtyTabs: [EditorTab],
         in tabManager: TabManager,
         gitProvider: GitStatusProvider,
-        context: DialogPresentationContext = DialogPresenter.forKeyProject(),
+        context: DialogPresentationContext = .unscoped,
         presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil,
-        saveTab: ((Int) -> Bool)? = nil
+        saveTab: (@MainActor (Int) async -> Bool)? = nil,
+        targetTabIDs: Set<UUID>? = nil
     ) async -> Bool {
         guard !dirtyTabs.isEmpty else { return true }
 
+        let displayedDirtyContent = Dictionary(
+            dirtyTabs.map { ($0.id, $0.content) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        let targetTabIDs = targetTabIDs ?? Set(dirtyTabs.map(\.id))
         let fileList = dirtyTabs.map { "  \u{2022} \($0.fileName)" }.joined(separator: "\n")
         let response: NSApplication.ModalResponse
         if let presentAlert {
@@ -91,14 +147,42 @@ enum TabCloseHelper {
         }
         switch response {
         case .alertFirstButtonReturn:
-            for tab in dirtyTabs {
+            // Save the latest dirty state, including a tab that became dirty
+            // while the sheet was visible. Saving is non-destructive and
+            // therefore does not need a second confirmation.
+            let currentDirtyTabs = tabManager.tabs.filter {
+                targetTabIDs.contains($0.id) && $0.isDirty
+            }
+            for tab in currentDirtyTabs {
                 guard let index = tabManager.tabs.firstIndex(where: { $0.id == tab.id }) else { continue }
-                let didSave = saveTab?(index) ?? tabManager.saveTabSync(at: index)
+                let didSave: Bool
+                if let saveTab {
+                    didSave = await saveTab(index)
+                } else {
+                    didSave = await tabManager.saveTab(at: index, context: context)
+                }
                 guard didSave else { return false }
+            }
+            // A previously saved target can be edited again while a later
+            // save or error sheet is suspended. Do not force-close it.
+            guard !tabManager.tabs.contains(where: {
+                targetTabIDs.contains($0.id) && $0.isDirty
+            }) else {
+                return false
             }
             Task { await gitProvider.refreshAsync() }
             return true
         case .alertSecondButtonReturn:
+            // Do not apply "Don't Save" to a new or changed dirty buffer that
+            // was not represented by the sheet the user answered.
+            let currentDirtyTabs = tabManager.tabs.filter {
+                targetTabIDs.contains($0.id) && $0.isDirty
+            }
+            guard currentDirtyTabs.allSatisfy({
+                displayedDirtyContent[$0.id] == $0.content
+            }) else {
+                return false
+            }
             return true
         default:
             return false
@@ -112,10 +196,15 @@ enum TabCloseHelper {
         keeping tabID: UUID,
         in tabManager: TabManager,
         gitProvider: GitStatusProvider,
-        context: DialogPresentationContext = DialogPresenter.forKeyProject(),
+        context: DialogPresentationContext = .unscoped,
         presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil,
-        saveTab: ((Int) -> Bool)? = nil
+        saveTab: (@MainActor (Int) async -> Bool)? = nil
     ) async -> Bool {
+        let targetTabIDs = Set(
+            tabManager.tabs
+                .filter { $0.id != tabID && !$0.isPinned }
+                .map(\.id)
+        )
         let dirty = tabManager.dirtyTabsForCloseOthers(keeping: tabID)
         guard await confirmBulkClose(
             dirtyTabs: dirty,
@@ -123,9 +212,14 @@ enum TabCloseHelper {
             gitProvider: gitProvider,
             context: context,
             presentAlert: presentAlert,
-            saveTab: saveTab
+            saveTab: saveTab,
+            targetTabIDs: targetTabIDs
         ) else { return false }
-        tabManager.closeOtherTabs(keeping: tabID, force: true)
+        guard tabManager.tabs.contains(where: { $0.id == tabID }) else {
+            return false
+        }
+        closeTabs(withIDs: targetTabIDs, in: tabManager)
+        tabManager.activeTabID = tabID
         return true
     }
 
@@ -136,10 +230,20 @@ enum TabCloseHelper {
         of tabID: UUID,
         in tabManager: TabManager,
         gitProvider: GitStatusProvider,
-        context: DialogPresentationContext = DialogPresenter.forKeyProject(),
+        context: DialogPresentationContext = .unscoped,
         presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil,
-        saveTab: ((Int) -> Bool)? = nil
+        saveTab: (@MainActor (Int) async -> Bool)? = nil
     ) async -> Bool {
+        let targetTabIDs: Set<UUID>
+        if let index = tabManager.tabs.firstIndex(where: { $0.id == tabID }) {
+            targetTabIDs = Set(
+                tabManager.tabs[(index + 1)...]
+                    .filter { !$0.isPinned }
+                    .map(\.id)
+            )
+        } else {
+            targetTabIDs = []
+        }
         let dirty = tabManager.dirtyTabsForCloseRight(of: tabID)
         guard await confirmBulkClose(
             dirtyTabs: dirty,
@@ -147,9 +251,13 @@ enum TabCloseHelper {
             gitProvider: gitProvider,
             context: context,
             presentAlert: presentAlert,
-            saveTab: saveTab
+            saveTab: saveTab,
+            targetTabIDs: targetTabIDs
         ) else { return false }
-        tabManager.closeTabsToTheRight(of: tabID, force: true)
+        guard tabManager.tabs.contains(where: { $0.id == tabID }) else {
+            return false
+        }
+        closeTabs(withIDs: targetTabIDs, in: tabManager)
         return true
     }
 
@@ -159,10 +267,11 @@ enum TabCloseHelper {
     static func closeAllTabs(
         in tabManager: TabManager,
         gitProvider: GitStatusProvider,
-        context: DialogPresentationContext = DialogPresenter.forKeyProject(),
+        context: DialogPresentationContext = .unscoped,
         presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil,
-        saveTab: ((Int) -> Bool)? = nil
+        saveTab: (@MainActor (Int) async -> Bool)? = nil
     ) async -> Bool {
+        let targetTabIDs = Set(tabManager.tabs.map(\.id))
         let dirty = tabManager.dirtyTabsForCloseAll()
         guard await confirmBulkClose(
             dirtyTabs: dirty,
@@ -170,10 +279,23 @@ enum TabCloseHelper {
             gitProvider: gitProvider,
             context: context,
             presentAlert: presentAlert,
-            saveTab: saveTab
+            saveTab: saveTab,
+            targetTabIDs: targetTabIDs
         ) else { return false }
-        tabManager.closeAllTabs(force: true)
+        // A tab created while the sheet was visible was not part of this
+        // close authorization and must survive.
+        closeTabs(withIDs: targetTabIDs, in: tabManager)
         return true
+    }
+
+    private static func closeTabs(
+        withIDs tabIDs: Set<UUID>,
+        in tabManager: TabManager
+    ) {
+        tabManager.tabs
+            .filter { tabIDs.contains($0.id) }
+            .map(\.id)
+            .forEach { tabManager.closeTab(id: $0, force: true) }
     }
 
     // MARK: - Terminal foreground-process confirmation
@@ -192,17 +314,21 @@ enum TabCloseHelper {
     ///     or the user confirmed. `false` to abort the stop/close.
     static func confirmTerminalStop(
         hasForegroundProcess: Bool,
-        context: DialogPresentationContext = DialogPresenter.forKeyProject(),
-        presentAlert: @MainActor () async -> NSApplication.ModalResponse = {
-            await AlertTemplate.terminalTabCloseWarning.runSheet(
-                on: DialogPresenter.forKeyProject(),
+        context: DialogPresentationContext = .unscoped,
+        presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil
+    ) async -> Bool {
+        guard hasForegroundProcess else { return true }
+        let response: NSApplication.ModalResponse
+        if let presentAlert {
+            response = await presentAlert()
+        } else {
+            response = await AlertTemplate.terminalTabCloseWarning.runSheet(
+                on: context,
                 messageText: Strings.terminalTabCloseWarningTitle,
                 informativeText: Strings.terminalTabCloseWarningMessage
             )
         }
-    ) async -> Bool {
-        guard hasForegroundProcess else { return true }
-        return await presentAlert() == .alertFirstButtonReturn
+        return response == .alertFirstButtonReturn
     }
 
     /// Convenience overload that checks the foreground-process predicate on
@@ -217,19 +343,39 @@ enum TabCloseHelper {
     ///     user confirmed. `false` to abort.
     static func confirmTerminalProcessStop(
         tabs: [TerminalTab],
-        context: DialogPresentationContext = DialogPresenter.forKeyProject(),
-        presentAlert: @MainActor () async -> NSApplication.ModalResponse = {
-            await AlertTemplate.terminalTabCloseWarning.runSheet(
-                on: DialogPresenter.forKeyProject(),
-                messageText: Strings.terminalTabCloseWarningTitle,
-                informativeText: Strings.terminalTabCloseWarningMessage
-            )
-        }
+        context: DialogPresentationContext = .unscoped,
+        presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil
     ) async -> Bool {
-        await confirmTerminalStop(
-            hasForegroundProcess: tabs.contains { $0.hasForegroundProcess },
+        let authorizedProcesses = foregroundProcessSnapshot(for: tabs)
+        guard !authorizedProcesses.isEmpty else { return true }
+        guard await confirmTerminalStop(
+            hasForegroundProcess: true,
             context: context,
             presentAlert: presentAlert
-        )
+        ) else {
+            return false
+        }
+        return foregroundProcessSnapshot(for: tabs)
+            .isSubset(of: authorizedProcesses)
+    }
+
+    static func foregroundProcessSnapshot(
+        for tabs: [TerminalTab]
+    ) -> Set<TerminalForegroundProcessIdentity> {
+        Set(tabs.compactMap { tab in
+            let processGroupID = tab.foregroundProcessID
+            guard processGroupID > 0 else { return nil }
+            return TerminalForegroundProcessIdentity(
+                tabID: tab.id,
+                processGroupID: processGroupID
+            )
+        })
+    }
+
+    nonisolated static func foregroundProcessSnapshotIsAuthorized(
+        _ current: Set<TerminalForegroundProcessIdentity>,
+        by authorized: Set<TerminalForegroundProcessIdentity>
+    ) -> Bool {
+        current.isSubset(of: authorized)
     }
 }

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -16,7 +16,7 @@ import AppKit
 /// Exact foreground job identity covered by a destructive terminal prompt.
 /// A new process group in the same terminal tab is a new authorization
 /// generation and must not be covered by the previous answer.
-struct TerminalForegroundProcessIdentity: Hashable, Sendable {
+nonisolated struct TerminalForegroundProcessIdentity: Hashable, Sendable {
     let tabID: UUID
     let processGroupID: Int32
 }
@@ -62,6 +62,10 @@ enum TabCloseHelper {
         } else {
             response = await AlertTemplate.unsavedChangesSingle.runSheet(
                 on: context,
+                deduplicationKey: .editorTabs(
+                    tabManager: ObjectIdentifier(tabManager),
+                    tabIDs: [tabID]
+                ),
                 messageText: Strings.unsavedChangesTitle,
                 informativeText: Strings.unsavedChangesMessage
             )
@@ -141,6 +145,10 @@ enum TabCloseHelper {
         } else {
             response = await AlertTemplate.unsavedChangesBulk.runSheet(
                 on: context,
+                deduplicationKey: .editorTabs(
+                    tabManager: ObjectIdentifier(tabManager),
+                    tabIDs: targetTabIDs
+                ),
                 messageText: Strings.unsavedChangesTitle,
                 informativeText: Strings.unsavedChangesListMessage(fileList)
             )
@@ -315,6 +323,7 @@ enum TabCloseHelper {
     static func confirmTerminalStop(
         hasForegroundProcess: Bool,
         context: DialogPresentationContext = .unscoped,
+        deduplicationKey: DialogRequestKey? = nil,
         presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil
     ) async -> Bool {
         guard hasForegroundProcess else { return true }
@@ -324,6 +333,7 @@ enum TabCloseHelper {
         } else {
             response = await AlertTemplate.terminalTabCloseWarning.runSheet(
                 on: context,
+                deduplicationKey: deduplicationKey,
                 messageText: Strings.terminalTabCloseWarningTitle,
                 informativeText: Strings.terminalTabCloseWarningMessage
             )
@@ -351,6 +361,10 @@ enum TabCloseHelper {
         guard await confirmTerminalStop(
             hasForegroundProcess: true,
             context: context,
+            deduplicationKey: .terminalTabs(
+                tabIDs: Set(tabs.map(\.id)),
+                foregroundProcesses: authorizedProcesses
+            ),
             presentAlert: presentAlert
         ) else {
             return false

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -77,6 +77,18 @@ final class TabManager {
         }
     }
 
+    /// Result of the deliberately narrow crash-recovery append path.
+    ///
+    /// Normal opens preserve the pane-local one-file/one-tab invariant.
+    /// Recovery is the sole exception: it must keep an already-open buffer
+    /// untouched while exposing a second, independently identified buffer
+    /// for the same URL.
+    enum RecoveryAppendResult: Equatable {
+        case appended(tabID: UUID)
+        case capacityReached
+        case sourceMissing
+    }
+
     private static let logger = Logger.editor
 
     nonisolated static let maxTabs = 1_000
@@ -355,6 +367,51 @@ final class TabManager {
         case .cancel:
             return .cancelled
         }
+    }
+
+    /// Whether recovery can keep the disk/current buffer and append a
+    /// separately identified recovered buffer without exceeding `maxTabs`.
+    ///
+    /// A URL that is not open yet needs two slots: the ordinary open supplies
+    /// the baseline buffer and ``appendRecoveredTab`` supplies the crash
+    /// buffer. An already-open URL needs only the latter.
+    func canRestoreRecoveryEntry(for url: URL) -> Bool {
+        let hasBaseline = tabs.contains(where: { $0.url == url })
+        let requiredSlots = hasBaseline ? 1 : 2
+        return tabs.count <= Self.maxTabs - requiredSlots
+    }
+
+    /// Appends recovered content as a new tab while preserving the source tab
+    /// exactly as it was. This is intentionally not part of the ordinary open
+    /// path: duplicate URLs inside one pane are allowed only when retaining
+    /// divergent crash-recovery buffers would otherwise lose user data.
+    ///
+    /// `savedContent` and file metadata come from the source tab, so dirty
+    /// state is computed against the same baseline that the user can inspect
+    /// in the separately retained source tab.
+    func appendRecoveredTab(
+        basedOn sourceTabID: UUID,
+        content: String,
+        encoding: String.Encoding
+    ) -> RecoveryAppendResult {
+        guard tabs.count < Self.maxTabs else {
+            return .capacityReached
+        }
+        guard let source = tabs.first(where: { $0.id == sourceTabID }) else {
+            return .sourceMissing
+        }
+
+        var recovered = EditorTab.reidentified(from: source)
+        recovered.kind = .text
+        recovered.content = content
+        recovered.encoding = encoding
+        recovered.cachedHighlightResult = nil
+        recovered.isPinned = false
+        recovered.isTransientPreview = false
+        recovered.recomputeContentCaches()
+        tabs.append(recovered)
+        activeTabID = recovered.id
+        return .appended(tabID: recovered.id)
     }
 
     // MARK: - Transient preview tabs

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -61,6 +61,21 @@ final class TabManager {
         _ messageText: String,
         _ informativeText: String
     ) async -> NSApplication.ModalResponse
+    typealias OpenCompletion = @MainActor (OpenRequestResult) -> Void
+
+    /// Immediate state returned by an open request. Large-file decisions are
+    /// reported as ``pending`` and later deliver one terminal result through
+    /// `OpenCompletion`; ordinary opens deliver their terminal result both
+    /// synchronously and through the completion.
+    enum OpenRequestResult: Equatable {
+        case opened(tabID: UUID)
+        case pending
+        case cancelled
+
+        var wasAccepted: Bool {
+            self != .cancelled
+        }
+    }
 
     private static let logger = Logger.editor
 
@@ -122,7 +137,41 @@ final class TabManager {
         )
     }
     @ObservationIgnored
-    private var pendingLargeFileOpenIntents: [URL: LargeFileOpenIntent] = [:]
+    private var pendingLargeFileOpens: [URL: PendingLargeFileOpen] = [:]
+
+    private final class PendingLargeFileOpen {
+        var intent: LargeFileOpenIntent
+        var completions: [OpenCompletion]
+        private var didComplete = false
+
+        init(
+            intent: LargeFileOpenIntent,
+            completions: [OpenCompletion]
+        ) {
+            self.intent = intent
+            self.completions = completions
+        }
+
+        func merge(
+            intent newerIntent: LargeFileOpenIntent,
+            completion: OpenCompletion?
+        ) {
+            intent = intent.merging(newerIntent)
+            if let completion {
+                completions.append(completion)
+            }
+        }
+
+        func complete(with result: OpenRequestResult) {
+            guard !didComplete else { return }
+            didComplete = true
+            let completions = completions
+            self.completions.removeAll()
+            for completion in completions {
+                completion(result)
+            }
+        }
+    }
 
     private enum LargeFileOpenIntent {
         case regular(location: EditorNavigationLocation?)
@@ -199,74 +248,88 @@ final class TabManager {
 
     // MARK: - Open
 
+    @discardableResult
     func openTab(
         url: URL,
-        context: DialogPresentationContext? = nil
-    ) {
-        openTab(
+        context: DialogPresentationContext? = nil,
+        completion: OpenCompletion? = nil
+    ) -> OpenRequestResult {
+        return openTab(
             url: url,
             location: nil,
-            context: context ?? dialogContextProvider()
+            context: context ?? dialogContextProvider(),
+            completion: completion
         )
     }
 
+    @discardableResult
     func openTabAndGoToLine(
         url: URL,
         line: Int,
-        context: DialogPresentationContext? = nil
-    ) {
-        openTabAndGoToLocation(
+        context: DialogPresentationContext? = nil,
+        completion: OpenCompletion? = nil
+    ) -> OpenRequestResult {
+        return openTabAndGoToLocation(
             url: url,
             line: line,
             column: nil,
-            context: context
+            context: context,
+            completion: completion
         )
     }
 
+    @discardableResult
     func openTabAndGoToLocation(
         url: URL,
         line: Int,
         column: Int?,
-        context: DialogPresentationContext? = nil
-    ) {
+        context: DialogPresentationContext? = nil,
+        completion: OpenCompletion? = nil
+    ) -> OpenRequestResult {
         // A new navigation request supersedes any not-yet-consumed route for
         // the currently active tab. Install the destination only after the
         // file actually opens, including after a large-file decision.
         pendingGoToLocation = nil
-        openTab(
+        return openTab(
             url: url,
             location: EditorNavigationLocation(
                 line: line,
                 column: column
             ),
-            context: context ?? dialogContextProvider()
+            context: context ?? dialogContextProvider(),
+            completion: completion
         )
     }
 
+    @discardableResult
     private func openTab(
         url: URL,
         location: EditorNavigationLocation?,
-        context: DialogPresentationContext
-    ) {
+        context: DialogPresentationContext,
+        completion: OpenCompletion?
+    ) -> OpenRequestResult {
         guard TabPersistence.requiresLargeFileDecision(
             url: url,
             existingTabs: tabs,
             syntaxHighlightingDisabled: nil
         ) else {
-            if applyOpenDecision(TabPersistence.resolveOpen(
+            let result = applyOpenDecision(TabPersistence.resolveOpen(
                 url: url,
                 existingTabs: tabs,
                 syntaxHighlightingDisabled: nil
-            )), let location {
+            ))
+            if case .opened = result, let location {
                 pendingGoToLocation = location
             }
-            return
+            completion?(result)
+            return result
         }
 
-        requestLargeFileOpen(
+        return requestLargeFileOpen(
             url: url,
             intent: .regular(location: location),
-            context: context
+            context: context,
+            completion: completion
         )
     }
 
@@ -275,20 +338,22 @@ final class TabManager {
     }
 
     @discardableResult
-    private func applyOpenDecision(_ decision: TabPersistence.OpenDecision) -> Bool {
+    private func applyOpenDecision(
+        _ decision: TabPersistence.OpenDecision
+    ) -> OpenRequestResult {
         switch decision {
         case .activateExisting(let id):
             // A normal open is explicit. If the file was previously shown as
             // a transient preview, opening it normally promotes it in place.
             promoteTransientPreview(tabID: id)
             activeTabID = id
-            return true
+            return .opened(tabID: id)
         case .openNew(let tab):
             tabs.append(tab)
             activeTabID = tab.id
-            return true
+            return .opened(tabID: tab.id)
         case .cancel:
-            return false
+            return .cancelled
         }
     }
 
@@ -302,16 +367,20 @@ final class TabManager {
     ///
     /// Promotion triggers (defined in ``promoteTransientPreview``) upgrade a
     /// transient preview to a permanent tab.
+    @discardableResult
     func openTabAsPreview(
         url: URL,
-        context: DialogPresentationContext? = nil
-    ) {
+        context: DialogPresentationContext? = nil,
+        completion: OpenCompletion? = nil
+    ) -> OpenRequestResult {
         let context = context ?? dialogContextProvider()
         // If the file is already open as a permanent tab, just activate it.
         if let existing = tabs.first(where: { $0.url.standardizedFileURL == url.standardizedFileURL }),
            !existing.isTransientPreview {
             activeTabID = existing.id
-            return
+            let result = OpenRequestResult.opened(tabID: existing.id)
+            completion?(result)
+            return result
         }
 
         guard TabPersistence.requiresLargeFileDecision(
@@ -319,33 +388,45 @@ final class TabManager {
             existingTabs: tabs,
             syntaxHighlightingDisabled: nil
         ) else {
-            applyPreviewOpenDecision(TabPersistence.resolveOpen(
+            let result = applyPreviewOpenDecision(TabPersistence.resolveOpen(
                 url: url,
                 existingTabs: tabs,
                 syntaxHighlightingDisabled: nil
             ))
-            return
+            completion?(result)
+            return result
         }
 
-        requestLargeFileOpen(url: url, intent: .preview, context: context)
+        return requestLargeFileOpen(
+            url: url,
+            intent: .preview,
+            context: context,
+            completion: completion
+        )
     }
 
+    @discardableResult
     private func requestLargeFileOpen(
         url: URL,
         intent: LargeFileOpenIntent,
-        context: DialogPresentationContext
-    ) {
+        context: DialogPresentationContext,
+        completion: OpenCompletion?
+    ) -> OpenRequestResult {
         let requestURL = url.standardizedFileURL
-        if let pendingIntent = pendingLargeFileOpenIntents[requestURL] {
-            pendingLargeFileOpenIntents[requestURL] = pendingIntent.merging(intent)
-            return
+        if let pendingOpen = pendingLargeFileOpens[requestURL] {
+            pendingOpen.merge(intent: intent, completion: completion)
+            return .pending
         }
-        pendingLargeFileOpenIntents[requestURL] = intent
+        let pendingOpen = PendingLargeFileOpen(
+            intent: intent,
+            completions: completion.map { [$0] } ?? []
+        )
+        pendingLargeFileOpens[requestURL] = pendingOpen
 
         let sizeMB = Double(TabPersistence.fileSize(url: url) ?? 0)
             / Double(FileSizeConstants.oneMB)
         let presentAlert = largeFileAlertPresenter
-        Task { @MainActor [weak self] in
+        Task { @MainActor [weak self, pendingOpen] in
             let response = await presentAlert(
                 context,
                 Strings.largeFileWarningTitle,
@@ -354,33 +435,45 @@ final class TabManager {
                     sizeMB
                 )
             )
-            guard let self else { return }
-            guard let resolvedIntent = pendingLargeFileOpenIntents.removeValue(
-                forKey: requestURL
-            ) else { return }
+            guard let self else {
+                pendingOpen.complete(with: .cancelled)
+                return
+            }
+            guard pendingLargeFileOpens[requestURL] === pendingOpen else {
+                pendingOpen.complete(with: .cancelled)
+                return
+            }
+            pendingLargeFileOpens.removeValue(forKey: requestURL)
             let decision = TabPersistence.resolveOpen(
                 url: url,
                 existingTabs: tabs,
                 syntaxHighlightingDisabled: nil,
                 largeFileDecision: TabPersistence.largeFileDecision(for: response)
             )
-            switch resolvedIntent {
+            let result: OpenRequestResult
+            switch pendingOpen.intent {
             case .regular(let location):
-                if applyOpenDecision(decision), let location {
+                result = applyOpenDecision(decision)
+                if case .opened = result, let location {
                     pendingGoToLocation = location
                 }
             case .preview:
-                applyPreviewOpenDecision(decision)
+                result = applyPreviewOpenDecision(decision)
             }
+            pendingOpen.complete(with: result)
         }
+        return .pending
     }
 
-    private func applyPreviewOpenDecision(_ decision: TabPersistence.OpenDecision) {
+    private func applyPreviewOpenDecision(
+        _ decision: TabPersistence.OpenDecision
+    ) -> OpenRequestResult {
         switch decision {
         case .activateExisting(let id):
             activeTabID = id
+            return .opened(tabID: id)
         case .cancel:
-            break
+            return .cancelled
         case .openNew(var tab):
             tab.isTransientPreview = true
             // Replacement is pane-scoped, not selection-scoped. A user may
@@ -392,6 +485,7 @@ final class TabManager {
                 tabs.append(tab)
             }
             activeTabID = tab.id
+            return .opened(tabID: tab.id)
         }
     }
 

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -319,7 +319,7 @@ final class TabManager {
     func saveActiveTab() -> Bool {
         guard let index = activeTabIndex else { return false }
         cancelAutoSave(for: tabs[index].id)
-        return saveTab(at: index)
+        return saveTabSync(at: index)
     }
 
     @discardableResult
@@ -350,8 +350,27 @@ final class TabManager {
     }
 
     @discardableResult
-    func saveTab(at index: Int) -> Bool {
+    func saveTab(at index: Int, context: DialogPresentationContext = .unscoped) {
         assert(tabs.indices.contains(index), "saveTab: index \(index) out of bounds, count \(tabs.count)")
+        do {
+            _ = try trySaveTab(at: index)
+        } catch {
+            Task { @MainActor in
+                _ = await AlertTemplate.fileOperationErrorCritical.runSheet(
+                    on: context,
+                    messageText: Strings.fileOperationErrorTitle,
+                    informativeText: error.localizedDescription
+                )
+            }
+        }
+    }
+
+    /// Synchronous save used by flows that are already inside an `inout`
+    /// scope or otherwise cannot await. Falls back to application-modal
+    /// `runModal()` for the error alert.
+    @discardableResult
+    func saveTabSync(at index: Int) -> Bool {
+        assert(tabs.indices.contains(index), "saveTabSync: index \(index) out of bounds, count \(tabs.count)")
         do {
             return try trySaveTab(at: index)
         } catch {
@@ -367,6 +386,9 @@ final class TabManager {
         for index in tabs.indices where tabs[index].isDirty { try trySaveTab(at: index) }
     }
 
+    /// Synchronous save-all. The error alert uses `runModal()` because the
+    /// callers (quit/window-close flows) run synchronously under
+    /// `applicationShouldTerminate` / `windowShouldClose`, which cannot await.
     @discardableResult
     func saveAllTabs() -> Bool {
         do { try trySaveAllTabs(); return true } catch {
@@ -608,9 +630,13 @@ final class TabManager {
     @discardableResult
     func duplicateActiveTab(projectRoot: URL? = nil) -> Bool {
         do { return try tryDuplicateActiveTab(projectRoot: projectRoot) } catch {
-            AlertTemplate.fileOperationErrorCritical.runModal(
-                messageText: Strings.fileOperationErrorTitle, informativeText: error.localizedDescription
-            )
+            Task { @MainActor in
+                _ = await AlertTemplate.fileOperationErrorCritical.runSheet(
+                    on: DialogPresenter.forKeyProject(),
+                    messageText: Strings.fileOperationErrorTitle,
+                    informativeText: error.localizedDescription
+                )
+            }
             return false
         }
     }

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -5,6 +5,7 @@
 //  Created by Pine Team on 12.03.2026.
 //
 
+import AppKit
 import os
 import SwiftUI
 
@@ -13,6 +14,33 @@ import SwiftUI
 nonisolated struct EditorNavigationLocation: Equatable, Sendable {
     let line: Int
     let column: Int?
+}
+
+/// Exact authorization captured by a dialog that displayed dirty editor
+/// buffers. It deliberately records only buffers that were dirty at capture
+/// time: a formerly clean tab that becomes dirty while a sheet is visible is
+/// therefore absent and fails validation.
+struct DirtyEditorContentAuthorization: Equatable {
+    private(set) var contentByTabID: [UUID: String]
+
+    init(tabs: [EditorTab]) {
+        contentByTabID = Dictionary(
+            tabs.lazy
+                .filter(\.isDirty)
+                .map { ($0.id, $0.content) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+    }
+
+    func covers(_ currentDirtyTabs: [EditorTab]) -> Bool {
+        currentDirtyTabs.allSatisfy {
+            contentByTabID[$0.id] == $0.content
+        }
+    }
+
+    var isEmpty: Bool {
+        contentByTabID.isEmpty
+    }
 }
 
 /// Manages the set of open editor tabs and the active selection.
@@ -28,6 +56,12 @@ nonisolated struct EditorNavigationLocation: Equatable, Sendable {
 @MainActor
 @Observable
 final class TabManager {
+    typealias LargeFileAlertPresenter = @MainActor (
+        _ context: DialogPresentationContext,
+        _ messageText: String,
+        _ informativeText: String
+    ) async -> NSApplication.ModalResponse
+
     private static let logger = Logger.editor
 
     nonisolated static let maxTabs = 1_000
@@ -72,6 +106,41 @@ final class TabManager {
     var onActiveTabChanged: ((UUID?) -> Void)?
     var editorSettings: EditorSettings = .shared
     var fileFormatters: FileFormatterRegistry = .default
+    /// Project wiring replaces this fallback for every pane-owned manager,
+    /// so model-triggered large-file and error flows do not depend on which
+    /// unrelated window happens to be key.
+    @ObservationIgnored
+    var dialogContextProvider: @MainActor () -> DialogPresentationContext = {
+        .unscoped
+    }
+    @ObservationIgnored
+    var largeFileAlertPresenter: LargeFileAlertPresenter = { context, messageText, informativeText in
+        await AlertTemplate.largeFileWarning.runSheet(
+            on: context,
+            messageText: messageText,
+            informativeText: informativeText
+        )
+    }
+    @ObservationIgnored
+    private var pendingLargeFileOpenIntents: [URL: LargeFileOpenIntent] = [:]
+
+    private enum LargeFileOpenIntent {
+        case regular(location: EditorNavigationLocation?)
+        case preview
+
+        func merging(_ newer: LargeFileOpenIntent) -> LargeFileOpenIntent {
+            switch (self, newer) {
+            case (.regular(let existingLocation), .regular(let newerLocation)):
+                return .regular(location: newerLocation ?? existingLocation)
+            case (.preview, .regular):
+                return newer
+            case (.regular, .preview):
+                return self
+            case (.preview, .preview):
+                return .preview
+            }
+        }
+    }
 
     // MARK: - Computed
 
@@ -130,23 +199,74 @@ final class TabManager {
 
     // MARK: - Open
 
-    func openTab(url: URL) {
-        applyOpenDecision(TabPersistence.resolveOpen(url: url, existingTabs: tabs, syntaxHighlightingDisabled: nil))
+    func openTab(
+        url: URL,
+        context: DialogPresentationContext? = nil
+    ) {
+        openTab(
+            url: url,
+            location: nil,
+            context: context ?? dialogContextProvider()
+        )
     }
 
-    func openTabAndGoToLine(url: URL, line: Int) {
-        openTabAndGoToLocation(url: url, line: line, column: nil)
+    func openTabAndGoToLine(
+        url: URL,
+        line: Int,
+        context: DialogPresentationContext? = nil
+    ) {
+        openTabAndGoToLocation(
+            url: url,
+            line: line,
+            column: nil,
+            context: context
+        )
     }
 
     func openTabAndGoToLocation(
         url: URL,
         line: Int,
-        column: Int?
+        column: Int?,
+        context: DialogPresentationContext? = nil
     ) {
-        openTab(url: url)
-        pendingGoToLocation = EditorNavigationLocation(
-            line: line,
-            column: column
+        // A new navigation request supersedes any not-yet-consumed route for
+        // the currently active tab. Install the destination only after the
+        // file actually opens, including after a large-file decision.
+        pendingGoToLocation = nil
+        openTab(
+            url: url,
+            location: EditorNavigationLocation(
+                line: line,
+                column: column
+            ),
+            context: context ?? dialogContextProvider()
+        )
+    }
+
+    private func openTab(
+        url: URL,
+        location: EditorNavigationLocation?,
+        context: DialogPresentationContext
+    ) {
+        guard TabPersistence.requiresLargeFileDecision(
+            url: url,
+            existingTabs: tabs,
+            syntaxHighlightingDisabled: nil
+        ) else {
+            if applyOpenDecision(TabPersistence.resolveOpen(
+                url: url,
+                existingTabs: tabs,
+                syntaxHighlightingDisabled: nil
+            )), let location {
+                pendingGoToLocation = location
+            }
+            return
+        }
+
+        requestLargeFileOpen(
+            url: url,
+            intent: .regular(location: location),
+            context: context
         )
     }
 
@@ -154,15 +274,21 @@ final class TabManager {
         applyOpenDecision(TabPersistence.resolveOpen(url: url, existingTabs: tabs, syntaxHighlightingDisabled: syntaxHighlightingDisabled))
     }
 
-    private func applyOpenDecision(_ decision: TabPersistence.OpenDecision) {
+    @discardableResult
+    private func applyOpenDecision(_ decision: TabPersistence.OpenDecision) -> Bool {
         switch decision {
         case .activateExisting(let id):
             // A normal open is explicit. If the file was previously shown as
             // a transient preview, opening it normally promotes it in place.
             promoteTransientPreview(tabID: id)
             activeTabID = id
-        case .openNew(let tab): tabs.append(tab); activeTabID = tab.id
-        case .cancel: break
+            return true
+        case .openNew(let tab):
+            tabs.append(tab)
+            activeTabID = tab.id
+            return true
+        case .cancel:
+            return false
         }
     }
 
@@ -176,7 +302,11 @@ final class TabManager {
     ///
     /// Promotion triggers (defined in ``promoteTransientPreview``) upgrade a
     /// transient preview to a permanent tab.
-    func openTabAsPreview(url: URL) {
+    func openTabAsPreview(
+        url: URL,
+        context: DialogPresentationContext? = nil
+    ) {
+        let context = context ?? dialogContextProvider()
         // If the file is already open as a permanent tab, just activate it.
         if let existing = tabs.first(where: { $0.url.standardizedFileURL == url.standardizedFileURL }),
            !existing.isTransientPreview {
@@ -184,7 +314,68 @@ final class TabManager {
             return
         }
 
-        let decision = TabPersistence.resolveOpen(url: url, existingTabs: tabs, syntaxHighlightingDisabled: nil)
+        guard TabPersistence.requiresLargeFileDecision(
+            url: url,
+            existingTabs: tabs,
+            syntaxHighlightingDisabled: nil
+        ) else {
+            applyPreviewOpenDecision(TabPersistence.resolveOpen(
+                url: url,
+                existingTabs: tabs,
+                syntaxHighlightingDisabled: nil
+            ))
+            return
+        }
+
+        requestLargeFileOpen(url: url, intent: .preview, context: context)
+    }
+
+    private func requestLargeFileOpen(
+        url: URL,
+        intent: LargeFileOpenIntent,
+        context: DialogPresentationContext
+    ) {
+        let requestURL = url.standardizedFileURL
+        if let pendingIntent = pendingLargeFileOpenIntents[requestURL] {
+            pendingLargeFileOpenIntents[requestURL] = pendingIntent.merging(intent)
+            return
+        }
+        pendingLargeFileOpenIntents[requestURL] = intent
+
+        let sizeMB = Double(TabPersistence.fileSize(url: url) ?? 0)
+            / Double(FileSizeConstants.oneMB)
+        let presentAlert = largeFileAlertPresenter
+        Task { @MainActor [weak self] in
+            let response = await presentAlert(
+                context,
+                Strings.largeFileWarningTitle,
+                Strings.largeFileWarningMessage(
+                    url.lastPathComponent,
+                    sizeMB
+                )
+            )
+            guard let self else { return }
+            guard let resolvedIntent = pendingLargeFileOpenIntents.removeValue(
+                forKey: requestURL
+            ) else { return }
+            let decision = TabPersistence.resolveOpen(
+                url: url,
+                existingTabs: tabs,
+                syntaxHighlightingDisabled: nil,
+                largeFileDecision: TabPersistence.largeFileDecision(for: response)
+            )
+            switch resolvedIntent {
+            case .regular(let location):
+                if applyOpenDecision(decision), let location {
+                    pendingGoToLocation = location
+                }
+            case .preview:
+                applyPreviewOpenDecision(decision)
+            }
+        }
+    }
+
+    private func applyPreviewOpenDecision(_ decision: TabPersistence.OpenDecision) {
         switch decision {
         case .activateExisting(let id):
             activeTabID = id
@@ -266,6 +457,42 @@ final class TabManager {
         tabs.filter { force || !$0.isDirty }.map(\.id).forEach { closeTab(id: $0, force: true) }
     }
 
+    /// Commits a previously authorized "Don't Save" decision without doing
+    /// file I/O. Validation happens before the first mutation so a new/edited
+    /// dirty buffer leaves the entire manager untouched.
+    @discardableResult
+    func discardChanges(
+        authorizedBy authorization: DirtyEditorContentAuthorization,
+        postReloads: Bool = true
+    ) -> Bool {
+        let currentDirtyTabs = tabs.filter(\.isDirty)
+        guard authorization.covers(currentDirtyTabs) else { return false }
+
+        var reloads: [ReloadedTab] = []
+        let authorizedExistingIDs = tabs.compactMap { tab in
+            authorization.contentByTabID[tab.id] == nil ? nil : tab.id
+        }
+        for index in tabs.indices where tabs[index].isDirty {
+            let tabID = tabs[index].id
+            cancelAutoSave(for: tabID)
+            tabs[index].content = tabs[index].savedContent
+            tabs[index].cachedHighlightResult = nil
+            tabs[index].recomputeContentCaches()
+            reloads.append(.init(
+                url: tabs[index].url,
+                text: tabs[index].savedContent
+            ))
+        }
+        for tabID in authorizedExistingIDs {
+            cancelAutoSave(for: tabID)
+            recoveryManager?.deleteRecoveryFile(for: tabID)
+        }
+        if postReloads {
+            postReloadNotifications(reloads)
+        }
+        return true
+    }
+
     // MARK: - Content updates
 
     func updateContent(_ newContent: String) {
@@ -319,7 +546,7 @@ final class TabManager {
     func saveActiveTab() -> Bool {
         guard let index = activeTabIndex else { return false }
         cancelAutoSave(for: tabs[index].id)
-        return saveTabSync(at: index)
+        return saveTab(at: index)
     }
 
     @discardableResult
@@ -349,33 +576,35 @@ final class TabManager {
         return outcome.saved
     }
 
+    /// Synchronous, UI-free save primitive used by autosave and tests.
+    ///
+    /// Errors are reported by the async window-scoped overload at user
+    /// interaction boundaries. Keeping this primitive UI-free prevents a
+    /// background/autosave failure from creating detached modal UI.
     @discardableResult
-    func saveTab(at index: Int, context: DialogPresentationContext = .unscoped) {
+    func saveTab(at index: Int) -> Bool {
         assert(tabs.indices.contains(index), "saveTab: index \(index) out of bounds, count \(tabs.count)")
-        do {
-            _ = try trySaveTab(at: index)
-        } catch {
-            Task { @MainActor in
-                _ = await AlertTemplate.fileOperationErrorCritical.runSheet(
-                    on: context,
-                    messageText: Strings.fileOperationErrorTitle,
-                    informativeText: error.localizedDescription
-                )
-            }
-        }
-    }
-
-    /// Synchronous save used by flows that are already inside an `inout`
-    /// scope or otherwise cannot await. Falls back to application-modal
-    /// `runModal()` for the error alert.
-    @discardableResult
-    func saveTabSync(at index: Int) -> Bool {
-        assert(tabs.indices.contains(index), "saveTabSync: index \(index) out of bounds, count \(tabs.count)")
         do {
             return try trySaveTab(at: index)
         } catch {
-            AlertTemplate.fileOperationErrorCritical.runModal(
-                messageText: Strings.fileOperationErrorTitle, informativeText: error.localizedDescription
+            return false
+        }
+    }
+
+    /// Saves and presents any failure on the captured project window.
+    @discardableResult
+    func saveTab(
+        at index: Int,
+        context: DialogPresentationContext
+    ) async -> Bool {
+        assert(tabs.indices.contains(index), "saveTab: index \(index) out of bounds, count \(tabs.count)")
+        do {
+            return try trySaveTab(at: index)
+        } catch {
+            _ = await AlertTemplate.fileOperationErrorCritical.runSheet(
+                on: context,
+                messageText: Strings.fileOperationErrorTitle,
+                informativeText: error.localizedDescription
             )
             return false
         }
@@ -386,14 +615,24 @@ final class TabManager {
         for index in tabs.indices where tabs[index].isDirty { try trySaveTab(at: index) }
     }
 
-    /// Synchronous save-all. The error alert uses `runModal()` because the
-    /// callers (quit/window-close flows) run synchronously under
-    /// `applicationShouldTerminate` / `windowShouldClose`, which cannot await.
+    /// Synchronous, UI-free save-all primitive.
     @discardableResult
     func saveAllTabs() -> Bool {
-        do { try trySaveAllTabs(); return true } catch {
-            AlertTemplate.fileOperationErrorCritical.runModal(
-                messageText: Strings.fileOperationErrorTitle, informativeText: error.localizedDescription
+        do { try trySaveAllTabs(); return true } catch { return false }
+    }
+
+    /// Save-all variant for close/termination flows. The first error is
+    /// presented as a sheet owned by the initiating project window.
+    @discardableResult
+    func saveAllTabs(context: DialogPresentationContext) async -> Bool {
+        do {
+            try trySaveAllTabs()
+            return true
+        } catch {
+            _ = await AlertTemplate.fileOperationErrorCritical.runSheet(
+                on: context,
+                messageText: Strings.fileOperationErrorTitle,
+                informativeText: error.localizedDescription
             )
             return false
         }
@@ -628,11 +867,15 @@ final class TabManager {
     }
 
     @discardableResult
-    func duplicateActiveTab(projectRoot: URL? = nil) -> Bool {
+    func duplicateActiveTab(
+        projectRoot: URL? = nil,
+        context: DialogPresentationContext? = nil
+    ) -> Bool {
+        let context = context ?? dialogContextProvider()
         do { return try tryDuplicateActiveTab(projectRoot: projectRoot) } catch {
             Task { @MainActor in
                 _ = await AlertTemplate.fileOperationErrorCritical.runSheet(
-                    on: DialogPresenter.forKeyProject(),
+                    on: context,
                     messageText: Strings.fileOperationErrorTitle,
                     informativeText: error.localizedDescription
                 )

--- a/Pine/Tabs/TabPersistence.swift
+++ b/Pine/Tabs/TabPersistence.swift
@@ -183,13 +183,17 @@ enum TabPersistence {
         case cancel
     }
 
-    /// Resolves what to do when opening a file: activate existing tab, create new, or cancel.
-    /// When `syntaxHighlightingDisabled` is nil, the large file alert is shown for large files.
-    /// When it's non-nil (session restore), the alert is skipped.
+    /// Resolves what to do when opening a file: activate existing tab, create
+    /// new, or cancel. For an interactive large-file open, the caller first
+    /// presents the window-owned warning and supplies `largeFileDecision`.
+    /// A missing decision fails closed. A non-nil
+    /// `syntaxHighlightingDisabled` is a restored-session decision and skips
+    /// the warning.
     static func resolveOpen(
         url: URL,
         existingTabs: [EditorTab],
-        syntaxHighlightingDisabled: Bool?
+        syntaxHighlightingDisabled: Bool?,
+        largeFileDecision: LargeFileAlertResult? = nil
     ) -> OpenDecision {
         if let existing = existingTabs.first(where: { $0.url == url }) {
             return .activateExisting(existing.id)
@@ -204,9 +208,11 @@ enum TabPersistence {
         }
 
         // Only show large file alert when not restoring a session
-        if syntaxHighlightingDisabled == nil, let size = fileSize(url: url), size >= largeFileThreshold {
-            let sizeMB = Double(size) / Double(FileSizeConstants.oneMB)
-            switch showLargeFileAlert(fileName: url.lastPathComponent, sizeMB: sizeMB) {
+        if syntaxHighlightingDisabled == nil,
+           let size = fileSize(url: url),
+           size >= largeFileThreshold {
+            guard let largeFileDecision else { return .cancel }
+            switch largeFileDecision {
             case .cancel:
                 return .cancel
             case .openWithoutHighlighting:
@@ -219,22 +225,30 @@ enum TabPersistence {
         return .openNew(createTextTab(url: url, syntaxHighlightingDisabled: syntaxHighlightingDisabled ?? false))
     }
 
-    // MARK: - Save
+    // MARK: - Large-file decision
 
     /// Result of the large file warning alert.
-    enum LargeFileAlertResult {
+    enum LargeFileAlertResult: Equatable {
         case openWithHighlighting
         case openWithoutHighlighting
         case cancel
     }
 
-    /// Shows a warning alert for large files. Returns the user's choice.
-    @discardableResult
-    static func showLargeFileAlert(fileName: String, sizeMB: Double) -> LargeFileAlertResult {
-        let response = AlertTemplate.largeFileWarning.runModal(
-            messageText: Strings.largeFileWarningTitle,
-            informativeText: Strings.largeFileWarningMessage(fileName, sizeMB)
-        )
+    static func requiresLargeFileDecision(
+        url: URL,
+        existingTabs: [EditorTab],
+        syntaxHighlightingDisabled: Bool?
+    ) -> Bool {
+        guard syntaxHighlightingDisabled == nil,
+              !existingTabs.contains(where: { $0.url == url }),
+              !isPreviewFile(url: url),
+              let size = fileSize(url: url) else { return false }
+        return size >= largeFileThreshold && size < hugeFileThreshold
+    }
+
+    static func largeFileDecision(
+        for response: NSApplication.ModalResponse
+    ) -> LargeFileAlertResult {
         switch response {
         case .alertFirstButtonReturn:
             return .openWithoutHighlighting
@@ -244,6 +258,8 @@ enum TabPersistence {
             return .cancel
         }
     }
+
+    // MARK: - Save
 
     /// Saves tab content to disk.
     ///

--- a/Pine/TerminalPaneContent.swift
+++ b/Pine/TerminalPaneContent.swift
@@ -14,13 +14,15 @@ struct TerminalPaneContent: View {
     let terminalState: TerminalPaneState
     @Environment(PaneManager.self) private var paneManager
     @Environment(WorkspaceManager.self) private var workspace
+    @Environment(ProjectManager.self) private var projectManager
 
     var body: some View {
         VStack(spacing: 0) {
             TerminalPaneTabBar(
                 paneID: paneID,
                 terminalState: terminalState,
-                workingDirectory: workspace.rootURL
+                workingDirectory: workspace.rootURL,
+                projectManager: projectManager
             )
             TerminalSearchBarContainer(terminalState: terminalState)
             TerminalContentView(

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -39,11 +39,13 @@ struct TerminalPaneTabBar: View {
     }
 
     private func closeTerminalTabWithConfirmation(_ tab: TerminalTab) {
-        guard TabCloseHelper.confirmTerminalProcessStop(tabs: [tab]) else { return }
-        terminalState.removeTab(id: tab.id)
-        // Remove the pane if no tabs remain
-        if terminalState.terminalTabs.isEmpty {
-            paneManager.removePane(paneID)
+        Task { @MainActor in
+            guard await TabCloseHelper.confirmTerminalProcessStop(tabs: [tab]) else { return }
+            terminalState.removeTab(id: tab.id)
+            // Remove the pane if no tabs remain
+            if terminalState.terminalTabs.isEmpty {
+                paneManager.removePane(paneID)
+            }
         }
     }
 
@@ -319,15 +321,17 @@ struct TerminalPaneTabBar: View {
 
             // Close terminal pane
             Button {
-                // Warn if any tab has a foreground process
-                guard TabCloseHelper.confirmTerminalProcessStop(
-                    tabs: terminalState.terminalTabs
-                ) else { return }
-                // Stop all tabs and remove pane
-                for tab in terminalState.terminalTabs {
-                    tab.stop()
+                // Warn if any tab has a foreground process (window-scoped sheet, #1241)
+                Task { @MainActor in
+                    guard await TabCloseHelper.confirmTerminalProcessStop(
+                        tabs: terminalState.terminalTabs
+                    ) else { return }
+                    // Stop all tabs and remove pane
+                    for tab in terminalState.terminalTabs {
+                        tab.stop()
+                    }
+                    paneManager.removePane(paneID)
                 }
-                paneManager.removePane(paneID)
             } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 10, weight: .semibold))

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -13,6 +13,7 @@ struct TerminalPaneTabBar: View {
     let paneID: PaneID
     let terminalState: TerminalPaneState
     var workingDirectory: URL?
+    var projectManager: ProjectManager? = nil
     @Environment(PaneManager.self) private var paneManager
     @State private var tabFrames: [UUID: CGRect] = [:]
     @State private var autoScrollSession = TabStripAutoScrollSession()
@@ -39,8 +40,21 @@ struct TerminalPaneTabBar: View {
     }
 
     private func closeTerminalTabWithConfirmation(_ tab: TerminalTab) {
+        let context = if let projectManager {
+            DialogPresenter.forProject(projectManager)
+        } else {
+            DialogPresentationContext.unscoped
+        }
         Task { @MainActor in
-            guard await TabCloseHelper.confirmTerminalProcessStop(tabs: [tab]) else { return }
+            guard await TabCloseHelper.confirmTerminalProcessStop(
+                tabs: [tab],
+                context: context
+            ) else { return }
+            guard let currentTab = terminalState.terminalTabs.first(where: {
+                $0.id == tab.id
+            }), currentTab === tab else {
+                return
+            }
             terminalState.removeTab(id: tab.id)
             // Remove the pane if no tabs remain
             if terminalState.terminalTabs.isEmpty {
@@ -322,12 +336,37 @@ struct TerminalPaneTabBar: View {
             // Close terminal pane
             Button {
                 // Warn if any tab has a foreground process (window-scoped sheet, #1241)
+                let context = if let projectManager {
+                    DialogPresenter.forProject(projectManager)
+                } else {
+                    DialogPresentationContext.unscoped
+                }
+                let targetTabs = terminalState.terminalTabs
+                let targetTabIDs = Set(targetTabs.map(\.id))
+                let authorizedForegroundProcesses =
+                    TabCloseHelper.foregroundProcessSnapshot(
+                        for: targetTabs
+                    )
                 Task { @MainActor in
                     guard await TabCloseHelper.confirmTerminalProcessStop(
-                        tabs: terminalState.terminalTabs
+                        tabs: targetTabs,
+                        context: context
                     ) else { return }
+                    let currentTabs = terminalState.terminalTabs
+                    let currentTabIDs = Set(currentTabs.map(\.id))
+                    let currentForegroundProcesses =
+                        TabCloseHelper.foregroundProcessSnapshot(
+                            for: currentTabs
+                        )
+                    guard currentTabIDs.isSubset(of: targetTabIDs),
+                          TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
+                              currentForegroundProcesses,
+                              by: authorizedForegroundProcesses
+                          ) else {
+                        return
+                    }
                     // Stop all tabs and remove pane
-                    for tab in terminalState.terminalTabs {
+                    for tab in currentTabs {
                         tab.stop()
                     }
                     paneManager.removePane(paneID)

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -249,9 +249,14 @@ struct WelcomeView: View {
     }
 
     private func openFolder() {
-        if let url = registry.openProjectViaPanel() {
-            openProjectWindow(url)
-            closeWelcome()
+        let context = DialogPresenter.context(
+            for: appDelegate?.welcomeWindow ?? NSApp.keyWindow
+        )
+        Task { @MainActor in
+            if let url = await registry.openProjectViaPanel(context: context) {
+                openProjectWindow(url)
+                closeWelcome()
+            }
         }
     }
 

--- a/Pine/WelcomeView.swift
+++ b/Pine/WelcomeView.swift
@@ -221,29 +221,34 @@ struct WelcomeView: View {
     /// Handles file URLs dropped onto the Welcome window.
     /// Directories are opened as projects; files determine the project from their parent directory.
     private func handleDrop(providers: [NSItemProvider]) {
-        for provider in providers {
-            Task {
+        Task { @MainActor in
+            var urls: [URL] = []
+            for provider in providers {
                 guard let url = try? await provider.loadItem(
                     forTypeIdentifier: UTType.fileURL.identifier
-                ) as? URL else { return }
+                ) as? URL else { continue }
+                urls.append(url)
+            }
 
-                let classified = DropHandler.classifyURLs([url])
+            let classified = DropHandler.classifyURLs(urls)
+            for directory in classified.directories {
+                openProject(at: directory)
+            }
 
-                await MainActor.run {
-                    if let dir = classified.directories.first {
-                        // Open directory as project
-                        openProject(at: dir)
-                    } else if let file = classified.files.first {
-                        // Open file's parent directory as project, then open the file as a tab
-                        let projectDir = file.deletingLastPathComponent()
-                        openProject(at: projectDir)
-                        // Give the project window time to initialize, then open the file
-                        DispatchQueue.main.asyncAfter(deadline: .now() + UITimings.Delay.standard) {
-                            let canonical = projectDir.resolvingSymlinksInPath()
-                            registry.openProjects[canonical]?.primaryTabManager.openTab(url: file)
-                        }
-                    }
-                }
+            guard let firstFile = classified.files.first else { return }
+            // Open one parent project for the complete file batch, then wait
+            // once for its real AppKit owner before any possible large-file
+            // sheet is requested.
+            let projectDir = firstFile.deletingLastPathComponent()
+                .resolvingSymlinksInPath()
+            guard let projectManager = openProject(at: projectDir),
+                  let owner = await projectManager.awaitDialogOwnerWindow(),
+                  projectManager.dialogOwnerWindow === owner,
+                  registry.openProjects[projectDir] === projectManager else {
+                return
+            }
+            for file in classified.files {
+                projectManager.paneManager.openFileInActiveEditor(url: file)
             }
         }
     }
@@ -260,7 +265,8 @@ struct WelcomeView: View {
         }
     }
 
-    private func openProject(at url: URL) {
+    @discardableResult
+    private func openProject(at url: URL) -> ProjectManager? {
         let canonical = url.resolvingSymlinksInPath()
         // If the project is still in openProjects (window close didn't clean up),
         // save its session and remove it so projectManager(for:) creates a fresh PM.
@@ -268,9 +274,12 @@ struct WelcomeView: View {
             registry.openProjects[canonical]?.saveSession()
             registry.closeProject(canonical)
         }
-        guard registry.projectManager(for: canonical) != nil else { return }
+        guard let projectManager = registry.projectManager(for: canonical) else {
+            return nil
+        }
         openProjectWindow(canonical)
         closeWelcome()
+        return projectManager
     }
 
     /// Opens a project window using AppDelegate's captured closure (works from both
@@ -286,6 +295,10 @@ struct WelcomeView: View {
 
     /// Closes all Welcome windows — both SwiftUI-managed and AppKit-created fallback.
     private func closeWelcome() {
+        if let appDelegate {
+            appDelegate.hideWelcome()
+            return
+        }
         dismissWindow(id: "welcome")
         // Close any AppKit-created welcome windows that dismissWindow doesn't handle
         for window in NSApp.windows

--- a/Pine/WindowNonmodalFeedbackPresenter.swift
+++ b/Pine/WindowNonmodalFeedbackPresenter.swift
@@ -1,0 +1,180 @@
+//
+//  WindowNonmodalFeedbackPresenter.swift
+//  Pine
+//
+//  Shared visible, non-blocking feedback for app-owned windows that do not
+//  have a ProjectManager/ToastManager (Welcome and Settings).
+//
+
+import AppKit
+
+@MainActor
+protocol WindowNonmodalFeedbackPresenting {
+    /// Shows feedback without activating a modal session or attaching a
+    /// sheet. Returns false when there is no suitable live owner.
+    @discardableResult
+    func present(
+        message: String,
+        context: DialogPresentationContext
+    ) -> Bool
+}
+
+/// Presents a compact non-activating child panel near the top of its owner.
+/// The panel is deliberately window-scoped, ignores input, and auto-dismisses
+/// so success feedback never blocks another command.
+@MainActor
+final class WindowNonmodalFeedbackPresenter:
+    WindowNonmodalFeedbackPresenting {
+    static let shared = WindowNonmodalFeedbackPresenter()
+
+    private final class Presentation {
+        weak var owner: NSWindow?
+        let panel: NSPanel
+        var dismissalTask: Task<Void, Never>?
+        var closeObserver: Any?
+
+        init(owner: NSWindow, panel: NSPanel) {
+            self.owner = owner
+            self.panel = panel
+        }
+    }
+
+    private var presentations: [ObjectIdentifier: Presentation] = [:]
+    private let displayDuration: Duration
+
+    init(displayDuration: Duration = .seconds(3)) {
+        self.displayDuration = displayDuration
+    }
+
+    @discardableResult
+    func present(
+        message: String,
+        context: DialogPresentationContext
+    ) -> Bool {
+        let accessibilityElement: Any
+        defer {
+            NSAccessibility.post(
+                element: accessibilityElement,
+                notification: .announcementRequested,
+                userInfo: [.announcement: message]
+            )
+        }
+
+        guard let owner = context.nsWindow,
+              owner.isVisible,
+              !owner.isMiniaturized else {
+            accessibilityElement = NSApplication.shared
+            return false
+        }
+        accessibilityElement = owner
+
+        dismiss(for: owner)
+        let panel = makePanel(message: message)
+        let identifier = ObjectIdentifier(owner)
+        let presentation = Presentation(owner: owner, panel: panel)
+        presentations[identifier] = presentation
+        presentation.closeObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: owner,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.dismiss(identifier: identifier)
+            }
+        }
+
+        owner.addChildWindow(panel, ordered: .above)
+        position(panel, in: owner)
+        panel.orderFront(nil)
+        presentation.dismissalTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: self?.displayDuration ?? .seconds(3))
+            guard !Task.isCancelled, let self else { return }
+            self.dismiss(identifier: identifier)
+        }
+        return true
+    }
+
+    func dismiss(for owner: NSWindow) {
+        dismiss(identifier: ObjectIdentifier(owner))
+    }
+
+    private func dismiss(identifier: ObjectIdentifier) {
+        guard let presentation = presentations.removeValue(
+            forKey: identifier
+        ) else {
+            return
+        }
+        presentation.dismissalTask?.cancel()
+        if let closeObserver = presentation.closeObserver {
+            NotificationCenter.default.removeObserver(closeObserver)
+        }
+        if let owner = presentation.owner,
+           presentation.panel.parent === owner {
+            owner.removeChildWindow(presentation.panel)
+        }
+        presentation.panel.orderOut(nil)
+        presentation.panel.close()
+    }
+
+    func hasVisibleFeedback(for owner: NSWindow) -> Bool {
+        presentations[ObjectIdentifier(owner)]?.panel.isVisible == true
+    }
+
+    private func makePanel(message: String) -> NSPanel {
+        let text = NSTextField(wrappingLabelWithString: message)
+        text.alignment = .center
+        text.font = .systemFont(ofSize: NSFont.systemFontSize, weight: .medium)
+        text.textColor = .labelColor
+        text.maximumNumberOfLines = 3
+        text.translatesAutoresizingMaskIntoConstraints = false
+
+        let effect = NSVisualEffectView()
+        effect.material = .popover
+        effect.blendingMode = .behindWindow
+        effect.state = .active
+        effect.wantsLayer = true
+        effect.layer?.cornerRadius = 10
+        effect.layer?.masksToBounds = true
+        effect.setAccessibilityElement(true)
+        effect.setAccessibilityLabel(message)
+        effect.addSubview(text)
+        NSLayoutConstraint.activate([
+            text.leadingAnchor.constraint(equalTo: effect.leadingAnchor, constant: 16),
+            text.trailingAnchor.constraint(equalTo: effect.trailingAnchor, constant: -16),
+            text.topAnchor.constraint(equalTo: effect.topAnchor, constant: 10),
+            text.bottomAnchor.constraint(equalTo: effect.bottomAnchor, constant: -10),
+            text.widthAnchor.constraint(lessThanOrEqualToConstant: 420),
+        ])
+
+        let fittingSize = effect.fittingSize
+        let panel = NSPanel(
+            contentRect: NSRect(
+                origin: .zero,
+                size: NSSize(
+                    width: max(220, fittingSize.width),
+                    height: max(44, fittingSize.height)
+                )
+            ),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.contentView = effect
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.hidesOnDeactivate = false
+        panel.ignoresMouseEvents = true
+        panel.isReleasedWhenClosed = false
+        return panel
+    }
+
+    private func position(_ panel: NSPanel, in owner: NSWindow) {
+        let ownerFrame = owner.frame
+        let panelSize = panel.frame.size
+        panel.setFrameOrigin(NSPoint(
+            x: ownerFrame.midX - panelSize.width / 2,
+            y: ownerFrame.maxY - panelSize.height - 56
+        ))
+    }
+}

--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -171,7 +171,7 @@ final class WorkspaceManager {
         }
     }
 
-    func openFolder() {
+    func openFolder(context: DialogPresentationContext) async {
         let panel = NSOpenPanel()
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
@@ -179,7 +179,8 @@ final class WorkspaceManager {
         panel.message = Strings.openPanelMessage
         panel.prompt = Strings.openPanelPrompt
 
-        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard await panel.runSheet(on: context) == .OK,
+              let url = panel.url else { return }
         loadDirectory(url: url)
     }
 

--- a/PineTests/AlertTemplateTests.swift
+++ b/PineTests/AlertTemplateTests.swift
@@ -249,6 +249,20 @@ struct AlertTemplateTests {
         for expected in expectations {
             let alert = expected.template.makeAlert(messageText: "Test")
             let buttons = alert.buttons
+            var keyboardButtons = buttons
+            var seenButtons = Set(buttons.map(ObjectIdentifier.init))
+            func collectButtons(in view: NSView) {
+                if let button = view as? NSButton,
+                   seenButtons.insert(ObjectIdentifier(button)).inserted {
+                    keyboardButtons.append(button)
+                }
+                for subview in view.subviews {
+                    collectButtons(in: subview)
+                }
+            }
+            if let contentView = alert.window.contentView {
+                collectButtons(in: contentView)
+            }
             let defaultIndices = buttons.indices.filter {
                 alert.window.defaultButtonCell ===
                     (buttons[$0].cell as? NSButtonCell)
@@ -257,13 +271,36 @@ struct AlertTemplateTests {
                 defaultIndices == [expected.defaultIndex],
                 "Wrong Return default for \(expected.template)"
             )
-            let cancelIndices = buttons.indices.filter {
-                buttons[$0].keyEquivalent == "\u{1b}"
-            }
-            let expectedCancelIndices = expected.cancelIndex.map { [$0] } ?? []
+            let escapeTargetTags = Set(keyboardButtons.compactMap { button in
+                button.keyEquivalent == "\u{1b}" ? button.tag : nil
+            })
+            let commandPeriodTargetTags = Set(keyboardButtons.compactMap { button in
+                button.keyEquivalent == "."
+                    && button.keyEquivalentModifierMask.contains(.command)
+                    ? button.tag
+                    : nil
+            })
+            let expectedCancelTags = expected.cancelIndex.map {
+                Set([buttons[$0].tag])
+            } ?? []
             #expect(
-                cancelIndices == expectedCancelIndices,
+                escapeTargetTags == expectedCancelTags,
                 "Wrong Escape target for \(expected.template)"
+            )
+            #expect(
+                commandPeriodTargetTags == expectedCancelTags,
+                "Wrong Command-Period target for \(expected.template)"
+            )
+            let accessibilityShortcutProxies = keyboardButtons.filter { candidate in
+                !buttons.contains(where: { $0 === candidate })
+                    && (candidate.keyEquivalent == "\u{1b}"
+                        || candidate.keyEquivalent == ".")
+            }
+            #expect(
+                accessibilityShortcutProxies.allSatisfy {
+                    !$0.isAccessibilityElement()
+                },
+                "Keyboard proxies must stay out of VoiceOver for \(expected.template)"
             )
             let destructiveIndices = Set(buttons.indices.filter {
                 buttons[$0].hasDestructiveAction

--- a/PineTests/AlertTemplateTests.swift
+++ b/PineTests/AlertTemplateTests.swift
@@ -129,16 +129,6 @@ struct AlertTemplateTests {
         #expect(buttons[1].title == Strings.dialogCancel)
     }
 
-    @Test("cliInstallerInfo has OK and informational style")
-    func cliInstallerInfoButtons() {
-        let template = AlertTemplate.cliInstallerInfo
-        let alert = template.makeAlert(messageText: "Title", informativeText: "Message")
-        let buttons = alert.buttons
-        #expect(buttons.count == 1)
-        #expect(buttons[0].title == Strings.dialogOK)
-        #expect(alert.alertStyle == .informational)
-    }
-
     // MARK: - Alert style defaults
 
     @Test("most templates default to warning style")
@@ -177,5 +167,121 @@ struct AlertTemplateTests {
         let alert = template.makeAlert(messageText: "Just title")
         #expect(alert.messageText == "Just title")
         #expect(alert.informativeText == "")
+    }
+
+    @Test("every template has exact native default, cancel, and destructive semantics")
+    func buttonRoles() {
+        struct Expected {
+            let template: AlertTemplate
+            let defaultIndex: Int
+            let cancelIndex: Int?
+            let destructiveIndices: Set<Int>
+        }
+        let expectations: [Expected] = [
+            .init(
+                template: .unsavedChangesSingle,
+                defaultIndex: 0,
+                cancelIndex: 2,
+                destructiveIndices: [1]
+            ),
+            .init(
+                template: .unsavedChangesBulk,
+                defaultIndex: 0,
+                cancelIndex: 2,
+                destructiveIndices: [1]
+            ),
+            .init(
+                template: .terminalTabCloseWarning,
+                defaultIndex: 1,
+                cancelIndex: 1,
+                destructiveIndices: [0]
+            ),
+            .init(
+                template: .terminalActiveProcessWarning,
+                defaultIndex: 1,
+                cancelIndex: 1,
+                destructiveIndices: [0]
+            ),
+            .init(
+                template: .externalModifyConflict,
+                defaultIndex: 1,
+                cancelIndex: 1,
+                destructiveIndices: [0]
+            ),
+            .init(
+                template: .fileDeletedSaveAs,
+                defaultIndex: 0,
+                cancelIndex: 2,
+                destructiveIndices: [1]
+            ),
+            .init(
+                template: .fileOperationErrorCritical,
+                defaultIndex: 0,
+                cancelIndex: nil,
+                destructiveIndices: []
+            ),
+            .init(
+                template: .fileOperationErrorWarning,
+                defaultIndex: 0,
+                cancelIndex: nil,
+                destructiveIndices: []
+            ),
+            .init(
+                template: .largeFileWarning,
+                defaultIndex: 0,
+                cancelIndex: 2,
+                destructiveIndices: []
+            ),
+            .init(
+                template: .branchUncommittedChanges,
+                defaultIndex: 1,
+                cancelIndex: 1,
+                destructiveIndices: [0]
+            ),
+            .init(
+                template: .revertAllConfirmation,
+                defaultIndex: 1,
+                cancelIndex: 1,
+                destructiveIndices: [0]
+            ),
+        ]
+
+        for expected in expectations {
+            let alert = expected.template.makeAlert(messageText: "Test")
+            let buttons = alert.buttons
+            let defaultIndices = buttons.indices.filter {
+                alert.window.defaultButtonCell ===
+                    (buttons[$0].cell as? NSButtonCell)
+            }
+            #expect(
+                defaultIndices == [expected.defaultIndex],
+                "Wrong Return default for \(expected.template)"
+            )
+            let cancelIndices = buttons.indices.filter {
+                buttons[$0].keyEquivalent == "\u{1b}"
+            }
+            let expectedCancelIndices = expected.cancelIndex.map { [$0] } ?? []
+            #expect(
+                cancelIndices == expectedCancelIndices,
+                "Wrong Escape target for \(expected.template)"
+            )
+            let destructiveIndices = Set(buttons.indices.filter {
+                buttons[$0].hasDestructiveAction
+            })
+            #expect(
+                destructiveIndices == expected.destructiveIndices,
+                "Wrong destructive role for \(expected.template)"
+            )
+            #expect(
+                !destructiveIndices.contains(expected.defaultIndex),
+                "Destructive action must never be the Return default"
+            )
+            for index in expected.destructiveIndices {
+                #expect(
+                    buttons[index].keyEquivalent != "\r",
+                    "Destructive action must not retain implicit Return"
+                )
+            }
+        }
     }
 }

--- a/PineTests/AsyncLargeFilePaneOpenTests.swift
+++ b/PineTests/AsyncLargeFilePaneOpenTests.swift
@@ -1,0 +1,392 @@
+//
+//  AsyncLargeFilePaneOpenTests.swift
+//  PineTests
+//
+
+import AppKit
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Async Large File Pane Open Tests")
+@MainActor
+struct AsyncLargeFilePaneOpenTests {
+    private typealias ResponseContinuation =
+        AsyncStream<NSApplication.ModalResponse>.Continuation
+
+    private func makeFile(
+        name: String,
+        size: Int = 16
+    ) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineAsyncOpen-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        let url = directory.appendingPathComponent(name)
+        try Data(repeating: 0x61, count: size).write(to: url)
+        return url
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(
+            at: url.deletingLastPathComponent()
+        )
+    }
+
+    private func installDecisionGate(
+        on tabManager: TabManager
+    ) -> ResponseContinuation {
+        let (responses, continuation) = AsyncStream.makeStream(
+            of: NSApplication.ModalResponse.self
+        )
+        tabManager.largeFileAlertPresenter = { _, _, _ in
+            for await response in responses {
+                return response
+            }
+            return .abort
+        }
+        return continuation
+    }
+
+    private func installDecisionGate(
+        on paneManager: PaneManager
+    ) -> ResponseContinuation {
+        let (responses, continuation) = AsyncStream.makeStream(
+            of: NSApplication.ModalResponse.self
+        )
+        paneManager.configureEditorTabManager = { tabManager in
+            tabManager.largeFileAlertPresenter = { _, _, _ in
+                for await response in responses {
+                    return response
+                }
+                return .abort
+            }
+        }
+        return continuation
+    }
+
+    private func settle(
+        until condition: @MainActor () -> Bool
+    ) async {
+        for _ in 0..<100 {
+            if condition() { return }
+            await Task.yield()
+        }
+    }
+
+    @Test func invalidDestinationsCompleteExactlyOnce() throws {
+        let file = try makeFile(name: "invalid-destination.swift")
+        defer { cleanup(file) }
+        let paneManager = PaneManager()
+        var explicitResults: [TabManager.OpenRequestResult] = []
+        var directoryResults: [TabManager.OpenRequestResult] = []
+        var splitResults: [TabManager.OpenRequestResult] = []
+
+        let didOpen = paneManager.openFileInPane(
+            url: file,
+            paneID: PaneID(),
+            completion: { explicitResults.append($0) }
+        )
+        let didOpenDirectory = paneManager.openFileInPane(
+            url: file.deletingLastPathComponent(),
+            paneID: paneManager.activePaneID,
+            completion: { directoryResults.append($0) }
+        )
+        let splitPaneID = paneManager.splitAndOpenFile(
+            url: file,
+            relativeTo: PaneID(),
+            axis: .horizontal,
+            completion: { splitResults.append($0) }
+        )
+
+        #expect(!didOpen)
+        #expect(!didOpenDirectory)
+        #expect(splitPaneID == nil)
+        #expect(explicitResults == [.cancelled])
+        #expect(directoryResults == [.cancelled])
+        #expect(splitResults == [.cancelled])
+    }
+
+    @Test func pendingOpenDoesNotRetainPaneOrTabManager() async throws {
+        let file = try makeFile(
+            name: "released-manager.swift",
+            size: TabManager.largeFileThreshold + 1
+        )
+        defer { cleanup(file) }
+        var paneManager: PaneManager? = PaneManager()
+        let paneID = try #require(paneManager?.activePaneID)
+        var tabManager: TabManager? = try #require(
+            paneManager?.tabManager(for: paneID)
+        )
+        weak var weakPaneManager = paneManager
+        weak var weakTabManager = tabManager
+        let responses = installDecisionGate(on: try #require(tabManager))
+        var completionResults: [TabManager.OpenRequestResult] = []
+
+        paneManager?.openFileInActiveEditor(
+            url: file,
+            completion: { completionResults.append($0) }
+        )
+        tabManager = nil
+        paneManager = nil
+
+        #expect(weakPaneManager == nil)
+        #expect(weakTabManager == nil)
+
+        responses.yield(.alertSecondButtonReturn)
+        responses.finish()
+        await settle { !completionResults.isEmpty }
+
+        #expect(completionResults == [.cancelled])
+    }
+
+    @Test func activePaneAcceptActivatesFocusesAndRecordsMRU() async throws {
+        let file = try makeFile(
+            name: "active-accept.swift",
+            size: TabManager.largeFileThreshold + 1
+        )
+        defer { cleanup(file) }
+        let paneManager = PaneManager()
+        let paneID = paneManager.activePaneID
+        let tabManager = try #require(paneManager.tabManager(for: paneID))
+        let responses = installDecisionGate(on: tabManager)
+        var terminalResult: TabManager.OpenRequestResult?
+
+        let accepted = paneManager.openFileInActiveEditor(url: file) {
+            terminalResult = $0
+        }
+
+        #expect(accepted)
+        #expect(terminalResult == nil)
+        #expect(tabManager.tabs.isEmpty)
+        #expect(tabManager.pendingFocusTabID == nil)
+        #expect(paneManager.globalTabSwitchOrder.isEmpty)
+
+        responses.yield(.alertSecondButtonReturn)
+        responses.finish()
+        await settle {
+            terminalResult != nil && !tabManager.tabs.isEmpty
+        }
+
+        let tab = try #require(tabManager.activeTab)
+        #expect(terminalResult == .opened(tabID: tab.id))
+        #expect(tab.url == file)
+        #expect(paneManager.activePaneID == paneID)
+        #expect(tabManager.pendingFocusTabID == tab.id)
+        #expect(
+            paneManager.globalTabSwitchOrder.first ==
+                GlobalTabIdentity(
+                    paneID: paneID,
+                    tabID: tab.id,
+                    contentType: .editor
+                )
+        )
+    }
+
+    @Test func activePaneCancelRollsBackProvisionedEditor() async throws {
+        let file = try makeFile(
+            name: "active-cancel.swift",
+            size: TabManager.largeFileThreshold + 1
+        )
+        defer { cleanup(file) }
+        let paneManager = PaneManager()
+        let terminalPaneID = paneManager.createTerminalPaneAtBottom(
+            workingDirectory: nil
+        )
+        paneManager.pruneEmptyEditorLeaves()
+        #expect(paneManager.root.leafCount == 1)
+        #expect(paneManager.activePaneID == terminalPaneID)
+        let originalSwitchOrder = paneManager.globalTabSwitchOrder
+        let responses = installDecisionGate(on: paneManager)
+        var terminalResult: TabManager.OpenRequestResult?
+
+        let accepted = paneManager.openFileInActiveEditor(url: file) {
+            terminalResult = $0
+        }
+        #expect(accepted)
+        #expect(terminalResult == nil)
+        #expect(paneManager.root.leafCount == 2)
+        #expect(paneManager.activePaneID == terminalPaneID)
+
+        responses.yield(.abort)
+        responses.finish()
+        await settle { terminalResult == .cancelled }
+
+        #expect(terminalResult == .cancelled)
+        #expect(paneManager.root.leafCount == 1)
+        #expect(paneManager.root.firstLeafID == terminalPaneID)
+        #expect(paneManager.activePaneID == terminalPaneID)
+        #expect(paneManager.globalTabSwitchOrder == originalSwitchOrder)
+    }
+
+    @Test func explicitPaneAcceptActivatesDestinationAfterDecision() async throws {
+        let file = try makeFile(
+            name: "explicit-accept.swift",
+            size: TabManager.largeFileThreshold + 1
+        )
+        defer { cleanup(file) }
+        let paneManager = PaneManager()
+        let originalPaneID = paneManager.activePaneID
+        let destinationPaneID = try #require(
+            paneManager.splitPane(originalPaneID, axis: .horizontal)
+        )
+        let tabManager = try #require(
+            paneManager.tabManager(for: destinationPaneID)
+        )
+        paneManager.activePaneID = originalPaneID
+        let responses = installDecisionGate(on: tabManager)
+        var terminalResult: TabManager.OpenRequestResult?
+
+        let accepted = paneManager.openFileInPane(
+            url: file,
+            paneID: destinationPaneID,
+            completion: { terminalResult = $0 }
+        )
+
+        #expect(accepted)
+        #expect(terminalResult == nil)
+        #expect(paneManager.activePaneID == originalPaneID)
+        #expect(tabManager.pendingFocusTabID == nil)
+
+        responses.yield(.alertSecondButtonReturn)
+        responses.finish()
+        await settle {
+            terminalResult != nil && !tabManager.tabs.isEmpty
+        }
+
+        let tab = try #require(tabManager.activeTab)
+        #expect(terminalResult == .opened(tabID: tab.id))
+        #expect(paneManager.activePaneID == destinationPaneID)
+        #expect(tabManager.pendingFocusTabID == tab.id)
+        #expect(
+            paneManager.globalTabSwitchOrder.first ==
+                GlobalTabIdentity(
+                    paneID: destinationPaneID,
+                    tabID: tab.id,
+                    contentType: .editor
+                )
+        )
+    }
+
+    @Test func explicitPaneCancelKeepsOriginalPaneActive() async throws {
+        let file = try makeFile(
+            name: "explicit-cancel.swift",
+            size: TabManager.largeFileThreshold + 1
+        )
+        defer { cleanup(file) }
+        let paneManager = PaneManager()
+        let originalPaneID = paneManager.activePaneID
+        let destinationPaneID = try #require(
+            paneManager.splitPane(originalPaneID, axis: .horizontal)
+        )
+        let tabManager = try #require(
+            paneManager.tabManager(for: destinationPaneID)
+        )
+        paneManager.activePaneID = originalPaneID
+        let responses = installDecisionGate(on: tabManager)
+        var terminalResult: TabManager.OpenRequestResult?
+
+        let accepted = paneManager.openFileInPane(
+            url: file,
+            paneID: destinationPaneID,
+            completion: { terminalResult = $0 }
+        )
+        #expect(accepted)
+        #expect(terminalResult == nil)
+
+        responses.yield(.abort)
+        responses.finish()
+        await settle { terminalResult == .cancelled }
+
+        #expect(terminalResult == .cancelled)
+        #expect(tabManager.tabs.isEmpty)
+        #expect(tabManager.pendingFocusTabID == nil)
+        #expect(paneManager.activePaneID == originalPaneID)
+        #expect(paneManager.globalTabSwitchOrder.isEmpty)
+    }
+
+    @Test func splitAcceptKeepsSourceActiveUntilDecision() async throws {
+        let file = try makeFile(
+            name: "split-accept.swift",
+            size: TabManager.largeFileThreshold + 1
+        )
+        defer { cleanup(file) }
+        let paneManager = PaneManager()
+        let originalPaneID = paneManager.activePaneID
+        let responses = installDecisionGate(on: paneManager)
+        var terminalResult: TabManager.OpenRequestResult?
+
+        let requestedPaneID = paneManager.splitAndOpenFile(
+            url: file,
+            relativeTo: originalPaneID,
+            axis: .horizontal,
+            completion: { terminalResult = $0 }
+        )
+        let newPaneID = try #require(requestedPaneID)
+        let tabManager = try #require(
+            paneManager.tabManager(for: newPaneID)
+        )
+
+        #expect(paneManager.root.leafCount == 2)
+        #expect(paneManager.activePaneID == originalPaneID)
+        #expect(tabManager.tabs.isEmpty)
+        #expect(terminalResult == nil)
+
+        responses.yield(.alertSecondButtonReturn)
+        responses.finish()
+        await settle {
+            terminalResult != nil && !tabManager.tabs.isEmpty
+        }
+
+        let tab = try #require(tabManager.activeTab)
+        #expect(terminalResult == .opened(tabID: tab.id))
+        #expect(paneManager.activePaneID == newPaneID)
+        #expect(tabManager.pendingFocusTabID == tab.id)
+        #expect(
+            paneManager.globalTabSwitchOrder.first ==
+                GlobalTabIdentity(
+                    paneID: newPaneID,
+                    tabID: tab.id,
+                    contentType: .editor
+                )
+        )
+    }
+
+    @Test func splitCancelRemovesEmptyDestinationAndRestoresSource() async throws {
+        let file = try makeFile(
+            name: "split-cancel.swift",
+            size: TabManager.largeFileThreshold + 1
+        )
+        defer { cleanup(file) }
+        let paneManager = PaneManager()
+        let originalPaneID = paneManager.activePaneID
+        let responses = installDecisionGate(on: paneManager)
+        var terminalResult: TabManager.OpenRequestResult?
+
+        let requestedPaneID = paneManager.splitAndOpenFile(
+            url: file,
+            relativeTo: originalPaneID,
+            axis: .vertical,
+            completion: { terminalResult = $0 }
+        )
+        let newPaneID = try #require(requestedPaneID)
+        #expect(paneManager.activePaneID == originalPaneID)
+        #expect(terminalResult == nil)
+
+        responses.yield(.abort)
+        responses.finish()
+        await settle {
+            terminalResult == .cancelled
+                && paneManager.tabManager(for: newPaneID) == nil
+        }
+
+        #expect(terminalResult == .cancelled)
+        #expect(paneManager.root.leafCount == 1)
+        #expect(paneManager.root.firstLeafID == originalPaneID)
+        #expect(paneManager.activePaneID == originalPaneID)
+        #expect(paneManager.globalTabSwitchOrder.isEmpty)
+    }
+}

--- a/PineTests/CLIInstallerTests.swift
+++ b/PineTests/CLIInstallerTests.swift
@@ -3,6 +3,7 @@
 //  PineTests
 //
 
+import AppKit
 import Foundation
 import Testing
 
@@ -21,5 +22,69 @@ struct CLIInstallerTests {
 
     @Test func isInstalledFromCurrentBundleReturnsBool() {
         _ = CLIInstaller.isInstalledFromCurrentBundle
+    }
+
+    @Test func successUsesNonBlockingProjectToast() {
+        let projectManager = ProjectManager()
+        projectManager.toastManager.announce = { _ in }
+        let window = NSWindow()
+        let context = DialogPresenter.register(
+            window: window,
+            projectManager: projectManager
+        )
+        window.orderFront(nil)
+        defer {
+            DialogPresenter.ownerDidClose(window)
+            window.orderOut(nil)
+        }
+
+        CLIInstaller.presentSuccess(
+            title: "Installed",
+            message: "Ready",
+            projectManager: projectManager,
+            context: context
+        )
+
+        #expect(projectManager.toastManager.currentToast?.message == "Installed. Ready")
+        #expect(window.sheets.isEmpty)
+    }
+
+    @Test func noProjectSuccessUsesVisibleWindowFeedback() {
+        let window = NSWindow()
+        window.orderFront(nil)
+        let context = DialogPresentationContext(window: window)
+        let feedback = RecordingCLIFeedbackPresenter()
+        defer {
+            DialogPresenter.ownerDidClose(window)
+            window.orderOut(nil)
+        }
+
+        CLIInstaller.presentSuccess(
+            title: "Installed",
+            message: "Ready",
+            projectManager: nil,
+            context: context,
+            feedbackPresenter: feedback
+        )
+
+        #expect(feedback.messages == ["Installed. Ready"])
+        #expect(feedback.owner === window)
+        #expect(window.sheets.isEmpty)
+    }
+}
+
+@MainActor
+private final class RecordingCLIFeedbackPresenter:
+    WindowNonmodalFeedbackPresenting {
+    private(set) var messages: [String] = []
+    private(set) weak var owner: NSWindow?
+
+    func present(
+        message: String,
+        context: DialogPresentationContext
+    ) -> Bool {
+        messages.append(message)
+        owner = context.nsWindow
+        return owner != nil
     }
 }

--- a/PineTests/CloseDelegateTests.swift
+++ b/PineTests/CloseDelegateTests.swift
@@ -11,6 +11,9 @@ import AppKit
 @Suite("CloseDelegate Tests")
 @MainActor
 struct CloseDelegateTests {
+    private func settle() async {
+        for _ in 0..<8 { await Task.yield() }
+    }
 
     private func makeTempDir() throws -> URL {
         let url = FileManager.default.temporaryDirectory
@@ -23,7 +26,12 @@ struct CloseDelegateTests {
         try? FileManager.default.removeItem(at: url)
     }
 
-    private func makeCloseDelegate(projectURL: URL) -> (CloseDelegate, ProjectManager, ProjectRegistry) {
+    private func makeCloseDelegate(
+        projectURL: URL,
+        original: (any NSWindowDelegate)? = nil,
+        presentAlert: CloseDelegate.CloseAlertPresenter? = nil,
+        saveAll: CloseDelegate.CloseSaveAll? = nil
+    ) -> (CloseDelegate, ProjectManager, ProjectRegistry) {
         let pm = ProjectManager()
         let registry = ProjectRegistry()
         let appDelegate = AppDelegate()
@@ -32,9 +40,25 @@ struct CloseDelegateTests {
             registry: registry,
             projectURL: projectURL,
             appDelegate: appDelegate,
-            original: nil
+            original: original,
+            presentAlert: presentAlert,
+            saveAll: saveAll
         )
         return (delegate, pm, registry)
+    }
+
+    private func addDirtyTab(
+        to projectManager: ProjectManager,
+        in directory: URL
+    ) throws {
+        let fileURL = directory.appendingPathComponent("dirty.swift")
+        try "original".write(
+            to: fileURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        projectManager.primaryTabManager.openTab(url: fileURL)
+        projectManager.primaryTabManager.updateContent("modified")
     }
 
     // MARK: - Initialization
@@ -50,13 +74,203 @@ struct CloseDelegateTests {
 
     // MARK: - windowShouldClose
 
-    @Test func windowShouldCloseAllowsWithNoDirtyTabs() throws {
+    @Test func windowShouldCloseDefersEvenWithNoDirtyTabs() async throws {
         let dir = try makeTempDir()
         defer { cleanup(dir) }
         let (delegate, _, _) = makeCloseDelegate(projectURL: dir)
 
         let window = NSWindow()
-        #expect(delegate.windowShouldClose(window) == true)
+        defer { DialogPresenter.ownerDidClose(window) }
+        #expect(delegate.windowShouldClose(window) == false)
+        await settle()
+    }
+
+    @Test func approvedCloseReentersThroughPerformCloseExactlyOnce() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let (delegate, _, _) = makeCloseDelegate(projectURL: dir)
+        let window = CloseTrackingWindow()
+        defer { DialogPresenter.ownerDidClose(window) }
+        window.delegate = delegate
+
+        #expect(!delegate.windowShouldClose(window))
+        await settle()
+
+        #expect(window.performCloseCount == 1)
+        #expect(window.approvedCloseCount == 1)
+    }
+
+    @Test func originalDelegateIsConsultedOnlyOnInitialCloseAttempt() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let original = CountingCloseDelegate(shouldApprove: true)
+        let (delegate, _, _) = makeCloseDelegate(
+            projectURL: dir,
+            original: original
+        )
+        let window = CloseTrackingWindow()
+        defer { DialogPresenter.ownerDidClose(window) }
+        window.delegate = delegate
+
+        #expect(!delegate.windowShouldClose(window))
+        await settle()
+
+        #expect(original.shouldCloseCount == 1)
+        #expect(window.performCloseCount == 1)
+        #expect(window.approvedCloseCount == 1)
+    }
+
+    @Test func failedSaveKeepsDirtyWindowOpen() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        var presentedTemplates: [AlertTemplate] = []
+        var saveCount = 0
+        let (delegate, projectManager, _) = makeCloseDelegate(
+            projectURL: dir,
+            presentAlert: { template, _, _, _ in
+                presentedTemplates.append(template)
+                return .alertFirstButtonReturn
+            },
+            saveAll: { _, _ in
+                saveCount += 1
+                return false
+            }
+        )
+        try addDirtyTab(to: projectManager, in: dir)
+        let window = CloseTrackingWindow()
+        window.delegate = delegate
+        defer { DialogPresenter.ownerDidClose(window) }
+
+        #expect(!delegate.windowShouldClose(window))
+        await settle()
+
+        #expect(presentedTemplates == [.unsavedChangesBulk])
+        #expect(saveCount == 1)
+        #expect(window.performCloseCount == 0)
+        #expect(projectManager.hasUnsavedChanges)
+    }
+
+    @Test func discardApprovesDirtyWindowCloseWithoutSaving() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        var saveCount = 0
+        let (delegate, projectManager, _) = makeCloseDelegate(
+            projectURL: dir,
+            presentAlert: { _, _, _, _ in .alertSecondButtonReturn },
+            saveAll: { _, _ in
+                saveCount += 1
+                return true
+            }
+        )
+        try addDirtyTab(to: projectManager, in: dir)
+        let window = CloseTrackingWindow()
+        window.delegate = delegate
+        defer { DialogPresenter.ownerDidClose(window) }
+
+        #expect(!delegate.windowShouldClose(window))
+        await settle()
+
+        #expect(saveCount == 0)
+        #expect(window.performCloseCount == 1)
+        #expect(window.approvedCloseCount == 1)
+        #expect(!projectManager.hasUnsavedChanges)
+        #expect(projectManager.primaryTabManager.activeTab?.content == "original")
+    }
+
+    @Test func discardCommitSurvivesBackgroundCloseAndReopen() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let appDelegate = AppDelegate()
+        appDelegate.registry = registry
+        try addDirtyTab(to: project, in: dir)
+        project.recoveryManager?.snapshotDirtyTabs(project.allTabs)
+        #expect(project.recoveryManager?.pendingRecoveryEntries().isEmpty == false)
+        let delegate = CloseDelegate(
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: appDelegate,
+            original: nil,
+            presentAlert: { _, _, _, _ in .alertSecondButtonReturn }
+        )
+        let window = CloseTrackingWindow()
+        window.delegate = delegate
+        delegate.observeWindowClose(window)
+        defer {
+            delegate.detachFromWindow()
+            window.delegate = nil
+        }
+
+        #expect(!delegate.windowShouldClose(window))
+        await settle()
+        #expect(window.approvedCloseCount == 1)
+        delegate.windowWillClose(
+            Notification(name: NSWindow.willCloseNotification, object: window)
+        )
+
+        let reopened = try #require(registry.projectManager(for: dir))
+        #expect(reopened === project)
+        #expect(!reopened.hasUnsavedChanges)
+        #expect(reopened.primaryTabManager.activeTab?.content == "original")
+        #expect(reopened.recoveryManager?.pendingRecoveryEntries().isEmpty == true)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func cancelKeepsDirtyWindowOpenWithoutSaving() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        var saveCount = 0
+        let (delegate, projectManager, _) = makeCloseDelegate(
+            projectURL: dir,
+            presentAlert: { _, _, _, _ in .alertThirdButtonReturn },
+            saveAll: { _, _ in
+                saveCount += 1
+                return true
+            }
+        )
+        try addDirtyTab(to: projectManager, in: dir)
+        let window = CloseTrackingWindow()
+        window.delegate = delegate
+        defer { DialogPresenter.ownerDidClose(window) }
+
+        #expect(!delegate.windowShouldClose(window))
+        await settle()
+
+        #expect(saveCount == 0)
+        #expect(window.performCloseCount == 0)
+        #expect(projectManager.hasUnsavedChanges)
+    }
+
+    @Test func staleDiscardCannotCoverNewBufferContent() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        var mutateWhilePresented: (() -> Void)?
+        let (delegate, projectManager, _) = makeCloseDelegate(
+            projectURL: dir,
+            presentAlert: { _, _, _, _ in
+                mutateWhilePresented?()
+                return .alertSecondButtonReturn
+            }
+        )
+        try addDirtyTab(to: projectManager, in: dir)
+        mutateWhilePresented = {
+            projectManager.primaryTabManager.updateContent(
+                "changed while confirmation was visible"
+            )
+        }
+        let window = CloseTrackingWindow()
+        window.delegate = delegate
+        defer { DialogPresenter.ownerDidClose(window) }
+
+        #expect(!delegate.windowShouldClose(window))
+        await settle()
+
+        #expect(window.performCloseCount == 0)
+        #expect(projectManager.primaryTabManager.activeTab?.content ==
+                "changed while confirmation was visible")
+        #expect(projectManager.hasUnsavedChanges)
     }
 
     // MARK: - closeActiveTab
@@ -71,7 +285,7 @@ struct CloseDelegateTests {
         #expect(pm.primaryTabManager.tabs.isEmpty)
     }
 
-    @Test func closeActiveTabClosesCleanTab() throws {
+    @Test func closeActiveTabClosesCleanTab() async throws {
         let dir = try makeTempDir()
         defer { cleanup(dir) }
         let (delegate, pm, _) = makeCloseDelegate(projectURL: dir)
@@ -82,6 +296,7 @@ struct CloseDelegateTests {
 
         #expect(pm.primaryTabManager.tabs.count == 1)
         delegate.closeActiveTab()
+        await settle()
         #expect(pm.primaryTabManager.tabs.isEmpty)
     }
 
@@ -100,7 +315,7 @@ struct CloseDelegateTests {
 
     // MARK: - closeActiveTab removes empty pane
 
-    @Test func closeActiveTabRemovesEmptyPane() throws {
+    @Test func closeActiveTabRemovesEmptyPane() async throws {
         let dir = try makeTempDir()
         defer { cleanup(dir) }
         let (delegate, pm, _) = makeCloseDelegate(projectURL: dir)
@@ -127,13 +342,14 @@ struct CloseDelegateTests {
 
         // Close the only tab in the active (second) pane via CloseDelegate
         delegate.closeActiveTab()
+        await settle()
 
         // The empty pane should have been removed
         #expect(pane.root.leafCount == 1)
         #expect(pane.tabManagers[secondPaneID] == nil)
     }
 
-    @Test func closeActiveTabDoesNotRemovePaneWithRemainingTabs() throws {
+    @Test func closeActiveTabDoesNotRemovePaneWithRemainingTabs() async throws {
         let dir = try makeTempDir()
         defer { cleanup(dir) }
         let (delegate, pm, _) = makeCloseDelegate(projectURL: dir)
@@ -163,6 +379,7 @@ struct CloseDelegateTests {
 
         // Close one tab — pane should remain since it still has a tab
         delegate.closeActiveTab()
+        await settle()
 
         #expect(pane.root.leafCount == 2)
         #expect(pane.tabManagers[secondPaneID] != nil)
@@ -173,10 +390,183 @@ struct CloseDelegateTests {
     @Test func observeWindowCloseRegistersNotification() throws {
         let dir = try makeTempDir()
         defer { cleanup(dir) }
-        let (delegate, _, _) = makeCloseDelegate(projectURL: dir)
+        let (delegate, projectManager, _) = makeCloseDelegate(projectURL: dir)
 
         let window = NSWindow()
         delegate.observeWindowClose(window)
-        // Observer registered; cleanup in deinit
+        #expect(projectManager.dialogOwnerWindow === window)
+        #expect(delegate.dialogContext.nsWindow === window)
+        DialogPresenter.ownerDidClose(window)
+        #expect(projectManager.dialogOwnerWindow == nil)
+    }
+
+    @Test func interceptorRewrapsAReplacedDelegateAndPreservesDirtyVeto() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let project = ProjectManager()
+        let registry = ProjectRegistry()
+        let appDelegate = AppDelegate()
+        try addDirtyTab(to: project, in: dir)
+        let window = CloseTrackingWindow()
+        let initialOriginal = CountingCloseDelegate(shouldApprove: true)
+        window.delegate = initialOriginal
+        let coordinator = WindowCloseInterceptor.Coordinator()
+        var promptCount = 0
+
+        coordinator.installDelegate(
+            on: window,
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: appDelegate,
+            presentAlert: { _, _, _, _ in
+                promptCount += 1
+                return .alertThirdButtonReturn
+            }
+        )
+        let firstInterceptor = try #require(
+            window.delegate as? CloseDelegate
+        )
+
+        let replacement = CountingCloseDelegate(shouldApprove: true)
+        window.delegate = replacement
+        coordinator.installDelegate(
+            on: window,
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: appDelegate,
+            presentAlert: { _, _, _, _ in
+                promptCount += 1
+                return .alertThirdButtonReturn
+            }
+        )
+        let secondInterceptor = try #require(
+            window.delegate as? CloseDelegate
+        )
+        defer {
+            secondInterceptor.detachFromWindow()
+            window.delegate = nil
+        }
+
+        #expect(secondInterceptor !== firstInterceptor)
+        #expect(secondInterceptor.original === replacement)
+        window.performClose(nil)
+        await settle()
+
+        #expect(promptCount == 1)
+        #expect(window.approvedCloseCount == 0)
+        #expect(project.hasUnsavedChanges)
+    }
+
+    @Test func interceptorLifecycleNotificationRepairsDelegateReplacement() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let project = ProjectManager()
+        let registry = ProjectRegistry()
+        let appDelegate = AppDelegate()
+        let window = NSWindow()
+        let coordinator = WindowCloseInterceptor.Coordinator()
+        coordinator.installDelegate(
+            on: window,
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: appDelegate
+        )
+        let firstInterceptor = try #require(
+            window.delegate as? CloseDelegate
+        )
+        let replacement = CountingCloseDelegate(shouldApprove: true)
+        window.delegate = replacement
+
+        NotificationCenter.default.post(
+            name: NSWindow.didUpdateNotification,
+            object: window
+        )
+        let repaired = try #require(window.delegate as? CloseDelegate)
+        defer {
+            repaired.detachFromWindow()
+            window.delegate = nil
+        }
+
+        #expect(repaired !== firstInterceptor)
+        #expect(repaired.original === replacement)
+        #expect(project.dialogOwnerWindow === window)
+    }
+
+    @Test func interceptorMoveRestoresOldWindowAndRebindsProjectOwner() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let project = ProjectManager()
+        let registry = ProjectRegistry()
+        let appDelegate = AppDelegate()
+        let firstWindow = NSWindow()
+        let secondWindow = NSWindow()
+        let firstOriginal = CountingCloseDelegate(shouldApprove: true)
+        let secondOriginal = CountingCloseDelegate(shouldApprove: true)
+        firstWindow.delegate = firstOriginal
+        secondWindow.delegate = secondOriginal
+        let coordinator = WindowCloseInterceptor.Coordinator()
+
+        coordinator.installDelegate(
+            on: firstWindow,
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: appDelegate
+        )
+        let firstContext = try #require(
+            firstWindow.delegate as? CloseDelegate
+        ).dialogContext
+        coordinator.installDelegate(
+            on: secondWindow,
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: appDelegate
+        )
+        let secondInterceptor = try #require(
+            secondWindow.delegate as? CloseDelegate
+        )
+        defer {
+            secondInterceptor.detachFromWindow()
+            firstWindow.delegate = nil
+            secondWindow.delegate = nil
+        }
+
+        #expect(firstWindow.delegate === firstOriginal)
+        #expect(firstContext.nsWindow == nil)
+        #expect(secondInterceptor.original === secondOriginal)
+        #expect(project.dialogOwnerWindow === secondWindow)
+        #expect(secondInterceptor.dialogContext.nsWindow === secondWindow)
+    }
+}
+
+@MainActor
+private final class CloseTrackingWindow: NSWindow {
+    private(set) var performCloseCount = 0
+    private(set) var approvedCloseCount = 0
+
+    override func performClose(_ sender: Any?) {
+        performCloseCount += 1
+        if delegate?.windowShouldClose?(self) != false {
+            approvedCloseCount += 1
+        }
+    }
+}
+
+@MainActor
+private final class CountingCloseDelegate: NSObject, NSWindowDelegate {
+    private let shouldApprove: Bool
+    private(set) var shouldCloseCount = 0
+
+    init(shouldApprove: Bool) {
+        self.shouldApprove = shouldApprove
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        shouldCloseCount += 1
+        return shouldApprove
     }
 }

--- a/PineTests/CloseDelegateTests.swift
+++ b/PineTests/CloseDelegateTests.swift
@@ -541,6 +541,112 @@ struct CloseDelegateTests {
         #expect(project.dialogOwnerWindow === secondWindow)
         #expect(secondInterceptor.dialogContext.nsWindow === secondWindow)
     }
+
+    @Test func interceptorDismantleRestoresDelegateAndRetiresDialogAuthority() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let project = ProjectManager()
+        let registry = ProjectRegistry()
+        let appDelegate = AppDelegate()
+        let window = NSWindow()
+        let original = CountingCloseDelegate(shouldApprove: true)
+        window.delegate = original
+        let coordinator = WindowCloseInterceptor.Coordinator()
+        let sentinel = WindowCloseInterceptor.InterceptorView()
+
+        coordinator.installDelegate(
+            on: window,
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: appDelegate
+        )
+        let capturedContext = try #require(
+            window.delegate as? CloseDelegate
+        ).dialogContext
+        #expect(project.dialogOwnerWindow === window)
+
+        WindowCloseInterceptor.dismantleNSView(
+            sentinel,
+            coordinator: coordinator
+        )
+
+        #expect(window.delegate === original)
+        #expect(project.dialogOwnerWindow == nil)
+        #expect(capturedContext.nsWindow == nil)
+        let response = await capturedContext.present(
+            start: { _, completion in
+                completion(.alertFirstButtonReturn)
+            },
+            cancel: { _ in }
+        )
+        #expect(response == .abort)
+
+        // A second teardown must not disturb the restored delegate.
+        coordinator.detach()
+        #expect(window.delegate === original)
+    }
+
+    @Test func interceptorRearmsRetainedDelegateForReopenedWindowGeneration() async throws {
+        let dir = try makeTempDir()
+        let otherDir = try makeTempDir()
+        defer {
+            cleanup(dir)
+            cleanup(otherDir)
+        }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        // Keep another project window logically open so closing `dir` does
+        // not schedule the global delayed Welcome fallback and contaminate
+        // otherwise unrelated window-lifecycle tests.
+        _ = try #require(registry.projectManager(for: otherDir))
+        let appDelegate = AppDelegate()
+        let window = CloseTrackingWindow()
+        let original = CountingCloseDelegate(shouldApprove: true)
+        window.delegate = original
+        let coordinator = WindowCloseInterceptor.Coordinator()
+
+        coordinator.installDelegate(
+            on: window,
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: appDelegate
+        )
+        let interceptor = try #require(window.delegate as? CloseDelegate)
+        interceptor.windowWillClose(
+            Notification(name: NSWindow.willCloseNotification, object: window)
+        )
+        #expect(interceptor.didCompleteWindowLifecycle)
+        #expect(!registry.isWindowOpen(dir))
+        #expect(project.dialogOwnerWindow == nil)
+
+        #expect(registry.projectManager(for: dir) === project)
+        #expect(registry.isWindowOpen(dir))
+        coordinator.installDelegate(
+            on: window,
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: appDelegate
+        )
+
+        #expect(window.delegate === interceptor)
+        #expect(!interceptor.didCompleteWindowLifecycle)
+        #expect(project.dialogOwnerWindow === window)
+        window.performClose(nil)
+        await settle()
+        #expect(window.approvedCloseCount == 1)
+
+        interceptor.windowWillClose(
+            Notification(name: NSWindow.willCloseNotification, object: window)
+        )
+        #expect(interceptor.didCompleteWindowLifecycle)
+        #expect(!registry.isWindowOpen(dir))
+        #expect(project.dialogOwnerWindow == nil)
+        coordinator.detach()
+        #expect(window.delegate === original)
+    }
 }
 
 @MainActor

--- a/PineTests/DialogPresentationCoordinatorTests.swift
+++ b/PineTests/DialogPresentationCoordinatorTests.swift
@@ -1,0 +1,795 @@
+//
+//  DialogPresentationCoordinatorTests.swift
+//  PineTests
+//
+
+import AppKit
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Window dialog coordinator")
+@MainActor
+struct DialogPresentationCoordinatorTests {
+    private func settle() async {
+        for _ in 0..<8 {
+            await Task.yield()
+        }
+    }
+
+    private func makeVisibleWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.orderFront(nil)
+        return window
+    }
+
+    @Test("requests for one window are presented FIFO, never concurrently")
+    func serializesRequestsPerWindow() async {
+        let window = NSWindow()
+        let coordinator = WindowDialogCoordinator(ownerWindow: window)
+        var starts: [Int] = []
+        var completions: [(NSApplication.ModalResponse) -> Void] = []
+
+        let first = Task {
+            await coordinator.present(
+                start: { _, completion in
+                    starts.append(1)
+                    completions.append(completion)
+                },
+                cancel: { _ in }
+            )
+        }
+        await settle()
+
+        let second = Task {
+            await coordinator.present(
+                start: { _, completion in
+                    starts.append(2)
+                    completions.append(completion)
+                },
+                cancel: { _ in }
+            )
+        }
+        await settle()
+
+        #expect(starts == [1])
+        #expect(coordinator.pendingRequestCount == 2)
+
+        completions[0](.alertFirstButtonReturn)
+        await settle()
+        #expect(starts == [1, 2])
+        #expect(coordinator.pendingRequestCount == 1)
+
+        completions[1](.alertSecondButtonReturn)
+        await settle()
+        #expect(await first.value == .alertFirstButtonReturn)
+        #expect(await second.value == .alertSecondButtonReturn)
+        #expect(coordinator.pendingRequestCount == 0)
+    }
+
+    @Test("different owner windows can present independently")
+    func isolatesWindows() async {
+        let firstWindow = NSWindow()
+        let secondWindow = NSWindow()
+        let firstCoordinator = WindowDialogCoordinator(ownerWindow: firstWindow)
+        let secondCoordinator = WindowDialogCoordinator(ownerWindow: secondWindow)
+        var firstCompletion: ((NSApplication.ModalResponse) -> Void)?
+        var secondCompletion: ((NSApplication.ModalResponse) -> Void)?
+        var starts: [String] = []
+
+        let first = Task {
+            await firstCoordinator.present(
+                start: { _, completion in
+                    starts.append("first")
+                    firstCompletion = completion
+                },
+                cancel: { _ in }
+            )
+        }
+        let second = Task {
+            await secondCoordinator.present(
+                start: { _, completion in
+                    starts.append("second")
+                    secondCompletion = completion
+                },
+                cancel: { _ in }
+            )
+        }
+        await settle()
+
+        #expect(Set(starts) == Set(["first", "second"]))
+        #expect(firstCoordinator.pendingRequestCount == 1)
+        #expect(secondCoordinator.pendingRequestCount == 1)
+
+        firstCompletion?(.alertFirstButtonReturn)
+        secondCompletion?(.alertSecondButtonReturn)
+        #expect(await first.value == .alertFirstButtonReturn)
+        #expect(await second.value == .alertSecondButtonReturn)
+    }
+
+    @Test("real sheets stay scoped and can coexist on separate windows")
+    func realSheetsDoNotBlockOtherWindows() async {
+        let firstWindow = makeVisibleWindow()
+        let secondWindow = makeVisibleWindow()
+        defer {
+            DialogPresenter.ownerDidClose(firstWindow)
+            DialogPresenter.ownerDidClose(secondWindow)
+            firstWindow.orderOut(nil)
+            secondWindow.orderOut(nil)
+        }
+        let firstContext = DialogPresentationContext(window: firstWindow)
+        let secondContext = DialogPresentationContext(window: secondWindow)
+        let firstAlert = NSAlert()
+        firstAlert.messageText = "First"
+        firstAlert.addButton(withTitle: "OK")
+        let secondAlert = NSAlert()
+        secondAlert.messageText = "Second"
+        secondAlert.addButton(withTitle: "OK")
+
+        let firstResponse = Task {
+            await firstAlert.runSheet(on: firstContext)
+        }
+        let secondResponse = Task {
+            await secondAlert.runSheet(on: secondContext)
+        }
+        for _ in 0..<50 {
+            if firstWindow.attachedSheet != nil,
+               secondWindow.attachedSheet != nil {
+                break
+            }
+            await Task.yield()
+        }
+
+        #expect(firstWindow.attachedSheet === firstAlert.window)
+        #expect(secondWindow.attachedSheet === secondAlert.window)
+        if firstWindow.attachedSheet === firstAlert.window {
+            firstWindow.endSheet(
+                firstAlert.window,
+                returnCode: .alertFirstButtonReturn
+            )
+        } else {
+            DialogPresenter.ownerDidClose(firstWindow)
+        }
+        if secondWindow.attachedSheet === secondAlert.window {
+            secondWindow.endSheet(
+                secondAlert.window,
+                returnCode: .alertFirstButtonReturn
+            )
+        } else {
+            DialogPresenter.ownerDidClose(secondWindow)
+        }
+
+        #expect(await firstResponse.value == .alertFirstButtonReturn)
+        #expect(await secondResponse.value == .alertFirstButtonReturn)
+    }
+
+    @Test("queued native dialog waits for a framework-owned sheet")
+    func waitsForExistingOwnerSheet() async {
+        let owner = makeVisibleWindow()
+        let frameworkSheet = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 120),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let coordinator = WindowDialogCoordinator(ownerWindow: owner)
+        var startCount = 0
+        var completion: ((NSApplication.ModalResponse) -> Void)?
+        defer {
+            coordinator.ownerDidClose()
+            owner.orderOut(nil)
+        }
+
+        owner.beginSheet(frameworkSheet) { _ in }
+        let response = Task {
+            await coordinator.present(
+                start: { _, callback in
+                    startCount += 1
+                    completion = callback
+                },
+                cancel: { _ in }
+            )
+        }
+        await settle()
+        #expect(startCount == 0)
+
+        owner.endSheet(frameworkSheet, returnCode: .cancel)
+        for _ in 0..<50 {
+            if startCount == 1 { break }
+            await Task.yield()
+        }
+        #expect(startCount == 1)
+
+        if let completion {
+            completion(.alertFirstButtonReturn)
+        } else {
+            coordinator.ownerDidClose()
+        }
+        #expect(await response.value == .alertFirstButtonReturn)
+    }
+
+    @Test("owner close aborts active and queued requests exactly once")
+    func ownerCloseCancelsEverythingOnce() async {
+        let window = NSWindow()
+        let coordinator = WindowDialogCoordinator(ownerWindow: window)
+        var activeCompletion: ((NSApplication.ModalResponse) -> Void)?
+        var cancelCount = 0
+        var queuedStarted = false
+
+        let active = Task {
+            await coordinator.present(
+                start: { _, completion in activeCompletion = completion },
+                cancel: { _ in cancelCount += 1 }
+            )
+        }
+        await settle()
+        let queued = Task {
+            await coordinator.present(
+                start: { _, _ in queuedStarted = true },
+                cancel: { _ in cancelCount += 1 }
+            )
+        }
+        await settle()
+
+        coordinator.ownerDidClose()
+        coordinator.ownerDidClose()
+        await settle()
+
+        #expect(await active.value == .abort)
+        #expect(await queued.value == .abort)
+        #expect(cancelCount == 1)
+        #expect(!queuedStarted)
+        #expect(coordinator.pendingRequestCount == 0)
+
+        // AppKit may deliver the sheet completion after endSheet/cancel.
+        // It must not resume the request a second time.
+        activeCompletion?(.alertFirstButtonReturn)
+        await settle()
+        #expect(cancelCount == 1)
+    }
+
+    @Test("task cancellation aborts its active request exactly once")
+    func taskCancellationEndsActiveRequest() async {
+        let window = NSWindow()
+        let coordinator = WindowDialogCoordinator(ownerWindow: window)
+        var lateCompletion: ((NSApplication.ModalResponse) -> Void)?
+        var cancelCount = 0
+
+        let request = Task {
+            await coordinator.present(
+                start: { _, completion in
+                    lateCompletion = completion
+                },
+                cancel: { _ in cancelCount += 1 }
+            )
+        }
+        await settle()
+        request.cancel()
+        await settle()
+
+        let didCancelRequest = coordinator.pendingRequestCount == 0
+        #expect(didCancelRequest)
+        #expect(!coordinator.isOwnerClosed)
+        if !didCancelRequest {
+            coordinator.ownerDidClose()
+        }
+        #expect(await request.value == .abort)
+        #expect(cancelCount == 1)
+        #expect(coordinator.pendingRequestCount == 0)
+
+        lateCompletion?(.alertFirstButtonReturn)
+        await settle()
+        #expect(cancelCount == 1)
+        #expect(coordinator.pendingRequestCount == 0)
+    }
+
+    @Test("injected notification center owns the close lifecycle")
+    func injectedNotificationCenterCancelsRequest() async {
+        let window = NSWindow()
+        let notificationCenter = NotificationCenter()
+        let coordinator = WindowDialogCoordinator(
+            ownerWindow: window,
+            notificationCenter: notificationCenter
+        )
+        var cancelCount = 0
+
+        let request = Task {
+            await coordinator.present(
+                start: { _, _ in },
+                cancel: { _ in cancelCount += 1 }
+            )
+        }
+        await settle()
+
+        notificationCenter.post(
+            name: NSWindow.willCloseNotification,
+            object: window
+        )
+        await settle()
+
+        #expect(await request.value == .abort)
+        #expect(cancelCount == 1)
+        #expect(coordinator.pendingRequestCount == 0)
+    }
+
+    @Test("missing owner fails closed without starting UI")
+    func missingOwnerFailsClosed() async {
+        var didStart = false
+        let response = await DialogPresentationContext.unscoped.present(
+            start: { _, _ in didStart = true },
+            cancel: { _ in }
+        )
+        #expect(response == .abort)
+        #expect(!didStart)
+    }
+
+    @Test("native adapters fail closed for a hidden owner")
+    func hiddenOwnerFailsClosed() async {
+        let window = NSWindow()
+        let context = DialogPresentationContext(window: window)
+        let alert = NSAlert()
+        alert.messageText = "Hidden"
+        alert.addButton(withTitle: "OK")
+
+        let response = await alert.runSheet(on: context)
+
+        #expect(response == .abort)
+        #expect(window.attachedSheet == nil)
+        DialogPresenter.ownerDidClose(window)
+    }
+
+    @Test("native adapters reject a miniaturized owner")
+    func miniaturizedOwnerFailsClosed() async {
+        let window = makeVisibleWindow()
+        window.miniaturize(nil)
+        let context = DialogPresentationContext(window: window)
+        let alert = NSAlert()
+        alert.messageText = "Miniaturized"
+        alert.addButton(withTitle: "OK")
+        defer {
+            DialogPresenter.ownerDidClose(window)
+            window.orderOut(nil)
+        }
+
+        #expect(window.isMiniaturized)
+        #expect(!DialogPresenter.isEligibleApplicationOwner(window))
+        let response = await alert.runSheet(on: context)
+
+        #expect(response == .abort)
+        #expect(window.attachedSheet == nil)
+    }
+
+    @Test("application dialog preparation restores an all-minimized owner set")
+    func applicationDialogPreparationRestoresMiniaturizedWindow() {
+        let window = makeVisibleWindow()
+        window.miniaturize(nil)
+        let appDelegate = AppDelegate()
+        defer {
+            DialogPresenter.ownerDidClose(window)
+            window.orderOut(nil)
+        }
+
+        #expect(window.isMiniaturized)
+        appDelegate.prepareApplicationDialogOwner(windows: [window])
+
+        #expect(!window.isMiniaturized)
+        #expect(window.isVisible)
+        #expect(DialogPresenter.isEligibleApplicationOwner(window))
+    }
+
+    @Test("project lookup captures the matching window, not the key window")
+    func routesToMatchingProjectWindow() {
+        // This is a routing test, so do not load real project directories:
+        // doing so starts asynchronous workspace + git work unrelated to the
+        // presentation contract.
+        let firstProject = ProjectManager()
+        let secondProject = ProjectManager()
+        let firstWindow = NSWindow()
+        let secondWindow = NSWindow()
+        DialogPresenter.register(window: firstWindow, projectManager: firstProject)
+        DialogPresenter.register(window: secondWindow, projectManager: secondProject)
+        defer {
+            DialogPresenter.ownerDidClose(firstWindow)
+            DialogPresenter.ownerDidClose(secondWindow)
+        }
+
+        #expect(DialogPresenter.forProject(firstProject).nsWindow === firstWindow)
+        #expect(DialogPresenter.forProject(secondProject).nsWindow === secondWindow)
+        #expect(firstProject.primaryTabManager.dialogContextProvider().nsWindow === firstWindow)
+        #expect(secondProject.primaryTabManager.dialogContextProvider().nsWindow === secondWindow)
+    }
+
+    @Test("same-window project rebind aborts the old active and queued generation")
+    func sameWindowProjectRebindRetiresCoordinatorGeneration() async {
+        let window = NSWindow()
+        let firstProject = ProjectManager()
+        let secondProject = ProjectManager()
+        let firstContext = DialogPresenter.register(
+            window: window,
+            projectManager: firstProject
+        )
+        var activeCompletion: ((NSApplication.ModalResponse) -> Void)?
+        var activeCancelCount = 0
+        var queuedStarted = false
+
+        let active = Task {
+            await firstContext.present(
+                start: { _, completion in
+                    activeCompletion = completion
+                },
+                cancel: { _ in
+                    activeCancelCount += 1
+                }
+            )
+        }
+        await settle()
+        let queued = Task {
+            await firstContext.present(
+                start: { _, _ in
+                    queuedStarted = true
+                },
+                cancel: { _ in }
+            )
+        }
+        await settle()
+
+        let secondContext = DialogPresenter.register(
+            window: window,
+            projectManager: secondProject
+        )
+        await settle()
+
+        #expect(await active.value == .abort)
+        #expect(await queued.value == .abort)
+        #expect(activeCancelCount == 1)
+        #expect(!queuedStarted)
+        #expect(firstContext.nsWindow == nil)
+        #expect(DialogPresenter.projectManager(for: window) === secondProject)
+        #expect(firstProject.dialogOwnerWindow == nil)
+        #expect(secondProject.dialogOwnerWindow === window)
+
+        var secondCompletion: ((NSApplication.ModalResponse) -> Void)?
+        let secondRequest = Task {
+            await secondContext.present(
+                start: { _, completion in
+                    secondCompletion = completion
+                },
+                cancel: { _ in }
+            )
+        }
+        await settle()
+        if let secondCompletion {
+            secondCompletion(.alertFirstButtonReturn)
+        } else {
+            DialogPresenter.ownerDidClose(window)
+        }
+        #expect(await secondRequest.value == .alertFirstButtonReturn)
+
+        // A late AppKit callback from the retired generation is harmless.
+        activeCompletion?(.alertFirstButtonReturn)
+        await settle()
+        #expect(activeCancelCount == 1)
+        DialogPresenter.ownerDidClose(window)
+    }
+
+    @Test("owner close clears the project-owned weak anchor")
+    func ownerCloseClearsProjectAnchor() {
+        let project = ProjectManager()
+        let window = NSWindow()
+        DialogPresenter.register(window: window, projectManager: project)
+
+        #expect(project.dialogOwnerWindow === window)
+        DialogPresenter.ownerDidClose(window)
+        #expect(project.dialogOwnerWindow == nil)
+        #expect(DialogPresenter.forProject(project).nsWindow == nil)
+    }
+
+    @Test("closing an obsolete owner does not clear a rebound project anchor")
+    func obsoleteOwnerClosePreservesNewAnchor() {
+        let project = ProjectManager()
+        let oldWindow = NSWindow()
+        let newWindow = NSWindow()
+        let oldContext = DialogPresenter.register(
+            window: oldWindow,
+            projectManager: project
+        )
+        DialogPresenter.register(window: newWindow, projectManager: project)
+        defer { DialogPresenter.ownerDidClose(newWindow) }
+
+        DialogPresenter.ownerDidClose(oldWindow)
+
+        #expect(oldContext.nsWindow == nil)
+        #expect(DialogPresenter.projectManager(for: oldWindow) == nil)
+        #expect(project.dialogOwnerWindow === newWindow)
+        #expect(DialogPresenter.forProject(project).nsWindow === newWindow)
+    }
+
+    @Test("project stateful dialog operations recompute in FIFO order")
+    func projectDialogOperationsAreSerialized() async {
+        let project = ProjectManager()
+        var events: [String] = []
+        let (gate, gateContinuation) = AsyncStream.makeStream(of: Void.self)
+
+        project.enqueueDialogOperation {
+            events.append("first-start")
+            for await _ in gate {
+                break
+            }
+            events.append("first-end")
+        }
+        project.enqueueDialogOperation {
+            events.append("second")
+        }
+        await settle()
+
+        #expect(events == ["first-start"])
+        gateContinuation.yield()
+        gateContinuation.finish()
+        for _ in 0..<50 {
+            if events.count == 3 { break }
+            await Task.yield()
+        }
+
+        #expect(events == ["first-start", "first-end", "second"])
+    }
+}
+
+@Suite("Dialog flow regressions")
+@MainActor
+struct DialogFlowRegressionTests {
+    @Test("single dirty tab remains open when save fails")
+    func dirtySingleTabSaveFailureIsFailClosed() async {
+        let manager = TabManager()
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-dialog-save-failure.swift"),
+            content: "modified",
+            savedContent: "original"
+        )
+        manager.tabs = [tab]
+        manager.activeTabID = tab.id
+
+        let closed = await TabCloseHelper.closeTab(
+            tab,
+            in: manager,
+            gitProvider: GitStatusProvider(),
+            presentAlert: { .alertFirstButtonReturn },
+            saveTab: { _ in false }
+        )
+
+        #expect(!closed)
+        #expect(manager.tabs.map(\.id) == [tab.id])
+        #expect(manager.tabs[0].isDirty)
+    }
+
+    @Test("discard closes the last dirty tab only after the decision resolves")
+    func dirtyLastTabDiscardCompletesClose() async {
+        let manager = TabManager()
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-dialog-discard.swift"),
+            content: "modified",
+            savedContent: "original"
+        )
+        manager.tabs = [tab]
+        manager.activeTabID = tab.id
+
+        let closed = await TabCloseHelper.closeTab(
+            tab,
+            in: manager,
+            gitProvider: GitStatusProvider(),
+            presentAlert: { .alertSecondButtonReturn }
+        )
+
+        #expect(closed)
+        #expect(manager.tabs.isEmpty)
+    }
+
+    @Test("single-tab discard is rejected when content changes during the sheet")
+    func dirtySingleTabRejectsStaleDiscard() async {
+        let manager = TabManager()
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-dialog-stale-discard.swift"),
+            content: "first modification",
+            savedContent: "original"
+        )
+        manager.tabs = [tab]
+        manager.activeTabID = tab.id
+
+        let closed = await TabCloseHelper.closeTab(
+            tab,
+            in: manager,
+            gitProvider: GitStatusProvider(),
+            presentAlert: {
+                manager.updateContent("new modification")
+                return .alertSecondButtonReturn
+            }
+        )
+
+        #expect(!closed)
+        #expect(manager.tabs.count == 1)
+        #expect(manager.activeTab?.content == "new modification")
+    }
+
+    @Test("single-tab save is rejected when the tab is dirtied again")
+    func dirtySingleTabRejectsStaleSave() async {
+        let manager = TabManager()
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-dialog-stale-save.swift"),
+            content: "first modification",
+            savedContent: "original"
+        )
+        manager.tabs = [tab]
+        manager.activeTabID = tab.id
+
+        let closed = await TabCloseHelper.closeTab(
+            tab,
+            in: manager,
+            gitProvider: GitStatusProvider(),
+            presentAlert: { .alertFirstButtonReturn },
+            saveTab: { index in
+                manager.tabs[index].savedContent = manager.tabs[index].content
+                manager.tabs[index].content = "edited after save"
+                return true
+            }
+        )
+
+        #expect(!closed)
+        #expect(manager.tabs.count == 1)
+        #expect(manager.tabs[0].isDirty)
+        #expect(manager.tabs[0].content == "edited after save")
+    }
+
+    @Test("captured clean value cannot bypass a newly dirty live tab")
+    func capturedCleanTabReResolvesDirtyState() async {
+        let manager = TabManager()
+        let captured = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-dialog-clean-snapshot.swift"),
+            content: "original",
+            savedContent: "original"
+        )
+        var live = captured
+        live.content = "edited before async entry"
+        manager.tabs = [live]
+        manager.activeTabID = live.id
+        var alertCount = 0
+
+        let closed = await TabCloseHelper.closeTab(
+            captured,
+            in: manager,
+            gitProvider: GitStatusProvider(),
+            presentAlert: {
+                alertCount += 1
+                return .alertThirdButtonReturn
+            }
+        )
+
+        #expect(!closed)
+        #expect(alertCount == 1)
+        #expect(manager.tabs.first?.content == "edited before async entry")
+        #expect(manager.tabs.first?.isDirty == true)
+    }
+
+    @Test("disappeared captured tab fails closed without presenting")
+    func disappearedTabDoesNotReportFalseClose() async {
+        let manager = TabManager()
+        let captured = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-dialog-missing.swift"),
+            content: "edited",
+            savedContent: "original"
+        )
+        var alertCount = 0
+
+        let closed = await TabCloseHelper.closeTab(
+            captured,
+            in: manager,
+            gitProvider: GitStatusProvider(),
+            presentAlert: {
+                alertCount += 1
+                return .alertSecondButtonReturn
+            }
+        )
+
+        #expect(!closed)
+        #expect(alertCount == 0)
+        #expect(manager.tabs.isEmpty)
+    }
+
+    @Test("dirty authorization excludes clean tabs and rejects clean-to-dirty")
+    func dirtyAuthorizationRejectsCleanToDirtyTransition() {
+        let displayedDirty = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-dialog-displayed-dirty.swift"),
+            content: "edited",
+            savedContent: "saved"
+        )
+        var displayedClean = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-dialog-displayed-clean.swift"),
+            content: "saved",
+            savedContent: "saved"
+        )
+        let authorization = DirtyEditorContentAuthorization(
+            tabs: [displayedDirty, displayedClean]
+        )
+
+        #expect(authorization.covers([displayedDirty]))
+        displayedClean.content = "became dirty while sheet was visible"
+        #expect(!authorization.covers([displayedDirty, displayedClean]))
+    }
+
+    @Test("discard commit validates every buffer before mutating any buffer")
+    func discardCommitIsAtomicWithinTabManager() {
+        let manager = TabManager()
+        let first = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-discard-atomic-first.swift"),
+            content: "first edit",
+            savedContent: "first saved"
+        )
+        var second = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-discard-atomic-second.swift"),
+            content: "second edit",
+            savedContent: "second saved"
+        )
+        manager.tabs = [first, second]
+        let authorization = DirtyEditorContentAuthorization(tabs: manager.tabs)
+        second.content = "newer second edit"
+        manager.tabs[1] = second
+
+        #expect(!manager.discardChanges(authorizedBy: authorization))
+        #expect(manager.tabs[0].content == "first edit")
+        #expect(manager.tabs[0].isDirty)
+        #expect(manager.tabs[1].content == "newer second edit")
+        #expect(manager.tabs[1].isDirty)
+    }
+
+    @Test("large-file response mapping is fail closed")
+    func largeFileResponseMapping() {
+        #expect(
+            TabPersistence.largeFileDecision(for: .alertFirstButtonReturn)
+                == .openWithoutHighlighting
+        )
+        #expect(
+            TabPersistence.largeFileDecision(for: .alertSecondButtonReturn)
+                == .openWithHighlighting
+        )
+        #expect(TabPersistence.largeFileDecision(for: .abort) == .cancel)
+        #expect(TabPersistence.largeFileDecision(for: .cancel) == .cancel)
+    }
+
+    @Test("production Swift contains no application-modal dialog calls")
+    func noApplicationModalRegression() throws {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceRoot = repositoryRoot.appendingPathComponent("Pine")
+        let enumerator = try #require(
+            FileManager.default.enumerator(
+                at: sourceRoot,
+                includingPropertiesForKeys: nil
+            )
+        )
+        let forbiddenAPIs = [
+            "runModal(",
+            "beginModalSession(",
+            "runModalSession(",
+            "runModal(for:",
+            "beginModal(for:",
+            "panel.begin {",
+            "panel.begin(completionHandler:",
+        ]
+        var offenders: [String] = []
+        for case let fileURL as URL in enumerator
+        where fileURL.pathExtension == "swift" {
+            let source = try String(contentsOf: fileURL, encoding: .utf8)
+            for forbiddenAPI in forbiddenAPIs where source.contains(forbiddenAPI) {
+                offenders.append(
+                    "\(fileURL.lastPathComponent): \(forbiddenAPI)"
+                )
+            }
+        }
+        #expect(offenders.isEmpty, "Application-modal calls: \(offenders)")
+    }
+}

--- a/PineTests/DialogPresentationCoordinatorTests.swift
+++ b/PineTests/DialogPresentationCoordinatorTests.swift
@@ -21,7 +21,7 @@ struct DialogPresentationCoordinatorTests {
     private func makeVisibleWindow() -> NSWindow {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
-            styleMask: [.titled, .closable],
+            styleMask: [.titled, .closable, .miniaturizable],
             backing: .buffered,
             defer: false
         )
@@ -70,6 +70,59 @@ struct DialogPresentationCoordinatorTests {
         await settle()
         #expect(await first.value == .alertFirstButtonReturn)
         #expect(await second.value == .alertSecondButtonReturn)
+        #expect(coordinator.pendingRequestCount == 0)
+    }
+
+    @Test("duplicate destructive request is rejected until the original finishes")
+    func deduplicatesInFlightRequestKey() async {
+        let window = NSWindow()
+        let coordinator = WindowDialogCoordinator(ownerWindow: window)
+        let key = DialogRequestKey.editorTabs(
+            tabManager: ObjectIdentifier(window),
+            tabIDs: [UUID()]
+        )
+        var startCount = 0
+        var firstCompletion: ((NSApplication.ModalResponse) -> Void)?
+
+        let first = Task {
+            await coordinator.present(
+                deduplicationKey: key,
+                start: { _, completion in
+                    startCount += 1
+                    firstCompletion = completion
+                },
+                cancel: { _ in }
+            )
+        }
+        await settle()
+
+        let duplicate = await coordinator.present(
+            deduplicationKey: key,
+            start: { _, completion in
+                startCount += 1
+                completion(.alertFirstButtonReturn)
+            },
+            cancel: { _ in }
+        )
+
+        #expect(duplicate == .abort)
+        #expect(startCount == 1)
+        #expect(coordinator.pendingRequestCount == 1)
+
+        firstCompletion?(.alertSecondButtonReturn)
+        #expect(await first.value == .alertSecondButtonReturn)
+        await settle()
+
+        let next = await coordinator.present(
+            deduplicationKey: key,
+            start: { _, completion in
+                startCount += 1
+                completion(.alertFirstButtonReturn)
+            },
+            cancel: { _ in }
+        )
+        #expect(next == .alertFirstButtonReturn)
+        #expect(startCount == 2)
         #expect(coordinator.pendingRequestCount == 0)
     }
 
@@ -344,43 +397,54 @@ struct DialogPresentationCoordinatorTests {
         DialogPresenter.ownerDidClose(window)
     }
 
-    @Test("native adapters reject a miniaturized owner")
-    func miniaturizedOwnerFailsClosed() async {
-        let window = makeVisibleWindow()
-        window.miniaturize(nil)
-        let context = DialogPresentationContext(window: window)
-        let alert = NSAlert()
-        alert.messageText = "Miniaturized"
-        alert.addButton(withTitle: "OK")
-        defer {
-            DialogPresenter.ownerDidClose(window)
-            window.orderOut(nil)
-        }
-
-        #expect(window.isMiniaturized)
-        #expect(!DialogPresenter.isEligibleApplicationOwner(window))
-        let response = await alert.runSheet(on: context)
-
-        #expect(response == .abort)
-        #expect(window.attachedSheet == nil)
+    @Test("application owner eligibility rejects hidden and miniaturized states")
+    func applicationOwnerEligibility() {
+        #expect(
+            DialogPresenter.applicationOwnerState(
+                isVisible: true,
+                isMiniaturized: false
+            ) == .eligible
+        )
+        #expect(
+            DialogPresenter.applicationOwnerState(
+                isVisible: true,
+                isMiniaturized: true
+            ) == .miniaturized
+        )
+        #expect(
+            DialogPresenter.applicationOwnerState(
+                isVisible: false,
+                isMiniaturized: false
+            ) == .unavailable
+        )
+        #expect(
+            DialogPresenter.applicationOwnerState(
+                isVisible: false,
+                isMiniaturized: true
+            ) == .unavailable
+        )
     }
 
-    @Test("application dialog preparation restores an all-minimized owner set")
-    func applicationDialogPreparationRestoresMiniaturizedWindow() {
-        let window = makeVisibleWindow()
-        window.miniaturize(nil)
-        let appDelegate = AppDelegate()
-        defer {
-            DialogPresenter.ownerDidClose(window)
-            window.orderOut(nil)
-        }
-
-        #expect(window.isMiniaturized)
-        appDelegate.prepareApplicationDialogOwner(windows: [window])
-
-        #expect(!window.isMiniaturized)
-        #expect(window.isVisible)
-        #expect(DialogPresenter.isEligibleApplicationOwner(window))
+    @Test("application dialog owner plan keeps, restores, or creates deterministically")
+    func applicationDialogOwnerPlan() {
+        #expect(
+            DialogPresenter.applicationOwnerPlan(
+                for: [.miniaturized, .eligible, .unavailable]
+            ) == .keepExisting
+        )
+        #expect(
+            DialogPresenter.applicationOwnerPlan(
+                for: [.unavailable, .miniaturized, .miniaturized]
+            ) == .restore(index: 1)
+        )
+        #expect(
+            DialogPresenter.applicationOwnerPlan(
+                for: [.unavailable, .unavailable]
+            ) == .showWelcome
+        )
+        #expect(
+            DialogPresenter.applicationOwnerPlan(for: []) == .showWelcome
+        )
     }
 
     @Test("project lookup captures the matching window, not the key window")

--- a/PineTests/ProjectDialogOwnerReadinessTests.swift
+++ b/PineTests/ProjectDialogOwnerReadinessTests.swift
@@ -1,0 +1,72 @@
+//
+//  ProjectDialogOwnerReadinessTests.swift
+//  PineTests
+//
+
+import AppKit
+import Testing
+
+@testable import Pine
+
+@Suite("Project Dialog Owner Readiness Tests")
+@MainActor
+struct ProjectDialogOwnerReadinessTests {
+    @Test func delayedOwnerBindingIsObservedWithoutFixedDelay() async {
+        let projectManager = ProjectManager()
+        let window = NSWindow()
+        var waitCount = 0
+
+        let resolved = await projectManager.awaitDialogOwnerWindow(
+            maximumAttempts: 6,
+            waitForNextAttempt: {
+                waitCount += 1
+                if waitCount == 3 {
+                    projectManager.bindDialogOwnerWindow(window)
+                }
+                await Task.yield()
+            },
+            isEligible: { _ in true }
+        )
+
+        #expect(resolved === window)
+        #expect(waitCount == 3)
+    }
+
+    @Test func missingOwnerStopsAtBound() async {
+        let projectManager = ProjectManager()
+        var waitCount = 0
+
+        let resolved = await projectManager.awaitDialogOwnerWindow(
+            maximumAttempts: 3,
+            waitForNextAttempt: {
+                waitCount += 1
+                await Task.yield()
+            },
+            isEligible: { _ in true }
+        )
+
+        #expect(resolved == nil)
+        #expect(waitCount == 3)
+    }
+
+    @Test func cancelledWaitStopsBeforePolling() async {
+        let projectManager = ProjectManager()
+        var waitCount = 0
+        let task = Task { @MainActor in
+            await projectManager.awaitDialogOwnerWindow(
+                maximumAttempts: 10,
+                waitForNextAttempt: {
+                    waitCount += 1
+                    await Task.yield()
+                },
+                isEligible: { _ in true }
+            )
+        }
+
+        task.cancel()
+        let resolved = await task.value
+
+        #expect(resolved == nil)
+        #expect(waitCount == 0)
+    }
+}

--- a/PineTests/RecoveryManagerTests.swift
+++ b/PineTests/RecoveryManagerTests.swift
@@ -3,8 +3,9 @@
 //  PineTests
 //
 
-import Testing
+import AppKit
 import Foundation
+import Testing
 @testable import Pine
 
 @MainActor
@@ -19,6 +20,19 @@ struct RecoveryManagerTests {
 
     private func cleanup(_ url: URL) {
         try? FileManager.default.removeItem(at: url)
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        _ condition: @MainActor () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !condition() {
+            guard clock.now < deadline else { return false }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return true
     }
 
     private func makeDirtyTab(
@@ -131,6 +145,457 @@ struct RecoveryManagerTests {
         // Simulate save — TabManager calls deleteRecoveryFile after trySaveTab
         manager.deleteRecoveryFile(for: tab.id)
         #expect(manager.pendingRecoveryEntries().isEmpty)
+    }
+
+    @Test func restoreWaitsForLargeFileOpenBeforeApplyingAndDeleting() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let manager = RecoveryManager(recoveryDirectory: dir)
+        let file = dir.appendingPathComponent("large.swift")
+        let diskContent = String(
+            repeating: "d",
+            count: TabManager.largeFileThreshold + 1
+        )
+        try diskContent.write(to: file, atomically: true, encoding: .utf8)
+        let recoveredContent = "recovered unsaved content"
+        let crashedTab = makeDirtyTab(
+            url: file,
+            content: recoveredContent,
+            savedContent: diskContent,
+            encoding: .utf16
+        )
+        manager.snapshotDirtyTabs([crashedTab])
+        let entries = manager.pendingRecoveryEntries()
+        let tabManager = TabManager()
+        let (responses, responseContinuation) = AsyncStream.makeStream(
+            of: NSApplication.ModalResponse.self
+        )
+        var presentationCount = 0
+        tabManager.largeFileAlertPresenter = { _, _, _ in
+            presentationCount += 1
+            for await response in responses {
+                return response
+            }
+            return .abort
+        }
+
+        let restoreTask = Task { @MainActor in
+            await manager.restorePendingEntries(
+                entries,
+                in: tabManager,
+                context: .unscoped
+            )
+        }
+        #expect(await waitUntil { presentationCount == 1 })
+        #expect(tabManager.tabs.isEmpty)
+        #expect(manager.pendingRecoveryEntries().map(\.0) == [crashedTab.id])
+
+        responseContinuation.yield(.alertSecondButtonReturn)
+        responseContinuation.finish()
+        let retained = await restoreTask.value
+
+        let restoredTab = try #require(tabManager.activeTab)
+        #expect(retained.isEmpty)
+        #expect(tabManager.tabs.count == 2)
+        let baselineTab = try #require(tabManager.tabs.first)
+        #expect(baselineTab.id != restoredTab.id)
+        #expect(baselineTab.content == diskContent)
+        #expect(baselineTab.savedContent == diskContent)
+        #expect(restoredTab.content == recoveredContent)
+        #expect(restoredTab.savedContent == diskContent)
+        #expect(restoredTab.encoding == .utf16)
+        #expect(restoredTab.isDirty)
+        let currentSnapshots = manager.pendingRecoveryEntries()
+        #expect(currentSnapshots.map(\.0) == [restoredTab.id])
+        #expect(currentSnapshots.first?.1.content == recoveredContent)
+    }
+
+    @Test func cancelledLargeFileRecoveryRetainsSnapshot() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let manager = RecoveryManager(recoveryDirectory: dir)
+        let file = dir.appendingPathComponent("cancelled-large.swift")
+        let diskContent = String(
+            repeating: "d",
+            count: TabManager.largeFileThreshold + 1
+        )
+        try diskContent.write(to: file, atomically: true, encoding: .utf8)
+        let crashedTab = makeDirtyTab(
+            url: file,
+            content: "keep this recovery",
+            savedContent: diskContent
+        )
+        manager.snapshotDirtyTabs([crashedTab])
+        let entries = manager.pendingRecoveryEntries()
+        let tabManager = TabManager()
+        tabManager.largeFileAlertPresenter = { _, _, _ in .abort }
+
+        let retained = await manager.restorePendingEntries(
+            entries,
+            in: tabManager,
+            context: .unscoped
+        )
+
+        #expect(retained.map(\.0) == [crashedTab.id])
+        #expect(tabManager.tabs.isEmpty)
+        #expect(manager.pendingRecoveryEntries().map(\.0) == [crashedTab.id])
+    }
+
+    @Test func partialRestoreRetainsOnlyCancelledEntryAndSelectiveDiscard() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let manager = RecoveryManager(recoveryDirectory: dir)
+        let restoredURL = dir.appendingPathComponent("restored.swift")
+        let restoredDiskContent = "let disk = true"
+        try restoredDiskContent.write(
+            to: restoredURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        let cancelledURL = dir.appendingPathComponent("cancelled.swift")
+        let cancelledDiskContent = String(
+            repeating: "c",
+            count: TabManager.largeFileThreshold + 1
+        )
+        try cancelledDiskContent.write(
+            to: cancelledURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        let restoredCrashTab = makeDirtyTab(
+            url: restoredURL,
+            content: "let recovered = true",
+            savedContent: restoredDiskContent
+        )
+        let cancelledCrashTab = makeDirtyTab(
+            url: cancelledURL,
+            content: "retain cancelled recovery",
+            savedContent: cancelledDiskContent
+        )
+        manager.snapshotDirtyTabs([
+            restoredCrashTab,
+            cancelledCrashTab
+        ])
+        let tabManager = TabManager()
+        tabManager.largeFileAlertPresenter = { _, _, _ in .abort }
+
+        let retained = await manager.restorePendingEntries(
+            manager.pendingRecoveryEntries(),
+            in: tabManager,
+            context: .unscoped
+        )
+
+        #expect(retained.map(\.0) == [cancelledCrashTab.id])
+        let recoveredTab = try #require(tabManager.tabs.first(where: {
+            $0.content == "let recovered = true"
+        }))
+        #expect(recoveredTab.id != restoredCrashTab.id)
+        #expect(recoveredTab.isDirty)
+        #expect(
+            Set(manager.pendingRecoveryEntries().map(\.0)) ==
+                Set([cancelledCrashTab.id, recoveredTab.id])
+        )
+
+        manager.deleteRecoveryFiles(for: retained.map(\.0))
+
+        #expect(
+            manager.pendingRecoveryEntries().map(\.0) ==
+                [recoveredTab.id]
+        )
+        #expect(
+            manager.pendingRecoveryEntries().first?.1.content ==
+                "let recovered = true"
+        )
+    }
+
+    @Test func duplicateURLRecoveryKeepsEveryDivergentBuffer() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let recoveryManager = RecoveryManager(recoveryDirectory: dir)
+        let file = dir.appendingPathComponent("duplicate.swift")
+        let diskContent = "let value = \"disk\""
+        try diskContent.write(to: file, atomically: true, encoding: .utf8)
+        let firstRecoveredContent = "let value = \"first 🧪\"\n\u{0}"
+        let secondRecoveredContent = "let value = \"second\""
+        let firstCrashTab = makeDirtyTab(
+            url: file,
+            content: firstRecoveredContent,
+            savedContent: diskContent,
+            encoding: .utf16
+        )
+        let secondCrashTab = makeDirtyTab(
+            url: file,
+            content: secondRecoveredContent,
+            savedContent: diskContent,
+            encoding: .ascii
+        )
+        recoveryManager.snapshotDirtyTabs([
+            firstCrashTab,
+            secondCrashTab
+        ])
+
+        let tabManager = TabManager()
+        tabManager.openTab(url: file)
+        let existingID = try #require(tabManager.activeTabID)
+        tabManager.tabs[0].content = "live unsaved buffer"
+        tabManager.tabs[0].recomputeContentCaches()
+
+        let retained = await recoveryManager.restorePendingEntries(
+            recoveryManager.pendingRecoveryEntries(),
+            in: tabManager,
+            context: .unscoped
+        )
+
+        #expect(retained.isEmpty)
+        #expect(tabManager.tabs.count == 3)
+        let existing = try #require(tabManager.tabs.first(where: {
+            $0.id == existingID
+        }))
+        #expect(existing.content == "live unsaved buffer")
+        #expect(existing.savedContent == diskContent)
+
+        let recoveredTabs = tabManager.tabs.filter { $0.id != existingID }
+        #expect(Set(recoveredTabs.map(\.content)) == Set([
+            firstRecoveredContent,
+            secondRecoveredContent
+        ]))
+        #expect(
+            recoveredTabs.first(where: {
+                $0.content == firstRecoveredContent
+            })?.encoding == .utf16
+        )
+        #expect(
+            recoveredTabs.first(where: {
+                $0.content == secondRecoveredContent
+            })?.encoding == .ascii
+        )
+        let allRecoveredTabsShareBaseline = recoveredTabs.allSatisfy {
+            $0.savedContent == diskContent
+        }
+        #expect(allRecoveredTabsShareBaseline)
+        let allRecoveredTabsAreDirty = recoveredTabs.allSatisfy {
+            $0.isDirty
+        }
+        #expect(allRecoveredTabsAreDirty)
+        #expect(Set(tabManager.tabs.map(\.id)).count == 3)
+        #expect(
+            Set(recoveryManager.pendingRecoveryEntries().map(\.1.content)) ==
+                Set([firstRecoveredContent, secondRecoveredContent])
+        )
+        #expect(
+            Set(recoveryManager.pendingRecoveryEntries().map(\.0))
+                .isDisjoint(with: [firstCrashTab.id, secondCrashTab.id])
+        )
+    }
+
+    @Test func maxTabsRecoveryIsRetainedWithoutOverwritingExistingTab() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let recoveryManager = RecoveryManager(recoveryDirectory: dir)
+        let file = dir.appendingPathComponent("full.swift")
+        let baseline = "baseline"
+        try baseline.write(to: file, atomically: true, encoding: .utf8)
+        let crashTab = makeDirtyTab(
+            url: file,
+            content: "must remain recoverable",
+            savedContent: baseline
+        )
+        recoveryManager.snapshotDirtyTabs([crashTab])
+
+        let tabManager = TabManager()
+        tabManager.tabs = [EditorTab(
+            url: file,
+            content: baseline,
+            savedContent: baseline
+        )]
+        for index in 1..<TabManager.maxTabs {
+            tabManager.tabs.append(EditorTab(
+                url: dir.appendingPathComponent("filler-\(index).swift"),
+                content: "",
+                savedContent: ""
+            ))
+        }
+        let existingID = tabManager.tabs[0].id
+
+        let retained = await recoveryManager.restorePendingEntries(
+            recoveryManager.pendingRecoveryEntries(),
+            in: tabManager,
+            context: .unscoped
+        )
+
+        #expect(retained.map(\.0) == [crashTab.id])
+        #expect(tabManager.tabs.count == TabManager.maxTabs)
+        #expect(tabManager.tabs[0].id == existingID)
+        #expect(tabManager.tabs[0].content == baseline)
+        #expect(
+            recoveryManager.pendingRecoveryEntries().map(\.0) ==
+                [crashTab.id]
+        )
+    }
+
+    @Test func unopenedRecoveryNeedsRoomForBaselineAndRecoveredTabs() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let recoveryManager = RecoveryManager(recoveryDirectory: dir)
+        let file = dir.appendingPathComponent("needs-two-slots.swift")
+        try "disk".write(to: file, atomically: true, encoding: .utf8)
+        let crashTab = makeDirtyTab(
+            url: file,
+            content: "recovered",
+            savedContent: "disk"
+        )
+        recoveryManager.snapshotDirtyTabs([crashTab])
+
+        let tabManager = TabManager()
+        for index in 0..<(TabManager.maxTabs - 1) {
+            tabManager.tabs.append(EditorTab(
+                url: dir.appendingPathComponent("filler-\(index).swift")
+            ))
+        }
+        let originalIDs = tabManager.tabs.map(\.id)
+
+        let retained = await recoveryManager.restorePendingEntries(
+            recoveryManager.pendingRecoveryEntries(),
+            in: tabManager,
+            context: .unscoped
+        )
+
+        #expect(retained.map(\.0) == [crashTab.id])
+        #expect(tabManager.tabs.map(\.id) == originalIDs)
+        #expect(!tabManager.tabs.contains { $0.url == file })
+        #expect(
+            recoveryManager.pendingRecoveryEntries().map(\.0) ==
+                [crashTab.id]
+        )
+    }
+
+    @Test func cleanRecoveredContentConsumesOldSnapshotWithoutCreatingNewOne() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let recoveryManager = RecoveryManager(recoveryDirectory: dir)
+        let file = dir.appendingPathComponent("clean.swift")
+        let diskContent = "already on disk"
+        try diskContent.write(to: file, atomically: true, encoding: .utf8)
+        let crashTab = makeDirtyTab(
+            url: file,
+            content: diskContent,
+            savedContent: "older baseline"
+        )
+        recoveryManager.snapshotDirtyTabs([crashTab])
+        let tabManager = TabManager()
+
+        let retained = await recoveryManager.restorePendingEntries(
+            recoveryManager.pendingRecoveryEntries(),
+            in: tabManager,
+            context: .unscoped
+        )
+
+        #expect(retained.isEmpty)
+        #expect(tabManager.tabs.count == 2)
+        #expect(tabManager.tabs.allSatisfy { $0.content == diskContent })
+        #expect(tabManager.tabs.allSatisfy { !$0.isDirty })
+        #expect(Set(tabManager.tabs.map(\.id)).count == 2)
+        #expect(recoveryManager.pendingRecoveryEntries().isEmpty)
+    }
+
+    @Test func failedRuntimeSnapshotKeepsOldUntilLaterSnapshotSucceeds() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let manager = RecoveryManager(recoveryDirectory: dir)
+        let oldTab = makeDirtyTab(content: "old durable recovery")
+        manager.snapshotDirtyTabs([oldTab])
+        let runtimeTab = makeDirtyTab(
+            content: "runtime recovered content"
+        )
+        let blockingDestination = dir.appendingPathComponent(
+            "\(runtimeTab.id.uuidString).json"
+        )
+        try FileManager.default.createDirectory(
+            at: blockingDestination,
+            withIntermediateDirectories: false
+        )
+
+        #expect(
+            manager.migrateRecoverySnapshot(
+                from: oldTab.id,
+                to: runtimeTab
+            ) == false
+        )
+        #expect(
+            manager.pendingRecoveryEntries().map(\.0) == [oldTab.id]
+        )
+        var isDirectory: ObjCBool = false
+        #expect(FileManager.default.fileExists(
+            atPath: blockingDestination.path,
+            isDirectory: &isDirectory
+        ))
+        #expect(isDirectory.boolValue)
+
+        try FileManager.default.removeItem(at: blockingDestination)
+        manager.snapshotDirtyTabs([runtimeTab])
+
+        let entries = manager.pendingRecoveryEntries()
+        #expect(entries.map(\.0) == [runtimeTab.id])
+        #expect(entries.first?.1.content == "runtime recovered content")
+    }
+
+    @Test func failedRuntimeSnapshotOldIDIsAlsoCleanedAfterSave() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let manager = RecoveryManager(recoveryDirectory: dir)
+        let oldTab = makeDirtyTab(content: "old durable recovery")
+        manager.snapshotDirtyTabs([oldTab])
+        let documentURL = dir.appendingPathComponent("saved.swift")
+        try "disk baseline".write(
+            to: documentURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        let runtimeTab = makeDirtyTab(
+            url: documentURL,
+            content: "now saved elsewhere",
+            savedContent: "disk baseline"
+        )
+        let blockingDestination = dir.appendingPathComponent(
+            "\(runtimeTab.id.uuidString).json"
+        )
+        try FileManager.default.createDirectory(
+            at: blockingDestination,
+            withIntermediateDirectories: false
+        )
+        #expect(
+            !manager.migrateRecoverySnapshot(
+                from: oldTab.id,
+                to: runtimeTab
+            )
+        )
+
+        let tabManager = TabManager()
+        tabManager.recoveryManager = manager
+        tabManager.tabs = [runtimeTab]
+        tabManager.activeTabID = runtimeTab.id
+        #expect(tabManager.saveActiveTab())
+
+        #expect(manager.pendingRecoveryEntries().isEmpty)
+        #expect(!FileManager.default.fileExists(
+            atPath: blockingDestination.path
+        ))
+    }
+
+    @Test func sameIDMigrationKeepsNewlyReplacedSnapshot() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let manager = RecoveryManager(recoveryDirectory: dir)
+        var tab = makeDirtyTab(content: "older recovery")
+        manager.snapshotDirtyTabs([tab])
+        tab.content = "newer recovery under same ID"
+
+        #expect(manager.migrateRecoverySnapshot(from: tab.id, to: tab))
+
+        let entries = manager.pendingRecoveryEntries()
+        #expect(entries.count == 1)
+        #expect(entries.first?.0 == tab.id)
+        #expect(entries.first?.1.content == "newer recovery under same ID")
     }
 
     // MARK: - Delete recovery file

--- a/PineTests/SplitPaneRoutingTests.swift
+++ b/PineTests/SplitPaneRoutingTests.swift
@@ -487,7 +487,7 @@ struct SplitPaneRoutingTests {
     }
 
     @Test("closeTabWithConfirmation closes only the active pane's tab")
-    func closeTabRoutesToActivePaneOnly() throws {
+    func closeTabRoutesToActivePaneOnly() async throws {
         let f = try makeSplitWithTwoPanes()
         let pm = f.pm
         let firstTM = f.firstTM
@@ -498,7 +498,11 @@ struct SplitPaneRoutingTests {
             return
         }
         let provider = GitStatusProvider()
-        let closed = TabCloseHelper.closeTab(activeTab, in: pm.activeTabManager, gitProvider: provider)
+        let closed = await TabCloseHelper.closeTab(
+            activeTab,
+            in: pm.activeTabManager,
+            gitProvider: provider
+        )
 
         #expect(closed)
         #expect(secondTM.tabs.isEmpty, "the active pane's tab must be closed")

--- a/PineTests/SplitPaneRoutingTests.swift
+++ b/PineTests/SplitPaneRoutingTests.swift
@@ -411,7 +411,7 @@ struct SplitPaneRoutingTests {
     // confirmation alert blocks the test.
 
     @Test("closeAllTabsWithConfirmation closes only the active pane (TabCloseHelper contract)")
-    func closeAllTabsRoutesToActivePaneOnly() throws {
+    func closeAllTabsRoutesToActivePaneOnly() async throws {
         let f = try makeSplitWithTwoPanes()
         let pm = f.pm
         let firstTM = f.firstTM
@@ -424,14 +424,14 @@ struct SplitPaneRoutingTests {
         // Mirror the active-pane close-all contract (TabCloseHelper):
         //   TabCloseHelper.closeAllTabs(in: activeTabManager, gitProvider:)
         let provider = GitStatusProvider()
-        TabCloseHelper.closeAllTabs(in: pm.activeTabManager, gitProvider: provider)
+        await TabCloseHelper.closeAllTabs(in: pm.activeTabManager, gitProvider: provider)
 
         #expect(secondTM.tabs.isEmpty, "close-all must affect only the active pane")
         #expect(firstTM.tabs.count == 1, "primary pane must be untouched by active-pane close-all")
     }
 
     @Test("closeOtherTabsWithConfirmation closes only the active pane's other tabs")
-    func closeOtherTabsRoutesToActivePaneOnly() throws {
+    func closeOtherTabsRoutesToActivePaneOnly() async throws {
         let f = try makeSplitWithTwoPanes()
         let pm = f.pm
         let firstTM = f.firstTM
@@ -452,7 +452,7 @@ struct SplitPaneRoutingTests {
             return
         }
         let provider = GitStatusProvider()
-        TabCloseHelper.closeOtherTabs(keeping: keepID, in: pm.activeTabManager, gitProvider: provider)
+        await TabCloseHelper.closeOtherTabs(keeping: keepID, in: pm.activeTabManager, gitProvider: provider)
 
         #expect(secondTM.tabs.count == 1)
         #expect(secondTM.tabs.first?.id == keepID)
@@ -460,7 +460,7 @@ struct SplitPaneRoutingTests {
     }
 
     @Test("closeTabsToTheRightWithConfirmation closes only the active pane's right tabs")
-    func closeTabsToTheRightRoutesToActivePaneOnly() throws {
+    func closeTabsToTheRightRoutesToActivePaneOnly() async throws {
         let f = try makeSplitWithTwoPanes()
         let pm = f.pm
         let firstTM = f.firstTM
@@ -479,7 +479,7 @@ struct SplitPaneRoutingTests {
             return
         }
         let provider = GitStatusProvider()
-        TabCloseHelper.closeTabsToTheRight(of: keepID, in: pm.activeTabManager, gitProvider: provider)
+        await TabCloseHelper.closeTabsToTheRight(of: keepID, in: pm.activeTabManager, gitProvider: provider)
 
         #expect(secondTM.tabs.count == 1, "only the kept tab plus those left of it survive in the active pane")
         #expect(secondTM.tabs.first?.id == keepID)

--- a/PineTests/TabCloseHelperBulkTests.swift
+++ b/PineTests/TabCloseHelperBulkTests.swift
@@ -45,11 +45,11 @@ struct TabCloseHelperBulkTests {
     }
 
     @Test("Don't Save completes close-all and permits empty-pane removal")
-    func confirmedDiscardRemovesPane() {
+    func confirmedDiscardRemovesPane() async {
         guard let fixture = makeDirtyPane() else { return }
         var saveAttempted = false
 
-        let didClose = TabCloseHelper.closeAllTabs(
+        let didClose = await TabCloseHelper.closeAllTabs(
             in: fixture.tabManager,
             gitProvider: GitStatusProvider(),
             presentAlert: { .alertSecondButtonReturn },
@@ -68,7 +68,7 @@ struct TabCloseHelperBulkTests {
     }
 
     @Test("Save All persists changes, completes close-all, and permits pane removal")
-    func saveSuccessRemovesPane() throws {
+    func saveSuccessRemovesPane() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("pine-bulk-close-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -90,7 +90,7 @@ struct TabCloseHelperBulkTests {
         settings.formatOnSave = false
         fixture.tabManager.editorSettings = settings
 
-        let didClose = TabCloseHelper.closeAllTabs(
+        let didClose = await TabCloseHelper.closeAllTabs(
             in: fixture.tabManager,
             gitProvider: GitStatusProvider(),
             presentAlert: { .alertFirstButtonReturn }
@@ -104,10 +104,10 @@ struct TabCloseHelperBulkTests {
     }
 
     @Test("Cancel aborts close-all and keeps the dirty pane accessible")
-    func cancelPreservesPaneAndDirtyTab() {
+    func cancelPreservesPaneAndDirtyTab() async {
         guard let fixture = makeDirtyPane() else { return }
 
-        let didClose = TabCloseHelper.closeAllTabs(
+        let didClose = await TabCloseHelper.closeAllTabs(
             in: fixture.tabManager,
             gitProvider: GitStatusProvider(),
             presentAlert: { .alertThirdButtonReturn }
@@ -122,7 +122,7 @@ struct TabCloseHelperBulkTests {
     }
 
     @Test("Save failure aborts close-all and keeps every tab accessible")
-    func saveFailurePreservesPaneAndDirtyTabs() {
+    func saveFailurePreservesPaneAndDirtyTabs() async {
         guard let fixture = makeDirtyPane() else { return }
         let secondTab = EditorTab(
             url: URL(fileURLWithPath: "/tmp/pine-bulk-close-\(UUID().uuidString).swift"),
@@ -132,7 +132,7 @@ struct TabCloseHelperBulkTests {
         fixture.tabManager.tabs.append(secondTab)
         var saveAttempts = 0
 
-        let didClose = TabCloseHelper.closeAllTabs(
+        let didClose = await TabCloseHelper.closeAllTabs(
             in: fixture.tabManager,
             gitProvider: GitStatusProvider(),
             presentAlert: { .alertFirstButtonReturn },
@@ -156,7 +156,7 @@ struct TabCloseHelperBulkTests {
     }
 
     @Test("Clean close-all skips the alert and reports completion")
-    func cleanTabsCloseWithoutAlert() {
+    func cleanTabsCloseWithoutAlert() async {
         let tabManager = TabManager()
         let tab = EditorTab(
             url: URL(fileURLWithPath: "/tmp/pine-clean-close-\(UUID().uuidString).swift"),
@@ -167,7 +167,7 @@ struct TabCloseHelperBulkTests {
         tabManager.activeTabID = tab.id
         var alertPresented = false
 
-        let didClose = TabCloseHelper.closeAllTabs(
+        let didClose = await TabCloseHelper.closeAllTabs(
             in: tabManager,
             gitProvider: GitStatusProvider(),
             presentAlert: {
@@ -182,7 +182,7 @@ struct TabCloseHelperBulkTests {
     }
 
     @Test("Cancelled Close Others and Close Right report failure without mutation")
-    func cancelledScopedBulkClosesPreserveTabs() {
+    func cancelledScopedBulkClosesPreserveTabs() async {
         let tabManager = TabManager()
         let first = EditorTab(
             url: URL(fileURLWithPath: "/tmp/pine-keep-\(UUID().uuidString).swift"),
@@ -198,13 +198,13 @@ struct TabCloseHelperBulkTests {
         tabManager.activeTabID = second.id
         let provider = GitStatusProvider()
 
-        let closedOthers = TabCloseHelper.closeOtherTabs(
+        let closedOthers = await TabCloseHelper.closeOtherTabs(
             keeping: first.id,
             in: tabManager,
             gitProvider: provider,
             presentAlert: { .alertThirdButtonReturn }
         )
-        let closedRight = TabCloseHelper.closeTabsToTheRight(
+        let closedRight = await TabCloseHelper.closeTabsToTheRight(
             of: first.id,
             in: tabManager,
             gitProvider: provider,

--- a/PineTests/TabCloseHelperBulkTests.swift
+++ b/PineTests/TabCloseHelperBulkTests.swift
@@ -121,6 +121,57 @@ struct TabCloseHelperBulkTests {
         #expect(fixture.tabManager.tabs.first?.isDirty == true)
     }
 
+    @Test("Discard never covers a tab dirtied while the sheet is visible")
+    func staleDiscardPreservesNewDirtyTab() async {
+        guard let fixture = makeDirtyPane() else { return }
+        let newlyDirty = EditorTab(
+            url: URL(
+                fileURLWithPath: "/tmp/pine-new-dirty-\(UUID().uuidString).swift"
+            ),
+            content: "clean",
+            savedContent: "clean"
+        )
+        fixture.tabManager.tabs.append(newlyDirty)
+
+        let didClose = await TabCloseHelper.closeAllTabs(
+            in: fixture.tabManager,
+            gitProvider: GitStatusProvider(),
+            presentAlert: {
+                fixture.tabManager.tabs[1].content = "changed during sheet"
+                return .alertSecondButtonReturn
+            }
+        )
+
+        #expect(!didClose)
+        #expect(fixture.tabManager.tabs.count == 2)
+        #expect(fixture.tabManager.tabs[0].isDirty)
+        #expect(fixture.tabManager.tabs[1].isDirty)
+    }
+
+    @Test("Close All preserves a clean tab created while the sheet is visible")
+    func closeAllPreservesNewCleanTab() async {
+        guard let fixture = makeDirtyPane() else { return }
+        let newTab = EditorTab(
+            url: URL(
+                fileURLWithPath: "/tmp/pine-new-clean-\(UUID().uuidString).swift"
+            ),
+            content: "clean",
+            savedContent: "clean"
+        )
+
+        let didClose = await TabCloseHelper.closeAllTabs(
+            in: fixture.tabManager,
+            gitProvider: GitStatusProvider(),
+            presentAlert: {
+                fixture.tabManager.tabs.append(newTab)
+                return .alertSecondButtonReturn
+            }
+        )
+
+        #expect(didClose)
+        #expect(fixture.tabManager.tabs.map(\.id) == [newTab.id])
+    }
+
     @Test("Save failure aborts close-all and keeps every tab accessible")
     func saveFailurePreservesPaneAndDirtyTabs() async {
         guard let fixture = makeDirtyPane() else { return }
@@ -153,6 +204,39 @@ struct TabCloseHelperBulkTests {
         #expect(fixture.tabManager.tabs.count == 2)
         #expect(fixture.tabManager.tabs[0].isDirty == false)
         #expect(fixture.tabManager.tabs[1].isDirty == true)
+    }
+
+    @Test("Save All rejects a target edited again during a later save")
+    func saveAllRejectsRedirtiedEarlierTarget() async {
+        guard let fixture = makeDirtyPane() else { return }
+        let secondTab = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-bulk-close-\(UUID().uuidString).swift"),
+            content: "second modified",
+            savedContent: "second original"
+        )
+        fixture.tabManager.tabs.append(secondTab)
+        var saveAttempts = 0
+
+        let didClose = await TabCloseHelper.closeAllTabs(
+            in: fixture.tabManager,
+            gitProvider: GitStatusProvider(),
+            presentAlert: { .alertFirstButtonReturn },
+            saveTab: { index in
+                saveAttempts += 1
+                let savedContent = fixture.tabManager.tabs[index].content
+                fixture.tabManager.tabs[index].savedContent = savedContent
+                if saveAttempts == 2 {
+                    fixture.tabManager.tabs[0].content = "edited after first save"
+                }
+                return true
+            }
+        )
+
+        #expect(!didClose)
+        #expect(saveAttempts == 2)
+        #expect(fixture.tabManager.tabs.count == 2)
+        #expect(fixture.tabManager.tabs[0].isDirty)
+        #expect(!fixture.tabManager.tabs[1].isDirty)
     }
 
     @Test("Clean close-all skips the alert and reports completion")

--- a/PineTests/TabManagerEdgeTests.swift
+++ b/PineTests/TabManagerEdgeTests.swift
@@ -640,18 +640,22 @@ struct TabManagerEdgeTests {
         )
         let url = try tempFile(in: dir, content: content)
         manager.pendingGoToLine = 99
+        var completionResult: TabManager.OpenRequestResult?
 
-        manager.openTabAndGoToLine(
+        let request = manager.openTabAndGoToLine(
             url: url,
             line: 2,
-            context: DialogPresentationContext.unscoped
+            context: DialogPresentationContext.unscoped,
+            completion: { completionResult = $0 }
         )
+        #expect(request == .pending)
         for _ in 0..<5 {
             await Task.yield()
         }
 
         #expect(manager.tabs.isEmpty)
         #expect(manager.pendingGoToLine == nil)
+        #expect(completionResult == .cancelled)
     }
 
     @Test func explicitLargeFileOpenUpgradesQueuedPreviewAndRoutesLine() async throws {
@@ -667,6 +671,7 @@ struct TabManagerEdgeTests {
             of: NSApplication.ModalResponse.self
         )
         var presentationCount = 0
+        var completionResults: [TabManager.OpenRequestResult] = []
         manager.largeFileAlertPresenter = { _, _, _ in
             presentationCount += 1
             for await response in responses {
@@ -675,16 +680,20 @@ struct TabManagerEdgeTests {
             return .abort
         }
 
-        manager.openTabAsPreview(
+        let previewRequest = manager.openTabAsPreview(
             url: url,
-            context: DialogPresentationContext.unscoped
+            context: DialogPresentationContext.unscoped,
+            completion: { completionResults.append($0) }
         )
-        manager.openTabAndGoToLine(
+        let explicitRequest = manager.openTabAndGoToLine(
             url: url,
             line: 7,
-            context: DialogPresentationContext.unscoped
+            context: DialogPresentationContext.unscoped,
+            completion: { completionResults.append($0) }
         )
 
+        #expect(previewRequest == .pending)
+        #expect(explicitRequest == .pending)
         #expect(manager.tabs.isEmpty)
         #expect(manager.pendingGoToLine == nil)
         responseContinuation.yield(.alertSecondButtonReturn)
@@ -694,12 +703,19 @@ struct TabManagerEdgeTests {
             await Task.yield()
         }
 
+        let openedTab = try #require(manager.activeTab)
         #expect(manager.tabs.count == 1)
-        #expect(manager.activeTab?.url == url)
-        #expect(manager.activeTab?.isTransientPreview == false)
-        #expect(manager.activeTab?.syntaxHighlightingDisabled == false)
+        #expect(openedTab.url == url)
+        #expect(openedTab.isTransientPreview == false)
+        #expect(openedTab.syntaxHighlightingDisabled == false)
         #expect(manager.pendingGoToLine == 7)
         #expect(presentationCount == 1)
+        #expect(
+            completionResults == [
+                .opened(tabID: openedTab.id),
+                .opened(tabID: openedTab.id)
+            ]
+        )
     }
 
     // MARK: - Auto-save

--- a/PineTests/TabManagerEdgeTests.swift
+++ b/PineTests/TabManagerEdgeTests.swift
@@ -3,6 +3,7 @@
 //  PineTests
 //
 
+import AppKit
 import Foundation
 import Testing
 @testable import Pine
@@ -627,6 +628,78 @@ struct TabManagerEdgeTests {
         let url = try tempFile(in: dir, content: "line1\nline2\nline3")
         manager.openTabAndGoToLine(url: url, line: 2)
         #expect(manager.pendingGoToLine == 2)
+    }
+
+    @Test func openTabAndGoToLine_cancelledLargeFileDoesNotRouteLine() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let manager = makeTabManager()
+        let content = String(
+            repeating: "a",
+            count: TabManager.largeFileThreshold + 1
+        )
+        let url = try tempFile(in: dir, content: content)
+        manager.pendingGoToLine = 99
+
+        manager.openTabAndGoToLine(
+            url: url,
+            line: 2,
+            context: DialogPresentationContext.unscoped
+        )
+        for _ in 0..<5 {
+            await Task.yield()
+        }
+
+        #expect(manager.tabs.isEmpty)
+        #expect(manager.pendingGoToLine == nil)
+    }
+
+    @Test func explicitLargeFileOpenUpgradesQueuedPreviewAndRoutesLine() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let manager = makeTabManager()
+        let content = String(
+            repeating: "a",
+            count: TabManager.largeFileThreshold + 1
+        )
+        let url = try tempFile(in: dir, content: content)
+        let (responses, responseContinuation) = AsyncStream.makeStream(
+            of: NSApplication.ModalResponse.self
+        )
+        var presentationCount = 0
+        manager.largeFileAlertPresenter = { _, _, _ in
+            presentationCount += 1
+            for await response in responses {
+                return response
+            }
+            return .abort
+        }
+
+        manager.openTabAsPreview(
+            url: url,
+            context: DialogPresentationContext.unscoped
+        )
+        manager.openTabAndGoToLine(
+            url: url,
+            line: 7,
+            context: DialogPresentationContext.unscoped
+        )
+
+        #expect(manager.tabs.isEmpty)
+        #expect(manager.pendingGoToLine == nil)
+        responseContinuation.yield(.alertSecondButtonReturn)
+        responseContinuation.finish()
+        for _ in 0..<50 {
+            if !manager.tabs.isEmpty { break }
+            await Task.yield()
+        }
+
+        #expect(manager.tabs.count == 1)
+        #expect(manager.activeTab?.url == url)
+        #expect(manager.activeTab?.isTransientPreview == false)
+        #expect(manager.activeTab?.syntaxHighlightingDisabled == false)
+        #expect(manager.pendingGoToLine == 7)
+        #expect(presentationCount == 1)
     }
 
     // MARK: - Auto-save

--- a/PineTests/TabManagerEdgeTests.swift
+++ b/PineTests/TabManagerEdgeTests.swift
@@ -49,6 +49,19 @@ struct TabManagerEdgeTests {
         try? FileManager.default.removeItem(at: dir)
     }
 
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        _ condition: @MainActor () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while !condition() {
+            guard clock.now < deadline else { return false }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return true
+    }
+
     // MARK: - Tab navigation
 
     @Test func selectTab_validIndex() throws {
@@ -649,9 +662,7 @@ struct TabManagerEdgeTests {
             completion: { completionResult = $0 }
         )
         #expect(request == .pending)
-        for _ in 0..<5 {
-            await Task.yield()
-        }
+        #expect(await waitUntil { completionResult != nil })
 
         #expect(manager.tabs.isEmpty)
         #expect(manager.pendingGoToLine == nil)
@@ -698,10 +709,7 @@ struct TabManagerEdgeTests {
         #expect(manager.pendingGoToLine == nil)
         responseContinuation.yield(.alertSecondButtonReturn)
         responseContinuation.finish()
-        for _ in 0..<50 {
-            if !manager.tabs.isEmpty { break }
-            await Task.yield()
-        }
+        #expect(await waitUntil { !manager.tabs.isEmpty })
 
         let openedTab = try #require(manager.activeTab)
         #expect(manager.tabs.count == 1)
@@ -715,6 +723,189 @@ struct TabManagerEdgeTests {
                 .opened(tabID: openedTab.id),
                 .opened(tabID: openedTab.id)
             ]
+        )
+    }
+
+    @Test func lspLargeFileNavigationWaitsForOpenAndPreservesLocation() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let manager = makeTabManager()
+        let sourceURL = try tempFile(
+            in: dir,
+            name: "source.swift",
+            content: "let source = true"
+        )
+        manager.openTab(url: sourceURL)
+        let sourceTabID = try #require(manager.activeTabID)
+        let targetLine = "😀target\n"
+        let targetURL = try tempFile(
+            in: dir,
+            name: "definition.swift",
+            content: String(
+                repeating: targetLine,
+                count: (TabManager.largeFileThreshold / 11) + 1
+            )
+        )
+        let (responses, responseContinuation) = AsyncStream.makeStream(
+            of: NSApplication.ModalResponse.self
+        )
+        var completionResult: TabManager.OpenRequestResult?
+        manager.largeFileAlertPresenter = { _, _, _ in
+            for await response in responses {
+                return response
+            }
+            return .abort
+        }
+
+        let request = PaneLeafView.openLSPFile(
+            url: targetURL,
+            line: 0,
+            character: 2,
+            in: manager,
+            completion: { completionResult = $0 }
+        )
+
+        #expect(request == .pending)
+        #expect(manager.activeTabID == sourceTabID)
+        #expect(manager.pendingGoToLocation == nil)
+
+        responseContinuation.yield(.alertSecondButtonReturn)
+        responseContinuation.finish()
+        #expect(await waitUntil { completionResult != nil })
+
+        let targetTabID = try #require(manager.activeTabID)
+        #expect(manager.activeTab?.url == targetURL)
+        #expect(
+            manager.pendingGoToLocation ==
+                EditorNavigationLocation(line: 1, column: 3)
+        )
+        #expect(completionResult == .opened(tabID: targetTabID))
+        #expect(
+            ContentView.cursorOffset(
+                forLine: 1,
+                column: 3,
+                in: manager.activeTab?.content ?? ""
+            ) == 2
+        )
+    }
+
+    @Test func lspImmediateNavigationUsesUTF16CharacterOffsets() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let manager = makeTabManager()
+        let content = "😀x\nsecond"
+        let url = try tempFile(
+            in: dir,
+            name: "emoji.swift",
+            content: content
+        )
+
+        let result = PaneLeafView.openLSPFile(
+            url: url,
+            line: 0,
+            character: 2,
+            in: manager
+        )
+
+        let activeTabID = try #require(manager.activeTabID)
+        #expect(result == .opened(tabID: activeTabID))
+        #expect(
+            manager.pendingGoToLocation ==
+                EditorNavigationLocation(line: 1, column: 3)
+        )
+        #expect(
+            ContentView.cursorOffset(
+                forLine: 1,
+                column: 3,
+                in: content
+            ) == 2
+        )
+    }
+
+    @Test func lspCancelledLargeFileDoesNotRouteOrChangeSelection() async throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let manager = makeTabManager()
+        let sourceURL = try tempFile(
+            in: dir,
+            name: "source.swift",
+            content: "let source = true"
+        )
+        manager.openTab(url: sourceURL)
+        let sourceTabID = try #require(manager.activeTabID)
+        let targetURL = try tempFile(
+            in: dir,
+            name: "cancelled.swift",
+            content: String(
+                repeating: "x",
+                count: TabManager.largeFileThreshold + 1
+            )
+        )
+        let (responses, responseContinuation) = AsyncStream.makeStream(
+            of: NSApplication.ModalResponse.self
+        )
+        var presentationCount = 0
+        var completionResult: TabManager.OpenRequestResult?
+        manager.largeFileAlertPresenter = { _, _, _ in
+            presentationCount += 1
+            for await response in responses {
+                return response
+            }
+            return .abort
+        }
+
+        let result = PaneLeafView.openLSPFile(
+            url: targetURL,
+            line: 4,
+            character: 7,
+            in: manager,
+            completion: { completionResult = $0 }
+        )
+
+        #expect(result == .pending)
+        #expect(await waitUntil { presentationCount == 1 })
+        #expect(manager.activeTabID == sourceTabID)
+        #expect(manager.pendingGoToLocation == nil)
+
+        responseContinuation.yield(.abort)
+        responseContinuation.finish()
+        #expect(await waitUntil { completionResult != nil })
+        #expect(completionResult == .cancelled)
+        #expect(manager.activeTabID == sourceTabID)
+        #expect(manager.pendingGoToLocation == nil)
+        #expect(!manager.tabs.contains { $0.url == targetURL })
+    }
+
+    @Test func lspCoordinatesClampNegativeAndSaturateAtIntMax() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let manager = makeTabManager()
+        let url = try tempFile(
+            in: dir,
+            name: "extreme.swift",
+            content: "value"
+        )
+
+        _ = PaneLeafView.openLSPFile(
+            url: url,
+            line: .max,
+            character: .max,
+            in: manager
+        )
+        #expect(
+            manager.pendingGoToLocation ==
+                EditorNavigationLocation(line: .max, column: .max)
+        )
+
+        _ = PaneLeafView.openLSPFile(
+            url: url,
+            line: -1,
+            character: .min,
+            in: manager
+        )
+        #expect(
+            manager.pendingGoToLocation ==
+                EditorNavigationLocation(line: 1, column: 1)
         )
     }
 

--- a/PineTests/TerminalProcessConfirmationTests.swift
+++ b/PineTests/TerminalProcessConfirmationTests.swift
@@ -19,9 +19,9 @@ struct TerminalProcessConfirmationTests {
 
     // MARK: - confirmTerminalStop (pure decision function)
 
-    @Test func noForegroundProcess_doesNotPresentAlert_proceedsImmediately() {
+    @Test func noForegroundProcess_doesNotPresentAlert_proceedsImmediately() async {
         var alertCalled = false
-        let result = TabCloseHelper.confirmTerminalStop(
+        let result = await TabCloseHelper.confirmTerminalStop(
             hasForegroundProcess: false,
             presentAlert: {
                 alertCalled = true
@@ -32,9 +32,9 @@ struct TerminalProcessConfirmationTests {
         #expect(alertCalled == false)
     }
 
-    @Test func foregroundProcess_userConfirms_proceeds() {
+    @Test func foregroundProcess_userConfirms_proceeds() async {
         var alertCalled = false
-        let result = TabCloseHelper.confirmTerminalStop(
+        let result = await TabCloseHelper.confirmTerminalStop(
             hasForegroundProcess: true,
             presentAlert: {
                 alertCalled = true
@@ -45,8 +45,8 @@ struct TerminalProcessConfirmationTests {
         #expect(alertCalled == true)
     }
 
-    @Test func foregroundProcess_userCancels_aborts() {
-        let result = TabCloseHelper.confirmTerminalStop(
+    @Test func foregroundProcess_userCancels_aborts() async {
+        let result = await TabCloseHelper.confirmTerminalStop(
             hasForegroundProcess: true,
             presentAlert: { .alertSecondButtonReturn } // "Cancel"
         )
@@ -55,9 +55,9 @@ struct TerminalProcessConfirmationTests {
 
     // MARK: - confirmTerminalProcessStop (tabs-based convenience)
 
-    @Test func emptyTabs_proceedsImmediately() {
+    @Test func emptyTabs_proceedsImmediately() async {
         var alertCalled = false
-        let result = TabCloseHelper.confirmTerminalProcessStop(
+        let result = await TabCloseHelper.confirmTerminalProcessStop(
             tabs: [],
             presentAlert: {
                 alertCalled = true
@@ -68,13 +68,13 @@ struct TerminalProcessConfirmationTests {
         #expect(alertCalled == false)
     }
 
-    @Test func tabsWithoutForegroundProcess_proceedsImmediately() {
+    @Test func tabsWithoutForegroundProcess_proceedsImmediately() async {
         // Newly created TerminalTabs have hasForegroundProcess == false
         // because no process has been started. We use this to verify the
         // no-warning fast path with real tab objects.
         let tab = TerminalTab(name: "Test Terminal")
         var alertCalled = false
-        let result = TabCloseHelper.confirmTerminalProcessStop(
+        let result = await TabCloseHelper.confirmTerminalProcessStop(
             tabs: [tab],
             presentAlert: {
                 alertCalled = true
@@ -87,27 +87,27 @@ struct TerminalProcessConfirmationTests {
 
     // MARK: - Default alert (production path)
 
-    @Test func defaultAlertIsUsedWhenNoInjectionProvided() {
+    @Test func defaultAlertIsUsedWhenNoInjectionProvided() async {
         // Verify the default parameter compiles and runs without crashing.
         // We can't meaningfully test the modal result in a headless test
         // (it would present a real NSAlert), so we only verify the no-process
         // fast path which never calls the alert.
-        let result = TabCloseHelper.confirmTerminalStop(hasForegroundProcess: false)
+        let result = await TabCloseHelper.confirmTerminalStop(hasForegroundProcess: false)
         #expect(result == true)
     }
 
-    @Test func defaultAlertIsUsedForTabsOverload_noProcess() {
+    @Test func defaultAlertIsUsedForTabsOverload_noProcess() async {
         let tab = TerminalTab(name: "Idle Terminal")
-        let result = TabCloseHelper.confirmTerminalProcessStop(tabs: [tab])
+        let result = await TabCloseHelper.confirmTerminalProcessStop(tabs: [tab])
         #expect(result == true)
     }
 
     // MARK: - Multiple tabs aggregation
 
-    @Test func multipleTabs_allIdle_proceedsImmediately() {
+    @Test func multipleTabs_allIdle_proceedsImmediately() async {
         let tabs = (0..<5).map { TerminalTab(name: "Terminal \($0)") }
         var alertCalled = false
-        let result = TabCloseHelper.confirmTerminalProcessStop(
+        let result = await TabCloseHelper.confirmTerminalProcessStop(
             tabs: tabs,
             presentAlert: {
                 alertCalled = true

--- a/PineTests/TerminalProcessConfirmationTests.swift
+++ b/PineTests/TerminalProcessConfirmationTests.swift
@@ -117,4 +117,28 @@ struct TerminalProcessConfirmationTests {
         #expect(result == true)
         #expect(alertCalled == false)
     }
+
+    @Test func foregroundAuthorizationUsesProcessGroupGeneration() {
+        let tabID = UUID()
+        let authorized: Set<TerminalForegroundProcessIdentity> = [
+            .init(tabID: tabID, processGroupID: 101),
+        ]
+
+        #expect(TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
+            [.init(tabID: tabID, processGroupID: 101)],
+            by: authorized
+        ))
+        #expect(!TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
+            [.init(tabID: tabID, processGroupID: 202)],
+            by: authorized
+        ))
+        #expect(!TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
+            [.init(tabID: UUID(), processGroupID: 101)],
+            by: authorized
+        ))
+        #expect(TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
+            [],
+            by: authorized
+        ))
+    }
 }

--- a/PineTests/UserConfigurationAlertPresenterTests.swift
+++ b/PineTests/UserConfigurationAlertPresenterTests.swift
@@ -2,7 +2,7 @@
 //  UserConfigurationAlertPresenterTests.swift
 //  PineTests
 //
-//  Hosted seam tests for reload-alert content and modal lifecycle.
+//  Hosted seam tests for reload-alert content and presentation lifecycle.
 //
 
 import AppKit
@@ -14,6 +14,96 @@ import Testing
 @Suite("User configuration alert presentation")
 @MainActor
 struct UserConfigurationAlertPresenterTests {
+    @Test("Production informational result uses a project toast without a sheet")
+    func productionInformationalResultUsesToast() async {
+        let projectManager = ProjectManager()
+        projectManager.toastManager.announce = { _ in }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let context = DialogPresenter.register(
+            window: window,
+            projectManager: projectManager
+        )
+        window.orderFront(nil)
+        defer {
+            DialogPresenter.ownerDidClose(window)
+            window.orderOut(nil)
+        }
+
+        let response = await AppKitUserConfigurationAlertPresenter(
+            context: context
+        ).present(UserConfigurationAlertDescriptor(
+            style: .informational,
+            messageText: "Configuration Reloaded",
+            informativeText: "1 task loaded.",
+            buttonTitle: "OK"
+        ))
+
+        #expect(response == .alertFirstButtonReturn)
+        #expect(projectManager.toastManager.currentToast?.message ==
+                "Configuration Reloaded. 1 task loaded.")
+        #expect(window.sheets.isEmpty)
+    }
+
+    @Test("No-project informational result uses visible nonmodal feedback")
+    func noProjectInformationalResultUsesWindowFeedback() async {
+        let window = NSWindow()
+        window.orderFront(nil)
+        let context = DialogPresentationContext(window: window)
+        let feedback = RecordingWindowFeedbackPresenter()
+        defer {
+            DialogPresenter.ownerDidClose(window)
+            window.orderOut(nil)
+        }
+
+        let response = await AppKitUserConfigurationAlertPresenter(
+            context: context,
+            feedbackPresenter: feedback
+        ).present(UserConfigurationAlertDescriptor(
+            style: .informational,
+            messageText: "Configuration Reloaded",
+            informativeText: "1 task loaded.",
+            buttonTitle: "OK"
+        ))
+
+        #expect(response == .alertFirstButtonReturn)
+        #expect(feedback.messages == [
+            "Configuration Reloaded. 1 task loaded.",
+        ])
+        #expect(feedback.owners.count == 1)
+        #expect(feedback.owners[0] === window)
+        #expect(window.sheets.isEmpty)
+    }
+
+    @Test("AppKit window feedback is visible and remains nonmodal")
+    func appKitWindowFeedbackIsVisibleAndNonmodal() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.orderFront(nil)
+        let context = DialogPresentationContext(window: window)
+        let feedback = WindowNonmodalFeedbackPresenter(
+            displayDuration: .seconds(60)
+        )
+        defer {
+            feedback.dismiss(for: window)
+            DialogPresenter.ownerDidClose(window)
+            window.orderOut(nil)
+        }
+
+        #expect(feedback.present(message: "Visible success", context: context))
+        #expect(feedback.hasVisibleFeedback(for: window))
+        #expect(window.childWindows?.contains(where: \.isVisible) == true)
+        #expect(window.sheets.isEmpty)
+    }
+
     @Test("Successful reload presents counts and completes dismissal")
     func successfulReloadPresentation() async {
         let presenter = RecordingReloadAlertPresenter()
@@ -84,11 +174,27 @@ private final class RecordingReloadAlertPresenter:
 
     func present(
         _ descriptor: UserConfigurationAlertDescriptor
-    ) -> NSApplication.ModalResponse {
+    ) async -> NSApplication.ModalResponse {
         isPresenting = true
         descriptors.append(descriptor)
         dismissalCount += 1
         isPresenting = false
         return .alertFirstButtonReturn
+    }
+}
+
+@MainActor
+private final class RecordingWindowFeedbackPresenter:
+    WindowNonmodalFeedbackPresenting {
+    private(set) var messages: [String] = []
+    private(set) var owners: [NSWindow?] = []
+
+    func present(
+        message: String,
+        context: DialogPresentationContext
+    ) -> Bool {
+        messages.append(message)
+        owners.append(context.nsWindow)
+        return context.nsWindow != nil
     }
 }

--- a/PineTests/UserConfigurationEditorTests.swift
+++ b/PineTests/UserConfigurationEditorTests.swift
@@ -395,7 +395,7 @@ private final class RecordingConfigurationAlertPresenter:
 
     func present(
         _ descriptor: UserConfigurationAlertDescriptor
-    ) -> NSApplication.ModalResponse {
+    ) async -> NSApplication.ModalResponse {
         isPresenting = true
         descriptors.append(descriptor)
         dismissalCount += 1

--- a/PineTests/UserTaskInvocationControllerTests.swift
+++ b/PineTests/UserTaskInvocationControllerTests.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import AppKit
 import Testing
 
 @testable import Pine
@@ -51,5 +52,131 @@ struct UserTaskInvocationControllerTests {
             currentTabID: currentTabID,
             currentContent: currentContent
         ))
+    }
+
+    @Test("Editing during suspended confirmation never reaches the runner")
+    @MainActor
+    func editDuringConfirmationFailsClosed() async {
+        let project = ProjectManager()
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-user-task-edit.swift"),
+            content: "before",
+            savedContent: "before"
+        )
+        project.primaryTabManager.tabs = [tab]
+        project.primaryTabManager.activeTabID = tab.id
+        let window = NSWindow()
+        window.orderFront(nil)
+        let context = DialogPresenter.register(
+            window: window,
+            projectManager: project
+        )
+        defer {
+            DialogPresenter.ownerDidClose(window)
+            window.orderOut(nil)
+        }
+        let task = UserTask(
+            id: "format",
+            label: "Format",
+            command: "swiftformat",
+            replacesFileContent: true,
+            requireConfirmation: true
+        )
+        let (confirmationGate, confirmationContinuation) =
+            AsyncStream.makeStream(of: Bool.self)
+        var confirmationStarted = false
+        var runnerInputs: [(URL?, String?)] = []
+
+        let invocation = Task { @MainActor in
+            await UserTaskInvocationController.invokePrepared(
+                task,
+                projectManager: project,
+                context: context,
+                presentConfirmation: { _, _ in
+                    confirmationStarted = true
+                    for await response in confirmationGate {
+                        return response
+                    }
+                    return false
+                },
+                runTask: { _, fileURL, _, content, _ in
+                    runnerInputs.append((fileURL, content))
+                }
+            )
+        }
+        for _ in 0..<50 where !confirmationStarted {
+            await Task.yield()
+        }
+        project.primaryTabManager.updateContent("edited during confirmation")
+        confirmationContinuation.yield(true)
+        confirmationContinuation.finish()
+
+        #expect(await invocation.value == false)
+        #expect(runnerInputs.isEmpty)
+    }
+
+    @Test("Switching files during suspended confirmation never retargets the task")
+    @MainActor
+    func switchDuringConfirmationFailsClosed() async {
+        let project = ProjectManager()
+        let first = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-user-task-first.swift"),
+            content: "first",
+            savedContent: "first"
+        )
+        let second = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-user-task-second.swift"),
+            content: "second",
+            savedContent: "second"
+        )
+        project.primaryTabManager.tabs = [first, second]
+        project.primaryTabManager.activeTabID = first.id
+        let window = NSWindow()
+        window.orderFront(nil)
+        let context = DialogPresenter.register(
+            window: window,
+            projectManager: project
+        )
+        defer {
+            DialogPresenter.ownerDidClose(window)
+            window.orderOut(nil)
+        }
+        let task = UserTask(
+            id: "lint",
+            label: "Lint",
+            command: "swiftlint",
+            requireConfirmation: true
+        )
+        let (confirmationGate, confirmationContinuation) =
+            AsyncStream.makeStream(of: Bool.self)
+        var confirmationStarted = false
+        var runnerFileURLs: [URL?] = []
+
+        let invocation = Task { @MainActor in
+            await UserTaskInvocationController.invokePrepared(
+                task,
+                projectManager: project,
+                context: context,
+                presentConfirmation: { _, _ in
+                    confirmationStarted = true
+                    for await response in confirmationGate {
+                        return response
+                    }
+                    return false
+                },
+                runTask: { _, fileURL, _, _, _ in
+                    runnerFileURLs.append(fileURL)
+                }
+            )
+        }
+        for _ in 0..<50 where !confirmationStarted {
+            await Task.yield()
+        }
+        project.primaryTabManager.activeTabID = second.id
+        confirmationContinuation.yield(true)
+        confirmationContinuation.finish()
+
+        #expect(await invocation.value == false)
+        #expect(runnerFileURLs.isEmpty)
     }
 }

--- a/PineTests/WelcomeVisibilityGenerationTests.swift
+++ b/PineTests/WelcomeVisibilityGenerationTests.swift
@@ -1,0 +1,39 @@
+//
+//  WelcomeVisibilityGenerationTests.swift
+//  PineTests
+//
+
+import Testing
+
+@testable import Pine
+
+@Suite("Welcome Visibility Generation Tests")
+@MainActor
+struct WelcomeVisibilityGenerationTests {
+    @Test func hideBeforeDelayedEnsureDoesNotShowWelcomeAgain() async {
+        let delegate = AppDelegate()
+        delegate.openNamedWindow = { _ in }
+        let (gate, continuation) = AsyncStream.makeStream(of: Void.self)
+        var ensureCount = 0
+
+        delegate.showWelcome(
+            waitBeforeEnsure: {
+                for await _ in gate {
+                    return
+                }
+            },
+            ensureVisible: {
+                ensureCount += 1
+            }
+        )
+        delegate.hideWelcome()
+
+        continuation.yield(())
+        continuation.finish()
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+
+        #expect(ensureCount == 0)
+    }
+}

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -449,6 +449,14 @@ struct WindowLifecycleTests {
                 }
                 await Task.yield()
             },
+            resolveVisibleWindow: {
+                guard let capturedWindow,
+                      capturedWindow.isVisible,
+                      !capturedWindow.isMiniaturized else {
+                    return nil
+                }
+                return capturedWindow
+            },
             presentPanel: { context in
                 presentedOwner = context.nsWindow
                 return selectedURL
@@ -465,6 +473,7 @@ struct WindowLifecycleTests {
         #expect(attempts == 3)
         #expect(presentedOwner === capturedWindow)
         #expect(openedURL == selectedURL)
+        #expect(capturedWindow?.isVisible == false)
     }
 
     @Test func openFolderFailsClosedWhenWelcomeOwnerNeverAppears() async {
@@ -479,6 +488,7 @@ struct WindowLifecycleTests {
                 waitCount += 1
                 await Task.yield()
             },
+            resolveVisibleWindow: { nil },
             presentPanel: { _ in
                 panelCount += 1
                 return URL(fileURLWithPath: "/tmp/should-not-open")
@@ -488,5 +498,29 @@ struct WindowLifecycleTests {
         #expect(!didOpen)
         #expect(waitCount == 3)
         #expect(panelCount == 0)
+    }
+
+    @Test func openFolderFailsClosedWithoutProjectWindowAction() async {
+        let delegate = AppDelegate()
+        delegate.openNamedWindow = { _ in }
+        let welcome = NSWindow()
+        welcome.identifier = .init("welcome")
+        welcome.orderFront(nil)
+        defer {
+            DialogPresenter.ownerDidClose(welcome)
+            welcome.orderOut(nil)
+        }
+
+        let didOpen = await delegate.openFolderFromWelcomeOwner(
+            maximumAttempts: 1,
+            waitForNextAttempt: { await Task.yield() },
+            resolveVisibleWindow: { welcome },
+            presentPanel: { _ in
+                URL(fileURLWithPath: "/tmp/pine-no-window-action")
+            }
+        )
+
+        #expect(!didOpen)
+        #expect(welcome.isVisible)
     }
 }

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -12,6 +12,11 @@ import Testing
 @Suite("Window Lifecycle Tests")
 @MainActor
 struct WindowLifecycleTests {
+    private func settle() async {
+        for _ in 0..<8 {
+            await Task.yield()
+        }
+    }
 
     private func makeTempDirectory() throws -> URL {
         let dir = FileManager.default.temporaryDirectory
@@ -131,40 +136,210 @@ struct WindowLifecycleTests {
         #expect(session2?.existingFileURLs.count == 1)
     }
 
-    // MARK: - windowShouldClose (CloseDelegate)
-
-    @Test func windowShouldCloseReturnsTrueWhenNoTabs() throws {
-        let dir = try makeTempDirectory()
-        defer { cleanup(dir) }
-
-        let registry = ProjectRegistry()
-        let pm = try #require(registry.projectManager(for: dir))
-        let delegate = AppDelegate()
-        let window = NSWindow()
-
-        let closeDelegate = Pine.CloseDelegate(
-            projectManager: pm,
-            registry: registry,
-            projectURL: dir,
-            appDelegate: delegate,
-            original: nil
-        )
-
-        // No tabs open — window should close
-        #expect(closeDelegate.windowShouldClose(window))
-    }
-
-    @Test func windowShouldCloseReturnsTrueWithCleanTabs() throws {
+    @Test func asyncTerminationFailsClosedWhenSaveFails() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
 
         let registry = ProjectRegistry()
-        let pm = try #require(registry.projectManager(for: dir))
-        pm.primaryTabManager.openTab(url: file)
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        project.primaryTabManager.updateContent("// dirty")
 
         let delegate = AppDelegate()
+        delegate.registry = registry
+        var presentedTemplates: [AlertTemplate] = []
+        var saveAttempts = 0
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presentedTemplates.append(template)
+                return .alertFirstButtonReturn
+            },
+            saveAll: { _, _ in
+                saveAttempts += 1
+                return false
+            }
+        )
+
+        #expect(!result)
+        #expect(presentedTemplates == [.unsavedChangesBulk])
+        #expect(saveAttempts == 1)
+        #expect(project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func asyncTerminationCancelNeverAttemptsSave() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        project.primaryTabManager.updateContent("// dirty")
+
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var saveAttempts = 0
+        let fallbackWindow = NSWindow()
+        let fallbackContext = DialogPresentationContext(window: fallbackWindow)
+        defer { DialogPresenter.ownerDidClose(fallbackWindow) }
+        var presentedOwner: NSWindow?
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { _, context, _, _ in
+                presentedOwner = context.nsWindow
+                return .alertThirdButtonReturn
+            },
+            saveAll: { _, _ in
+                saveAttempts += 1
+                return true
+            },
+            applicationContext: fallbackContext
+        )
+
+        #expect(!result)
+        #expect(saveAttempts == 0)
+        #expect(project.hasUnsavedChanges)
+        #expect(presentedOwner === fallbackWindow)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func asyncTerminationRejectsStaleDiscardAuthorization() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        project.primaryTabManager.updateContent("// first dirty state")
+
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                #expect(template == .unsavedChangesBulk)
+                project.primaryTabManager.updateContent(
+                    "// changed while quit sheet was visible"
+                )
+                return .alertSecondButtonReturn
+            }
+        )
+
+        #expect(!result)
+        #expect(project.hasUnsavedChanges)
+        #expect(project.primaryTabManager.activeTab?.content ==
+                "// changed while quit sheet was visible")
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func quitDiscardCommitsCleanStateAndDeletesRecovery() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        project.primaryTabManager.updateContent("// discarded")
+        project.recoveryManager?.snapshotDirtyTabs(project.allTabs)
+        #expect(project.recoveryManager?.pendingRecoveryEntries().isEmpty == false)
+        let delegate = AppDelegate()
+        delegate.registry = registry
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                #expect(template == .unsavedChangesBulk)
+                return .alertSecondButtonReturn
+            }
+        )
+
+        #expect(result)
+        #expect(!project.hasUnsavedChanges)
+        #expect(project.primaryTabManager.activeTab?.content == "// test.swift")
+        #expect(project.recoveryManager?.pendingRecoveryEntries().isEmpty == true)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func laterQuitCancelDoesNotCommitEarlierDiscard() async throws {
+        let firstDirectory = try makeTempDirectory()
+        let secondDirectory = try makeTempDirectory()
+        defer {
+            cleanup(firstDirectory)
+            cleanup(secondDirectory)
+        }
+        let firstFile = try makeTempFile(in: firstDirectory, name: "first.swift")
+        let secondFile = try makeTempFile(in: secondDirectory, name: "second.swift")
+        let registry = ProjectRegistry()
+        let firstProject = try #require(
+            registry.projectManager(for: firstDirectory)
+        )
+        let secondProject = try #require(
+            registry.projectManager(for: secondDirectory)
+        )
+        firstProject.primaryTabManager.openTab(url: firstFile)
+        secondProject.primaryTabManager.openTab(url: secondFile)
+        firstProject.primaryTabManager.updateContent("// first dirty")
+        secondProject.primaryTabManager.updateContent("// second dirty")
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var promptCount = 0
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                #expect(template == .unsavedChangesBulk)
+                promptCount += 1
+                return promptCount == 1
+                    ? .alertSecondButtonReturn
+                    : .alertThirdButtonReturn
+            }
+        )
+
+        #expect(!result)
+        #expect(promptCount == 2)
+        #expect(firstProject.hasUnsavedChanges)
+        #expect(firstProject.primaryTabManager.activeTab?.content == "// first dirty")
+        #expect(secondProject.hasUnsavedChanges)
+        #expect(secondProject.primaryTabManager.activeTab?.content == "// second dirty")
+        await firstProject.workspace.waitForLoadingComplete()
+        await secondProject.workspace.waitForLoadingComplete()
+    }
+
+    @Test func terminationHandshakeDefersAndRepliesExactlyOnce() async {
+        let delegate = AppDelegate()
+        var replies: [Bool] = []
+
+        let initialReply = delegate.beginApplicationTermination {
+            replies.append($0)
+        }
+        #expect(initialReply == .terminateLater)
+        for _ in 0..<50 {
+            if !replies.isEmpty { break }
+            await Task.yield()
+        }
+
+        #expect(replies == [true])
+        #expect(delegate.isTerminating)
+        let committedReply = delegate.beginApplicationTermination { _ in
+            Issue.record("Committed termination must not reply a second time")
+        }
+        #expect(committedReply == .terminateNow)
+        await settle()
+        #expect(replies == [true])
+    }
+
+    // MARK: - windowShouldClose (CloseDelegate)
+
+    @Test func windowShouldCloseDefersWhenNoTabs() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        let registry = ProjectRegistry()
+        let pm = ProjectManager()
+        let delegate = AppDelegate()
         let window = NSWindow()
+        defer { DialogPresenter.ownerDidClose(window) }
 
         let closeDelegate = Pine.CloseDelegate(
             projectManager: pm,
@@ -174,25 +349,53 @@ struct WindowLifecycleTests {
             original: nil
         )
 
-        // Clean tabs — window should close (not close tab one by one)
-        #expect(closeDelegate.windowShouldClose(window))
-        // Tabs should NOT have been closed individually
-        #expect(pm.primaryTabManager.tabs.count == 1)
+        // Every close is approved asynchronously, then re-entered through
+        // performClose so no delegate callback blocks on modal UI.
+        #expect(!closeDelegate.windowShouldClose(window))
+        await settle()
     }
 
-    @Test func windowShouldCloseDoesNotCloseIndividualCleanTab() throws {
+    @Test func windowShouldCloseDefersWithCleanTabs() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+
+        let registry = ProjectRegistry()
+        let pm = ProjectManager()
+        pm.primaryTabManager.openTab(url: file)
+
+        let delegate = AppDelegate()
+        let window = NSWindow()
+        defer { DialogPresenter.ownerDidClose(window) }
+
+        let closeDelegate = Pine.CloseDelegate(
+            projectManager: pm,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: delegate,
+            original: nil
+        )
+
+        #expect(!closeDelegate.windowShouldClose(window))
+        // Tabs should NOT have been closed individually
+        #expect(pm.primaryTabManager.tabs.count == 1)
+        await settle()
+    }
+
+    @Test func windowShouldCloseDoesNotCloseIndividualCleanTab() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let file1 = try makeTempFile(in: dir, name: "a.swift")
         let file2 = try makeTempFile(in: dir, name: "b.swift")
 
         let registry = ProjectRegistry()
-        let pm = try #require(registry.projectManager(for: dir))
+        let pm = ProjectManager()
         pm.primaryTabManager.openTab(url: file1)
         pm.primaryTabManager.openTab(url: file2)
 
         let delegate = AppDelegate()
         let window = NSWindow()
+        defer { DialogPresenter.ownerDidClose(window) }
 
         let closeDelegate = Pine.CloseDelegate(
             projectManager: pm,
@@ -204,8 +407,9 @@ struct WindowLifecycleTests {
 
         // With multiple clean tabs, should close window (return true)
         // and NOT close tabs one by one
-        #expect(closeDelegate.windowShouldClose(window))
+        #expect(!closeDelegate.windowShouldClose(window))
         #expect(pm.primaryTabManager.tabs.count == 2)
+        await settle()
     }
 
     // MARK: - showWelcome
@@ -220,5 +424,69 @@ struct WindowLifecycleTests {
         delegate.showWelcome()
 
         #expect(openedWindowID == "welcome")
+    }
+
+    @Test func openFolderWaitsForDelayedWelcomeCapture() async {
+        let delegate = AppDelegate()
+        delegate.openNamedWindow = { _ in }
+        var attempts = 0
+        var capturedWindow: NSWindow?
+        var presentedOwner: NSWindow?
+        var openedURL: URL?
+        let selectedURL = URL(fileURLWithPath: "/tmp/pine-delayed-welcome")
+        delegate.openProjectWindow = { openedURL = $0 }
+
+        let didOpen = await delegate.openFolderFromWelcomeOwner(
+            maximumAttempts: 6,
+            waitForNextAttempt: {
+                attempts += 1
+                if attempts == 3 {
+                    let window = NSWindow()
+                    window.identifier = .init("welcome")
+                    window.orderFront(nil)
+                    capturedWindow = window
+                    delegate.welcomeWindow = window
+                }
+                await Task.yield()
+            },
+            presentPanel: { context in
+                presentedOwner = context.nsWindow
+                return selectedURL
+            }
+        )
+        defer {
+            if let capturedWindow {
+                DialogPresenter.ownerDidClose(capturedWindow)
+                capturedWindow.orderOut(nil)
+            }
+        }
+
+        #expect(didOpen)
+        #expect(attempts == 3)
+        #expect(presentedOwner === capturedWindow)
+        #expect(openedURL == selectedURL)
+    }
+
+    @Test func openFolderFailsClosedWhenWelcomeOwnerNeverAppears() async {
+        let delegate = AppDelegate()
+        delegate.openNamedWindow = { _ in }
+        var waitCount = 0
+        var panelCount = 0
+
+        let didOpen = await delegate.openFolderFromWelcomeOwner(
+            maximumAttempts: 3,
+            waitForNextAttempt: {
+                waitCount += 1
+                await Task.yield()
+            },
+            presentPanel: { _ in
+                panelCount += 1
+                return URL(fileURLWithPath: "/tmp/should-not-open")
+            }
+        )
+
+        #expect(!didOpen)
+        #expect(waitCount == 3)
+        #expect(panelCount == 0)
     }
 }

--- a/PineUITests/MultiWindowTests.swift
+++ b/PineUITests/MultiWindowTests.swift
@@ -127,6 +127,35 @@ final class MultiWindowTests: PineUITestCase {
         XCTAssertTrue(sidebar.exists, "Window should remain open after closing tab")
     }
 
+    func testLargeFileWarningCancelsWithCommandPeriod() throws {
+        let largeFile = projectURL.appendingPathComponent("large.swift")
+        try String(repeating: "a", count: 1_048_577).write(
+            to: largeFile,
+            atomically: true,
+            encoding: .utf8
+        )
+        launchWithProject(projectURL)
+
+        let fileNode = app.sidebarNodes["fileNode_large.swift"]
+        XCTAssertTrue(waitForExistence(fileNode, timeout: 10))
+        fileNode.click()
+
+        let warningSheet = app.sheets.firstMatch
+        XCTAssertTrue(
+            warningSheet.waitForExistence(timeout: 5),
+            "Large-file warning should attach to the project window"
+        )
+
+        app.typeKey(".", modifierFlags: .command)
+
+        XCTAssertTrue(
+            warningSheet.waitForNonExistence(timeout: 5),
+            "Command-. should cancel the large-file warning"
+        )
+        XCTAssertFalse(editorTab("large.swift").exists)
+        XCTAssertTrue(app.scrollViews["sidebar"].exists)
+    }
+
     // Note: Cmd+W tab closing is handled by NSEvent.addLocalMonitorForEvents
     // in AppDelegate, but XCUITest's typeKey bypasses the app's event queue
     // (uses Accessibility APIs instead), so Cmd+W cannot be reliably UI-tested.

--- a/PineUITests/WelcomeWindowTests.swift
+++ b/PineUITests/WelcomeWindowTests.swift
@@ -68,6 +68,28 @@ final class WelcomeWindowTests: PineUITestCase {
         XCTAssertTrue(welcomeWindow.exists, "Welcome should remain after cancelling Open Folder")
     }
 
+    func testOpenFolderPanelCancelsWithCommandPeriod() throws {
+        launchClean()
+
+        let openFolderButton = app.buttons["welcomeOpenFolderButton"]
+        XCTAssertTrue(waitForExistence(openFolderButton))
+        openFolderButton.click()
+
+        let openPanel = app.sheets.firstMatch
+        XCTAssertTrue(
+            openPanel.waitForExistence(timeout: 5),
+            "Open panel should be attached to the Welcome window"
+        )
+
+        app.typeKey(".", modifierFlags: .command)
+
+        XCTAssertTrue(
+            openPanel.waitForNonExistence(timeout: 5),
+            "Command-. should cancel the attached panel"
+        )
+        XCTAssertTrue(app.windows["welcome"].exists)
+    }
+
     // MARK: - P0: Recent project click → project opens
 
     func testClickRecentProjectOpensProject() throws {

--- a/scripts/tests/test-xcodebuild-cli-options.sh
+++ b/scripts/tests/test-xcodebuild-cli-options.sh
@@ -5,52 +5,316 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 CI_WORKFLOW="$REPO_ROOT/.github/workflows/ci.yml"
 
-timeout_lines="$(
-    grep -nF -- '-test-timeouts-enabled' "$CI_WORKFLOW" \
-        | grep -vE '^[0-9]+:[[:space:]]*#' \
+active_option_lines() {
+    local workflow="$1"
+    local option="$2"
+
+    printf '%s\n' "$workflow" \
+        | grep -nE -- "^[[:space:]]*${option}([[:space:]]|$)" \
         || true
-)"
+}
 
-if [ -z "$timeout_lines" ]; then
-    echo "✗ CI workflow no longer enables per-test timeouts"
-    exit 1
-fi
+line_count() {
+    printf '%s\n' "$1" | grep -c . || true
+}
 
-invalid_lines="$(
-    printf '%s\n' "$timeout_lines" \
-        | grep -vE -- '-test-timeouts-enabled[[:space:]]+YES([[:space:]]|$)' \
-        || true
-)"
+named_step_count() {
+    local workflow="$1"
+    local step_name="$2"
 
-if [ -n "$invalid_lines" ]; then
-    echo "✗ Every -test-timeouts-enabled option must pass an explicit YES value:"
-    echo "$invalid_lines"
-    exit 1
-fi
+    printf '%s\n' "$workflow" | awk -v target="- name: $step_name" '
+        {
+            trimmed = $0
+            sub(/^[[:space:]]*/, "", trimmed)
+            if (trimmed == target) {
+                count += 1
+            }
+        }
+        END { print count + 0 }
+    '
+}
 
-echo "✓ All xcodebuild test-timeout options pass an explicit YES value"
+named_step_block() {
+    local workflow="$1"
+    local step_name="$2"
 
-xcode_27_block="$(
-    sed -n \
-        '/- name: Unit Tests with Xcode 27/,/^  unit-tests:/p' \
-        "$CI_WORKFLOW"
-)"
-all_parallel_lines="$(
-    grep -nF -- '-parallel-testing-enabled' "$CI_WORKFLOW" || true
-)"
-xcode_27_parallel_lines="$(
-    printf '%s\n' "$xcode_27_block" \
-        | grep -F -- '-parallel-testing-enabled' \
-        || true
-)"
+    printf '%s\n' "$workflow" | awk -v target="- name: $step_name" '
+        {
+            trimmed = $0
+            sub(/^[[:space:]]*/, "", trimmed)
+        }
+        trimmed == target {
+            capture = 1
+        }
+        capture && trimmed != target {
+            if (trimmed ~ /^- name:/ || trimmed ~ /^- uses:/ ||
+                $0 ~ /^  [[:alnum:]_-]+:$/) {
+                exit
+            }
+        }
+        capture {
+            print
+        }
+    '
+}
 
-if [ "$(printf '%s\n' "$all_parallel_lines" | grep -c . || true)" -ne 1 ] \
-    || [ "$(printf '%s\n' "$xcode_27_parallel_lines" | grep -c . || true)" -ne 1 ] \
-    || ! printf '%s\n' "$xcode_27_parallel_lines" \
-        | grep -qF -- '-parallel-testing-enabled NO'; then
-    echo "✗ The Xcode 27 unit-test lane must be the only serialized lane and pass an explicit NO value"
-    echo "$all_parallel_lines"
-    exit 1
-fi
+validate_timeout_options() {
+    local workflow="$1"
+    local timeout_lines
+    local invalid_lines
 
-echo "✓ Only the Xcode 27 unit-test lane disables parallel testing"
+    timeout_lines="$(active_option_lines "$workflow" '-test-timeouts-enabled')"
+    if [ -z "$timeout_lines" ]; then
+        echo "✗ CI workflow no longer enables per-test timeouts" >&2
+        return 1
+    fi
+
+    invalid_lines="$(
+        printf '%s\n' "$timeout_lines" \
+            | grep -vE -- \
+                '-test-timeouts-enabled[[:space:]]+YES([[:space:]]|$)' \
+            || true
+    )"
+    if [ -n "$invalid_lines" ]; then
+        echo "✗ Every -test-timeouts-enabled option must pass an explicit YES value:" >&2
+        echo "$invalid_lines" >&2
+        return 1
+    fi
+}
+
+validate_serialized_step() {
+    local workflow="$1"
+    local step_name="$2"
+    local label="$3"
+    local step_count
+    local step_block
+    local parallel_lines
+    local parallel_count
+
+    step_count="$(named_step_count "$workflow" "$step_name")"
+    if [ "$step_count" -ne 1 ]; then
+        echo "✗ $label must appear exactly once (found $step_count)" >&2
+        return 1
+    fi
+
+    step_block="$(named_step_block "$workflow" "$step_name")"
+    parallel_lines="$(
+        active_option_lines "$step_block" '-parallel-testing-enabled'
+    )"
+    parallel_count="$(line_count "$parallel_lines")"
+    if [ "$parallel_count" -ne 1 ]; then
+        echo "✗ $label must contain exactly one active -parallel-testing-enabled option (found $parallel_count)" >&2
+        return 1
+    fi
+
+    if ! printf '%s\n' "$parallel_lines" \
+        | grep -qE -- \
+            '-parallel-testing-enabled[[:space:]]+NO([[:space:]]|$)'; then
+        echo "✗ $label must pass an explicit NO value to -parallel-testing-enabled" >&2
+        echo "$parallel_lines" >&2
+        return 1
+    fi
+}
+
+validate_parallel_options() {
+    local workflow="$1"
+    local all_parallel_lines
+    local all_parallel_count
+
+    validate_serialized_step \
+        "$workflow" \
+        "Unit Tests with Xcode 27" \
+        "The Xcode 27 unit-test lane" \
+        || return 1
+    validate_serialized_step \
+        "$workflow" \
+        "Unit Tests" \
+        "The macOS 26 unit-test lane" \
+        || return 1
+
+    all_parallel_lines="$(
+        active_option_lines "$workflow" '-parallel-testing-enabled'
+    )"
+    all_parallel_count="$(line_count "$all_parallel_lines")"
+    if [ "$all_parallel_count" -ne 2 ]; then
+        echo "✗ CI workflow must contain exactly two active serialized unit-test options (found $all_parallel_count)" >&2
+        echo "$all_parallel_lines" >&2
+        return 1
+    fi
+}
+
+validate_workflow() {
+    local workflow="$1"
+
+    validate_timeout_options "$workflow" || return 1
+    validate_parallel_options "$workflow" || return 1
+}
+
+fixture_workflow() {
+    local xcode_27_parallel="$1"
+    local macos_26_parallel="$2"
+    local extra_parallel="$3"
+    local xcode_27_timeout='-test-timeouts-enabled YES \'
+    local macos_26_timeout='-test-timeouts-enabled YES \'
+
+    if [ "$#" -ge 4 ]; then
+        xcode_27_timeout="$4"
+    fi
+    if [ "$#" -ge 5 ]; then
+        macos_26_timeout="$5"
+    fi
+
+    printf '%s\n' \
+        'jobs:' \
+        '  xcode-27-compatibility:' \
+        '    steps:' \
+        '      - name: Unit Tests with Xcode 27' \
+        '        run: |' \
+        '          xcodebuild test \' \
+        "            $xcode_27_parallel" \
+        "            $xcode_27_timeout" \
+        '            -resultBundlePath Xcode27TestResults.xcresult' \
+        '  unit-tests:' \
+        '    steps:' \
+        '      - name: Unit Tests' \
+        '        run: |' \
+        '          xcodebuild test-without-building \' \
+        "            $macos_26_parallel" \
+        "            $macos_26_timeout" \
+        '            -resultBundlePath TestResults.xcresult' \
+        '      - name: Detect Flaky Tests' \
+        '        run: python3 .github/scripts/detect_flaky_tests.py' \
+        '  ui-tests:' \
+        '    steps:' \
+        '      - name: UI Tests' \
+        '        run: |' \
+        '          xcodebuild test-without-building \' \
+        "            $extra_parallel" \
+        '            -only-testing:PineUITests'
+}
+
+assert_fixture_passes() {
+    local name="$1"
+    local workflow="$2"
+    local output
+
+    if ! output="$(validate_workflow "$workflow" 2>&1)"; then
+        echo "✗ Fixture '$name' should pass:" >&2
+        echo "$output" >&2
+        exit 1
+    fi
+    echo "✓ Fixture '$name' passes"
+}
+
+assert_fixture_fails() {
+    local name="$1"
+    local expected_diagnostic="$2"
+    local workflow="$3"
+    local output
+
+    if output="$(validate_workflow "$workflow" 2>&1)"; then
+        echo "✗ Fixture '$name' should fail" >&2
+        exit 1
+    fi
+    if ! grep -qF -- "$expected_diagnostic" <<< "$output"; then
+        echo "✗ Fixture '$name' failed for the wrong reason:" >&2
+        echo "$output" >&2
+        exit 1
+    fi
+    echo "✓ Fixture '$name' fails closed: $expected_diagnostic"
+}
+
+SERIALIZED='-parallel-testing-enabled NO \'
+MISSING_VALUE='-parallel-testing-enabled \'
+WRONG_VALUE='-parallel-testing-enabled YES \'
+TIMEOUT='-test-timeouts-enabled YES \'
+TIMEOUT_MISSING_VALUE='-test-timeouts-enabled \'
+TIMEOUT_WRONG_VALUE='-test-timeouts-enabled NO \'
+
+assert_fixture_passes \
+    "both unit lanes explicitly serialized" \
+    "$(fixture_workflow "$SERIALIZED" "$SERIALIZED" "")"
+assert_fixture_passes \
+    "commented lookalike outside unit lanes is ignored" \
+    "$(fixture_workflow \
+        "$SERIALIZED" \
+        "$SERIALIZED" \
+        '# -parallel-testing-enabled YES')"
+assert_fixture_passes \
+    "commented lookalike inside a unit lane is ignored" \
+    "$(fixture_workflow \
+        "$SERIALIZED
+            # $WRONG_VALUE" \
+        "$SERIALIZED" \
+        "")"
+
+assert_fixture_fails \
+    "missing Xcode 27 serialization" \
+    "The Xcode 27 unit-test lane must contain exactly one active" \
+    "$(fixture_workflow "" "$SERIALIZED" "")"
+assert_fixture_fails \
+    "missing macOS 26 serialization" \
+    "The macOS 26 unit-test lane must contain exactly one active" \
+    "$(fixture_workflow "$SERIALIZED" "" "")"
+assert_fixture_fails \
+    "Xcode 27 serialization missing value" \
+    "The Xcode 27 unit-test lane must pass an explicit NO value" \
+    "$(fixture_workflow "$MISSING_VALUE" "$SERIALIZED" "")"
+assert_fixture_fails \
+    "macOS 26 serialization missing value" \
+    "The macOS 26 unit-test lane must pass an explicit NO value" \
+    "$(fixture_workflow "$SERIALIZED" "$MISSING_VALUE" "")"
+assert_fixture_fails \
+    "Xcode 27 serialization enabled" \
+    "The Xcode 27 unit-test lane must pass an explicit NO value" \
+    "$(fixture_workflow "$WRONG_VALUE" "$SERIALIZED" "")"
+assert_fixture_fails \
+    "macOS 26 serialization enabled" \
+    "The macOS 26 unit-test lane must pass an explicit NO value" \
+    "$(fixture_workflow "$SERIALIZED" "$WRONG_VALUE" "")"
+assert_fixture_fails \
+    "duplicate serialization in Xcode 27 unit lane" \
+    "The Xcode 27 unit-test lane must contain exactly one active" \
+    "$(fixture_workflow \
+        "$SERIALIZED
+            $SERIALIZED" \
+        "$SERIALIZED" \
+        "")"
+assert_fixture_fails \
+    "duplicate serialization in macOS 26 unit lane" \
+    "The macOS 26 unit-test lane must contain exactly one active" \
+    "$(fixture_workflow \
+        "$SERIALIZED" \
+        "$SERIALIZED
+            $SERIALIZED" \
+        "")"
+assert_fixture_fails \
+    "serialization added outside unit lanes" \
+    "CI workflow must contain exactly two active serialized unit-test options" \
+    "$(fixture_workflow "$SERIALIZED" "$SERIALIZED" "$SERIALIZED")"
+assert_fixture_fails \
+    "timeout option missing value" \
+    "Every -test-timeouts-enabled option must pass an explicit YES value" \
+    "$(fixture_workflow \
+        "$SERIALIZED" \
+        "$SERIALIZED" \
+        "" \
+        "$TIMEOUT_MISSING_VALUE" \
+        "$TIMEOUT")"
+assert_fixture_fails \
+    "timeout option has wrong value" \
+    "Every -test-timeouts-enabled option must pass an explicit YES value" \
+    "$(fixture_workflow \
+        "$SERIALIZED" \
+        "$SERIALIZED" \
+        "" \
+        "$TIMEOUT" \
+        "$TIMEOUT_WRONG_VALUE")"
+assert_fixture_fails \
+    "timeout options removed" \
+    "CI workflow no longer enables per-test timeouts" \
+    "$(fixture_workflow "$SERIALIZED" "$SERIALIZED" "" "" "")"
+
+validate_workflow "$(< "$CI_WORKFLOW")"
+echo "✓ Every xcodebuild test-timeout option passes an explicit YES value"
+echo "✓ Both unit-test lanes disable parallel testing exactly once"


### PR DESCRIPTION
Closes #1241. Adds DialogPresentationContext and async sheet presentation bound to NSWindow. Replaces application-modal runModal.