### PR TITLE
fix: use native ellipsis in app menu

### DIFF
--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -6092,7 +6092,7 @@
         }
       }
     },
-    "Install Command Line Tool...": {
+    "Install Command Line Tool…": {
       "localizations": {
         "de": {
           "stringUnit": {
@@ -6103,7 +6103,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Install Command Line Tool..."
+            "value": "Install Command Line Tool…"
           }
         },
         "es": {
@@ -19097,7 +19097,7 @@
         }
       }
     },
-    "Uninstall Command Line Tool...": {
+    "Uninstall Command Line Tool…": {
       "localizations": {
         "de": {
           "stringUnit": {
@@ -19108,7 +19108,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Uninstall Command Line Tool..."
+            "value": "Uninstall Command Line Tool…"
           }
         },
         "es": {

--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -63,8 +63,8 @@ struct PineAppMenuCommands: Commands {
                 }
             } label: {
                 Text(CLIInstaller.isInstalled
-                     ? "Uninstall Command Line Tool..."
-                     : "Install Command Line Tool...")
+                     ? "Uninstall Command Line Tool…"
+                     : "Install Command Line Tool…")
             }
         }
 

--- a/PineUITests/CheckForUpdatesTests.swift
+++ b/PineUITests/CheckForUpdatesTests.swift
@@ -40,4 +40,22 @@ final class CheckForUpdatesTests: PineUITestCase {
         XCTAssertTrue(aboutItem.exists, "About Pine menu item should exist")
         XCTAssertTrue(updateItem.exists, "Check for Updates… menu item should exist")
     }
+
+    func testCommandLineToolMenuItemUsesNativeEllipsis() throws {
+        launchClean()
+
+        let welcomeWindow = app.windows["welcome"]
+        XCTAssertTrue(waitForExistence(welcomeWindow))
+
+        app.menuBars.menuBarItems["Pine"].click()
+
+        let install = app.menuItems["Install Command Line Tool…"]
+        let uninstall = app.menuItems["Uninstall Command Line Tool…"]
+        XCTAssertTrue(
+            install.exists || uninstall.exists,
+            "The CLI command should use the native ellipsis character"
+        )
+        XCTAssertFalse(app.menuItems["Install Command Line Tool..."].exists)
+        XCTAssertFalse(app.menuItems["Uninstall Command Line Tool..."].exists)
+    }
 }


### PR DESCRIPTION
## Summary

- replace ASCII three-dot suffixes in the command-line tool menu items with the native ellipsis character
- keep all nine existing localizations intact
- add UI regression coverage for both installed and uninstalled CLI states

## Testing

- SwiftLint on changed Swift files
- LocalizationCatalogCompletenessTests (4 tests)
- CheckForUpdatesTests.testCommandLineToolMenuItemUsesNativeEllipsis

Tested with Xcode 27 beta because stable Xcode.app is not installed on the machine.