### PR TITLE
fix: show state in view menu

### DIFF
--- a/Pine/PineAppMenuCommands.swift
+++ b/Pine/PineAppMenuCommands.swift
@@ -36,6 +36,9 @@ struct PineAppMenuCommands: Commands {
     /// observation of `ProjectRegistry.recentProjects` in the menu body.
     let recentProjects: () -> [URL]
     @FocusedValue(\.projectManager) private var focusedProject: ProjectManager?
+    @AppStorage("minimapVisible") private var minimapVisible = true
+    @AppStorage(BlameConstants.storageKey) private var blameVisible = true
+    @AppStorage("wordWrapEnabled") private var wordWrapEnabled = true
     @AppStorage(TabManager.autoSaveKey) private var autoSaveEnabled = false
     private var keybindings: UserKeybindingRegistry {
         ExtensibilityManager.shared.keybindings
@@ -572,24 +575,17 @@ struct PineAppMenuCommands: Commands {
 
             Divider()
 
-            Button {
-                MinimapSettings.toggle()
-            } label: {
+            Toggle(isOn: $minimapVisible) {
                 Label(Strings.menuToggleMinimap, systemImage: MenuIcons.toggleMinimap)
             }
             .keyboardShortcut("m", modifiers: [.command, .shift])
 
-            Button {
-                let key = BlameConstants.storageKey
-                UserDefaults.standard.set(!UserDefaults.standard.bool(forKey: key), forKey: key)
-            } label: {
+            Toggle(isOn: $blameVisible) {
                 Label(Strings.menuToggleBlame, systemImage: MenuIcons.toggleBlame)
             }
             .keyboardShortcut("b", modifiers: [.command, .control])
 
-            Button {
-                NotificationCenter.default.post(name: .toggleWordWrap, object: nil)
-            } label: {
+            Toggle(isOn: $wordWrapEnabled) {
                 Label(Strings.menuToggleWordWrap, systemImage: MenuIcons.toggleWordWrap)
             }
             .keyboardShortcut("z", modifiers: .option)

--- a/PineUITests/BlameViewTests.swift
+++ b/PineUITests/BlameViewTests.swift
@@ -70,7 +70,7 @@ final class BlameViewTests: PineUITestCase {
             return
         }
 
-        // Toggle blame ON via View menu
+        // The native menu toggle changes the persisted preference.
         app.menuBars.menuBarItems["View"].click()
         let toggleItem = app.menuItems["Toggle Git Blame"]
         guard waitForExistence(toggleItem, timeout: 3) else {
@@ -79,7 +79,7 @@ final class BlameViewTests: PineUITestCase {
         }
         toggleItem.click()
 
-        // Toggle blame OFF via View menu
+        // Toggle it again to leave the persisted preference unchanged for later tests.
         app.menuBars.menuBarItems["View"].click()
         let toggleItemOff = app.menuItems["Toggle Git Blame"]
         guard waitForExistence(toggleItemOff, timeout: 3) else {

--- a/PineUITests/MinimapTests.swift
+++ b/PineUITests/MinimapTests.swift
@@ -90,4 +90,24 @@ final class MinimapTests: PineUITestCase {
             "Minimap should reappear after toggle on"
         )
     }
+
+    func testToggleMinimapViaViewMenu() throws {
+        launchWithProject(projectURL)
+
+        let fileRow = app.sidebarNodes["fileNode_main.swift"]
+        XCTAssertTrue(waitForExistence(fileRow, timeout: 10))
+        fileRow.click()
+        let minimapWasVisible = minimap.waitForExistence(timeout: 2)
+
+        app.menuBars.menuBarItems["View"].click()
+        let minimapItem = app.menuItems["Toggle Minimap"]
+        XCTAssertTrue(waitForExistence(minimapItem, timeout: 3))
+
+        minimapItem.click()
+        if minimapWasVisible {
+            XCTAssertTrue(minimap.waitForNonExistence(timeout: 3))
+        } else {
+            XCTAssertTrue(waitForExistence(minimap, timeout: 3))
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- replace action-only Minimap, Git Blame, and Word Wrap menu buttons with native stateful toggles
- bind each View menu item to the same persisted preference used by the corresponding UI
- avoid the unset-UserDefaults mismatch that made the first Git Blame click ineffective
- cover Minimap and Git Blame menu interaction with UI tests

## Tests
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swiftlint lint --strict Pine/PineAppMenuCommands.swift PineUITests/MinimapTests.swift PineUITests/BlameViewTests.swift` (0 violations; SwiftLint cache write warning after lint completion)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild test -project Pine.xcodeproj -scheme Pine -destination platform=macOS -derivedDataPath /tmp/pine-derived-native-audit -only-testing:PineTests/PineAppMenuCommandsTests -only-testing:PineTests/MinimapViewTests` (17 passed)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild test -project Pine.xcodeproj -scheme Pine -destination platform=macOS -derivedDataPath /tmp/pine-derived-native-audit -only-testing:PineUITests/MinimapTests/testToggleMinimapViaViewMenu -only-testing:PineUITests/BlameViewTests/testToggleBlameViaMenu` (2 passed)