### PR TITLE
fix: show native keybinding glyphs in settings

### DIFF
--- a/Pine/Settings/KeyBindingsTasksSettingsView.swift
+++ b/Pine/Settings/KeyBindingsTasksSettingsView.swift
@@ -204,16 +204,9 @@ struct KeyBindingsTasksSettingsView: View {
         return ""
     }
 
-    /// Renders a `ParsedKeyChord` as a human-readable shortcut string
-    /// (e.g. `cmd+shift+f`). Modifiers are listed in a stable order.
+    /// Renders a `ParsedKeyChord` using the same native macOS glyphs as the
+    /// command palette and menu key equivalents (for example, `⇧⌘F`).
     static func chordDescription(_ chord: ParsedKeyChord) -> String {
-        var parts: [String] = []
-        let modifiers = chord.modifiers
-        if modifiers.contains(.control) { parts.append("ctrl") }
-        if modifiers.contains(.option) { parts.append("option") }
-        if modifiers.contains(.shift) { parts.append("shift") }
-        if modifiers.contains(.command) { parts.append("cmd") }
-        parts.append(chord.key)
-        return parts.joined(separator: "+")
+        chord.displayText
     }
 }

--- a/PineTests/SettingsLocalizationTests.swift
+++ b/PineTests/SettingsLocalizationTests.swift
@@ -10,6 +10,25 @@ import Testing
 
 @Suite("Settings localization")
 struct SettingsLocalizationTests {
+    @Test("Key bindings use native macOS shortcut glyphs")
+    func keyBindingGlyphs() throws {
+        let letterChord = try #require(
+            UserKeybindingRegistry.parse("ctrl+option+shift+cmd+f")
+        )
+        let namedKeyChord = try #require(
+            UserKeybindingRegistry.parse("cmd+return")
+        )
+
+        #expect(
+            KeyBindingsTasksSettingsView.chordDescription(letterChord)
+                == "⌃⌥⇧⌘F"
+        )
+        #expect(
+            KeyBindingsTasksSettingsView.chordDescription(namedKeyChord)
+                == "⌘↩"
+        )
+    }
+
     @Test("Active-entry counts follow English and Russian plural rules")
     func activeEntryCountPlurals() {
         let counts = [0, 1, 2, 5, 21, 22, 25]


### PR DESCRIPTION
## Summary

- render Settings key bindings with native macOS modifier and named-key glyphs
- reuse the command palette shortcut formatter so the two surfaces cannot drift
- replace strings such as `ctrl+option+shift+cmd+f` with `⌃⌥⇧⌘F`
- add regression coverage for letter and Return shortcuts

## Testing

- SwiftLint on changed Swift files
- SettingsLocalizationTests (5 tests)

Tested with Xcode 27 beta because stable Xcode.app is not installed on the machine.