### PR TITLE
fix(sidebar): preserve position during keyboard navigation

### DIFF
--- a/Pine/SidebarTreeNavigation.swift
+++ b/Pine/SidebarTreeNavigation.swift
@@ -292,12 +292,40 @@ enum SidebarTabTraversalDirection: Equatable, Sendable {
     }
 }
 
-enum SidebarKeyboardScrollMotion: Equatable, Sendable {
+enum SidebarScrollMotion: Equatable, Sendable {
     case animated
     case immediate
 
     static func resolve(reduceMotion: Bool) -> Self {
         reduceMotion ? .immediate : .animated
+    }
+}
+
+enum SidebarScrollAlignment: Equatable, Sendable {
+    /// Let SwiftUI move the smallest amount needed to reveal the row.
+    case nearestEdge
+    /// Deliberately place a newly-created item in the middle of the viewport.
+    case center
+}
+
+struct SidebarScrollRequest: Equatable, Sendable {
+    let id: URL
+    let alignment: SidebarScrollAlignment
+    let motion: SidebarScrollMotion
+
+    static func keyboardSelection(_ id: URL) -> Self {
+        Self(id: id, alignment: .nearestEdge, motion: .immediate)
+    }
+
+    static func intentionalReveal(
+        _ id: URL,
+        reduceMotion: Bool
+    ) -> Self {
+        Self(
+            id: id,
+            alignment: .center,
+            motion: .resolve(reduceMotion: reduceMotion)
+        )
     }
 }
 
@@ -446,10 +474,7 @@ final class SidebarTreeNavigation {
     /// Scroll callback invoked after selection changes to keep the
     /// selected row visible. Set by ``SidebarView`` via the
     /// ``ScrollViewProxy`` captured inside ``ScrollViewReader``.
-    var scrollToNode: ((URL, SidebarKeyboardScrollMotion) -> Void)?
-
-    /// Updated from SwiftUI's Reduce Motion environment.
-    var scrollMotion: SidebarKeyboardScrollMotion = .animated
+    var scrollToNode: ((SidebarScrollRequest) -> Void)?
 
     /// Viewport height of the sidebar scroll area, used to estimate page
     /// size for Page Up / Page Down.
@@ -656,7 +681,7 @@ final class SidebarTreeNavigation {
     // MARK: - Helpers
 
     func scroll(to node: FileNode) {
-        scrollToNode?(node.id, scrollMotion)
+        scrollToNode?(.keyboardSelection(node.id))
     }
 
     private func indexOf(_ node: FileNode?, in rows: [SidebarVisibleRow]) -> Int? {

--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -671,29 +671,18 @@ struct SidebarView: View {
                     }
                     .onAppear {
                         // Wire the ScrollViewReader proxy so selection
-                        // changes can keep the selected row visible.
-                        navigation.scrollMotion = .resolve(
-                            reduceMotion: reduceMotion
-                        )
-                        navigation.scrollToNode = { id, motion in
+                        // changes reveal a row only after it leaves the
+                        // viewport. Omitting an anchor asks SwiftUI for the
+                        // smallest scroll needed to make the row visible,
+                        // matching Finder instead of recentering every move.
+                        navigation.scrollToNode = { request in
                             DispatchQueue.main.async {
-                                if motion == .animated {
-                                    withAnimation {
-                                        scrollProxy.scrollTo(
-                                            id,
-                                            anchor: .center
-                                        )
-                                    }
-                                } else {
-                                    scrollProxy.scrollTo(id, anchor: .center)
-                                }
+                                performSidebarScroll(
+                                    request,
+                                    using: scrollProxy
+                                )
                             }
                         }
-                    }
-                    .onChange(of: reduceMotion) { _, newValue in
-                        navigation.scrollMotion = .resolve(
-                            reduceMotion: newValue
-                        )
                     }
                     .sidebarKeyboardNavigation(
                         SidebarKeyboardActions(
@@ -802,9 +791,13 @@ struct SidebarView: View {
                                 ) {
                                 selectedFile = node
                             }
-                            withAnimation {
-                                scrollProxy.scrollTo(targetID, anchor: .center)
-                            }
+                            performSidebarScroll(
+                                .intentionalReveal(
+                                    targetID,
+                                    reduceMotion: reduceMotion
+                                ),
+                                using: scrollProxy
+                            )
                             editState.scrollToNodeID = nil
                         }
                     }
@@ -813,6 +806,28 @@ struct SidebarView: View {
         }
         .listStyle(.sidebar)
         .frame(minWidth: 200, idealWidth: 250)
+    }
+
+    private func performSidebarScroll(
+        _ request: SidebarScrollRequest,
+        using proxy: ScrollViewProxy
+    ) {
+        let scroll = {
+            switch request.alignment {
+            case .nearestEdge:
+                proxy.scrollTo(request.id)
+            case .center:
+                proxy.scrollTo(request.id, anchor: .center)
+            }
+        }
+
+        if request.motion == .animated {
+            withAnimation {
+                scroll()
+            }
+        } else {
+            scroll()
+        }
     }
 
     /// Opens a new project via folder picker in a new window.

--- a/PineTests/SidebarTreeNavigationTests.swift
+++ b/PineTests/SidebarTreeNavigationTests.swift
@@ -615,32 +615,39 @@ struct SidebarTreeNavigationTests {
         defer { removeTree(fixture.root) }
         let node = try #require(fixture.rows.first?.node)
         let navigation = SidebarTreeNavigation()
-        var scrolledURL: URL?
-        var scrollMotion: SidebarKeyboardScrollMotion?
-        navigation.scrollToNode = {
-            scrolledURL = $0
-            scrollMotion = $1
-        }
+        var request: SidebarScrollRequest?
+        navigation.scrollToNode = { request = $0 }
 
         navigation.scroll(to: node)
 
-        #expect(scrolledURL == node.url)
-        #expect(scrollMotion == .animated)
-
-        navigation.scrollMotion = .immediate
-        navigation.scroll(to: node)
-        #expect(scrollMotion == .immediate)
+        #expect(request == SidebarScrollRequest(
+            id: node.url,
+            alignment: .nearestEdge,
+            motion: .immediate
+        ))
     }
 
-    @Test("Reduce Motion makes keyboard scrolling immediate")
-    func keyboardScrollMotionPolicy() {
+    @Test("Intentional centered reveal honors Reduce Motion")
+    func centeredRevealMotionPolicy() {
         #expect(
-            SidebarKeyboardScrollMotion.resolve(reduceMotion: false)
-                == .animated
+            SidebarScrollRequest.intentionalReveal(
+                URL(fileURLWithPath: "/tmp/new.swift"),
+                reduceMotion: false
+            ) == SidebarScrollRequest(
+                id: URL(fileURLWithPath: "/tmp/new.swift"),
+                alignment: .center,
+                motion: .animated
+            )
         )
         #expect(
-            SidebarKeyboardScrollMotion.resolve(reduceMotion: true)
-                == .immediate
+            SidebarScrollRequest.intentionalReveal(
+                URL(fileURLWithPath: "/tmp/new.swift"),
+                reduceMotion: true
+            ) == SidebarScrollRequest(
+                id: URL(fileURLWithPath: "/tmp/new.swift"),
+                alignment: .center,
+                motion: .immediate
+            )
         )
     }
 


### PR DESCRIPTION
## Summary

- stop recentering the file tree after every keyboard selection change
- use SwiftUI native nearest-edge reveal for Arrow, Home/End, Page Up/Down, type-to-select, and reload reconciliation
- keep intentional centered reveal for newly created or duplicated items
- make intentional reveal respect Reduce Motion
- encode minimal and centered scrolling as distinct, unit-tested requests

## User impact

The sidebar now stays spatially stable while the selected row remains visible. When selection crosses a viewport boundary, it scrolls only enough to reveal the row instead of moving it to the center.

## Validation

- `SidebarTreeNavigationTests`: 23/23 passed with Xcode 27 beta, deployment target macOS 26.0
- SwiftLint: 0 violations in changed files
- UI tests were intentionally not run

## Manual release check

Please verify Arrow navigation near the top and bottom viewport edges, held-key repeat, type-to-select to an off-screen row, Home/End, Page Up/Down, and create/duplicate centering.

Closes #1292