### PR TITLE
fix(git): harden command process lifecycle

### DIFF
--- a/Pine/Agent/AgentHistoryContentHash.swift
+++ b/Pine/Agent/AgentHistoryContentHash.swift
@@ -41,7 +41,7 @@ nonisolated enum AgentHistoryContentHash {
         )
         let raw = indexResult.output.trimmingCharacters(in: .whitespacesAndNewlines)
         var indexURL: URL
-        if indexResult.exitCode == 0, !raw.isEmpty {
+        if indexResult.succeeded, !raw.isEmpty {
             indexURL = URL(
                 fileURLWithPath: raw,
                 relativeTo: repositoryRoot
@@ -68,7 +68,7 @@ nonisolated enum AgentHistoryContentHash {
     /// the repository has no commits yet.
     static func headOID(in repositoryRoot: URL) -> String {
         let result = GitCommand.run(["rev-parse", "HEAD"], at: repositoryRoot)
-        guard result.exitCode == 0 else { return "" }
+        guard result.succeeded else { return "" }
         return result.output.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 

--- a/Pine/Git/GitCheckout.swift
+++ b/Pine/Git/GitCheckout.swift
@@ -15,7 +15,7 @@ extension GitStatusProvider {
     func checkoutBranch(_ branch: String) -> (success: Bool, error: String) {
         guard let url = repositoryURL else { return (false, "No repository") }
         let result = GitCommand.run(["switch", branch], at: url)
-        if result.exitCode == 0 {
+        if result.completedSuccessfully {
             refresh()
             return (true, "")
         }
@@ -33,7 +33,7 @@ extension GitStatusProvider {
             GitCommand.run(["switch", branch], at: url)
         }
 
-        guard result.exitCode == 0 else {
+        guard result.completedSuccessfully else {
             if let progressID { self.progressTracker?.endOperation(progressID) }
             return (false, result.errorOutput.trimmingCharacters(in: .whitespacesAndNewlines))
         }

--- a/Pine/Git/GitCommand.swift
+++ b/Pine/Git/GitCommand.swift
@@ -5,13 +5,105 @@
 //  Low-level git process execution. No business logic, no state.
 //
 
+import Darwin
 import Foundation
 
 /// Result of a git command invocation.
-struct GitCommandResult: Sendable {
+nonisolated struct GitCommandResult: Sendable {
     let output: String
     let errorOutput: String
     let exitCode: Int32
+    let timedOut: Bool
+    let cancelled: Bool
+    let outputTruncated: Bool
+    let errorOutputTruncated: Bool
+    let outputCaptureComplete: Bool
+    let errorOutputCaptureComplete: Bool
+    let outputReadError: Int32?
+    let errorOutputReadError: Int32?
+
+    /// True when the child process itself completed successfully. Use this
+    /// for mutating commands whose side effect is authoritative even if a
+    /// verbose hook overflowed the bounded diagnostic capture.
+    var completedSuccessfully: Bool {
+        exitCode == 0 && !timedOut && !cancelled
+    }
+
+    /// True only when the process exited successfully and both captured
+    /// streams are complete. Use this when parsing stdout or stderr.
+    var succeeded: Bool {
+        completedSuccessfully
+            && !outputTruncated
+            && !errorOutputTruncated
+            && outputCaptureComplete
+            && errorOutputCaptureComplete
+    }
+}
+
+/// Thread-safe cancellation authority for a single command invocation.
+///
+/// The async API owns one token and flips it from its task cancellation
+/// handler. Keeping the token independent from a Swift task is important:
+/// process I/O runs on a GCD worker where `Task.isCancelled` is not inherited.
+nonisolated final class GitCommandCancellationToken: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+}
+
+nonisolated enum GitCommandStream: Sendable {
+    case standardOutput
+    case standardError
+}
+
+/// Injectable POSIX seam for deterministic lifecycle and I/O failure tests.
+nonisolated struct GitCommandSystemCalls: @unchecked Sendable {
+    let read: @Sendable (
+        GitCommandStream,
+        Int32,
+        UnsafeMutableRawPointer?,
+        Int
+    ) -> Int
+    let waitpid: @Sendable (pid_t, UnsafeMutablePointer<Int32>?, Int32) -> pid_t
+    let kill: @Sendable (pid_t, Int32) -> Int32
+
+    init(
+        read: @escaping @Sendable (
+            GitCommandStream,
+            Int32,
+            UnsafeMutableRawPointer?,
+            Int
+        ) -> Int = { _, descriptor, buffer, count in
+            Darwin.read(descriptor, buffer, count)
+        },
+        waitpid: @escaping @Sendable (
+            pid_t,
+            UnsafeMutablePointer<Int32>?,
+            Int32
+        ) -> pid_t = { processIdentifier, status, options in
+            Darwin.waitpid(processIdentifier, status, options)
+        },
+        kill: @escaping @Sendable (pid_t, Int32) -> Int32 = { processIdentifier, signal in
+            Darwin.kill(processIdentifier, signal)
+        }
+    ) {
+        self.read = read
+        self.waitpid = waitpid
+        self.kill = kill
+    }
+
+    static let live = GitCommandSystemCalls()
 }
 
 /// Runs git commands as subprocesses with timeout support.
@@ -19,6 +111,17 @@ nonisolated enum GitCommand {
 
     /// Default timeout for git commands (30 seconds).
     static let defaultTimeout: TimeInterval = 30.0
+    /// Maximum number of bytes retained from either output stream.
+    static let defaultCaptureLimit = 4 * 1_024 * 1_024
+
+    /// Grace period between SIGTERM and the SIGKILL fallback.
+    private static let terminationGracePeriod: TimeInterval = 0.25
+    /// Bounded interval for draining final output and reaping after SIGKILL.
+    private static let killCleanupPeriod: TimeInterval = 0.25
+    /// Maximum sleep between lifecycle observations.
+    private static let pollIntervalMilliseconds: Int32 = 20
+    private static let readBufferSize = 16 * 1_024
+    private static let maximumDrainBytesPerPass = 64 * 1_024
 
     /// Executes `git` with the given arguments in the specified directory.
     ///
@@ -26,54 +129,855 @@ nonisolated enum GitCommand {
     ///   - arguments: Git subcommand and arguments (e.g. `["status", "--porcelain"]`).
     ///   - directory: Working directory for the git process.
     ///   - timeout: Maximum time to wait before terminating the process.
-    /// - Returns: A `GitCommandResult` with stdout, stderr, and exit code.
+    ///   - captureLimit: Maximum bytes retained from each output stream.
+    /// - Returns: Captured output, exit status, and whether the timeout fired.
     static func run(
         _ arguments: [String],
         at directory: URL,
-        timeout: TimeInterval = defaultTimeout
+        timeout: TimeInterval = defaultTimeout,
+        captureLimit: Int = defaultCaptureLimit
     ) -> GitCommandResult {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
-        process.arguments = arguments
-        process.currentDirectoryURL = directory
+        runExecutable(
+            URL(fileURLWithPath: "/usr/bin/git"),
+            arguments: arguments,
+            at: directory,
+            timeout: timeout,
+            captureLimit: captureLimit
+        )
+    }
 
-        let outPipe = Pipe()
-        let errPipe = Pipe()
-        process.standardOutput = outPipe
-        process.standardError = errPipe
+    /// Executes git without blocking the caller's cooperative executor.
+    ///
+    /// Cancelling the calling task cancels the subprocess process group using
+    /// the same TERM/grace/KILL lifecycle as a timeout.
+    static func runAsync(
+        _ arguments: [String],
+        at directory: URL,
+        timeout: TimeInterval = defaultTimeout,
+        captureLimit: Int = defaultCaptureLimit
+    ) async -> GitCommandResult {
+        await runExecutableAsync(
+            URL(fileURLWithPath: "/usr/bin/git"),
+            arguments: arguments,
+            at: directory,
+            timeout: timeout,
+            captureLimit: captureLimit
+        )
+    }
 
-        do {
-            try process.run()
+    /// Process-execution seam used by deterministic lifecycle tests.
+    ///
+    /// Production callers use ``run(_:at:timeout:)`` so the executable remains
+    /// fixed to `/usr/bin/git`.
+    static func runExecutable(
+        _ executableURL: URL,
+        arguments: [String],
+        at directory: URL,
+        timeout: TimeInterval = defaultTimeout,
+        captureLimit: Int = defaultCaptureLimit,
+        cancellationToken: GitCommandCancellationToken? = nil,
+        systemCalls: GitCommandSystemCalls = .live
+    ) -> GitCommandResult {
+        if cancellationToken?.isCancelled == true {
+            return cancelledBeforeLaunchResult()
+        }
 
-            // Schedule a timeout to terminate hung processes
-            let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
-            timer.schedule(deadline: .now() + timeout)
-            timer.setEventHandler {
-                if process.isRunning {
-                    process.terminate()
-                }
-            }
-            timer.resume()
+        let startedAt = DispatchTime.now()
+        let commandDeadline = startedAt + normalizedTimeout(timeout)
 
-            // Read pipe data before waitUntilExit to avoid deadlock:
-            // if the process fills the pipe buffer, it blocks on write
-            // and never exits, while we block on waitUntilExit.
-            let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
-            let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
-
-            process.waitUntilExit()
-            timer.cancel()
-            return GitCommandResult(
-                output: String(bytes: outData, encoding: .utf8) ?? "",
-                errorOutput: String(bytes: errData, encoding: .utf8) ?? "",
-                exitCode: process.terminationStatus
-            )
-        } catch {
+        let child: GitCommandChild
+        switch spawn(
+            executableURL,
+            arguments: arguments,
+            directory: directory
+        ) {
+        case let .success(spawnedChild):
+            child = spawnedChild
+        case let .failure(error):
             return GitCommandResult(
                 output: "",
-                errorOutput: error.localizedDescription,
-                exitCode: -1
+                errorOutput: error.message,
+                exitCode: -1,
+                timedOut: false,
+                cancelled: false,
+                outputTruncated: false,
+                errorOutputTruncated: false,
+                outputCaptureComplete: false,
+                errorOutputCaptureComplete: false,
+                outputReadError: nil,
+                errorOutputReadError: nil
             )
+        }
+
+        var standardOutput = GitCommandCapture(limit: captureLimit)
+        var standardError = GitCommandCapture(limit: captureLimit)
+        var stdoutDescriptor = child.stdoutDescriptor
+        var stderrDescriptor = child.stderrDescriptor
+        var rawWaitStatus: Int32?
+        var phase = GitCommandTerminationPhase.running
+        var terminalCause: GitCommandTerminalCause?
+        var phaseDeadline = commandDeadline
+        var readBuffer = [UInt8](repeating: 0, count: readBufferSize)
+
+        lifecycleLoop: while true {
+            drain(
+                stream: .standardOutput,
+                descriptor: &stdoutDescriptor,
+                into: &standardOutput,
+                buffer: &readBuffer,
+                systemCalls: systemCalls
+            )
+            drain(
+                stream: .standardError,
+                descriptor: &stderrDescriptor,
+                into: &standardError,
+                buffer: &readBuffer,
+                systemCalls: systemCalls
+            )
+            let streamsAreClosed = stdoutDescriptor == -1
+                && stderrDescriptor == -1
+            if shouldAttemptReap(
+                phase: phase,
+                streamsAreClosed: streamsAreClosed
+            ) {
+                reap(
+                    processIdentifier: child.processIdentifier,
+                    rawStatus: &rawWaitStatus,
+                    systemCalls: systemCalls
+                )
+            }
+
+            if rawWaitStatus != nil,
+               streamsAreClosed {
+                break
+            }
+
+            let now = DispatchTime.now()
+            if terminalCause == nil {
+                if cancellationToken?.isCancelled == true {
+                    terminalCause = .cancelled
+                    signalProcessGroup(
+                        child.processIdentifier,
+                        signal: SIGTERM,
+                        systemCalls: systemCalls
+                    )
+                    phase = .terminating
+                    phaseDeadline = DispatchTime.now()
+                        + terminationGracePeriod
+                    continue
+                }
+                if now >= commandDeadline {
+                    terminalCause = .timedOut
+                    signalProcessGroup(
+                        child.processIdentifier,
+                        signal: SIGTERM,
+                        systemCalls: systemCalls
+                    )
+                    phase = .terminating
+                    // Start the grace period from the actual signal attempt. A
+                    // delayed worker must not collapse TERM and KILL together.
+                    phaseDeadline = DispatchTime.now()
+                        + terminationGracePeriod
+                    continue
+                }
+            }
+
+            switch phase {
+            case .terminating where now >= phaseDeadline:
+                signalProcessGroup(
+                    child.processIdentifier,
+                    signal: SIGKILL,
+                    systemCalls: systemCalls
+                )
+                phase = .killing
+                phaseDeadline = DispatchTime.now() + killCleanupPeriod
+                continue
+            case .killing where now >= phaseDeadline:
+                closeDescriptor(&stdoutDescriptor)
+                closeDescriptor(&stderrDescriptor)
+                if rawWaitStatus == nil {
+                    GitCommandDeferredReaper(
+                        processIdentifier: child.processIdentifier,
+                        waitpid: systemCalls.waitpid
+                    ).start()
+                }
+                break lifecycleLoop
+            default:
+                break
+            }
+
+            poll(
+                stdoutDescriptor: stdoutDescriptor,
+                stderrDescriptor: stderrDescriptor,
+                until: phaseDeadline
+            )
+        }
+
+        closeDescriptor(&stdoutDescriptor)
+        closeDescriptor(&stderrDescriptor)
+
+        let timedOut = terminalCause == .timedOut
+        let cancelled = terminalCause == .cancelled
+        let exitCode: Int32
+        if let rawWaitStatus {
+            let decodedCode = decodedExitCode(rawWaitStatus)
+            if timedOut, decodedCode == 0 {
+                exitCode = ETIMEDOUT
+            } else if cancelled, decodedCode == 0 {
+                exitCode = ECANCELED
+            } else {
+                exitCode = decodedCode
+            }
+        } else if timedOut {
+            exitCode = SIGKILL
+        } else if cancelled {
+            exitCode = ECANCELED
+        } else {
+            exitCode = -1
+        }
+
+        // A byte cap can split a multi-byte scalar. Preserve the valid prefix
+        // plus a replacement scalar instead of discarding the entire stream.
+        // swiftlint:disable:next optional_data_string_conversion
+        let output = String(decoding: standardOutput.data, as: UTF8.self)
+        // swiftlint:disable:next optional_data_string_conversion
+        let errorOutput = String(decoding: standardError.data, as: UTF8.self)
+        return GitCommandResult(
+            output: output,
+            errorOutput: errorOutput,
+            exitCode: exitCode,
+            timedOut: timedOut,
+            cancelled: cancelled,
+            outputTruncated: standardOutput.truncated,
+            errorOutputTruncated: standardError.truncated,
+            outputCaptureComplete: standardOutput.captureComplete,
+            errorOutputCaptureComplete: standardError.captureComplete,
+            outputReadError: standardOutput.readError,
+            errorOutputReadError: standardError.readError
+        )
+    }
+
+    /// Testable async executable seam used by ``runAsync(_:at:timeout:)``.
+    static func runExecutableAsync(
+        _ executableURL: URL,
+        arguments: [String],
+        at directory: URL,
+        timeout: TimeInterval = defaultTimeout,
+        captureLimit: Int = defaultCaptureLimit,
+        systemCalls: GitCommandSystemCalls = .live
+    ) async -> GitCommandResult {
+        let cancellationToken = GitCommandCancellationToken()
+        return await withTaskCancellationHandler {
+            if Task.isCancelled {
+                cancellationToken.cancel()
+            }
+            return await withCheckedContinuation { continuation in
+                DispatchQueue.global(qos: .utility).async {
+                    continuation.resume(
+                        returning: runExecutable(
+                            executableURL,
+                            arguments: arguments,
+                            at: directory,
+                            timeout: timeout,
+                            captureLimit: captureLimit,
+                            cancellationToken: cancellationToken,
+                            systemCalls: systemCalls
+                        )
+                    )
+                }
+            }
+        } onCancel: {
+            cancellationToken.cancel()
+        }
+    }
+
+    private static func cancelledBeforeLaunchResult() -> GitCommandResult {
+        GitCommandResult(
+            output: "",
+            errorOutput: "",
+            exitCode: ECANCELED,
+            timedOut: false,
+            cancelled: true,
+            outputTruncated: false,
+            errorOutputTruncated: false,
+            outputCaptureComplete: false,
+            errorOutputCaptureComplete: false,
+            outputReadError: nil,
+            errorOutputReadError: nil
+        )
+    }
+
+    /// A wait consumes the zombie and releases its PID for reuse. Preserve the
+    /// process-group leader until no more group signal can be sent, unless all
+    /// captured streams are closed and the invocation can return immediately.
+    static func shouldAttemptReap(
+        phase: GitCommandTerminationPhase,
+        streamsAreClosed: Bool
+    ) -> Bool {
+        if streamsAreClosed {
+            return true
+        }
+        if case .killing = phase {
+            return true
+        }
+        return false
+    }
+
+    private static func spawn(
+        _ executableURL: URL,
+        arguments: [String],
+        directory: URL
+    ) -> Result<GitCommandChild, GitCommandLaunchError> {
+        guard var stdoutPipe = makePipe() else {
+            return .failure(GitCommandLaunchError(code: errno))
+        }
+        defer { stdoutPipe.closeAll() }
+
+        guard var stderrPipe = makePipe() else {
+            return .failure(GitCommandLaunchError(code: errno))
+        }
+        defer { stderrPipe.closeAll() }
+
+        var fileActions: posix_spawn_file_actions_t?
+        let fileActionsError = posix_spawn_file_actions_init(&fileActions)
+        guard fileActionsError == 0 else {
+            return .failure(GitCommandLaunchError(code: fileActionsError))
+        }
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+
+        let stdinError = "/dev/null".withCString { nullDevicePath in
+            posix_spawn_file_actions_addopen(
+                &fileActions,
+                STDIN_FILENO,
+                nullDevicePath,
+                O_RDONLY,
+                0
+            )
+        }
+        guard stdinError == 0 else {
+            return .failure(GitCommandLaunchError(code: stdinError))
+        }
+        let stdoutDupError = posix_spawn_file_actions_adddup2(
+            &fileActions,
+            stdoutPipe.writeDescriptor,
+            STDOUT_FILENO
+        )
+        guard stdoutDupError == 0 else {
+            return .failure(GitCommandLaunchError(code: stdoutDupError))
+        }
+        let stderrDupError = posix_spawn_file_actions_adddup2(
+            &fileActions,
+            stderrPipe.writeDescriptor,
+            STDERR_FILENO
+        )
+        guard stderrDupError == 0 else {
+            return .failure(GitCommandLaunchError(code: stderrDupError))
+        }
+
+        for descriptor in [
+            stdoutPipe.readDescriptor,
+            stdoutPipe.writeDescriptor,
+            stderrPipe.readDescriptor,
+            stderrPipe.writeDescriptor
+        ] {
+            let closeError = posix_spawn_file_actions_addclose(
+                &fileActions,
+                descriptor
+            )
+            guard closeError == 0 else {
+                return .failure(GitCommandLaunchError(code: closeError))
+            }
+        }
+
+        let chdirError = directory.path.withCString { directoryPath in
+            posix_spawn_file_actions_addchdir(&fileActions, directoryPath)
+        }
+        guard chdirError == 0 else {
+            return .failure(GitCommandLaunchError(code: chdirError))
+        }
+
+        var attributes: posix_spawnattr_t?
+        let attributesError = posix_spawnattr_init(&attributes)
+        guard attributesError == 0 else {
+            return .failure(GitCommandLaunchError(code: attributesError))
+        }
+        defer { posix_spawnattr_destroy(&attributes) }
+
+        // Do not inherit the host's signal handling. Test runners and GUI
+        // launchers may ignore or block SIGTERM; POSIX shells then preserve
+        // that ignored disposition and cannot install a TERM trap. Reset all
+        // catchable signals and clear the signal mask so TERM/grace/KILL has
+        // the same semantics regardless of Pine's parent process.
+        var defaultSignals = sigset_t()
+        guard sigfillset(&defaultSignals) == 0,
+              sigdelset(&defaultSignals, SIGKILL) == 0,
+              sigdelset(&defaultSignals, SIGSTOP) == 0 else {
+            return .failure(GitCommandLaunchError(code: errno))
+        }
+        let signalDefaultsError = posix_spawnattr_setsigdefault(
+            &attributes,
+            &defaultSignals
+        )
+        guard signalDefaultsError == 0 else {
+            return .failure(GitCommandLaunchError(code: signalDefaultsError))
+        }
+
+        var signalMask = sigset_t()
+        guard sigemptyset(&signalMask) == 0 else {
+            return .failure(GitCommandLaunchError(code: errno))
+        }
+        let signalMaskError = posix_spawnattr_setsigmask(
+            &attributes,
+            &signalMask
+        )
+        guard signalMaskError == 0 else {
+            return .failure(GitCommandLaunchError(code: signalMaskError))
+        }
+
+        let attributeFlags = Int16(
+            POSIX_SPAWN_SETPGROUP
+                | POSIX_SPAWN_CLOEXEC_DEFAULT
+                | POSIX_SPAWN_SETSIGDEF
+                | POSIX_SPAWN_SETSIGMASK
+        )
+        let flagsError = posix_spawnattr_setflags(
+            &attributes,
+            attributeFlags
+        )
+        guard flagsError == 0 else {
+            return .failure(GitCommandLaunchError(code: flagsError))
+        }
+        // Darwin defines spawn-pgroup 0 as a new group whose ID is the child
+        // PID. This avoids the post-launch setpgid race entirely.
+        let groupError = posix_spawnattr_setpgroup(&attributes, 0)
+        guard groupError == 0 else {
+            return .failure(GitCommandLaunchError(code: groupError))
+        }
+
+        let argumentStrings = [executableURL.path] + arguments
+        let environmentStrings = ProcessInfo.processInfo.environment.map {
+            "\($0.key)=\($0.value)"
+        }
+        var processIdentifier: pid_t = 0
+        let spawnError = withMutableCStringArray(argumentStrings) { argv in
+            withMutableCStringArray(environmentStrings) { environment in
+                executableURL.path.withCString { executablePath in
+                    posix_spawn(
+                        &processIdentifier,
+                        executablePath,
+                        &fileActions,
+                        &attributes,
+                        argv,
+                        environment
+                    )
+                }
+            }
+        }
+        guard spawnError == 0 else {
+            return .failure(GitCommandLaunchError(code: spawnError))
+        }
+
+        stdoutPipe.closeWrite()
+        stderrPipe.closeWrite()
+        let child = GitCommandChild(
+            processIdentifier: processIdentifier,
+            stdoutDescriptor: stdoutPipe.takeReadDescriptor(),
+            stderrDescriptor: stderrPipe.takeReadDescriptor()
+        )
+        return .success(child)
+    }
+
+    private static func makePipe() -> GitCommandPipe? {
+        var descriptors = [Int32](repeating: -1, count: 2)
+        let pipeResult = descriptors.withUnsafeMutableBufferPointer { buffer in
+            guard let baseAddress = buffer.baseAddress else {
+                return Int32(-1)
+            }
+            return Darwin.pipe(baseAddress)
+        }
+        guard pipeResult == 0 else { return nil }
+
+        var pipe = GitCommandPipe(
+            readDescriptor: descriptors[0],
+            writeDescriptor: descriptors[1]
+        )
+        guard moveAboveStandardDescriptors(&pipe.readDescriptor),
+              moveAboveStandardDescriptors(&pipe.writeDescriptor),
+              setCloseOnExec(pipe.readDescriptor),
+              setCloseOnExec(pipe.writeDescriptor),
+              setNonBlocking(pipe.readDescriptor) else {
+            let savedError = errno
+            pipe.closeAll()
+            errno = savedError
+            return nil
+        }
+        return pipe
+    }
+
+    private static func moveAboveStandardDescriptors(
+        _ descriptor: inout Int32
+    ) -> Bool {
+        guard descriptor <= STDERR_FILENO else { return true }
+        let duplicated = Darwin.fcntl(
+            descriptor,
+            F_DUPFD_CLOEXEC,
+            STDERR_FILENO + 1
+        )
+        guard duplicated != -1 else { return false }
+        Darwin.close(descriptor)
+        descriptor = duplicated
+        return true
+    }
+
+    private static func setCloseOnExec(_ descriptor: Int32) -> Bool {
+        Darwin.fcntl(descriptor, F_SETFD, FD_CLOEXEC) != -1
+    }
+
+    private static func setNonBlocking(_ descriptor: Int32) -> Bool {
+        let flags = Darwin.fcntl(descriptor, F_GETFL)
+        guard flags != -1 else { return false }
+
+        return Darwin.fcntl(
+            descriptor,
+            F_SETFL,
+            flags | O_NONBLOCK
+        ) != -1
+    }
+
+    private static func drain(
+        stream: GitCommandStream,
+        descriptor: inout Int32,
+        into capture: inout GitCommandCapture,
+        buffer: inout [UInt8],
+        systemCalls: GitCommandSystemCalls
+    ) {
+        guard descriptor != -1 else { return }
+        var drainedBytes = 0
+
+        while drainedBytes < maximumDrainBytesPerPass {
+            let bytesRead = buffer.withUnsafeMutableBytes { bytes in
+                systemCalls.read(
+                    stream,
+                    descriptor,
+                    bytes.baseAddress,
+                    bytes.count
+                )
+            }
+            if bytesRead > 0 {
+                capture.append(buffer, count: bytesRead)
+                drainedBytes += bytesRead
+                continue
+            }
+            if bytesRead == 0 {
+                capture.markEndOfFile()
+                closeDescriptor(&descriptor)
+                return
+            }
+            if errno == EINTR {
+                return
+            }
+            if errno == EAGAIN || errno == EWOULDBLOCK {
+                return
+            }
+            capture.markReadFailure(errno)
+            closeDescriptor(&descriptor)
+            return
+        }
+    }
+
+    private static func reap(
+        processIdentifier: pid_t,
+        rawStatus: inout Int32?,
+        systemCalls: GitCommandSystemCalls
+    ) {
+        guard rawStatus == nil else { return }
+        var status: Int32 = 0
+        let result = systemCalls.waitpid(
+            processIdentifier,
+            &status,
+            WNOHANG
+        )
+
+        if result == processIdentifier {
+            rawStatus = status
+        } else if result == -1 && errno == ECHILD {
+            rawStatus = unknownWaitStatus
+        }
+    }
+
+    private static func poll(
+        stdoutDescriptor: Int32,
+        stderrDescriptor: Int32,
+        until deadline: DispatchTime
+    ) {
+        let timeout = pollTimeout(until: deadline)
+        var descriptors: [pollfd] = []
+        let events = Int16(POLLIN | POLLHUP | POLLERR)
+        if stdoutDescriptor != -1 {
+            descriptors.append(
+                pollfd(fd: stdoutDescriptor, events: events, revents: 0)
+            )
+        }
+        if stderrDescriptor != -1 {
+            descriptors.append(
+                pollfd(fd: stderrDescriptor, events: events, revents: 0)
+            )
+        }
+
+        guard !descriptors.isEmpty else {
+            Darwin.poll(nil, 0, timeout)
+            return
+        }
+        descriptors.withUnsafeMutableBufferPointer { buffer in
+            _ = Darwin.poll(
+                buffer.baseAddress,
+                nfds_t(buffer.count),
+                timeout
+            )
+        }
+    }
+
+    private static func pollTimeout(until deadline: DispatchTime) -> Int32 {
+        let now = DispatchTime.now()
+        guard now < deadline else { return 0 }
+        let remainingNanoseconds = deadline.uptimeNanoseconds
+            - now.uptimeNanoseconds
+        let wholeMilliseconds = remainingNanoseconds / 1_000_000
+        let roundedMilliseconds = wholeMilliseconds
+            + (remainingNanoseconds.isMultiple(of: 1_000_000) ? 0 : 1)
+        return Int32(
+            min(
+                UInt64(pollIntervalMilliseconds),
+                max(roundedMilliseconds, 1)
+            )
+        )
+    }
+
+    private static func signalProcessGroup(
+        _ processIdentifier: pid_t,
+        signal: Int32,
+        systemCalls: GitCommandSystemCalls
+    ) {
+        guard processIdentifier > 0 else { return }
+        _ = systemCalls.kill(-processIdentifier, signal)
+    }
+
+    private static func closeDescriptor(_ descriptor: inout Int32) {
+        guard descriptor != -1 else { return }
+        _ = Darwin.close(descriptor)
+        descriptor = -1
+    }
+
+    private static func decodedExitCode(_ status: Int32) -> Int32 {
+        guard status != unknownWaitStatus else { return -1 }
+        let signal = status & 0x7f
+        if signal == 0 {
+            return (status >> 8) & 0xff
+        }
+        return signal
+    }
+
+    private static func normalizedTimeout(_ timeout: TimeInterval) -> TimeInterval {
+        guard timeout.isFinite else { return defaultTimeout }
+        return max(timeout, 0)
+    }
+
+    private static func withMutableCStringArray<Result>(
+        _ strings: [String],
+        body: (
+            UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>
+        ) -> Result
+    ) -> Result {
+        var pointers = strings.map { strdup($0) }
+        pointers.append(nil)
+        defer {
+            for case let pointer? in pointers {
+                free(pointer)
+            }
+        }
+        return pointers.withUnsafeMutableBufferPointer { buffer in
+            guard let baseAddress = buffer.baseAddress else {
+                preconditionFailure("C string array must contain a terminator")
+            }
+            return body(baseAddress)
+        }
+    }
+
+    private static let unknownWaitStatus = Int32.min
+}
+
+nonisolated private struct GitCommandChild {
+    let processIdentifier: pid_t
+    let stdoutDescriptor: Int32
+    let stderrDescriptor: Int32
+}
+
+nonisolated private struct GitCommandLaunchError: Error {
+    let code: Int32
+
+    var message: String {
+        guard let description = strerror(code) else {
+            return "Process launch failed (\(code))"
+        }
+        return String(cString: description)
+    }
+}
+
+nonisolated private struct GitCommandPipe {
+    var readDescriptor: Int32
+    var writeDescriptor: Int32
+
+    mutating func closeAll() {
+        closeRead()
+        closeWrite()
+    }
+
+    mutating func closeRead() {
+        guard readDescriptor != -1 else { return }
+        _ = Darwin.close(readDescriptor)
+        readDescriptor = -1
+    }
+
+    mutating func closeWrite() {
+        guard writeDescriptor != -1 else { return }
+        _ = Darwin.close(writeDescriptor)
+        writeDescriptor = -1
+    }
+
+    mutating func takeReadDescriptor() -> Int32 {
+        let descriptor = readDescriptor
+        readDescriptor = -1
+        return descriptor
+    }
+}
+
+nonisolated private struct GitCommandCapture {
+    let limit: Int
+    private(set) var data = Data()
+    private(set) var truncated = false
+    private(set) var reachedEndOfFile = false
+    private(set) var readError: Int32?
+
+    var captureComplete: Bool {
+        reachedEndOfFile && readError == nil && !truncated
+    }
+
+    init(limit: Int) {
+        self.limit = max(limit, 0)
+    }
+
+    mutating func append(_ bytes: [UInt8], count: Int) {
+        let retainedCount = min(count, max(limit - data.count, 0))
+        if retainedCount > 0 {
+            data.append(contentsOf: bytes.prefix(retainedCount))
+        }
+        if retainedCount < count {
+            truncated = true
+        }
+    }
+
+    mutating func markEndOfFile() {
+        reachedEndOfFile = true
+    }
+
+    mutating func markReadFailure(_ error: Int32) {
+        readError = error
+    }
+}
+
+nonisolated enum GitCommandTerminationPhase {
+    case running
+    case terminating
+    case killing
+}
+
+nonisolated private enum GitCommandTerminalCause {
+    case timedOut
+    case cancelled
+}
+
+/// A final nonblocking reaper for the extremely small window where SIGKILL has
+/// been sent but the kernel has not yet made the direct child waitable.
+///
+/// One process-exit source replaces periodic retry work. The source holds the
+/// unreaped direct child identity until NOTE_EXIT, so its PID cannot be reused
+/// while this owner still needs to wait for it.
+nonisolated private final class GitCommandDeferredReaper: @unchecked Sendable {
+    private let processIdentifier: pid_t
+    private let waitpid: @Sendable (
+        pid_t,
+        UnsafeMutablePointer<Int32>?,
+        Int32
+    ) -> pid_t
+    private let queue: DispatchQueue
+    private var source: DispatchSourceProcess?
+
+    init(
+        processIdentifier: pid_t,
+        waitpid: @escaping @Sendable (
+            pid_t,
+            UnsafeMutablePointer<Int32>?,
+            Int32
+        ) -> pid_t
+    ) {
+        self.processIdentifier = processIdentifier
+        self.waitpid = waitpid
+        self.queue = DispatchQueue(
+            label: "com.pine.git-command-reaper.\(processIdentifier)",
+            qos: .utility
+        )
+    }
+
+    func start() {
+        queue.async {
+            if self.reapIfExited() {
+                return
+            }
+
+            let source = DispatchSource.makeProcessSource(
+                identifier: self.processIdentifier,
+                eventMask: .exit,
+                queue: self.queue
+            )
+            self.source = source
+            source.setEventHandler {
+                _ = source.data
+                self.reapAfterExitEvent()
+                source.cancel()
+                self.source = nil
+            }
+            source.resume()
+
+            // Close the registration race where the child exits after the
+            // first WNOHANG observation but before the process source starts.
+            if self.reapIfExited() {
+                source.cancel()
+                self.source = nil
+            }
+        }
+    }
+
+    private func reapIfExited() -> Bool {
+        var status: Int32 = 0
+        let result = waitpid(processIdentifier, &status, WNOHANG)
+        return result == processIdentifier
+            || (result == -1 && errno == ECHILD)
+    }
+
+    private func reapAfterExitEvent() {
+        while true {
+            var status: Int32 = 0
+            // NOTE_EXIT has already established that a blocking wait cannot
+            // wait on a live child.
+            let result = waitpid(processIdentifier, &status, 0)
+            if result == processIdentifier
+                || (result == -1 && errno == ECHILD) {
+                return
+            }
+            if result == -1 && errno == EINTR {
+                continue
+            }
+            return
         }
     }
 }

--- a/Pine/Git/GitFetcher.swift
+++ b/Pine/Git/GitFetcher.swift
@@ -56,7 +56,7 @@ nonisolated enum GitFetcher {
 
     static func fetchBranch(at url: URL) -> String {
         let result = GitCommand.run(["rev-parse", "--abbrev-ref", "HEAD"], at: url)
-        return result.exitCode == 0
+        return result.succeeded
             ? result.output.trimmingCharacters(in: .whitespacesAndNewlines)
             : ""
     }
@@ -68,7 +68,7 @@ nonisolated enum GitFetcher {
             ["--no-optional-locks", "status", "--ignored", "--porcelain"],
             at: url
         )
-        guard result.exitCode == 0 else { return ([:], []) }
+        guard result.succeeded else { return ([:], []) }
         return (
             GitParser.parseStatusOutput(result.output),
             GitParser.parseIgnoredOutput(result.output)
@@ -80,7 +80,7 @@ nonisolated enum GitFetcher {
             ["branch", "--sort=-committerdate", "--format=%(refname:short)"],
             at: url
         )
-        guard result.exitCode == 0 else { return [] }
+        guard result.succeeded else { return [] }
         return result.output
             .components(separatedBy: "\n")
             .filter { !$0.isEmpty }

--- a/Pine/Git/GitFileRevert.swift
+++ b/Pine/Git/GitFileRevert.swift
@@ -38,7 +38,7 @@ nonisolated enum GitFileRevert {
             let result = GitCommand.run(["checkout", "--", path], at: repositoryRoot)
             return GitFileRevertResult(
                 relativePath: path,
-                success: result.exitCode == 0,
+                success: result.completedSuccessfully,
                 errorOutput: result.errorOutput.trimmingCharacters(in: .whitespacesAndNewlines)
             )
         }

--- a/Pine/GitStatusProvider.swift
+++ b/Pine/GitStatusProvider.swift
@@ -40,7 +40,7 @@ final class GitStatusProvider {
     func setup(repositoryURL: URL) {
         self.repositoryURL = repositoryURL
         let result = Self.runGit(["rev-parse", "--show-toplevel"], at: repositoryURL)
-        let detected = result.exitCode == 0
+        let detected = result.succeeded
         if detected {
             gitRootPath = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
             let fetched = Self.fetchAllInParallel(at: repositoryURL)
@@ -115,7 +115,7 @@ final class GitStatusProvider {
         // nonisolated-check:ignore -- closure body only calls nonisolated static helpers; tracked in #720
         let (isRepo, rootPath, branch, statuses, ignored, branchList) = await runOnBackground {
             let result = GitCommand.run(["rev-parse", "--show-toplevel"], at: repositoryURL)
-            let isRepo = result.exitCode == 0
+            let isRepo = result.succeeded
             guard isRepo else {
                 return (false, nil as String?, "", [:] as [String: GitFileStatus], Set<String>(), [String]())
             }
@@ -206,7 +206,10 @@ final class GitStatusProvider {
             && fetched.branches.isEmpty
             && (!self.currentBranch.isEmpty || !self.branches.isEmpty)
         if looksUnreachable {
-            let stillRepo = Self.runGit(["rev-parse", "--show-toplevel"], at: url).exitCode == 0
+            let stillRepo = Self.runGit(
+                ["rev-parse", "--show-toplevel"],
+                at: url
+            ).succeeded
             if !stillRepo {
                 applyEmptyState()
             }
@@ -276,10 +279,10 @@ final class GitStatusProvider {
     func diffForFile(at url: URL) -> [GitLineDiff] {
         guard isGitRepository, let repoURL = repositoryURL else { return [] }
         let headCheck = Self.runGit(["rev-parse", "HEAD"], at: repoURL)
-        guard headCheck.exitCode == 0 else { return [] }
+        guard headCheck.succeeded else { return [] }
 
         let result = Self.runGit(["diff", "HEAD", "--unified=0", "--", url.path], at: repoURL)
-        guard result.exitCode == 0, !result.output.isEmpty else { return [] }
+        guard result.succeeded, !result.output.isEmpty else { return [] }
         return GitParser.parseDiff(result.output)
     }
 
@@ -287,17 +290,19 @@ final class GitStatusProvider {
         guard isGitRepository, let repoURL = repositoryURL else { return [] }
         let filePath = url.path
 
-        // nonisolated-check:ignore -- closure body only calls nonisolated static helpers; tracked in #720
-        return await runOnBackground {
-            let headCheck = GitCommand.run(["rev-parse", "HEAD"], at: repoURL)
-            guard headCheck.exitCode == 0 else { return [] }
-            let result = GitCommand.run(
-                ["diff", "HEAD", "--unified=0", "--", filePath],
-                at: repoURL
-            )
-            guard result.exitCode == 0, !result.output.isEmpty else { return [] }
-            return GitParser.parseDiff(result.output)
-        }
+        let headCheck = await GitCommand.runAsync(
+            ["rev-parse", "HEAD"],
+            at: repoURL
+        )
+        guard !Task.isCancelled, headCheck.succeeded else { return [] }
+        let result = await GitCommand.runAsync(
+            ["diff", "HEAD", "--unified=0", "--", filePath],
+            at: repoURL
+        )
+        guard !Task.isCancelled,
+              result.succeeded,
+              !result.output.isEmpty else { return [] }
+        return GitParser.parseDiff(result.output)
     }
 
     // MARK: - Private Helpers
@@ -348,9 +353,28 @@ final class GitStatusProvider {
     nonisolated static func runGit(
         _ arguments: [String],
         at directory: URL,
-        timeout: TimeInterval = defaultGitTimeout
-    ) -> (output: String, errorOutput: String, exitCode: Int32) {
-        let result = GitCommand.run(arguments, at: directory, timeout: timeout)
-        return (result.output, result.errorOutput, result.exitCode)
+        timeout: TimeInterval = defaultGitTimeout,
+        captureLimit: Int = GitCommand.defaultCaptureLimit
+    ) -> GitCommandResult {
+        GitCommand.run(
+            arguments,
+            at: directory,
+            timeout: timeout,
+            captureLimit: captureLimit
+        )
+    }
+
+    nonisolated static func runGitAsync(
+        _ arguments: [String],
+        at directory: URL,
+        timeout: TimeInterval = defaultGitTimeout,
+        captureLimit: Int = GitCommand.defaultCaptureLimit
+    ) async -> GitCommandResult {
+        await GitCommand.runAsync(
+            arguments,
+            at: directory,
+            timeout: timeout,
+            captureLimit: captureLimit
+        )
     }
 }

--- a/Pine/InlineDiffProvider.swift
+++ b/Pine/InlineDiffProvider.swift
@@ -287,16 +287,19 @@ nonisolated enum InlineDiffProvider {
     /// Fetches diff hunks for a file asynchronously.
     /// Returns full `git diff HEAD` output parsed into hunks.
     static func fetchHunks(for fileURL: URL, repoURL: URL) async -> [DiffHunk] {
-        await runOnBackground {
-            let headCheck = GitStatusProvider.runGit(["rev-parse", "HEAD"], at: repoURL)
-            guard headCheck.exitCode == 0 else { return [] }
-            let result = GitStatusProvider.runGit(
-                ["diff", "HEAD", "--unified=1", "--", fileURL.path],
-                at: repoURL
-            )
-            guard result.exitCode == 0, !result.output.isEmpty else { return [] }
-            return parseHunks(result.output)
-        }
+        let headCheck = await GitStatusProvider.runGitAsync(
+            ["rev-parse", "HEAD"],
+            at: repoURL
+        )
+        guard !Task.isCancelled, headCheck.succeeded else { return [] }
+        let result = await GitStatusProvider.runGitAsync(
+            ["diff", "HEAD", "--unified=1", "--", fileURL.path],
+            at: repoURL
+        )
+        guard !Task.isCancelled,
+              result.succeeded,
+              !result.output.isEmpty else { return [] }
+        return parseHunks(result.output)
     }
 
     // MARK: - Accept (stage) a hunk
@@ -318,7 +321,7 @@ nonisolated enum InlineDiffProvider {
     static func acceptAllHunks(fileURL: URL, repoURL: URL) async -> Bool {
         await runOnBackground {
             let result = GitStatusProvider.runGit(["add", "--", fileURL.path], at: repoURL)
-            return result.exitCode == 0
+            return result.completedSuccessfully
         }
     }
 
@@ -344,7 +347,7 @@ nonisolated enum InlineDiffProvider {
                 ["checkout", "HEAD", "--", fileURL.path],
                 at: repoURL
             )
-            guard result.exitCode == 0 else { return nil }
+            guard result.completedSuccessfully else { return nil }
             return try? String(contentsOf: fileURL, encoding: .utf8)
         }
     }

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -571,12 +571,12 @@ struct PaneLeafView: View {
         }
         let filePath = fileURL.path
         blameTask = Task.detached {
-            let result = GitStatusProvider.runGit(
+            let result = await GitStatusProvider.runGitAsync(
                 ["blame", "--porcelain", "--", filePath], at: repoURL
             )
             guard !Task.isCancelled else { return }
             let lines: [GitBlameLine]
-            if result.exitCode == 0, !result.output.isEmpty {
+            if result.succeeded, !result.output.isEmpty {
                 lines = GitStatusProvider.parseBlame(result.output)
             } else {
                 lines = []

--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -371,7 +371,7 @@ final class WorkspaceManager {
     /// from any thread / `Task.detached` context.
     nonisolated private static func fetchGitInfo(at url: URL) -> GitLoadSnapshot {
         let topLevel = GitStatusProvider.runGit(["rev-parse", "--show-toplevel"], at: url)
-        guard topLevel.exitCode == 0 else {
+        guard topLevel.succeeded else {
             return GitLoadSnapshot(
                 repositoryURL: url,
                 gitRootPath: nil,

--- a/PineTests/GitCommandTests.swift
+++ b/PineTests/GitCommandTests.swift
@@ -1,0 +1,847 @@
+//
+//  GitCommandTests.swift
+//  PineTests
+//
+
+import Darwin
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("GitCommand Process Lifecycle Tests", .serialized)
+struct GitCommandTests {
+    private let shellURL = URL(fileURLWithPath: "/bin/sh")
+    private let workingDirectory = FileManager.default.temporaryDirectory
+
+    @Test("stdout and stderr are drained concurrently")
+    func drainsLargeStdoutAndStderr() {
+        let lineCount = 12_000
+        let script = """
+        i=0
+        while [ "$i" -lt \(lineCount) ]; do
+          printf 'out-%05d-xxxxxxxxxxxxxxxx\\n' "$i"
+          printf 'err-%05d-yyyyyyyyyyyyyyyy\\n' "$i" >&2
+          i=$((i + 1))
+        done
+        """
+
+        let result = GitCommand.runExecutable(
+            shellURL,
+            arguments: ["-c", script],
+            at: workingDirectory,
+            timeout: 5
+        )
+
+        #expect(result.succeeded)
+        #expect(result.outputTruncated == false)
+        #expect(result.errorOutputTruncated == false)
+        #expect(result.output.split(separator: "\n").count == lineCount)
+        #expect(result.errorOutput.split(separator: "\n").count == lineCount)
+        #expect(result.output.hasSuffix("out-11999-xxxxxxxxxxxxxxxx\n"))
+        #expect(result.errorOutput.hasSuffix("err-11999-yyyyyyyyyyyyyyyy\n"))
+    }
+
+    @Test("output is bounded while both pipes continue draining")
+    func boundsCapturedOutput() {
+        let captureLimit = 1_024
+        let lineCount = 12_000
+        let script = """
+        i=0
+        while [ "$i" -lt \(lineCount) ]; do
+          printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\\n'
+          printf 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\\n' >&2
+          i=$((i + 1))
+        done
+        """
+
+        let result = GitCommand.runExecutable(
+            shellURL,
+            arguments: ["-c", script],
+            at: workingDirectory,
+            timeout: 5,
+            captureLimit: captureLimit
+        )
+
+        #expect(result.exitCode == 0)
+        #expect(result.timedOut == false)
+        #expect(result.completedSuccessfully)
+        #expect(result.succeeded == false)
+        #expect(result.output.utf8.count == captureLimit)
+        #expect(result.errorOutput.utf8.count == captureLimit)
+        #expect(result.outputTruncated)
+        #expect(result.errorOutputTruncated)
+    }
+
+    @Test("truncation of either stream prevents success")
+    func eitherTruncatedStreamIsUnsuccessful() {
+        let truncatedOutput = GitCommandResult(
+            output: "partial",
+            errorOutput: "",
+            exitCode: 0,
+            timedOut: false,
+            cancelled: false,
+            outputTruncated: true,
+            errorOutputTruncated: false,
+            outputCaptureComplete: false,
+            errorOutputCaptureComplete: true,
+            outputReadError: nil,
+            errorOutputReadError: nil
+        )
+        let truncatedError = GitCommandResult(
+            output: "",
+            errorOutput: "partial",
+            exitCode: 0,
+            timedOut: false,
+            cancelled: false,
+            outputTruncated: false,
+            errorOutputTruncated: true,
+            outputCaptureComplete: true,
+            errorOutputCaptureComplete: false,
+            outputReadError: nil,
+            errorOutputReadError: nil
+        )
+
+        #expect(truncatedOutput.succeeded == false)
+        #expect(truncatedError.succeeded == false)
+        #expect(truncatedOutput.completedSuccessfully)
+        #expect(truncatedError.completedSuccessfully)
+    }
+
+    @Test("an unexpected stdout read error fails closed")
+    func stdoutReadErrorFailsClosed() {
+        let injector = GitCommandReadInjector(
+            stream: .standardOutput,
+            error: EIO
+        )
+        let result = GitCommand.runExecutable(
+            shellURL,
+            arguments: ["-c", ":"],
+            at: workingDirectory,
+            timeout: 1,
+            systemCalls: GitCommandSystemCalls(
+                read: { stream, descriptor, buffer, count in
+                    injector.read(
+                        stream: stream,
+                        descriptor: descriptor,
+                        buffer: buffer,
+                        count: count
+                    )
+                }
+            )
+        )
+
+        #expect(result.exitCode == 0)
+        #expect(result.outputReadError == EIO)
+        #expect(result.outputCaptureComplete == false)
+        #expect(result.errorOutputCaptureComplete)
+        #expect(result.succeeded == false)
+    }
+
+    @Test("an unexpected stderr read error fails closed")
+    func stderrReadErrorFailsClosed() {
+        let injector = GitCommandReadInjector(
+            stream: .standardError,
+            error: EIO
+        )
+        let result = GitCommand.runExecutable(
+            shellURL,
+            arguments: ["-c", ":"],
+            at: workingDirectory,
+            timeout: 1,
+            systemCalls: GitCommandSystemCalls(
+                read: { stream, descriptor, buffer, count in
+                    injector.read(
+                        stream: stream,
+                        descriptor: descriptor,
+                        buffer: buffer,
+                        count: count
+                    )
+                }
+            )
+        )
+
+        #expect(result.exitCode == 0)
+        #expect(result.errorOutputReadError == EIO)
+        #expect(result.errorOutputCaptureComplete == false)
+        #expect(result.outputCaptureComplete)
+        #expect(result.succeeded == false)
+    }
+
+    @Test("an interrupted read retries without losing output")
+    func interruptedReadRetries() {
+        let injector = GitCommandReadInjector(
+            stream: .standardOutput,
+            error: EINTR
+        )
+        let result = GitCommand.runExecutable(
+            shellURL,
+            arguments: ["-c", "printf complete"],
+            at: workingDirectory,
+            timeout: 1,
+            systemCalls: GitCommandSystemCalls(
+                read: { stream, descriptor, buffer, count in
+                    injector.read(
+                        stream: stream,
+                        descriptor: descriptor,
+                        buffer: buffer,
+                        count: count
+                    )
+                }
+            )
+        )
+
+        #expect(result.succeeded)
+        #expect(result.output == "complete")
+        #expect(result.outputReadError == nil)
+        #expect(result.outputCaptureComplete)
+    }
+
+    @Test("an inherited pipe descriptor cannot outlive the timeout")
+    func inheritedDescriptorIsBounded() {
+        let startedAt = ProcessInfo.processInfo.systemUptime
+        let result = GitCommand.runExecutable(
+            shellURL,
+            arguments: [
+                "-c",
+                "(sleep 3) & child=$!; printf '%s\\n' \"$child\"; exit 0"
+            ],
+            at: workingDirectory,
+            timeout: 0.2
+        )
+        let elapsed = ProcessInfo.processInfo.systemUptime - startedAt
+        let descendant = pid_t(
+            result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+
+        #expect(result.timedOut)
+        #expect(result.exitCode != 0)
+        #expect(result.succeeded == false)
+        #expect(elapsed < 2)
+        #expect(descendant != nil)
+        if let descendant {
+            #expect(waitUntilProcessDisappears(descendant))
+        }
+    }
+
+    @Test("SIGKILL fallback removes a TERM-ignoring descendant")
+    func timeoutKillsTermIgnoringProcessGroup() {
+        let script = """
+        trap '' TERM
+        (
+          trap '' TERM
+          sleep 3
+        ) &
+        child=$!
+        printf '%s\\n' "$child"
+        wait "$child"
+        """
+        let startedAt = ProcessInfo.processInfo.systemUptime
+        let result = GitCommand.runExecutable(
+            shellURL,
+            arguments: ["-c", script],
+            at: workingDirectory,
+            timeout: 0.2
+        )
+        let elapsed = ProcessInfo.processInfo.systemUptime - startedAt
+        let descendant = pid_t(
+            result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+
+        #expect(result.timedOut)
+        #expect(result.exitCode != 0)
+        #expect(result.succeeded == false)
+        #expect(elapsed >= 0.4)
+        #expect(elapsed < 2)
+        #expect(descendant != nil)
+        if let descendant {
+            #expect(waitUntilProcessDisappears(descendant))
+        }
+    }
+
+    @Test("a TERM-respecting process receives the full grace period")
+    func timeoutAllowsTermHandlerToExit() {
+        let signals = GitCommandSignalRecorder()
+        let systemCalls = GitCommandSystemCalls(
+            kill: { processIdentifier, signal in
+                signals.kill(
+                    processIdentifier: processIdentifier,
+                    signal: signal
+                )
+            }
+        )
+        let script = """
+        trap 'printf "term-handled\\n"; exit 0' TERM
+        while :; do sleep 1; done
+        """
+        let startedAt = ProcessInfo.processInfo.systemUptime
+        let result = GitCommand.runExecutable(
+            shellURL,
+            arguments: ["-c", script],
+            at: workingDirectory,
+            timeout: 0.2,
+            systemCalls: systemCalls
+        )
+        let elapsed = ProcessInfo.processInfo.systemUptime - startedAt
+
+        #expect(result.timedOut)
+        #expect(result.cancelled == false)
+        #expect(result.output.contains("term-handled"))
+        #expect(signals.recordedSignals == [SIGTERM])
+        #expect(elapsed >= 0.18)
+        #expect(elapsed < 2)
+    }
+
+    @Test("cancellation before spawn never launches the executable")
+    func cancellationBeforeSpawn() async {
+        let sentinel = workingDirectory.appendingPathComponent(
+            "pine-git-command-\(UUID().uuidString)"
+        )
+        defer { try? FileManager.default.removeItem(at: sentinel) }
+        let gate = GitCommandBlockingGate()
+        let executableURL = shellURL
+        let directoryURL = workingDirectory
+        let task = Task.detached {
+            gate.wait()
+            return await GitCommand.runExecutableAsync(
+                executableURL,
+                arguments: [
+                    "-c",
+                    "printf launched > \"$1\"",
+                    "pine-test",
+                    sentinel.path
+                ],
+                at: directoryURL,
+                timeout: 5
+            )
+        }
+
+        task.cancel()
+        gate.open()
+        let result = await task.value
+
+        #expect(result.cancelled)
+        #expect(result.timedOut == false)
+        #expect(result.succeeded == false)
+        #expect(FileManager.default.fileExists(atPath: sentinel.path) == false)
+    }
+
+    @Test("cancellation after spawn sends TERM and reaps the process group")
+    func cancellationAfterSpawn() async {
+        let started = workingDirectory.appendingPathComponent(
+            "pine-git-command-started-\(UUID().uuidString)"
+        )
+        let signals = GitCommandSignalRecorder()
+        let systemCalls = GitCommandSystemCalls(
+            kill: { processIdentifier, signal in
+                signals.kill(
+                    processIdentifier: processIdentifier,
+                    signal: signal
+                )
+            }
+        )
+        defer { try? FileManager.default.removeItem(at: started) }
+        let executableURL = shellURL
+        let directoryURL = workingDirectory
+        let task = Task.detached {
+            await GitCommand.runExecutableAsync(
+                executableURL,
+                arguments: [
+                    "-c",
+                    """
+                    printf started > "$1"
+                    printf '%s\\n' "$$"
+                    while :; do :; done
+                    """,
+                    "pine-test",
+                    started.path
+                ],
+                at: directoryURL,
+                timeout: 10,
+                systemCalls: systemCalls
+            )
+        }
+
+        #expect(await waitUntilFileExists(started))
+        let cancelledAt = ProcessInfo.processInfo.systemUptime
+        task.cancel()
+        let result = await task.value
+        let elapsed = ProcessInfo.processInfo.systemUptime - cancelledAt
+        let processIdentifier = pid_t(
+            result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+
+        #expect(result.cancelled)
+        #expect(result.timedOut == false)
+        #expect(result.succeeded == false)
+        #expect(signals.recordedSignals == [SIGTERM])
+        #expect(elapsed < 2)
+        #expect(processIdentifier != nil)
+        if let processIdentifier {
+            #expect(waitUntilProcessDisappears(processIdentifier))
+        }
+    }
+
+    @Test("natural completion wins over a later cancellation")
+    func completionBeforeCancellation() async {
+        let completionGate = GitCommandCompletionGate()
+        let cancellationToken = GitCommandCancellationToken()
+        // Other suites deliberately saturate the shared utility pool. Use a
+        // private higher-QoS queue so this test controls the lifecycle race
+        // itself instead of racing unrelated worker scheduling.
+        let workerQueue = DispatchQueue(
+            label: "com.pine.tests.git-command-completion",
+            qos: .userInitiated
+        )
+        defer { completionGate.allowWaitpidToReturn() }
+        let executableURL = shellURL
+        let directoryURL = workingDirectory
+        let task = Task<GitCommandResult, Never> {
+            await withCheckedContinuation { continuation in
+                workerQueue.async {
+                    continuation.resume(
+                        returning: GitCommand.runExecutable(
+                            executableURL,
+                            arguments: ["-c", ":"],
+                            at: directoryURL,
+                            timeout: 5,
+                            cancellationToken: cancellationToken,
+                            systemCalls: GitCommandSystemCalls(
+                                waitpid: { processIdentifier, status, options in
+                                    completionGate.waitpid(
+                                        processIdentifier: processIdentifier,
+                                        status: status,
+                                        options: options
+                                    )
+                                }
+                            )
+                        )
+                    )
+                }
+            }
+        }
+
+        guard await completionGate.waitUntilProcessIsReaped() else {
+            cancellationToken.cancel()
+            completionGate.allowWaitpidToReturn()
+            _ = await task.value
+            Issue.record(
+                "GitCommand did not reach its natural-reap boundary"
+            )
+            return
+        }
+        // The child is already naturally complete and reaped. Hold the
+        // injected waitpid return just long enough to flip the same token that
+        // runExecutableAsync's cancellation handler owns, proving the loop
+        // commits the observed exit status before consulting later
+        // cancellation.
+        cancellationToken.cancel()
+        completionGate.allowWaitpidToReturn()
+        let result = await task.value
+
+        #expect(result.succeeded)
+        #expect(result.cancelled == false)
+        #expect(result.timedOut == false)
+    }
+
+    @Test("cancellation kills a TERM-ignoring process group")
+    func cancellationKillsTermIgnoringProcessGroup() async {
+        let started = workingDirectory.appendingPathComponent(
+            "pine-git-command-ignore-started-\(UUID().uuidString)"
+        )
+        defer { try? FileManager.default.removeItem(at: started) }
+        let executableURL = shellURL
+        let directoryURL = workingDirectory
+        let task = Task.detached {
+            await GitCommand.runExecutableAsync(
+                executableURL,
+                arguments: [
+                    "-c",
+                    """
+                    trap '' TERM
+                    printf started > "$1"
+                    printf '%s\\n' "$$"
+                    while :; do sleep 1; done
+                    """,
+                    "pine-test",
+                    started.path
+                ],
+                at: directoryURL,
+                timeout: 10
+            )
+        }
+
+        #expect(await waitUntilFileExists(started))
+        let cancelledAt = ProcessInfo.processInfo.systemUptime
+        task.cancel()
+        let result = await task.value
+        let elapsed = ProcessInfo.processInfo.systemUptime - cancelledAt
+        let processIdentifier = pid_t(
+            result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+
+        #expect(result.cancelled)
+        #expect(result.timedOut == false)
+        #expect(result.succeeded == false)
+        #expect(elapsed >= 0.2)
+        #expect(elapsed < 2)
+        #expect(processIdentifier != nil)
+        if let processIdentifier {
+            #expect(waitUntilProcessDisappears(processIdentifier))
+        }
+    }
+
+    @Test("parallel successes and timeouts keep lifecycle state isolated")
+    func parallelInvocationsRemainIsolated() async {
+        let invocationCount = 24
+        let executableURL = shellURL
+        let directoryURL = workingDirectory
+        let results = await withTaskGroup(
+            of: (Int, GitCommandResult).self,
+            returning: [(Int, GitCommandResult)].self
+        ) { group in
+            for index in 0..<invocationCount {
+                group.addTask {
+                    let shouldTimeOut = index.isMultiple(of: 3)
+                    let script = shouldTimeOut
+                        ? """
+                          trap '' TERM
+                          while :; do sleep 1; done
+                          """
+                        : """
+                          printf 'stdout-\(index)'
+                          printf 'stderr-\(index)' >&2
+                          """
+                    let result = GitCommand.runExecutable(
+                        executableURL,
+                        arguments: ["-c", script],
+                        at: directoryURL,
+                        timeout: shouldTimeOut ? 0.2 : 5
+                    )
+                    return (index, result)
+                }
+            }
+
+            var collected: [(Int, GitCommandResult)] = []
+            for await result in group {
+                collected.append(result)
+            }
+            return collected
+        }
+
+        #expect(results.count == invocationCount)
+        for (index, result) in results {
+            if index.isMultiple(of: 3) {
+                #expect(result.timedOut)
+                #expect(result.exitCode != 0)
+                #expect(result.succeeded == false)
+            } else {
+                #expect(result.succeeded)
+                #expect(result.output == "stdout-\(index)")
+                #expect(result.errorOutput == "stderr-\(index)")
+            }
+        }
+    }
+
+    @Test("the process-group leader remains waitable until final signalling")
+    func reapPolicyPreservesProcessGroupIdentity() {
+        #expect(
+            GitCommand.shouldAttemptReap(
+                phase: .running,
+                streamsAreClosed: false
+            ) == false
+        )
+        #expect(
+            GitCommand.shouldAttemptReap(
+                phase: .terminating,
+                streamsAreClosed: false
+            ) == false
+        )
+        #expect(
+            GitCommand.shouldAttemptReap(
+                phase: .killing,
+                streamsAreClosed: false
+            )
+        )
+        #expect(
+            GitCommand.shouldAttemptReap(
+                phase: .running,
+                streamsAreClosed: true
+            )
+        )
+    }
+
+    @Test("deferred cleanup reaps once from a process-exit event")
+    func deferredReaperUsesExitEvent() async {
+        let waiter = GitCommandDeferredWaiter()
+        let result = GitCommand.runExecutable(
+            shellURL,
+            arguments: [
+                "-c",
+                "trap '' TERM; while :; do sleep 1; done"
+            ],
+            at: workingDirectory,
+            timeout: 0,
+            systemCalls: GitCommandSystemCalls(
+                waitpid: { processIdentifier, status, options in
+                    waiter.waitpid(
+                        processIdentifier: processIdentifier,
+                        status: status,
+                        options: options
+                    )
+                }
+            )
+        )
+
+        #expect(result.timedOut)
+        #expect(result.succeeded == false)
+        #expect(await waiter.waitForBlockingReap())
+        #expect(waiter.blockingWaitCount == 1)
+        let observationsAfterReap = waiter.nonblockingWaitCount
+        usleep(100_000)
+        #expect(waiter.nonblockingWaitCount == observationsAfterReap)
+    }
+
+    @Test("launch failures release their pipe descriptors")
+    func launchFailureCleansUp() {
+        let missingExecutable = workingDirectory
+            .appendingPathComponent(UUID().uuidString)
+
+        for _ in 0..<256 {
+            let result = GitCommand.runExecutable(
+                missingExecutable,
+                arguments: [],
+                at: workingDirectory,
+                timeout: 0.05
+            )
+            #expect(result.exitCode == -1)
+            #expect(result.timedOut == false)
+            #expect(result.errorOutput.isEmpty == false)
+        }
+
+        let result = GitCommand.runExecutable(
+            shellURL,
+            arguments: ["-c", "printf ready"],
+            at: workingDirectory,
+            timeout: 1
+        )
+        #expect(result.succeeded)
+        #expect(result.output == "ready")
+    }
+
+    @Test("unrelated parent descriptors are closed across exec")
+    func unrelatedParentDescriptorsAreClosed() {
+        var descriptors = [Int32](repeating: -1, count: 2)
+        #expect(Darwin.pipe(&descriptors) == 0)
+        guard descriptors.allSatisfy({ $0 >= 0 }) else { return }
+        defer {
+            _ = Darwin.close(descriptors[0])
+            _ = Darwin.close(descriptors[1])
+        }
+        _ = Darwin.fcntl(descriptors[0], F_SETFD, 0)
+        _ = Darwin.fcntl(descriptors[1], F_SETFD, 0)
+
+        let script = """
+        if [ -e "/dev/fd/$1" ] || [ -e "/dev/fd/$2" ]; then
+          exit 42
+        fi
+        """
+        let result = GitCommand.runExecutable(
+            shellURL,
+            arguments: [
+                "-c",
+                script,
+                "pine-test",
+                String(descriptors[0]),
+                String(descriptors[1])
+            ],
+            at: workingDirectory,
+            timeout: 1
+        )
+
+        #expect(result.succeeded)
+    }
+
+    private func waitUntilProcessDisappears(
+        _ processIdentifier: pid_t
+    ) -> Bool {
+        let deadline = ProcessInfo.processInfo.systemUptime + 1
+        while ProcessInfo.processInfo.systemUptime < deadline {
+            errno = 0
+            if Darwin.kill(processIdentifier, 0) == -1, errno == ESRCH {
+                return true
+            }
+            usleep(10_000)
+        }
+        errno = 0
+        return Darwin.kill(processIdentifier, 0) == -1
+            && errno == ESRCH
+    }
+
+    private func waitUntilFileExists(
+        _ url: URL,
+        timeout: TimeInterval = 1
+    ) async -> Bool {
+        let deadline = ProcessInfo.processInfo.systemUptime + timeout
+        while ProcessInfo.processInfo.systemUptime < deadline {
+            if FileManager.default.fileExists(atPath: url.path) {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return FileManager.default.fileExists(atPath: url.path)
+    }
+}
+
+nonisolated private final class GitCommandBlockingGate: @unchecked Sendable {
+    private let semaphore = DispatchSemaphore(value: 0)
+
+    func wait() {
+        semaphore.wait()
+    }
+
+    func open() {
+        semaphore.signal()
+    }
+}
+
+nonisolated private final class GitCommandReadInjector: @unchecked Sendable {
+    private let lock = NSLock()
+    private let stream: GitCommandStream
+    private let error: Int32
+    private var injected = false
+
+    init(stream: GitCommandStream, error: Int32) {
+        self.stream = stream
+        self.error = error
+    }
+
+    func read(
+        stream: GitCommandStream,
+        descriptor: Int32,
+        buffer: UnsafeMutableRawPointer?,
+        count: Int
+    ) -> Int {
+        lock.lock()
+        let shouldInject = stream == self.stream && !injected
+        if shouldInject {
+            injected = true
+        }
+        lock.unlock()
+
+        if shouldInject {
+            errno = error
+            return -1
+        }
+        return Darwin.read(descriptor, buffer, count)
+    }
+}
+
+nonisolated private final class GitCommandSignalRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var signals: [Int32] = []
+
+    var recordedSignals: [Int32] {
+        lock.lock()
+        defer { lock.unlock() }
+        return signals
+    }
+
+    func kill(processIdentifier: pid_t, signal: Int32) -> Int32 {
+        lock.lock()
+        signals.append(signal)
+        lock.unlock()
+        return Darwin.kill(processIdentifier, signal)
+    }
+}
+
+nonisolated private final class GitCommandCompletionGate:
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private let returnGate = DispatchSemaphore(value: 0)
+    private var processWasReaped = false
+    private var didAllowReturn = false
+
+    func waitpid(
+        processIdentifier: pid_t,
+        status: UnsafeMutablePointer<Int32>?,
+        options: Int32
+    ) -> pid_t {
+        let result = Darwin.waitpid(processIdentifier, status, options)
+        guard result == processIdentifier else { return result }
+        lock.withLock {
+            processWasReaped = true
+        }
+        returnGate.wait()
+        return result
+    }
+
+    func waitUntilProcessIsReaped() async -> Bool {
+        let deadline = ProcessInfo.processInfo.systemUptime + 5
+        while ProcessInfo.processInfo.systemUptime < deadline {
+            if lock.withLock({ processWasReaped }) {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return lock.withLock { processWasReaped }
+    }
+
+    func allowWaitpidToReturn() {
+        let shouldSignal = lock.withLock {
+            guard !didAllowReturn else { return false }
+            didAllowReturn = true
+            return true
+        }
+        if shouldSignal {
+            returnGate.signal()
+        }
+    }
+}
+
+nonisolated private final class GitCommandDeferredWaiter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedBlockingWaitCount = 0
+    private var storedNonblockingWaitCount = 0
+
+    var blockingWaitCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedBlockingWaitCount
+    }
+
+    var nonblockingWaitCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedNonblockingWaitCount
+    }
+
+    func waitpid(
+        processIdentifier: pid_t,
+        status: UnsafeMutablePointer<Int32>?,
+        options: Int32
+    ) -> pid_t {
+        if options == 0 {
+            lock.lock()
+            storedBlockingWaitCount += 1
+            lock.unlock()
+            return Darwin.waitpid(processIdentifier, status, options)
+        }
+
+        lock.lock()
+        storedNonblockingWaitCount += 1
+        lock.unlock()
+        return 0
+    }
+
+    func waitForBlockingReap() async -> Bool {
+        let deadline = ProcessInfo.processInfo.systemUptime + 2
+        while ProcessInfo.processInfo.systemUptime < deadline {
+            if blockingWaitCount > 0 {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return blockingWaitCount > 0
+    }
+}

--- a/PineTests/GitStatusProviderTests.swift
+++ b/PineTests/GitStatusProviderTests.swift
@@ -413,6 +413,33 @@ struct GitStatusProviderTests {
         #expect(provider.currentBranch == "test-branch")
     }
 
+    @Test("checkoutBranch honors a successful switch with truncated hook output")
+    func checkoutBranchNoisyHookSuccess() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        try runShell("git branch test-branch", at: dir)
+        let hookURL = dir.appendingPathComponent(".git/hooks/post-checkout")
+        let outputSize = GitCommand.defaultCaptureLimit + 1_024
+        try """
+        #!/bin/sh
+        /usr/bin/yes pine-hook-output | /usr/bin/head -c \(outputSize)
+        """.write(to: hookURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: hookURL.path
+        )
+
+        let provider = GitStatusProvider()
+        provider.setup(repositoryURL: dir)
+
+        let result = provider.checkoutBranch("test-branch")
+
+        #expect(result.success)
+        #expect(result.error.isEmpty)
+        #expect(provider.currentBranch == "test-branch")
+    }
+
     @Test("checkoutBranch fails for non-existent branch")
     func checkoutBranchFailure() throws {
         let dir = try makeGitRepo()
@@ -795,21 +822,56 @@ struct GitStatusProviderTests {
         #expect(diffs.isEmpty)
     }
 
-    // MARK: - runGit timeout
+    // MARK: - runGit process lifecycle
 
     @Test("runGit terminates process after timeout")
-    func runGitTimeout() {
-        // Use git hash-object --stdin which blocks waiting for input
-        let start = Date()
+    func runGitTimeout() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        let startedAt = ProcessInfo.processInfo.systemUptime
+        let result = GitStatusProvider.runGit(
+            ["-c", "alias.pine-hang=!sleep 30", "pine-hang"],
+            at: dir,
+            timeout: 0.2
+        )
+        let elapsed = ProcessInfo.processInfo.systemUptime - startedAt
+
+        #expect(result.timedOut)
+        #expect(result.succeeded == false)
+        #expect(result.exitCode != 0)
+        #expect(elapsed < 2)
+    }
+
+    @Test("runGit supplies EOF on standard input")
+    func runGitUsesNullStandardInput() {
+        let startedAt = ProcessInfo.processInfo.systemUptime
         let result = GitStatusProvider.runGit(
             ["hash-object", "--stdin"],
-            at: URL(fileURLWithPath: "/tmp"),
-            timeout: 1.0
+            at: FileManager.default.temporaryDirectory,
+            timeout: 1
         )
-        let elapsed = Date().timeIntervalSince(start)
-        // Process should be terminated by timeout, not hang for 30s+
-        #expect(elapsed < 5.0)
-        #expect(result.exitCode != 0)
+        let elapsed = ProcessInfo.processInfo.systemUptime - startedAt
+
+        #expect(result.succeeded)
+        #expect(result.output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
+        #expect(elapsed < 2)
+    }
+
+    @Test("runGit propagates an incomplete capture as unsuccessful")
+    func runGitPropagatesTruncation() throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        let result = GitStatusProvider.runGit(
+            ["rev-parse", "HEAD"],
+            at: dir,
+            captureLimit: 8
+        )
+
+        #expect(result.exitCode == 0)
+        #expect(result.outputTruncated)
+        #expect(result.succeeded == false)
     }
 
     // MARK: - hasUncommittedChanges


### PR DESCRIPTION
## Summary
- replace Foundation Process pipe handling with bounded concurrent POSIX process I/O
- make timeout and Swift task cancellation terminate and reap the entire process group deterministically
- migrate Git status, diff, blame, checkout, revert, workspace, and agent-history callers to the hardened API
- distinguish successful mutation from complete parser capture so noisy hooks cannot report a false checkout failure

## Crash addressed
The previous implementation could leave several cooperative threads blocked in FileHandle reads while parallel workspace Git refreshes raced process termination. The supplied macOS 27 XCTest crash showed that exact call chain through GitCommand.run, GitStatusProvider, and WorkspaceManager.

## Validation
- 240 targeted Git lifecycle, status, revert, and inline-diff tests pass on macOS 27 / Xcode 27 beta
- adversarial coverage includes cancellation before and after spawn, timeout, TERM grace, KILL fallback, descendants, descriptor inheritance, bounded stdout/stderr, read faults, EINTR, noisy post-checkout hooks, and parallel refreshes
- strict SwiftLint, diff check, and reentrancy guard pass
- independent strict review found no release blockers