### PR TITLE
fix(macos): restore Open Folder menu routing

### DIFF
--- a/Pine/Extensibility/UserCommandInvocationRouter.swift
+++ b/Pine/Extensibility/UserCommandInvocationRouter.swift
@@ -73,7 +73,7 @@ enum UserCommandInvocationRouter {
         case .openFolder:
             notificationCenter.post(
                 name: .openFolder,
-                object: nil
+                object: projectManager
             )
 
         case .newFile, .openFile, .closeTab, .closeWindow:

--- a/Pine/GitAndNotificationObserver.swift
+++ b/Pine/GitAndNotificationObserver.swift
@@ -74,9 +74,20 @@ struct GitAndNotificationObserver: ViewModifier {
                 onRefreshLineDiffs()
                 onRefreshBlame()
             }
-            .onReceive(NotificationCenter.default.publisher(for: .openFolder)) { _ in
-                guard controlActiveState == .key else { return }
-                onOpenNewProject()
+            .onReceive(NotificationCenter.default.publisher(for: .openFolder)) { notification in
+                guard ContentView.shouldHandleTargetedCommand(
+                    notificationObject: notification.object,
+                    currentProject: projectManager,
+                    isKeyWindow: controlActiveState == .key
+                ) else { return }
+                // A mouse click in the native File menu can temporarily make
+                // SwiftUI report the project window as non-key while AppKit is
+                // still tracking that menu. The targeted project identity
+                // above preserves ownership; deferring presentation lets menu
+                // tracking unwind before NSOpenPanel attaches its sheet.
+                NativeCommandDelivery.deferToNextMainRunLoop {
+                    onOpenNewProject()
+                }
             }
             .onReceive(NotificationCenter.default.publisher(for: .fileRenamed)) { notification in
                 handleFileRenamed(notification)

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -135,7 +135,10 @@ struct PineAppMenuCommands: Commands {
             Divider()
 
             Button {
-                NotificationCenter.default.post(name: .openFolder, object: nil)
+                UserCommandInvocationRouter.dispatch(
+                    .openFolder,
+                    projectManager: focusedProject
+                )
             } label: {
                 Label(Strings.menuOpenFolder, systemImage: MenuIcons.openFolder)
             }

--- a/PineTests/UserCommandInvocationRouterTests.swift
+++ b/PineTests/UserCommandInvocationRouterTests.swift
@@ -11,16 +11,43 @@ import Testing
 @Suite("Registered command invocation router")
 @MainActor
 struct UserCommandInvocationRouterTests {
-    @Test("Application command dispatches exactly one notification")
-    func openFolderDispatch() {
+    @Test("Open Folder dispatch targets its owning project")
+    func openFolderDispatchTargetsProject() {
+        let projectManager = ProjectManager()
+        let projectIdentifier = ObjectIdentifier(projectManager)
         let center = NotificationCenter()
         let probe = NotificationProbe()
         let token = center.addObserver(
             forName: .openFolder,
             object: nil,
             queue: nil
-        ) { _ in
-            probe.record("openFolder")
+        ) { notification in
+            let target = notification.object as AnyObject?
+            let isTargeted = target.map(ObjectIdentifier.init)
+                == projectIdentifier
+            probe.record("openFolder:\(isTargeted)")
+        }
+        defer { center.removeObserver(token) }
+
+        UserCommandInvocationRouter.dispatch(
+            .openFolder,
+            projectManager: projectManager,
+            notificationCenter: center
+        )
+
+        #expect(probe.values == ["openFolder:true"])
+    }
+
+    @Test("Open Folder remains global when no project owns the command")
+    func openFolderDispatchWithoutProject() {
+        let center = NotificationCenter()
+        let probe = NotificationProbe()
+        let token = center.addObserver(
+            forName: .openFolder,
+            object: nil,
+            queue: nil
+        ) { notification in
+            probe.record(notification.object == nil ? "global" : "targeted")
         }
         defer { center.removeObserver(token) }
 
@@ -30,7 +57,7 @@ struct UserCommandInvocationRouterTests {
             notificationCenter: center
         )
 
-        #expect(probe.values == ["openFolder"])
+        #expect(probe.values == ["global"])
     }
 
     @Test("Structured fold command preserves its action payload")

--- a/PineUITests/NativeFileWindowMenuUITests.swift
+++ b/PineUITests/NativeFileWindowMenuUITests.swift
@@ -197,6 +197,46 @@ final class NativeFileWindowMenuUITests: PineUITestCase {
         )
     }
 
+    func testOpenFolderFromProjectMenuPresentsReusableOwnedPanel() throws {
+        launchWithProject(projectURL)
+        let sidebar = app.scrollViews["sidebar"]
+        XCTAssertTrue(
+            waitForExistence(sidebar, timeout: 10),
+            "The project window should be ready before opening File"
+        )
+
+        for attempt in 1...2 {
+            clickMenuBarItem("File")
+            let openFolder = app.menuItems["Open Folder…"].firstMatch
+            XCTAssertTrue(
+                openFolder.waitForExistence(timeout: 5),
+                "File should expose Open Folder…"
+            )
+            XCTAssertTrue(openFolder.isEnabled)
+            openFolder.click()
+
+            let openPanel = app.sheets.firstMatch
+            XCTAssertTrue(
+                openPanel.waitForExistence(timeout: 5),
+                "File > Open Folder… should present a project-window-owned sheet on attempt \(attempt)"
+            )
+            XCTAssertTrue(
+                openPanel.buttons["Open"].firstMatch.exists,
+                "The owned folder picker should expose its Open action"
+            )
+
+            app.typeKey(".", modifierFlags: .command)
+            XCTAssertTrue(
+                openPanel.waitForNonExistence(timeout: 5),
+                "Cancelling the folder picker should dismiss the owned sheet"
+            )
+            XCTAssertTrue(
+                sidebar.exists,
+                "Cancelling Open Folder must leave the current project open"
+            )
+        }
+    }
+
     func testOpenRecentClearMenuByMouse() throws {
         launchWithProject(projectURL)
         XCTAssertTrue(


### PR DESCRIPTION
## Summary

- route `File > Open Folder…` through the focused project instead of an unscoped notification
- defer `NSOpenPanel` presentation until native menu tracking unwinds
- add unit coverage for targeted and global dispatch
- add a mouse-driven XCUITest that opens, cancels, and reopens the folder picker

Closes #1288.

## Verification

- targeted unit suites: 25 tests passed
- new Open Folder XCUITest: passed, including two consecutive presentations
- prerelease smoke: 40/44 passed; the existing Open Recent failure passed on isolated retry
- three existing `SplitPaneRoutingUITests` reproducibly fail on macOS 27 beta because their pre-seeded UserDefaults session is not restored; this is outside the Open Folder path
- SwiftLint: 0 violations across 687 files
- `check-no-post-under-inout.py`: passed
- `git diff --check`: passed

Environment: macOS 27.0 (26A5388g), Xcode 27.0 beta (27A5218g), macOS SDK 27.0 (26A5378i).