### PR TITLE
feat(agent): add durable cross-project agent tasks (#1302)

### DIFF
--- a/Pine/Agent/AgentDetectionCoordinator.swift
+++ b/Pine/Agent/AgentDetectionCoordinator.swift
@@ -277,7 +277,9 @@ nonisolated final class AgentDetectionCoordinator {
 
         var pathBuffer = [CChar](
             repeating: 0,
-            count: Int(PROC_PIDPATHINFO_MAXSIZE)
+            // libproc defines PROC_PIDPATHINFO_MAXSIZE as 4 * MAXPATHLEN,
+            // but Swift's Clang importer does not expose that compound macro.
+            count: 4 * Int(MAXPATHLEN)
         )
         let pathLength = pathBuffer.withUnsafeMutableBytes { buffer in
             proc_pidpath(

--- a/Pine/Agent/AgentDetectionCoordinator.swift
+++ b/Pine/Agent/AgentDetectionCoordinator.swift
@@ -271,6 +271,9 @@ nonisolated final class AgentDetectionCoordinator {
         before.pbi_pid == UInt32(process.pid) else {
             return nil
         }
+        guard let kernelArguments = kernelArguments(for: process.pid) else {
+            return nil
+        }
 
         var pathBuffer = [CChar](
             repeating: 0,
@@ -286,6 +289,11 @@ nonisolated final class AgentDetectionCoordinator {
         guard pathLength > 0 else { return nil }
         let currentExecutable = URL(fileURLWithPath: String(cString: pathBuffer))
             .lastPathComponent.lowercased()
+        guard processArgumentsAreCoherent(
+            observedCommand: process.command,
+            kernelArguments: kernelArguments,
+            currentExecutable: currentExecutable
+        ) else { return nil }
 
         guard proc_pidinfo(
             process.pid,
@@ -314,6 +322,82 @@ nonisolated final class AgentDetectionCoordinator {
         ) ? preciseStart : nil
     }
 
+    nonisolated private static func kernelArguments(
+        for pid: Int32
+    ) -> [String]? {
+        var mib = [Int32(CTL_KERN), Int32(KERN_PROCARGS2), pid]
+        var size = 0
+        guard sysctl(&mib, u_int(mib.count), nil, &size, nil, 0) == 0,
+              size >= MemoryLayout<Int32>.size,
+              size <= 16_384 else { return nil }
+        var bytes = [UInt8](repeating: 0, count: size)
+        guard sysctl(&mib, u_int(mib.count), &bytes, &size, nil, 0) == 0,
+              size <= bytes.count else { return nil }
+        bytes.removeSubrange(size..<bytes.count)
+        let argumentCount = Int(bytes.withUnsafeBytes {
+            $0.loadUnaligned(as: Int32.self)
+        })
+        guard argumentCount > 0 else { return nil }
+        var cursor = MemoryLayout<Int32>.size
+        guard consumeCString(in: bytes, cursor: &cursor) != nil else {
+            return nil
+        }
+        while cursor < bytes.count, bytes[cursor] == 0 { cursor += 1 }
+        var arguments: [String] = []
+        while arguments.count < min(argumentCount, 2), cursor < bytes.count {
+            guard let argument = consumeCString(in: bytes, cursor: &cursor) else {
+                return nil
+            }
+            arguments.append(argument)
+        }
+        return arguments.count == min(argumentCount, 2) ? arguments : nil
+    }
+
+    nonisolated private static func consumeCString(
+        in bytes: [UInt8],
+        cursor: inout Int
+    ) -> String? {
+        guard cursor < bytes.count,
+              let terminator = bytes[cursor...].firstIndex(of: 0),
+              let value = String(
+                  bytes: bytes[cursor..<terminator],
+                  encoding: .utf8
+              ) else { return nil }
+        cursor = terminator + 1
+        return value
+    }
+
+    nonisolated private static func processArgumentsAreCoherent(
+        observedCommand: String,
+        kernelArguments: [String],
+        currentExecutable: String
+    ) -> Bool {
+        let observedArguments = observedCommand.split(
+            separator: " ",
+            omittingEmptySubsequences: true
+        ).map(String.init)
+        guard let observedFirst = observedArguments.first,
+              let kernelFirst = kernelArguments.first else { return false }
+        let observedBase = URL(fileURLWithPath: observedFirst)
+            .lastPathComponent.lowercased()
+        let kernelBase = URL(fileURLWithPath: kernelFirst)
+            .lastPathComponent.lowercased()
+        guard observedBase == kernelBase,
+              kernelBase == currentExecutable,
+              AgentDetector.extractExecutableName(arguments: observedArguments)
+                .lowercased()
+                == AgentDetector.extractExecutableName(arguments: kernelArguments)
+                    .lowercased() else { return false }
+        let isWrapped = AgentDetector.extractExecutableName(
+            arguments: observedArguments
+        ).lowercased() != observedBase
+        return !isWrapped || (
+            observedArguments.count >= 2
+                && kernelArguments.count >= 2
+                && observedArguments[1] == kernelArguments[1]
+        )
+    }
+
     nonisolated private static func processSampleIsCoherent(
         coarseStart: Date,
         beforeStart: Date,
@@ -328,6 +412,18 @@ nonisolated final class AgentDetectionCoordinator {
     }
 
     #if DEBUG
+    nonisolated static func processArgumentsAreCoherentForTesting(
+        observedCommand: String,
+        kernelArguments: [String],
+        currentExecutable: String
+    ) -> Bool {
+        processArgumentsAreCoherent(
+            observedCommand: observedCommand,
+            kernelArguments: kernelArguments,
+            currentExecutable: currentExecutable
+        )
+    }
+
     nonisolated static func processSampleIsCoherentForTesting(
         coarseStart: Date,
         beforeStart: Date,

--- a/Pine/Agent/AgentDetectionCoordinator.swift
+++ b/Pine/Agent/AgentDetectionCoordinator.swift
@@ -9,7 +9,15 @@
 //  `AgentSession` badge (#951).
 //
 
+import Darwin
 import Foundation
+
+nonisolated enum AgentMonotonicCounter {
+    static func next(after value: UInt64) -> UInt64? {
+        guard value < UInt64.max else { return nil }
+        return value + 1
+    }
+}
 
 /// Polls `ps` off the main thread and drives `AgentDetector` lifecycle,
 /// then maps detected agent pids to terminal tabs via `tcgetpgrp`.
@@ -74,8 +82,9 @@ nonisolated final class AgentDetectionCoordinator {
 
     @MainActor func start() {
         guard !isRunning else { return }
+        guard let generation = lifecycleGate.begin() else { return }
         isRunning = true
-        let run = AgentPollingRun(generation: lifecycleGate.begin())
+        let run = AgentPollingRun(generation: generation)
         let timer = DispatchSource.makeTimerSource(queue: pollQueue)
         timer.schedule(deadline: .now() + pollInterval, repeating: pollInterval)
         // Build the handler via the nonisolated makePollHandler(): a closure
@@ -108,6 +117,7 @@ nonisolated final class AgentDetectionCoordinator {
         lifecycleGate.end()
         timer?.cancel()
         timer = nil
+        terminalManager?.markAgentEvidenceUnavailable()
         clearAllTabSessions()
     }
 
@@ -132,7 +142,10 @@ nonisolated final class AgentDetectionCoordinator {
     /// `@MainActor` closure never captures `self`, avoiding the strict-
     /// concurrency "sending 'self' risks causing data races" error.
     nonisolated private func captureSnapshot(run: AgentPollingRun) {
-        let sequence = run.nextSequence()
+        guard let sequence = run.nextSequence() else {
+            lifecycleGate.end()
+            return
+        }
         let result = processRunner(
             "/bin/sh",
             ["-c", Self.psSnapshotCommand],
@@ -145,10 +158,10 @@ nonisolated final class AgentDetectionCoordinator {
             generation: run.generation,
             sequence: sequence
         )
-        let snapshot = Self.makeSnapshot(
+        let snapshot = Self.enrichProcessStarts(Self.makeSnapshot(
             from: result,
             observation: observation
-        )
+        ))
         // Extract references before the hop — the DispatchWorkItem closure
         // must not capture `self` (nonisolated, non-Sendable).
         let detector = self.detector
@@ -187,7 +200,7 @@ nonisolated final class AgentDetectionCoordinator {
             let tokens = trimmed.split(separator: " ", omittingEmptySubsequences: true)
             guard tokens.count >= 8,
                   let pid = Int32(tokens[0]),
-                  validLongStart(tokens[1...5]),
+                  parseLongStart(tokens[1...5]) != nil,
                   let cpuTime = parseCpuTime(String(tokens[6])) else {
                 continue
             }
@@ -204,6 +217,133 @@ nonisolated final class AgentDetectionCoordinator {
         }
         return processes
     }
+
+    nonisolated private static func enrichProcessStarts(
+        _ snapshot: AgentProcessSnapshot
+    ) -> AgentProcessSnapshot {
+        guard case .success(let processes, let observation) = snapshot else {
+            return snapshot
+        }
+        return .success(
+            processes: processes.map { process in
+                DetectedProcess(
+                    pid: process.pid,
+                    command: process.command,
+                    cwd: process.cwd,
+                    cpuTime: process.cpuTime,
+                    startIdentifier: process.startIdentifier,
+                    preciseStartedAt: coherentProcessStart(process)
+                )
+            },
+            observation: observation
+        )
+    }
+
+    nonisolated private static func coherentProcessStart(
+        _ process: DetectedProcess
+    ) -> Date? {
+        guard process.pid > 1,
+              let startIdentifier = process.startIdentifier,
+              let coarseStart = parseLongStart(
+                  startIdentifier.split(separator: " ")[...]
+              ),
+              let observedToken = process.command.split(
+                  separator: " ",
+                  maxSplits: 1,
+                  omittingEmptySubsequences: true
+              ).first else {
+            return nil
+        }
+        let observedExecutable = URL(fileURLWithPath: String(observedToken))
+            .lastPathComponent.lowercased()
+        guard !observedExecutable.isEmpty else { return nil }
+
+        var before = proc_bsdinfo()
+        var after = proc_bsdinfo()
+        let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.size)
+        guard proc_pidinfo(
+            process.pid,
+            PROC_PIDTBSDINFO,
+            0,
+            &before,
+            expectedSize
+        ) == expectedSize,
+        before.pbi_pid == UInt32(process.pid) else {
+            return nil
+        }
+
+        var pathBuffer = [CChar](
+            repeating: 0,
+            count: Int(PROC_PIDPATHINFO_MAXSIZE)
+        )
+        let pathLength = pathBuffer.withUnsafeMutableBytes { buffer in
+            proc_pidpath(
+                process.pid,
+                buffer.baseAddress,
+                UInt32(buffer.count)
+            )
+        }
+        guard pathLength > 0 else { return nil }
+        let currentExecutable = URL(fileURLWithPath: String(cString: pathBuffer))
+            .lastPathComponent.lowercased()
+
+        guard proc_pidinfo(
+            process.pid,
+            PROC_PIDTBSDINFO,
+            0,
+            &after,
+            expectedSize
+        ) == expectedSize,
+        after.pbi_pid == UInt32(process.pid) else {
+            return nil
+        }
+        let beforeStart = Date(
+            timeIntervalSince1970: TimeInterval(before.pbi_start_tvsec)
+                + TimeInterval(before.pbi_start_tvusec) / 1_000_000
+        )
+        let preciseStart = Date(
+            timeIntervalSince1970: TimeInterval(after.pbi_start_tvsec)
+                + TimeInterval(after.pbi_start_tvusec) / 1_000_000
+        )
+        return processSampleIsCoherent(
+            coarseStart: coarseStart,
+            beforeStart: beforeStart,
+            afterStart: preciseStart,
+            observedExecutable: observedExecutable,
+            currentExecutable: currentExecutable
+        ) ? preciseStart : nil
+    }
+
+    nonisolated private static func processSampleIsCoherent(
+        coarseStart: Date,
+        beforeStart: Date,
+        afterStart: Date,
+        observedExecutable: String,
+        currentExecutable: String
+    ) -> Bool {
+        observedExecutable == currentExecutable
+            && beforeStart == afterStart
+            && coarseStart.timeIntervalSince1970
+                == afterStart.timeIntervalSince1970.rounded(.down)
+    }
+
+    #if DEBUG
+    nonisolated static func processSampleIsCoherentForTesting(
+        coarseStart: Date,
+        beforeStart: Date,
+        afterStart: Date,
+        observedExecutable: String,
+        currentExecutable: String
+    ) -> Bool {
+        processSampleIsCoherent(
+            coarseStart: coarseStart,
+            beforeStart: beforeStart,
+            afterStart: afterStart,
+            observedExecutable: observedExecutable,
+            currentExecutable: currentExecutable
+        )
+    }
+    #endif
 
     #if DEBUG
     /// Parses the historical injected-test `pid command [cputime]` shape.
@@ -258,13 +398,13 @@ nonisolated final class AgentDetectionCoordinator {
         "exit \"$status\"",
     ].joined(separator: " ")
 
-    /// Validates the five fixed UTC `lstart` tokens, including the actual
+    /// Parses the five fixed UTC `lstart` tokens, including the actual
     /// Gregorian date and matching weekday. This rejects values such as
     /// `Wed Xxx 99 25:80:80 2026` that merely occupy the expected columns.
-    nonisolated private static func validLongStart(
+    nonisolated private static func parseLongStart(
         _ tokens: ArraySlice<Substring>
-    ) -> Bool {
-        guard tokens.count == 5 else { return false }
+    ) -> Date? {
+        guard tokens.count == 5 else { return nil }
         let values = Array(tokens)
         guard let expectedWeekday = psWeekdays[String(values[0])],
               let month = psMonths[String(values[1])],
@@ -272,11 +412,11 @@ nonisolated final class AgentDetectionCoordinator {
               let year = Int(values[4]),
               (1970...9999).contains(year),
               let clock = parseClock(String(values[3])) else {
-            return false
+            return nil
         }
 
         var calendar = Calendar(identifier: .gregorian)
-        guard let utc = TimeZone(secondsFromGMT: 0) else { return false }
+        guard let utc = TimeZone(secondsFromGMT: 0) else { return nil }
         calendar.timeZone = utc
         var components = DateComponents()
         components.calendar = calendar
@@ -287,18 +427,21 @@ nonisolated final class AgentDetectionCoordinator {
         components.hour = clock.hour
         components.minute = clock.minute
         components.second = clock.second
-        guard let date = calendar.date(from: components) else { return false }
+        guard let date = calendar.date(from: components) else { return nil }
         let resolved = calendar.dateComponents(
             [.year, .month, .day, .hour, .minute, .second, .weekday],
             from: date
         )
-        return resolved.year == year
-            && resolved.month == month
-            && resolved.day == day
-            && resolved.hour == clock.hour
-            && resolved.minute == clock.minute
-            && resolved.second == clock.second
-            && resolved.weekday == expectedWeekday
+        guard resolved.year == year,
+              resolved.month == month,
+              resolved.day == day,
+              resolved.hour == clock.hour,
+              resolved.minute == clock.minute,
+              resolved.second == clock.second,
+              resolved.weekday == expectedWeekday else {
+            return nil
+        }
+        return date
     }
 
     nonisolated private static func parseClock(
@@ -457,6 +600,7 @@ nonisolated final class AgentDetectionCoordinator {
             // snapshot, so its one-interval exit badge can expire even though
             // this poll failed. Live/stale associations remain untouched.
             guard let terminalManager else { return }
+            terminalManager.refreshAgentTasks()
             for tab in terminalManager.allTerminalTabs
             where shouldExpireAfterFailedSnapshot(tab.agentSession) {
                 tab.agentSession = nil
@@ -469,13 +613,23 @@ nonisolated final class AgentDetectionCoordinator {
             )
             guard let terminalManager else { return }
             for tab in terminalManager.allTerminalTabs {
-                tab.agentSession = reconciledSession(
-                    previous: tab.agentSession,
+                let previous = tab.agentSession
+                let current = reconciledSession(
+                    previous: previous,
                     foregroundPID: tab.foregroundProcessID,
                     detector: detector,
                     newlyTerminated: newlyTerminated
                 )
+                if let current {
+                    terminalManager.bridgeAgentSession(
+                        current,
+                        replacing: previous,
+                        in: tab
+                    )
+                }
+                tab.agentSession = current
             }
+            terminalManager.refreshAgentTasks()
         }
     }
 
@@ -531,7 +685,7 @@ nonisolated final class AgentDetectionCoordinator {
             wallTime: Date(),
             uptime: uptimeProvider(),
             generation: testingRun.generation,
-            sequence: testingRun.nextSequence()
+            sequence: testingRun.nextSequence() ?? UInt64.max
         )
         let snapshot = Self.makeSnapshot(
             from: result,
@@ -571,10 +725,13 @@ nonisolated private final class AgentPollingRun: @unchecked Sendable {
         self.generation = generation
     }
 
-    func nextSequence() -> UInt64 {
+    func nextSequence() -> UInt64? {
         lock.lock()
         defer { lock.unlock() }
-        sequence &+= 1
+        guard let next = AgentMonotonicCounter.next(after: sequence) else {
+            return nil
+        }
+        sequence = next
         return sequence
     }
 }
@@ -587,10 +744,16 @@ nonisolated private final class AgentPollingLifecycleGate: @unchecked Sendable {
     private var nextGeneration: UInt64 = 0
     private var activeGeneration: UInt64?
 
-    func begin() -> UInt64 {
+    func begin() -> UInt64? {
         lock.lock()
         defer { lock.unlock() }
-        nextGeneration &+= 1
+        guard let next = AgentMonotonicCounter.next(
+            after: nextGeneration
+        ) else {
+            activeGeneration = nil
+            return nil
+        }
+        nextGeneration = next
         activeGeneration = nextGeneration
         return nextGeneration
     }

--- a/Pine/Agent/AgentDetector.swift
+++ b/Pine/Agent/AgentDetector.swift
@@ -227,12 +227,15 @@ final class AgentDetector {
                 } else {
                     false
                 }
+                let preciseAuthorityLost = preciseStartByPID[process.pid] != nil
+                    && process.preciseStartedAt == nil
 
                 // A pid may exec another agent or be recycled for the same
                 // command. A changed lstart value proves a new generation;
                 // cumulative CPU regression is the conservative fallback.
                 if existing.agentType != resolved || startChanged
-                    || preciseStartChanged || cpuRegressed {
+                    || preciseStartChanged || preciseAuthorityLost
+                    || cpuRegressed {
                     if let terminatedID = markDone(pid: process.pid) {
                         newlyTerminated.insert(terminatedID)
                     }
@@ -445,20 +448,26 @@ final class AgentDetector {
     /// the *second* token as the real CLI, resolving its basename and stripping
     /// a common script extension. A second token that is not a known agent
     /// (e.g. `server.js`) still resolves to `.generic` and is not tracked.
-    static func extractExecutableName(from command: String) -> String {
+    nonisolated static func extractExecutableName(from command: String) -> String {
         let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return "" }
+        let arguments = trimmed.split(
+            separator: " ",
+            omittingEmptySubsequences: true
+        ).map(String.init)
+        return extractExecutableName(arguments: arguments)
+    }
 
-        let tokens = trimmed.split(separator: " ", omittingEmptySubsequences: true)
-        guard let firstToken = tokens.first else { return "" }
-        let firstBase = (String(firstToken) as NSString).lastPathComponent
+    nonisolated static func extractExecutableName(
+        arguments: [String]
+    ) -> String {
+        guard let firstToken = arguments.first else { return "" }
+        let firstBase = (firstToken as NSString).lastPathComponent
 
-        // Interpreter-wrapper form: `node /path/pi`, `python3 …/aider`, …
-        // The second token is the real CLI; resolve its basename and strip a
-        // common script extension so `claude.js` → `claude`.
-        if Self.interpreterWrappers.contains(firstBase.lowercased()), tokens.count >= 2 {
-            let scriptBase = (String(tokens[1]) as NSString).lastPathComponent
-            return Self.strippingScriptExtension(scriptBase)
+        if interpreterWrappers.contains(firstBase.lowercased()),
+           arguments.count >= 2 {
+            let scriptBase = (arguments[1] as NSString).lastPathComponent
+            return strippingScriptExtension(scriptBase)
         }
         return firstBase
     }
@@ -466,7 +475,7 @@ final class AgentDetector {
     /// Interpreter executable basenames that wrap a script CLI. When the first
     /// token of a command is one of these, the second token holds the real CLI.
     /// Lowercased; compared case-insensitively.
-    private static let interpreterWrappers: Set<String> = [
+    nonisolated private static let interpreterWrappers: Set<String> = [
         "node", "node.exe",
         "python", "python3", "python3.exe",
         "ruby", "ruby.exe",
@@ -478,13 +487,15 @@ final class AgentDetector {
 
     /// Script-file extensions stripped from a wrapped script's basename so
     /// `node …/claude.js` resolves to `claude`.
-    private static let scriptExtensions: Set<String> = [
+    nonisolated private static let scriptExtensions: Set<String> = [
         "js", "mjs", "cjs", "ts", "mts", "cts",
     ]
 
     /// Returns `name` with a single trailing script extension removed (if any),
     /// preserving the original casing of the stem.
-    private static func strippingScriptExtension(_ name: String) -> String {
+    nonisolated private static func strippingScriptExtension(
+        _ name: String
+    ) -> String {
         let lower = name.lowercased()
         for ext in scriptExtensions where lower.hasSuffix("." + ext) {
             return String(name.dropLast(ext.count + 1))

--- a/Pine/Agent/AgentDetector.swift
+++ b/Pine/Agent/AgentDetector.swift
@@ -46,19 +46,23 @@ nonisolated struct DetectedProcess: Sendable, Equatable {
     let cpuTime: Int?
     /// Stable process-start discriminator from `ps lstart=`.
     let startIdentifier: String?
+    /// High-resolution OS process start time, when `proc_pidinfo` proves it.
+    let preciseStartedAt: Date?
 
     init(
         pid: Int32,
         command: String,
         cwd: URL? = nil,
         cpuTime: Int? = nil,
-        startIdentifier: String? = nil
+        startIdentifier: String? = nil,
+        preciseStartedAt: Date? = nil
     ) {
         self.pid = pid
         self.command = command
         self.cwd = cwd
         self.cpuTime = cpuTime
         self.startIdentifier = startIdentifier
+        self.preciseStartedAt = preciseStartedAt
     }
 }
 
@@ -107,9 +111,20 @@ final class AgentDetector {
 
     /// Stable process-start value seen for each tracked pid.
     private var startIdentifierByPID: [Int32: String] = [:]
+    /// Authoritative microsecond process start seen for each tracked pid.
+    private var preciseStartByPID: [Int32: Date] = [:]
+
+    /// Monotonic detector-owned process generation. It advances for every
+    /// newly recognised process, including PID reuse and command replacement.
+    private var nextProcessGeneration: UInt64 = 0
+
+    /// Runtime-only causal floor captured by a terminal launch owner
+    /// immediately before spawning a process.
+    var processGenerationFloor: UInt64 { nextProcessGeneration }
 
     /// Supplies monotonic process uptime. Injected for deterministic tests.
     private let uptimeProvider: @Sendable () -> TimeInterval
+    private let maxSessionHistory: Int
 
     /// Latest accepted poll, successful or failed. Older whole snapshots are
     /// discarded before they can refine, revive, or terminate sessions.
@@ -117,11 +132,13 @@ final class AgentDetector {
 
     init(
         staleAfter: TimeInterval = 300,
+        maxSessionHistory: Int = 512,
         uptimeProvider: @escaping @Sendable () -> TimeInterval = {
             ProcessInfo.processInfo.systemUptime
         }
     ) {
         livenessTracker = AgentSessionLivenessTracker(staleAfter: staleAfter)
+        self.maxSessionHistory = max(1, maxSessionHistory)
         self.uptimeProvider = uptimeProvider
     }
 
@@ -204,11 +221,18 @@ final class AgentDetector {
                 } else {
                     false
                 }
+                let preciseStartChanged = if let previousStart = preciseStartByPID[process.pid],
+                                             let currentStart = process.preciseStartedAt {
+                    previousStart != currentStart
+                } else {
+                    false
+                }
 
                 // A pid may exec another agent or be recycled for the same
                 // command. A changed lstart value proves a new generation;
                 // cumulative CPU regression is the conservative fallback.
-                if existing.agentType != resolved || startChanged || cpuRegressed {
+                if existing.agentType != resolved || startChanged
+                    || preciseStartChanged || cpuRegressed {
                     if let terminatedID = markDone(pid: process.pid) {
                         newlyTerminated.insert(terminatedID)
                     }
@@ -229,6 +253,10 @@ final class AgentDetector {
                 if startIdentifierByPID[process.pid] == nil,
                    let startIdentifier = process.startIdentifier {
                     startIdentifierByPID[process.pid] = startIdentifier
+                }
+                if preciseStartByPID[process.pid] == nil,
+                   let preciseStartedAt = process.preciseStartedAt {
+                    preciseStartByPID[process.pid] = preciseStartedAt
                 }
                 if let cpu = process.cpuTime {
                     if let previousCPU, existing.state != .done {
@@ -313,6 +341,7 @@ final class AgentDetector {
         guard let session = sessionsByPID.removeValue(forKey: pid) else { return nil }
         lastCpuTimeByPID.removeValue(forKey: pid)
         startIdentifierByPID.removeValue(forKey: pid)
+        preciseStartByPID.removeValue(forKey: pid)
         livenessTracker.recordTermination(of: session)
         session.state = .done
         return session.id
@@ -324,6 +353,13 @@ final class AgentDetector {
         agentType: AgentType,
         observation: AgentObservationStamp
     ) {
+        while detectedSessions.count >= maxSessionHistory,
+              let doneIndex = detectedSessions.firstIndex(where: {
+                  $0.state == .done
+              }) {
+            detectedSessions.remove(at: doneIndex)
+        }
+        guard detectedSessions.count < maxSessionHistory else { return }
         let session = AgentSession(
             agentType: agentType,
             state: .idle,
@@ -333,6 +369,19 @@ final class AgentDetector {
             observationGeneration: observation.generation,
             observationSequence: observation.sequence
         )
+        guard nextProcessGeneration < UInt64.max else {
+            return
+        }
+        nextProcessGeneration += 1
+        _ = session.bindProcessEvidence(
+            AgentProcessEvidence(
+                processIdentifier: process.pid,
+                processGeneration: nextProcessGeneration,
+                startIdentifier: process.startIdentifier,
+                observedStartedAt: process.preciseStartedAt ?? observation.wallTime,
+                startIsAuthoritative: process.preciseStartedAt != nil
+            )
+        )
         sessionsByPID[process.pid] = session
         detectedSessions.append(session)
         if let cpu = process.cpuTime {
@@ -341,16 +390,21 @@ final class AgentDetector {
         if let startIdentifier = process.startIdentifier {
             startIdentifierByPID[process.pid] = startIdentifier
         }
+        if let preciseStartedAt = process.preciseStartedAt {
+            preciseStartByPID[process.pid] = preciseStartedAt
+        }
     }
 
     /// Produces a stamp newer than any explicit coordinator stamp already
     /// accepted, preserving the convenient direct API for in-process callers.
     private func nextLocalObservation(at wallTime: Date) -> AgentObservationStamp {
-        AgentObservationStamp(
+        let prior = latestSnapshotStamp?.sequence ?? 0
+        let sequence = AgentMonotonicCounter.next(after: prior) ?? UInt64.max
+        return AgentObservationStamp(
             wallTime: wallTime,
             uptime: uptimeProvider(),
             generation: latestSnapshotStamp?.generation ?? 0,
-            sequence: (latestSnapshotStamp?.sequence ?? 0) &+ 1
+            sequence: sequence
         )
     }
 

--- a/Pine/Agent/AgentModels.swift
+++ b/Pine/Agent/AgentModels.swift
@@ -145,13 +145,21 @@ enum AgentState: Equatable, Sendable {
     /// Resolved through ``Strings`` so the same label is used everywhere —
     /// attention overlay, status bar, terminal badges, and accessibility —
     /// and is localized across the 9 supported languages (#1245).
+    @MainActor
     var displayName: String {
+        displayName(locale: .current)
+    }
+
+    /// Localized state label in an explicitly selected language. Status-bar
+    /// snapshots and previews must not mix this with the host's locale.
+    @MainActor
+    func displayName(locale: Locale) -> String {
         switch self {
-        case .idle: Strings.agentStateIdle
-        case .thinking: Strings.agentStateThinking
-        case .executing: Strings.agentStateExecuting
-        case .waitingInput: Strings.agentStateWaitingInput
-        case .done: Strings.agentStateDone
+        case .idle: Strings.agentStateIdle(locale: locale)
+        case .thinking: Strings.agentStateThinking(locale: locale)
+        case .executing: Strings.agentStateExecuting(locale: locale)
+        case .waitingInput: Strings.agentStateWaitingInput(locale: locale)
+        case .done: Strings.agentStateDone(locale: locale)
         }
     }
 

--- a/Pine/Agent/AgentModels.swift
+++ b/Pine/Agent/AgentModels.swift
@@ -217,6 +217,12 @@ final class AgentSession: Identifiable {
     /// When the session started.
     let startedAt: Date
 
+    /// Immutable evidence for the process generation backing this run. The
+    /// detector binds it once after creating the legacy session model; tests
+    /// and pre-#1302 migration may leave it absent. Evidence-free sessions
+    /// remain terminal-local and are never bridged into durable tasks.
+    private(set) var processEvidence: AgentProcessEvidence?
+
     /// Optional human-readable description of the task the agent is working on.
     var currentTask: String?
 
@@ -245,6 +251,7 @@ final class AgentSession: Identifiable {
         self.agentType = agentType
         self.state = state
         self.startedAt = startedAt
+        self.processEvidence = nil
         self.liveness = liveness
         self.lastObservedAt = observedAt
         self.lastObservationStamp = AgentObservationStamp(
@@ -256,6 +263,15 @@ final class AgentSession: Identifiable {
         self.currentTask = currentTask
         self.filesModified = filesModified
         self.filesRead = filesRead
+    }
+
+    /// Binds process identity exactly once. Reusing an `AgentSession` object for
+    /// a restarted command is forbidden; the detector must create a new run.
+    @discardableResult
+    func bindProcessEvidence(_ evidence: AgentProcessEvidence) -> Bool {
+        guard processEvidence == nil else { return false }
+        processEvidence = evidence
+        return true
     }
 
     /// Records a successful observation. Kept internal to centralize mutable

--- a/Pine/Agent/AgentStatusBarItem.swift
+++ b/Pine/Agent/AgentStatusBarItem.swift
@@ -227,7 +227,7 @@ extension AgentStatusSummary {
 
     @MainActor
     func detailText(locale: Locale) -> String {
-        let stateText = "\(agentType.displayName): \(state.displayName)"
+        let stateText = "\(agentType.displayName): \(state.displayName(locale: locale))"
         guard liveness != .live else { return stateText }
         return "\(stateText) — \(liveness.displayName(locale: locale))"
     }

--- a/Pine/Agent/AgentTaskMetadataStore.swift
+++ b/Pine/Agent/AgentTaskMetadataStore.swift
@@ -1266,9 +1266,9 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
                     &live,
                     AT_SYMLINK_NOFOLLOW
                 ) == 0
-                && samePrivateFile(opened, live)
-                && descriptorHasNoExtendedACL(descriptor)
-                && privateFileUnchanged(
+                && self.samePrivateFile(opened, live)
+                && self.descriptorHasNoExtendedACL(descriptor)
+                && self.privateFileUnchanged(
                     initialFinalIdentity,
                     name: fileName,
                     directoryDescriptor: directoryDescriptor
@@ -1283,7 +1283,7 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         }
         let publish = {
             guard canPublish() else { return false }
-            reportPhase(.beforeAtomicRename)
+            self.reportPhase(.beforeAtomicRename)
             guard canPublish() else { return false }
             return renameat(
                 directoryDescriptor,

--- a/Pine/Agent/AgentTaskMetadataStore.swift
+++ b/Pine/Agent/AgentTaskMetadataStore.swift
@@ -41,6 +41,7 @@ nonisolated enum AgentTaskStorePhase: Sendable {
     case lockAcquired
     case beforeReadOpen
     case readOpened
+    case beforeTemporaryCreate
     case temporaryWritten
     case beforePublish
     case beforeCleanupRetire
@@ -210,11 +211,14 @@ nonisolated enum AgentTaskPublicationDecision: Sendable {
     case superseded
 }
 
-/// Synchronous because the authorization lock must cover the final check and
-/// `renameat` as one publication transaction. The unchecked conformance wraps
-/// only NSLock-protected value state; it carries no UI or process references.
+/// The short state lock protects authorization and receipts. A separate
+/// publication lock serializes final renames, but generation advancement never
+/// waits for filesystem I/O: an operation that already passed its final check
+/// may finish and publish a receipt, while every later generation waits behind
+/// it and revalidates CAS before rename.
 nonisolated final class AgentTaskPublicationFence: @unchecked Sendable {
-    private let lock = NSLock()
+    private let stateLock = NSLock()
+    private let publicationLock = NSLock()
     private var generation: UUID
     private var latestTicketByProject: [String: AgentTaskPersistenceTicket] = [:]
     private var publishedRevisionByProject: [String: AgentTaskDiskRevision] = [:]
@@ -224,8 +228,8 @@ nonisolated final class AgentTaskPublicationFence: @unchecked Sendable {
     }
 
     func authorize(_ ticket: AgentTaskPersistenceTicket) {
-        lock.lock()
-        defer { lock.unlock() }
+        stateLock.lock()
+        defer { stateLock.unlock() }
         guard ticket.generation == generation else { return }
         if let latest = latestTicketByProject[ticket.projectKey],
            latest.sequence >= ticket.sequence {
@@ -236,29 +240,41 @@ nonisolated final class AgentTaskPublicationFence: @unchecked Sendable {
 
     @discardableResult
     func advance(to generation: UUID) -> [String: AgentTaskDiskRevision] {
-        lock.lock()
-        defer { lock.unlock() }
+        stateLock.lock()
+        defer { stateLock.unlock() }
         let published = publishedRevisionByProject
         self.generation = generation
         latestTicketByProject.removeAll(keepingCapacity: true)
-        publishedRevisionByProject.removeAll(keepingCapacity: true)
         return published
+    }
+
+    func publishedRevision(
+        for projectKey: String
+    ) -> AgentTaskDiskRevision? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return publishedRevisionByProject[projectKey]
     }
 
     fileprivate func publish(
         _ ticket: AgentTaskPersistenceTicket,
         operation: () -> Bool
     ) -> AgentTaskPublicationDecision {
-        lock.lock()
-        defer { lock.unlock() }
-        guard generation == ticket.generation,
-              latestTicketByProject[ticket.projectKey] == ticket else {
-            return .superseded
-        }
+        publicationLock.lock()
+        defer { publicationLock.unlock() }
+
+        stateLock.lock()
+        let isAuthorized = generation == ticket.generation
+            && latestTicketByProject[ticket.projectKey] == ticket
+        stateLock.unlock()
+        guard isAuthorized else { return .superseded }
         guard operation() else { return .failed }
+
+        stateLock.lock()
         publishedRevisionByProject[ticket.projectKey] = .versioned(
             ticket.nextDiskRevision
         )
+        stateLock.unlock()
         return .published
     }
 }
@@ -272,9 +288,17 @@ nonisolated struct AgentTaskPublicationAuthorization: Sendable {
         self.fence = fence
     }
 
-    func publish(operation: () -> Bool) -> AgentTaskPublicationDecision {
+    fileprivate func publish(operation: () -> Bool) -> AgentTaskPublicationDecision {
         fence.publish(ticket, operation: operation)
     }
+
+    #if DEBUG
+    func publishForTesting(
+        operation: () -> Bool
+    ) -> AgentTaskPublicationDecision {
+        publish(operation: operation)
+    }
+    #endif
 }
 
 nonisolated protocol AgentTaskPersisting: Sendable {
@@ -484,7 +508,16 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
             guard !Task.isCancelled else {
                 throw AgentTaskDirectoryError.superseded
             }
-            cleanupStaleTemporaryFiles(directoryDescriptor: storage.leaf)
+            cleanupStaleTemporaryFiles(
+                directoryDescriptor: storage.leaf,
+                verifyContext: {
+                    self.verifyStorageChain(storage)
+                        && self.verifyLock(
+                            lock,
+                            directoryDescriptor: storage.leaf
+                        )
+                }
+            )
             try secureAtomicWrite(
                 data,
                 fileName: fileURL.lastPathComponent,
@@ -500,7 +533,7 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
             )
             guard verifyStorageChain(storage),
                   verifyLock(lock, directoryDescriptor: storage.leaf) else {
-                throw AgentTaskDirectoryError.unsafe
+                throw AgentTaskDirectoryError.durabilityUnknownAfterPublication
             }
             return .saved(taskCount: bounded.count)
         } catch AgentTaskDirectoryError.unsafe {
@@ -583,7 +616,16 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
               verifyLock(lock, directoryDescriptor: storage.leaf) else {
             return rejectedLoad(.unsafeFilesystemObject)
         }
-        cleanupStaleTemporaryFiles(directoryDescriptor: storage.leaf)
+        cleanupStaleTemporaryFiles(
+            directoryDescriptor: storage.leaf,
+            verifyContext: {
+                self.verifyStorageChain(storage)
+                    && self.verifyLock(
+                        lock,
+                        directoryDescriptor: storage.leaf
+                    )
+            }
+        )
         let read = secureBoundedRead(
             fileName: fileURL.lastPathComponent,
             directoryDescriptor: storage.leaf
@@ -688,7 +730,8 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
     ) throws -> AgentTaskStorageHandle {
         let components = url.standardizedFileURL.pathComponents.dropFirst()
         let names = Array(components)
-        let privateCount = configuration.privateComponentCount ?? 1
+        let privateCount = configuration.privateComponentCount
+            ?? (storageRoot == nil ? 2 : 1)
         guard !names.isEmpty, (1...names.count).contains(privateCount) else {
             throw AgentTaskDirectoryError.unsafe
         }
@@ -986,6 +1029,8 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         }
         try enforceTombstoneCapacity(directoryDescriptor)
         let temporaryName = ".agent-tasks-\(UUID().uuidString).tmp"
+        reportPhase(.beforeTemporaryCreate)
+        guard verifyContext() else { throw AgentTaskDirectoryError.unsafe }
         let descriptor = openat(
             directoryDescriptor,
             temporaryName,
@@ -1005,7 +1050,8 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
                     temporaryName,
                     expectedDevice: UInt64(writerIdentity.st_dev),
                     expectedInode: UInt64(writerIdentity.st_ino),
-                    directoryDescriptor: directoryDescriptor
+                    directoryDescriptor: directoryDescriptor,
+                    verifyContext: verifyContext
                 )
             }
         }
@@ -1059,9 +1105,26 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
               ) else {
             throw AgentTaskDirectoryError.unsafe
         }
+        guard !Task.isCancelled,
+              verifyContext(),
+              fstat(descriptor, &opened) == 0,
+              fstatat(
+                directoryDescriptor,
+                temporaryName,
+                &live,
+                AT_SYMLINK_NOFOLLOW
+              ) == 0,
+              samePrivateFile(opened, live),
+              descriptorHasNoExtendedACL(descriptor),
+              privateFileUnchanged(
+                initialFinalIdentity,
+                name: fileName,
+                directoryDescriptor: directoryDescriptor
+              ) else {
+            throw AgentTaskDirectoryError.unsafe
+        }
         let publish = {
-            guard !Task.isCancelled,
-                  verifyContext(),
+            guard verifyContext(),
                   fstat(descriptor, &opened) == 0,
                   fstatat(
                     directoryDescriptor,
@@ -1075,7 +1138,14 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
                     initialFinalIdentity,
                     name: fileName,
                     directoryDescriptor: directoryDescriptor
-                  ) else {
+                  ),
+                  authorization.map({
+                    self.diskRevisionMatches(
+                        $0.ticket.expectedDiskRevision,
+                        fileName: fileName,
+                        directoryDescriptor: directoryDescriptor
+                    )
+                  }) ?? true else {
                 return false
             }
             return renameat(
@@ -1105,7 +1175,7 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
               ) == 0,
               samePrivateFile(opened, live),
               descriptorHasNoExtendedACL(descriptor) else {
-            throw AgentTaskDirectoryError.unsafe
+            throw AgentTaskDirectoryError.durabilityUnknownAfterPublication
         }
         guard durableSync(
             directoryDescriptor,
@@ -1113,7 +1183,9 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         ) else {
             throw AgentTaskDirectoryError.durabilityUnknownAfterPublication
         }
-        guard verifyContext() else { throw AgentTaskDirectoryError.unsafe }
+        guard verifyContext() else {
+            throw AgentTaskDirectoryError.durabilityUnknownAfterPublication
+        }
     }
 
     private func diskRevisionMatches(
@@ -1192,13 +1264,14 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         var scanned = 0
         var tombstones = 0
         while let entry = readdir(directory) {
-            scanned += 1
-            guard scanned <= configuration.cleanup.directoryEntryLimit else {
-                throw AgentTaskDirectoryError.storageLimit
-            }
             let name = withUnsafePointer(to: &entry.pointee.d_name) {
                 String(cString: UnsafeRawPointer($0)
                     .assumingMemoryBound(to: CChar.self))
+            }
+            guard name != ".", name != ".." else { continue }
+            scanned += 1
+            guard scanned < configuration.cleanup.directoryEntryLimit else {
+                throw AgentTaskDirectoryError.storageLimit
             }
             guard isCanonicalTemporaryName(name) else { continue }
             var info = stat()
@@ -1234,7 +1307,10 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         return parsed.uuidString == identifier.uppercased()
     }
 
-    private func cleanupStaleTemporaryFiles(directoryDescriptor: Int32) {
+    private func cleanupStaleTemporaryFiles(
+        directoryDescriptor: Int32,
+        verifyContext: () -> Bool
+    ) {
         var directoryInfo = stat()
         guard fstat(directoryDescriptor, &directoryInfo) == 0 else { return }
         let identity = AgentTaskCleanupDirectory(
@@ -1301,21 +1377,24 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         for candidate in ordered.prefix(configuration.cleanup.retireLimit) {
             retireCleanupCandidateIfUnchanged(
                 candidate,
-                directoryDescriptor: directoryDescriptor
+                directoryDescriptor: directoryDescriptor,
+                verifyContext: verifyContext
             )
         }
     }
 
     private func retireCleanupCandidateIfUnchanged(
         _ candidate: AgentTaskCleanupCandidate,
-        directoryDescriptor: Int32
+        directoryDescriptor: Int32,
+        verifyContext: () -> Bool
     ) {
         reportPhase(.beforeCleanupRetire)
         retirePrivateFileIfUnchanged(
             candidate.name,
             expectedDevice: candidate.device,
             expectedInode: candidate.inode,
-            directoryDescriptor: directoryDescriptor
+            directoryDescriptor: directoryDescriptor,
+            verifyContext: verifyContext
         )
     }
 
@@ -1323,7 +1402,8 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         _ fileName: String,
         expectedDevice: UInt64,
         expectedInode: UInt64,
-        directoryDescriptor: Int32
+        directoryDescriptor: Int32,
+        verifyContext: () -> Bool
     ) {
         let descriptor = openat(
             directoryDescriptor,
@@ -1348,7 +1428,8 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         reportPhase(.beforeRetireMutation)
         var finalOpened = stat()
         var finalLive = stat()
-        guard fstat(descriptor, &finalOpened) == 0,
+        guard verifyContext(),
+              fstat(descriptor, &finalOpened) == 0,
               fstatat(
                   directoryDescriptor,
                   fileName,
@@ -1359,17 +1440,29 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
               UInt64(finalOpened.st_ino) == expectedInode,
               exactPrivateIdentity(finalOpened, finalLive),
               descriptorHasNoExtendedACL(descriptor) else { return }
-        guard ftruncate(descriptor, 0) == 0 else { return }
+        guard ftruncate(descriptor, 0) == 0,
+              verifyContext(),
+              fstat(descriptor, &finalOpened) == 0,
+              fstatat(
+                directoryDescriptor,
+                fileName,
+                &finalLive,
+                AT_SYMLINK_NOFOLLOW
+              ) == 0,
+              UInt64(finalOpened.st_dev) == expectedDevice,
+              UInt64(finalOpened.st_ino) == expectedInode,
+              exactPrivateIdentity(finalOpened, finalLive),
+              descriptorHasNoExtendedACL(descriptor) else { return }
         _ = fchmod(descriptor, mode_t(0o000))
     }
 
     private func descriptorHasNoExtendedACL(_ descriptor: Int32) -> Bool {
+        errno = 0
         guard let acl = acl_get_fd_np(descriptor, ACL_TYPE_EXTENDED) else {
-            return false
+            return errno == 0 || errno == ENOENT
         }
-        defer { acl_free(acl) }
-        var entry: acl_entry_t?
-        return acl_get_entry(acl, ACL_FIRST_ENTRY, &entry) == 0
+        _ = acl_free(UnsafeMutableRawPointer(acl))
+        return false
     }
 
     private func sameObject(_ lhs: stat, _ rhs: stat) -> Bool {
@@ -1545,6 +1638,10 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
                   maximum: limits.maxAgentIdentifierBytes,
                   allowsEmpty: false
               ),
+              validOptionalExecutable(
+                  task.descriptor.launchExecutable,
+                  maximum: limits.maxAgentIdentifierBytes
+              ),
               validOptionalText(task.title, maximum: limits.maxTitleBytes),
               validOptionalText(
                   task.objective,
@@ -1651,6 +1748,22 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
             guard task.route.availability == .missing else { return false }
         }
         return true
+    }
+
+    private func validOptionalExecutable(
+        _ value: String?,
+        maximum: Int
+    ) -> Bool {
+        guard let value,
+              validText(value, maximum: maximum, allowsEmpty: false) else {
+            return value == nil
+        }
+        return value.utf8.allSatisfy { byte in
+            (byte >= 0x61 && byte <= 0x7A)
+                || (byte >= 0x30 && byte <= 0x39)
+                || byte == 0x2D
+                || byte == 0x5F
+        }
     }
 
     private func validOptionalText(

--- a/Pine/Agent/AgentTaskMetadataStore.swift
+++ b/Pine/Agent/AgentTaskMetadataStore.swift
@@ -44,6 +44,7 @@ nonisolated enum AgentTaskStorePhase: Sendable {
     case beforeTemporaryCreate
     case temporaryWritten
     case beforePublish
+    case beforeAtomicRename
     case beforeCleanupRetire
     case beforeRetireMutation
 }
@@ -485,6 +486,10 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
             guard verifyStorageChain(storage) else {
                 throw AgentTaskDirectoryError.unsafe
             }
+            try ensureLockEntryCapacity(
+                storage.leaf,
+                reservesWriterTemporary: true
+            )
             let lock = try acquireLock(storage.leaf)
             defer { releaseLock(lock) }
             reportPhase(.lockAcquired)
@@ -587,9 +592,15 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
             guard verifyStorageChain(storage) else {
                 throw AgentTaskDirectoryError.unsafe
             }
+            try ensureLockEntryCapacity(
+                storage.leaf,
+                reservesWriterTemporary: false
+            )
             lock = try acquireLock(storage.leaf)
         } catch AgentTaskDirectoryError.unsafe {
             return rejectedLoad(.unsafeFilesystemObject)
+        } catch AgentTaskDirectoryError.storageLimit {
+            return rejectedLoad(.storageLimit)
         } catch AgentTaskDirectoryError.lockContention {
             return rejectedLoad(.lockContention)
         } catch {
@@ -863,22 +874,72 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         return true
     }
 
+    private func ensureLockEntryCapacity(
+        _ directoryDescriptor: Int32,
+        reservesWriterTemporary: Bool
+    ) throws {
+        func exists(_ name: String) throws -> Bool {
+            var info = stat()
+            if fstatat(
+                directoryDescriptor,
+                name,
+                &info,
+                AT_SYMLINK_NOFOLLOW
+            ) == 0 {
+                return true
+            }
+            guard errno == ENOENT else {
+                throw AgentTaskDirectoryError.transient
+            }
+            return false
+        }
+        var pending = reservesWriterTemporary ? 1 : 0
+        if try !exists(".agent-tasks.lock") { pending += 1 }
+        if try !exists(".agent-tasks.lock.guard") { pending += 1 }
+        let duplicate = Darwin.dup(directoryDescriptor)
+        guard duplicate >= 0, let directory = fdopendir(duplicate) else {
+            if duplicate >= 0 { Darwin.close(duplicate) }
+            throw AgentTaskDirectoryError.transient
+        }
+        defer { closedir(directory) }
+        var entries = 0
+        while let entry = readdir(directory) {
+            let name = withUnsafePointer(to: &entry.pointee.d_name) {
+                String(cString: UnsafeRawPointer($0)
+                    .assumingMemoryBound(to: CChar.self))
+            }
+            guard name != ".", name != ".." else { continue }
+            entries += 1
+            guard entries <= configuration.cleanup.directoryEntryLimit else {
+                throw AgentTaskDirectoryError.storageLimit
+            }
+        }
+        guard pending <= configuration.cleanup.directoryEntryLimit,
+              entries <= configuration.cleanup.directoryEntryLimit - pending else {
+            throw AgentTaskDirectoryError.storageLimit
+        }
+    }
+
     private func acquireLock(_ directoryDescriptor: Int32) throws -> Int32 {
-        try preflightPrivateFile(
-            ".agent-tasks.lock",
-            directoryDescriptor: directoryDescriptor,
-            allowsMissing: true
-        )
         let descriptor = openat(
             directoryDescriptor,
             ".agent-tasks.lock",
-            O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW,
+            O_RDWR | O_CREAT | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW,
             mode_t(0o600)
         )
         guard descriptor >= 0 else {
             throw unsafeOpenError(errno)
                 ? AgentTaskDirectoryError.unsafe
                 : AgentTaskDirectoryError.transient
+        }
+        do {
+            try establishLockGuard(
+                descriptor,
+                directoryDescriptor: directoryDescriptor
+            )
+        } catch {
+            Darwin.close(descriptor)
+            throw error
         }
         guard verifyLock(descriptor, directoryDescriptor: directoryDescriptor) else {
             Darwin.close(descriptor)
@@ -903,16 +964,89 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         return descriptor
     }
 
+    private func establishLockGuard(
+        _ descriptor: Int32,
+        directoryDescriptor: Int32
+    ) throws {
+        var opened = stat()
+        guard fstat(descriptor, &opened) == 0,
+              opened.st_uid == getuid(),
+              (opened.st_mode & S_IFMT) == S_IFREG,
+              (opened.st_mode & 0o777) == 0o600,
+              opened.st_nlink == 1 || opened.st_nlink == 2,
+              descriptorHasNoExtendedACL(descriptor) else {
+            throw AgentTaskDirectoryError.unsafe
+        }
+        var guardIdentity = stat()
+        if fstatat(
+            directoryDescriptor,
+            ".agent-tasks.lock.guard",
+            &guardIdentity,
+            AT_SYMLINK_NOFOLLOW
+        ) == 0 {
+            guard verifyLock(
+                descriptor,
+                directoryDescriptor: directoryDescriptor
+            ) else { throw AgentTaskDirectoryError.unsafe }
+            return
+        }
+        guard errno == ENOENT, opened.st_nlink == 1 else {
+            throw AgentTaskDirectoryError.unsafe
+        }
+        let linked = linkat(
+            directoryDescriptor,
+            ".agent-tasks.lock",
+            directoryDescriptor,
+            ".agent-tasks.lock.guard",
+            0
+        ) == 0
+        if !linked, errno != EEXIST {
+            throw unsafeOpenError(errno)
+                ? AgentTaskDirectoryError.unsafe
+                : AgentTaskDirectoryError.transient
+        }
+        guard verifyLock(
+            descriptor,
+            directoryDescriptor: directoryDescriptor
+        ) else { throw AgentTaskDirectoryError.unsafe }
+        if linked, !durableSync(
+            directoryDescriptor,
+            target: .storageDirectory
+        ) {
+            throw AgentTaskDirectoryError.durabilityUnknown
+        }
+    }
+
     private func verifyLock(
         _ descriptor: Int32,
         directoryDescriptor: Int32
     ) -> Bool {
         var opened = stat()
         var live = stat()
+        var guardIdentity = stat()
         return fstat(descriptor, &opened) == 0
             && fstatat(directoryDescriptor, ".agent-tasks.lock", &live,
                        AT_SYMLINK_NOFOLLOW) == 0
-            && samePrivateFile(opened, live)
+            && fstatat(
+                directoryDescriptor,
+                ".agent-tasks.lock.guard",
+                &guardIdentity,
+                AT_SYMLINK_NOFOLLOW
+            ) == 0
+            && sameObject(opened, live)
+            && sameObject(opened, guardIdentity)
+            && opened.st_uid == getuid()
+            && live.st_uid == getuid()
+            && guardIdentity.st_uid == getuid()
+            && opened.st_nlink == 2
+            && live.st_nlink == 2
+            && guardIdentity.st_nlink == 2
+            && (opened.st_mode & S_IFMT) == S_IFREG
+            && (live.st_mode & S_IFMT) == S_IFREG
+            && (guardIdentity.st_mode & S_IFMT) == S_IFREG
+            && (opened.st_mode & 0o777) == 0o600
+            && (live.st_mode & 0o777) == 0o600
+            && (guardIdentity.st_mode & 0o777) == 0o600
             && descriptorHasNoExtendedACL(descriptor)
     }
 
@@ -1123,31 +1257,34 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
               ) else {
             throw AgentTaskDirectoryError.unsafe
         }
-        let publish = {
-            guard verifyContext(),
-                  fstat(descriptor, &opened) == 0,
-                  fstatat(
+        let canPublish = {
+            verifyContext()
+                && fstat(descriptor, &opened) == 0
+                && fstatat(
                     directoryDescriptor,
                     temporaryName,
                     &live,
                     AT_SYMLINK_NOFOLLOW
-                  ) == 0,
-                  samePrivateFile(opened, live),
-                  descriptorHasNoExtendedACL(descriptor),
-                  privateFileUnchanged(
+                ) == 0
+                && samePrivateFile(opened, live)
+                && descriptorHasNoExtendedACL(descriptor)
+                && privateFileUnchanged(
                     initialFinalIdentity,
                     name: fileName,
                     directoryDescriptor: directoryDescriptor
-                  ),
-                  authorization.map({
+                )
+                && (authorization.map({
                     self.diskRevisionMatches(
                         $0.ticket.expectedDiskRevision,
                         fileName: fileName,
                         directoryDescriptor: directoryDescriptor
                     )
-                  }) ?? true else {
-                return false
-            }
+                }) ?? true)
+        }
+        let publish = {
+            guard canPublish() else { return false }
+            reportPhase(.beforeAtomicRename)
+            guard canPublish() else { return false }
             return renameat(
                 directoryDescriptor,
                 temporaryName,

--- a/Pine/Agent/AgentTaskMetadataStore.swift
+++ b/Pine/Agent/AgentTaskMetadataStore.swift
@@ -1145,7 +1145,7 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         fileName: String,
         directoryDescriptor: Int32,
         authorization: AgentTaskPublicationAuthorization?,
-        verifyContext: () -> Bool
+        verifyContext: @escaping () -> Bool
     ) throws {
         guard verifyContext() else { throw AgentTaskDirectoryError.unsafe }
         let initialFinalIdentity = try existingPrivateFileIdentity(
@@ -1258,15 +1258,17 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
             throw AgentTaskDirectoryError.unsafe
         }
         let canPublish = {
-            verifyContext()
-                && fstat(descriptor, &opened) == 0
+            var openedAtPublish = stat()
+            var liveAtPublish = stat()
+            return verifyContext()
+                && fstat(descriptor, &openedAtPublish) == 0
                 && fstatat(
                     directoryDescriptor,
                     temporaryName,
-                    &live,
+                    &liveAtPublish,
                     AT_SYMLINK_NOFOLLOW
                 ) == 0
-                && self.samePrivateFile(opened, live)
+                && self.samePrivateFile(openedAtPublish, liveAtPublish)
                 && self.descriptorHasNoExtendedACL(descriptor)
                 && self.privateFileUnchanged(
                     initialFinalIdentity,

--- a/Pine/Agent/AgentTaskMetadataStore.swift
+++ b/Pine/Agent/AgentTaskMetadataStore.swift
@@ -88,9 +88,9 @@ nonisolated struct AgentTaskStoreHooks: Sendable {
     let shouldSync: @Sendable (AgentTaskSyncTarget) -> Bool
 
     init(
+        phase: @escaping @Sendable (AgentTaskStorePhase) -> Void = { _ in },
         didSync: @escaping @Sendable (AgentTaskSyncTarget) -> Void = { _ in },
-        shouldSync: @escaping @Sendable (AgentTaskSyncTarget) -> Bool = { _ in true },
-        phase: @escaping @Sendable (AgentTaskStorePhase) -> Void = { _ in }
+        shouldSync: @escaping @Sendable (AgentTaskSyncTarget) -> Bool = { _ in true }
     ) {
         self.phase = phase
         self.didSync = didSync

--- a/Pine/Agent/AgentTaskMetadataStore.swift
+++ b/Pine/Agent/AgentTaskMetadataStore.swift
@@ -760,10 +760,10 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         }
         for (componentIndex, component) in names.enumerated() {
             var created = false
-            var next = openat(
-                descriptor,
+            var next = openDirectoryComponent(
                 component,
-                O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW
+                relativeTo: descriptor,
+                allowsSystemRedirect: componentIndex < privateComponentStart
             )
             if next < 0, errno == ENOENT, create {
                 guard componentIndex >= privateComponentStart,
@@ -785,10 +785,10 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
                 ) else {
                     throw AgentTaskDirectoryError.durabilityUnknown
                 }
-                next = openat(
-                    descriptor,
+                next = openDirectoryComponent(
                     component,
-                    O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW
+                    relativeTo: descriptor,
+                    allowsSystemRedirect: false
                 )
             }
             guard next >= 0 else {
@@ -804,7 +804,13 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
             guard fstat(next, &opened) == 0,
                   fstatat(descriptors[descriptors.count - 2], component, &live,
                           AT_SYMLINK_NOFOLLOW) == 0,
-                  sameObject(opened, live) else {
+                  sameDirectoryComponent(
+                      opened,
+                      live,
+                      name: component,
+                      parentDescriptor: descriptors[descriptors.count - 2],
+                      allowsSystemRedirect: componentIndex < privateComponentStart
+                  ) else {
                 throw AgentTaskDirectoryError.unsafe
             }
             if componentIndex >= privateComponentStart {
@@ -838,6 +844,92 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         )
     }
 
+    /// Inside the Xcode 27 test-host sandbox, `O_NOFOLLOW` sees the
+    /// system-protected `/private/var` redirect and rejects it as `ENOTDIR`.
+    /// Every user-controlled and private component stays no-follow.
+    private func openDirectoryComponent(
+        _ name: String,
+        relativeTo parentDescriptor: Int32,
+        allowsSystemRedirect: Bool
+    ) -> Int32 {
+        let flags = O_RDONLY | O_DIRECTORY | O_CLOEXEC
+        let descriptor = openat(
+            parentDescriptor,
+            name,
+            flags | O_NOFOLLOW
+        )
+        guard descriptor < 0,
+              errno == ENOTDIR,
+              allowsSystemRedirect else {
+            return descriptor
+        }
+
+        var info = stat()
+        guard fstatat(
+            parentDescriptor,
+            name,
+            &info,
+            AT_SYMLINK_NOFOLLOW
+        ) == 0,
+        isSystemProtectedDirectoryRedirect(
+            info,
+            name: name,
+            parentDescriptor: parentDescriptor
+        ) else {
+            errno = ENOTDIR
+            return -1
+        }
+        return openat(parentDescriptor, name, flags)
+    }
+
+    private func sameDirectoryComponent(
+        _ opened: stat,
+        _ live: stat,
+        name: String,
+        parentDescriptor: Int32,
+        allowsSystemRedirect: Bool
+    ) -> Bool {
+        if sameObject(opened, live) { return true }
+        return allowsSystemRedirect
+            && opened.st_uid == 0
+            && (opened.st_mode & S_IFMT) == S_IFDIR
+            && (opened.st_flags & UInt32(SF_NOUNLINK)) != 0
+            && isSystemProtectedDirectoryRedirect(
+                live,
+                name: name,
+                parentDescriptor: parentDescriptor
+            )
+    }
+
+    private func isSystemProtectedDirectoryRedirect(
+        _ info: stat,
+        name: String,
+        parentDescriptor: Int32
+    ) -> Bool {
+        guard name == "var",
+              info.st_uid == 0,
+              (info.st_mode & S_IFMT) == S_IFLNK,
+              (info.st_flags & UInt32(SF_RESTRICTED)) != 0 else {
+            return false
+        }
+        var parent = stat()
+        guard fstat(parentDescriptor, &parent) == 0,
+              parent.st_uid == 0,
+              (parent.st_mode & S_IFMT) == S_IFDIR,
+              (parent.st_flags & UInt32(SF_NOUNLINK)) != 0 else {
+            return false
+        }
+        var target = [CChar](repeating: 0, count: Int(PATH_MAX))
+        let count = readlinkat(
+            parentDescriptor,
+            name,
+            &target,
+            target.count - 1
+        )
+        guard count >= 0 else { return false }
+        return String(cString: target) == "private/var"
+    }
+
     private func verifyStorageChain(_ storage: AgentTaskStorageHandle) -> Bool {
         verifyDescriptorLinks(
             descriptors: storage.descriptors,
@@ -860,7 +952,14 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
                 guard fstatat(
                     descriptors[index - 1], names[index - 1], &live,
                     AT_SYMLINK_NOFOLLOW
-                ) == 0, sameObject(opened, live) else { return false }
+                ) == 0,
+                sameDirectoryComponent(
+                    opened,
+                    live,
+                    name: names[index - 1],
+                    parentDescriptor: descriptors[index - 1],
+                    allowsSystemRedirect: index < privateDescriptorStart
+                ) else { return false }
             }
             if index >= privateDescriptorStart {
                 guard opened.st_uid == getuid(),
@@ -896,9 +995,15 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         var pending = reservesWriterTemporary ? 1 : 0
         if try !exists(".agent-tasks.lock") { pending += 1 }
         if try !exists(".agent-tasks.lock.guard") { pending += 1 }
-        let duplicate = Darwin.dup(directoryDescriptor)
-        guard duplicate >= 0, let directory = fdopendir(duplicate) else {
-            if duplicate >= 0 { Darwin.close(duplicate) }
+        // `dup` would share the directory offset and leave later scans at EOF.
+        let streamDescriptor = openat(
+            directoryDescriptor,
+            ".",
+            O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW
+        )
+        guard streamDescriptor >= 0,
+              let directory = fdopendir(streamDescriptor) else {
+            if streamDescriptor >= 0 { Darwin.close(streamDescriptor) }
             throw AgentTaskDirectoryError.transient
         }
         defer { closedir(directory) }
@@ -1394,9 +1499,15 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
     private func enforceTombstoneCapacity(
         _ directoryDescriptor: Int32
     ) throws {
-        let duplicate = Darwin.dup(directoryDescriptor)
-        guard duplicate >= 0, let directory = fdopendir(duplicate) else {
-            if duplicate >= 0 { Darwin.close(duplicate) }
+        // Use an independent open file description for every directory scan.
+        let streamDescriptor = openat(
+            directoryDescriptor,
+            ".",
+            O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW
+        )
+        guard streamDescriptor >= 0,
+              let directory = fdopendir(streamDescriptor) else {
+            if streamDescriptor >= 0 { Darwin.close(streamDescriptor) }
             throw AgentTaskDirectoryError.transient
         }
         defer { closedir(directory) }
@@ -1456,13 +1567,35 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
             device: UInt64(directoryInfo.st_dev),
             inode: UInt64(directoryInfo.st_ino)
         )
-        guard let directory = fdopendir(dup(directoryDescriptor)) else { return }
+        // Xcode 27 test hosts can report a zero `telldir` cookie for every
+        // entry, so retain a portable ordinal within the already capped dir.
+        let streamDescriptor = openat(
+            directoryDescriptor,
+            ".",
+            O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW
+        )
+        guard streamDescriptor >= 0,
+              let directory = fdopendir(streamDescriptor) else {
+            if streamDescriptor >= 0 { Darwin.close(streamDescriptor) }
+            return
+        }
         defer { closedir(directory) }
-        if let cursor = cleanupCursorByDirectory[identity], cursor > 0 {
-            seekdir(directory, cursor)
+        let cursor = max(0, cleanupCursorByDirectory[identity] ?? 0)
+        var skipped = 0
+        var reachedEnd = false
+        while skipped < cursor {
+            guard let entry = readdir(directory) else {
+                reachedEnd = true
+                break
+            }
+            let name = withUnsafePointer(to: &entry.pointee.d_name) {
+                String(cString: UnsafeRawPointer($0)
+                    .assumingMemoryBound(to: CChar.self))
+            }
+            guard name != ".", name != ".." else { continue }
+            skipped += 1
         }
         var scanned = 0
-        var reachedEnd = false
         var candidates: [AgentTaskCleanupCandidate] = []
         let staleBefore = configuration.cleanup.now().timeIntervalSince1970
             - configuration.cleanup.staleAge
@@ -1471,11 +1604,12 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
                 reachedEnd = true
                 break
             }
-            scanned += 1
             let name = withUnsafePointer(to: &entry.pointee.d_name) {
                 String(cString: UnsafeRawPointer($0)
                     .assumingMemoryBound(to: CChar.self))
             }
+            guard name != ".", name != ".." else { continue }
+            scanned += 1
             guard isCanonicalTemporaryName(name) else { continue }
             var info = stat()
             guard fstatat(
@@ -1502,7 +1636,7 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
         if reachedEnd {
             cleanupCursorByDirectory[identity] = 0
         } else {
-            cleanupCursorByDirectory[identity] = max(0, telldir(directory))
+            cleanupCursorByDirectory[identity] = cursor + scanned
         }
         let ordered = candidates.sorted { lhs, rhs in
             if lhs.modifiedSeconds != rhs.modifiedSeconds {

--- a/Pine/Agent/AgentTaskMetadataStore.swift
+++ b/Pine/Agent/AgentTaskMetadataStore.swift
@@ -1,0 +1,1725 @@
+//
+//  AgentTaskMetadataStore.swift
+//  Pine
+//
+//  Bounded, project-scoped durable task metadata (#1302).
+//
+
+import CryptoKit
+import Darwin
+import Foundation
+
+nonisolated struct AgentTaskPersistenceLimits: Sendable {
+    let maxTasksPerProject: Int
+    let maxRunsPerTask: Int
+    let maxHistoricalRunIDs: Int
+    let maxFileBytes: Int
+    let maxAgentIdentifierBytes: Int
+    let maxProcessStartBytes: Int
+    let maxTitleBytes: Int
+    let maxObjectiveBytes: Int
+
+    init(
+        maxTasksPerProject: Int = 200,
+        maxRunsPerTask: Int = 50,
+        maxHistoricalRunIDs: Int = 8_192,
+        maxFileBytes: Int = 1_048_576
+    ) {
+        self.maxTasksPerProject = max(1, maxTasksPerProject)
+        self.maxRunsPerTask = max(1, maxRunsPerTask)
+        self.maxHistoricalRunIDs = max(1, maxHistoricalRunIDs)
+        self.maxFileBytes = max(1_024, maxFileBytes)
+        maxAgentIdentifierBytes = 128
+        maxProcessStartBytes = 512
+        maxTitleBytes = 256
+        maxObjectiveBytes = 2_048
+    }
+}
+
+nonisolated enum AgentTaskStorePhase: Sendable {
+    case directoryOpened
+    case lockAcquired
+    case beforeReadOpen
+    case readOpened
+    case temporaryWritten
+    case beforePublish
+    case beforeCleanupRetire
+    case beforeRetireMutation
+}
+
+nonisolated enum AgentTaskSyncTarget: Hashable, Sendable {
+    case parentDirectory
+    case createdDirectory
+    case metadataFile
+    case storageDirectory
+}
+
+nonisolated struct AgentTaskCleanupConfiguration: Sendable {
+    let staleAge: TimeInterval
+    let scanLimit: Int
+    let retireLimit: Int
+    let tombstoneLimit: Int
+    let directoryEntryLimit: Int
+    let now: @Sendable () -> Date
+
+    init(
+        staleAge: TimeInterval = 3_600,
+        scanLimit: Int = 256,
+        retireLimit: Int = 32,
+        tombstoneLimit: Int = 64,
+        directoryEntryLimit: Int = 4_096,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.staleAge = max(0, staleAge)
+        self.scanLimit = max(1, scanLimit)
+        self.retireLimit = max(0, retireLimit)
+        self.tombstoneLimit = max(1, tombstoneLimit)
+        self.directoryEntryLimit = max(self.tombstoneLimit, max(1, directoryEntryLimit))
+        self.now = now
+    }
+}
+
+#if DEBUG
+nonisolated struct AgentTaskStoreHooks: Sendable {
+    let phase: @Sendable (AgentTaskStorePhase) -> Void
+    let didSync: @Sendable (AgentTaskSyncTarget) -> Void
+    let shouldSync: @Sendable (AgentTaskSyncTarget) -> Bool
+
+    init(
+        didSync: @escaping @Sendable (AgentTaskSyncTarget) -> Void = { _ in },
+        shouldSync: @escaping @Sendable (AgentTaskSyncTarget) -> Bool = { _ in true },
+        phase: @escaping @Sendable (AgentTaskStorePhase) -> Void = { _ in }
+    ) {
+        self.phase = phase
+        self.didSync = didSync
+        self.shouldSync = shouldSync
+    }
+}
+#endif
+
+nonisolated struct AgentTaskStoreConfiguration: Sendable {
+    let privateComponentCount: Int?
+    let cleanup: AgentTaskCleanupConfiguration
+    #if DEBUG
+    let hooks: AgentTaskStoreHooks
+    #endif
+
+    #if DEBUG
+    init(
+        privateComponentCount: Int? = nil,
+        cleanup: AgentTaskCleanupConfiguration = AgentTaskCleanupConfiguration(),
+        hooks: AgentTaskStoreHooks = AgentTaskStoreHooks()
+    ) {
+        self.privateComponentCount = privateComponentCount
+        self.cleanup = cleanup
+        self.hooks = hooks
+    }
+    #else
+    init(
+        privateComponentCount: Int? = nil,
+        cleanup: AgentTaskCleanupConfiguration = AgentTaskCleanupConfiguration()
+    ) {
+        self.privateComponentCount = privateComponentCount
+        self.cleanup = cleanup
+    }
+    #endif
+}
+
+nonisolated enum AgentTaskMetadataRejection: Error, Equatable, Sendable {
+    case corrupt
+    case unknownSchema
+    case missingProject
+    case invalidMetadata
+    case storageLimit
+    case ioFailure
+    case unsafeFilesystemObject
+    case lockContention
+    case transientIO
+    case durabilityUnknown
+    case concurrentMutation
+    case superseded
+}
+
+nonisolated enum AgentTaskMetadataSaveResult: Equatable, Sendable {
+    case saved(taskCount: Int)
+    case publishedButDurabilityUnknown(taskCount: Int, revision: UUID)
+    case rejected(AgentTaskMetadataRejection)
+
+    var isDurablySaved: Bool {
+        if case .saved = self { return true }
+        return false
+    }
+}
+
+nonisolated enum AgentTaskMetadataLoadStatus: Equatable, Sendable {
+    case missing
+    case loaded
+    case loadedWithMissingWorktrees(Int)
+    case rejected(AgentTaskMetadataRejection)
+}
+
+nonisolated enum AgentTaskDiskRevision: Equatable, Hashable, Sendable {
+    case versioned(UUID)
+    case legacySHA256(Data)
+}
+
+nonisolated struct AgentTaskMetadataLoadResult: Sendable {
+    let status: AgentTaskMetadataLoadStatus
+    let tasks: [AgentTask]
+    let revision: AgentTaskDiskRevision?
+    let requiresMigration: Bool
+
+    init(
+        status: AgentTaskMetadataLoadStatus,
+        tasks: [AgentTask],
+        revision: AgentTaskDiskRevision? = nil,
+        requiresMigration: Bool = false
+    ) {
+        self.status = status
+        self.tasks = tasks
+        self.revision = revision
+        self.requiresMigration = requiresMigration
+    }
+}
+
+nonisolated struct AgentTaskPersistenceTicket: Equatable, Hashable, Sendable {
+    let generation: UUID
+    let sequence: UInt64
+    let projectKey: String
+    let expectedDiskRevision: AgentTaskDiskRevision?
+    let nextDiskRevision: UUID
+
+    init(
+        generation: UUID,
+        sequence: UInt64,
+        projectKey: String,
+        expectedDiskRevision: AgentTaskDiskRevision? = nil,
+        nextDiskRevision: UUID = UUID()
+    ) {
+        self.generation = generation
+        self.sequence = sequence
+        self.projectKey = projectKey
+        self.expectedDiskRevision = expectedDiskRevision
+        self.nextDiskRevision = nextDiskRevision
+    }
+}
+
+nonisolated enum AgentTaskPublicationDecision: Sendable {
+    case published
+    case failed
+    case superseded
+}
+
+/// Synchronous because the authorization lock must cover the final check and
+/// `renameat` as one publication transaction. The unchecked conformance wraps
+/// only NSLock-protected value state; it carries no UI or process references.
+nonisolated final class AgentTaskPublicationFence: @unchecked Sendable {
+    private let lock = NSLock()
+    private var generation: UUID
+    private var latestTicketByProject: [String: AgentTaskPersistenceTicket] = [:]
+    private var publishedRevisionByProject: [String: AgentTaskDiskRevision] = [:]
+
+    init(generation: UUID) {
+        self.generation = generation
+    }
+
+    func authorize(_ ticket: AgentTaskPersistenceTicket) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard ticket.generation == generation else { return }
+        if let latest = latestTicketByProject[ticket.projectKey],
+           latest.sequence >= ticket.sequence {
+            return
+        }
+        latestTicketByProject[ticket.projectKey] = ticket
+    }
+
+    @discardableResult
+    func advance(to generation: UUID) -> [String: AgentTaskDiskRevision] {
+        lock.lock()
+        defer { lock.unlock() }
+        let published = publishedRevisionByProject
+        self.generation = generation
+        latestTicketByProject.removeAll(keepingCapacity: true)
+        publishedRevisionByProject.removeAll(keepingCapacity: true)
+        return published
+    }
+
+    fileprivate func publish(
+        _ ticket: AgentTaskPersistenceTicket,
+        operation: () -> Bool
+    ) -> AgentTaskPublicationDecision {
+        lock.lock()
+        defer { lock.unlock() }
+        guard generation == ticket.generation,
+              latestTicketByProject[ticket.projectKey] == ticket else {
+            return .superseded
+        }
+        guard operation() else { return .failed }
+        publishedRevisionByProject[ticket.projectKey] = .versioned(
+            ticket.nextDiskRevision
+        )
+        return .published
+    }
+}
+
+nonisolated struct AgentTaskPublicationAuthorization: Sendable {
+    let ticket: AgentTaskPersistenceTicket
+    fileprivate let fence: AgentTaskPublicationFence
+
+    init(ticket: AgentTaskPersistenceTicket, fence: AgentTaskPublicationFence) {
+        self.ticket = ticket
+        self.fence = fence
+    }
+
+    func publish(operation: () -> Bool) -> AgentTaskPublicationDecision {
+        fence.publish(ticket, operation: operation)
+    }
+}
+
+nonisolated protocol AgentTaskPersisting: Sendable {
+    func save(
+        tasks: [AgentTask],
+        project: AgentTaskProjectIdentity,
+        authorization: AgentTaskPublicationAuthorization?
+    ) async -> AgentTaskMetadataSaveResult
+
+    func load(
+        project: AgentTaskProjectIdentity
+    ) async -> AgentTaskMetadataLoadResult
+}
+
+nonisolated extension AgentTaskPersisting {
+    func save(
+        tasks: [AgentTask],
+        project: AgentTaskProjectIdentity
+    ) async -> AgentTaskMetadataSaveResult {
+        await save(tasks: tasks, project: project, authorization: nil)
+    }
+}
+
+nonisolated private struct AgentTaskMetadataHeader: Decodable, Sendable {
+    let schemaVersion: Int
+    let revision: UUID?
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case revision
+    }
+}
+
+nonisolated private struct AgentTaskMetadataEnvelope: Codable, Sendable {
+    let schemaVersion: Int
+    let revision: UUID
+    let canonicalProjectPath: String
+    let canonicalWorktreePath: String
+    let tasks: [AgentTask]
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case revision
+        case canonicalProjectPath
+        case canonicalWorktreePath
+        case tasks
+    }
+}
+
+nonisolated private struct AgentTaskLegacyMetadataEnvelope: Decodable, Sendable {
+    let schemaVersion: Int
+    let canonicalProjectPath: String
+    let canonicalWorktreePath: String
+    let tasks: [AgentTask]
+}
+
+nonisolated private enum AgentTaskSecureReadResult: Sendable {
+    case data(Data)
+    case missing
+    case rejected(AgentTaskMetadataRejection)
+}
+
+nonisolated private enum AgentTaskDirectoryError: Error, Sendable {
+    case missing
+    case unsafe
+    case transient
+    case durabilityUnknown
+    case durabilityUnknownAfterPublication
+    case lockContention
+    case superseded
+    case storageLimit
+}
+
+nonisolated private struct AgentTaskCleanupDirectory: Hashable, Sendable {
+    let device: UInt64
+    let inode: UInt64
+}
+
+nonisolated private struct AgentTaskCleanupCandidate: Sendable {
+    let name: String
+    let device: UInt64
+    let inode: UInt64
+    let modifiedSeconds: Int64
+    let modifiedNanoseconds: Int64
+}
+
+nonisolated private final class AgentTaskStorageHandle {
+    let descriptors: [Int32]
+    let componentNames: [String]
+    let privateDescriptorStart: Int
+
+    init(
+        descriptors: [Int32],
+        componentNames: [String],
+        privateDescriptorStart: Int
+    ) {
+        self.descriptors = descriptors
+        self.componentNames = componentNames
+        self.privateDescriptorStart = privateDescriptorStart
+    }
+
+    var leaf: Int32 { descriptors[descriptors.count - 1] }
+
+    deinit {
+        for descriptor in descriptors.reversed() { Darwin.close(descriptor) }
+    }
+}
+
+/// Serializes all metadata I/O away from MainActor. Files are scoped by a hash
+/// of the canonical project path and contain value metadata only.
+actor AgentTaskMetadataStore: AgentTaskPersisting {
+    static let currentSchemaVersion = 2
+    private static let directoryName = ".pine-agent-tasks-private"
+
+    private let storageRoot: URL?
+    private let limits: AgentTaskPersistenceLimits
+    private let configuration: AgentTaskStoreConfiguration
+    private let fileManager = FileManager()
+    private var cleanupCursorByDirectory: [AgentTaskCleanupDirectory: Int] = [:]
+
+    init(
+        storageRoot: URL? = nil,
+        limits: AgentTaskPersistenceLimits = AgentTaskPersistenceLimits(),
+        configuration: AgentTaskStoreConfiguration = AgentTaskStoreConfiguration()
+    ) {
+        self.storageRoot = storageRoot
+        self.limits = limits
+        self.configuration = configuration
+    }
+
+    nonisolated static func metadataURL(
+        for project: AgentTaskProjectIdentity,
+        storageRoot: URL
+    ) -> URL {
+        let digest = SHA256.hash(
+            data: Data(project.persistenceKey.utf8)
+        )
+        let fileName = digest.prefix(16)
+            .map { String(format: "%02x", $0) }
+            .joined() + ".json"
+        return storageRoot.appendingPathComponent(fileName)
+    }
+
+    func save(
+        tasks: [AgentTask],
+        project: AgentTaskProjectIdentity,
+        authorization: AgentTaskPublicationAuthorization?
+    ) -> AgentTaskMetadataSaveResult {
+        guard !Task.isCancelled else { return .rejected(.superseded) }
+        guard canonicalExistingDirectory(project.canonicalProjectPath)
+                == project.canonicalProjectPath else {
+            return .rejected(.missingProject)
+        }
+        let bounded: [AgentTask]
+        switch boundedTasks(tasks, project: project) {
+        case .success(let value): bounded = value
+        case .failure(let rejection): return .rejected(rejection)
+        }
+        let nextDiskRevision = authorization?.ticket.nextDiskRevision ?? UUID()
+        let envelope = AgentTaskMetadataEnvelope(
+            schemaVersion: Self.currentSchemaVersion,
+            revision: nextDiskRevision,
+            canonicalProjectPath: project.canonicalProjectPath,
+            canonicalWorktreePath: project.canonicalWorktreePath,
+            tasks: bounded
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .millisecondsSince1970
+        encoder.outputFormatting = [.sortedKeys]
+        guard var data = try? encoder.encode(envelope) else {
+            return .rejected(.invalidMetadata)
+        }
+        data.append(0x0A)
+        guard data.count <= limits.maxFileBytes else {
+            return .rejected(.storageLimit)
+        }
+
+        do {
+            let directory = resolvedStorageRoot()
+            let storage = try openStorageDirectory(
+                directory,
+                create: true
+            )
+            guard verifyStorageChain(storage) else {
+                throw AgentTaskDirectoryError.unsafe
+            }
+            let lock = try acquireLock(storage.leaf)
+            defer { releaseLock(lock) }
+            reportPhase(.lockAcquired)
+            guard verifyStorageChain(storage),
+                  verifyLock(lock, directoryDescriptor: storage.leaf) else {
+                throw AgentTaskDirectoryError.unsafe
+            }
+            let fileURL = Self.metadataURL(
+                for: project,
+                storageRoot: directory
+            )
+            try preflightPrivateFile(
+                fileURL.lastPathComponent,
+                directoryDescriptor: storage.leaf,
+                allowsMissing: true
+            )
+            guard verifyStorageChain(storage),
+                  verifyLock(lock, directoryDescriptor: storage.leaf) else {
+                throw AgentTaskDirectoryError.unsafe
+            }
+            guard !Task.isCancelled else {
+                throw AgentTaskDirectoryError.superseded
+            }
+            cleanupStaleTemporaryFiles(directoryDescriptor: storage.leaf)
+            try secureAtomicWrite(
+                data,
+                fileName: fileURL.lastPathComponent,
+                directoryDescriptor: storage.leaf,
+                authorization: authorization,
+                verifyContext: {
+                    self.verifyStorageChain(storage)
+                        && self.verifyLock(
+                            lock,
+                            directoryDescriptor: storage.leaf
+                        )
+                }
+            )
+            guard verifyStorageChain(storage),
+                  verifyLock(lock, directoryDescriptor: storage.leaf) else {
+                throw AgentTaskDirectoryError.unsafe
+            }
+            return .saved(taskCount: bounded.count)
+        } catch AgentTaskDirectoryError.unsafe {
+            return .rejected(.unsafeFilesystemObject)
+        } catch AgentTaskDirectoryError.durabilityUnknown {
+            return .rejected(.durabilityUnknown)
+        } catch AgentTaskDirectoryError.durabilityUnknownAfterPublication {
+            return .publishedButDurabilityUnknown(
+                taskCount: bounded.count,
+                revision: nextDiskRevision
+            )
+        } catch AgentTaskDirectoryError.superseded {
+            return .rejected(.superseded)
+        } catch AgentTaskDirectoryError.storageLimit {
+            return .rejected(.storageLimit)
+        } catch AgentTaskDirectoryError.lockContention {
+            return .rejected(.lockContention)
+        } catch AgentTaskDirectoryError.transient {
+            return .rejected(.transientIO)
+        } catch {
+            return .rejected(.transientIO)
+        }
+    }
+
+    func load(
+        project: AgentTaskProjectIdentity
+    ) -> AgentTaskMetadataLoadResult {
+        guard canonicalExistingDirectory(project.canonicalProjectPath)
+                == project.canonicalProjectPath else {
+            return rejectedLoad(.missingProject)
+        }
+        let fileURL = Self.metadataURL(
+            for: project,
+            storageRoot: resolvedStorageRoot()
+        )
+        let storage: AgentTaskStorageHandle
+        do {
+            storage = try openStorageDirectory(
+                resolvedStorageRoot(),
+                create: false
+            )
+        } catch AgentTaskDirectoryError.missing {
+            return AgentTaskMetadataLoadResult(status: .missing, tasks: [])
+        } catch AgentTaskDirectoryError.unsafe {
+            return rejectedLoad(.unsafeFilesystemObject)
+        } catch {
+            return rejectedLoad(.transientIO)
+        }
+        let lock: Int32
+        do {
+            guard verifyStorageChain(storage) else {
+                throw AgentTaskDirectoryError.unsafe
+            }
+            lock = try acquireLock(storage.leaf)
+        } catch AgentTaskDirectoryError.unsafe {
+            return rejectedLoad(.unsafeFilesystemObject)
+        } catch AgentTaskDirectoryError.lockContention {
+            return rejectedLoad(.lockContention)
+        } catch {
+            return rejectedLoad(.transientIO)
+        }
+        defer { releaseLock(lock) }
+        reportPhase(.lockAcquired)
+        guard verifyStorageChain(storage),
+              verifyLock(lock, directoryDescriptor: storage.leaf) else {
+            return rejectedLoad(.unsafeFilesystemObject)
+        }
+        do {
+            try preflightPrivateFile(
+                fileURL.lastPathComponent,
+                directoryDescriptor: storage.leaf,
+                allowsMissing: true
+            )
+        } catch AgentTaskDirectoryError.unsafe {
+            return rejectedLoad(.unsafeFilesystemObject)
+        } catch {
+            return rejectedLoad(.transientIO)
+        }
+        guard verifyStorageChain(storage),
+              verifyLock(lock, directoryDescriptor: storage.leaf) else {
+            return rejectedLoad(.unsafeFilesystemObject)
+        }
+        cleanupStaleTemporaryFiles(directoryDescriptor: storage.leaf)
+        let read = secureBoundedRead(
+            fileName: fileURL.lastPathComponent,
+            directoryDescriptor: storage.leaf
+        )
+        guard verifyStorageChain(storage),
+              verifyLock(lock, directoryDescriptor: storage.leaf) else {
+            return rejectedLoad(.unsafeFilesystemObject)
+        }
+        let data: Data
+        switch read {
+        case .data(let value): data = value
+        case .missing:
+            return AgentTaskMetadataLoadResult(status: .missing, tasks: [])
+        case .rejected(let rejection):
+            return rejectedLoad(rejection)
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+        guard let header = try? decoder.decode(
+            AgentTaskMetadataHeader.self,
+            from: data
+        ) else {
+            return rejectedLoad(.corrupt)
+        }
+        let storedProjectPath: String
+        let storedWorktreePath: String
+        let storedTasks: [AgentTask]
+        let revision: AgentTaskDiskRevision?
+        let requiresMigration: Bool
+        switch header.schemaVersion {
+        case 1:
+            guard let envelope = try? decoder.decode(
+                AgentTaskLegacyMetadataEnvelope.self,
+                from: data
+            ) else {
+                return rejectedLoad(.corrupt)
+            }
+            storedProjectPath = envelope.canonicalProjectPath
+            storedWorktreePath = envelope.canonicalWorktreePath
+            storedTasks = envelope.tasks
+            revision = .legacySHA256(Data(SHA256.hash(data: data)))
+            requiresMigration = true
+        case Self.currentSchemaVersion:
+            guard let envelope = try? decoder.decode(
+                AgentTaskMetadataEnvelope.self,
+                from: data
+            ) else {
+                return rejectedLoad(.corrupt)
+            }
+            storedProjectPath = envelope.canonicalProjectPath
+            storedWorktreePath = envelope.canonicalWorktreePath
+            storedTasks = envelope.tasks
+            revision = .versioned(envelope.revision)
+            requiresMigration = false
+        default:
+            return rejectedLoad(.unknownSchema)
+        }
+        guard storedProjectPath == project.canonicalProjectPath,
+              storedWorktreePath == project.canonicalWorktreePath,
+              storedTasks.count <= limits.maxTasksPerProject,
+              validateLoadedTasks(storedTasks, project: project) else {
+            return rejectedLoad(.invalidMetadata)
+        }
+
+        var tasks = storedTasks
+        var missingWorktrees = 0
+        for index in tasks.indices where canonicalExistingDirectory(
+            tasks[index].project.canonicalWorktreePath
+        ) != tasks[index].project.canonicalWorktreePath {
+            missingWorktrees += 1
+            tasks[index].route.availability = .missing
+        }
+        let status: AgentTaskMetadataLoadStatus = missingWorktrees == 0
+            ? .loaded
+            : .loadedWithMissingWorktrees(missingWorktrees)
+        return AgentTaskMetadataLoadResult(
+            status: status,
+            tasks: tasks,
+            revision: revision,
+            requiresMigration: requiresMigration
+        )
+    }
+
+    private func resolvedStorageRoot() -> URL {
+        if let storageRoot {
+            return storageRoot.standardizedFileURL
+        }
+        guard let base = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return URL(fileURLWithPath: "/dev/null/pine-agent-tasks")
+        }
+        return base.resolvingSymlinksInPath()
+            .appendingPathComponent(Self.directoryName)
+    }
+
+    private func openStorageDirectory(
+        _ url: URL,
+        create: Bool
+    ) throws -> AgentTaskStorageHandle {
+        let components = url.standardizedFileURL.pathComponents.dropFirst()
+        let names = Array(components)
+        let privateCount = configuration.privateComponentCount ?? 1
+        guard !names.isEmpty, (1...names.count).contains(privateCount) else {
+            throw AgentTaskDirectoryError.unsafe
+        }
+        let privateComponentStart = max(0, names.count - privateCount)
+        var descriptor = Darwin.open("/", O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+        guard descriptor >= 0 else { throw AgentTaskDirectoryError.transient }
+        var descriptors = [descriptor]
+        var transferred = false
+        defer {
+            if !transferred {
+                for openDescriptor in descriptors.reversed() {
+                    Darwin.close(openDescriptor)
+                }
+            }
+        }
+        for (componentIndex, component) in names.enumerated() {
+            var created = false
+            var next = openat(
+                descriptor,
+                component,
+                O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW
+            )
+            if next < 0, errno == ENOENT, create {
+                guard componentIndex >= privateComponentStart,
+                      verifyDescriptorLinks(
+                          descriptors: descriptors,
+                          names: Array(names.prefix(componentIndex)),
+                          privateDescriptorStart: privateComponentStart + 1
+                      ) else {
+                    throw AgentTaskDirectoryError.unsafe
+                }
+                guard mkdirat(descriptor, component, mode_t(0o700)) == 0
+                        || errno == EEXIST else {
+                    throw CocoaError(.fileWriteNoPermission)
+                }
+                created = true
+                guard durableSync(
+                    descriptor,
+                    target: .parentDirectory
+                ) else {
+                    throw AgentTaskDirectoryError.durabilityUnknown
+                }
+                next = openat(
+                    descriptor,
+                    component,
+                    O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW
+                )
+            }
+            guard next >= 0 else {
+                let wasMissing = errno == ENOENT
+                throw wasMissing
+                    ? AgentTaskDirectoryError.missing
+                    : AgentTaskDirectoryError.unsafe
+            }
+            descriptor = next
+            descriptors.append(next)
+            var opened = stat()
+            var live = stat()
+            guard fstat(next, &opened) == 0,
+                  fstatat(descriptors[descriptors.count - 2], component, &live,
+                          AT_SYMLINK_NOFOLLOW) == 0,
+                  sameObject(opened, live) else {
+                throw AgentTaskDirectoryError.unsafe
+            }
+            if componentIndex >= privateComponentStart {
+                guard opened.st_uid == getuid(),
+                      (opened.st_mode & S_IFMT) == S_IFDIR,
+                      (opened.st_mode & 0o777) == 0o700,
+                      descriptorHasNoExtendedACL(next) else {
+                    throw AgentTaskDirectoryError.unsafe
+                }
+            }
+            guard !created || durableSync(
+                next,
+                target: .createdDirectory
+            ) else {
+                throw AgentTaskDirectoryError.durabilityUnknown
+            }
+        }
+        guard verifyDescriptorLinks(
+            descriptors: descriptors,
+            names: names,
+            privateDescriptorStart: privateComponentStart + 1
+        ) else {
+            throw AgentTaskDirectoryError.unsafe
+        }
+        transferred = true
+        reportPhase(.directoryOpened)
+        return AgentTaskStorageHandle(
+            descriptors: descriptors,
+            componentNames: names,
+            privateDescriptorStart: privateComponentStart + 1
+        )
+    }
+
+    private func verifyStorageChain(_ storage: AgentTaskStorageHandle) -> Bool {
+        verifyDescriptorLinks(
+            descriptors: storage.descriptors,
+            names: storage.componentNames,
+            privateDescriptorStart: storage.privateDescriptorStart
+        )
+    }
+
+    private func verifyDescriptorLinks(
+        descriptors: [Int32],
+        names: [String],
+        privateDescriptorStart: Int
+    ) -> Bool {
+        guard descriptors.count == names.count + 1 else { return false }
+        for index in descriptors.indices {
+            var opened = stat()
+            guard fstat(descriptors[index], &opened) == 0 else { return false }
+            if index > 0 {
+                var live = stat()
+                guard fstatat(
+                    descriptors[index - 1], names[index - 1], &live,
+                    AT_SYMLINK_NOFOLLOW
+                ) == 0, sameObject(opened, live) else { return false }
+            }
+            if index >= privateDescriptorStart {
+                guard opened.st_uid == getuid(),
+                      (opened.st_mode & S_IFMT) == S_IFDIR,
+                      (opened.st_mode & 0o777) == 0o700,
+                      descriptorHasNoExtendedACL(descriptors[index]) else {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+
+    private func acquireLock(_ directoryDescriptor: Int32) throws -> Int32 {
+        try preflightPrivateFile(
+            ".agent-tasks.lock",
+            directoryDescriptor: directoryDescriptor,
+            allowsMissing: true
+        )
+        let descriptor = openat(
+            directoryDescriptor,
+            ".agent-tasks.lock",
+            O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW,
+            mode_t(0o600)
+        )
+        guard descriptor >= 0 else {
+            throw unsafeOpenError(errno)
+                ? AgentTaskDirectoryError.unsafe
+                : AgentTaskDirectoryError.transient
+        }
+        guard verifyLock(descriptor, directoryDescriptor: directoryDescriptor) else {
+            Darwin.close(descriptor)
+            throw AgentTaskDirectoryError.unsafe
+        }
+        var lockResult: Int32
+        repeat {
+            lockResult = flock(descriptor, LOCK_EX | LOCK_NB)
+        } while lockResult != 0 && errno == EINTR
+        guard lockResult == 0 else {
+            let failure = errno
+            Darwin.close(descriptor)
+            throw failure == EWOULDBLOCK
+                ? AgentTaskDirectoryError.lockContention
+                : AgentTaskDirectoryError.transient
+        }
+        guard verifyLock(descriptor, directoryDescriptor: directoryDescriptor) else {
+            _ = flock(descriptor, LOCK_UN)
+            Darwin.close(descriptor)
+            throw AgentTaskDirectoryError.unsafe
+        }
+        return descriptor
+    }
+
+    private func verifyLock(
+        _ descriptor: Int32,
+        directoryDescriptor: Int32
+    ) -> Bool {
+        var opened = stat()
+        var live = stat()
+        return fstat(descriptor, &opened) == 0
+            && fstatat(directoryDescriptor, ".agent-tasks.lock", &live,
+                       AT_SYMLINK_NOFOLLOW) == 0
+            && samePrivateFile(opened, live)
+            && descriptorHasNoExtendedACL(descriptor)
+    }
+
+    private func releaseLock(_ descriptor: Int32) {
+        _ = flock(descriptor, LOCK_UN)
+        Darwin.close(descriptor)
+    }
+
+    private func secureBoundedRead(
+        fileName: String,
+        directoryDescriptor: Int32
+    ) -> AgentTaskSecureReadResult {
+        reportPhase(.beforeReadOpen)
+        let descriptor = openat(
+            directoryDescriptor,
+            fileName,
+            O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW
+        )
+        if descriptor < 0, errno == ENOENT { return .missing }
+        guard descriptor >= 0 else {
+            return .rejected(
+                errno == ELOOP ? .unsafeFilesystemObject : .transientIO
+            )
+        }
+        defer { Darwin.close(descriptor) }
+        var info = stat()
+        var liveBefore = stat()
+        guard fstat(descriptor, &info) == 0,
+              fstatat(
+                  directoryDescriptor,
+                  fileName,
+                  &liveBefore,
+                  AT_SYMLINK_NOFOLLOW
+              ) == 0,
+              samePrivateFile(info, liveBefore),
+              descriptorHasNoExtendedACL(descriptor),
+              info.st_uid == getuid(),
+              info.st_nlink == 1,
+              (info.st_mode & S_IFMT) == S_IFREG,
+              (info.st_mode & 0o077) == 0,
+              info.st_size >= 0 else {
+            return .rejected(.unsafeFilesystemObject)
+        }
+        guard UInt64(info.st_size) <= UInt64(limits.maxFileBytes) else {
+            return .rejected(.storageLimit)
+        }
+        reportPhase(.readOpened)
+        var data = Data(count: Int(info.st_size))
+        let succeeded = data.withUnsafeMutableBytes { bytes in
+            guard let base = bytes.baseAddress else { return true }
+            var offset = 0
+            while offset < bytes.count {
+                let count = Darwin.read(
+                    descriptor,
+                    base.advanced(by: offset),
+                    bytes.count - offset
+                )
+                if count < 0, errno == EINTR { continue }
+                guard count > 0 else { return false }
+                offset += count
+            }
+            return true
+        }
+        guard succeeded else {
+            var changed = stat()
+            if fstat(descriptor, &changed) == 0,
+               changed.st_size != info.st_size {
+                return .rejected(.concurrentMutation)
+            }
+            return .rejected(.transientIO)
+        }
+        var extra: UInt8 = 0
+        var extraCount: Int
+        repeat {
+            extraCount = Darwin.read(descriptor, &extra, 1)
+        } while extraCount < 0 && errno == EINTR
+        var after = stat()
+        var live = stat()
+        guard extraCount == 0,
+              fstat(descriptor, &after) == 0,
+              fstatat(
+                  directoryDescriptor,
+                  fileName,
+                  &live,
+                  AT_SYMLINK_NOFOLLOW
+              ) == 0,
+              stableReadIdentity(info, after),
+              samePrivateFile(after, live) else {
+            return .rejected(.concurrentMutation)
+        }
+        return .data(data)
+    }
+
+    private func secureAtomicWrite(
+        _ data: Data,
+        fileName: String,
+        directoryDescriptor: Int32,
+        authorization: AgentTaskPublicationAuthorization?,
+        verifyContext: () -> Bool
+    ) throws {
+        guard verifyContext() else { throw AgentTaskDirectoryError.unsafe }
+        let initialFinalIdentity = try existingPrivateFileIdentity(
+            fileName,
+            directoryDescriptor: directoryDescriptor,
+            allowsMissing: true
+        )
+        if let authorization,
+           !diskRevisionMatches(
+               authorization.ticket.expectedDiskRevision,
+               fileName: fileName,
+               directoryDescriptor: directoryDescriptor
+           ) {
+            throw AgentTaskDirectoryError.superseded
+        }
+        try enforceTombstoneCapacity(directoryDescriptor)
+        let temporaryName = ".agent-tasks-\(UUID().uuidString).tmp"
+        let descriptor = openat(
+            directoryDescriptor,
+            temporaryName,
+            O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
+            mode_t(0o600)
+        )
+        guard descriptor >= 0 else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        var published = false
+        var writerIdentity: stat?
+        defer {
+            Darwin.close(descriptor)
+            if !published,
+               let writerIdentity {
+                retirePrivateFileIfUnchanged(
+                    temporaryName,
+                    expectedDevice: UInt64(writerIdentity.st_dev),
+                    expectedInode: UInt64(writerIdentity.st_ino),
+                    directoryDescriptor: directoryDescriptor
+                )
+            }
+        }
+        var opened = stat()
+        var live = stat()
+        guard verifyContext(),
+              fstat(descriptor, &opened) == 0,
+              fstatat(
+                  directoryDescriptor,
+                  temporaryName,
+                  &live,
+                  AT_SYMLINK_NOFOLLOW
+              ) == 0,
+              samePrivateFile(opened, live),
+              descriptorHasNoExtendedACL(descriptor) else {
+            throw AgentTaskDirectoryError.unsafe
+        }
+        writerIdentity = opened
+        try writeAll(data, descriptor: descriptor)
+        guard durableSync(descriptor, target: .metadataFile) else {
+            throw AgentTaskDirectoryError.durabilityUnknown
+        }
+        reportPhase(.temporaryWritten)
+        guard verifyContext(),
+              fstat(descriptor, &opened) == 0,
+              fstatat(
+                  directoryDescriptor,
+                  temporaryName,
+                  &live,
+                  AT_SYMLINK_NOFOLLOW
+              ) == 0,
+              samePrivateFile(opened, live),
+              descriptorHasNoExtendedACL(descriptor) else {
+            throw AgentTaskDirectoryError.unsafe
+        }
+        reportPhase(.beforePublish)
+        guard verifyContext(),
+              fstat(descriptor, &opened) == 0,
+              fstatat(
+                  directoryDescriptor,
+                  temporaryName,
+                  &live,
+                  AT_SYMLINK_NOFOLLOW
+              ) == 0,
+              samePrivateFile(opened, live),
+              descriptorHasNoExtendedACL(descriptor),
+              privateFileUnchanged(
+                  initialFinalIdentity,
+                  name: fileName,
+                  directoryDescriptor: directoryDescriptor
+              ) else {
+            throw AgentTaskDirectoryError.unsafe
+        }
+        let publish = {
+            guard !Task.isCancelled,
+                  verifyContext(),
+                  fstat(descriptor, &opened) == 0,
+                  fstatat(
+                    directoryDescriptor,
+                    temporaryName,
+                    &live,
+                    AT_SYMLINK_NOFOLLOW
+                  ) == 0,
+                  samePrivateFile(opened, live),
+                  descriptorHasNoExtendedACL(descriptor),
+                  privateFileUnchanged(
+                    initialFinalIdentity,
+                    name: fileName,
+                    directoryDescriptor: directoryDescriptor
+                  ) else {
+                return false
+            }
+            return renameat(
+                directoryDescriptor,
+                temporaryName,
+                directoryDescriptor,
+                fileName
+            ) == 0
+        }
+        let decision = authorization?.publish(operation: publish)
+            ?? (publish() ? .published : .failed)
+        switch decision {
+        case .published:
+            break
+        case .failed:
+            throw CocoaError(.fileWriteUnknown)
+        case .superseded:
+            throw AgentTaskDirectoryError.superseded
+        }
+        published = true
+        guard verifyContext(),
+              fstatat(
+                  directoryDescriptor,
+                  fileName,
+                  &live,
+                  AT_SYMLINK_NOFOLLOW
+              ) == 0,
+              samePrivateFile(opened, live),
+              descriptorHasNoExtendedACL(descriptor) else {
+            throw AgentTaskDirectoryError.unsafe
+        }
+        guard durableSync(
+            directoryDescriptor,
+            target: .storageDirectory
+        ) else {
+            throw AgentTaskDirectoryError.durabilityUnknownAfterPublication
+        }
+        guard verifyContext() else { throw AgentTaskDirectoryError.unsafe }
+    }
+
+    private func diskRevisionMatches(
+        _ expected: AgentTaskDiskRevision?,
+        fileName: String,
+        directoryDescriptor: Int32
+    ) -> Bool {
+        switch secureBoundedRead(
+            fileName: fileName,
+            directoryDescriptor: directoryDescriptor
+        ) {
+        case .missing:
+            return expected == nil
+        case .rejected:
+            return false
+        case .data(let data):
+            let decoder = JSONDecoder()
+            guard let header = try? decoder.decode(
+                AgentTaskMetadataHeader.self,
+                from: data
+            ) else { return false }
+            if header.schemaVersion == 1, header.revision == nil {
+                return expected == .legacySHA256(Data(SHA256.hash(data: data)))
+            }
+            guard header.schemaVersion == Self.currentSchemaVersion,
+                  let revision = header.revision else { return false }
+            return expected == .versioned(revision)
+        }
+    }
+
+    private func durableSync(
+        _ descriptor: Int32,
+        target: AgentTaskSyncTarget
+    ) -> Bool {
+        guard shouldAttemptSync(target) else { return false }
+        #if os(macOS)
+        if fcntl(descriptor, F_FULLFSYNC) == 0 {
+            reportSync(target)
+            return true
+        }
+        #endif
+        let succeeded = Darwin.fsync(descriptor) == 0
+        if succeeded { reportSync(target) }
+        return succeeded
+    }
+
+    private func reportPhase(_ phase: AgentTaskStorePhase) {
+        #if DEBUG
+        configuration.hooks.phase(phase)
+        #endif
+    }
+
+    private func shouldAttemptSync(_ target: AgentTaskSyncTarget) -> Bool {
+        #if DEBUG
+        return configuration.hooks.shouldSync(target)
+        #else
+        return true
+        #endif
+    }
+
+    private func reportSync(_ target: AgentTaskSyncTarget) {
+        #if DEBUG
+        configuration.hooks.didSync(target)
+        #endif
+    }
+
+    private func enforceTombstoneCapacity(
+        _ directoryDescriptor: Int32
+    ) throws {
+        let duplicate = Darwin.dup(directoryDescriptor)
+        guard duplicate >= 0, let directory = fdopendir(duplicate) else {
+            if duplicate >= 0 { Darwin.close(duplicate) }
+            throw AgentTaskDirectoryError.transient
+        }
+        defer { closedir(directory) }
+        var scanned = 0
+        var tombstones = 0
+        while let entry = readdir(directory) {
+            scanned += 1
+            guard scanned <= configuration.cleanup.directoryEntryLimit else {
+                throw AgentTaskDirectoryError.storageLimit
+            }
+            let name = withUnsafePointer(to: &entry.pointee.d_name) {
+                String(cString: UnsafeRawPointer($0)
+                    .assumingMemoryBound(to: CChar.self))
+            }
+            guard isCanonicalTemporaryName(name) else { continue }
+            var info = stat()
+            guard fstatat(
+                directoryDescriptor,
+                name,
+                &info,
+                AT_SYMLINK_NOFOLLOW
+            ) == 0 else {
+                if errno == ENOENT { continue }
+                throw AgentTaskDirectoryError.transient
+            }
+            guard info.st_uid == getuid(),
+                  info.st_nlink == 1,
+                  (info.st_mode & S_IFMT) == S_IFREG,
+                  (info.st_mode & 0o777) == 0 else { continue }
+            tombstones += 1
+            guard tombstones < configuration.cleanup.tombstoneLimit else {
+                throw AgentTaskDirectoryError.storageLimit
+            }
+        }
+    }
+
+    private func isCanonicalTemporaryName(_ name: String) -> Bool {
+        let prefix = ".agent-tasks-"
+        guard name.hasPrefix(prefix), name.hasSuffix(".tmp") else {
+            return false
+        }
+        let start = name.index(name.startIndex, offsetBy: prefix.count)
+        let end = name.index(name.endIndex, offsetBy: -4)
+        let identifier = String(name[start..<end])
+        guard let parsed = UUID(uuidString: identifier) else { return false }
+        return parsed.uuidString == identifier.uppercased()
+    }
+
+    private func cleanupStaleTemporaryFiles(directoryDescriptor: Int32) {
+        var directoryInfo = stat()
+        guard fstat(directoryDescriptor, &directoryInfo) == 0 else { return }
+        let identity = AgentTaskCleanupDirectory(
+            device: UInt64(directoryInfo.st_dev),
+            inode: UInt64(directoryInfo.st_ino)
+        )
+        guard let directory = fdopendir(dup(directoryDescriptor)) else { return }
+        defer { closedir(directory) }
+        if let cursor = cleanupCursorByDirectory[identity], cursor > 0 {
+            seekdir(directory, cursor)
+        }
+        var scanned = 0
+        var reachedEnd = false
+        var candidates: [AgentTaskCleanupCandidate] = []
+        let staleBefore = configuration.cleanup.now().timeIntervalSince1970
+            - configuration.cleanup.staleAge
+        while scanned < configuration.cleanup.scanLimit {
+            guard let entry = readdir(directory) else {
+                reachedEnd = true
+                break
+            }
+            scanned += 1
+            let name = withUnsafePointer(to: &entry.pointee.d_name) {
+                String(cString: UnsafeRawPointer($0)
+                    .assumingMemoryBound(to: CChar.self))
+            }
+            guard isCanonicalTemporaryName(name) else { continue }
+            var info = stat()
+            guard fstatat(
+                directoryDescriptor,
+                name,
+                &info,
+                AT_SYMLINK_NOFOLLOW
+            ) == 0,
+            info.st_uid == getuid(),
+            info.st_nlink == 1,
+            (info.st_mode & S_IFMT) == S_IFREG,
+            (info.st_mode & 0o777) == 0o600,
+            TimeInterval(info.st_mtimespec.tv_sec) <= staleBefore else {
+                continue
+            }
+            candidates.append(AgentTaskCleanupCandidate(
+                name: name,
+                device: UInt64(info.st_dev),
+                inode: UInt64(info.st_ino),
+                modifiedSeconds: Int64(info.st_mtimespec.tv_sec),
+                modifiedNanoseconds: Int64(info.st_mtimespec.tv_nsec)
+            ))
+        }
+        if reachedEnd {
+            cleanupCursorByDirectory[identity] = 0
+        } else {
+            cleanupCursorByDirectory[identity] = max(0, telldir(directory))
+        }
+        let ordered = candidates.sorted { lhs, rhs in
+            if lhs.modifiedSeconds != rhs.modifiedSeconds {
+                return lhs.modifiedSeconds < rhs.modifiedSeconds
+            }
+            if lhs.modifiedNanoseconds != rhs.modifiedNanoseconds {
+                return lhs.modifiedNanoseconds < rhs.modifiedNanoseconds
+            }
+            return lhs.name < rhs.name
+        }
+        for candidate in ordered.prefix(configuration.cleanup.retireLimit) {
+            retireCleanupCandidateIfUnchanged(
+                candidate,
+                directoryDescriptor: directoryDescriptor
+            )
+        }
+    }
+
+    private func retireCleanupCandidateIfUnchanged(
+        _ candidate: AgentTaskCleanupCandidate,
+        directoryDescriptor: Int32
+    ) {
+        reportPhase(.beforeCleanupRetire)
+        retirePrivateFileIfUnchanged(
+            candidate.name,
+            expectedDevice: candidate.device,
+            expectedInode: candidate.inode,
+            directoryDescriptor: directoryDescriptor
+        )
+    }
+
+    private func retirePrivateFileIfUnchanged(
+        _ fileName: String,
+        expectedDevice: UInt64,
+        expectedInode: UInt64,
+        directoryDescriptor: Int32
+    ) {
+        let descriptor = openat(
+            directoryDescriptor,
+            fileName,
+            O_RDWR | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW
+        )
+        guard descriptor >= 0 else { return }
+        defer { Darwin.close(descriptor) }
+        var opened = stat()
+        var live = stat()
+        guard fstat(descriptor, &opened) == 0,
+              fstatat(
+                directoryDescriptor,
+                fileName,
+                &live,
+                AT_SYMLINK_NOFOLLOW
+              ) == 0,
+              UInt64(opened.st_dev) == expectedDevice,
+              UInt64(opened.st_ino) == expectedInode,
+              exactPrivateIdentity(opened, live),
+              descriptorHasNoExtendedACL(descriptor) else { return }
+        reportPhase(.beforeRetireMutation)
+        var finalOpened = stat()
+        var finalLive = stat()
+        guard fstat(descriptor, &finalOpened) == 0,
+              fstatat(
+                  directoryDescriptor,
+                  fileName,
+                  &finalLive,
+                  AT_SYMLINK_NOFOLLOW
+              ) == 0,
+              UInt64(finalOpened.st_dev) == expectedDevice,
+              UInt64(finalOpened.st_ino) == expectedInode,
+              exactPrivateIdentity(finalOpened, finalLive),
+              descriptorHasNoExtendedACL(descriptor) else { return }
+        guard ftruncate(descriptor, 0) == 0 else { return }
+        _ = fchmod(descriptor, mode_t(0o000))
+    }
+
+    private func descriptorHasNoExtendedACL(_ descriptor: Int32) -> Bool {
+        guard let acl = acl_get_fd_np(descriptor, ACL_TYPE_EXTENDED) else {
+            return false
+        }
+        defer { acl_free(acl) }
+        var entry: acl_entry_t?
+        return acl_get_entry(acl, ACL_FIRST_ENTRY, &entry) == 0
+    }
+
+    private func sameObject(_ lhs: stat, _ rhs: stat) -> Bool {
+        lhs.st_dev == rhs.st_dev
+            && lhs.st_ino == rhs.st_ino
+            && (lhs.st_mode & S_IFMT) == (rhs.st_mode & S_IFMT)
+    }
+
+    private func samePrivateFile(_ lhs: stat, _ rhs: stat) -> Bool {
+        sameObject(lhs, rhs)
+            && lhs.st_uid == getuid()
+            && rhs.st_uid == getuid()
+            && lhs.st_nlink == 1
+            && rhs.st_nlink == 1
+            && (lhs.st_mode & S_IFMT) == S_IFREG
+            && (rhs.st_mode & S_IFMT) == S_IFREG
+            && (lhs.st_mode & 0o777) == 0o600
+            && (rhs.st_mode & 0o777) == 0o600
+    }
+
+    private func exactPrivateIdentity(_ lhs: stat, _ rhs: stat) -> Bool {
+        samePrivateFile(lhs, rhs)
+            && lhs.st_mode == rhs.st_mode
+    }
+
+    private func preflightPrivateFile(
+        _ name: String,
+        directoryDescriptor: Int32,
+        allowsMissing: Bool
+    ) throws {
+        _ = try existingPrivateFileIdentity(
+            name,
+            directoryDescriptor: directoryDescriptor,
+            allowsMissing: allowsMissing
+        )
+    }
+
+    private func existingPrivateFileIdentity(
+        _ name: String,
+        directoryDescriptor: Int32,
+        allowsMissing: Bool
+    ) throws -> stat? {
+        var info = stat()
+        if fstatat(
+            directoryDescriptor,
+            name,
+            &info,
+            AT_SYMLINK_NOFOLLOW
+        ) == 0 {
+            guard info.st_uid == getuid(),
+                  info.st_nlink == 1,
+                  (info.st_mode & S_IFMT) == S_IFREG,
+                  (info.st_mode & 0o777) == 0o600 else {
+                throw AgentTaskDirectoryError.unsafe
+            }
+            return info
+        }
+        if allowsMissing, errno == ENOENT { return nil }
+        throw unsafeOpenError(errno)
+            ? AgentTaskDirectoryError.unsafe
+            : AgentTaskDirectoryError.transient
+    }
+
+    private func privateFileUnchanged(
+        _ initial: stat?,
+        name: String,
+        directoryDescriptor: Int32
+    ) -> Bool {
+        var current = stat()
+        let result = fstatat(
+            directoryDescriptor,
+            name,
+            &current,
+            AT_SYMLINK_NOFOLLOW
+        )
+        if let initial {
+            return result == 0 && exactPrivateIdentity(initial, current)
+        }
+        return result < 0 && errno == ENOENT
+    }
+
+    private func unsafeOpenError(_ code: Int32) -> Bool {
+        code == ELOOP || code == ENOTDIR || code == EISDIR
+    }
+
+    private func stableReadIdentity(_ lhs: stat, _ rhs: stat) -> Bool {
+        sameObject(lhs, rhs)
+            && lhs.st_size == rhs.st_size
+            && lhs.st_mtimespec.tv_sec == rhs.st_mtimespec.tv_sec
+            && lhs.st_mtimespec.tv_nsec == rhs.st_mtimespec.tv_nsec
+            && lhs.st_ctimespec.tv_sec == rhs.st_ctimespec.tv_sec
+            && lhs.st_ctimespec.tv_nsec == rhs.st_ctimespec.tv_nsec
+    }
+
+    private func writeAll(_ data: Data, descriptor: Int32) throws {
+        try data.withUnsafeBytes { bytes in
+            guard let base = bytes.baseAddress else { return }
+            var offset = 0
+            while offset < bytes.count {
+                let count = Darwin.write(
+                    descriptor,
+                    base.advanced(by: offset),
+                    bytes.count - offset
+                )
+                if count < 0, errno == EINTR { continue }
+                guard count > 0 else {
+                    throw CocoaError(.fileWriteUnknown)
+                }
+                offset += count
+            }
+        }
+    }
+
+    private func boundedTasks(
+        _ tasks: [AgentTask],
+        project: AgentTaskProjectIdentity
+    ) -> Result<[AgentTask], AgentTaskMetadataRejection> {
+        var identifiers = Set<UUID>()
+        var sessionIdentifiers = Set<UUID>()
+        var candidates: [AgentTask] = []
+        for task in tasks where task.project == project {
+            guard identifiers.insert(task.id).inserted,
+                  validateTask(task),
+                  task.runs.allSatisfy({
+                      sessionIdentifiers.insert($0.id).inserted
+                  }) else {
+                return .failure(.invalidMetadata)
+            }
+            var bounded = task
+            if bounded.runs.count > limits.maxRunsPerTask {
+                bounded.runs = Array(
+                    bounded.runs.suffix(limits.maxRunsPerTask)
+                )
+            }
+            candidates.append(bounded)
+        }
+        candidates.sort(by: newestTaskFirst)
+        let protected = candidates.filter(isRetentionProtected)
+        guard protected.count <= limits.maxTasksPerProject else {
+            return .failure(.storageLimit)
+        }
+        let protectedIDs = Set(protected.map(\.id))
+        let terminal = candidates.filter { !protectedIDs.contains($0.id) }
+        let retained = protected + terminal.prefix(
+            limits.maxTasksPerProject - protected.count
+        )
+        return .success(retained.sorted(by: oldestTaskFirst))
+    }
+
+    private func validateLoadedTasks(
+        _ tasks: [AgentTask],
+        project: AgentTaskProjectIdentity
+    ) -> Bool {
+        var taskIDs = Set<UUID>()
+        var runIDs = Set<UUID>()
+        for task in tasks {
+            guard task.project == project,
+                  taskIDs.insert(task.id).inserted,
+                  task.runs.count <= limits.maxRunsPerTask,
+                  validateTask(task),
+                  task.runs.allSatisfy({ runIDs.insert($0.id).inserted }) else {
+                return false
+            }
+        }
+        return true
+    }
+
+    private func validateTask(_ task: AgentTask) -> Bool {
+        guard isCanonicalAbsolute(task.project.canonicalProjectPath),
+              isCanonicalAbsolute(task.project.canonicalWorktreePath),
+              validText(
+                  task.descriptor.typeIdentifier,
+                  maximum: limits.maxAgentIdentifierBytes,
+                  allowsEmpty: false
+              ),
+              validOptionalText(task.title, maximum: limits.maxTitleBytes),
+              validOptionalText(
+                  task.objective,
+                  maximum: limits.maxObjectiveBytes
+              ),
+              validDate(task.createdAt),
+              validDate(task.updatedAt),
+              validDate(task.lastActivityAt),
+              task.updatedAt >= task.createdAt,
+              task.lastActivityAt >= task.createdAt,
+              task.completedAt == nil,
+              task.lifecycle != .completed,
+              task.attention != .completed,
+              task.attention != .failed,
+              validOptionalDate(task.completedAt),
+              task.runs.allSatisfy(validateRun),
+              validateChronology(task) else {
+            return false
+        }
+        return true
+    }
+
+    private func validateRun(_ run: AgentTaskRun) -> Bool {
+        guard run.process.processGeneration > 0,
+              validDate(run.process.observedStartedAt),
+              validOptionalText(
+                  run.process.startIdentifier,
+                  maximum: limits.maxProcessStartBytes
+              ),
+              run.process.processIdentifier.map({ $0 > 0 }) ?? true,
+              validDate(run.startedAt),
+              run.startedAt == run.process.observedStartedAt,
+              validDate(run.lastObservedAt),
+              run.lastObservedAt >= run.startedAt,
+              validOptionalDate(run.endedAt) else {
+            return false
+        }
+        if let endedAt = run.endedAt, endedAt < run.startedAt {
+            return false
+        }
+        if let endedAt = run.endedAt, endedAt < run.lastObservedAt {
+            return false
+        }
+        guard (run.liveness == .terminated) == (run.endedAt != nil) else {
+            return false
+        }
+        return true
+    }
+
+    private func validateChronology(_ task: AgentTask) -> Bool {
+        guard task.route.tabID == task.route.terminalID else { return false }
+        guard !task.runs.isEmpty else {
+            return (task.lifecycle == .paused || task.lifecycle == .dismissed)
+                && task.route.availability == .missing
+                && task.attention == .none
+        }
+        var prior: AgentTaskRun?
+        var generationByTerminal: [UUID: UInt64] = [:]
+        for run in task.runs {
+            if let prior {
+                let priorTail = prior.endedAt ?? prior.lastObservedAt
+                guard run.startedAt >= priorTail else {
+                    return false
+                }
+            }
+            if let generation = generationByTerminal[run.terminalID],
+               run.process.processGeneration <= generation { return false }
+            generationByTerminal[run.terminalID] = run.process.processGeneration
+            prior = run
+        }
+        if let last = task.runs.last {
+            guard task.route.terminalID == last.terminalID,
+                  task.updatedAt >= last.lastObservedAt,
+                  task.updatedAt >= (last.endedAt ?? last.lastObservedAt),
+                  task.lastActivityAt >= last.lastObservedAt,
+                  task.lastActivityAt >= (last.endedAt ?? last.lastObservedAt)
+            else {
+                return false
+            }
+            if task.lifecycle == .active {
+                guard last.liveness != .terminated,
+                      task.route.availability != .missing else { return false }
+            }
+            if task.lifecycle == .paused {
+                guard last.liveness != .live,
+                      task.route.availability == .missing else { return false }
+            }
+            if task.lifecycle == .dismissed {
+                guard last.liveness == .terminated,
+                      task.route.availability == .missing else { return false }
+            }
+            let waitingIsAllowed = task.lifecycle == .active
+                && last.liveness == .live
+                && last.state == .waitingInput
+            guard task.attention == .none
+                    || (waitingIsAllowed && task.attention == .waitingInput) else {
+                return false
+            }
+        } else if task.lifecycle == .active {
+            return false
+        } else if task.lifecycle == .paused {
+            guard task.route.availability == .missing else { return false }
+        } else if task.lifecycle == .dismissed {
+            guard task.route.availability == .missing else { return false }
+        }
+        return true
+    }
+
+    private func validOptionalText(
+        _ value: String?,
+        maximum: Int
+    ) -> Bool {
+        guard let value else { return true }
+        return validText(value, maximum: maximum, allowsEmpty: false)
+    }
+
+    private func validText(
+        _ value: String,
+        maximum: Int,
+        allowsEmpty: Bool
+    ) -> Bool {
+        let size = value.utf8.count
+        return (allowsEmpty || size > 0)
+            && size <= maximum
+            && !value.contains("\0")
+    }
+
+    private func validDate(_ date: Date) -> Bool {
+        date.timeIntervalSinceReferenceDate.isFinite
+    }
+
+    private func validOptionalDate(_ date: Date?) -> Bool {
+        date.map(validDate) ?? true
+    }
+
+    private func isCanonicalAbsolute(_ path: String) -> Bool {
+        guard path.hasPrefix("/") else { return false }
+        return URL(fileURLWithPath: path).standardizedFileURL.path == path
+    }
+
+    private func canonicalExistingDirectory(_ path: String) -> String? {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            return nil
+        }
+        return ProjectRegistry.canonicalProjectURL(
+            URL(fileURLWithPath: path, isDirectory: true)
+        ).path
+    }
+
+    private func newestTaskFirst(_ lhs: AgentTask, _ rhs: AgentTask) -> Bool {
+        if lhs.updatedAt != rhs.updatedAt {
+            return lhs.updatedAt > rhs.updatedAt
+        }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private func isRetentionProtected(_ task: AgentTask) -> Bool {
+        task.lifecycle == .active || task.lifecycle == .paused
+    }
+
+    private func oldestTaskFirst(_ lhs: AgentTask, _ rhs: AgentTask) -> Bool {
+        if lhs.createdAt != rhs.createdAt {
+            return lhs.createdAt < rhs.createdAt
+        }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+
+    private func rejectedLoad(
+        _ rejection: AgentTaskMetadataRejection
+    ) -> AgentTaskMetadataLoadResult {
+        AgentTaskMetadataLoadResult(
+            status: .rejected(rejection),
+            tasks: []
+        )
+    }
+}

--- a/Pine/Agent/AgentTaskModels.swift
+++ b/Pine/Agent/AgentTaskModels.swift
@@ -1,0 +1,367 @@
+//
+//  AgentTaskModels.swift
+//  Pine
+//
+//  Durable, value-only identity for cross-project agent work (#1302).
+//
+
+import Foundation
+
+/// Canonical project and worktree scope for one durable agent task.
+///
+/// Paths are standardized lexically here. Project discovery resolves symlinks
+/// before constructing the value, while persistence revalidates both paths away
+/// from MainActor. The value deliberately contains no project or window object.
+nonisolated struct AgentTaskProjectIdentity: Codable, Hashable, Sendable {
+    let canonicalProjectPath: String
+    let canonicalWorktreePath: String
+
+    private enum CodingKeys: String, CodingKey {
+        case canonicalProjectPath
+        case canonicalWorktreePath
+    }
+
+    init(canonicalProjectPath: String, canonicalWorktreePath: String) {
+        self.canonicalProjectPath = Self.standardize(canonicalProjectPath)
+        self.canonicalWorktreePath = Self.standardize(canonicalWorktreePath)
+    }
+
+    private static func standardize(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+
+    var persistenceKey: String {
+        canonicalProjectPath + "\u{0}" + canonicalWorktreePath
+    }
+}
+
+nonisolated enum AgentTaskRouteAvailability: String, Codable, Sendable {
+    case available
+    case background
+    case missing
+}
+
+/// Stable value route back to the terminal surface that owns a run.
+///
+/// `terminalID` identifies the terminal lifetime; `tabID` and `paneID` locate
+/// it in the current layout. Moving a tab changes only `paneID`.
+nonisolated struct AgentTaskRoute: Codable, Equatable, Sendable {
+    let paneID: UUID
+    let tabID: UUID
+    let terminalID: UUID
+    var availability: AgentTaskRouteAvailability
+
+    private enum CodingKeys: String, CodingKey {
+        case paneID
+        case tabID
+        case terminalID
+        case availability
+    }
+
+    init(
+        paneID: UUID,
+        tabID: UUID,
+        terminalID: UUID,
+        availability: AgentTaskRouteAvailability = .available
+    ) {
+        self.paneID = paneID
+        self.tabID = tabID
+        self.terminalID = terminalID
+        self.availability = availability
+    }
+}
+
+/// The source that first established durable task intent.
+nonisolated enum AgentTaskOrigin: String, Codable, Sendable {
+    /// A user launched an agent manually and Pine discovered its process.
+    case discoveredInTerminal
+    /// Pine reserved the task before launching an agent in its terminal.
+    case pineLaunched
+}
+
+/// Forward-compatible agent metadata. Unknown type identifiers remain opaque.
+nonisolated struct AgentDescriptor: Codable, Equatable, Sendable {
+    let typeIdentifier: String
+
+    private enum CodingKeys: String, CodingKey {
+        case typeIdentifier
+    }
+
+    @MainActor
+    init(agentType: AgentType) {
+        typeIdentifier = agentType.stableIdentifier
+    }
+
+    @MainActor
+    var agentType: AgentType {
+        AgentType(stableIdentifier: typeIdentifier)
+            ?? .generic(name: String(typeIdentifier.prefix(64)))
+    }
+}
+
+nonisolated enum AgentTaskLifecycle: String, Codable, Sendable {
+    case active
+    case paused
+    case completed
+    case dismissed
+}
+
+nonisolated enum AgentTaskAttention: String, Codable, Sendable {
+    case none
+    case waitingInput
+    case completed
+    case failed
+}
+
+/// A run's last reported state, kept separate from evidence freshness.
+nonisolated enum AgentRunState: String, Codable, Sendable {
+    case idle
+    case thinking
+    case executing
+    case waitingInput
+    case done
+
+    @MainActor
+    init(_ state: AgentState) {
+        switch state {
+        case .idle: self = .idle
+        case .thinking: self = .thinking
+        case .executing: self = .executing
+        case .waitingInput: self = .waitingInput
+        case .done: self = .done
+        }
+    }
+}
+
+/// Whether a run's last state is current evidence, stale evidence, or ended.
+nonisolated enum AgentRunLiveness: String, Codable, Sendable {
+    case live
+    case stale
+    case terminated
+
+    init(_ liveness: AgentLiveness) {
+        switch liveness {
+        case .live: self = .live
+        case .stale: self = .stale
+        case .terminated: self = .terminated
+        }
+    }
+}
+
+/// Opaque vendor identity is an adapter hint, never Pine identity or authority.
+/// It is intentionally excluded from persisted `AgentTaskRun` metadata.
+nonisolated struct AgentVendorSessionIdentity: Equatable, Sendable {
+    let provider: String
+    let opaqueIdentifier: String
+}
+
+/// Process-start evidence that prevents PID reuse from extending an old run.
+nonisolated struct AgentProcessEvidence: Codable, Equatable, Sendable {
+    let processIdentifier: Int32?
+    let processGeneration: UInt64
+    let startIdentifier: String?
+    let observedStartedAt: Date
+    let startIsAuthoritative: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case processGeneration
+        case observedStartedAt
+    }
+
+    init(
+        processIdentifier: Int32?,
+        processGeneration: UInt64,
+        startIdentifier: String?,
+        observedStartedAt: Date,
+        startIsAuthoritative: Bool = false
+    ) {
+        self.processIdentifier = processIdentifier
+        self.processGeneration = processGeneration
+        self.startIdentifier = startIdentifier
+        self.observedStartedAt = observedStartedAt
+        self.startIsAuthoritative = startIsAuthoritative
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        processIdentifier = nil
+        processGeneration = try values.decode(
+            UInt64.self,
+            forKey: .processGeneration
+        )
+        startIdentifier = nil
+        startIsAuthoritative = false
+        observedStartedAt = try values.decode(
+            Date.self,
+            forKey: .observedStartedAt
+        )
+    }
+
+    func identifiesSameProcess(as other: Self) -> Bool {
+        processIdentifier == other.processIdentifier
+            && processGeneration == other.processGeneration
+            && startIdentifier == other.startIdentifier
+            && observedStartedAt == other.observedStartedAt
+            && startIsAuthoritative == other.startIsAuthoritative
+    }
+}
+
+/// One observed execution of an agent task. The UUID intentionally equals the
+/// bridged legacy `AgentSession.id` so Activity, History, provenance, verified
+/// patches, and checked undo retain their existing join key.
+nonisolated struct AgentTaskRunInput: Sendable {
+    let id: UUID
+    let terminalID: UUID
+    let process: AgentProcessEvidence
+    let status: AgentTaskRunStatus
+}
+
+nonisolated struct AgentTaskRunStatus: Sendable {
+    let state: AgentRunState
+    let liveness: AgentRunLiveness
+    let observedAt: Date
+}
+
+nonisolated struct AgentTaskRun: Codable, Equatable, Sendable, Identifiable {
+    let id: UUID
+    let terminalID: UUID
+    var process: AgentProcessEvidence
+    var state: AgentRunState
+    var liveness: AgentRunLiveness
+    let startedAt: Date
+    var lastObservedAt: Date
+    var endedAt: Date?
+    var vendorIdentity: AgentVendorSessionIdentity?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case terminalID
+        case process
+        case state
+        case liveness
+        case startedAt
+        case lastObservedAt
+        case endedAt
+    }
+
+    init(_ input: AgentTaskRunInput) {
+        id = input.id
+        terminalID = input.terminalID
+        process = input.process
+        state = input.status.state
+        liveness = input.status.liveness
+        startedAt = input.process.observedStartedAt
+        lastObservedAt = input.status.observedAt
+        endedAt = input.status.liveness == .terminated
+            ? input.status.observedAt
+            : nil
+        vendorIdentity = nil
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        id = try values.decode(UUID.self, forKey: .id)
+        terminalID = try values.decode(UUID.self, forKey: .terminalID)
+        process = try values.decode(AgentProcessEvidence.self, forKey: .process)
+        state = try values.decode(AgentRunState.self, forKey: .state)
+        liveness = try values.decode(AgentRunLiveness.self, forKey: .liveness)
+        startedAt = try values.decode(Date.self, forKey: .startedAt)
+        lastObservedAt = try values.decode(Date.self, forKey: .lastObservedAt)
+        endedAt = try values.decodeIfPresent(Date.self, forKey: .endedAt)
+        vendorIdentity = nil
+    }
+}
+
+/// Durable user work identity. A task survives individual runs and process
+/// generations, and stores only bounded value metadata.
+nonisolated struct AgentTask: Codable, Equatable, Sendable, Identifiable {
+    let id: UUID
+    let project: AgentTaskProjectIdentity
+    var route: AgentTaskRoute
+    let descriptor: AgentDescriptor
+    let origin: AgentTaskOrigin
+    var lifecycle: AgentTaskLifecycle
+    var runs: [AgentTaskRun]
+    let createdAt: Date
+    var updatedAt: Date
+    var lastActivityAt: Date
+    var completedAt: Date?
+    var isUnread: Bool
+    var attention: AgentTaskAttention
+    var title: String?
+    var objective: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case project
+        case route
+        case descriptor
+        case origin
+        case lifecycle
+        case runs
+        case createdAt
+        case updatedAt
+        case lastActivityAt
+        case completedAt
+        case isUnread
+        case attention
+        case title
+        case objective
+    }
+
+    init(
+        descriptor: AgentDescriptor,
+        context: AgentTaskBridgeContext,
+        title: String? = nil,
+        objective: String? = nil,
+        createdAt: Date? = nil
+    ) {
+        let timestamp = createdAt ?? context.observedAt
+        id = UUID()
+        project = context.project
+        route = context.route
+        self.descriptor = descriptor
+        origin = context.origin
+        lifecycle = .active
+        runs = []
+        self.createdAt = timestamp
+        updatedAt = timestamp
+        lastActivityAt = timestamp
+        completedAt = nil
+        isUnread = false
+        attention = .none
+        self.title = title
+        self.objective = objective
+    }
+}
+
+/// Value bundle used by the terminal bridge. It cannot retain UI or process
+/// objects and can therefore be safely copied into registry mutations.
+nonisolated struct AgentTaskBridgeContext: Sendable {
+    let project: AgentTaskProjectIdentity
+    let route: AgentTaskRoute
+    let origin: AgentTaskOrigin
+    let observedAt: Date
+
+    init(
+        project: AgentTaskProjectIdentity,
+        route: AgentTaskRoute,
+        origin: AgentTaskOrigin,
+        observedAt: Date = Date()
+    ) {
+        self.project = project
+        self.route = route
+        self.origin = origin
+        self.observedAt = observedAt
+    }
+}
+
+nonisolated enum AgentTaskPersistenceFlushResult: Equatable, Sendable {
+    case saved
+    case failed
+}
+
+nonisolated struct AgentTaskLaunchBoundary: Sendable {
+    let generationFloor: UInt64
+    let capturedAt: Date
+}

--- a/Pine/Agent/AgentTaskModels.swift
+++ b/Pine/Agent/AgentTaskModels.swift
@@ -82,14 +82,17 @@ nonisolated enum AgentTaskOrigin: String, Codable, Sendable {
 /// Forward-compatible agent metadata. Unknown type identifiers remain opaque.
 nonisolated struct AgentDescriptor: Codable, Equatable, Sendable {
     let typeIdentifier: String
+    let launchExecutable: String?
 
     private enum CodingKeys: String, CodingKey {
         case typeIdentifier
+        case launchExecutable
     }
 
     @MainActor
-    init(agentType: AgentType) {
+    init(agentType: AgentType, launchExecutable: String? = nil) {
         typeIdentifier = agentType.stableIdentifier
+        self.launchExecutable = launchExecutable
     }
 
     @MainActor

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -1443,7 +1443,7 @@ final class AgentTaskRegistry {
 
     private func acceptedProcessForNewRun(
         _ session: AgentSession
-    ) -> AgentRuntimeProcessIdentity? {
+    ) -> AgentProcessEvidence? {
         guard historicalTaskIDByRunID[session.id] != nil
                 || historicalTaskIDByRunID.count < limits.maxHistoricalRunIDs,
               let process = session.processEvidence,

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -1,0 +1,1395 @@
+//
+//  AgentTaskRegistry.swift
+//  Pine
+//
+//  Application-lifetime durable agent task registry (#1302).
+//
+
+import Foundation
+import Observation
+
+nonisolated private struct AgentTaskTerminalKey: Hashable, Sendable {
+    let project: AgentTaskProjectIdentity
+    let terminalID: UUID
+}
+
+nonisolated struct AgentTaskLaunchReservation: Equatable, Sendable {
+    let taskID: UUID
+    fileprivate let token: UUID
+
+}
+
+nonisolated enum AgentTaskLaunchResult: Equatable, Sendable {
+    case reserved(AgentTaskLaunchReservation)
+    case rejected
+}
+
+nonisolated private enum AgentTaskClaimKind: Sendable {
+    case initialLaunch
+    case resume(previousRunID: UUID)
+}
+
+nonisolated private struct AgentTaskPendingClaim: Sendable {
+    let token: UUID
+    let taskID: UUID
+    let project: AgentTaskProjectIdentity
+    var route: AgentTaskRoute
+    let descriptor: AgentDescriptor
+    let kind: AgentTaskClaimKind
+    let expectedRunCount: Int
+    let generationFloor: UInt64
+    let launchBoundary: Date
+    var deadline: ContinuousClock.Instant
+}
+
+nonisolated private struct AgentTaskTerminationRollback: Sendable {
+    let lifecycle: AgentTaskLifecycle
+    let availability: AgentTaskRouteAvailability
+    let liveness: AgentRunLiveness?
+    let attention: AgentTaskAttention
+    let updatedAt: Date
+}
+
+/// Application-lifetime durable task ownership. The registry is MainActor so
+/// terminal lifecycle mutations are ordered, while its metadata actor performs
+/// all file I/O. Stored state consists only of value models and identifier maps:
+/// no ProjectManager, window, view, TerminalTab, Process, or session references.
+@MainActor
+@Observable
+final class AgentTaskRegistry {
+    private(set) var tasks: [AgentTask] = []
+    private(set) var loadStatusByProject:
+        [String: AgentTaskMetadataLoadStatus] = [:]
+    private(set) var saveResultByProject:
+        [String: AgentTaskMetadataSaveResult] = [:]
+
+    @ObservationIgnored
+    private let persistence: any AgentTaskPersisting
+    @ObservationIgnored
+    private let limits: AgentTaskPersistenceLimits
+    @ObservationIgnored
+    private var taskIDByRunID: [UUID: UUID] = [:]
+    @ObservationIgnored
+    private var historicalTaskIDByRunID: [UUID: UUID] = [:]
+    @ObservationIgnored
+    private var taskIDByTerminal: [AgentTaskTerminalKey: UUID] = [:]
+    @ObservationIgnored
+    private var pendingClaims: [AgentTaskTerminalKey: AgentTaskPendingClaim] = [:]
+    @ObservationIgnored
+    private var pendingClaimKeyByToken: [UUID: AgentTaskTerminalKey] = [:]
+    @ObservationIgnored
+    private var terminationClaimRemaining: [UUID: Duration] = [:]
+    @ObservationIgnored
+    private var registeredProjects = Set<AgentTaskProjectIdentity>()
+    @ObservationIgnored
+    private var loadedProjects = Set<AgentTaskProjectIdentity>()
+    @ObservationIgnored
+    private var quarantinedProjects = Set<AgentTaskProjectIdentity>()
+    @ObservationIgnored
+    private var loadedInterruptedTaskIDs = Set<UUID>()
+    @ObservationIgnored
+    private var dirtyProjects = Set<AgentTaskProjectIdentity>()
+    @ObservationIgnored
+    private var persistenceRetryBlocked = Set<AgentTaskProjectIdentity>()
+    @ObservationIgnored
+    private var persistenceRevision: [AgentTaskProjectIdentity: UUID] = [:]
+    @ObservationIgnored
+    private var diskRevisionByProject:
+        [AgentTaskProjectIdentity: AgentTaskDiskRevision] = [:]
+    @ObservationIgnored
+    private var loadTasks:
+        [AgentTaskProjectIdentity: Task<Void, Never>] = [:]
+    @ObservationIgnored
+    private var persistenceTail: Task<Void, Never>?
+    @ObservationIgnored
+    private var persistenceTailTicket: AgentTaskPersistenceTicket?
+    @ObservationIgnored
+    private var abandonedPersistenceTickets = Set<AgentTaskPersistenceTicket>()
+    @ObservationIgnored
+    private var persistenceSequence: UInt64 = 0
+    @ObservationIgnored
+    private var completedPersistenceSequence: UInt64 = 0
+    @ObservationIgnored
+    private var persistenceGeneration: UUID
+    @ObservationIgnored
+    private let publicationFence: AgentTaskPublicationFence
+    @ObservationIgnored
+    private var isTerminating = false
+    @ObservationIgnored
+    private var terminationRollback:
+        [UUID: AgentTaskTerminationRollback] = [:]
+    @ObservationIgnored
+    private var claimExpiryTasks: [UUID: Task<Void, Never>] = [:]
+    @ObservationIgnored
+    private let monotonicNow: @Sendable () -> ContinuousClock.Instant
+    @ObservationIgnored
+    private let claimTTL: Duration
+    @ObservationIgnored
+    private let flushTotal: Duration
+    @ObservationIgnored
+    private let flushTail: Duration
+    @ObservationIgnored
+    private let abandonedPersistenceLimit = 2
+
+    init(
+        persistence: any AgentTaskPersisting = AgentTaskMetadataStore(),
+        monotonicNow: @escaping @Sendable () -> ContinuousClock.Instant = {
+            ContinuousClock().now
+        },
+        claimTTL: Duration = .seconds(30),
+        flushTotal: Duration = .seconds(5),
+        flushTail: Duration = .seconds(2),
+        limits: AgentTaskPersistenceLimits = AgentTaskPersistenceLimits()
+    ) {
+        let generation = UUID()
+        self.persistence = persistence
+        self.limits = limits
+        persistenceGeneration = generation
+        publicationFence = AgentTaskPublicationFence(generation: generation)
+        self.monotonicNow = monotonicNow
+        self.claimTTL = claimTTL
+        self.flushTotal = flushTotal
+        self.flushTail = flushTail
+    }
+
+    func task(for id: UUID) -> AgentTask? {
+        tasks.first { $0.id == id }
+    }
+
+    func taskID(forSessionID sessionID: UUID) -> UUID? {
+        taskIDByRunID[sessionID]
+    }
+
+    func task(forSessionID sessionID: UUID) -> AgentTask? {
+        guard let taskID = taskIDByRunID[sessionID] else { return nil }
+        return task(for: taskID)
+    }
+
+    func historicalTask(forSessionID sessionID: UUID) -> AgentTask? {
+        tasks.first { task in task.runs.contains { $0.id == sessionID } }
+    }
+
+    func isExactLiveOwner(
+        taskID: UUID,
+        terminalID: UUID,
+        runID: UUID
+    ) -> Bool {
+        guard let task = task(for: taskID) else { return false }
+        let key = AgentTaskTerminalKey(
+            project: task.project,
+            terminalID: terminalID
+        )
+        return taskIDByTerminal[key] == taskID
+            && taskIDByRunID[runID] == taskID
+    }
+
+    /// Loads a canonical project scope once. The metadata actor performs path
+    /// checks and decoding; MainActor only merges the returned values.
+    func registerProject(_ project: AgentTaskProjectIdentity) {
+        guard !isTerminating else { return }
+        guard registeredProjects.insert(project).inserted else { return }
+        let store = persistence
+        let load = Task { @MainActor [weak self] in
+            let result = await store.load(project: project)
+            guard let self, !Task.isCancelled else { return }
+            acceptLoad(result, project: project)
+            loadTasks[project] = nil
+        }
+        loadTasks[project] = load
+    }
+
+    /// Bridges the legacy terminal `AgentSession` model into durable identity.
+    /// Repeated observations retain both IDs. A detector replacement ends the
+    /// old run; only a Pine-owned reservation may inherit the durable task.
+    func bridge(
+        _ session: AgentSession,
+        replacing previous: AgentSession?,
+        context: AgentTaskBridgeContext,
+        reservation: AgentTaskLaunchReservation? = nil
+    ) {
+        expireClaims()
+        // Manual discovery is eligible only with a complete detector-owned
+        // process observation. Never infer ownership from agent type or route.
+        guard !isTerminating, session.processEvidence != nil else {
+            return
+        }
+        if let existingTaskID = taskIDByRunID[session.id] {
+            guard mappedEvidenceMatches(
+                session,
+                context: context,
+                taskID: existingTaskID
+            ) else { return }
+            updateMappedSession(session, route: context.route)
+            if session.liveness == .terminated,
+               let task = task(for: existingTaskID) {
+                removeLiveOwnership(
+                    taskID: existingTaskID,
+                    key: AgentTaskTerminalKey(
+                        project: task.project,
+                        terminalID: task.route.terminalID
+                    )
+                )
+            }
+            markDirty(taskID: existingTaskID)
+            return
+        }
+        // Terminal close removes live ownership before the detector reports
+        // process termination. A durable run UUID is a tombstone: late
+        // evidence may never create another task containing that run.
+        if historicalTaskIDByRunID[session.id] != nil { return }
+
+        let key = terminalKey(context)
+        if let previous, previous.id != session.id,
+           let previousTaskID = taskIDByRunID[previous.id],
+           taskIDByTerminal[key] == previousTaskID {
+            updateMappedSession(previous, route: nil)
+            detachRun(sessionID: previous.id, at: context.observedAt)
+        }
+
+        if let reservation {
+            let reservationBelongsToKey = pendingClaimKeyByToken[reservation.token]
+                == key
+                && pendingClaims[key]?.taskID == reservation.taskID
+            guard consume(
+                reservation,
+                session: session,
+                context: context
+            ) else {
+                if !reservationBelongsToKey {
+                    cancelClaim(reservation)
+                    cancelClaim(for: key)
+                }
+                return
+            }
+            return
+        }
+        if pendingClaims[key] != nil {
+            // An ordinary detector poll is not launch-owner authority. Keep
+            // the one-shot claim until its owner attaches, cancels, or its
+            // deterministic deadline expires.
+            return
+        }
+
+        guard acceptedProcessForNewRun(session) != nil else { return }
+        guard makeRoomForTask(in: context.project) else { return }
+        detachCurrentOwner(for: key, at: context.observedAt)
+
+        let discoveryContext = AgentTaskBridgeContext(
+            project: context.project,
+            route: context.route,
+            origin: .discoveredInTerminal,
+            observedAt: context.observedAt
+        )
+        var task = AgentTask(
+            descriptor: AgentDescriptor(agentType: session.agentType),
+            context: discoveryContext
+        )
+        guard appendRun(session, to: &task, context: discoveryContext) else {
+            return
+        }
+        tasks.append(task)
+        indexLiveTask(task)
+        markDirty(task.project)
+    }
+
+    /// Refreshes mapped runs after every successful or failed detector poll,
+    /// including sessions whose terminal pane has already disappeared.
+    func refresh(sessions: [AgentSession]) {
+        expireClaims()
+        guard !isTerminating else { return }
+        var changedProjects = Set<AgentTaskProjectIdentity>()
+        for session in sessions {
+            guard let taskID = taskIDByRunID[session.id],
+                  updateMappedSession(session, route: nil),
+                  let task = task(for: taskID) else {
+                continue
+            }
+            if session.liveness == .terminated {
+                removeLiveOwnership(
+                    taskID: taskID,
+                    key: AgentTaskTerminalKey(
+                    project: task.project,
+                    terminalID: task.route.terminalID
+                    )
+                )
+            }
+            changedProjects.insert(task.project)
+        }
+        changedProjects.forEach(markDirty)
+    }
+
+    /// Records detector unavailability without claiming process termination.
+    func markEvidenceUnavailable(sessionIDs: [UUID]) {
+        expireClaims()
+        guard !isTerminating else { return }
+        var changedProjects = Set<AgentTaskProjectIdentity>()
+        for sessionID in sessionIDs {
+            guard let taskIndex = taskIndex(forRunID: sessionID),
+                  let runIndex = tasks[taskIndex].runs.firstIndex(
+                    where: { $0.id == sessionID }
+                  ),
+                  tasks[taskIndex].runs[runIndex].liveness != .terminated else {
+                continue
+            }
+            tasks[taskIndex].runs[runIndex].liveness = .stale
+            tasks[taskIndex].attention = .none
+            tasks[taskIndex].updatedAt = max(
+                tasks[taskIndex].updatedAt,
+                tasks[taskIndex].runs[runIndex].lastObservedAt
+            )
+            changedProjects.insert(tasks[taskIndex].project)
+        }
+        changedProjects.forEach(markDirty)
+    }
+
+    /// Reserves durable identity before a Pine-owned launch. The real detector
+    /// later supplies the run and process evidence for this exact route.
+    func preparePineLaunch(
+        descriptor: AgentDescriptor,
+        context: AgentTaskBridgeContext,
+        title: String?,
+        objective: String?,
+        boundary: AgentTaskLaunchBoundary
+    ) -> AgentTaskLaunchResult {
+        expireClaims()
+        guard !isTerminating,
+              context.origin == .pineLaunched,
+              validLaunchRoute(context.route),
+              validUserText(title, maximum: limits.maxTitleBytes),
+              validUserText(objective, maximum: limits.maxObjectiveBytes) else {
+            return .rejected
+        }
+        let key = terminalKey(context)
+        guard pendingClaims[key] == nil,
+              taskIDByTerminal[key] == nil else { return .rejected }
+        guard makeRoomForTask(in: context.project) else { return .rejected }
+        var task = AgentTask(
+            descriptor: descriptor,
+            context: context,
+            title: title,
+            objective: objective
+        )
+        task.lifecycle = .paused
+        task.route.availability = .missing
+        let reservation = AgentTaskLaunchReservation(
+            taskID: task.id,
+            token: UUID()
+        )
+        tasks.append(task)
+        installClaim(AgentTaskPendingClaim(
+            token: reservation.token,
+            taskID: task.id,
+            project: context.project,
+            route: context.route,
+            descriptor: descriptor,
+            kind: .initialLaunch,
+            expectedRunCount: 0,
+            generationFloor: boundary.generationFloor,
+            launchBoundary: normalizedLaunchBoundary(boundary.capturedAt),
+            deadline: monotonicNow().advanced(by: claimTTL)
+        ), key: key)
+        markDirty(task.project)
+        return .reserved(reservation)
+    }
+
+    /// Reserves relaunch intent. Detector-owned evidence must claim it later.
+    func prepareResume(
+        taskID: UUID,
+        context: AgentTaskBridgeContext,
+        boundary: AgentTaskLaunchBoundary
+    ) -> AgentTaskLaunchResult {
+        expireClaims()
+        guard let index = taskIndex(for: taskID),
+              !isTerminating,
+              context.origin == .pineLaunched,
+              validLaunchRoute(context.route),
+              tasks[index].project == context.project,
+              isResumableTask(at: index),
+              let prior = tasks[index].runs.last,
+              pendingClaims[terminalKey(context)] == nil,
+              taskIDByTerminal[terminalKey(context)] == nil else {
+            return .rejected
+        }
+        let previousRunID = prior.id
+        let reservation = AgentTaskLaunchReservation(
+            taskID: taskID,
+            token: UUID()
+        )
+        installClaim(AgentTaskPendingClaim(
+            token: reservation.token,
+            taskID: taskID,
+            project: context.project,
+            route: context.route,
+            descriptor: tasks[index].descriptor,
+            kind: .resume(previousRunID: previousRunID),
+            expectedRunCount: tasks[index].runs.count,
+            generationFloor: boundary.generationFloor,
+            launchBoundary: normalizedLaunchBoundary(boundary.capturedAt),
+            deadline: monotonicNow().advanced(by: claimTTL)
+        ), key: terminalKey(context))
+        return .reserved(reservation)
+    }
+
+    func canResumeTask(_ taskID: UUID) -> Bool {
+        expireClaims()
+        guard !isTerminating,
+              let index = taskIndex(for: taskID) else { return false }
+        return isResumableTask(at: index)
+    }
+
+    func cancelLaunch(_ reservation: AgentTaskLaunchReservation) {
+        guard !isTerminating else { return }
+        expireClaims()
+        cancelClaim(reservation)
+    }
+
+    func isLaunchPending(_ reservation: AgentTaskLaunchReservation) -> Bool {
+        guard let key = pendingClaimKeyByToken[reservation.token] else {
+            return false
+        }
+        return pendingClaims[key]?.taskID == reservation.taskID
+    }
+
+    /// A closed project window leaves terminal processes alive in Pine's
+    /// background project registry. Only route presentation changes.
+    func setWindowOpen(_ isOpen: Bool, projectPath: String) {
+        expireClaims()
+        guard !isTerminating else { return }
+        var projects = Set<AgentTaskProjectIdentity>()
+        for key in Array(pendingClaims.keys)
+        where key.project.canonicalProjectPath == projectPath {
+            guard var claim = pendingClaims[key] else { continue }
+            if isOpen, claim.route.availability == .background {
+                claim.route.availability = .available
+            } else if !isOpen, claim.route.availability == .available {
+                claim.route.availability = .background
+            } else {
+                continue
+            }
+            pendingClaims[key] = claim
+        }
+        for (_, taskID) in taskIDByTerminal
+        where task(for: taskID)?.project.canonicalProjectPath == projectPath {
+            guard let index = taskIndex(for: taskID) else { continue }
+            let availability = tasks[index].route.availability
+            if isOpen, availability == .background {
+                tasks[index].route.availability = .available
+            } else if !isOpen, availability == .available {
+                tasks[index].route.availability = .background
+            } else {
+                continue
+            }
+            tasks[index].updatedAt = max(
+                tasks[index].updatedAt,
+                tasks[index].runs.last?.lastObservedAt ?? tasks[index].createdAt
+            )
+            projects.insert(tasks[index].project)
+        }
+        projects.forEach(markDirty)
+    }
+
+    /// Updates a runtime route only for the uniquely owned terminal in the
+    /// same canonical project/worktree scope. A move never ends its run.
+    func updateRoute(
+        terminalID: UUID,
+        project: AgentTaskProjectIdentity,
+        route: AgentTaskRoute
+    ) {
+        expireClaims()
+        let key = AgentTaskTerminalKey(
+            project: project,
+            terminalID: terminalID
+        )
+        guard !isTerminating,
+              route.terminalID == terminalID,
+              route.tabID == terminalID else { return }
+        if var claim = pendingClaims[key] {
+            claim.route = route
+            pendingClaims[key] = claim
+        }
+        guard let taskID = taskIDByTerminal[key],
+              let index = taskIndex(for: taskID) else { return }
+        let availability = tasks[index].route.availability
+        tasks[index].route = AgentTaskRoute(
+            paneID: route.paneID,
+            tabID: route.tabID,
+            terminalID: route.terminalID,
+            availability: availability
+        )
+        tasks[index].updatedAt = max(
+            tasks[index].updatedAt,
+            tasks[index].runs.last?.lastObservedAt ?? tasks[index].createdAt
+        )
+        taskIDByTerminal[AgentTaskTerminalKey(
+            project: project,
+            terminalID: terminalID
+        )] = tasks[index].id
+        markDirty(project)
+    }
+
+    /// Closing a terminal is authoritative terminal-lifecycle evidence. The
+    /// process observer may confirm termination later, but may not revive it.
+    func markTerminalClosed(
+        terminalID: UUID,
+        project: AgentTaskProjectIdentity,
+        at timestamp: Date = Date()
+    ) {
+        expireClaims()
+        guard !isTerminating else { return }
+        let key = AgentTaskTerminalKey(project: project, terminalID: terminalID)
+        cancelClaim(for: key)
+        guard let taskID = taskIDByTerminal[key],
+              let index = taskIndex(for: taskID) else { return }
+        tasks[index].route.availability = .missing
+        if let runIndex = tasks[index].runs.indices.last,
+           tasks[index].runs[runIndex].liveness != .terminated {
+            tasks[index].runs[runIndex].liveness = .terminated
+            tasks[index].runs[runIndex].endedAt = max(
+                tasks[index].runs[runIndex].lastObservedAt,
+                timestamp
+            )
+            tasks[index].lifecycle = .paused
+            tasks[index].attention = .none
+            tasks[index].lastActivityAt = max(
+                tasks[index].lastActivityAt,
+                timestamp
+            )
+        }
+        tasks[index].updatedAt = max(tasks[index].updatedAt, timestamp)
+        removeLiveOwnership(taskID: taskID, key: key)
+        markDirty(project)
+    }
+
+    /// Invalidates runtime-only routing before the asynchronous quit barrier.
+    /// This is not task completion and does not manufacture user attention.
+    func prepareForApplicationTermination(at timestamp: Date = Date()) {
+        guard !isTerminating else { return }
+        expireClaims()
+        isTerminating = true
+        let now = monotonicNow()
+        terminationClaimRemaining.removeAll(keepingCapacity: true)
+        for claim in pendingClaims.values {
+            terminationClaimRemaining[claim.token] = max(
+                .zero,
+                now.duration(to: claim.deadline)
+            )
+            claimExpiryTasks.removeValue(forKey: claim.token)?.cancel()
+        }
+        var changedProjects = Set<AgentTaskProjectIdentity>()
+        for taskIndex in tasks.indices {
+            let runIndex = tasks[taskIndex].runs.indices.last
+            terminationRollback[tasks[taskIndex].id] = AgentTaskTerminationRollback(
+                lifecycle: tasks[taskIndex].lifecycle,
+                availability: tasks[taskIndex].route.availability,
+                liveness: runIndex.map { tasks[taskIndex].runs[$0].liveness },
+                attention: tasks[taskIndex].attention,
+                updatedAt: tasks[taskIndex].updatedAt
+            )
+            tasks[taskIndex].route.availability = .missing
+            if let runIndex,
+               tasks[taskIndex].runs[runIndex].liveness == .live {
+                tasks[taskIndex].runs[runIndex].liveness = .stale
+            }
+            if tasks[taskIndex].lifecycle == .active {
+                tasks[taskIndex].lifecycle = .paused
+            }
+            tasks[taskIndex].attention = .none
+            tasks[taskIndex].updatedAt = max(
+                tasks[taskIndex].updatedAt,
+                timestamp
+            )
+            changedProjects.insert(tasks[taskIndex].project)
+        }
+        changedProjects.forEach(markDirty)
+    }
+
+    func cancelApplicationTermination() {
+        guard isTerminating else { return }
+        isTerminating = false
+        var restoredProjects = Set<AgentTaskProjectIdentity>()
+        for index in tasks.indices {
+            if let rollback = terminationRollback[tasks[index].id] {
+                tasks[index].lifecycle = rollback.lifecycle
+                tasks[index].route.availability = rollback.availability
+                tasks[index].attention = rollback.attention
+                tasks[index].updatedAt = rollback.updatedAt
+                if let runIndex = tasks[index].runs.indices.last,
+                   let liveness = rollback.liveness {
+                    tasks[index].runs[runIndex].liveness = liveness
+                }
+                restoredProjects.insert(tasks[index].project)
+            }
+        }
+        terminationRollback.removeAll()
+        let now = monotonicNow()
+        for key in Array(pendingClaims.keys) {
+            guard var claim = pendingClaims[key],
+                  let remaining = terminationClaimRemaining[claim.token] else {
+                continue
+            }
+            claim.deadline = now.advanced(by: remaining)
+            installClaim(claim, key: key)
+        }
+        terminationClaimRemaining.removeAll(keepingCapacity: true)
+        restoredProjects.forEach(markDirty)
+    }
+
+    /// Waits for loads and every queued save, with a five-second total and
+    /// two-second per-tail monotonic deadline. A hung store fails closed.
+    func flushPersistence() async -> AgentTaskPersistenceFlushResult {
+        let deadline = monotonicNow().advanced(by: flushTotal)
+        let loadingProjects = Array(loadTasks.keys)
+        for project in loadingProjects {
+            guard await waitForLoad(project, until: deadline) else {
+                return .failed
+            }
+        }
+        var failedAttempts = 0
+        while monotonicNow() < deadline {
+            guard monotonicNow() < deadline else { return .failed }
+            if persistenceTail == nil,
+               !dirtyProjects.isEmpty,
+               dirtyProjects.isSubset(of: persistenceRetryBlocked) {
+                let retry = dirtyProjects.min {
+                    $0.persistenceKey < $1.persistenceKey
+                }
+                if let retry { persistenceRetryBlocked.remove(retry) }
+            }
+            let dirty = dirtyProjects
+            dirty.forEach(scheduleSaveIfReady)
+            guard persistenceTail != nil else {
+                return dirtyProjects.isEmpty ? .saved : .failed
+            }
+            let ticket = persistenceTailTicket
+            let attempt = min(
+                deadline,
+                monotonicNow().advanced(by: flushTail)
+            )
+            guard let ticket,
+                  await waitForPersistence(ticket, until: attempt) else {
+                abandonPersistenceTail()
+                return .failed
+            }
+            if let result = saveResultByProject[ticket.projectKey],
+               !result.isDurablySaved {
+                failedAttempts += 1
+                if failedAttempts >= 3 { return .failed }
+            }
+        }
+        return .failed
+    }
+
+    private func acceptLoad(
+        _ result: AgentTaskMetadataLoadResult,
+        project: AgentTaskProjectIdentity
+    ) {
+        loadStatusByProject[project.persistenceKey] = result.status
+        if result.status == .rejected(.unknownSchema)
+            || result.status == .rejected(.storageLimit) {
+            quarantinedProjects.insert(project)
+            dirtyProjects.remove(project)
+            persistenceRetryBlocked.remove(project)
+            return
+        }
+        var currentTaskIDs = Set(tasks.map(\.id))
+        var currentRunIDs = Set(tasks.flatMap(\.runs).map(\.id))
+        var needsNormalizedSave = result.requiresMigration
+        var stagedTasks: [AgentTask] = []
+        for loadedTask in result.tasks {
+            if loadedTask.origin == .pineLaunched,
+               loadedTask.runs.isEmpty {
+                needsNormalizedSave = true
+                continue
+            }
+            let loadedRunIDs = Set(loadedTask.runs.map(\.id))
+            guard loadedRunIDs.count == loadedTask.runs.count,
+                  currentTaskIDs.insert(loadedTask.id).inserted,
+                  currentRunIDs.isDisjoint(with: loadedRunIDs) else {
+                continue
+            }
+            currentRunIDs.formUnion(loadedRunIDs)
+            var task = loadedTask
+            normalizeLoadedTask(&task)
+            if task != loadedTask { needsNormalizedSave = true }
+            stagedTasks.append(task)
+            if isTerminating { needsNormalizedSave = true }
+        }
+        var stagedHistorical = historicalTaskIDByRunID
+        for task in stagedTasks {
+            for run in task.runs {
+                if let existing = stagedHistorical[run.id], existing != task.id {
+                    quarantineLoadedProject(project)
+                    return
+                }
+                if stagedHistorical[run.id] == nil,
+                   stagedHistorical.count >= limits.maxHistoricalRunIDs {
+                    quarantineLoadedProject(project)
+                    return
+                }
+                stagedHistorical[run.id] = task.id
+            }
+        }
+        loadedProjects.insert(project)
+        diskRevisionByProject[project] = result.revision
+        historicalTaskIDByRunID = stagedHistorical
+        tasks.append(contentsOf: stagedTasks)
+        if needsNormalizedSave { markDirty(project) }
+        scheduleSaveIfReady(project)
+    }
+
+    private func quarantineLoadedProject(_ project: AgentTaskProjectIdentity) {
+        loadStatusByProject[project.persistenceKey] = .rejected(.storageLimit)
+        loadedProjects.remove(project)
+        diskRevisionByProject[project] = nil
+        quarantinedProjects.insert(project)
+        dirtyProjects.remove(project)
+        persistenceRetryBlocked.remove(project)
+    }
+
+    private func waitForLoad(
+        _ project: AgentTaskProjectIdentity,
+        until deadline: ContinuousClock.Instant
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        while loadTasks[project] != nil, monotonicNow() < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
+        }
+        return loadTasks[project] == nil
+    }
+
+    private func waitForPersistence(
+        _ ticket: AgentTaskPersistenceTicket,
+        until deadline: ContinuousClock.Instant
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        while monotonicNow() < deadline {
+            guard ticket.generation == persistenceGeneration else {
+                return false
+            }
+            if completedPersistenceSequence >= ticket.sequence {
+                return true
+            }
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
+        }
+        return ticket.generation == persistenceGeneration
+            && completedPersistenceSequence >= ticket.sequence
+    }
+
+    private func normalizeLoadedTask(_ task: inout AgentTask) {
+        task.route.availability = .missing
+        var invalidatedLiveRun = false
+        for index in task.runs.indices
+        where task.runs[index].liveness == .live
+            || task.runs[index].liveness == .stale {
+            task.runs[index].liveness = .stale
+            invalidatedLiveRun = true
+        }
+        if invalidatedLiveRun {
+            loadedInterruptedTaskIDs.insert(task.id)
+            task.attention = .none
+            if task.lifecycle == .active {
+                task.lifecycle = .paused
+            }
+        }
+    }
+
+    private func appendRun(
+        _ session: AgentSession,
+        to taskID: UUID,
+        context: AgentTaskBridgeContext
+    ) -> Bool {
+        guard let index = taskIndex(for: taskID),
+              acceptedProcessForNewRun(session) != nil,
+              canMakeRoomForRun(at: index) else {
+            return false
+        }
+        trimRunHistoryForAppend(at: index)
+        guard appendRun(
+            session,
+            to: &tasks[index],
+            context: context
+        ) else {
+            return false
+        }
+        indexLiveTask(tasks[index])
+        markDirty(tasks[index].project)
+        return true
+    }
+
+    private func appendRun(
+        _ session: AgentSession,
+        to task: inout AgentTask,
+        context: AgentTaskBridgeContext
+    ) -> Bool {
+        guard let process = acceptedProcessForNewRun(session) else { return false }
+        let liveness = AgentRunLiveness(session.liveness)
+        let run = AgentTaskRun(AgentTaskRunInput(
+            id: session.id,
+            terminalID: context.route.terminalID,
+            process: process,
+            status: AgentTaskRunStatus(
+                state: AgentRunState(session.state),
+                liveness: liveness,
+                observedAt: max(session.lastObservedAt, session.startedAt)
+            )
+        ))
+        task.route = context.route
+        task.runs.append(run)
+        task.lifecycle = liveness == .terminated ? .paused : .active
+        if liveness == .terminated {
+            task.route.availability = .missing
+        }
+        task.completedAt = nil
+        task.updatedAt = max(
+            task.updatedAt,
+            max(context.observedAt, session.lastObservedAt)
+        )
+        task.lastActivityAt = max(
+            task.lastActivityAt,
+            session.lastObservedAt
+        )
+        applyAttention(to: &task, from: run)
+        return true
+    }
+
+    @discardableResult
+    private func updateMappedSession(
+        _ session: AgentSession,
+        route: AgentTaskRoute?
+    ) -> Bool {
+        guard let taskIndex = taskIndex(forRunID: session.id),
+              let runIndex = tasks[taskIndex].runs.firstIndex(
+                where: { $0.id == session.id }
+              ),
+              tasks[taskIndex].runs[runIndex].liveness != .terminated else {
+            return false
+        }
+        var run = tasks[taskIndex].runs[runIndex]
+        let nextState = AgentRunState(session.state)
+        let nextLiveness = AgentRunLiveness(session.liveness)
+        let nextObservedAt = max(session.lastObservedAt, run.startedAt)
+        let changed = run.state != nextState
+            || run.liveness != nextLiveness
+            || run.lastObservedAt != nextObservedAt
+            || route.map({ $0 != tasks[taskIndex].route }) == true
+        guard changed else { return false }
+
+        run.state = nextState
+        run.liveness = nextLiveness
+        run.lastObservedAt = nextObservedAt
+        if nextLiveness == .terminated {
+            run.endedAt = nextObservedAt
+        }
+        tasks[taskIndex].runs[runIndex] = run
+        if let route,
+           route.terminalID == run.terminalID,
+           route.tabID == run.terminalID {
+            let availability = tasks[taskIndex].route.availability
+            tasks[taskIndex].route = AgentTaskRoute(
+                paneID: route.paneID,
+                tabID: route.tabID,
+                terminalID: route.terminalID,
+                availability: availability
+            )
+        }
+        tasks[taskIndex].updatedAt = max(
+            tasks[taskIndex].updatedAt,
+            nextObservedAt
+        )
+        tasks[taskIndex].lastActivityAt = max(
+            tasks[taskIndex].lastActivityAt,
+            nextObservedAt
+        )
+        if nextLiveness == .terminated,
+           tasks[taskIndex].lifecycle == .active {
+            tasks[taskIndex].lifecycle = .paused
+            tasks[taskIndex].route.availability = .missing
+        }
+        applyAttention(to: &tasks[taskIndex], from: run)
+        return true
+    }
+
+    private func applyAttention(
+        to task: inout AgentTask,
+        from run: AgentTaskRun
+    ) {
+        let next: AgentTaskAttention
+        if run.liveness != .live {
+            next = .none
+        } else if run.state == .waitingInput {
+            next = .waitingInput
+        } else {
+            next = .none
+        }
+        if next != .none, next != task.attention {
+            task.isUnread = true
+        }
+        task.attention = next
+    }
+
+    private func consume(
+        _ reservation: AgentTaskLaunchReservation,
+        session: AgentSession,
+        context: AgentTaskBridgeContext
+    ) -> Bool {
+        guard let key = pendingClaimKeyByToken[reservation.token],
+              let claim = pendingClaims[key],
+              claim.token == reservation.token,
+              claim.taskID == reservation.taskID,
+              monotonicNow() < claim.deadline,
+              canAcceptPending(claim, session: session, context: context),
+              acceptedProcessForNewRun(session) != nil,
+              canMakeRoomForClaimRun(taskID: claim.taskID) else {
+            return false
+        }
+        removeClaim(for: key)
+        if loadedInterruptedTaskIDs.remove(claim.taskID) != nil,
+           let index = taskIndex(for: claim.taskID),
+           let runIndex = tasks[index].runs.indices.last {
+            let end = max(
+                tasks[index].runs[runIndex].lastObservedAt,
+                session.startedAt
+            )
+            tasks[index].runs[runIndex].liveness = .terminated
+            tasks[index].runs[runIndex].endedAt = end
+            advanceTaskChronology(at: index, through: end)
+        }
+        return appendRun(session, to: claim.taskID, context: context)
+    }
+
+    private func canAcceptPending(
+        _ claim: AgentTaskPendingClaim,
+        session: AgentSession,
+        context: AgentTaskBridgeContext
+    ) -> Bool {
+        guard let task = task(for: claim.taskID),
+              let evidence = session.processEvidence else { return false }
+        guard task.runs.count == claim.expectedRunCount,
+              context.origin == .pineLaunched,
+              task.origin == .pineLaunched,
+              task.project == claim.project,
+              context.project == claim.project,
+              context.route == claim.route,
+              task.descriptor == claim.descriptor,
+              claim.descriptor == AgentDescriptor(agentType: session.agentType),
+              evidence.startIdentifier != nil,
+              evidence.startIsAuthoritative,
+              evidence.processGeneration > claim.generationFloor,
+              evidence.observedStartedAt >= claim.launchBoundary else {
+            return false
+        }
+        switch claim.kind {
+        case .initialLaunch:
+            return task.runs.isEmpty
+                && task.route.terminalID == claim.route.terminalID
+        case .resume(let previousRunID):
+            guard let previous = task.runs.last else { return false }
+            let generationIsValid = previous.terminalID != context.route.terminalID
+                || evidence.processGeneration
+                    > previous.process.processGeneration
+            let interruptedTail = loadedInterruptedTaskIDs.contains(task.id)
+                && previous.liveness == .stale
+                && previous.endedAt == nil
+                && session.startedAt >= previous.lastObservedAt
+            let terminatedTail = previous.liveness == .terminated
+                && previous.endedAt != nil
+            return previous.id == previousRunID
+                && (terminatedTail || interruptedTail)
+                && generationIsValid
+        }
+    }
+
+    private func endRun(sessionID: UUID, at timestamp: Date) {
+        guard let taskIndex = taskIndex(forRunID: sessionID),
+              let runIndex = tasks[taskIndex].runs.firstIndex(
+                where: { $0.id == sessionID }
+              ) else {
+            return
+        }
+        tasks[taskIndex].runs[runIndex].liveness = .terminated
+        tasks[taskIndex].runs[runIndex].endedAt = max(
+            tasks[taskIndex].runs[runIndex].lastObservedAt,
+            timestamp
+        )
+        tasks[taskIndex].lifecycle = .paused
+        tasks[taskIndex].attention = .none
+        if let endedAt = tasks[taskIndex].runs[runIndex].endedAt {
+            advanceTaskChronology(at: taskIndex, through: endedAt)
+        }
+    }
+
+    private func indexLiveTask(_ task: AgentTask) {
+        guard let run = task.runs.last else { return }
+        historicalTaskIDByRunID[run.id] = task.id
+        guard task.lifecycle == .active,
+              run.liveness != .terminated else { return }
+        taskIDByRunID[run.id] = task.id
+        taskIDByTerminal[AgentTaskTerminalKey(
+            project: task.project,
+            terminalID: task.route.terminalID
+        )] = task.id
+    }
+
+    private func removeLiveOwnership(
+        taskID: UUID,
+        key: AgentTaskTerminalKey
+    ) {
+        if let task = task(for: taskID), let run = task.runs.last {
+            taskIDByRunID[run.id] = nil
+        }
+        if taskIDByTerminal[key] == taskID {
+            taskIDByTerminal[key] = nil
+        }
+        if let index = taskIndex(for: taskID) {
+            tasks[index].route.availability = .missing
+        }
+    }
+
+    private func installClaim(
+        _ claim: AgentTaskPendingClaim,
+        key: AgentTaskTerminalKey
+    ) {
+        pendingClaims[key] = claim
+        pendingClaimKeyByToken[claim.token] = key
+        claimExpiryTasks[claim.token]?.cancel()
+        claimExpiryTasks[claim.token] = Task { @MainActor [weak self] in
+            do {
+                try await ContinuousClock().sleep(until: claim.deadline)
+            } catch {
+                return
+            }
+            guard let self,
+                  pendingClaims[key]?.token == claim.token else { return }
+            cancelClaim(for: key)
+        }
+    }
+
+    private func removeClaim(for key: AgentTaskTerminalKey) {
+        guard let claim = pendingClaims.removeValue(forKey: key) else { return }
+        pendingClaimKeyByToken[claim.token] = nil
+        claimExpiryTasks.removeValue(forKey: claim.token)?.cancel()
+    }
+
+    private func cancelClaim(_ reservation: AgentTaskLaunchReservation) {
+        guard let key = pendingClaimKeyByToken[reservation.token],
+              pendingClaims[key]?.taskID == reservation.taskID else { return }
+        cancelClaim(for: key)
+    }
+
+    private func cancelClaim(for key: AgentTaskTerminalKey) {
+        guard let claim = pendingClaims[key] else { return }
+        removeClaim(for: key)
+        guard let index = taskIndex(for: claim.taskID) else { return }
+        tasks[index].route.availability = .missing
+        if case .initialLaunch = claim.kind, tasks[index].runs.isEmpty {
+            let project = tasks[index].project
+            tasks.remove(at: index)
+            markDirty(project)
+        } else {
+            tasks[index].lifecycle = .paused
+            markDirty(tasks[index].project)
+        }
+    }
+
+    private func expireClaims() {
+        let now = monotonicNow()
+        let expired = pendingClaims.compactMap { key, claim in
+            claim.deadline <= now ? key : nil
+        }
+        expired.forEach(cancelClaim)
+    }
+
+    private func terminalKey(
+        _ context: AgentTaskBridgeContext
+    ) -> AgentTaskTerminalKey {
+        AgentTaskTerminalKey(
+            project: context.project,
+            terminalID: context.route.terminalID
+        )
+    }
+
+    private func taskIndex(for taskID: UUID) -> Int? {
+        tasks.firstIndex { $0.id == taskID }
+    }
+
+    private func taskIndex(forRunID runID: UUID) -> Int? {
+        guard let taskID = taskIDByRunID[runID] else { return nil }
+        return taskIndex(for: taskID)
+    }
+
+    private func markDirty(taskID: UUID) {
+        guard let task = task(for: taskID) else { return }
+        markDirty(task.project)
+    }
+
+    private func markDirty(_ project: AgentTaskProjectIdentity) {
+        guard !quarantinedProjects.contains(project) else { return }
+        guard !isTerminating || registeredProjects.contains(project) else {
+            return
+        }
+        persistenceRevision[project] = UUID()
+        dirtyProjects.insert(project)
+        persistenceRetryBlocked.remove(project)
+        scheduleSaveIfReady(project)
+    }
+
+    private func scheduleSaveIfReady(_ project: AgentTaskProjectIdentity) {
+        guard registeredProjects.contains(project),
+              loadedProjects.contains(project),
+              !quarantinedProjects.contains(project),
+              !persistenceRetryBlocked.contains(project),
+              abandonedPersistenceTickets.count < abandonedPersistenceLimit,
+              persistenceTail == nil,
+              dirtyProjects.remove(project) != nil else {
+            return
+        }
+        guard persistenceSequence < UInt64.max else {
+            dirtyProjects.insert(project)
+            return
+        }
+        persistenceSequence += 1
+        let snapshot = tasks.filter { $0.project == project }
+        let store = persistence
+        let revision = persistenceRevision[project]
+        let ticket = AgentTaskPersistenceTicket(
+            generation: persistenceGeneration,
+            sequence: persistenceSequence,
+            projectKey: project.persistenceKey,
+            expectedDiskRevision: diskRevisionByProject[project],
+            nextDiskRevision: UUID()
+        )
+        publicationFence.authorize(ticket)
+        let authorization = AgentTaskPublicationAuthorization(
+            ticket: ticket,
+            fence: publicationFence
+        )
+        saveResultByProject[project.persistenceKey] = nil
+        persistenceTailTicket = ticket
+        persistenceTail = Task { @MainActor [weak self] in
+            defer { self?.abandonedPersistenceTickets.remove(ticket) }
+            let result = await store.save(
+                tasks: snapshot,
+                project: project,
+                authorization: authorization
+            )
+            guard let self,
+                  persistenceGeneration == ticket.generation else { return }
+            completedPersistenceSequence = max(
+                completedPersistenceSequence,
+                ticket.sequence
+            )
+            switch result {
+            case .saved:
+                diskRevisionByProject[project] = .versioned(
+                    ticket.nextDiskRevision
+                )
+            case .publishedButDurabilityUnknown(_, let revision):
+                diskRevisionByProject[project] = .versioned(revision)
+            case .rejected:
+                break
+            }
+            let ownsTail = persistenceTailTicket == ticket
+            if ownsTail {
+                persistenceTail = nil
+                persistenceTailTicket = nil
+            }
+            if persistenceRevision[project] == revision {
+                saveResultByProject[project.persistenceKey] = result
+                if !result.isDurablySaved {
+                    dirtyProjects.insert(project)
+                    persistenceRetryBlocked.insert(project)
+                } else {
+                    persistenceRetryBlocked.remove(project)
+                }
+            }
+            if ownsTail {
+                let pendingProjects = Array(dirtyProjects)
+                pendingProjects.forEach(scheduleSaveIfReady)
+            }
+        }
+    }
+
+    private func abandonPersistenceTail() {
+        persistenceTail?.cancel()
+        if let persistenceTailTicket {
+            abandonedPersistenceTickets.insert(persistenceTailTicket)
+        }
+        persistenceGeneration = UUID()
+        let published = publicationFence.advance(to: persistenceGeneration)
+        for project in registeredProjects {
+            if let revision = published[project.persistenceKey] {
+                diskRevisionByProject[project] = revision
+            }
+        }
+        persistenceSequence = 0
+        completedPersistenceSequence = 0
+        persistenceTail = nil
+        persistenceTailTicket = nil
+        persistenceRetryBlocked.removeAll(keepingCapacity: true)
+        for project in registeredProjects where !quarantinedProjects.contains(project) {
+            dirtyProjects.insert(project)
+            persistenceRevision[project] = UUID()
+        }
+    }
+
+    private func advanceTaskChronology(at index: Int, through timestamp: Date) {
+        tasks[index].updatedAt = max(tasks[index].updatedAt, timestamp)
+        tasks[index].lastActivityAt = max(
+            tasks[index].lastActivityAt,
+            timestamp
+        )
+    }
+
+    private func mappedEvidenceMatches(
+        _ session: AgentSession,
+        context: AgentTaskBridgeContext,
+        taskID: UUID
+    ) -> Bool {
+        guard let task = task(for: taskID),
+              task.project == context.project,
+              task.route.terminalID == context.route.terminalID,
+              task.descriptor == AgentDescriptor(agentType: session.agentType),
+              let run = task.runs.last,
+              run.id == session.id,
+              run.terminalID == context.route.terminalID,
+              let evidence = session.processEvidence else { return false }
+        return run.process.identifiesSameProcess(as: evidence)
+    }
+
+    private func detachCurrentOwner(
+        for key: AgentTaskTerminalKey,
+        at timestamp: Date
+    ) {
+        guard let taskID = taskIDByTerminal.removeValue(forKey: key),
+              let task = task(for: taskID),
+              let run = task.runs.last else { return }
+        detachRun(sessionID: run.id, at: timestamp)
+    }
+
+    private func detachRun(sessionID: UUID, at timestamp: Date) {
+        guard let index = taskIndex(forRunID: sessionID) else { return }
+        let key = AgentTaskTerminalKey(
+            project: tasks[index].project,
+            terminalID: tasks[index].route.terminalID
+        )
+        endRun(sessionID: sessionID, at: timestamp)
+        tasks[index].route.availability = .missing
+        taskIDByRunID[sessionID] = nil
+        taskIDByTerminal[key] = nil
+        markDirty(tasks[index].project)
+    }
+
+    private func makeRoomForTask(
+        in project: AgentTaskProjectIdentity
+    ) -> Bool {
+        let maximum = max(1, limits.maxTasksPerProject)
+        while tasks.lazy.filter({ $0.project == project }).count >= maximum {
+            guard let removalIndex = tasks.indices
+                .filter({ tasks[$0].project == project })
+                .filter({
+                    tasks[$0].lifecycle == .completed
+                        || tasks[$0].lifecycle == .dismissed
+                })
+                .min(by: {
+                    tasks[$0].updatedAt < tasks[$1].updatedAt
+                }) else {
+                return false
+            }
+            removeTaskFromMemory(at: removalIndex)
+        }
+        return true
+    }
+
+    private func removeTaskFromMemory(at index: Int) {
+        let task = tasks[index]
+        let claimKeys = pendingClaims.compactMap { key, claim in
+            claim.taskID == task.id ? key : nil
+        }
+        claimKeys.forEach { removeClaim(for: $0) }
+        for run in task.runs {
+            taskIDByRunID[run.id] = nil
+        }
+        taskIDByTerminal = taskIDByTerminal.filter { $0.value != task.id }
+        loadedInterruptedTaskIDs.remove(task.id)
+        terminationRollback[task.id] = nil
+        tasks.remove(at: index)
+    }
+
+    private func acceptedProcessForNewRun(
+        _ session: AgentSession
+    ) -> AgentRuntimeProcessIdentity? {
+        guard historicalTaskIDByRunID[session.id] != nil
+                || historicalTaskIDByRunID.count < limits.maxHistoricalRunIDs,
+              let process = session.processEvidence,
+              validUserText(
+                  process.startIdentifier,
+                  maximum: limits.maxProcessStartBytes
+              ) else {
+            return nil
+        }
+        return process
+    }
+
+    private func canMakeRoomForClaimRun(taskID: UUID) -> Bool {
+        guard let index = taskIndex(for: taskID) else { return false }
+        if canMakeRoomForRun(at: index) { return true }
+        return loadedInterruptedTaskIDs.contains(taskID)
+            && tasks[index].runs.indices.last != nil
+    }
+
+    private func canMakeRoomForRun(at taskIndex: Int) -> Bool {
+        let maximum = max(1, limits.maxRunsPerTask)
+        return tasks[taskIndex].runs.count < maximum
+            || tasks[taskIndex].runs.contains(where: {
+                $0.liveness == .terminated
+            })
+    }
+
+    private func trimRunHistoryForAppend(at taskIndex: Int) {
+        let maximum = max(1, limits.maxRunsPerTask)
+        while tasks[taskIndex].runs.count >= maximum,
+              let removalIndex = tasks[taskIndex].runs.firstIndex(where: {
+                  $0.liveness == .terminated
+              }) {
+            let runID = tasks[taskIndex].runs.remove(at: removalIndex).id
+            taskIDByRunID[runID] = nil
+        }
+    }
+
+    private func validUserText(_ value: String?, maximum: Int) -> Bool {
+        guard let value else { return true }
+        return !value.isEmpty && value.utf8.count <= maximum
+            && !value.contains("\0")
+    }
+
+    private func normalizedLaunchBoundary(_ date: Date) -> Date { date }
+
+    private func validLaunchRoute(_ route: AgentTaskRoute) -> Bool {
+        route.terminalID == route.tabID && route.availability != .missing
+    }
+
+    private func isResumableTask(at index: Int) -> Bool {
+        let task = tasks[index]
+        guard task.origin == .pineLaunched,
+              task.lifecycle == .paused,
+              task.route.availability == .missing,
+              let tail = task.runs.last,
+              resumableTail(tail, taskID: task.id) else {
+            return false
+        }
+        return !pendingClaims.values.contains { $0.taskID == task.id }
+    }
+
+    private func resumableTail(_ run: AgentTaskRun, taskID: UUID) -> Bool {
+        run.liveness == .terminated && run.endedAt != nil
+            || loadedInterruptedTaskIDs.contains(taskID)
+    }
+}

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -21,6 +21,7 @@ nonisolated struct AgentTaskLaunchReservation: Equatable, Sendable {
 
 nonisolated enum AgentTaskLaunchResult: Equatable, Sendable {
     case reserved(AgentTaskLaunchReservation)
+    case sentWithoutReservation
     case rejected
 }
 
@@ -91,6 +92,8 @@ final class AgentTaskRegistry {
     private var dirtyProjects = Set<AgentTaskProjectIdentity>()
     @ObservationIgnored
     private var persistenceRetryBlocked = Set<AgentTaskProjectIdentity>()
+    @ObservationIgnored
+    private var unpersistableDirtyProjects = Set<AgentTaskProjectIdentity>()
     @ObservationIgnored
     private var persistenceRevision: [AgentTaskProjectIdentity: UUID] = [:]
     @ObservationIgnored
@@ -355,6 +358,7 @@ final class AgentTaskRegistry {
         guard !isTerminating,
               context.origin == .pineLaunched,
               validLaunchRoute(context.route),
+              validLaunchExecutable(descriptor),
               validUserText(title, maximum: limits.maxTitleBytes),
               validUserText(objective, maximum: limits.maxObjectiveBytes) else {
             return .rejected
@@ -603,9 +607,25 @@ final class AgentTaskRegistry {
         changedProjects.forEach(markDirty)
     }
 
+    func cancelApplicationTerminationAndFlush(
+        maximumDuration: Duration? = nil
+    ) async -> Bool {
+        guard isTerminating else { return true }
+        restoreTerminationSnapshot()
+        guard await flushPersistence(maximumDuration: maximumDuration) == .saved else { return false }
+        finishTerminationCancellation()
+        return true
+    }
+
+    #if DEBUG
     func cancelApplicationTermination() {
         guard isTerminating else { return }
-        isTerminating = false
+        restoreTerminationSnapshot()
+        finishTerminationCancellation()
+    }
+    #endif
+
+    private func restoreTerminationSnapshot() {
         var restoredProjects = Set<AgentTaskProjectIdentity>()
         for index in tasks.indices {
             if let rollback = terminationRollback[tasks[index].id] {
@@ -620,6 +640,11 @@ final class AgentTaskRegistry {
                 restoredProjects.insert(tasks[index].project)
             }
         }
+        restoredProjects.forEach(markDirty)
+    }
+
+    private func finishTerminationCancellation() {
+        isTerminating = false
         terminationRollback.removeAll()
         let now = monotonicNow()
         for key in Array(pendingClaims.keys) {
@@ -631,21 +656,29 @@ final class AgentTaskRegistry {
             installClaim(claim, key: key)
         }
         terminationClaimRemaining.removeAll(keepingCapacity: true)
-        restoredProjects.forEach(markDirty)
     }
 
     /// Waits for loads and every queued save, with a five-second total and
     /// two-second per-tail monotonic deadline. A hung store fails closed.
-    func flushPersistence() async -> AgentTaskPersistenceFlushResult {
-        let deadline = monotonicNow().advanced(by: flushTotal)
+    func flushPersistence(
+        maximumDuration: Duration? = nil
+    ) async -> AgentTaskPersistenceFlushResult {
+        let requestedDuration = maximumDuration.map {
+            max(.zero, $0)
+        } ?? flushTotal
+        let deadline = monotonicNow().advanced(
+            by: min(flushTotal, requestedDuration)
+        )
         let loadingProjects = Array(loadTasks.keys)
         for project in loadingProjects {
             guard await waitForLoad(project, until: deadline) else {
                 return .failed
             }
         }
+        guard unpersistableDirtyProjects.isEmpty else { return .failed }
         var failedAttempts = 0
         while monotonicNow() < deadline {
+            guard unpersistableDirtyProjects.isEmpty else { return .failed }
             guard monotonicNow() < deadline else { return .failed }
             if persistenceTail == nil,
                !dirtyProjects.isEmpty,
@@ -684,17 +717,19 @@ final class AgentTaskRegistry {
         project: AgentTaskProjectIdentity
     ) {
         loadStatusByProject[project.persistenceKey] = result.status
-        if result.status == .rejected(.unknownSchema)
-            || result.status == .rejected(.storageLimit) {
-            quarantinedProjects.insert(project)
-            dirtyProjects.remove(project)
-            persistenceRetryBlocked.remove(project)
+        if case .rejected(let rejection) = result.status {
+            if rejection == .unknownSchema || rejection == .storageLimit {
+                quarantineLoadedProject(project, rejection: rejection)
+            }
             return
         }
-        var currentTaskIDs = Set(tasks.map(\.id))
-        var currentRunIDs = Set(tasks.flatMap(\.runs).map(\.id))
+        let currentTaskIDs = Set(tasks.map(\.id))
+        let currentRunIDs = Set(tasks.flatMap(\.runs).map(\.id))
+        var stagedTaskIDs = Set<UUID>()
+        var stagedRunIDs = Set<UUID>()
         var needsNormalizedSave = result.requiresMigration
         var stagedTasks: [AgentTask] = []
+        var stagedInterruptedTaskIDs = Set<UUID>()
         for loadedTask in result.tasks {
             if loadedTask.origin == .pineLaunched,
                loadedTask.runs.isEmpty {
@@ -702,28 +737,42 @@ final class AgentTaskRegistry {
                 continue
             }
             let loadedRunIDs = Set(loadedTask.runs.map(\.id))
-            guard loadedRunIDs.count == loadedTask.runs.count,
-                  currentTaskIDs.insert(loadedTask.id).inserted,
-                  currentRunIDs.isDisjoint(with: loadedRunIDs) else {
-                continue
+            guard loadedTask.project == project,
+                  loadedRunIDs.count == loadedTask.runs.count,
+                  !currentTaskIDs.contains(loadedTask.id),
+                  stagedTaskIDs.insert(loadedTask.id).inserted,
+                  currentRunIDs.isDisjoint(with: loadedRunIDs),
+                  stagedRunIDs.isDisjoint(with: loadedRunIDs) else {
+                quarantineLoadedProject(project, rejection: .invalidMetadata)
+                return
             }
-            currentRunIDs.formUnion(loadedRunIDs)
+            stagedRunIDs.formUnion(loadedRunIDs)
             var task = loadedTask
-            normalizeLoadedTask(&task)
-            if task != loadedTask { needsNormalizedSave = true }
+            if normalizeLoadedTask(&task) {
+                stagedInterruptedTaskIDs.insert(task.id)
+                needsNormalizedSave = true
+            }
             stagedTasks.append(task)
             if isTerminating { needsNormalizedSave = true }
+        }
+        let currentProjectTaskCount = tasks.lazy.filter {
+            $0.project == project
+        }.count
+        guard currentProjectTaskCount + stagedTasks.count
+                <= limits.maxTasksPerProject else {
+            quarantineLoadedProject(project, rejection: .storageLimit)
+            return
         }
         var stagedHistorical = historicalTaskIDByRunID
         for task in stagedTasks {
             for run in task.runs {
                 if let existing = stagedHistorical[run.id], existing != task.id {
-                    quarantineLoadedProject(project)
+                    quarantineLoadedProject(project, rejection: .invalidMetadata)
                     return
                 }
                 if stagedHistorical[run.id] == nil,
                    stagedHistorical.count >= limits.maxHistoricalRunIDs {
-                    quarantineLoadedProject(project)
+                    quarantineLoadedProject(project, rejection: .storageLimit)
                     return
                 }
                 stagedHistorical[run.id] = task.id
@@ -732,16 +781,23 @@ final class AgentTaskRegistry {
         loadedProjects.insert(project)
         diskRevisionByProject[project] = result.revision
         historicalTaskIDByRunID = stagedHistorical
+        loadedInterruptedTaskIDs.formUnion(stagedInterruptedTaskIDs)
         tasks.append(contentsOf: stagedTasks)
         if needsNormalizedSave { markDirty(project) }
         scheduleSaveIfReady(project)
     }
 
-    private func quarantineLoadedProject(_ project: AgentTaskProjectIdentity) {
-        loadStatusByProject[project.persistenceKey] = .rejected(.storageLimit)
+    private func quarantineLoadedProject(
+        _ project: AgentTaskProjectIdentity,
+        rejection: AgentTaskMetadataRejection
+    ) {
+        loadStatusByProject[project.persistenceKey] = .rejected(rejection)
         loadedProjects.remove(project)
         diskRevisionByProject[project] = nil
         quarantinedProjects.insert(project)
+        if dirtyProjects.contains(project) {
+            unpersistableDirtyProjects.insert(project)
+        }
         dirtyProjects.remove(project)
         persistenceRetryBlocked.remove(project)
     }
@@ -783,7 +839,7 @@ final class AgentTaskRegistry {
             && completedPersistenceSequence >= ticket.sequence
     }
 
-    private func normalizeLoadedTask(_ task: inout AgentTask) {
+    private func normalizeLoadedTask(_ task: inout AgentTask) -> Bool {
         task.route.availability = .missing
         var invalidatedLiveRun = false
         for index in task.runs.indices
@@ -793,12 +849,12 @@ final class AgentTaskRegistry {
             invalidatedLiveRun = true
         }
         if invalidatedLiveRun {
-            loadedInterruptedTaskIDs.insert(task.id)
             task.attention = .none
             if task.lifecycle == .active {
                 task.lifecycle = .paused
             }
         }
+        return invalidatedLiveRun
     }
 
     private func appendRun(
@@ -979,11 +1035,11 @@ final class AgentTaskRegistry {
               context.project == claim.project,
               context.route == claim.route,
               task.descriptor == claim.descriptor,
-              claim.descriptor == AgentDescriptor(agentType: session.agentType),
+              claim.descriptor.agentType == session.agentType,
               evidence.startIdentifier != nil,
               evidence.startIsAuthoritative,
               evidence.processGeneration > claim.generationFloor,
-              evidence.observedStartedAt >= claim.launchBoundary else {
+              evidence.observedStartedAt > claim.launchBoundary else {
             return false
         }
         switch claim.kind {
@@ -1131,7 +1187,10 @@ final class AgentTaskRegistry {
     }
 
     private func markDirty(_ project: AgentTaskProjectIdentity) {
-        guard !quarantinedProjects.contains(project) else { return }
+        if quarantinedProjects.contains(project) {
+            unpersistableDirtyProjects.insert(project)
+            return
+        }
         guard !isTerminating || registeredProjects.contains(project) else {
             return
         }
@@ -1180,8 +1239,13 @@ final class AgentTaskRegistry {
                 project: project,
                 authorization: authorization
             )
-            guard let self,
-                  persistenceGeneration == ticket.generation else { return }
+            guard let self else { return }
+            if let published = publicationFence.publishedRevision(
+                for: ticket.projectKey
+            ) {
+                diskRevisionByProject[project] = published
+            }
+            guard persistenceGeneration == ticket.generation else { return }
             completedPersistenceSequence = max(
                 completedPersistenceSequence,
                 ticket.sequence
@@ -1256,7 +1320,7 @@ final class AgentTaskRegistry {
         guard let task = task(for: taskID),
               task.project == context.project,
               task.route.terminalID == context.route.terminalID,
-              task.descriptor == AgentDescriptor(agentType: session.agentType),
+              task.descriptor.agentType == session.agentType,
               let run = task.runs.last,
               run.id == session.id,
               run.terminalID == context.route.terminalID,
@@ -1364,6 +1428,15 @@ final class AgentTaskRegistry {
         }
     }
 
+    private func validLaunchExecutable(_ descriptor: AgentDescriptor) -> Bool {
+        guard let executable = descriptor.launchExecutable else { return true }
+        return descriptor.agentType.cliNames.contains(executable)
+            && executable.utf8.count <= limits.maxAgentIdentifierBytes
+            && !executable.contains(where: { $0.isWhitespace })
+            && !executable.contains("/")
+            && !executable.contains("\0")
+    }
+
     private func validUserText(_ value: String?, maximum: Int) -> Bool {
         guard let value else { return true }
         return !value.isEmpty && value.utf8.count <= maximum
@@ -1381,6 +1454,9 @@ final class AgentTaskRegistry {
         guard task.origin == .pineLaunched,
               task.lifecycle == .paused,
               task.route.availability == .missing,
+              let executable = task.descriptor.launchExecutable,
+              task.descriptor.agentType.cliNames.contains(executable),
+              !executable.contains(where: { $0.isWhitespace }),
               let tail = task.runs.last,
               resumableTail(tail, taskID: task.id) else {
             return false

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -1095,7 +1095,7 @@ final class AgentTaskRegistry {
             let interruptedTail = loadedInterruptedTaskIDs.contains(task.id)
                 && previous.liveness == .stale
                 && previous.endedAt == nil
-                && session.startedAt >= previous.lastObservedAt
+                && evidence.observedStartedAt >= previous.lastObservedAt
             let terminatedTail = previous.liveness == .terminated
                 && previous.endedAt != nil
             return previous.id == previousRunID

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -178,6 +178,14 @@ final class AgentTaskRegistry {
         tasks.first { task in task.runs.contains { $0.id == sessionID } }
     }
 
+    #if DEBUG
+    func persistenceIsQuarantinedForTesting(
+        _ project: AgentTaskProjectIdentity
+    ) -> Bool {
+        quarantinedProjects.contains(project)
+    }
+    #endif
+
     func isExactLiveOwner(
         taskID: UUID,
         terminalID: UUID,
@@ -453,22 +461,26 @@ final class AgentTaskRegistry {
     /// but detector evidence cannot consume them.
     @discardableResult
     func armLaunch(_ reservation: AgentTaskLaunchReservation) -> Bool {
-        expireClaims()
-        guard !isTerminating,
-              let key = pendingClaimKeyByToken[reservation.token],
+        if !isTerminating { expireClaims() }
+        guard let key = pendingClaimKeyByToken[reservation.token],
               var claim = pendingClaims[key],
               claim.taskID == reservation.taskID,
-              claim.state == .dormant,
-              monotonicNow() < claim.deadline else { return false }
+              claim.state == .dormant else { return false }
+        let deadlineIsValid: Bool
+        if isTerminating {
+            deadlineIsValid = terminationClaimRemaining[reservation.token]
+                .map { $0 > .zero } ?? false
+        } else {
+            deadlineIsValid = monotonicNow() < claim.deadline
+        }
+        guard deadlineIsValid else { return false }
         claim.state = .armed
         pendingClaims[key] = claim
-        markDirty(claim.project)
         return true
     }
 
     func cancelLaunch(_ reservation: AgentTaskLaunchReservation) {
-        guard !isTerminating else { return }
-        expireClaims()
+        if !isTerminating { expireClaims() }
         cancelClaim(reservation)
     }
 
@@ -637,9 +649,14 @@ final class AgentTaskRegistry {
     ) async -> Bool {
         guard isTerminating else { return true }
         restoreTerminationSnapshot()
-        guard await flushPersistence(maximumDuration: maximumDuration) == .saved else { return false }
+        let rollbackWasSaved = await flushPersistence(
+            maximumDuration: maximumDuration
+        ) == .saved
+        // A failed durability barrier is surfaced to the caller, but it must
+        // never leave the still-running application in termination mode.
+        // Runtime admission and bounded claim expiry are restored regardless.
         finishTerminationCancellation()
-        return true
+        return rollbackWasSaved
     }
 
     #if DEBUG
@@ -743,9 +760,7 @@ final class AgentTaskRegistry {
     ) {
         loadStatusByProject[project.persistenceKey] = result.status
         if case .rejected(let rejection) = result.status {
-            if rejection == .unknownSchema || rejection == .storageLimit {
-                quarantineLoadedProject(project, rejection: rejection)
-            }
+            quarantineLoadedProject(project, rejection: rejection)
             return
         }
         let currentTaskIDs = Set(tasks.map(\.id))
@@ -1157,6 +1172,7 @@ final class AgentTaskRegistry {
     private func removeClaim(for key: AgentTaskTerminalKey) {
         guard let claim = pendingClaims.removeValue(forKey: key) else { return }
         pendingClaimKeyByToken[claim.token] = nil
+        terminationClaimRemaining[claim.token] = nil
         claimExpiryTasks.removeValue(forKey: claim.token)?.cancel()
     }
 
@@ -1241,16 +1257,18 @@ final class AgentTaskRegistry {
             return
         }
         persistenceSequence += 1
-        let unacknowledgedInitialTaskIDs = Set<UUID>(
+        let pendingInitialTaskIDs = Set<UUID>(
             pendingClaims.values.compactMap { claim in
-                guard claim.state == .dormant,
-                      case .initialLaunch = claim.kind else { return nil }
+                guard case .initialLaunch = claim.kind else { return nil }
                 return claim.taskID
             }
         )
+        // A Pine-owned task is not durable until authoritative process
+        // evidence appends its first run. This covers both pre-ACK dormant and
+        // post-ACK armed claims, including snapshots taken during Quit.
         let snapshot = tasks.filter {
             $0.project == project
-                && !unacknowledgedInitialTaskIDs.contains($0.id)
+                && !pendingInitialTaskIDs.contains($0.id)
         }
         let store = persistence
         let revision = persistenceRevision[project]

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -30,6 +30,11 @@ nonisolated private enum AgentTaskClaimKind: Sendable {
     case resume(previousRunID: UUID)
 }
 
+nonisolated private enum AgentTaskClaimState: Equatable, Sendable {
+    case dormant
+    case armed
+}
+
 nonisolated private struct AgentTaskPendingClaim: Sendable {
     let token: UUID
     let taskID: UUID
@@ -41,6 +46,7 @@ nonisolated private struct AgentTaskPendingClaim: Sendable {
     let generationFloor: UInt64
     let launchBoundary: Date
     var deadline: ContinuousClock.Instant
+    var state: AgentTaskClaimState
 }
 
 nonisolated private struct AgentTaskTerminationRollback: Sendable {
@@ -390,9 +396,9 @@ final class AgentTaskRegistry {
             expectedRunCount: 0,
             generationFloor: boundary.generationFloor,
             launchBoundary: normalizedLaunchBoundary(boundary.capturedAt),
-            deadline: monotonicNow().advanced(by: claimTTL)
+            deadline: monotonicNow().advanced(by: claimTTL),
+            state: .dormant
         ), key: key)
-        markDirty(task.project)
         return .reserved(reservation)
     }
 
@@ -429,7 +435,8 @@ final class AgentTaskRegistry {
             expectedRunCount: tasks[index].runs.count,
             generationFloor: boundary.generationFloor,
             launchBoundary: normalizedLaunchBoundary(boundary.capturedAt),
-            deadline: monotonicNow().advanced(by: claimTTL)
+            deadline: monotonicNow().advanced(by: claimTTL),
+            state: .dormant
         ), key: terminalKey(context))
         return .reserved(reservation)
     }
@@ -439,6 +446,24 @@ final class AgentTaskRegistry {
         guard !isTerminating,
               let index = taskIndex(for: taskID) else { return false }
         return isResumableTask(at: index)
+    }
+
+    /// Makes a reserved claim consumable only after Pine's exact PTY write was
+    /// acknowledged in full. Dormant claims still occupy their route and TTL,
+    /// but detector evidence cannot consume them.
+    @discardableResult
+    func armLaunch(_ reservation: AgentTaskLaunchReservation) -> Bool {
+        expireClaims()
+        guard !isTerminating,
+              let key = pendingClaimKeyByToken[reservation.token],
+              var claim = pendingClaims[key],
+              claim.taskID == reservation.taskID,
+              claim.state == .dormant,
+              monotonicNow() < claim.deadline else { return false }
+        claim.state = .armed
+        pendingClaims[key] = claim
+        markDirty(claim.project)
+        return true
     }
 
     func cancelLaunch(_ reservation: AgentTaskLaunchReservation) {
@@ -998,6 +1023,7 @@ final class AgentTaskRegistry {
     ) -> Bool {
         guard let key = pendingClaimKeyByToken[reservation.token],
               let claim = pendingClaims[key],
+              claim.state == .armed,
               claim.token == reservation.token,
               claim.taskID == reservation.taskID,
               monotonicNow() < claim.deadline,
@@ -1215,7 +1241,17 @@ final class AgentTaskRegistry {
             return
         }
         persistenceSequence += 1
-        let snapshot = tasks.filter { $0.project == project }
+        let unacknowledgedInitialTaskIDs = Set<UUID>(
+            pendingClaims.values.compactMap { claim in
+                guard claim.state == .dormant,
+                      case .initialLaunch = claim.kind else { return nil }
+                return claim.taskID
+            }
+        )
+        let snapshot = tasks.filter {
+            $0.project == project
+                && !unacknowledgedInitialTaskIDs.contains($0.id)
+        }
         let store = persistence
         let revision = persistenceRevision[project]
         let ticket = AgentTaskPersistenceTicket(

--- a/Pine/AlertTemplate.swift
+++ b/Pine/AlertTemplate.swift
@@ -41,6 +41,9 @@ enum AlertTemplate: Sendable, Equatable {
     /// Quit / Cancel  — quitting the app with active terminal processes.
     case terminalActiveProcessWarning
 
+    /// OK — Quit is refused while a user task still owns an execution.
+    case activeUserTasksPreventQuit
+
     // MARK: - External changes
 
     /// Reload / Keep  — file was modified externally.
@@ -228,6 +231,7 @@ extension AlertTemplate {
             return .critical
         case .unsavedChangesSingle, .unsavedChangesBulk,
              .terminalTabCloseWarning, .terminalActiveProcessWarning,
+             .activeUserTasksPreventQuit,
              .externalModifyConflict, .fileDeletedSaveAs,
              .fileOperationErrorWarning, .largeFileWarning,
              .branchUncommittedChanges, .revertAllConfirmation:
@@ -246,6 +250,8 @@ extension AlertTemplate {
             return [Strings.terminalTabCloseWarningClose, Strings.dialogCancel]
         case .terminalActiveProcessWarning:
             return [Strings.terminalActiveProcessWarningQuit, Strings.dialogCancel]
+        case .activeUserTasksPreventQuit:
+            return [Strings.dialogOK]
         case .externalModifyConflict:
             return [Strings.externalModifyReload, Strings.externalModifyKeep]
         case .fileDeletedSaveAs:
@@ -279,6 +285,8 @@ extension AlertTemplate {
             return [.destructive, [.default, .cancel]]
         case .terminalActiveProcessWarning:
             return [.destructive, [.default, .cancel]]
+        case .activeUserTasksPreventQuit:
+            return [.default]
         case .externalModifyConflict:
             // Reload discards local edits (destructive); Keep is the safe default.
             return [.destructive, [.default, .cancel]]

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -609,7 +609,19 @@ extension ContentView {
               let state = paneManager.terminalState(for: tpID),
               let activeTab = state.activeTab else { return }
 
-        // Send text followed by newline to execute
+        // A single known agent executable is an explicit Pine-owned launch.
+        // Shell expressions and argument-bearing commands remain ordinary,
+        // untrusted terminal input and are attributed only by observation.
+        if let descriptor = TerminalManager.exactAgentLaunchDescriptor(for: text) {
+            _ = terminal.launchAgentCommand(
+                text,
+                descriptor: descriptor,
+                in: activeTab
+            )
+            return
+        }
+
+        // Send ordinary text followed by newline to execute.
         activeTab.sendText(text + "\n")
     }
 

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -613,11 +613,13 @@ extension ContentView {
         // Shell expressions and argument-bearing commands remain ordinary,
         // untrusted terminal input and are attributed only by observation.
         if let descriptor = TerminalManager.exactAgentLaunchDescriptor(for: text) {
-            _ = terminal.launchAgentCommand(
-                text,
-                descriptor: descriptor,
-                in: activeTab
-            )
+            Task { @MainActor in
+                _ = await terminal.launchAgentCommand(
+                    text,
+                    descriptor: descriptor,
+                    in: activeTab
+                )
+            }
             return
         }
 

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -506,6 +506,66 @@
         }
       }
     },
+    "agent.resumeTask": {
+      "comment": "Terminal tab context menu for explicitly resuming a paused durable agent task.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent-Aufgabe fortsetzen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume Agent Task"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reanudar tarea del agente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reprendre la tâche de l’agent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェントタスクを再開"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에이전트 작업 재개"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retomar tarefa do agente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Возобновить задачу агента"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复智能体任务"
+          }
+        }
+      }
+    },
     "agentHistory.emptyMessage": {
       "comment": "Agent History: empty-state explanation (#1073).",
       "extractionState": "manual",

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -14213,6 +14213,126 @@
         }
       }
     },
+    "task.activePreventQuit.message": {
+      "comment": "Alert message explaining why Quit is refused while a user task owns an execution.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine kann nicht beendet werden, solange eine Benutzeraufgabe noch einen laufenden Prozess besitzt. Brechen Sie die Aufgabe ab und warten Sie, bis die Bereinigung abgeschlossen ist. Beenden Sie Pine anschließend erneut."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine cannot quit while a user task still owns a running process. Cancel the task and wait for cleanup to finish, then quit again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine no puede salir mientras una tarea de usuario siga controlando un proceso en ejecución. Cancela la tarea y espera a que termine la limpieza; después, vuelve a salir."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine ne peut pas quitter tant qu’une tâche utilisateur contrôle encore un processus en cours. Annulez la tâche et attendez la fin du nettoyage, puis quittez à nouveau."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ユーザータスクが実行中のプロセスを保持している間は Pine を終了できません。タスクをキャンセルし、クリーンアップの完了を待ってから、もう一度終了してください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 작업이 실행 중인 프로세스를 소유하고 있는 동안에는 Pine을 종료할 수 없습니다. 작업을 취소하고 정리가 끝날 때까지 기다린 후 다시 종료하세요."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Pine não pode sair enquanto uma tarefa do usuário ainda controlar um processo em execução. Cancele a tarefa, aguarde a conclusão da limpeza e tente sair novamente."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine не может завершить работу, пока пользовательская задача управляет запущенным процессом. Отмените задачу, дождитесь завершения очистки и повторите выход."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当用户任务仍拥有正在运行的进程时，Pine 无法退出。请取消该任务并等待清理完成，然后再次退出。"
+          }
+        }
+      }
+    },
+    "task.activePreventQuit.title": {
+      "comment": "Alert title when Quit is refused because a user task still owns an execution.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktive Aufgaben werden noch ausgeführt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active Tasks Are Still Running"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todavía hay tareas activas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Des tâches actives sont toujours en cours"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクティブなタスクがまだ実行中です"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "활성 작업이 아직 실행 중입니다"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda há tarefas ativas em execução"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Активные задачи ещё выполняются"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "活动任务仍在运行"
+          }
+        }
+      }
+    },
     "terminal.activeProcessWarning.message": {
       "comment": "Alert message when quitting with active terminal processes.",
       "extractionState": "manual",

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -65,6 +65,21 @@ final class PaneManager {
         }
     }
 
+    /// Applies project-scoped lifecycle wiring to every terminal tab without
+    /// making the durable registry retain pane, tab, view, or process objects.
+    var configureTerminalTab: ((TerminalTab) -> Void)? {
+        didSet {
+            guard let configureTerminalTab else { return }
+            allTerminalTabs.forEach(configureTerminalTab)
+            terminalStates.values.forEach {
+                $0.onTabCreated = configureTerminalTab
+            }
+        }
+    }
+
+    /// Reports value-only terminal route changes after a completed tab move.
+    var terminalTabDidMove: ((TerminalTab, PaneID) -> Void)?
+
     /// Saved root before maximize, for restore.
     private(set) var savedRootBeforeMaximize: PaneNode?
 
@@ -1162,6 +1177,7 @@ final class PaneManager {
         // Special case: removing the only leaf in the tree → replace it with
         // a fresh empty editor leaf so the user always has a destination.
         if root.leafCount == 1, root.firstLeafID == paneID {
+            terminalStates[paneID]?.terminalTabs.forEach { $0.stop() }
             tabManagers[paneID] = nil
             terminalStates[paneID] = nil
             let newID = PaneID()
@@ -1175,6 +1191,7 @@ final class PaneManager {
         guard root.leafCount > 1,
               let newRoot = root.removing(paneID) else { return }
 
+        terminalStates[paneID]?.terminalTabs.forEach { $0.stop() }
         tabManagers[paneID] = nil
         terminalStates[paneID] = nil
         root = newRoot
@@ -1517,6 +1534,7 @@ final class PaneManager {
             srcState.activeTerminalID = srcState.terminalTabs.last?.id
         }
         activePaneID = targetID
+        terminalTabDidMove?(tab, targetID)
         if srcState.terminalTabs.isEmpty {
             removePane(sourceID)
         }
@@ -1555,6 +1573,7 @@ final class PaneManager {
         }
 
         activePaneID = newID
+        terminalTabDidMove?(tab, newID)
 
         if srcState.terminalTabs.isEmpty {
             removePane(sourceID)
@@ -1609,6 +1628,7 @@ final class PaneManager {
         newState.activeTerminalID = tab.id
         newState.pendingFocusTabID = tab.id
         activePaneID = newID
+        terminalTabDidMove?(tab, newID)
         recordTabActivation(paneID: newID, tabID: tab.id, contentType: .terminal)
         reconcileGlobalTabSwitcherAfterInventoryChange()
         return true
@@ -1698,6 +1718,12 @@ final class PaneManager {
                 break
             }
         }
+
+        // A restored layout replaces runtime terminal identity. Report every
+        // discarded terminal exactly once before publishing the new tree.
+        terminalStates.values
+            .flatMap(\.terminalTabs)
+            .forEach { $0.stop() }
 
         // Replace root and tab managers atomically
         root = node
@@ -2239,6 +2265,7 @@ final class PaneManager {
 
     private func makeTerminalPaneState(for paneID: PaneID) -> TerminalPaneState {
         let terminalState = TerminalPaneState()
+        terminalState.onTabCreated = configureTerminalTab
         trackTerminalActivations(in: terminalState, paneID: paneID)
         return terminalState
     }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -777,8 +777,9 @@ class CloseDelegate: NSObject, NSWindowDelegate {
 
 // MARK: - AppDelegate
 
-@MainActor
-private final class TerminationDeadlineResolver<Value: Sendable> {
+nonisolated private final class TerminationDeadlineResolver<Value: Sendable>:
+    @unchecked Sendable {
+    private let lock = NSLock()
     private var continuation: CheckedContinuation<Value?, Never>?
 
     init(_ continuation: CheckedContinuation<Value?, Never>) {
@@ -787,11 +788,24 @@ private final class TerminationDeadlineResolver<Value: Sendable> {
 
     @discardableResult
     func resolve(_ value: Value?) -> Bool {
+        let continuation = lock.withLock {
+            let continuation = self.continuation
+            self.continuation = nil
+            return continuation
+        }
         guard let continuation else { return false }
-        self.continuation = nil
         continuation.resume(returning: value)
         return true
     }
+}
+
+nonisolated private enum TerminationDeadlineTimer {
+    /// A Swift-executor sleep can be delayed badly when the app or test host
+    /// is saturated. Quit's hard deadline is a wall-clock contract.
+    static let queue = DispatchQueue(
+        label: "com.pine.termination-deadline",
+        qos: .userInteractive
+    )
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
@@ -1759,33 +1773,31 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
 
     private func valueBeforeTerminationDeadline<Value: Sendable>(
         _ deadline: DispatchTime,
+        deadlineObserver: @escaping @Sendable () -> Void,
         onTimeout: @escaping @MainActor () -> Void,
         operation: @escaping @MainActor () async -> Value
     ) async -> Value? {
         let now = DispatchTime.now().uptimeNanoseconds
         guard now < deadline.uptimeNanoseconds else {
+            deadlineObserver()
             onTimeout()
             return nil
         }
-        let delay = deadline.uptimeNanoseconds - now
         return await withCheckedContinuation { continuation in
             let resolver = TerminationDeadlineResolver<Value>(continuation)
-            var timeoutTask: Task<Void, Never>?
             let operationTask = Task { @MainActor in
                 let value = await operation()
-                if resolver.resolve(value) {
-                    timeoutTask?.cancel()
-                }
+                resolver.resolve(value)
             }
-            timeoutTask = Task { @MainActor in
-                do {
-                    try await Task.sleep(nanoseconds: delay)
-                } catch {
-                    return
-                }
+            TerminationDeadlineTimer.queue.asyncAfter(
+                deadline: deadline
+            ) {
                 if resolver.resolve(nil) {
+                    deadlineObserver()
                     operationTask.cancel()
-                    onTimeout()
+                    Task { @MainActor in
+                        onTimeout()
+                    }
                 }
             }
         }
@@ -1800,7 +1812,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         presentAlert: TerminationAlertPresenter? = nil,
         saveAll: TerminationSaveAll? = nil,
         applicationContext: DialogPresentationContext? = nil,
-        terminationDeadlineOverride: DispatchTime? = nil
+        terminationDeadlineOverride: DispatchTime? = nil,
+        terminationDeadlineObserver: @escaping @Sendable () -> Void = {}
     ) async -> Bool {
         let terminationDeadline = terminationDeadlineOverride
             ?? DispatchTime.now() + .seconds(30)
@@ -1828,6 +1841,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         if registry.hasOutstandingUserTaskExecution {
             _ = await valueBeforeTerminationDeadline(
                 terminationDeadline,
+                deadlineObserver: terminationDeadlineObserver,
                 onTimeout: {
                     guard let window = fallbackContext.nsWindow,
                           let sheet = window.attachedSheet else { return }
@@ -1879,6 +1893,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             let message = Strings.unsavedChangesListMessage(fileList)
             let response = await valueBeforeTerminationDeadline(
                 terminationDeadline,
+                deadlineObserver: terminationDeadlineObserver,
                 onTimeout: {
                     guard let window = context.nsWindow,
                           let sheet = window.attachedSheet else { return }
@@ -1905,6 +1920,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             case .alertFirstButtonReturn:
                 let didSave = await valueBeforeTerminationDeadline(
                     terminationDeadline,
+                    deadlineObserver: terminationDeadlineObserver,
                     onTimeout: {
                         guard let window = context.nsWindow,
                               let sheet = window.attachedSheet else { return }
@@ -1950,6 +1966,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 : fallbackContext
             let response = await valueBeforeTerminationDeadline(
                 terminationDeadline,
+                deadlineObserver: terminationDeadlineObserver,
                 onTimeout: {
                     guard let window = context.nsWindow,
                           let sheet = window.attachedSheet else { return }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -1800,17 +1800,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         presentAlert: TerminationAlertPresenter? = nil,
         saveAll: TerminationSaveAll? = nil,
         applicationContext: DialogPresentationContext? = nil,
-        userTaskShutdownDeadline: DispatchTime? = nil
+        terminationDeadlineOverride: DispatchTime? = nil
     ) async -> Bool {
-        let terminationDeadline = userTaskShutdownDeadline
+        let terminationDeadline = terminationDeadlineOverride
             ?? DispatchTime.now() + .seconds(30)
         let projects = registry.openProjects
             .sorted { $0.key.path.localizedStandardCompare($1.key.path) == .orderedAscending }
             .map(\.value)
         let needsNativeDecision = presentAlert == nil
-            && projects.contains {
-                !$0.allDirtyTabs.isEmpty || $0.terminal.hasActiveProcesses
-            }
+            && (registry.hasOutstandingUserTaskExecution
+                || projects.contains {
+                    !$0.allDirtyTabs.isEmpty || $0.terminal.hasActiveProcesses
+                })
         if applicationContext == nil, needsNativeDecision {
             // Quit can arrive from the Dock while Pine is hidden or every
             // project is miniaturized. Restore/create a discoverable owner
@@ -1819,6 +1820,38 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         }
         let fallbackContext = applicationContext
             ?? DialogPresenter.forApplicationWindow()
+
+        // A cancellable Quit cannot safely start TERM/KILL: a later save,
+        // metadata barrier, or authorization check may still fail, but a
+        // destroyed process cannot be rolled back. Keep execution ownership
+        // intact and require the user to cancel the task explicitly first.
+        if registry.hasOutstandingUserTaskExecution {
+            _ = await valueBeforeTerminationDeadline(
+                terminationDeadline,
+                onTimeout: {
+                    guard let window = fallbackContext.nsWindow,
+                          let sheet = window.attachedSheet else { return }
+                    window.endSheet(sheet, returnCode: .abort)
+                },
+                operation: {
+                    if let presentAlert {
+                        return await presentAlert(
+                            .activeUserTasksPreventQuit,
+                            fallbackContext,
+                            Strings.activeUserTasksPreventQuitTitle,
+                            Strings.activeUserTasksPreventQuitMessage
+                        )
+                    }
+                    return await AlertTemplate.activeUserTasksPreventQuit.runSheet(
+                        on: fallbackContext,
+                        messageText: Strings.activeUserTasksPreventQuitTitle,
+                        informativeText: Strings.activeUserTasksPreventQuitMessage
+                    )
+                }
+            )
+            return false
+        }
+
         var discardAuthorizations: [
             ObjectIdentifier: DirtyEditorContentAuthorization
         ] = [:]
@@ -1946,26 +1979,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 activeTerminalProcesses
         }
 
-        // Window closure keeps project tasks alive by policy; application
-        // termination does not. Use one shared deadline across every project
-        // so N concurrent tasks cannot multiply the quit delay. Process waits
-        // happen off-main while AppKit remains in its `.terminateLater`
-        // handshake. A timeout cancels Quit before any authorized editor
-        // discard is committed and retains every cleanup handle.
-        let taskStageDeadline = DispatchTime.now() + .seconds(3)
-        let taskShutdownDeadline = min(
-            terminationDeadline,
-            taskStageDeadline
-        )
-        guard await registry.shutdownUserTasks(
-            until: taskShutdownDeadline
-        ) else {
-            Logger.task.error(
-                "User-task cleanup exceeded Pine's quit deadline; cancelling Quit"
-            )
-            return false
-        }
-
         // Runtime pane/tab IDs cannot be trusted across relaunch. Reserve a
         // rollback slice before freezing so every failed Quit can durably
         // restore the pre-handshake snapshot within the same absolute budget.
@@ -2001,11 +2014,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             return false
         }
 
-        // Other project windows remain interactive while sheets and off-main
-        // process waits are in flight. Revalidate every destructive
-        // authorization after the final suspension point, immediately before
-        // committing Quit, so later edits/processes are never covered by an
-        // earlier answer.
+        // Other project windows remain interactive while sheets and metadata
+        // waits are in flight. A task can therefore start after the initial
+        // refusal check; revalidate execution ownership after the final
+        // suspension point, before any editor discard is committed.
+        guard !registry.hasOutstandingUserTaskExecution else {
+            await rollbackAgentTasks()
+            return false
+        }
+
+        // Revalidate every destructive authorization after the final
+        // suspension point, immediately before committing Quit, so later
+        // edits/processes are never covered by an earlier answer.
         for projectManager in registry.openProjects.values {
             let identifier = ObjectIdentifier(projectManager)
             let currentDirtyTabs = projectManager.allDirtyTabs
@@ -2035,7 +2055,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         }
 
         // Two-phase destructive commit: no project is mutated until every
-        // project/terminal authorization and task cleanup above has passed.
+        // project/terminal authorization and task-ownership checks above pass.
         for projectManager in registry.openProjects.values {
             let identifier = ObjectIdentifier(projectManager)
             if let authorization = discardAuthorizations[identifier],

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -1869,6 +1869,24 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             return false
         }
 
+        // Runtime pane/tab IDs cannot be trusted across relaunch. Freeze new
+        // mutations and publish the final task snapshot before any destructive
+        // editor discard. Every later failure rolls this state back.
+        registry.freezeAgentTasksForTermination()
+        registry.agentTasks.prepareForApplicationTermination()
+        var shouldRollbackAgentTasks = true
+        defer {
+            if shouldRollbackAgentTasks {
+                registry.cancelAgentTaskTermination()
+            }
+        }
+        guard await registry.agentTasks.flushPersistence() == .saved else {
+            Logger.app.error(
+                "Agent task metadata did not reach a clean persistence barrier"
+            )
+            return false
+        }
+
         // Other project windows remain interactive while sheets and off-main
         // process waits are in flight. Revalidate every destructive
         // authorization after the final suspension point, immediately before
@@ -1912,6 +1930,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             }
         }
 
+        shouldRollbackAgentTasks = false
         return true
     }
 }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -777,6 +777,23 @@ class CloseDelegate: NSObject, NSWindowDelegate {
 
 // MARK: - AppDelegate
 
+@MainActor
+private final class TerminationDeadlineResolver<Value: Sendable> {
+    private var continuation: CheckedContinuation<Value?, Never>?
+
+    init(_ continuation: CheckedContinuation<Value?, Never>) {
+        self.continuation = continuation
+    }
+
+    @discardableResult
+    func resolve(_ value: Value?) -> Bool {
+        guard let continuation else { return false }
+        self.continuation = nil
+        continuation.resume(returning: value)
+        return true
+    }
+}
+
 class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                    GlobalTabSwitcherKeyControllerDelegate {
     typealias TerminationAlertPresenter = @MainActor (
@@ -1730,6 +1747,50 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         return .terminateLater
     }
 
+    private func remainingTerminationDuration(
+        until deadline: DispatchTime
+    ) -> Duration? {
+        let now = DispatchTime.now().uptimeNanoseconds
+        guard now < deadline.uptimeNanoseconds else { return nil }
+        return .nanoseconds(
+            Int64(clamping: deadline.uptimeNanoseconds - now)
+        )
+    }
+
+    private func valueBeforeTerminationDeadline<Value: Sendable>(
+        _ deadline: DispatchTime,
+        onTimeout: @escaping @MainActor () -> Void,
+        operation: @escaping @MainActor () async -> Value
+    ) async -> Value? {
+        let now = DispatchTime.now().uptimeNanoseconds
+        guard now < deadline.uptimeNanoseconds else {
+            onTimeout()
+            return nil
+        }
+        let delay = deadline.uptimeNanoseconds - now
+        return await withCheckedContinuation { continuation in
+            let resolver = TerminationDeadlineResolver<Value>(continuation)
+            var timeoutTask: Task<Void, Never>?
+            let operationTask = Task { @MainActor in
+                let value = await operation()
+                if resolver.resolve(value) {
+                    timeoutTask?.cancel()
+                }
+            }
+            timeoutTask = Task { @MainActor in
+                do {
+                    try await Task.sleep(nanoseconds: delay)
+                } catch {
+                    return
+                }
+                if resolver.resolve(nil) {
+                    operationTask.cancel()
+                    onTimeout()
+                }
+            }
+        }
+    }
+
     /// Runs all quit decisions asynchronously on their owning project
     /// windows. Background projects fall back to one captured visible
     /// application window (normally Welcome); with no live owner, native
@@ -1741,6 +1802,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         applicationContext: DialogPresentationContext? = nil,
         userTaskShutdownDeadline: DispatchTime? = nil
     ) async -> Bool {
+        let terminationDeadline = userTaskShutdownDeadline
+            ?? DispatchTime.now() + .seconds(30)
         let projects = registry.openProjects
             .sorted { $0.key.path.localizedStandardCompare($1.key.path) == .orderedAscending }
             .map(\.value)
@@ -1781,28 +1844,49 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
 
             let fileList = dirty.map { "  • \($0.fileName)" }.joined(separator: "\n")
             let message = Strings.unsavedChangesListMessage(fileList)
-            let response = if let presentAlert {
-                await presentAlert(
-                    .unsavedChangesBulk,
-                    context,
-                    Strings.unsavedChangesTitle,
-                    message
-                )
-            } else {
-                await AlertTemplate.unsavedChangesBulk.runSheet(
-                    on: context,
-                    messageText: Strings.unsavedChangesTitle,
-                    informativeText: message
-                )
-            }
+            let response = await valueBeforeTerminationDeadline(
+                terminationDeadline,
+                onTimeout: {
+                    guard let window = context.nsWindow,
+                          let sheet = window.attachedSheet else { return }
+                    window.endSheet(sheet, returnCode: .abort)
+                },
+                operation: {
+                    if let presentAlert {
+                        return await presentAlert(
+                            .unsavedChangesBulk,
+                            context,
+                            Strings.unsavedChangesTitle,
+                            message
+                        )
+                    }
+                    return await AlertTemplate.unsavedChangesBulk.runSheet(
+                        on: context,
+                        messageText: Strings.unsavedChangesTitle,
+                        informativeText: message
+                    )
+                }
+            )
+            guard let response else { return false }
             switch response {
             case .alertFirstButtonReturn:
-                let didSave = if let saveAll {
-                    await saveAll(projectManager, context)
-                } else {
-                    await projectManager.saveAllPaneTabs(context: context)
-                }
-                guard didSave else {
+                let didSave = await valueBeforeTerminationDeadline(
+                    terminationDeadline,
+                    onTimeout: {
+                        guard let window = context.nsWindow,
+                              let sheet = window.attachedSheet else { return }
+                        window.endSheet(sheet, returnCode: .abort)
+                    },
+                    operation: {
+                        if let saveAll {
+                            return await saveAll(projectManager, context)
+                        }
+                        return await projectManager.saveAllPaneTabs(
+                            context: context
+                        )
+                    }
+                )
+                guard didSave == true else {
                     return false
                 }
             case .alertSecondButtonReturn:
@@ -1831,20 +1915,30 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             let context = hasEligibleProjectOwner
                 ? projectContext
                 : fallbackContext
-            let response = if let presentAlert {
-                await presentAlert(
-                    .terminalActiveProcessWarning,
-                    context,
-                    Strings.terminalActiveProcessWarningTitle,
-                    Strings.terminalActiveProcessWarningMessage
-                )
-            } else {
-                await AlertTemplate.terminalActiveProcessWarning.runSheet(
-                    on: context,
-                    messageText: Strings.terminalActiveProcessWarningTitle,
-                    informativeText: Strings.terminalActiveProcessWarningMessage
-                )
-            }
+            let response = await valueBeforeTerminationDeadline(
+                terminationDeadline,
+                onTimeout: {
+                    guard let window = context.nsWindow,
+                          let sheet = window.attachedSheet else { return }
+                    window.endSheet(sheet, returnCode: .abort)
+                },
+                operation: {
+                    if let presentAlert {
+                        return await presentAlert(
+                            .terminalActiveProcessWarning,
+                            context,
+                            Strings.terminalActiveProcessWarningTitle,
+                            Strings.terminalActiveProcessWarningMessage
+                        )
+                    }
+                    return await AlertTemplate.terminalActiveProcessWarning.runSheet(
+                        on: context,
+                        messageText: Strings.terminalActiveProcessWarningTitle,
+                        informativeText: Strings.terminalActiveProcessWarningMessage
+                    )
+                }
+            )
+            guard let response else { return false }
             guard response == .alertFirstButtonReturn else {
                 return false
             }
@@ -1858,8 +1952,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         // happen off-main while AppKit remains in its `.terminateLater`
         // handshake. A timeout cancels Quit before any authorized editor
         // discard is committed and retains every cleanup handle.
-        let taskShutdownDeadline =
-            userTaskShutdownDeadline ?? DispatchTime.now() + 3
+        let taskStageDeadline = DispatchTime.now() + .seconds(3)
+        let taskShutdownDeadline = min(
+            terminationDeadline,
+            taskStageDeadline
+        )
         guard await registry.shutdownUserTasks(
             until: taskShutdownDeadline
         ) else {
@@ -1869,21 +1966,38 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             return false
         }
 
-        // Runtime pane/tab IDs cannot be trusted across relaunch. Freeze new
-        // mutations and publish the final task snapshot before any destructive
-        // editor discard. Every later failure rolls this state back.
+        // Runtime pane/tab IDs cannot be trusted across relaunch. Reserve a
+        // rollback slice before freezing so every failed Quit can durably
+        // restore the pre-handshake snapshot within the same absolute budget.
+        let rollbackReserve: Duration = .seconds(2)
+        guard let availablePersistenceTime = remainingTerminationDuration(
+            until: terminationDeadline
+        ), availablePersistenceTime > rollbackReserve else {
+            return false
+        }
         registry.freezeAgentTasksForTermination()
         registry.agentTasks.prepareForApplicationTermination()
-        var shouldRollbackAgentTasks = true
-        defer {
-            if shouldRollbackAgentTasks {
-                registry.cancelAgentTaskTermination()
+        func rollbackAgentTasks() async {
+            let remaining = remainingTerminationDuration(
+                until: terminationDeadline
+            ) ?? .zero
+            guard await registry.cancelAgentTaskTermination(
+                maximumDuration: remaining
+            ) else {
+                Logger.app.error(
+                    "Agent task rollback did not reach a clean persistence barrier"
+                )
+                return
             }
         }
-        guard await registry.agentTasks.flushPersistence() == .saved else {
+        let persistenceBudget = availablePersistenceTime - rollbackReserve
+        guard await registry.agentTasks.flushPersistence(
+            maximumDuration: persistenceBudget
+        ) == .saved else {
             Logger.app.error(
                 "Agent task metadata did not reach a clean persistence barrier"
             )
+            await rollbackAgentTasks()
             return false
         }
 
@@ -1897,9 +2011,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             let currentDirtyTabs = projectManager.allDirtyTabs
             if let authorization = discardAuthorizations[identifier] {
                 guard authorization.covers(currentDirtyTabs) else {
+                    await rollbackAgentTasks()
                     return false
                 }
             } else if !currentDirtyTabs.isEmpty {
+                await rollbackAgentTasks()
                 return false
             }
 
@@ -1913,6 +2029,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 currentTerminalProcesses,
                 by: allowedTerminalProcesses
             ) else {
+                await rollbackAgentTasks()
                 return false
             }
         }
@@ -1926,11 +2043,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                    authorization,
                    postReloadNotifications: false
                ) {
+                await rollbackAgentTasks()
                 return false
             }
         }
 
-        shouldRollbackAgentTasks = false
         return true
     }
 }

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -30,7 +30,7 @@ final class ProjectManager {
     }
 
     let workspace = WorkspaceManager()
-    let terminal = TerminalManager()
+    let terminal: TerminalManager
     /// Structured agent-action feed for the Activity Panel (vision #933,
     /// Phase 2 — Visibility, issue #1072).
     let agentActivity = AgentActivityStore()
@@ -598,7 +598,13 @@ final class ProjectManager {
     /// Recovery snapshots and their lifecycle are owned by the main actor.
     private(set) var recoveryManager: RecoveryManager?
 
-    init(lspSettings: LSPSettings = .shared) {
+    init(
+        lspSettings: LSPSettings = .shared,
+        agentTaskRegistry: AgentTaskRegistry? = nil
+    ) {
+        self.terminal = TerminalManager(
+            agentTaskRegistry: agentTaskRegistry
+        )
         self.lspManager = LSPManager(settings: lspSettings)
         self.problemsController = ProblemsPanelController(lspManager: lspManager)
         workspace.setOnRootNodesChanged { [weak self] nodes in
@@ -613,6 +619,12 @@ final class ProjectManager {
         workspace.gitProvider.progressTracker = progress
         paneManager.configureEditorTabManager = { [weak self] tabManager in
             self?.configureEditorTabManager(tabManager)
+        }
+        paneManager.configureTerminalTab = { [weak self] tab in
+            self?.terminal.configureAgentLifecycle(for: tab)
+        }
+        paneManager.terminalTabDidMove = { [weak self] tab, paneID in
+            self?.terminal.agentTerminalDidMove(tab, to: paneID)
         }
         problemsController.configureDocumentStatesProvider { [weak self] in
             self?.problemsDocumentStates ?? []
@@ -971,6 +983,7 @@ final class ProjectManager {
     }
     func loadDirectory(url: URL) {
         workspace.loadDirectory(url: url)
+        terminal.configureAgentTaskProject(url)
         setupRecovery(projectURL: url)
         agentHistory.updateProjectRoot(url)
         synchronizeAgentHandoff(projectRoot: url)

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -29,6 +29,8 @@ final class ProjectRegistry: LSPSettingsObserver {
 
     /// Application-wide LSP preferences shared by every project manager.
     let lspSettings: LSPSettings
+    /// Application-lifetime durable agent identity across every project.
+    let agentTasks: AgentTaskRegistry
 
     private static let recentProjectsKey = "recentProjectPaths"
     private static let maxRecentProjects = 10
@@ -44,11 +46,13 @@ final class ProjectRegistry: LSPSettingsObserver {
         lspSettings: LSPSettings = .shared,
         defaults: UserDefaults = .standard,
         fileManager: FileManager = .default,
+        agentTasks: AgentTaskRegistry = AgentTaskRegistry(),
         clearRecentProjects: Bool = CommandLine.arguments.contains(
             "--clear-recent-projects"
         )
     ) {
         self.lspSettings = lspSettings
+        self.agentTasks = agentTasks
         self.defaults = defaults
         self.fileManager = fileManager
         if clearRecentProjects {
@@ -87,11 +91,18 @@ final class ProjectRegistry: LSPSettingsObserver {
                     }
                     openProjects.removeValue(forKey: canonical)
                     backgroundProjects.remove(canonical)
+                    agentTasks.setWindowOpen(
+                        false,
+                        projectPath: canonical.path
+                    )
+                    existing.terminal.setAgentTaskWindowOpen(false)
                     recentProjects.removeAll { $0 == canonical }
                     saveRecentProjects()
                     return nil
                 }
                 backgroundProjects.remove(canonical)
+                agentTasks.setWindowOpen(true, projectPath: canonical.path)
+                existing.terminal.setAgentTaskWindowOpen(true)
             }
             addToRecent(canonical)
             return existing
@@ -104,7 +115,15 @@ final class ProjectRegistry: LSPSettingsObserver {
             saveRecentProjects()
             return nil
         }
-        let pm = ProjectManager(lspSettings: lspSettings)
+        let identity = AgentTaskProjectIdentity(
+            canonicalProjectPath: canonical.path,
+            canonicalWorktreePath: canonical.path
+        )
+        agentTasks.registerProject(identity)
+        let pm = ProjectManager(
+            lspSettings: lspSettings,
+            agentTaskRegistry: agentTasks
+        )
         pm.loadDirectory(url: canonical)
         openProjects[canonical] = pm
         addToRecent(canonical)
@@ -137,12 +156,167 @@ final class ProjectRegistry: LSPSettingsObserver {
         let canonical = canonicalProjectURL(url)
         guard openProjects[canonical] != nil else { return }
         backgroundProjects.insert(canonical)
+        agentTasks.setWindowOpen(false, projectPath: canonical.path)
+        openProjects[canonical]?.terminal.setAgentTaskWindowOpen(false)
     }
 
     /// Closes a project and removes it from open projects.
     /// For backwards compatibility, delegates to `closeProjectWindow`.
     func closeProject(_ url: URL) {
         closeProjectWindow(url)
+    }
+
+    /// Re-resolves a persisted route against current application ownership.
+    /// No UI object is retained by the durable registry; every activation must
+    /// cross this boundary immediately before use.
+    func resolveAgentTaskRoute(
+        _ taskID: UUID,
+        targetTerminalID: UUID? = nil
+    ) async -> AgentTaskRoute? {
+        guard let task = agentTasks.task(for: taskID) else { return nil }
+        if task.lifecycle == .paused, let targetTerminalID {
+            return await resolvePausedAgentTaskRoute(
+                task,
+                targetTerminalID: targetTerminalID
+            )
+        }
+        guard task.lifecycle == .active,
+              task.route.availability == .available,
+              let run = task.runs.last,
+              run.liveness == .live,
+              run.endedAt == nil,
+              agentTasks.isExactLiveOwner(
+                  taskID: taskID,
+                  terminalID: task.route.terminalID,
+                  runID: run.id
+              ) else { return nil }
+        let rawURL = URL(
+            fileURLWithPath: task.project.canonicalProjectPath,
+            isDirectory: true
+        )
+        let projectURL = await Task.detached {
+            Self.canonicalProjectURL(rawURL)
+        }.value
+        guard let currentTask = agentTasks.task(for: taskID),
+              currentTask == task,
+              currentTask.lifecycle == .active,
+              currentTask.route.availability == .available,
+              let currentRun = currentTask.runs.last,
+              currentRun == run,
+              currentRun.liveness == .live,
+              currentRun.endedAt == nil,
+              agentTasks.isExactLiveOwner(
+                  taskID: taskID,
+                  terminalID: currentTask.route.terminalID,
+                  runID: currentRun.id
+              ),
+              !backgroundProjects.contains(projectURL),
+              let manager = openProjects[projectURL],
+              manager.rootURL == projectURL,
+              projectURL.path == task.project.canonicalProjectPath,
+              projectURL.path == task.project.canonicalWorktreePath else {
+            return nil
+        }
+
+        var matches: [AgentTaskRoute] = []
+        for paneID in manager.paneManager.terminalPaneIDs {
+            guard let state = manager.paneManager.terminalState(for: paneID) else {
+                continue
+            }
+            for tab in state.terminalTabs {
+                guard tab.id == task.route.terminalID,
+                      let session = tab.agentSession,
+                      session.id == run.id,
+                      session.liveness == .live,
+                      AgentDescriptor(agentType: session.agentType)
+                        == task.descriptor,
+                      let observed = session.processEvidence,
+                      observed.identifiesSameProcess(as: run.process),
+                      run.terminalID == tab.id,
+                      agentTasks.isExactLiveOwner(
+                          taskID: taskID,
+                          terminalID: tab.id,
+                          runID: session.id
+                      ) else {
+                    continue
+                }
+                matches.append(AgentTaskRoute(
+                    paneID: paneID.id,
+                    tabID: tab.id,
+                    terminalID: tab.id
+                ))
+            }
+        }
+        guard matches.count == 1,
+              matches[0] == currentTask.route,
+              agentTasks.task(for: taskID) == currentTask,
+              agentTasks.isExactLiveOwner(
+                  taskID: taskID,
+                  terminalID: currentTask.route.terminalID,
+                  runID: currentRun.id
+              ),
+              !backgroundProjects.contains(projectURL) else { return nil }
+        return matches[0]
+    }
+
+    private func resolvePausedAgentTaskRoute(
+        _ task: AgentTask,
+        targetTerminalID: UUID
+    ) async -> AgentTaskRoute? {
+        let rawURL = URL(
+            fileURLWithPath: task.project.canonicalWorktreePath,
+            isDirectory: true
+        )
+        let projectURL = await Task.detached {
+            Self.canonicalProjectURL(rawURL)
+        }.value
+        guard let currentTask = agentTasks.task(for: task.id),
+              currentTask == task,
+              agentTasks.canResumeTask(task.id),
+              !backgroundProjects.contains(projectURL),
+              let manager = openProjects[projectURL],
+              manager.rootURL == projectURL,
+              projectURL.path == task.project.canonicalWorktreePath else {
+            return nil
+        }
+
+        var matches: [AgentTaskRoute] = []
+        for paneID in manager.paneManager.terminalPaneIDs {
+            guard let state = manager.paneManager.terminalState(for: paneID) else {
+                continue
+            }
+            for tab in state.terminalTabs where tab.id == targetTerminalID {
+                matches.append(AgentTaskRoute(
+                    paneID: paneID.id,
+                    tabID: tab.id,
+                    terminalID: tab.id
+                ))
+            }
+        }
+        guard matches.count == 1,
+              agentTasks.task(for: task.id) == currentTask else {
+            return nil
+        }
+        return matches[0]
+    }
+
+    func freezeAgentTasksForTermination() {
+        for manager in openProjects.values {
+            manager.terminal.freezeAgentTasksForTermination()
+        }
+        for manager in detachedTaskCleanupProjects.values {
+            manager.terminal.freezeAgentTasksForTermination()
+        }
+    }
+
+    func cancelAgentTaskTermination() {
+        agentTasks.cancelApplicationTermination()
+        for manager in openProjects.values {
+            manager.terminal.cancelAgentTaskTermination()
+        }
+        for manager in detachedTaskCleanupProjects.values {
+            manager.terminal.cancelAgentTaskTermination()
+        }
     }
 
     /// Cancels and waits for all project-owned user tasks against one shared
@@ -303,25 +477,7 @@ final class ProjectRegistry: LSPSettingsObserver {
     }
 
     func canonicalProjectURL(_ projectURL: URL) -> URL {
-        let standardized = projectURL.standardizedFileURL
-        var existingAncestor = standardized
-        var missingComponents: [String] = []
-
-        while !fileManager.fileExists(atPath: existingAncestor.path) {
-            let parent = existingAncestor.deletingLastPathComponent()
-            guard parent.path != existingAncestor.path else { break }
-            missingComponents.append(existingAncestor.lastPathComponent)
-            existingAncestor = parent
-        }
-
-        var canonical = existingAncestor.resolvingSymlinksInPath()
-        for component in missingComponents.reversed() {
-            canonical.appendPathComponent(component)
-        }
-        return URL(
-            fileURLWithPath: canonical.path,
-            isDirectory: true
-        ).standardizedFileURL
+        Self.canonicalProjectURL(projectURL)
     }
 
     /// Resolves a stable project identity even after the project directory is

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -324,6 +324,13 @@ final class ProjectRegistry: LSPSettingsObserver {
         return rollbackWasSaved
     }
 
+    /// Whether any open or detached project still owns a user-task execution.
+    /// Application termination uses this as a fail-closed preflight and final
+    /// revalidation; it never sends TERM/KILL as part of a cancellable Quit.
+    var hasOutstandingUserTaskExecution: Bool {
+        userTaskOwners.contains { $0.hasOutstandingUserTaskExecution }
+    }
+
     /// Cancels and waits for all project-owned user tasks against one shared
     /// absolute deadline. Blocking process waits happen off the main actor.
     @discardableResult

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -228,8 +228,7 @@ final class ProjectRegistry: LSPSettingsObserver {
                       let session = tab.agentSession,
                       session.id == run.id,
                       session.liveness == .live,
-                      AgentDescriptor(agentType: session.agentType)
-                        == task.descriptor,
+                      session.agentType == task.descriptor.agentType,
                       let observed = session.processEvidence,
                       observed.identifiesSameProcess(as: run.process),
                       run.terminalID == tab.id,
@@ -309,14 +308,22 @@ final class ProjectRegistry: LSPSettingsObserver {
         }
     }
 
-    func cancelAgentTaskTermination() {
-        agentTasks.cancelApplicationTermination()
+    @discardableResult
+    func cancelAgentTaskTermination(
+        maximumDuration: Duration? = nil
+    ) async -> Bool {
+        guard await agentTasks.cancelApplicationTerminationAndFlush(
+            maximumDuration: maximumDuration
+        ) else {
+            return false
+        }
         for manager in openProjects.values {
             manager.terminal.cancelAgentTaskTermination()
         }
         for manager in detachedTaskCleanupProjects.values {
             manager.terminal.cancelAgentTaskTermination()
         }
+        return true
     }
 
     /// Cancels and waits for all project-owned user tasks against one shared

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -312,18 +312,16 @@ final class ProjectRegistry: LSPSettingsObserver {
     func cancelAgentTaskTermination(
         maximumDuration: Duration? = nil
     ) async -> Bool {
-        guard await agentTasks.cancelApplicationTerminationAndFlush(
+        let rollbackWasSaved = await agentTasks.cancelApplicationTerminationAndFlush(
             maximumDuration: maximumDuration
-        ) else {
-            return false
-        }
+        )
         for manager in openProjects.values {
             manager.terminal.cancelAgentTaskTermination()
         }
         for manager in detachedTaskCleanupProjects.values {
             manager.terminal.cancelAgentTaskTermination()
         }
-        return true
+        return rollbackWasSaved
     }
 
     /// Cancels and waits for all project-owned user tasks against one shared

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -1768,6 +1768,14 @@ enum Strings {
         String(localized: "terminal.activeProcessWarning.quit")
     }
 
+    static var activeUserTasksPreventQuitTitle: String {
+        String(localized: "task.activePreventQuit.title")
+    }
+
+    static var activeUserTasksPreventQuitMessage: String {
+        String(localized: "task.activePreventQuit.message")
+    }
+
     static var terminalTabCloseWarningTitle: String {
         String(localized: "terminal.tabCloseWarning.title")
     }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -583,20 +583,24 @@ enum Strings {
     }
 
     // MARK: - Agent state labels (#1245)
-    static var agentStateIdle: String {
-        String(localized: "agentState.idle", defaultValue: "Idle")
+    static func agentStateIdle(locale: Locale = .current) -> String {
+        localizedString(forKey: "agentState.idle", fallback: "Idle", locale: locale)
     }
-    static var agentStateThinking: String {
-        String(localized: "agentState.thinking", defaultValue: "Thinking")
+    static func agentStateThinking(locale: Locale = .current) -> String {
+        localizedString(forKey: "agentState.thinking", fallback: "Thinking", locale: locale)
     }
-    static var agentStateExecuting: String {
-        String(localized: "agentState.executing", defaultValue: "Executing")
+    static func agentStateExecuting(locale: Locale = .current) -> String {
+        localizedString(forKey: "agentState.executing", fallback: "Executing", locale: locale)
     }
-    static var agentStateWaitingInput: String {
-        String(localized: "agentState.waitingInput", defaultValue: "Waiting for input")
+    static func agentStateWaitingInput(locale: Locale = .current) -> String {
+        localizedString(
+            forKey: "agentState.waitingInput",
+            fallback: "Waiting for input",
+            locale: locale
+        )
     }
-    static var agentStateDone: String {
-        String(localized: "agentState.done", defaultValue: "Done")
+    static func agentStateDone(locale: Locale = .current) -> String {
+        localizedString(forKey: "agentState.done", fallback: "Done", locale: locale)
     }
 
     // MARK: - Agent Attention overlay (#1112)

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -1527,6 +1527,7 @@ enum Strings {
     static let tabRevealInSidebar: LocalizedStringKey = "tab.revealInSidebar"
     static let tabRevealInFinder: LocalizedStringKey = "tab.revealInFinder"
     static let tabCloseTabDisabledPinned: LocalizedStringKey = "tab.closeTabDisabledPinned"
+    static let agentResumeTask: LocalizedStringKey = "agent.resumeTask"
     static let tabMoveLeading: LocalizedStringKey = "tab.moveLeading"
     static let tabMoveTrailing: LocalizedStringKey = "tab.moveTrailing"
     static let tabMoveToPreviousPane: LocalizedStringKey = "tab.moveToPreviousPane"

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -145,6 +145,12 @@ final class TabManager {
     var onTabInventoryChanged: (() -> Void)?
     var editorSettings: EditorSettings = .shared
     var fileFormatters: FileFormatterRegistry = .default
+    /// Injectable preference lookup keeps independent project/test contexts
+    /// from inheriting a concurrently mutated process-wide UserDefaults key.
+    @ObservationIgnored
+    var autoSavePreferenceProvider: @MainActor () -> Bool = {
+        UserDefaults.standard.bool(forKey: TabAutoSave.autoSaveKey)
+    }
     /// Project wiring replaces this fallback for every pane-owned manager,
     /// so model-triggered large-file and error flows do not depend on which
     /// unrelated window happens to be key.
@@ -235,7 +241,7 @@ final class TabManager {
 
     var hasUnsavedChanges: Bool { TabCollection.hasUnsavedChanges(in: tabs) }
     var dirtyTabs: [EditorTab] { TabCollection.dirtyTabs(in: tabs) }
-    var isAutoSaveEnabled: Bool { UserDefaults.standard.bool(forKey: Self.autoSaveKey) }
+    var isAutoSaveEnabled: Bool { autoSavePreferenceProvider() }
     var pinnedTabCount: Int { TabPinning.pinnedTabCount(in: tabs) }
 
     /// Consumes the terminal result of a bounded AppKit focus request.

--- a/Pine/TerminalBarView.swift
+++ b/Pine/TerminalBarView.swift
@@ -105,6 +105,12 @@ struct AgentTabBadge: View {
 
 // MARK: - Terminal tab item (capsule style)
 
+struct TerminalAgentResumeAction: Identifiable {
+    let id: UUID
+    let title: String
+    let action: () -> Void
+}
+
 struct TerminalNativeTabItem: View {
     let tab: TerminalTab
     let isActive: Bool
@@ -115,6 +121,7 @@ struct TerminalNativeTabItem: View {
     var onMoveTrailing: (() -> Void)?
     var onMoveToPreviousPane: (() -> Void)?
     var onMoveToNextPane: (() -> Void)?
+    var agentResumeActions: [TerminalAgentResumeAction] = []
 
     @State private var isHovering = false
     @State private var closeGlyphFrame = CGRect.null
@@ -198,6 +205,15 @@ struct TerminalNativeTabItem: View {
                 onMoveToNextPane?()
             }
             .disabled(onMoveToNextPane == nil)
+
+            if !agentResumeActions.isEmpty {
+                Divider()
+                Menu(Strings.agentResumeTask) {
+                    ForEach(agentResumeActions) { resume in
+                        Button(resume.title, action: resume.action)
+                    }
+                }
+            }
 
             Divider()
 

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -214,14 +214,17 @@ final class TerminalManager {
               !token.contains(where: { $0.isWhitespace }),
               let agentType = AgentType.resolve(fromProcessName: token),
               agentType.cliNames.contains(token) else { return nil }
-        return AgentDescriptor(agentType: agentType)
+        return AgentDescriptor(
+            agentType: agentType,
+            launchExecutable: token
+        )
     }
 
     func launchAgentCommand(
         _ command: String,
         descriptor: AgentDescriptor,
         in tab: TerminalTab
-    ) -> AgentTaskLaunchResult {
+    ) async -> AgentTaskLaunchResult {
         guard Self.exactAgentLaunchDescriptor(for: command) == descriptor else {
             return .rejected
         }
@@ -231,8 +234,12 @@ final class TerminalManager {
             title: nil,
             objective: nil
         )
-        guard case .reserved(let reservation) = result else { return result }
-        guard tab.sendText(command + "\n") else {
+        guard case .reserved(let reservation) = result else {
+            return await tab.sendTextAcknowledged(command + "\n")
+                ? .sentWithoutReservation
+                : .rejected
+        }
+        guard await tab.sendTextAcknowledged(command + "\n") else {
             cancelAgentLaunch(in: tab)
             return .rejected
         }
@@ -250,15 +257,16 @@ final class TerminalManager {
         taskID: UUID,
         command: String,
         in tab: TerminalTab
-    ) -> AgentTaskLaunchResult {
+    ) async -> AgentTaskLaunchResult {
         guard let agentTaskRegistry,
               let task = agentTaskRegistry.task(for: taskID),
+              task.descriptor.launchExecutable == command,
               Self.exactAgentLaunchDescriptor(for: command) == task.descriptor else {
             return .rejected
         }
         let result = prepareAgentResume(taskID: taskID, in: tab)
         guard case .reserved(let reservation) = result else { return result }
-        guard tab.sendText(command + "\n") else {
+        guard await tab.sendTextAcknowledged(command + "\n") else {
             cancelAgentLaunch(in: tab)
             return .rejected
         }

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -237,6 +237,10 @@ final class TerminalManager {
     }
 
 #if DEBUG
+    var agentCallbacksFrozenForTesting: Bool {
+        agentTaskCallbacksFrozen
+    }
+
     func launchAgentCommandForTesting(
         _ command: String,
         descriptor: AgentDescriptor,

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -42,6 +42,8 @@ final class TerminalManager {
     private var agentTaskWindowOpen = true
     @ObservationIgnored
     private var launchReservations: [UUID: AgentTaskLaunchReservation] = [:]
+    @ObservationIgnored
+    private var launchWritesInFlight: Set<UUID> = []
 
     /// `true` once agent-detection polling has started. Read-only diagnostic /
     /// test hook. Delegates to the coordinator's `isRunning` so it correctly
@@ -225,7 +227,51 @@ final class TerminalManager {
         descriptor: AgentDescriptor,
         in tab: TerminalTab
     ) async -> AgentTaskLaunchResult {
+        await performAgentLaunch(
+            command,
+            descriptor: descriptor,
+            in: tab
+        ) {
+            await tab.sendTextAcknowledged(command + "\n")
+        }
+    }
+
+#if DEBUG
+    func launchAgentCommandForTesting(
+        _ command: String,
+        descriptor: AgentDescriptor,
+        in tab: TerminalTab,
+        acknowledgedWrite: () async -> Bool
+    ) async -> AgentTaskLaunchResult {
+        await performAgentLaunch(
+            command,
+            descriptor: descriptor,
+            in: tab,
+            acknowledgedWrite: acknowledgedWrite
+        )
+    }
+#endif
+
+    private func performAgentLaunch(
+        _ command: String,
+        descriptor: AgentDescriptor,
+        in tab: TerminalTab,
+        acknowledgedWrite: () async -> Bool
+    ) async -> AgentTaskLaunchResult {
         guard Self.exactAgentLaunchDescriptor(for: command) == descriptor else {
+            return .rejected
+        }
+        guard agentTaskRegistry != nil,
+              agentTaskContext(for: tab) != nil else {
+            return await acknowledgedWrite()
+                ? .sentWithoutReservation
+                : .rejected
+        }
+        guard !launchWritesInFlight.contains(tab.id) else {
+            return .rejected
+        }
+        if let existing = launchReservations[tab.id],
+           agentTaskRegistry?.isLaunchPending(existing) == true {
             return .rejected
         }
         let result = prepareAgentLaunch(
@@ -235,21 +281,35 @@ final class TerminalManager {
             objective: nil
         )
         guard case .reserved(let reservation) = result else {
-            return await tab.sendTextAcknowledged(command + "\n")
-                ? .sentWithoutReservation
-                : .rejected
-        }
-        guard await tab.sendTextAcknowledged(command + "\n") else {
-            cancelAgentLaunch(in: tab)
             return .rejected
+        }
+        launchWritesInFlight.insert(tab.id)
+        let acknowledged = await acknowledgedWrite()
+        launchWritesInFlight.remove(tab.id)
+        guard acknowledged else {
+            cancelAgentLaunch(reservation, in: tab)
+            return .rejected
+        }
+        guard launchReservations[tab.id] == reservation,
+              agentTaskRegistry?.armLaunch(reservation) == true else {
+            cancelAgentLaunch(reservation, in: tab)
+            return .sentWithoutReservation
         }
         return .reserved(reservation)
     }
 
     func cancelAgentLaunch(in tab: TerminalTab) {
-        guard let reservation = launchReservations.removeValue(
-            forKey: tab.id
-        ) else { return }
+        guard let reservation = launchReservations[tab.id] else { return }
+        cancelAgentLaunch(reservation, in: tab)
+    }
+
+    private func cancelAgentLaunch(
+        _ reservation: AgentTaskLaunchReservation,
+        in tab: TerminalTab
+    ) {
+        if launchReservations[tab.id] == reservation {
+            launchReservations[tab.id] = nil
+        }
         agentTaskRegistry?.cancelLaunch(reservation)
     }
 
@@ -261,14 +321,23 @@ final class TerminalManager {
         guard let agentTaskRegistry,
               let task = agentTaskRegistry.task(for: taskID),
               task.descriptor.launchExecutable == command,
-              Self.exactAgentLaunchDescriptor(for: command) == task.descriptor else {
+              Self.exactAgentLaunchDescriptor(for: command) == task.descriptor,
+              !launchWritesInFlight.contains(tab.id) else {
             return .rejected
         }
         let result = prepareAgentResume(taskID: taskID, in: tab)
         guard case .reserved(let reservation) = result else { return result }
-        guard await tab.sendTextAcknowledged(command + "\n") else {
-            cancelAgentLaunch(in: tab)
+        launchWritesInFlight.insert(tab.id)
+        let acknowledged = await tab.sendTextAcknowledged(command + "\n")
+        launchWritesInFlight.remove(tab.id)
+        guard acknowledged else {
+            cancelAgentLaunch(reservation, in: tab)
             return .rejected
+        }
+        guard launchReservations[tab.id] == reservation,
+              agentTaskRegistry.armLaunch(reservation) else {
+            cancelAgentLaunch(reservation, in: tab)
+            return .sentWithoutReservation
         }
         return .reserved(reservation)
     }

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -30,6 +30,19 @@ final class TerminalManager {
     /// privately so it cannot be mutated after construction.
     private let agentDetectionProcessRunner: ProcessRunner
 
+    /// Application-lifetime registry and canonical project scope. The
+    /// registry itself retains value metadata only; terminal objects retain no
+    /// back-reference from it.
+    private let agentTaskRegistry: AgentTaskRegistry?
+    @ObservationIgnored
+    private var agentTaskProject: AgentTaskProjectIdentity?
+    @ObservationIgnored
+    private var agentTaskCallbacksFrozen = false
+    @ObservationIgnored
+    private var agentTaskWindowOpen = true
+    @ObservationIgnored
+    private var launchReservations: [UUID: AgentTaskLaunchReservation] = [:]
+
     /// `true` once agent-detection polling has started. Read-only diagnostic /
     /// test hook. Delegates to the coordinator's `isRunning` so it correctly
     /// reports `false` after a future `stop()`.
@@ -47,8 +60,275 @@ final class TerminalManager {
     /// here (rather than exposed as a mutable property) so the coordinator's
     /// runner is fixed for the manager's lifetime — matches the init-param
     /// injection pattern used by `ExternalFileFormatter` / `FileFormatter`.
-    init(agentDetectionProcessRunner: @escaping ProcessRunner = runRealProcess) {
+    init(
+        agentDetectionProcessRunner: @escaping ProcessRunner = runRealProcess,
+        agentTaskRegistry: AgentTaskRegistry? = nil
+    ) {
         self.agentDetectionProcessRunner = agentDetectionProcessRunner
+        self.agentTaskRegistry = agentTaskRegistry
+    }
+
+    /// Receives the already canonical root from `ProjectRegistry`; this method
+    /// performs no filesystem work on MainActor.
+    func configureAgentTaskProject(_ projectURL: URL) {
+        let path = projectURL.standardizedFileURL.path
+        agentTaskProject = AgentTaskProjectIdentity(
+            canonicalProjectPath: path,
+            canonicalWorktreePath: path
+        )
+    }
+
+    func setAgentTaskWindowOpen(_ isOpen: Bool) {
+        agentTaskWindowOpen = isOpen
+    }
+
+    func configureAgentLifecycle(for tab: TerminalTab) {
+        guard let agentTaskRegistry, let project = agentTaskProject else { return }
+        tab.onLifecycleEnded = { [weak self, weak agentTaskRegistry] terminalID in
+            if let reservation = self?.launchReservations.removeValue(
+                forKey: terminalID
+            ) {
+                agentTaskRegistry?.cancelLaunch(reservation)
+            }
+            agentTaskRegistry?.markTerminalClosed(
+                terminalID: terminalID,
+                project: project
+            )
+        }
+    }
+
+    func agentTerminalDidMove(_ tab: TerminalTab, to paneID: PaneID) {
+        guard let project = agentTaskProject else { return }
+        agentTaskRegistry?.updateRoute(
+            terminalID: tab.id,
+            project: project,
+            route: AgentTaskRoute(
+                paneID: paneID.id,
+                tabID: tab.id,
+                terminalID: tab.id
+            )
+        )
+    }
+
+    func agentTaskContext(for tab: TerminalTab) -> AgentTaskBridgeContext? {
+        guard let paneManager,
+              let project = agentTaskProject,
+              let paneID = paneManager.terminalPaneIDs.first(where: { paneID in
+                  paneManager.terminalState(for: paneID)?
+                      .terminalTabs.contains(where: { $0 === tab }) == true
+              }) else {
+            return nil
+        }
+        return AgentTaskBridgeContext(
+            project: project,
+            route: AgentTaskRoute(
+                paneID: paneID.id,
+                tabID: tab.id,
+                terminalID: tab.id,
+                availability: agentTaskWindowOpen ? .available : .background
+            ),
+            origin: .discoveredInTerminal
+        )
+    }
+
+    func bridgeAgentSession(
+        _ session: AgentSession,
+        replacing previous: AgentSession?,
+        in tab: TerminalTab,
+        reservation: AgentTaskLaunchReservation? = nil
+    ) {
+        guard !agentTaskCallbacksFrozen,
+              let base = agentTaskContext(for: tab),
+              let agentTaskRegistry else { return }
+        let ownedReservation = reservation ?? launchReservations[tab.id]
+        let context = AgentTaskBridgeContext(
+            project: base.project,
+            route: base.route,
+            origin: ownedReservation == nil
+                ? .discoveredInTerminal
+                : .pineLaunched,
+            observedAt: base.observedAt
+        )
+        agentTaskRegistry.bridge(
+            session,
+            replacing: previous,
+            context: context,
+            reservation: ownedReservation
+        )
+        if let ownedReservation,
+           !agentTaskRegistry.isLaunchPending(ownedReservation) {
+            launchReservations[tab.id] = nil
+        }
+    }
+
+    /// Captures the detector boundary and reserves durable identity for the
+    /// exact terminal launch. The caller must invoke this immediately before
+    /// starting the process and cancel on launch failure.
+    func prepareAgentLaunch(
+        in tab: TerminalTab,
+        descriptor: AgentDescriptor,
+        title: String? = nil,
+        objective: String? = nil
+    ) -> AgentTaskLaunchResult {
+        guard !agentTaskCallbacksFrozen,
+              let base = agentTaskContext(for: tab),
+              let agentTaskRegistry else { return .rejected }
+        if let reservation = launchReservations[tab.id] {
+            guard !agentTaskRegistry.isLaunchPending(reservation) else {
+                return .rejected
+            }
+            launchReservations[tab.id] = nil
+        }
+        let boundary = Date()
+        let context = AgentTaskBridgeContext(
+            project: base.project,
+            route: base.route,
+            origin: .pineLaunched,
+            observedAt: boundary
+        )
+        let result = agentTaskRegistry.preparePineLaunch(
+            descriptor: descriptor,
+            context: context,
+            title: title,
+            objective: objective,
+            boundary: AgentTaskLaunchBoundary(
+                generationFloor: agentDetector.processGenerationFloor,
+                capturedAt: boundary
+            )
+        )
+        if case .reserved(let reservation) = result {
+            launchReservations[tab.id] = reservation
+        }
+        return result
+    }
+
+    /// Owns the exact production handoff for Pine's existing Send to Terminal
+    /// action. Only a single known executable token receives launch authority;
+    /// arbitrary shell text remains untrusted detector input.
+    static func exactAgentLaunchDescriptor(
+        for command: String
+    ) -> AgentDescriptor? {
+        let token = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard command == token,
+              !token.isEmpty,
+              !token.contains(where: { $0.isWhitespace }),
+              let agentType = AgentType.resolve(fromProcessName: token),
+              agentType.cliNames.contains(token) else { return nil }
+        return AgentDescriptor(agentType: agentType)
+    }
+
+    func launchAgentCommand(
+        _ command: String,
+        descriptor: AgentDescriptor,
+        in tab: TerminalTab
+    ) -> AgentTaskLaunchResult {
+        guard Self.exactAgentLaunchDescriptor(for: command) == descriptor else {
+            return .rejected
+        }
+        let result = prepareAgentLaunch(
+            in: tab,
+            descriptor: descriptor,
+            title: nil,
+            objective: nil
+        )
+        guard case .reserved(let reservation) = result else { return result }
+        guard tab.sendText(command + "\n") else {
+            cancelAgentLaunch(in: tab)
+            return .rejected
+        }
+        return .reserved(reservation)
+    }
+
+    func cancelAgentLaunch(in tab: TerminalTab) {
+        guard let reservation = launchReservations.removeValue(
+            forKey: tab.id
+        ) else { return }
+        agentTaskRegistry?.cancelLaunch(reservation)
+    }
+
+    func resumeAgentTaskCommand(
+        taskID: UUID,
+        command: String,
+        in tab: TerminalTab
+    ) -> AgentTaskLaunchResult {
+        guard let agentTaskRegistry,
+              let task = agentTaskRegistry.task(for: taskID),
+              Self.exactAgentLaunchDescriptor(for: command) == task.descriptor else {
+            return .rejected
+        }
+        let result = prepareAgentResume(taskID: taskID, in: tab)
+        guard case .reserved(let reservation) = result else { return result }
+        guard tab.sendText(command + "\n") else {
+            cancelAgentLaunch(in: tab)
+            return .rejected
+        }
+        return .reserved(reservation)
+    }
+
+    func prepareAgentResume(
+        taskID: UUID,
+        in tab: TerminalTab
+    ) -> AgentTaskLaunchResult {
+        guard !agentTaskCallbacksFrozen,
+              let base = agentTaskContext(for: tab),
+              let agentTaskRegistry else { return .rejected }
+        if let reservation = launchReservations[tab.id] {
+            guard !agentTaskRegistry.isLaunchPending(reservation) else {
+                return .rejected
+            }
+            launchReservations[tab.id] = nil
+        }
+        let capturedAt = Date()
+        let context = AgentTaskBridgeContext(
+            project: base.project,
+            route: base.route,
+            origin: .pineLaunched,
+            observedAt: capturedAt
+        )
+        let result = agentTaskRegistry.prepareResume(
+            taskID: taskID,
+            context: context,
+            boundary: AgentTaskLaunchBoundary(
+                generationFloor: agentDetector.processGenerationFloor,
+                capturedAt: capturedAt
+            )
+        )
+        if case .reserved(let reservation) = result {
+            launchReservations[tab.id] = reservation
+        }
+        return result
+    }
+
+    func refreshAgentTasks() {
+        guard !agentTaskCallbacksFrozen else { return }
+        agentTaskRegistry?.refresh(sessions: agentDetector.detectedSessions)
+    }
+
+    func markAgentEvidenceUnavailable() {
+        guard !agentTaskCallbacksFrozen else { return }
+        agentTaskRegistry?.markEvidenceUnavailable(
+            sessionIDs: agentDetector.detectedSessions.map(\.id)
+        )
+    }
+
+    /// Stops polling and invalidates already captured generations before the
+    /// app takes its final durable-task snapshot. Late callbacks are ignored.
+    func freezeAgentTasksForTermination() {
+        guard !agentTaskCallbacksFrozen else { return }
+        agentTaskCallbacksFrozen = true
+        agentCoordinator?.stop()
+    }
+
+    func cancelAgentTaskTermination() {
+        guard agentTaskCallbacksFrozen else { return }
+        agentTaskCallbacksFrozen = false
+        if paneManager?.allTerminalTabs.isEmpty == false {
+            if let agentCoordinator {
+                agentCoordinator.start()
+            } else {
+                ensureAgentDetectionStarted()
+            }
+        }
     }
 
     // MARK: - Tab creation

--- a/Pine/TerminalPaneState.swift
+++ b/Pine/TerminalPaneState.swift
@@ -45,6 +45,8 @@ final class TerminalPaneState {
     /// Called after terminal identities are inserted or removed so a live
     /// global switcher can reconcile independently of SwiftUI rendering.
     var onTabInventoryChanged: (() -> Void)?
+    /// Applies project-scoped lifecycle wiring to every newly created tab.
+    var onTabCreated: ((TerminalTab) -> Void)?
 
     /// Monotonically increasing counter for unique terminal tab names.
     private var nextTabNumber = 1
@@ -93,6 +95,7 @@ final class TerminalPaneState {
             themeSettings: themeSettings
         )
         tab.configure(workingDirectory: workingDirectory)
+        onTabCreated?(tab)
         terminalTabs.append(tab)
         activeTerminalID = tab.id
         pendingFocusTabID = tab.id

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -67,8 +67,8 @@ struct TerminalPaneTabBar: View {
     private func agentResumeActions(
         for tab: TerminalTab
     ) -> [TerminalAgentResumeAction] {
-        guard let projectManager else { return [] }
-        let projectURL = projectManager.rootURL
+        guard let projectManager,
+              let projectURL = projectManager.rootURL else { return [] }
         return projectRegistry.agentTasks.tasks.compactMap { task in
             guard projectRegistry.agentTasks.canResumeTask(task.id),
                   task.project.canonicalWorktreePath == projectURL.path,

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -15,6 +15,7 @@ struct TerminalPaneTabBar: View {
     var workingDirectory: URL?
     var projectManager: ProjectManager? = nil
     @Environment(PaneManager.self) private var paneManager
+    @Environment(ProjectRegistry.self) private var projectRegistry
     @State private var tabFrames: [UUID: CGRect] = [:]
     @State private var autoScrollSession = TabStripAutoScrollSession()
 
@@ -59,6 +60,44 @@ struct TerminalPaneTabBar: View {
             // Remove the pane if no tabs remain
             if terminalState.terminalTabs.isEmpty {
                 paneManager.removePane(paneID)
+            }
+        }
+    }
+
+    private func agentResumeActions(
+        for tab: TerminalTab
+    ) -> [TerminalAgentResumeAction] {
+        guard let projectManager else { return [] }
+        let projectURL = projectRegistry.canonicalProjectURL(
+            projectManager.rootURL
+        )
+        return projectRegistry.agentTasks.tasks.compactMap { task in
+            guard projectRegistry.agentTasks.canResumeTask(task.id),
+                  task.project.canonicalWorktreePath == projectURL.path,
+                  let command = task.descriptor.agentType.cliNames.sorted().first else {
+                return nil
+            }
+            let taskID = task.id
+            let displayName = task.descriptor.agentType.displayName
+            let suffix = task.title ?? String(taskID.uuidString.prefix(8))
+            return TerminalAgentResumeAction(
+                id: taskID,
+                title: "\(displayName) — \(suffix)"
+            ) {
+                Task { @MainActor in
+                    guard let route = await projectRegistry.resolveAgentTaskRoute(
+                        taskID,
+                        targetTerminalID: tab.id
+                    ),
+                    route.terminalID == tab.id else {
+                        return
+                    }
+                    _ = projectManager.terminal.resumeAgentTaskCommand(
+                        taskID: taskID,
+                        command: command,
+                        in: tab
+                    )
+                }
             }
         }
     }
@@ -204,7 +243,10 @@ struct TerminalPaneTabBar: View {
                                                 contentType: .terminal,
                                                 action: .nextPane
                                             )
-                                        } : nil
+                                        } : nil,
+                                        agentResumeActions: agentResumeActions(
+                                            for: tab
+                                        )
                                     )
                                     .opacity(isDragged ? 0.4 : 1.0)
                                     .scaleEffect(isDragged ? 0.95 : 1.0)

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -68,18 +68,21 @@ struct TerminalPaneTabBar: View {
         for tab: TerminalTab
     ) -> [TerminalAgentResumeAction] {
         guard let projectManager else { return [] }
-        let projectURL = projectRegistry.canonicalProjectURL(
-            projectManager.rootURL
-        )
+        let projectURL = projectManager.rootURL
         return projectRegistry.agentTasks.tasks.compactMap { task in
             guard projectRegistry.agentTasks.canResumeTask(task.id),
                   task.project.canonicalWorktreePath == projectURL.path,
-                  let command = task.descriptor.agentType.cliNames.sorted().first else {
+                  let command = task.descriptor.launchExecutable else {
                 return nil
             }
             let taskID = task.id
             let displayName = task.descriptor.agentType.displayName
-            let suffix = task.title ?? String(taskID.uuidString.prefix(8))
+            let created = task.createdAt.formatted(
+                date: .abbreviated,
+                time: .shortened
+            )
+            let context = task.title ?? task.objective ?? created
+            let suffix = "\(context) · \(taskID.uuidString.prefix(8))"
             return TerminalAgentResumeAction(
                 id: taskID,
                 title: "\(displayName) — \(suffix)"
@@ -92,7 +95,7 @@ struct TerminalPaneTabBar: View {
                     route.terminalID == tab.id else {
                         return
                     }
-                    _ = projectManager.terminal.resumeAgentTaskCommand(
+                    _ = await projectManager.terminal.resumeAgentTaskCommand(
                         taskID: taskID,
                         command: command,
                         in: tab

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -34,6 +34,13 @@ nonisolated enum AcknowledgedPTYWriter {
     }
     #endif
 
+    static func acknowledgesCompletion(
+        error: Int32,
+        remainingByteCount: Int
+    ) -> Bool {
+        error == 0 && remainingByteCount == 0
+    }
+
     private static func write(
         _ bytes: [UInt8],
         to borrowedDescriptor: Int32,
@@ -54,8 +61,11 @@ nonisolated enum AcknowledgedPTYWriter {
                 data: data,
                 runningHandlerOn: DispatchQueue.global(qos: .userInitiated)
             ) { remaining, error in
-                continuation.resume(
-                    returning: error == 0 && (remaining?.isEmpty ?? true)
+                continuation.resume(returning:
+                    AcknowledgedPTYWriter.acknowledgesCompletion(
+                        error: error,
+                        remainingByteCount: remaining?.count ?? 0
+                    )
                 )
             }
         }

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -5,13 +5,48 @@
 //  Created by Федор Батоногов on 09.03.2026.
 //
 
+import Darwin
 import Dispatch
 import SwiftUI
 import SwiftTerm
 import os
 
-nonisolated private enum AcknowledgedPTYWriter {
-    static func write(_ bytes: [UInt8], to descriptor: Int32) async -> Bool {
+nonisolated enum AcknowledgedPTYWriter {
+    static func write(_ bytes: [UInt8], to borrowedDescriptor: Int32) async -> Bool {
+        await write(
+            bytes,
+            to: borrowedDescriptor,
+            didAcquireDescriptor: {}
+        )
+    }
+
+    #if DEBUG
+    static func writeForTesting(
+        _ bytes: [UInt8],
+        to borrowedDescriptor: Int32,
+        didAcquireDescriptor: @escaping @Sendable () -> Void
+    ) async -> Bool {
+        await write(
+            bytes,
+            to: borrowedDescriptor,
+            didAcquireDescriptor: didAcquireDescriptor
+        )
+    }
+    #endif
+
+    private static func write(
+        _ bytes: [UInt8],
+        to borrowedDescriptor: Int32,
+        didAcquireDescriptor: @escaping @Sendable () -> Void
+    ) async -> Bool {
+        let descriptor = Darwin.fcntl(
+            borrowedDescriptor,
+            F_DUPFD_CLOEXEC,
+            0
+        )
+        guard descriptor >= 0 else { return false }
+        defer { Darwin.close(descriptor) }
+        didAcquireDescriptor()
         let data = bytes.withUnsafeBytes { DispatchData(bytes: $0) }
         return await withCheckedContinuation { continuation in
             DispatchIO.write(
@@ -2114,10 +2149,10 @@ final class TerminalTab: Identifiable, Hashable {
         return true
     }
 
-    /// Writes launch input directly to SwiftTerm's public PTY descriptor and
-    /// resumes only after DispatchIO reports that every byte was accepted.
-    /// Durable launch authority must never rely on SwiftTerm's fire-and-forget
-    /// `send(data:)` API.
+    /// Duplicates SwiftTerm's public PTY descriptor before suspension, writes
+    /// launch input through that owned lease, and resumes only after DispatchIO
+    /// reports that every byte was accepted. SwiftTerm may close its descriptor
+    /// while the write is pending without redirecting bytes after descriptor reuse.
     func sendTextAcknowledged(_ text: String) async -> Bool {
         guard isProcessRunning else { return false }
         let descriptor = terminalView.process.childfd

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -5,9 +5,27 @@
 //  Created by Федор Батоногов on 09.03.2026.
 //
 
+import Dispatch
 import SwiftUI
 import SwiftTerm
 import os
+
+nonisolated private enum AcknowledgedPTYWriter {
+    static func write(_ bytes: [UInt8], to descriptor: Int32) async -> Bool {
+        let data = bytes.withUnsafeBytes { DispatchData(bytes: $0) }
+        return await withCheckedContinuation { continuation in
+            DispatchIO.write(
+                toFileDescriptor: descriptor,
+                data: data,
+                runningHandlerOn: DispatchQueue.global(qos: .userInitiated)
+            ) { remaining, error in
+                continuation.resume(
+                    returning: error == 0 && (remaining?.isEmpty ?? true)
+                )
+            }
+        }
+    }
+}
 
 /// Pine-specific terminal view wrapper.
 ///
@@ -2094,6 +2112,18 @@ final class TerminalTab: Identifiable, Hashable {
         let data = Array(text.utf8)
         terminalView.process.send(data: data[...])
         return true
+    }
+
+    /// Writes launch input directly to SwiftTerm's public PTY descriptor and
+    /// resumes only after DispatchIO reports that every byte was accepted.
+    /// Durable launch authority must never rely on SwiftTerm's fire-and-forget
+    /// `send(data:)` API.
+    func sendTextAcknowledged(_ text: String) async -> Bool {
+        guard isProcessRunning else { return false }
+        let descriptor = terminalView.process.childfd
+        guard descriptor >= 0 else { return false }
+        let bytes = Array(text.utf8)
+        return await AcknowledgedPTYWriter.write(bytes, to: descriptor)
     }
 
     static func == (lhs: TerminalTab, rhs: TerminalTab) -> Bool { lhs.id == rhs.id }

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -1605,6 +1605,7 @@ final class TerminalTab: Identifiable, Hashable {
     let stableLabel: String
     let terminalView: LocalProcessTerminalView
     fileprivate(set) var isTerminated = false
+    private var didReportLifecycleEnd = false
     /// The AppKit container currently presenting `terminalView`.
     ///
     /// A pane maximize/restore can keep outgoing and incoming SwiftUI
@@ -1659,6 +1660,10 @@ final class TerminalTab: Identifiable, Hashable {
     /// Stored separately so the nonisolated `deinit` can remove the observer
     /// from the exact center that registered it.
     private let themeNotificationCenter: NotificationCenter
+    /// Value-only lifecycle callback installed by the terminal coordinator.
+    /// The tab never exposes its process or view to the durable task registry.
+    @ObservationIgnored
+    var onLifecycleEnded: ((UUID) -> Void)?
 
     init(
         name: String,
@@ -1875,9 +1880,21 @@ final class TerminalTab: Identifiable, Hashable {
     }
 
     func stop() {
+        if !didReportLifecycleEnd {
+            didReportLifecycleEnd = true
+            onLifecycleEnded?(id)
+        }
         guard !isTerminated else { return }
         isTerminated = true
         terminalView.terminate()
+    }
+
+    func processDidTerminate() {
+        if !didReportLifecycleEnd {
+            didReportLifecycleEnd = true
+            onLifecycleEnded?(id)
+        }
+        isTerminated = true
     }
 
     /// Forces SwiftTerm to mark the entire visible buffer as dirty and asks
@@ -2071,10 +2088,12 @@ final class TerminalTab: Identifiable, Hashable {
 
     /// Sends the given text to the terminal process as keyboard input.
     /// The text is written to the PTY as if the user typed it.
-    func sendText(_ text: String) {
-        guard isProcessRunning else { return }
+    @discardableResult
+    func sendText(_ text: String) -> Bool {
+        guard isProcessRunning else { return false }
         let data = Array(text.utf8)
         terminalView.process.send(data: data[...])
+        return true
     }
 
     static func == (lhs: TerminalTab, rhs: TerminalTab) -> Bool { lhs.id == rhs.id }
@@ -2095,6 +2114,6 @@ class TerminalTabDelegate: NSObject, LocalProcessTerminalViewDelegate {
     func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
 
     func processTerminated(source: TerminalView, exitCode: Int32?) {
-        tab?.isTerminated = true
+        tab?.processDidTerminate()
     }
 }

--- a/PineTests/AgentDetectionCoordinatorTests.swift
+++ b/PineTests/AgentDetectionCoordinatorTests.swift
@@ -722,7 +722,8 @@ struct AgentDetectionCoordinatorTests {
     @Test func tooltipFormatIsDisplayNameAndState() {
         let session = AgentSession(agentType: .claudeCode, state: .executing)
         let expected = "\(session.agentType.displayName) — \(session.state.displayName)"
-        #expect(expected == "Claude Code — Executing")
+        #expect(expected.hasPrefix("Claude Code — "))
+        #expect(expected.hasSuffix(session.state.displayName))
     }
 
     // MARK: - cputime parsing (#1112 fix: `times=` was an invalid ps keyword;

--- a/PineTests/AgentDetectorTests.swift
+++ b/PineTests/AgentDetectorTests.swift
@@ -11,6 +11,11 @@ import Testing
 
 @MainActor
 struct AgentDetectorTests {
+    @Test("monotonic counters fail closed before wrap")
+    func monotonicCounterExhaustion() {
+        #expect(AgentMonotonicCounter.next(after: UInt64.max - 1) == UInt64.max)
+        #expect(AgentMonotonicCounter.next(after: UInt64.max) == nil)
+    }
 
     // MARK: - Detection of known agents
 
@@ -354,6 +359,8 @@ struct AgentDetectorTests {
             DetectedProcess(pid: 500, command: "claude"),
         ])
         let originalID = detector.detectedSessions[0].id
+        let originalGeneration = detector.detectedSessions[0]
+            .processEvidence?.processGeneration
 
         // Process exits.
         detector.processSnapshotDidUpdate([])
@@ -368,6 +375,10 @@ struct AgentDetectorTests {
         #expect(allClaude[1].id != originalID)
         #expect(allClaude[1].state == .idle)
         #expect(allClaude[0].state == .done)
+        #expect(
+            allClaude[1].processEvidence?.processGeneration
+                != originalGeneration
+        )
     }
 
     @Test func samePidCpuRegressionCreatesFreshSession() throws {
@@ -387,6 +398,10 @@ struct AgentDetectorTests {
         #expect(original.liveness == .terminated)
         #expect(replacement !== original)
         #expect(replacement.state == .idle)
+        #expect(
+            replacement.processEvidence?.processGeneration
+                != original.processEvidence?.processGeneration
+        )
     }
 
     @Test func changedProcessStartIdentifierCreatesFreshSession() throws {
@@ -413,6 +428,10 @@ struct AgentDetectorTests {
         let replacement = try #require(detector.session(forPID: 511))
         #expect(original.state == .done)
         #expect(replacement !== original)
+        #expect(
+            replacement.processEvidence?.processGeneration
+                != original.processEvidence?.processGeneration
+        )
     }
 
     @Test func stableProcessStartIdentifierKeepsSessionIdentity() throws {
@@ -439,6 +458,96 @@ struct AgentDetectorTests {
 
         #expect(detector.session(forPID: 512) === original)
         #expect(detector.detectedSessions == [original])
+        #expect(original.processEvidence?.startIdentifier == start)
+    }
+
+    @Test func preciseProcessStartIsRuntimeAuthorityEvidence() throws {
+        let detector = AgentDetector()
+        let preciseStart = Date(timeIntervalSince1970: 7_000.125)
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(
+                pid: 515,
+                command: "codex",
+                startIdentifier: "Mon Jul 20 10:00:00 2026",
+                preciseStartedAt: preciseStart
+            ),
+        ])
+        let precise = try #require(detector.session(forPID: 515))
+        #expect(precise.processEvidence?.observedStartedAt == preciseStart)
+        #expect(precise.processEvidence?.startIsAuthoritative == true)
+
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(
+                pid: 515,
+                command: "codex",
+                startIdentifier: "Mon Jul 20 10:00:00 2026",
+                preciseStartedAt: preciseStart.addingTimeInterval(0.25)
+            ),
+        ])
+        let replacement = try #require(detector.session(forPID: 515))
+        #expect(replacement.id != precise.id)
+        #expect(
+            replacement.processEvidence?.processGeneration
+                == (precise.processEvidence?.processGeneration ?? 0) + 1
+        )
+
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 516, command: "pi"),
+        ])
+        let fallback = try #require(detector.session(forPID: 516))
+        #expect(fallback.processEvidence?.startIsAuthoritative == false)
+    }
+
+    @Test func processSampleRequiresCoherentGeneration() {
+        let coarse = Date(timeIntervalSince1970: 1_722_000_000)
+        let precise = Date(timeIntervalSince1970: 1_722_000_000.125)
+        #expect(AgentDetectionCoordinator.processSampleIsCoherentForTesting(
+            coarseStart: coarse,
+            beforeStart: precise,
+            afterStart: precise,
+            observedExecutable: "codex",
+            currentExecutable: "codex"
+        ))
+        #expect(!AgentDetectionCoordinator.processSampleIsCoherentForTesting(
+            coarseStart: coarse,
+            beforeStart: precise,
+            afterStart: precise.addingTimeInterval(0.001),
+            observedExecutable: "codex",
+            currentExecutable: "codex"
+        ))
+        #expect(!AgentDetectionCoordinator.processSampleIsCoherentForTesting(
+            coarseStart: coarse,
+            beforeStart: precise,
+            afterStart: precise,
+            observedExecutable: "codex",
+            currentExecutable: "node"
+        ))
+        #expect(!AgentDetectionCoordinator.processSampleIsCoherentForTesting(
+            coarseStart: coarse.addingTimeInterval(-1),
+            beforeStart: precise,
+            afterStart: precise,
+            observedExecutable: "codex",
+            currentExecutable: "codex"
+        ))
+    }
+
+    @Test func detectorHistoryIsBoundedWithoutDroppingLiveSessions() {
+        let detector = AgentDetector(maxSessionHistory: 2)
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 801, command: "codex"),
+            DetectedProcess(pid: 802, command: "pi"),
+            DetectedProcess(pid: 803, command: "aider"),
+        ])
+        #expect(detector.detectedSessions.count == 2)
+        #expect(detector.activeCount == 2)
+
+        detector.processSnapshotDidUpdate([])
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 804, command: "codex"),
+            DetectedProcess(pid: 805, command: "pi"),
+        ])
+        #expect(detector.detectedSessions.count == 2)
+        #expect(detector.activeCount == 2)
     }
 
     @Test func olderSuccessfulSnapshotCannotTerminateNewerEvidence() throws {

--- a/PineTests/AgentDetectorTests.swift
+++ b/PineTests/AgentDetectorTests.swift
@@ -498,6 +498,55 @@ struct AgentDetectorTests {
         #expect(fallback.processEvidence?.startIsAuthoritative == false)
     }
 
+    @Test func missingPreciseEvidenceCannotRefreshAuthoritativeGeneration() throws {
+        let detector = AgentDetector()
+        let coarse = "Mon Jul 20 10:00:00 2026"
+        let precise = Date(timeIntervalSince1970: 7_100.125)
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(
+                pid: 517,
+                command: "codex",
+                cpuTime: 3,
+                startIdentifier: coarse,
+                preciseStartedAt: precise
+            ),
+        ])
+        let original = try #require(detector.session(forPID: 517))
+
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(
+                pid: 517,
+                command: "codex",
+                cpuTime: 3,
+                startIdentifier: coarse,
+                preciseStartedAt: nil
+            ),
+        ])
+
+        let replacement = try #require(detector.session(forPID: 517))
+        #expect(replacement.id != original.id)
+        #expect(original.state == .done)
+        #expect(replacement.processEvidence?.startIsAuthoritative == false)
+    }
+
+    @Test func kernelArgumentsBindInterpreterScriptIdentity() {
+        #expect(AgentDetectionCoordinator.processArgumentsAreCoherentForTesting(
+            observedCommand: "node /opt/agents/claude.js --verbose",
+            kernelArguments: ["/usr/local/bin/node", "/opt/agents/claude.js"],
+            currentExecutable: "node"
+        ))
+        #expect(!AgentDetectionCoordinator.processArgumentsAreCoherentForTesting(
+            observedCommand: "node /opt/agents/claude.js --verbose",
+            kernelArguments: ["/usr/local/bin/node", "/tmp/benign.js"],
+            currentExecutable: "node"
+        ))
+        #expect(!AgentDetectionCoordinator.processArgumentsAreCoherentForTesting(
+            observedCommand: "node /opt/agents/claude.js --verbose",
+            kernelArguments: ["/usr/local/bin/python3", "/opt/agents/claude.js"],
+            currentExecutable: "python3"
+        ))
+    }
+
     @Test func processSampleRequiresCoherentGeneration() {
         let coarse = Date(timeIntervalSince1970: 1_722_000_000)
         let precise = Date(timeIntervalSince1970: 1_722_000_000.125)

--- a/PineTests/AgentModelsTests.swift
+++ b/PineTests/AgentModelsTests.swift
@@ -131,11 +131,11 @@ struct AgentModelsTests {
     // MARK: - AgentState
 
     @Test func agentState_displayNames() {
-        #expect(AgentState.idle.displayName == Strings.agentStateIdle)
-        #expect(AgentState.thinking.displayName == Strings.agentStateThinking)
-        #expect(AgentState.executing.displayName == Strings.agentStateExecuting)
-        #expect(AgentState.waitingInput.displayName == Strings.agentStateWaitingInput)
-        #expect(AgentState.done.displayName == Strings.agentStateDone)
+        #expect(AgentState.idle.displayName == Strings.agentStateIdle())
+        #expect(AgentState.thinking.displayName == Strings.agentStateThinking())
+        #expect(AgentState.executing.displayName == Strings.agentStateExecuting())
+        #expect(AgentState.waitingInput.displayName == Strings.agentStateWaitingInput())
+        #expect(AgentState.done.displayName == Strings.agentStateDone())
     }
 
     // MARK: - AgentSession

--- a/PineTests/AgentStatusSummaryTests.swift
+++ b/PineTests/AgentStatusSummaryTests.swift
@@ -292,7 +292,7 @@ struct AgentStatusSummaryTests {
         }
     }
 
-    @Test func presentationHonorsExplicitLocaleForCountAndLiveness() {
+    @Test func presentationHonorsExplicitLocaleForCountStateAndLiveness() {
         let stale = statusSummary(
             agentType: .claudeCode,
             state: .waitingInput,
@@ -313,7 +313,7 @@ struct AgentStatusSummaryTests {
         #expect(russian.countText == "1 сессия агента")
         #expect(
             russian.detailTexts
-                == ["Claude Code: Waiting for input — Устарела"]
+                == ["Claude Code: Ожидает ввода — Устарела"]
         )
     }
 

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -190,6 +190,7 @@ struct AgentTaskRegistryTests {
             Issue.record("initial reservation was rejected")
             return
         }
+        #expect(registry.armLaunch(launch))
         registry.bridge(
             original,
             replacing: nil,
@@ -217,6 +218,7 @@ struct AgentTaskRegistryTests {
             Issue.record("resume reservation was rejected")
             return
         }
+        #expect(registry.armLaunch(reservation))
         registry.bridge(
             resumed,
             replacing: original,
@@ -265,6 +267,15 @@ struct AgentTaskRegistryTests {
             context: launchContext,
             reservation: reservation
         )
+        #expect(registry.task(for: reservation.taskID)?.runs.isEmpty == true)
+        #expect(registry.isLaunchPending(reservation))
+        #expect(registry.armLaunch(reservation))
+        registry.bridge(
+            detected,
+            replacing: nil,
+            context: launchContext,
+            reservation: reservation
+        )
 
         let taskID = reservation.taskID
         let task = try #require(registry.task(for: taskID))
@@ -293,6 +304,7 @@ struct AgentTaskRegistryTests {
             Issue.record("launch reservation was rejected")
             return
         }
+        #expect(registry.armLaunch(reservation))
         #expect(
             registry.task(for: reservation.taskID)?.route.availability
                 == .missing
@@ -339,6 +351,7 @@ struct AgentTaskRegistryTests {
             Issue.record("launch reservation was rejected")
             return
         }
+        #expect(registry.armLaunch(reservation))
         let preexisting = makeSession(
             pid: 702,
             generation: 6,
@@ -404,6 +417,7 @@ struct AgentTaskRegistryTests {
             Issue.record("reservation was rejected")
             return
         }
+        #expect(registry.armLaunch(reservation))
         let session = makeSession(
             pid: 705,
             generation: 2,
@@ -463,6 +477,8 @@ struct AgentTaskRegistryTests {
             Issue.record("launch reservation was rejected")
             return
         }
+        #expect(registry.armLaunch(reservation))
+        #expect(!registry.armLaunch(reservation))
         let first = makeSession(pid: 703, generation: 1, agentType: .codex)
         registry.bridge(
             first,
@@ -502,6 +518,8 @@ struct AgentTaskRegistryTests {
             Issue.record("reservations were rejected")
             return
         }
+        #expect(registry.armLaunch(firstClaim))
+        #expect(registry.armLaunch(secondClaim))
         registry.bridge(
             makeSession(pid: 705, generation: 1, agentType: .codex),
             replacing: nil,
@@ -526,6 +544,7 @@ struct AgentTaskRegistryTests {
             Issue.record("reservation was rejected")
             return
         }
+        #expect(registry.armLaunch(claim))
         let session = makeSession(pid: 706, generation: 1)
         registry.bridge(
             session, replacing: nil, context: launchContext,
@@ -560,6 +579,7 @@ struct AgentTaskRegistryTests {
             Issue.record("reservation was rejected")
             return
         }
+        #expect(registry.armLaunch(claim))
         let before = try #require(registry.task(for: claim.taskID))
         registry.prepareForApplicationTermination(
             at: before.updatedAt.addingTimeInterval(10)
@@ -602,6 +622,7 @@ struct AgentTaskRegistryTests {
             Issue.record("reservation was rejected")
             return
         }
+        #expect(registry.armLaunch(reservation))
         let movedRoute = AgentTaskRoute(
             paneID: uuid(668),
             tabID: initial.route.tabID,
@@ -805,6 +826,7 @@ struct AgentTaskRegistryTests {
             Issue.record("terminal launch reservation was rejected")
             return
         }
+        #expect(taskRegistry.armLaunch(reservation))
         let now = Date()
         let preexisting = makeSession(
             pid: 1_109,
@@ -852,13 +874,14 @@ struct AgentTaskRegistryTests {
                 targetTerminalID: tab.id
             )?.terminalID == tab.id
         )
-        guard case .reserved = manager.terminal.prepareAgentResume(
+        guard case .reserved(let resumeReservation) = manager.terminal.prepareAgentResume(
             taskID: reservation.taskID,
             in: tab
         ) else {
             Issue.record("production resume reservation was rejected")
             return
         }
+        #expect(taskRegistry.armLaunch(resumeReservation))
         let resumed = makeSession(
             pid: 1_111,
             generation: 3,
@@ -872,6 +895,170 @@ struct AgentTaskRegistryTests {
         )
         #expect(taskRegistry.taskID(forSessionID: resumed.id) == reservation.taskID)
         #expect(taskRegistry.task(for: reservation.taskID)?.runs.count == 2)
+    }
+
+    @Test("PTY acknowledgement arms launch authority exactly once")
+    func acknowledgedWriteArmsLaunchAuthority() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let taskRegistry = AgentTaskRegistry(claimTTL: .milliseconds(50))
+        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let state = try #require(
+            manager.paneManager.terminalState(for: pane)
+        )
+        let tab = try #require(state.terminalTabs.first)
+        let descriptor = AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        )
+        let gate = AgentLaunchWriteGate()
+        let launch = Task { @MainActor in
+            await manager.terminal.launchAgentCommandForTesting(
+                "codex",
+                descriptor: descriptor,
+                in: tab
+            ) {
+                await gate.waitForCompletion()
+            }
+        }
+        await gate.waitUntilStarted()
+        let dormantTaskID = try #require(taskRegistry.tasks.first?.id)
+        let observed = makeSession(
+            pid: 1_109,
+            generation: 1,
+            agentType: .codex,
+            preciseStartedAt: Date().addingTimeInterval(60)
+        )
+        manager.terminal.bridgeAgentSession(
+            observed,
+            replacing: nil,
+            in: tab
+        )
+        #expect(taskRegistry.task(for: dormantTaskID)?.runs.isEmpty == true)
+        try await ContinuousClock().sleep(for: .milliseconds(100))
+        #expect(taskRegistry.task(for: dormantTaskID) == nil)
+
+        var duplicateWriteCalled = false
+        let duplicate = await manager.terminal.launchAgentCommandForTesting(
+            "codex",
+            descriptor: descriptor,
+            in: tab
+        ) {
+            duplicateWriteCalled = true
+            return true
+        }
+        #expect(duplicate == .rejected)
+        #expect(!duplicateWriteCalled)
+
+        gate.finish(false)
+        #expect(await launch.value == .rejected)
+        #expect(taskRegistry.task(for: dormantTaskID) == nil)
+
+        let armed = await manager.terminal.launchAgentCommandForTesting(
+            "codex",
+            descriptor: descriptor,
+            in: tab
+        ) {
+            true
+        }
+        guard case .reserved(let reservation) = armed else {
+            Issue.record("acknowledged launch was not armed")
+            return
+        }
+        let launched = makeSession(
+            pid: 1_110,
+            generation: 2,
+            agentType: .codex,
+            preciseStartedAt: Date().addingTimeInterval(120)
+        )
+        manager.terminal.bridgeAgentSession(
+            launched,
+            replacing: observed,
+            in: tab
+        )
+        #expect(
+            taskRegistry.taskID(forSessionID: launched.id)
+                == reservation.taskID
+        )
+        #expect(!taskRegistry.armLaunch(reservation))
+    }
+
+    @Test("closing a dormant launch cancels its authority")
+    func closingDormantLaunchCancelsClaim() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-dormant-close")
+        let launchContext = context(
+            project: identity,
+            routeSeed: 669,
+            origin: .pineLaunched
+        )
+        guard case .reserved(let reservation) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(
+                agentType: .claudeCode,
+                launchExecutable: "claude"
+            ),
+            context: launchContext,
+            title: nil,
+            objective: nil
+        ) else {
+            Issue.record("reservation was rejected")
+            return
+        }
+
+        registry.markTerminalClosed(
+            terminalID: launchContext.route.terminalID,
+            project: identity
+        )
+
+        #expect(!registry.isLaunchPending(reservation))
+        #expect(!registry.armLaunch(reservation))
+        #expect(registry.task(for: reservation.taskID) == nil)
+    }
+
+    @Test("unacknowledged launch is never published")
+    func unacknowledgedLaunchIsNotPersisted() async throws {
+        let identity = project("/tmp/pine-agent-dormant-persistence")
+        let store = ScriptedAgentTaskStore()
+        let registry = AgentTaskRegistry(persistence: store)
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+        let callsBeforeReservation = await store.saveCallCount()
+        let launchContext = context(
+            project: identity,
+            routeSeed: 670,
+            origin: .pineLaunched
+        )
+        guard case .reserved(let reservation) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(
+                agentType: .claudeCode,
+                launchExecutable: "claude"
+            ),
+            context: launchContext,
+            title: nil,
+            objective: nil
+        ) else {
+            Issue.record("reservation was rejected")
+            return
+        }
+
+        #expect(await registry.flushPersistence() == .saved)
+        #expect(await store.saveCallCount() == callsBeforeReservation)
+
+        registry.prepareForApplicationTermination()
+        #expect(await registry.flushPersistence() == .saved)
+        #expect(await store.savedTaskCounts().last == 0)
+        #expect(await registry.cancelApplicationTerminationAndFlush())
+        #expect(await store.savedTaskCounts().last == 0)
+
+        registry.cancelLaunch(reservation)
+        #expect(await registry.flushPersistence() == .saved)
+        #expect(await store.savedTaskCounts().last == 0)
     }
 
     @Test("expired local reservation permits a new terminal launch")
@@ -1055,6 +1242,7 @@ struct AgentTaskRegistryTests {
             Issue.record("initial reservation was rejected")
             return
         }
+        #expect(registry.armLaunch(initial))
         registry.bridge(
             previous,
             replacing: nil,
@@ -1085,6 +1273,7 @@ struct AgentTaskRegistryTests {
                 Issue.record("resume reservation was rejected")
                 return
             }
+            #expect(registry.armLaunch(reservation))
             registry.bridge(
                 next,
                 replacing: previous,
@@ -1539,6 +1728,7 @@ struct AgentTaskRegistryTests {
             Issue.record("launch reservation was rejected")
             return
         }
+        #expect(registry.armLaunch(reservation))
         registry.bridge(
             session,
             replacing: nil,
@@ -1992,6 +2182,7 @@ struct AgentTaskRegistryTests {
             Issue.record("initial reservation was rejected")
             return
         }
+        #expect(registry.armLaunch(firstReservation))
         let first = makeSession(
             pid: 1_397,
             generation: 1,
@@ -2022,6 +2213,7 @@ struct AgentTaskRegistryTests {
             Issue.record("Expected resume reservation")
             return
         }
+        #expect(registry.armLaunch(resume))
         let second = makeSession(
             pid: 1_398,
             generation: 2,
@@ -2318,6 +2510,7 @@ struct AgentTaskRegistryTests {
             Issue.record("launch reservation was rejected")
             return
         }
+        #expect(writer.armLaunch(launch))
         let original = makeSession(pid: 1_651, generation: 1)
         writer.bridge(
             original,
@@ -2349,6 +2542,7 @@ struct AgentTaskRegistryTests {
             Issue.record("loaded interruption was not resumable")
             return
         }
+        #expect(reader.armLaunch(resume))
         let resumed = makeSession(pid: 1_652, generation: 2)
         reader.bridge(
             resumed,
@@ -2785,6 +2979,34 @@ private actor LoadedAgentTaskStore: AgentTaskPersisting {
         authorization: AgentTaskPublicationAuthorization?
     ) async -> AgentTaskMetadataSaveResult {
         .saved(taskCount: tasks.count)
+    }
+}
+
+@MainActor
+private final class AgentLaunchWriteGate {
+    private var started = false
+    private var startedContinuation: CheckedContinuation<Void, Never>?
+    private var completionContinuation: CheckedContinuation<Bool, Never>?
+
+    func waitForCompletion() async -> Bool {
+        started = true
+        startedContinuation?.resume()
+        startedContinuation = nil
+        return await withCheckedContinuation { continuation in
+            completionContinuation = continuation
+        }
+    }
+
+    func waitUntilStarted() async {
+        guard !started else { return }
+        await withCheckedContinuation { continuation in
+            startedContinuation = continuation
+        }
+    }
+
+    func finish(_ result: Bool) {
+        completionContinuation?.resume(returning: result)
+        completionContinuation = nil
     }
 }
 

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -10,7 +10,7 @@ import Testing
 @testable import Pine
 
 @MainActor
-@Suite("Agent Task Registry Tests")
+@Suite("Agent Task Registry Tests", .serialized)
 struct AgentTaskRegistryTests {
     @Test("same agent type remains distinct across projects")
     func sameTypeAcrossProjects() throws {
@@ -1852,8 +1852,8 @@ struct AgentTaskRegistryTests {
         let store = ScriptedAgentTaskStore()
         let registry = AgentTaskRegistry(
             persistence: store,
-            flushTotal: .milliseconds(100),
-            flushTail: .milliseconds(20)
+            flushTotal: .seconds(120),
+            flushTail: .seconds(120)
         )
         registry.registerProject(identity)
         #expect(await registry.flushPersistence() == .saved)
@@ -1888,8 +1888,8 @@ struct AgentTaskRegistryTests {
         let store = ScriptedAgentTaskStore()
         let agentTasks = AgentTaskRegistry(
             persistence: store,
-            flushTotal: .milliseconds(100),
-            flushTail: .milliseconds(20)
+            flushTotal: .seconds(120),
+            flushTail: .seconds(120)
         )
         let projects = ProjectRegistry(agentTasks: agentTasks)
         let manager = try #require(projects.projectManager(for: fixture.project))
@@ -2249,7 +2249,8 @@ struct AgentTaskRegistryTests {
         ).load(project: identity)
         #expect(loaded.status == .loaded)
         #expect(loaded.tasks.count == 1)
-        #expect(loaded.tasks[0].runs.map(\.id) == [firstSession.id])
+        let persistedTask = try #require(loaded.tasks.first)
+        #expect(persistedTask.runs.map(\.id) == [firstSession.id])
     }
 
     @Test("in-memory task cap never evicts a paused resumable task")
@@ -2755,9 +2756,11 @@ struct AgentTaskRegistryTests {
         reader.registerProject(identity)
         #expect(await reader.flushPersistence() == .saved)
         #expect(reader.tasks.count == 1)
-        #expect(reader.tasks[0].route.availability == .missing)
-        #expect(reader.tasks[0].lifecycle == .paused)
-        #expect(reader.tasks[0].runs[0].liveness == .stale)
+        let loadedTask = try #require(reader.tasks.first)
+        #expect(loadedTask.route.availability == .missing)
+        #expect(loadedTask.lifecycle == .paused)
+        let loadedRun = try #require(loadedTask.runs.first)
+        #expect(loadedRun.liveness == .stale)
         #expect(reader.taskID(forSessionID: session.id) == nil)
     }
 
@@ -2818,7 +2821,11 @@ struct AgentTaskRegistryTests {
             return
         }
         #expect(reader.armLaunch(resume))
-        let resumed = makeSession(pid: 1_652, generation: 2)
+        let resumed = makeSession(
+            pid: 1_652,
+            generation: 2,
+            preciseStartedAt: Date(timeIntervalSince1970: 2)
+        )
         reader.bridge(
             resumed,
             replacing: nil,
@@ -2828,9 +2835,11 @@ struct AgentTaskRegistryTests {
 
         let task = try #require(reader.task(for: launch.taskID))
         #expect(task.runs.map(\.id) == [original.id, resumed.id])
-        #expect(task.runs[0].liveness == .terminated)
-        #expect(task.runs[0].endedAt != nil)
-        #expect(task.runs[1].liveness == .live)
+        let originalRun = try #require(task.runs.first)
+        let resumedRun = try #require(task.runs.last)
+        #expect(originalRun.liveness == .terminated)
+        #expect(originalRun.endedAt != nil)
+        #expect(resumedRun.liveness == .live)
         #expect(task.lifecycle == .active)
         #expect(reader.taskID(forSessionID: resumed.id) == launch.taskID)
         #expect(await reader.flushPersistence() == .saved)
@@ -2844,12 +2853,12 @@ struct AgentTaskRegistryTests {
     func failedSaveRetriesAfterProjectReturns() async throws {
         let fixture = try PersistenceFixture()
         defer { fixture.cleanup() }
-        try FileManager.default.removeItem(at: fixture.project)
         let identity = project(fixture.project.path)
         let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
         let registry = AgentTaskRegistry(persistence: store)
         registry.registerProject(identity)
-        await registry.flushPersistence()
+        #expect(await registry.flushPersistence() == .saved)
+        try FileManager.default.removeItem(at: fixture.project)
         let session = makeSession(pid: 1_701, generation: 1)
         registry.bridge(
             session,
@@ -2909,8 +2918,8 @@ struct AgentTaskRegistryTests {
         let store = ScriptedAgentTaskStore(suspendFirstSave: true)
         let registry = AgentTaskRegistry(
             persistence: store,
-            flushTotal: .milliseconds(100),
-            flushTail: .milliseconds(20)
+            flushTotal: .seconds(1),
+            flushTail: .milliseconds(100)
         )
         registry.registerProject(identity)
         #expect(await registry.flushPersistence() == .saved)

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -91,7 +91,7 @@ struct AgentTaskRegistryTests {
         )
 
         #expect(
-            registry.task(forSessionID: first.id)?.route.availability
+            registry.historicalTask(forSessionID: first.id)?.route.availability
                 == .missing
         )
         #expect(
@@ -852,6 +852,7 @@ struct AgentTaskRegistryTests {
             replacing: preexisting,
             in: tab
         )
+        tab.agentSession = launched
         #expect(
             taskRegistry.taskID(forSessionID: launched.id)
                 == reservation.taskID
@@ -1154,7 +1155,11 @@ struct AgentTaskRegistryTests {
     func acknowledgedLaunchSurvivesTerminationRollback() async throws {
         let fixture = try PersistenceFixture()
         defer { fixture.cleanup() }
-        let taskRegistry = AgentTaskRegistry(claimTTL: .seconds(1))
+        let store = ScriptedAgentTaskStore()
+        let taskRegistry = AgentTaskRegistry(
+            persistence: store,
+            claimTTL: .seconds(1)
+        )
         let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
         let manager = try #require(
             projectRegistry.projectManager(for: fixture.project)
@@ -1375,7 +1380,12 @@ struct AgentTaskRegistryTests {
             routeSeed: 110,
             origin: .pineLaunched
         )
-        var previous = makeSession(pid: 1_201, generation: 1)
+        let initialStartedAt = Date(timeIntervalSince1970: 1)
+        var previous = makeSession(
+            pid: 1_201,
+            generation: 1,
+            preciseStartedAt: initialStartedAt
+        )
         guard case .reserved(let initial) = registry.preparePineLaunch(
             descriptor: AgentDescriptor(
                 agentType: previous.agentType,
@@ -1402,15 +1412,19 @@ struct AgentTaskRegistryTests {
             previous.applyLiveness(.terminated)
             previous.state = .done
             registry.refresh(sessions: [previous])
+            let nextStartedAt = Date(
+                timeIntervalSince1970: TimeInterval(sequence)
+            )
             let next = makeSession(
                 pid: 1_200 + Int32(sequence),
-                generation: UInt64(sequence)
+                generation: UInt64(sequence),
+                preciseStartedAt: nextStartedAt
             )
             let resumeContext = AgentTaskBridgeContext(
                 project: identity,
                 route: sharedContext.route,
                 origin: .pineLaunched,
-                observedAt: Date(timeIntervalSince1970: 0)
+                observedAt: nextStartedAt
             )
             guard case .reserved(let reservation) = registry.prepareResume(
                 taskID: retainedTaskID,
@@ -3116,15 +3130,37 @@ private final class PersistenceFixture {
         worktree = makeWorktree
             ? root.appendingPathComponent("worktree", isDirectory: true)
             : nil
-        try FileManager.default.createDirectory(
-            at: project,
-            withIntermediateDirectories: true
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(
+            at: root,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
         )
-        if let worktree {
-            try FileManager.default.createDirectory(
-                at: worktree,
-                withIntermediateDirectories: true
+        do {
+            // GitHub-hosted macOS temp directories carry an inherited ACL.
+            // The production store correctly rejects such a private root, so
+            // make the test fixture match a clean user-owned storage root.
+            let chmod = Process()
+            chmod.executableURL = URL(fileURLWithPath: "/bin/chmod")
+            chmod.arguments = ["-N", root.path]
+            try chmod.run()
+            chmod.waitUntilExit()
+            guard chmod.terminationStatus == 0 else {
+                throw CocoaError(.fileWriteNoPermission)
+            }
+            try fileManager.createDirectory(
+                at: project,
+                withIntermediateDirectories: false
             )
+            if let worktree {
+                try fileManager.createDirectory(
+                    at: worktree,
+                    withIntermediateDirectories: false
+                )
+            }
+        } catch {
+            try? fileManager.removeItem(at: root)
+            throw error
         }
     }
 

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -980,8 +980,8 @@ struct AgentTaskRegistryTests {
         let observed = makeSession(
             pid: 1_109,
             generation: 1,
-            agentType: .codex,
-            preciseStartedAt: Date().addingTimeInterval(60)
+            preciseStartedAt: Date().addingTimeInterval(60),
+            agentType: .codex
         )
         manager.terminal.bridgeAgentSession(
             observed,
@@ -1022,8 +1022,8 @@ struct AgentTaskRegistryTests {
         let launched = makeSession(
             pid: 1_110,
             generation: 2,
-            agentType: .codex,
-            preciseStartedAt: Date().addingTimeInterval(120)
+            preciseStartedAt: Date().addingTimeInterval(120),
+            agentType: .codex
         )
         manager.terminal.bridgeAgentSession(
             launched,
@@ -1196,8 +1196,8 @@ struct AgentTaskRegistryTests {
         let launched = makeSession(
             pid: 1_495,
             generation: 2,
-            agentType: .codex,
-            preciseStartedAt: Date().addingTimeInterval(60)
+            preciseStartedAt: Date().addingTimeInterval(60),
+            agentType: .codex
         )
         manager.terminal.bridgeAgentSession(
             launched,
@@ -1733,7 +1733,7 @@ struct AgentTaskRegistryTests {
                 replacing: nil,
                 context: context(
                     project: identity,
-                    routeSeed: UInt8(152 + offset)
+                    routeSeed: 152 + offset
                 )
             )
 
@@ -2192,7 +2192,7 @@ struct AgentTaskRegistryTests {
         await store.releaseFirstSave()
         await store.waitUntilFirstSaveReturned()
 
-        session.updateState(.thinking)
+        session.state = .thinking
         registry.refresh(sessions: [session])
         #expect(await registry.flushPersistence() == .saved)
         #expect(await store.retryUsedPublishedRevision())
@@ -2424,7 +2424,10 @@ struct AgentTaskRegistryTests {
             routeSeed: 147,
             origin: .pineLaunched
         )
-        let firstBoundary = launchBoundary(generation: 1, at: launchContext.observedAt)
+        let firstBoundary = AgentTaskLaunchBoundary(
+            generationFloor: 0,
+            capturedAt: launchContext.observedAt
+        )
         let firstReservation: AgentTaskLaunchReservation
         switch registry.preparePineLaunch(
             descriptor: AgentDescriptor(
@@ -2446,8 +2449,7 @@ struct AgentTaskRegistryTests {
         let first = makeSession(
             pid: 1_397,
             generation: 1,
-            startedAt: launchContext.observedAt.addingTimeInterval(1),
-            preciseStart: launchContext.observedAt.addingTimeInterval(1)
+            preciseStartedAt: launchContext.observedAt.addingTimeInterval(1)
         )
         registry.bridge(
             first,
@@ -2458,9 +2460,9 @@ struct AgentTaskRegistryTests {
         first.applyLiveness(.terminated)
         registry.bridge(first, replacing: first, context: launchContext)
         let before = try #require(registry.task(for: firstReservation.taskID))
-        let resumeBoundary = launchBoundary(
-            generation: 2,
-            at: launchContext.observedAt.addingTimeInterval(2)
+        let resumeBoundary = AgentTaskLaunchBoundary(
+            generationFloor: 1,
+            capturedAt: launchContext.observedAt.addingTimeInterval(2)
         )
         let resume: AgentTaskLaunchReservation
         switch registry.prepareResume(
@@ -2477,8 +2479,7 @@ struct AgentTaskRegistryTests {
         let second = makeSession(
             pid: 1_398,
             generation: 2,
-            startedAt: launchContext.observedAt.addingTimeInterval(3),
-            preciseStart: launchContext.observedAt.addingTimeInterval(3)
+            preciseStartedAt: launchContext.observedAt.addingTimeInterval(3)
         )
 
         registry.bridge(
@@ -3305,7 +3306,7 @@ private actor SelectiveAgentTaskStore: AgentTaskPersisting {
         guard project.persistenceKey != failingProjectKey else {
             return .rejected(.transientIO)
         }
-        let decision = authorization?.publishForTesting({ true }) ?? .published
+        let decision = authorization?.publishForTesting(operation: { true }) ?? .published
         switch decision {
         case .published:
             savedTaskCounts[project.persistenceKey] = tasks.count

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -897,8 +897,56 @@ struct AgentTaskRegistryTests {
         #expect(taskRegistry.task(for: reservation.taskID)?.runs.count == 2)
     }
 
-    @Test("PTY acknowledgement arms launch authority exactly once")
-    func acknowledgedWriteArmsLaunchAuthority() async throws {
+    @Test("failed PTY write cancels live launch reservation before expiry")
+    func failedWriteCancelsLaunchReservation() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let taskRegistry = AgentTaskRegistry(claimTTL: .seconds(1))
+        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let state = try #require(
+            manager.paneManager.terminalState(for: pane)
+        )
+        let tab = try #require(state.terminalTabs.first)
+        let descriptor = AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        )
+
+        let failed = await manager.terminal.launchAgentCommandForTesting(
+            "codex",
+            descriptor: descriptor,
+            in: tab
+        ) {
+            false
+        }
+        #expect(failed == .rejected)
+        #expect(taskRegistry.tasks.isEmpty)
+
+        var retryWriteCalled = false
+        let retry = await manager.terminal.launchAgentCommandForTesting(
+            "codex",
+            descriptor: descriptor,
+            in: tab
+        ) {
+            retryWriteCalled = true
+            return true
+        }
+        #expect(retryWriteCalled)
+        guard case .reserved = retry else {
+            Issue.record("failed write left the terminal reservation occupied")
+            return
+        }
+        manager.terminal.cancelAgentLaunch(in: tab)
+    }
+
+    @Test("stale successful PTY acknowledgement cannot arm launch authority")
+    func staleAcknowledgementCannotArmLaunchAuthority() async throws {
         let fixture = try PersistenceFixture()
         defer { fixture.cleanup() }
         let taskRegistry = AgentTaskRegistry(claimTTL: .milliseconds(50))
@@ -927,7 +975,7 @@ struct AgentTaskRegistryTests {
                 await gate.waitForCompletion()
             }
         }
-        await gate.waitUntilStarted()
+        #expect(await gate.waitUntilStarted())
         let dormantTaskID = try #require(taskRegistry.tasks.first?.id)
         let observed = makeSession(
             pid: 1_109,
@@ -956,8 +1004,8 @@ struct AgentTaskRegistryTests {
         #expect(duplicate == .rejected)
         #expect(!duplicateWriteCalled)
 
-        gate.finish(false)
-        #expect(await launch.value == .rejected)
+        gate.finish(true)
+        #expect(await launch.value == .sentWithoutReservation)
         #expect(taskRegistry.task(for: dormantTaskID) == nil)
 
         let armed = await manager.terminal.launchAgentCommandForTesting(
@@ -1059,6 +1107,104 @@ struct AgentTaskRegistryTests {
         registry.cancelLaunch(reservation)
         #expect(await registry.flushPersistence() == .saved)
         #expect(await store.savedTaskCounts().last == 0)
+    }
+
+    @Test("acknowledged initial launch is not published before observation")
+    func armedInitialLaunchIsNotPersisted() async throws {
+        let identity = project("/tmp/pine-agent-armed-persistence")
+        let store = ScriptedAgentTaskStore()
+        let registry = AgentTaskRegistry(persistence: store)
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+        let launchContext = context(
+            project: identity,
+            routeSeed: 671,
+            origin: .pineLaunched
+        )
+        guard case .reserved(let reservation) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(
+                agentType: .claudeCode,
+                launchExecutable: "claude"
+            ),
+            context: launchContext,
+            title: nil,
+            objective: nil
+        ) else {
+            Issue.record("reservation was rejected")
+            return
+        }
+        let callsBeforeArm = await store.saveCallCount()
+
+        #expect(registry.armLaunch(reservation))
+        #expect(await registry.flushPersistence() == .saved)
+        #expect(await store.saveCallCount() == callsBeforeArm)
+
+        registry.prepareForApplicationTermination()
+        #expect(await registry.flushPersistence() == .saved)
+        #expect(await store.savedTaskCounts().last == 0)
+        #expect(await registry.cancelApplicationTerminationAndFlush())
+        #expect(await store.savedTaskCounts().last == 0)
+
+        registry.cancelLaunch(reservation)
+        #expect(await registry.flushPersistence() == .saved)
+        #expect(await store.savedTaskCounts().last == 0)
+    }
+
+    @Test("successful launch acknowledgement survives Quit rollback")
+    func acknowledgedLaunchSurvivesTerminationRollback() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let taskRegistry = AgentTaskRegistry(claimTTL: .seconds(1))
+        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        #expect(await taskRegistry.flushPersistence() == .saved)
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let state = try #require(
+            manager.paneManager.terminalState(for: pane)
+        )
+        let tab = try #require(state.terminalTabs.first)
+        let descriptor = AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        )
+        let gate = AgentLaunchWriteGate()
+        let launch = Task { @MainActor in
+            await manager.terminal.launchAgentCommandForTesting(
+                "codex",
+                descriptor: descriptor,
+                in: tab
+            ) {
+                await gate.waitForCompletion()
+            }
+        }
+        #expect(await gate.waitUntilStarted())
+
+        projectRegistry.freezeAgentTasksForTermination()
+        taskRegistry.prepareForApplicationTermination()
+        gate.finish(true)
+        guard case .reserved(let reservation) = await launch.value else {
+            Issue.record("successful write lost its reservation during Quit")
+            return
+        }
+        #expect(await projectRegistry.cancelAgentTaskTermination())
+        #expect(taskRegistry.isLaunchPending(reservation))
+
+        let launched = makeSession(
+            pid: 1_495,
+            generation: 2,
+            agentType: .codex,
+            preciseStartedAt: Date().addingTimeInterval(60)
+        )
+        manager.terminal.bridgeAgentSession(
+            launched,
+            replacing: nil,
+            in: tab
+        )
+        #expect(taskRegistry.taskID(forSessionID: launched.id) == reservation.taskID)
     }
 
     @Test("expired local reservation permits a new terminal launch")
@@ -1550,6 +1696,52 @@ struct AgentTaskRegistryTests {
         )
     }
 
+    @Test("every rejected load quarantines later registry mutations")
+    func rejectedLoadQuarantinesRegistryWrites() async throws {
+        let rejections: [AgentTaskMetadataRejection] = [
+            .corrupt,
+            .unknownSchema,
+            .missingProject,
+            .invalidMetadata,
+            .storageLimit,
+            .ioFailure,
+            .unsafeFilesystemObject,
+            .lockContention,
+            .transientIO,
+            .durabilityUnknown,
+            .concurrentMutation,
+            .superseded
+        ]
+        for (offset, rejection) in rejections.enumerated() {
+            let identity = project(
+                "/tmp/pine-agent-rejected-load-\(offset)"
+            )
+            let store = LoadedAgentTaskStore(
+                status: .rejected(rejection),
+                tasks: []
+            )
+            let registry = AgentTaskRegistry(persistence: store)
+            registry.registerProject(identity)
+            #expect(await registry.flushPersistence() == .saved)
+            #expect(registry.persistenceIsQuarantinedForTesting(identity))
+
+            registry.bridge(
+                makeSession(
+                    pid: 1_492 + Int32(offset),
+                    generation: UInt64(offset + 1)
+                ),
+                replacing: nil,
+                context: context(
+                    project: identity,
+                    routeSeed: UInt8(152 + offset)
+                )
+            )
+
+            #expect(await registry.flushPersistence() == .failed)
+            #expect(registry.saveResultByProject[identity.persistenceKey] == nil)
+        }
+    }
+
     @Test("oversized metadata quarantines registry writes byte-for-byte")
     func oversizedMetadataQuarantinesWrites() async throws {
         let fixture = try PersistenceFixture()
@@ -1638,6 +1830,74 @@ struct AgentTaskRegistryTests {
         #expect(
             abs(rolledBack.updatedAt.timeIntervalSince(originalUpdatedAt)) < 0.001
         )
+    }
+
+    @Test("failed durable rollback still releases termination admission")
+    func failedRollbackReleasesTerminationAdmission() async throws {
+        let identity = project("/tmp/pine-agent-failed-rollback")
+        let store = ScriptedAgentTaskStore()
+        let registry = AgentTaskRegistry(
+            persistence: store,
+            flushTotal: .milliseconds(100),
+            flushTail: .milliseconds(20)
+        )
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+        registry.bridge(
+            makeSession(pid: 1_493, generation: 1),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 153)
+        )
+        #expect(await registry.flushPersistence() == .saved)
+        registry.prepareForApplicationTermination()
+        #expect(await registry.flushPersistence() == .saved)
+        await store.setSaveResult(.rejected(.ioFailure))
+
+        let didPersistRollback = await registry.cancelApplicationTerminationAndFlush(
+            maximumDuration: .milliseconds(100)
+        )
+        #expect(!didPersistRollback)
+        let replacement = makeSession(pid: 1_494, generation: 2)
+        registry.bridge(
+            replacement,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 154)
+        )
+        #expect(registry.task(forSessionID: replacement.id) != nil)
+    }
+
+    @Test("failed durable rollback still thaws project terminal callbacks")
+    func failedRollbackThawsProjectTerminalCallbacks() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let store = ScriptedAgentTaskStore()
+        let agentTasks = AgentTaskRegistry(
+            persistence: store,
+            flushTotal: .milliseconds(100),
+            flushTail: .milliseconds(20)
+        )
+        let projects = ProjectRegistry(agentTasks: agentTasks)
+        let manager = try #require(projects.projectManager(for: fixture.project))
+        #expect(await agentTasks.flushPersistence() == .saved)
+        agentTasks.bridge(
+            makeSession(pid: 1_496, generation: 1),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 155)
+        )
+        #expect(await agentTasks.flushPersistence() == .saved)
+        projects.freezeAgentTasksForTermination()
+        #expect(manager.terminal.agentCallbacksFrozenForTesting)
+        agentTasks.prepareForApplicationTermination()
+        #expect(await agentTasks.flushPersistence() == .saved)
+        await store.setSaveResult(.rejected(.ioFailure))
+
+        let didPersistRollback = await projects.cancelAgentTaskTermination(
+            maximumDuration: .milliseconds(100)
+        )
+
+        #expect(!didPersistRollback)
+        #expect(!manager.terminal.agentCallbacksFrozenForTesting)
     }
 
     @Test("one rejected project cannot starve another project save")
@@ -2985,28 +3245,41 @@ private actor LoadedAgentTaskStore: AgentTaskPersisting {
 @MainActor
 private final class AgentLaunchWriteGate {
     private var started = false
-    private var startedContinuation: CheckedContinuation<Void, Never>?
-    private var completionContinuation: CheckedContinuation<Bool, Never>?
+    private var completion: Bool?
 
-    func waitForCompletion() async -> Bool {
+    func waitForCompletion(
+        maximumDuration: Duration = .seconds(2)
+    ) async -> Bool {
         started = true
-        startedContinuation?.resume()
-        startedContinuation = nil
-        return await withCheckedContinuation { continuation in
-            completionContinuation = continuation
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: maximumDuration)
+        while completion == nil, clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
         }
+        return completion ?? false
     }
 
-    func waitUntilStarted() async {
-        guard !started else { return }
-        await withCheckedContinuation { continuation in
-            startedContinuation = continuation
+    func waitUntilStarted(
+        maximumDuration: Duration = .seconds(1)
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: maximumDuration)
+        while !started, clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
         }
+        return started
     }
 
     func finish(_ result: Bool) {
-        completionContinuation?.resume(returning: result)
-        completionContinuation = nil
+        completion = result
     }
 }
 
@@ -3063,7 +3336,7 @@ private actor SelectiveAgentTaskStore: AgentTaskPersisting {
 }
 
 private actor ScriptedAgentTaskStore: AgentTaskPersisting {
-    private let saveResult: AgentTaskMetadataSaveResult
+    private var saveResult: AgentTaskMetadataSaveResult
     private let suspendFirstSave: Bool
     private let suspendEverySave: Bool
     private var saveSnapshots: [[AgentTask]] = []
@@ -3123,6 +3396,10 @@ private actor ScriptedAgentTaskStore: AgentTaskPersisting {
         case .superseded:
             return .rejected(.superseded)
         }
+    }
+
+    func setSaveResult(_ result: AgentTaskMetadataSaveResult) {
+        saveResult = result
     }
 
     func waitForFirstSave() async -> Bool {

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -179,7 +179,10 @@ struct AgentTaskRegistryTests {
         )
         let original = makeSession(pid: 601, generation: 1)
         guard case .reserved(let launch) = registry.preparePineLaunch(
-            descriptor: AgentDescriptor(agentType: original.agentType),
+            descriptor: AgentDescriptor(
+                agentType: original.agentType,
+                launchExecutable: "claude"
+            ),
             context: originalContext,
             title: nil,
             objective: nil
@@ -350,15 +353,29 @@ struct AgentTaskRegistryTests {
         )
         #expect(registry.task(for: reservation.taskID)?.runs.isEmpty == true)
 
-        let launched = makeSession(
+        let boundaryEqual = makeSession(
             pid: 703,
             generation: 7,
+            start: "Sun Aug 2 10:00:00 2026",
+            preciseStartedAt: capturedAt
+        )
+        registry.bridge(
+            boundaryEqual,
+            replacing: preexisting,
+            context: launchContext,
+            reservation: reservation
+        )
+        #expect(registry.task(for: reservation.taskID)?.runs.isEmpty == true)
+
+        let launched = makeSession(
+            pid: 704,
+            generation: 8,
             start: "Mon Aug 3 10:00:00 2026",
             preciseStartedAt: capturedAt.addingTimeInterval(86_400)
         )
         registry.bridge(
             launched,
-            replacing: preexisting,
+            replacing: boundaryEqual,
             context: launchContext,
             reservation: reservation
         )
@@ -745,7 +762,10 @@ struct AgentTaskRegistryTests {
     func exactAgentLaunchCommandClassification() {
         #expect(
             TerminalManager.exactAgentLaunchDescriptor(for: "codex")
-                == AgentDescriptor(agentType: .codex)
+                == AgentDescriptor(
+                    agentType: .codex,
+                    launchExecutable: "codex"
+                )
         )
         for untrusted in [
             " codex", "codex ", "codex\n", "CODEX", "codex --help",
@@ -775,7 +795,10 @@ struct AgentTaskRegistryTests {
         let tab = try #require(state.terminalTabs.first)
         guard case .reserved(let reservation) = manager.terminal.prepareAgentLaunch(
             in: tab,
-            descriptor: AgentDescriptor(agentType: .claudeCode),
+            descriptor: AgentDescriptor(
+                agentType: .claudeCode,
+                launchExecutable: "claude"
+            ),
             title: nil,
             objective: nil
         ) else {
@@ -1021,7 +1044,10 @@ struct AgentTaskRegistryTests {
         )
         var previous = makeSession(pid: 1_201, generation: 1)
         guard case .reserved(let initial) = registry.preparePineLaunch(
-            descriptor: AgentDescriptor(agentType: previous.agentType),
+            descriptor: AgentDescriptor(
+                agentType: previous.agentType,
+                launchExecutable: "claude"
+            ),
             context: sharedContext,
             title: nil,
             objective: nil
@@ -1328,7 +1354,7 @@ struct AgentTaskRegistryTests {
         )
         registry.prepareForApplicationTermination()
 
-        #expect(await registry.flushPersistence() == .saved)
+        #expect(await registry.flushPersistence() == .failed)
         #expect(try Data(contentsOf: fileURL) == original)
         #expect(
             registry.saveResultByProject[identity.persistenceKey] == nil
@@ -1375,7 +1401,7 @@ struct AgentTaskRegistryTests {
         )
         registry.prepareForApplicationTermination()
 
-        #expect(await registry.flushPersistence() == .saved)
+        #expect(await registry.flushPersistence() == .failed)
         #expect(try Data(contentsOf: fileURL) == original)
         #expect(registry.saveResultByProject[identity.persistenceKey] == nil)
     }
@@ -1406,7 +1432,7 @@ struct AgentTaskRegistryTests {
         #expect(snapshot.route.availability == .missing)
         #expect(snapshot.runs.last?.liveness == .stale)
 
-        registry.cancelApplicationTermination()
+        #expect(await registry.cancelApplicationTerminationAndFlush())
         let restored = try #require(registry.task(forSessionID: session.id))
         #expect(restored.lifecycle == .active)
         #expect(restored.route.availability == .available)
@@ -1502,7 +1528,10 @@ struct AgentTaskRegistryTests {
             origin: .pineLaunched
         )
         guard case .reserved(let reservation) = registry.preparePineLaunch(
-            descriptor: AgentDescriptor(agentType: session.agentType),
+            descriptor: AgentDescriptor(
+                agentType: session.agentType,
+                launchExecutable: "claude"
+            ),
             context: launchContext,
             title: "User title",
             objective: "User objective"
@@ -1565,7 +1594,8 @@ struct AgentTaskRegistryTests {
             "availability", "paneID", "tabID", "terminalID",
         ])
         let descriptor = try #require(task["descriptor"] as? [String: Any])
-        #expect(Set(descriptor.keys) == ["typeIdentifier"])
+        #expect(Set(descriptor.keys) == ["launchExecutable", "typeIdentifier"])
+        #expect(descriptor["launchExecutable"] as? String == "claude")
         let run = try #require((task["runs"] as? [[String: Any]])?.first)
         #expect(Set(run.keys) == [
             "id", "lastObservedAt", "liveness", "process", "startedAt",
@@ -1852,6 +1882,84 @@ struct AgentTaskRegistryTests {
         )
     }
 
+    @Test("load identity collision rejects whole persisted project")
+    func loadedIdentityCollisionIsAtomic() async throws {
+        let identity = project("/tmp/pine-agent-loaded-collision")
+        let store = LoadedAgentTaskStore(tasks: [])
+        let registry = AgentTaskRegistry(persistence: store)
+        let runtimeSession = makeSession(pid: 1_401, generation: 1)
+        let runtimeContext = context(project: identity, routeSeed: 151)
+        registry.bridge(runtimeSession, replacing: nil, context: runtimeContext)
+        let runtimeTask = try #require(registry.tasks.first)
+        let seed = AgentTaskRegistry()
+        let otherSession = makeSession(pid: 1_402, generation: 1)
+        let otherContext = context(project: identity, routeSeed: 152)
+        seed.bridge(otherSession, replacing: nil, context: otherContext)
+        let otherTask = try #require(seed.tasks.first)
+        await store.replaceTasks([runtimeTask, otherTask])
+
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .failed)
+
+        #expect(registry.tasks == [runtimeTask])
+        #expect(
+            registry.loadStatusByProject[identity.persistenceKey]
+                == .rejected(.invalidMetadata)
+        )
+    }
+
+    @Test("loaded tasks cannot exceed combined per-project runtime cap")
+    func loadedTasksRespectCombinedRuntimeCap() async throws {
+        let identity = project("/tmp/pine-agent-loaded-task-cap")
+        let seed = AgentTaskRegistry()
+        seed.bridge(
+            makeSession(pid: 1_404, generation: 1),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 154)
+        )
+        let loadedTask = try #require(seed.tasks.first)
+        let registry = AgentTaskRegistry(
+            persistence: LoadedAgentTaskStore(tasks: [loadedTask]),
+            limits: AgentTaskPersistenceLimits(maxTasksPerProject: 1)
+        )
+        registry.bridge(
+            makeSession(pid: 1_405, generation: 1),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 155)
+        )
+        let admittedRuntimeTask = try #require(registry.tasks.first)
+
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .failed)
+
+        #expect(registry.tasks == [admittedRuntimeTask])
+        #expect(
+            registry.loadStatusByProject[identity.persistenceKey]
+                == .rejected(.storageLimit)
+        )
+    }
+
+    @Test("quarantined project mutations fail persistence barrier")
+    func quarantinedMutationFailsFlush() async {
+        let identity = project("/tmp/pine-agent-quarantine-mutation")
+        let registry = AgentTaskRegistry(
+            persistence: LoadedAgentTaskStore(
+                status: .rejected(.unknownSchema),
+                tasks: []
+            )
+        )
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+
+        registry.bridge(
+            makeSession(pid: 1_406, generation: 1),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 156)
+        )
+
+        #expect(await registry.flushPersistence() == .failed)
+    }
+
     @Test("failed resume admission preserves claim and run history")
     func failedResumeAdmissionIsNonDestructive() throws {
         let identity = project("/tmp/pine-agent-resume-admission")
@@ -1867,11 +1975,23 @@ struct AgentTaskRegistryTests {
             origin: .pineLaunched
         )
         let firstBoundary = launchBoundary(generation: 1, at: launchContext.observedAt)
-        let firstReservation = try #require(preparePineLaunch(
-            registry,
+        let firstReservation: AgentTaskLaunchReservation
+        switch registry.preparePineLaunch(
+            descriptor: AgentDescriptor(
+                agentType: .claudeCode,
+                launchExecutable: "claude"
+            ),
             context: launchContext,
+            title: nil,
+            objective: nil,
             boundary: firstBoundary
-        ))
+        ) {
+        case .reserved(let reservation):
+            firstReservation = reservation
+        case .sentWithoutReservation, .rejected:
+            Issue.record("initial reservation was rejected")
+            return
+        }
         let first = makeSession(
             pid: 1_397,
             generation: 1,
@@ -1898,7 +2018,8 @@ struct AgentTaskRegistryTests {
             boundary: resumeBoundary
         ) {
         case .reserved(let reservation): resume = reservation
-        case .rejected: Issue.record("Expected resume reservation")
+        case .sentWithoutReservation, .rejected:
+            Issue.record("Expected resume reservation")
             return
         }
         let second = makeSession(
@@ -2186,7 +2307,10 @@ struct AgentTaskRegistryTests {
             origin: .pineLaunched
         )
         guard case .reserved(let launch) = writer.preparePineLaunch(
-            descriptor: AgentDescriptor(agentType: .claudeCode),
+            descriptor: AgentDescriptor(
+                agentType: .claudeCode,
+                launchExecutable: "claude"
+            ),
             context: launchContext,
             title: nil,
             objective: nil
@@ -2209,6 +2333,10 @@ struct AgentTaskRegistryTests {
         let reader = AgentTaskRegistry(persistence: store)
         reader.registerProject(identity)
         #expect(await reader.flushPersistence() == .saved)
+        #expect(
+            reader.task(for: launch.taskID)?.descriptor.launchExecutable
+                == "claude"
+        )
         let resumeContext = context(
             project: identity,
             routeSeed: 152,
@@ -2577,7 +2705,7 @@ private actor PostPublicationBlockingStore: AgentTaskPersisting {
             retryMatchedRevision = authorization.ticket.expectedDiskRevision
                 == .versioned(firstRevision)
         }
-        guard authorization.publish(operation: { true }) == .published else {
+        guard authorization.publishForTesting(operation: { true }) == .published else {
             return .rejected(.superseded)
         }
         if call == 1 {
@@ -2630,16 +2758,25 @@ nonisolated private final class OneShotStorageSyncFault: @unchecked Sendable {
 }
 
 private actor LoadedAgentTaskStore: AgentTaskPersisting {
-    private let tasks: [AgentTask]
+    private let status: AgentTaskMetadataLoadStatus
+    private var tasks: [AgentTask]
 
-    init(tasks: [AgentTask]) {
+    init(
+        status: AgentTaskMetadataLoadStatus = .loaded,
+        tasks: [AgentTask]
+    ) {
+        self.status = status
         self.tasks = tasks
     }
 
     func load(
         project: AgentTaskProjectIdentity
     ) async -> AgentTaskMetadataLoadResult {
-        AgentTaskMetadataLoadResult(status: .loaded, tasks: tasks)
+        AgentTaskMetadataLoadResult(status: status, tasks: tasks)
+    }
+
+    func replaceTasks(_ tasks: [AgentTask]) {
+        self.tasks = tasks
     }
 
     func save(
@@ -2673,7 +2810,7 @@ private actor SelectiveAgentTaskStore: AgentTaskPersisting {
         guard project.persistenceKey != failingProjectKey else {
             return .rejected(.transientIO)
         }
-        let decision = authorization?.publish({ true }) ?? .published
+        let decision = authorization?.publishForTesting({ true }) ?? .published
         switch decision {
         case .published:
             savedTaskCounts[project.persistenceKey] = tasks.count
@@ -2748,7 +2885,7 @@ private actor ScriptedAgentTaskStore: AgentTaskPersisting {
         guard case .saved = saveResult else { return saveResult }
         let decision: AgentTaskPublicationDecision
         if let authorization {
-            decision = authorization.publish {
+            decision = authorization.publishForTesting {
                 publishedSnapshots.append(tasks)
                 return true
             }

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -1,0 +1,2817 @@
+//
+//  AgentTaskRegistryTests.swift
+//  PineTests
+//
+//  Durable cross-project agent task identity and persistence (issue #1302).
+//
+
+import Foundation
+import Testing
+@testable import Pine
+
+@MainActor
+@Suite("Agent Task Registry Tests")
+struct AgentTaskRegistryTests {
+    @Test("same agent type remains distinct across projects")
+    func sameTypeAcrossProjects() throws {
+        let registry = AgentTaskRegistry()
+        let first = project("/tmp/pine-agent-first")
+        let second = project("/tmp/pine-agent-second")
+        let firstSession = makeSession(pid: 101, generation: 1)
+        let secondSession = makeSession(pid: 202, generation: 2)
+
+        registry.bridge(
+            firstSession,
+            replacing: nil,
+            context: context(project: first, routeSeed: 1)
+        )
+        registry.bridge(
+            secondSession,
+            replacing: nil,
+            context: context(project: second, routeSeed: 2)
+        )
+
+        let firstTaskID = try #require(
+            registry.taskID(forSessionID: firstSession.id)
+        )
+        let secondTaskID = try #require(
+            registry.taskID(forSessionID: secondSession.id)
+        )
+        #expect(firstTaskID != secondTaskID)
+        #expect(registry.tasks.count == 2)
+        #expect(registry.task(for: firstTaskID)?.project == first)
+        #expect(registry.task(for: secondTaskID)?.project == second)
+    }
+
+    @Test("one project supports simultaneous routed tasks")
+    func multipleTasksInProject() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-shared")
+        let first = makeSession(pid: 301, generation: 1)
+        let second = makeSession(pid: 302, generation: 2)
+
+        registry.bridge(
+            first,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 10)
+        )
+        registry.bridge(
+            second,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 20)
+        )
+
+        let firstTask = try #require(
+            registry.task(forSessionID: first.id)
+        )
+        let secondTask = try #require(
+            registry.task(forSessionID: second.id)
+        )
+        #expect(firstTask.id != secondTask.id)
+        #expect(firstTask.route != secondTask.route)
+        #expect(firstTask.runs.map(\.id) == [first.id])
+        #expect(secondTask.runs.map(\.id) == [second.id])
+    }
+
+    @Test("identical terminal hints stay project scoped")
+    func identicalTerminalHintsAreIsolated() throws {
+        let registry = AgentTaskRegistry()
+        let firstProject = project("/tmp/pine-agent-scope-a")
+        let secondProject = project("/tmp/pine-agent-scope-b")
+        let firstContext = context(project: firstProject, routeSeed: 25)
+        let secondContext = context(project: secondProject, routeSeed: 25)
+        let first = makeSession(pid: 351, generation: 1)
+        let second = makeSession(pid: 352, generation: 1)
+        registry.bridge(first, replacing: nil, context: firstContext)
+        registry.bridge(second, replacing: nil, context: secondContext)
+
+        registry.markTerminalClosed(
+            terminalID: firstContext.route.terminalID,
+            project: firstProject
+        )
+
+        #expect(
+            registry.task(forSessionID: first.id)?.route.availability
+                == .missing
+        )
+        #expect(
+            registry.task(forSessionID: second.id)?.route.availability
+                == .available
+        )
+    }
+
+    @Test("repeated evidence keeps task and run identity")
+    func stableIdentity() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-stable")
+        let route = context(project: identity, routeSeed: 30)
+        let session = makeSession(pid: 401, generation: 1)
+
+        registry.bridge(session, replacing: nil, context: route)
+        let original = try #require(registry.task(forSessionID: session.id))
+        session.state = .executing
+        registry.bridge(session, replacing: session, context: route)
+        let updated = try #require(registry.task(forSessionID: session.id))
+
+        #expect(updated.id == original.id)
+        #expect(updated.runs.count == 1)
+        #expect(updated.runs[0].id == session.id)
+        #expect(updated.runs[0].state == .executing)
+    }
+
+    @Test("manual discovery without process evidence is not joined")
+    func missingProcessEvidenceFailsClosed() {
+        let registry = AgentTaskRegistry()
+        let session = AgentSession(agentType: .codex, state: .idle)
+        registry.bridge(
+            session,
+            replacing: nil,
+            context: context(
+                project: project("/tmp/pine-agent-unproven"),
+                routeSeed: 31
+            )
+        )
+
+        #expect(registry.tasks.isEmpty)
+        #expect(registry.taskID(forSessionID: session.id) == nil)
+    }
+
+    @Test("same PID replacement cannot inherit a discovered task")
+    func pidReuseStartsNewTask() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-reuse")
+        let route = context(project: identity, routeSeed: 40)
+        let first = makeSession(
+            pid: 501,
+            generation: 4,
+            start: "Mon Aug 3 10:00:00 2026"
+        )
+        registry.bridge(first, replacing: nil, context: route)
+
+        first.applyLiveness(.terminated)
+        first.state = .done
+        let replacement = makeSession(
+            pid: 501,
+            generation: 4,
+            start: "Mon Aug 3 10:05:00 2026"
+        )
+        registry.bridge(replacement, replacing: first, context: route)
+
+        let task = try #require(
+            registry.task(forSessionID: replacement.id)
+        )
+        #expect(task.runs.count == 1)
+        #expect(task.runs[0].id == replacement.id)
+        #expect(
+            registry.taskID(forSessionID: first.id)
+                != registry.taskID(forSessionID: replacement.id)
+        )
+    }
+
+    @Test("explicit resume reserves before detector appends a fresh run")
+    func explicitResumeStartsRun() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-resume")
+        let originalContext = context(
+            project: identity,
+            routeSeed: 50,
+            origin: .pineLaunched
+        )
+        let original = makeSession(pid: 601, generation: 1)
+        guard case .reserved(let launch) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: original.agentType),
+            context: originalContext,
+            title: nil,
+            objective: nil
+        ) else {
+            Issue.record("initial reservation was rejected")
+            return
+        }
+        registry.bridge(
+            original,
+            replacing: nil,
+            context: originalContext,
+            reservation: launch
+        )
+        original.applyLiveness(.terminated)
+        original.state = .done
+        registry.refresh(sessions: [original])
+
+        let taskID = try #require(
+            registry.historicalTask(forSessionID: original.id)?.id
+        )
+        let resumed = makeSession(pid: 602, generation: 2)
+        let resumedContext = AgentTaskBridgeContext(
+            project: identity,
+            route: originalContext.route,
+            origin: .pineLaunched,
+            observedAt: Date(timeIntervalSince1970: 0)
+        )
+        guard case .reserved(let reservation) = registry.prepareResume(
+            taskID: taskID,
+            context: resumedContext
+        ) else {
+            Issue.record("resume reservation was rejected")
+            return
+        }
+        registry.bridge(
+            resumed,
+            replacing: original,
+            context: resumedContext,
+            reservation: reservation
+        )
+
+        let task = try #require(registry.task(for: taskID))
+        #expect(task.runs.map(\.id) == [original.id, resumed.id])
+        #expect(task.route == resumedContext.route)
+        #expect(task.lifecycle == .active)
+    }
+
+    @Test("Pine launch reservation bridges to detector session")
+    func pineLaunchBridgesDetector() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-launched")
+        let baseContext = context(
+            project: identity, routeSeed: 60, origin: .pineLaunched
+        )
+        let launchContext = AgentTaskBridgeContext(
+            project: identity,
+            route: baseContext.route,
+            origin: .pineLaunched,
+            observedAt: Date(timeIntervalSince1970: 0)
+        )
+        let result = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: .codex),
+            context: launchContext,
+            title: "Review",
+            objective: "Inspect the patch"
+        )
+        guard case .reserved(let reservation) = result else {
+            Issue.record("launch reservation was rejected")
+            return
+        }
+        let detected = makeSession(
+            pid: 701,
+            generation: 1,
+            agentType: .codex
+        )
+
+        registry.bridge(
+            detected,
+            replacing: nil,
+            context: launchContext,
+            reservation: reservation
+        )
+
+        let taskID = reservation.taskID
+        let task = try #require(registry.task(for: taskID))
+        #expect(task.origin == .pineLaunched)
+        #expect(task.title == "Review")
+        #expect(task.objective == "Inspect the patch")
+        #expect(task.runs.map(\.id) == [detected.id])
+        #expect(registry.taskID(forSessionID: detected.id) == taskID)
+    }
+
+    @Test("untokened polling preserves Pine intent for its launch owner")
+    func untokenedPollingPreservesReservation() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-token-race")
+        let launchContext = context(
+            project: identity,
+            routeSeed: 61,
+            origin: .pineLaunched
+        )
+        guard case .reserved(let reservation) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: .codex),
+            context: launchContext,
+            title: nil,
+            objective: nil
+        ) else {
+            Issue.record("launch reservation was rejected")
+            return
+        }
+        #expect(
+            registry.task(for: reservation.taskID)?.route.availability
+                == .missing
+        )
+        let unrelated = makeSession(
+            pid: 702,
+            generation: 1,
+            agentType: .codex
+        )
+        registry.bridge(unrelated, replacing: nil, context: launchContext)
+
+        #expect(registry.task(for: reservation.taskID)?.runs.isEmpty == true)
+        #expect(registry.task(forSessionID: unrelated.id) == nil)
+        registry.bridge(
+            unrelated,
+            replacing: nil,
+            context: launchContext,
+            reservation: reservation
+        )
+        #expect(registry.taskID(forSessionID: unrelated.id) == reservation.taskID)
+    }
+
+    @Test("pre-existing process cannot consume or destroy launch intent")
+    func preexistingProcessPreservesReservation() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-process-boundary")
+        let capturedAt = Date(timeIntervalSince1970: 1_785_672_000)
+        let launchContext = AgentTaskBridgeContext(
+            project: identity,
+            route: context(project: identity, routeSeed: 615).route,
+            origin: .pineLaunched,
+            observedAt: capturedAt
+        )
+        guard case .reserved(let reservation) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: .claudeCode),
+            context: launchContext,
+            title: nil,
+            objective: nil,
+            boundary: AgentTaskLaunchBoundary(
+                generationFloor: 5,
+                capturedAt: capturedAt
+            )
+        ) else {
+            Issue.record("launch reservation was rejected")
+            return
+        }
+        let preexisting = makeSession(
+            pid: 702,
+            generation: 6,
+            start: "Sat Aug 1 10:00:00 2026",
+            preciseStartedAt: capturedAt.addingTimeInterval(-86_400)
+        )
+        registry.bridge(
+            preexisting,
+            replacing: nil,
+            context: launchContext,
+            reservation: reservation
+        )
+        #expect(registry.task(for: reservation.taskID)?.runs.isEmpty == true)
+
+        let launched = makeSession(
+            pid: 703,
+            generation: 7,
+            start: "Mon Aug 3 10:00:00 2026",
+            preciseStartedAt: capturedAt.addingTimeInterval(86_400)
+        )
+        registry.bridge(
+            launched,
+            replacing: preexisting,
+            context: launchContext,
+            reservation: reservation
+        )
+        #expect(registry.taskID(forSessionID: launched.id) == reservation.taskID)
+    }
+
+    @Test("launch claim requires authoritative process start evidence")
+    func launchClaimRequiresAuthoritativeStart() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-authoritative-start")
+        let launchContext = context(
+            project: identity,
+            routeSeed: 616,
+            origin: .pineLaunched
+        )
+        guard case .reserved(let reservation) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: .claudeCode),
+            context: launchContext,
+            title: nil,
+            objective: nil,
+            boundary: AgentTaskLaunchBoundary(
+                generationFloor: 1,
+                capturedAt: Date(timeIntervalSince1970: 100)
+            )
+        ) else {
+            Issue.record("reservation was rejected")
+            return
+        }
+        let session = makeSession(
+            pid: 705,
+            generation: 2,
+            preciseStartedAt: Date(timeIntervalSince1970: 200),
+            startIsAuthoritative: false
+        )
+
+        registry.bridge(
+            session,
+            replacing: nil,
+            context: launchContext,
+            reservation: reservation
+        )
+
+        #expect(registry.task(for: reservation.taskID)?.runs.isEmpty == true)
+        #expect(registry.task(forSessionID: session.id) == nil)
+    }
+
+    @Test("claims expire without a later registry mutation")
+    func claimExpiresWithoutPolling() async throws {
+        let registry = AgentTaskRegistry(claimTTL: .milliseconds(1))
+        let identity = project("/tmp/pine-agent-expiry")
+        let launchContext = context(
+            project: identity,
+            routeSeed: 651,
+            origin: .pineLaunched
+        )
+        guard case .reserved(let reservation) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: .claudeCode),
+            context: launchContext,
+            title: nil,
+            objective: nil
+        ) else {
+            Issue.record("launch reservation was rejected")
+            return
+        }
+
+        try await ContinuousClock().sleep(for: .milliseconds(50))
+        #expect(registry.task(for: reservation.taskID) == nil)
+    }
+
+    @Test("a real reservation is single use")
+    func reservationCannotBeConsumedTwice() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-token-once")
+        let launchContext = context(
+            project: identity,
+            routeSeed: 62,
+            origin: .pineLaunched
+        )
+        guard case .reserved(let reservation) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: .codex),
+            context: launchContext,
+            title: nil,
+            objective: nil
+        ) else {
+            Issue.record("launch reservation was rejected")
+            return
+        }
+        let first = makeSession(pid: 703, generation: 1, agentType: .codex)
+        registry.bridge(
+            first,
+            replacing: nil,
+            context: launchContext,
+            reservation: reservation
+        )
+        let duplicate = makeSession(pid: 704, generation: 2, agentType: .codex)
+        registry.bridge(
+            duplicate,
+            replacing: first,
+            context: launchContext,
+            reservation: reservation
+        )
+        let task = try #require(registry.task(for: reservation.taskID))
+        #expect(task.runs.map(\.id) == [first.id])
+        #expect(registry.taskID(forSessionID: duplicate.id) == nil)
+    }
+
+    @Test("claims reject another real token and clean both initial tasks")
+    func wrongRealTokenCancelsClaims() {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-wrong-token")
+        let first = context(
+            project: identity, routeSeed: 63, origin: .pineLaunched
+        )
+        let second = context(
+            project: identity, routeSeed: 64, origin: .pineLaunched
+        )
+        guard case .reserved(let firstClaim) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: .codex),
+            context: first, title: nil, objective: nil
+        ), case .reserved(let secondClaim) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: .codex),
+            context: second, title: nil, objective: nil
+        ) else {
+            Issue.record("reservations were rejected")
+            return
+        }
+        registry.bridge(
+            makeSession(pid: 705, generation: 1, agentType: .codex),
+            replacing: nil,
+            context: first,
+            reservation: secondClaim
+        )
+        #expect(registry.task(for: firstClaim.taskID) == nil)
+        #expect(registry.task(for: secondClaim.taskID) == nil)
+    }
+
+    @Test("done or stale evidence cannot reserve resume")
+    func resumeRequiresTerminatedPineTail() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-resume-negative")
+        let launchContext = context(
+            project: identity, routeSeed: 65, origin: .pineLaunched
+        )
+        guard case .reserved(let claim) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: .claudeCode),
+            context: launchContext, title: nil, objective: nil
+        ) else {
+            Issue.record("reservation was rejected")
+            return
+        }
+        let session = makeSession(pid: 706, generation: 1)
+        registry.bridge(
+            session, replacing: nil, context: launchContext,
+            reservation: claim
+        )
+        session.state = .done
+        registry.refresh(sessions: [session])
+        #expect(
+            registry.prepareResume(taskID: claim.taskID, context: launchContext)
+                == .rejected
+        )
+        session.applyLiveness(.stale)
+        registry.refresh(sessions: [session])
+        #expect(
+            registry.prepareResume(taskID: claim.taskID, context: launchContext)
+                == .rejected
+        )
+        #expect(registry.taskID(forSessionID: session.id) == claim.taskID)
+    }
+
+    @Test("cancelled termination restores pending launch ownership")
+    func terminationRestoresPendingLaunch() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-quit-rollback")
+        let launchContext = context(
+            project: identity, routeSeed: 66, origin: .pineLaunched
+        )
+        guard case .reserved(let claim) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: .codex),
+            context: launchContext, title: nil, objective: nil
+        ) else {
+            Issue.record("reservation was rejected")
+            return
+        }
+        let before = try #require(registry.task(for: claim.taskID))
+        registry.prepareForApplicationTermination(
+            at: before.updatedAt.addingTimeInterval(10)
+        )
+        #expect(registry.task(for: claim.taskID) != nil)
+        #expect(registry.isLaunchPending(claim))
+        registry.cancelApplicationTermination()
+        #expect(registry.isLaunchPending(claim))
+        #expect(registry.task(for: claim.taskID)?.updatedAt == before.updatedAt)
+        let observed = makeSession(pid: 707, generation: 1, agentType: .codex)
+        registry.bridge(
+            observed,
+            replacing: nil,
+            context: launchContext,
+            reservation: claim
+        )
+        #expect(registry.taskID(forSessionID: observed.id) == claim.taskID)
+    }
+
+    @Test("pending launch follows pane move and background state")
+    func pendingLaunchRouteCanMove() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-pending-move")
+        let initial = context(
+            project: identity,
+            routeSeed: 667,
+            origin: .pineLaunched
+        )
+        let boundary = Date(timeIntervalSince1970: 1_785_672_000.75)
+        guard case .reserved(let reservation) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: .claudeCode),
+            context: initial,
+            title: nil,
+            objective: nil,
+            boundary: AgentTaskLaunchBoundary(
+                generationFloor: 4,
+                capturedAt: boundary
+            )
+        ) else {
+            Issue.record("reservation was rejected")
+            return
+        }
+        let movedRoute = AgentTaskRoute(
+            paneID: uuid(668),
+            tabID: initial.route.tabID,
+            terminalID: initial.route.terminalID
+        )
+        registry.updateRoute(
+            terminalID: initial.route.terminalID,
+            project: identity,
+            route: movedRoute
+        )
+        registry.setWindowOpen(false, projectPath: identity.canonicalProjectPath)
+        let moved = AgentTaskBridgeContext(
+            project: identity,
+            route: AgentTaskRoute(
+                paneID: movedRoute.paneID,
+                tabID: movedRoute.tabID,
+                terminalID: movedRoute.terminalID,
+                availability: .background
+            ),
+            origin: .pineLaunched,
+            observedAt: boundary
+        )
+        let observed = makeSession(
+            pid: 708,
+            generation: 5,
+            start: processStartIdentifier(boundary),
+            preciseStartedAt: boundary.addingTimeInterval(0.001)
+        )
+
+        registry.bridge(
+            observed,
+            replacing: nil,
+            context: moved,
+            reservation: reservation
+        )
+        let task = try #require(registry.task(for: reservation.taskID))
+        #expect(task.runs.last?.id == observed.id)
+        #expect(task.route == moved.route)
+    }
+
+    @Test("stale evidence clears attention without changing state")
+    func staleClearsAttention() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-stale")
+        let session = makeSession(
+            pid: 801,
+            generation: 1,
+            state: .waitingInput
+        )
+        registry.bridge(
+            session,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 70)
+        )
+        var task = try #require(registry.task(forSessionID: session.id))
+        #expect(task.attention == .waitingInput)
+        #expect(task.isUnread)
+
+        session.applyLiveness(.stale)
+        registry.refresh(sessions: [session])
+        task = try #require(registry.historicalTask(forSessionID: session.id))
+        #expect(task.runs.last?.state == .waitingInput)
+        #expect(task.runs.last?.liveness == .stale)
+        #expect(task.attention == .none)
+    }
+
+    @Test("route changes retain task identity")
+    func canonicalRouteUpdate() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/../tmp/pine-agent-route")
+        let firstContext = context(project: identity, routeSeed: 80)
+        let session = makeSession(pid: 901, generation: 1)
+        registry.bridge(session, replacing: nil, context: firstContext)
+        let taskID = try #require(
+            registry.taskID(forSessionID: session.id)
+        )
+
+        let movedContext = AgentTaskBridgeContext(
+            project: identity,
+            route: AgentTaskRoute(
+                paneID: uuid(81),
+                tabID: firstContext.route.tabID,
+                terminalID: firstContext.route.terminalID
+            ),
+            origin: .discoveredInTerminal
+        )
+        registry.bridge(session, replacing: session, context: movedContext)
+
+        let task = try #require(registry.task(for: taskID))
+        #expect(task.id == taskID)
+        #expect(task.route == movedContext.route)
+        #expect(task.project.canonicalProjectPath == "/tmp/pine-agent-route")
+    }
+
+    @Test("legacy session IDs still bridge Activity and History")
+    func legacyBridgePreservesLinks() throws {
+        let registry = AgentTaskRegistry()
+        let session = makeSession(pid: 1_001, generation: 1)
+        let activity = AgentActivityStore()
+        let history = AgentHistoryStore()
+        let action = AgentAction(
+            sessionID: session.id,
+            agentType: session.agentType,
+            kind: .command,
+            status: .completed,
+            summary: "legacy"
+        )
+        activity.record(action)
+
+        registry.bridge(
+            session,
+            replacing: nil,
+            context: context(
+                project: project("/tmp/pine-agent-migration"),
+                routeSeed: 90
+            )
+        )
+        session.applyLiveness(.terminated)
+        session.state = .done
+        history.finalize(
+            session: session,
+            summary: "legacy",
+            affectedRelativePaths: []
+        )
+
+        let task = try #require(registry.task(forSessionID: session.id))
+        #expect(task.runs.first?.id == session.id)
+        #expect(activity.actions(forSession: session.id) == [action])
+        #expect(history.entries.first?.sessionID == session.id)
+    }
+
+    @Test("pane close terminates route but window close does not")
+    func terminalAndWindowLifecycle() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-lifecycle")
+        let bridgeContext = context(project: identity, routeSeed: 100)
+        let session = makeSession(pid: 1_101, generation: 1)
+        registry.bridge(session, replacing: nil, context: bridgeContext)
+
+        registry.setWindowOpen(false, projectPath: identity.canonicalProjectPath)
+        var task = try #require(registry.task(forSessionID: session.id))
+        #expect(task.route.availability == .background)
+        #expect(task.runs.last?.liveness == .live)
+
+        registry.markTerminalClosed(
+            terminalID: bridgeContext.route.terminalID,
+            project: identity,
+            at: Date(timeIntervalSince1970: 2_000)
+        )
+        task = try #require(registry.historicalTask(forSessionID: session.id))
+        #expect(task.route.availability == .missing)
+        #expect(task.runs.last?.liveness == .terminated)
+        #expect(task.lifecycle == .paused)
+        #expect(task.attention == .none)
+    }
+
+    @Test("launch authority accepts only an exact canonical executable token")
+    func exactAgentLaunchCommandClassification() {
+        #expect(
+            TerminalManager.exactAgentLaunchDescriptor(for: "codex")
+                == AgentDescriptor(agentType: .codex)
+        )
+        for untrusted in [
+            " codex", "codex ", "codex\n", "CODEX", "codex --help",
+            "env codex", "codex; echo injected", "./codex",
+        ] {
+            #expect(TerminalManager.exactAgentLaunchDescriptor(for: untrusted) == nil)
+        }
+    }
+
+    @Test("terminal launch owner carries reservation to exact new process")
+    func productionLaunchReservationHandoff() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let taskRegistry = AgentTaskRegistry(persistence: store)
+        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        #expect(await taskRegistry.flushPersistence() == .saved)
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let state = try #require(
+            manager.paneManager.terminalState(for: pane)
+        )
+        let tab = try #require(state.terminalTabs.first)
+        guard case .reserved(let reservation) = manager.terminal.prepareAgentLaunch(
+            in: tab,
+            descriptor: AgentDescriptor(agentType: .claudeCode),
+            title: nil,
+            objective: nil
+        ) else {
+            Issue.record("terminal launch reservation was rejected")
+            return
+        }
+        let now = Date()
+        let preexisting = makeSession(
+            pid: 1_109,
+            generation: 1,
+            start: processStartIdentifier(now.addingTimeInterval(-60)),
+            preciseStartedAt: now.addingTimeInterval(-60)
+        )
+        manager.terminal.bridgeAgentSession(
+            preexisting,
+            replacing: nil,
+            in: tab
+        )
+        #expect(taskRegistry.task(for: reservation.taskID)?.runs.isEmpty == true)
+
+        let launched = makeSession(
+            pid: 1_110,
+            generation: 2,
+            start: processStartIdentifier(now),
+            preciseStartedAt: now.addingTimeInterval(0.001)
+        )
+        manager.terminal.bridgeAgentSession(
+            launched,
+            replacing: preexisting,
+            in: tab
+        )
+        #expect(
+            taskRegistry.taskID(forSessionID: launched.id)
+                == reservation.taskID
+        )
+        #expect(
+            await projectRegistry.resolveAgentTaskRoute(reservation.taskID)?.paneID
+                == pane.id
+        )
+
+        launched.applyLiveness(.terminated)
+        manager.terminal.bridgeAgentSession(
+            launched,
+            replacing: launched,
+            in: tab
+        )
+        tab.agentSession = nil
+        #expect(
+            await projectRegistry.resolveAgentTaskRoute(
+                reservation.taskID,
+                targetTerminalID: tab.id
+            )?.terminalID == tab.id
+        )
+        guard case .reserved = manager.terminal.prepareAgentResume(
+            taskID: reservation.taskID,
+            in: tab
+        ) else {
+            Issue.record("production resume reservation was rejected")
+            return
+        }
+        let resumed = makeSession(
+            pid: 1_111,
+            generation: 3,
+            start: processStartIdentifier(now.addingTimeInterval(1)),
+            preciseStartedAt: now.addingTimeInterval(1.001)
+        )
+        manager.terminal.bridgeAgentSession(
+            resumed,
+            replacing: nil,
+            in: tab
+        )
+        #expect(taskRegistry.taskID(forSessionID: resumed.id) == reservation.taskID)
+        #expect(taskRegistry.task(for: reservation.taskID)?.runs.count == 2)
+    }
+
+    @Test("expired local reservation permits a new terminal launch")
+    func expiredTerminalReservationCanBeReplaced() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let taskRegistry = AgentTaskRegistry(claimTTL: .milliseconds(1))
+        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        #expect(await taskRegistry.flushPersistence() == .saved)
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let state = try #require(
+            manager.paneManager.terminalState(for: pane)
+        )
+        let tab = try #require(state.terminalTabs.first)
+        guard case .reserved(let expired) = manager.terminal.prepareAgentLaunch(
+            in: tab,
+            descriptor: AgentDescriptor(agentType: .codex)
+        ) else {
+            Issue.record("first reservation was rejected")
+            return
+        }
+        try await ContinuousClock().sleep(for: .milliseconds(10))
+        #expect(!taskRegistry.isLaunchPending(expired))
+
+        guard case .reserved = manager.terminal.prepareAgentLaunch(
+            in: tab,
+            descriptor: AgentDescriptor(agentType: .codex)
+        ) else {
+            Issue.record("expired local slot was not reconciled")
+            return
+        }
+        manager.terminal.cancelAgentLaunch(in: tab)
+    }
+
+    @Test("project and pane wiring moves then closes a task route")
+    func productionPaneLifecycleWiring() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let taskRegistry = AgentTaskRegistry(persistence: store)
+        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        await taskRegistry.flushPersistence()
+        let firstPane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let firstState = try #require(
+            manager.paneManager.terminalState(for: firstPane)
+        )
+        let tab = try #require(firstState.terminalTabs.first)
+        let session = makeSession(pid: 1_111, generation: 1)
+        manager.terminal.bridgeAgentSession(
+            session,
+            replacing: nil,
+            in: tab
+        )
+        tab.agentSession = session
+        let historicalTaskID = try #require(
+            taskRegistry.taskID(forSessionID: session.id)
+        )
+        #expect(
+            await projectRegistry.resolveAgentTaskRoute(historicalTaskID)?.paneID
+                == firstPane.id
+        )
+        session.applyLiveness(.terminated)
+        session.state = .done
+        let replacement = makeSession(pid: 1_112, generation: 2)
+        manager.terminal.bridgeAgentSession(
+            replacement,
+            replacing: session,
+            in: tab
+        )
+        tab.agentSession = replacement
+        let taskID = try #require(
+            taskRegistry.taskID(forSessionID: replacement.id)
+        )
+        #expect(taskID != historicalTaskID)
+        #expect(
+            taskRegistry.task(for: historicalTaskID)?.route.availability
+                == .missing
+        )
+        let secondPane = try #require(manager.paneManager.createTerminalPane(
+            relativeTo: firstPane,
+            axis: .horizontal,
+            workingDirectory: fixture.project
+        ))
+
+        #expect(manager.paneManager.moveTerminalTab(
+            tab.id,
+            from: firstPane,
+            to: secondPane
+        ))
+        #expect(taskRegistry.task(for: taskID)?.route.paneID == secondPane.id)
+        #expect(
+            await projectRegistry.resolveAgentTaskRoute(taskID)?.paneID
+                == secondPane.id
+        )
+        manager.paneManager.removePane(secondPane)
+        let task = try #require(taskRegistry.task(for: taskID))
+        #expect(task.route.availability == .missing)
+        #expect(task.attention == .none)
+        #expect(await projectRegistry.resolveAgentTaskRoute(taskID) == nil)
+    }
+
+    @Test("duplicate live tab ownership fails route resolution closed")
+    func duplicateLiveTabRouteIsRejected() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let taskRegistry = AgentTaskRegistry()
+        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        let firstPane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let firstState = try #require(
+            manager.paneManager.terminalState(for: firstPane)
+        )
+        let tab = try #require(firstState.terminalTabs.first)
+        let session = makeSession(pid: 1_113, generation: 1)
+        manager.terminal.bridgeAgentSession(
+            session,
+            replacing: nil,
+            in: tab
+        )
+        tab.agentSession = session
+        let taskID = try #require(taskRegistry.taskID(forSessionID: session.id))
+        #expect(await projectRegistry.resolveAgentTaskRoute(taskID) != nil)
+        let secondPane = try #require(manager.paneManager.createTerminalPane(
+            relativeTo: firstPane,
+            axis: .horizontal,
+            workingDirectory: fixture.project
+        ))
+        let secondState = try #require(
+            manager.paneManager.terminalState(for: secondPane)
+        )
+        secondState.terminalTabs.append(tab)
+
+        #expect(await projectRegistry.resolveAgentTaskRoute(taskID) == nil)
+        secondState.terminalTabs.removeAll { $0 === tab }
+    }
+
+    @Test("persistence trims task and run bounds")
+    func boundedPersistence() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let limits = AgentTaskPersistenceLimits(
+            maxTasksPerProject: 3,
+            maxRunsPerTask: 2,
+            maxFileBytes: 128_000
+        )
+        let store = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            limits: limits
+        )
+        let registry = AgentTaskRegistry()
+        let identity = project(fixture.project.path)
+        let sharedContext = context(
+            project: identity,
+            routeSeed: 110,
+            origin: .pineLaunched
+        )
+        var previous = makeSession(pid: 1_201, generation: 1)
+        guard case .reserved(let initial) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: previous.agentType),
+            context: sharedContext,
+            title: nil,
+            objective: nil
+        ) else {
+            Issue.record("initial reservation was rejected")
+            return
+        }
+        registry.bridge(
+            previous,
+            replacing: nil,
+            context: sharedContext,
+            reservation: initial
+        )
+        let retainedTaskID = try #require(
+            registry.taskID(forSessionID: previous.id)
+        )
+        for sequence in 2...4 {
+            previous.applyLiveness(.terminated)
+            previous.state = .done
+            registry.refresh(sessions: [previous])
+            let next = makeSession(
+                pid: 1_200 + Int32(sequence),
+                generation: UInt64(sequence)
+            )
+            let resumeContext = AgentTaskBridgeContext(
+                project: identity,
+                route: sharedContext.route,
+                origin: .pineLaunched,
+                observedAt: Date(timeIntervalSince1970: 0)
+            )
+            guard case .reserved(let reservation) = registry.prepareResume(
+                taskID: retainedTaskID,
+                context: resumeContext
+            ) else {
+                Issue.record("resume reservation was rejected")
+                return
+            }
+            registry.bridge(
+                next,
+                replacing: previous,
+                context: resumeContext,
+                reservation: reservation
+            )
+            previous = next
+        }
+        for seed in 111...112 {
+            registry.bridge(
+                makeSession(
+                    pid: 1_300 + Int32(seed),
+                    generation: UInt64(seed)
+                ),
+                replacing: nil,
+                context: context(project: identity, routeSeed: seed)
+            )
+        }
+
+        let save = await store.save(
+            tasks: registry.tasks,
+            project: identity
+        )
+        let loaded = await store.load(project: identity)
+
+        #expect(save == .saved(taskCount: 3))
+        #expect(loaded.tasks.count == 3)
+        #expect(loaded.tasks.allSatisfy { $0.runs.count <= 2 })
+        let retained = try #require(
+            loaded.tasks.first(where: { $0.id == retainedTaskID })
+        )
+        #expect(retained.runs.map(\.process.processGeneration) == [3, 4])
+    }
+
+    @Test("active retention overflow fails instead of truncating")
+    func activeRetentionOverflowFailsClosed() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let limits = AgentTaskPersistenceLimits(maxTasksPerProject: 1)
+        let store = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            limits: limits
+        )
+        let identity = project(fixture.project.path)
+        let registry = AgentTaskRegistry()
+        for seed in 201...202 {
+            registry.bridge(
+                makeSession(pid: 2_000 + Int32(seed), generation: UInt64(seed)),
+                replacing: nil,
+                context: context(project: identity, routeSeed: seed)
+            )
+        }
+
+        #expect(await store.save(tasks: registry.tasks, project: identity)
+            == .rejected(.storageLimit))
+    }
+
+    @Test("paused retention overflow fails instead of deleting resumable tasks")
+    func pausedRetentionOverflowFailsClosed() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let store = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            limits: AgentTaskPersistenceLimits(maxTasksPerProject: 1)
+        )
+        let identity = project(fixture.project.path)
+        let registry = AgentTaskRegistry()
+        for seed in 203...204 {
+            let session = makeSession(
+                pid: 2_000 + Int32(seed),
+                generation: UInt64(seed)
+            )
+            let bridgeContext = context(project: identity, routeSeed: seed)
+            registry.bridge(session, replacing: nil, context: bridgeContext)
+            session.applyLiveness(.terminated)
+            registry.bridge(session, replacing: session, context: bridgeContext)
+        }
+
+        #expect(registry.tasks.allSatisfy { $0.lifecycle == .paused })
+        #expect(await store.save(tasks: registry.tasks, project: identity)
+            == .rejected(.storageLimit))
+    }
+
+    @Test("impossible lifecycle route and attention metadata is rejected")
+    func impossibleMetadataIsRejected() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let identity = project(fixture.project.path)
+        let discovered = context(project: identity, routeSeed: 210)
+        var activeWithoutRun = AgentTask(
+            descriptor: AgentDescriptor(agentType: .claudeCode),
+            context: discovered
+        )
+        #expect(await store.save(tasks: [activeWithoutRun], project: identity)
+            == .rejected(.invalidMetadata))
+
+        activeWithoutRun.lifecycle = .paused
+        #expect(await store.save(tasks: [activeWithoutRun], project: identity)
+            == .rejected(.invalidMetadata))
+        activeWithoutRun.route.availability = .missing
+        #expect(await store.save(tasks: [activeWithoutRun], project: identity)
+            == .saved(taskCount: 1))
+
+        let registry = AgentTaskRegistry()
+        let session = makeSession(pid: 2_211, generation: 1)
+        registry.bridge(session, replacing: nil, context: discovered)
+        var task = try #require(registry.tasks.first)
+        task.attention = .waitingInput
+        #expect(await store.save(tasks: [task], project: identity)
+            == .rejected(.invalidMetadata))
+        task.attention = .none
+        task.route = AgentTaskRoute(
+            paneID: task.route.paneID,
+            tabID: uuid(9_999),
+            terminalID: task.route.terminalID
+        )
+        #expect(await store.save(tasks: [task], project: identity)
+            == .rejected(.invalidMetadata))
+    }
+
+    @Test("hostile decoded no-run active task fails closed")
+    func hostileDecodedTaskFailsClosed() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let identity = project(fixture.project.path)
+        let registry = AgentTaskRegistry()
+        registry.bridge(
+            makeSession(pid: 2_301, generation: 1),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 220)
+        )
+        #expect(await store.save(tasks: registry.tasks, project: identity)
+            == .saved(taskCount: 1))
+        let fileURL = AgentTaskMetadataStore.metadataURL(
+            for: identity,
+            storageRoot: fixture.storage
+        )
+        let original = try Data(contentsOf: fileURL)
+        let hostile = try metadataWithoutRuns(original)
+        try hostile.write(to: fileURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: fileURL.path
+        )
+
+        #expect(await store.load(project: identity).status
+            == .rejected(.invalidMetadata))
+        #expect(try Data(contentsOf: fileURL) == hostile)
+    }
+
+    @Test("atomic failed save preserves previous metadata")
+    func atomicSaveLoad() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let identity = project(fixture.project.path)
+        let registry = AgentTaskRegistry()
+        let first = makeSession(pid: 1_401, generation: 1)
+        registry.bridge(
+            first,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 120)
+        )
+        #expect(
+            await store.save(tasks: registry.tasks, project: identity)
+                == .saved(taskCount: 1)
+        )
+        let fileURL = AgentTaskMetadataStore.metadataURL(
+            for: identity,
+            storageRoot: fixture.storage
+        )
+        let originalData = try Data(contentsOf: fileURL)
+
+        var invalid = try #require(registry.tasks.first)
+        invalid.title = String(repeating: "x", count: 10_000)
+        #expect(
+            await store.save(tasks: [invalid], project: identity)
+                == .rejected(.invalidMetadata)
+        )
+        #expect(try Data(contentsOf: fileURL) == originalData)
+
+        let second = makeSession(pid: 1_402, generation: 2)
+        registry.bridge(
+            second,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 121)
+        )
+        #expect(
+            await store.save(tasks: registry.tasks, project: identity)
+                == .saved(taskCount: 2)
+        )
+        let loaded = await store.load(project: identity)
+        #expect(loaded.tasks.count == 2)
+        #expect(!FileManager.default.fileExists(
+            atPath: fileURL.appendingPathExtension("tmp").path
+        ))
+    }
+
+    @Test("corrupt and future schemas fail closed")
+    func invalidSchemaFailsClosed() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let identity = project(fixture.project.path)
+        let fileURL = AgentTaskMetadataStore.metadataURL(
+            for: identity,
+            storageRoot: fixture.storage
+        )
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: fileURL.deletingLastPathComponent().path
+        )
+
+        try Data("not-json".utf8).write(to: fileURL, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: fileURL.path
+        )
+        var loaded = await store.load(project: identity)
+        #expect(loaded.status == .rejected(.corrupt))
+        #expect(loaded.tasks.isEmpty)
+
+        let future = """
+        {"schemaVersion":999,"canonicalProjectPath":"\(identity.canonicalProjectPath)","tasks":[]}
+        """
+        try Data(future.utf8).write(to: fileURL, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: fileURL.path
+        )
+        loaded = await store.load(project: identity)
+        #expect(loaded.status == .rejected(.unknownSchema))
+        #expect(loaded.tasks.isEmpty)
+    }
+
+    @Test("future schema quarantines normal registry writes")
+    func futureSchemaQuarantinesRegistryWrites() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let fileURL = AgentTaskMetadataStore.metadataURL(
+            for: identity,
+            storageRoot: fixture.storage
+        )
+        try FileManager.default.createDirectory(
+            at: fixture.storage,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let original = Data("{\"schemaVersion\":999,\"future\":true}\n".utf8)
+        try original.write(to: fileURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: fileURL.path
+        )
+        let registry = AgentTaskRegistry(persistence: store)
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+        registry.bridge(
+            makeSession(pid: 1_490, generation: 1),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 149)
+        )
+        registry.prepareForApplicationTermination()
+
+        #expect(await registry.flushPersistence() == .saved)
+        #expect(try Data(contentsOf: fileURL) == original)
+        #expect(
+            registry.saveResultByProject[identity.persistenceKey] == nil
+        )
+    }
+
+    @Test("oversized metadata quarantines registry writes byte-for-byte")
+    func oversizedMetadataQuarantinesWrites() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let store = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            limits: AgentTaskPersistenceLimits(maxFileBytes: 1_024)
+        )
+        let fileURL = AgentTaskMetadataStore.metadataURL(
+            for: identity,
+            storageRoot: fixture.storage
+        )
+        try FileManager.default.createDirectory(
+            at: fixture.storage,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let original = Data(
+            "{\"schemaVersion\":999,\"future\":\"\(String(repeating: "A", count: 2_048))\"}\n".utf8
+        )
+        try original.write(to: fileURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: fileURL.path
+        )
+        let registry = AgentTaskRegistry(persistence: store)
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+        #expect(
+            registry.loadStatusByProject[identity.persistenceKey]
+                == .rejected(.storageLimit)
+        )
+        registry.bridge(
+            makeSession(pid: 1_489, generation: 1),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 148)
+        )
+        registry.prepareForApplicationTermination()
+
+        #expect(await registry.flushPersistence() == .saved)
+        #expect(try Data(contentsOf: fileURL) == original)
+        #expect(registry.saveResultByProject[identity.persistenceKey] == nil)
+    }
+
+    @Test("quit snapshot is valid and rollback restores live ownership")
+    func quitSnapshotPersistsAndRollsBack() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let registry = AgentTaskRegistry(persistence: store)
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+        let session = makeSession(pid: 1_491, generation: 1)
+        let route = context(project: identity, routeSeed: 150)
+        registry.bridge(session, replacing: nil, context: route)
+        let originalUpdatedAt = try #require(
+            registry.task(forSessionID: session.id)?.updatedAt
+        )
+        registry.prepareForApplicationTermination(
+            at: Date(timeIntervalSince1970: 10)
+        )
+
+        #expect(await registry.flushPersistence() == .saved)
+        let stored = await store.load(project: identity)
+        let snapshot = try #require(stored.tasks.first)
+        #expect(snapshot.lifecycle == .paused)
+        #expect(snapshot.route.availability == .missing)
+        #expect(snapshot.runs.last?.liveness == .stale)
+
+        registry.cancelApplicationTermination()
+        let restored = try #require(registry.task(forSessionID: session.id))
+        #expect(restored.lifecycle == .active)
+        #expect(restored.route.availability == .available)
+        #expect(restored.runs.last?.liveness == .live)
+        #expect(restored.updatedAt == originalUpdatedAt)
+        #expect(registry.taskID(forSessionID: session.id) == restored.id)
+        #expect(await registry.flushPersistence() == .saved)
+        let rolledBack = try #require(
+            await store.load(project: identity).tasks.first
+        )
+        #expect(rolledBack.lifecycle == .active)
+        #expect(rolledBack.route.availability == .available)
+        #expect(rolledBack.runs.last?.liveness == .live)
+        #expect(
+            abs(rolledBack.updatedAt.timeIntervalSince(originalUpdatedAt)) < 0.001
+        )
+    }
+
+    @Test("one rejected project cannot starve another project save")
+    func rejectedProjectDoesNotStarveOtherProjects() async {
+        let first = project("/tmp/pine-agent-failing-project")
+        let second = project("/tmp/pine-agent-healthy-project")
+        let store = SelectiveAgentTaskStore(failingProjectKey: first.persistenceKey)
+        let registry = AgentTaskRegistry(persistence: store)
+        registry.registerProject(first)
+        registry.registerProject(second)
+        #expect(await registry.flushPersistence() == .saved)
+
+        registry.bridge(
+            makeSession(pid: 1_480, generation: 1),
+            replacing: nil,
+            context: context(project: first, routeSeed: 120)
+        )
+        registry.bridge(
+            makeSession(pid: 1_481, generation: 2),
+            replacing: nil,
+            context: context(project: second, routeSeed: 121)
+        )
+
+        #expect(await store.waitForSave(projectKey: second.persistenceKey))
+        #expect(await store.savedTaskCount(projectKey: second.persistenceKey) == 1)
+    }
+
+    @Test("missing worktrees and projects fail closed")
+    func missingPathsFailClosed() async throws {
+        let fixture = try PersistenceFixture(makeWorktree: true)
+        defer { fixture.cleanup() }
+        let worktree = try #require(fixture.worktree)
+        let identity = AgentTaskProjectIdentity(
+            canonicalProjectPath: fixture.project.path,
+            canonicalWorktreePath: worktree.path
+        )
+        let registry = AgentTaskRegistry()
+        registry.bridge(
+            makeSession(pid: 1_501, generation: 1),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 130)
+        )
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(
+            await store.save(tasks: registry.tasks, project: identity)
+                == .saved(taskCount: 1)
+        )
+
+        try FileManager.default.removeItem(at: worktree)
+        var loaded = await store.load(project: identity)
+        #expect(loaded.status == .loadedWithMissingWorktrees(1))
+        #expect(loaded.tasks.count == 1)
+        #expect(loaded.tasks.first?.route.availability == .missing)
+
+        try FileManager.default.removeItem(at: fixture.project)
+        loaded = await store.load(project: identity)
+        #expect(loaded.status == .rejected(.missingProject))
+        #expect(loaded.tasks.isEmpty)
+    }
+
+    @Test("persisted metadata excludes session-private content")
+    func persistencePrivacy() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let registry = AgentTaskRegistry()
+        let session = makeSession(pid: 987_654_321, generation: 1)
+        let secretPrompt = "PROMPT_DO_NOT_PERSIST"
+        let terminalOutput = "TERMINAL_OUTPUT_DO_NOT_PERSIST"
+        let credential = "TOKEN_DO_NOT_PERSIST"
+        session.currentTask = secretPrompt
+        session.filesRead = [URL(fileURLWithPath: terminalOutput)]
+        session.filesModified = [URL(fileURLWithPath: credential)]
+        let launchContext = context(
+            project: identity,
+            routeSeed: 140,
+            origin: .pineLaunched
+        )
+        guard case .reserved(let reservation) = registry.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: session.agentType),
+            context: launchContext,
+            title: "User title",
+            objective: "User objective"
+        ) else {
+            Issue.record("launch reservation was rejected")
+            return
+        }
+        registry.bridge(
+            session,
+            replacing: nil,
+            context: launchContext,
+            reservation: reservation
+        )
+        var privateTask = try #require(registry.tasks.first)
+        let vendorCanary = "VENDOR_IDENTITY_DO_NOT_PERSIST"
+        privateTask.runs[0].vendorIdentity = AgentVendorSessionIdentity(
+            provider: "PRIVATE_PROVIDER",
+            opaqueIdentifier: vendorCanary
+        )
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(
+            await store.save(tasks: [privateTask], project: identity)
+                == .saved(taskCount: 1)
+        )
+
+        let fileURL = AgentTaskMetadataStore.metadataURL(
+            for: identity,
+            storageRoot: fixture.storage
+        )
+        let data = try Data(contentsOf: fileURL)
+        let persisted = try #require(String(data: data, encoding: .utf8))
+        #expect(!persisted.contains(secretPrompt))
+        #expect(!persisted.contains(terminalOutput))
+        #expect(!persisted.contains(credential))
+        #expect(!persisted.contains(vendorCanary))
+        #expect(!persisted.contains("environment"))
+        #expect(!persisted.contains("transcript"))
+        #expect(!persisted.contains("prompt"))
+        #expect(!persisted.contains("Mon Aug 3 10:00:00 2026"))
+        #expect(!persisted.contains("987654321"))
+        let root = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        #expect(Set(root.keys) == [
+            "schemaVersion", "revision", "canonicalProjectPath",
+            "canonicalWorktreePath", "tasks",
+        ])
+        let task = try #require((root["tasks"] as? [[String: Any]])?.first)
+        #expect(Set(task.keys) == [
+            "attention", "createdAt", "descriptor", "id", "isUnread",
+            "lastActivityAt", "lifecycle", "origin", "project", "route",
+            "runs", "title", "objective", "updatedAt",
+        ])
+        let projectObject = try #require(task["project"] as? [String: Any])
+        #expect(Set(projectObject.keys) == [
+            "canonicalProjectPath", "canonicalWorktreePath",
+        ])
+        let route = try #require(task["route"] as? [String: Any])
+        #expect(Set(route.keys) == [
+            "availability", "paneID", "tabID", "terminalID",
+        ])
+        let descriptor = try #require(task["descriptor"] as? [String: Any])
+        #expect(Set(descriptor.keys) == ["typeIdentifier"])
+        let run = try #require((task["runs"] as? [[String: Any]])?.first)
+        #expect(Set(run.keys) == [
+            "id", "lastObservedAt", "liveness", "process", "startedAt",
+            "state", "terminalID",
+        ])
+        let process = try #require(run["process"] as? [String: Any])
+        #expect(Set(process.keys) == [
+            "observedStartedAt", "processGeneration",
+        ])
+        let forbiddenKeys: Set<String> = [
+            "prompt", "command", "arguments", "environment", "output",
+            "transcript", "fileContents", "activitySummary", "credentials",
+            "vendorIdentity", "processIdentifier", "startIdentifier",
+        ]
+        func assertNoForbiddenKeys(_ value: Any) {
+            if let object = value as? [String: Any] {
+                #expect(forbiddenKeys.isDisjoint(with: object.keys))
+                object.values.forEach(assertNoForbiddenKeys)
+            } else if let array = value as? [Any] {
+                array.forEach(assertNoForbiddenKeys)
+            }
+        }
+        assertNoForbiddenKeys(root)
+    }
+
+    @Test("schema v1 metadata migrates to revisioned v2")
+    func legacyMetadataMigratesToRevisionedEnvelope() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        try FileManager.default.createDirectory(
+            at: fixture.storage,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        let fileURL = AgentTaskMetadataStore.metadataURL(
+            for: identity,
+            storageRoot: fixture.storage
+        )
+        let legacy: [String: Any] = [
+            "schemaVersion": 1,
+            "canonicalProjectPath": identity.canonicalProjectPath,
+            "canonicalWorktreePath": identity.canonicalWorktreePath,
+            "tasks": [],
+        ]
+        try JSONSerialization.data(withJSONObject: legacy).write(to: fileURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: fileURL.path
+        )
+
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let loadedLegacy = await store.load(project: identity)
+        let staleRevision = try #require(loadedLegacy.revision)
+        var changedLegacy = try Data(contentsOf: fileURL)
+        changedLegacy.append(0x0A)
+        try changedLegacy.write(to: fileURL)
+        let generation = UUID()
+        let ticket = AgentTaskPersistenceTicket(
+            generation: generation,
+            sequence: 1,
+            projectKey: identity.persistenceKey,
+            expectedDiskRevision: staleRevision
+        )
+        let fence = AgentTaskPublicationFence(generation: generation)
+        fence.authorize(ticket)
+        #expect(
+            await store.save(
+                tasks: [],
+                project: identity,
+                authorization: AgentTaskPublicationAuthorization(
+                    ticket: ticket,
+                    fence: fence
+                )
+            ) == .rejected(.superseded)
+        )
+        #expect(try Data(contentsOf: fileURL) == changedLegacy)
+
+        let registry = AgentTaskRegistry(persistence: store)
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+
+        let root = try #require(
+            JSONSerialization.jsonObject(
+                with: Data(contentsOf: fileURL)
+            ) as? [String: Any]
+        )
+        #expect(root["schemaVersion"] as? Int == 2)
+        #expect(UUID(uuidString: root["revision"] as? String ?? "") != nil)
+    }
+
+    @Test("post-rename durability uncertainty advances CAS and retry converges")
+    func durabilityUnknownAfterPublicationCanRetry() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let fault = OneShotStorageSyncFault()
+        let store = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                hooks: AgentTaskStoreHooks(shouldSync: fault.shouldSync)
+            )
+        )
+        let identity = project(fixture.project.path)
+        let registry = AgentTaskRegistry(persistence: store)
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+        let session = makeSession(pid: 1_387, generation: 1)
+        registry.bridge(
+            session,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 140)
+        )
+
+        #expect(await registry.flushPersistence() == .saved)
+        #expect(fault.storageFailureCount == 1)
+        #expect(
+            registry.saveResultByProject[identity.persistenceKey]
+                == .saved(taskCount: 1)
+        )
+        let loaded = await store.load(project: identity)
+        #expect(loaded.tasks.first?.runs.map(\.id) == [session.id])
+    }
+
+    @Test("timeout after publication carries CAS revision into retry")
+    func timeoutAfterRenameCannotDesynchronizeCAS() async throws {
+        let store = PostPublicationBlockingStore()
+        let identity = project("/tmp/pine-agent-post-publication-timeout")
+        let registry = AgentTaskRegistry(
+            persistence: store,
+            flushTotal: .milliseconds(25),
+            flushTail: .milliseconds(5)
+        )
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+        let session = makeSession(pid: 1_391, generation: 1)
+        registry.bridge(
+            session,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 141)
+        )
+        await store.waitUntilFirstPublication()
+
+        #expect(await registry.flushPersistence() == .failed)
+        await store.releaseFirstSave()
+        await store.waitUntilFirstSaveReturned()
+
+        session.updateState(.thinking)
+        registry.refresh(sessions: [session])
+        #expect(await registry.flushPersistence() == .saved)
+        #expect(await store.retryUsedPublishedRevision())
+    }
+
+    @Test("stale registry snapshot cannot overwrite another store instance")
+    func diskRevisionRejectsCrossStoreLostUpdate() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let first = AgentTaskRegistry(
+            persistence: AgentTaskMetadataStore(storageRoot: fixture.storage)
+        )
+        let second = AgentTaskRegistry(
+            persistence: AgentTaskMetadataStore(storageRoot: fixture.storage)
+        )
+        first.registerProject(identity)
+        second.registerProject(identity)
+        #expect(await first.flushPersistence() == .saved)
+        #expect(await second.flushPersistence() == .saved)
+
+        let firstSession = makeSession(pid: 1_385, generation: 1)
+        first.bridge(
+            firstSession,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 138)
+        )
+        #expect(await first.flushPersistence() == .saved)
+
+        let staleSession = makeSession(pid: 1_386, generation: 1)
+        second.bridge(
+            staleSession,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 139)
+        )
+        #expect(await second.flushPersistence() == .failed)
+
+        let loaded = await AgentTaskMetadataStore(
+            storageRoot: fixture.storage
+        ).load(project: identity)
+        #expect(loaded.status == .loaded)
+        #expect(loaded.tasks.count == 1)
+        #expect(loaded.tasks[0].runs.map(\.id) == [firstSession.id])
+    }
+
+    @Test("in-memory task cap never evicts a paused resumable task")
+    func runtimeTaskCapProtectsPausedIdentity() {
+        let identity = project("/tmp/pine-agent-runtime-cap")
+        let registry = AgentTaskRegistry(
+            limits: AgentTaskPersistenceLimits(maxTasksPerProject: 1)
+        )
+        let first = makeSession(pid: 1_392, generation: 1)
+        let firstContext = context(project: identity, routeSeed: 142)
+        registry.bridge(first, replacing: nil, context: firstContext)
+        let firstTaskID = registry.tasks.first?.id
+        first.applyLiveness(.terminated)
+        registry.bridge(first, replacing: first, context: firstContext)
+
+        registry.bridge(
+            makeSession(pid: 1_393, generation: 1),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 143)
+        )
+
+        #expect(registry.tasks.count == 1)
+        #expect(registry.tasks.first?.id == firstTaskID)
+        #expect(registry.tasks.first?.lifecycle == .paused)
+    }
+
+    @Test("historical run tombstones are exact and admission-bounded")
+    func historicalRunAdmissionCapFailsClosed() {
+        let identity = project("/tmp/pine-agent-run-tombstone-cap")
+        let registry = AgentTaskRegistry(
+            limits: AgentTaskPersistenceLimits(
+                maxHistoricalRunIDs: 2
+            )
+        )
+        let first = makeSession(pid: 1_394, generation: 1)
+        let second = makeSession(pid: 1_395, generation: 1)
+        let third = makeSession(pid: 1_396, generation: 1)
+        registry.bridge(
+            first,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 144)
+        )
+        registry.bridge(
+            second,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 145)
+        )
+        registry.bridge(
+            third,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 146)
+        )
+
+        #expect(registry.tasks.count == 2)
+        #expect(registry.taskID(forSessionID: third.id) == nil)
+        first.applyLiveness(.terminated)
+        registry.bridge(
+            first,
+            replacing: first,
+            context: context(project: identity, routeSeed: 144)
+        )
+        #expect(registry.tasks.count == 2)
+        #expect(registry.historicalTask(forSessionID: first.id) != nil)
+    }
+
+    @Test("loaded run tombstones enforce cap without partial project merge")
+    func loadedRunTombstonesFailClosed() async throws {
+        let identity = project("/tmp/pine-agent-loaded-run-cap")
+        let seed = AgentTaskRegistry()
+        let first = makeSession(pid: 1_399, generation: 1)
+        let second = makeSession(pid: 1_400, generation: 1)
+        let firstContext = context(project: identity, routeSeed: 148)
+        let secondContext = context(project: identity, routeSeed: 149)
+        seed.bridge(first, replacing: nil, context: firstContext)
+        seed.bridge(second, replacing: nil, context: secondContext)
+        first.applyLiveness(.terminated)
+        second.applyLiveness(.terminated)
+        seed.bridge(first, replacing: first, context: firstContext)
+        seed.bridge(second, replacing: second, context: secondContext)
+        let loadedTasks = seed.tasks
+        #expect(loadedTasks.count == 2)
+        let registry = AgentTaskRegistry(
+            persistence: LoadedAgentTaskStore(tasks: loadedTasks),
+            limits: AgentTaskPersistenceLimits(maxHistoricalRunIDs: 1)
+        )
+
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+
+        #expect(registry.tasks.isEmpty)
+        #expect(
+            registry.loadStatusByProject[identity.persistenceKey]
+                == .rejected(.storageLimit)
+        )
+    }
+
+    @Test("failed resume admission preserves claim and run history")
+    func failedResumeAdmissionIsNonDestructive() throws {
+        let identity = project("/tmp/pine-agent-resume-admission")
+        let registry = AgentTaskRegistry(
+            limits: AgentTaskPersistenceLimits(
+                maxRunsPerTask: 1,
+                maxHistoricalRunIDs: 1
+            )
+        )
+        let launchContext = context(
+            project: identity,
+            routeSeed: 147,
+            origin: .pineLaunched
+        )
+        let firstBoundary = launchBoundary(generation: 1, at: launchContext.observedAt)
+        let firstReservation = try #require(preparePineLaunch(
+            registry,
+            context: launchContext,
+            boundary: firstBoundary
+        ))
+        let first = makeSession(
+            pid: 1_397,
+            generation: 1,
+            startedAt: launchContext.observedAt.addingTimeInterval(1),
+            preciseStart: launchContext.observedAt.addingTimeInterval(1)
+        )
+        registry.bridge(
+            first,
+            replacing: nil,
+            context: launchContext,
+            reservation: firstReservation
+        )
+        first.applyLiveness(.terminated)
+        registry.bridge(first, replacing: first, context: launchContext)
+        let before = try #require(registry.task(for: firstReservation.taskID))
+        let resumeBoundary = launchBoundary(
+            generation: 2,
+            at: launchContext.observedAt.addingTimeInterval(2)
+        )
+        let resume: AgentTaskLaunchReservation
+        switch registry.prepareResume(
+            taskID: before.id,
+            context: launchContext,
+            boundary: resumeBoundary
+        ) {
+        case .reserved(let reservation): resume = reservation
+        case .rejected: Issue.record("Expected resume reservation")
+            return
+        }
+        let second = makeSession(
+            pid: 1_398,
+            generation: 2,
+            startedAt: launchContext.observedAt.addingTimeInterval(3),
+            preciseStart: launchContext.observedAt.addingTimeInterval(3)
+        )
+
+        registry.bridge(
+            second,
+            replacing: nil,
+            context: launchContext,
+            reservation: resume
+        )
+
+        #expect(registry.task(for: before.id) == before)
+        #expect(registry.isLaunchPending(resume))
+    }
+
+    @Test("late detector termination cannot duplicate a terminal-closed run")
+    func lateDetectorTerminationUsesRunTombstone() throws {
+        let registry = AgentTaskRegistry()
+        let identity = project("/tmp/pine-agent-terminal-close-tombstone")
+        let route = context(project: identity, routeSeed: 139)
+        let session = makeSession(pid: 1_390, generation: 1)
+        registry.bridge(session, replacing: nil, context: route)
+        let taskID = try #require(registry.taskID(forSessionID: session.id))
+
+        registry.markTerminalClosed(
+            terminalID: route.route.terminalID,
+            project: identity,
+            at: route.observedAt.addingTimeInterval(1)
+        )
+        session.applyLiveness(.terminated)
+        registry.bridge(session, replacing: nil, context: route)
+
+        #expect(registry.tasks.count == 1)
+        #expect(registry.tasks[0].id == taskID)
+        #expect(registry.tasks[0].runs.map(\.id) == [session.id])
+        #expect(registry.historicalTask(forSessionID: session.id)?.id == taskID)
+    }
+
+    @Test("metadata with an extended ACL is rejected")
+    func metadataExtendedACLIsRejected() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await store.save(tasks: [], project: identity)
+            == .saved(taskCount: 0))
+        let fileURL = AgentTaskMetadataStore.metadataURL(
+            for: identity,
+            storageRoot: fixture.storage
+        )
+        let chmod = Process()
+        chmod.executableURL = URL(fileURLWithPath: "/bin/chmod")
+        chmod.arguments = [
+            "+a",
+            "\(NSUserName()) allow read",
+            fileURL.path,
+        ]
+        try chmod.run()
+        chmod.waitUntilExit()
+        #expect(chmod.terminationStatus == 0)
+
+        #expect(await store.load(project: identity).status
+            == .rejected(.unsafeFilesystemObject))
+    }
+
+    @Test("metadata storage is private and rejects symlink files")
+    func privateStorageRejectsSymlink() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await store.save(tasks: [], project: identity) == .saved(taskCount: 0))
+        let fileURL = AgentTaskMetadataStore.metadataURL(
+            for: identity,
+            storageRoot: fixture.storage
+        )
+        let attributes = try FileManager.default.attributesOfItem(
+            atPath: fileURL.path
+        )
+        #expect(attributes[.posixPermissions] as? Int == 0o600)
+        let directoryAttributes = try FileManager.default.attributesOfItem(
+            atPath: fixture.storage.path
+        )
+        #expect(directoryAttributes[.posixPermissions] as? Int == 0o700)
+
+        try FileManager.default.removeItem(at: fileURL)
+        let target = fixture.root.appendingPathComponent("target")
+        try Data("sentinel".utf8).write(to: target)
+        try FileManager.default.createSymbolicLink(
+            at: fileURL,
+            withDestinationURL: target
+        )
+        let loaded = await store.load(project: identity)
+        #expect(loaded.tasks.isEmpty)
+        #expect(loaded.status == .rejected(.unsafeFilesystemObject))
+        #expect(try String(contentsOf: target, encoding: .utf8) == "sentinel")
+    }
+
+    @Test("natural exit then close reports terminal lifecycle exactly once")
+    func naturalExitThenCloseReportsOnce() {
+        let tab = TerminalTab(name: "lifecycle")
+        var reports = 0
+        tab.onLifecycleEnded = { _ in reports += 1 }
+        tab.processDidTerminate()
+        #expect(reports == 1)
+        tab.stop()
+        tab.stop()
+        #expect(reports == 1)
+    }
+
+    @Test("symlinked storage root fails closed without changing target")
+    func symlinkedStorageRootFailsClosed() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let target = fixture.root.appendingPathComponent("target-store")
+        try FileManager.default.createDirectory(
+            at: target,
+            withIntermediateDirectories: false
+        )
+        try FileManager.default.createSymbolicLink(
+            at: fixture.storage,
+            withDestinationURL: target
+        )
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let identity = project(fixture.project.path)
+        #expect(
+            await store.save(tasks: [], project: identity)
+                == .rejected(.unsafeFilesystemObject)
+        )
+        let loaded = await store.load(project: identity)
+        #expect(loaded.status == .rejected(.unsafeFilesystemObject))
+        #expect(try FileManager.default.contentsOfDirectory(
+            atPath: target.path
+        ).isEmpty)
+    }
+
+    @Test("metadata mode links and size are classified fail closed")
+    func metadataSecurityClassifications() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let limits = AgentTaskPersistenceLimits(maxFileBytes: 1_024)
+        let store = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            limits: limits
+        )
+        #expect(await store.save(tasks: [], project: identity) == .saved(taskCount: 0))
+        let fileURL = AgentTaskMetadataStore.metadataURL(
+            for: identity,
+            storageRoot: fixture.storage
+        )
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o644], ofItemAtPath: fileURL.path
+        )
+        var loaded = await store.load(project: identity)
+        #expect(loaded.status == .rejected(.unsafeFilesystemObject))
+
+        try FileManager.default.removeItem(at: fileURL)
+        let hardLinkSource = fixture.root.appendingPathComponent("hard-link")
+        try Data("{}".utf8).write(to: hardLinkSource)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: hardLinkSource.path
+        )
+        try FileManager.default.linkItem(at: hardLinkSource, to: fileURL)
+        loaded = await store.load(project: identity)
+        #expect(loaded.status == .rejected(.unsafeFilesystemObject))
+
+        try FileManager.default.removeItem(at: fileURL)
+        try Data(repeating: 0x41, count: 1_025).write(to: fileURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: fileURL.path
+        )
+        loaded = await store.load(project: identity)
+        #expect(loaded.status == .rejected(.storageLimit))
+    }
+
+    @Test("terminal callback then detector reconciliation keeps one durable run")
+    func productionTerminalCloseReconciliationUsesTombstone() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let taskRegistry = AgentTaskRegistry()
+        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        #expect(await taskRegistry.flushPersistence() == .saved)
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let state = try #require(manager.paneManager.terminalState(for: pane))
+        let tab = try #require(state.terminalTabs.first)
+        let session = makeSession(pid: 1_391, generation: 1)
+        manager.terminal.bridgeAgentSession(
+            session,
+            replacing: nil,
+            in: tab
+        )
+        tab.agentSession = session
+        let taskID = try #require(taskRegistry.taskID(forSessionID: session.id))
+
+        tab.processDidTerminate()
+        session.applyLiveness(.terminated)
+        manager.terminal.bridgeAgentSession(
+            session,
+            replacing: session,
+            in: tab
+        )
+
+        #expect(taskRegistry.tasks.count == 1)
+        #expect(taskRegistry.tasks[0].id == taskID)
+        #expect(taskRegistry.tasks[0].runs.map(\.id) == [session.id])
+    }
+
+    @Test("worktrees in one project use distinct metadata files")
+    func worktreeMetadataDoesNotCollide() async throws {
+        let fixture = try PersistenceFixture(makeWorktree: true)
+        defer { fixture.cleanup() }
+        let worktree = try #require(fixture.worktree)
+        let first = project(fixture.project.path)
+        let second = AgentTaskProjectIdentity(
+            canonicalProjectPath: fixture.project.path,
+            canonicalWorktreePath: worktree.path
+        )
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await store.save(tasks: [], project: first) == .saved(taskCount: 0))
+        #expect(await store.save(tasks: [], project: second) == .saved(taskCount: 0))
+
+        let firstURL = AgentTaskMetadataStore.metadataURL(
+            for: first,
+            storageRoot: fixture.storage
+        )
+        let secondURL = AgentTaskMetadataStore.metadataURL(
+            for: second,
+            storageRoot: fixture.storage
+        )
+        #expect(firstURL != secondURL)
+        #expect(FileManager.default.fileExists(atPath: firstURL.path))
+        #expect(FileManager.default.fileExists(atPath: secondURL.path))
+    }
+
+    @Test("loaded routes are hints and never enter runtime ownership maps")
+    func loadedRouteIsNotRuntimeOwned() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let session = makeSession(pid: 1_650, generation: 1)
+        let writer = AgentTaskRegistry()
+        writer.bridge(
+            session,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 149)
+        )
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(
+            await store.save(tasks: writer.tasks, project: identity)
+                == .saved(taskCount: 1)
+        )
+
+        let reader = AgentTaskRegistry(persistence: store)
+        reader.registerProject(identity)
+        #expect(await reader.flushPersistence() == .saved)
+        #expect(reader.tasks.count == 1)
+        #expect(reader.tasks[0].route.availability == .missing)
+        #expect(reader.tasks[0].lifecycle == .paused)
+        #expect(reader.tasks[0].runs[0].liveness == .stale)
+        #expect(reader.taskID(forSessionID: session.id) == nil)
+    }
+
+    @Test("loaded Pine interruption resumes as a fresh run")
+    func loadedInterruptionResumesFreshRun() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let writer = AgentTaskRegistry()
+        let launchContext = context(
+            project: identity,
+            routeSeed: 151,
+            origin: .pineLaunched
+        )
+        guard case .reserved(let launch) = writer.preparePineLaunch(
+            descriptor: AgentDescriptor(agentType: .claudeCode),
+            context: launchContext,
+            title: nil,
+            objective: nil
+        ) else {
+            Issue.record("launch reservation was rejected")
+            return
+        }
+        let original = makeSession(pid: 1_651, generation: 1)
+        writer.bridge(
+            original,
+            replacing: nil,
+            context: launchContext,
+            reservation: launch
+        )
+        #expect(
+            await store.save(tasks: writer.tasks, project: identity)
+                == .saved(taskCount: 1)
+        )
+
+        let reader = AgentTaskRegistry(persistence: store)
+        reader.registerProject(identity)
+        #expect(await reader.flushPersistence() == .saved)
+        let resumeContext = context(
+            project: identity,
+            routeSeed: 152,
+            origin: .pineLaunched
+        )
+        guard case .reserved(let resume) = reader.prepareResume(
+            taskID: launch.taskID,
+            context: resumeContext
+        ) else {
+            Issue.record("loaded interruption was not resumable")
+            return
+        }
+        let resumed = makeSession(pid: 1_652, generation: 2)
+        reader.bridge(
+            resumed,
+            replacing: nil,
+            context: resumeContext,
+            reservation: resume
+        )
+
+        let task = try #require(reader.task(for: launch.taskID))
+        #expect(task.runs.map(\.id) == [original.id, resumed.id])
+        #expect(task.runs[0].liveness == .terminated)
+        #expect(task.runs[0].endedAt != nil)
+        #expect(task.runs[1].liveness == .live)
+        #expect(task.lifecycle == .active)
+        #expect(reader.taskID(forSessionID: resumed.id) == launch.taskID)
+        #expect(await reader.flushPersistence() == .saved)
+        let reloaded = try #require(
+            await store.load(project: identity).tasks.first
+        )
+        #expect(reloaded.runs.map(\.id) == [original.id, resumed.id])
+    }
+
+    @Test("failed save remains dirty and retries deterministically")
+    func failedSaveRetriesAfterProjectReturns() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        try FileManager.default.removeItem(at: fixture.project)
+        let identity = project(fixture.project.path)
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let registry = AgentTaskRegistry(persistence: store)
+        registry.registerProject(identity)
+        await registry.flushPersistence()
+        let session = makeSession(pid: 1_701, generation: 1)
+        registry.bridge(
+            session,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 150)
+        )
+        await registry.flushPersistence()
+        #expect(
+            registry.saveResultByProject[identity.persistenceKey]
+                == .rejected(.missingProject)
+        )
+
+        try FileManager.default.createDirectory(
+            at: fixture.project,
+            withIntermediateDirectories: true
+        )
+        await registry.flushPersistence()
+        #expect(
+            registry.saveResultByProject[identity.persistenceKey]
+                == .saved(taskCount: 1)
+        )
+    }
+
+    @Test("flush follows a newer mutation scheduled during a suspended save")
+    func flushFollowsMutatingSaveTail() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let store = ScriptedAgentTaskStore(suspendFirstSave: true)
+        let registry = AgentTaskRegistry(persistence: store)
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+        registry.bridge(
+            makeSession(pid: 1_801, generation: 1),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 160)
+        )
+        let flush = Task { await registry.flushPersistence() }
+        #expect(await store.waitForFirstSave())
+        registry.bridge(
+            makeSession(pid: 1_802, generation: 2),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 161)
+        )
+        await store.releaseFirstSave()
+
+        #expect(await flush.value == .saved)
+        #expect(await store.savedTaskCounts() == [1, 2])
+        #expect(await registry.flushPersistence() == .saved)
+    }
+
+    @Test("timed-out save detaches and late completion is fenced")
+    func timedOutSaveCannotBlockOrOverwriteRetry() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let store = ScriptedAgentTaskStore(suspendFirstSave: true)
+        let registry = AgentTaskRegistry(
+            persistence: store,
+            flushTotal: .milliseconds(100),
+            flushTail: .milliseconds(20)
+        )
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+        registry.bridge(
+            makeSession(pid: 1_811, generation: 1),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 162)
+        )
+        #expect(await store.waitForFirstSave())
+        #expect(await registry.flushPersistence() == .failed)
+
+        registry.bridge(
+            makeSession(pid: 1_812, generation: 2),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 163)
+        )
+        #expect(await registry.flushPersistence() == .saved)
+        #expect(await store.savedTaskCounts() == [2])
+        await store.releaseFirstSave()
+        #expect(await store.waitForCompletedSaveCount(2))
+        #expect(await store.savedTaskCounts() == [2])
+        #expect(
+            registry.saveResultByProject[identity.persistenceKey]
+                == .saved(taskCount: 2)
+        )
+    }
+
+    @Test("repeated persistence timeouts bound abandoned writers")
+    func repeatedTimeoutsDoNotAccumulateWriters() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let store = ScriptedAgentTaskStore(suspendEverySave: true)
+        let registry = AgentTaskRegistry(
+            persistence: store,
+            flushTotal: .milliseconds(100),
+            flushTail: .milliseconds(20)
+        )
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+
+        for generation in 1...3 {
+            registry.bridge(
+                makeSession(
+                    pid: 1_820 + Int32(generation),
+                    generation: UInt64(generation)
+                ),
+                replacing: nil,
+                context: context(
+                    project: identity,
+                    routeSeed: 180 + generation
+                )
+            )
+            #expect(await registry.flushPersistence() == .failed)
+        }
+
+        #expect(await store.saveCallCount() == 2)
+        await store.releaseAllSaves()
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while clock.now < deadline {
+            if await store.completedSaveCount() >= 2 {
+                break
+            }
+            try await clock.sleep(for: .milliseconds(1))
+        }
+        #expect(await store.completedSaveCount() == 2)
+    }
+
+    @Test("flush reports failure after its bounded retry policy")
+    func flushReportsRepeatedFailure() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let store = ScriptedAgentTaskStore(
+            saveResult: .rejected(.ioFailure)
+        )
+        let registry = AgentTaskRegistry(persistence: store)
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+        registry.bridge(
+            makeSession(pid: 1_901, generation: 1),
+            replacing: nil,
+            context: context(project: identity, routeSeed: 170)
+        )
+
+        #expect(await registry.flushPersistence() == .failed)
+        #expect(await store.saveCallCount() == 3)
+    }
+
+    private func metadataWithoutRuns(_ data: Data) throws -> Data {
+        guard var root = try JSONSerialization.jsonObject(with: data)
+                as? [String: Any],
+              var tasks = root["tasks"] as? [[String: Any]],
+              !tasks.isEmpty else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        tasks[0]["runs"] = []
+        root["tasks"] = tasks
+        return try JSONSerialization.data(withJSONObject: root, options: [.sortedKeys])
+    }
+
+    private func project(_ path: String) -> AgentTaskProjectIdentity {
+        AgentTaskProjectIdentity(
+            canonicalProjectPath: URL(fileURLWithPath: path)
+                .standardizedFileURL.path,
+            canonicalWorktreePath: URL(fileURLWithPath: path)
+                .standardizedFileURL.path
+        )
+    }
+
+    private func context(
+        project: AgentTaskProjectIdentity,
+        routeSeed: Int,
+        origin: AgentTaskOrigin = .discoveredInTerminal
+    ) -> AgentTaskBridgeContext {
+        AgentTaskBridgeContext(
+            project: project,
+            route: AgentTaskRoute(
+                paneID: uuid(routeSeed),
+                tabID: uuid(routeSeed + 2_000),
+                terminalID: uuid(routeSeed + 2_000)
+            ),
+            origin: origin
+        )
+    }
+
+    private func processStartIdentifier(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE MMM d HH:mm:ss yyyy"
+        return formatter.string(from: date)
+    }
+
+    private func makeSession(
+        pid: Int32,
+        generation: UInt64,
+        start: String = "Mon Aug 3 10:00:00 2026",
+        preciseStartedAt: Date = Date(timeIntervalSince1970: 0),
+        startIsAuthoritative: Bool = true,
+        agentType: AgentType = .claudeCode,
+        state: AgentState = .idle
+    ) -> AgentSession {
+        let session = AgentSession(
+            agentType: agentType,
+            state: state,
+            startedAt: Date(timeIntervalSince1970: TimeInterval(generation))
+        )
+        _ = session.bindProcessEvidence(
+            AgentProcessEvidence(
+                processIdentifier: pid,
+                processGeneration: generation,
+                startIdentifier: start,
+                observedStartedAt: preciseStartedAt,
+                startIsAuthoritative: startIsAuthoritative
+            )
+        )
+        return session
+    }
+
+    private func uuid(_ seed: Int) -> UUID {
+        let suffix = String(format: "%012llX", UInt64(seed))
+        return UUID(uuidString: "00000000-0000-0000-0000-\(suffix)")
+            ?? UUID()
+    }
+}
+
+@MainActor
+private extension AgentTaskRegistry {
+    func preparePineLaunch(
+        descriptor: AgentDescriptor,
+        context: AgentTaskBridgeContext,
+        title: String?,
+        objective: String?
+    ) -> AgentTaskLaunchResult {
+        preparePineLaunch(
+            descriptor: descriptor,
+            context: context,
+            title: title,
+            objective: objective,
+            boundary: AgentTaskLaunchBoundary(
+                generationFloor: 0,
+                capturedAt: .distantPast
+            )
+        )
+    }
+
+    func prepareResume(
+        taskID: UUID,
+        context: AgentTaskBridgeContext
+    ) -> AgentTaskLaunchResult {
+        prepareResume(
+            taskID: taskID,
+            context: context,
+            boundary: AgentTaskLaunchBoundary(
+                generationFloor: 0,
+                capturedAt: .distantPast
+            )
+        )
+    }
+}
+
+private final class PersistenceFixture {
+    let root: URL
+    let project: URL
+    let storage: URL
+    let worktree: URL?
+
+    init(makeWorktree: Bool = false) throws {
+        root = FileManager.default.temporaryDirectory
+            .resolvingSymlinksInPath()
+            .appendingPathComponent("PineAgentTasks-\(UUID().uuidString)")
+        project = root.appendingPathComponent("project", isDirectory: true)
+        storage = root.appendingPathComponent("storage", isDirectory: true)
+        worktree = makeWorktree
+            ? root.appendingPathComponent("worktree", isDirectory: true)
+            : nil
+        try FileManager.default.createDirectory(
+            at: project,
+            withIntermediateDirectories: true
+        )
+        if let worktree {
+            try FileManager.default.createDirectory(
+                at: worktree,
+                withIntermediateDirectories: true
+            )
+        }
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}
+
+private actor PostPublicationBlockingStore: AgentTaskPersisting {
+    private var saveCount = 0
+    private var firstPublished = false
+    private var firstReturned = false
+    private var releaseFirst = false
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+    private var firstRevision: UUID?
+    private var retryMatchedRevision = false
+
+    func load(project: AgentTaskProjectIdentity) -> AgentTaskMetadataLoadResult {
+        AgentTaskMetadataLoadResult(status: .missing, tasks: [])
+    }
+
+    func save(
+        tasks: [AgentTask],
+        project: AgentTaskProjectIdentity,
+        authorization: AgentTaskPublicationAuthorization?
+    ) async -> AgentTaskMetadataSaveResult {
+        guard let authorization else { return .rejected(.superseded) }
+        saveCount += 1
+        let call = saveCount
+        if call == 1 {
+            firstRevision = authorization.ticket.nextDiskRevision
+        } else if let firstRevision {
+            retryMatchedRevision = authorization.ticket.expectedDiskRevision
+                == .versioned(firstRevision)
+        }
+        guard authorization.publish(operation: { true }) == .published else {
+            return .rejected(.superseded)
+        }
+        if call == 1 {
+            firstPublished = true
+            if !releaseFirst {
+                await withCheckedContinuation { continuation in
+                    releaseWaiters.append(continuation)
+                }
+            }
+            firstReturned = true
+        }
+        return .saved(taskCount: tasks.count)
+    }
+
+    func waitUntilFirstPublication() async {
+        while !firstPublished { await Task.yield() }
+    }
+
+    func releaseFirstSave() {
+        releaseFirst = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+
+    func waitUntilFirstSaveReturned() async {
+        while !firstReturned { await Task.yield() }
+    }
+
+    func retryUsedPublishedRevision() -> Bool { retryMatchedRevision }
+}
+
+nonisolated private final class OneShotStorageSyncFault: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didFailStorageSync = false
+
+    var storageFailureCount: Int {
+        lock.withLock { didFailStorageSync ? 1 : 0 }
+    }
+
+    func shouldSync(_ target: AgentTaskSyncTarget) -> Bool {
+        lock.withLock {
+            guard target == .storageDirectory, !didFailStorageSync else {
+                return true
+            }
+            didFailStorageSync = true
+            return false
+        }
+    }
+}
+
+private actor LoadedAgentTaskStore: AgentTaskPersisting {
+    private let tasks: [AgentTask]
+
+    init(tasks: [AgentTask]) {
+        self.tasks = tasks
+    }
+
+    func load(
+        project: AgentTaskProjectIdentity
+    ) async -> AgentTaskMetadataLoadResult {
+        AgentTaskMetadataLoadResult(status: .loaded, tasks: tasks)
+    }
+
+    func save(
+        tasks: [AgentTask],
+        project: AgentTaskProjectIdentity,
+        authorization: AgentTaskPublicationAuthorization?
+    ) async -> AgentTaskMetadataSaveResult {
+        .saved(taskCount: tasks.count)
+    }
+}
+
+private actor SelectiveAgentTaskStore: AgentTaskPersisting {
+    private let failingProjectKey: String
+    private var savedTaskCounts: [String: Int] = [:]
+
+    init(failingProjectKey: String) {
+        self.failingProjectKey = failingProjectKey
+    }
+
+    func load(
+        project: AgentTaskProjectIdentity
+    ) async -> AgentTaskMetadataLoadResult {
+        AgentTaskMetadataLoadResult(status: .missing, tasks: [])
+    }
+
+    func save(
+        tasks: [AgentTask],
+        project: AgentTaskProjectIdentity,
+        authorization: AgentTaskPublicationAuthorization?
+    ) async -> AgentTaskMetadataSaveResult {
+        guard project.persistenceKey != failingProjectKey else {
+            return .rejected(.transientIO)
+        }
+        let decision = authorization?.publish({ true }) ?? .published
+        switch decision {
+        case .published:
+            savedTaskCounts[project.persistenceKey] = tasks.count
+            return .saved(taskCount: tasks.count)
+        case .failed:
+            return .rejected(.transientIO)
+        case .superseded:
+            return .rejected(.superseded)
+        }
+    }
+
+    func waitForSave(projectKey: String) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while savedTaskCounts[projectKey] == nil, clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
+        }
+        return savedTaskCounts[projectKey] != nil
+    }
+
+    func savedTaskCount(projectKey: String) -> Int? {
+        savedTaskCounts[projectKey]
+    }
+}
+
+private actor ScriptedAgentTaskStore: AgentTaskPersisting {
+    private let saveResult: AgentTaskMetadataSaveResult
+    private let suspendFirstSave: Bool
+    private let suspendEverySave: Bool
+    private var saveSnapshots: [[AgentTask]] = []
+    private var publishedSnapshots: [[AgentTask]] = []
+    private var completedSaves = 0
+    private var firstSaveContinuation: CheckedContinuation<Void, Never>?
+    private var saveContinuations: [CheckedContinuation<Void, Never>] = []
+
+    init(
+        saveResult: AgentTaskMetadataSaveResult = .saved(taskCount: 0),
+        suspendFirstSave: Bool = false,
+        suspendEverySave: Bool = false
+    ) {
+        self.saveResult = saveResult
+        self.suspendFirstSave = suspendFirstSave
+        self.suspendEverySave = suspendEverySave
+    }
+
+    func load(
+        project: AgentTaskProjectIdentity
+    ) async -> AgentTaskMetadataLoadResult {
+        AgentTaskMetadataLoadResult(status: .missing, tasks: [])
+    }
+
+    func save(
+        tasks: [AgentTask],
+        project: AgentTaskProjectIdentity,
+        authorization: AgentTaskPublicationAuthorization?
+    ) async -> AgentTaskMetadataSaveResult {
+        saveSnapshots.append(tasks)
+        defer { completedSaves += 1 }
+        if suspendEverySave {
+            await withCheckedContinuation { continuation in
+                saveContinuations.append(continuation)
+            }
+        } else if suspendFirstSave, saveSnapshots.count == 1 {
+            await withCheckedContinuation { continuation in
+                firstSaveContinuation = continuation
+            }
+        }
+        guard case .saved = saveResult else { return saveResult }
+        let decision: AgentTaskPublicationDecision
+        if let authorization {
+            decision = authorization.publish {
+                publishedSnapshots.append(tasks)
+                return true
+            }
+        } else {
+            publishedSnapshots.append(tasks)
+            decision = .published
+        }
+        switch decision {
+        case .published:
+            return .saved(taskCount: tasks.count)
+        case .failed:
+            return .rejected(.transientIO)
+        case .superseded:
+            return .rejected(.superseded)
+        }
+    }
+
+    func waitForFirstSave() async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while saveSnapshots.isEmpty, clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
+        }
+        return !saveSnapshots.isEmpty
+    }
+
+    func releaseFirstSave() {
+        firstSaveContinuation?.resume()
+        firstSaveContinuation = nil
+    }
+
+    func releaseAllSaves() {
+        let continuations = saveContinuations
+        saveContinuations.removeAll()
+        continuations.forEach { $0.resume() }
+    }
+
+    func savedTaskCounts() -> [Int] {
+        publishedSnapshots.map(\.count)
+    }
+
+    func saveCallCount() -> Int {
+        saveSnapshots.count
+    }
+
+    func completedSaveCount() -> Int {
+        completedSaves
+    }
+
+    func waitForCompletedSaveCount(_ expected: Int) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while completedSaves < expected, clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
+        }
+        return completedSaves >= expected
+    }
+}

--- a/PineTests/AgentTaskStoreRaceTests.swift
+++ b/PineTests/AgentTaskStoreRaceTests.swift
@@ -221,6 +221,23 @@ struct AgentTaskStoreRaceTests {
         #expect(await store.save(tasks: [], project: fixture.identity)
             == .saved(taskCount: 0))
         let lockPath = fixture.storage.appendingPathComponent(".agent-tasks.lock").path
+        let guardPath = fixture.storage.appendingPathComponent(
+            ".agent-tasks.lock.guard"
+        ).path
+        let lockAttributes = try FileManager.default.attributesOfItem(
+            atPath: lockPath
+        )
+        let guardAttributes = try FileManager.default.attributesOfItem(
+            atPath: guardPath
+        )
+        let lockNode = try #require(
+            lockAttributes[.systemFileNumber] as? NSNumber
+        )
+        let guardNode = try #require(
+            guardAttributes[.systemFileNumber] as? NSNumber
+        )
+        #expect(lockNode == guardNode)
+        #expect((lockAttributes[.referenceCount] as? NSNumber)?.intValue == 2)
         let lock = StoreRacePOSIX.lock(lockPath)
         defer { StoreRacePOSIX.unlock(lock) }
         let contender = AgentTaskMetadataStore(storageRoot: fixture.storage)
@@ -250,6 +267,37 @@ struct AgentTaskStoreRaceTests {
 
         #expect(await hooked.save(tasks: [], project: fixture.identity)
             == .rejected(.unsafeFilesystemObject))
+    }
+
+    @Test("lock replacement at atomic rename cannot publish")
+    func lockReplacementAtAtomicRenameFailsClosed() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let plain = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await plain.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let metadataURL = AgentTaskMetadataStore.metadataURL(
+            for: fixture.identity,
+            storageRoot: fixture.storage
+        )
+        let original = try Data(contentsOf: metadataURL)
+        let lockPath = fixture.storage.appendingPathComponent(
+            ".agent-tasks.lock"
+        ).path
+        let hooked = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                hooks: AgentTaskStoreHooks { phase in
+                    if case .beforeAtomicRename = phase {
+                        StoreRacePOSIX.replacePrivateFile(lockPath)
+                    }
+                }
+            )
+        )
+
+        #expect(await hooked.save(tasks: [], project: fixture.identity)
+            == .rejected(.transientIO))
+        #expect(try Data(contentsOf: metadataURL) == original)
     }
 
     @Test("metadata growth and shrink during read are rejected")
@@ -376,10 +424,14 @@ struct AgentTaskStoreRaceTests {
             expectedDiskRevision: nil
         )
         fence.authorize(ticket)
+        let authorization = AgentTaskPublicationAuthorization(
+            ticket: ticket,
+            fence: fence
+        )
         let entered = DispatchSemaphore(value: 0)
         let release = DispatchSemaphore(value: 0)
         let publication = Task.detached {
-            fence.publishForTesting {
+            authorization.publishForTesting {
                 entered.signal()
                 _ = release.wait(timeout: .now() + 2)
                 return true
@@ -694,6 +746,7 @@ struct AgentTaskStoreRaceTests {
         let entries = try FileManager.default.contentsOfDirectory(
             atPath: fixture.storage.path
         )
+        #expect(Set(entries) == ["unrelated-one", "unrelated-two"])
         #expect(entries.filter { $0.hasSuffix(".tmp") }.isEmpty)
     }
 
@@ -748,6 +801,7 @@ struct AgentTaskStoreRaceTests {
         #expect(counter.targets == [
             .parentDirectory,
             .createdDirectory,
+            .storageDirectory,
             .metadataFile,
             .storageDirectory,
         ])

--- a/PineTests/AgentTaskStoreRaceTests.swift
+++ b/PineTests/AgentTaskStoreRaceTests.swift
@@ -1,0 +1,757 @@
+import Darwin
+import Foundation
+import Testing
+@testable import Pine
+
+@Suite("Agent task descriptor storage races")
+struct AgentTaskStoreRaceTests {
+    @Test("permissive owned parent is rejected before side effects")
+    func permissiveParentHasNoSideEffects() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let ownedParent = fixture.root.appendingPathComponent("private")
+        let storage = ownedParent.appendingPathComponent("leaf")
+        try FileManager.default.createDirectory(
+            at: ownedParent, withIntermediateDirectories: false
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: ownedParent.path
+        )
+        let store = AgentTaskMetadataStore(
+            storageRoot: storage,
+            configuration: AgentTaskStoreConfiguration(privateComponentCount: 2)
+        )
+
+        #expect(await store.save(tasks: [], project: fixture.identity)
+            == .rejected(.unsafeFilesystemObject))
+        #expect(!FileManager.default.fileExists(atPath: storage.path))
+        #expect(!FileManager.default.fileExists(
+            atPath: ownedParent.appendingPathComponent(".agent-tasks.lock").path
+        ))
+    }
+
+    @Test("trusted permissive anchor creates one private storage leaf")
+    func trustedAnchorCreatesPrivateLeaf() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let anchor = fixture.root.appendingPathComponent("trusted-anchor")
+        let storage = anchor.appendingPathComponent("private-leaf")
+        try FileManager.default.createDirectory(
+            at: anchor,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o755]
+        )
+        let store = AgentTaskMetadataStore(
+            storageRoot: storage,
+            configuration: AgentTaskStoreConfiguration(privateComponentCount: 1)
+        )
+
+        #expect(await store.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let attributes = try FileManager.default.attributesOfItem(
+            atPath: storage.path
+        )
+        let permissions = try #require(
+            attributes[.posixPermissions] as? NSNumber
+        )
+        #expect(permissions.intValue & 0o777 == 0o700)
+    }
+
+    @Test("owned intermediate symlink is rejected without traversal")
+    func ownedIntermediateSymlinkIsRejected() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let target = fixture.root.appendingPathComponent("target")
+        let ownedParent = fixture.root.appendingPathComponent("private")
+        let storage = ownedParent.appendingPathComponent("leaf")
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: false)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: target.path
+        )
+        try FileManager.default.createSymbolicLink(at: ownedParent, withDestinationURL: target)
+        let store = AgentTaskMetadataStore(
+            storageRoot: storage,
+            configuration: AgentTaskStoreConfiguration(privateComponentCount: 2)
+        )
+
+        #expect(await store.save(tasks: [], project: fixture.identity)
+            == .rejected(.unsafeFilesystemObject))
+        #expect(!FileManager.default.fileExists(
+            atPath: target.appendingPathComponent("leaf").path
+        ))
+    }
+
+    @Test("directory pathname replacement after open fails closed")
+    func directoryReplacementFailsClosed() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let plain = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await plain.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let storagePath = fixture.storage.path
+        let displaced = storagePath + ".displaced"
+        let hooked = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                hooks: AgentTaskStoreHooks { phase in
+                    if case .directoryOpened = phase {
+                        StoreRacePOSIX.replaceDirectory(storagePath, displaced: displaced)
+                    }
+                }
+            )
+        )
+
+        #expect(await hooked.save(tasks: [], project: fixture.identity)
+            == .rejected(.unsafeFilesystemObject))
+        #expect(!FileManager.default.fileExists(
+            atPath: fixture.storage.appendingPathComponent(".agent-tasks.lock").path
+        ))
+    }
+
+    @Test("load revalidates storage before creating its lock")
+    func loadDirectoryReplacementFailsClosed() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let plain = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await plain.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let storagePath = fixture.storage.path
+        let displaced = storagePath + ".load-displaced"
+        let hooked = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                hooks: AgentTaskStoreHooks { phase in
+                    if case .directoryOpened = phase {
+                        StoreRacePOSIX.replaceDirectory(
+                            storagePath,
+                            displaced: displaced
+                        )
+                    }
+                }
+            )
+        )
+
+        #expect(await hooked.load(project: fixture.identity).status
+            == .rejected(.unsafeFilesystemObject))
+        #expect(!FileManager.default.fileExists(
+            atPath: fixture.storage.appendingPathComponent(".agent-tasks.lock").path
+        ))
+    }
+
+    @Test("verified advisory lock serializes store instances")
+    func advisoryLockSerializesStores() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await store.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let lockPath = fixture.storage.appendingPathComponent(".agent-tasks.lock").path
+        let lock = StoreRacePOSIX.lock(lockPath)
+        defer { StoreRacePOSIX.unlock(lock) }
+        let contender = AgentTaskMetadataStore(storageRoot: fixture.storage)
+
+        #expect(await contender.save(tasks: [], project: fixture.identity)
+            == .rejected(.lockContention))
+    }
+
+    @Test("lock pathname replacement after flock fails closed")
+    func lockReplacementFailsClosed() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let plain = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await plain.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let lockPath = fixture.storage.appendingPathComponent(".agent-tasks.lock").path
+        let hooked = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                hooks: AgentTaskStoreHooks { phase in
+                    if case .lockAcquired = phase {
+                        StoreRacePOSIX.replacePrivateFile(lockPath)
+                    }
+                }
+            )
+        )
+
+        #expect(await hooked.save(tasks: [], project: fixture.identity)
+            == .rejected(.unsafeFilesystemObject))
+    }
+
+    @Test("metadata growth and shrink during read are rejected")
+    func concurrentReadMutationIsRejected() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let plain = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await plain.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let filePath = AgentTaskMetadataStore.metadataURL(
+            for: fixture.identity, storageRoot: fixture.storage
+        ).path
+        let growing = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                hooks: AgentTaskStoreHooks { phase in
+                    if case .readOpened = phase { StoreRacePOSIX.appendByte(filePath) }
+                }
+            )
+        )
+        #expect(await growing.load(project: fixture.identity).status
+            == .rejected(.concurrentMutation))
+
+        #expect(await plain.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let shrinking = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                hooks: AgentTaskStoreHooks { phase in
+                    if case .readOpened = phase { StoreRacePOSIX.truncateFile(filePath) }
+                }
+            )
+        )
+        #expect(await shrinking.load(project: fixture.identity).status
+            == .rejected(.concurrentMutation))
+    }
+
+    @Test("metadata FIFO replacement cannot block the store")
+    func fifoReplacementFailsClosed() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let plain = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await plain.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let filePath = AgentTaskMetadataStore.metadataURL(
+            for: fixture.identity,
+            storageRoot: fixture.storage
+        ).path
+        let hooked = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                hooks: AgentTaskStoreHooks { phase in
+                    if case .beforeReadOpen = phase {
+                        StoreRacePOSIX.replaceWithFIFO(filePath)
+                    }
+                }
+            )
+        )
+
+        #expect(await hooked.load(project: fixture.identity).status
+            == .rejected(.unsafeFilesystemObject))
+    }
+
+    @Test("superseded publication cannot replace current metadata")
+    func supersededPublicationIsFencedAtRename() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await store.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let baseline = await store.load(project: fixture.identity)
+        let baselineRevision = try #require(baseline.revision)
+        let fileURL = AgentTaskMetadataStore.metadataURL(
+            for: fixture.identity,
+            storageRoot: fixture.storage
+        )
+        let generation = UUID()
+        let fence = AgentTaskPublicationFence(generation: generation)
+        let staleTicket = AgentTaskPersistenceTicket(
+            generation: generation,
+            sequence: 1,
+            projectKey: fixture.identity.persistenceKey,
+            expectedDiskRevision: baselineRevision
+        )
+        let currentTicket = AgentTaskPersistenceTicket(
+            generation: generation,
+            sequence: 2,
+            projectKey: fixture.identity.persistenceKey,
+            expectedDiskRevision: baselineRevision
+        )
+        fence.authorize(staleTicket)
+        fence.authorize(currentTicket)
+        let current = AgentTaskPublicationAuthorization(
+            ticket: currentTicket,
+            fence: fence
+        )
+        let stale = AgentTaskPublicationAuthorization(
+            ticket: staleTicket,
+            fence: fence
+        )
+
+        #expect(await store.save(
+            tasks: [],
+            project: fixture.identity,
+            authorization: current
+        ) == .saved(taskCount: 0))
+        let published = try Data(contentsOf: fileURL)
+        #expect(await store.save(
+            tasks: [],
+            project: fixture.identity,
+            authorization: stale
+        ) == .rejected(.superseded))
+        #expect(try Data(contentsOf: fileURL) == published)
+    }
+
+    @Test("temporary pathname replacement cannot publish")
+    func temporaryReplacementCannotPublish() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let plain = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await plain.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let fileURL = AgentTaskMetadataStore.metadataURL(
+            for: fixture.identity, storageRoot: fixture.storage
+        )
+        let original = try Data(contentsOf: fileURL)
+        let storagePath = fixture.storage.path
+        let hooked = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                hooks: AgentTaskStoreHooks { phase in
+                    if case .beforePublish = phase {
+                        StoreRacePOSIX.replaceTemporaryFile(in: storagePath)
+                    }
+                }
+            )
+        )
+
+        #expect(await hooked.save(tasks: [], project: fixture.identity)
+            == .rejected(.unsafeFilesystemObject))
+        #expect(try Data(contentsOf: fileURL) == original)
+        let survivors = try FileManager.default.contentsOfDirectory(
+            atPath: storagePath
+        ).filter { $0.hasPrefix(".agent-tasks-") && $0.hasSuffix(".tmp") }
+        #expect(survivors.count == 1)
+    }
+
+    @Test("failed-writer retirement mutates descriptor not replacement pathname")
+    func failedWriterRetirementPreservesReplacement() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let replacement = fixture.root.appendingPathComponent("writer-replacement")
+        let replacementBytes = Data("writer-replacement-must-survive".utf8)
+        try replacementBytes.write(to: replacement)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: replacement.path
+        )
+        let storagePath = fixture.storage.path
+        let hooked = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                hooks: AgentTaskStoreHooks(
+                    shouldSync: { $0 != .metadataFile },
+                    phase: { phase in
+                        if case .beforeRetireMutation = phase {
+                            StoreRacePOSIX.replaceTemporaryPath(
+                                in: storagePath,
+                                with: replacement.path
+                            )
+                        }
+                    }
+                )
+            )
+        )
+
+        #expect(await hooked.save(tasks: [], project: fixture.identity)
+            == .rejected(.durabilityUnknown))
+        let survivorNames = try FileManager.default.contentsOfDirectory(
+            atPath: storagePath
+        ).filter { $0.hasPrefix(".agent-tasks-") && $0.hasSuffix(".tmp") }
+        let survivor = try #require(survivorNames.first)
+        #expect(survivorNames.count == 1)
+        #expect(
+            try Data(contentsOf: fixture.storage.appendingPathComponent(survivor))
+                == replacementBytes
+        )
+    }
+
+    @Test("final pathname replacement before publish fails closed")
+    func finalReplacementBeforePublishFailsClosed() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let plain = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await plain.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let fileURL = AgentTaskMetadataStore.metadataURL(
+            for: fixture.identity,
+            storageRoot: fixture.storage
+        )
+        let hooked = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                hooks: AgentTaskStoreHooks { phase in
+                    if case .beforePublish = phase {
+                        StoreRacePOSIX.replacePrivateFile(fileURL.path)
+                    }
+                }
+            )
+        )
+
+        #expect(await hooked.save(tasks: [], project: fixture.identity)
+            == .rejected(.unsafeFilesystemObject))
+        #expect(try Data(contentsOf: fileURL).isEmpty)
+    }
+
+    @Test("cleanup honors grammar age mode and retirement cap")
+    func cleanupIsBoundedAndExact() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let plain = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await plain.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let now = Date(timeIntervalSince1970: 20_000)
+        let fresh = try fixture.makeTemporary(age: 10, now: now)
+        let stale = try fixture.makeTemporary(age: 1_000, now: now)
+        let oldest = try fixture.makeTemporary(age: 2_000, now: now)
+        let permissive = try fixture.makeTemporary(age: 1_000, now: now, mode: 0o644)
+        let malformed = fixture.storage.appendingPathComponent(".agent-tasks-not-a-uuid.tmp")
+        try Data([1]).write(to: malformed)
+        let cleanup = AgentTaskCleanupConfiguration(
+            staleAge: 100, scanLimit: 256, retireLimit: 1, now: { now }
+        )
+        let store = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(cleanup: cleanup)
+        )
+
+        #expect(await store.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        #expect(FileManager.default.fileExists(atPath: fresh.path))
+        #expect(FileManager.default.fileExists(atPath: stale.path))
+        #expect(FileManager.default.fileExists(atPath: oldest.path))
+        let retired = try FileManager.default.attributesOfItem(
+            atPath: oldest.path
+        )
+        #expect((retired[.size] as? NSNumber)?.intValue == 0)
+        #expect((retired[.posixPermissions] as? NSNumber)?.intValue == 0)
+        #expect(FileManager.default.fileExists(atPath: permissive.path))
+        #expect(FileManager.default.fileExists(atPath: malformed.path))
+    }
+
+    @Test("cleanup preserves a pathname replacement before unlink")
+    func cleanupReplacementRaceFailsClosed() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let plain = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await plain.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let now = Date(timeIntervalSince1970: 25_000)
+        let stale = try fixture.makeTemporary(age: 1_000, now: now)
+        let replacement = fixture.root.appendingPathComponent("cleanup-replacement")
+        let replacementBytes = Data("replacement-must-survive".utf8)
+        try replacementBytes.write(to: replacement)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: replacement.path
+        )
+        let cleanup = AgentTaskCleanupConfiguration(
+            staleAge: 100,
+            scanLimit: 256,
+            retireLimit: 1,
+            now: { now }
+        )
+        let store = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                cleanup: cleanup,
+                hooks: AgentTaskStoreHooks { phase in
+                    if case .beforeRetireMutation = phase {
+                        StoreRacePOSIX.replacePath(
+                            stale.path,
+                            with: replacement.path
+                        )
+                    }
+                }
+            )
+        )
+
+        #expect(await store.load(project: fixture.identity).status == .loaded)
+        #expect(try Data(contentsOf: stale) == replacementBytes)
+    }
+
+    @Test("retirement rejects a hard link added after validation")
+    func cleanupHardLinkRaceFailsClosed() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        try fixture.prepareStorage()
+        let staleURL = fixture.storage.appendingPathComponent(
+            ".agent-tasks-66666666-6666-4666-8666-666666666666.tmp"
+        )
+        let aliasURL = fixture.root.appendingPathComponent("hard-link-alias")
+        let bytes = Data("preserve-shared-inode".utf8)
+        try bytes.write(to: staleURL)
+        try FileManager.default.setAttributes(
+            [
+                .posixPermissions: 0o600,
+                .modificationDate: Date(timeIntervalSince1970: 0),
+            ],
+            ofItemAtPath: staleURL.path
+        )
+        let store = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                cleanup: AgentTaskCleanupConfiguration(
+                    staleAge: 1,
+                    now: { Date(timeIntervalSince1970: 10_000) }
+                ),
+                hooks: AgentTaskStoreHooks { phase in
+                    if case .beforeRetireMutation = phase {
+                        StoreRacePOSIX.createHardLink(
+                            from: staleURL.path,
+                            to: aliasURL.path
+                        )
+                    }
+                }
+            )
+        )
+
+        _ = await store.load(project: fixture.identity)
+        #expect(try Data(contentsOf: staleURL) == bytes)
+        #expect(try Data(contentsOf: aliasURL) == bytes)
+    }
+
+    @Test("tombstone cap rejects before creating a new writer temp")
+    func tombstoneCapFailsBeforeCreate() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        try fixture.prepareStorage()
+        for suffix in [
+            "77777777-7777-4777-8777-777777777777",
+            "88888888-8888-4888-8888-888888888888",
+        ] {
+            let url = fixture.storage.appendingPathComponent(
+                ".agent-tasks-\(suffix).tmp"
+            )
+            try Data().write(to: url)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o000],
+                ofItemAtPath: url.path
+            )
+        }
+        let store = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                cleanup: AgentTaskCleanupConfiguration(
+                    tombstoneLimit: 2,
+                    directoryEntryLimit: 16
+                )
+            )
+        )
+
+        #expect(await store.save(tasks: [], project: fixture.identity)
+            == .rejected(.storageLimit))
+        let entries = try FileManager.default.contentsOfDirectory(
+            atPath: fixture.storage.path
+        )
+        #expect(entries.filter { $0.hasSuffix(".tmp") }.count == 2)
+    }
+
+    @Test("bounded cleanup cursor cannot starve a stale orphan")
+    func cleanupCursorReachesStaleOrphan() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let plain = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await plain.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let now = Date(timeIntervalSince1970: 30_000)
+        for index in 0..<12 {
+            let unrelated = fixture.storage.appendingPathComponent("unrelated-\(index)")
+            try Data([1]).write(to: unrelated)
+        }
+        let stale = try fixture.makeTemporary(age: 1_000, now: now)
+        let cleanup = AgentTaskCleanupConfiguration(
+            staleAge: 100,
+            scanLimit: 1,
+            retireLimit: 1,
+            now: { now }
+        )
+        let store = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(cleanup: cleanup)
+        )
+
+        for _ in 0..<32 {
+            _ = await store.load(project: fixture.identity)
+        }
+        let retired = try FileManager.default.attributesOfItem(
+            atPath: stale.path
+        )
+        #expect((retired[.size] as? NSNumber)?.intValue == 0)
+        #expect((retired[.posixPermissions] as? NSNumber)?.intValue == 0)
+    }
+
+    @Test("creating private storage durably syncs parent and child")
+    func createdStorageSyncsDescriptors() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let counter = StoreRaceCounter()
+        let store = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                hooks: AgentTaskStoreHooks(didSync: { counter.record($0) })
+            )
+        )
+
+        #expect(await store.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        #expect(counter.targets == [
+            .parentDirectory,
+            .createdDirectory,
+            .metadataFile,
+            .storageDirectory,
+        ])
+    }
+}
+
+nonisolated private final class StoreRaceCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedTargets: [AgentTaskSyncTarget] = []
+
+    var targets: [AgentTaskSyncTarget] {
+        lock.withLock { recordedTargets }
+    }
+
+    func record(_ target: AgentTaskSyncTarget) {
+        lock.withLock { recordedTargets.append(target) }
+    }
+}
+
+nonisolated private enum StoreRacePOSIX {
+    static func replaceDirectory(_ path: String, displaced: String) {
+        _ = path.withCString { source in
+            displaced.withCString { destination in Darwin.rename(source, destination) }
+        }
+        _ = path.withCString { Darwin.mkdir($0, mode_t(0o700)) }
+    }
+
+    static func lock(_ path: String) -> Int32 {
+        let descriptor = path.withCString {
+            Darwin.open($0, O_RDWR | O_CLOEXEC | O_NOFOLLOW)
+        }
+        guard descriptor >= 0, flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+            if descriptor >= 0 { Darwin.close(descriptor) }
+            return -1
+        }
+        return descriptor
+    }
+
+    static func unlock(_ descriptor: Int32) {
+        guard descriptor >= 0 else { return }
+        _ = flock(descriptor, LOCK_UN)
+        Darwin.close(descriptor)
+    }
+
+    static func replacePrivateFile(_ path: String) {
+        _ = path.withCString { Darwin.unlink($0) }
+        let descriptor = path.withCString {
+            Darwin.open($0, O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, mode_t(0o600))
+        }
+        if descriptor >= 0 { Darwin.close(descriptor) }
+    }
+
+    static func replacePath(_ path: String, with replacement: String) {
+        _ = path.withCString { Darwin.unlink($0) }
+        _ = replacement.withCString { source in
+            path.withCString { destination in Darwin.rename(source, destination) }
+        }
+    }
+
+    static func createHardLink(from source: String, to destination: String) {
+        _ = destination.withCString { Darwin.unlink($0) }
+        _ = source.withCString { sourcePath in
+            destination.withCString { destinationPath in
+                Darwin.link(sourcePath, destinationPath)
+            }
+        }
+    }
+
+    static func replaceWithFIFO(_ path: String) {
+        _ = path.withCString { Darwin.unlink($0) }
+        _ = path.withCString { Darwin.mkfifo($0, mode_t(0o600)) }
+    }
+
+    static func appendByte(_ path: String) {
+        let descriptor = path.withCString { Darwin.open($0, O_WRONLY | O_APPEND) }
+        guard descriptor >= 0 else { return }
+        var byte: UInt8 = 0x20
+        _ = Darwin.write(descriptor, &byte, 1)
+        Darwin.close(descriptor)
+    }
+
+    static func truncateFile(_ path: String) {
+        _ = path.withCString { Darwin.truncate($0, 0) }
+    }
+
+    static func replaceTemporaryFile(in directoryPath: String) {
+        guard let directory = directoryPath.withCString({ opendir($0) }) else { return }
+        defer { closedir(directory) }
+        while let entry = readdir(directory) {
+            let name = withUnsafePointer(to: &entry.pointee.d_name) {
+                String(cString: UnsafeRawPointer($0).assumingMemoryBound(to: CChar.self))
+            }
+            guard name.hasPrefix(".agent-tasks-"), name.hasSuffix(".tmp") else {
+                continue
+            }
+            replacePrivateFile(directoryPath + "/" + name)
+            return
+        }
+    }
+
+    static func replaceTemporaryPath(
+        in directoryPath: String,
+        with replacement: String
+    ) {
+        guard let directory = directoryPath.withCString({ opendir($0) }) else { return }
+        defer { closedir(directory) }
+        while let entry = readdir(directory) {
+            let name = withUnsafePointer(to: &entry.pointee.d_name) {
+                String(cString: UnsafeRawPointer($0).assumingMemoryBound(to: CChar.self))
+            }
+            guard name.hasPrefix(".agent-tasks-"), name.hasSuffix(".tmp") else {
+                continue
+            }
+            replacePath(directoryPath + "/" + name, with: replacement)
+            return
+        }
+    }
+}
+
+private struct StoreRaceFixture {
+    let root: URL
+    let project: URL
+    let storage: URL
+    let identity: AgentTaskProjectIdentity
+
+    init() throws {
+        let manager = FileManager.default
+        root = manager.temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("PineStoreRace-\(UUID().uuidString)")
+        project = root.appendingPathComponent("project")
+        storage = root.appendingPathComponent("storage")
+        try manager.createDirectory(at: project, withIntermediateDirectories: true)
+        identity = AgentTaskProjectIdentity(
+            canonicalProjectPath: project.path,
+            canonicalWorktreePath: project.path
+        )
+    }
+
+    func makeTemporary(
+        age: TimeInterval,
+        now: Date,
+        mode: Int = 0o600
+    ) throws -> URL {
+        let url = storage.appendingPathComponent(
+            ".agent-tasks-\(UUID().uuidString).tmp"
+        )
+        try Data([1]).write(to: url)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: mode, .modificationDate: now.addingTimeInterval(-age)],
+            ofItemAtPath: url.path
+        )
+        return url
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}

--- a/PineTests/AgentTaskStoreRaceTests.swift
+++ b/PineTests/AgentTaskStoreRaceTests.swift
@@ -437,9 +437,13 @@ struct AgentTaskStoreRaceTests {
                 return true
             }
         }
-        let didEnter = await Task.detached {
-            entered.wait(timeout: .now() + 1) == .success
-        }.value
+        let didEnter = await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                continuation.resume(
+                    returning: entered.wait(timeout: .now() + 1) == .success
+                )
+            }
+        }
         #expect(didEnter)
         let clock = ContinuousClock()
         let started = clock.now
@@ -507,7 +511,6 @@ struct AgentTaskStoreRaceTests {
             storageRoot: fixture.storage,
             configuration: AgentTaskStoreConfiguration(
                 hooks: AgentTaskStoreHooks(
-                    shouldSync: { $0 != .metadataFile },
                     phase: { phase in
                         if case .beforeRetireMutation = phase {
                             StoreRacePOSIX.replaceTemporaryPath(
@@ -515,7 +518,8 @@ struct AgentTaskStoreRaceTests {
                                 with: replacement.path
                             )
                         }
-                    }
+                    },
+                    shouldSync: { $0 != .metadataFile }
                 )
             )
         )

--- a/PineTests/AgentTaskStoreRaceTests.swift
+++ b/PineTests/AgentTaskStoreRaceTests.swift
@@ -109,6 +109,80 @@ struct AgentTaskStoreRaceTests {
         ))
     }
 
+    @Test("directory replacement immediately before temp creation has no side effect")
+    func directoryReplacementBeforeTempCreateFailsClosed() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let plain = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await plain.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let storagePath = fixture.storage.path
+        let displaced = storagePath + ".before-temp-displaced"
+        let hooked = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                hooks: AgentTaskStoreHooks { phase in
+                    if case .beforeTemporaryCreate = phase {
+                        StoreRacePOSIX.replaceDirectory(
+                            storagePath,
+                            displaced: displaced
+                        )
+                    }
+                }
+            )
+        )
+
+        #expect(await hooked.save(tasks: [], project: fixture.identity)
+            == .rejected(.unsafeFilesystemObject))
+        let displacedEntries = try FileManager.default.contentsOfDirectory(
+            atPath: displaced
+        )
+        #expect(displacedEntries.allSatisfy { !$0.hasSuffix(".tmp") })
+    }
+
+    @Test("directory replacement before cleanup mutation preserves candidate")
+    func directoryReplacementBeforeRetirementFailsClosed() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        let plain = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(await plain.save(tasks: [], project: fixture.identity)
+            == .saved(taskCount: 0))
+        let now = Date(timeIntervalSince1970: 26_000)
+        let stale = try fixture.makeTemporary(age: 1_000, now: now)
+        let original = try Data(contentsOf: stale)
+        let storagePath = fixture.storage.path
+        let displaced = storagePath + ".retire-displaced"
+        let store = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                cleanup: AgentTaskCleanupConfiguration(
+                    staleAge: 100,
+                    scanLimit: 256,
+                    retireLimit: 1,
+                    now: { now }
+                ),
+                hooks: AgentTaskStoreHooks { phase in
+                    if case .beforeRetireMutation = phase {
+                        StoreRacePOSIX.replaceDirectory(
+                            storagePath,
+                            displaced: displaced
+                        )
+                    }
+                }
+            )
+        )
+
+        #expect(await store.load(project: fixture.identity).status
+            == .rejected(.unsafeFilesystemObject))
+        let displacedCandidate = URL(fileURLWithPath: displaced)
+            .appendingPathComponent(stale.lastPathComponent)
+        #expect(try Data(contentsOf: displacedCandidate) == original)
+        let attributes = try FileManager.default.attributesOfItem(
+            atPath: displacedCandidate.path
+        )
+        #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+    }
+
     @Test("load revalidates storage before creating its lock")
     func loadDirectoryReplacementFailsClosed() async throws {
         let fixture = try StoreRaceFixture()
@@ -289,6 +363,48 @@ struct AgentTaskStoreRaceTests {
             authorization: stale
         ) == .rejected(.superseded))
         #expect(try Data(contentsOf: fileURL) == published)
+    }
+
+    @Test("publication generation advance never waits for in-flight rename")
+    func publicationAdvanceIsNonblocking() async {
+        let generation = UUID()
+        let fence = AgentTaskPublicationFence(generation: generation)
+        let ticket = AgentTaskPersistenceTicket(
+            generation: generation,
+            sequence: 1,
+            projectKey: "deadline-project",
+            expectedDiskRevision: nil
+        )
+        fence.authorize(ticket)
+        let entered = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+        let publication = Task.detached {
+            fence.publishForTesting {
+                entered.signal()
+                _ = release.wait(timeout: .now() + 2)
+                return true
+            }
+        }
+        let didEnter = await Task.detached {
+            entered.wait(timeout: .now() + 1) == .success
+        }.value
+        #expect(didEnter)
+        let clock = ContinuousClock()
+        let started = clock.now
+        _ = fence.advance(to: UUID())
+        #expect(started.duration(to: clock.now) < .milliseconds(250))
+        release.signal()
+        let decision = await publication.value
+        switch decision {
+        case .published:
+            break
+        case .failed, .superseded:
+            Issue.record("in-flight authorized publication was lost")
+        }
+        #expect(
+            fence.publishedRevision(for: ticket.projectKey)
+                == .versioned(ticket.nextDiskRevision)
+        )
     }
 
     @Test("temporary pathname replacement cannot publish")
@@ -546,6 +662,41 @@ struct AgentTaskStoreRaceTests {
         #expect(entries.filter { $0.hasSuffix(".tmp") }.count == 2)
     }
 
+    @Test("directory entry cap rejects at exact capacity before writer temp")
+    func directoryEntryCapFailsAtEquality() async throws {
+        let fixture = try StoreRaceFixture()
+        defer { fixture.cleanup() }
+        try FileManager.default.createDirectory(
+            at: fixture.storage,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        for name in ["unrelated-one", "unrelated-two"] {
+            let url = fixture.storage.appendingPathComponent(name)
+            try Data([1]).write(to: url)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: url.path
+            )
+        }
+        let store = AgentTaskMetadataStore(
+            storageRoot: fixture.storage,
+            configuration: AgentTaskStoreConfiguration(
+                cleanup: AgentTaskCleanupConfiguration(
+                    tombstoneLimit: 3,
+                    directoryEntryLimit: 3
+                )
+            )
+        )
+
+        #expect(await store.save(tasks: [], project: fixture.identity)
+            == .rejected(.storageLimit))
+        let entries = try FileManager.default.contentsOfDirectory(
+            atPath: fixture.storage.path
+        )
+        #expect(entries.filter { $0.hasSuffix(".tmp") }.isEmpty)
+    }
+
     @Test("bounded cleanup cursor cannot starve a stale orphan")
     func cleanupCursorReachesStaleOrphan() async throws {
         let fixture = try StoreRaceFixture()
@@ -732,6 +883,14 @@ private struct StoreRaceFixture {
         identity = AgentTaskProjectIdentity(
             canonicalProjectPath: project.path,
             canonicalWorktreePath: project.path
+        )
+    }
+
+    func prepareStorage() throws {
+        try FileManager.default.createDirectory(
+            at: storage,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
         )
     }
 

--- a/PineTests/AlertTemplateTests.swift
+++ b/PineTests/AlertTemplateTests.swift
@@ -57,6 +57,16 @@ struct AlertTemplateTests {
         #expect(buttons[1].title == Strings.dialogCancel)
     }
 
+    @Test("activeUserTasksPreventQuit has one safe OK button")
+    func activeUserTasksPreventQuitButtons() {
+        let template = AlertTemplate.activeUserTasksPreventQuit
+        let alert = template.makeAlert(messageText: "Test")
+        let buttons = alert.buttons
+        #expect(buttons.count == 1)
+        #expect(buttons[0].title == Strings.dialogOK)
+        #expect(alert.alertStyle == .warning)
+    }
+
     @Test("externalModifyConflict has Reload / Keep")
     func externalModifyConflictButtons() {
         let template = AlertTemplate.externalModifyConflict

--- a/PineTests/CloseDelegateTests.swift
+++ b/PineTests/CloseDelegateTests.swift
@@ -51,6 +51,7 @@ struct CloseDelegateTests {
         to projectManager: ProjectManager,
         in directory: URL
     ) throws {
+        projectManager.primaryTabManager.autoSavePreferenceProvider = { false }
         let fileURL = directory.appendingPathComponent("dirty.swift")
         try "original".write(
             to: fileURL,

--- a/PineTests/RecoveryManagerTests.swift
+++ b/PineTests/RecoveryManagerTests.swift
@@ -23,7 +23,7 @@ struct RecoveryManagerTests {
     }
 
     private func waitUntil(
-        timeout: Duration = .seconds(2),
+        timeout: Duration = .seconds(120),
         _ condition: @MainActor () -> Bool
     ) async -> Bool {
         let clock = ContinuousClock()

--- a/PineTests/SnapshotTests/TabStripOverflowHostedTests.swift
+++ b/PineTests/SnapshotTests/TabStripOverflowHostedTests.swift
@@ -36,6 +36,7 @@ struct TabStripOverflowHostedTests {
 
     private struct TerminalHarness: View {
         let paneManager: PaneManager
+        let projectRegistry: ProjectRegistry
         let paneID: PaneID
         let terminalState: TerminalPaneState
 
@@ -45,6 +46,7 @@ struct TabStripOverflowHostedTests {
                 terminalState: terminalState
             )
             .environment(paneManager)
+            .environment(projectRegistry)
             .overlay(alignment: .topLeading) {
                 TabInsertionIndicator(x: 164)
             }
@@ -90,6 +92,7 @@ struct TabStripOverflowHostedTests {
     @Test("Overflowing terminal strip snapshots active and indicator states")
     func terminalOverflow() throws {
         let paneManager = PaneManager()
+        let projectRegistry = ProjectRegistry()
         let paneID = paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
         let terminalState = try #require(paneManager.terminalState(for: paneID))
         terminalState.terminalTabs = (1...7).map { TerminalTab(name: "Terminal \($0)") }
@@ -99,6 +102,7 @@ struct TabStripOverflowHostedTests {
             try assertSnapshot(
                 of: TerminalHarness(
                     paneManager: paneManager,
+                    projectRegistry: projectRegistry,
                     paneID: paneID,
                     terminalState: terminalState
                 ),

--- a/PineTests/SparkleUpdaterTests.swift
+++ b/PineTests/SparkleUpdaterTests.swift
@@ -153,7 +153,7 @@ struct SparkleUpdaterTests {
         guard let enumerator = FileManager.default.enumerator(
             at: sourceRoot,
             includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles]
+            options: []
         ) else {
             throw CocoaError(.fileReadUnknown)
         }

--- a/PineTests/TabManagerEdgeTests.swift
+++ b/PineTests/TabManagerEdgeTests.swift
@@ -50,7 +50,7 @@ struct TabManagerEdgeTests {
     }
 
     private func waitUntil(
-        timeout: Duration = .seconds(2),
+        timeout: Duration = .seconds(120),
         _ condition: @MainActor () -> Bool
     ) async -> Bool {
         let clock = ContinuousClock()

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -3,6 +3,7 @@
 //  PineTests
 //
 
+import Darwin
 import Testing
 import AppKit
 import SwiftTerm
@@ -32,6 +33,60 @@ struct TerminalTabTests {
         let tab2 = TerminalTab(name: "tab2")
         #expect(tab1.id != tab2.id)
         #expect(tab1 != tab2)
+    }
+
+    @Test("acknowledged PTY write retains its descriptor identity")
+    func acknowledgedWriteOwnsDescriptor() async throws {
+        var pipeDescriptors: [Int32] = [-1, -1]
+        try #require(Darwin.pipe(&pipeDescriptors) == 0)
+        let readDescriptor = pipeDescriptors[0]
+        let borrowedDescriptor = pipeDescriptors[1]
+        defer { Darwin.close(readDescriptor) }
+        let temporaryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: temporaryURL) }
+        let acquired = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+        let expected = Array("resume\n".utf8)
+        let writeTask = Task.detached {
+            await AcknowledgedPTYWriter.writeForTesting(
+                expected,
+                to: borrowedDescriptor
+            ) {
+                acquired.signal()
+                _ = release.wait(timeout: .now() + 2)
+            }
+        }
+        let didAcquire = await Task.detached {
+            acquired.wait(timeout: .now() + 1) == .success
+        }.value
+        try #require(didAcquire)
+        Darwin.close(borrowedDescriptor)
+        let replacement = Darwin.open(
+            temporaryURL.path,
+            O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC,
+            mode_t(0o600)
+        )
+        try #require(replacement >= 0)
+        let reusedDescriptor: Int32
+        if replacement == borrowedDescriptor {
+            reusedDescriptor = replacement
+        } else {
+            try #require(Darwin.dup2(replacement, borrowedDescriptor) >= 0)
+            Darwin.close(replacement)
+            reusedDescriptor = borrowedDescriptor
+        }
+        defer { Darwin.close(reusedDescriptor) }
+        release.signal()
+
+        #expect(await writeTask.value)
+        var received = [UInt8](repeating: 0, count: expected.count)
+        let readCount = received.withUnsafeMutableBytes { bytes in
+            Darwin.read(readDescriptor, bytes.baseAddress, bytes.count)
+        }
+        #expect(readCount == expected.count)
+        #expect(received == expected)
+        #expect((try? Data(contentsOf: temporaryURL)).map(\.isEmpty) == true)
     }
 
     @Test @MainActor func terminalTabHashable() {

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -89,6 +89,28 @@ struct TerminalTabTests {
         #expect((try? Data(contentsOf: temporaryURL)).map(\.isEmpty) == true)
     }
 
+    @Test("partial and failed PTY completions are never acknowledged")
+    func incompletePTYWriteIsRejected() {
+        #expect(
+            AcknowledgedPTYWriter.acknowledgesCompletion(
+                error: 0,
+                remainingByteCount: 0
+            )
+        )
+        #expect(
+            !AcknowledgedPTYWriter.acknowledgesCompletion(
+                error: 0,
+                remainingByteCount: 1
+            )
+        )
+        #expect(
+            !AcknowledgedPTYWriter.acknowledgesCompletion(
+                error: EIO,
+                remainingByteCount: 0
+            )
+        )
+    }
+
     @Test @MainActor func terminalTabHashable() {
         let tab = TerminalTab(name: "test")
         var set: Set<TerminalTab> = [tab, tab]

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -57,9 +57,13 @@ struct TerminalTabTests {
                 _ = release.wait(timeout: .now() + 2)
             }
         }
-        let didAcquire = await Task.detached {
-            acquired.wait(timeout: .now() + 1) == .success
-        }.value
+        let didAcquire = await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                continuation.resume(
+                    returning: acquired.wait(timeout: .now() + 1) == .success
+                )
+            }
+        }
         try #require(didAcquire)
         Darwin.close(borrowedDescriptor)
         let replacement = Darwin.open(

--- a/PineTests/UserTaskRunStoreTests.swift
+++ b/PineTests/UserTaskRunStoreTests.swift
@@ -479,7 +479,7 @@ struct UserTaskRunStoreTests {
         )
 
         let shutdown = Task { @MainActor in
-            await store.shutdownAll(until: .now() + 2)
+            await store.shutdownAll(until: .now() + 120)
         }
         defer { gate.release() }
 

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -169,6 +169,33 @@ struct WindowLifecycleTests {
         await project.workspace.waitForLoadingComplete()
     }
 
+    @Test func terminationDeadlineBoundsHungAlertPresenter() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        project.primaryTabManager.updateContent("// dirty")
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        let clock = ContinuousClock()
+        let started = clock.now
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { _, _, _, _ in
+                try? await Task.sleep(for: .seconds(10))
+                return .alertFirstButtonReturn
+            },
+            userTaskShutdownDeadline: .now() + .milliseconds(25)
+        )
+
+        #expect(!result)
+        #expect(started.duration(to: clock.now) < .seconds(1))
+        #expect(project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
     @Test func asyncTerminationCancelNeverAttemptsSave() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -35,6 +35,14 @@ struct WindowLifecycleTests {
         try? FileManager.default.removeItem(at: url)
     }
 
+    private func updateContent(
+        _ content: String,
+        in project: ProjectManager
+    ) {
+        project.primaryTabManager.autoSavePreferenceProvider = { false }
+        project.primaryTabManager.updateContent(content)
+    }
+
     // MARK: - onDisappear logic (handleProjectWindowDisappear)
 
     @Test func closingLastProjectTriggersShowWelcome() throws {
@@ -144,7 +152,7 @@ struct WindowLifecycleTests {
         let registry = ProjectRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
-        project.primaryTabManager.updateContent("// dirty")
+        updateContent("// dirty", in: project)
 
         let delegate = AppDelegate()
         delegate.registry = registry
@@ -159,7 +167,8 @@ struct WindowLifecycleTests {
             saveAll: { _, _ in
                 saveAttempts += 1
                 return false
-            }
+            },
+            terminationDeadlineOverride: .now() + 120
         )
 
         #expect(!result)
@@ -176,22 +185,24 @@ struct WindowLifecycleTests {
         let registry = ProjectRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
-        project.primaryTabManager.updateContent("// dirty")
+        updateContent("// dirty", in: project)
         let delegate = AppDelegate()
         delegate.registry = registry
-        let clock = ContinuousClock()
-        let started = clock.now
+        let deadlineProbe = TerminationDeadlineProbe()
 
         let result = await delegate.confirmApplicationTermination(
             presentAlert: { _, _, _, _ in
                 try? await Task.sleep(for: .seconds(10))
                 return .alertFirstButtonReturn
             },
-            terminationDeadlineOverride: .now() + .milliseconds(25)
+            terminationDeadlineOverride: .now() + .milliseconds(25),
+            terminationDeadlineObserver: deadlineProbe.record
         )
 
         #expect(!result)
-        #expect(started.duration(to: clock.now) < .seconds(1))
+        #expect(
+            deadlineProbe.elapsedNanoseconds.map { $0 < 1_000_000_000 } == true
+        )
         #expect(project.hasUnsavedChanges)
         await project.workspace.waitForLoadingComplete()
     }
@@ -204,7 +215,7 @@ struct WindowLifecycleTests {
         let registry = ProjectRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
-        project.primaryTabManager.updateContent("// dirty")
+        updateContent("// dirty", in: project)
 
         let delegate = AppDelegate()
         delegate.registry = registry
@@ -223,7 +234,8 @@ struct WindowLifecycleTests {
                 saveAttempts += 1
                 return true
             },
-            applicationContext: fallbackContext
+            applicationContext: fallbackContext,
+            terminationDeadlineOverride: .now() + 120
         )
 
         #expect(!result)
@@ -241,18 +253,20 @@ struct WindowLifecycleTests {
         let registry = ProjectRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
-        project.primaryTabManager.updateContent("// first dirty state")
+        updateContent("// first dirty state", in: project)
 
         let delegate = AppDelegate()
         delegate.registry = registry
         let result = await delegate.confirmApplicationTermination(
             presentAlert: { template, _, _, _ in
                 #expect(template == .unsavedChangesBulk)
-                project.primaryTabManager.updateContent(
-                    "// changed while quit sheet was visible"
+                updateContent(
+                    "// changed while quit sheet was visible",
+                    in: project
                 )
                 return .alertSecondButtonReturn
-            }
+            },
+            terminationDeadlineOverride: .now() + 120
         )
 
         #expect(!result)
@@ -269,7 +283,7 @@ struct WindowLifecycleTests {
         let registry = ProjectRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
-        project.primaryTabManager.updateContent("// discarded")
+        updateContent("// discarded", in: project)
         project.recoveryManager?.snapshotDirtyTabs(project.allTabs)
         #expect(project.recoveryManager?.pendingRecoveryEntries().isEmpty == false)
         let delegate = AppDelegate()
@@ -279,7 +293,8 @@ struct WindowLifecycleTests {
             presentAlert: { template, _, _, _ in
                 #expect(template == .unsavedChangesBulk)
                 return .alertSecondButtonReturn
-            }
+            },
+            terminationDeadlineOverride: .now() + 120
         )
 
         #expect(result)
@@ -307,8 +322,8 @@ struct WindowLifecycleTests {
         )
         firstProject.primaryTabManager.openTab(url: firstFile)
         secondProject.primaryTabManager.openTab(url: secondFile)
-        firstProject.primaryTabManager.updateContent("// first dirty")
-        secondProject.primaryTabManager.updateContent("// second dirty")
+        updateContent("// first dirty", in: firstProject)
+        updateContent("// second dirty", in: secondProject)
         let delegate = AppDelegate()
         delegate.registry = registry
         var promptCount = 0
@@ -320,7 +335,8 @@ struct WindowLifecycleTests {
                 return promptCount == 1
                     ? .alertSecondButtonReturn
                     : .alertThirdButtonReturn
-            }
+            },
+            terminationDeadlineOverride: .now() + 120
         )
 
         #expect(!result)
@@ -417,7 +433,7 @@ struct WindowLifecycleTests {
         let registry = ProjectRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
-        project.primaryTabManager.updateContent("// keep after refused quit")
+        updateContent("// keep after refused quit", in: project)
         let probe = TerminationTaskProbe(waitResult: true)
         var run: UserTaskRun?
         let delegate = AppDelegate()
@@ -689,6 +705,24 @@ struct WindowLifecycleTests {
             exitCode: 0,
             timedOut: false
         )
+    }
+}
+
+nonisolated private final class TerminationDeadlineProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let started = DispatchTime.now().uptimeNanoseconds
+    private var recordedElapsedNanoseconds: UInt64?
+
+    var elapsedNanoseconds: UInt64? {
+        lock.withLock { recordedElapsedNanoseconds }
+    }
+
+    func record() {
+        lock.withLock {
+            guard recordedElapsedNanoseconds == nil else { return }
+            recordedElapsedNanoseconds =
+                DispatchTime.now().uptimeNanoseconds - started
+        }
     }
 }
 

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -187,7 +187,7 @@ struct WindowLifecycleTests {
                 try? await Task.sleep(for: .seconds(10))
                 return .alertFirstButtonReturn
             },
-            userTaskShutdownDeadline: .now() + .milliseconds(25)
+            terminationDeadlineOverride: .now() + .milliseconds(25)
         )
 
         #expect(!result)
@@ -333,12 +333,12 @@ struct WindowLifecycleTests {
         await secondProject.workspace.waitForLoadingComplete()
     }
 
-    @Test func quitTaskTimeoutRetainsProjectAndCleanupOwnership() async throws {
+    @Test func quitRefusesWhileUserTaskOwnsExecution() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let registry = ProjectRegistry()
         let project = try #require(registry.projectManager(for: dir))
-        let run = project.taskRunStore.start(makeTaskRun(id: "timeout"))
+        let run = project.taskRunStore.start(makeTaskRun(id: "active"))
         let probe = TerminationTaskProbe(waitResult: false)
         project.taskRunStore.registerCancellation(
             probe.makeCancellation(),
@@ -346,14 +346,20 @@ struct WindowLifecycleTests {
         )
         let delegate = AppDelegate()
         delegate.registry = registry
+        var presentedTemplates: [AlertTemplate] = []
 
         let result = await delegate.confirmApplicationTermination(
-            userTaskShutdownDeadline: .now()
+            presentAlert: { template, _, _, _ in
+                presentedTemplates.append(template)
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 1
         )
 
         #expect(!result)
-        #expect(probe.cancellationCount == 1)
-        #expect(probe.waitCount == 1)
+        #expect(presentedTemplates == [.activeUserTasksPreventQuit])
+        #expect(probe.cancellationCount == 0)
+        #expect(probe.waitCount == 0)
         #expect(project.hasOutstandingUserTaskExecution)
         #expect(registry.isProjectOpen(dir))
         #expect(!registry.destroyAllProjects())
@@ -361,18 +367,18 @@ struct WindowLifecycleTests {
 
         project.taskRunStore.finishRun(
             id: run.id,
-            outcome: makeTaskOutcome(id: "timeout"),
-            cancelled: true
+            outcome: makeTaskOutcome(id: "active"),
+            cancelled: false
         )
         #expect(registry.destroyAllProjects())
     }
 
-    @Test func quitWaitsForTaskCleanupBeforeAllowingTeardown() async throws {
+    @Test func quitNeverKillsTaskWhoseCleanupWouldFitDeadline() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let registry = ProjectRegistry()
         let project = try #require(registry.projectManager(for: dir))
-        let run = project.taskRunStore.start(makeTaskRun(id: "success"))
+        let run = project.taskRunStore.start(makeTaskRun(id: "active"))
         let probe = TerminationTaskProbe(waitResult: true)
         project.taskRunStore.registerCancellation(
             probe.makeCancellation(),
@@ -382,56 +388,69 @@ struct WindowLifecycleTests {
         delegate.registry = registry
 
         let result = await delegate.confirmApplicationTermination(
-            userTaskShutdownDeadline: .now() + 1
+            presentAlert: { template, _, _, _ in
+                #expect(template == .activeUserTasksPreventQuit)
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 1
         )
 
-        #expect(result)
-        #expect(probe.cancellationCount == 1)
-        #expect(probe.waitCount == 1)
-        #expect(!project.hasOutstandingUserTaskExecution)
-        #expect(project.taskRunStore.runs.isEmpty)
+        #expect(!result)
+        #expect(probe.cancellationCount == 0)
+        #expect(probe.waitCount == 0)
+        #expect(project.hasOutstandingUserTaskExecution)
+        #expect(project.taskRunStore.runs.count == 1)
+        #expect(!registry.destroyAllProjects())
+
+        project.taskRunStore.finishRun(
+            id: run.id,
+            outcome: makeTaskOutcome(id: "active"),
+            cancelled: false
+        )
         #expect(registry.destroyAllProjects())
     }
 
-    @Test func quitRevalidatesEditsMadeDuringTaskCleanup() async throws {
+    @Test func taskStartedDuringQuitDoesNotCommitDiscard() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
         let registry = ProjectRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
-        let run = project.taskRunStore.start(makeTaskRun(id: "delayed"))
-        let gate = TerminationWaitGate()
-        project.taskRunStore.registerCancellation(
-            UserTaskCancellation(
-                terminate: { true },
-                waitForCompletion: { deadline in
-                    gate.waitForRelease(until: deadline)
-                }
-            ),
-            forRunID: run.id
-        )
+        project.primaryTabManager.updateContent("// keep after refused quit")
+        let probe = TerminationTaskProbe(waitResult: true)
+        var run: UserTaskRun?
         let delegate = AppDelegate()
         delegate.registry = registry
 
-        let decision = Task { @MainActor in
-            await delegate.confirmApplicationTermination(
-                userTaskShutdownDeadline: .now() + 2
-            )
-        }
-        defer { gate.release() }
-        for _ in 0..<200 where !gate.didStartWaiting {
-            try? await Task.sleep(for: .milliseconds(5))
-        }
-        #expect(gate.didStartWaiting)
-        project.primaryTabManager.updateContent("// edited during cleanup")
-        gate.release()
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                #expect(template == .unsavedChangesBulk)
+                let started = project.taskRunStore.start(
+                    makeTaskRun(id: "late-active")
+                )
+                project.taskRunStore.registerCancellation(
+                    probe.makeCancellation(),
+                    forRunID: started.id
+                )
+                run = started
+                return .alertSecondButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 2
+        )
 
-        let result = await decision.value
         #expect(!result)
+        #expect(probe.cancellationCount == 0)
+        #expect(probe.waitCount == 0)
         #expect(project.hasUnsavedChanges)
         #expect(project.primaryTabManager.activeTab?.content ==
-                "// edited during cleanup")
+                "// keep after refused quit")
+        let activeRun = try #require(run)
+        project.taskRunStore.finishRun(
+            id: activeRun.id,
+            outcome: makeTaskOutcome(id: "late-active"),
+            cancelled: false
+        )
         await project.workspace.waitForLoadingComplete()
     }
 
@@ -706,26 +725,5 @@ nonisolated private final class TerminationTaskProbe: @unchecked Sendable {
                 return waitResult
             }
         )
-    }
-}
-
-nonisolated private final class TerminationWaitGate: @unchecked Sendable {
-    private let lock = NSLock()
-    private let releaseSemaphore = DispatchSemaphore(value: 0)
-    private var startedWaiting = false
-
-    var didStartWaiting: Bool {
-        lock.withLock { startedWaiting }
-    }
-
-    func waitForRelease(until deadline: DispatchTime) -> Bool {
-        lock.withLock {
-            startedWaiting = true
-        }
-        return releaseSemaphore.wait(timeout: deadline) == .success
-    }
-
-    func release() {
-        releaseSemaphore.signal()
     }
 }

--- a/docs/adr/0003-durable-agent-task-identity.md
+++ b/docs/adr/0003-durable-agent-task-identity.md
@@ -1,0 +1,160 @@
+# ADR 0003: Durable agent task identity
+
+Status: Accepted
+
+## Context
+
+Pine already observes agent processes through terminal-scoped `AgentSession`
+values and joins those session IDs to Activity, History, provenance, verified
+patches, and checked undo. A PID is reusable, a terminal can launch multiple
+processes, and a vendor conversation ID is private adapter data. None of these
+is a durable user-task identity.
+
+## Decision
+
+Pine keeps five identities distinct:
+
+- `AgentTask.id` identifies durable user intent across windows and app launches.
+- `AgentTaskRun.id` identifies one attempt. For compatibility it equals the
+  legacy `AgentSession.id`; every resume or relaunch creates a new run/session.
+- A terminal ID and its monotonic process generation identify one PTY process
+  lifetime. PID and process-start evidence corroborate that lifetime but are
+  never sufficient to inherit a task.
+- `AgentSession` remains the observed, terminal-scoped run used by badges,
+  Activity, History, provenance, verified patches, and checked undo.
+- An opaque vendor session identity is an in-memory adapter hint. It is neither
+  Pine identity nor authority and is never persisted.
+
+The app-level registry stores value records only. Project and worktree paths
+enter through `ProjectRegistry.canonicalProjectURL`. Until #1309 supplies
+authenticated repository/worktree provenance, Pine's canonical opened project
+root is explicitly also its verified worktree root; no synchronous git or
+filesystem discovery runs on MainActor. Runtime pane and tab IDs
+are hints: routing must re-resolve the canonical project and exact live
+terminal/session/generation, reject duplicate matches, and fail closed when a
+project, worktree, pane, tab, run, or generation is unavailable. Uniqueness is
+assessed across every live matching pane before the persisted route hint is
+checked; a duplicate cannot be hidden by the expected pane.
+
+Manual discovery may create a new observed task only from a unique terminal
+plus session plus process-start/generation observation. It never claims an
+existing durable task by agent type, PID, cwd, or timing. The existing
+Send-to-Terminal action is the production launch boundary only when its complete
+payload is one exact canonical executable token from `AgentType.cliNames`.
+`TerminalManager` reserves immediately before sending those bytes, carries the
+runtime-only token to the detector bridge, and cancels if the terminal rejects
+the send. Arguments, whitespace, shell expressions, aliases outside the exact
+canonical set, and text typed directly into an interactive shell do not reserve
+intent. A terminal-tab context menu is the explicit resume UI: the user selects
+a paused durable task, Pine late-resolves exactly one canonical open-project and
+target-tab route, reserves that task, and only then sends the exact executable.
+No task is inferred from cwd, agent type, or timing.
+A claim requires the reserved terminal, project/worktree, agent descriptor,
+detector generation floor, and a coherent kernel-derived microsecond process
+start later than the captured launch boundary. Pine brackets `proc_pidpath` with
+two equal `proc_pidinfo` starts, requires the current executable basename to
+match the sampled command token, and requires the coarse `ps lstart` second to
+match that same generation. Mixed PID generations grant no ownership. The
+registry consumes the
+random token exactly once against a monotonic deadline and exact run tail; the
+token is never persisted. Untokened polling and pre-existing processes cannot
+consume or cancel matching intent. Expired, cancelled, duplicate, or mismatched
+claims create no inherited association and expose no usable route.
+
+Window closure only marks a route backgrounded. A tab move updates its pane
+hint and does not end the run. Pane/tab removal is termination evidence and
+detaches the route exactly once, but is not evidence of successful task
+completion. Every accepted run UUID remains a process-lifetime tombstone after
+live ownership is removed; delayed detector termination can update or no-op the
+original run but can never create another task containing that UUID. A process
+replacement, PID reuse, resume, or relaunch ends the old run and creates a new
+run. After app relaunch, only an explicit user resume may
+convert a runtime-marked loaded interruption into a terminated old run and a
+fresh run; persisted route hints never regain live ownership. Failed observation
+only makes evidence stale.
+Process disappearance and legacy `.done` are termination evidence, not
+authenticated success; explicit completion/failure requires later adapter
+evidence from #1303.
+
+## Persistence, privacy, and trust
+
+Metadata is stored in one dedicated `0700` private subtree directly below the
+trusted Application Support anchor, partitioned by a
+hash of the canonical project path and with the canonical worktree retained in
+each record. Reads are size-bounded before allocation; schema, counts, strings,
+dates, identities, and paths are validated fail-closed. Schema v2 carries an
+opaque per-project disk revision. Revision-less schema v1 loads carry an
+in-memory SHA-256 token over the exact source bytes, so migration proceeds only
+while that legacy baseline is unchanged; the digest is never persisted. Under
+the advisory lock, each save
+compares its loaded revision immediately before publication, so a stale registry
+or second store instance cannot overwrite a newer snapshot. Missing worktrees
+are retained with unavailable routes rather than deleted. An unsupported future
+schema or an uninspectably oversized file quarantines its project for the process
+lifetime, preserving the original bytes and blocking every publication. Writes
+use generation/sequence tickets
+authorized per project. The publication fence holds its lock across the final
+ticket check and `renameat`. A successful publication records its new revision
+inside that same fence lock; timeout generation advance atomically consumes the
+receipt, so a writer stalled after rename cannot leave the registry CASing from
+the old revision. A superseded writer cannot publish after a newer snapshot.
+Mutations coalesce behind one current writer; cancelled
+abandoned writers are tracked without helper waiters and bounded before another
+writer can spawn. Failures remain dirty for a bounded three-attempt quit retry.
+If the rename succeeds but directory durability cannot be confirmed, the
+registry advances to the published revision while still reporting failure and
+retrying; a pre-publication sync failure never advances that revision.
+Quit freezes mutations and persists live tasks as a valid paused/stale/missing
+snapshot; rollback restores and re-persists the exact runtime lifecycle,
+availability, liveness, attention, and chronology. Files and directories are
+owner-only, reject any extended ACL entry, and publication uses a same-directory
+atomic replacement with durable file and directory sync.
+Private components remain bound through a descriptor chain checked before and
+after I/O. A private advisory lock coordinates store instances, and bounded
+lock/flush deadlines prevent Quit from hanging. Symlinked or replaced storage
+paths are rejected. Temporary-orphan cleanup advances a bounded directory cursor
+and orders valid stale candidates by age and name, so unrelated entries cannot
+indefinitely starve eligible cleanup. Each candidate's device/inode identity is
+opened nonblocking and revalidated against the live pathname. Pine then retires
+the opened inode through its descriptor (`ftruncate` plus mode `000`) rather
+than calling pathname-based `unlink`; a concurrent pathname replacement is
+never deleted or truncated. The bounded scan may therefore leave zero-byte
+tombstones, preferring harmless directory entries over acting as a confused
+deputy for another same-UID process. A global tombstone count and directory-entry
+scan cap are checked before creating a writer temp; hitting either fails with a
+storage limit instead of growing the directory without bound. Device, inode,
+link count, mode, and ACL are revalidated after the final race hook and before
+descriptor mutation.
+
+Persisted records never contain prompts, terminal output, command arguments,
+file contents, environment values, credentials, transcripts, raw Activity
+summaries, process command lines, or vendor-private identity. Optional title
+and objective are explicitly user-authored and bounded.
+
+Task/run metadata is routing and presentation metadata only. It never upgrades
+observed or inferred evidence to verified. Existing provenance identity
+(`project`, canonical worktree, session, terminal, process generation, cursor,
+envelope, and journal sequence), private undo authority, consumption checks,
+and divergence checks remain mandatory and unchanged.
+
+## Migration and retention
+
+Existing `AgentSession` IDs remain run IDs, preserving all legacy joins. A new
+task UUID is minted separately. Observations without detector-owned process
+evidence fail closed and cannot create or attach to a task. Unknown schema
+fails closed; unknown agent identifiers remain
+opaque and grant no action authority. Retention is deterministic per project
+and per task, and must not discard active or paused records merely to satisfy
+history limits. Runtime task/run/session collections use the same hard limits;
+accepted run UUID tombstones are exact and never evicted, so new-run admission
+fails closed when their process-lifetime cap is reached. Only
+terminal/dismissed history is pruned, while protected overflow fails closed.
+Project and worktree together prevent collisions between multiple worktrees of
+the same repository.
+
+## Consequences
+
+The cross-project inbox and notifications remain out of scope. Persisted tab
+and pane IDs cannot restore a route after relaunch until the user explicitly
+selects a paused task and Pine re-resolves the intended live target tab. Richer
+resume policy remains tracked by #1307; adapter linkage is tracked by #1303.

--- a/docs/adr/0003-durable-agent-task-identity.md
+++ b/docs/adr/0003-durable-agent-task-identity.md
@@ -106,7 +106,12 @@ registry advances to the published revision while still reporting failure and
 retrying; a pre-publication sync failure never advances that revision.
 Quit freezes mutations and persists live tasks as a valid paused/stale/missing
 snapshot; rollback restores and re-persists the exact runtime lifecycle,
-availability, liveness, attention, and chronology. Files and directories are
+availability, liveness, attention, and chronology. If any user task still owns
+an executing process, Quit is refused before Pine sends TERM/KILL and an alert
+requires explicit task cancellation first. Ownership is checked again after the
+last persistence suspension and before editor discard, so a task started while
+a Quit sheet is visible also cancels Quit without being killed.
+Files and directories are
 owner-only, reject any extended ACL entry, and publication uses a same-directory
 atomic replacement with durable file and directory sync.
 Private components remain bound through a descriptor chain checked before and


### PR DESCRIPTION
## Summary

Introduces durable, cross-project `AgentTask` identity while keeping terminal process evidence as the source of truth.

- separates task, run, terminal route, and process-generation identity;
- adds an app-level task registry with exact project/worktree routing;
- supports Pine-owned launch and resume without granting authority before a complete PTY acknowledgement;
- persists bounded project-scoped metadata atomically with CAS, quarantine, owner-private filesystem checks, and publication fencing;
- adds lifecycle, PID-reuse, migration, resume, teardown, storage, and authority regressions.

## Current status

**Draft:** the implementation is visible for native CI and exact-SHA review.

The current candidate `600e0eed919f114a87c1de4a3d4e36270b68e3bc` closes the last known architecture blocker: application Quit now refuses while a user task owns execution, before any TERM/KILL, and revalidates ownership after the final suspension point before destructive commit.

It also corrects the macOS test fixtures exposed by the previous failed run: inherited temporary-directory ACLs, invalid synthetic run chronology, historical-task lookup, live tab-session wiring, and isolated rollback persistence.

All findings from the previous exact-SHA review are corrected, including rejected-load quarantine, rollback admission recovery, armed zero-run persistence exclusion, ACK-during-Quit ownership, optional project URL compilation, the persisted process-evidence type, Swift-importable libproc path capacity, Xcode 27 actor-region-safe publication buffers, production-aligned registry fixtures, correctly typed metadata-store race hooks, and async-safe PTY test synchronization.

## Verification available from Linux

- Swift 6.2.4 frontend parse across 691 Swift files
- Swift 6 strict extracted registry/runtime probes
- dormant/armed launch authority and replay probes
- ACK across Quit rollback probe
- armed zero-run persistence exclusion probe
- all rejected loads quarantine mutations probe
- failed rollback admission recovery probe
- bounded launch-write gate probe
- `check_nonisolated.py`
- `check-no-post-under-inout.py`
- SwiftLint 0.63.2 strict without SourceKit
- i18n and pre-push scans

Native macOS/Xcode tests remain required in CI.

Closes #1302
