### PR TITLE
feat(tasks): surface execution progress, output, and failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,7 +508,7 @@ jobs:
           fi
           echo "All $(echo "$ACTUAL" | wc -l | tr -d ' ') UI test classes are sharded."
 
-  # UI test shards — 7 parallel jobs, 27-29 tests each (delta 2).
+  # UI test shards — 7 parallel jobs, 28-30 tests each (delta 2).
   # To rebalance: count tests per class, redistribute so shards stay within ±3 tests.
   # List classes with: grep -r "func test" PineUITests/ | sed 's/:.*//' | sort | uniq -c | sort -rn
   ui-tests:
@@ -520,12 +520,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Shard 1 — Terminal (27 tests)
+          # Shard 1 — Terminal (29 tests)
           - shard-name: "Terminal"
             test-classes: >-
               -only-testing:PineUITests/TerminalTests
               -only-testing:PineUITests/TerminalMenuTests
-          # Shard 2 — Welcome & Session (28 tests)
+              -only-testing:PineUITests/AgentAttentionKeyboardUITests
+          # Shard 2 — Welcome & Session (29 tests)
           - shard-name: "Welcome & Session"
             test-classes: >-
               -only-testing:PineUITests/WelcomeWindowTests
@@ -547,13 +548,14 @@ jobs:
               -only-testing:PineUITests/BranchSwitcherTests
               -only-testing:PineUITests/CheckForUpdatesTests
               -only-testing:PineUITests/SplitPaneRoutingUITests
-          # Shard 5 — Files & Save (27 tests)
+          # Shard 5 — Files & Save (30 tests)
           - shard-name: "Files & Save"
             test-classes: >-
               -only-testing:PineUITests/EditorSaveFlowTests
               -only-testing:PineUITests/DeleteTests
               -only-testing:PineUITests/SidebarRenameTests
               -only-testing:PineUITests/SidebarFileOperationsTests
+              -only-testing:PineUITests/UserTaskExecutionUITests
           # Shard 6 — Search & Panes (28 tests)
           - shard-name: "Search & Panes"
             test-classes: >-
@@ -574,7 +576,6 @@ jobs:
               -only-testing:PineUITests/BlameViewTests
               -only-testing:PineUITests/HCLFormatOnSaveTests
               -only-testing:PineUITests/ToggleCommentTests
-              -only-testing:PineUITests/AgentAttentionKeyboardUITests
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -143,6 +143,33 @@ nonisolated enum AccessibilityID {
     // MARK: - Toast notifications
     static let toastNotification = "toastNotification"
 
+    // MARK: - User tasks
+    static let userTaskOutputPanel = "userTaskOutputPanel"
+    static let userTaskClearFinishedButton = "userTaskClearFinishedButton"
+    static let userTaskCloseOutputButton = "userTaskCloseOutputButton"
+    static let userTaskShowOutputButton = "userTaskShowOutputButton"
+    static func userTaskRun(_ id: UUID) -> String {
+        "userTaskRun_\(id.uuidString)"
+    }
+    static func userTaskStatusLabel(_ id: UUID) -> String {
+        "userTaskStatus_\(id.uuidString)"
+    }
+    static func userTaskElapsedLabel(_ id: UUID) -> String {
+        "userTaskElapsed_\(id.uuidString)"
+    }
+    static func userTaskCopyOutputButton(_ id: UUID) -> String {
+        "userTaskCopyOutput_\(id.uuidString)"
+    }
+    static func userTaskOutputText(_ id: UUID) -> String {
+        "userTaskOutputText_\(id.uuidString)"
+    }
+    static func userTaskCancelButton(_ id: UUID) -> String {
+        "userTaskCancel_\(id.uuidString)"
+    }
+    static func userTaskProgressIndicator(_ id: UUID) -> String {
+        "userTaskProgress_\(id.uuidString)"
+    }
+
     // MARK: - Context menu
     static let contextMenuNewFile = "contextMenuNewFile"
     static let contextMenuNewFolder = "contextMenuNewFolder"

--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -163,6 +163,9 @@ nonisolated enum AccessibilityID {
     static func userTaskOutputText(_ id: UUID) -> String {
         "userTaskOutputText_\(id.uuidString)"
     }
+    static func userTaskOutputTruncationNotice(_ id: UUID) -> String {
+        "userTaskOutputTruncation_\(id.uuidString)"
+    }
     static func userTaskCancelButton(_ id: UUID) -> String {
         "userTaskCancel_\(id.uuidString)"
     }

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -91,6 +91,7 @@ struct ContentView: View {
         .overlay(alignment: .top) {
             ToastOverlay()
         }
+        .modifier(UserTaskRunPresenter(store: projectManager.taskRunStore))
         .modifier(ProjectSearchModifier(
             projectManager: projectManager,
             isSearchPresented: $isSearchPresented

--- a/Pine/Extensibility/UserConfigurationPaths.swift
+++ b/Pine/Extensibility/UserConfigurationPaths.swift
@@ -32,7 +32,21 @@ nonisolated enum UserConfigurationPaths {
 
     /// `…/Pine/tasks.json` — user-defined external commands/tasks.
     static var userTasksFile: URL {
-        applicationSupportDirectory.appendingPathComponent("tasks.json", isDirectory: false)
+        // A narrowly gated UI-test hook keeps task execution scenarios
+        // deterministic without reading or overwriting a developer's real
+        // configuration. `--reset-state` is already Pine's UI-test launch
+        // mode; the environment override is ignored for normal launches.
+        if CommandLine.arguments.contains("--reset-state"),
+           let path = ProcessInfo.processInfo.environment[
+               "PINE_USER_TASKS_FILE"
+           ],
+           !path.isEmpty {
+            return URL(fileURLWithPath: path, isDirectory: false)
+        }
+        return applicationSupportDirectory.appendingPathComponent(
+            "tasks.json",
+            isDirectory: false
+        )
     }
 
     /// `…/Pine/keybindings.json` — user-defined command → key mappings.

--- a/Pine/Extensibility/UserTaskInvocationController.swift
+++ b/Pine/Extensibility/UserTaskInvocationController.swift
@@ -163,6 +163,13 @@ enum UserTaskInvocationController {
         return response == .alertFirstButtonReturn
     }
 
+    /// Snapshot of the active tab captured before a task runs, used to detect
+    /// whether the buffer changed while the task was executing.
+    struct CapturedTab: Equatable {
+        let id: UUID?
+        let content: String?
+    }
+
     private static func presentOutcome(
         _ outcome: UserTaskOutcome,
         cancelled: Bool,
@@ -202,8 +209,8 @@ enum UserTaskInvocationController {
             }
             let tabManager = projectManager.activeTabManager
             if canApplyReplacement(
-                capturedTabID: capturedTabID,
-                capturedContent: capturedContent,
+                capturedTabID: snapshot.tabID,
+                capturedContent: snapshot.content,
                 currentTabID: tabManager.activeTab?.id,
                 currentContent: tabManager.activeTab?.content
             ) {

--- a/Pine/Extensibility/UserTaskInvocationController.swift
+++ b/Pine/Extensibility/UserTaskInvocationController.swift
@@ -111,6 +111,16 @@ enum UserTaskInvocationController {
             content: currentActiveTab?.content,
             context: context
         )
+        let runStore = projectManager.taskRunStore
+        let run = runStore.start(
+            UserTaskRun(
+                taskID: task.id,
+                taskLabel: task.label,
+                command: task.command,
+                replacesFileContent: task.replacesFileContent
+            )
+        )
+        run.markRunning()
         runTask(
             task,
             currentActiveTab?.url,
@@ -118,9 +128,18 @@ enum UserTaskInvocationController {
             snapshot.content
         ) { outcome in
             Task { @MainActor in
+                run.applyOutcome(
+                    stdout: outcome.stdout,
+                    stderr: outcome.stderr,
+                    exitCode: outcome.exitCode,
+                    timedOut: outcome.timedOut,
+                    cancelled: false
+                )
                 presentOutcome(
                     outcome,
+                    cancelled: false,
                     task: task,
+                    run: run,
                     projectManager: projectManager,
                     snapshot: snapshot
                 )
@@ -146,41 +165,80 @@ enum UserTaskInvocationController {
 
     private static func presentOutcome(
         _ outcome: UserTaskOutcome,
+        cancelled: Bool,
         task: UserTask,
+        run: UserTaskRun,
         projectManager: ProjectManager,
         snapshot: InvocationSnapshot
     ) {
-        guard outcome.succeeded else {
+        // Always log for diagnostics (parity with the previous behaviour).
+        if outcome.succeeded {
+            Logger.extensibility.info(
+                "Task '\(task.label)' completed successfully"
+            )
+        } else {
             Logger.extensibility.error(
                 "Task '\(task.label)' failed (exit \(outcome.exitCode)): \(outcome.stderr)"
+            )
+        }
+
+        // A cancelled run needs no further UI — the output surface already
+        // reflects the cancelled state.
+        if cancelled { return }
+
+        // Fail closed for replacement-content tasks: only apply stdout when
+        // the active tab is unchanged. When the buffer moved, keep the newer
+        // edits and offer Copy / Open Output so the user can recover the
+        // output without clobbering their work.
+        if task.replacesFileContent {
+            guard let owner = snapshot.context.nsWindow,
+                  owner.isVisible,
+                  !owner.isMiniaturized else {
+                return
+            }
+            guard outcome.succeeded, !cancelled else {
+                projectManager.taskRunStore.isOutputVisible = true
+                return
+            }
+            let tabManager = projectManager.activeTabManager
+            if canApplyReplacement(
+                capturedTabID: capturedTabID,
+                capturedContent: capturedContent,
+                currentTabID: tabManager.activeTab?.id,
+                currentContent: tabManager.activeTab?.content
+            ) {
+                tabManager.updateContent(outcome.stdout)
+                // Simple success: brief, accessible toast. The output surface
+                // is kept available but not force-shown for a clean apply.
+                if outcome.succeeded {
+                    projectManager.toastManager.show(
+                        ToastItem(message: Strings.userTaskToastSucceeded(task.label))
+                    )
+                }
+                return
+            }
+            // Conflict: fail closed. Surface the output panel with Copy/Open
+            // actions so the user can recover stdout without losing edits.
+            presentReplacementConflict(
+                run: run,
+                projectManager: projectManager,
+                context: snapshot.context
             )
             return
         }
 
-        Logger.extensibility.info(
-            "Task '\(task.label)' completed successfully"
-        )
-        guard task.replacesFileContent else { return }
-        guard let owner = snapshot.context.nsWindow,
-              owner.isVisible,
-              !owner.isMiniaturized else {
-            return
+        // Non-replacement tasks: a clean success with no output is reported
+        // via a brief toast; failures or any captured output are routed to
+        // the durable output surface for inspection.
+        if outcome.succeeded && !run.hasOutput {
+            projectManager.toastManager.show(
+                ToastItem(message: Strings.userTaskToastSucceeded(task.label))
+            )
+        } else {
+            // Make sure the output surface is visible so the user sees the
+            // failure / captured output.
+            projectManager.taskRunStore.isOutputVisible = true
         }
-
-        // Fail closed if the user switched tabs or edited the file while the
-        // process ran. Applying stdout to a different/newer buffer would lose
-        // unrelated work and violate the task's active-file contract.
-        let tabManager = projectManager.activeTabManager
-        guard canApplyReplacement(
-            capturedTabID: snapshot.tabID,
-            capturedContent: snapshot.content,
-            currentTabID: tabManager.activeTab?.id,
-            currentContent: tabManager.activeTab?.content
-        ) else {
-            presentReplacementConflict(context: snapshot.context)
-            return
-        }
-        tabManager.updateContent(outcome.stdout)
     }
 
     nonisolated static func canApplyReplacement(
@@ -195,6 +253,8 @@ enum UserTaskInvocationController {
     }
 
     private static func presentReplacementConflict(
+        run: UserTaskRun,
+        projectManager: ProjectManager,
         context: DialogPresentationContext
     ) {
         Task { @MainActor in
@@ -202,8 +262,26 @@ enum UserTaskInvocationController {
             alert.alertStyle = .warning
             alert.messageText = Strings.userTaskOutputConflictTitle
             alert.informativeText = Strings.userTaskOutputConflictMessage
+            // Offer safe recovery actions: Copy the captured stdout to the
+            // pasteboard, and reveal the output surface for inspection.
+            alert.addButton(withTitle: Strings.userTaskCopyOutput)
+            alert.addButton(withTitle: Strings.userTaskOpenOutput)
             alert.addButton(withTitle: Strings.dialogOK)
-            _ = await alert.runSheet(on: context)
+            let response = await alert.runSheet(on: context)
+            guard let owner = context.nsWindow,
+                  owner.isVisible,
+                  !owner.isMiniaturized else {
+                return
+            }
+            switch response {
+            case .alertFirstButtonReturn:
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(run.stdout, forType: .string)
+            case .alertSecondButtonReturn:
+                projectManager.taskRunStore.isOutputVisible = true
+            default:
+                break
+            }
         }
     }
 

--- a/Pine/Extensibility/UserTaskInvocationController.swift
+++ b/Pine/Extensibility/UserTaskInvocationController.swift
@@ -324,19 +324,40 @@ enum UserTaskInvocationController {
             alert.addButton(withTitle: Strings.userTaskOpenOutput)
             alert.addButton(withTitle: Strings.dialogOK)
             let response = await alert.runSheet(on: context)
-            guard let owner = context.nsWindow,
-                  owner.isVisible,
-                  !owner.isMiniaturized else {
-                return
-            }
-            switch response {
-            case .alertFirstButtonReturn:
-                UserTaskOutputClipboard.copy(run.stdout)
-            case .alertSecondButtonReturn:
-                projectManager.taskRunStore.isOutputVisible = true
-            default:
-                break
-            }
+            applyReplacementConflictResponse(
+                response,
+                run: run,
+                projectManager: projectManager,
+                context: context
+            )
+        }
+    }
+
+    /// Applies a recovery choice from the replacement-conflict sheet.
+    ///
+    /// Kept as an internal seam so the safe Copy/Open actions can be hosted
+    /// against a real owner window without automating an `NSAlert`.
+    static func applyReplacementConflictResponse(
+        _ response: NSApplication.ModalResponse,
+        run: UserTaskRun,
+        projectManager: ProjectManager,
+        context: DialogPresentationContext,
+        copyOutput: (String) -> Void = {
+            UserTaskOutputClipboard.copy($0)
+        }
+    ) {
+        guard let owner = context.nsWindow,
+              owner.isVisible,
+              !owner.isMiniaturized else {
+            return
+        }
+        switch response {
+        case .alertFirstButtonReturn:
+            copyOutput(run.stdout)
+        case .alertSecondButtonReturn:
+            projectManager.taskRunStore.isOutputVisible = true
+        default:
+            break
         }
     }
 

--- a/Pine/Extensibility/UserTaskInvocationController.swift
+++ b/Pine/Extensibility/UserTaskInvocationController.swift
@@ -23,12 +23,11 @@ enum UserTaskInvocationController {
         URL?,
         URL?,
         String?,
-        @escaping @Sendable (UserTaskOutcome) -> Void
-    ) -> Void
+        UserTaskProgress
+    ) -> UserTaskCancellation
 
     private struct InvocationSnapshot {
-        let tabID: UUID?
-        let content: String?
+        let tab: CapturedTab
         let context: DialogPresentationContext
     }
 
@@ -45,13 +44,13 @@ enum UserTaskInvocationController {
                 presentConfirmation: { task, context in
                     await presentConfirmation(for: task, context: context)
                 },
-                runTask: { task, fileURL, projectRootURL, fileContent, completion in
+                runTask: { task, fileURL, projectRootURL, fileContent, progress in
                     UserTaskRunner.shared.run(
                         task: task,
                         fileURL: fileURL,
                         projectRootURL: projectRootURL,
                         fileContent: fileContent,
-                        completion: completion
+                        progress: progress
                     )
                 }
             )
@@ -75,12 +74,22 @@ enum UserTaskInvocationController {
             return false
         }
 
-        let initialActiveTab = projectManager.activeTabManager.activeTab
-        if task.scope == .activeFile, initialActiveTab == nil {
-            presentMissingActiveFile(context: context)
+        let activeTab = projectManager.activeTabManager.activeTab
+        if task.scope == .activeFile, activeTab == nil {
+            await presentMissingActiveFile(context: context)
+            return false
+        }
+        if task.replacesFileContent,
+           !replacementTargetIsEligible(
+               scope: task.scope,
+               isText: activeTab?.kind == .text,
+               isTruncated: activeTab?.isTruncated
+           ) {
+            await presentIneligibleReplacement(context: context)
             return false
         }
 
+        let capturedTab = capture(activeTab)
         if task.effectiveRequireConfirmation(),
            !(await presentConfirmation(task, context)) {
             return false
@@ -92,23 +101,19 @@ enum UserTaskInvocationController {
             return false
         }
 
-        let currentActiveTab = projectManager.activeTabManager.activeTab
         if task.scope == .activeFile {
             // The confirmation authorized the exact active-file intent that
             // existed when it appeared. Switching tabs, closing the file, or
             // editing its buffer while suspended must not retarget the task.
-            guard let initialActiveTab,
-                  let currentActiveTab,
-                  currentActiveTab.id == initialActiveTab.id,
-                  currentActiveTab.url == initialActiveTab.url,
-                  currentActiveTab.content == initialActiveTab.content else {
+            guard capturedTab == capture(
+                projectManager.activeTabManager.activeTab
+            ) else {
                 return false
             }
         }
 
         let snapshot = InvocationSnapshot(
-            tabID: currentActiveTab?.id,
-            content: currentActiveTab?.content,
+            tab: capturedTab,
             context: context
         )
         let runStore = projectManager.taskRunStore
@@ -120,30 +125,39 @@ enum UserTaskInvocationController {
                 replacesFileContent: task.replacesFileContent
             )
         )
-        run.markRunning()
-        runTask(
+
+        let cancellation = runTask(
             task,
-            currentActiveTab?.url,
+            capturedTab.url,
             projectManager.workspace.rootURL,
-            snapshot.content
-        ) { outcome in
-            Task { @MainActor in
-                run.applyOutcome(
-                    stdout: outcome.stdout,
-                    stderr: outcome.stderr,
-                    exitCode: outcome.exitCode,
-                    timedOut: outcome.timedOut,
-                    cancelled: false
-                )
-                presentOutcome(
-                    outcome,
-                    task: task,
-                    run: run,
-                    projectManager: projectManager,
-                    snapshot: snapshot
-                )
-            }
-        }
+            capturedTab.content,
+            UserTaskProgress(
+                onStart: { @Sendable in
+                    Task { @MainActor in
+                        run.markRunning()
+                    }
+                },
+                onFinish: { @Sendable outcome, cancelled in
+                    Task { @MainActor in
+                        guard runStore.finishRun(
+                            id: run.id,
+                            outcome: outcome,
+                            cancelled: cancelled
+                        ) else { return }
+                        presentOutcome(
+                            outcome,
+                            task: task,
+                            run: run,
+                            projectManager: projectManager,
+                            snapshot: snapshot
+                        )
+                    }
+                }
+            )
+        )
+        // Registration is synchronous, eliminating the cancel-before-handle
+        // gap while preserving the runner's callback API for other clients.
+        runStore.registerCancellation(cancellation, forRunID: run.id)
         return true
     }
 
@@ -164,9 +178,23 @@ enum UserTaskInvocationController {
 
     /// Snapshot of the active tab captured before a task runs, used to detect
     /// whether the buffer changed while the task was executing.
-    struct CapturedTab: Equatable {
+    nonisolated struct CapturedTab: Equatable, Sendable {
         let id: UUID?
+        let url: URL?
         let content: String?
+        let contentVersion: UInt64?
+        let isEligibleForReplacement: Bool
+    }
+
+    private static func capture(_ tab: EditorTab?) -> CapturedTab {
+        CapturedTab(
+            id: tab?.id,
+            url: tab?.url.standardizedFileURL,
+            content: tab?.content,
+            contentVersion: tab?.contentVersion,
+            isEligibleForReplacement:
+                tab?.kind == .text && tab?.isTruncated == false
+        )
     }
 
     private static func presentOutcome(
@@ -177,7 +205,7 @@ enum UserTaskInvocationController {
         snapshot: InvocationSnapshot
     ) {
         // Always log for diagnostics (parity with the previous behaviour).
-        if outcome.succeeded {
+        if outcome.succeeded, run.state != .cancelled {
             Logger.extensibility.info(
                 "Task '\(task.label)' completed successfully"
             )
@@ -187,30 +215,22 @@ enum UserTaskInvocationController {
             )
         }
 
-        // A cancelled run needs no further UI — the output surface already
-        // reflects the cancelled state.
-        if run.state == .cancelled { return }
-
         // Fail closed for replacement-content tasks: only apply stdout when
-        // the active tab is unchanged. When the buffer moved, keep the newer
-        // edits and offer Copy / Open Output so the user can recover the
-        // output without clobbering their work.
+        // the process completed successfully and the active tab is unchanged.
+        // Failed, timed-out, spawn-failed, and cancelled runs may contain
+        // partial stdout, which must never overwrite the editor buffer.
         if task.replacesFileContent {
             guard let owner = snapshot.context.nsWindow,
                   owner.isVisible,
                   !owner.isMiniaturized else {
                 return
             }
-            guard outcome.succeeded, run.state != .cancelled else {
-                projectManager.taskRunStore.isOutputVisible = true
-                return
-            }
             let tabManager = projectManager.activeTabManager
             if canApplyReplacement(
-                capturedTabID: snapshot.tabID,
-                capturedContent: snapshot.content,
-                currentTabID: tabManager.activeTab?.id,
-                currentContent: tabManager.activeTab?.content
+                outcome: outcome,
+                cancelled: run.state == .cancelled,
+                captured: snapshot.tab,
+                current: capture(tabManager.activeTab)
             ) {
                 tabManager.updateContent(outcome.stdout)
                 // Simple success: brief, accessible toast. The output surface
@@ -222,6 +242,15 @@ enum UserTaskInvocationController {
                 }
                 return
             }
+
+            // Process failures are already durable in the run model. Reveal
+            // that output without presenting the edit-conflict recovery
+            // dialog, because no replacement is eligible to apply.
+            guard outcome.succeeded, run.state != .cancelled else {
+                projectManager.taskRunStore.isOutputVisible = true
+                return
+            }
+
             // Conflict: fail closed. Surface the output panel with Copy/Open
             // actions so the user can recover stdout without losing edits.
             presentReplacementConflict(
@@ -231,6 +260,10 @@ enum UserTaskInvocationController {
             )
             return
         }
+
+        // A cancelled non-replacement run needs no further UI — the output
+        // surface already reflects the cancelled state.
+        if run.state == .cancelled { return }
 
         // Non-replacement tasks: a clean success with no output is reported
         // via a brief toast; failures or any captured output are routed to
@@ -247,14 +280,32 @@ enum UserTaskInvocationController {
     }
 
     nonisolated static func canApplyReplacement(
-        capturedTabID: UUID?,
-        capturedContent: String?,
-        currentTabID: UUID?,
-        currentContent: String?
+        outcome: UserTaskOutcome,
+        cancelled: Bool,
+        captured: CapturedTab,
+        current: CapturedTab
     ) -> Bool {
-        guard let capturedTabID, let capturedContent else { return false }
-        return currentTabID == capturedTabID
-            && currentContent == capturedContent
+        guard outcome.succeeded, !cancelled else { return false }
+        guard captured.id != nil,
+              captured.url != nil,
+              captured.content != nil,
+              captured.contentVersion != nil,
+              captured.isEligibleForReplacement,
+              current.isEligibleForReplacement else {
+            return false
+        }
+        return current.id == captured.id
+            && current.url == captured.url
+            && current.contentVersion == captured.contentVersion
+            && current.content == captured.content
+    }
+
+    nonisolated static func replacementTargetIsEligible(
+        scope: UserTask.Scope,
+        isText: Bool,
+        isTruncated: Bool?
+    ) -> Bool {
+        scope == .activeFile && isText && isTruncated == false
     }
 
     private static func presentReplacementConflict(
@@ -280,8 +331,7 @@ enum UserTaskInvocationController {
             }
             switch response {
             case .alertFirstButtonReturn:
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(run.stdout, forType: .string)
+                UserTaskOutputClipboard.copy(run.stdout)
             case .alertSecondButtonReturn:
                 projectManager.taskRunStore.isOutputVisible = true
             default:
@@ -292,14 +342,23 @@ enum UserTaskInvocationController {
 
     private static func presentMissingActiveFile(
         context: DialogPresentationContext
-    ) {
-        Task { @MainActor in
-            let alert = NSAlert()
-            alert.alertStyle = .warning
-            alert.messageText = Strings.userTaskMissingFileTitle
-            alert.informativeText = Strings.userTaskMissingFileMessage
-            alert.addButton(withTitle: Strings.dialogOK)
-            _ = await alert.runSheet(on: context)
-        }
+    ) async {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = Strings.userTaskMissingFileTitle
+        alert.informativeText = Strings.userTaskMissingFileMessage
+        alert.addButton(withTitle: Strings.dialogOK)
+        _ = await alert.runSheet(on: context)
+    }
+
+    private static func presentIneligibleReplacement(
+        context: DialogPresentationContext
+    ) async {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = Strings.userTaskReplacementUnavailableTitle
+        alert.informativeText = Strings.userTaskReplacementUnavailableMessage
+        alert.addButton(withTitle: Strings.dialogOK)
+        _ = await alert.runSheet(on: context)
     }
 }

--- a/Pine/Extensibility/UserTaskInvocationController.swift
+++ b/Pine/Extensibility/UserTaskInvocationController.swift
@@ -137,7 +137,6 @@ enum UserTaskInvocationController {
                 )
                 presentOutcome(
                     outcome,
-                    cancelled: false,
                     task: task,
                     run: run,
                     projectManager: projectManager,
@@ -172,7 +171,6 @@ enum UserTaskInvocationController {
 
     private static func presentOutcome(
         _ outcome: UserTaskOutcome,
-        cancelled: Bool,
         task: UserTask,
         run: UserTaskRun,
         projectManager: ProjectManager,
@@ -191,7 +189,7 @@ enum UserTaskInvocationController {
 
         // A cancelled run needs no further UI — the output surface already
         // reflects the cancelled state.
-        if cancelled { return }
+        if run.state == .cancelled { return }
 
         // Fail closed for replacement-content tasks: only apply stdout when
         // the active tab is unchanged. When the buffer moved, keep the newer
@@ -203,7 +201,7 @@ enum UserTaskInvocationController {
                   !owner.isMiniaturized else {
                 return
             }
-            guard outcome.succeeded, !cancelled else {
+            guard outcome.succeeded, run.state != .cancelled else {
                 projectManager.taskRunStore.isOutputVisible = true
                 return
             }

--- a/Pine/Extensibility/UserTaskRun.swift
+++ b/Pine/Extensibility/UserTaskRun.swift
@@ -1,0 +1,198 @@
+//
+//  UserTaskRun.swift
+//  Pine
+//
+//  Task execution UI (issue #1246): a lightweight, observable model that
+//  represents a single user-task invocation — running state, elapsed time,
+//  exit status, and captured stdout/stderr. Owned by `UserTaskRunStore`,
+//  which lives on the initiating `ProjectManager` so each project window
+//  surfaces only its own task activity.
+//
+//  The model is a pure UI projection: it never spawns processes or touches
+//  the shell. `UserTaskRunner` drives it by updating state as the task
+//  progresses; the validated command path (`UserTaskInvocationController`
+//  → `UserTaskValidator` → `UserTaskRunner`) is unchanged.
+//
+
+import Foundation
+
+/// Lifecycle phase of a single task run.
+nonisolated enum UserTaskRunState: Sendable, Equatable {
+    /// The task has been queued / is preparing to launch.
+    case pending
+    /// The process is running.
+    case running
+    /// The process exited with status 0.
+    case succeeded
+    /// The process exited with a non-zero status, was cancelled, timed out,
+    /// or could not be launched.
+    case failed
+    /// The user cancelled the run before it finished.
+    case cancelled
+
+    /// `true` while the run has not reached a terminal state.
+    var isActive: Bool {
+        switch self {
+        case .pending, .running: true
+        case .succeeded, .failed, .cancelled: false
+        }
+    }
+}
+
+/// A single user-task invocation surfaced in the UI.
+///
+/// `@MainActor @Observable` so SwiftUI can render progress, elapsed time,
+/// and captured output reactively. The `id` is stable for the lifetime of
+/// the run; the store replaces a run in place by `id` as state evolves.
+@MainActor
+@Observable
+final class UserTaskRun: Identifiable {
+    /// Stable identifier for this run.
+    let id: UUID
+    /// The task definition's id (from `tasks.json`).
+    let taskID: String
+    /// Human-readable task label, snapshotted at invocation time so later
+    /// edits to `tasks.json` do not retroactively rename an in-flight run.
+    let taskLabel: String
+    /// The validated shell command text, captured for display only. This is
+    /// the exact string handed to `/bin/sh -c` — never editor or terminal
+    /// content interpolated into shell text (issue #1117 safety contract).
+    let command: String
+    /// Whether this run was an active-file replacement task.
+    let replacesFileContent: Bool
+
+    /// Current lifecycle phase.
+    private(set) var state: UserTaskRunState
+    /// Wall-clock start time.
+    let startedAt: Date
+    /// Wall-clock finish time, set when the run reaches a terminal state.
+    private(set) var finishedAt: Date?
+
+    /// Captured stdout (UTF-8). Populated as/after the process runs.
+    private(set) var stdout: String
+    /// Captured stderr (UTF-8). Populated as/after the process runs.
+    private(set) var stderr: String
+    /// Process exit status. `-1` when the process could not be spawned or
+    /// was cancelled before exiting.
+    private(set) var exitCode: Int32?
+    /// `true` when the task exceeded its timeout and was terminated.
+    private(set) var timedOut: Bool
+    /// Short, human-readable reason when the run was blocked before launch
+    /// (e.g. the validator rejected the command) or failed to launch.
+    private(set) var blockedReason: String?
+
+    init(
+        taskID: String,
+        taskLabel: String,
+        command: String,
+        replacesFileContent: Bool,
+        startedAt: Date = Date()
+    ) {
+        self.id = UUID()
+        self.taskID = taskID
+        self.taskLabel = taskLabel
+        self.command = command
+        self.replacesFileContent = replacesFileContent
+        self.state = .pending
+        self.startedAt = startedAt
+        self.finishedAt = nil
+        self.stdout = ""
+        self.stderr = ""
+        self.exitCode = nil
+        self.timedOut = false
+        self.blockedReason = nil
+    }
+
+    // MARK: - Mutations (driven by UserTaskRunner)
+
+    /// Marks the run as having started executing.
+    func markRunning() {
+        guard state == .pending else { return }
+        state = .running
+    }
+
+    /// Records that the run was blocked before launch (validator rejection
+    /// or spawn failure). Treated as a failure with a descriptive reason.
+    func markBlocked(reason: String) {
+        state = .failed
+        finishedAt = Date()
+        blockedReason = reason
+    }
+
+    /// Applies the terminal outcome of the run.
+    func applyOutcome(
+        stdout: String,
+        stderr: String,
+        exitCode: Int32,
+        timedOut: Bool,
+        cancelled: Bool
+    ) {
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exitCode = exitCode
+        self.timedOut = timedOut
+        finishedAt = Date()
+        if cancelled {
+            state = .cancelled
+        } else if exitCode == 0 && !timedOut {
+            state = .succeeded
+        } else {
+            state = .failed
+        }
+    }
+
+    /// Forces the run into the cancelled state (used when the user cancels
+    /// an in-flight process whose exact exit code is not yet known).
+    func markCancelled() {
+        guard state.isActive else { return }
+        state = .cancelled
+        finishedAt = Date()
+    }
+
+    // MARK: - Derived presentation values
+
+    /// Elapsed seconds for an active run (computed at render time from
+    /// `startedAt` and now) or the final duration for a finished run.
+    var elapsedSeconds: TimeInterval {
+        let end = finishedAt ?? Date()
+        return max(0, end.timeIntervalSince(startedAt))
+    }
+
+    /// `true` when the run captured any stdout or stderr worth showing in
+    /// the output surface.
+    var hasOutput: Bool {
+        !stdout.isEmpty || !stderr.isEmpty
+    }
+
+    /// The output text to display, preferring stdout and appending stderr
+    /// when present. Returns an empty string when nothing was captured.
+    var combinedOutput: String {
+        if !stdout.isEmpty && !stderr.isEmpty {
+            return stdout + "\n" + stderr
+        }
+        return stdout.isEmpty ? stderr : stdout
+    }
+
+    /// A short, human-readable summary of the terminal status, e.g.
+    /// "Exit 0", "Exit 1", "Cancelled", "Timed out".
+    var statusSummary: String {
+        switch state {
+        case .pending:
+            return Strings.userTaskRunStatusPending
+        case .running:
+            return Strings.userTaskRunStatusRunning
+        case .succeeded:
+            return Strings.userTaskRunStatusSucceeded
+        case .failed:
+            if timedOut {
+                return Strings.userTaskRunStatusTimedOut
+            }
+            if let exitCode {
+                return Strings.userTaskRunStatusExitCode(Int(exitCode))
+            }
+            return Strings.userTaskRunStatusFailed
+        case .cancelled:
+            return Strings.userTaskRunStatusCancelled
+        }
+    }
+}

--- a/Pine/Extensibility/UserTaskRun.swift
+++ b/Pine/Extensibility/UserTaskRun.swift
@@ -16,6 +16,79 @@
 
 import Foundation
 
+/// Bounded text used by SwiftUI for task-output rendering.
+///
+/// The full captured streams remain available for an explicit Copy action,
+/// but rendering multi-megabyte output in one SwiftUI `Text` can synchronously
+/// allocate and lay out the whole value on the main actor. This preview is
+/// prepared with the outcome on the runner's background queue and caps both
+/// bytes and lines before the result reaches the UI model.
+nonisolated struct UserTaskOutputPreview: Sendable, Equatable {
+    static let maximumUTF8Bytes = 16 * 1_024
+    static let maximumLines = 200
+
+    let text: String
+    let wasTruncated: Bool
+
+    static let empty = UserTaskOutputPreview(
+        text: "",
+        wasTruncated: false
+    )
+
+    static func make(
+        stdout: String,
+        stderr: String,
+        maximumUTF8Bytes: Int = maximumUTF8Bytes,
+        maximumLines: Int = maximumLines
+    ) -> UserTaskOutputPreview {
+        let byteLimit = max(maximumUTF8Bytes, 0)
+        let lineLimit = max(maximumLines, 1)
+        var data = Data()
+        data.reserveCapacity(byteLimit)
+        var lineCount = 1
+        let newline: UInt8 = 0x0A
+
+        func append<Bytes: Sequence>(_ bytes: Bytes) -> Bool
+        where Bytes.Element == UInt8 {
+            for byte in bytes {
+                guard data.count < byteLimit else { return false }
+                if byte == newline, lineCount >= lineLimit {
+                    return false
+                }
+                data.append(byte)
+                if byte == newline {
+                    lineCount += 1
+                }
+            }
+            return true
+        }
+
+        var complete = append(stdout.utf8)
+        if complete, !stdout.isEmpty, !stderr.isEmpty {
+            complete = append(CollectionOfOne(newline))
+        }
+        if complete {
+            complete = append(stderr.utf8)
+        }
+
+        // Both source strings are valid UTF-8. A byte-boundary cut can only
+        // leave one incomplete scalar at the end, so remove at most its tail
+        // before publishing the preview. Never inject a replacement glyph.
+        var text: String?
+        repeat {
+            text = String(data: data, encoding: .utf8)
+            if text == nil, !data.isEmpty {
+                data.removeLast()
+            }
+        } while text == nil && !data.isEmpty
+
+        return UserTaskOutputPreview(
+            text: text ?? "",
+            wasTruncated: !complete
+        )
+    }
+}
+
 /// Lifecycle phase of a single task run.
 nonisolated enum UserTaskRunState: Sendable, Equatable {
     /// The task has been queued / is preparing to launch.
@@ -86,6 +159,8 @@ final class UserTaskRun: Identifiable {
     /// Cached retained bytes so history trimming never rescans large strings
     /// on the main actor.
     private(set) var retainedOutputBytes: Int
+    /// Cached, bounded output used by the SwiftUI history surface.
+    private(set) var outputPreview: UserTaskOutputPreview
 
     init(
         taskID: String,
@@ -108,6 +183,7 @@ final class UserTaskRun: Identifiable {
         self.timedOut = false
         self.blockedReason = nil
         self.retainedOutputBytes = 0
+        self.outputPreview = .empty
     }
 
     // MARK: - Mutations (driven by UserTaskRunner)
@@ -131,31 +207,22 @@ final class UserTaskRun: Identifiable {
 
     /// Applies the terminal outcome of the run.
     func applyOutcome(
-        stdout: String,
-        stderr: String,
-        exitCode: Int32,
-        timedOut: Bool,
+        _ outcome: UserTaskOutcome,
         cancelled: Bool,
-        cleanupSucceeded: Bool = true,
-        standardInputCompleted: Bool = true,
-        retainedOutputBytes: Int? = nil,
         finishedAt: Date = Date()
     ) {
-        self.stdout = stdout
-        self.stderr = stderr
-        self.exitCode = exitCode
-        self.timedOut = timedOut
-        self.retainedOutputBytes = max(
-            retainedOutputBytes
-                ?? stdout.utf8.count + stderr.utf8.count,
-            0
-        )
+        stdout = outcome.stdout
+        stderr = outcome.stderr
+        exitCode = outcome.exitCode
+        timedOut = outcome.timedOut
+        retainedOutputBytes = outcome.retainedOutputBytes
+        outputPreview = outcome.outputPreview
         self.finishedAt = finishedAt
-        if !cleanupSucceeded || !standardInputCompleted {
+        if !outcome.cleanupSucceeded || !outcome.standardInputCompleted {
             state = .failed
         } else if cancelled {
             state = .cancelled
-        } else if exitCode == 0 && !timedOut {
+        } else if outcome.exitCode == 0 && !outcome.timedOut {
             state = .succeeded
         } else {
             state = .failed
@@ -228,6 +295,16 @@ final class UserTaskRun: Identifiable {
     /// Exact payload copied by the ordinary task-row Copy Output action.
     var outputCopyPayload: String {
         combinedOutput
+    }
+
+    /// Bounded, precomputed text safe to lay out in the output panel.
+    var displayOutputPreview: String {
+        outputPreview.text
+    }
+
+    /// Whether the panel must explain that Copy retains more than it renders.
+    var displayOutputPreviewWasTruncated: Bool {
+        outputPreview.wasTruncated
     }
 
     /// A short, human-readable summary of the terminal status, e.g.

--- a/Pine/Extensibility/UserTaskRun.swift
+++ b/Pine/Extensibility/UserTaskRun.swift
@@ -43,33 +43,50 @@ nonisolated struct UserTaskOutputPreview: Sendable, Equatable {
     ) -> UserTaskOutputPreview {
         let byteLimit = max(maximumUTF8Bytes, 0)
         let lineLimit = max(maximumLines, 1)
-        var data = Data()
-        data.reserveCapacity(byteLimit)
-        var lineCount = 1
         let newline: UInt8 = 0x0A
 
-        func append<Bytes: Sequence>(_ bytes: Bytes) -> Bool
-        where Bytes.Element == UInt8 {
-            for byte in bytes {
-                guard data.count < byteLimit else { return false }
-                if byte == newline, lineCount >= lineLimit {
-                    return false
+        func buildPreview(
+            first: String,
+            second: String
+        ) -> (data: Data, complete: Bool) {
+            var data = Data()
+            data.reserveCapacity(byteLimit)
+            var lineCount = 1
+
+            func append<Bytes: Sequence>(_ bytes: Bytes) -> Bool
+            where Bytes.Element == UInt8 {
+                for byte in bytes {
+                    guard data.count < byteLimit else { return false }
+                    if byte == newline, lineCount >= lineLimit {
+                        return false
+                    }
+                    data.append(byte)
+                    if byte == newline {
+                        lineCount += 1
+                    }
                 }
-                data.append(byte)
-                if byte == newline {
-                    lineCount += 1
-                }
+                return true
             }
-            return true
+
+            var complete = append(first.utf8)
+            if complete, !first.isEmpty, !second.isEmpty {
+                complete = append(CollectionOfOne(newline))
+            }
+            if complete {
+                complete = append(second.utf8)
+            }
+            return (data, complete)
         }
 
-        var complete = append(stdout.utf8)
-        if complete, !stdout.isEmpty, !stderr.isEmpty {
-            complete = append(CollectionOfOne(newline))
+        var preview = buildPreview(first: stdout, second: stderr)
+        if !preview.complete, !stderr.isEmpty {
+            // When the ordinary stdout-first projection exceeds either bound,
+            // rebuild stderr-first so diagnostics are never hidden behind a
+            // noisy command. Copy Output still preserves the full canonical
+            // stdout-then-stderr payload.
+            preview = buildPreview(first: stderr, second: stdout)
         }
-        if complete {
-            complete = append(stderr.utf8)
-        }
+        var data = preview.data
 
         // Both source strings are valid UTF-8. A byte-boundary cut can only
         // leave one incomplete scalar at the end, so remove at most its tail
@@ -84,7 +101,7 @@ nonisolated struct UserTaskOutputPreview: Sendable, Equatable {
 
         return UserTaskOutputPreview(
             text: text ?? "",
-            wasTruncated: !complete
+            wasTruncated: !preview.complete
         )
     }
 }

--- a/Pine/Extensibility/UserTaskRun.swift
+++ b/Pine/Extensibility/UserTaskRun.swift
@@ -22,6 +22,9 @@ nonisolated enum UserTaskRunState: Sendable, Equatable {
     case pending
     /// The process is running.
     case running
+    /// Cancellation won, but subprocess cleanup and direct-child reaping have
+    /// not completed yet. The run remains active and waitable in this state.
+    case cancelling
     /// The process exited with status 0.
     case succeeded
     /// The process exited with a non-zero status, was cancelled, timed out,
@@ -33,7 +36,7 @@ nonisolated enum UserTaskRunState: Sendable, Equatable {
     /// `true` while the run has not reached a terminal state.
     var isActive: Bool {
         switch self {
-        case .pending, .running: true
+        case .pending, .running, .cancelling: true
         case .succeeded, .failed, .cancelled: false
         }
     }
@@ -80,6 +83,9 @@ final class UserTaskRun: Identifiable {
     /// Short, human-readable reason when the run was blocked before launch
     /// (e.g. the validator rejected the command) or failed to launch.
     private(set) var blockedReason: String?
+    /// Cached retained bytes so history trimming never rescans large strings
+    /// on the main actor.
+    private(set) var retainedOutputBytes: Int
 
     init(
         taskID: String,
@@ -101,6 +107,7 @@ final class UserTaskRun: Identifiable {
         self.exitCode = nil
         self.timedOut = false
         self.blockedReason = nil
+        self.retainedOutputBytes = 0
     }
 
     // MARK: - Mutations (driven by UserTaskRunner)
@@ -113,9 +120,12 @@ final class UserTaskRun: Identifiable {
 
     /// Records that the run was blocked before launch (validator rejection
     /// or spawn failure). Treated as a failure with a descriptive reason.
-    func markBlocked(reason: String) {
+    func markBlocked(
+        reason: String,
+        finishedAt: Date = Date()
+    ) {
         state = .failed
-        finishedAt = Date()
+        self.finishedAt = finishedAt
         blockedReason = reason
     }
 
@@ -125,14 +135,25 @@ final class UserTaskRun: Identifiable {
         stderr: String,
         exitCode: Int32,
         timedOut: Bool,
-        cancelled: Bool
+        cancelled: Bool,
+        cleanupSucceeded: Bool = true,
+        standardInputCompleted: Bool = true,
+        retainedOutputBytes: Int? = nil,
+        finishedAt: Date = Date()
     ) {
         self.stdout = stdout
         self.stderr = stderr
         self.exitCode = exitCode
         self.timedOut = timedOut
-        finishedAt = Date()
-        if cancelled {
+        self.retainedOutputBytes = max(
+            retainedOutputBytes
+                ?? stdout.utf8.count + stderr.utf8.count,
+            0
+        )
+        self.finishedAt = finishedAt
+        if !cleanupSucceeded || !standardInputCompleted {
+            state = .failed
+        } else if cancelled {
             state = .cancelled
         } else if exitCode == 0 && !timedOut {
             state = .succeeded
@@ -141,12 +162,11 @@ final class UserTaskRun: Identifiable {
         }
     }
 
-    /// Forces the run into the cancelled state (used when the user cancels
-    /// an in-flight process whose exact exit code is not yet known).
-    func markCancelled() {
+    /// Records an accepted cancellation request while retaining active
+    /// ownership until the runner confirms reaping and cleanup.
+    func markCancelling() {
         guard state.isActive else { return }
-        state = .cancelled
-        finishedAt = Date()
+        state = .cancelling
     }
 
     // MARK: - Derived presentation values
@@ -154,8 +174,40 @@ final class UserTaskRun: Identifiable {
     /// Elapsed seconds for an active run (computed at render time from
     /// `startedAt` and now) or the final duration for a finished run.
     var elapsedSeconds: TimeInterval {
-        let end = finishedAt ?? Date()
+        elapsedSeconds(at: Date())
+    }
+
+    /// Elapsed seconds at an explicit render instant. Terminal runs always
+    /// use their recorded finish time, so the displayed duration freezes
+    /// after completion.
+    func elapsedSeconds(at date: Date) -> TimeInterval {
+        let end = finishedAt ?? date
         return max(0, end.timeIntervalSince(startedAt))
+    }
+
+    /// Stable, compact duration text suitable for a live task-row timer.
+    func elapsedText(at date: Date) -> String {
+        Self.formatElapsedDuration(elapsedSeconds(at: date))
+    }
+
+    /// Formats a duration as `M:SS`, or `H:MM:SS` after the first hour.
+    nonisolated static func formatElapsedDuration(
+        _ duration: TimeInterval
+    ) -> String {
+        let totalSeconds = max(0, Int(duration.rounded(.down)))
+        let seconds = totalSeconds % 60
+        let totalMinutes = totalSeconds / 60
+        let minutes = totalMinutes % 60
+        let hours = totalMinutes / 60
+        if hours > 0 {
+            return String(
+                format: "%d:%02d:%02d",
+                hours,
+                minutes,
+                seconds
+            )
+        }
+        return String(format: "%d:%02d", totalMinutes, seconds)
     }
 
     /// `true` when the run captured any stdout or stderr worth showing in
@@ -173,6 +225,11 @@ final class UserTaskRun: Identifiable {
         return stdout.isEmpty ? stderr : stdout
     }
 
+    /// Exact payload copied by the ordinary task-row Copy Output action.
+    var outputCopyPayload: String {
+        combinedOutput
+    }
+
     /// A short, human-readable summary of the terminal status, e.g.
     /// "Exit 0", "Exit 1", "Cancelled", "Timed out".
     var statusSummary: String {
@@ -181,6 +238,8 @@ final class UserTaskRun: Identifiable {
             return Strings.userTaskRunStatusPending
         case .running:
             return Strings.userTaskRunStatusRunning
+        case .cancelling:
+            return Strings.userTaskRunStatusCancelling
         case .succeeded:
             return Strings.userTaskRunStatusSucceeded
         case .failed:

--- a/Pine/Extensibility/UserTaskRunPresenter.swift
+++ b/Pine/Extensibility/UserTaskRunPresenter.swift
@@ -1,0 +1,229 @@
+//
+//  UserTaskRunPresenter.swift
+//  Pine
+//
+//  Project-scoped task output and lifecycle controls.
+//
+
+import AppKit
+import SwiftUI
+
+@MainActor
+enum UserTaskOutputClipboard {
+    static func copy(_ output: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(output, forType: .string)
+    }
+}
+
+struct UserTaskRunPresenter: ViewModifier {
+    let store: UserTaskRunStore
+
+    func body(content: Content) -> some View {
+        content
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                if store.isOutputVisible {
+                    UserTaskRunHistoryView(store: store)
+                }
+            }
+            .overlay(alignment: .bottomTrailing) {
+                if !store.isOutputVisible, !store.runs.isEmpty {
+                    Button {
+                        store.isOutputVisible = true
+                    } label: {
+                        Label(
+                            Strings.userTaskOpenOutput,
+                            systemImage: "terminal"
+                        )
+                    }
+                    .padding(10)
+                    .accessibilityIdentifier(
+                        AccessibilityID.userTaskShowOutputButton
+                    )
+                }
+            }
+    }
+}
+
+private struct UserTaskRunHistoryView: View {
+    let store: UserTaskRunStore
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if store.runs.isEmpty {
+                Text(Strings.userTaskOutputEmpty)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 72)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 8) {
+                        ForEach(store.runs) { run in
+                            UserTaskRunRow(
+                                run: run,
+                                cancel: {
+                                    store.cancelRun(id: run.id)
+                                }
+                            )
+                        }
+                    }
+                    .padding(8)
+                }
+            }
+        }
+        .frame(maxHeight: 280)
+        .background(.bar)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Label(
+                Strings.userTaskOutputTitle,
+                systemImage: "terminal"
+            )
+            .font(.headline)
+            // Put the panel marker on a semantic leaf. Applying an
+            // accessibility identifier to the root VStack causes SwiftUI on
+            // macOS to propagate it over descendant controls, hiding their
+            // more specific identifiers from VoiceOver and XCUITest.
+            .accessibilityIdentifier(AccessibilityID.userTaskOutputPanel)
+            Spacer()
+            Button(Strings.userTaskClearFinished) {
+                store.clearFinished()
+            }
+            .disabled(!store.runs.contains { !$0.state.isActive })
+            .accessibilityIdentifier(
+                AccessibilityID.userTaskClearFinishedButton
+            )
+            Button {
+                store.isOutputVisible = false
+            } label: {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.borderless)
+            .help(Strings.userTaskCloseOutput)
+            .accessibilityLabel(Strings.userTaskCloseOutput)
+            .accessibilityIdentifier(
+                AccessibilityID.userTaskCloseOutputButton
+            )
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 34)
+    }
+}
+
+private struct UserTaskRunRow: View {
+    let run: UserTaskRun
+    let cancel: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 8) {
+                Text(run.taskLabel)
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+                    // As with the panel marker, keep the stable run id on a
+                    // leaf so status, elapsed, copy, and cancel controls retain
+                    // their own accessibility identities.
+                    .accessibilityIdentifier(
+                        AccessibilityID.userTaskRun(run.id)
+                    )
+                Text(run.statusSummary)
+                    .foregroundStyle(statusColor)
+                    .accessibilityIdentifier(
+                        AccessibilityID.userTaskStatusLabel(run.id)
+                    )
+                UserTaskElapsedView(run: run)
+                Spacer()
+                if run.hasOutput {
+                    Button {
+                        UserTaskOutputClipboard.copy(
+                            run.outputCopyPayload
+                        )
+                    } label: {
+                        Label(
+                            Strings.userTaskCopyOutput,
+                            systemImage: "doc.on.doc"
+                        )
+                    }
+                    .controlSize(.small)
+                    .accessibilityIdentifier(
+                        AccessibilityID.userTaskCopyOutputButton(run.id)
+                    )
+                }
+                if run.state.isActive {
+                    ProgressView()
+                        .controlSize(.small)
+                        .accessibilityLabel(run.statusSummary)
+                        .accessibilityIdentifier(
+                            AccessibilityID.userTaskProgressIndicator(run.id)
+                        )
+                    Button(Strings.userTaskCancel) {
+                        cancel()
+                    }
+                    .disabled(run.state == .cancelling)
+                    .accessibilityIdentifier(
+                        AccessibilityID.userTaskCancelButton(run.id)
+                    )
+                }
+            }
+
+            Text(verbatim: run.command)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+
+            if run.hasOutput {
+                Text(verbatim: run.combinedOutput)
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(6)
+                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 5))
+                    .accessibilityIdentifier(
+                        AccessibilityID.userTaskOutputText(run.id)
+                    )
+            }
+        }
+        .padding(8)
+        .background(.background, in: RoundedRectangle(cornerRadius: 7))
+        .accessibilityElement(children: .contain)
+    }
+
+    private var statusColor: Color {
+        switch run.state {
+        case .pending, .running, .cancelling:
+            return .secondary
+        case .succeeded:
+            return .green
+        case .failed:
+            return .red
+        case .cancelled:
+            return .orange
+        }
+    }
+}
+
+private struct UserTaskElapsedView: View {
+    let run: UserTaskRun
+
+    var body: some View {
+        if run.state.isActive {
+            TimelineView(.periodic(from: .now, by: 1)) { context in
+                elapsedLabel(at: context.date)
+            }
+        } else {
+            elapsedLabel(at: run.finishedAt ?? run.startedAt)
+        }
+    }
+
+    private func elapsedLabel(at date: Date) -> some View {
+        Text(Strings.userTaskElapsed(run.elapsedText(at: date)))
+            .font(.caption.monospacedDigit())
+            .foregroundStyle(.secondary)
+            .accessibilityIdentifier(
+                AccessibilityID.userTaskElapsedLabel(run.id)
+            )
+    }
+}

--- a/Pine/Extensibility/UserTaskRunPresenter.swift
+++ b/Pine/Extensibility/UserTaskRunPresenter.swift
@@ -175,15 +175,29 @@ private struct UserTaskRunRow: View {
                 .textSelection(.enabled)
 
             if run.hasOutput {
-                Text(verbatim: run.combinedOutput)
-                    .font(.system(.caption, design: .monospaced))
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(6)
-                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 5))
-                    .accessibilityIdentifier(
-                        AccessibilityID.userTaskOutputText(run.id)
-                    )
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(verbatim: run.displayOutputPreview)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .accessibilityIdentifier(
+                            AccessibilityID.userTaskOutputText(run.id)
+                        )
+                    if run.displayOutputPreviewWasTruncated {
+                        Text(Strings.userTaskOutputPreviewTruncated)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .accessibilityIdentifier(
+                                AccessibilityID
+                                    .userTaskOutputTruncationNotice(run.id)
+                            )
+                    }
+                }
+                .padding(6)
+                .background(
+                    .quaternary,
+                    in: RoundedRectangle(cornerRadius: 5)
+                )
             }
         }
         .padding(8)

--- a/Pine/Extensibility/UserTaskRunStore.swift
+++ b/Pine/Extensibility/UserTaskRunStore.swift
@@ -92,12 +92,6 @@ final class UserTaskRunStore {
 
     // MARK: - Mutation
 
-    /// Marks an active run as cancelled. No-op for finished runs.
-    func cancelRun(id: UUID) {
-        guard let run = run(forID: id), run.state.isActive else { return }
-        run.markCancelled()
-    }
-
     /// Removes a finished run from the history (used by the output surface's
     /// Clear action). Active runs cannot be dismissed — cancel them first.
     func removeRun(id: UUID) {

--- a/Pine/Extensibility/UserTaskRunStore.swift
+++ b/Pine/Extensibility/UserTaskRunStore.swift
@@ -35,10 +35,15 @@ final class UserTaskRunStore {
     var isOutputVisible: Bool = false
 
     /// Cancellation handles keyed by run id, so the UI's Cancel button can
-    /// terminate the spawned process. Cleared when a run finishes.
+    /// terminate the spawned process. A failed bounded cleanup retains its
+    /// handle until the runner's deferred ownership cleanup resolves.
     private var cancellationHandles: [UUID: UserTaskCancellation] = [:]
     /// Cancel clicks received before the runner publishes its handle.
     private var pendingCancellationRunIDs: Set<UUID> = []
+    /// Terminal outcomes whose subprocess/descriptor ownership has not yet
+    /// been released. This also covers the short race before a late handle is
+    /// published on the main queue.
+    private var unresolvedCleanupRunIDs: Set<UUID> = []
     private let maximumRuns: Int
     private let maximumRetainedOutputBytes: Int
 
@@ -71,12 +76,19 @@ final class UserTaskRunStore {
         _ handle: UserTaskCancellation,
         forRunID id: UUID
     ) {
-        if pendingCancellationRunIDs.remove(id) != nil {
+        let cancellationWasPending =
+            pendingCancellationRunIDs.remove(id) != nil
+        if unresolvedCleanupRunIDs.contains(id) {
+            cancellationHandles[id] = handle
+            pruneResolvedCleanupOwnership()
+            return
+        }
+        if cancellationWasPending {
+            cancellationHandles[id] = handle
             guard let run = run(forID: id), run.state.isActive else {
                 _ = handle.cancel()
                 return
             }
-            cancellationHandles[id] = handle
             if handle.cancel() {
                 run.markCancelling()
             }
@@ -99,7 +111,7 @@ final class UserTaskRunStore {
         }
     }
 
-    /// Applies the terminal result and releases its cancellation handle.
+    /// Applies the terminal result and releases resolved execution ownership.
     ///
     /// A run cancelled before its handle arrived remains cancelled when the
     /// process later reports its concrete exit status and captured output.
@@ -109,9 +121,27 @@ final class UserTaskRunStore {
         outcome: UserTaskOutcome,
         cancelled: Bool
     ) -> Bool {
-        cancellationHandles.removeValue(forKey: id)
+        let run = run(forID: id)
+        let ownsExecution =
+            cancellationHandles[id] != nil
+            || pendingCancellationRunIDs.contains(id)
+            || unresolvedCleanupRunIDs.contains(id)
+        let tracksExecution =
+            run?.state.isActive == true || ownsExecution
+        guard tracksExecution else { return false }
+
         pendingCancellationRunIDs.remove(id)
-        guard let run = run(forID: id) else { return false }
+        if outcome.cleanupSucceeded {
+            cancellationHandles.removeValue(forKey: id)
+            unresolvedCleanupRunIDs.remove(id)
+        } else {
+            unresolvedCleanupRunIDs.insert(id)
+        }
+
+        guard let run else {
+            pruneResolvedCleanupOwnership()
+            return false
+        }
         let cancellationWon = cancelled || run.state == .cancelling
         guard run.state.isActive else { return false }
         run.applyOutcome(outcome, cancelled: cancellationWon)
@@ -119,6 +149,7 @@ final class UserTaskRunStore {
             isOutputVisible = true
         }
         trimToCapacity()
+        pruneResolvedCleanupOwnership()
         return true
     }
 
@@ -168,8 +199,10 @@ final class UserTaskRunStore {
     func removeRun(id: UUID) {
         guard let run = run(forID: id), !run.state.isActive else { return }
         runs.removeAll { $0.id == id }
-        cancellationHandles.removeValue(forKey: id)
-        pendingCancellationRunIDs.remove(id)
+        if !unresolvedCleanupRunIDs.contains(id) {
+            cancellationHandles.removeValue(forKey: id)
+            pendingCancellationRunIDs.remove(id)
+        }
     }
 
     /// Clears all finished runs.
@@ -180,12 +213,16 @@ final class UserTaskRunStore {
         runs.removeAll { finishedIDs.contains($0.id) }
         cancellationHandles = cancellationHandles.filter {
             !finishedIDs.contains($0.key)
+                || unresolvedCleanupRunIDs.contains($0.key)
         }
-        pendingCancellationRunIDs.subtract(finishedIDs)
+        pendingCancellationRunIDs.subtract(
+            finishedIDs.subtracting(unresolvedCleanupRunIDs)
+        )
     }
 
-    /// Immediately clears every run and requests active-process cancellation.
-    /// Project teardown should prefer ``shutdownAll(until:)`` so it can wait.
+    /// Immediately clears UI history and requests active-process cancellation.
+    /// Execution handles remain owned until their terminal callbacks resolve;
+    /// project teardown should prefer ``shutdownAll(until:)`` so it can wait.
     ///
     /// Runs whose handle has not arrived remain in the pending-cancellation
     /// set so a late handle is terminated instead of becoming unreachable.
@@ -199,7 +236,6 @@ final class UserTaskRunStore {
             }
         }
         runs.removeAll()
-        cancellationHandles.removeAll()
     }
 
     /// Requests cancellation for every active run without waiting. Project
@@ -228,41 +264,27 @@ final class UserTaskRunStore {
     @discardableResult
     func shutdownAll(until deadline: DispatchTime) async -> Bool {
         requestShutdown()
-        let activeIDs = Set(runs.lazy
-            .filter { $0.state.isActive }
-            .map { $0.id })
+        pruneResolvedCleanupOwnership()
+        let ownershipIDs = executionOwnershipRunIDs
         var handles: [UserTaskCancellation] = []
-        var ownsEveryActiveRun = true
+        var ownsEveryExecution = true
 
-        for id in activeIDs {
+        for id in ownershipIDs {
             if let handle = cancellationHandles[id] {
                 handles.append(handle)
             } else {
                 pendingCancellationRunIDs.insert(id)
-                ownsEveryActiveRun = false
+                ownsEveryExecution = false
             }
         }
         let handlesCompleted = await Self.waitForCompletion(
             of: handles,
             until: deadline
         )
-        let snapshotStillOwned = runs.contains {
-            activeIDs.contains($0.id) && $0.state.isActive
-        } || cancellationHandles.keys.contains {
-            activeIDs.contains($0)
-        } || pendingCancellationRunIDs.contains {
-            activeIDs.contains($0)
-        }
-        let hasNewExecutionOwnership = runs.contains {
-            !activeIDs.contains($0.id) && $0.state.isActive
-        } || cancellationHandles.keys.contains {
-            !activeIDs.contains($0)
-        } || pendingCancellationRunIDs.contains {
-            !activeIDs.contains($0)
-        }
+        let hasNewExecutionOwnership =
+            !executionOwnershipRunIDs.subtracting(ownershipIDs).isEmpty
         let capturedExecutionsCompleted =
-            (ownsEveryActiveRun && handlesCompleted)
-            || !snapshotStillOwned
+            ownsEveryExecution && handlesCompleted
         let allCompleted =
             capturedExecutionsCompleted && !hasNewExecutionOwnership
 
@@ -270,6 +292,7 @@ final class UserTaskRunStore {
             runs.removeAll()
             cancellationHandles.removeAll()
             pendingCancellationRunIDs.removeAll()
+            unresolvedCleanupRunIDs.removeAll()
         }
         return allCompleted
     }
@@ -277,9 +300,11 @@ final class UserTaskRunStore {
     /// Whether teardown can release this store without dropping ownership of
     /// an active or not-yet-published task execution.
     var hasOutstandingExecutionOwnership: Bool {
-        hasActiveRuns
+        pruneResolvedCleanupOwnership()
+        return hasActiveRuns
             || !cancellationHandles.isEmpty
             || !pendingCancellationRunIDs.isEmpty
+            || !unresolvedCleanupRunIDs.isEmpty
     }
 
     // MARK: - Private
@@ -297,6 +322,30 @@ final class UserTaskRunStore {
                 }
                 continuation.resume(returning: allCompleted)
             }
+        }
+    }
+
+    private var executionOwnershipRunIDs: Set<UUID> {
+        var ids = Set(runs.lazy
+            .filter { $0.state.isActive }
+            .map { $0.id })
+        ids.formUnion(cancellationHandles.keys)
+        ids.formUnion(pendingCancellationRunIDs)
+        ids.formUnion(unresolvedCleanupRunIDs)
+        return ids
+    }
+
+    /// Drops only cleanup handles whose runner-owned completion token is
+    /// already resolved. The zero-deadline wait never blocks the main actor.
+    private func pruneResolvedCleanupOwnership() {
+        let resolvedIDs = unresolvedCleanupRunIDs.filter { id in
+            guard let handle = cancellationHandles[id] else { return false }
+            return handle.wait(until: .now())
+        }
+        guard !resolvedIDs.isEmpty else { return }
+        unresolvedCleanupRunIDs.subtract(resolvedIDs)
+        for id in resolvedIDs {
+            cancellationHandles.removeValue(forKey: id)
         }
     }
 
@@ -320,7 +369,10 @@ final class UserTaskRunStore {
         runs.removeAll { toDrop.contains($0.id) }
         cancellationHandles = cancellationHandles.filter {
             !toDrop.contains($0.key)
+                || unresolvedCleanupRunIDs.contains($0.key)
         }
-        pendingCancellationRunIDs.subtract(toDrop)
+        pendingCancellationRunIDs.subtract(
+            toDrop.subtracting(unresolvedCleanupRunIDs)
+        )
     }
 }

--- a/Pine/Extensibility/UserTaskRunStore.swift
+++ b/Pine/Extensibility/UserTaskRunStore.swift
@@ -1,0 +1,130 @@
+//
+//  UserTaskRunStore.swift
+//  Pine
+//
+//  Task execution UI (issue #1246): a `@MainActor @Observable` store, owned
+//  by the initiating `ProjectManager`, that tracks active and recent
+//  user-task runs for a single project window. It is the single source of
+//  truth for the task output surface and the success/failure toast.
+//
+//  The store only holds UI state; it never spawns processes. `UserTaskRunner`
+//  reports progress and outcomes here, and `UserTaskRunPresenter` renders it.
+//
+
+import Foundation
+
+/// Owns the active and recent task runs for one project window.
+///
+/// Capped to `maxRuns` to bound memory; the most-recent run is always
+/// retained so the output surface can show the latest result. A run is kept
+/// while active so the UI can show elapsed time and a Cancel button, then
+/// transitions to a finished state in place.
+@MainActor
+@Observable
+final class UserTaskRunStore {
+    /// All tracked runs, newest-first. Active runs are kept at the front.
+    private(set) var runs: [UserTaskRun] = []
+
+    /// Maximum number of finished runs retained for the output history.
+    static let maxRuns = 25
+
+    /// Optional binding target the presenter watches to auto-expand the
+    /// output surface when a new run starts or fails.
+    var isOutputVisible: Bool = false
+
+    /// Cancellation handles keyed by run id, so the UI's Cancel button can
+    /// terminate the spawned process. Cleared when a run finishes.
+    private var cancellationHandles: [UUID: UserTaskCancellation] = [:]
+
+    init() {}
+
+    // MARK: - Recording
+
+    /// Registers a new run and surfaces it immediately so the UI can show
+    /// progress. Returns the run so the caller can drive its state.
+    @discardableResult
+    func start(_ run: UserTaskRun) -> UserTaskRun {
+        runs.insert(run, at: 0)
+        trimToCapacity()
+        return run
+    }
+
+    // MARK: - Cancellation
+
+    /// Stores the cancellation handle for a run so the UI can cancel it.
+    func registerCancellation(
+        _ handle: UserTaskCancellation,
+        forRunID id: UUID
+    ) {
+        cancellationHandles[id] = handle
+    }
+
+    /// Cancels an active run by id, terminating its process and updating the
+    /// UI model. No-op for finished runs or unknown ids.
+    func cancelRun(id: UUID) {
+        guard let run = run(forID: id), run.state.isActive else { return }
+        cancellationHandles[id]?.cancel()
+        run.markCancelled()
+        cancellationHandles.removeValue(forKey: id)
+    }
+
+    // MARK: - Queries
+
+    /// Runs that have not reached a terminal state.
+    var activeRuns: [UserTaskRun] {
+        runs.filter { $0.state.isActive }
+    }
+
+    /// `true` when at least one run is pending or running.
+    var hasActiveRuns: Bool {
+        runs.contains { $0.state.isActive }
+    }
+
+    /// The most recent run, if any.
+    var mostRecentRun: UserTaskRun? {
+        runs.first
+    }
+
+    /// Finds a run by id.
+    func run(forID id: UUID) -> UserTaskRun? {
+        runs.first { $0.id == id }
+    }
+
+    // MARK: - Mutation
+
+    /// Cancels an active run by id. The actual process termination is
+    /// performed by the runner via its cancellation handle; this only marks
+    /// the UI model so the row reflects the user's intent immediately.
+    func cancelRun(id: UUID) {
+        guard let run = run(forID: id), run.state.isActive else { return }
+        run.markCancelled()
+    }
+
+    /// Removes a finished run from the history (used by the output surface's
+    /// Clear action). Active runs cannot be dismissed — cancel them first.
+    func removeRun(id: UUID) {
+        guard let run = run(forID: id), !run.state.isActive else { return }
+        runs.removeAll { $0.id == id }
+    }
+
+    /// Clears all finished runs.
+    func clearFinished() {
+        runs.removeAll { !$0.state.isActive }
+    }
+
+    /// Clears every run (used on project teardown).
+    func clearAll() {
+        runs.removeAll()
+    }
+
+    // MARK: - Private
+
+    private func trimToCapacity() {
+        // Never trim active runs; only drop the oldest finished runs.
+        let finished = runs.filter { !$0.state.isActive }
+        let overflow = finished.count - Self.maxRuns
+        guard overflow > 0 else { return }
+        let toDrop = Set(finished.suffix(overflow).map { $0.id })
+        runs.removeAll { toDrop.contains($0.id) }
+    }
+}

--- a/Pine/Extensibility/UserTaskRunStore.swift
+++ b/Pine/Extensibility/UserTaskRunStore.swift
@@ -27,6 +27,8 @@ final class UserTaskRunStore {
 
     /// Maximum number of finished runs retained for the output history.
     static let maxRuns = 25
+    /// Independent memory bound for retained UTF-8 stdout/stderr history.
+    static let maxRetainedOutputBytes = 32 * 1_024 * 1_024
 
     /// Optional binding target the presenter watches to auto-expand the
     /// output surface when a new run starts or fails.
@@ -35,8 +37,20 @@ final class UserTaskRunStore {
     /// Cancellation handles keyed by run id, so the UI's Cancel button can
     /// terminate the spawned process. Cleared when a run finishes.
     private var cancellationHandles: [UUID: UserTaskCancellation] = [:]
+    /// Cancel clicks received before the runner publishes its handle.
+    private var pendingCancellationRunIDs: Set<UUID> = []
+    private let maximumRuns: Int
+    private let maximumRetainedOutputBytes: Int
 
-    init() {}
+    init(
+        maximumRuns: Int = UserTaskRunStore.maxRuns,
+        maximumRetainedOutputBytes: Int =
+            UserTaskRunStore.maxRetainedOutputBytes
+    ) {
+        self.maximumRuns = max(maximumRuns, 0)
+        self.maximumRetainedOutputBytes =
+            max(maximumRetainedOutputBytes, 0)
+    }
 
     // MARK: - Recording
 
@@ -45,6 +59,7 @@ final class UserTaskRunStore {
     @discardableResult
     func start(_ run: UserTaskRun) -> UserTaskRun {
         runs.insert(run, at: 0)
+        isOutputVisible = true
         trimToCapacity()
         return run
     }
@@ -56,6 +71,18 @@ final class UserTaskRunStore {
         _ handle: UserTaskCancellation,
         forRunID id: UUID
     ) {
+        if pendingCancellationRunIDs.remove(id) != nil {
+            guard let run = run(forID: id), run.state.isActive else {
+                _ = handle.cancel()
+                return
+            }
+            cancellationHandles[id] = handle
+            if handle.cancel() {
+                run.markCancelling()
+            }
+            return
+        }
+        guard let run = run(forID: id), run.state.isActive else { return }
         cancellationHandles[id] = handle
     }
 
@@ -63,9 +90,45 @@ final class UserTaskRunStore {
     /// UI model. No-op for finished runs or unknown ids.
     func cancelRun(id: UUID) {
         guard let run = run(forID: id), run.state.isActive else { return }
-        cancellationHandles[id]?.cancel()
-        run.markCancelled()
+        guard let handle = cancellationHandles[id] else {
+            pendingCancellationRunIDs.insert(id)
+            return
+        }
+        if handle.cancel() {
+            run.markCancelling()
+        }
+    }
+
+    /// Applies the terminal result and releases its cancellation handle.
+    ///
+    /// A run cancelled before its handle arrived remains cancelled when the
+    /// process later reports its concrete exit status and captured output.
+    @discardableResult
+    func finishRun(
+        id: UUID,
+        outcome: UserTaskOutcome,
+        cancelled: Bool
+    ) -> Bool {
         cancellationHandles.removeValue(forKey: id)
+        pendingCancellationRunIDs.remove(id)
+        guard let run = run(forID: id) else { return false }
+        let cancellationWon = cancelled || run.state == .cancelling
+        guard run.state.isActive else { return false }
+        run.applyOutcome(
+            stdout: outcome.stdout,
+            stderr: outcome.stderr,
+            exitCode: outcome.exitCode,
+            timedOut: outcome.timedOut,
+            cancelled: cancellationWon,
+            cleanupSucceeded: outcome.cleanupSucceeded,
+            standardInputCompleted: outcome.standardInputCompleted,
+            retainedOutputBytes: outcome.retainedOutputBytes
+        )
+        if run.state == .failed || run.hasOutput {
+            isOutputVisible = true
+        }
+        trimToCapacity()
+        return true
     }
 
     // MARK: - Queries
@@ -85,6 +148,23 @@ final class UserTaskRunStore {
         runs.first
     }
 
+    /// Internal lifecycle observability used by unit tests.
+    var cancellationHandleCount: Int {
+        cancellationHandles.count
+    }
+
+    var pendingCancellationCount: Int {
+        pendingCancellationRunIDs.count
+    }
+
+    var retainedOutputByteCount: Int {
+        runs.lazy
+            .filter { !$0.state.isActive }
+            .reduce(into: 0) { total, run in
+                total += run.retainedOutputBytes
+            }
+    }
+
     /// Finds a run by id.
     func run(forID id: UUID) -> UserTaskRun? {
         runs.first { $0.id == id }
@@ -97,26 +177,110 @@ final class UserTaskRunStore {
     func removeRun(id: UUID) {
         guard let run = run(forID: id), !run.state.isActive else { return }
         runs.removeAll { $0.id == id }
+        cancellationHandles.removeValue(forKey: id)
+        pendingCancellationRunIDs.remove(id)
     }
 
     /// Clears all finished runs.
     func clearFinished() {
-        runs.removeAll { !$0.state.isActive }
+        let finishedIDs = Set(
+            runs.lazy.filter { !$0.state.isActive }.map { $0.id }
+        )
+        runs.removeAll { finishedIDs.contains($0.id) }
+        cancellationHandles = cancellationHandles.filter {
+            !finishedIDs.contains($0.key)
+        }
+        pendingCancellationRunIDs.subtract(finishedIDs)
     }
 
-    /// Clears every run (used on project teardown).
+    /// Immediately clears every run and requests active-process cancellation.
+    /// Project teardown should prefer ``shutdownAll(until:)`` so it can wait.
+    ///
+    /// Runs whose handle has not arrived remain in the pending-cancellation
+    /// set so a late handle is terminated instead of becoming unreachable.
     func clearAll() {
+        let activeIDs = Set(runs.lazy.filter { $0.state.isActive }.map { $0.id })
+        for id in activeIDs {
+            if let handle = cancellationHandles[id] {
+                _ = handle.cancel()
+            } else {
+                pendingCancellationRunIDs.insert(id)
+            }
+        }
         runs.removeAll()
+        cancellationHandles.removeAll()
+    }
+
+    /// Requests cancellation for every active run without waiting. Project
+    /// shutdown calls this across all stores before it waits on any one store,
+    /// ensuring the first TERM reaches every project promptly.
+    func requestShutdown() {
+        for run in runs where run.state.isActive {
+            if let handle = cancellationHandles[run.id] {
+                if handle.cancel() {
+                    run.markCancelling()
+                }
+            } else {
+                pendingCancellationRunIDs.insert(run.id)
+            }
+        }
+    }
+
+    /// Cancels and waits for every active run using one shared absolute
+    /// deadline. Runner completion is published before its main-thread finish
+    /// callback, so this bounded wait cannot deadlock the main actor.
+    @discardableResult
+    func shutdownAll(until deadline: DispatchTime) -> Bool {
+        requestShutdown()
+        let activeIDs = Array(runs.lazy
+            .filter { $0.state.isActive }
+            .map { $0.id })
+        var handles: [UserTaskCancellation] = []
+        var allCompleted = true
+
+        for id in activeIDs {
+            if let handle = cancellationHandles[id] {
+                handles.append(handle)
+            } else {
+                pendingCancellationRunIDs.insert(id)
+                allCompleted = false
+            }
+        }
+        for handle in handles where !handle.wait(until: deadline) {
+            allCompleted = false
+        }
+
+        if allCompleted {
+            runs.removeAll()
+            cancellationHandles.removeAll()
+            pendingCancellationRunIDs.removeAll()
+        }
+        return allCompleted
     }
 
     // MARK: - Private
 
     private func trimToCapacity() {
-        // Never trim active runs; only drop the oldest finished runs.
-        let finished = runs.filter { !$0.state.isActive }
-        let overflow = finished.count - Self.maxRuns
-        guard overflow > 0 else { return }
-        let toDrop = Set(finished.suffix(overflow).map { $0.id })
+        // Never trim active runs. Remove oldest terminal runs until both the
+        // count and retained-byte limits hold after every terminal transition.
+        var finishedCount = runs.lazy.filter { !$0.state.isActive }.count
+        var retainedBytes = retainedOutputByteCount
+        var toDrop: Set<UUID> = []
+
+        for run in runs.reversed() where !run.state.isActive {
+            guard finishedCount > maximumRuns
+                    || retainedBytes > maximumRetainedOutputBytes else {
+                break
+            }
+            toDrop.insert(run.id)
+            finishedCount -= 1
+            retainedBytes -= run.retainedOutputBytes
+        }
+        guard !toDrop.isEmpty else { return }
         runs.removeAll { toDrop.contains($0.id) }
+        cancellationHandles = cancellationHandles.filter {
+            !toDrop.contains($0.key)
+        }
+        pendingCancellationRunIDs.subtract(toDrop)
     }
 }

--- a/Pine/Extensibility/UserTaskRunStore.swift
+++ b/Pine/Extensibility/UserTaskRunStore.swift
@@ -91,11 +91,6 @@ final class UserTaskRunStore {
     }
 
     // MARK: - Mutation
-
-    /// Cancels an active run by id. The actual process termination is
-    /// performed by the runner via its cancellation handle; this only marks
-    /// the UI model so the row reflects the user's intent immediately.
-    func cancelRun(id: UUID) {
         guard let run = run(forID: id), run.state.isActive else { return }
         run.markCancelled()
     }

--- a/Pine/Extensibility/UserTaskRunStore.swift
+++ b/Pine/Extensibility/UserTaskRunStore.swift
@@ -114,16 +114,7 @@ final class UserTaskRunStore {
         guard let run = run(forID: id) else { return false }
         let cancellationWon = cancelled || run.state == .cancelling
         guard run.state.isActive else { return false }
-        run.applyOutcome(
-            stdout: outcome.stdout,
-            stderr: outcome.stderr,
-            exitCode: outcome.exitCode,
-            timedOut: outcome.timedOut,
-            cancelled: cancellationWon,
-            cleanupSucceeded: outcome.cleanupSucceeded,
-            standardInputCompleted: outcome.standardInputCompleted,
-            retainedOutputBytes: outcome.retainedOutputBytes
-        )
+        run.applyOutcome(outcome, cancelled: cancellationWon)
         if run.state == .failed || run.hasOutput {
             isOutputVisible = true
         }

--- a/Pine/Extensibility/UserTaskRunStore.swift
+++ b/Pine/Extensibility/UserTaskRunStore.swift
@@ -91,6 +91,9 @@ final class UserTaskRunStore {
     }
 
     // MARK: - Mutation
+
+    /// Marks an active run as cancelled. No-op for finished runs.
+    func cancelRun(id: UUID) {
         guard let run = run(forID: id), run.state.isActive else { return }
         run.markCancelled()
     }

--- a/Pine/Extensibility/UserTaskRunStore.swift
+++ b/Pine/Extensibility/UserTaskRunStore.swift
@@ -206,7 +206,8 @@ final class UserTaskRunStore {
     /// shutdown calls this across all stores before it waits on any one store,
     /// ensuring the first TERM reaches every project promptly.
     func requestShutdown() {
-        for run in runs where run.state.isActive {
+        for run in runs
+        where run.state.isActive && run.state != .cancelling {
             if let handle = cancellationHandles[run.id] {
                 if handle.cancel() {
                     run.markCancelling()
@@ -218,28 +219,52 @@ final class UserTaskRunStore {
     }
 
     /// Cancels and waits for every active run using one shared absolute
-    /// deadline. Runner completion is published before its main-thread finish
-    /// callback, so this bounded wait cannot deadlock the main actor.
+    /// deadline.
+    ///
+    /// Cancellation ownership is snapshotted on the main actor, but the
+    /// blocking process waits run on a background queue. This keeps project
+    /// reopening and AppKit's asynchronous termination handshake responsive
+    /// while the runner reaps direct children and finishes bounded cleanup.
     @discardableResult
-    func shutdownAll(until deadline: DispatchTime) -> Bool {
+    func shutdownAll(until deadline: DispatchTime) async -> Bool {
         requestShutdown()
-        let activeIDs = Array(runs.lazy
+        let activeIDs = Set(runs.lazy
             .filter { $0.state.isActive }
             .map { $0.id })
         var handles: [UserTaskCancellation] = []
-        var allCompleted = true
+        var ownsEveryActiveRun = true
 
         for id in activeIDs {
             if let handle = cancellationHandles[id] {
                 handles.append(handle)
             } else {
                 pendingCancellationRunIDs.insert(id)
-                allCompleted = false
+                ownsEveryActiveRun = false
             }
         }
-        for handle in handles where !handle.wait(until: deadline) {
-            allCompleted = false
+        let handlesCompleted = await Self.waitForCompletion(
+            of: handles,
+            until: deadline
+        )
+        let snapshotStillOwned = runs.contains {
+            activeIDs.contains($0.id) && $0.state.isActive
+        } || cancellationHandles.keys.contains {
+            activeIDs.contains($0)
+        } || pendingCancellationRunIDs.contains {
+            activeIDs.contains($0)
         }
+        let hasNewExecutionOwnership = runs.contains {
+            !activeIDs.contains($0.id) && $0.state.isActive
+        } || cancellationHandles.keys.contains {
+            !activeIDs.contains($0)
+        } || pendingCancellationRunIDs.contains {
+            !activeIDs.contains($0)
+        }
+        let capturedExecutionsCompleted =
+            (ownsEveryActiveRun && handlesCompleted)
+            || !snapshotStillOwned
+        let allCompleted =
+            capturedExecutionsCompleted && !hasNewExecutionOwnership
 
         if allCompleted {
             runs.removeAll()
@@ -249,7 +274,31 @@ final class UserTaskRunStore {
         return allCompleted
     }
 
+    /// Whether teardown can release this store without dropping ownership of
+    /// an active or not-yet-published task execution.
+    var hasOutstandingExecutionOwnership: Bool {
+        hasActiveRuns
+            || !cancellationHandles.isEmpty
+            || !pendingCancellationRunIDs.isEmpty
+    }
+
     // MARK: - Private
+
+    nonisolated private static func waitForCompletion(
+        of handles: [UserTaskCancellation],
+        until deadline: DispatchTime
+    ) async -> Bool {
+        guard !handles.isEmpty else { return true }
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                var allCompleted = true
+                for handle in handles where !handle.wait(until: deadline) {
+                    allCompleted = false
+                }
+                continuation.resume(returning: allCompleted)
+            }
+        }
+    }
 
     private func trimToCapacity() {
         // Never trim active runs. Remove oldest terminal runs until both the

--- a/Pine/Extensibility/UserTaskRunStore.swift
+++ b/Pine/Extensibility/UserTaskRunStore.swift
@@ -13,6 +13,24 @@
 
 import Foundation
 
+nonisolated private enum UserTaskCompletionWaiter {
+    static func wait(
+        for handles: [UserTaskCancellation],
+        until deadline: DispatchTime
+    ) async -> Bool {
+        guard !handles.isEmpty else { return true }
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                var allCompleted = true
+                for handle in handles where !handle.wait(until: deadline) {
+                    allCompleted = false
+                }
+                continuation.resume(returning: allCompleted)
+            }
+        }
+    }
+}
+
 /// Owns the active and recent task runs for one project window.
 ///
 /// Capped to `maxRuns` to bound memory; the most-recent run is always
@@ -277,8 +295,8 @@ final class UserTaskRunStore {
                 ownsEveryExecution = false
             }
         }
-        let handlesCompleted = await Self.waitForCompletion(
-            of: handles,
+        let handlesCompleted = await UserTaskCompletionWaiter.wait(
+            for: handles,
             until: deadline
         )
         let hasNewExecutionOwnership =
@@ -308,22 +326,6 @@ final class UserTaskRunStore {
     }
 
     // MARK: - Private
-
-    nonisolated private static func waitForCompletion(
-        of handles: [UserTaskCancellation],
-        until deadline: DispatchTime
-    ) async -> Bool {
-        guard !handles.isEmpty else { return true }
-        return await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                var allCompleted = true
-                for handle in handles where !handle.wait(until: deadline) {
-                    allCompleted = false
-                }
-                continuation.resume(returning: allCompleted)
-            }
-        }
-    }
 
     private var executionOwnershipRunIDs: Set<UUID> {
         var ids = Set(runs.lazy

--- a/Pine/Extensibility/UserTaskRunner.swift
+++ b/Pine/Extensibility/UserTaskRunner.swift
@@ -131,6 +131,28 @@ nonisolated struct UserTaskProgress: Sendable {
     }
 }
 
+/// Schedules the blocking owner of a complete user-task execution.
+///
+/// A task owner waits for process exit and bounded descriptor cleanup, so it
+/// must not consume or depend on a shared libdispatch worker. The injectable
+/// scheduler keeps that ownership policy explicit and testable.
+nonisolated protocol UserTaskExecutionScheduling: Sendable {
+    func schedule(_ operation: @escaping @Sendable () -> Void)
+}
+
+/// Starts every complete task execution on its own OS thread.
+nonisolated struct UserTaskThreadExecutionScheduler:
+    UserTaskExecutionScheduling {
+    func schedule(_ operation: @escaping @Sendable () -> Void) {
+        let thread = Thread {
+            operation()
+        }
+        thread.name = "com.pine.user-task-execution"
+        thread.qualityOfService = .userInitiated
+        thread.start()
+    }
+}
+
 /// Schedules the blocking workers that own a task's stdin/stdout/stderr
 /// handles. The injectable implementation lets tests hold workers before
 /// their entry point without suspending a process-wide dispatch queue.
@@ -190,6 +212,7 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
     /// Injectable for deterministic spawn-failure coverage. Production always
     /// uses the system POSIX shell.
     private let shellExecutableURL: URL
+    private let executionScheduler: any UserTaskExecutionScheduling
     private let ioExecutionPolicy: UserTaskIOExecutionPolicy
     /// Internal lifecycle observation used by process-ownership tests. The
     /// public progress contract deliberately does not expose process IDs.
@@ -198,11 +221,14 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
     init(
         timeout: TimeInterval = 30.0,
         shellExecutableURL: URL = URL(fileURLWithPath: "/bin/sh"),
+        executionScheduler: (any UserTaskExecutionScheduling)? = nil,
         ioExecutionPolicy: UserTaskIOExecutionPolicy? = nil,
         processDidSpawn: (@Sendable (pid_t) -> Void)? = nil
     ) {
         self.timeout = timeout
         self.shellExecutableURL = shellExecutableURL
+        self.executionScheduler =
+            executionScheduler ?? UserTaskThreadExecutionScheduler()
         self.ioExecutionPolicy = ioExecutionPolicy ?? UserTaskIOExecutionPolicy(
             workerScheduler: UserTaskThreadIOWorkerScheduler(),
             startupDeadline: Self.ioStartupDeadline,
@@ -311,7 +337,7 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
             progress.onCancellationReady?(cancellation)
         }
 
-        DispatchQueue.global(qos: .userInitiated).async {
+        executionScheduler.schedule {
             let execution = Self.execute(
                 config: .init(
                     executableURL: self.shellExecutableURL,

--- a/Pine/Extensibility/UserTaskRunner.swift
+++ b/Pine/Extensibility/UserTaskRunner.swift
@@ -138,13 +138,22 @@ nonisolated protocol UserTaskIOWorkerScheduling: Sendable {
     func schedule(_ operation: @escaping @Sendable () -> Void)
 }
 
-nonisolated struct UserTaskDispatchIOWorkerScheduler:
-    UserTaskIOWorkerScheduling,
-    @unchecked Sendable {
-    let queue: DispatchQueue
-
+/// Starts each blocking descriptor owner on its own OS thread.
+///
+/// Pipe reads can remain blocked for the lifetime of a user task. Scheduling
+/// them on a shared concurrent dispatch queue lets libdispatch's worker limit
+/// delay every worker of a later task, so its startup barrier can expire before
+/// any descriptor is owned. Dedicated threads keep task startup independent
+/// while the injected scheduler preserves deterministic lifecycle tests.
+nonisolated struct UserTaskThreadIOWorkerScheduler:
+    UserTaskIOWorkerScheduling {
     func schedule(_ operation: @escaping @Sendable () -> Void) {
-        queue.async(execute: operation)
+        let thread = Thread {
+            operation()
+        }
+        thread.name = "com.pine.user-task-io"
+        thread.qualityOfService = .userInitiated
+        thread.start()
     }
 }
 
@@ -163,11 +172,6 @@ nonisolated struct UserTaskIOExecutionPolicy: Sendable {
 /// fully async — tasks are user-facing and may take longer than a formatter.
 nonisolated final class UserTaskRunner: @unchecked Sendable {
     static let shared = UserTaskRunner()
-    private static let processIOQueue = DispatchQueue(
-        label: "com.pine.user-task-io",
-        qos: .userInitiated,
-        attributes: .concurrent
-    )
     private static let deferredCleanupQueue = DispatchQueue(
         label: "com.pine.user-task-deferred-cleanup",
         qos: .userInitiated,
@@ -200,9 +204,7 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
         self.timeout = timeout
         self.shellExecutableURL = shellExecutableURL
         self.ioExecutionPolicy = ioExecutionPolicy ?? UserTaskIOExecutionPolicy(
-            workerScheduler: UserTaskDispatchIOWorkerScheduler(
-                queue: Self.processIOQueue
-            ),
+            workerScheduler: UserTaskThreadIOWorkerScheduler(),
             startupDeadline: Self.ioStartupDeadline,
             shutdownDeadline: Self.ioShutdownDeadline
         )

--- a/Pine/Extensibility/UserTaskRunner.swift
+++ b/Pine/Extensibility/UserTaskRunner.swift
@@ -182,12 +182,14 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
 
         DispatchQueue.global(qos: .userInitiated).async {
             let outcome = Self.execute(
-                command: task.command,
-                workingDirectory: workingDir,
-                stdin: stdinText,
-                timeout: timeout,
-                taskID: task.id,
-                cancelFlag: cancelFlag,
+                config: .init(
+                    command: task.command,
+                    workingDirectory: workingDir,
+                    stdin: stdinText,
+                    timeout: timeout,
+                    taskID: task.id,
+                    cancelFlag: cancelFlag
+                ),
                 onStart: {
                     DispatchQueue.main.async { progress.onStart?() }
                 }
@@ -225,13 +227,17 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
     // MARK: - Private
 
     /// Spawns the shell command and waits for it (called off the main thread).
+    struct ExecuteConfig: Sendable {
+        let command: String
+        let workingDirectory: URL?
+        let stdin: String
+        let timeout: TimeInterval
+        let taskID: String
+        let cancelFlag: UserTaskCancellationFlag
+    }
+
     private static func execute(
-        command: String,
-        workingDirectory: URL?,
-        stdin: String,
-        timeout: TimeInterval,
-        taskID: String,
-        cancelFlag: UserTaskCancellationFlag,
+        config: ExecuteConfig,
         onStart: @escaping @Sendable () -> Void
     ) -> UserTaskOutcome {
         precondition(!Thread.isMainThread, "UserTaskRunner must run off the main thread")

--- a/Pine/Extensibility/UserTaskRunner.swift
+++ b/Pine/Extensibility/UserTaskRunner.swift
@@ -3,47 +3,101 @@
 //  Pine
 //
 //  Lightweight extensibility (issue #1009): runs user-defined tasks
-//  (UserTask) via `Process` on a background queue, reporting the outcome
-//  through a callback. Mirrors the threading contract of
+//  (UserTask) in an isolated POSIX process group on a background queue,
+//  reporting the outcome through a callback. Mirrors the threading contract of
 //  `ExternalFileFormatter` / `runRealProcess`: never blocks the main thread.
 //
 
+import Darwin
 import Foundation
 import os
 
 /// Outcome of running a user task.
 nonisolated struct UserTaskOutcome: Sendable, Equatable {
     let taskID: String
-    /// Captured stdout (UTF-8). Empty on error or no output.
+    /// Captured stdout (UTF-8), including partial output from failed runs.
     let stdout: String
-    /// Captured stderr (UTF-8). Empty on success.
+    /// Captured stderr (UTF-8), regardless of the exit status.
     let stderr: String
-    /// Process exit status. -1 when the process could not be spawned.
+    /// Process exit status. -1 when launch, cleanup, or output capture failed.
     let exitCode: Int32
     let timedOut: Bool
+    /// `true` only after Pine reaped the direct child and completed bounded
+    /// process-tree and pipe cleanup.
+    let cleanupSucceeded: Bool
+    /// `true` when every byte intended for stdin was delivered. Replacement
+    /// tasks fail closed when the child exits before consuming the buffer.
+    let standardInputCompleted: Bool
+    /// UTF-8 bytes retained by the UI history, calculated off the main actor
+    /// for process outcomes so store trimming remains constant-time per run.
+    let retainedOutputBytes: Int
 
-    var succeeded: Bool { exitCode == 0 && !timedOut }
+    init(
+        taskID: String,
+        stdout: String,
+        stderr: String,
+        exitCode: Int32,
+        timedOut: Bool,
+        cleanupSucceeded: Bool = true,
+        standardInputCompleted: Bool = true,
+        retainedOutputBytes: Int? = nil
+    ) {
+        self.taskID = taskID
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exitCode = exitCode
+        self.timedOut = timedOut
+        self.cleanupSucceeded = cleanupSucceeded
+        self.standardInputCompleted = standardInputCompleted
+        self.retainedOutputBytes = max(
+            retainedOutputBytes
+                ?? stdout.utf8.count + stderr.utf8.count,
+            0
+        )
+    }
+
+    var succeeded: Bool {
+        exitCode == 0
+            && !timedOut
+            && cleanupSucceeded
+            && standardInputCompleted
+    }
 }
 
 /// A handle that can cancel a running task (issue #1246).
 ///
-/// Cancelling terminates the spawned process (if still running) via
-/// `Process.terminate()`. The handle is safe to invoke from the main actor;
-/// process termination itself happens synchronously on the calling thread
-/// (Process is thread-safe for `terminate`).
+/// Cancelling requests bounded TERM-to-KILL cleanup of the spawned shell's
+/// process group. The handle is safe to invoke from the main actor: the first
+/// TERM is delivered synchronously, while grace-period polling and KILL run
+/// on a dedicated background queue.
 nonisolated final class UserTaskCancellation: @unchecked Sendable {
-    private let terminate: @Sendable () -> Void
+    private let terminate: @Sendable () -> Bool
+    private let waitForCompletion: @Sendable (DispatchTime) -> Bool
 
-    init(terminate: @escaping @Sendable () -> Void) {
+    init(
+        terminate: @escaping @Sendable () -> Bool,
+        waitForCompletion: @escaping @Sendable (DispatchTime) -> Bool = { _ in true }
+    ) {
         self.terminate = terminate
+        self.waitForCompletion = waitForCompletion
     }
 
     /// A no-op handle used when a task was blocked before launch.
-    static let noop = UserTaskCancellation(terminate: {})
+    static let noop = UserTaskCancellation(terminate: { false })
 
-    /// Terminates the underlying process if it is still running.
-    func cancel() {
+    /// Requests termination while the task is still active.
+    ///
+    /// Returns false when execution already finished, allowing the store to
+    /// avoid falsely reclassifying a completed task as cancelled.
+    @discardableResult
+    func cancel() -> Bool {
         terminate()
+    }
+
+    /// Waits until subprocess cleanup has completed, sharing the caller's
+    /// absolute deadline with every other task being shut down.
+    func wait(until deadline: DispatchTime) -> Bool {
+        waitForCompletion(deadline)
     }
 }
 
@@ -51,13 +105,13 @@ nonisolated final class UserTaskCancellation: @unchecked Sendable {
 ///
 /// Each closure is invoked on the main thread so `@MainActor` UI models can
 /// be updated directly. All are optional; `onStart` fires when the process
-/// has been spawned, `onFinish` when it has exited (or was cancelled), and
-/// `cancellation` returns a handle the caller stores to enable Cancel.
+/// has been spawned, `onFinish` after bounded lifecycle cleanup, and
+/// `onCancellationReady` supplies the handle used by Cancel.
 nonisolated struct UserTaskProgress: Sendable {
     let onStart: (@Sendable () -> Void)?
     let onFinish: (@Sendable (UserTaskOutcome, Bool) -> Void)?
-    /// Receives the cancellation handle once the process is spawned so the
-    /// caller can terminate it later.
+    /// Receives a cancellation handle before background execution begins, so
+    /// the caller can also cancel while the process is still queued.
     let onCancellationReady: (@Sendable (UserTaskCancellation) -> Void)?
 
     init(
@@ -73,20 +127,37 @@ nonisolated struct UserTaskProgress: Sendable {
 
 /// Runs `UserTask`s on a background queue.
 ///
-/// Threading: `run(...)` dispatches the `Process` to `DispatchQueue.global`
-/// and invokes `completion` on the main thread. The caller (main actor) is
-/// never blocked. This mirrors `ExternalFileFormatter.format()`'s
-/// `DispatchGroup.wait()` pattern but is fully async — tasks are user-facing
-/// and may take longer than a formatter.
+/// Threading: `run(...)` dispatches subprocess execution to
+/// `DispatchQueue.global` and invokes progress callbacks on the main thread.
+/// The caller (main actor) is never blocked. This mirrors
+/// `ExternalFileFormatter.format()`'s `DispatchGroup.wait()` pattern but is
+/// fully async — tasks are user-facing and may take longer than a formatter.
 nonisolated final class UserTaskRunner: @unchecked Sendable {
     static let shared = UserTaskRunner()
+    private static let processIOQueue = DispatchQueue(
+        label: "com.pine.user-task-io",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+    private static let processPollIntervalMicroseconds: useconds_t = 10_000
+    private static let descendantSnapshotInterval: TimeInterval = 0.025
+    private static let terminationReapDeadline: TimeInterval = 2.0
+    private static let overallDeadlineLeeway: TimeInterval = 3.0
+    private static let ioShutdownDeadline: TimeInterval = 0.5
 
     /// Per-task timeout. Matches the formatter default; generous enough for
     /// lint/compile commands but bounded so a hung task can't wedge the menu.
     private let timeout: TimeInterval
+    /// Injectable for deterministic spawn-failure coverage. Production always
+    /// uses the system POSIX shell.
+    private let shellExecutableURL: URL
 
-    init(timeout: TimeInterval = 30.0) {
+    init(
+        timeout: TimeInterval = 30.0,
+        shellExecutableURL: URL = URL(fileURLWithPath: "/bin/sh")
+    ) {
         self.timeout = timeout
+        self.shellExecutableURL = shellExecutableURL
     }
 
     /// Runs a task against the given file/project context.
@@ -98,13 +169,14 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
     ///   - fileContent: Content of the active file for stdin (only used when
     ///     `task.replacesFileContent` and `task.scope == .activeFile`).
     ///   - completion: Invoked on the main thread with the outcome.
+    @discardableResult
     func run(
         task: UserTask,
         fileURL: URL?,
         projectRootURL: URL?,
         fileContent: String?,
         completion: @escaping @Sendable (UserTaskOutcome) -> Void
-    ) {
+    ) -> UserTaskCancellation {
         run(
             task: task,
             fileURL: fileURL,
@@ -123,13 +195,14 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
     /// so the UI can render running state, elapsed time, and a Cancel button.
     /// Shell text still comes directly from the validated task definition —
     /// editor, terminal, and OSC-derived content is never interpolated.
+    @discardableResult
     func run(
         task: UserTask,
         fileURL: URL?,
         projectRootURL: URL?,
         fileContent: String?,
         progress: UserTaskProgress
-    ) {
+    ) -> UserTaskCancellation {
         // --- Security gate (milestone #1088, item 4) ---
         // Validate the command *before* spawning any process.  Commands that
         // match known-dangerous patterns (rm -rf, sudo, curl|sh, …) are
@@ -142,18 +215,17 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
             let outcome = UserTaskOutcome(
                 taskID: task.id,
                 stdout: "",
-                stderr: "Task blocked: \(validation.reason)",
+                stderr: Strings.userTaskBlocked,
                 exitCode: -1,
                 timedOut: false
             )
-            // Surface the blocked outcome through the progress callbacks so
-            // the UI model reflects the rejection (issue #1246), then invoke
-            // the legacy completion for backward compatibility.
+            // Surface the blocked outcome through the progress callback so
+            // the UI model reflects the rejection (issue #1246).
             DispatchQueue.main.async {
+                progress.onCancellationReady?(.noop)
                 progress.onFinish?(outcome, false)
-                completion(outcome)
             }
-            return
+            return .noop
         }
 
         let workingDir: URL?
@@ -172,30 +244,39 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
 
         // Log the attempt (what + when).
         Logger.task.info(
-            "Task '\(task.id, privacy: .public)' starting: '\(task.command, privacy: .public)'"
+            "Task '\(task.id, privacy: .public)' starting: '\(task.command, privacy: .private)'"
         )
 
-        // Cancellation flag shared between the cancel handle and the execute
-        // path. Set to `true` when the user cancels so the reported outcome
-        // is marked as cancelled rather than a generic failure.
-        let cancelFlag = UserTaskCancellationFlag()
+        let executionState = UserTaskExecutionState()
+
+        // Publish the handle before dispatch so a caller can cancel even while
+        // the background queue is still waiting to start the process.
+        let cancellation = UserTaskCancellation {
+            executionState.requestCancellation()
+        } waitForCompletion: { deadline in
+            executionState.waitForCompletion(until: deadline)
+        }
+        DispatchQueue.main.async {
+            progress.onCancellationReady?(cancellation)
+        }
 
         DispatchQueue.global(qos: .userInitiated).async {
-            let outcome = Self.execute(
+            let execution = Self.execute(
                 config: .init(
+                    executableURL: self.shellExecutableURL,
                     command: task.command,
                     workingDirectory: workingDir,
                     stdin: stdinText,
                     timeout: timeout,
                     taskID: task.id,
-                    cancelFlag: cancelFlag
+                    executionState: executionState
                 ),
                 onStart: {
                     DispatchQueue.main.async { progress.onStart?() }
                 }
             )
-
-            let didCancel = cancelFlag.isCancelled
+            let outcome = execution.outcome
+            let didCancel = execution.cancelled
 
             // Log the result (exit code).
             if outcome.succeeded {
@@ -210,170 +291,456 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
                     "Task '\(task.id, privacy: .public)' exit \(exitCode), timedOut: \(timedOut), cancelled: \(didCancel)"
                 )
                 if !stderr.isEmpty {
-                    Logger.task.error("stderr: \(stderr, privacy: .public)")
+                    Logger.task.error("stderr: \(stderr, privacy: .private)")
                 }
             }
 
             DispatchQueue.main.async {
                 progress.onFinish?(outcome, didCancel)
-                completion(outcome)
             }
         }
-
-        // Provide the cancellation handle so the caller can terminate the
-        // process. The handle flips `cancelFlag` and calls `terminate()` on
-        // the process once it has been spawned.
-        progress.onCancellationReady?(UserTaskCancellation {
-            cancelFlag.cancel()
-        })
+        return cancellation
     }
 
     // MARK: - Private
 
     /// Spawns the shell command and waits for it (called off the main thread).
     struct ExecuteConfig: Sendable {
+        let executableURL: URL
         let command: String
         let workingDirectory: URL?
         let stdin: String
         let timeout: TimeInterval
         let taskID: String
-        let cancelFlag: UserTaskCancellationFlag
+        let executionState: UserTaskExecutionState
+    }
+
+    private struct ExecutionResult: Sendable {
+        let outcome: UserTaskOutcome
+        let cancelled: Bool
     }
 
     private static func execute(
         config: ExecuteConfig,
         onStart: @escaping @Sendable () -> Void
-    ) -> UserTaskOutcome {
+    ) -> ExecutionResult {
         precondition(!Thread.isMainThread, "UserTaskRunner must run off the main thread")
-
-        let process = Process()
-        process.launchPath = "/bin/sh"
-        process.arguments = ["-c", command]
-        if let workingDirectory {
-            process.currentDirectoryURL = workingDirectory
-        }
-
-        let stdinPipe = Pipe()
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
-        process.standardInput = stdinPipe
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
-
-        do {
-            try process.run()
-        } catch {
-            Logger.task.error("Task '\(taskID, privacy: .public)' failed to launch: \(error.localizedDescription, privacy: .public)")
-            return UserTaskOutcome(
-                taskID: taskID, stdout: "", stderr: error.localizedDescription,
-                exitCode: -1, timedOut: false
+        var completedCleanup = false
+        defer {
+            config.executionState.complete(
+                cleanupSucceeded: completedCleanup
             )
         }
 
-        // Publish the process so user-initiated cancellation can terminate it
-        // (issue #1246). If the user cancelled between spawn and here, the
-        // flag terminates the process immediately.
-        cancelFlag.setProcess(process)
+        // A cancellation accepted while this work item was still queued must
+        // not launch a process merely to terminate it.
+        if config.executionState.terminalCause == .cancelled {
+            completedCleanup = true
+            return ExecutionResult(
+                outcome: UserTaskOutcome(
+                    taskID: config.taskID,
+                    stdout: "",
+                    stderr: "",
+                    exitCode: -1,
+                    timedOut: false,
+                    cleanupSucceeded: true
+                ),
+                cancelled: true
+            )
+        }
+
+        let subprocess: UserTaskSubprocess
+        do {
+            subprocess = try UserTaskSubprocess(
+                executableURL: config.executableURL,
+                command: config.command,
+                workingDirectory: config.workingDirectory
+            )
+        } catch {
+            // No child exists, so there is nothing for shutdown to reap even
+            // though the task outcome itself is a launch failure.
+            completedCleanup = true
+            Logger.task.error(
+                "Task '\(config.taskID, privacy: .public)' failed to launch: \(error.localizedDescription, privacy: .public)"
+            )
+            return ExecutionResult(
+                outcome: UserTaskOutcome(
+                    taskID: config.taskID,
+                    stdout: "",
+                    stderr: Strings.userTaskLaunchFailed(
+                        error.localizedDescription
+                    ),
+                    exitCode: -1,
+                    timedOut: false,
+                    cleanupSucceeded: false
+                ),
+                cancelled: config.executionState.closeWithoutProcess() == .cancelled
+            )
+        }
+
+        let descendantTracker = UserTaskDescendantTracker(
+            rootProcessID: subprocess.processGroup.identifier
+        )
+
+        // Publish the isolated process group so cancellation terminates the
+        // shell and ordinary descendants. A pre-spawn cancellation is applied
+        // immediately; observed group escapees are cleaned up below.
+        config.executionState.publishProcessGroup(subprocess.processGroup)
 
         // Notify the caller that the process is now running so the UI can
         // switch from the pending to the running state and start the timer.
         onStart()
 
-        // Write stdin and close.
-        if !stdin.isEmpty {
-            stdinPipe.fileHandleForWriting.write(stdin.data(using: .utf8) ?? Data())
+        // Each pipe has one owning worker. Polling readers/writer observe the
+        // shared stop state, so cleanup never closes a FileHandle underneath
+        // a blocking operation on another thread.
+        let ioGroup = DispatchGroup()
+        let ioStopState = UserTaskIOStopState()
+        let outputCapture = UserTaskOutputCapture()
+        let inputCapture = UserTaskInputCapture()
+        ioGroup.enter()
+        processIOQueue.async {
+            defer { ioGroup.leave() }
+            outputCapture.setStdout(
+                UserTaskPipeReader.read(
+                    from: subprocess.standardOutput,
+                    stopState: ioStopState
+                )
+            )
         }
-        stdinPipe.fileHandleForWriting.closeFile()
-
-        // Timeout via a timer source. The same terminate path is reused for
-        // user-initiated cancellation (issue #1246): `cancelFlag.cancel()`
-        // terminates the process and records that the exit was a cancel.
-        let timedOutLock = NSLock()
-        nonisolated(unsafe) var timedOutValue = false
-        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
-        timer.schedule(deadline: .now() + timeout)
-        timer.setEventHandler {
-            timedOutLock.lock()
-            timedOutValue = true
-            timedOutLock.unlock()
-            if process.isRunning { process.terminate() }
+        ioGroup.enter()
+        processIOQueue.async {
+            defer { ioGroup.leave() }
+            outputCapture.setStderr(
+                UserTaskPipeReader.read(
+                    from: subprocess.standardError,
+                    stopState: ioStopState
+                )
+            )
         }
-        timer.resume()
 
-        // Read both pipes concurrently to avoid deadlock on full stderr buffer.
-        let readGroup = DispatchGroup()
-        nonisolated(unsafe) var outData = Data()
-        nonisolated(unsafe) var errData = Data()
-        readGroup.enter()
-        DispatchQueue.global().async {
-            outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-            readGroup.leave()
+        let stdinData = config.stdin.data(using: .utf8) ?? Data()
+        if stdinData.isEmpty {
+            subprocess.standardInput.closeFile()
+            inputCapture.setResult(.complete)
+        } else {
+            ioGroup.enter()
+            processIOQueue.async {
+                defer { ioGroup.leave() }
+                inputCapture.setResult(
+                    UserTaskPipeWriter.write(
+                        stdinData,
+                        to: subprocess.standardInput,
+                        stopState: ioStopState
+                    )
+                )
+            }
         }
-        readGroup.enter()
-        DispatchQueue.global().async {
-            errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-            readGroup.leave()
-        }
-        readGroup.wait()
-        process.waitUntilExit()
-        timer.cancel()
 
-        timedOutLock.lock()
-        let didTimeout = timedOutValue
-        timedOutLock.unlock()
+        // One polling loop owns both waitpid and the timeout decision. It
+        // always checks for process exit first, eliminating the old timer
+        // race that could mark an already-reapable command as timed out.
+        let effectiveTimeout = max(config.timeout, 0)
+        let lifecycleStart = DispatchTime.now()
+        let timeoutDeadline = lifecycleStart + effectiveTimeout
 
-        return UserTaskOutcome(
-            taskID: taskID,
-            stdout: String(data: outData, encoding: .utf8) ?? "",
-            stderr: String(data: errData, encoding: .utf8) ?? "",
-            exitCode: process.terminationStatus,
-            timedOut: didTimeout
+        // Polling waitpid keeps descendant snapshots current and gives the
+        // runner a hard return deadline. If SIGKILL cannot promptly finish
+        // the shell, ownership moves to the dedicated background reaper.
+        let directChild = waitForDirectChild(
+            subprocess,
+            descendantTracker: descendantTracker,
+            executionState: config.executionState,
+            timeoutDeadline: timeoutDeadline,
+            overallDeadline: timeoutDeadline + overallDeadlineLeeway
         )
+
+        let terminalCause = config.executionState.terminalCause
+        let didTimeout = terminalCause == .timedOut
+        let didCancel = terminalCause == .cancelled
+
+        // A command can deliberately background a child and let its shell
+        // exit. Clean ordinary group members plus best-effort identities for
+        // children that changed groups before declaring the task finished.
+        descendantTracker.captureDescendants()
+        subprocess.processGroup.captureKnownMembers()
+        if subprocess.processGroup.isAlive {
+            subprocess.processGroup.requestTermination()
+        }
+        let terminatedProcessGroup =
+            subprocess.processGroup.waitForRequestedTermination()
+        let terminatedTrackedDescendants =
+            descendantTracker.terminateTrackedProcesses()
+
+        // Readers drain buffered bytes and then close their own descriptors.
+        // The timed wait is defensive; capture publication remains locked if
+        // a system call ever outlives the expected poll interval.
+        ioStopState.stop()
+        let ioFinished = ioGroup.wait(
+            timeout: .now() + ioShutdownDeadline
+        ) == .success
+        let output = outputCapture.snapshot()
+        let inputResult = inputCapture.snapshot()
+        let streamsReachedEOF =
+            output.stdout.reachedEndOfFile
+            && output.stderr.reachedEndOfFile
+        let outputWasTruncated =
+            output.stdout.truncated || output.stderr.truncated
+        let decodedStdout = String(
+            data: output.stdout.data,
+            encoding: .utf8
+        )
+        let decodedStderr = String(
+            data: output.stderr.data,
+            encoding: .utf8
+        )
+        let outputWasValidUTF8 =
+            decodedStdout != nil && decodedStderr != nil
+        let standardInputCompleted = inputResult == .complete
+
+        var diagnostics: [String] = []
+        if !directChild.reaped {
+            diagnostics.append(
+                Strings.userTaskDiagnosticBackgroundReaper
+            )
+        }
+        if !terminatedProcessGroup || !terminatedTrackedDescendants {
+            diagnostics.append(
+                Strings.userTaskDiagnosticSubprocessCleanup
+            )
+        }
+        if !ioFinished || !streamsReachedEOF {
+            diagnostics.append(
+                Strings.userTaskDiagnosticOutputDeadline
+            )
+        }
+        if outputWasTruncated {
+            diagnostics.append(
+                Strings.userTaskDiagnosticOutputTruncated
+            )
+        }
+        if !outputWasValidUTF8 {
+            diagnostics.append(
+                Strings.userTaskDiagnosticInvalidUTF8
+            )
+        }
+        if !standardInputCompleted {
+            diagnostics.append(
+                Strings.userTaskDiagnosticInputIncomplete
+            )
+        }
+
+        var stderr = decodedStderr ?? ""
+        if !diagnostics.isEmpty {
+            if !stderr.isEmpty { stderr.append("\n") }
+            stderr.append(diagnostics.joined(separator: "\n"))
+        }
+        let cleanupSucceeded =
+            directChild.reaped
+            && terminatedProcessGroup
+            && terminatedTrackedDescendants
+            && ioFinished
+            && streamsReachedEOF
+        let resultIsValid =
+            cleanupSucceeded
+            && !outputWasTruncated
+            && outputWasValidUTF8
+            && standardInputCompleted
+        let reportedExitCode = resultIsValid
+            ? directChild.exitCode
+            : -1
+        completedCleanup = cleanupSucceeded
+
+        return ExecutionResult(
+            outcome: UserTaskOutcome(
+                taskID: config.taskID,
+                stdout: decodedStdout ?? "",
+                stderr: stderr,
+                exitCode: reportedExitCode,
+                timedOut: didTimeout,
+                cleanupSucceeded: cleanupSucceeded,
+                standardInputCompleted: standardInputCompleted,
+                retainedOutputBytes:
+                    (decodedStdout?.utf8.count ?? 0)
+                    + stderr.utf8.count
+            ),
+            cancelled: didCancel
+        )
+    }
+
+    private struct DirectChildWaitResult {
+        let exitCode: Int32
+        let reaped: Bool
+    }
+
+    private static func waitForDirectChild(
+        _ subprocess: UserTaskSubprocess,
+        descendantTracker: UserTaskDescendantTracker,
+        executionState: UserTaskExecutionState,
+        timeoutDeadline: DispatchTime,
+        overallDeadline: DispatchTime
+    ) -> DirectChildWaitResult {
+        var terminationDeadline: DispatchTime?
+        var nextDescendantSnapshot = DispatchTime.now()
+
+        while true {
+            let now = DispatchTime.now()
+            if now >= nextDescendantSnapshot {
+                // Snapshot before waitpid can reap a zombie group leader. The
+                // leader's start identity is still a safe anchor at this point,
+                // allowing ordinary background members to be recorded.
+                descendantTracker.captureDescendants()
+                subprocess.processGroup.captureKnownMembers()
+                nextDescendantSnapshot =
+                    now + descendantSnapshotInterval
+            }
+
+            switch subprocess.pollExit(beforeReaping: {
+                // `pollExit` first retains the shell's final process-group
+                // snapshot while WNOWAIT still reserves its pid. Capture the
+                // best-effort descendant tree in the same pre-reap window.
+                descendantTracker.captureDescendants()
+            }) {
+            case .exited(let exitCode):
+                executionState.claimNaturalExit()
+                return DirectChildWaitResult(
+                    exitCode: exitCode,
+                    reaped: true
+                )
+            case .waitFailed(let error):
+                Logger.task.error(
+                    "waitpid failed for task shell: errno \(error)"
+                )
+                executionState.closeWithoutProcess()
+                return DirectChildWaitResult(exitCode: -1, reaped: false)
+            case .running:
+                break
+            }
+
+            if now >= timeoutDeadline {
+                executionState.requestTimeout()
+            }
+            if subprocess.processGroup.terminationWasRequested,
+               terminationDeadline == nil {
+                terminationDeadline = now + terminationReapDeadline
+            }
+            let terminationExpired =
+                terminationDeadline.map { now >= $0 } ?? false
+            if terminationExpired || now >= overallDeadline {
+                subprocess.processGroup.requestTermination()
+                descendantTracker.captureDescendants()
+                subprocess.processGroup.captureKnownMembers()
+                subprocess.reapInBackground()
+                executionState.closeWithoutProcess()
+                return DirectChildWaitResult(exitCode: -1, reaped: false)
+            }
+
+            Darwin.usleep(processPollIntervalMicroseconds)
+        }
     }
 }
 
-/// Thread-safe handle coordinating user cancellation with the background
-/// `execute` path (issue #1246). Lives outside actor isolation because the
-/// process runs on `DispatchQueue.global` and the cancel handle may be
-/// invoked from the main actor.
+nonisolated enum UserTaskTerminalCause: Sendable, Equatable {
+    case active
+    case naturalExit
+    case cancelled
+    case timedOut
+}
+
+/// The single lock-protected arbiter for every terminal transition.
 ///
-/// The spawned `Process` is stored as a weak, locked reference so that
-/// `cancel()` can terminate it even if it is called before `execute` has
-/// finished wiring (the handle captures the flag; `execute` publishes the
-/// process into it once spawned).
-final class UserTaskCancellationFlag: @unchecked Sendable {
+/// Cancellation, timeout, and direct-child exit compete exactly once. The
+/// winning cause cannot be overwritten by a later callback. Completion is a
+/// separate milestone: it is published only after reaping, descendant cleanup,
+/// and pipe shutdown, which makes cancellation handles safe to wait on during
+/// application termination without depending on the main-thread finish callback.
+nonisolated final class UserTaskExecutionState: @unchecked Sendable {
     private let lock = NSLock()
-    private var cancelled = false
-    private weak var process: Process?
+    private let completion = DispatchGroup()
+    private var cause: UserTaskTerminalCause = .active
+    private var processGroup: UserTaskProcessGroup?
+    private var didComplete = false
+    private var completionSucceeded = false
 
-    /// Publishes the spawned process so `cancel()` can terminate it. Called
-    /// from `execute` on the background queue right after `process.run()`.
-    func setProcess(_ process: Process) {
-        lock.lock()
-        self.process = process
-        let shouldTerminate = cancelled
-        lock.unlock()
-        // If the user cancelled between spawn and publication, terminate now.
-        if shouldTerminate, process.isRunning {
-            process.terminate()
+    init() {
+        completion.enter()
+    }
+
+    var terminalCause: UserTaskTerminalCause {
+        lock.withLock { cause }
+    }
+
+    /// Publishes the spawned group. A pre-spawn cancellation is forwarded
+    /// immediately. `requestTermination()` synchronously sends the first TERM
+    /// before returning and schedules only the grace/KILL portion.
+    func publishProcessGroup(_ processGroup: UserTaskProcessGroup) {
+        let shouldTerminate = lock.withLock {
+            self.processGroup = processGroup
+            return cause == .cancelled || cause == .timedOut
+        }
+        if shouldTerminate {
+            processGroup.requestTermination()
         }
     }
 
-    var isCancelled: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return cancelled
+    @discardableResult
+    func requestCancellation() -> Bool {
+        claim(.cancelled)
     }
 
-    func cancel() {
-        lock.lock()
-        let alreadyCancelled = cancelled
-        cancelled = true
-        let proc = process
-        lock.unlock()
-        guard !alreadyCancelled else { return }
-        if let proc, proc.isRunning {
-            proc.terminate()
+    @discardableResult
+    func requestTimeout() -> Bool {
+        claim(.timedOut)
+    }
+
+    @discardableResult
+    func claimNaturalExit() -> Bool {
+        claim(.naturalExit)
+    }
+
+    /// Closes a launch/wait failure to late cancellation while preserving an
+    /// earlier cancellation or timeout winner.
+    @discardableResult
+    func closeWithoutProcess() -> UserTaskTerminalCause {
+        lock.withLock {
+            if cause == .active {
+                cause = .naturalExit
+            }
+            processGroup = nil
+            return cause
         }
+    }
+
+    func complete(cleanupSucceeded: Bool = true) {
+        let shouldLeave = lock.withLock {
+            guard !didComplete else { return false }
+            didComplete = true
+            completionSucceeded = cleanupSucceeded
+            processGroup = nil
+            return true
+        }
+        if shouldLeave {
+            completion.leave()
+        }
+    }
+
+    func waitForCompletion(until deadline: DispatchTime) -> Bool {
+        guard completion.wait(timeout: deadline) == .success else {
+            return false
+        }
+        return lock.withLock { completionSucceeded }
+    }
+
+    private func claim(_ requestedCause: UserTaskTerminalCause) -> Bool {
+        let result: (accepted: Bool, group: UserTaskProcessGroup?) = lock.withLock {
+            guard cause == .active, !didComplete else {
+                return (false, nil)
+            }
+            cause = requestedCause
+            return (true, processGroup)
+        }
+        guard result.accepted else { return false }
+        result.group?.requestTermination()
+        return true
     }
 }

--- a/Pine/Extensibility/UserTaskRunner.swift
+++ b/Pine/Extensibility/UserTaskRunner.swift
@@ -185,13 +185,12 @@ nonisolated struct UserTaskIOExecutionPolicy: Sendable {
     let shutdownDeadline: TimeInterval
 }
 
-/// Runs `UserTask`s on a background queue.
+/// Runs `UserTask`s off the main thread.
 ///
-/// Threading: `run(...)` dispatches subprocess execution to
-/// `DispatchQueue.global` and invokes progress callbacks on the main thread.
-/// The caller (main actor) is never blocked. This mirrors
-/// `ExternalFileFormatter.format()`'s `DispatchGroup.wait()` pattern but is
-/// fully async — tasks are user-facing and may take longer than a formatter.
+/// Threading: `run(...)` schedules each complete subprocess execution on a
+/// dedicated owner thread and invokes progress callbacks on the main thread.
+/// The caller (main actor) is never blocked. Dedicated ownership prevents a
+/// task waiting for process exit from starving another task's startup.
 nonisolated final class UserTaskRunner: @unchecked Sendable {
     static let shared = UserTaskRunner()
     private static let deferredCleanupQueue = DispatchQueue(

--- a/Pine/Extensibility/UserTaskRunner.swift
+++ b/Pine/Extensibility/UserTaskRunner.swift
@@ -168,6 +168,11 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
         qos: .userInitiated,
         attributes: .concurrent
     )
+    private static let deferredCleanupQueue = DispatchQueue(
+        label: "com.pine.user-task-deferred-cleanup",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
     private static let processPollIntervalMicroseconds: useconds_t = 10_000
     private static let descendantSnapshotInterval: TimeInterval = 0.025
     private static let terminationReapDeadline: TimeInterval = 2.0
@@ -374,10 +379,13 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
     ) -> ExecutionResult {
         precondition(!Thread.isMainThread, "UserTaskRunner must run off the main thread")
         var completedCleanup = false
+        var executionStateWasCompleted = false
         defer {
-            config.executionState.complete(
-                cleanupSucceeded: completedCleanup
-            )
+            if !executionStateWasCompleted {
+                config.executionState.complete(
+                    cleanupSucceeded: completedCleanup
+                )
+            }
         }
 
         // A cancellation accepted while this work item was still queued must
@@ -618,6 +626,21 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
             ? directChild.exitCode
             : -1
         completedCleanup = cleanupSucceeded
+        if !cleanupSucceeded {
+            // Close the terminal-cause race before publishing the outcome, but
+            // keep the cancellation handle unresolved until every resource
+            // transferred to background cleanup has actually released.
+            config.executionState.complete(cleanupSucceeded: false)
+            executionStateWasCompleted = true
+            continueDeferredCleanup(.init(
+                subprocess: subprocess,
+                descendantTracker: descendantTracker,
+                backgroundReaper: directChild.backgroundReaper,
+                ioGroup: ioGroup,
+                ioStopState: ioStopState,
+                executionState: config.executionState
+            ))
+        }
 
         return ExecutionResult(
             outcome: UserTaskOutcome(
@@ -639,6 +662,29 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
     private struct DirectChildWaitResult {
         let exitCode: Int32
         let reaped: Bool
+        let backgroundReaper: UserTaskBackgroundReaper?
+    }
+
+    private struct DeferredCleanup: @unchecked Sendable {
+        let subprocess: UserTaskSubprocess
+        let descendantTracker: UserTaskDescendantTracker
+        let backgroundReaper: UserTaskBackgroundReaper?
+        let ioGroup: DispatchGroup
+        let ioStopState: UserTaskIOStopState
+        let executionState: UserTaskExecutionState
+    }
+
+    private static func continueDeferredCleanup(_ cleanup: DeferredCleanup) {
+        deferredCleanupQueue.async {
+            // Stop descriptor workers first so a delayed executor slot cannot
+            // extend ownership after process cleanup has already finished.
+            cleanup.ioStopState.stop()
+            cleanup.subprocess.processGroup.finishDeferredCleanup()
+            cleanup.descendantTracker.finishDeferredCleanup()
+            cleanup.backgroundReaper?.waitForOwnershipRelease()
+            cleanup.ioGroup.wait()
+            cleanup.executionState.resolveDeferredCleanup()
+        }
     }
 
     private static func waitForDirectChild(
@@ -673,14 +719,20 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
                 executionState.claimNaturalExit()
                 return DirectChildWaitResult(
                     exitCode: exitCode,
-                    reaped: true
+                    reaped: true,
+                    backgroundReaper: nil
                 )
             case .waitFailed(let error):
                 Logger.task.error(
                     "waitpid failed for task shell: errno \(error)"
                 )
+                let backgroundReaper = subprocess.reapInBackground()
                 executionState.closeWithoutProcess()
-                return DirectChildWaitResult(exitCode: -1, reaped: false)
+                return DirectChildWaitResult(
+                    exitCode: -1,
+                    reaped: false,
+                    backgroundReaper: backgroundReaper
+                )
             case .running:
                 break
             }
@@ -698,9 +750,13 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
                 subprocess.processGroup.requestTermination()
                 descendantTracker.captureDescendants()
                 subprocess.processGroup.captureKnownMembers()
-                subprocess.reapInBackground()
+                let backgroundReaper = subprocess.reapInBackground()
                 executionState.closeWithoutProcess()
-                return DirectChildWaitResult(exitCode: -1, reaped: false)
+                return DirectChildWaitResult(
+                    exitCode: -1,
+                    reaped: false,
+                    backgroundReaper: backgroundReaper
+                )
             }
 
             Darwin.usleep(processPollIntervalMicroseconds)
@@ -727,8 +783,8 @@ nonisolated final class UserTaskExecutionState: @unchecked Sendable {
     private let completion = DispatchGroup()
     private var cause: UserTaskTerminalCause = .active
     private var processGroup: UserTaskProcessGroup?
-    private var didComplete = false
-    private var completionSucceeded = false
+    private var didFinishExecution = false
+    private var didResolveOwnership = false
 
     init() {
         completion.enter()
@@ -781,10 +837,29 @@ nonisolated final class UserTaskExecutionState: @unchecked Sendable {
 
     func complete(cleanupSucceeded: Bool = true) {
         let shouldLeave = lock.withLock {
-            guard !didComplete else { return false }
-            didComplete = true
-            completionSucceeded = cleanupSucceeded
+            guard !didFinishExecution else { return false }
+            didFinishExecution = true
             processGroup = nil
+            guard cleanupSucceeded, !didResolveOwnership else { return false }
+            didResolveOwnership = true
+            return true
+        }
+        if shouldLeave {
+            completion.leave()
+        }
+    }
+
+    /// Resolves the cleanup ownership retained by `complete(false)`.
+    ///
+    /// This is called only by the off-main deferred cleanup continuation after
+    /// its direct-child reaper, process identities, and descriptor workers
+    /// have all completed.
+    func resolveDeferredCleanup() {
+        let shouldLeave = lock.withLock {
+            guard didFinishExecution, !didResolveOwnership else {
+                return false
+            }
+            didResolveOwnership = true
             return true
         }
         if shouldLeave {
@@ -793,15 +868,12 @@ nonisolated final class UserTaskExecutionState: @unchecked Sendable {
     }
 
     func waitForCompletion(until deadline: DispatchTime) -> Bool {
-        guard completion.wait(timeout: deadline) == .success else {
-            return false
-        }
-        return lock.withLock { completionSucceeded }
+        completion.wait(timeout: deadline) == .success
     }
 
     private func claim(_ requestedCause: UserTaskTerminalCause) -> Bool {
         let result: (accepted: Bool, group: UserTaskProcessGroup?) = lock.withLock {
-            guard cause == .active, !didComplete else {
+            guard cause == .active, !didFinishExecution else {
                 return (false, nil)
             }
             cause = requestedCause

--- a/Pine/Extensibility/UserTaskRunner.swift
+++ b/Pine/Extensibility/UserTaskRunner.swift
@@ -25,6 +25,52 @@ nonisolated struct UserTaskOutcome: Sendable, Equatable {
     var succeeded: Bool { exitCode == 0 && !timedOut }
 }
 
+/// A handle that can cancel a running task (issue #1246).
+///
+/// Cancelling terminates the spawned process (if still running) via
+/// `Process.terminate()`. The handle is safe to invoke from the main actor;
+/// process termination itself happens synchronously on the calling thread
+/// (Process is thread-safe for `terminate`).
+nonisolated final class UserTaskCancellation: @unchecked Sendable {
+    private let terminate: @Sendable () -> Void
+
+    init(terminate: @escaping @Sendable () -> Void) {
+        self.terminate = terminate
+    }
+
+    /// A no-op handle used when a task was blocked before launch.
+    static let noop = UserTaskCancellation(terminate: {})
+
+    /// Terminates the underlying process if it is still running.
+    func cancel() {
+        terminate()
+    }
+}
+
+/// Progress callbacks for a running task (issue #1246).
+///
+/// Each closure is invoked on the main thread so `@MainActor` UI models can
+/// be updated directly. All are optional; `onStart` fires when the process
+/// has been spawned, `onFinish` when it has exited (or was cancelled), and
+/// `cancellation` returns a handle the caller stores to enable Cancel.
+nonisolated struct UserTaskProgress: Sendable {
+    let onStart: (@Sendable () -> Void)?
+    let onFinish: (@Sendable (UserTaskOutcome, Bool) -> Void)?
+    /// Receives the cancellation handle once the process is spawned so the
+    /// caller can terminate it later.
+    let onCancellationReady: (@Sendable (UserTaskCancellation) -> Void)?
+
+    init(
+        onStart: (@Sendable () -> Void)? = nil,
+        onFinish: (@Sendable (UserTaskOutcome, Bool) -> Void)? = nil,
+        onCancellationReady: (@Sendable (UserTaskCancellation) -> Void)? = nil
+    ) {
+        self.onStart = onStart
+        self.onFinish = onFinish
+        self.onCancellationReady = onCancellationReady
+    }
+}
+
 /// Runs `UserTask`s on a background queue.
 ///
 /// Threading: `run(...)` dispatches the `Process` to `DispatchQueue.global`
@@ -59,6 +105,31 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
         fileContent: String?,
         completion: @escaping @Sendable (UserTaskOutcome) -> Void
     ) {
+        run(
+            task: task,
+            fileURL: fileURL,
+            projectRootURL: projectRootURL,
+            fileContent: fileContent,
+            progress: UserTaskProgress(onFinish: { outcome, _ in
+                completion(outcome)
+            })
+        )
+    }
+
+    /// Runs a task with structured progress reporting (issue #1246).
+    ///
+    /// The validated command path is identical to ``run(task:fileURL:projectRootURL:fileContent:completion:)``;
+    /// this overload additionally surfaces start/cancellation/finish events
+    /// so the UI can render running state, elapsed time, and a Cancel button.
+    /// Shell text still comes directly from the validated task definition —
+    /// editor, terminal, and OSC-derived content is never interpolated.
+    func run(
+        task: UserTask,
+        fileURL: URL?,
+        projectRootURL: URL?,
+        fileContent: String?,
+        progress: UserTaskProgress
+    ) {
         // --- Security gate (milestone #1088, item 4) ---
         // Validate the command *before* spawning any process.  Commands that
         // match known-dangerous patterns (rm -rf, sudo, curl|sh, …) are
@@ -75,7 +146,13 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
                 exitCode: -1,
                 timedOut: false
             )
-            DispatchQueue.main.async { completion(outcome) }
+            // Surface the blocked outcome through the progress callbacks so
+            // the UI model reflects the rejection (issue #1246), then invoke
+            // the legacy completion for backward compatibility.
+            DispatchQueue.main.async {
+                progress.onFinish?(outcome, false)
+                completion(outcome)
+            }
             return
         }
 
@@ -98,14 +175,25 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
             "Task '\(task.id, privacy: .public)' starting: '\(task.command, privacy: .public)'"
         )
 
+        // Cancellation flag shared between the cancel handle and the execute
+        // path. Set to `true` when the user cancels so the reported outcome
+        // is marked as cancelled rather than a generic failure.
+        let cancelFlag = UserTaskCancellationFlag()
+
         DispatchQueue.global(qos: .userInitiated).async {
             let outcome = Self.execute(
                 command: task.command,
                 workingDirectory: workingDir,
                 stdin: stdinText,
                 timeout: timeout,
-                taskID: task.id
+                taskID: task.id,
+                cancelFlag: cancelFlag,
+                onStart: {
+                    DispatchQueue.main.async { progress.onStart?() }
+                }
             )
+
+            let didCancel = cancelFlag.isCancelled
 
             // Log the result (exit code).
             if outcome.succeeded {
@@ -116,14 +204,22 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
                 let exitCode = outcome.exitCode
                 let timedOut = outcome.timedOut
                 Logger.task.error(
-                    "Task '\(task.id, privacy: .public)' finished (exit \(exitCode), timedOut: \(timedOut)): \(outcome.stderr, privacy: .public)"
+                    "Task '\(task.id, privacy: .public)' finished (exit \(exitCode), timedOut: \(timedOut), cancelled: \(didCancel)): \(outcome.stderr, privacy: .public)"
                 )
             }
 
             DispatchQueue.main.async {
+                progress.onFinish?(outcome, didCancel)
                 completion(outcome)
             }
         }
+
+        // Provide the cancellation handle so the caller can terminate the
+        // process. The handle flips `cancelFlag` and calls `terminate()` on
+        // the process once it has been spawned.
+        progress.onCancellationReady?(UserTaskCancellation {
+            cancelFlag.cancel()
+        })
     }
 
     // MARK: - Private
@@ -134,7 +230,9 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
         workingDirectory: URL?,
         stdin: String,
         timeout: TimeInterval,
-        taskID: String
+        taskID: String,
+        cancelFlag: UserTaskCancellationFlag,
+        onStart: @escaping @Sendable () -> Void
     ) -> UserTaskOutcome {
         precondition(!Thread.isMainThread, "UserTaskRunner must run off the main thread")
 
@@ -162,13 +260,24 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
             )
         }
 
+        // Publish the process so user-initiated cancellation can terminate it
+        // (issue #1246). If the user cancelled between spawn and here, the
+        // flag terminates the process immediately.
+        cancelFlag.setProcess(process)
+
+        // Notify the caller that the process is now running so the UI can
+        // switch from the pending to the running state and start the timer.
+        onStart()
+
         // Write stdin and close.
         if !stdin.isEmpty {
             stdinPipe.fileHandleForWriting.write(stdin.data(using: .utf8) ?? Data())
         }
         stdinPipe.fileHandleForWriting.closeFile()
 
-        // Timeout via a timer source.
+        // Timeout via a timer source. The same terminate path is reused for
+        // user-initiated cancellation (issue #1246): `cancelFlag.cancel()`
+        // terminates the process and records that the exit was a cancel.
         let timedOutLock = NSLock()
         nonisolated(unsafe) var timedOutValue = false
         let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
@@ -210,5 +319,51 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
             exitCode: process.terminationStatus,
             timedOut: didTimeout
         )
+    }
+}
+
+/// Thread-safe handle coordinating user cancellation with the background
+/// `execute` path (issue #1246). Lives outside actor isolation because the
+/// process runs on `DispatchQueue.global` and the cancel handle may be
+/// invoked from the main actor.
+///
+/// The spawned `Process` is stored as a weak, locked reference so that
+/// `cancel()` can terminate it even if it is called before `execute` has
+/// finished wiring (the handle captures the flag; `execute` publishes the
+/// process into it once spawned).
+final class UserTaskCancellationFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+    private weak var process: Process?
+
+    /// Publishes the spawned process so `cancel()` can terminate it. Called
+    /// from `execute` on the background queue right after `process.run()`.
+    func setProcess(_ process: Process) {
+        lock.lock()
+        self.process = process
+        let shouldTerminate = cancelled
+        lock.unlock()
+        // If the user cancelled between spawn and publication, terminate now.
+        if shouldTerminate, process.isRunning {
+            process.terminate()
+        }
+    }
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        let alreadyCancelled = cancelled
+        cancelled = true
+        let proc = process
+        lock.unlock()
+        guard !alreadyCancelled else { return }
+        if let proc, proc.isRunning {
+            proc.terminate()
+        }
     }
 }

--- a/Pine/Extensibility/UserTaskRunner.swift
+++ b/Pine/Extensibility/UserTaskRunner.swift
@@ -31,6 +31,8 @@ nonisolated struct UserTaskOutcome: Sendable, Equatable {
     /// UTF-8 bytes retained by the UI history, calculated off the main actor
     /// for process outcomes so store trimming remains constant-time per run.
     let retainedOutputBytes: Int
+    /// Bounded rendering payload, prepared beside the outcome off-main.
+    let outputPreview: UserTaskOutputPreview
 
     init(
         taskID: String,
@@ -53,6 +55,10 @@ nonisolated struct UserTaskOutcome: Sendable, Equatable {
             retainedOutputBytes
                 ?? stdout.utf8.count + stderr.utf8.count,
             0
+        )
+        outputPreview = UserTaskOutputPreview.make(
+            stdout: stdout,
+            stderr: stderr
         )
     }
 

--- a/Pine/Extensibility/UserTaskRunner.swift
+++ b/Pine/Extensibility/UserTaskRunner.swift
@@ -205,9 +205,13 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
             } else {
                 let exitCode = outcome.exitCode
                 let timedOut = outcome.timedOut
+                let stderr = outcome.stderr
                 Logger.task.error(
-                    "Task '\(task.id, privacy: .public)' finished (exit \(exitCode), timedOut: \(timedOut), cancelled: \(didCancel)): \(outcome.stderr, privacy: .public)"
+                    "Task '\(task.id, privacy: .public)' exit \(exitCode), timedOut: \(timedOut), cancelled: \(didCancel)"
                 )
+                if !stderr.isEmpty {
+                    Logger.task.error("stderr: \(stderr, privacy: .public)")
+                }
             }
 
             DispatchQueue.main.async {

--- a/Pine/Extensibility/UserTaskRunner.swift
+++ b/Pine/Extensibility/UserTaskRunner.swift
@@ -110,9 +110,9 @@ nonisolated final class UserTaskCancellation: @unchecked Sendable {
 /// Progress callbacks for a running task (issue #1246).
 ///
 /// Each closure is invoked on the main thread so `@MainActor` UI models can
-/// be updated directly. All are optional; `onStart` fires when the process
-/// has been spawned, `onFinish` after bounded lifecycle cleanup, and
-/// `onCancellationReady` supplies the handle used by Cancel.
+/// be updated directly. All are optional; `onStart` fires after the process
+/// and its I/O workers are ready, `onFinish` after bounded lifecycle cleanup,
+/// and `onCancellationReady` supplies the handle used by Cancel.
 nonisolated struct UserTaskProgress: Sendable {
     let onStart: (@Sendable () -> Void)?
     let onFinish: (@Sendable (UserTaskOutcome, Bool) -> Void)?
@@ -129,6 +129,29 @@ nonisolated struct UserTaskProgress: Sendable {
         self.onFinish = onFinish
         self.onCancellationReady = onCancellationReady
     }
+}
+
+/// Schedules the blocking workers that own a task's stdin/stdout/stderr
+/// handles. The injectable implementation lets tests hold workers before
+/// their entry point without suspending a process-wide dispatch queue.
+nonisolated protocol UserTaskIOWorkerScheduling: Sendable {
+    func schedule(_ operation: @escaping @Sendable () -> Void)
+}
+
+nonisolated struct UserTaskDispatchIOWorkerScheduler:
+    UserTaskIOWorkerScheduling,
+    @unchecked Sendable {
+    let queue: DispatchQueue
+
+    func schedule(_ operation: @escaping @Sendable () -> Void) {
+        queue.async(execute: operation)
+    }
+}
+
+nonisolated struct UserTaskIOExecutionPolicy: Sendable {
+    let workerScheduler: any UserTaskIOWorkerScheduling
+    let startupDeadline: TimeInterval
+    let shutdownDeadline: TimeInterval
 }
 
 /// Runs `UserTask`s on a background queue.
@@ -149,6 +172,7 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
     private static let descendantSnapshotInterval: TimeInterval = 0.025
     private static let terminationReapDeadline: TimeInterval = 2.0
     private static let overallDeadlineLeeway: TimeInterval = 3.0
+    private static let ioStartupDeadline: TimeInterval = 2.0
     private static let ioShutdownDeadline: TimeInterval = 0.5
 
     /// Per-task timeout. Matches the formatter default; generous enough for
@@ -157,13 +181,27 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
     /// Injectable for deterministic spawn-failure coverage. Production always
     /// uses the system POSIX shell.
     private let shellExecutableURL: URL
+    private let ioExecutionPolicy: UserTaskIOExecutionPolicy
+    /// Internal lifecycle observation used by process-ownership tests. The
+    /// public progress contract deliberately does not expose process IDs.
+    private let processDidSpawn: (@Sendable (pid_t) -> Void)?
 
     init(
         timeout: TimeInterval = 30.0,
-        shellExecutableURL: URL = URL(fileURLWithPath: "/bin/sh")
+        shellExecutableURL: URL = URL(fileURLWithPath: "/bin/sh"),
+        ioExecutionPolicy: UserTaskIOExecutionPolicy? = nil,
+        processDidSpawn: (@Sendable (pid_t) -> Void)? = nil
     ) {
         self.timeout = timeout
         self.shellExecutableURL = shellExecutableURL
+        self.ioExecutionPolicy = ioExecutionPolicy ?? UserTaskIOExecutionPolicy(
+            workerScheduler: UserTaskDispatchIOWorkerScheduler(
+                queue: Self.processIOQueue
+            ),
+            startupDeadline: Self.ioStartupDeadline,
+            shutdownDeadline: Self.ioShutdownDeadline
+        )
+        self.processDidSpawn = processDidSpawn
     }
 
     /// Runs a task against the given file/project context.
@@ -275,7 +313,9 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
                     stdin: stdinText,
                     timeout: timeout,
                     taskID: task.id,
-                    executionState: executionState
+                    executionState: executionState,
+                    ioExecutionPolicy: self.ioExecutionPolicy,
+                    processDidSpawn: self.processDidSpawn
                 ),
                 onStart: {
                     DispatchQueue.main.async { progress.onStart?() }
@@ -319,6 +359,8 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
         let timeout: TimeInterval
         let taskID: String
         let executionState: UserTaskExecutionState
+        let ioExecutionPolicy: UserTaskIOExecutionPolicy
+        let processDidSpawn: (@Sendable (pid_t) -> Void)?
     }
 
     private struct ExecutionResult: Sendable {
@@ -383,7 +425,6 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
                 cancelled: config.executionState.closeWithoutProcess() == .cancelled
             )
         }
-
         let descendantTracker = UserTaskDescendantTracker(
             rootProcessID: subprocess.processGroup.identifier
         )
@@ -392,10 +433,7 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
         // shell and ordinary descendants. A pre-spawn cancellation is applied
         // immediately; observed group escapees are cleaned up below.
         config.executionState.publishProcessGroup(subprocess.processGroup)
-
-        // Notify the caller that the process is now running so the UI can
-        // switch from the pending to the running state and start the timer.
-        onStart()
+        config.processDidSpawn?(subprocess.processGroup.identifier)
 
         // Each pipe has one owning worker. Polling readers/writer observe the
         // shared stop state, so cleanup never closes a FileHandle underneath
@@ -404,8 +442,13 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
         let ioStopState = UserTaskIOStopState()
         let outputCapture = UserTaskOutputCapture()
         let inputCapture = UserTaskInputCapture()
+        let stdinData = config.stdin.data(using: .utf8) ?? Data()
+        let ioStartup = UserTaskIOStartupBarrier(
+            workerCount: stdinData.isEmpty ? 2 : 3
+        )
         ioGroup.enter()
-        processIOQueue.async {
+        config.ioExecutionPolicy.workerScheduler.schedule {
+            ioStartup.workerDidStart()
             defer { ioGroup.leave() }
             outputCapture.setStdout(
                 UserTaskPipeReader.read(
@@ -415,7 +458,8 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
             )
         }
         ioGroup.enter()
-        processIOQueue.async {
+        config.ioExecutionPolicy.workerScheduler.schedule {
+            ioStartup.workerDidStart()
             defer { ioGroup.leave() }
             outputCapture.setStderr(
                 UserTaskPipeReader.read(
@@ -425,13 +469,13 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
             )
         }
 
-        let stdinData = config.stdin.data(using: .utf8) ?? Data()
         if stdinData.isEmpty {
             subprocess.standardInput.closeFile()
             inputCapture.setResult(.complete)
         } else {
             ioGroup.enter()
-            processIOQueue.async {
+            config.ioExecutionPolicy.workerScheduler.schedule {
+                ioStartup.workerDidStart()
                 defer { ioGroup.leave() }
                 inputCapture.setResult(
                     UserTaskPipeWriter.write(
@@ -441,6 +485,20 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
                     )
                 )
             }
+        }
+
+        // A task is not "running" until every worker owns its descriptor.
+        // This also keeps Pine's own executor delay outside the task timeout.
+        // If scheduling never begins, fail closed and start bounded process
+        // cleanup instead of waiting indefinitely.
+        let ioWorkersStarted = ioStartup.wait(
+            timeout: config.ioExecutionPolicy.startupDeadline
+        )
+        if ioWorkersStarted {
+            onStart()
+        } else {
+            ioStopState.stop()
+            subprocess.processGroup.requestTermination()
         }
 
         // One polling loop owns both waitpid and the timeout decision. It
@@ -478,13 +536,16 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
         let terminatedTrackedDescendants =
             descendantTracker.terminateTrackedProcesses()
 
-        // Readers drain buffered bytes and then close their own descriptors.
-        // The timed wait is defensive; capture publication remains locked if
-        // a system call ever outlives the expected poll interval.
-        ioStopState.stop()
-        let ioFinished = ioGroup.wait(
-            timeout: .now() + ioShutdownDeadline
-        ) == .success
+        // Readers normally observe EOF and drain buffered bytes before their
+        // bounded stop fallback is requested. Under executor contention a
+        // worker may not start until after the shell exits; stopping first
+        // would incorrectly classify that clean run as incomplete.
+        let ioFinished = UserTaskIOShutdown.waitForCompletion(
+            ioGroup,
+            stopState: ioStopState,
+            naturalTimeout: config.ioExecutionPolicy.shutdownDeadline,
+            forcedTimeout: config.ioExecutionPolicy.shutdownDeadline
+        )
         let output = outputCapture.snapshot()
         let inputResult = inputCapture.snapshot()
         let streamsReachedEOF =
@@ -515,7 +576,7 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
                 Strings.userTaskDiagnosticSubprocessCleanup
             )
         }
-        if !ioFinished || !streamsReachedEOF {
+        if !ioWorkersStarted || !ioFinished || !streamsReachedEOF {
             diagnostics.append(
                 Strings.userTaskDiagnosticOutputDeadline
             )
@@ -545,6 +606,7 @@ nonisolated final class UserTaskRunner: @unchecked Sendable {
             directChild.reaped
             && terminatedProcessGroup
             && terminatedTrackedDescendants
+            && ioWorkersStarted
             && ioFinished
             && streamsReachedEOF
         let resultIsValid =

--- a/Pine/Extensibility/UserTaskSubprocess.swift
+++ b/Pine/Extensibility/UserTaskSubprocess.swift
@@ -384,6 +384,7 @@ nonisolated final class UserTaskProcessGroup: @unchecked Sendable {
     private let leader: UserTaskProcessIdentity?
     private var knownMembers: [pid_t: UserTaskProcessIdentity] = [:]
     private var terminationRequested = false
+    private var terminationFinished = false
     private var terminationSucceeded = true
 
     init(identifier: pid_t) {
@@ -455,12 +456,12 @@ nonisolated final class UserTaskProcessGroup: @unchecked Sendable {
         }
     }
 
-    func requestTermination() {
-        // Capture ordinary children before TERM can turn the direct shell into
-        // a zombie that another thread promptly reaps. This preserves an
-        // identity-qualified anchor for the later KILL fallback.
-        captureKnownMembers()
-
+    func requestTermination(
+        beforeMemberCapture: (@Sendable () -> Void)? = nil
+    ) {
+        // Publish the request and its pending completion atomically before
+        // process inspection. libproc can be slow under system load; a waiter
+        // must never mistake that inspection window for "not requested".
         let shouldStart = lock.withLock {
             guard !terminationRequested else { return false }
             terminationRequested = true
@@ -469,17 +470,22 @@ nonisolated final class UserTaskProcessGroup: @unchecked Sendable {
         }
         guard shouldStart else { return }
 
+        // Capture ordinary children before TERM can turn the direct shell into
+        // a zombie that another thread promptly reaps. This preserves an
+        // identity-qualified anchor for the later KILL fallback.
+        beforeMemberCapture?()
+        captureKnownMembers()
+
         // Deliver the first TERM synchronously. App termination may only have
         // a short shared deadline, so merely enqueueing the first signal would
         // leave a queued task with no cleanup request at all.
-        let initialSignalSucceeded = signalIdentitySafeGroup(SIGTERM)
+        _ = signalIdentitySafeGroup(SIGTERM)
 
         Self.lifecycleQueue.async {
-            let succeeded = self.finishTermination(
-                initialSignalSucceeded: initialSignalSucceeded
-            )
+            let succeeded = self.finishTermination()
             self.lock.withLock {
                 self.terminationSucceeded = succeeded
+                self.terminationFinished = true
             }
             self.terminationCompletion.leave()
         }
@@ -488,19 +494,39 @@ nonisolated final class UserTaskProcessGroup: @unchecked Sendable {
     /// Waits only when termination was requested, returning whether the whole
     /// process group disappeared within the bounded TERM-to-KILL sequence.
     func waitForRequestedTermination() -> Bool {
-        let requested = lock.withLock { terminationRequested }
-        guard requested else { return true }
+        waitForRequestedTermination(
+            completionTimeout: Self.completionWaitPeriod
+        )
+    }
+
+    func waitForRequestedTermination(
+        completionTimeout: TimeInterval
+    ) -> Bool {
+        let state = lock.withLock {
+            (
+                requested: terminationRequested,
+                finished: terminationFinished,
+                succeeded: terminationSucceeded
+            )
+        }
+        guard state.requested else { return true }
+        if state.finished {
+            return state.succeeded
+        }
+        // The direct shell may have exited and been reaped before the
+        // asynchronous lifecycle continuation gets scheduled. In that case
+        // there is no process group left to clean up, so queue contention
+        // must not turn successful termination into a false diagnostic.
+        guard Self.isProcessGroupAlive(identifier) else { return true }
         guard terminationCompletion.wait(
-            timeout: .now() + Self.completionWaitPeriod
+            timeout: .now() + max(completionTimeout, 0)
         ) == .success else {
-            return false
+            return !Self.isProcessGroupAlive(identifier)
         }
         return lock.withLock { terminationSucceeded }
     }
 
-    private func finishTermination(
-        initialSignalSucceeded: Bool
-    ) -> Bool {
+    private func finishTermination() -> Bool {
         if Self.isProcessGroupAlive(identifier) {
             Self.waitUntilGone(
                 identifier,
@@ -508,19 +534,19 @@ nonisolated final class UserTaskProcessGroup: @unchecked Sendable {
             )
         }
 
-        var signallingSucceeded = initialSignalSucceeded
         if Self.isProcessGroupAlive(identifier) {
             captureKnownMembers()
-            signallingSucceeded =
-                signalIdentitySafeGroup(SIGKILL) && signallingSucceeded
+            _ = signalIdentitySafeGroup(SIGKILL)
             Self.waitUntilGone(
                 identifier,
                 timeout: Self.killWaitPeriod
             )
         }
 
-        let succeeded =
-            signallingSucceeded && !Self.isProcessGroupAlive(identifier)
+        // Disappearance is the cleanup contract. A signal syscall can race a
+        // natural exit and report a transient failure even though there is no
+        // process left to clean up.
+        let succeeded = !Self.isProcessGroupAlive(identifier)
         if !succeeded {
             Logger.task.error(
                 "Task process group \(self.identifier) survived SIGKILL"
@@ -905,6 +931,54 @@ nonisolated final class UserTaskIOStopState: @unchecked Sendable {
         lock.withLock {
             stopped = true
         }
+    }
+}
+
+/// Tracks entry into every descriptor-owning worker. Waiting happens only on
+/// the runner's background execution thread; worker entry itself is a single
+/// non-blocking `leave`.
+nonisolated final class UserTaskIOStartupBarrier: @unchecked Sendable {
+    private let group = DispatchGroup()
+
+    init(workerCount: Int) {
+        precondition(workerCount >= 0)
+        for _ in 0..<workerCount {
+            group.enter()
+        }
+    }
+
+    func workerDidStart() {
+        group.leave()
+    }
+
+    func wait(timeout: TimeInterval) -> Bool {
+        group.wait(
+            timeout: .now() + max(timeout, 0)
+        ) == .success
+    }
+}
+
+/// Gives pipe workers a chance to observe EOF before requesting their bounded
+/// fallback shutdown. Stopping first can make a worker that was merely waiting
+/// for an executor thread report an incomplete stream even though the child
+/// and every observed descendant have already exited.
+nonisolated enum UserTaskIOShutdown {
+    static func waitForCompletion(
+        _ group: DispatchGroup,
+        stopState: UserTaskIOStopState,
+        naturalTimeout: TimeInterval,
+        forcedTimeout: TimeInterval
+    ) -> Bool {
+        if group.wait(
+            timeout: .now() + max(naturalTimeout, 0)
+        ) == .success {
+            return true
+        }
+
+        stopState.stop()
+        return group.wait(
+            timeout: .now() + max(forcedTimeout, 0)
+        ) == .success
     }
 }
 

--- a/Pine/Extensibility/UserTaskSubprocess.swift
+++ b/Pine/Extensibility/UserTaskSubprocess.swift
@@ -1,0 +1,1157 @@
+//
+//  UserTaskSubprocess.swift
+//  Pine
+//
+//  POSIX process-group wrapper for user tasks. A dedicated process group lets
+//  cancellation and timeout terminate the shell together with ordinary
+//  descendants, while waitpid always reaps Pine's direct child. Descendants
+//  that setsid/double-fork between identity snapshots are a documented
+//  best-effort case; no public Darwin API provides an atomic process-tree kill.
+//
+
+import Darwin
+import Foundation
+import os
+
+nonisolated final class UserTaskSubprocess: @unchecked Sendable {
+    private static let reaperQueue = DispatchQueue(
+        label: "com.pine.user-task-reaper",
+        qos: .utility,
+        attributes: .concurrent
+    )
+
+    let processGroup: UserTaskProcessGroup
+    let standardInput: FileHandle
+    let standardOutput: FileHandle
+    let standardError: FileHandle
+
+    private let processID: pid_t
+
+    init(
+        executableURL: URL,
+        command: String,
+        workingDirectory: URL?
+    ) throws {
+        let pipes = SpawnPipes(
+            stdin: Pipe(),
+            stdout: Pipe(),
+            stderr: Pipe()
+        )
+        var childProcessID: pid_t = 0
+
+        do {
+            try Self.markAllCloseOnExec(pipes)
+            try Self.spawn(
+                processID: &childProcessID,
+                executableURL: executableURL,
+                command: command,
+                workingDirectory: workingDirectory,
+                pipes: pipes
+            )
+        } catch {
+            Self.closeAll(pipes)
+            throw error
+        }
+
+        pipes.stdin.fileHandleForReading.closeFile()
+        pipes.stdout.fileHandleForWriting.closeFile()
+        pipes.stderr.fileHandleForWriting.closeFile()
+
+        processID = childProcessID
+        processGroup = UserTaskProcessGroup(identifier: childProcessID)
+        standardInput = pipes.stdin.fileHandleForWriting
+        standardOutput = pipes.stdout.fileHandleForReading
+        standardError = pipes.stderr.fileHandleForReading
+    }
+
+    /// Waits for and reaps Pine's direct shell child.
+    ///
+    /// Signal exits use the signal number, matching Foundation `Process`'s
+    /// `terminationStatus` convention.
+    func waitForExit() -> Int32 {
+        var status: Int32 = 0
+        var result: pid_t
+        repeat {
+            result = Darwin.waitpid(processID, &status, 0)
+        } while result == -1 && errno == EINTR
+
+        guard result == processID else { return -1 }
+        return Self.exitCode(from: status)
+    }
+
+    /// Non-blocking wait used by the runner's bounded lifecycle loop.
+    ///
+    /// `waitid(..., WNOWAIT)` observes a completed child without reaping it.
+    /// The caller can therefore take one final process-tree snapshot while the
+    /// unreaped PID still reserves its original process-group identifier. Only
+    /// after that snapshot do we call `waitpid` to collect the exit status.
+    func pollExit(
+        beforeReaping: () -> Void = {}
+    ) -> UserTaskProcessExitPoll {
+        var info = siginfo_t()
+        var observationResult: Int32
+        repeat {
+            observationResult = Darwin.waitid(
+                P_PID,
+                id_t(processID),
+                &info,
+                WEXITED | WNOHANG | WNOWAIT
+            )
+        } while observationResult == -1 && errno == EINTR
+
+        if observationResult == -1 {
+            return .waitFailed(errno)
+        }
+        guard info.si_pid != 0 else {
+            return .running
+        }
+
+        processGroup.captureKnownMembersBeforeReaping()
+        beforeReaping()
+
+        var status: Int32 = 0
+        var result: pid_t
+        repeat {
+            result = Darwin.waitpid(processID, &status, WNOHANG)
+        } while result == -1 && errno == EINTR
+
+        if result == processID {
+            return .exited(Self.exitCode(from: status))
+        }
+        if result == 0 {
+            return .running
+        }
+        return .waitFailed(errno)
+    }
+
+    /// Transfers a still-running direct child to a dedicated blocking reaper
+    /// after the runner's hard lifecycle deadline. No other waiter may touch
+    /// this pid after handoff.
+    func reapInBackground() {
+        let processID = self.processID
+        Self.reaperQueue.async {
+            var status: Int32 = 0
+            var result: pid_t
+            repeat {
+                result = Darwin.waitpid(processID, &status, 0)
+            } while result == -1 && errno == EINTR
+
+            if result == -1, errno != ECHILD {
+                Logger.task.error(
+                    "Background task reaper failed for pid \(processID): errno \(errno)"
+                )
+            }
+        }
+    }
+
+    private static func spawn(
+        processID: inout pid_t,
+        executableURL: URL,
+        command: String,
+        workingDirectory: URL?,
+        pipes: SpawnPipes
+    ) throws {
+        var fileActions: posix_spawn_file_actions_t?
+        try check(posix_spawn_file_actions_init(&fileActions))
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+
+        let stdinRead = pipes.stdin.fileHandleForReading.fileDescriptor
+        let stdinWrite = pipes.stdin.fileHandleForWriting.fileDescriptor
+        let stdoutRead = pipes.stdout.fileHandleForReading.fileDescriptor
+        let stdoutWrite = pipes.stdout.fileHandleForWriting.fileDescriptor
+        let stderrRead = pipes.stderr.fileHandleForReading.fileDescriptor
+        let stderrWrite = pipes.stderr.fileHandleForWriting.fileDescriptor
+
+        try check(posix_spawn_file_actions_adddup2(
+            &fileActions,
+            stdinRead,
+            STDIN_FILENO
+        ))
+        try check(posix_spawn_file_actions_adddup2(
+            &fileActions,
+            stdoutWrite,
+            STDOUT_FILENO
+        ))
+        try check(posix_spawn_file_actions_adddup2(
+            &fileActions,
+            stderrWrite,
+            STDERR_FILENO
+        ))
+
+        for descriptor in [
+            stdinRead,
+            stdinWrite,
+            stdoutRead,
+            stdoutWrite,
+            stderrRead,
+            stderrWrite,
+        ] where descriptor > STDERR_FILENO {
+            try check(posix_spawn_file_actions_addclose(
+                &fileActions,
+                descriptor
+            ))
+        }
+
+        if let workingDirectory {
+            try workingDirectory.path.withCString { path in
+                try check(posix_spawn_file_actions_addchdir(
+                    &fileActions,
+                    path
+                ))
+            }
+        }
+
+        var attributes: posix_spawnattr_t?
+        try check(posix_spawnattr_init(&attributes))
+        defer { posix_spawnattr_destroy(&attributes) }
+        try check(posix_spawnattr_setpgroup(&attributes, 0))
+
+        // Pine may have ignored or blocked signals on another subsystem's
+        // thread. The child starts with an empty mask and shell-appropriate
+        // defaults instead of inheriting that ambient process state.
+        var emptySignalMask = sigset_t()
+        try checkErrno(sigemptyset(&emptySignalMask))
+        try check(posix_spawnattr_setsigmask(
+            &attributes,
+            &emptySignalMask
+        ))
+        var defaultSignals = sigset_t()
+        try checkErrno(sigemptyset(&defaultSignals))
+        for signalValue in [
+            SIGHUP,
+            SIGINT,
+            SIGQUIT,
+            SIGPIPE,
+            SIGTERM,
+            SIGCHLD,
+        ] {
+            try checkErrno(sigaddset(&defaultSignals, signalValue))
+        }
+        try check(posix_spawnattr_setsigdefault(
+            &attributes,
+            &defaultSignals
+        ))
+
+        // CLOEXEC_DEFAULT closes every ambient Pine descriptor in the child.
+        // The three dup2 actions above are the complete inheritance allowlist:
+        // stdin, stdout, and stderr only.
+        let spawnFlags =
+            Int16(POSIX_SPAWN_SETPGROUP)
+            | Int16(POSIX_SPAWN_CLOEXEC_DEFAULT)
+            | Int16(POSIX_SPAWN_SETSIGMASK)
+            | Int16(POSIX_SPAWN_SETSIGDEF)
+        try check(posix_spawnattr_setflags(
+            &attributes,
+            spawnFlags
+        ))
+
+        let executablePath = executableURL.path
+        let arguments = [executablePath, "-c", command]
+        var argumentPointers: [UnsafeMutablePointer<CChar>?] = []
+        defer {
+            for pointer in argumentPointers {
+                free(pointer)
+            }
+        }
+        for argument in arguments {
+            guard let pointer = strdup(argument) else {
+                throw posixError(ENOMEM)
+            }
+            argumentPointers.append(pointer)
+        }
+        argumentPointers.append(nil)
+
+        let environment = ProcessInfo.processInfo.environment
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+        var environmentPointers: [UnsafeMutablePointer<CChar>?] = []
+        defer {
+            for pointer in environmentPointers {
+                free(pointer)
+            }
+        }
+        for entry in environment {
+            guard let pointer = strdup(entry) else {
+                throw posixError(ENOMEM)
+            }
+            environmentPointers.append(pointer)
+        }
+        environmentPointers.append(nil)
+
+        let spawnResult = argumentPointers.withUnsafeMutableBufferPointer { buffer in
+            environmentPointers.withUnsafeMutableBufferPointer { environmentBuffer in
+                executablePath.withCString { executablePathPointer in
+                    posix_spawn(
+                        &processID,
+                        executablePathPointer,
+                        &fileActions,
+                        &attributes,
+                        buffer.baseAddress,
+                        environmentBuffer.baseAddress
+                    )
+                }
+            }
+        }
+        try check(spawnResult)
+    }
+
+    private static func check(_ result: Int32) throws {
+        guard result == 0 else { throw posixError(result) }
+    }
+
+    private static func checkErrno(_ result: Int32) throws {
+        guard result == 0 else { throw posixError(errno) }
+    }
+
+    private static func markAllCloseOnExec(_ pipes: SpawnPipes) throws {
+        for descriptor in [
+            pipes.stdin.fileHandleForReading.fileDescriptor,
+            pipes.stdin.fileHandleForWriting.fileDescriptor,
+            pipes.stdout.fileHandleForReading.fileDescriptor,
+            pipes.stdout.fileHandleForWriting.fileDescriptor,
+            pipes.stderr.fileHandleForReading.fileDescriptor,
+            pipes.stderr.fileHandleForWriting.fileDescriptor,
+        ] {
+            let flags = Darwin.fcntl(descriptor, F_GETFD)
+            guard flags != -1 else { throw posixError(errno) }
+            guard Darwin.fcntl(
+                descriptor,
+                F_SETFD,
+                flags | FD_CLOEXEC
+            ) != -1 else {
+                throw posixError(errno)
+            }
+        }
+    }
+
+    private static func exitCode(from status: Int32) -> Int32 {
+        let terminatingSignal = status & 0x7f
+        if terminatingSignal == 0 {
+            return (status >> 8) & 0xff
+        }
+        return terminatingSignal
+    }
+
+    private static func posixError(_ code: Int32) -> NSError {
+        NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(code),
+            userInfo: nil
+        )
+    }
+
+    private static func closeAll(_ pipes: SpawnPipes) {
+        pipes.stdin.fileHandleForReading.closeFile()
+        pipes.stdin.fileHandleForWriting.closeFile()
+        pipes.stdout.fileHandleForReading.closeFile()
+        pipes.stdout.fileHandleForWriting.closeFile()
+        pipes.stderr.fileHandleForReading.closeFile()
+        pipes.stderr.fileHandleForWriting.closeFile()
+    }
+
+    private struct SpawnPipes {
+        let stdin: Pipe
+        let stdout: Pipe
+        let stderr: Pipe
+    }
+}
+
+nonisolated enum UserTaskProcessExitPoll: Sendable, Equatable {
+    case running
+    case exited(Int32)
+    case waitFailed(Int32)
+}
+
+/// Owns termination of one isolated POSIX process group.
+///
+/// TERM is followed by a bounded KILL fallback. The completion group lets the
+/// runner wait until cleanup finishes before it reports the task as complete.
+nonisolated final class UserTaskProcessGroup: @unchecked Sendable {
+    private static let lifecycleQueue = DispatchQueue(
+        label: "com.pine.user-task-process-group",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+    private static let termGracePeriod: TimeInterval = 0.25
+    private static let killWaitPeriod: TimeInterval = 1.0
+    private static let completionWaitPeriod: TimeInterval = 1.5
+    private static let pollIntervalMicroseconds: useconds_t = 10_000
+
+    let identifier: pid_t
+
+    private let lock = NSLock()
+    private let terminationCompletion = DispatchGroup()
+    private let leader: UserTaskProcessIdentity?
+    private var knownMembers: [pid_t: UserTaskProcessIdentity] = [:]
+    private var terminationRequested = false
+    private var terminationSucceeded = true
+
+    init(identifier: pid_t) {
+        precondition(identifier > 1)
+        self.identifier = identifier
+        leader = UserTaskProcessInspector.identity(for: identifier)
+        if let leader {
+            knownMembers[leader.processID] = leader
+        }
+        captureKnownMembers()
+    }
+
+    var isAlive: Bool {
+        Self.isProcessGroupAlive(identifier)
+    }
+
+    var terminationWasRequested: Bool {
+        lock.withLock { terminationRequested }
+    }
+
+    /// Records identity-qualified members while at least one previously known
+    /// process still anchors this group. This prevents a reused pgid from
+    /// becoming a new signalling target after Pine's original group exits.
+    func captureKnownMembers() {
+        captureKnownMembers(unreapedLeaderWasObserved: false)
+    }
+
+    /// Records the last group snapshot after `waitid(..., WNOWAIT)` has
+    /// observed the direct shell's exit but before `waitpid` reaps it.
+    ///
+    /// Darwin can reject `getpgid` for a zombie, so the usual live-anchor
+    /// check is not sufficient here. The still-unreaped pid cannot yet be
+    /// reused, which makes its original pgid a safe one-shot enumeration
+    /// anchor for retaining live background-member identities.
+    fileprivate func captureKnownMembersBeforeReaping() {
+        captureKnownMembers(unreapedLeaderWasObserved: true)
+    }
+
+    private func captureKnownMembers(
+        unreapedLeaderWasObserved: Bool
+    ) {
+        let anchors = lock.withLock {
+            Array(knownMembers.values)
+        }
+        let hasLiveAnchor =
+            unreapedLeaderWasObserved
+            || (leader.map { Self.isCurrentGroupMember($0, group: identifier) } ?? false)
+            || anchors.contains {
+                Self.isCurrentGroupMember($0, group: identifier)
+            }
+        guard hasLiveAnchor,
+              case .known(let processIDs) =
+                UserTaskProcessInspector.processIDs(inGroup: identifier) else {
+            return
+        }
+
+        let identities: [UserTaskProcessIdentity] =
+            processIDs.compactMap { processID in
+            guard Darwin.getpgid(processID) == identifier else { return nil }
+            return UserTaskProcessInspector.identity(for: processID)
+        }
+        lock.withLock {
+            for identity in identities {
+                knownMembers[identity.processID] = identity
+            }
+            knownMembers = knownMembers.filter {
+                UserTaskProcessInspector.identity(for: $0.key) == $0.value
+            }
+        }
+    }
+
+    func requestTermination() {
+        // Capture ordinary children before TERM can turn the direct shell into
+        // a zombie that another thread promptly reaps. This preserves an
+        // identity-qualified anchor for the later KILL fallback.
+        captureKnownMembers()
+
+        let shouldStart = lock.withLock {
+            guard !terminationRequested else { return false }
+            terminationRequested = true
+            terminationCompletion.enter()
+            return true
+        }
+        guard shouldStart else { return }
+
+        // Deliver the first TERM synchronously. App termination may only have
+        // a short shared deadline, so merely enqueueing the first signal would
+        // leave a queued task with no cleanup request at all.
+        let initialSignalSucceeded = signalIdentitySafeGroup(SIGTERM)
+
+        Self.lifecycleQueue.async {
+            let succeeded = self.finishTermination(
+                initialSignalSucceeded: initialSignalSucceeded
+            )
+            self.lock.withLock {
+                self.terminationSucceeded = succeeded
+            }
+            self.terminationCompletion.leave()
+        }
+    }
+
+    /// Waits only when termination was requested, returning whether the whole
+    /// process group disappeared within the bounded TERM-to-KILL sequence.
+    func waitForRequestedTermination() -> Bool {
+        let requested = lock.withLock { terminationRequested }
+        guard requested else { return true }
+        guard terminationCompletion.wait(
+            timeout: .now() + Self.completionWaitPeriod
+        ) == .success else {
+            return false
+        }
+        return lock.withLock { terminationSucceeded }
+    }
+
+    private func finishTermination(
+        initialSignalSucceeded: Bool
+    ) -> Bool {
+        if Self.isProcessGroupAlive(identifier) {
+            Self.waitUntilGone(
+                identifier,
+                timeout: Self.termGracePeriod
+            )
+        }
+
+        var signallingSucceeded = initialSignalSucceeded
+        if Self.isProcessGroupAlive(identifier) {
+            captureKnownMembers()
+            signallingSucceeded =
+                signalIdentitySafeGroup(SIGKILL) && signallingSucceeded
+            Self.waitUntilGone(
+                identifier,
+                timeout: Self.killWaitPeriod
+            )
+        }
+
+        let succeeded =
+            signallingSucceeded && !Self.isProcessGroupAlive(identifier)
+        if !succeeded {
+            Logger.task.error(
+                "Task process group \(self.identifier) survived SIGKILL"
+            )
+        }
+        return succeeded
+    }
+
+    /// Signals the negative pgid only while a current identity proves it is
+    /// still Pine's original group. When inspection is unknown, signal known
+    /// identities individually rather than risking an unrelated reused pgid.
+    private func signalIdentitySafeGroup(_ signalValue: Int32) -> Bool {
+        let identities = lock.withLock { Array(knownMembers.values) }
+        let hasCurrentAnchor = identities.contains {
+            Self.isCurrentGroupMember($0, group: identifier)
+        }
+        guard hasCurrentAnchor else {
+            return signalKnownMembers(signalValue, identities: identities)
+        }
+
+        if Darwin.kill(-identifier, signalValue) == 0 || errno == ESRCH {
+            return true
+        }
+        Logger.task.error(
+            "Failed to signal task process group \(self.identifier): errno \(errno)"
+        )
+        return false
+    }
+
+    private func signalKnownMembers(
+        _ signalValue: Int32,
+        identities: [UserTaskProcessIdentity]
+    ) -> Bool {
+        var succeeded = true
+        for identity in identities
+        where UserTaskProcessInspector.identity(for: identity.processID) == identity {
+            if Darwin.kill(identity.processID, signalValue) != 0,
+               errno != ESRCH {
+                succeeded = false
+                Logger.task.error(
+                    "Failed to signal known task process \(identity.processID): errno \(errno)"
+                )
+            }
+        }
+        return succeeded
+    }
+
+    private static func waitUntilGone(
+        _ identifier: pid_t,
+        timeout: TimeInterval
+    ) {
+        let deadline = DispatchTime.now() + timeout
+        while isProcessGroupAlive(identifier), DispatchTime.now() < deadline {
+            Darwin.usleep(pollIntervalMicroseconds)
+        }
+    }
+
+    private static func isProcessGroupAlive(_ identifier: pid_t) -> Bool {
+        if let inspected = inspectedProcessGroupLiveness(identifier) {
+            return inspected
+        }
+        if Darwin.kill(-identifier, 0) == 0 {
+            return true
+        }
+        return errno != ESRCH
+    }
+
+    /// `kill(-pgid, 0)` can report a group containing only zombies as alive.
+    /// Prefer libproc status when available so already-dead descendants do not
+    /// turn bounded cleanup into a false failure.
+    private static func inspectedProcessGroupLiveness(
+        _ identifier: pid_t
+    ) -> Bool? {
+        guard case .known(let processIDs) =
+                UserTaskProcessInspector.processIDs(inGroup: identifier) else {
+            return nil
+        }
+
+        var encounteredUnknownProcess = false
+        for processID in processIDs where processID > 1 {
+            var info = proc_bsdinfo()
+            let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.size)
+            let result = proc_pidinfo(
+                processID,
+                PROC_PIDTBSDINFO,
+                0,
+                &info,
+                expectedSize
+            )
+            if result == expectedSize {
+                if info.pbi_status != UInt32(SZOMB) {
+                    return true
+                }
+            } else if Darwin.kill(processID, 0) == 0 || errno != ESRCH {
+                encounteredUnknownProcess = true
+            }
+        }
+        return encounteredUnknownProcess ? nil : false
+    }
+
+    private static func isCurrentGroupMember(
+        _ identity: UserTaskProcessIdentity,
+        group: pid_t
+    ) -> Bool {
+        guard UserTaskProcessInspector.identity(
+            for: identity.processID,
+            includeZombie: true
+        ) == identity,
+              Darwin.getpgid(identity.processID) == group else {
+            return false
+        }
+        return UserTaskProcessInspector.identity(
+            for: identity.processID,
+            includeZombie: true
+        ) == identity
+    }
+}
+
+/// Best-effort tracker for descendants that leave the shell's process group.
+///
+/// Darwin does not provide a public "kill process tree" primitive. The runner
+/// therefore combines process-group ownership with bounded libproc snapshots.
+/// Start timestamps protect against signalling an unrelated process after PID
+/// reuse. A descendant that daemonizes between snapshots can still escape, so
+/// callers must also bound pipe draining and direct-child waiting.
+nonisolated final class UserTaskDescendantTracker {
+    private static let maximumTrackedProcesses = 1_024
+    private static let termGracePeriod: TimeInterval = 0.25
+    private static let killWaitPeriod: TimeInterval = 1.0
+    private static let pollIntervalMicroseconds: useconds_t = 10_000
+
+    private let root: UserTaskProcessIdentity?
+    private var descendants: [pid_t: UserTaskProcessIdentity] = [:]
+
+    init(rootProcessID: pid_t) {
+        root = Self.identity(for: rootProcessID)
+        captureDescendants()
+    }
+
+    /// Records the currently visible process tree rooted at the shell and at
+    /// every previously observed descendant.
+    func captureDescendants() {
+        let stillLive = liveDescendants()
+        descendants = Dictionary(
+            uniqueKeysWithValues: stillLive.map {
+                ($0.processID, $0)
+            }
+        )
+
+        var pending: [UserTaskProcessIdentity] = []
+        if let root, Self.identity(for: root.processID) == root {
+            pending.append(root)
+        }
+        pending.append(contentsOf: stillLive)
+
+        var visited: Set<UserTaskProcessIdentity> = []
+        while let parent = pending.popLast(),
+              descendants.count < Self.maximumTrackedProcesses {
+            guard visited.insert(parent).inserted else { continue }
+            for childProcessID in Self.childProcessIDs(of: parent.processID) {
+                guard descendants.count < Self.maximumTrackedProcesses,
+                      let child = UserTaskProcessInspector.identity(
+                          for: childProcessID,
+                          expectedParent: parent.processID
+                      ) else {
+                    continue
+                }
+                descendants[childProcessID] = child
+                pending.append(child)
+            }
+        }
+    }
+
+    /// Applies TERM then KILL to every observed descendant, including members
+    /// that changed process groups. Returns false when a known identity
+    /// survives the bounded cleanup window.
+    func terminateTrackedProcesses() -> Bool {
+        captureDescendants()
+        signalLiveDescendants(SIGTERM)
+        waitUntilGone(
+            timeout: Self.termGracePeriod,
+            repeatingSignal: SIGTERM
+        )
+
+        if !liveDescendants().isEmpty {
+            signalLiveDescendants(SIGKILL)
+            waitUntilGone(
+                timeout: Self.killWaitPeriod,
+                repeatingSignal: SIGKILL
+            )
+        }
+
+        let succeeded = liveDescendants().isEmpty
+        if !succeeded {
+            Logger.task.error(
+                "One or more observed task descendants survived SIGKILL"
+            )
+        }
+        return succeeded
+    }
+
+    private func waitUntilGone(
+        timeout: TimeInterval,
+        repeatingSignal signalValue: Int32
+    ) {
+        let deadline = DispatchTime.now() + timeout
+        while DispatchTime.now() < deadline {
+            captureDescendants()
+            let live = liveDescendants()
+            guard !live.isEmpty else { return }
+            send(signalValue, to: live)
+            Darwin.usleep(Self.pollIntervalMicroseconds)
+        }
+    }
+
+    private func signalLiveDescendants(_ signalValue: Int32) {
+        send(signalValue, to: liveDescendants())
+    }
+
+    private func send(
+        _ signalValue: Int32,
+        to identities: [UserTaskProcessIdentity]
+    ) {
+        for identity in identities
+        where Self.identity(for: identity.processID) == identity {
+            if Darwin.kill(identity.processID, signalValue) != 0,
+               errno != ESRCH {
+                Logger.task.error(
+                    "Failed to signal task descendant \(identity.processID): errno \(errno)"
+                )
+            }
+        }
+    }
+
+    private func liveDescendants() -> [UserTaskProcessIdentity] {
+        descendants.values.filter {
+            Self.identity(for: $0.processID) == $0
+        }
+    }
+
+    private static func childProcessIDs(of parent: pid_t) -> [pid_t] {
+        errno = 0
+        let requestedCount = proc_listchildpids(parent, nil, 0)
+        guard requestedCount > 0 else { return [] }
+        let capacity = min(
+            max(Int(requestedCount) + 16, 16),
+            maximumTrackedProcesses
+        )
+        var processIDs = [pid_t](repeating: 0, count: capacity)
+        errno = 0
+        let returnedCount = processIDs.withUnsafeMutableBytes { buffer in
+            proc_listchildpids(
+                parent,
+                buffer.baseAddress,
+                Int32(buffer.count)
+            )
+        }
+        guard returnedCount > 0,
+              Int(returnedCount) < processIDs.count else {
+            return []
+        }
+        return Array(
+            processIDs
+                .prefix(Int(returnedCount))
+                .filter { $0 > 1 }
+        )
+    }
+
+    private static func identity(
+        for processID: pid_t
+    ) -> UserTaskProcessIdentity? {
+        UserTaskProcessInspector.identity(for: processID)
+    }
+}
+
+nonisolated struct UserTaskProcessIdentity: Hashable, Sendable {
+    let processID: pid_t
+    let startSeconds: UInt64
+    let startMicroseconds: UInt64
+}
+
+nonisolated enum UserTaskProcessGroupSnapshot: Sendable {
+    case known([pid_t])
+    /// libproc reports errors and an empty result with the same sentinel on
+    /// some macOS releases. A full buffer is also unknowable because members
+    /// may have been omitted. Callers must use a conservative fallback.
+    case unknown
+}
+
+nonisolated enum UserTaskProcessInspector {
+    private static let maximumGroupMembers = 1_024
+
+    static func identity(
+        for processID: pid_t,
+        includeZombie: Bool = false,
+        expectedParent: pid_t? = nil
+    ) -> UserTaskProcessIdentity? {
+        guard processID > 1 else { return nil }
+        var info = proc_bsdinfo()
+        let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.size)
+        let result = proc_pidinfo(
+            processID,
+            PROC_PIDTBSDINFO,
+            0,
+            &info,
+            expectedSize
+        )
+        guard result == expectedSize,
+              info.pbi_pid == UInt32(processID),
+              includeZombie || info.pbi_status != UInt32(SZOMB) else {
+            return nil
+        }
+        if let expectedParent,
+           info.pbi_ppid != UInt32(expectedParent) {
+            return nil
+        }
+        return UserTaskProcessIdentity(
+            processID: processID,
+            startSeconds: info.pbi_start_tvsec,
+            startMicroseconds: info.pbi_start_tvusec
+        )
+    }
+
+    static func processIDs(
+        inGroup identifier: pid_t
+    ) -> UserTaskProcessGroupSnapshot {
+        errno = 0
+        let requestedCount = proc_listpgrppids(identifier, nil, 0)
+        guard requestedCount > 0 else { return .unknown }
+        let capacity = min(
+            max(Int(requestedCount) + 16, 16),
+            maximumGroupMembers
+        )
+
+        var processIDs = [pid_t](repeating: 0, count: capacity)
+        errno = 0
+        let returnedCount = processIDs.withUnsafeMutableBytes { buffer in
+            proc_listpgrppids(
+                identifier,
+                buffer.baseAddress,
+                Int32(buffer.count)
+            )
+        }
+        guard groupCountsAreComplete(
+            requestedCount: requestedCount,
+            returnedCount: returnedCount,
+            capacity: processIDs.count
+        ) else {
+            return .unknown
+        }
+        return .known(
+            Array(
+                processIDs
+                    .prefix(Int(returnedCount))
+                    .filter { $0 > 1 }
+            )
+        )
+    }
+
+    static func groupCountsAreComplete(
+        requestedCount: Int32,
+        returnedCount: Int32,
+        capacity: Int
+    ) -> Bool {
+        requestedCount > 0
+            && returnedCount > 0
+            && Int(returnedCount) < capacity
+    }
+}
+
+/// Coordinates bounded output-reader shutdown without closing a FileHandle
+/// from a thread other than the one currently polling and reading it.
+nonisolated final class UserTaskIOStopState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stopped = false
+
+    var shouldStop: Bool {
+        lock.withLock { stopped }
+    }
+
+    func stop() {
+        lock.withLock {
+            stopped = true
+        }
+    }
+}
+
+nonisolated struct UserTaskPipeReadResult: Sendable {
+    let data: Data
+    let reachedEndOfFile: Bool
+    let truncated: Bool
+
+    static let incomplete = UserTaskPipeReadResult(
+        data: Data(),
+        reachedEndOfFile: false,
+        truncated: false
+    )
+}
+
+nonisolated struct UserTaskOutputSnapshot: Sendable {
+    let stdout: UserTaskPipeReadResult
+    let stderr: UserTaskPipeReadResult
+}
+
+/// Locked publication point for reader-local buffers. If a defensive reader
+/// deadline is ever hit, the runner can snapshot safely while that reader
+/// still owns its FileHandle.
+nonisolated final class UserTaskOutputCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stdoutResult: UserTaskPipeReadResult?
+    private var stderrResult: UserTaskPipeReadResult?
+
+    func setStdout(_ result: UserTaskPipeReadResult) {
+        lock.withLock {
+            stdoutResult = result
+        }
+    }
+
+    func setStderr(_ result: UserTaskPipeReadResult) {
+        lock.withLock {
+            stderrResult = result
+        }
+    }
+
+    func snapshot() -> UserTaskOutputSnapshot {
+        lock.withLock {
+            UserTaskOutputSnapshot(
+                stdout: stdoutResult ?? .incomplete,
+                stderr: stderrResult ?? .incomplete
+            )
+        }
+    }
+}
+
+nonisolated enum UserTaskPipeReader {
+    /// Bounds retained memory while continuing to drain excess bytes so a
+    /// verbose child cannot deadlock on a full pipe.
+    static let maximumCapturedBytes = 4 * 1_024 * 1_024
+
+    private static let bufferSize = 64 * 1_024
+    private static let pollIntervalMilliseconds: Int32 = 20
+    private static let maximumDrainReadsAfterStop = 8
+
+    static func read(
+        from handle: FileHandle,
+        stopState: UserTaskIOStopState
+    ) -> UserTaskPipeReadResult {
+        defer { handle.closeFile() }
+
+        let fileDescriptor = handle.fileDescriptor
+        var data = Data()
+        var truncated = false
+        var buffer = [UInt8](repeating: 0, count: bufferSize)
+        var remainingDrainReads = maximumDrainReadsAfterStop
+
+        while true {
+            let stopping = stopState.shouldStop
+            if stopping {
+                guard remainingDrainReads > 0 else {
+                    return UserTaskPipeReadResult(
+                        data: data,
+                        reachedEndOfFile: false,
+                        truncated: truncated
+                    )
+                }
+                remainingDrainReads -= 1
+            }
+
+            var descriptor = pollfd(
+                fd: fileDescriptor,
+                events: Int16(POLLIN | POLLHUP | POLLERR),
+                revents: 0
+            )
+            let pollResult = Darwin.poll(
+                &descriptor,
+                1,
+                stopping ? 0 : pollIntervalMilliseconds
+            )
+            if pollResult == 0 {
+                if stopping {
+                    return UserTaskPipeReadResult(
+                        data: data,
+                        reachedEndOfFile: false,
+                        truncated: truncated
+                    )
+                }
+                continue
+            }
+            if pollResult == -1 {
+                if errno == EINTR { continue }
+                return UserTaskPipeReadResult(
+                    data: data,
+                    reachedEndOfFile: false,
+                    truncated: truncated
+                )
+            }
+
+            let bytesRead = buffer.withUnsafeMutableBytes { bytes in
+                Darwin.read(
+                    fileDescriptor,
+                    bytes.baseAddress,
+                    bytes.count
+                )
+            }
+            if bytesRead == 0 {
+                return UserTaskPipeReadResult(
+                    data: data,
+                    reachedEndOfFile: true,
+                    truncated: truncated
+                )
+            }
+            if bytesRead == -1 {
+                if errno == EINTR || errno == EAGAIN { continue }
+                return UserTaskPipeReadResult(
+                    data: data,
+                    reachedEndOfFile: false,
+                    truncated: truncated
+                )
+            }
+
+            let availableCapacity = max(
+                maximumCapturedBytes - data.count,
+                0
+            )
+            let capturedCount = min(bytesRead, availableCapacity)
+            if capturedCount > 0 {
+                data.append(contentsOf: buffer.prefix(capturedCount))
+            }
+            if capturedCount < bytesRead {
+                truncated = true
+            }
+        }
+    }
+}
+
+nonisolated enum UserTaskPipeWriter {
+    private static let pollIntervalMilliseconds: Int32 = 20
+
+    /// Writes stdin without ever blocking the runner thread. The writer owns
+    /// and closes its FileHandle; `F_SETNOSIGPIPE` prevents a child that exits
+    /// early from turning EPIPE into a Pine process crash.
+    static func write(
+        _ data: Data,
+        to handle: FileHandle,
+        stopState: UserTaskIOStopState
+    ) -> UserTaskPipeWriteResult {
+        defer { handle.closeFile() }
+        guard !data.isEmpty else { return .complete }
+
+        let fileDescriptor = handle.fileDescriptor
+        guard Darwin.fcntl(fileDescriptor, F_SETNOSIGPIPE, 1) != -1 else {
+            return .failed(errno)
+        }
+        let currentFlags = Darwin.fcntl(fileDescriptor, F_GETFL)
+        guard currentFlags != -1 else {
+            return .failed(errno)
+        }
+        guard Darwin.fcntl(
+            fileDescriptor,
+            F_SETFL,
+            currentFlags | O_NONBLOCK
+        ) != -1 else {
+            return .failed(errno)
+        }
+
+        var result = UserTaskPipeWriteResult.complete
+        data.withUnsafeBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else {
+                result = .failed(EFAULT)
+                return
+            }
+            var offset = 0
+            while offset < bytes.count {
+                if stopState.shouldStop {
+                    result = .stopped
+                    return
+                }
+                var descriptor = pollfd(
+                    fd: fileDescriptor,
+                    events: Int16(POLLOUT | POLLHUP | POLLERR),
+                    revents: 0
+                )
+                let pollResult = Darwin.poll(
+                    &descriptor,
+                    1,
+                    pollIntervalMilliseconds
+                )
+                if pollResult == 0 { continue }
+                if pollResult == -1 {
+                    if errno == EINTR { continue }
+                    result = .failed(errno)
+                    return
+                }
+
+                let written = Darwin.write(
+                    fileDescriptor,
+                    baseAddress.advanced(by: offset),
+                    bytes.count - offset
+                )
+                if written > 0 {
+                    offset += written
+                } else if written == -1,
+                          errno != EINTR,
+                          errno != EAGAIN {
+                    result = .failed(errno)
+                    return
+                }
+            }
+        }
+        return result
+    }
+}
+
+nonisolated enum UserTaskPipeWriteResult: Sendable, Equatable {
+    case complete
+    case stopped
+    case failed(Int32)
+}
+
+/// Locked publication point for the single stdin writer.
+nonisolated final class UserTaskInputCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var result: UserTaskPipeWriteResult?
+
+    func setResult(_ result: UserTaskPipeWriteResult) {
+        lock.withLock {
+            self.result = result
+        }
+    }
+
+    func snapshot() -> UserTaskPipeWriteResult {
+        lock.withLock { result ?? .stopped }
+    }
+}

--- a/Pine/Extensibility/UserTaskSubprocess.swift
+++ b/Pine/Extensibility/UserTaskSubprocess.swift
@@ -16,7 +16,7 @@ import os
 nonisolated final class UserTaskSubprocess: @unchecked Sendable {
     private static let reaperQueue = DispatchQueue(
         label: "com.pine.user-task-reaper",
-        qos: .utility,
+        qos: .userInitiated,
         attributes: .concurrent
     )
 
@@ -127,21 +127,33 @@ nonisolated final class UserTaskSubprocess: @unchecked Sendable {
     /// Transfers a still-running direct child to a dedicated blocking reaper
     /// after the runner's hard lifecycle deadline. No other waiter may touch
     /// this pid after handoff.
-    func reapInBackground() {
+    func reapInBackground() -> UserTaskBackgroundReaper {
         let processID = self.processID
+        let reaper = UserTaskBackgroundReaper()
         Self.reaperQueue.async {
             var status: Int32 = 0
-            var result: pid_t
-            repeat {
-                result = Darwin.waitpid(processID, &status, 0)
-            } while result == -1 && errno == EINTR
+            while true {
+                let result = Darwin.waitpid(processID, &status, 0)
+                if result == processID || (result == -1 && errno == ECHILD) {
+                    reaper.resolveOwnership()
+                    return
+                }
+                if result == -1, errno == EINTR {
+                    continue
+                }
 
-            if result == -1, errno != ECHILD {
+                let waitError = errno
                 Logger.task.error(
-                    "Background task reaper failed for pid \(processID): errno \(errno)"
+                    "Background task reaper retrying pid \(processID): errno \(waitError)"
                 )
+                if Darwin.kill(processID, 0) == -1, errno == ESRCH {
+                    reaper.resolveOwnership()
+                    return
+                }
+                Darwin.usleep(10_000)
             }
         }
+        return reaper
     }
 
     private static func spawn(
@@ -356,6 +368,36 @@ nonisolated final class UserTaskSubprocess: @unchecked Sendable {
     }
 }
 
+/// Completion token for a direct child transferred to the blocking reaper.
+///
+/// The token resolves only after `waitpid` collected the child or proved that
+/// no child remains. It lets project teardown keep execution ownership after
+/// the bounded task outcome has already been presented.
+nonisolated final class UserTaskBackgroundReaper: @unchecked Sendable {
+    private let completion = DispatchGroup()
+    private let lock = NSLock()
+    private var didResolve = false
+
+    init() {
+        completion.enter()
+    }
+
+    fileprivate func resolveOwnership() {
+        let shouldLeave = lock.withLock {
+            guard !didResolve else { return false }
+            didResolve = true
+            return true
+        }
+        if shouldLeave {
+            completion.leave()
+        }
+    }
+
+    func waitForOwnershipRelease() {
+        completion.wait()
+    }
+}
+
 nonisolated enum UserTaskProcessExitPoll: Sendable, Equatable {
     case running
     case exited(Int32)
@@ -526,6 +568,33 @@ nonisolated final class UserTaskProcessGroup: @unchecked Sendable {
         return lock.withLock { terminationSucceeded }
     }
 
+    /// Finishes ownership cleanup after the bounded presentation deadline.
+    ///
+    /// The normal TERM-to-KILL sequence remains bounded so task output can be
+    /// shown promptly. If it reports failure, this background-only continuation
+    /// keeps signalling identity-qualified members until every process Pine
+    /// actually observed has exited. PID reuse cannot redirect these signals.
+    func finishDeferredCleanup() {
+        let shouldWaitForLifecycle = lock.withLock {
+            terminationRequested && !terminationFinished
+        }
+        if shouldWaitForLifecycle {
+            terminationCompletion.wait()
+        }
+
+        while true {
+            captureKnownMembers()
+            let liveMembers = lock.withLock {
+                knownMembers.values.filter {
+                    UserTaskProcessInspector.identity(for: $0.processID) == $0
+                }
+            }
+            guard !liveMembers.isEmpty else { return }
+            _ = signalKnownMembers(SIGKILL, identities: liveMembers)
+            Darwin.usleep(Self.pollIntervalMicroseconds)
+        }
+    }
+
     private func finishTermination() -> Bool {
         if Self.isProcessGroupAlive(identifier) {
             Self.waitUntilGone(
@@ -672,7 +741,7 @@ nonisolated final class UserTaskProcessGroup: @unchecked Sendable {
 /// Start timestamps protect against signalling an unrelated process after PID
 /// reuse. A descendant that daemonizes between snapshots can still escape, so
 /// callers must also bound pipe draining and direct-child waiting.
-nonisolated final class UserTaskDescendantTracker {
+nonisolated final class UserTaskDescendantTracker: @unchecked Sendable {
     private static let maximumTrackedProcesses = 1_024
     private static let termGracePeriod: TimeInterval = 0.25
     private static let killWaitPeriod: TimeInterval = 1.0
@@ -746,6 +815,20 @@ nonisolated final class UserTaskDescendantTracker {
             )
         }
         return succeeded
+    }
+
+    /// Continues identity-safe cleanup off-main after the bounded task result
+    /// was published. This owns only descendants captured during execution;
+    /// an unobserved immediate double-fork remains the documented Darwin
+    /// best-effort limitation.
+    func finishDeferredCleanup() {
+        while true {
+            captureDescendants()
+            let live = liveDescendants()
+            guard !live.isEmpty else { return }
+            send(SIGKILL, to: live)
+            Darwin.usleep(Self.pollIntervalMicroseconds)
+        }
     }
 
     private func waitUntilGone(

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -22290,6 +22290,441 @@
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "运行此任务前请先打开文件。" } }
       }
     },
+    "userTask.replacementUnavailable.title": {
+      "comment": "Title shown when a replacement task cannot safely target the active editor.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Aufgabe kann diese Datei nicht ersetzen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Task Cannot Replace This Editor" } },
+        "es": { "stringUnit": { "state": "translated", "value": "La tarea no puede reemplazar este archivo" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "La tâche ne peut pas remplacer ce fichier" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "タスクはこのファイルを置き換えられません" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "작업이 이 파일을 대체할 수 없음" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "A tarefa não pode substituir este arquivo" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Задача не может заменить этот файл" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "任务无法替换此文件" } }
+      }
+    },
+    "userTask.replacementUnavailable.message": {
+      "comment": "Explains that replacement tasks require a complete text file in the active editor.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Ersetzungsaufgaben erfordern eine vollständige Textdatei im aktiven Editor." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Replacement tasks require an active, fully loaded text file and cannot run with project scope or a preview tab." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Las tareas de reemplazo requieren un archivo de texto completo en el editor activo." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Les tâches de remplacement nécessitent un fichier texte complet dans l’éditeur actif." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "置換タスクには、アクティブなエディタで完全なテキストファイルを開く必要があります。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "대체 작업을 실행하려면 활성 편집기에 전체 텍스트 파일이 필요합니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "As tarefas de substituição exigem um arquivo de texto completo no editor ativo." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Для задачи с заменой нужен полностью загруженный текстовый файл в активном редакторе." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "替换任务需要活动编辑器中完整加载的文本文件。" } }
+      }
+    },
+    "userTask.toast.succeeded": {
+      "comment": "Toast shown after a task succeeds. %@ is the task label.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Aufgabe „%@“ erfolgreich" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Task “%@” completed" } },
+        "es": { "stringUnit": { "state": "translated", "value": "La tarea «%@» se completó correctamente" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "La tâche « %@ » a réussi" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "タスク「%@」が成功しました" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "“%@” 작업 성공" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "A tarefa “%@” foi concluída" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Задача «%@» выполнена" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "任务“%@”已成功" } }
+      }
+    },
+    "userTask.copyOutput": {
+      "comment": "Button that copies a task's captured output.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Ausgabe kopieren" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Copy Output" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Copiar salida" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Copier la sortie" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "出力をコピー" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "출력 복사" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Copiar saída" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Скопировать вывод" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "复制输出" } }
+      }
+    },
+    "userTask.openOutput": {
+      "comment": "Button that opens the task output surface.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Ausgabe öffnen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Open Output" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Abrir salida" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Ouvrir la sortie" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "出力を開く" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "출력 열기" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Abrir saída" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Открыть вывод" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "打开输出" } }
+      }
+    },
+    "userTask.run.status.pending": {
+      "comment": "Status label for a task waiting to start.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Ausstehend" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Pending" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Pendiente" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "En attente" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "保留中" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "대기 중" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Pendente" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Ожидание" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "等待中" } }
+      }
+    },
+    "userTask.run.status.running": {
+      "comment": "Status label for a running task.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Wird ausgeführt" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Running" } },
+        "es": { "stringUnit": { "state": "translated", "value": "En ejecución" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "En cours" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "実行中" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "실행 중" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Em execução" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Выполняется" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "正在运行" } }
+      }
+    },
+    "userTask.run.status.cancelling": {
+      "comment": "Status label while task cancellation and cleanup are in progress.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Wird abgebrochen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Cancelling" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Cancelando" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Annulation" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "キャンセル中" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "취소 중" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Cancelando" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Отмена" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "正在取消" } }
+      }
+    },
+    "userTask.run.status.succeeded": {
+      "comment": "Status label for a successful task.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Erfolgreich" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Succeeded" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Correcta" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Réussie" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "成功" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "성공" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Concluída" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Выполнена" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "成功" } }
+      }
+    },
+    "userTask.run.status.timedOut": {
+      "comment": "Status label for a task that exceeded its deadline.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Zeitüberschreitung" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Timed out" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Tiempo agotado" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Délai dépassé" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "タイムアウト" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "시간 초과" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Tempo esgotado" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Истекло время" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已超时" } }
+      }
+    },
+    "userTask.run.status.failed": {
+      "comment": "Status label for a failed task without an exit code.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Fehlgeschlagen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Failed" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Fallida" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Échouée" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "失敗" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "실패" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Falhou" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Ошибка" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "失败" } }
+      }
+    },
+    "userTask.run.status.cancelled": {
+      "comment": "Status label for a cancelled task.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Abgebrochen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Cancelled" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Cancelada" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Annulée" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "キャンセル済み" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "취소됨" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Cancelada" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Отменена" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已取消" } }
+      }
+    },
+    "userTask.run.status.exitCode": {
+      "comment": "Status label for a failed task. %lld is its process exit code.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Exit-Code %lld" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Exit %lld" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Código de salida %lld" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Code de sortie %lld" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "終了コード %lld" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "종료 코드 %lld" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Código de saída %lld" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Код завершения %lld" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "退出代码 %lld" } }
+      }
+    },
+    "userTask.run.elapsed": {
+      "comment": "Elapsed duration for a task run. %@ is a formatted duration.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Vergangen %@" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Elapsed %@" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Transcurrido %@" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Écoulé %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "経過 %@" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "경과 %@" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Decorrido %@" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Прошло %@" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已用 %@" } }
+      }
+    },
+    "userTask.output.title": {
+      "comment": "Title of the task output surface.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Aufgabenausgabe" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Task Output" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Salida de tareas" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Sortie des tâches" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "タスク出力" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "작업 출력" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Saída das tarefas" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Вывод задач" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "任务输出" } }
+      }
+    },
+    "userTask.output.empty": {
+      "comment": "Empty state for the task output history.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Noch keine Aufgabenläufe" } },
+        "en": { "stringUnit": { "state": "translated", "value": "No task history" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Aún no hay ejecuciones de tareas" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Aucune exécution de tâche" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "タスクの実行履歴はまだありません" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "아직 실행한 작업이 없음" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Ainda não há execuções de tarefas" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Запусков задач пока нет" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "尚无任务运行记录" } }
+      }
+    },
+    "userTask.output.previewTruncated": {
+      "comment": "Notice that only a bounded task-output preview is shown.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Vorschau gekürzt. „Ausgabe kopieren“ enthält die vollständige erfasste Ausgabe." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Preview truncated. Copy Output includes the complete captured output." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Vista previa truncada. Copiar salida incluye toda la salida capturada." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Aperçu tronqué. Copier la sortie inclut toute la sortie capturée." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "プレビューは省略されています。「出力をコピー」には取得した出力全体が含まれます。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "미리보기가 잘렸습니다. 출력 복사에는 캡처된 전체 출력이 포함됩니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Prévia truncada. Copiar saída inclui toda a saída capturada." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Предпросмотр сокращён. Команда «Скопировать вывод» включает весь сохранённый вывод." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "预览已截断。“复制输出”包含全部捕获的输出。" } }
+      }
+    },
+    "userTask.output.clearFinished": {
+      "comment": "Button that removes completed task runs from output history.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Beendete löschen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Clear Finished" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Borrar finalizadas" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Effacer les tâches terminées" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "完了済みを消去" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "완료 항목 지우기" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Limpar concluídas" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Очистить завершённые" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "清除已完成项" } }
+      }
+    },
+    "userTask.output.close": {
+      "comment": "Accessibility label for closing the task output surface.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Aufgabenausgabe schließen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Close Task Output" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Cerrar salida de tareas" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Fermer la sortie des tâches" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "タスク出力を閉じる" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "작업 출력 닫기" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Fechar saída das tarefas" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Закрыть вывод задач" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "关闭任务输出" } }
+      }
+    },
+    "userTask.output.show": {
+      "comment": "Button that reveals the task output surface.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Aufgabenausgabe" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Task Output" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Salida de tareas" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Sortie des tâches" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "タスク出力" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "작업 출력" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Saída das tarefas" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Вывод задач" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "任务输出" } }
+      }
+    },
+    "userTask.cancel": {
+      "comment": "Button that cancels an active task run.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Abbrechen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Cancel" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Cancelar" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Annuler" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "キャンセル" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "취소" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Cancelar" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Отменить" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "取消" } }
+      }
+    },
+    "userTask.diagnostic.blocked": {
+      "comment": "Diagnostic shown when task validation blocks execution.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Aufgabe durch Sicherheitsprüfung blockiert." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Task blocked by Pine’s safety policy." } },
+        "es": { "stringUnit": { "state": "translated", "value": "La validación de seguridad bloqueó la tarea." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Tâche bloquée par la validation de sécurité." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "安全性検証によりタスクがブロックされました。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "안전성 검사에서 작업이 차단되었습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Tarefa bloqueada pela validação de segurança." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Задача заблокирована проверкой безопасности." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "任务被安全验证阻止。" } }
+      }
+    },
+    "userTask.diagnostic.launchFailed": {
+      "comment": "Diagnostic shown when a task cannot launch. %@ is the underlying reason.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Aufgabe konnte nicht gestartet werden: %@" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Task failed to launch: %@" } },
+        "es": { "stringUnit": { "state": "translated", "value": "No se pudo iniciar la tarea: %@" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Impossible de lancer la tâche : %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "タスクを起動できませんでした: %@" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "작업을 시작할 수 없습니다: %@" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Não foi possível iniciar a tarefa: %@" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Не удалось запустить задачу: %@" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法启动任务：%@" } }
+      }
+    },
+    "userTask.diagnostic.backgroundReaper": {
+      "comment": "Diagnostic shown when task cleanup continues in a background reaper.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Prozessbereinigung wird im Hintergrund fortgesetzt." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Pine handed the task shell to its background reaper." } },
+        "es": { "stringUnit": { "state": "translated", "value": "La limpieza del proceso continúa en segundo plano." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Le nettoyage du processus se poursuit en arrière-plan." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "プロセスのクリーンアップはバックグラウンドで続行中です。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "프로세스 정리가 백그라운드에서 계속됩니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "A limpeza do processo continua em segundo plano." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Очистка процесса продолжается в фоновом режиме." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "进程清理正在后台继续。" } }
+      }
+    },
+    "userTask.diagnostic.subprocessCleanup": {
+      "comment": "Diagnostic shown when task subprocess cleanup is incomplete.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Unterprozessbereinigung wurde nicht abgeschlossen." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Pine could not terminate every observed task subprocess." } },
+        "es": { "stringUnit": { "state": "translated", "value": "La limpieza de subprocesos no se completó." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Le nettoyage des sous-processus ne s’est pas terminé." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "サブプロセスのクリーンアップが完了しませんでした。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "하위 프로세스 정리가 완료되지 않았습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "A limpeza dos subprocessos não foi concluída." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Очистка дочерних процессов не завершена." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "子进程清理未完成。" } }
+      }
+    },
+    "userTask.diagnostic.outputDeadline": {
+      "comment": "Diagnostic shown when output collection reaches its deadline.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Zeitlimit für die Ausgabenerfassung erreicht." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Pine stopped waiting for task output at its hard deadline." } },
+        "es": { "stringUnit": { "state": "translated", "value": "La recopilación de salida alcanzó su límite de tiempo." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "La collecte de la sortie a atteint son délai limite." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "出力収集が期限に達しました。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "출력 수집 시간이 초과되었습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "A coleta da saída atingiu o limite de tempo." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Истекло время сбора вывода." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "输出收集已到截止时间。" } }
+      }
+    },
+    "userTask.diagnostic.outputTruncated": {
+      "comment": "Diagnostic shown when captured task output was truncated.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Die erfasste Ausgabe wurde gekürzt." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Task output exceeded Pine's capture limit and was truncated." } },
+        "es": { "stringUnit": { "state": "translated", "value": "La salida capturada se truncó." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "La sortie capturée a été tronquée." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "取得した出力は切り詰められました。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "캡처된 출력이 잘렸습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "A saída capturada foi truncada." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Сохранённый вывод был сокращён." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "捕获的输出已截断。" } }
+      }
+    },
+    "userTask.diagnostic.invalidUTF8": {
+      "comment": "Diagnostic shown when task output contains invalid UTF-8.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Die Ausgabe enthielt ungültigen UTF-8-Text." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Task output contained invalid UTF-8 and was rejected." } },
+        "es": { "stringUnit": { "state": "translated", "value": "La salida contenía texto UTF-8 no válido." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "La sortie contenait du texte UTF-8 non valide." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "出力に無効な UTF-8 テキストが含まれていました。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "출력에 잘못된 UTF-8 텍스트가 포함되어 있습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "A saída continha texto UTF-8 inválido." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Вывод содержал некорректный текст UTF-8." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "输出包含无效的 UTF-8 文本。" } }
+      }
+    },
+    "userTask.diagnostic.inputIncomplete": {
+      "comment": "Diagnostic shown when task standard input could not be delivered completely.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Die Standardeingabe wurde nicht vollständig übermittelt." } },
+        "en": { "stringUnit": { "state": "translated", "value": "The task stopped before Pine finished writing standard input." } },
+        "es": { "stringUnit": { "state": "translated", "value": "La entrada estándar no se entregó por completo." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "L’entrée standard n’a pas été transmise entièrement." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "標準入力を完全に送信できませんでした。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "표준 입력이 완전히 전달되지 않았습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "A entrada padrão não foi entregue por completo." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Стандартный ввод передан не полностью." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "标准输入未完整传递。" } }
+      }
+    },
     "userConfig.diagnostic.duplicateCommand": {
       "comment": "Diagnostic: duplicate command id. %1$@ is the id, %2$lld is the first entry number.",
       "extractionState": "manual",

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -1377,9 +1377,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             }
             pm.recoveryManager?.stopPeriodicSnapshots()
         }
-        // `applicationShouldTerminate` already spent the one shared task
-        // shutdown budget. Do not multiply quit latency in this final hook.
-        _ = registry.destroyAllProjects(userTaskDeadline: .now())
+        // `applicationShouldTerminate` already completed task shutdown before
+        // replying to AppKit. Fail closed if lifecycle wiring ever regresses:
+        // project teardown must not discard live cancellation handles.
+        if !registry.destroyAllProjects() {
+            Logger.task.critical(
+                "Application termination reached teardown with live user tasks"
+            )
+        }
 
         // Stop the global quick-terminal session so its PTY does not outlive
         // Pine (#1113 review). The session is keep-alive across toggles but
@@ -1426,7 +1431,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     func confirmApplicationTermination(
         presentAlert: TerminationAlertPresenter? = nil,
         saveAll: TerminationSaveAll? = nil,
-        applicationContext: DialogPresentationContext? = nil
+        applicationContext: DialogPresentationContext? = nil,
+        userTaskShutdownDeadline: DispatchTime? = nil
     ) async -> Bool {
         let projects = registry.openProjects
             .sorted { $0.key.path.localizedStandardCompare($1.key.path) == .orderedAscending }
@@ -1539,10 +1545,28 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
                 activeTerminalProcesses
         }
 
-        // Other project windows stay interactive while each sheet is open.
-        // Revalidate every destructive authorization immediately before
-        // committing Quit so no new buffer edit or foreground process is
-        // silently covered by an earlier answer.
+        // Window closure keeps project tasks alive by policy; application
+        // termination does not. Use one shared deadline across every project
+        // so N concurrent tasks cannot multiply the quit delay. Process waits
+        // happen off-main while AppKit remains in its `.terminateLater`
+        // handshake. A timeout cancels Quit before any authorized editor
+        // discard is committed and retains every cleanup handle.
+        let taskShutdownDeadline =
+            userTaskShutdownDeadline ?? DispatchTime.now() + 3
+        guard await registry.shutdownUserTasks(
+            until: taskShutdownDeadline
+        ) else {
+            Logger.task.error(
+                "User-task cleanup exceeded Pine's quit deadline; cancelling Quit"
+            )
+            return false
+        }
+
+        // Other project windows remain interactive while sheets and off-main
+        // process waits are in flight. Revalidate every destructive
+        // authorization after the final suspension point, immediately before
+        // committing Quit, so later edits/processes are never covered by an
+        // earlier answer.
         for projectManager in registry.openProjects.values {
             let identifier = ObjectIdentifier(projectManager)
             let currentDirtyTabs = projectManager.allDirtyTabs
@@ -1569,7 +1593,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         }
 
         // Two-phase destructive commit: no project is mutated until every
-        // project and terminal authorization above has passed.
+        // project/terminal authorization and task cleanup above has passed.
         for projectManager in registry.openProjects.values {
             let identifier = ObjectIdentifier(projectManager)
             if let authorization = discardAuthorizations[identifier],
@@ -1579,27 +1603,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
                ) {
                 return false
             }
-        }
-
-        // Window closure keeps project tasks alive by policy; application
-        // termination does not. Use one shared deadline across every project
-        // so N concurrent tasks cannot multiply the quit delay. This happens
-        // only after every user authorization and discard commit above.
-        let taskShutdownDeadline = DispatchTime.now() + 3
-        var userTasksStopped = true
-        for projectManager in registry.openProjects.values {
-            projectManager.requestUserTaskShutdown()
-        }
-        for projectManager in registry.openProjects.values
-        where !projectManager.shutdownUserTasks(
-            until: taskShutdownDeadline
-        ) {
-            userTasksStopped = false
-        }
-        if !userTasksStopped {
-            Logger.task.error(
-                "One or more user tasks exceeded Pine's quit cleanup deadline"
-            )
         }
 
         return true

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -12,6 +12,7 @@
 
 import Sparkle
 import SwiftUI
+import os
 
 @main
 struct PineApp: App {
@@ -1376,7 +1377,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             }
             pm.recoveryManager?.stopPeriodicSnapshots()
         }
-        registry.destroyAllProjects()
+        // `applicationShouldTerminate` already spent the one shared task
+        // shutdown budget. Do not multiply quit latency in this final hook.
+        _ = registry.destroyAllProjects(userTaskDeadline: .now())
 
         // Stop the global quick-terminal session so its PTY does not outlive
         // Pine (#1113 review). The session is keep-alive across toggles but
@@ -1576,6 +1579,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
                ) {
                 return false
             }
+        }
+
+        // Window closure keeps project tasks alive by policy; application
+        // termination does not. Use one shared deadline across every project
+        // so N concurrent tasks cannot multiply the quit delay. This happens
+        // only after every user authorization and discard commit above.
+        let taskShutdownDeadline = DispatchTime.now() + 3
+        var userTasksStopped = true
+        for projectManager in registry.openProjects.values {
+            projectManager.requestUserTaskShutdown()
+        }
+        for projectManager in registry.openProjects.values
+        where !projectManager.shutdownUserTasks(
+            until: taskShutdownDeadline
+        ) {
+            userTasksStopped = false
+        }
+        if !userTasksStopped {
+            Logger.task.error(
+                "One or more user tasks exceeded Pine's quit cleanup deadline"
+            )
         }
 
         return true

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -960,7 +960,12 @@ final class ProjectManager {
     /// Waits for project-owned user tasks only until the shared absolute
     /// deadline, requesting cancellation first when needed.
     @discardableResult
-    func shutdownUserTasks(until deadline: DispatchTime) -> Bool {
-        taskRunStore.shutdownAll(until: deadline)
+    func shutdownUserTasks(until deadline: DispatchTime) async -> Bool {
+        await taskRunStore.shutdownAll(until: deadline)
+    }
+
+    /// `true` while destroying this project would drop task cleanup ownership.
+    var hasOutstandingUserTaskExecution: Bool {
+        taskRunStore.hasOutstandingExecutionOwnership
     }
 }

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -949,4 +949,18 @@ final class ProjectManager {
     func shutdownLanguageServers() {
         lspManager.shutdownAll()
     }
+
+    /// Requests cancellation without waiting. Closing a project window does
+    /// not call this: background projects intentionally keep both terminals
+    /// and tasks alive.
+    func requestUserTaskShutdown() {
+        taskRunStore.requestShutdown()
+    }
+
+    /// Waits for project-owned user tasks only until the shared absolute
+    /// deadline, requesting cancellation first when needed.
+    @discardableResult
+    func shutdownUserTasks(until deadline: DispatchTime) -> Bool {
+        taskRunStore.shutdownAll(until: deadline)
+    }
 }

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -252,6 +252,10 @@ final class ProjectManager {
     }
 
     let toastManager = ToastManager()
+    /// Tracks active and recent user-task runs for the task execution UI
+    /// (issue #1246). Owned by the project window so the output surface,
+    /// toast, and Cancel button all share one source of truth.
+    let taskRunStore = UserTaskRunStore()
     /// Recovery snapshots and their lifecycle are owned by the main actor.
     private(set) var recoveryManager: RecoveryManager?
 

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -51,7 +51,7 @@ final class ProjectRegistry: LSPSettingsObserver {
     /// URLs are resolved to their canonical (real) path to prevent duplicates via symlinks.
     /// Returns nil if the directory no longer exists on disk.
     func projectManager(for projectURL: URL) -> ProjectManager? {
-        let canonical = projectURL.resolvingSymlinksInPath()
+        let canonical = Self.canonicalProjectURL(projectURL)
         if let existing = openProjects[canonical] {
             // Verify directory still exists when reopening from background
             if backgroundProjects.contains(canonical) {
@@ -113,7 +113,7 @@ final class ProjectRegistry: LSPSettingsObserver {
 
         guard await panel.runSheet(on: context) == .OK,
               let url = panel.url else { return nil }
-        let canonical = url.resolvingSymlinksInPath()
+        let canonical = Self.canonicalProjectURL(url)
         guard projectManager(for: canonical) != nil else { return nil }
         return canonical
     }
@@ -122,7 +122,7 @@ final class ProjectRegistry: LSPSettingsObserver {
     /// sessions and user tasks continue in the background; reopening the
     /// project restores access to their current state and output history.
     func closeProjectWindow(_ url: URL) {
-        let canonical = url.resolvingSymlinksInPath()
+        let canonical = Self.canonicalProjectURL(url)
         guard openProjects[canonical] != nil else { return }
         backgroundProjects.insert(canonical)
     }
@@ -196,13 +196,13 @@ final class ProjectRegistry: LSPSettingsObserver {
 
     /// Returns true if the project has an open (non-background) window.
     func isWindowOpen(_ url: URL) -> Bool {
-        let canonical = url.resolvingSymlinksInPath()
+        let canonical = Self.canonicalProjectURL(url)
         return openProjects[canonical] != nil && !backgroundProjects.contains(canonical)
     }
 
     /// Checks if a project is already open (including background).
     func isProjectOpen(_ url: URL) -> Bool {
-        openProjects[url.resolvingSymlinksInPath()] != nil
+        openProjects[Self.canonicalProjectURL(url)] != nil
     }
 
     // MARK: - Language Server Settings
@@ -259,6 +259,35 @@ final class ProjectRegistry: LSPSettingsObserver {
     private func saveRecentProjects() {
         let paths = recentProjects.map(\.path)
         UserDefaults.standard.set(paths, forKey: Self.recentProjectsKey)
+    }
+
+    /// Resolves a stable project identity even after the project directory is
+    /// deleted. `resolvingSymlinksInPath()` requires the path to exist before
+    /// it reliably resolves prefix symlinks such as `/var` → `/private/var`.
+    /// Resolve the nearest existing ancestor, then append every missing
+    /// component to preserve the key previously stored in `openProjects`.
+    nonisolated static func canonicalProjectURL(_ projectURL: URL) -> URL {
+        let standardized = projectURL.standardizedFileURL
+        var existingAncestor = standardized
+        var missingComponents: [String] = []
+
+        while !FileManager.default.fileExists(
+            atPath: existingAncestor.path
+        ) {
+            let parent = existingAncestor.deletingLastPathComponent()
+            guard parent.path != existingAncestor.path else { break }
+            missingComponents.append(existingAncestor.lastPathComponent)
+            existingAncestor = parent
+        }
+
+        var canonical = existingAncestor.resolvingSymlinksInPath()
+        for component in missingComponents.reversed() {
+            canonical.appendPathComponent(component)
+        }
+        return URL(
+            fileURLWithPath: canonical.path,
+            isDirectory: true
+        ).standardizedFileURL
     }
 
     private var userTaskOwners: [ProjectManager] {

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -17,6 +17,13 @@ final class ProjectRegistry: LSPSettingsObserver {
     /// Projects whose window was closed but whose ProjectManager (and terminal processes)
     /// are kept alive. Reopening the same project returns the existing PM.
     private(set) var backgroundProjects: Set<URL> = []
+    /// Project managers detached after their directory disappeared. They stay
+    /// retained until user-task process cleanup completes, so a later Quit
+    /// can still wait for and reap those executions.
+    @ObservationIgnored
+    private var detachedTaskCleanupProjects: [
+        ObjectIdentifier: ProjectManager
+    ] = [:]
     /// Recently opened project paths (most recent first), persisted to UserDefaults.
     var recentProjects: [URL] = []
 
@@ -52,8 +59,21 @@ final class ProjectRegistry: LSPSettingsObserver {
                 guard FileManager.default.fileExists(atPath: canonical.path, isDirectory: &isDir),
                       isDir.boolValue else {
                     // Directory was deleted while in background — clean up
-                    _ = existing.shutdownUserTasks(until: .now() + 2)
+                    existing.requestUserTaskShutdown()
                     existing.terminal.terminateAll()
+                    existing.shutdownLanguageServers()
+                    let ownerID = ObjectIdentifier(existing)
+                    detachedTaskCleanupProjects[ownerID] = existing
+                    Task { @MainActor [weak self] in
+                        let didStop = await existing.shutdownUserTasks(
+                            until: .now() + 2
+                        )
+                        if didStop {
+                            self?.detachedTaskCleanupProjects.removeValue(
+                                forKey: ownerID
+                            )
+                        }
+                    }
                     openProjects.removeValue(forKey: canonical)
                     backgroundProjects.remove(canonical)
                     recentProjects.removeAll { $0 == canonical }
@@ -113,27 +133,65 @@ final class ProjectRegistry: LSPSettingsObserver {
         closeProjectWindow(url)
     }
 
-    /// Fully destroys all project managers. Called during app termination.
+    /// Cancels and waits for all project-owned user tasks against one shared
+    /// absolute deadline. Blocking process waits happen off the main actor.
     @discardableResult
-    func destroyAllProjects(
-        userTaskDeadline: DispatchTime = .now() + 3
-    ) -> Bool {
-        lspSettingsChangeTask?.cancel()
-        lspSettingsChangeTask = nil
-        var tasksStopped = true
-        for projectManager in openProjects.values {
+    func shutdownUserTasks(until deadline: DispatchTime) async -> Bool {
+        // Snapshot before the first suspension point. Main-actor reentrancy may
+        // otherwise mutate the registry while an iterator is held across an
+        // `await`.
+        let projectManagers = userTaskOwners
+        for projectManager in projectManagers {
             projectManager.requestUserTaskShutdown()
         }
-        for (_, pm) in openProjects {
-            if !pm.shutdownUserTasks(until: userTaskDeadline) {
-                tasksStopped = false
+        for projectManager in projectManagers {
+            _ = await projectManager.shutdownUserTasks(
+                until: deadline
+            )
+        }
+
+        detachedTaskCleanupProjects = detachedTaskCleanupProjects.filter {
+            $0.value.hasOutstandingUserTaskExecution
+        }
+
+        // A project or task may have appeared while process waits ran off the
+        // main actor. Treat that as an incomplete shutdown so Quit fails
+        // closed instead of dropping its execution ownership.
+        return !userTaskOwners.contains(where: {
+            $0.hasOutstandingUserTaskExecution
+        })
+    }
+
+    /// Fully destroys all project managers after task cleanup has completed.
+    ///
+    /// Fails closed instead of discarding cancellation handles if a caller
+    /// attempts teardown while any user-task execution is still owned.
+    @discardableResult
+    func destroyAllProjects() -> Bool {
+        guard !userTaskOwners.contains(where: {
+            $0.hasOutstandingUserTaskExecution
+        }) else {
+            for projectManager in userTaskOwners {
+                projectManager.requestUserTaskShutdown()
             }
+            return false
+        }
+
+        lspSettingsChangeTask?.cancel()
+        lspSettingsChangeTask = nil
+        for (_, pm) in openProjects {
             pm.terminal.terminateAll()
             pm.shutdownLanguageServers()
         }
         openProjects.removeAll()
         backgroundProjects.removeAll()
-        return tasksStopped
+        detachedTaskCleanupProjects.removeAll()
+        return true
+    }
+
+    /// Internal lifecycle observability used by unit tests.
+    var detachedUserTaskCleanupCount: Int {
+        detachedTaskCleanupProjects.count
     }
 
     /// Returns true if the project has an open (non-background) window.
@@ -201,5 +259,14 @@ final class ProjectRegistry: LSPSettingsObserver {
     private func saveRecentProjects() {
         let paths = recentProjects.map(\.path)
         UserDefaults.standard.set(paths, forKey: Self.recentProjectsKey)
+    }
+
+    private var userTaskOwners: [ProjectManager] {
+        var owners: [ObjectIdentifier: ProjectManager] =
+            detachedTaskCleanupProjects
+        for projectManager in openProjects.values {
+            owners[ObjectIdentifier(projectManager)] = projectManager
+        }
+        return Array(owners.values)
     }
 }

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -52,6 +52,7 @@ final class ProjectRegistry: LSPSettingsObserver {
                 guard FileManager.default.fileExists(atPath: canonical.path, isDirectory: &isDir),
                       isDir.boolValue else {
                     // Directory was deleted while in background — clean up
+                    _ = existing.shutdownUserTasks(until: .now() + 2)
                     existing.terminal.terminateAll()
                     openProjects.removeValue(forKey: canonical)
                     backgroundProjects.remove(canonical)
@@ -97,8 +98,9 @@ final class ProjectRegistry: LSPSettingsObserver {
         return canonical
     }
 
-    /// Closes the project window but keeps the ProjectManager alive (preserving terminal sessions).
-    /// The PM moves to `backgroundProjects` and will be reused if the project is reopened.
+    /// Closes the project window but keeps the ProjectManager alive. Terminal
+    /// sessions and user tasks continue in the background; reopening the
+    /// project restores access to their current state and output history.
     func closeProjectWindow(_ url: URL) {
         let canonical = url.resolvingSymlinksInPath()
         guard openProjects[canonical] != nil else { return }
@@ -112,15 +114,26 @@ final class ProjectRegistry: LSPSettingsObserver {
     }
 
     /// Fully destroys all project managers. Called during app termination.
-    func destroyAllProjects() {
+    @discardableResult
+    func destroyAllProjects(
+        userTaskDeadline: DispatchTime = .now() + 3
+    ) -> Bool {
         lspSettingsChangeTask?.cancel()
         lspSettingsChangeTask = nil
+        var tasksStopped = true
+        for projectManager in openProjects.values {
+            projectManager.requestUserTaskShutdown()
+        }
         for (_, pm) in openProjects {
+            if !pm.shutdownUserTasks(until: userTaskDeadline) {
+                tasksStopped = false
+            }
             pm.terminal.terminateAll()
             pm.shutdownLanguageServers()
         }
         openProjects.removeAll()
         backgroundProjects.removeAll()
+        return tasksStopped
     }
 
     /// Returns true if the project has an open (non-background) window.

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -1210,6 +1210,15 @@ enum Strings {
         )
     }
 
+    static var userTaskOutputPreviewTruncated: String {
+        String(
+            localized: "userTask.output.previewTruncated",
+            defaultValue: """
+            Preview truncated. Copy Output includes the complete captured output.
+            """
+        )
+    }
+
     static var userTaskClearFinished: String {
         String(
             localized: "userTask.output.clearFinished",

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -1148,6 +1148,27 @@ enum Strings {
         String(localized: "userTask.openOutput", defaultValue: "Open Output")
     }
 
+    /// Short status summaries for a task run (issue #1246).
+    nonisolated static let userTaskRunStatusPending: String =
+        String(localized: "userTask.run.status.pending", defaultValue: "Pending")
+    nonisolated static let userTaskRunStatusRunning: String =
+        String(localized: "userTask.run.status.running", defaultValue: "Running")
+    nonisolated static let userTaskRunStatusSucceeded: String =
+        String(localized: "userTask.run.status.succeeded", defaultValue: "Succeeded")
+    nonisolated static let userTaskRunStatusTimedOut: String =
+        String(localized: "userTask.run.status.timedOut", defaultValue: "Timed out")
+    nonisolated static let userTaskRunStatusFailed: String =
+        String(localized: "userTask.run.status.failed", defaultValue: "Failed")
+    nonisolated static let userTaskRunStatusCancelled: String =
+        String(localized: "userTask.run.status.cancelled", defaultValue: "Cancelled")
+
+    nonisolated static func userTaskRunStatusExitCode(_ code: Int) -> String {
+        String(
+            localized: "userTask.run.status.exitCode",
+            defaultValue: "Exit \(code)"
+        )
+    }
+
     // MARK: - Quick Open
 
     static let menuQuickOpen: LocalizedStringKey = "menu.quickOpen"

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -1130,6 +1130,23 @@ enum Strings {
         String(localized: "userTask.missingFile.message")
     }
 
+    static var userTaskReplacementUnavailableTitle: String {
+        String(
+            localized: "userTask.replacementUnavailable.title",
+            defaultValue: "Task Cannot Replace This Editor"
+        )
+    }
+
+    static var userTaskReplacementUnavailableMessage: String {
+        String(
+            localized: "userTask.replacementUnavailable.message",
+            defaultValue: """
+            Replacement tasks require an active, fully loaded text file and \
+            cannot run with project scope or a preview tab.
+            """
+        )
+    }
+
     /// Toast shown when a user task completes successfully (issue #1246).
     static func userTaskToastSucceeded(_ label: String) -> String {
         String(
@@ -1138,7 +1155,7 @@ enum Strings {
         )
     }
 
-    /// Copy the captured stdout to the pasteboard (issue #1246).
+    /// Copy captured task output to the pasteboard (issue #1246).
     static var userTaskCopyOutput: String {
         String(localized: "userTask.copyOutput", defaultValue: "Copy Output")
     }
@@ -1153,6 +1170,11 @@ enum Strings {
         String(localized: "userTask.run.status.pending", defaultValue: "Pending")
     nonisolated static let userTaskRunStatusRunning: String =
         String(localized: "userTask.run.status.running", defaultValue: "Running")
+    nonisolated static let userTaskRunStatusCancelling: String =
+        String(
+            localized: "userTask.run.status.cancelling",
+            defaultValue: "Cancelling"
+        )
     nonisolated static let userTaskRunStatusSucceeded: String =
         String(localized: "userTask.run.status.succeeded", defaultValue: "Succeeded")
     nonisolated static let userTaskRunStatusTimedOut: String =
@@ -1168,6 +1190,87 @@ enum Strings {
             defaultValue: "Exit \(code)"
         )
     }
+
+    /// Live or final elapsed duration for a task run (issue #1246).
+    nonisolated static func userTaskElapsed(_ duration: String) -> String {
+        String(
+            localized: "userTask.run.elapsed",
+            defaultValue: "Elapsed \(duration)"
+        )
+    }
+
+    static var userTaskOutputTitle: String {
+        String(localized: "userTask.output.title", defaultValue: "Task Output")
+    }
+
+    static var userTaskOutputEmpty: String {
+        String(
+            localized: "userTask.output.empty",
+            defaultValue: "No task history"
+        )
+    }
+
+    static var userTaskClearFinished: String {
+        String(
+            localized: "userTask.output.clearFinished",
+            defaultValue: "Clear Finished"
+        )
+    }
+
+    static var userTaskCloseOutput: String {
+        String(
+            localized: "userTask.output.close",
+            defaultValue: "Close Task Output"
+        )
+    }
+
+    static var userTaskShowOutput: String {
+        String(
+            localized: "userTask.output.show",
+            defaultValue: "Task Output"
+        )
+    }
+
+    static var userTaskCancel: String {
+        String(localized: "userTask.cancel", defaultValue: "Cancel")
+    }
+
+    nonisolated static let userTaskBlocked = String(
+        localized: "userTask.diagnostic.blocked",
+        defaultValue: "Task blocked by Pine’s safety policy."
+    )
+
+    nonisolated static func userTaskLaunchFailed(_ reason: String) -> String {
+        String(
+            localized: "userTask.diagnostic.launchFailed",
+            defaultValue: "Task failed to launch: \(reason)"
+        )
+    }
+
+    nonisolated static let userTaskDiagnosticBackgroundReaper = String(
+        localized: "userTask.diagnostic.backgroundReaper",
+        defaultValue: "Pine handed the task shell to its background reaper."
+    )
+    nonisolated static let userTaskDiagnosticSubprocessCleanup = String(
+        localized: "userTask.diagnostic.subprocessCleanup",
+        defaultValue: "Pine could not terminate every observed task subprocess."
+    )
+    nonisolated static let userTaskDiagnosticOutputDeadline = String(
+        localized: "userTask.diagnostic.outputDeadline",
+        defaultValue: "Pine stopped waiting for task output at its hard deadline."
+    )
+    nonisolated static let userTaskDiagnosticOutputTruncated = String(
+        localized: "userTask.diagnostic.outputTruncated",
+        defaultValue: "Task output exceeded Pine's capture limit and was truncated."
+    )
+    nonisolated static let userTaskDiagnosticInvalidUTF8 = String(
+        localized: "userTask.diagnostic.invalidUTF8",
+        defaultValue: "Task output contained invalid UTF-8 and was rejected."
+    )
+    nonisolated static let userTaskDiagnosticInputIncomplete = String(
+        localized: "userTask.diagnostic.inputIncomplete",
+        defaultValue: "The task stopped before Pine finished writing standard input."
+    )
 
     // MARK: - Quick Open
 

--- a/PineTests/ProjectRegistryTests.swift
+++ b/PineTests/ProjectRegistryTests.swift
@@ -122,6 +122,116 @@ struct ProjectRegistryTests {
         #expect(pm1 === pm2)
     }
 
+    @Test func taskHistoryIsProjectIsolatedAcrossCloseAndReopen() throws {
+        let firstDirectory = try makeTempDirectory()
+        let secondDirectory = try makeTempDirectory()
+        defer {
+            cleanup(firstDirectory)
+            cleanup(secondDirectory)
+        }
+
+        let registry = ProjectRegistry()
+        let first = try #require(
+            registry.projectManager(for: firstDirectory)
+        )
+        let second = try #require(
+            registry.projectManager(for: secondDirectory)
+        )
+        let firstRun = first.taskRunStore.start(makeTaskRun(id: "first"))
+        let secondRun = second.taskRunStore.start(makeTaskRun(id: "second"))
+
+        first.taskRunStore.finishRun(
+            id: firstRun.id,
+            outcome: makeTaskOutcome(id: "first"),
+            cancelled: false
+        )
+        #expect(firstRun.state == .succeeded)
+        #expect(secondRun.state == .pending)
+        #expect(first.taskRunStore.runs.map(\.taskID) == ["first"])
+        #expect(second.taskRunStore.runs.map(\.taskID) == ["second"])
+
+        registry.closeProjectWindow(firstDirectory)
+        #expect(!registry.isWindowOpen(firstDirectory))
+        #expect(first.taskRunStore.run(forID: firstRun.id) === firstRun)
+
+        let reopened = try #require(
+            registry.projectManager(for: firstDirectory)
+        )
+        #expect(reopened === first)
+        #expect(reopened.taskRunStore.run(forID: firstRun.id) === firstRun)
+        #expect(second.taskRunStore.run(forID: secondRun.id) === secondRun)
+    }
+
+    @Test func deletedBackgroundProjectCompletesTaskCleanup() async throws {
+        let tempDir = try makeTempDirectory()
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: tempDir))
+        let run = project.taskRunStore.start(makeTaskRun(id: "deleted"))
+        let probe = ProjectTaskCancellationProbe()
+        project.taskRunStore.registerCancellation(
+            UserTaskCancellation(
+                terminate: {
+                    probe.recordCancellation()
+                    return true
+                },
+                waitForCompletion: { _ in
+                    probe.recordWait()
+                    return true
+                }
+            ),
+            forRunID: run.id
+        )
+
+        registry.closeProjectWindow(tempDir)
+        cleanup(tempDir)
+        #expect(registry.projectManager(for: tempDir) == nil)
+        #expect(registry.detachedUserTaskCleanupCount == 1)
+
+        for _ in 0..<200 where project.hasOutstandingUserTaskExecution {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(probe.cancellationCount == 1)
+        #expect(probe.waitCount == 1)
+        #expect(!project.hasOutstandingUserTaskExecution)
+        #expect(project.taskRunStore.runs.isEmpty)
+        #expect(!registry.isProjectOpen(tempDir))
+        #expect(registry.detachedUserTaskCleanupCount == 0)
+    }
+
+    @Test func deletedProjectTimeoutRetainsCleanupOwnerForQuit() async throws {
+        let tempDir = try makeTempDirectory()
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: tempDir))
+        let run = project.taskRunStore.start(makeTaskRun(id: "slow-delete"))
+        let probe = ProjectTaskCancellationProbe(waitResult: false)
+        project.taskRunStore.registerCancellation(
+            probe.makeCancellation(),
+            forRunID: run.id
+        )
+
+        registry.closeProjectWindow(tempDir)
+        cleanup(tempDir)
+        #expect(registry.projectManager(for: tempDir) == nil)
+        for _ in 0..<200 where probe.waitCount == 0 {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+
+        #expect(probe.cancellationCount == 1)
+        #expect(probe.waitCount == 1)
+        #expect(project.hasOutstandingUserTaskExecution)
+        #expect(registry.detachedUserTaskCleanupCount == 1)
+        let didShutdown = await registry.shutdownUserTasks(until: .now())
+        #expect(!didShutdown)
+        #expect(!registry.destroyAllProjects())
+
+        project.taskRunStore.finishRun(
+            id: run.id,
+            outcome: makeTaskOutcome(id: "slow-delete"),
+            cancelled: true
+        )
+        #expect(registry.destroyAllProjects())
+    }
+
     // MARK: - Recent projects
 
     @Test func recentProjectsAddedOnOpen() throws {
@@ -255,5 +365,69 @@ struct ProjectRegistryTests {
         registry.closeProject(tempDir)
         #expect(registry.isProjectOpen(tempDir))
         #expect(!registry.isWindowOpen(tempDir))
+    }
+
+    private func makeTaskRun(id: String) -> UserTaskRun {
+        UserTaskRun(
+            taskID: id,
+            taskLabel: id,
+            command: "printf done",
+            replacesFileContent: false
+        )
+    }
+
+    private func makeTaskOutcome(id: String) -> UserTaskOutcome {
+        UserTaskOutcome(
+            taskID: id,
+            stdout: "done",
+            stderr: "",
+            exitCode: 0,
+            timedOut: false
+        )
+    }
+}
+
+nonisolated private final class ProjectTaskCancellationProbe:
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private let waitResult: Bool
+    private var cancellations = 0
+    private var waits = 0
+
+    init(waitResult: Bool = true) {
+        self.waitResult = waitResult
+    }
+
+    var cancellationCount: Int {
+        lock.withLock { cancellations }
+    }
+
+    var waitCount: Int {
+        lock.withLock { waits }
+    }
+
+    func recordCancellation() {
+        lock.withLock {
+            cancellations += 1
+        }
+    }
+
+    func recordWait() {
+        lock.withLock {
+            waits += 1
+        }
+    }
+
+    func makeCancellation() -> UserTaskCancellation {
+        UserTaskCancellation(
+            terminate: { [self] in
+                recordCancellation()
+                return true
+            },
+            waitForCompletion: { [self] _ in
+                recordWait()
+                return waitResult
+            }
+        )
     }
 }

--- a/PineTests/ProjectRegistryTests.swift
+++ b/PineTests/ProjectRegistryTests.swift
@@ -164,6 +164,8 @@ struct ProjectRegistryTests {
 
     @Test func deletedBackgroundProjectCompletesTaskCleanup() async throws {
         let tempDir = try makeTempDirectory()
+        let canonicalBeforeDeletion =
+            ProjectRegistry.canonicalProjectURL(tempDir)
         let registry = ProjectRegistry()
         let project = try #require(registry.projectManager(for: tempDir))
         let run = project.taskRunStore.start(makeTaskRun(id: "deleted"))
@@ -184,6 +186,10 @@ struct ProjectRegistryTests {
 
         registry.closeProjectWindow(tempDir)
         cleanup(tempDir)
+        #expect(
+            ProjectRegistry.canonicalProjectURL(tempDir)
+                == canonicalBeforeDeletion
+        )
         #expect(registry.projectManager(for: tempDir) == nil)
         #expect(registry.detachedUserTaskCleanupCount == 1)
 
@@ -200,6 +206,8 @@ struct ProjectRegistryTests {
 
     @Test func deletedProjectTimeoutRetainsCleanupOwnerForQuit() async throws {
         let tempDir = try makeTempDirectory()
+        let canonicalBeforeDeletion =
+            ProjectRegistry.canonicalProjectURL(tempDir)
         let registry = ProjectRegistry()
         let project = try #require(registry.projectManager(for: tempDir))
         let run = project.taskRunStore.start(makeTaskRun(id: "slow-delete"))
@@ -211,6 +219,10 @@ struct ProjectRegistryTests {
 
         registry.closeProjectWindow(tempDir)
         cleanup(tempDir)
+        #expect(
+            ProjectRegistry.canonicalProjectURL(tempDir)
+                == canonicalBeforeDeletion
+        )
         #expect(registry.projectManager(for: tempDir) == nil)
         for _ in 0..<200 where probe.waitCount == 0 {
             try? await Task.sleep(for: .milliseconds(5))

--- a/PineTests/UserTaskInvocationControllerTests.swift
+++ b/PineTests/UserTaskInvocationControllerTests.swift
@@ -11,46 +11,93 @@ import Testing
 
 @Suite("User task invocation safety")
 struct UserTaskInvocationControllerTests {
-    @Test("Output replacement requires the same unchanged editor buffer")
+    @Test("Successful output replacement requires the same unchanged editor buffer")
     func replacementRequiresSameUnchangedBuffer() {
         let tabID = UUID()
+        let fileURL = URL(fileURLWithPath: "/tmp/source.swift")
+        let success = outcome(exitCode: 0)
 
         #expect(UserTaskInvocationController.canApplyReplacement(
-            capturedTabID: tabID,
-            capturedContent: "before",
-            currentTabID: tabID,
-            currentContent: "before"
+            outcome: success,
+            cancelled: false,
+            captured: capture(id: tabID, url: fileURL),
+            current: capture(id: tabID, url: fileURL)
         ))
         #expect(!UserTaskInvocationController.canApplyReplacement(
-            capturedTabID: tabID,
-            capturedContent: "before",
-            currentTabID: UUID(),
-            currentContent: "before"
+            outcome: success,
+            cancelled: false,
+            captured: capture(id: tabID, url: fileURL),
+            current: capture(id: UUID(), url: fileURL)
         ))
         #expect(!UserTaskInvocationController.canApplyReplacement(
-            capturedTabID: tabID,
-            capturedContent: "before",
-            currentTabID: tabID,
-            currentContent: "human edit"
+            outcome: success,
+            cancelled: false,
+            captured: capture(id: tabID, url: fileURL),
+            current: capture(
+                id: tabID,
+                url: fileURL,
+                content: "human edit"
+            )
+        ))
+        #expect(!UserTaskInvocationController.canApplyReplacement(
+            outcome: success,
+            cancelled: false,
+            captured: capture(id: tabID, url: fileURL),
+            current: capture(
+                id: tabID,
+                url: URL(fileURLWithPath: "/tmp/saved-as.swift")
+            )
+        ))
+        #expect(!UserTaskInvocationController.canApplyReplacement(
+            outcome: success,
+            cancelled: false,
+            captured: capture(id: tabID, url: fileURL),
+            current: capture(id: tabID, url: fileURL, contentVersion: 2)
+        ))
+        #expect(!UserTaskInvocationController.canApplyReplacement(
+            outcome: success,
+            cancelled: false,
+            captured: capture(id: tabID, url: fileURL),
+            current: .init(
+                id: tabID,
+                url: fileURL.standardizedFileURL,
+                content: "before",
+                contentVersion: 1,
+                isEligibleForReplacement: false
+            )
         ))
     }
 
     @Test("Missing capture data always fails closed", arguments: [
-        (nil, "before", UUID(), "before"),
-        (UUID(), nil, UUID(), "before"),
+        (nil, URL(fileURLWithPath: "/tmp/a"), "before", 1),
+        (UUID(), nil, "before", 1),
+        (UUID(), URL(fileURLWithPath: "/tmp/a"), nil, 1),
+        (UUID(), URL(fileURLWithPath: "/tmp/a"), "before", nil),
         (nil, nil, nil, nil),
-    ] as [(UUID?, String?, UUID?, String?)])
+    ] as [(UUID?, URL?, String?, UInt64?)])
     func missingCaptureFailsClosed(
         capturedTabID: UUID?,
+        capturedURL: URL?,
         capturedContent: String?,
-        currentTabID: UUID?,
-        currentContent: String?
+        capturedContentVersion: UInt64?
     ) {
+        let current = capture(
+            id: capturedTabID ?? UUID(),
+            url: capturedURL ?? URL(fileURLWithPath: "/tmp/a"),
+            content: capturedContent ?? "before",
+            contentVersion: capturedContentVersion ?? 1
+        )
         #expect(!UserTaskInvocationController.canApplyReplacement(
-            capturedTabID: capturedTabID,
-            capturedContent: capturedContent,
-            currentTabID: currentTabID,
-            currentContent: currentContent
+            outcome: outcome(exitCode: 0),
+            cancelled: false,
+            captured: .init(
+                id: capturedTabID,
+                url: capturedURL,
+                content: capturedContent,
+                contentVersion: capturedContentVersion,
+                isEligibleForReplacement: true
+            ),
+            current: current
         ))
     }
 
@@ -101,6 +148,7 @@ struct UserTaskInvocationControllerTests {
                 },
                 runTask: { _, fileURL, _, content, _ in
                     runnerInputs.append((fileURL, content))
+                    return .noop
                 }
             )
         }
@@ -166,6 +214,7 @@ struct UserTaskInvocationControllerTests {
                 },
                 runTask: { _, fileURL, _, _, _ in
                     runnerFileURLs.append(fileURL)
+                    return .noop
                 }
             )
         }
@@ -178,5 +227,115 @@ struct UserTaskInvocationControllerTests {
 
         #expect(await invocation.value == false)
         #expect(runnerFileURLs.isEmpty)
+    }
+
+    @Test("Partial stdout from every unsuccessful path fails closed")
+    func unsuccessfulOutcomesNeverReplaceContent() {
+        let tabID = UUID()
+        let fileURL = URL(fileURLWithPath: "/tmp/source.swift")
+        let unsuccessfulPaths: [(UserTaskOutcome, Bool)] = [
+            (outcome(exitCode: 7, stdout: "partial"), false),
+            (outcome(exitCode: 15, stdout: "partial", timedOut: true), false),
+            (outcome(exitCode: -1, stdout: "partial"), false),
+            (outcome(exitCode: 15, stdout: "partial"), true),
+            // Cancellation wins even if the process happened to exit zero
+            // before termination was observed.
+            (outcome(exitCode: 0, stdout: "partial"), true),
+        ]
+
+        for (taskOutcome, cancelled) in unsuccessfulPaths {
+            #expect(!UserTaskInvocationController.canApplyReplacement(
+                outcome: taskOutcome,
+                cancelled: cancelled,
+                captured: capture(id: tabID, url: fileURL),
+                current: capture(id: tabID, url: fileURL)
+            ))
+        }
+    }
+
+    @Test(
+        "Replacement preflight requires active-file scope and a complete text tab",
+        arguments: [
+            (UserTask.Scope.activeFile, true, false, true),
+            (.project, true, false, false),
+            (.activeFile, false, false, false),
+            (.activeFile, true, true, false),
+            (.activeFile, true, nil, false),
+        ] as [(UserTask.Scope, Bool, Bool?, Bool)]
+    )
+    func replacementPreflight(
+        scope: UserTask.Scope,
+        isText: Bool,
+        isTruncated: Bool?,
+        expected: Bool
+    ) {
+        #expect(
+            UserTaskInvocationController.replacementTargetIsEligible(
+                scope: scope,
+                isText: isText,
+                isTruncated: isTruncated
+            ) == expected
+        )
+    }
+
+    @Test("Cleanup and incomplete stdin failures never replace content")
+    func lifecycleFailuresNeverReplaceContent() {
+        let tabID = UUID()
+        let fileURL = URL(fileURLWithPath: "/tmp/source.swift")
+        let capture = capture(id: tabID, url: fileURL)
+        let cleanupFailure = UserTaskOutcome(
+            taskID: "format",
+            stdout: "partial",
+            stderr: "cleanup",
+            exitCode: 0,
+            timedOut: false,
+            cleanupSucceeded: false
+        )
+        let inputFailure = UserTaskOutcome(
+            taskID: "format",
+            stdout: "partial",
+            stderr: "stdin",
+            exitCode: 0,
+            timedOut: false,
+            standardInputCompleted: false
+        )
+
+        for failure in [cleanupFailure, inputFailure] {
+            #expect(!UserTaskInvocationController.canApplyReplacement(
+                outcome: failure,
+                cancelled: false,
+                captured: capture,
+                current: capture
+            ))
+        }
+    }
+
+    private func capture(
+        id: UUID,
+        url: URL = URL(fileURLWithPath: "/tmp/source.swift"),
+        content: String = "before",
+        contentVersion: UInt64 = 1
+    ) -> UserTaskInvocationController.CapturedTab {
+        .init(
+            id: id,
+            url: url.standardizedFileURL,
+            content: content,
+            contentVersion: contentVersion,
+            isEligibleForReplacement: true
+        )
+    }
+
+    private func outcome(
+        exitCode: Int32,
+        stdout: String = "formatted",
+        timedOut: Bool = false
+    ) -> UserTaskOutcome {
+        UserTaskOutcome(
+            taskID: "format",
+            stdout: stdout,
+            stderr: exitCode == 0 ? "" : "failure",
+            exitCode: exitCode,
+            timedOut: timedOut
+        )
     }
 }

--- a/PineTests/UserTaskInvocationControllerTests.swift
+++ b/PineTests/UserTaskInvocationControllerTests.swift
@@ -310,6 +310,60 @@ struct UserTaskInvocationControllerTests {
         }
     }
 
+    @Test("Replacement conflict Copy and Open preserve the edited buffer")
+    @MainActor
+    func replacementConflictRecoveryActionsPreserveEdits() {
+        let project = ProjectManager()
+        let tab = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/pine-conflict.swift"),
+            content: "human edits",
+            savedContent: "before"
+        )
+        project.primaryTabManager.tabs = [tab]
+        project.primaryTabManager.activeTabID = tab.id
+        let run = UserTaskRun(
+            taskID: "format",
+            taskLabel: "Format",
+            command: "formatter",
+            replacesFileContent: true
+        )
+        run.applyOutcome(
+            outcome(exitCode: 0, stdout: "formatted output"),
+            cancelled: false
+        )
+        let window = NSWindow()
+        window.orderFront(nil)
+        let context = DialogPresenter.register(
+            window: window,
+            projectManager: project
+        )
+        defer {
+            DialogPresenter.ownerDidClose(window)
+            window.orderOut(nil)
+        }
+        var copiedOutput: String?
+
+        UserTaskInvocationController.applyReplacementConflictResponse(
+            .alertFirstButtonReturn,
+            run: run,
+            projectManager: project,
+            context: context,
+            copyOutput: { copiedOutput = $0 }
+        )
+        #expect(copiedOutput == "formatted output")
+        #expect(project.primaryTabManager.activeTab?.content == "human edits")
+
+        project.taskRunStore.isOutputVisible = false
+        UserTaskInvocationController.applyReplacementConflictResponse(
+            .alertSecondButtonReturn,
+            run: run,
+            projectManager: project,
+            context: context
+        )
+        #expect(project.taskRunStore.isOutputVisible)
+        #expect(project.primaryTabManager.activeTab?.content == "human edits")
+    }
+
     private func capture(
         id: UUID,
         url: URL = URL(fileURLWithPath: "/tmp/source.swift"),

--- a/PineTests/UserTaskLocalizationTests.swift
+++ b/PineTests/UserTaskLocalizationTests.swift
@@ -1,0 +1,115 @@
+//
+//  UserTaskLocalizationTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@Suite("User task localization")
+struct UserTaskLocalizationTests {
+    private static let locales = Set([
+        "de", "en", "es", "fr", "ja", "ko", "pt-BR", "ru", "zh-Hans",
+    ])
+
+    private static let keys = [
+        "userTask.replacementUnavailable.title",
+        "userTask.replacementUnavailable.message",
+        "userTask.toast.succeeded",
+        "userTask.copyOutput",
+        "userTask.openOutput",
+        "userTask.run.status.pending",
+        "userTask.run.status.running",
+        "userTask.run.status.cancelling",
+        "userTask.run.status.succeeded",
+        "userTask.run.status.timedOut",
+        "userTask.run.status.failed",
+        "userTask.run.status.cancelled",
+        "userTask.run.status.exitCode",
+        "userTask.run.elapsed",
+        "userTask.output.title",
+        "userTask.output.empty",
+        "userTask.output.previewTruncated",
+        "userTask.output.clearFinished",
+        "userTask.output.close",
+        "userTask.output.show",
+        "userTask.cancel",
+        "userTask.diagnostic.blocked",
+        "userTask.diagnostic.launchFailed",
+        "userTask.diagnostic.backgroundReaper",
+        "userTask.diagnostic.subprocessCleanup",
+        "userTask.diagnostic.outputDeadline",
+        "userTask.diagnostic.outputTruncated",
+        "userTask.diagnostic.invalidUTF8",
+        "userTask.diagnostic.inputIncomplete",
+    ]
+
+    @Test("Every task UI key is translated for all supported locales")
+    func completeCatalogCoverage() throws {
+        let catalog = try loadCatalog()
+
+        for key in Self.keys {
+            let entry = try #require(catalog[key] as? [String: Any])
+            let localizations = try #require(
+                entry["localizations"] as? [String: Any]
+            )
+            #expect(Set(localizations.keys) == Self.locales)
+
+            let english = try localizedValue(
+                in: localizations,
+                locale: "en"
+            )
+            let englishPlaceholders = placeholders(in: english)
+            for locale in Self.locales {
+                let value = try localizedValue(
+                    in: localizations,
+                    locale: locale
+                )
+                #expect(!value.trimmingCharacters(
+                    in: .whitespacesAndNewlines
+                ).isEmpty)
+                #expect(
+                    placeholders(in: value) == englishPlaceholders,
+                    "Placeholder mismatch for \(key) [\(locale)]"
+                )
+            }
+        }
+    }
+
+    private func loadCatalog() throws -> [String: Any] {
+        let projectRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let data = try Data(contentsOf: projectRoot.appendingPathComponent(
+            "Pine/Localizable.xcstrings"
+        ))
+        let root = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        return try #require(root["strings"] as? [String: Any])
+    }
+
+    private func localizedValue(
+        in localizations: [String: Any],
+        locale: String
+    ) throws -> String {
+        let localization = try #require(
+            localizations[locale] as? [String: Any]
+        )
+        let unit = try #require(
+            localization["stringUnit"] as? [String: Any]
+        )
+        #expect(unit["state"] as? String == "translated")
+        return try #require(unit["value"] as? String)
+    }
+
+    private func placeholders(in value: String) -> [String] {
+        let expression = try? NSRegularExpression(
+            pattern: #"%([0-9]+\$)?(?:@|lld)"#
+        )
+        let range = NSRange(value.startIndex..., in: value)
+        return expression?.matches(in: value, range: range).compactMap {
+            Range($0.range, in: value).map { String(value[$0]) }
+        } ?? []
+    }
+}

--- a/PineTests/UserTaskRunStoreTests.swift
+++ b/PineTests/UserTaskRunStoreTests.swift
@@ -1,0 +1,457 @@
+//
+//  UserTaskRunStoreTests.swift
+//  PineTests
+//
+
+import Darwin
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("User task run store lifecycle")
+@MainActor
+struct UserTaskRunStoreTests {
+    @Test("Cancel before handle arrival forwards cancellation exactly once")
+    func cancelBeforeHandleArrival() {
+        let store = UserTaskRunStore()
+        let run = store.start(makeRun())
+        let counter = CancellationCounter()
+
+        store.cancelRun(id: run.id)
+        #expect(run.state == .pending)
+        #expect(store.cancellationHandleCount == 0)
+        #expect(store.pendingCancellationCount == 1)
+
+        store.registerCancellation(
+            makeCancellation(counter: counter),
+            forRunID: run.id
+        )
+        #expect(counter.value == 1)
+        #expect(run.state == .cancelling)
+        #expect(run.state.isActive)
+        #expect(store.cancellationHandleCount == 1)
+        #expect(store.pendingCancellationCount == 0)
+
+        #expect(store.finishRun(
+            id: run.id,
+            outcome: outcome(exitCode: SIGTERM, stdout: "partial"),
+            cancelled: true
+        ))
+        #expect(run.state == .cancelled)
+        #expect(run.stdout == "partial")
+        #expect(counter.value == 1)
+        #expect(store.cancellationHandleCount == 0)
+        #expect(!store.finishRun(
+            id: run.id,
+            outcome: outcome(exitCode: 9, stdout: "late"),
+            cancelled: true
+        ))
+        #expect(run.stdout == "partial")
+    }
+
+    @Test("Normal finish releases its handle without cancelling it")
+    func normalFinishReleasesHandle() {
+        let store = UserTaskRunStore()
+        let run = store.start(makeRun())
+        let counter = CancellationCounter()
+        store.registerCancellation(
+            makeCancellation(counter: counter),
+            forRunID: run.id
+        )
+        #expect(store.cancellationHandleCount == 1)
+
+        #expect(store.finishRun(
+            id: run.id,
+            outcome: outcome(exitCode: 0, stdout: "complete"),
+            cancelled: false
+        ))
+
+        #expect(run.state == .succeeded)
+        #expect(run.stdout == "complete")
+        #expect(counter.value == 0)
+        #expect(store.cancellationHandleCount == 0)
+        #expect(!store.finishRun(
+            id: run.id,
+            outcome: outcome(exitCode: 9, stdout: "late"),
+            cancelled: false
+        ))
+        #expect(run.state == .succeeded)
+        #expect(run.stdout == "complete")
+    }
+
+    @Test("Rejected late cancellation preserves the completed outcome")
+    func rejectedLateCancellationPreservesOutcome() {
+        let store = UserTaskRunStore()
+        let run = store.start(makeRun())
+        let counter = CancellationCounter()
+
+        store.cancelRun(id: run.id)
+        #expect(store.pendingCancellationCount == 1)
+        store.registerCancellation(
+            makeCancellation(counter: counter, accepted: false),
+            forRunID: run.id
+        )
+
+        #expect(counter.value == 1)
+        #expect(run.state == .pending)
+        #expect(store.pendingCancellationCount == 0)
+
+        store.finishRun(
+            id: run.id,
+            outcome: outcome(exitCode: 0, stdout: "complete"),
+            cancelled: false
+        )
+        #expect(run.state == .succeeded)
+        #expect(run.stdout == "complete")
+    }
+
+    @Test("Late handle for a normally finished run is discarded")
+    func lateHandleAfterFinishIsDiscarded() {
+        let store = UserTaskRunStore()
+        let run = store.start(makeRun())
+        let counter = CancellationCounter()
+        store.finishRun(
+            id: run.id,
+            outcome: outcome(exitCode: 0),
+            cancelled: false
+        )
+
+        store.registerCancellation(
+            makeCancellation(counter: counter),
+            forRunID: run.id
+        )
+
+        #expect(run.state == .succeeded)
+        #expect(counter.value == 0)
+        #expect(store.cancellationHandleCount == 0)
+    }
+
+    @Test("Clear all cancels every retained handle before dropping it")
+    func clearAllCancelsHandles() {
+        let store = UserTaskRunStore()
+        let first = store.start(makeRun(taskID: "first"))
+        let second = store.start(makeRun(taskID: "second"))
+        let counter = CancellationCounter()
+        store.registerCancellation(
+            makeCancellation(counter: counter),
+            forRunID: first.id
+        )
+        store.registerCancellation(
+            makeCancellation(counter: counter),
+            forRunID: second.id
+        )
+        #expect(store.cancellationHandleCount == 2)
+
+        store.clearAll()
+
+        #expect(store.runs.isEmpty)
+        #expect(store.cancellationHandleCount == 0)
+        #expect(store.pendingCancellationCount == 0)
+        #expect(counter.value == 2)
+    }
+
+    @Test("Clear all forwards cancellation to a handle that arrives later")
+    func clearAllCancelsLateHandle() {
+        let store = UserTaskRunStore()
+        let run = store.start(makeRun())
+        let counter = CancellationCounter()
+
+        store.clearAll()
+        #expect(store.runs.isEmpty)
+        #expect(store.pendingCancellationCount == 1)
+
+        store.registerCancellation(
+            makeCancellation(counter: counter),
+            forRunID: run.id
+        )
+        #expect(counter.value == 1)
+        #expect(store.pendingCancellationCount == 0)
+        #expect(!store.finishRun(
+            id: run.id,
+            outcome: outcome(exitCode: SIGTERM),
+            cancelled: true
+        ))
+    }
+
+    @Test("Accepted cancellation remains active until cleanup outcome")
+    func cancellingRemainsActiveUntilFinish() {
+        let store = UserTaskRunStore()
+        let run = store.start(makeRun())
+        let counter = CancellationCounter()
+        store.registerCancellation(
+            makeCancellation(counter: counter),
+            forRunID: run.id
+        )
+
+        store.cancelRun(id: run.id)
+
+        #expect(run.state == .cancelling)
+        #expect(store.hasActiveRuns)
+        #expect(store.cancellationHandleCount == 1)
+
+        #expect(store.finishRun(
+            id: run.id,
+            outcome: outcome(exitCode: SIGTERM),
+            cancelled: true
+        ))
+        #expect(run.state == .cancelled)
+        #expect(!store.hasActiveRuns)
+        #expect(store.cancellationHandleCount == 0)
+    }
+
+    @Test("Cleanup failure is visible failure even after cancellation")
+    func cleanupFailureOverridesCancelledPresentation() {
+        let store = UserTaskRunStore()
+        let run = store.start(makeRun())
+        let counter = CancellationCounter()
+        store.registerCancellation(
+            makeCancellation(counter: counter),
+            forRunID: run.id
+        )
+        store.cancelRun(id: run.id)
+        store.isOutputVisible = false
+
+        #expect(store.finishRun(
+            id: run.id,
+            outcome: UserTaskOutcome(
+                taskID: "task",
+                stdout: "",
+                stderr: "cleanup failed",
+                exitCode: -1,
+                timedOut: false,
+                cleanupSucceeded: false
+            ),
+            cancelled: true
+        ))
+
+        #expect(run.state == .failed)
+        #expect(store.isOutputVisible)
+    }
+
+    @Test("Terminal transitions trim count while preserving active runs")
+    func terminalTrimCount() {
+        let store = UserTaskRunStore(
+            maximumRuns: 2,
+            maximumRetainedOutputBytes: 1_024
+        )
+        let active = store.start(makeRun(taskID: "active"))
+        let first = store.start(makeRun(taskID: "first"))
+        let second = store.start(makeRun(taskID: "second"))
+        let third = store.start(makeRun(taskID: "third"))
+
+        for run in [first, second, third] {
+            #expect(store.finishRun(
+                id: run.id,
+                outcome: outcome(exitCode: 0, stdout: run.taskID),
+                cancelled: false
+            ))
+        }
+
+        #expect(store.runs.count == 3)
+        #expect(store.run(forID: active.id) != nil)
+        #expect(store.run(forID: third.id) != nil)
+        #expect(store.run(forID: second.id) != nil)
+        #expect(store.run(forID: first.id) == nil)
+    }
+
+    @Test("Terminal transitions enforce retained UTF-8 byte budget")
+    func terminalTrimByteBudget() {
+        let store = UserTaskRunStore(
+            maximumRuns: 10,
+            maximumRetainedOutputBytes: 8
+        )
+        let first = store.start(makeRun(taskID: "first"))
+        let second = store.start(makeRun(taskID: "second"))
+
+        store.finishRun(
+            id: first.id,
+            outcome: outcome(exitCode: 0, stdout: "123456"),
+            cancelled: false
+        )
+        store.finishRun(
+            id: second.id,
+            outcome: outcome(exitCode: 0, stdout: "abcdef"),
+            cancelled: false
+        )
+
+        #expect(store.run(forID: first.id) == nil)
+        #expect(store.run(forID: second.id) != nil)
+        #expect(store.retainedOutputByteCount == 6)
+    }
+
+    @Test("Shutdown cancels and waits on every registered active handle")
+    func shutdownCancelsAndWaits() {
+        let store = UserTaskRunStore()
+        let first = store.start(makeRun(taskID: "first"))
+        let second = store.start(makeRun(taskID: "second"))
+        let counter = CancellationCounter()
+        let waits = CancellationCounter()
+        let handle = {
+            UserTaskCancellation(
+                terminate: {
+                    counter.increment()
+                    return true
+                },
+                waitForCompletion: { _ in
+                    waits.increment()
+                    return true
+                }
+            )
+        }
+        store.registerCancellation(handle(), forRunID: first.id)
+        store.registerCancellation(handle(), forRunID: second.id)
+
+        #expect(store.shutdownAll(until: .now() + 1))
+        #expect(counter.value == 2)
+        #expect(waits.value == 2)
+        #expect(store.runs.isEmpty)
+    }
+
+    @Test("Shutdown timeout retains cancelling run and its handle")
+    func shutdownTimeoutRetainsOwnership() {
+        let store = UserTaskRunStore()
+        let run = store.start(makeRun())
+        let counter = CancellationCounter()
+        store.registerCancellation(
+            UserTaskCancellation(
+                terminate: {
+                    counter.increment()
+                    return true
+                },
+                waitForCompletion: { _ in false }
+            ),
+            forRunID: run.id
+        )
+
+        #expect(!store.shutdownAll(until: .now()))
+        #expect(run.state == .cancelling)
+        #expect(store.run(forID: run.id)?.id == run.id)
+        #expect(store.cancellationHandleCount == 1)
+        #expect(counter.value == 1)
+    }
+
+    @Test("Elapsed time advances while active and freezes at completion")
+    func elapsedTimeLifecycle() {
+        let startedAt = Date(timeIntervalSinceReferenceDate: 1_000)
+        let run = makeRun(startedAt: startedAt)
+
+        #expect(run.elapsedSeconds(at: startedAt - 10) == 0)
+        #expect(run.elapsedText(at: startedAt + 65.9) == "1:05")
+
+        run.markRunning()
+        run.applyOutcome(
+            stdout: "",
+            stderr: "",
+            exitCode: 0,
+            timedOut: false,
+            cancelled: false,
+            finishedAt: startedAt + 3_661.9
+        )
+
+        #expect(run.state == .succeeded)
+        #expect(run.elapsedText(at: startedAt + 10_000) == "1:01:01")
+        #expect(
+            abs(run.elapsedSeconds(at: startedAt + 10_000) - 3_661.9)
+                < 0.001
+        )
+    }
+
+    @Test("Elapsed formatter covers minute and hour boundaries")
+    func elapsedFormatterBoundaries() {
+        #expect(UserTaskRun.formatElapsedDuration(0) == "0:00")
+        #expect(UserTaskRun.formatElapsedDuration(59.999) == "0:59")
+        #expect(UserTaskRun.formatElapsedDuration(60) == "1:00")
+        #expect(UserTaskRun.formatElapsedDuration(3_599) == "59:59")
+        #expect(UserTaskRun.formatElapsedDuration(3_600) == "1:00:00")
+        #expect(UserTaskRun.formatElapsedDuration(90_061) == "25:01:01")
+    }
+
+    @Test("Copy payload exactly matches the displayed combined output")
+    func outputCopyPayload() {
+        let stdoutOnly = makeRun(taskID: "stdout")
+        stdoutOnly.applyOutcome(
+            stdout: "standard output",
+            stderr: "",
+            exitCode: 0,
+            timedOut: false,
+            cancelled: false
+        )
+        #expect(stdoutOnly.outputCopyPayload == "standard output")
+
+        let stderrOnly = makeRun(taskID: "stderr")
+        stderrOnly.applyOutcome(
+            stdout: "",
+            stderr: "standard error",
+            exitCode: 7,
+            timedOut: false,
+            cancelled: false
+        )
+        #expect(stderrOnly.outputCopyPayload == "standard error")
+
+        let combined = makeRun(taskID: "combined")
+        combined.applyOutcome(
+            stdout: "standard output",
+            stderr: "standard error",
+            exitCode: 7,
+            timedOut: false,
+            cancelled: false
+        )
+        #expect(
+            combined.outputCopyPayload
+                == "standard output\nstandard error"
+        )
+        #expect(combined.outputCopyPayload == combined.combinedOutput)
+    }
+
+    private func makeRun(
+        taskID: String = "task",
+        startedAt: Date = Date()
+    ) -> UserTaskRun {
+        UserTaskRun(
+            taskID: taskID,
+            taskLabel: taskID,
+            command: "printf done",
+            replacesFileContent: false,
+            startedAt: startedAt
+        )
+    }
+
+    private func makeCancellation(
+        counter: CancellationCounter,
+        accepted: Bool = true
+    ) -> UserTaskCancellation {
+        UserTaskCancellation {
+            counter.increment()
+            return accepted
+        }
+    }
+
+    private func outcome(
+        exitCode: Int32,
+        stdout: String = ""
+    ) -> UserTaskOutcome {
+        UserTaskOutcome(
+            taskID: "task",
+            stdout: stdout,
+            stderr: "",
+            exitCode: exitCode,
+            timedOut: false
+        )
+    }
+}
+
+nonisolated private final class CancellationCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = 0
+
+    var value: Int {
+        lock.withLock { storage }
+    }
+
+    func increment() {
+        lock.withLock {
+            storage += 1
+        }
+    }
+}

--- a/PineTests/UserTaskRunStoreTests.swift
+++ b/PineTests/UserTaskRunStoreTests.swift
@@ -341,10 +341,13 @@ struct UserTaskRunStoreTests {
 
         run.markRunning()
         run.applyOutcome(
-            stdout: "",
-            stderr: "",
-            exitCode: 0,
-            timedOut: false,
+            UserTaskOutcome(
+                taskID: "elapsed",
+                stdout: "",
+                stderr: "",
+                exitCode: 0,
+                timedOut: false
+            ),
             cancelled: false,
             finishedAt: startedAt + 3_661.9
         )
@@ -367,34 +370,43 @@ struct UserTaskRunStoreTests {
         #expect(UserTaskRun.formatElapsedDuration(90_061) == "25:01:01")
     }
 
-    @Test("Copy payload exactly matches the displayed combined output")
+    @Test("Copy payload exactly preserves the captured combined output")
     func outputCopyPayload() {
         let stdoutOnly = makeRun(taskID: "stdout")
         stdoutOnly.applyOutcome(
-            stdout: "standard output",
-            stderr: "",
-            exitCode: 0,
-            timedOut: false,
+            UserTaskOutcome(
+                taskID: "stdout",
+                stdout: "standard output",
+                stderr: "",
+                exitCode: 0,
+                timedOut: false
+            ),
             cancelled: false
         )
         #expect(stdoutOnly.outputCopyPayload == "standard output")
 
         let stderrOnly = makeRun(taskID: "stderr")
         stderrOnly.applyOutcome(
-            stdout: "",
-            stderr: "standard error",
-            exitCode: 7,
-            timedOut: false,
+            UserTaskOutcome(
+                taskID: "stderr",
+                stdout: "",
+                stderr: "standard error",
+                exitCode: 7,
+                timedOut: false
+            ),
             cancelled: false
         )
         #expect(stderrOnly.outputCopyPayload == "standard error")
 
         let combined = makeRun(taskID: "combined")
         combined.applyOutcome(
-            stdout: "standard output",
-            stderr: "standard error",
-            exitCode: 7,
-            timedOut: false,
+            UserTaskOutcome(
+                taskID: "combined",
+                stdout: "standard output",
+                stderr: "standard error",
+                exitCode: 7,
+                timedOut: false
+            ),
             cancelled: false
         )
         #expect(
@@ -402,6 +414,80 @@ struct UserTaskRunStoreTests {
                 == "standard output\nstandard error"
         )
         #expect(combined.outputCopyPayload == combined.combinedOutput)
+    }
+
+    @Test("Output preview bounds bytes and preserves exact Copy payload")
+    func outputPreviewByteBoundaries() {
+        let limit = UserTaskOutputPreview.maximumUTF8Bytes
+        let exactText = String(repeating: "x", count: limit)
+        let exact = UserTaskOutcome(
+            taskID: "exact-preview",
+            stdout: exactText,
+            stderr: "",
+            exitCode: 0,
+            timedOut: false
+        )
+        #expect(exact.outputPreview.text == exactText)
+        #expect(!exact.outputPreview.wasTruncated)
+
+        let overLimitText = exactText + "y"
+        let overLimit = UserTaskOutcome(
+            taskID: "truncated-preview",
+            stdout: overLimitText,
+            stderr: "",
+            exitCode: 0,
+            timedOut: false
+        )
+        #expect(overLimit.outputPreview.text == exactText)
+        #expect(overLimit.outputPreview.wasTruncated)
+
+        let run = makeRun(taskID: "truncated-preview")
+        run.applyOutcome(overLimit, cancelled: false)
+        #expect(run.displayOutputPreview == exactText)
+        #expect(run.displayOutputPreviewWasTruncated)
+        #expect(run.outputCopyPayload == overLimitText)
+    }
+
+    @Test("Output preview accounts for stream separator and line boundary")
+    func outputPreviewStreamAndLineBoundaries() {
+        let byteLimit = UserTaskOutputPreview.maximumUTF8Bytes
+        let stdout = String(repeating: "x", count: byteLimit - 1)
+        let splitStreams = UserTaskOutputPreview.make(
+            stdout: stdout,
+            stderr: "z"
+        )
+        #expect(splitStreams.text == stdout + "\n")
+        #expect(splitStreams.wasTruncated)
+
+        let lineLimit = UserTaskOutputPreview.maximumLines
+        let lines = Array(
+            repeating: "line",
+            count: lineLimit + 1
+        ).joined(separator: "\n")
+        let lineBounded = UserTaskOutputPreview.make(
+            stdout: lines,
+            stderr: ""
+        )
+        #expect(lineBounded.text.split(
+            separator: "\n",
+            omittingEmptySubsequences: false
+        ).count == lineLimit)
+        #expect(lineBounded.wasTruncated)
+    }
+
+    @Test("Output preview never publishes partial UTF-8 scalars")
+    func outputPreviewUTF8Boundary() {
+        let limit = UserTaskOutputPreview.maximumUTF8Bytes
+        let prefix = String(repeating: "a", count: limit - 1)
+        let fullOutput = prefix + "🙂"
+        let preview = UserTaskOutputPreview.make(
+            stdout: fullOutput,
+            stderr: ""
+        )
+
+        #expect(preview.text == prefix)
+        #expect(preview.wasTruncated)
+        #expect(!preview.text.contains("\u{FFFD}"))
     }
 
     private func makeRun(

--- a/PineTests/UserTaskRunStoreTests.swift
+++ b/PineTests/UserTaskRunStoreTests.swift
@@ -127,7 +127,7 @@ struct UserTaskRunStoreTests {
         #expect(store.cancellationHandleCount == 0)
     }
 
-    @Test("Clear all cancels every retained handle before dropping it")
+    @Test("Clear all cancels every retained handle without dropping ownership")
     func clearAllCancelsHandles() {
         let store = UserTaskRunStore()
         let first = store.start(makeRun(taskID: "first"))
@@ -146,9 +146,23 @@ struct UserTaskRunStoreTests {
         store.clearAll()
 
         #expect(store.runs.isEmpty)
-        #expect(store.cancellationHandleCount == 0)
+        #expect(store.cancellationHandleCount == 2)
         #expect(store.pendingCancellationCount == 0)
         #expect(counter.value == 2)
+        #expect(store.hasOutstandingExecutionOwnership)
+
+        #expect(!store.finishRun(
+            id: first.id,
+            outcome: outcome(exitCode: SIGTERM),
+            cancelled: true
+        ))
+        #expect(!store.finishRun(
+            id: second.id,
+            outcome: outcome(exitCode: SIGTERM),
+            cancelled: true
+        ))
+        #expect(store.cancellationHandleCount == 0)
+        #expect(!store.hasOutstandingExecutionOwnership)
     }
 
     @Test("Clear all forwards cancellation to a handle that arrives later")
@@ -167,11 +181,13 @@ struct UserTaskRunStoreTests {
         )
         #expect(counter.value == 1)
         #expect(store.pendingCancellationCount == 0)
+        #expect(store.cancellationHandleCount == 1)
         #expect(!store.finishRun(
             id: run.id,
             outcome: outcome(exitCode: SIGTERM),
             cancelled: true
         ))
+        #expect(store.cancellationHandleCount == 0)
     }
 
     @Test("Accepted cancellation remains active until cleanup outcome")
@@ -205,8 +221,17 @@ struct UserTaskRunStoreTests {
         let store = UserTaskRunStore()
         let run = store.start(makeRun())
         let counter = CancellationCounter()
+        let cleanupGate = ShutdownWaitGate()
         store.registerCancellation(
-            makeCancellation(counter: counter),
+            UserTaskCancellation(
+                terminate: {
+                    counter.increment()
+                    return true
+                },
+                waitForCompletion: { deadline in
+                    cleanupGate.waitForRelease(until: deadline)
+                }
+            ),
             forRunID: run.id
         )
         store.cancelRun(id: run.id)
@@ -227,6 +252,73 @@ struct UserTaskRunStoreTests {
 
         #expect(run.state == .failed)
         #expect(store.isOutputVisible)
+        #expect(store.cancellationHandleCount == 1)
+        #expect(store.hasOutstandingExecutionOwnership)
+
+        cleanupGate.release()
+        #expect(!store.hasOutstandingExecutionOwnership)
+        #expect(store.cancellationHandleCount == 0)
+    }
+
+    @Test("Removing failed cleanup history preserves execution ownership")
+    func removeRunPreservesUnresolvedCleanup() {
+        let store = UserTaskRunStore()
+        let run = store.start(makeRun())
+        let cleanupGate = ShutdownWaitGate()
+        registerUnresolvedCleanup(
+            in: store,
+            run: run,
+            cleanupGate: cleanupGate
+        )
+
+        store.removeRun(id: run.id)
+
+        #expect(store.runs.isEmpty)
+        #expect(store.cancellationHandleCount == 1)
+        #expect(store.hasOutstandingExecutionOwnership)
+        cleanupGate.release()
+        #expect(!store.hasOutstandingExecutionOwnership)
+        #expect(store.cancellationHandleCount == 0)
+    }
+
+    @Test("Clearing failed cleanup history preserves execution ownership")
+    func clearFinishedPreservesUnresolvedCleanup() {
+        let store = UserTaskRunStore()
+        let run = store.start(makeRun())
+        let cleanupGate = ShutdownWaitGate()
+        registerUnresolvedCleanup(
+            in: store,
+            run: run,
+            cleanupGate: cleanupGate
+        )
+
+        store.clearFinished()
+
+        #expect(store.runs.isEmpty)
+        #expect(store.cancellationHandleCount == 1)
+        #expect(store.hasOutstandingExecutionOwnership)
+        cleanupGate.release()
+        #expect(!store.hasOutstandingExecutionOwnership)
+        #expect(store.cancellationHandleCount == 0)
+    }
+
+    @Test("History trimming preserves unresolved cleanup ownership")
+    func trimmingPreservesUnresolvedCleanup() {
+        let store = UserTaskRunStore(maximumRuns: 0)
+        let run = store.start(makeRun())
+        let cleanupGate = ShutdownWaitGate()
+        registerUnresolvedCleanup(
+            in: store,
+            run: run,
+            cleanupGate: cleanupGate
+        )
+
+        #expect(store.runs.isEmpty)
+        #expect(store.cancellationHandleCount == 1)
+        #expect(store.hasOutstandingExecutionOwnership)
+        cleanupGate.release()
+        #expect(!store.hasOutstandingExecutionOwnership)
+        #expect(store.cancellationHandleCount == 0)
     }
 
     @Test("Terminal transitions trim count while preserving active runs")
@@ -331,6 +423,44 @@ struct UserTaskRunStoreTests {
         #expect(store.run(forID: run.id)?.id == run.id)
         #expect(store.cancellationHandleCount == 1)
         #expect(counter.value == 1)
+    }
+
+    @Test("Failed wait cannot become successful when finish removes the handle")
+    func shutdownWaitFailureStaysFailClosedAcrossFinishRace() async {
+        let store = UserTaskRunStore()
+        let run = store.start(makeRun())
+        let gate = ShutdownWaitGate()
+        store.registerCancellation(
+            UserTaskCancellation(
+                terminate: { true },
+                waitForCompletion: { deadline in
+                    _ = gate.waitForRelease(until: deadline)
+                    return false
+                }
+            ),
+            forRunID: run.id
+        )
+
+        let shutdown = Task { @MainActor in
+            await store.shutdownAll(until: .now() + 2)
+        }
+        defer { gate.release() }
+
+        for _ in 0..<200 where !gate.didStartWaiting {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(gate.didStartWaiting)
+
+        #expect(store.finishRun(
+            id: run.id,
+            outcome: outcome(exitCode: 0),
+            cancelled: false
+        ))
+        gate.release()
+
+        let didShutdown = await shutdown.value
+        #expect(!didShutdown)
+        #expect(!store.runs.isEmpty)
     }
 
     @Test("Shutdown process waits do not block the main actor")
@@ -602,6 +732,34 @@ struct UserTaskRunStoreTests {
             counter.increment()
             return accepted
         }
+    }
+
+    private func registerUnresolvedCleanup(
+        in store: UserTaskRunStore,
+        run: UserTaskRun,
+        cleanupGate: ShutdownWaitGate
+    ) {
+        store.registerCancellation(
+            UserTaskCancellation(
+                terminate: { true },
+                waitForCompletion: { deadline in
+                    cleanupGate.waitForRelease(until: deadline)
+                }
+            ),
+            forRunID: run.id
+        )
+        #expect(store.finishRun(
+            id: run.id,
+            outcome: UserTaskOutcome(
+                taskID: run.taskID,
+                stdout: "",
+                stderr: "cleanup failed",
+                exitCode: -1,
+                timedOut: false,
+                cleanupSucceeded: false
+            ),
+            cancelled: false
+        ))
     }
 
     private func outcome(

--- a/PineTests/UserTaskRunStoreTests.swift
+++ b/PineTests/UserTaskRunStoreTests.swift
@@ -281,7 +281,7 @@ struct UserTaskRunStoreTests {
     }
 
     @Test("Shutdown cancels and waits on every registered active handle")
-    func shutdownCancelsAndWaits() {
+    func shutdownCancelsAndWaits() async {
         let store = UserTaskRunStore()
         let first = store.start(makeRun(taskID: "first"))
         let second = store.start(makeRun(taskID: "second"))
@@ -302,14 +302,15 @@ struct UserTaskRunStoreTests {
         store.registerCancellation(handle(), forRunID: first.id)
         store.registerCancellation(handle(), forRunID: second.id)
 
-        #expect(store.shutdownAll(until: .now() + 1))
+        let didShutdown = await store.shutdownAll(until: .now() + 1)
+        #expect(didShutdown)
         #expect(counter.value == 2)
         #expect(waits.value == 2)
         #expect(store.runs.isEmpty)
     }
 
     @Test("Shutdown timeout retains cancelling run and its handle")
-    func shutdownTimeoutRetainsOwnership() {
+    func shutdownTimeoutRetainsOwnership() async {
         let store = UserTaskRunStore()
         let run = store.start(makeRun())
         let counter = CancellationCounter()
@@ -324,11 +325,82 @@ struct UserTaskRunStoreTests {
             forRunID: run.id
         )
 
-        #expect(!store.shutdownAll(until: .now()))
+        let didShutdown = await store.shutdownAll(until: .now())
+        #expect(!didShutdown)
         #expect(run.state == .cancelling)
         #expect(store.run(forID: run.id)?.id == run.id)
         #expect(store.cancellationHandleCount == 1)
         #expect(counter.value == 1)
+    }
+
+    @Test("Shutdown process waits do not block the main actor")
+    func shutdownWaitDoesNotBlockMainActor() async {
+        let store = UserTaskRunStore()
+        let run = store.start(makeRun())
+        let gate = ShutdownWaitGate()
+        store.registerCancellation(
+            UserTaskCancellation(
+                terminate: { true },
+                waitForCompletion: { deadline in
+                    gate.waitForRelease(until: deadline)
+                }
+            ),
+            forRunID: run.id
+        )
+
+        let shutdown = Task { @MainActor in
+            await store.shutdownAll(until: .now() + 2)
+        }
+        defer { gate.release() }
+
+        for _ in 0..<200 where !gate.didStartWaiting {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(gate.didStartWaiting)
+
+        // This task cannot run until `shutdownAll` suspends the main actor.
+        let heartbeat = Task { @MainActor in true }
+        let mainActorResponded = await heartbeat.value
+        #expect(mainActorResponded)
+
+        gate.release()
+        let didShutdown = await shutdown.value
+        #expect(didShutdown)
+        #expect(store.runs.isEmpty)
+    }
+
+    @Test("A run started during shutdown is retained and fails shutdown closed")
+    func runStartedDuringShutdownIsNotDiscarded() async {
+        let store = UserTaskRunStore()
+        let first = store.start(makeRun(taskID: "first"))
+        let gate = ShutdownWaitGate()
+        store.registerCancellation(
+            UserTaskCancellation(
+                terminate: { true },
+                waitForCompletion: { deadline in
+                    gate.waitForRelease(until: deadline)
+                }
+            ),
+            forRunID: first.id
+        )
+        let shutdown = Task { @MainActor in
+            await store.shutdownAll(until: .now() + 2)
+        }
+        defer { gate.release() }
+
+        for _ in 0..<200 where !gate.didStartWaiting {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        let lateRun = store.start(makeRun(taskID: "late"))
+        store.registerCancellation(.noop, forRunID: lateRun.id)
+        gate.release()
+
+        let didShutdown = await shutdown.value
+        #expect(!didShutdown)
+        #expect(store.run(forID: first.id) != nil)
+        #expect(store.run(forID: lateRun.id) === lateRun)
+        #expect(lateRun.state == .pending)
+        #expect(store.hasOutstandingExecutionOwnership)
     }
 
     @Test("Elapsed time advances while active and freezes at completion")
@@ -558,5 +630,26 @@ nonisolated private final class CancellationCounter: @unchecked Sendable {
         lock.withLock {
             storage += 1
         }
+    }
+}
+
+nonisolated private final class ShutdownWaitGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private var startedWaiting = false
+
+    var didStartWaiting: Bool {
+        lock.withLock { startedWaiting }
+    }
+
+    func waitForRelease(until deadline: DispatchTime) -> Bool {
+        lock.withLock {
+            startedWaiting = true
+        }
+        return releaseSemaphore.wait(timeout: deadline) == .success
+    }
+
+    func release() {
+        releaseSemaphore.signal()
     }
 }

--- a/PineTests/UserTaskRunStoreTests.swift
+++ b/PineTests/UserTaskRunStoreTests.swift
@@ -456,7 +456,10 @@ struct UserTaskRunStoreTests {
             stdout: stdout,
             stderr: "z"
         )
-        #expect(splitStreams.text == stdout + "\n")
+        #expect(
+            splitStreams.text
+                == "z\n" + String(repeating: "x", count: byteLimit - 2)
+        )
         #expect(splitStreams.wasTruncated)
 
         let lineLimit = UserTaskOutputPreview.maximumLines
@@ -473,6 +476,22 @@ struct UserTaskRunStoreTests {
             omittingEmptySubsequences: false
         ).count == lineLimit)
         #expect(lineBounded.wasTruncated)
+    }
+
+    @Test("Bounded output preview prioritizes stderr diagnostics")
+    func outputPreviewPrioritizesStderr() {
+        let stdout = String(
+            repeating: "noisy output",
+            count: UserTaskOutputPreview.maximumUTF8Bytes
+        )
+        let stderr = "actionable failure"
+        let preview = UserTaskOutputPreview.make(
+            stdout: stdout,
+            stderr: stderr
+        )
+
+        #expect(preview.text.hasPrefix(stderr + "\n"))
+        #expect(preview.wasTruncated)
     }
 
     @Test("Output preview never publishes partial UTF-8 scalars")

--- a/PineTests/UserTaskRunnerTests.swift
+++ b/PineTests/UserTaskRunnerTests.swift
@@ -287,6 +287,55 @@ nonisolated struct UserTaskRunnerTests {
         #expect(executions.wait(timeout: .now() + 1) == .success)
     }
 
+    @Test("Runner schedules execution through the injected owner")
+    func runnerUsesInjectedExecutionScheduler() async {
+        let scheduler = HoldingUserTaskExecutionScheduler()
+        defer { scheduler.releaseAll() }
+        let runner = UserTaskRunner(
+            timeout: 2,
+            executionScheduler: scheduler
+        )
+        let probe = UserTaskRunnerProbe()
+
+        let cancellation = runner.run(
+            task: UserTask(
+                id: "held-owner",
+                label: "Held Owner",
+                command: "printf 'must-not-run'"
+            ),
+            fileURL: nil,
+            projectRootURL: FileManager.default.temporaryDirectory,
+            fileContent: nil,
+            progress: UserTaskProgress(
+                onStart: {
+                    probe.recordStart(
+                        callbackWasOnMainThread: Thread.isMainThread
+                    )
+                },
+                onFinish: { outcome, cancelled in
+                    probe.recordFinish(
+                        outcome: outcome,
+                        cancelled: cancelled,
+                        callbackWasOnMainThread: Thread.isMainThread
+                    )
+                }
+            )
+        )
+
+        await scheduler.waitUntilScheduled()
+        #expect(scheduler.scheduledOperationCount == 1)
+        #expect(!probe.didStart)
+        #expect(cancellation.cancel())
+        #expect(scheduler.releaseAll() == 1)
+
+        let completion = await probe.waitForCompletion()
+        #expect(completion.cancelled)
+        #expect(completion.outcome.exitCode == -1)
+        #expect(completion.outcome.stdout.isEmpty)
+        #expect(!probe.didStart)
+        #expect(probe.callbacksWereOnMainThread)
+    }
+
     @Test("Task start waits for stdout, stderr, and stdin workers")
     func taskStartWaitsForEveryIOWorker() async {
         let scheduler = HoldingUserTaskIOWorkerScheduler()
@@ -1253,6 +1302,53 @@ nonisolated private final class CancellationRaceResult: @unchecked Sendable {
         lock.withLock {
             finishStorage = cancelled
         }
+    }
+}
+
+nonisolated private final class HoldingUserTaskExecutionScheduler:
+    UserTaskExecutionScheduling,
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private let workerScheduler = UserTaskThreadExecutionScheduler()
+    private var operations: [@Sendable () -> Void] = []
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    var scheduledOperationCount: Int {
+        lock.withLock { operations.count }
+    }
+
+    func schedule(_ operation: @escaping @Sendable () -> Void) {
+        let waiters = lock.withLock {
+            operations.append(operation)
+            let waiters = self.waiters
+            self.waiters.removeAll()
+            return waiters
+        }
+        waiters.forEach { $0.resume() }
+    }
+
+    func waitUntilScheduled() async {
+        await withCheckedContinuation { continuation in
+            let shouldResume = lock.withLock {
+                guard operations.isEmpty else { return true }
+                waiters.append(continuation)
+                return false
+            }
+            if shouldResume {
+                continuation.resume()
+            }
+        }
+    }
+
+    @discardableResult
+    func releaseAll() -> Int {
+        let released = lock.withLock {
+            let operations = self.operations
+            self.operations.removeAll()
+            return operations
+        }
+        released.forEach { workerScheduler.schedule($0) }
+        return released.count
     }
 }
 

--- a/PineTests/UserTaskRunnerTests.swift
+++ b/PineTests/UserTaskRunnerTests.swift
@@ -25,7 +25,10 @@ nonisolated struct UserTaskRunnerTests {
         completed.complete(cleanupSucceeded: false)
         #expect(!completed.requestCancellation())
         #expect(completed.terminalCause == .naturalExit)
-        #expect(!completed.waitForCompletion(until: .now() + 1))
+        #expect(!completed.waitForCompletion(until: .now()))
+        completed.resolveDeferredCleanup()
+        completed.resolveDeferredCleanup()
+        #expect(completed.waitForCompletion(until: .now() + 1))
     }
 
     @Test("Concurrent cancel and natural exit select one lifecycle winner")
@@ -290,6 +293,7 @@ nonisolated struct UserTaskRunnerTests {
                 command: "while :; do /bin/sleep 1; done"
             )
         )
+        let cancellation = await probe.waitForCancellation()
         let processID = await processIDProbe.waitForProcessID()
         let completion = await probe.waitForCompletion()
 
@@ -308,10 +312,12 @@ nonisolated struct UserTaskRunnerTests {
         #expect(Darwin.waitpid(processID, &status, WNOHANG) == -1)
         #expect(errno == ECHILD)
 
+        #expect(!cancellation.wait(until: .now()))
         #expect(scheduler.releaseAll() == 2)
         #expect(
             scheduler.waitForReleasedOperations(until: .now() + 1)
         )
+        #expect(cancellation.wait(until: .now() + 1))
     }
 
     @Test("Successful replacement task receives stdin and captures stdout")

--- a/PineTests/UserTaskRunnerTests.swift
+++ b/PineTests/UserTaskRunnerTests.swift
@@ -1,0 +1,963 @@
+//
+//  UserTaskRunnerTests.swift
+//  PineTests
+//
+
+import Darwin
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("User task runner", .serialized, .timeLimit(.minutes(1)))
+nonisolated struct UserTaskRunnerTests {
+    @Test("Execution arbiter accepts pre-spawn cancel and rejects late cancel")
+    func executionStateLifecycle() {
+        let preSpawn = UserTaskExecutionState()
+        #expect(preSpawn.requestCancellation())
+        #expect(preSpawn.terminalCause == .cancelled)
+        #expect(!preSpawn.requestCancellation())
+        preSpawn.complete()
+        #expect(preSpawn.waitForCompletion(until: .now() + 1))
+
+        let completed = UserTaskExecutionState()
+        #expect(completed.claimNaturalExit())
+        completed.complete(cleanupSucceeded: false)
+        #expect(!completed.requestCancellation())
+        #expect(completed.terminalCause == .naturalExit)
+        #expect(!completed.waitForCompletion(until: .now() + 1))
+    }
+
+    @Test("Concurrent cancel and natural exit select one lifecycle winner")
+    func executionStateRace() {
+        for _ in 0..<250 {
+            let state = UserTaskExecutionState()
+            let result = CancellationRaceResult()
+
+            DispatchQueue.concurrentPerform(iterations: 2) { index in
+                if index == 0 {
+                    result.recordCancel(state.requestCancellation())
+                } else {
+                    result.recordFinish(state.claimNaturalExit())
+                }
+            }
+
+            #expect(result.cancelAccepted != result.finishAccepted)
+            let expectedCause: UserTaskTerminalCause =
+                result.cancelAccepted == true ? .cancelled : .naturalExit
+            #expect(state.terminalCause == expectedCause)
+            state.complete()
+        }
+    }
+
+    @Test("Subprocess owns its process group and reaps the direct shell")
+    func subprocessGroupAndReaping() throws {
+        let subprocess = try UserTaskSubprocess(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            command: "while :; do :; done",
+            workingDirectory: FileManager.default.temporaryDirectory
+        )
+        let processID = subprocess.processGroup.identifier
+        #expect(Darwin.getpgid(processID) == processID)
+
+        subprocess.standardInput.closeFile()
+        subprocess.processGroup.requestTermination()
+        let exitCode = subprocess.waitForExit()
+        #expect(exitCode == SIGTERM || exitCode == SIGKILL)
+        #expect(subprocess.processGroup.waitForRequestedTermination())
+
+        var status: Int32 = 0
+        errno = 0
+        #expect(Darwin.waitpid(processID, &status, WNOHANG) == -1)
+        #expect(errno == ECHILD)
+    }
+
+    @Test("Pipe reader stop is bounded while a writer remains open")
+    func pipeReaderStopIsBounded() {
+        let pipe = Pipe()
+        let readHandle = pipe.fileHandleForReading
+        let writeHandle = pipe.fileHandleForWriting
+        defer { writeHandle.closeFile() }
+        let stopState = UserTaskIOStopState()
+        let capture = UserTaskOutputCapture()
+        let finished = DispatchGroup()
+
+        finished.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer { finished.leave() }
+            capture.setStdout(
+                UserTaskPipeReader.read(
+                    from: readHandle,
+                    stopState: stopState
+                )
+            )
+        }
+        stopState.stop()
+
+        #expect(finished.wait(timeout: .now() + 0.5) == .success)
+        #expect(!capture.snapshot().stdout.reachedEndOfFile)
+    }
+
+    @Test("Successful replacement task receives stdin and captures stdout")
+    func successfulRun() async {
+        let runner = UserTaskRunner(timeout: 2)
+        let task = UserTask(
+            id: "success",
+            label: "Success",
+            command: "printf 'formatted:'; cat",
+            replacesFileContent: true
+        )
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("input.txt")
+        let probe = start(
+            runner: runner,
+            task: task,
+            fileURL: fileURL,
+            fileContent: "source"
+        )
+
+        let completion = await probe.waitForCompletion()
+
+        #expect(completion.outcome == UserTaskOutcome(
+            taskID: "success",
+            stdout: "formatted:source",
+            stderr: "",
+            exitCode: 0,
+            timedOut: false
+        ))
+        #expect(!completion.cancelled)
+        #expect(probe.didStart)
+        #expect(probe.callbacksWereOnMainThread)
+    }
+
+    @Test("Non-zero exit preserves partial stdout and stderr")
+    func nonZeroExit() async {
+        let runner = UserTaskRunner(timeout: 2)
+        let task = UserTask(
+            id: "nonzero",
+            label: "Non-zero",
+            command: "printf 'partial'; printf 'failure' >&2; exit 7"
+        )
+        let probe = start(runner: runner, task: task)
+
+        let completion = await probe.waitForCompletion()
+
+        #expect(completion.outcome.taskID == "nonzero")
+        #expect(completion.outcome.stdout == "partial")
+        #expect(completion.outcome.stderr == "failure")
+        #expect(completion.outcome.exitCode == 7)
+        #expect(!completion.outcome.timedOut)
+        #expect(!completion.outcome.succeeded)
+        #expect(!completion.cancelled)
+        #expect(probe.didStart)
+        #expect(probe.callbacksWereOnMainThread)
+    }
+
+    @Test("Invalid UTF-8 output fails closed")
+    func invalidUTF8Output() async {
+        let runner = UserTaskRunner(timeout: 2)
+        let task = UserTask(
+            id: "invalid-utf8",
+            label: "Invalid UTF-8",
+            command: "/usr/bin/printf '\\377'"
+        )
+        let probe = start(runner: runner, task: task)
+
+        let completion = await probe.waitForCompletion()
+
+        #expect(completion.outcome.stdout.isEmpty)
+        #expect(completion.outcome.exitCode == -1)
+        #expect(
+            completion.outcome.stderr.contains(
+                Strings.userTaskDiagnosticInvalidUTF8
+            )
+        )
+        #expect(!completion.outcome.succeeded)
+    }
+
+    @Test("Timeout terminates the process and is distinct from cancellation")
+    func timeout() async {
+        let runner = UserTaskRunner(timeout: 0.05)
+        let task = UserTask(
+            id: "timeout",
+            label: "Timeout",
+            command: "while :; do :; done"
+        )
+        let probe = start(runner: runner, task: task)
+
+        let completion = await probe.waitForCompletion()
+
+        #expect(completion.outcome.taskID == "timeout")
+        #expect(completion.outcome.timedOut)
+        #expect(completion.outcome.exitCode != 0)
+        #expect(!completion.outcome.succeeded)
+        #expect(!completion.cancelled)
+        #expect(probe.didStart)
+        #expect(probe.callbacksWereOnMainThread)
+    }
+
+    @Test("Spawn failure reports exit -1 without a start callback")
+    func spawnFailure() async {
+        let missingShell = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-pine-shell-\(UUID().uuidString)")
+        let runner = UserTaskRunner(
+            timeout: 2,
+            shellExecutableURL: missingShell
+        )
+        let task = UserTask(
+            id: "spawn",
+            label: "Spawn",
+            command: "printf 'unreachable'"
+        )
+        let probe = start(runner: runner, task: task)
+
+        let completion = await probe.waitForCompletion()
+
+        #expect(completion.outcome.taskID == "spawn")
+        #expect(completion.outcome.stdout.isEmpty)
+        #expect(!completion.outcome.stderr.isEmpty)
+        #expect(completion.outcome.exitCode == -1)
+        #expect(!completion.outcome.timedOut)
+        #expect(!completion.cancelled)
+        #expect(!probe.didStart)
+        #expect(probe.callbacksWereOnMainThread)
+    }
+
+    @Test("Validator rejection publishes ready then finish exactly once")
+    func validatorCallbackOrdering() async {
+        let task = UserTask(
+            id: "blocked",
+            label: "Blocked",
+            command: "rm -rf /"
+        )
+        let probe = start(
+            runner: UserTaskRunner(timeout: 2),
+            task: task
+        )
+
+        let completion = await probe.waitForCompletion()
+
+        #expect(!completion.outcome.succeeded)
+        #expect(!probe.didStart)
+        #expect(probe.callbackEvents == ["cancellation", "finish"])
+        #expect(probe.callbacksWereOnMainThread)
+    }
+
+    @Test("Cancellation terminates an active process without reporting timeout")
+    func cancellation() async {
+        let runner = UserTaskRunner(timeout: 5)
+        let task = UserTask(
+            id: "cancel",
+            label: "Cancel",
+            command: "while :; do :; done"
+        )
+        let probe = start(runner: runner, task: task)
+
+        let cancellation = await probe.waitForCancellation()
+        await probe.waitForStart()
+        cancellation.cancel()
+        let completion = await probe.waitForCompletion()
+
+        #expect(completion.outcome.taskID == "cancel")
+        #expect(cancellation.wait(until: .now() + 1))
+        #expect(completion.outcome.exitCode != 0)
+        #expect(!completion.outcome.timedOut)
+        #expect(!completion.outcome.succeeded)
+        #expect(completion.cancelled)
+        #expect(probe.didStart)
+        #expect(probe.callbacksWereOnMainThread)
+    }
+
+    @Test("Cancellation wins before timeout even when TERM is ignored")
+    func cancellationWinsBeforeTimeout() async {
+        let runner = UserTaskRunner(timeout: 0.5)
+        let task = UserTask(
+            id: "cancel-before-timeout",
+            label: "Cancel Before Timeout",
+            command: "trap '' TERM; while :; do :; done"
+        )
+        let probe = start(runner: runner, task: task)
+        let cancellation = await probe.waitForCancellation()
+        await probe.waitForStart()
+
+        #expect(cancellation.cancel())
+        #expect(!cancellation.cancel())
+        let completion = await probe.waitForCompletion()
+
+        #expect(completion.cancelled)
+        #expect(!completion.outcome.timedOut)
+    }
+
+    @Test("Timeout wins before a late cancellation")
+    func timeoutWinsBeforeCancellation() async {
+        let runner = UserTaskRunner(timeout: 0.05)
+        let task = UserTask(
+            id: "timeout-before-cancel",
+            label: "Timeout Before Cancel",
+            command: "trap '' TERM; while :; do :; done"
+        )
+        let probe = start(runner: runner, task: task)
+        let cancellation = await probe.waitForCancellation()
+        await probe.waitForStart()
+        try? await Task.sleep(for: .milliseconds(120))
+
+        #expect(!cancellation.cancel())
+        let completion = await probe.waitForCompletion()
+
+        #expect(!completion.cancelled)
+        #expect(completion.outcome.timedOut)
+    }
+
+    @Test("Natural, cancelled, and timed-out shells are reaped")
+    func directShellsAreReaped() async {
+        let cases: [(id: String, timeout: TimeInterval, cancel: Bool)] = [
+            ("natural-reap", 2, false),
+            ("cancel-reap", 2, true),
+            ("timeout-reap", 0.05, false),
+        ]
+
+        for testCase in cases {
+            let processIDURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(
+                    "pine-task-\(testCase.id)-\(UUID().uuidString)"
+                )
+            let body = testCase.id == "natural-reap"
+                ? "/bin/sleep 0.1"
+                : "trap '' TERM; while :; do :; done"
+            let command = """
+            /usr/bin/printf '%s' "$$" > \(shellQuote(processIDURL.path))
+            \(body)
+            """
+            let probe = start(
+                runner: UserTaskRunner(timeout: testCase.timeout),
+                task: UserTask(
+                    id: testCase.id,
+                    label: testCase.id,
+                    command: command
+                )
+            )
+            let cancellation = await probe.waitForCancellation()
+            await probe.waitForStart()
+            guard let processID = await waitForProcessID(
+                at: processIDURL
+            ), let identity = UserTaskProcessInspector.identity(
+                for: processID
+            ) else {
+                Issue.record("Task did not publish a live direct-shell pid")
+                try? FileManager.default.removeItem(at: processIDURL)
+                continue
+            }
+            if testCase.cancel {
+                #expect(cancellation.cancel())
+            }
+
+            _ = await probe.waitForCompletion()
+
+            #expect(
+                UserTaskProcessInspector.identity(for: processID) != identity
+            )
+            terminateIfStillCurrent(identity)
+            try? FileManager.default.removeItem(at: processIDURL)
+        }
+    }
+
+    @Test("CLOEXEC default rejects an ambient descriptor")
+    func ambientDescriptorIsNotInherited() async {
+        let sentinel = Pipe()
+        let descriptor = sentinel.fileHandleForReading.fileDescriptor
+        defer {
+            sentinel.fileHandleForReading.closeFile()
+            sentinel.fileHandleForWriting.closeFile()
+        }
+        let descriptorFlags = Darwin.fcntl(descriptor, F_GETFD)
+        #expect(descriptorFlags != -1)
+        #expect(
+            Darwin.fcntl(
+                descriptor,
+                F_SETFD,
+                descriptorFlags & ~FD_CLOEXEC
+            ) != -1
+        )
+        let task = UserTask(
+            id: "fd-inheritance",
+            label: "FD Inheritance",
+            command: """
+            if [ -e /dev/fd/\(descriptor) ]; then exit 91; else exit 0; fi
+            """
+        )
+        let probe = start(
+            runner: UserTaskRunner(timeout: 2),
+            task: task
+        )
+
+        let completion = await probe.waitForCompletion()
+
+        #expect(completion.outcome.succeeded)
+    }
+
+    @Test("Concurrent task spawn does not delay another task's pipe EOF")
+    func concurrentRunsDoNotCrossInheritPipes() async {
+        let runner = UserTaskRunner(timeout: 3)
+        let quick = UserTask(
+            id: "quick",
+            label: "Quick",
+            command: "printf quick; /bin/sleep 0.1"
+        )
+        let slow = UserTask(
+            id: "slow",
+            label: "Slow",
+            command: "/bin/sleep 1"
+        )
+        let clock = ContinuousClock()
+        let startTime = clock.now
+        let quickProbe = start(runner: runner, task: quick)
+        let slowProbe = start(runner: runner, task: slow)
+
+        let quickCompletion = await quickProbe.waitForCompletion()
+        let quickElapsed = startTime.duration(to: clock.now)
+        let slowCompletion = await slowProbe.waitForCompletion()
+
+        #expect(quickCompletion.outcome.succeeded)
+        #expect(quickCompletion.outcome.stdout == "quick")
+        #expect(quickElapsed < .milliseconds(700))
+        #expect(slowCompletion.outcome.succeeded)
+    }
+
+    @Test("Output capture accepts the exact limit and rejects one byte more")
+    func outputCaptureBoundaries() async {
+        let limit = UserTaskPipeReader.maximumCapturedBytes
+        let exactTask = UserTask(
+            id: "exact-output",
+            label: "Exact Output",
+            command: "/usr/bin/perl -e 'print \"x\" x \(limit)'"
+        )
+        let overflowTask = UserTask(
+            id: "overflow-output",
+            label: "Overflow Output",
+            command: "/usr/bin/perl -e 'print \"x\" x \(limit + 1)'"
+        )
+
+        let exact = await start(
+            runner: UserTaskRunner(timeout: 5),
+            task: exactTask
+        ).waitForCompletion()
+        let overflow = await start(
+            runner: UserTaskRunner(timeout: 5),
+            task: overflowTask
+        ).waitForCompletion()
+
+        #expect(exact.outcome.succeeded)
+        #expect(exact.outcome.stdout.utf8.count == limit)
+        #expect(!overflow.outcome.succeeded)
+        #expect(overflow.outcome.exitCode == -1)
+        #expect(overflow.outcome.stdout.utf8.count == limit)
+    }
+
+    @Test("Large stdout and stderr drain concurrently")
+    func largeOutputOnBothStreams() async {
+        let byteCount = 1_024 * 1_024
+        let task = UserTask(
+            id: "dual-output",
+            label: "Dual Output",
+            command: """
+            /usr/bin/perl -e \
+            'print STDOUT "o" x \(byteCount); print STDERR "e" x \(byteCount)'
+            """
+        )
+        let completion = await start(
+            runner: UserTaskRunner(timeout: 5),
+            task: task
+        ).waitForCompletion()
+
+        #expect(completion.outcome.succeeded)
+        #expect(completion.outcome.stdout.utf8.count == byteCount)
+        #expect(completion.outcome.stderr.utf8.count == byteCount)
+    }
+
+    @Test("Replacement fails when child closes stdin early")
+    func incompleteStandardInputFailsClosed() async {
+        let task = UserTask(
+            id: "stdin-epipe",
+            label: "Stdin EPIPE",
+            command: "exit 0",
+            replacesFileContent: true
+        )
+        let completion = await start(
+            runner: UserTaskRunner(timeout: 3),
+            task: task,
+            fileURL: URL(fileURLWithPath: "/tmp/input.txt"),
+            fileContent: String(repeating: "x", count: 2 * 1_024 * 1_024)
+        ).waitForCompletion()
+
+        #expect(!completion.outcome.standardInputCompleted)
+        #expect(!completion.outcome.succeeded)
+        #expect(completion.outcome.exitCode == -1)
+    }
+
+    @Test("libproc empty and saturated snapshots require fallback")
+    func libprocUnknownAndSaturation() {
+        #expect(!UserTaskProcessInspector.groupCountsAreComplete(
+            requestedCount: 0,
+            returnedCount: 0,
+            capacity: 16
+        ))
+        #expect(!UserTaskProcessInspector.groupCountsAreComplete(
+            requestedCount: 16,
+            returnedCount: 16,
+            capacity: 16
+        ))
+        #expect(!UserTaskProcessInspector.groupCountsAreComplete(
+            requestedCount: 1,
+            returnedCount: 16,
+            capacity: 16
+        ))
+        #expect(UserTaskProcessInspector.groupCountsAreComplete(
+            requestedCount: 1,
+            returnedCount: 1,
+            capacity: 16
+        ))
+    }
+
+    @Test("Cancellation terminates a shell descendant before completion")
+    func cancellationTerminatesDescendant() async {
+        let childPIDURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-task-child-\(UUID().uuidString)")
+        var childIdentity: UserTaskProcessIdentity?
+        defer {
+            terminateIfStillCurrent(childIdentity)
+            try? FileManager.default.removeItem(at: childPIDURL)
+        }
+        let command = """
+        /bin/sh -c 'trap "" HUP TERM; exec /bin/sleep 30' &
+        child=$!
+        /usr/bin/printf '%s' "$child" > \(shellQuote(childPIDURL.path))
+        wait "$child"
+        """
+        let runner = UserTaskRunner(timeout: 5)
+        let task = UserTask(
+            id: "cancel-child",
+            label: "Cancel Child",
+            command: command
+        )
+        let probe = start(runner: runner, task: task)
+
+        let cancellation = await probe.waitForCancellation()
+        await probe.waitForStart()
+        let childProcessID = await waitForProcessID(at: childPIDURL)
+        childIdentity = childProcessID.flatMap {
+            UserTaskProcessInspector.identity(for: $0)
+        }
+        cancellation.cancel()
+        let completion = await probe.waitForCompletion()
+
+        #expect(completion.cancelled)
+        #expect(!completion.outcome.timedOut)
+        if let childProcessID {
+            #expect(await waitForProcessExit(childProcessID))
+        } else {
+            Issue.record("Task did not publish its descendant pid")
+        }
+    }
+
+    @Test("Successful shell exit cleans a background descendant")
+    func successfulExitCleansBackgroundDescendant() async {
+        let childPIDURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-task-background-\(UUID().uuidString)")
+        var childIdentity: UserTaskProcessIdentity?
+        defer {
+            terminateIfStillCurrent(childIdentity)
+            try? FileManager.default.removeItem(at: childPIDURL)
+        }
+        let command = """
+        /bin/sh -c 'trap "" HUP TERM; exec /bin/sleep 30' &
+        child=$!
+        /usr/bin/printf '%s' "$child" > \(shellQuote(childPIDURL.path))
+        """
+        let runner = UserTaskRunner(timeout: 5)
+        let task = UserTask(
+            id: "background-child",
+            label: "Background Child",
+            command: command
+        )
+        let probe = start(runner: runner, task: task)
+
+        let completion = await probe.waitForCompletion()
+        let childProcessID = await waitForProcessID(at: childPIDURL)
+        childIdentity = childProcessID.flatMap {
+            UserTaskProcessInspector.identity(for: $0)
+        }
+
+        #expect(completion.outcome.succeeded)
+        #expect(!completion.cancelled)
+        if let childProcessID {
+            #expect(await waitForProcessExit(childProcessID))
+        } else {
+            Issue.record("Task did not publish its background child pid")
+        }
+    }
+
+    @Test("Escaped descendant cannot hold output pipes open indefinitely")
+    func escapedDescendantHasBoundedCleanup() async {
+        let childPIDURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-task-escaped-\(UUID().uuidString)")
+        var childProcessID: pid_t?
+        var childIdentity: UserTaskProcessIdentity?
+        defer {
+            terminateIfStillCurrent(childIdentity)
+            try? FileManager.default.removeItem(at: childPIDURL)
+        }
+        let command = """
+        /usr/bin/perl -MPOSIX=setsid -e '
+            my $path = shift;
+            setsid() >= 0 or die "setsid";
+            open my $file, ">", $path or die "pid file";
+            print {$file} $$;
+            close $file;
+            $SIG{HUP} = "IGNORE";
+            $SIG{TERM} = "IGNORE";
+            exec "/bin/sleep", "30";
+        ' \(shellQuote(childPIDURL.path)) &
+        /bin/sleep 0.3
+        """
+        let runner = UserTaskRunner(timeout: 5)
+        let task = UserTask(
+            id: "escaped-child",
+            label: "Escaped Child",
+            command: command
+        )
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+        let probe = start(runner: runner, task: task)
+
+        childProcessID = await waitForProcessID(at: childPIDURL)
+        childIdentity = childProcessID.flatMap {
+            UserTaskProcessInspector.identity(for: $0)
+        }
+        if let childProcessID {
+            #expect(Darwin.getpgid(childProcessID) == childProcessID)
+        } else {
+            Issue.record("Task did not publish its escaped descendant pid")
+        }
+
+        let completion = await probe.waitForCompletion()
+        let elapsed = startedAt.duration(to: clock.now)
+
+        #expect(elapsed < .seconds(3))
+        #expect(completion.outcome.succeeded)
+        #expect(!completion.cancelled)
+        if let childProcessID {
+            #expect(await waitForProcessExit(childProcessID))
+        }
+    }
+
+    @Test("Immediate double-fork escape follows the documented best-effort contract")
+    func immediateDoubleForkIsBounded() async {
+        let childPIDURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pine-task-double-fork-\(UUID().uuidString)")
+        var escapedIdentity: UserTaskProcessIdentity?
+        defer {
+            terminateIfStillCurrent(escapedIdentity)
+            try? FileManager.default.removeItem(at: childPIDURL)
+        }
+        let command = """
+        /usr/bin/perl -MPOSIX=setsid -e '
+            my $path = shift;
+            my $first = fork();
+            exit 0 if $first;
+            setsid() >= 0 or exit 1;
+            my $second = fork();
+            exit 0 if $second;
+            open STDIN, "<", "/dev/null";
+            open STDOUT, ">", "/dev/null";
+            open STDERR, ">", "/dev/null";
+            open my $file, ">", $path or exit 1;
+            print {$file} $$;
+            close $file;
+            sleep 30;
+        ' \(shellQuote(childPIDURL.path))
+        """
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+        let completion = await start(
+            runner: UserTaskRunner(timeout: 3),
+            task: UserTask(
+                id: "double-fork",
+                label: "Double Fork",
+                command: command
+            )
+        ).waitForCompletion()
+        let elapsed = startedAt.duration(to: clock.now)
+
+        // Darwin has no public kill-process-tree primitive. A daemon that
+        // double-forks and calls setsid between 25 ms identity snapshots can
+        // escape; the supported guarantee is bounded return plus cleanup of
+        // every identity Pine actually observed.
+        #expect(elapsed < .seconds(3))
+        #expect(!completion.outcome.timedOut)
+
+        if let childProcessID = await waitForProcessID(at: childPIDURL) {
+            escapedIdentity = UserTaskProcessInspector.identity(
+                for: childProcessID
+            )
+            if let escapedIdentity,
+               UserTaskProcessInspector.identity(
+                   for: escapedIdentity.processID
+               ) == escapedIdentity {
+                _ = Darwin.kill(escapedIdentity.processID, SIGKILL)
+                #expect(await waitForProcessExit(escapedIdentity.processID))
+            }
+        }
+    }
+
+    private func start(
+        runner: UserTaskRunner,
+        task: UserTask,
+        fileURL: URL? = nil,
+        fileContent: String? = nil
+    ) -> UserTaskRunnerProbe {
+        let probe = UserTaskRunnerProbe()
+        runner.run(
+            task: task,
+            fileURL: fileURL,
+            projectRootURL: FileManager.default.temporaryDirectory,
+            fileContent: fileContent,
+            progress: UserTaskProgress(
+                onStart: {
+                    probe.recordStart(
+                        callbackWasOnMainThread: Thread.isMainThread
+                    )
+                },
+                onFinish: { outcome, cancelled in
+                    probe.recordFinish(
+                        outcome: outcome,
+                        cancelled: cancelled,
+                        callbackWasOnMainThread: Thread.isMainThread
+                    )
+                },
+                onCancellationReady: { cancellation in
+                    probe.recordCancellation(
+                        cancellation,
+                        callbackWasOnMainThread: Thread.isMainThread
+                    )
+                }
+            )
+        )
+        return probe
+    }
+
+    private func shellQuote(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    private func waitForProcessID(at url: URL) async -> pid_t? {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while clock.now < deadline {
+            if let text = try? String(contentsOf: url, encoding: .utf8),
+               let processID = pid_t(text) {
+                return processID
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return nil
+    }
+
+    private func waitForProcessExit(_ processID: pid_t) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while isProcessAlive(processID), clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return !isProcessAlive(processID)
+    }
+
+    private func isProcessAlive(_ processID: pid_t) -> Bool {
+        var info = proc_bsdinfo()
+        let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.size)
+        if proc_pidinfo(
+            processID,
+            PROC_PIDTBSDINFO,
+            0,
+            &info,
+            expectedSize
+        ) == expectedSize,
+           info.pbi_status == UInt32(SZOMB) {
+            return false
+        }
+        if Darwin.kill(processID, 0) == 0 {
+            return true
+        }
+        return errno != ESRCH
+    }
+
+    private func terminateIfStillCurrent(
+        _ identity: UserTaskProcessIdentity?
+    ) {
+        guard let identity,
+              UserTaskProcessInspector.identity(
+                  for: identity.processID
+              ) == identity else {
+            return
+        }
+        _ = Darwin.kill(identity.processID, SIGKILL)
+        let deadline = DispatchTime.now() + 1
+        while UserTaskProcessInspector.identity(
+            for: identity.processID
+        ) == identity,
+              DispatchTime.now() < deadline {
+            Darwin.usleep(10_000)
+        }
+    }
+}
+
+nonisolated private struct UserTaskRunnerCompletion: Sendable {
+    let outcome: UserTaskOutcome
+    let cancelled: Bool
+}
+
+nonisolated private final class CancellationRaceResult: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelStorage: Bool?
+    private var finishStorage: Bool?
+
+    var cancelAccepted: Bool? {
+        lock.withLock { cancelStorage }
+    }
+
+    var finishAccepted: Bool? {
+        lock.withLock { finishStorage }
+    }
+
+    func recordCancel(_ accepted: Bool) {
+        lock.withLock {
+            cancelStorage = accepted
+        }
+    }
+
+    func recordFinish(_ cancelled: Bool) {
+        lock.withLock {
+            finishStorage = cancelled
+        }
+    }
+}
+
+nonisolated private final class UserTaskRunnerProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var started = false
+    private var completion: UserTaskRunnerCompletion?
+    private var cancellation: UserTaskCancellation?
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+    private var completionWaiters: [
+        CheckedContinuation<UserTaskRunnerCompletion, Never>
+    ] = []
+    private var cancellationWaiters: [
+        CheckedContinuation<UserTaskCancellation, Never>
+    ] = []
+    private var callbackThreadChecks: [Bool] = []
+    private var events: [String] = []
+
+    var didStart: Bool {
+        lock.withLock { started }
+    }
+
+    var callbacksWereOnMainThread: Bool {
+        lock.withLock {
+            !callbackThreadChecks.isEmpty
+                && callbackThreadChecks.allSatisfy { $0 }
+        }
+    }
+
+    var callbackEvents: [String] {
+        lock.withLock { events }
+    }
+
+    func recordStart(callbackWasOnMainThread: Bool) {
+        let waiters = lock.withLock {
+            started = true
+            callbackThreadChecks.append(callbackWasOnMainThread)
+            events.append("start")
+            let waiters = startWaiters
+            startWaiters.removeAll()
+            return waiters
+        }
+        waiters.forEach { $0.resume() }
+    }
+
+    func recordFinish(
+        outcome: UserTaskOutcome,
+        cancelled: Bool,
+        callbackWasOnMainThread: Bool
+    ) {
+        let value = UserTaskRunnerCompletion(
+            outcome: outcome,
+            cancelled: cancelled
+        )
+        let waiters = lock.withLock {
+            completion = value
+            callbackThreadChecks.append(callbackWasOnMainThread)
+            events.append("finish")
+            let waiters = completionWaiters
+            completionWaiters.removeAll()
+            return waiters
+        }
+        waiters.forEach { $0.resume(returning: value) }
+    }
+
+    func recordCancellation(
+        _ cancellation: UserTaskCancellation,
+        callbackWasOnMainThread: Bool
+    ) {
+        let waiters = lock.withLock {
+            self.cancellation = cancellation
+            callbackThreadChecks.append(callbackWasOnMainThread)
+            events.append("cancellation")
+            let waiters = cancellationWaiters
+            cancellationWaiters.removeAll()
+            return waiters
+        }
+        waiters.forEach { $0.resume(returning: cancellation) }
+    }
+
+    func waitForStart() async {
+        await withCheckedContinuation { continuation in
+            let shouldResume = lock.withLock {
+                guard !started else { return true }
+                startWaiters.append(continuation)
+                return false
+            }
+            if shouldResume {
+                continuation.resume()
+            }
+        }
+    }
+
+    func waitForCompletion() async -> UserTaskRunnerCompletion {
+        await withCheckedContinuation { continuation in
+            let completed: UserTaskRunnerCompletion? = lock.withLock {
+                guard let completion else {
+                    completionWaiters.append(continuation)
+                    return nil
+                }
+                return completion
+            }
+            if let completed {
+                continuation.resume(returning: completed)
+            }
+        }
+    }
+
+    func waitForCancellation() async -> UserTaskCancellation {
+        await withCheckedContinuation { continuation in
+            let ready: UserTaskCancellation? = lock.withLock {
+                guard let cancellation else {
+                    cancellationWaiters.append(continuation)
+                    return nil
+                }
+                return cancellation
+            }
+            if let ready {
+                continuation.resume(returning: ready)
+            }
+        }
+    }
+}

--- a/PineTests/UserTaskRunnerTests.swift
+++ b/PineTests/UserTaskRunnerTests.swift
@@ -54,7 +54,7 @@ nonisolated struct UserTaskRunnerTests {
     func subprocessGroupAndReaping() throws {
         let subprocess = try UserTaskSubprocess(
             executableURL: URL(fileURLWithPath: "/bin/sh"),
-            command: "while :; do :; done",
+            command: "while :; do /bin/sleep 1; done",
             workingDirectory: FileManager.default.temporaryDirectory
         )
         let processID = subprocess.processGroup.identifier
@@ -72,6 +72,62 @@ nonisolated struct UserTaskRunnerTests {
         #expect(errno == ECHILD)
     }
 
+    @Test("Termination wait observes the request before member capture")
+    func terminationRequestIsPublishedBeforeCapture() throws {
+        let subprocess = try UserTaskSubprocess(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            command: "while :; do /bin/sleep 1; done",
+            workingDirectory: FileManager.default.temporaryDirectory
+        )
+        let captureStarted = DispatchSemaphore(value: 0)
+        let releaseCapture = DispatchSemaphore(value: 0)
+        let requestFinished = DispatchSemaphore(value: 0)
+        var didReap = false
+        defer {
+            releaseCapture.signal()
+            subprocess.processGroup.requestTermination()
+            if !didReap {
+                _ = Darwin.kill(
+                    -subprocess.processGroup.identifier,
+                    SIGKILL
+                )
+                _ = subprocess.waitForExit()
+            }
+        }
+
+        let requestQueue = DispatchQueue(
+            label: "com.pine.tests.user-task-termination-request"
+        )
+        requestQueue.async {
+            subprocess.processGroup.requestTermination(
+                beforeMemberCapture: {
+                    captureStarted.signal()
+                    _ = releaseCapture.wait(timeout: .now() + 2)
+                }
+            )
+            requestFinished.signal()
+        }
+
+        #expect(captureStarted.wait(timeout: .now() + 2) == .success)
+        #expect(subprocess.processGroup.terminationWasRequested)
+        #expect(!subprocess.processGroup.waitForRequestedTermination(
+            completionTimeout: 0
+        ))
+
+        releaseCapture.signal()
+        let requestDidFinish =
+            requestFinished.wait(timeout: .now() + 2) == .success
+        #expect(requestDidFinish)
+        if !requestDidFinish {
+            _ = Darwin.kill(-subprocess.processGroup.identifier, SIGKILL)
+        }
+        let exitCode = subprocess.waitForExit()
+        didReap = true
+
+        #expect(exitCode == SIGTERM || exitCode == SIGKILL)
+        #expect(subprocess.processGroup.waitForRequestedTermination())
+    }
+
     @Test("Pipe reader stop is bounded while a writer remains open")
     func pipeReaderStopIsBounded() {
         let pipe = Pipe()
@@ -81,10 +137,15 @@ nonisolated struct UserTaskRunnerTests {
         let stopState = UserTaskIOStopState()
         let capture = UserTaskOutputCapture()
         let finished = DispatchGroup()
+        let started = DispatchSemaphore(value: 0)
+        let readerQueue = DispatchQueue(
+            label: "com.pine.tests.user-task-pipe-reader"
+        )
 
         finished.enter()
-        DispatchQueue.global(qos: .userInitiated).async {
+        readerQueue.async {
             defer { finished.leave() }
+            started.signal()
             capture.setStdout(
                 UserTaskPipeReader.read(
                     from: readHandle,
@@ -92,10 +153,165 @@ nonisolated struct UserTaskRunnerTests {
                 )
             )
         }
+        #expect(started.wait(timeout: .now() + 1) == .success)
         stopState.stop()
 
-        #expect(finished.wait(timeout: .now() + 0.5) == .success)
+        #expect(finished.wait(timeout: .now() + 1) == .success)
         #expect(!capture.snapshot().stdout.reachedEndOfFile)
+    }
+
+    @Test("I/O shutdown allows delayed workers to finish before forcing stop")
+    func ioShutdownAllowsNaturalDrain() {
+        let group = DispatchGroup()
+        let stopState = UserTaskIOStopState()
+        let queue = DispatchQueue(
+            label: "com.pine.tests.user-task-delayed-io"
+        )
+
+        group.enter()
+        queue.asyncAfter(deadline: .now() + 0.05) {
+            group.leave()
+        }
+
+        #expect(UserTaskIOShutdown.waitForCompletion(
+            group,
+            stopState: stopState,
+            naturalTimeout: 0.5,
+            forcedTimeout: 0.5
+        ))
+        #expect(!stopState.shouldStop)
+    }
+
+    @Test("I/O shutdown forces a bounded stop after the drain deadline")
+    func ioShutdownForcesStop() {
+        let group = DispatchGroup()
+        let stopState = UserTaskIOStopState()
+        let started = DispatchSemaphore(value: 0)
+        let queue = DispatchQueue(
+            label: "com.pine.tests.user-task-forced-io"
+        )
+
+        group.enter()
+        queue.async {
+            started.signal()
+            while !stopState.shouldStop {
+                Darwin.usleep(1_000)
+            }
+            group.leave()
+        }
+        #expect(started.wait(timeout: .now() + 1) == .success)
+
+        #expect(UserTaskIOShutdown.waitForCompletion(
+            group,
+            stopState: stopState,
+            naturalTimeout: 0.01,
+            forcedTimeout: 0.5
+        ))
+        #expect(stopState.shouldStop)
+    }
+
+    @Test("I/O startup barrier opens only after every worker starts")
+    func ioStartupBarrierRequiresEveryWorker() {
+        let barrier = UserTaskIOStartupBarrier(workerCount: 3)
+
+        barrier.workerDidStart()
+        barrier.workerDidStart()
+        #expect(!barrier.wait(timeout: 0))
+
+        barrier.workerDidStart()
+        #expect(barrier.wait(timeout: 0))
+    }
+
+    @Test("Task start waits for stdout, stderr, and stdin workers")
+    func taskStartWaitsForEveryIOWorker() async {
+        let scheduler = HoldingUserTaskIOWorkerScheduler()
+        defer { scheduler.releaseAll() }
+        let runner = UserTaskRunner(
+            timeout: 2,
+            ioExecutionPolicy: UserTaskIOExecutionPolicy(
+                workerScheduler: scheduler,
+                startupDeadline: 5,
+                shutdownDeadline: 0.5
+            )
+        )
+        let task = UserTask(
+            id: "io-startup",
+            label: "I/O Startup",
+            command: "cat",
+            replacesFileContent: true
+        )
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("io-startup.txt")
+        let probe = start(
+            runner: runner,
+            task: task,
+            fileURL: fileURL,
+            fileContent: "source"
+        )
+
+        await scheduler.waitUntilScheduled(operationCount: 3)
+        #expect(!probe.didStart)
+        #expect(scheduler.release(operationCount: 2) == 2)
+        #expect(!probe.didStart)
+        #expect(scheduler.releaseAll() == 1)
+
+        await probe.waitForStart()
+        let completion = await probe.waitForCompletion()
+
+        #expect(completion.outcome.succeeded)
+        #expect(completion.outcome.stdout == "source")
+        #expect(probe.didStart)
+        #expect(
+            scheduler.waitForReleasedOperations(until: .now() + 1)
+        )
+    }
+
+    @Test("I/O startup failure reaps the child without publishing start")
+    func ioStartupFailureIsBoundedAndReapsChild() async {
+        let scheduler = HoldingUserTaskIOWorkerScheduler()
+        defer { scheduler.releaseAll() }
+        let processIDProbe = UserTaskProcessIDProbe()
+        let runner = UserTaskRunner(
+            timeout: 5,
+            ioExecutionPolicy: UserTaskIOExecutionPolicy(
+                workerScheduler: scheduler,
+                startupDeadline: 0,
+                shutdownDeadline: 0
+            ),
+            processDidSpawn: { processID in
+                processIDProbe.record(processID)
+            }
+        )
+        let probe = start(
+            runner: runner,
+            task: UserTask(
+                id: "io-startup-failure",
+                label: "I/O Startup Failure",
+                command: "while :; do /bin/sleep 1; done"
+            )
+        )
+        let processID = await processIDProbe.waitForProcessID()
+        let completion = await probe.waitForCompletion()
+
+        #expect(!probe.didStart)
+        #expect(!completion.cancelled)
+        #expect(!completion.outcome.timedOut)
+        #expect(!completion.outcome.cleanupSucceeded)
+        #expect(
+            completion.outcome.stderr.contains(
+                Strings.userTaskDiagnosticOutputDeadline
+            )
+        )
+
+        var status: Int32 = 0
+        errno = 0
+        #expect(Darwin.waitpid(processID, &status, WNOHANG) == -1)
+        #expect(errno == ECHILD)
+
+        #expect(scheduler.releaseAll() == 2)
+        #expect(
+            scheduler.waitForReleasedOperations(until: .now() + 1)
+        )
     }
 
     @Test("Successful replacement task receives stdin and captures stdout")
@@ -189,7 +405,7 @@ nonisolated struct UserTaskRunnerTests {
         let task = UserTask(
             id: "timeout",
             label: "Timeout",
-            command: "while :; do :; done"
+            command: "while :; do /bin/sleep 1; done"
         )
         let probe = start(runner: runner, task: task)
 
@@ -257,7 +473,7 @@ nonisolated struct UserTaskRunnerTests {
         let task = UserTask(
             id: "cancel",
             label: "Cancel",
-            command: "while :; do :; done"
+            command: "while :; do /bin/sleep 1; done"
         )
         let probe = start(runner: runner, task: task)
 
@@ -276,17 +492,32 @@ nonisolated struct UserTaskRunnerTests {
         #expect(probe.callbacksWereOnMainThread)
     }
 
-    @Test("Cancellation wins before timeout even when TERM is ignored")
+    @Test("Cancellation falls back to KILL when TERM is ignored")
     func cancellationWinsBeforeTimeout() async {
-        let runner = UserTaskRunner(timeout: 0.5)
+        let readyURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "pine-task-term-ignored-\(UUID().uuidString)"
+            )
+        defer { try? FileManager.default.removeItem(at: readyURL) }
+        let runner = UserTaskRunner(timeout: 5)
         let task = UserTask(
             id: "cancel-before-timeout",
             label: "Cancel Before Timeout",
-            command: "trap '' TERM; while :; do :; done"
+            command: """
+            trap '' TERM
+            /usr/bin/printf ready > \(shellQuote(readyURL.path))
+            while :; do /bin/sleep 1; done
+            """
         )
         let probe = start(runner: runner, task: task)
         let cancellation = await probe.waitForCancellation()
         await probe.waitForStart()
+        guard await waitForFile(at: readyURL) else {
+            _ = cancellation.cancel()
+            _ = await probe.waitForCompletion()
+            Issue.record("TERM-ignoring shell did not publish readiness")
+            return
+        }
 
         #expect(cancellation.cancel())
         #expect(!cancellation.cancel())
@@ -294,6 +525,8 @@ nonisolated struct UserTaskRunnerTests {
 
         #expect(completion.cancelled)
         #expect(!completion.outcome.timedOut)
+        #expect(completion.outcome.exitCode == SIGKILL)
+        #expect(completion.outcome.cleanupSucceeded)
     }
 
     @Test("Timeout wins before a late cancellation")
@@ -302,7 +535,7 @@ nonisolated struct UserTaskRunnerTests {
         let task = UserTask(
             id: "timeout-before-cancel",
             label: "Timeout Before Cancel",
-            command: "trap '' TERM; while :; do :; done"
+            command: "trap '' TERM; while :; do /bin/sleep 1; done"
         )
         let probe = start(runner: runner, task: task)
         let cancellation = await probe.waitForCancellation()
@@ -318,20 +551,26 @@ nonisolated struct UserTaskRunnerTests {
 
     @Test("Natural, cancelled, and timed-out shells are reaped")
     func directShellsAreReaped() async {
-        let cases: [(id: String, timeout: TimeInterval, cancel: Bool)] = [
-            ("natural-reap", 2, false),
-            ("cancel-reap", 2, true),
-            ("timeout-reap", 0.05, false),
+        let cases: [
+            (
+                id: String,
+                timeout: TimeInterval,
+                cancel: Bool,
+                timedOut: Bool
+            )
+        ] = [
+            ("natural-reap", 2, false, false),
+            ("cancel-reap", 5, true, false),
+            ("timeout-reap", 0.2, false, true),
         ]
-
         for testCase in cases {
             let processIDURL = FileManager.default.temporaryDirectory
                 .appendingPathComponent(
                     "pine-task-\(testCase.id)-\(UUID().uuidString)"
                 )
             let body = testCase.id == "natural-reap"
-                ? "/bin/sleep 0.1"
-                : "trap '' TERM; while :; do :; done"
+                ? "/bin/sleep 0.25"
+                : "trap '' TERM; while :; do /bin/sleep 1; done"
             let command = """
             /usr/bin/printf '%s' "$$" > \(shellQuote(processIDURL.path))
             \(body)
@@ -346,25 +585,45 @@ nonisolated struct UserTaskRunnerTests {
             )
             let cancellation = await probe.waitForCancellation()
             await probe.waitForStart()
-            guard let processID = await waitForProcessID(
-                at: processIDURL
-            ), let identity = UserTaskProcessInspector.identity(
-                for: processID
-            ) else {
-                Issue.record("Task did not publish a live direct-shell pid")
-                try? FileManager.default.removeItem(at: processIDURL)
-                continue
-            }
             if testCase.cancel {
+                // Wait for the script itself, not merely posix_spawn, before
+                // cancelling so the PID probe is deterministic under load.
+                guard await waitForProcessID(at: processIDURL) != nil else {
+                    _ = cancellation.cancel()
+                    _ = await probe.waitForCompletion()
+                    Issue.record("Task did not publish its direct-shell pid")
+                    try? FileManager.default.removeItem(at: processIDURL)
+                    continue
+                }
                 #expect(cancellation.cancel())
             }
 
-            _ = await probe.waitForCompletion()
+            let completion = await probe.waitForCompletion()
+            guard let processID = await waitForProcessID(at: processIDURL) else {
+                Issue.record("Task did not publish its direct-shell pid")
+                try? FileManager.default.removeItem(at: processIDURL)
+                continue
+            }
 
-            #expect(
-                UserTaskProcessInspector.identity(for: processID) != identity
-            )
-            terminateIfStillCurrent(identity)
+            #expect(completion.outcome.cleanupSucceeded)
+            #expect(completion.cancelled == testCase.cancel)
+            #expect(completion.outcome.timedOut == testCase.timedOut)
+            if !testCase.cancel && !testCase.timedOut {
+                #expect(completion.outcome.succeeded)
+            } else {
+                #expect(!completion.outcome.succeeded)
+            }
+
+            // A PID cannot be reused while an unreaped direct child still owns
+            // it. Therefore ECHILD proves Pine collected its shell without a
+            // racy pre-completion identity lookup that can observe an already
+            // reaped process under test-runner contention.
+            if completion.outcome.cleanupSucceeded {
+                var status: Int32 = 0
+                errno = 0
+                #expect(Darwin.waitpid(processID, &status, WNOHANG) == -1)
+                #expect(errno == ECHILD)
+            }
             try? FileManager.default.removeItem(at: processIDURL)
         }
     }
@@ -403,32 +662,100 @@ nonisolated struct UserTaskRunnerTests {
         #expect(completion.outcome.succeeded)
     }
 
-    @Test("Concurrent task spawn does not delay another task's pipe EOF")
-    func concurrentRunsDoNotCrossInheritPipes() async {
-        let runner = UserTaskRunner(timeout: 3)
+    @Test("Concurrent task spawn does not cross-inherit another task's pipe")
+    func concurrentRunsDoNotCrossInheritPipes() async throws {
+        let handshakeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "pine-task-handshake-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: handshakeURL,
+            withIntermediateDirectories: false
+        )
+        let quickReadyURL = handshakeURL.appendingPathComponent("quick-ready")
+        let slowReadyURL = handshakeURL.appendingPathComponent("slow-ready")
+        let quickAcknowledgedURL = handshakeURL
+            .appendingPathComponent("quick-saw-slow")
+        let slowAcknowledgedURL = handshakeURL
+            .appendingPathComponent("slow-saw-quick")
+        let releaseSlowURL = handshakeURL
+            .appendingPathComponent("release-slow")
         let quick = UserTask(
             id: "quick",
             label: "Quick",
-            command: "printf quick; /bin/sleep 0.1"
+            command: """
+            /usr/bin/printf ready > \(shellQuote(quickReadyURL.path))
+            while [ ! -e \(shellQuote(slowReadyURL.path)) ]; do
+                /bin/sleep 0.01
+            done
+            /usr/bin/printf acknowledged > \(shellQuote(quickAcknowledgedURL.path))
+            /usr/bin/printf quick
+            """
         )
         let slow = UserTask(
             id: "slow",
             label: "Slow",
-            command: "/bin/sleep 1"
+            command: """
+            /usr/bin/printf ready > \(shellQuote(slowReadyURL.path))
+            while [ ! -e \(shellQuote(quickReadyURL.path)) ]; do
+                /bin/sleep 0.01
+            done
+            /usr/bin/printf acknowledged > \(shellQuote(slowAcknowledgedURL.path))
+            while [ ! -e \(shellQuote(releaseSlowURL.path)) ]; do
+                /bin/sleep 0.01
+            done
+            """
         )
-        let clock = ContinuousClock()
-        let startTime = clock.now
-        let quickProbe = start(runner: runner, task: quick)
-        let slowProbe = start(runner: runner, task: slow)
+        let quickProbe = start(
+            runner: UserTaskRunner(timeout: 2),
+            task: quick
+        )
+        let slowProbe = start(
+            runner: UserTaskRunner(timeout: 5),
+            task: slow
+        )
+        let quickCancellation = await quickProbe.waitForCancellation()
+        let slowCancellation = await slowProbe.waitForCancellation()
+        defer {
+            try? Data().write(to: releaseSlowURL, options: .atomic)
+            _ = quickCancellation.cancel()
+            _ = slowCancellation.cancel()
+            try? FileManager.default.removeItem(at: handshakeURL)
+        }
+
+        let quickObservedSlow = await waitForFile(
+            at: quickAcknowledgedURL
+        )
+        let slowObservedQuick = await waitForFile(
+            at: slowAcknowledgedURL
+        )
+        guard quickObservedSlow, slowObservedQuick else {
+            _ = quickCancellation.cancel()
+            _ = slowCancellation.cancel()
+            _ = await quickProbe.waitForCompletion()
+            _ = await slowProbe.waitForCompletion()
+            Issue.record("Concurrent shells did not complete their handshake")
+            return
+        }
 
         let quickCompletion = await quickProbe.waitForCompletion()
-        let quickElapsed = startTime.duration(to: clock.now)
+        guard (try? Data().write(
+            to: releaseSlowURL,
+            options: .atomic
+        )) != nil else {
+            _ = quickCancellation.cancel()
+            _ = slowCancellation.cancel()
+            _ = await slowProbe.waitForCompletion()
+            Issue.record("Could not release the slow handshake shell")
+            return
+        }
         let slowCompletion = await slowProbe.waitForCompletion()
 
         #expect(quickCompletion.outcome.succeeded)
         #expect(quickCompletion.outcome.stdout == "quick")
-        #expect(quickElapsed < .milliseconds(700))
         #expect(slowCompletion.outcome.succeeded)
+        #expect(!slowCompletion.outcome.timedOut)
     }
 
     @Test("Output capture accepts the exact limit and rejects one byte more")
@@ -760,14 +1087,26 @@ nonisolated struct UserTaskRunnerTests {
     private func waitForProcessID(at url: URL) async -> pid_t? {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: .seconds(2))
-        while clock.now < deadline {
+        while true {
             if let text = try? String(contentsOf: url, encoding: .utf8),
                let processID = pid_t(text) {
                 return processID
             }
+            guard clock.now < deadline else { return nil }
             try? await Task.sleep(for: .milliseconds(10))
         }
-        return nil
+    }
+
+    private func waitForFile(at url: URL) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while true {
+            if FileManager.default.fileExists(atPath: url.path) {
+                return true
+            }
+            guard clock.now < deadline else { return false }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
     }
 
     private func waitForProcessExit(_ processID: pid_t) async -> Bool {
@@ -845,6 +1184,115 @@ nonisolated private final class CancellationRaceResult: @unchecked Sendable {
     func recordFinish(_ cancelled: Bool) {
         lock.withLock {
             finishStorage = cancelled
+        }
+    }
+}
+
+nonisolated private final class HoldingUserTaskIOWorkerScheduler:
+    UserTaskIOWorkerScheduling,
+    @unchecked Sendable {
+    private struct ScheduleWaiter {
+        let operationCount: Int
+        let continuation: CheckedContinuation<Void, Never>
+    }
+
+    private let lock = NSLock()
+    private let queue = DispatchQueue(
+        label: "com.pine.tests.user-task-held-io",
+        attributes: .concurrent
+    )
+    private let releasedOperations = DispatchGroup()
+    private var operations: [@Sendable () -> Void] = []
+    private var scheduleWaiters: [ScheduleWaiter] = []
+
+    func schedule(_ operation: @escaping @Sendable () -> Void) {
+        releasedOperations.enter()
+        let wrapped: @Sendable () -> Void = {
+            defer { self.releasedOperations.leave() }
+            operation()
+        }
+        let readyWaiters = lock.withLock {
+            operations.append(wrapped)
+            var ready: [ScheduleWaiter] = []
+            scheduleWaiters.removeAll { waiter in
+                guard operations.count >= waiter.operationCount else {
+                    return false
+                }
+                ready.append(waiter)
+                return true
+            }
+            return ready
+        }
+        readyWaiters.forEach { $0.continuation.resume() }
+    }
+
+    func waitUntilScheduled(operationCount: Int) async {
+        await withCheckedContinuation { continuation in
+            let shouldResume = lock.withLock {
+                guard operations.count < operationCount else { return true }
+                scheduleWaiters.append(
+                    ScheduleWaiter(
+                        operationCount: operationCount,
+                        continuation: continuation
+                    )
+                )
+                return false
+            }
+            if shouldResume {
+                continuation.resume()
+            }
+        }
+    }
+
+    @discardableResult
+    func release(operationCount: Int) -> Int {
+        let released = lock.withLock {
+            let count = min(max(operationCount, 0), operations.count)
+            let released = Array(operations.prefix(count))
+            operations.removeFirst(count)
+            return released
+        }
+        released.forEach { queue.async(execute: $0) }
+        return released.count
+    }
+
+    @discardableResult
+    func releaseAll() -> Int {
+        release(operationCount: .max)
+    }
+
+    func waitForReleasedOperations(until deadline: DispatchTime) -> Bool {
+        releasedOperations.wait(timeout: deadline) == .success
+    }
+}
+
+nonisolated private final class UserTaskProcessIDProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var processID: pid_t?
+    private var waiters: [CheckedContinuation<pid_t, Never>] = []
+
+    func record(_ processID: pid_t) {
+        let waiters = lock.withLock {
+            self.processID = processID
+            let waiters = self.waiters
+            self.waiters.removeAll()
+            return waiters
+        }
+        waiters.forEach { $0.resume(returning: processID) }
+    }
+
+    func waitForProcessID() async -> pid_t {
+        await withCheckedContinuation { continuation in
+            let processID: pid_t? = lock.withLock {
+                guard let processID else {
+                    waiters.append(continuation)
+                    return nil
+                }
+                return processID
+            }
+            if let processID {
+                continuation.resume(returning: processID)
+            }
         }
     }
 }

--- a/PineTests/UserTaskRunnerTests.swift
+++ b/PineTests/UserTaskRunnerTests.swift
@@ -256,6 +256,37 @@ nonisolated struct UserTaskRunnerTests {
         #expect(workers.wait(timeout: .now() + 1) == .success)
     }
 
+    @Test("Blocking task owner does not delay the next execution")
+    func blockingTaskOwnerDoesNotDelayNextExecution() {
+        let scheduler = UserTaskThreadExecutionScheduler()
+        let firstStarted = DispatchSemaphore(value: 0)
+        let releaseFirst = DispatchSemaphore(value: 0)
+        let secondStarted = DispatchSemaphore(value: 0)
+        let executions = DispatchGroup()
+        defer {
+            releaseFirst.signal()
+            _ = executions.wait(timeout: .now() + 1)
+        }
+
+        executions.enter()
+        scheduler.schedule {
+            defer { executions.leave() }
+            firstStarted.signal()
+            _ = releaseFirst.wait(timeout: .now() + 2)
+        }
+        #expect(firstStarted.wait(timeout: .now() + 1) == .success)
+
+        executions.enter()
+        scheduler.schedule {
+            defer { executions.leave() }
+            secondStarted.signal()
+        }
+        #expect(secondStarted.wait(timeout: .now() + 1) == .success)
+
+        releaseFirst.signal()
+        #expect(executions.wait(timeout: .now() + 1) == .success)
+    }
+
     @Test("Task start waits for stdout, stderr, and stdin workers")
     func taskStartWaitsForEveryIOWorker() async {
         let scheduler = HoldingUserTaskIOWorkerScheduler()

--- a/PineTests/UserTaskRunnerTests.swift
+++ b/PineTests/UserTaskRunnerTests.swift
@@ -225,6 +225,37 @@ nonisolated struct UserTaskRunnerTests {
         #expect(barrier.wait(timeout: 0))
     }
 
+    @Test("Blocking I/O worker does not delay the next worker")
+    func blockingIOWorkerDoesNotDelayNextWorker() {
+        let scheduler = UserTaskThreadIOWorkerScheduler()
+        let firstStarted = DispatchSemaphore(value: 0)
+        let releaseFirst = DispatchSemaphore(value: 0)
+        let secondStarted = DispatchSemaphore(value: 0)
+        let workers = DispatchGroup()
+        defer {
+            releaseFirst.signal()
+            _ = workers.wait(timeout: .now() + 1)
+        }
+
+        workers.enter()
+        scheduler.schedule {
+            defer { workers.leave() }
+            firstStarted.signal()
+            _ = releaseFirst.wait(timeout: .now() + 2)
+        }
+        #expect(firstStarted.wait(timeout: .now() + 1) == .success)
+
+        workers.enter()
+        scheduler.schedule {
+            defer { workers.leave() }
+            secondStarted.signal()
+        }
+        #expect(secondStarted.wait(timeout: .now() + 1) == .success)
+
+        releaseFirst.signal()
+        #expect(workers.wait(timeout: .now() + 1) == .success)
+    }
+
     @Test("Task start waits for stdout, stderr, and stdin workers")
     func taskStartWaitsForEveryIOWorker() async {
         let scheduler = HoldingUserTaskIOWorkerScheduler()

--- a/PineTests/UserTaskRunnerTests.swift
+++ b/PineTests/UserTaskRunnerTests.swift
@@ -172,6 +172,14 @@ nonisolated struct UserTaskRunnerTests {
                 Strings.userTaskDiagnosticInvalidUTF8
             )
         )
+        #expect(
+            completion.outcome.outputPreview.text
+                == completion.outcome.stderr
+        )
+        #expect(
+            !completion.outcome.outputPreview.text.contains("\u{FFFD}")
+        )
+        #expect(!completion.outcome.outputPreview.wasTruncated)
         #expect(!completion.outcome.succeeded)
     }
 

--- a/PineTests/UserTaskRunnerTests.swift
+++ b/PineTests/UserTaskRunnerTests.swift
@@ -1283,15 +1283,15 @@ nonisolated private final class UserTaskProcessIDProbe: @unchecked Sendable {
 
     func waitForProcessID() async -> pid_t {
         await withCheckedContinuation { continuation in
-            let processID: pid_t? = lock.withLock {
-                guard let processID else {
+            let recordedProcessID: pid_t? = lock.withLock {
+                guard let processID = self.processID else {
                     waiters.append(continuation)
                     return nil
                 }
                 return processID
             }
-            if let processID {
-                continuation.resume(returning: processID)
+            if let recordedProcessID {
+                continuation.resume(returning: recordedProcessID)
             }
         }
     }

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -306,6 +306,108 @@ struct WindowLifecycleTests {
         await secondProject.workspace.waitForLoadingComplete()
     }
 
+    @Test func quitTaskTimeoutRetainsProjectAndCleanupOwnership() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let run = project.taskRunStore.start(makeTaskRun(id: "timeout"))
+        let probe = TerminationTaskProbe(waitResult: false)
+        project.taskRunStore.registerCancellation(
+            probe.makeCancellation(),
+            forRunID: run.id
+        )
+        let delegate = AppDelegate()
+        delegate.registry = registry
+
+        let result = await delegate.confirmApplicationTermination(
+            userTaskShutdownDeadline: .now()
+        )
+
+        #expect(!result)
+        #expect(probe.cancellationCount == 1)
+        #expect(probe.waitCount == 1)
+        #expect(project.hasOutstandingUserTaskExecution)
+        #expect(registry.isProjectOpen(dir))
+        #expect(!registry.destroyAllProjects())
+        #expect(registry.isProjectOpen(dir))
+
+        project.taskRunStore.finishRun(
+            id: run.id,
+            outcome: makeTaskOutcome(id: "timeout"),
+            cancelled: true
+        )
+        #expect(registry.destroyAllProjects())
+    }
+
+    @Test func quitWaitsForTaskCleanupBeforeAllowingTeardown() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let run = project.taskRunStore.start(makeTaskRun(id: "success"))
+        let probe = TerminationTaskProbe(waitResult: true)
+        project.taskRunStore.registerCancellation(
+            probe.makeCancellation(),
+            forRunID: run.id
+        )
+        let delegate = AppDelegate()
+        delegate.registry = registry
+
+        let result = await delegate.confirmApplicationTermination(
+            userTaskShutdownDeadline: .now() + 1
+        )
+
+        #expect(result)
+        #expect(probe.cancellationCount == 1)
+        #expect(probe.waitCount == 1)
+        #expect(!project.hasOutstandingUserTaskExecution)
+        #expect(project.taskRunStore.runs.isEmpty)
+        #expect(registry.destroyAllProjects())
+    }
+
+    @Test func quitRevalidatesEditsMadeDuringTaskCleanup() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        let run = project.taskRunStore.start(makeTaskRun(id: "delayed"))
+        let gate = TerminationWaitGate()
+        project.taskRunStore.registerCancellation(
+            UserTaskCancellation(
+                terminate: { true },
+                waitForCompletion: { deadline in
+                    gate.waitForRelease(until: deadline)
+                }
+            ),
+            forRunID: run.id
+        )
+        let delegate = AppDelegate()
+        delegate.registry = registry
+
+        let decision = Task { @MainActor in
+            await delegate.confirmApplicationTermination(
+                userTaskShutdownDeadline: .now() + 2
+            )
+        }
+        defer { gate.release() }
+        for _ in 0..<200 where !gate.didStartWaiting {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(gate.didStartWaiting)
+        project.primaryTabManager.updateContent("// edited during cleanup")
+        gate.release()
+
+        let result = await decision.value
+        #expect(!result)
+        #expect(project.hasUnsavedChanges)
+        #expect(project.primaryTabManager.activeTab?.content ==
+                "// edited during cleanup")
+        await project.workspace.waitForLoadingComplete()
+    }
+
     @Test func terminationHandshakeDefersAndRepliesExactlyOnce() async {
         let delegate = AppDelegate()
         var replies: [Bool] = []
@@ -522,5 +624,81 @@ struct WindowLifecycleTests {
 
         #expect(!didOpen)
         #expect(welcome.isVisible)
+    }
+
+    private func makeTaskRun(id: String) -> UserTaskRun {
+        UserTaskRun(
+            taskID: id,
+            taskLabel: id,
+            command: "printf done",
+            replacesFileContent: false
+        )
+    }
+
+    private func makeTaskOutcome(id: String) -> UserTaskOutcome {
+        UserTaskOutcome(
+            taskID: id,
+            stdout: "",
+            stderr: "",
+            exitCode: 0,
+            timedOut: false
+        )
+    }
+}
+
+nonisolated private final class TerminationTaskProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let waitResult: Bool
+    private var cancellations = 0
+    private var waits = 0
+
+    init(waitResult: Bool) {
+        self.waitResult = waitResult
+    }
+
+    var cancellationCount: Int {
+        lock.withLock { cancellations }
+    }
+
+    var waitCount: Int {
+        lock.withLock { waits }
+    }
+
+    func makeCancellation() -> UserTaskCancellation {
+        UserTaskCancellation(
+            terminate: { [self] in
+                lock.withLock {
+                    cancellations += 1
+                }
+                return true
+            },
+            waitForCompletion: { [self] _ in
+                lock.withLock {
+                    waits += 1
+                }
+                return waitResult
+            }
+        )
+    }
+}
+
+nonisolated private final class TerminationWaitGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private var startedWaiting = false
+
+    var didStartWaiting: Bool {
+        lock.withLock { startedWaiting }
+    }
+
+    func waitForRelease(until deadline: DispatchTime) -> Bool {
+        lock.withLock {
+            startedWaiting = true
+        }
+        return releaseSemaphore.wait(timeout: deadline) == .success
+    }
+
+    func release() {
+        releaseSemaphore.signal()
     }
 }

--- a/PineUITests/UserTaskExecutionUITests.swift
+++ b/PineUITests/UserTaskExecutionUITests.swift
@@ -1,0 +1,305 @@
+//
+//  UserTaskExecutionUITests.swift
+//  PineUITests
+//
+//  End-to-end coverage for the project-scoped task execution surface.
+//
+
+import AppKit
+import XCTest
+
+final class UserTaskExecutionUITests: PineUITestCase {
+    private var projectURL: URL!
+    private var tasksFileURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        projectURL = try createTempProject()
+        tasksFileURL = projectURL.appendingPathComponent(
+            ".pine-ui-tasks.json",
+            isDirectory: false
+        )
+        NSPasteboard.general.clearContents()
+    }
+
+    override func tearDownWithError() throws {
+        NSPasteboard.general.clearContents()
+        if let projectURL {
+            cleanupProject(projectURL)
+        }
+        try super.tearDownWithError()
+    }
+
+    func testRunningTaskShowsLiveElapsedProgressAndCancellation() throws {
+        try launchWithTask(
+            id: "ui-progress",
+            label: "UI Progress Task",
+            command: "trap '' TERM; printf 'started'; sleep 30"
+        )
+
+        let panel = app.descendants(matching: .any)[
+            "userTaskOutputPanel"
+        ].firstMatch
+        XCTAssertTrue(panel.waitForExistence(timeout: 5))
+
+        let status = app.staticTexts.matching(
+            identifierBeginningWith: "userTaskStatus_"
+        ).firstMatch
+        XCTAssertTrue(waitForLabel("Running", on: status, timeout: 5))
+
+        let elapsed = app.staticTexts.matching(
+            identifierBeginningWith: "userTaskElapsed_"
+        ).firstMatch
+        XCTAssertTrue(elapsed.waitForExistence(timeout: 5))
+        let initialElapsed = elapsed.label
+        XCTAssertTrue(
+            waitForDifferentLabel(
+                from: initialElapsed,
+                on: elapsed,
+                timeout: 3
+            ),
+            "Elapsed time should update while the task is running"
+        )
+        let progress = app.progressIndicators.matching(
+            NSPredicate(
+                format: "identifier BEGINSWITH %@",
+                "userTaskProgress_"
+            )
+        ).firstMatch
+        XCTAssertTrue(
+            progress.exists,
+            "An active task should expose a progress indicator"
+        )
+
+        let cancel = app.buttons.matching(
+            NSPredicate(
+                format: "identifier BEGINSWITH %@",
+                "userTaskCancel_"
+            )
+        ).firstMatch
+        XCTAssertTrue(cancel.waitForExistence(timeout: 3))
+        cancel.click()
+
+        XCTAssertTrue(
+            waitForOneOfLabels(
+                ["Cancelling", "Cancelled"],
+                on: status,
+                timeout: 3
+            ),
+            "Accepted cancellation should enter cleanup or finish cancelled"
+        )
+        XCTAssertTrue(
+            !cancel.exists || !cancel.isEnabled,
+            "Cancel should disable during cleanup or disappear after completion"
+        )
+        XCTAssertTrue(
+            waitForLabel("Cancelled", on: status, timeout: 5),
+            "The task should reach a terminal cancelled state"
+        )
+        XCTAssertFalse(cancel.exists)
+        XCTAssertFalse(progress.exists)
+    }
+
+    func testSuccessfulTaskCopiesExactCombinedOutputWithoutModal() throws {
+        let expectedOutput = "success-out\nsuccess-err"
+        try launchWithTask(
+            id: "ui-success",
+            label: "UI Success Task",
+            command: """
+            printf 'success-out'; printf 'success-err' >&2
+            """
+        )
+
+        let status = app.staticTexts.matching(
+            identifierBeginningWith: "userTaskStatus_"
+        ).firstMatch
+        XCTAssertTrue(waitForLabel("Succeeded", on: status, timeout: 8))
+
+        let output = app.staticTexts.matching(
+            identifierBeginningWith: "userTaskOutputText_"
+        ).firstMatch
+        XCTAssertTrue(output.waitForExistence(timeout: 3))
+        XCTAssertEqual(output.label, expectedOutput)
+        XCTAssertFalse(
+            app.dialogs.firstMatch.exists,
+            "Ordinary task success should not present a modal alert"
+        )
+
+        let copy = app.buttons.matching(
+            identifierBeginningWith: "userTaskCopyOutput_"
+        ).firstMatch
+        XCTAssertTrue(copy.waitForExistence(timeout: 3))
+        copy.click()
+        XCTAssertEqual(
+            NSPasteboard.general.string(forType: .string),
+            expectedOutput
+        )
+        XCTAssertFalse(app.dialogs.firstMatch.exists)
+    }
+
+    func testFailedTaskPersistsCopyAndOpenActionsAfterReopeningOutput() throws {
+        let expectedOutput = "failure-out\nfailure-err"
+        try launchWithTask(
+            id: "ui-failure",
+            label: "UI Failure Task",
+            command: """
+            printf 'failure-out'; printf 'failure-err' >&2; exit 7
+            """
+        )
+
+        let status = app.staticTexts.matching(
+            identifierBeginningWith: "userTaskStatus_"
+        ).firstMatch
+        XCTAssertTrue(waitForLabel("Exit 7", on: status, timeout: 8))
+
+        let copy = app.buttons.matching(
+            identifierBeginningWith: "userTaskCopyOutput_"
+        ).firstMatch
+        XCTAssertTrue(copy.waitForExistence(timeout: 3))
+        copy.click()
+        XCTAssertEqual(
+            NSPasteboard.general.string(forType: .string),
+            expectedOutput
+        )
+
+        let panel = app.descendants(matching: .any)[
+            "userTaskOutputPanel"
+        ].firstMatch
+        let close = app.buttons["userTaskCloseOutputButton"].firstMatch
+        XCTAssertTrue(close.waitForExistence(timeout: 3))
+        close.click()
+        XCTAssertTrue(
+            waitForNonExistence(panel, timeout: 3),
+            "Close Output should hide the durable task history"
+        )
+
+        let show = app.buttons["userTaskShowOutputButton"].firstMatch
+        XCTAssertTrue(show.waitForExistence(timeout: 3))
+        show.click()
+        XCTAssertTrue(
+            panel.waitForExistence(timeout: 3),
+            "Open Output should restore the same task history"
+        )
+        XCTAssertTrue(waitForLabel("Exit 7", on: status, timeout: 3))
+
+        NSPasteboard.general.clearContents()
+        XCTAssertTrue(copy.waitForExistence(timeout: 3))
+        copy.click()
+        XCTAssertEqual(
+            NSPasteboard.general.string(forType: .string),
+            expectedOutput,
+            "The reopened history should retain the exact failure output"
+        )
+        XCTAssertFalse(
+            app.dialogs.firstMatch.exists,
+            "Ordinary task failure should use the output surface, not a modal"
+        )
+    }
+
+    private func launchWithTask(
+        id: String,
+        label: String,
+        command: String
+    ) throws {
+        let document: [String: Any] = [
+            "tasks": [
+                [
+                    "id": id,
+                    "label": label,
+                    "command": command,
+                    "scope": "project",
+                    "replaces_file_content": false,
+                    "require_confirmation": false,
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(
+            withJSONObject: document,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try data.write(to: tasksFileURL, options: .atomic)
+
+        app.launchEnvironment["PINE_USER_TASKS_FILE"] = tasksFileURL.path
+        launchWithProject(projectURL)
+
+        clickMenuBarItem("Tasks")
+        let taskItem = app.menuItems[label]
+        XCTAssertTrue(
+            taskItem.waitForExistence(timeout: 5),
+            "The task from PINE_USER_TASKS_FILE should appear in the Tasks menu"
+        )
+        taskItem.click()
+    }
+
+    private func waitForLabel(
+        _ expected: String,
+        on element: XCUIElement,
+        timeout: TimeInterval
+    ) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label == %@", expected),
+            object: element
+        )
+        return XCTWaiter.wait(
+            for: [expectation],
+            timeout: timeout
+        ) == .completed
+    }
+
+    private func waitForOneOfLabels(
+        _ expected: [String],
+        on element: XCUIElement,
+        timeout: TimeInterval
+    ) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label IN %@", expected),
+            object: element
+        )
+        return XCTWaiter.wait(
+            for: [expectation],
+            timeout: timeout
+        ) == .completed
+    }
+
+    private func waitForDifferentLabel(
+        from original: String,
+        on element: XCUIElement,
+        timeout: TimeInterval
+    ) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label != %@", original),
+            object: element
+        )
+        return XCTWaiter.wait(
+            for: [expectation],
+            timeout: timeout
+        ) == .completed
+    }
+
+    private func waitForNonExistence(
+        _ element: XCUIElement,
+        timeout: TimeInterval
+    ) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == false"),
+            object: element
+        )
+        return XCTWaiter.wait(
+            for: [expectation],
+            timeout: timeout
+        ) == .completed
+    }
+}
+
+private extension XCUIElementQuery {
+    func matching(
+        identifierBeginningWith prefix: String
+    ) -> XCUIElementQuery {
+        matching(
+            NSPredicate(
+                format: "identifier BEGINSWITH %@",
+                prefix
+            )
+        )
+    }
+}

--- a/PineUITests/UserTaskExecutionUITests.swift
+++ b/PineUITests/UserTaskExecutionUITests.swift
@@ -77,7 +77,7 @@ final class UserTaskExecutionUITests: PineUITestCase {
             )
         ).firstMatch
         XCTAssertTrue(cancel.waitForExistence(timeout: 3))
-        cancel.click()
+        clickCenter(of: cancel)
 
         XCTAssertTrue(
             waitForOneOfAccessibleTexts(

--- a/PineUITests/UserTaskExecutionUITests.swift
+++ b/PineUITests/UserTaskExecutionUITests.swift
@@ -45,15 +45,17 @@ final class UserTaskExecutionUITests: PineUITestCase {
         let status = app.staticTexts.matching(
             identifierBeginningWith: "userTaskStatus_"
         ).firstMatch
-        XCTAssertTrue(waitForLabel("Running", on: status, timeout: 5))
+        XCTAssertTrue(
+            waitForAccessibleText("Running", on: status, timeout: 5)
+        )
 
         let elapsed = app.staticTexts.matching(
             identifierBeginningWith: "userTaskElapsed_"
         ).firstMatch
         XCTAssertTrue(elapsed.waitForExistence(timeout: 5))
-        let initialElapsed = elapsed.label
+        let initialElapsed = accessibleText(of: elapsed)
         XCTAssertTrue(
-            waitForDifferentLabel(
+            waitForDifferentAccessibleText(
                 from: initialElapsed,
                 on: elapsed,
                 timeout: 3
@@ -81,7 +83,7 @@ final class UserTaskExecutionUITests: PineUITestCase {
         cancel.click()
 
         XCTAssertTrue(
-            waitForOneOfLabels(
+            waitForOneOfAccessibleTexts(
                 ["Cancelling", "Cancelled"],
                 on: status,
                 timeout: 3
@@ -93,7 +95,7 @@ final class UserTaskExecutionUITests: PineUITestCase {
             "Cancel should disable during cleanup or disappear after completion"
         )
         XCTAssertTrue(
-            waitForLabel("Cancelled", on: status, timeout: 5),
+            waitForAccessibleText("Cancelled", on: status, timeout: 5),
             "The task should reach a terminal cancelled state"
         )
         XCTAssertFalse(cancel.exists)
@@ -115,22 +117,25 @@ final class UserTaskExecutionUITests: PineUITestCase {
         let status = app.staticTexts.matching(
             identifierBeginningWith: "userTaskStatus_"
         ).firstMatch
-        XCTAssertTrue(waitForLabel("Succeeded", on: status, timeout: 8))
+        XCTAssertTrue(
+            waitForAccessibleText("Succeeded", on: status, timeout: 8)
+        )
 
         let output = app.staticTexts.matching(
             identifierBeginningWith: "userTaskOutputText_"
         ).firstMatch
         XCTAssertTrue(output.waitForExistence(timeout: 3))
-        XCTAssertEqual(output.label.utf8.count, 16 * 1_024)
-        XCTAssertTrue(output.label.allSatisfy { $0 == "x" })
-        XCTAssertLessThan(output.label.utf8.count, expectedOutput.utf8.count)
+        let outputText = accessibleText(of: output)
+        XCTAssertEqual(outputText.utf8.count, 16 * 1_024)
+        XCTAssertTrue(outputText.allSatisfy { $0 == "x" })
+        XCTAssertLessThan(outputText.utf8.count, expectedOutput.utf8.count)
 
         let truncationNotice = app.staticTexts.matching(
             identifierBeginningWith: "userTaskOutputTruncation_"
         ).firstMatch
         XCTAssertTrue(truncationNotice.waitForExistence(timeout: 3))
         XCTAssertEqual(
-            truncationNotice.label,
+            accessibleText(of: truncationNotice),
             """
             Preview truncated. Copy Output includes the complete captured output.
             """
@@ -165,7 +170,9 @@ final class UserTaskExecutionUITests: PineUITestCase {
         let status = app.staticTexts.matching(
             identifierBeginningWith: "userTaskStatus_"
         ).firstMatch
-        XCTAssertTrue(waitForLabel("Exit 7", on: status, timeout: 8))
+        XCTAssertTrue(
+            waitForAccessibleText("Exit 7", on: status, timeout: 8)
+        )
 
         let copy = app.buttons.matching(
             identifierBeginningWith: "userTaskCopyOutput_"
@@ -195,7 +202,9 @@ final class UserTaskExecutionUITests: PineUITestCase {
             panel.waitForExistence(timeout: 3),
             "Open Output should restore the same task history"
         )
-        XCTAssertTrue(waitForLabel("Exit 7", on: status, timeout: 3))
+        XCTAssertTrue(
+            waitForAccessibleText("Exit 7", on: status, timeout: 3)
+        )
 
         NSPasteboard.general.clearContents()
         XCTAssertTrue(copy.waitForExistence(timeout: 3))
@@ -246,13 +255,17 @@ final class UserTaskExecutionUITests: PineUITestCase {
         taskItem.click()
     }
 
-    private func waitForLabel(
+    private func waitForAccessibleText(
         _ expected: String,
         on element: XCUIElement,
         timeout: TimeInterval
     ) -> Bool {
         let expectation = XCTNSPredicateExpectation(
-            predicate: NSPredicate(format: "label == %@", expected),
+            predicate: NSPredicate(
+                format: "label == %@ OR value == %@",
+                expected,
+                expected
+            ),
             object: element
         )
         let result = XCTWaiter.wait(
@@ -261,7 +274,7 @@ final class UserTaskExecutionUITests: PineUITestCase {
         )
         if result != .completed {
             print(
-                "Expected \(expected), actual label: "
+                "Expected accessible text \(expected), actual label: "
                     + "\(element.label.debugDescription), value: "
                     + "\(String(describing: element.value)), exists: "
                     + "\(element.exists); \(element.debugDescription)"
@@ -270,13 +283,17 @@ final class UserTaskExecutionUITests: PineUITestCase {
         return result == .completed
     }
 
-    private func waitForOneOfLabels(
+    private func waitForOneOfAccessibleTexts(
         _ expected: [String],
         on element: XCUIElement,
         timeout: TimeInterval
     ) -> Bool {
         let expectation = XCTNSPredicateExpectation(
-            predicate: NSPredicate(format: "label IN %@", expected),
+            predicate: NSPredicate(
+                format: "label IN %@ OR value IN %@",
+                expected,
+                expected
+            ),
             object: element
         )
         return XCTWaiter.wait(
@@ -285,19 +302,33 @@ final class UserTaskExecutionUITests: PineUITestCase {
         ) == .completed
     }
 
-    private func waitForDifferentLabel(
+    private func waitForDifferentAccessibleText(
         from original: String,
         on element: XCUIElement,
         timeout: TimeInterval
     ) -> Bool {
         let expectation = XCTNSPredicateExpectation(
-            predicate: NSPredicate(format: "label != %@", original),
+            predicate: NSPredicate(
+                format: """
+                (label != %@ AND value != %@)
+                AND (label != '' OR value != nil)
+                """,
+                original,
+                original
+            ),
             object: element
         )
         return XCTWaiter.wait(
             for: [expectation],
             timeout: timeout
         ) == .completed
+    }
+
+    private func accessibleText(of element: XCUIElement) -> String {
+        if !element.label.isEmpty {
+            return element.label
+        }
+        return element.value as? String ?? ""
     }
 
     private func waitForNonExistence(

--- a/PineUITests/UserTaskExecutionUITests.swift
+++ b/PineUITests/UserTaskExecutionUITests.swift
@@ -255,10 +255,19 @@ final class UserTaskExecutionUITests: PineUITestCase {
             predicate: NSPredicate(format: "label == %@", expected),
             object: element
         )
-        return XCTWaiter.wait(
+        let result = XCTWaiter.wait(
             for: [expectation],
             timeout: timeout
-        ) == .completed
+        )
+        if result != .completed {
+            print(
+                "Expected \(expected), actual label: "
+                    + "\(element.label.debugDescription), value: "
+                    + "\(String(describing: element.value)), exists: "
+                    + "\(element.exists); \(element.debugDescription)"
+            )
+        }
+        return result == .completed
     }
 
     private func waitForOneOfLabels(

--- a/PineUITests/UserTaskExecutionUITests.swift
+++ b/PineUITests/UserTaskExecutionUITests.swift
@@ -62,14 +62,11 @@ final class UserTaskExecutionUITests: PineUITestCase {
             ),
             "Elapsed time should update while the task is running"
         )
-        let progress = app.progressIndicators.matching(
-            NSPredicate(
-                format: "identifier BEGINSWITH %@",
-                "userTaskProgress_"
-            )
+        let progress = app.descendants(matching: .any).matching(
+            identifierBeginningWith: "userTaskProgress_"
         ).firstMatch
         XCTAssertTrue(
-            progress.exists,
+            progress.waitForExistence(timeout: 3),
             "An active task should expose a progress indicator"
         )
 
@@ -99,7 +96,7 @@ final class UserTaskExecutionUITests: PineUITestCase {
             "The task should reach a terminal cancelled state"
         )
         XCTAssertFalse(cancel.exists)
-        XCTAssertFalse(progress.exists)
+        XCTAssertTrue(waitForNonExistence(progress, timeout: 3))
     }
 
     func testSuccessfulTaskCopiesExactCombinedOutputWithoutModal() throws {
@@ -126,8 +123,13 @@ final class UserTaskExecutionUITests: PineUITestCase {
         ).firstMatch
         XCTAssertTrue(output.waitForExistence(timeout: 3))
         let outputText = accessibleText(of: output)
+        let diagnosticPrefix = "success-err\n"
+        let expectedPreview = diagnosticPrefix + String(
+            repeating: "x",
+            count: 16 * 1_024 - diagnosticPrefix.utf8.count
+        )
         XCTAssertEqual(outputText.utf8.count, 16 * 1_024)
-        XCTAssertTrue(outputText.allSatisfy { $0 == "x" })
+        XCTAssertEqual(outputText, expectedPreview)
         XCTAssertLessThan(outputText.utf8.count, expectedOutput.utf8.count)
 
         let truncationNotice = app.staticTexts.matching(
@@ -148,8 +150,7 @@ final class UserTaskExecutionUITests: PineUITestCase {
         let copy = app.buttons.matching(
             identifierBeginningWith: "userTaskCopyOutput_"
         ).firstMatch
-        XCTAssertTrue(copy.waitForExistence(timeout: 3))
-        copy.click()
+        clickCenter(of: copy)
         XCTAssertEqual(
             NSPasteboard.general.string(forType: .string),
             expectedOutput
@@ -177,8 +178,7 @@ final class UserTaskExecutionUITests: PineUITestCase {
         let copy = app.buttons.matching(
             identifierBeginningWith: "userTaskCopyOutput_"
         ).firstMatch
-        XCTAssertTrue(copy.waitForExistence(timeout: 3))
-        copy.click()
+        clickCenter(of: copy)
         XCTAssertEqual(
             NSPasteboard.general.string(forType: .string),
             expectedOutput
@@ -207,8 +207,7 @@ final class UserTaskExecutionUITests: PineUITestCase {
         )
 
         NSPasteboard.general.clearContents()
-        XCTAssertTrue(copy.waitForExistence(timeout: 3))
-        copy.click()
+        clickCenter(of: copy)
         XCTAssertEqual(
             NSPasteboard.general.string(forType: .string),
             expectedOutput,
@@ -329,6 +328,17 @@ final class UserTaskExecutionUITests: PineUITestCase {
             return element.label
         }
         return element.value as? String ?? ""
+    }
+
+    private func clickCenter(
+        of element: XCUIElement,
+        timeout: TimeInterval = 3
+    ) {
+        XCTAssertTrue(element.waitForExistence(timeout: timeout))
+        XCTAssertFalse(element.frame.isEmpty)
+        element.coordinate(
+            withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)
+        ).click()
     }
 
     private func waitForNonExistence(

--- a/PineUITests/UserTaskExecutionUITests.swift
+++ b/PineUITests/UserTaskExecutionUITests.swift
@@ -101,12 +101,14 @@ final class UserTaskExecutionUITests: PineUITestCase {
     }
 
     func testSuccessfulTaskCopiesExactCombinedOutputWithoutModal() throws {
-        let expectedOutput = "success-out\nsuccess-err"
+        let stdout = String(repeating: "x", count: 20_000)
+        let expectedOutput = stdout + "\nsuccess-err"
         try launchWithTask(
             id: "ui-success",
             label: "UI Success Task",
             command: """
-            printf 'success-out'; printf 'success-err' >&2
+            /usr/bin/perl -e \
+            'print "x" x 20000; print STDERR "success-err"'
             """
         )
 
@@ -119,7 +121,20 @@ final class UserTaskExecutionUITests: PineUITestCase {
             identifierBeginningWith: "userTaskOutputText_"
         ).firstMatch
         XCTAssertTrue(output.waitForExistence(timeout: 3))
-        XCTAssertEqual(output.label, expectedOutput)
+        XCTAssertEqual(output.label.utf8.count, 16 * 1_024)
+        XCTAssertTrue(output.label.allSatisfy { $0 == "x" })
+        XCTAssertLessThan(output.label.utf8.count, expectedOutput.utf8.count)
+
+        let truncationNotice = app.staticTexts.matching(
+            identifierBeginningWith: "userTaskOutputTruncation_"
+        ).firstMatch
+        XCTAssertTrue(truncationNotice.waitForExistence(timeout: 3))
+        XCTAssertEqual(
+            truncationNotice.label,
+            """
+            Preview truncated. Copy Output includes the complete captured output.
+            """
+        )
         XCTAssertFalse(
             app.dialogs.firstMatch.exists,
             "Ordinary task success should not present a modal alert"


### PR DESCRIPTION
Closes #1246. Adds the user-task execution progress/output/failure surface and hardens subprocess lifecycle ownership: cancellation, timeout, process-tree cleanup, direct-child reaping, bounded I/O, failed-cleanup retention, and quit-time shutdown now remain fail-closed until every resource is released. Local verification after rebase onto current main: strict SwiftLint passed, reentrancy guard 5/5 passed, 125 selected PineTests across 8 suites passed, and all 36 userTask.* localization keys are complete across 9 locales. Local PineUITests were not run; all UI shards are delegated to CI.