### PR TITLE
fix: consolidate editor preferences in settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,7 +496,7 @@ jobs:
             --workflow .github/workflows/ci.yml \
             --max-delta 3
 
-  # UI test shards — 7 parallel jobs, 29-31 tests each (delta 2).
+  # UI test shards — 7 parallel jobs, 29-32 tests each (delta 3).
   # To rebalance: count tests per class, redistribute so shards stay within ±3 tests.
   # List classes with: grep -r "func test" PineUITests/ | sed 's/:.*//' | sort | uniq -c | sort -rn
   ui-tests:
@@ -514,11 +514,10 @@ jobs:
               -only-testing:PineUITests/TerminalTests
               -only-testing:PineUITests/TerminalMenuTests
               -only-testing:PineUITests/AgentAttentionKeyboardUITests
-          # Shard 2 — Welcome & Session (31 tests)
+          # Shard 2 — Welcome & Session (30 tests)
           - shard-name: "Welcome & Session"
             test-classes: >-
               -only-testing:PineUITests/WelcomeWindowTests
-              -only-testing:PineUITests/MinimapTests
               -only-testing:PineUITests/SessionRestoreTests
               -only-testing:PineUITests/SidebarFolderClickTests
               -only-testing:PineUITests/NativeFileWindowMenuUITests
@@ -546,7 +545,7 @@ jobs:
               -only-testing:PineUITests/SidebarRenameTests
               -only-testing:PineUITests/SidebarFileOperationsTests
               -only-testing:PineUITests/UserTaskExecutionUITests
-          # Shard 6 — Search & Panes (29 tests)
+          # Shard 6 — Search & Panes (32 tests)
           - shard-name: "Search & Panes"
             test-classes: >-
               -only-testing:PineUITests/SidebarSearchTests
@@ -554,6 +553,7 @@ jobs:
               -only-testing:PineUITests/SplitPaneLifecycleTests
               -only-testing:PineUITests/FontSizeTests
               -only-testing:PineUITests/AgentActivityFilterUITests
+              -only-testing:PineUITests/MinimapTests
           # Shard 7 — Security & Layout (31 tests)
           - shard-name: "Security & Layout"
             test-classes: >-

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -29157,6 +29157,21 @@
         "zh-Hans": { "stringUnit": { "state": "translated", "value": "关闭" } }
       }
     },
+    "settings.general.autoSave": {
+      "comment": "Toggle that automatically saves edited files after a delay.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Automatisch speichern" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Auto Save" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Guardar automáticamente" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Enregistrement automatique" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "自動保存" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "자동 저장" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Salvar automaticamente" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Автосохранение" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "自动保存" } }
+      }
+    },
     "settings.general.display": {
       "comment": "Heading for editor display preferences in General Settings.",
       "extractionState": "manual",

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -36,7 +36,6 @@ struct PineAppMenuCommands: Commands {
     /// observation of `ProjectRegistry.recentProjects` in the menu body.
     let recentProjects: () -> [URL]
     @FocusedValue(\.projectManager) private var focusedProject: ProjectManager?
-    @AppStorage(TabManager.autoSaveKey) private var autoSaveEnabled = false
     private var keybindings: UserKeybindingRegistry {
         ExtensibilityManager.shared.keybindings
     }
@@ -267,23 +266,6 @@ struct PineAppMenuCommands: Commands {
             )
             .disabled(!nativeState.canDuplicate)
 
-            Divider()
-
-            Toggle(isOn: $autoSaveEnabled) {
-                Label(Strings.menuAutoSave, systemImage: MenuIcons.autoSave)
-            }
-
-            Toggle(
-                isOn: Bindable(EditorSettings.shared).formatOnSave
-            ) {
-                Label(Strings.menuFormatOnSave, systemImage: MenuIcons.formatOnSave)
-            }
-
-            Toggle(
-                isOn: Bindable(EditorSettings.shared).smartListContinuation
-            ) {
-                Label(Strings.menuSmartListContinuation, systemImage: MenuIcons.smartListContinuation)
-            }
         }
 
         // MARK: - Window menu

--- a/Pine/Settings/GeneralSettingsView.swift
+++ b/Pine/Settings/GeneralSettingsView.swift
@@ -6,8 +6,7 @@
 //  Surfaces the editor formatting defaults (EditorSettings), font size
 //  (FontSizeSettings), and the default visibility of the minimap and word
 //  wrap. Every control binds directly to the same source of truth used by
-//  the File / View menus, so changes apply immediately and the menu
-//  checkmarks stay in sync.
+//  the editor, so changes apply immediately.
 //
 
 import SwiftUI
@@ -22,6 +21,7 @@ import SwiftUI
 struct GeneralSettingsView: View {
     @Bindable var editor: EditorSettings
     @Bindable var fontSizeSettings: FontSizeSettings
+    @AppStorage(TabManager.autoSaveKey) private var autoSaveEnabled = false
     @AppStorage("minimapVisible") private var defaultMinimapVisible = true
     @AppStorage("wordWrapEnabled") private var defaultWordWrap = true
 
@@ -32,6 +32,11 @@ struct GeneralSettingsView: View {
     ) {
         self.editor = editor
         self.fontSizeSettings = fontSizeSettings
+        _autoSaveEnabled = AppStorage(
+            wrappedValue: false,
+            TabManager.autoSaveKey,
+            store: defaults
+        )
         _defaultMinimapVisible = AppStorage(
             wrappedValue: true,
             "minimapVisible",
@@ -51,6 +56,10 @@ struct GeneralSettingsView: View {
 
             GroupBox(Strings.settingsGeneralFormatting) {
                 VStack(alignment: .leading, spacing: 12) {
+                    Toggle(
+                        Strings.settingsGeneralAutoSave,
+                        isOn: $autoSaveEnabled
+                    )
                     Toggle(
                         Strings.settingsGeneralInsertFinalNewline,
                         isOn: $editor.insertFinalNewline

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -24,6 +24,8 @@ enum Strings {
         "settings.general.insertFinalNewline"
     static let settingsGeneralStripTrailingWhitespace: LocalizedStringKey =
         "settings.general.stripTrailingWhitespace"
+    static let settingsGeneralAutoSave: LocalizedStringKey =
+        "settings.general.autoSave"
     static let settingsGeneralFormatOnSave: LocalizedStringKey =
         "settings.general.formatOnSave"
     static let settingsGeneralSmartListContinuation: LocalizedStringKey =
@@ -1493,9 +1495,6 @@ enum Strings {
         String(localized: "branch.uncommittedChanges.switch")
     }
 
-    static let menuAutoSave: LocalizedStringKey = "menu.autoSave"
-    static let menuFormatOnSave: LocalizedStringKey = "menu.formatOnSave"
-    static let menuSmartListContinuation: LocalizedStringKey = "menu.smartListContinuation"
     static let autoSaving: LocalizedStringKey = "editor.autoSaving"
     static let menuSave: LocalizedStringKey = "menu.save"
     static let menuSaveAll: LocalizedStringKey = "menu.saveAll"

--- a/PineUITests/NativeFileWindowMenuUITests.swift
+++ b/PineUITests/NativeFileWindowMenuUITests.swift
@@ -52,6 +52,29 @@ final class NativeFileWindowMenuUITests: PineUITestCase {
         ) == .completed
     }
 
+    /// Polls for the first hittable text field within `timeout`.
+    ///
+    /// `NSOpenPanel`'s "Go to Folder" sheet animates its path field in
+    /// asynchronously, and `app.typeKey` can race the field's appearance on
+    /// CI runners. Polling avoids `XCTUnwrap` failing fast before the sheet is
+    /// fully interactive (stabilizes #1291, #1295).
+    private func firstHittableTextField(
+        timeout: TimeInterval
+    ) -> XCUIElement? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let field = app.textFields.allElementsBoundByIndex.first(
+                where: { $0.isHittable }
+            ) {
+                return field
+            }
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+        return app.textFields.allElementsBoundByIndex.first {
+            $0.isHittable
+        }
+    }
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         projectURL = try createTempProject(
@@ -264,11 +287,22 @@ final class NativeFileWindowMenuUITests: PineUITestCase {
             "Open Folder should present a directory picker"
         )
 
-        app.typeKey("g", modifierFlags: [.command, .shift])
+        // Wait for the open panel to become interactive (it animates in),
+        // then route Cmd+Shift+G to the sheet itself so the "Go to Folder"
+        // path field reliably appears. Sending the shortcut to `app` can race
+        // the panel gaining first-responder on CI (#1291, #1295).
+        _ = XCTWaiter.wait(
+            for: [
+                XCTNSPredicateExpectation(
+                    predicate: NSPredicate(format: "isHittable == true"),
+                    object: openPanel
+                )
+            ],
+            timeout: 5
+        )
+        openPanel.typeKey("g", modifierFlags: [.command, .shift])
         let pathField = try XCTUnwrap(
-            app.textFields.allElementsBoundByIndex.first(where: {
-                $0.isHittable
-            }),
+            firstHittableTextField(timeout: 5),
             "Go to Folder should expose a hittable path field"
         )
         pathField.typeText(secondProjectURL.path)

--- a/PineUITests/NativeFileWindowMenuUITests.swift
+++ b/PineUITests/NativeFileWindowMenuUITests.swift
@@ -341,4 +341,19 @@ final class NativeFileWindowMenuUITests: PineUITestCase {
             "Clear Menu should disable an empty Open Recent submenu"
         )
     }
+
+    func testFileMenuContainsActionsNotEditorPreferences() throws {
+        launchWithProject(projectURL)
+        XCTAssertTrue(
+            waitForExistence(app.scrollViews["sidebar"], timeout: 10)
+        )
+
+        clickMenuBarItem("File")
+
+        XCTAssertFalse(app.menuItems["Auto Save"].exists)
+        XCTAssertFalse(app.menuItems["Format on Save"].exists)
+        XCTAssertFalse(app.menuItems["Smart List Continuation"].exists)
+        XCTAssertTrue(app.menuItems["Save"].exists)
+        XCTAssertTrue(app.menuItems["Save As…"].exists)
+    }
 }

--- a/PineUITests/SettingsUITests.swift
+++ b/PineUITests/SettingsUITests.swift
@@ -255,6 +255,7 @@ final class SettingsUITests: PineUITestCase {
                 tab: "General",
                 contentIdentifier: "generalSettingsPane",
                 expectedLabels: [
+                    "Auto Save",
                     "Insert Final Newline",
                     "Strip Trailing Whitespace",
                     "Format on Save",
@@ -307,6 +308,7 @@ final class SettingsUITests: PineUITestCase {
                 tab: "Основные",
                 contentIdentifier: "generalSettingsPane",
                 expectedLabels: [
+                    "Автосохранение",
                     "Добавлять перевод строки в конце",
                     "Удалять пробелы в конце строк",
                     "Форматировать при сохранении",


### PR DESCRIPTION
## Summary

- remove Auto Save, Format on Save, and Smart List Continuation preference toggles from the File menu
- expose Auto Save in General Settings alongside the existing save and formatting preferences
- preserve command-palette and user-keybinding commands for compatibility
- localize the new Settings label in all nine supported languages
- add UI regression coverage for the File menu and English/Russian Settings labels

## Testing

- SwiftLint on changed Swift files
- PineAppMenuCommandsTests and SettingsLocalizationTests (8 tests)
- SettingsPaneSnapshotTests (4 tests)
- NativeFileWindowMenuUITests.testFileMenuContainsActionsNotEditorPreferences
- SettingsUITests.testEverySettingsPaneUsesLocalizedLabels
- SettingsUITests.testEverySettingsPaneUsesRussianLabelsWithoutRawKeys

All tests passed with Xcode 27 beta; stable Xcode.app is not installed on the test machine.