### PR TITLE
test: cover release-critical UI journeys

### DIFF
--- a/.github/scripts/check_ui_test_shards.py
+++ b/.github/scripts/check_ui_test_shards.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Validate UI test shard membership and balance.
+
+The check fails closed when a concrete PineUITestCase subclass is missing,
+listed more than once, unknown to the test target, or makes the test-count
+delta between shards exceed the configured limit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CLASS_PATTERN = re.compile(
+    r"\b(?:final\s+)?class\s+([A-Za-z0-9_]+)\s*:\s*PineUITestCase\b"
+)
+TEST_PATTERN = re.compile(r"^\s+func\s+(test[A-Za-z0-9_]+)\s*\(", re.MULTILINE)
+SHARD_PATTERN = re.compile(r'^\s*-\s+shard-name:\s*"?([^"]+?)"?\s*$')
+ASSIGNMENT_PATTERN = re.compile(
+    r"-only-testing:PineUITests/([A-Za-z0-9_]+)"
+)
+
+
+class ShardValidationError(Exception):
+    """Raised when the shard matrix cannot prove complete balanced coverage."""
+
+
+@dataclass(frozen=True)
+class ShardReport:
+    """Validated test counts for each workflow shard."""
+
+    class_counts: dict[str, int]
+    shard_counts: dict[str, int]
+
+    @property
+    def total_tests(self) -> int:
+        return sum(self.class_counts.values())
+
+    @property
+    def delta(self) -> int:
+        counts = list(self.shard_counts.values())
+        return max(counts) - min(counts)
+
+
+def discover_test_classes(tests_directory: Path) -> dict[str, int]:
+    """Return concrete PineUITestCase subclasses and their test counts."""
+    class_counts: dict[str, int] = {}
+    for source in sorted(tests_directory.rglob("*.swift")):
+        text = source.read_text(encoding="utf-8")
+        class_names = CLASS_PATTERN.findall(text)
+        if not class_names:
+            continue
+        if len(class_names) != 1:
+            raise ShardValidationError(
+                f"{source} declares {len(class_names)} PineUITestCase subclasses"
+            )
+        class_name = class_names[0]
+        if class_name in class_counts:
+            raise ShardValidationError(
+                f"duplicate UI test class declaration: {class_name}"
+            )
+        class_counts[class_name] = len(TEST_PATTERN.findall(text))
+
+    if not class_counts:
+        raise ShardValidationError(
+            f"no PineUITestCase subclasses found under {tests_directory}"
+        )
+    return class_counts
+
+
+def parse_shards(workflow: Path) -> dict[str, list[str]]:
+    """Parse shard-name/test-class pairs from the UI test matrix."""
+    shards: dict[str, list[str]] = {}
+    current_shard: str | None = None
+
+    for line in workflow.read_text(encoding="utf-8").splitlines():
+        shard_match = SHARD_PATTERN.match(line)
+        if shard_match:
+            current_shard = shard_match.group(1)
+            if current_shard in shards:
+                raise ShardValidationError(
+                    f"duplicate shard name: {current_shard}"
+                )
+            shards[current_shard] = []
+            continue
+
+        for class_name in ASSIGNMENT_PATTERN.findall(line):
+            if current_shard is None:
+                raise ShardValidationError(
+                    f"UI test class {class_name} appears before a shard name"
+                )
+            shards[current_shard].append(class_name)
+
+    if not shards:
+        raise ShardValidationError(f"no UI test shards found in {workflow}")
+    return shards
+
+
+def validate_shards(
+    class_counts: dict[str, int],
+    shards: dict[str, list[str]],
+    max_delta: int,
+) -> ShardReport:
+    """Validate exact membership and test-count balance."""
+    assignments = [
+        class_name
+        for classes in shards.values()
+        for class_name in classes
+    ]
+    assignment_counts = Counter(assignments)
+    actual = set(class_counts)
+    assigned = set(assignments)
+
+    problems: list[str] = []
+    missing = sorted(actual - assigned)
+    if missing:
+        problems.append("unassigned UI test classes: " + ", ".join(missing))
+
+    unknown = sorted(assigned - actual)
+    if unknown:
+        problems.append("unknown UI test classes: " + ", ".join(unknown))
+
+    duplicates = sorted(
+        class_name
+        for class_name, count in assignment_counts.items()
+        if count > 1
+    )
+    if duplicates:
+        problems.append(
+            "multiply assigned UI test classes: " + ", ".join(duplicates)
+        )
+
+    shard_counts = {
+        shard: sum(class_counts.get(class_name, 0) for class_name in classes)
+        for shard, classes in shards.items()
+    }
+    if shard_counts:
+        delta = max(shard_counts.values()) - min(shard_counts.values())
+        if delta > max_delta:
+            formatted = ", ".join(
+                f"{name}={count}"
+                for name, count in shard_counts.items()
+            )
+            problems.append(
+                f"shard test-count delta {delta} exceeds {max_delta}: "
+                + formatted
+            )
+
+    if problems:
+        raise ShardValidationError("\n".join(problems))
+    return ShardReport(class_counts, shard_counts)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tests-dir", type=Path, required=True)
+    parser.add_argument("--workflow", type=Path, required=True)
+    parser.add_argument("--max-delta", type=int, default=3)
+    args = parser.parse_args()
+    if args.max_delta < 0:
+        parser.error("--max-delta must be non-negative")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        report = validate_shards(
+            discover_test_classes(args.tests_dir),
+            parse_shards(args.workflow),
+            args.max_delta,
+        )
+    except (OSError, ShardValidationError) as error:
+        print(f"::error::{error}")
+        return 1
+
+    counts = ", ".join(
+        f"{name}={count}"
+        for name, count in report.shard_counts.items()
+    )
+    print(
+        f"Validated {len(report.class_counts)} UI test classes and "
+        f"{report.total_tests} tests; delta={report.delta} ({counts})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_check_ui_test_shards.py
+++ b/.github/scripts/test_check_ui_test_shards.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Tests for check_ui_test_shards.py."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_ui_test_shards import (
+    ShardValidationError,
+    discover_test_classes,
+    parse_shards,
+    validate_shards,
+)
+
+
+class CheckUITestShardsTests(unittest.TestCase):
+    def test_discovers_classes_and_counts_test_methods(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            tests = Path(directory)
+            (tests / "AlphaTests.swift").write_text(
+                """
+final class AlphaTests: PineUITestCase {
+    func testFirst() {}
+    func testSecond() throws {}
+}
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                discover_test_classes(tests),
+                {"AlphaTests": 2},
+            )
+
+    def test_parses_matrix_assignments(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            workflow = Path(directory) / "ci.yml"
+            workflow.write_text(
+                """
+          - shard-name: "First"
+            test-classes: >-
+              -only-testing:PineUITests/AlphaTests
+          - shard-name: "Second"
+            test-classes: >-
+              -only-testing:PineUITests/BetaTests
+""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                parse_shards(workflow),
+                {
+                    "First": ["AlphaTests"],
+                    "Second": ["BetaTests"],
+                },
+            )
+
+    def test_accepts_complete_unique_balanced_assignment(self) -> None:
+        report = validate_shards(
+            {"AlphaTests": 3, "BetaTests": 2},
+            {"First": ["AlphaTests"], "Second": ["BetaTests"]},
+            max_delta=1,
+        )
+
+        self.assertEqual(report.total_tests, 5)
+        self.assertEqual(report.delta, 1)
+
+    def test_rejects_missing_unknown_duplicate_and_imbalanced_classes(
+        self,
+    ) -> None:
+        with self.assertRaises(ShardValidationError) as context:
+            validate_shards(
+                {"AlphaTests": 5, "BetaTests": 1},
+                {
+                    "First": ["AlphaTests", "UnknownTests"],
+                    "Second": ["AlphaTests"],
+                    "Third": [],
+                },
+                max_delta=1,
+            )
+
+        message = str(context.exception)
+        self.assertIn("unassigned UI test classes: BetaTests", message)
+        self.assertIn("unknown UI test classes: UnknownTests", message)
+        self.assertIn("multiply assigned UI test classes: AlphaTests", message)
+        self.assertIn("shard test-count delta", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,8 +476,8 @@ jobs:
               });
             }
 
-  # Verify every UI test class is listed in the shard matrix below.
-  # Fails CI if someone adds a new test class and forgets to shard it.
+  # Verify every UI test class is assigned exactly once and the shard test
+  # counts stay within the release gate's maximum delta.
   verify-ui-shards:
     name: Verify UI Test Shards
     runs-on: ubuntu-latest
@@ -485,30 +485,18 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Check all UI test classes are sharded
+      - name: Test UI shard validator
+        working-directory: .github/scripts
+        run: python3 -m unittest test_check_ui_test_shards.py -v
+
+      - name: Check UI test shard membership and balance
         run: |
-          # Extract concrete test class names (exclude base class PineUITestCase and on-demand ScreenshotTests)
-          ACTUAL=$(grep -rh 'class.*:.*PineUITestCase' PineUITests/ \
-            | sed -E 's/.*class ([A-Za-z0-9_]+).*/\1/' \
-            | grep -v ScreenshotTests \
-            | sort)
+          python3 .github/scripts/check_ui_test_shards.py \
+            --tests-dir PineUITests \
+            --workflow .github/workflows/ci.yml \
+            --max-delta 3
 
-          # Extract class names from this workflow's shard matrix
-          SHARDED=$(grep -E '^\s+\-only-testing:PineUITests/' .github/workflows/ci.yml \
-            | sed -E 's/.*PineUITests\/([A-Za-z0-9_]+).*/\1/' \
-            | sort)
-
-          MISSING=$(comm -23 <(echo "$ACTUAL") <(echo "$SHARDED"))
-          if [ -n "$MISSING" ]; then
-            echo "::error::UI test classes not included in any shard:"
-            echo "$MISSING"
-            echo ""
-            echo "Add them to the ui-tests matrix in .github/workflows/ci.yml"
-            exit 1
-          fi
-          echo "All $(echo "$ACTUAL" | wc -l | tr -d ' ') UI test classes are sharded."
-
-  # UI test shards — 7 parallel jobs, 28-31 tests each (delta 3).
+  # UI test shards — 7 parallel jobs, 29-31 tests each (delta 2).
   # To rebalance: count tests per class, redistribute so shards stay within ±3 tests.
   # List classes with: grep -r "func test" PineUITests/ | sed 's/:.*//' | sort | uniq -c | sort -rn
   ui-tests:
@@ -526,22 +514,22 @@ jobs:
               -only-testing:PineUITests/TerminalTests
               -only-testing:PineUITests/TerminalMenuTests
               -only-testing:PineUITests/AgentAttentionKeyboardUITests
-          # Shard 2 — Welcome & Session (29 tests)
+          # Shard 2 — Welcome & Session (31 tests)
           - shard-name: "Welcome & Session"
             test-classes: >-
               -only-testing:PineUITests/WelcomeWindowTests
               -only-testing:PineUITests/MinimapTests
-              -only-testing:PineUITests/DiffNavigationUITests
               -only-testing:PineUITests/SessionRestoreTests
               -only-testing:PineUITests/SidebarFolderClickTests
+              -only-testing:PineUITests/NativeFileWindowMenuUITests
           # Shard 3 — Navigation (31 tests)
           - shard-name: "Navigation"
             test-classes: >-
               -only-testing:PineUITests/GoToLineTabOverflowExternalChangesUITests
               -only-testing:PineUITests/QuickOpenUITests
               -only-testing:PineUITests/EditorTabNavigationTests
-              -only-testing:PineUITests/NativeFileWindowMenuUITests
-          # Shard 4 — Editor Chrome (28 tests)
+              -only-testing:PineUITests/DiffNavigationUITests
+          # Shard 4 — Editor Chrome (31 tests)
           - shard-name: "Editor Chrome"
             test-classes: >-
               -only-testing:PineUITests/EditorWindowTests
@@ -549,6 +537,7 @@ jobs:
               -only-testing:PineUITests/BranchSwitcherTests
               -only-testing:PineUITests/CheckForUpdatesTests
               -only-testing:PineUITests/SplitPaneRoutingUITests
+              -only-testing:PineUITests/UnsavedChangesUITests
           # Shard 5 — Files & Save (30 tests)
           - shard-name: "Files & Save"
             test-classes: >-
@@ -557,7 +546,7 @@ jobs:
               -only-testing:PineUITests/SidebarRenameTests
               -only-testing:PineUITests/SidebarFileOperationsTests
               -only-testing:PineUITests/UserTaskExecutionUITests
-          # Shard 6 — Search & Panes (28 tests)
+          # Shard 6 — Search & Panes (29 tests)
           - shard-name: "Search & Panes"
             test-classes: >-
               -only-testing:PineUITests/SidebarSearchTests
@@ -565,7 +554,7 @@ jobs:
               -only-testing:PineUITests/SplitPaneLifecycleTests
               -only-testing:PineUITests/FontSizeTests
               -only-testing:PineUITests/AgentActivityFilterUITests
-          # Shard 7 — Security & Layout (29 tests)
+          # Shard 7 — Security & Layout (31 tests)
           - shard-name: "Security & Layout"
             test-classes: >-
               -only-testing:PineUITests/GitignoreFilterTests

--- a/PineUITests/NativeFileWindowMenuUITests.swift
+++ b/PineUITests/NativeFileWindowMenuUITests.swift
@@ -9,6 +9,7 @@ import XCTest
 
 final class NativeFileWindowMenuUITests: PineUITestCase {
     private var projectURL: URL!
+    private var secondProjectURL: URL!
 
     private func visibleMenuItem(
         matching predicate: NSPredicate
@@ -57,11 +58,18 @@ final class NativeFileWindowMenuUITests: PineUITestCase {
             files: ["main.swift": "let value = 1\n"],
             projectName: "Native Menu Project"
         )
+        secondProjectURL = try createTempProject(
+            files: ["second.swift": "let second = true\n"],
+            projectName: "Second Native Menu Project"
+        )
     }
 
     override func tearDownWithError() throws {
         if let projectURL {
             cleanupProject(projectURL)
+        }
+        if let secondProjectURL {
+            cleanupProject(secondProjectURL)
         }
         try super.tearDownWithError()
     }
@@ -235,6 +243,70 @@ final class NativeFileWindowMenuUITests: PineUITestCase {
                 "Cancelling Open Folder must leave the current project open"
             )
         }
+    }
+
+    func testOpenFolderSelectsDirectoryAndRoutesCommandToNewWindow() throws {
+        launchWithProject(projectURL)
+        let firstWindow = app.windows[projectURL.lastPathComponent].firstMatch
+        XCTAssertTrue(
+            firstWindow.waitForExistence(timeout: 10),
+            "The original project window should be visible"
+        )
+
+        clickMenuBarItem("File")
+        let openFolder = app.menuItems["Open Folder…"].firstMatch
+        XCTAssertTrue(openFolder.waitForExistence(timeout: 5))
+        openFolder.click()
+
+        let openPanel = app.sheets.firstMatch
+        XCTAssertTrue(
+            openPanel.waitForExistence(timeout: 5),
+            "Open Folder should present a directory picker"
+        )
+
+        app.typeKey("g", modifierFlags: [.command, .shift])
+        let pathField = try XCTUnwrap(
+            app.textFields.allElementsBoundByIndex.first(where: {
+                $0.isHittable
+            }),
+            "Go to Folder should expose a hittable path field"
+        )
+        pathField.typeText(secondProjectURL.path)
+        pathField.typeKey(.return, modifierFlags: [])
+
+        let openButton = openPanel.buttons["Open"].firstMatch
+        XCTAssertTrue(
+            waitForEnabled(openButton, timeout: 5),
+            "Resolving the directory should enable Open"
+        )
+        openButton.click()
+
+        let secondWindow = app.windows[
+            secondProjectURL.lastPathComponent
+        ].firstMatch
+        XCTAssertTrue(
+            secondWindow.waitForExistence(timeout: 10),
+            "Selecting a directory should open its project window"
+        )
+        XCTAssertTrue(
+            secondWindow.descendants(matching: .any)[
+                "fileNode_second.swift"
+            ].firstMatch.waitForExistence(timeout: 10),
+            "The new window should display the selected project"
+        )
+
+        clickMenuBarItem("File")
+        app.menuItems["New File"].firstMatch.click()
+
+        XCTAssertTrue(
+            secondWindow.buttons["editorTab_Untitled"]
+                .firstMatch.waitForExistence(timeout: 5),
+            "File > New File should route to the newly focused project"
+        )
+        XCTAssertFalse(
+            firstWindow.buttons["editorTab_Untitled"].firstMatch.exists,
+            "The command must not mutate the background project"
+        )
     }
 
     func testOpenRecentClearMenuByMouse() throws {

--- a/PineUITests/PineUITestCase.swift
+++ b/PineUITests/PineUITestCase.swift
@@ -89,6 +89,23 @@ class PineUITestCase: XCTestCase {
         app.activate()
     }
 
+    /// Overrides the deterministic locale configured by the base class.
+    ///
+    /// Keep locale changes explicit in the individual test so menu labels and
+    /// application strings are asserted under the same language.
+    func useLaunchLocale(language: String, locale: String) {
+        replaceLaunchArgument("-AppleLanguages", with: "(\(language))")
+        replaceLaunchArgument("-AppleLocale", with: locale)
+    }
+
+    /// Enables the production first-launch terminal path for tests that cover
+    /// startup behavior instead of the suite's legacy empty-editor fixture.
+    func enableInitialTerminalSeeding() {
+        app.launchArguments.removeAll {
+            $0 == "--disable-terminal-seeding"
+        }
+    }
+
     /// Waits for an element to exist with a timeout.
     @discardableResult
     func waitForExistence(_ element: XCUIElement, timeout: TimeInterval = 5) -> Bool {
@@ -118,6 +135,18 @@ class PineUITestCase: XCTestCase {
         app.descendants(matching: .any)
             .matching(identifier: identifier)
             .firstMatch
+    }
+
+    private func replaceLaunchArgument(
+        _ key: String,
+        with value: String
+    ) {
+        guard let index = app.launchArguments.firstIndex(of: key),
+              app.launchArguments.indices.contains(index + 1) else {
+            XCTFail("Missing \(key) in PineUITestCase launch arguments")
+            return
+        }
+        app.launchArguments[index + 1] = value
     }
 
     // MARK: - Editor Tab Helpers

--- a/PineUITests/SettingsUITests.swift
+++ b/PineUITests/SettingsUITests.swift
@@ -245,9 +245,12 @@ final class SettingsUITests: PineUITestCase {
 
     func testEverySettingsPaneUsesLocalizedLabels() throws {
         launchClean()
-        openSettings()
+        openSettings(
+            menuTitle: "Settings…",
+            generalTabTitle: "General"
+        )
 
-        let panes = [
+        assertSettingsPanes([
             (
                 tab: "General",
                 contentIdentifier: "generalSettingsPane",
@@ -288,8 +291,69 @@ final class SettingsUITests: PineUITestCase {
                 ],
                 expectedIdentifiers: []
             ),
-        ]
+        ])
+    }
 
+    func testEverySettingsPaneUsesRussianLabelsWithoutRawKeys() throws {
+        useLaunchLocale(language: "ru", locale: "ru_RU")
+        launchClean()
+        openSettings(
+            menuTitle: "Настройки…",
+            generalTabTitle: "Основные"
+        )
+
+        assertSettingsPanes([
+            (
+                tab: "Основные",
+                contentIdentifier: "generalSettingsPane",
+                expectedLabels: [
+                    "Добавлять перевод строки в конце",
+                    "Удалять пробелы в конце строк",
+                    "Форматировать при сохранении",
+                    "Продолжать списки автоматически",
+                    "Переносить строки",
+                    "Мини-карта",
+                ],
+                expectedIdentifiers: ["generalFontSizeSlider"]
+            ),
+            (
+                tab: "Терминал",
+                contentIdentifier: "terminalAppearancePicker",
+                expectedLabels: [],
+                expectedIdentifiers: []
+            ),
+            (
+                tab: "Языковые серверы",
+                contentIdentifier: "lsp-settings-executable",
+                expectedLabels: [],
+                expectedIdentifiers: []
+            ),
+            (
+                tab: "Передача контекста",
+                contentIdentifier: "agentHandoffReadOnlyContextToggle",
+                expectedLabels: [],
+                expectedIdentifiers: []
+            ),
+            (
+                tab: "Сочетания клавиш и задачи",
+                contentIdentifier: "keyBindingsSettingsPane",
+                expectedLabels: [
+                    "Открыть файл",
+                    "Перезагрузить",
+                ],
+                expectedIdentifiers: []
+            ),
+        ])
+    }
+
+    private func assertSettingsPanes(
+        _ panes: [(
+            tab: String,
+            contentIdentifier: String,
+            expectedLabels: [String],
+            expectedIdentifiers: [String]
+        )]
+    ) {
         for pane in panes {
             let tab = app.buttons[pane.tab].firstMatch
             XCTAssertTrue(
@@ -339,14 +403,17 @@ final class SettingsUITests: PineUITestCase {
         }
     }
 
-    private func openSettings() {
+    private func openSettings(
+        menuTitle: String = "Settings…",
+        generalTabTitle: String = "General"
+    ) {
         let appMenu = app.menuBars.menuBarItems["Pine"]
         XCTAssertTrue(
             appMenu.waitForExistence(timeout: 10),
             "Pine application menu should be available"
         )
         appMenu.click()
-        let settingsItem = app.menuItems["Settings…"].firstMatch
+        let settingsItem = app.menuItems[menuTitle].firstMatch
         XCTAssertTrue(
             settingsItem.waitForExistence(timeout: 5),
             "Application menu should expose Settings"
@@ -354,7 +421,7 @@ final class SettingsUITests: PineUITestCase {
         settingsItem.click()
 
         XCTAssertTrue(
-            app.buttons["General"].firstMatch.waitForExistence(timeout: 10),
+            app.buttons[generalTabTitle].firstMatch.waitForExistence(timeout: 10),
             "The consolidated Settings scene should open"
         )
     }

--- a/PineUITests/SplitPaneLifecycleTests.swift
+++ b/PineUITests/SplitPaneLifecycleTests.swift
@@ -65,6 +65,30 @@ final class SplitPaneLifecycleTests: PineUITestCase {
 
     // MARK: - Terminal toggle creates and removes split
 
+    func testFreshProjectSeedsProductionTerminalAsOnlyPane() throws {
+        enableInitialTerminalSeeding()
+        launchWithProject(projectURL)
+
+        XCTAssertTrue(
+            waitForExistence(terminalTab("Terminal 1"), timeout: 10),
+            "A fresh project should seed its initial terminal"
+        )
+        XCTAssertTrue(
+            app.descendants(matching: .any)["terminalSurface"]
+                .firstMatch.waitForExistence(timeout: 5),
+            "The seeded terminal should attach its terminal surface"
+        )
+        XCTAssertEqual(
+            paneDividers.count,
+            0,
+            "The seeded terminal should replace the untouched editor leaf"
+        )
+        XCTAssertFalse(
+            app.staticTexts["No File Selected"].firstMatch.exists,
+            "The legacy empty editor should not remain beside the terminal"
+        )
+    }
+
     func testTerminalToggleCreatesSplitWithDivider() throws {
         launchAndWaitForLoad()
         openFile("main.swift")

--- a/PineUITests/UnsavedChangesUITests.swift
+++ b/PineUITests/UnsavedChangesUITests.swift
@@ -1,0 +1,157 @@
+//
+//  UnsavedChangesUITests.swift
+//  PineUITests
+//
+//  End-to-end coverage for dirty untitled close decisions.
+//
+
+import AppKit
+import XCTest
+
+final class UnsavedChangesUITests: PineUITestCase {
+    private var projectURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        projectURL = try createTempProject(
+            projectName: "Unsaved Changes Project"
+        )
+        NSPasteboard.general.clearContents()
+    }
+
+    override func tearDownWithError() throws {
+        NSPasteboard.general.clearContents()
+        if let projectURL {
+            cleanupProject(projectURL)
+        }
+        try super.tearDownWithError()
+    }
+
+    func testCancelKeepsDirtyUntitledTabOpen() throws {
+        launchWithProject(projectURL)
+        let tab = try createDirtyUntitledTab()
+
+        let alert = closeActiveTab()
+        alert.buttons["Cancel"].firstMatch.click()
+
+        XCTAssertTrue(
+            alert.waitForNonExistence(timeout: 5),
+            "Cancel should dismiss the unsaved-changes alert"
+        )
+        XCTAssertTrue(
+            tab.exists,
+            "Cancel should keep the dirty untitled tab open"
+        )
+    }
+
+    func testDontSaveClosesDirtyUntitledTab() throws {
+        launchWithProject(projectURL)
+        let tab = try createDirtyUntitledTab()
+
+        let alert = closeActiveTab()
+        alert.buttons["Don't Save"].firstMatch.click()
+
+        XCTAssertTrue(
+            tab.waitForNonExistence(timeout: 5),
+            "Don't Save should discard and close the untitled tab"
+        )
+        XCTAssertTrue(
+            app.scrollViews["sidebar"].exists,
+            "Discarding a tab should leave its project window open"
+        )
+    }
+
+    func testSaveOpensDestinationPanelAndCancelKeepsDirtyTab() throws {
+        launchWithProject(projectURL)
+        let tab = try createDirtyUntitledTab()
+
+        let alert = closeActiveTab()
+        let alertTitle = alert.staticTexts["Unsaved Changes"].firstMatch
+        alert.buttons["Save"].firstMatch.click()
+        XCTAssertTrue(
+            alertTitle.waitForNonExistence(timeout: 5),
+            "Save should advance beyond the unsaved-changes alert"
+        )
+
+        let savePanel = app.sheets.firstMatch
+        XCTAssertTrue(
+            savePanel.waitForExistence(timeout: 5),
+            "Saving an untitled tab should request a destination"
+        )
+        XCTAssertTrue(
+            savePanel.buttons["Save"].firstMatch.exists,
+            "The destination panel should expose its Save action"
+        )
+
+        app.typeKey(".", modifierFlags: .command)
+        XCTAssertTrue(
+            savePanel.waitForNonExistence(timeout: 5),
+            "Cancelling Save As should dismiss the destination panel"
+        )
+        XCTAssertTrue(
+            tab.exists,
+            "Cancelling Save As should keep the dirty tab open"
+        )
+    }
+
+    private func createDirtyUntitledTab() throws -> XCUIElement {
+        XCTAssertTrue(
+            app.scrollViews["sidebar"].waitForExistence(timeout: 10),
+            "The project window should be ready"
+        )
+        clickMenuBarItem("File")
+        app.menuItems["New File"].firstMatch.click()
+
+        let tab = editorTab("Untitled")
+        XCTAssertTrue(
+            tab.waitForExistence(timeout: 5),
+            "New File should create an untitled tab"
+        )
+
+        let editor = app.textViews["codeEditor"].firstMatch
+        XCTAssertTrue(
+            editor.waitForExistence(timeout: 5),
+            "The untitled buffer should expose the code editor"
+        )
+        editor.click()
+
+        XCTAssertTrue(
+            NSPasteboard.general.setString(
+                "unsaved UI test content\n",
+                forType: .string
+            ),
+            "The test should seed the shared pasteboard"
+        )
+        clickMenuBarItem("Edit")
+        let paste = app.menuItems["Paste"].firstMatch
+        XCTAssertTrue(
+            paste.waitForExistence(timeout: 5),
+            "Edit should expose Paste"
+        )
+        XCTAssertTrue(
+            paste.isEnabled,
+            "Paste should target the focused code editor"
+        )
+        paste.click()
+
+        return tab
+    }
+
+    private func closeActiveTab() -> XCUIElement {
+        clickMenuBarItem("File")
+        let closeTab = app.menuItems["Close Tab"].firstMatch
+        XCTAssertTrue(closeTab.isEnabled)
+        closeTab.click()
+
+        let alert = app.sheets.firstMatch
+        XCTAssertTrue(
+            alert.waitForExistence(timeout: 5),
+            "Closing a dirty untitled tab should show an owned alert"
+        )
+        XCTAssertTrue(
+            alert.staticTexts["Unsaved Changes"].firstMatch.exists,
+            "The close decision should explain the unsaved state"
+        )
+        return alert
+    }
+}


### PR DESCRIPTION
## Summary
- add a Russian Settings smoke test covering every pane and rejecting raw localization keys
- exercise real Open Folder selection and verify key-window command routing across two projects
- cover production initial-terminal seeding and all dirty Untitled close decisions
- replace the loose shard check with a tested fail-closed validator for missing, unknown, duplicate, and imbalanced assignments
- rebalance all seven UI shards to 29–31 tests (delta 2)

## Validation
- SwiftLint strict on all changed Swift files: 0 violations
- `python3 .github/scripts/test_check_ui_test_shards.py`: 4 tests passed
- shard validation: 37 classes, 212 tests, delta 2
- targeted XCUITest scenarios: 6/6 passed on macOS 27 beta before further UI runs were paused

Compatibility environment:
- macOS 27.0 (26A5388g)
- Xcode 27.0 (27A5218g)
- macOS SDK 27.0 (26A5378i)

macOS 26 coverage remains assigned to the existing seven CI UI shards.

Closes #1290