### PR TITLE
feat(agent): add vendor-neutral adapter core (#1303)

### DIFF
--- a/Pine/Agent/Adapters/AdapterCapabilities.swift
+++ b/Pine/Agent/Adapters/AdapterCapabilities.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+nonisolated struct PineAdapterContractVersion: Hashable, Comparable, Sendable {
+    let major: UInt16
+    let minor: UInt16
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        (lhs.major, lhs.minor) < (rhs.major, rhs.minor)
+    }
+}
+
+nonisolated struct PineAdapterContractVersionRange: Equatable, Sendable {
+    let minimum: PineAdapterContractVersion
+    let maximum: PineAdapterContractVersion
+    var isValid: Bool { minimum <= maximum }
+    func contains(_ value: PineAdapterContractVersion) -> Bool { minimum <= value && value <= maximum }
+}
+
+nonisolated enum AdapterTransport: String, Hashable, Sendable { case ownedStandardIO, authenticatedLocalIPC }
+nonisolated enum AdapterLifecycleScope: String, Hashable, Sendable { case session, run, turn, item }
+nonisolated enum AdapterLifecyclePhase: String, Hashable, Sendable {
+    case started, working, waitingForQuestion, waitingForApproval, succeeded, failed, cancelled, settled
+}
+nonisolated enum AdapterEvidence: String, Hashable, Sendable { case tool, fileChange }
+nonisolated enum AdapterReplay: String, Hashable, Sendable { case none, sourceCursor }
+nonisolated enum AdapterOrdering: String, Hashable, Sendable { case unordered, ordered }
+nonisolated enum CoreAuthenticationRequirement: String, Hashable, Sendable {
+    case ownedChildPipe, authenticatedPeer
+}
+
+nonisolated enum AdapterProfileError: Error, Equatable, Sendable {
+    case emptyLifecycle
+    case missingDependency
+    case replayRequiresOrdering
+    case transportAuthenticationMismatch
+}
+
+nonisolated struct AdapterLifecycleCapabilities: Hashable, Sendable {
+    struct Signal: Hashable, Sendable {
+        let scope: AdapterLifecycleScope
+        let phase: AdapterLifecyclePhase
+    }
+
+    let signals: Set<Signal>
+    let evidence: Set<AdapterEvidence>
+
+    init(signals: Set<Signal>, evidence: Set<AdapterEvidence>) throws {
+        guard !signals.isEmpty else { throw AdapterProfileError.emptyLifecycle }
+        let scopes = Set(signals.map(\.scope))
+        guard !scopes.contains(.item) || scopes.contains(.turn) else { throw AdapterProfileError.missingDependency }
+        guard !evidence.contains(.fileChange) || evidence.contains(.tool) else {
+            throw AdapterProfileError.missingDependency
+        }
+        self.signals = signals
+        self.evidence = evidence
+    }
+
+    func authorizes(scope: AdapterLifecycleScope, phase: AdapterLifecyclePhase) -> Bool {
+        signals.contains(Signal(scope: scope, phase: phase))
+    }
+}
+
+nonisolated struct AdapterDeliverySemantics: Hashable, Sendable {
+    let replay: AdapterReplay
+    let ordering: AdapterOrdering
+    let minimumAuthentication: CoreAuthenticationRequirement
+
+    init(
+        replay: AdapterReplay = .none,
+        ordering: AdapterOrdering,
+        minimumAuthentication: CoreAuthenticationRequirement
+    ) throws {
+        guard replay == .none || ordering == .ordered else { throw AdapterProfileError.replayRequiresOrdering }
+        self.replay = replay
+        self.ordering = ordering
+        self.minimumAuthentication = minimumAuthentication
+    }
+}
+
+nonisolated struct AdapterCapabilityProfile: Hashable, Sendable {
+    let transport: AdapterTransport
+    let lifecycle: AdapterLifecycleCapabilities
+    let delivery: AdapterDeliverySemantics
+
+    var lifecycleSignals: Set<AdapterLifecycleCapabilities.Signal> { lifecycle.signals }
+    var evidence: Set<AdapterEvidence> { lifecycle.evidence }
+    var replay: AdapterReplay { delivery.replay }
+    var ordering: AdapterOrdering { delivery.ordering }
+    var minimumAuthentication: CoreAuthenticationRequirement { delivery.minimumAuthentication }
+
+    init(
+        transport: AdapterTransport,
+        lifecycle: AdapterLifecycleCapabilities,
+        delivery: AdapterDeliverySemantics
+    ) throws {
+        guard (transport == .ownedStandardIO && delivery.minimumAuthentication == .ownedChildPipe)
+                || (transport == .authenticatedLocalIPC && delivery.minimumAuthentication == .authenticatedPeer) else {
+            throw AdapterProfileError.transportAuthenticationMismatch
+        }
+        self.transport = transport
+        self.lifecycle = lifecycle
+        self.delivery = delivery
+    }
+
+    var deterministicWireValues: [String] {
+        (["transport:\(transport.rawValue)", "replay:\(replay.rawValue)",
+          "ordering:\(ordering.rawValue)", "authentication:\(minimumAuthentication.rawValue)"]
+            + lifecycleSignals.map { "lifecycle:\($0.scope.rawValue):\($0.phase.rawValue)" }
+            + evidence.map { "evidence:\($0.rawValue)" }).sorted()
+    }
+
+    func isSubset(of maximum: Self) -> Bool {
+        transport == maximum.transport && lifecycleSignals.isSubset(of: maximum.lifecycleSignals)
+            && evidence.isSubset(of: maximum.evidence)
+            && replay == maximum.replay && ordering == maximum.ordering
+            && minimumAuthentication == maximum.minimumAuthentication
+    }
+}

--- a/Pine/Agent/Adapters/AdapterIdentifiers.swift
+++ b/Pine/Agent/Adapters/AdapterIdentifiers.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+nonisolated enum AdapterValueError: Error, Equatable, Sendable {
+    case empty(String)
+    case tooLong(String, maximum: Int)
+    case invalidCharacters(String)
+    case invalidDisplayText
+}
+
+nonisolated protocol CanonicalAdapterIdentifier: Hashable, Sendable {
+    var value: String { get }
+    init(validating value: String) throws
+}
+
+nonisolated enum AdapterIdentifierValidation {
+    static let maximumBytes = 96
+
+    static func canonical(_ value: String, field: String) throws -> String {
+        guard !value.isEmpty else { throw AdapterValueError.empty(field) }
+        guard value.utf8.count <= maximumBytes else {
+            throw AdapterValueError.tooLong(field, maximum: maximumBytes)
+        }
+        let bytes = Array(value.utf8)
+        guard bytes.allSatisfy({
+            (97...122).contains($0) || (48...57).contains($0) || $0 == 45 || $0 == 46 || $0 == 58
+        }), bytes.first.map({ (97...122).contains($0) || (48...57).contains($0) }) == true,
+           bytes.last.map({ (97...122).contains($0) || (48...57).contains($0) }) == true else {
+            throw AdapterValueError.invalidCharacters(field)
+        }
+        return value
+    }
+
+    static func displayText(_ value: String) throws -> String {
+        let normalized = value.precomposedStringWithCanonicalMapping
+        guard !normalized.isEmpty, normalized.utf8.count <= 128,
+              normalized.unicodeScalars.allSatisfy({ scalar in
+                  !CharacterSet.controlCharacters.contains(scalar)
+                      && ![0x061C, 0x200E, 0x200F, 0x202A, 0x202B, 0x202C, 0x202D, 0x202E,
+                           0x2066, 0x2067, 0x2068, 0x2069].contains(scalar.value)
+                      && !scalar.properties.isDefaultIgnorableCodePoint
+              }) else { throw AdapterValueError.invalidDisplayText }
+        return normalized
+    }
+}
+
+nonisolated struct AgentID: CanonicalAdapterIdentifier {
+    let value: String
+    init(validating value: String) throws {
+        self.value = try AdapterIdentifierValidation.canonical(value, field: "agentID")
+    }
+
+    init(migratingLegacyStableIdentifier value: String) throws {
+        guard ["claudeCode", "codex", "aider", "copilot", "pi"].contains(value) else {
+            throw AdapterValueError.invalidCharacters("legacyAgentID")
+        }
+        self.value = value
+    }
+}
+
+nonisolated struct AdapterID: CanonicalAdapterIdentifier {
+    let value: String
+    init(validating value: String) throws {
+        self.value = try AdapterIdentifierValidation.canonical(value, field: "adapterID")
+    }
+}
+
+nonisolated struct AdapterFactoryID: CanonicalAdapterIdentifier {
+    let value: String
+    init(validating value: String) throws {
+        self.value = try AdapterIdentifierValidation.canonical(value, field: "factoryID")
+    }
+}
+
+nonisolated struct ExecutableAlias: CanonicalAdapterIdentifier {
+    let value: String
+    init(validating value: String) throws {
+        self.value = try AdapterIdentifierValidation.canonical(value, field: "executableAlias")
+        guard !value.contains(":"), !value.contains(".") else {
+            throw AdapterValueError.invalidCharacters("executableAlias")
+        }
+    }
+}
+
+nonisolated struct VendorReference: Hashable, Sendable, CustomStringConvertible,
+    CustomDebugStringConvertible, CustomReflectable {
+    enum Role: String, Sendable { case conversation, turn, item, toolCall, request, event }
+    let role: Role
+    private(set) var rawValue: String
+
+    init(role: Role, value: String) throws {
+        guard !value.isEmpty else { throw AdapterValueError.empty("vendorReference") }
+        guard value.utf8.count <= 256 else {
+            throw AdapterValueError.tooLong("vendorReference", maximum: 256)
+        }
+        guard value.unicodeScalars.allSatisfy({ !CharacterSet.controlCharacters.contains($0) }) else {
+            throw AdapterValueError.invalidCharacters("vendorReference")
+        }
+        self.role = role
+        rawValue = value
+    }
+
+    var description: String { "<redacted:\(role.rawValue)>" }
+    var debugDescription: String { description }
+    var customMirror: Mirror { Mirror(self, children: ["value": description]) }
+}
+
+nonisolated struct AdapterResumePosition: Sendable, CustomStringConvertible,
+    CustomDebugStringConvertible, CustomReflectable {
+    private(set) var rawValue: String
+    init(_ value: String) throws {
+        guard !value.isEmpty else { throw AdapterValueError.empty("resumePosition") }
+        guard value.utf8.count <= 256 else {
+            throw AdapterValueError.tooLong("resumePosition", maximum: 256)
+        }
+        guard value.unicodeScalars.allSatisfy({ !CharacterSet.controlCharacters.contains($0) }) else {
+            throw AdapterValueError.invalidCharacters("resumePosition")
+        }
+        rawValue = value
+    }
+    var description: String { "<redacted:resume-position>" }
+    var debugDescription: String { description }
+    var customMirror: Mirror { Mirror(self, children: ["value": description]) }
+}

--- a/Pine/Agent/Adapters/AdapterModels.swift
+++ b/Pine/Agent/Adapters/AdapterModels.swift
@@ -1,0 +1,347 @@
+import Foundation
+
+nonisolated enum AgentPresentationStyle: String, Sendable { case claude, codex, aider, copilot, pi, generic }
+
+nonisolated struct AgentPresentationDescriptor: Sendable {
+    let agentID: AgentID
+    let displayName: String
+    let executableAliases: Set<ExecutableAlias>
+    let style: AgentPresentationStyle
+
+    init(agentID: AgentID, displayName: String, executableAliases: Set<ExecutableAlias>, style: AgentPresentationStyle) throws {
+        guard executableAliases.count <= 16 else { throw AdapterValueError.tooLong("executableAliases", maximum: 16) }
+        self.agentID = agentID
+        self.displayName = try AdapterIdentifierValidation.displayText(displayName)
+        self.executableAliases = executableAliases
+        self.style = style
+    }
+}
+
+/// A bounded programmatic registration. A future config loader owns byte and JSON validation.
+nonisolated struct UserAgentPresentationRegistration: Sendable {
+    let identifier: String
+    let displayName: String
+    let executableAliases: [String]
+
+    init(identifier: String, displayName: String, executableAliases: [String]) throws {
+        self.identifier = identifier
+        self.displayName = displayName
+        self.executableAliases = executableAliases
+        _ = try normalized()
+    }
+
+    func normalized() throws -> AgentPresentationDescriptor {
+        guard executableAliases.count <= 16 else { throw AdapterValueError.tooLong("executableAliases", maximum: 16) }
+        let requested = try AgentID(validating: identifier)
+        let userID = try AgentID(validating: requested.value.hasPrefix("user:") ? requested.value : "user:\(requested.value)")
+        let aliases = try executableAliases.map(ExecutableAlias.init(validating:))
+        guard Set(aliases).count == aliases.count else { throw AdapterRegistrationError.duplicateAlias }
+        return try AgentPresentationDescriptor(
+            agentID: userID,
+            displayName: displayName,
+            executableAliases: Set(aliases),
+            style: .generic
+        )
+    }
+}
+
+nonisolated struct AdapterDescriptor: Sendable {
+    let adapterID: AdapterID
+    let agentID: AgentID
+    let factoryID: AdapterFactoryID
+    let contractVersions: PineAdapterContractVersionRange
+    let maximumProfiles: [AdapterCapabilityProfile]
+}
+
+nonisolated struct DetectedVendorVersion: Hashable, Sendable, CustomStringConvertible {
+    let value: String
+    init(_ value: String) throws {
+        guard value == value.trimmingCharacters(in: .whitespacesAndNewlines) else {
+            throw AdapterValueError.invalidDisplayText
+        }
+        self.value = try AdapterIdentifierValidation.displayText(value)
+    }
+    var description: String { value }
+}
+
+nonisolated struct AdapterProbeResult: Sendable {
+    let detectedVendorVersion: DetectedVendorVersion
+    let detectedSchema: DetectedVendorVersion?
+    let offeredProfiles: [AdapterCapabilityProfile]
+    init(
+        detectedVendorVersion: DetectedVendorVersion,
+        detectedSchema: DetectedVendorVersion?,
+        offeredProfiles: [AdapterCapabilityProfile]
+    ) throws {
+        guard offeredProfiles.count <= 16 else { throw AdapterProbeError.malformedResponse }
+        guard Set(offeredProfiles).count == offeredProfiles.count else { throw AdapterProbeError.malformedResponse }
+        self.detectedVendorVersion = detectedVendorVersion
+        self.detectedSchema = detectedSchema
+        self.offeredProfiles = offeredProfiles
+    }
+}
+
+nonisolated enum CandidateFileOperation: String, Sendable { case create, modify, delete, rename }
+
+nonisolated struct ClaimedContentIdentity: Equatable, Sendable {
+    let sha256: String
+    let byteCount: UInt64
+    init(sha256: String, byteCount: UInt64) throws {
+        guard sha256.utf8.count == 64,
+              sha256.utf8.allSatisfy({ (48...57).contains($0) || (97...102).contains($0) }),
+              byteCount <= 1_099_511_627_776 else {
+            throw AdapterCandidateError.invalidContentIdentity
+        }
+        self.sha256 = sha256
+        self.byteCount = byteCount
+    }
+}
+
+nonisolated struct CandidateFileChange: Equatable, Sendable {
+    let operation: CandidateFileOperation
+    let relativePath: String
+    let destinationRelativePath: String?
+    let before: ClaimedContentIdentity?
+    let after: ClaimedContentIdentity?
+
+    init(
+        operation: CandidateFileOperation,
+        relativePath: String,
+        destinationRelativePath: String? = nil,
+        before: ClaimedContentIdentity? = nil,
+        after: ClaimedContentIdentity? = nil
+    ) throws {
+        try Self.validate(path: relativePath)
+        if let destinationRelativePath { try Self.validate(path: destinationRelativePath) }
+        guard (operation == .rename) == (destinationRelativePath != nil) else {
+            throw AdapterCandidateError.contradictoryEvent
+        }
+        guard operation != .create || before == nil,
+              operation != .delete || after == nil else { throw AdapterCandidateError.contradictoryEvent }
+        self.operation = operation
+        self.relativePath = relativePath
+        self.destinationRelativePath = destinationRelativePath
+        self.before = before
+        self.after = after
+    }
+
+    private static func validate(path: String) throws {
+        guard path == path.precomposedStringWithCanonicalMapping,
+              path.utf8.count <= 4_096, path.split(separator: "/", omittingEmptySubsequences: false).count <= 128,
+              AgentHistoryUndoPreflight.isCanonicalRelativePath(path),
+              path.unicodeScalars.allSatisfy({ scalar in
+                  !CharacterSet.controlCharacters.contains(scalar)
+                      && ![0x061C, 0x200E, 0x200F, 0x202A, 0x202B, 0x202C, 0x202D, 0x202E,
+                           0x2066, 0x2067, 0x2068, 0x2069].contains(scalar.value)
+                      && !scalar.properties.isDefaultIgnorableCodePoint
+              }) else {
+            throw AdapterCandidateError.invalidRelativePath
+        }
+    }
+}
+
+nonisolated enum CandidateToolCategory: String, Sendable {
+    case read, write, search, execute, fileChange, network, other
+}
+nonisolated enum CandidateToolPhase: String, Sendable { case started, succeeded, failed, cancelled }
+
+nonisolated struct CandidateToolEvent: Sendable {
+    let phase: CandidateToolPhase
+    let category: CandidateToolCategory
+    let toolCall: VendorReference
+    let fileChanges: [CandidateFileChange]
+    init(phase: CandidateToolPhase, category: CandidateToolCategory, toolCall: VendorReference, fileChanges: [CandidateFileChange]) throws {
+        guard toolCall.role == .toolCall, fileChanges.count <= 128,
+              category != .fileChange || !fileChanges.isEmpty else {
+            throw AdapterCandidateError.contradictoryEvent
+        }
+        try Self.validateBatch(fileChanges)
+        self.phase = phase; self.category = category; self.toolCall = toolCall; self.fileChanges = fileChanges
+    }
+
+    private static func validateBatch(_ changes: [CandidateFileChange]) throws {
+        var endpoints: [String] = []
+        for change in changes {
+            let source = AgentHistoryUndoPreflight.conservativePathKey(change.relativePath)
+            try insert(source, into: &endpoints)
+            if let destination = change.destinationRelativePath {
+                let key = AgentHistoryUndoPreflight.conservativePathKey(destination)
+                try insert(key, into: &endpoints)
+            }
+        }
+    }
+
+    private static func insert(_ path: String, into endpoints: inout [String]) throws {
+        let components = path.split(separator: "/")
+        guard !endpoints.contains(where: { existing in
+            let existingComponents = existing.split(separator: "/")
+            return components.starts(with: existingComponents) || existingComponents.starts(with: components)
+        }) else { throw AdapterCandidateError.contradictoryEvent }
+        endpoints.append(path)
+    }
+}
+
+nonisolated struct CandidateLifecycleEvent: Sendable {
+    let scope: AdapterLifecycleScope
+    let phase: AdapterLifecyclePhase
+    let reference: VendorReference?
+    init(scope: AdapterLifecycleScope, phase: AdapterLifecyclePhase, reference: VendorReference?) throws {
+        guard phase != .waitingForQuestion,
+              phase != .waitingForApproval else {
+            throw AdapterCandidateError.contradictoryEvent
+        }
+        if let reference {
+            let validRole: Bool
+            switch scope {
+            case .session, .run: validRole = reference.role == .conversation
+            case .turn: validRole = reference.role == .turn
+            case .item: validRole = reference.role == .item
+            }
+            guard validRole else { throw AdapterCandidateError.contradictoryEvent }
+        }
+        self.scope = scope; self.phase = phase; self.reference = reference
+    }
+}
+
+nonisolated struct CandidateAttentionEvent: Sendable {
+    let scope: AdapterLifecycleScope
+    let phase: AdapterLifecyclePhase
+    let request: VendorReference
+    let context: VendorReference?
+
+    init(
+        scope: AdapterLifecycleScope,
+        phase: AdapterLifecyclePhase,
+        request: VendorReference,
+        context: VendorReference? = nil
+    ) throws {
+        guard [.waitingForQuestion, .waitingForApproval].contains(phase), request.role == .request else {
+            throw AdapterCandidateError.contradictoryEvent
+        }
+        if let context {
+            let expectedRole: VendorReference.Role = switch scope {
+            case .session, .run: .conversation
+            case .turn: .turn
+            case .item: .item
+            }
+            guard context.role == expectedRole else { throw AdapterCandidateError.contradictoryEvent }
+        }
+        self.scope = scope
+        self.phase = phase
+        self.request = request
+        self.context = context
+    }
+}
+
+nonisolated enum AdapterCandidateEvent: Sendable {
+    case lifecycle(CandidateLifecycleEvent)
+    case question(CandidateAttentionEvent)
+    case approval(CandidateAttentionEvent)
+    case tool(CandidateToolEvent)
+    case processExited(status: Int32?)
+
+    func validate(against contract: NegotiatedAdapterContract) throws {
+        let profile = contract.profile
+        switch self {
+        case let .lifecycle(event):
+            guard event.phase != .waitingForQuestion,
+                  event.phase != .waitingForApproval,
+                  profile.lifecycle.authorizes(scope: event.scope, phase: event.phase) else {
+                throw AdapterCandidateError.capabilityOverreach
+            }
+        case let .question(attention):
+            guard attention.phase == .waitingForQuestion,
+                  profile.lifecycle.authorizes(scope: attention.scope, phase: attention.phase) else {
+                throw AdapterCandidateError.capabilityOverreach
+            }
+        case let .approval(attention):
+            guard attention.phase == .waitingForApproval,
+                  profile.lifecycle.authorizes(scope: attention.scope, phase: attention.phase) else {
+                throw AdapterCandidateError.capabilityOverreach
+            }
+        case let .tool(event):
+            guard profile.evidence.contains(.tool),
+                  event.category != .fileChange || profile.evidence.contains(.fileChange),
+                  event.fileChanges.isEmpty || profile.evidence.contains(.fileChange) else {
+                throw AdapterCandidateError.capabilityOverreach
+            }
+        case .processExited:
+            break // Detection hint only; never successful lifecycle completion.
+        }
+    }
+}
+
+nonisolated struct AdapterCandidate: Sendable {
+    let event: AdapterCandidateEvent
+    let timestampHint: TimestampHint?
+    let sourcePosition: AdapterSourcePosition?
+
+    init(
+        event: AdapterCandidateEvent,
+        timestampHint: TimestampHint? = nil,
+        sourcePosition: AdapterSourcePosition? = nil
+    ) {
+        self.event = event
+        self.timestampHint = timestampHint
+        self.sourcePosition = sourcePosition
+    }
+
+    func validate(against contract: NegotiatedAdapterContract) throws {
+        try event.validate(against: contract)
+        let delivery = contract.profile.delivery
+        if delivery.replay == .sourceCursor {
+            guard sourcePosition?.sourceEvent != nil, sourcePosition?.resumePosition != nil,
+                  sourcePosition?.sourceSequence != nil else {
+                throw AdapterCandidateError.incompleteReplayPosition
+            }
+        } else if sourcePosition?.sourceEvent != nil || sourcePosition?.resumePosition != nil {
+            throw AdapterCandidateError.forbiddenReplayPosition
+        }
+        if delivery.ordering == .ordered, sourcePosition?.sourceSequence == nil {
+            throw AdapterCandidateError.missingSourceSequence
+        }
+        if delivery.ordering == .unordered, sourcePosition?.sourceSequence != nil {
+            throw AdapterCandidateError.forbiddenSourceSequence
+        }
+    }
+}
+
+nonisolated struct AdapterSourcePosition: Sendable {
+    let sourceEvent: VendorReference?
+    let resumePosition: AdapterResumePosition?
+    let sourceSequence: UInt64?
+
+    init(
+        sourceEvent: VendorReference? = nil,
+        resumePosition: AdapterResumePosition? = nil,
+        sourceSequence: UInt64? = nil
+    ) throws {
+        guard sourceEvent.map({ $0.role == .event }) ?? true,
+              sourceSequence.map({ $0 > 0 }) ?? true else {
+            throw AdapterCandidateError.invalidSourcePosition
+        }
+        self.sourceEvent = sourceEvent
+        self.resumePosition = resumePosition
+        self.sourceSequence = sourceSequence
+    }
+}
+
+nonisolated struct TimestampHint: Sendable {
+    let secondsSince1970: Double
+    let durationMilliseconds: UInt32?
+    init(secondsSince1970: Double, durationMilliseconds: UInt32?) throws {
+        guard secondsSince1970.isFinite, secondsSince1970 >= 0, secondsSince1970 <= 32_503_680_000 else {
+            throw AdapterCandidateError.invalidTimestamp
+        }
+        guard durationMilliseconds.map({ $0 <= 86_400_000 }) ?? true else {
+            throw AdapterCandidateError.invalidTimestamp
+        }
+        self.secondsSince1970 = secondsSince1970; self.durationMilliseconds = durationMilliseconds
+    }
+}
+
+nonisolated enum AdapterCandidateError: Error, Equatable, Sendable {
+    case invalidRelativePath, invalidContentIdentity, contradictoryEvent, invalidTimestamp, capabilityOverreach
+    case invalidSourcePosition, incompleteReplayPosition, forbiddenReplayPosition, missingSourceSequence
+    case forbiddenSourceSequence
+}

--- a/Pine/Agent/Adapters/AdapterModels.swift
+++ b/Pine/Agent/Adapters/AdapterModels.swift
@@ -68,16 +68,20 @@ nonisolated struct AdapterProbeResult: Sendable {
     let detectedVendorVersion: DetectedVendorVersion
     let detectedSchema: DetectedVendorVersion?
     let offeredProfiles: [AdapterCapabilityProfile]
+    let offeredContractVersions: PineAdapterContractVersionRange
     init(
         detectedVendorVersion: DetectedVendorVersion,
         detectedSchema: DetectedVendorVersion?,
-        offeredProfiles: [AdapterCapabilityProfile]
+        offeredProfiles: [AdapterCapabilityProfile],
+        offeredContractVersions: PineAdapterContractVersionRange
     ) throws {
         guard offeredProfiles.count <= 16 else { throw AdapterProbeError.malformedResponse }
         guard Set(offeredProfiles).count == offeredProfiles.count else { throw AdapterProbeError.malformedResponse }
+        guard offeredContractVersions.isValid else { throw AdapterProbeError.malformedResponse }
         self.detectedVendorVersion = detectedVendorVersion
         self.detectedSchema = detectedSchema
         self.offeredProfiles = offeredProfiles
+        self.offeredContractVersions = offeredContractVersions
     }
 }
 

--- a/Pine/Agent/Adapters/AdapterProtocols.swift
+++ b/Pine/Agent/Adapters/AdapterProtocols.swift
@@ -15,7 +15,7 @@ nonisolated protocol AgentAdapterSession: Sendable {
 
 nonisolated protocol AgentAdapterFactory: Sendable {
     var id: AdapterFactoryID { get }
-    /// Probes a factory instance already bound by a future supervised loader.
+    /// Probes the exact factory instance stored by the registry.
     /// This method neither searches PATH nor proves executable identity.
     /// Cancellation is reported by propagating `CancellationError`.
     func probe() async throws -> AdapterProbeResult
@@ -25,7 +25,9 @@ nonisolated protocol AgentAdapterFactory: Sendable {
 
 nonisolated enum AdapterFailureDisposition: Equatable, Sendable { case transient, permanent }
 nonisolated enum AdapterProbeError: Error, Equatable, Sendable {
-    case unavailable(AdapterFailureDisposition), malformedResponse
+    case unknownAdapter
+    case unavailable(AdapterFailureDisposition)
+    case malformedResponse
 }
 nonisolated enum AdapterSessionError: Error, Equatable, Sendable {
     case launchFailed(AdapterFailureDisposition)

--- a/Pine/Agent/Adapters/AdapterProtocols.swift
+++ b/Pine/Agent/Adapters/AdapterProtocols.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+nonisolated protocol AgentEventSink: Sendable {
+    /// The sink is created and authority-bound by Pine; producers supply candidate data only.
+    func ingest(_ candidate: AdapterCandidate) async -> AdapterIngestOutcome
+}
+
+nonisolated protocol AgentAdapterSession: Sendable {
+    var contract: NegotiatedAdapterContract { get }
+    /// Propagates `CancellationError` unchanged.
+    func start() async throws
+    /// Attempts bounded cleanup independently of caller cancellation; it does not promise forced termination.
+    func stop(deadline: ContinuousClock.Instant) async
+}
+
+nonisolated protocol AgentAdapterFactory: Sendable {
+    var id: AdapterFactoryID { get }
+    /// Probes a factory instance already bound by a future supervised loader.
+    /// This method neither searches PATH nor proves executable identity.
+    /// Cancellation is reported by propagating `CancellationError`.
+    func probe() async throws -> AdapterProbeResult
+    /// Propagates `CancellationError` unchanged.
+    func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession
+}
+
+nonisolated enum AdapterFailureDisposition: Equatable, Sendable { case transient, permanent }
+nonisolated enum AdapterProbeError: Error, Equatable, Sendable {
+    case unavailable(AdapterFailureDisposition), malformedResponse
+}
+nonisolated enum AdapterSessionError: Error, Equatable, Sendable {
+    case launchFailed(AdapterFailureDisposition)
+    case contractMismatch
+    case checkpointNotSupported
+    case checkpointMismatch
+    case checkpointUnavailable
+    case checkpointAlreadyConsumed
+    case invalidLifecycle
+}
+nonisolated enum AdapterIngestOutcome: Equatable, Sendable {
+    case accepted, bufferedUntilActivation, droppedInvalid, revoked
+}

--- a/Pine/Agent/Adapters/AdapterProtocols.swift
+++ b/Pine/Agent/Adapters/AdapterProtocols.swift
@@ -37,6 +37,7 @@ nonisolated enum AdapterSessionError: Error, Equatable, Sendable {
     case checkpointUnavailable
     case checkpointAlreadyConsumed
     case contractAlreadyConsumed
+    case cleanupCapacityUnavailable
     case invalidLifecycle
 }
 nonisolated enum AdapterIngestOutcome: Equatable, Sendable {

--- a/Pine/Agent/Adapters/AdapterProtocols.swift
+++ b/Pine/Agent/Adapters/AdapterProtocols.swift
@@ -36,8 +36,9 @@ nonisolated enum AdapterSessionError: Error, Equatable, Sendable {
     case checkpointMismatch
     case checkpointUnavailable
     case checkpointAlreadyConsumed
+    case contractAlreadyConsumed
     case invalidLifecycle
 }
 nonisolated enum AdapterIngestOutcome: Equatable, Sendable {
-    case accepted, bufferedUntilActivation, droppedInvalid, revoked
+    case accepted, bufferedUntilActivation, retryAfterActivation, droppedInvalid, revoked
 }

--- a/Pine/Agent/Adapters/AdapterValidation.swift
+++ b/Pine/Agent/Adapters/AdapterValidation.swift
@@ -10,6 +10,42 @@ nonisolated struct NegotiatedAdapterContract: Equatable, Sendable {
     let profile: AdapterCapabilityProfile
 }
 
+/// Discovery metadata and authority minted only after a registry-owned factory probe succeeds.
+nonisolated struct AgentAdapterOffer: Sendable, CustomStringConvertible,
+    CustomDebugStringConvertible, CustomReflectable {
+    fileprivate let registryID: UUID
+    fileprivate let agentID: AgentID
+    fileprivate let adapterID: AdapterID
+    fileprivate let factoryID: AdapterFactoryID
+    fileprivate let probeResult: AdapterProbeResult
+
+    var detectedVendorVersion: DetectedVendorVersion { probeResult.detectedVendorVersion }
+    var detectedSchema: DetectedVendorVersion? { probeResult.detectedSchema }
+
+    fileprivate init(
+        registryID: UUID,
+        agentID: AgentID,
+        adapterID: AdapterID,
+        factoryID: AdapterFactoryID,
+        probeResult: AdapterProbeResult
+    ) {
+        self.registryID = registryID
+        self.agentID = agentID
+        self.adapterID = adapterID
+        self.factoryID = factoryID
+        self.probeResult = probeResult
+    }
+
+    var description: String { "<redacted:agent-adapter-offer>" }
+    var debugDescription: String { description }
+    var customMirror: Mirror {
+        Mirror(self, children: [
+            "detectedVendorVersion": detectedVendorVersion.description,
+            "detectedSchema": detectedSchema?.description as Any
+        ])
+    }
+}
+
 /// A registry-minted request. Factories can consume, but cannot construct, session authority.
 nonisolated struct AgentAdapterSessionRequest: Sendable {
     let contract: NegotiatedAdapterContract
@@ -125,6 +161,7 @@ private actor SourceSessionState {
     private var latestAcceptedPosition: AdapterSourcePosition?
     private var checkpointedSequence: UInt64?
     private var pendingCandidates: [AdapterCandidate] = []
+    private var activationRemaining = 0
     private var inFlightCount = 0
     private let pendingLimit = AgentAdapterRegistry.startBufferLimit
 
@@ -143,10 +180,17 @@ private actor SourceSessionState {
     }
 
     func admit(_ candidate: AdapterCandidate) -> SourceAdmission {
-        guard canAcceptPayload() else { return .rejected(.revoked) }
-        let isBuffering = lifecycle == .starting || lifecycle == .flushing
-        if isBuffering, pendingCandidates.count >= pendingLimit {
+        switch lifecycle {
+        case .ready, .retired:
+            return .rejected(.revoked)
+        case .flushing:
             return .rejected(.droppedInvalid)
+        case .starting:
+            guard pendingCandidates.count < pendingLimit else {
+                return .rejected(.droppedInvalid)
+            }
+        case .active:
+            break
         }
         if let sequence = candidate.sourcePosition?.sourceSequence {
             guard sequence > highestAdmittedSequence else {
@@ -154,7 +198,7 @@ private actor SourceSessionState {
             }
             highestAdmittedSequence = sequence
         }
-        if isBuffering {
+        if lifecycle == .starting {
             pendingCandidates.append(candidate)
             return .buffered
         }
@@ -167,18 +211,26 @@ private actor SourceSessionState {
         guard !Task.isCancelled else {
             lifecycle = .retired
             pendingCandidates.removeAll(keepingCapacity: false)
+            activationRemaining = 0
             return .cancelled
         }
+        activationRemaining = pendingCandidates.count
         lifecycle = .flushing
         return .committed
     }
 
     func nextBuffered() -> AdapterCandidate? {
         guard lifecycle == .flushing else { return nil }
-        guard !pendingCandidates.isEmpty else {
+        guard activationRemaining > 0 else {
             lifecycle = .active
             return nil
         }
+        guard !pendingCandidates.isEmpty else {
+            activationRemaining = 0
+            lifecycle = .retired
+            return nil
+        }
+        activationRemaining -= 1
         inFlightCount += 1
         return pendingCandidates.removeFirst()
     }
@@ -193,6 +245,7 @@ private actor SourceSessionState {
         if outcome == .revoked {
             lifecycle = .retired
             pendingCandidates.removeAll(keepingCapacity: false)
+            activationRemaining = 0
             return .revoked
         }
         if outcome == .accepted, let position = candidate.sourcePosition,
@@ -217,6 +270,7 @@ private actor SourceSessionState {
     func revoke() {
         lifecycle = .retired
         pendingCandidates.removeAll(keepingCapacity: false)
+        activationRemaining = 0
     }
 }
 
@@ -325,7 +379,7 @@ nonisolated enum AdapterRegistrationError: Error, Equatable, Sendable {
 }
 
 nonisolated enum AdapterNegotiationError: Error, Equatable, Sendable {
-    case unknownAdapter, invalidPolicyRange, noCommonVersion, noCommonProfile, offeredProfileExceedsMaximum
+    case offerMismatch, invalidPolicyRange, noCommonVersion, noCommonProfile, offeredProfileExceedsMaximum
 }
 
 nonisolated struct AdapterNegotiationPolicy: Sendable {
@@ -467,19 +521,36 @@ nonisolated struct AgentAdapterRegistry: Sendable {
         )
     }
 
+    func probe(adapterID: AdapterID) async throws -> AgentAdapterOffer {
+        guard let pair = adapters[adapterID] else { throw AdapterProbeError.unknownAdapter }
+        let result = try await pair.1.probe()
+        return AgentAdapterOffer(
+            registryID: registryID,
+            agentID: pair.0.agentID,
+            adapterID: pair.0.adapterID,
+            factoryID: pair.0.factoryID,
+            probeResult: result
+        )
+    }
+
     func negotiate(
-        adapterID: AdapterID,
-        offeredProfiles: [AdapterCapabilityProfile],
-        offeredVersions: PineAdapterContractVersionRange,
+        offer: AgentAdapterOffer,
         policy: AdapterNegotiationPolicy
     ) throws -> NegotiatedAdapterContract {
-        guard let pair = adapters[adapterID] else { throw AdapterNegotiationError.unknownAdapter }
-        guard policy.allowedVersions.isValid, offeredVersions.isValid else { throw AdapterNegotiationError.invalidPolicyRange }
+        guard offer.registryID == registryID,
+              let pair = adapters[offer.adapterID],
+              pair.0.agentID == offer.agentID,
+              pair.0.adapterID == offer.adapterID,
+              pair.0.factoryID == offer.factoryID else {
+            throw AdapterNegotiationError.offerMismatch
+        }
+        guard policy.allowedVersions.isValid else { throw AdapterNegotiationError.invalidPolicyRange }
         guard !policy.transportPreference.isEmpty,
-              Set(policy.transportPreference).count == policy.transportPreference.count,
-              offeredProfiles.count <= 16, Set(offeredProfiles).count == offeredProfiles.count else {
+              Set(policy.transportPreference).count == policy.transportPreference.count else {
             throw AdapterNegotiationError.invalidPolicyRange
         }
+        let offeredProfiles = offer.probeResult.offeredProfiles
+        let offeredVersions = offer.probeResult.offeredContractVersions
         let lower = max(max(pair.0.contractVersions.minimum, offeredVersions.minimum), policy.allowedVersions.minimum)
         let upper = min(min(pair.0.contractVersions.maximum, offeredVersions.maximum), policy.allowedVersions.maximum)
         guard lower <= upper else { throw AdapterNegotiationError.noCommonVersion }
@@ -493,7 +564,7 @@ nonisolated struct AgentAdapterRegistry: Sendable {
         }.first
         guard let selected else { throw AdapterNegotiationError.noCommonProfile }
         return NegotiatedAdapterContract(
-            registryID: registryID, agentID: pair.0.agentID, adapterID: adapterID, factoryID: pair.0.factoryID,
+            registryID: registryID, agentID: pair.0.agentID, adapterID: offer.adapterID, factoryID: pair.0.factoryID,
             version: upper, profile: selected
         )
     }

--- a/Pine/Agent/Adapters/AdapterValidation.swift
+++ b/Pine/Agent/Adapters/AdapterValidation.swift
@@ -779,6 +779,15 @@ private actor AdapterCleanupSupervisor {
 
 nonisolated private final class CoreBoundSessionLifetime: Sendable {
     nonisolated static let cleanupGrace = Duration.seconds(5)
+
+    nonisolated private struct CleanupContext: Sendable {
+        let state: SourceSessionState
+        let underlying: any AgentAdapterSession
+        let cleanupPermit: AdapterCleanupPermit
+        let confirmedCleanup: BoundedAdapterStop
+        let deadlineSleeper: AdapterDeadlineSleeper
+    }
+
     let state: SourceSessionState
     let underlying: any AgentAdapterSession
     let cleanupPermit: AdapterCleanupPermit
@@ -799,11 +808,7 @@ nonisolated private final class CoreBoundSessionLifetime: Sendable {
 
     func requestStop(deadline: ContinuousClock.Instant) async -> BoundedAdapterStop {
         await Self.prepareStop(
-            state: state,
-            underlying: underlying,
-            cleanupPermit: cleanupPermit,
-            confirmedCleanup: confirmedCleanup,
-            deadlineSleeper: deadlineSleeper,
+            context: cleanupContext,
             deadline: deadline
         )
     }
@@ -832,58 +837,55 @@ nonisolated private final class CoreBoundSessionLifetime: Sendable {
         let confirmedCleanup = confirmedCleanup
         let deadlineSleeper = deadlineSleeper
         let deadline = ContinuousClock.now.advanced(by: Self.cleanupGrace)
+        let context = CleanupContext(
+            state: state,
+            underlying: underlying,
+            cleanupPermit: cleanupPermit,
+            confirmedCleanup: confirmedCleanup,
+            deadlineSleeper: deadlineSleeper
+        )
         Task.detached {
             await CoreBoundSessionLifetime.performStop(
-                state: state,
-                underlying: underlying,
-                cleanupPermit: cleanupPermit,
-                confirmedCleanup: confirmedCleanup,
-                deadlineSleeper: deadlineSleeper,
+                context: context,
                 deadline: deadline
             )
         }
     }
 
-    nonisolated private static func performStop(
-        state: SourceSessionState,
-        underlying: any AgentAdapterSession,
-        cleanupPermit: AdapterCleanupPermit,
-        confirmedCleanup: BoundedAdapterStop,
-        deadlineSleeper: AdapterDeadlineSleeper,
-        deadline: ContinuousClock.Instant
-    ) async {
-        let sharedCompletion = await prepareStop(
+    private var cleanupContext: CleanupContext {
+        CleanupContext(
             state: state,
             underlying: underlying,
             cleanupPermit: cleanupPermit,
             confirmedCleanup: confirmedCleanup,
-            deadlineSleeper: deadlineSleeper,
+            deadlineSleeper: deadlineSleeper
+        )
+    }
+
+    nonisolated private static func performStop(
+        context: CleanupContext,
+        deadline: ContinuousClock.Instant
+    ) async {
+        let sharedCompletion = await prepareStop(
+            context: context,
             deadline: deadline
         )
         await waitForSharedCleanup(
             sharedCompletion,
-            deadlineSleeper: deadlineSleeper,
+            deadlineSleeper: context.deadlineSleeper,
             deadline: deadline
         )
     }
 
     nonisolated private static func prepareStop(
-        state: SourceSessionState,
-        underlying: any AgentAdapterSession,
-        cleanupPermit: AdapterCleanupPermit,
-        confirmedCleanup: BoundedAdapterStop,
-        deadlineSleeper: AdapterDeadlineSleeper,
+        context: CleanupContext,
         deadline: ContinuousClock.Instant
     ) async -> BoundedAdapterStop {
-        let directive = await state.beginStop()
+        let directive = await context.state.beginStop()
         switch directive {
         case .start(let completion):
             startSharedCleanup(
-                state: state,
-                underlying: underlying,
-                cleanupPermit: cleanupPermit,
-                confirmedCleanup: confirmedCleanup,
-                deadlineSleeper: deadlineSleeper,
+                context: context,
                 completion: completion,
                 deadline: deadline
             )
@@ -894,11 +896,7 @@ nonisolated private final class CoreBoundSessionLifetime: Sendable {
     }
 
     nonisolated private static func startSharedCleanup(
-        state: SourceSessionState,
-        underlying: any AgentAdapterSession,
-        cleanupPermit: AdapterCleanupPermit,
-        confirmedCleanup: BoundedAdapterStop,
-        deadlineSleeper: AdapterDeadlineSleeper,
+        context: CleanupContext,
         completion: BoundedAdapterStop,
         deadline: ContinuousClock.Instant
     ) {
@@ -906,11 +904,11 @@ nonisolated private final class CoreBoundSessionLifetime: Sendable {
             let boundedWork = BoundedAdapterStop()
             let countdown = AdapterStopCountdown(
                 remaining: 2,
-                completion: confirmedCleanup
+                completion: context.confirmedCleanup
             )
             let ticket = await AdapterCleanupSupervisor.shared.submit(
-                underlying,
-                permit: cleanupPermit,
+                context.underlying,
+                permit: context.cleanupPermit,
                 deadline: deadline
             )
             let adapterWait = Task.detached {
@@ -918,22 +916,22 @@ nonisolated private final class CoreBoundSessionLifetime: Sendable {
                 await countdown.arrive()
             }
             let drainWait = Task.detached {
-                await state.waitUntilDrained()
+                await context.state.waitUntilDrained()
                 await countdown.arrive()
             }
             let confirmedWait = Task.detached {
-                await confirmedCleanup.wait()
+                await context.confirmedCleanup.wait()
                 await boundedWork.complete()
             }
             let timeout = Task.detached {
-                await deadlineSleeper.sleep(until: deadline)
+                await context.deadlineSleeper.sleep(until: deadline)
                 await boundedWork.complete()
             }
             await boundedWork.wait()
             await AdapterCleanupSupervisor.shared.cancel(ticket)
             confirmedWait.cancel()
             timeout.cancel()
-            await state.revoke()
+            await context.state.revoke()
             await completion.complete()
             _ = (adapterWait, drainWait)
         }

--- a/Pine/Agent/Adapters/AdapterValidation.swift
+++ b/Pine/Agent/Adapters/AdapterValidation.swift
@@ -329,6 +329,7 @@ private actor SourceSessionState {
     private var highestAdmittedSequence: UInt64
     private var latestAcceptedPosition: AdapterSourcePosition?
     private var checkpointedSequence: UInt64?
+    private var pendingCheckpointPosition: AdapterSourcePosition?
     private var pendingCandidates: [AdapterCandidate] = []
     private var activationRemaining = 0
     private var inFlightCount = 0
@@ -448,14 +449,22 @@ private actor SourceSessionState {
     }
 
     func checkpointPosition() -> AdapterSourcePosition? {
+        if let pendingCheckpointPosition { return pendingCheckpointPosition }
         guard lifecycle == .active, inFlightCount == 0,
               pendingCandidates.isEmpty,
               let position = latestAcceptedPosition,
               let sequence = position.sourceSequence,
               sequence > (checkpointedSequence ?? 0) else { return nil }
         checkpointedSequence = sequence
+        pendingCheckpointPosition = position
         lifecycle = .retired
         return position
+    }
+
+    func finalizeCheckpoint() -> Bool {
+        guard pendingCheckpointPosition != nil else { return false }
+        pendingCheckpointPosition = nil
+        return true
     }
 
     func failStart() {
@@ -574,6 +583,8 @@ private actor BoundedAdapterStop {
     private var completed = false
     private var waiters: [UUID: AsyncContinuationGate] = [:]
 
+    var isCompleted: Bool { completed }
+
     func wait() async {
         guard !completed, !Task.isCancelled else { return }
         let waiterID = UUID()
@@ -589,6 +600,41 @@ private actor BoundedAdapterStop {
         let retained = Array(waiters.values)
         waiters.removeAll(keepingCapacity: false)
         retained.forEach { $0.resolve() }
+    }
+}
+
+nonisolated struct AdapterDeadlineSleeper: Sendable {
+    nonisolated static let live = AdapterDeadlineSleeper { deadline in
+        try? await ContinuousClock().sleep(until: deadline)
+    }
+
+    private let operation: @Sendable (ContinuousClock.Instant) async -> Void
+
+    init(operation: @escaping @Sendable (ContinuousClock.Instant) async -> Void) {
+        self.operation = operation
+    }
+
+    func sleep(until deadline: ContinuousClock.Instant) async {
+        await operation(deadline)
+    }
+}
+
+nonisolated private final class AsyncBooleanDecision: Sendable {
+    private let value = Mutex<Bool?>(nil)
+    private let completion = AsyncContinuationGate()
+
+    func resolve(_ proposed: Bool) {
+        let accepted = value.withLock {
+            guard $0 == nil else { return false }
+            $0 = proposed
+            return true
+        }
+        if accepted { completion.resolve() }
+    }
+
+    func wait() async -> Bool {
+        await completion.wait()
+        return value.withLock { $0 ?? false }
     }
 }
 
@@ -732,26 +778,49 @@ private actor AdapterCleanupSupervisor {
 }
 
 nonisolated private final class CoreBoundSessionLifetime: Sendable {
-    nonisolated private static let abandonmentGrace = Duration.seconds(5)
+    nonisolated static let cleanupGrace = Duration.seconds(5)
     let state: SourceSessionState
     let underlying: any AgentAdapterSession
     let cleanupPermit: AdapterCleanupPermit
+    private let deadlineSleeper: AdapterDeadlineSleeper
+    private let confirmedCleanup = BoundedAdapterStop()
 
     init(
         state: SourceSessionState,
         underlying: any AgentAdapterSession,
-        cleanupPermit: AdapterCleanupPermit
+        cleanupPermit: AdapterCleanupPermit,
+        deadlineSleeper: AdapterDeadlineSleeper
     ) {
         self.state = state
         self.underlying = underlying
         self.cleanupPermit = cleanupPermit
+        self.deadlineSleeper = deadlineSleeper
     }
 
-    func stop(deadline: ContinuousClock.Instant) async {
-        await Self.performStop(
+    func requestStop(deadline: ContinuousClock.Instant) async -> BoundedAdapterStop {
+        await Self.prepareStop(
             state: state,
             underlying: underlying,
             cleanupPermit: cleanupPermit,
+            confirmedCleanup: confirmedCleanup,
+            deadlineSleeper: deadlineSleeper,
+            deadline: deadline
+        )
+    }
+
+    func stop(deadline: ContinuousClock.Instant) async {
+        let sharedCompletion = await requestStop(deadline: deadline)
+        await Self.waitForSharedCleanup(
+            sharedCompletion,
+            deadlineSleeper: deadlineSleeper,
+            deadline: deadline
+        )
+    }
+
+    func waitForConfirmedCleanup(until deadline: ContinuousClock.Instant) async -> Bool {
+        await Self.waitForConfirmation(
+            confirmedCleanup,
+            deadlineSleeper: deadlineSleeper,
             deadline: deadline
         )
     }
@@ -760,12 +829,16 @@ nonisolated private final class CoreBoundSessionLifetime: Sendable {
         let state = state
         let underlying = underlying
         let cleanupPermit = cleanupPermit
-        let deadline = ContinuousClock.now.advanced(by: Self.abandonmentGrace)
+        let confirmedCleanup = confirmedCleanup
+        let deadlineSleeper = deadlineSleeper
+        let deadline = ContinuousClock.now.advanced(by: Self.cleanupGrace)
         Task.detached {
             await CoreBoundSessionLifetime.performStop(
                 state: state,
                 underlying: underlying,
                 cleanupPermit: cleanupPermit,
+                confirmedCleanup: confirmedCleanup,
+                deadlineSleeper: deadlineSleeper,
                 deadline: deadline
             )
         }
@@ -775,30 +848,57 @@ nonisolated private final class CoreBoundSessionLifetime: Sendable {
         state: SourceSessionState,
         underlying: any AgentAdapterSession,
         cleanupPermit: AdapterCleanupPermit,
+        confirmedCleanup: BoundedAdapterStop,
+        deadlineSleeper: AdapterDeadlineSleeper,
         deadline: ContinuousClock.Instant
     ) async {
+        let sharedCompletion = await prepareStop(
+            state: state,
+            underlying: underlying,
+            cleanupPermit: cleanupPermit,
+            confirmedCleanup: confirmedCleanup,
+            deadlineSleeper: deadlineSleeper,
+            deadline: deadline
+        )
+        await waitForSharedCleanup(
+            sharedCompletion,
+            deadlineSleeper: deadlineSleeper,
+            deadline: deadline
+        )
+    }
+
+    nonisolated private static func prepareStop(
+        state: SourceSessionState,
+        underlying: any AgentAdapterSession,
+        cleanupPermit: AdapterCleanupPermit,
+        confirmedCleanup: BoundedAdapterStop,
+        deadlineSleeper: AdapterDeadlineSleeper,
+        deadline: ContinuousClock.Instant
+    ) async -> BoundedAdapterStop {
         let directive = await state.beginStop()
-        let sharedCompletion: BoundedAdapterStop
         switch directive {
         case .start(let completion):
-            sharedCompletion = completion
             startSharedCleanup(
                 state: state,
                 underlying: underlying,
                 cleanupPermit: cleanupPermit,
+                confirmedCleanup: confirmedCleanup,
+                deadlineSleeper: deadlineSleeper,
                 completion: completion,
                 deadline: deadline
             )
+            return completion
         case .wait(let completion):
-            sharedCompletion = completion
+            return completion
         }
-        await waitForSharedCleanup(sharedCompletion, deadline: deadline)
     }
 
     nonisolated private static func startSharedCleanup(
         state: SourceSessionState,
         underlying: any AgentAdapterSession,
         cleanupPermit: AdapterCleanupPermit,
+        confirmedCleanup: BoundedAdapterStop,
+        deadlineSleeper: AdapterDeadlineSleeper,
         completion: BoundedAdapterStop,
         deadline: ContinuousClock.Instant
     ) {
@@ -806,7 +906,7 @@ nonisolated private final class CoreBoundSessionLifetime: Sendable {
             let boundedWork = BoundedAdapterStop()
             let countdown = AdapterStopCountdown(
                 remaining: 2,
-                completion: boundedWork
+                completion: confirmedCleanup
             )
             let ticket = await AdapterCleanupSupervisor.shared.submit(
                 underlying,
@@ -821,26 +921,27 @@ nonisolated private final class CoreBoundSessionLifetime: Sendable {
                 await state.waitUntilDrained()
                 await countdown.arrive()
             }
+            let confirmedWait = Task.detached {
+                await confirmedCleanup.wait()
+                await boundedWork.complete()
+            }
             let timeout = Task.detached {
-                do {
-                    try await ContinuousClock().sleep(until: deadline)
-                } catch {
-                    // Cancellation means cleanup completed before the deadline.
-                }
+                await deadlineSleeper.sleep(until: deadline)
                 await boundedWork.complete()
             }
             await boundedWork.wait()
             await AdapterCleanupSupervisor.shared.cancel(ticket)
-            adapterWait.cancel()
-            drainWait.cancel()
+            confirmedWait.cancel()
             timeout.cancel()
             await state.revoke()
             await completion.complete()
+            _ = (adapterWait, drainWait)
         }
     }
 
     nonisolated private static func waitForSharedCleanup(
         _ sharedCompletion: BoundedAdapterStop,
+        deadlineSleeper: AdapterDeadlineSleeper,
         deadline: ContinuousClock.Instant
     ) async {
         let localCompletion = BoundedAdapterStop()
@@ -849,16 +950,33 @@ nonisolated private final class CoreBoundSessionLifetime: Sendable {
             await localCompletion.complete()
         }
         let timeout = Task.detached {
-            do {
-                try await ContinuousClock().sleep(until: deadline)
-            } catch {
-                // Cancellation means shared cleanup completed first.
-            }
+            await deadlineSleeper.sleep(until: deadline)
             await localCompletion.complete()
         }
         await localCompletion.wait()
         sharedWait.cancel()
         timeout.cancel()
+    }
+
+    nonisolated private static func waitForConfirmation(
+        _ confirmation: BoundedAdapterStop,
+        deadlineSleeper: AdapterDeadlineSleeper,
+        deadline: ContinuousClock.Instant
+    ) async -> Bool {
+        if await confirmation.isCompleted { return true }
+        let decision = AsyncBooleanDecision()
+        let confirmationWait = Task.detached {
+            await confirmation.wait()
+            decision.resolve(true)
+        }
+        let timeout = Task.detached {
+            await deadlineSleeper.sleep(until: deadline)
+            decision.resolve(false)
+        }
+        let result = await decision.wait()
+        confirmationWait.cancel()
+        timeout.cancel()
+        return result
     }
 }
 
@@ -920,11 +1038,13 @@ nonisolated struct AgentAdapterRegistry: Sendable {
     private let adapters: [AdapterID: (AdapterDescriptor, any AgentAdapterFactory)]
     private let registryID: UUID
     private let cleanupCapacity: AdapterCleanupCapacity
+    private let deadlineSleeper: AdapterDeadlineSleeper
 
     init(
         compiledPresentations: [AgentPresentationDescriptor],
         compiledAdapters: [(AdapterDescriptor, any AgentAdapterFactory)],
-        cleanupCapacity: AdapterCleanupCapacity = .shared
+        cleanupCapacity: AdapterCleanupCapacity = .shared,
+        deadlineSleeper: AdapterDeadlineSleeper = .live
     ) throws {
         guard compiledPresentations.count <= 128, compiledAdapters.count <= 128 else {
             throw AdapterRegistrationError.tooManyEntries
@@ -964,6 +1084,7 @@ nonisolated struct AgentAdapterRegistry: Sendable {
         adapters = adapterMap
         registryID = UUID()
         self.cleanupCapacity = cleanupCapacity
+        self.deadlineSleeper = deadlineSleeper
     }
 
     private func factory(for contract: NegotiatedAdapterContract) throws -> any AgentAdapterFactory {
@@ -1019,18 +1140,21 @@ nonisolated struct AgentAdapterRegistry: Sendable {
             downstream: downstream
         )
         let request = AgentAdapterSessionRequest(contract: contract, resumeFrom: checkpoint, sink: sink)
+        var guardedLifetime: CoreBoundSessionLifetime?
         do {
             try Task.checkCancellation()
             let session = try await resolved.makeSession(request)
+            let lifetime = CoreBoundSessionLifetime(
+                state: state,
+                underlying: session,
+                cleanupPermit: cleanupPermit,
+                deadlineSleeper: deadlineSleeper
+            )
+            guardedLifetime = lifetime
             try Task.checkCancellation()
             guard session.contract == contract else {
                 throw AdapterSessionError.contractMismatch
             }
-            let lifetime = CoreBoundSessionLifetime(
-                state: state,
-                underlying: session,
-                cleanupPermit: cleanupPermit
-            )
             return CoreBoundAdapterSession(
                 contract: contract,
                 registryID: registryID,
@@ -1042,6 +1166,11 @@ nonisolated struct AgentAdapterRegistry: Sendable {
             )
         } catch {
             await state.failStart()
+            if let guardedLifetime {
+                _ = await guardedLifetime.requestStop(
+                    deadline: ContinuousClock.now.advanced(by: CoreBoundSessionLifetime.cleanupGrace)
+                )
+            }
             throw error
         }
     }
@@ -1056,6 +1185,15 @@ nonisolated struct AgentAdapterRegistry: Sendable {
               let resumePosition = position.resumePosition,
               let lastSourceEvent = position.sourceEvent,
               let lastSourceSequence = position.sourceSequence else {
+            throw AdapterSessionError.checkpointUnavailable
+        }
+        try Task.checkCancellation()
+        let deadline = ContinuousClock.now.advanced(by: CoreBoundSessionLifetime.cleanupGrace)
+        _ = await source.lifetime.requestStop(deadline: deadline)
+        let cleanupConfirmed = await source.lifetime.waitForConfirmedCleanup(until: deadline)
+        try Task.checkCancellation()
+        guard cleanupConfirmed,
+              await source.state.finalizeCheckpoint() else {
             throw AdapterSessionError.checkpointUnavailable
         }
         return AdapterResumeCheckpoint(

--- a/Pine/Agent/Adapters/AdapterValidation.swift
+++ b/Pine/Agent/Adapters/AdapterValidation.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import Synchronization
 
 nonisolated struct NegotiatedAdapterContract: Equatable, Sendable {
     fileprivate let registryID: UUID
@@ -170,30 +171,41 @@ nonisolated struct AdapterResumeCheckpoint: Sendable, CustomStringConvertible,
 }
 
 // swiftlint:disable:next private_over_fileprivate
-fileprivate actor OneShotAuthorityGate {
+nonisolated fileprivate final class OneShotAuthorityGate: Sendable {
     private enum State: Equatable { case available, reserved(UUID), consumed }
-    private var state = State.available
+    private let state = Mutex(State.available)
 
     func consume() -> Bool {
-        guard state == .available else { return false }
-        state = .consumed
-        return true
+        state.withLock {
+            guard $0 == .available else { return false }
+            $0 = .consumed
+            return true
+        }
     }
 
     func reserve(_ reservationID: UUID) -> Bool {
-        guard state == .available else { return false }
-        state = .reserved(reservationID)
-        return true
+        state.withLock {
+            guard $0 == .available else { return false }
+            $0 = .reserved(reservationID)
+            return true
+        }
     }
 
-    func commit(_ reservationID: UUID) {
-        guard state == .reserved(reservationID) else { return }
-        state = .consumed
+    func commit(_ reservationID: UUID) -> Bool {
+        state.withLock {
+            guard $0 == .reserved(reservationID) else { return false }
+            $0 = .consumed
+            return true
+        }
     }
 
-    func rollback(_ reservationID: UUID) {
-        guard state == .reserved(reservationID) else { return }
-        state = .available
+    @discardableResult
+    func rollback(_ reservationID: UUID) -> Bool {
+        state.withLock {
+            guard $0 == .reserved(reservationID) else { return false }
+            $0 = .available
+            return true
+        }
     }
 }
 
@@ -206,20 +218,30 @@ nonisolated private final class OneShotAuthorityReservation: Sendable {
         self.reservationID = reservationID
     }
 
-    func commit() async {
-        await gate.commit(reservationID)
+    @discardableResult
+    func commit() -> Bool {
+        gate.commit(reservationID)
     }
 
-    func rollback() async {
-        await gate.rollback(reservationID)
+    @discardableResult
+    func rollback() -> Bool {
+        gate.rollback(reservationID)
     }
 
     deinit {
-        let gate = gate
-        let reservationID = reservationID
-        Task.detached {
-            await gate.rollback(reservationID)
-        }
+        gate.rollback(reservationID)
+    }
+}
+
+nonisolated private final class OneShotAuthorityLease: Sendable {
+    private let reservation: OneShotAuthorityReservation
+
+    init(reservation: OneShotAuthorityReservation) {
+        self.reservation = reservation
+    }
+
+    deinit {
+        reservation.rollback()
     }
 }
 
@@ -233,6 +255,11 @@ nonisolated private enum SourceActivationResult: Equatable, Sendable {
     case committed, cancelled, rejected
 }
 
+nonisolated private enum SourceStopDirective: Sendable {
+    case start(BoundedAdapterStop)
+    case wait(BoundedAdapterStop)
+}
+
 private actor SourceSessionState {
     private enum Lifecycle { case ready, starting, flushing, active, closing, retired }
     private var lifecycle = Lifecycle.ready
@@ -242,11 +269,16 @@ private actor SourceSessionState {
     private var pendingCandidates: [AdapterCandidate] = []
     private var activationRemaining = 0
     private var inFlightCount = 0
-    private let drainCompletion = BoundedAdapterStop()
+    private var drainWaiters: [UUID: CheckedContinuation<Void, Never>] = [:]
+    private var cancelledDrainWaiters = Set<UUID>()
+    private var resolvedDrainWaiters = Set<UUID>()
+    private var stopCompletion: BoundedAdapterStop?
+    private let authority: OneShotAuthorityReservation
     private let pendingLimit = AgentAdapterRegistry.startBufferLimit
 
-    init(baseline: UInt64) {
+    init(baseline: UInt64, authority: OneShotAuthorityReservation) {
         highestAdmittedSequence = baseline
+        self.authority = authority
     }
 
     func beginStart() -> Bool {
@@ -292,7 +324,14 @@ private actor SourceSessionState {
             lifecycle = .retired
             pendingCandidates.removeAll(keepingCapacity: false)
             activationRemaining = 0
+            authority.rollback()
             return .cancelled
+        }
+        guard authority.commit() else {
+            lifecycle = .retired
+            pendingCandidates.removeAll(keepingCapacity: false)
+            activationRemaining = 0
+            return .rejected
         }
         activationRemaining = pendingCandidates.count
         lifecycle = .flushing
@@ -315,13 +354,23 @@ private actor SourceSessionState {
         return pendingCandidates.removeFirst()
     }
 
+    func finishActivation() -> SourceActivationResult {
+        if Task.isCancelled {
+            lifecycle = .retired
+            pendingCandidates.removeAll(keepingCapacity: false)
+            activationRemaining = 0
+            return .cancelled
+        }
+        return lifecycle == .active ? .committed : .rejected
+    }
+
     func complete(
         _ candidate: AdapterCandidate,
         outcome: AdapterIngestOutcome
-    ) async -> AdapterIngestOutcome {
+    ) -> AdapterIngestOutcome {
         guard inFlightCount > 0 else { return .revoked }
         inFlightCount -= 1
-        if inFlightCount == 0 { await drainCompletion.complete() }
+        resumeDrainWaitersIfNeeded()
         if outcome == .revoked {
             lifecycle = .retired
             pendingCandidates.removeAll(keepingCapacity: false)
@@ -348,26 +397,70 @@ private actor SourceSessionState {
         return position
     }
 
-    func beginStop() async {
-        guard lifecycle != .retired else {
-            await drainCompletion.complete()
-            return
+    func failStart() {
+        if lifecycle == .ready || lifecycle == .starting {
+            authority.rollback()
         }
-        lifecycle = .closing
-        pendingCandidates.removeAll(keepingCapacity: false)
-        activationRemaining = 0
-        if inFlightCount == 0 { await drainCompletion.complete() }
-    }
-
-    func waitUntilDrained() async {
-        await drainCompletion.wait()
-    }
-
-    func revoke() async {
         lifecycle = .retired
         pendingCandidates.removeAll(keepingCapacity: false)
         activationRemaining = 0
-        await drainCompletion.complete()
+        resumeDrainWaitersIfNeeded()
+    }
+
+    func beginStop() -> SourceStopDirective {
+        if let stopCompletion { return .wait(stopCompletion) }
+        let completion = BoundedAdapterStop()
+        stopCompletion = completion
+        if lifecycle == .ready || lifecycle == .starting {
+            authority.rollback()
+        }
+        if lifecycle != .retired { lifecycle = .closing }
+        pendingCandidates.removeAll(keepingCapacity: false)
+        activationRemaining = 0
+        resumeDrainWaitersIfNeeded()
+        return .start(completion)
+    }
+
+    func waitUntilDrained() async {
+        guard inFlightCount > 0, !Task.isCancelled else { return }
+        let waiterID = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if inFlightCount == 0 || Task.isCancelled
+                    || cancelledDrainWaiters.remove(waiterID) != nil {
+                    resolvedDrainWaiters.insert(waiterID)
+                    continuation.resume()
+                } else {
+                    drainWaiters[waiterID] = continuation
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelDrainWaiter(waiterID) }
+        }
+    }
+
+    func revoke() {
+        lifecycle = .retired
+        pendingCandidates.removeAll(keepingCapacity: false)
+        activationRemaining = 0
+        resumeDrainWaitersIfNeeded()
+    }
+
+    private func resumeDrainWaitersIfNeeded() {
+        guard inFlightCount == 0 else { return }
+        let retained = drainWaiters
+        drainWaiters.removeAll(keepingCapacity: false)
+        resolvedDrainWaiters.formUnion(retained.keys)
+        retained.values.forEach { $0.resume() }
+    }
+
+    private func cancelDrainWaiter(_ waiterID: UUID) {
+        if let waiter = drainWaiters.removeValue(forKey: waiterID) {
+            resolvedDrainWaiters.insert(waiterID)
+            waiter.resume()
+        } else if resolvedDrainWaiters.remove(waiterID) == nil {
+            cancelledDrainWaiters.insert(waiterID)
+        }
     }
 }
 
@@ -421,8 +514,7 @@ private actor ValidatingAgentEventSink: AgentEventSink {
                 break
             }
         }
-        if Task.isCancelled { await state.revoke() }
-        return .committed
+        return await state.finishActivation()
     }
 
     private func deliver(_ candidate: AdapterCandidate) async -> AdapterIngestOutcome {
@@ -438,25 +530,44 @@ private actor ValidatingAgentEventSink: AgentEventSink {
 
 private actor BoundedAdapterStop {
     private var completed = false
-    private var waiter: CheckedContinuation<Void, Never>?
+    private var waiters: [UUID: CheckedContinuation<Void, Never>] = [:]
+    private var cancelledBeforeRegistration = Set<UUID>()
+    private var resolvedBeforeCancellation = Set<UUID>()
 
     func wait() async {
-        guard !completed else { return }
-        await withCheckedContinuation { continuation in
-            if completed {
-                continuation.resume()
-            } else {
-                waiter = continuation
+        guard !completed, !Task.isCancelled else { return }
+        let waiterID = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if completed || Task.isCancelled
+                    || cancelledBeforeRegistration.remove(waiterID) != nil {
+                    resolvedBeforeCancellation.insert(waiterID)
+                    continuation.resume()
+                } else {
+                    waiters[waiterID] = continuation
+                }
             }
+        } onCancel: {
+            Task { await self.cancel(waiterID) }
         }
     }
 
     func complete() {
         guard !completed else { return }
         completed = true
-        let retained = waiter
-        waiter = nil
-        retained?.resume()
+        let retained = waiters
+        waiters.removeAll(keepingCapacity: false)
+        resolvedBeforeCancellation.formUnion(retained.keys)
+        retained.values.forEach { $0.resume() }
+    }
+
+    private func cancel(_ waiterID: UUID) {
+        if let waiter = waiters.removeValue(forKey: waiterID) {
+            resolvedBeforeCancellation.insert(waiterID)
+            waiter.resume()
+        } else if resolvedBeforeCancellation.remove(waiterID) == nil {
+            cancelledBeforeRegistration.insert(waiterID)
+        }
     }
 }
 
@@ -468,51 +579,89 @@ nonisolated private struct CoreBoundAdapterSession: AgentAdapterSession {
     let state: SourceSessionState
     let sink: ValidatingAgentEventSink
     let underlying: any AgentAdapterSession
-    let authority: OneShotAuthorityReservation
+    let authorityLease: OneShotAuthorityLease
 
     func start() async throws {
         guard await state.beginStart() else {
             throw AdapterSessionError.invalidLifecycle
         }
         do { try await underlying.start() } catch {
-            await state.revoke()
-            await authority.rollback()
+            await state.failStart()
             throw error
         }
         switch await sink.activate() {
         case .committed:
-            await authority.commit()
+            return
         case .cancelled:
-            await authority.rollback()
             throw CancellationError()
         case .rejected:
-            await authority.rollback()
             throw AdapterSessionError.invalidLifecycle
         }
     }
 
     func stop(deadline: ContinuousClock.Instant) async {
-        await state.beginStop()
-        await authority.rollback()
-        let completion = BoundedAdapterStop()
-        let cleanup = Task.detached {
-            async let adapterStop: Void = underlying.stop(deadline: deadline)
-            async let admittedDeliveries: Void = state.waitUntilDrained()
-            _ = await (adapterStop, admittedDeliveries)
+        let directive = await state.beginStop()
+        let sharedCompletion: BoundedAdapterStop
+        switch directive {
+        case .start(let completion):
+            sharedCompletion = completion
+            startSharedCleanup(completion: completion, deadline: deadline)
+        case .wait(let completion):
+            sharedCompletion = completion
+        }
+        await waitForSharedCleanup(sharedCompletion, deadline: deadline)
+    }
+
+    private func startSharedCleanup(
+        completion: BoundedAdapterStop,
+        deadline: ContinuousClock.Instant
+    ) {
+        let state = state
+        let underlying = underlying
+        Task.detached {
+            let boundedWork = BoundedAdapterStop()
+            let cleanup = Task.detached {
+                async let adapterStop: Void = underlying.stop(deadline: deadline)
+                async let admittedDeliveries: Void = state.waitUntilDrained()
+                _ = await (adapterStop, admittedDeliveries)
+                await boundedWork.complete()
+            }
+            let timeout = Task.detached {
+                do {
+                    try await ContinuousClock().sleep(until: deadline)
+                } catch {
+                    // Cancellation means cleanup completed before the deadline.
+                }
+                await boundedWork.complete()
+            }
+            await boundedWork.wait()
+            cleanup.cancel()
+            timeout.cancel()
+            await state.revoke()
             await completion.complete()
+        }
+    }
+
+    private func waitForSharedCleanup(
+        _ sharedCompletion: BoundedAdapterStop,
+        deadline: ContinuousClock.Instant
+    ) async {
+        let localCompletion = BoundedAdapterStop()
+        let sharedWait = Task.detached {
+            await sharedCompletion.wait()
+            await localCompletion.complete()
         }
         let timeout = Task.detached {
             do {
                 try await ContinuousClock().sleep(until: deadline)
             } catch {
-                // Cancellation means the cleanup completed before the deadline.
+                // Cancellation means shared cleanup completed first.
             }
-            await completion.complete()
+            await localCompletion.complete()
         }
-        await completion.wait()
-        cleanup.cancel()
+        await localCompletion.wait()
+        sharedWait.cancel()
         timeout.cancel()
-        await state.revoke()
     }
 }
 
@@ -610,7 +759,7 @@ nonisolated struct AgentAdapterRegistry: Sendable {
         }
         let authorityGate = checkpoint?.gate ?? contract.freshSessionGate
         let reservationID = UUID()
-        guard await authorityGate.reserve(reservationID) else {
+        guard authorityGate.reserve(reservationID) else {
             if checkpoint != nil { throw AdapterSessionError.checkpointAlreadyConsumed }
             throw AdapterSessionError.contractAlreadyConsumed
         }
@@ -618,9 +767,13 @@ nonisolated struct AgentAdapterRegistry: Sendable {
             gate: authorityGate,
             reservationID: reservationID
         )
+        let authorityLease = OneShotAuthorityLease(reservation: authority)
         let namespace = checkpoint?.namespace ?? SourceNamespace()
         let attempt = SourceAttempt()
-        let state = SourceSessionState(baseline: checkpoint?.lastSourceSequence ?? 0)
+        let state = SourceSessionState(
+            baseline: checkpoint?.lastSourceSequence ?? 0,
+            authority: authority
+        )
         let sink = ValidatingAgentEventSink(
             contract: contract,
             namespace: namespace,
@@ -630,9 +783,10 @@ nonisolated struct AgentAdapterRegistry: Sendable {
         )
         let request = AgentAdapterSessionRequest(contract: contract, resumeFrom: checkpoint, sink: sink)
         do {
+            try Task.checkCancellation()
             let session = try await resolved.makeSession(request)
+            try Task.checkCancellation()
             guard session.contract == contract else {
-                await state.revoke()
                 throw AdapterSessionError.contractMismatch
             }
             return CoreBoundAdapterSession(
@@ -643,11 +797,10 @@ nonisolated struct AgentAdapterRegistry: Sendable {
                 state: state,
                 sink: sink,
                 underlying: session,
-                authority: authority
+                authorityLease: authorityLease
             )
         } catch {
-            await authority.rollback()
-            await state.revoke()
+            await state.failStart()
             throw error
         }
     }
@@ -697,7 +850,7 @@ nonisolated struct AgentAdapterRegistry: Sendable {
               pair.0.factoryID == offer.factoryID else {
             throw AdapterNegotiationError.offerMismatch
         }
-        guard await offer.gate.consume() else {
+        guard offer.gate.consume() else {
             throw AdapterNegotiationError.offerMismatch
         }
         guard policy.allowedVersions.isValid else { throw AdapterNegotiationError.invalidPolicyRange }

--- a/Pine/Agent/Adapters/AdapterValidation.swift
+++ b/Pine/Agent/Adapters/AdapterValidation.swift
@@ -3,11 +3,42 @@ import Foundation
 
 nonisolated struct NegotiatedAdapterContract: Equatable, Sendable {
     fileprivate let registryID: UUID
+    fileprivate let probeGeneration: UUID
+    fileprivate let freshSessionGate: OneShotAuthorityGate
     let agentID: AgentID
     let adapterID: AdapterID
     let factoryID: AdapterFactoryID
     let version: PineAdapterContractVersion
     let profile: AdapterCapabilityProfile
+
+    fileprivate init(
+        registryID: UUID,
+        probeGeneration: UUID,
+        agentID: AgentID,
+        adapterID: AdapterID,
+        factoryID: AdapterFactoryID,
+        version: PineAdapterContractVersion,
+        profile: AdapterCapabilityProfile
+    ) {
+        self.registryID = registryID
+        self.probeGeneration = probeGeneration
+        freshSessionGate = OneShotAuthorityGate()
+        self.agentID = agentID
+        self.adapterID = adapterID
+        self.factoryID = factoryID
+        self.version = version
+        self.profile = profile
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.registryID == rhs.registryID
+            && lhs.probeGeneration == rhs.probeGeneration
+            && lhs.agentID == rhs.agentID
+            && lhs.adapterID == rhs.adapterID
+            && lhs.factoryID == rhs.factoryID
+            && lhs.version == rhs.version
+            && lhs.profile == rhs.profile
+    }
 }
 
 /// Discovery metadata and authority minted only after a registry-owned factory probe succeeds.
@@ -18,6 +49,8 @@ nonisolated struct AgentAdapterOffer: Sendable, CustomStringConvertible,
     fileprivate let adapterID: AdapterID
     fileprivate let factoryID: AdapterFactoryID
     fileprivate let probeResult: AdapterProbeResult
+    fileprivate let probeGeneration: UUID
+    fileprivate let gate: OneShotAuthorityGate
 
     var detectedVendorVersion: DetectedVendorVersion { probeResult.detectedVendorVersion }
     var detectedSchema: DetectedVendorVersion? { probeResult.detectedSchema }
@@ -34,6 +67,8 @@ nonisolated struct AgentAdapterOffer: Sendable, CustomStringConvertible,
         self.adapterID = adapterID
         self.factoryID = factoryID
         self.probeResult = probeResult
+        probeGeneration = UUID()
+        gate = OneShotAuthorityGate()
     }
 
     var description: String { "<redacted:agent-adapter-offer>" }
@@ -107,7 +142,7 @@ nonisolated struct AdapterResumeCheckpoint: Sendable, CustomStringConvertible,
     fileprivate let registryID: UUID
     fileprivate let namespace: SourceNamespace
     fileprivate let sourceContract: NegotiatedAdapterContract
-    fileprivate let gate: CheckpointConsumptionGate
+    fileprivate let gate: OneShotAuthorityGate
     let resumePosition: AdapterResumePosition
     let lastSourceEvent: VendorReference
     let lastSourceSequence: UInt64
@@ -123,7 +158,7 @@ nonisolated struct AdapterResumeCheckpoint: Sendable, CustomStringConvertible,
         self.registryID = registryID
         self.namespace = namespace
         self.sourceContract = sourceContract
-        gate = CheckpointConsumptionGate()
+        gate = OneShotAuthorityGate()
         self.resumePosition = resumePosition
         self.lastSourceEvent = lastSourceEvent
         self.lastSourceSequence = lastSourceSequence
@@ -135,12 +170,56 @@ nonisolated struct AdapterResumeCheckpoint: Sendable, CustomStringConvertible,
 }
 
 // swiftlint:disable:next private_over_fileprivate
-fileprivate actor CheckpointConsumptionGate {
-    private var consumed = false
+fileprivate actor OneShotAuthorityGate {
+    private enum State: Equatable { case available, reserved(UUID), consumed }
+    private var state = State.available
+
     func consume() -> Bool {
-        guard !consumed else { return false }
-        consumed = true
+        guard state == .available else { return false }
+        state = .consumed
         return true
+    }
+
+    func reserve(_ reservationID: UUID) -> Bool {
+        guard state == .available else { return false }
+        state = .reserved(reservationID)
+        return true
+    }
+
+    func commit(_ reservationID: UUID) {
+        guard state == .reserved(reservationID) else { return }
+        state = .consumed
+    }
+
+    func rollback(_ reservationID: UUID) {
+        guard state == .reserved(reservationID) else { return }
+        state = .available
+    }
+}
+
+nonisolated private final class OneShotAuthorityReservation: Sendable {
+    private let gate: OneShotAuthorityGate
+    private let reservationID: UUID
+
+    init(gate: OneShotAuthorityGate, reservationID: UUID) {
+        self.gate = gate
+        self.reservationID = reservationID
+    }
+
+    func commit() async {
+        await gate.commit(reservationID)
+    }
+
+    func rollback() async {
+        await gate.rollback(reservationID)
+    }
+
+    deinit {
+        let gate = gate
+        let reservationID = reservationID
+        Task.detached {
+            await gate.rollback(reservationID)
+        }
     }
 }
 
@@ -155,7 +234,7 @@ nonisolated private enum SourceActivationResult: Equatable, Sendable {
 }
 
 private actor SourceSessionState {
-    private enum Lifecycle { case ready, starting, flushing, active, retired }
+    private enum Lifecycle { case ready, starting, flushing, active, closing, retired }
     private var lifecycle = Lifecycle.ready
     private var highestAdmittedSequence: UInt64
     private var latestAcceptedPosition: AdapterSourcePosition?
@@ -163,6 +242,7 @@ private actor SourceSessionState {
     private var pendingCandidates: [AdapterCandidate] = []
     private var activationRemaining = 0
     private var inFlightCount = 0
+    private let drainCompletion = BoundedAdapterStop()
     private let pendingLimit = AgentAdapterRegistry.startBufferLimit
 
     init(baseline: UInt64) {
@@ -181,13 +261,13 @@ private actor SourceSessionState {
 
     func admit(_ candidate: AdapterCandidate) -> SourceAdmission {
         switch lifecycle {
-        case .ready, .retired:
+        case .ready, .closing, .retired:
             return .rejected(.revoked)
         case .flushing:
-            return .rejected(.droppedInvalid)
+            return .rejected(.retryAfterActivation)
         case .starting:
             guard pendingCandidates.count < pendingLimit else {
-                return .rejected(.droppedInvalid)
+                return .rejected(.retryAfterActivation)
             }
         case .active:
             break
@@ -238,10 +318,10 @@ private actor SourceSessionState {
     func complete(
         _ candidate: AdapterCandidate,
         outcome: AdapterIngestOutcome
-    ) -> AdapterIngestOutcome {
+    ) async -> AdapterIngestOutcome {
         guard inFlightCount > 0 else { return .revoked }
         inFlightCount -= 1
-        guard lifecycle == .active || lifecycle == .flushing else { return .revoked }
+        if inFlightCount == 0 { await drainCompletion.complete() }
         if outcome == .revoked {
             lifecycle = .retired
             pendingCandidates.removeAll(keepingCapacity: false)
@@ -250,6 +330,7 @@ private actor SourceSessionState {
         }
         if outcome == .accepted, let position = candidate.sourcePosition,
            let sequence = position.sourceSequence,
+           lifecycle == .active || lifecycle == .flushing || lifecycle == .closing,
            sequence > (latestAcceptedPosition?.sourceSequence ?? 0) {
             latestAcceptedPosition = position
         }
@@ -267,10 +348,26 @@ private actor SourceSessionState {
         return position
     }
 
-    func revoke() {
+    func beginStop() async {
+        guard lifecycle != .retired else {
+            await drainCompletion.complete()
+            return
+        }
+        lifecycle = .closing
+        pendingCandidates.removeAll(keepingCapacity: false)
+        activationRemaining = 0
+        if inFlightCount == 0 { await drainCompletion.complete() }
+    }
+
+    func waitUntilDrained() async {
+        await drainCompletion.wait()
+    }
+
+    func revoke() async {
         lifecycle = .retired
         pendingCandidates.removeAll(keepingCapacity: false)
         activationRemaining = 0
+        await drainCompletion.complete()
     }
 }
 
@@ -339,6 +436,30 @@ private actor ValidatingAgentEventSink: AgentEventSink {
     }
 }
 
+private actor BoundedAdapterStop {
+    private var completed = false
+    private var waiter: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        guard !completed else { return }
+        await withCheckedContinuation { continuation in
+            if completed {
+                continuation.resume()
+            } else {
+                waiter = continuation
+            }
+        }
+    }
+
+    func complete() {
+        guard !completed else { return }
+        completed = true
+        let retained = waiter
+        waiter = nil
+        retained?.resume()
+    }
+}
+
 nonisolated private struct CoreBoundAdapterSession: AgentAdapterSession {
     let contract: NegotiatedAdapterContract
     let registryID: UUID
@@ -347,6 +468,7 @@ nonisolated private struct CoreBoundAdapterSession: AgentAdapterSession {
     let state: SourceSessionState
     let sink: ValidatingAgentEventSink
     let underlying: any AgentAdapterSession
+    let authority: OneShotAuthorityReservation
 
     func start() async throws {
         guard await state.beginStart() else {
@@ -354,21 +476,43 @@ nonisolated private struct CoreBoundAdapterSession: AgentAdapterSession {
         }
         do { try await underlying.start() } catch {
             await state.revoke()
+            await authority.rollback()
             throw error
         }
         switch await sink.activate() {
         case .committed:
-            break
+            await authority.commit()
         case .cancelled:
+            await authority.rollback()
             throw CancellationError()
         case .rejected:
+            await authority.rollback()
             throw AdapterSessionError.invalidLifecycle
         }
     }
 
     func stop(deadline: ContinuousClock.Instant) async {
+        await state.beginStop()
+        await authority.rollback()
+        let completion = BoundedAdapterStop()
+        let cleanup = Task.detached {
+            async let adapterStop: Void = underlying.stop(deadline: deadline)
+            async let admittedDeliveries: Void = state.waitUntilDrained()
+            _ = await (adapterStop, admittedDeliveries)
+            await completion.complete()
+        }
+        let timeout = Task.detached {
+            do {
+                try await ContinuousClock().sleep(until: deadline)
+            } catch {
+                // Cancellation means the cleanup completed before the deadline.
+            }
+            await completion.complete()
+        }
+        await completion.wait()
+        cleanup.cancel()
+        timeout.cancel()
         await state.revoke()
-        await underlying.stop(deadline: deadline)
     }
 }
 
@@ -463,10 +607,17 @@ nonisolated struct AgentAdapterRegistry: Sendable {
                   checkpoint.sourceContract == contract else {
                 throw AdapterSessionError.checkpointMismatch
             }
-            guard await checkpoint.gate.consume() else {
-                throw AdapterSessionError.checkpointAlreadyConsumed
-            }
         }
+        let authorityGate = checkpoint?.gate ?? contract.freshSessionGate
+        let reservationID = UUID()
+        guard await authorityGate.reserve(reservationID) else {
+            if checkpoint != nil { throw AdapterSessionError.checkpointAlreadyConsumed }
+            throw AdapterSessionError.contractAlreadyConsumed
+        }
+        let authority = OneShotAuthorityReservation(
+            gate: authorityGate,
+            reservationID: reservationID
+        )
         let namespace = checkpoint?.namespace ?? SourceNamespace()
         let attempt = SourceAttempt()
         let state = SourceSessionState(baseline: checkpoint?.lastSourceSequence ?? 0)
@@ -491,9 +642,11 @@ nonisolated struct AgentAdapterRegistry: Sendable {
                 attempt: attempt,
                 state: state,
                 sink: sink,
-                underlying: session
+                underlying: session,
+                authority: authority
             )
         } catch {
+            await authority.rollback()
             await state.revoke()
             throw error
         }
@@ -536,12 +689,15 @@ nonisolated struct AgentAdapterRegistry: Sendable {
     func negotiate(
         offer: AgentAdapterOffer,
         policy: AdapterNegotiationPolicy
-    ) throws -> NegotiatedAdapterContract {
+    ) async throws -> NegotiatedAdapterContract {
         guard offer.registryID == registryID,
               let pair = adapters[offer.adapterID],
               pair.0.agentID == offer.agentID,
               pair.0.adapterID == offer.adapterID,
               pair.0.factoryID == offer.factoryID else {
+            throw AdapterNegotiationError.offerMismatch
+        }
+        guard await offer.gate.consume() else {
             throw AdapterNegotiationError.offerMismatch
         }
         guard policy.allowedVersions.isValid else { throw AdapterNegotiationError.invalidPolicyRange }
@@ -564,7 +720,8 @@ nonisolated struct AgentAdapterRegistry: Sendable {
         }.first
         guard let selected else { throw AdapterNegotiationError.noCommonProfile }
         return NegotiatedAdapterContract(
-            registryID: registryID, agentID: pair.0.agentID, adapterID: offer.adapterID, factoryID: pair.0.factoryID,
+            registryID: registryID, probeGeneration: offer.probeGeneration,
+            agentID: pair.0.agentID, adapterID: offer.adapterID, factoryID: pair.0.factoryID,
             version: upper, profile: selected
         )
     }

--- a/Pine/Agent/Adapters/AdapterValidation.swift
+++ b/Pine/Agent/Adapters/AdapterValidation.swift
@@ -1,0 +1,638 @@
+import CryptoKit
+import Foundation
+
+nonisolated struct NegotiatedAdapterContract: Equatable, Sendable {
+    fileprivate let registryID: UUID
+    let agentID: AgentID
+    let adapterID: AdapterID
+    let factoryID: AdapterFactoryID
+    let version: PineAdapterContractVersion
+    let profile: AdapterCapabilityProfile
+}
+
+/// A registry-minted request. Factories can consume, but cannot construct, session authority.
+nonisolated struct AgentAdapterSessionRequest: Sendable {
+    let contract: NegotiatedAdapterContract
+    let resumeFrom: AdapterResumeCheckpoint?
+    let sink: any AgentEventSink
+
+    fileprivate init(
+        contract: NegotiatedAdapterContract,
+        resumeFrom: AdapterResumeCheckpoint?,
+        sink: any AgentEventSink
+    ) {
+        self.contract = contract
+        self.resumeFrom = resumeFrom
+        self.sink = sink
+    }
+}
+
+// swiftlint:disable:next private_over_fileprivate
+nonisolated fileprivate struct SourceNamespace: Hashable, Sendable, CustomStringConvertible,
+    CustomDebugStringConvertible, CustomReflectable {
+    private let value = UUID()
+    var description: String { "<redacted:source-namespace>" }
+    var debugDescription: String { description }
+    var customMirror: Mirror { Mirror(self, children: ["value": description]) }
+}
+
+// swiftlint:disable:next private_over_fileprivate
+nonisolated fileprivate struct SourceAttempt: Hashable, Sendable, CustomStringConvertible,
+    CustomDebugStringConvertible, CustomReflectable {
+    private let value = UUID()
+    var description: String { "<redacted:source-attempt>" }
+    var debugDescription: String { description }
+    var customMirror: Mirror { Mirror(self, children: ["value": description]) }
+}
+
+/// A core-wrapped event whose source authority cannot be supplied by a producer.
+nonisolated struct ValidatedAgentEvent: Sendable, CustomStringConvertible,
+    CustomDebugStringConvertible, CustomReflectable {
+    let candidate: AdapterCandidate
+    fileprivate let namespace: SourceNamespace
+    fileprivate let attempt: SourceAttempt
+
+    func hasSameLogicalSource(as other: Self) -> Bool { namespace == other.namespace }
+    func hasSameAttempt(as other: Self) -> Bool { attempt == other.attempt }
+    func hasSameLogicalSource(as session: any AgentAdapterSession) -> Bool {
+        (session as? CoreBoundAdapterSession)?.namespace == namespace
+    }
+    func hasSameAttempt(as session: any AgentAdapterSession) -> Bool {
+        (session as? CoreBoundAdapterSession)?.attempt == attempt
+    }
+
+    var description: String { "<redacted:validated-agent-event>" }
+    var debugDescription: String { description }
+    var customMirror: Mirror { Mirror(self, children: ["value": description]) }
+}
+
+nonisolated struct AdapterResumeCheckpoint: Sendable, CustomStringConvertible,
+    CustomDebugStringConvertible, CustomReflectable {
+    fileprivate let registryID: UUID
+    fileprivate let namespace: SourceNamespace
+    fileprivate let sourceContract: NegotiatedAdapterContract
+    fileprivate let gate: CheckpointConsumptionGate
+    let resumePosition: AdapterResumePosition
+    let lastSourceEvent: VendorReference
+    let lastSourceSequence: UInt64
+
+    fileprivate init(
+        registryID: UUID,
+        namespace: SourceNamespace,
+        sourceContract: NegotiatedAdapterContract,
+        resumePosition: AdapterResumePosition,
+        lastSourceEvent: VendorReference,
+        lastSourceSequence: UInt64
+    ) {
+        self.registryID = registryID
+        self.namespace = namespace
+        self.sourceContract = sourceContract
+        gate = CheckpointConsumptionGate()
+        self.resumePosition = resumePosition
+        self.lastSourceEvent = lastSourceEvent
+        self.lastSourceSequence = lastSourceSequence
+    }
+
+    var description: String { "<redacted:resume-checkpoint>" }
+    var debugDescription: String { description }
+    var customMirror: Mirror { Mirror(self, children: ["value": description]) }
+}
+
+// swiftlint:disable:next private_over_fileprivate
+nonisolated fileprivate actor CheckpointConsumptionGate {
+    private var consumed = false
+    func consume() -> Bool {
+        guard !consumed else { return false }
+        consumed = true
+        return true
+    }
+}
+
+nonisolated private enum SourceAdmission: Sendable {
+    case buffered
+    case deliver
+    case rejected(AdapterIngestOutcome)
+}
+
+nonisolated private enum SourceActivationResult: Equatable, Sendable {
+    case committed, cancelled, rejected
+}
+
+nonisolated private actor SourceSessionState {
+    private enum Lifecycle { case ready, starting, flushing, active, retired }
+    private var lifecycle = Lifecycle.ready
+    private var highestAdmittedSequence: UInt64
+    private var latestAcceptedPosition: AdapterSourcePosition?
+    private var checkpointedSequence: UInt64?
+    private var pendingCandidates: [AdapterCandidate] = []
+    private var inFlightCount = 0
+    private let pendingLimit = AgentAdapterRegistry.startBufferLimit
+
+    init(baseline: UInt64) {
+        highestAdmittedSequence = baseline
+    }
+
+    func beginStart() -> Bool {
+        guard lifecycle == .ready else { return false }
+        lifecycle = .starting
+        return true
+    }
+
+    func canAcceptPayload() -> Bool {
+        lifecycle == .starting || lifecycle == .flushing || lifecycle == .active
+    }
+
+    func admit(_ candidate: AdapterCandidate) -> SourceAdmission {
+        guard canAcceptPayload() else { return .rejected(.revoked) }
+        let isBuffering = lifecycle == .starting || lifecycle == .flushing
+        if isBuffering, pendingCandidates.count >= pendingLimit {
+            return .rejected(.droppedInvalid)
+        }
+        if let sequence = candidate.sourcePosition?.sourceSequence {
+            guard sequence > highestAdmittedSequence else {
+                return .rejected(.droppedInvalid)
+            }
+            highestAdmittedSequence = sequence
+        }
+        if isBuffering {
+            pendingCandidates.append(candidate)
+            return .buffered
+        }
+        inFlightCount += 1
+        return .deliver
+    }
+
+    func commitActivation() -> SourceActivationResult {
+        guard lifecycle == .starting else { return .rejected }
+        guard !Task.isCancelled else {
+            lifecycle = .retired
+            pendingCandidates.removeAll(keepingCapacity: false)
+            return .cancelled
+        }
+        lifecycle = .flushing
+        return .committed
+    }
+
+    func nextBuffered() -> AdapterCandidate? {
+        guard lifecycle == .flushing else { return nil }
+        guard !pendingCandidates.isEmpty else {
+            lifecycle = .active
+            return nil
+        }
+        inFlightCount += 1
+        return pendingCandidates.removeFirst()
+    }
+
+    func complete(
+        _ candidate: AdapterCandidate,
+        outcome: AdapterIngestOutcome
+    ) -> AdapterIngestOutcome {
+        guard inFlightCount > 0 else { return .revoked }
+        inFlightCount -= 1
+        guard lifecycle == .active || lifecycle == .flushing else { return .revoked }
+        if outcome == .revoked {
+            lifecycle = .retired
+            pendingCandidates.removeAll(keepingCapacity: false)
+            return .revoked
+        }
+        if outcome == .accepted, let position = candidate.sourcePosition,
+           let sequence = position.sourceSequence,
+           sequence > (latestAcceptedPosition?.sourceSequence ?? 0) {
+            latestAcceptedPosition = position
+        }
+        return outcome
+    }
+
+    func checkpointPosition() -> AdapterSourcePosition? {
+        guard lifecycle == .active, inFlightCount == 0,
+              pendingCandidates.isEmpty,
+              let position = latestAcceptedPosition,
+              let sequence = position.sourceSequence,
+              sequence > (checkpointedSequence ?? 0) else { return nil }
+        checkpointedSequence = sequence
+        lifecycle = .retired
+        return position
+    }
+
+    func revoke() {
+        lifecycle = .retired
+        pendingCandidates.removeAll(keepingCapacity: false)
+    }
+}
+
+nonisolated private actor ValidatingAgentEventSink: AgentEventSink {
+    typealias Downstream = @Sendable (ValidatedAgentEvent) async -> AdapterIngestOutcome
+    private let contract: NegotiatedAdapterContract
+    private let namespace: SourceNamespace
+    private let attempt: SourceAttempt
+    private let state: SourceSessionState
+    private let downstream: Downstream
+
+    init(
+        contract: NegotiatedAdapterContract,
+        namespace: SourceNamespace,
+        attempt: SourceAttempt,
+        state: SourceSessionState,
+        downstream: @escaping Downstream
+    ) {
+        self.contract = contract
+        self.namespace = namespace
+        self.attempt = attempt
+        self.state = state
+        self.downstream = downstream
+    }
+
+    func ingest(_ candidate: AdapterCandidate) async -> AdapterIngestOutcome {
+        guard !Task.isCancelled else { return .revoked }
+        guard await state.canAcceptPayload() else { return .revoked }
+        do { try candidate.validate(against: contract) } catch { return .droppedInvalid }
+        switch await state.admit(candidate) {
+        case .buffered:
+            return .bufferedUntilActivation
+        case .rejected(let outcome):
+            return outcome
+        case .deliver:
+            return await deliver(candidate)
+        }
+    }
+
+    func activate() async -> SourceActivationResult {
+        let commit = await state.commitActivation()
+        guard commit == .committed else { return commit }
+        while let candidate = await state.nextBuffered() {
+            if Task.isCancelled {
+                await state.revoke()
+                break
+            }
+            if await deliver(candidate) == .revoked { break }
+            if Task.isCancelled {
+                await state.revoke()
+                break
+            }
+        }
+        if Task.isCancelled { await state.revoke() }
+        return .committed
+    }
+
+    private func deliver(_ candidate: AdapterCandidate) async -> AdapterIngestOutcome {
+        let outcome = await downstream(ValidatedAgentEvent(
+            candidate: candidate,
+            namespace: namespace,
+            attempt: attempt
+        ))
+        let resolved = outcome == .bufferedUntilActivation ? .revoked : outcome
+        return await state.complete(candidate, outcome: resolved)
+    }
+}
+
+nonisolated private struct CoreBoundAdapterSession: AgentAdapterSession {
+    let contract: NegotiatedAdapterContract
+    let registryID: UUID
+    let namespace: SourceNamespace
+    let attempt: SourceAttempt
+    let state: SourceSessionState
+    let sink: ValidatingAgentEventSink
+    let underlying: any AgentAdapterSession
+
+    func start() async throws {
+        guard await state.beginStart() else {
+            throw AdapterSessionError.invalidLifecycle
+        }
+        do { try await underlying.start() } catch {
+            await state.revoke()
+            throw error
+        }
+        switch await sink.activate() {
+        case .committed:
+            break
+        case .cancelled:
+            throw CancellationError()
+        case .rejected:
+            throw AdapterSessionError.invalidLifecycle
+        }
+    }
+
+    func stop(deadline: ContinuousClock.Instant) async {
+        await state.revoke()
+        await underlying.stop(deadline: deadline)
+    }
+}
+
+nonisolated enum AdapterRegistrationError: Error, Equatable, Sendable {
+    case duplicateAgent, duplicateAdapter, duplicateFactory, duplicateAlias, aliasCollision
+    case invalidVersionRange, emptyProfiles, duplicateProfile, descriptorMismatch, unknownFactory, tooManyEntries
+    case invalidBuiltInPresentation
+}
+
+nonisolated enum AdapterNegotiationError: Error, Equatable, Sendable {
+    case unknownAdapter, invalidPolicyRange, noCommonVersion, noCommonProfile, offeredProfileExceedsMaximum
+}
+
+nonisolated struct AdapterNegotiationPolicy: Sendable {
+    let allowedVersions: PineAdapterContractVersionRange
+    let transportPreference: [AdapterTransport]
+    let acceptedAuthentication: Set<CoreAuthenticationRequirement>
+}
+
+nonisolated struct AgentAdapterRegistry: Sendable {
+    static let startBufferLimit = 64
+    typealias Downstream = @Sendable (ValidatedAgentEvent) async -> AdapterIngestOutcome
+    private struct Key: Hashable { let agent: AgentID; let adapter: AdapterID; let factory: AdapterFactoryID }
+    private let presentations: [AgentID: AgentPresentationDescriptor]
+    private let adapters: [AdapterID: (AdapterDescriptor, any AgentAdapterFactory)]
+    private let registryID: UUID
+
+    init(
+        compiledPresentations: [AgentPresentationDescriptor],
+        compiledAdapters: [(AdapterDescriptor, any AgentAdapterFactory)]
+    ) throws {
+        guard compiledPresentations.count <= 128, compiledAdapters.count <= 128 else {
+            throw AdapterRegistrationError.tooManyEntries
+        }
+        var presentationMap: [AgentID: AgentPresentationDescriptor] = [:]
+        var aliases = Set<ExecutableAlias>()
+        for presentation in compiledPresentations {
+            try AgentPresentationCatalog.validateBuiltIn(presentation)
+            try AgentPresentationCatalog.validateReservedNames(presentation)
+            guard presentationMap.updateValue(presentation, forKey: presentation.agentID) == nil else {
+                throw AdapterRegistrationError.duplicateAgent
+            }
+            guard aliases.isDisjoint(with: presentation.executableAliases) else {
+                throw AdapterRegistrationError.aliasCollision
+            }
+            aliases.formUnion(presentation.executableAliases)
+        }
+        var adapterMap: [AdapterID: (AdapterDescriptor, any AgentAdapterFactory)] = [:]
+        var keys = Set<Key>(), factories = Set<AdapterFactoryID>()
+        for (descriptor, factory) in compiledAdapters {
+            guard presentationMap[descriptor.agentID] != nil else { throw AdapterRegistrationError.descriptorMismatch }
+            guard descriptor.factoryID == factory.id else { throw AdapterRegistrationError.descriptorMismatch }
+            guard descriptor.contractVersions.isValid else { throw AdapterRegistrationError.invalidVersionRange }
+            guard !descriptor.maximumProfiles.isEmpty else { throw AdapterRegistrationError.emptyProfiles }
+            guard descriptor.maximumProfiles.count <= 16 else { throw AdapterRegistrationError.tooManyEntries }
+            guard Set(descriptor.maximumProfiles).count == descriptor.maximumProfiles.count else {
+                throw AdapterRegistrationError.duplicateProfile
+            }
+            let key = Key(agent: descriptor.agentID, adapter: descriptor.adapterID, factory: descriptor.factoryID)
+            guard keys.insert(key).inserted else { throw AdapterRegistrationError.descriptorMismatch }
+            guard factories.insert(descriptor.factoryID).inserted else { throw AdapterRegistrationError.duplicateFactory }
+            guard adapterMap.updateValue((descriptor, factory), forKey: descriptor.adapterID) == nil else {
+                throw AdapterRegistrationError.duplicateAdapter
+            }
+        }
+        presentations = presentationMap
+        adapters = adapterMap
+        registryID = UUID()
+    }
+
+    private func factory(for contract: NegotiatedAdapterContract) throws -> any AgentAdapterFactory {
+        guard contract.registryID == registryID, let pair = adapters[contract.adapterID],
+              pair.0.agentID == contract.agentID, pair.0.factoryID == contract.factoryID,
+              pair.0.contractVersions.contains(contract.version),
+              pair.0.maximumProfiles.contains(where: { contract.profile.isSubset(of: $0) }) else {
+            throw AdapterSessionError.contractMismatch
+        }
+        return pair.1
+    }
+
+    func makeSession(
+        contract: NegotiatedAdapterContract,
+        resumeFrom checkpoint: AdapterResumeCheckpoint?,
+        downstream: @escaping Downstream
+    ) async throws -> any AgentAdapterSession {
+        let resolved = try factory(for: contract)
+        guard checkpoint == nil || contract.profile.replay == .sourceCursor else {
+            throw AdapterSessionError.checkpointNotSupported
+        }
+        if let checkpoint {
+            guard checkpoint.registryID == registryID,
+                  checkpoint.sourceContract == contract else {
+                throw AdapterSessionError.checkpointMismatch
+            }
+            guard await checkpoint.gate.consume() else {
+                throw AdapterSessionError.checkpointAlreadyConsumed
+            }
+        }
+        let namespace = checkpoint?.namespace ?? SourceNamespace()
+        let attempt = SourceAttempt()
+        let state = SourceSessionState(baseline: checkpoint?.lastSourceSequence ?? 0)
+        let sink = ValidatingAgentEventSink(
+            contract: contract,
+            namespace: namespace,
+            attempt: attempt,
+            state: state,
+            downstream: downstream
+        )
+        let request = AgentAdapterSessionRequest(contract: contract, resumeFrom: checkpoint, sink: sink)
+        do {
+            let session = try await resolved.makeSession(request)
+            guard session.contract == contract else {
+                await state.revoke()
+                throw AdapterSessionError.contractMismatch
+            }
+            return CoreBoundAdapterSession(
+                contract: contract,
+                registryID: registryID,
+                namespace: namespace,
+                attempt: attempt,
+                state: state,
+                sink: sink,
+                underlying: session
+            )
+        } catch {
+            await state.revoke()
+            throw error
+        }
+    }
+
+    func makeCheckpoint(for sourceSession: any AgentAdapterSession) async throws -> AdapterResumeCheckpoint {
+        guard let source = sourceSession as? CoreBoundAdapterSession,
+              source.registryID == registryID else { throw AdapterSessionError.checkpointMismatch }
+        guard source.contract.profile.replay == .sourceCursor else {
+            throw AdapterSessionError.checkpointNotSupported
+        }
+        guard let position = await source.state.checkpointPosition(),
+              let resumePosition = position.resumePosition,
+              let lastSourceEvent = position.sourceEvent,
+              let lastSourceSequence = position.sourceSequence else {
+            throw AdapterSessionError.checkpointUnavailable
+        }
+        return AdapterResumeCheckpoint(
+            registryID: registryID,
+            namespace: source.namespace,
+            sourceContract: source.contract,
+            resumePosition: resumePosition,
+            lastSourceEvent: lastSourceEvent,
+            lastSourceSequence: lastSourceSequence
+        )
+    }
+
+    func negotiate(
+        adapterID: AdapterID,
+        offeredProfiles: [AdapterCapabilityProfile],
+        offeredVersions: PineAdapterContractVersionRange,
+        policy: AdapterNegotiationPolicy
+    ) throws -> NegotiatedAdapterContract {
+        guard let pair = adapters[adapterID] else { throw AdapterNegotiationError.unknownAdapter }
+        guard policy.allowedVersions.isValid, offeredVersions.isValid else { throw AdapterNegotiationError.invalidPolicyRange }
+        guard !policy.transportPreference.isEmpty,
+              Set(policy.transportPreference).count == policy.transportPreference.count,
+              offeredProfiles.count <= 16, Set(offeredProfiles).count == offeredProfiles.count else {
+            throw AdapterNegotiationError.invalidPolicyRange
+        }
+        let lower = max(max(pair.0.contractVersions.minimum, offeredVersions.minimum), policy.allowedVersions.minimum)
+        let upper = min(min(pair.0.contractVersions.maximum, offeredVersions.maximum), policy.allowedVersions.maximum)
+        guard lower <= upper else { throw AdapterNegotiationError.noCommonVersion }
+        guard offeredProfiles.allSatisfy({ offered in
+            pair.0.maximumProfiles.contains(where: { offered.isSubset(of: $0) })
+        }) else { throw AdapterNegotiationError.offeredProfileExceedsMaximum }
+        let eligible = offeredProfiles.filter { policy.acceptedAuthentication.contains($0.minimumAuthentication) }
+        let selected = policy.transportPreference.lazy.compactMap { transport in
+            eligible.filter { $0.transport == transport }
+                .sorted { $0.deterministicWireValues.lexicographicallyPrecedes($1.deterministicWireValues) }.first
+        }.first
+        guard let selected else { throw AdapterNegotiationError.noCommonProfile }
+        return NegotiatedAdapterContract(
+            registryID: registryID, agentID: pair.0.agentID, adapterID: adapterID, factoryID: pair.0.factoryID,
+            version: upper, profile: selected
+        )
+    }
+
+    func presentation(for id: AgentID) -> AgentPresentationDescriptor? { presentations[id] }
+
+    func validatedUserPresentations(
+        _ registrations: [UserAgentPresentationRegistration]
+    ) throws -> [AgentPresentationDescriptor] {
+        guard registrations.count <= 128 else { throw AdapterRegistrationError.tooManyEntries }
+        var ids = Set(presentations.keys)
+        var aliases = Set<ExecutableAlias>()
+        for presentation in presentations.values { aliases.formUnion(presentation.executableAliases) }
+        return try registrations.map { registration in
+            let presentation = try registration.normalized()
+            try AgentPresentationCatalog.validateReservedNames(presentation)
+            guard ids.insert(presentation.agentID).inserted else { throw AdapterRegistrationError.duplicateAgent }
+            guard aliases.isDisjoint(with: presentation.executableAliases) else {
+                throw AdapterRegistrationError.aliasCollision
+            }
+            aliases.formUnion(presentation.executableAliases)
+            return presentation
+        }
+    }
+}
+
+nonisolated enum AgentPresentationCatalog {
+    private static let builtIns: [String: (String, AgentPresentationStyle, Set<String>)] = [
+        "claudeCode": ("Claude Code", .claude, ["claude"]),
+        "codex": ("Codex", .codex, ["codex"]),
+        "aider": ("Aider", .aider, ["aider"]),
+        "copilot": ("Copilot", .copilot, ["github-copilot-cli", "copilot"]),
+        "pi": ("Pi", .pi, ["pi"])
+    ]
+
+    static func validateBuiltIn(_ descriptor: AgentPresentationDescriptor) throws {
+        guard let expected = builtIns[descriptor.agentID.value] else { return }
+        let aliases = Set(descriptor.executableAliases.map(\.value))
+        guard descriptor.displayName == expected.0, descriptor.style == expected.1,
+              aliases == expected.2 else { throw AdapterRegistrationError.invalidBuiltInPresentation }
+    }
+
+    static func validateReservedNames(_ descriptor: AgentPresentationDescriptor) throws {
+        let reservedAliases = Set(builtIns.values.flatMap { $0.2 })
+        guard builtIns[descriptor.agentID.value] != nil
+                || Set(descriptor.executableAliases.map(\.value)).isDisjoint(with: reservedAliases) else {
+            throw AdapterRegistrationError.aliasCollision
+        }
+    }
+
+    static func builtIn(stableIdentifier: String) throws -> AgentPresentationDescriptor? {
+        guard let record = builtIns[stableIdentifier] else { return nil }
+        return try AgentPresentationDescriptor(
+            agentID: AgentID(migratingLegacyStableIdentifier: stableIdentifier),
+            displayName: record.0,
+            executableAliases: Set(try record.2.map(ExecutableAlias.init(validating:))),
+            style: record.1
+        )
+    }
+}
+
+nonisolated struct LegacyAgentMigration: Sendable {
+    let originalStableIdentifier: String
+    let canonicalAgentID: AgentID
+    let presentation: AgentPresentationDescriptor
+}
+
+nonisolated enum LegacyMigrationError: Error, Equatable, Sendable {
+    case malformedIdentifier
+    case duplicateOriginalIdentifier
+    case canonicalCollision
+}
+
+nonisolated struct LegacyAgentMigrationCatalog: Sendable {
+    private let byOriginal: [String: LegacyAgentMigration]
+    private let byCanonical: [AgentID: LegacyAgentMigration]
+
+    init(stableIdentifiers: [String]) throws {
+        guard stableIdentifiers.count <= 128 else { throw LegacyMigrationError.malformedIdentifier }
+        var originals: [String: LegacyAgentMigration] = [:]
+        var migrations: [LegacyAgentMigration] = []
+        for stableIdentifier in stableIdentifiers {
+            guard originals[stableIdentifier] == nil else { throw LegacyMigrationError.duplicateOriginalIdentifier }
+            let migration = try Self.migration(for: stableIdentifier)
+            originals[stableIdentifier] = migration
+            migrations.append(migration)
+        }
+        try Self.validateCanonicalUniqueness(migrations.map(\.canonicalAgentID))
+        var canonicals: [AgentID: LegacyAgentMigration] = [:]
+        for migration in migrations { canonicals[migration.canonicalAgentID] = migration }
+        byOriginal = originals
+        byCanonical = canonicals
+    }
+
+    static func validateCanonicalUniqueness(_ identifiers: [AgentID]) throws {
+        guard Set(identifiers).count == identifiers.count else { throw LegacyMigrationError.canonicalCollision }
+    }
+
+    func lookup(stableIdentifier: String) -> LegacyAgentMigration? { byOriginal[stableIdentifier] }
+    func lookup(agentID: AgentID) -> LegacyAgentMigration? { byCanonical[agentID] }
+
+    private static func migration(for stableIdentifier: String) throws -> LegacyAgentMigration {
+        guard !stableIdentifier.isEmpty, stableIdentifier.utf8.count <= 256,
+              stableIdentifier == stableIdentifier.precomposedStringWithCanonicalMapping,
+              stableIdentifier.unicodeScalars.allSatisfy({ !CharacterSet.controlCharacters.contains($0) }) else {
+            throw LegacyMigrationError.malformedIdentifier
+        }
+        if let presentation = try AgentPresentationCatalog.builtIn(stableIdentifier: stableIdentifier) {
+            return LegacyAgentMigration(
+                originalStableIdentifier: stableIdentifier,
+                canonicalAgentID: presentation.agentID,
+                presentation: presentation
+            )
+        }
+        guard stableIdentifier.hasPrefix("generic:") else { throw LegacyMigrationError.malformedIdentifier }
+        let display = String(stableIdentifier.dropFirst("generic:".count))
+        let safeDisplay: String
+        do { safeDisplay = try AdapterIdentifierValidation.displayText(display) } catch {
+            throw LegacyMigrationError.malformedIdentifier
+        }
+        let digest = sha256(stableIdentifier)
+        guard digest.utf8.count == 64,
+              digest.utf8.allSatisfy({ (48...57).contains($0) || (97...102).contains($0) }) else {
+            throw LegacyMigrationError.malformedIdentifier
+        }
+        do {
+            let agentID = try AgentID(validating: "generic:\(digest)")
+            let presentation = try AgentPresentationDescriptor(
+                agentID: agentID, displayName: safeDisplay, executableAliases: [], style: .generic
+            )
+            return LegacyAgentMigration(
+                originalStableIdentifier: stableIdentifier,
+                canonicalAgentID: agentID,
+                presentation: presentation
+            )
+        } catch { throw LegacyMigrationError.malformedIdentifier }
+    }
+
+    private static func sha256(_ value: String) -> String {
+        SHA256.hash(data: Data(value.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Pine/Agent/Adapters/AdapterValidation.swift
+++ b/Pine/Agent/Adapters/AdapterValidation.swift
@@ -245,6 +245,45 @@ nonisolated private final class OneShotAuthorityLease: Sendable {
     }
 }
 
+nonisolated private final class AsyncContinuationGate: Sendable {
+    private enum State: Sendable {
+        case pendingRegistration
+        case registered(CheckedContinuation<Void, Never>)
+        case resolved
+    }
+
+    private let state = Mutex(State.pendingRegistration)
+
+    func register(_ continuation: CheckedContinuation<Void, Never>) {
+        let resumeImmediately = state.withLock {
+            switch $0 {
+            case .pendingRegistration:
+                $0 = .registered(continuation)
+                return false
+            case .registered, .resolved:
+                return true
+            }
+        }
+        if resumeImmediately { continuation.resume() }
+    }
+
+    func resolve() {
+        let continuation: CheckedContinuation<Void, Never>? = state.withLock {
+            switch $0 {
+            case .pendingRegistration:
+                $0 = .resolved
+                return nil
+            case .registered(let continuation):
+                $0 = .resolved
+                return continuation
+            case .resolved:
+                return nil
+            }
+        }
+        continuation?.resume()
+    }
+}
+
 nonisolated private enum SourceAdmission: Sendable {
     case buffered
     case deliver
@@ -269,9 +308,7 @@ private actor SourceSessionState {
     private var pendingCandidates: [AdapterCandidate] = []
     private var activationRemaining = 0
     private var inFlightCount = 0
-    private var drainWaiters: [UUID: CheckedContinuation<Void, Never>] = [:]
-    private var cancelledDrainWaiters = Set<UUID>()
-    private var resolvedDrainWaiters = Set<UUID>()
+    private var drainWaiters: [UUID: AsyncContinuationGate] = [:]
     private var stopCompletion: BoundedAdapterStop?
     private let authority: OneShotAuthorityReservation
     private let pendingLimit = AgentAdapterRegistry.startBufferLimit
@@ -424,19 +461,16 @@ private actor SourceSessionState {
     func waitUntilDrained() async {
         guard inFlightCount > 0, !Task.isCancelled else { return }
         let waiterID = UUID()
+        let waiter = AsyncContinuationGate()
+        drainWaiters[waiterID] = waiter
         await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
-                if inFlightCount == 0 || Task.isCancelled
-                    || cancelledDrainWaiters.remove(waiterID) != nil {
-                    resolvedDrainWaiters.insert(waiterID)
-                    continuation.resume()
-                } else {
-                    drainWaiters[waiterID] = continuation
-                }
+                waiter.register(continuation)
             }
         } onCancel: {
-            Task { await self.cancelDrainWaiter(waiterID) }
+            waiter.resolve()
         }
+        drainWaiters.removeValue(forKey: waiterID)
     }
 
     func revoke() {
@@ -448,19 +482,9 @@ private actor SourceSessionState {
 
     private func resumeDrainWaitersIfNeeded() {
         guard inFlightCount == 0 else { return }
-        let retained = drainWaiters
+        let retained = Array(drainWaiters.values)
         drainWaiters.removeAll(keepingCapacity: false)
-        resolvedDrainWaiters.formUnion(retained.keys)
-        retained.values.forEach { $0.resume() }
-    }
-
-    private func cancelDrainWaiter(_ waiterID: UUID) {
-        if let waiter = drainWaiters.removeValue(forKey: waiterID) {
-            resolvedDrainWaiters.insert(waiterID)
-            waiter.resume()
-        } else if resolvedDrainWaiters.remove(waiterID) == nil {
-            cancelledDrainWaiters.insert(waiterID)
-        }
+        retained.forEach { $0.resolve() }
     }
 }
 
@@ -530,44 +554,76 @@ private actor ValidatingAgentEventSink: AgentEventSink {
 
 private actor BoundedAdapterStop {
     private var completed = false
-    private var waiters: [UUID: CheckedContinuation<Void, Never>] = [:]
-    private var cancelledBeforeRegistration = Set<UUID>()
-    private var resolvedBeforeCancellation = Set<UUID>()
+    private var waiters: [UUID: AsyncContinuationGate] = [:]
 
     func wait() async {
         guard !completed, !Task.isCancelled else { return }
         let waiterID = UUID()
+        let waiter = AsyncContinuationGate()
+        waiters[waiterID] = waiter
         await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
-                if completed || Task.isCancelled
-                    || cancelledBeforeRegistration.remove(waiterID) != nil {
-                    resolvedBeforeCancellation.insert(waiterID)
-                    continuation.resume()
-                } else {
-                    waiters[waiterID] = continuation
-                }
+                waiter.register(continuation)
             }
         } onCancel: {
-            Task { await self.cancel(waiterID) }
+            waiter.resolve()
         }
+        waiters.removeValue(forKey: waiterID)
     }
 
     func complete() {
         guard !completed else { return }
         completed = true
-        let retained = waiters
+        let retained = Array(waiters.values)
         waiters.removeAll(keepingCapacity: false)
-        resolvedBeforeCancellation.formUnion(retained.keys)
-        retained.values.forEach { $0.resume() }
+        retained.forEach { $0.resolve() }
+    }
+}
+
+nonisolated private struct AdapterCleanupTicket: Sendable {
+    let completion: BoundedAdapterStop
+}
+
+private actor AdapterStopCountdown {
+    private var remaining: Int
+    private let completion: BoundedAdapterStop
+
+    init(remaining: Int, completion: BoundedAdapterStop) {
+        self.remaining = remaining
+        self.completion = completion
     }
 
-    private func cancel(_ waiterID: UUID) {
-        if let waiter = waiters.removeValue(forKey: waiterID) {
-            resolvedBeforeCancellation.insert(waiterID)
-            waiter.resume()
-        } else if resolvedBeforeCancellation.remove(waiterID) == nil {
-            cancelledBeforeRegistration.insert(waiterID)
+    func arrive() async {
+        guard remaining > 0 else { return }
+        remaining -= 1
+        if remaining == 0 { await completion.complete() }
+    }
+}
+
+private actor AdapterCleanupSupervisor {
+    nonisolated static let shared = AdapterCleanupSupervisor()
+    nonisolated static let capacity = 64
+    private var operations: [UUID: Task<Void, Never>] = [:]
+
+    func submit(
+        _ session: any AgentAdapterSession,
+        deadline: ContinuousClock.Instant
+    ) -> AdapterCleanupTicket? {
+        guard operations.count < Self.capacity else { return nil }
+        let operationID = UUID()
+        let completion = BoundedAdapterStop()
+        let supervisor = self
+        let task = Task.detached {
+            await session.stop(deadline: deadline)
+            await completion.complete()
+            await supervisor.finished(operationID)
         }
+        operations[operationID] = task
+        return AdapterCleanupTicket(completion: completion)
+    }
+
+    private func finished(_ operationID: UUID) {
+        operations.removeValue(forKey: operationID)
     }
 }
 
@@ -620,11 +676,23 @@ nonisolated private struct CoreBoundAdapterSession: AgentAdapterSession {
         let underlying = underlying
         Task.detached {
             let boundedWork = BoundedAdapterStop()
-            let cleanup = Task.detached {
-                async let adapterStop: Void = underlying.stop(deadline: deadline)
-                async let admittedDeliveries: Void = state.waitUntilDrained()
-                _ = await (adapterStop, admittedDeliveries)
-                await boundedWork.complete()
+            let countdown = AdapterStopCountdown(
+                remaining: 2,
+                completion: boundedWork
+            )
+            let ticket = await AdapterCleanupSupervisor.shared.submit(
+                underlying,
+                deadline: deadline
+            )
+            let adapterWait = ticket.map { ticket in
+                Task.detached {
+                    await ticket.completion.wait()
+                    await countdown.arrive()
+                }
+            }
+            let drainWait = Task.detached {
+                await state.waitUntilDrained()
+                await countdown.arrive()
             }
             let timeout = Task.detached {
                 do {
@@ -635,7 +703,8 @@ nonisolated private struct CoreBoundAdapterSession: AgentAdapterSession {
                 await boundedWork.complete()
             }
             await boundedWork.wait()
-            cleanup.cancel()
+            adapterWait?.cancel()
+            drainWait.cancel()
             timeout.cancel()
             await state.revoke()
             await completion.complete()
@@ -829,7 +898,9 @@ nonisolated struct AgentAdapterRegistry: Sendable {
 
     func probe(adapterID: AdapterID) async throws -> AgentAdapterOffer {
         guard let pair = adapters[adapterID] else { throw AdapterProbeError.unknownAdapter }
+        try Task.checkCancellation()
         let result = try await pair.1.probe()
+        try Task.checkCancellation()
         return AgentAdapterOffer(
             registryID: registryID,
             agentID: pair.0.agentID,

--- a/Pine/Agent/Adapters/AdapterValidation.swift
+++ b/Pine/Agent/Adapters/AdapterValidation.swift
@@ -245,7 +245,7 @@ nonisolated private final class OneShotAuthorityLease: Sendable {
     }
 }
 
-nonisolated private final class AsyncContinuationGate: Sendable {
+nonisolated final class AsyncContinuationGate: Sendable {
     private enum State: Sendable {
         case pendingRegistration
         case registered(CheckedContinuation<Void, Never>)
@@ -254,7 +254,31 @@ nonisolated private final class AsyncContinuationGate: Sendable {
 
     private let state = Mutex(State.pendingRegistration)
 
-    func register(_ continuation: CheckedContinuation<Void, Never>) {
+    var isResolved: Bool {
+        state.withLock {
+            if case .resolved = $0 { return true }
+            return false
+        }
+    }
+
+    var hasRegisteredWaiter: Bool {
+        state.withLock {
+            if case .registered = $0 { return true }
+            return false
+        }
+    }
+
+    func wait() async {
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                register(continuation)
+            }
+        } onCancel: {
+            resolve()
+        }
+    }
+
+    private func register(_ continuation: CheckedContinuation<Void, Never>) {
         let resumeImmediately = state.withLock {
             switch $0 {
             case .pendingRegistration:
@@ -463,13 +487,7 @@ private actor SourceSessionState {
         let waiterID = UUID()
         let waiter = AsyncContinuationGate()
         drainWaiters[waiterID] = waiter
-        await withTaskCancellationHandler {
-            await withCheckedContinuation { continuation in
-                waiter.register(continuation)
-            }
-        } onCancel: {
-            waiter.resolve()
-        }
+        await waiter.wait()
         drainWaiters.removeValue(forKey: waiterID)
     }
 
@@ -561,13 +579,7 @@ private actor BoundedAdapterStop {
         let waiterID = UUID()
         let waiter = AsyncContinuationGate()
         waiters[waiterID] = waiter
-        await withTaskCancellationHandler {
-            await withCheckedContinuation { continuation in
-                waiter.register(continuation)
-            }
-        } onCancel: {
-            waiter.resolve()
-        }
+        await waiter.wait()
         waiters.removeValue(forKey: waiterID)
     }
 
@@ -581,7 +593,91 @@ private actor BoundedAdapterStop {
 }
 
 nonisolated private struct AdapterCleanupTicket: Sendable {
+    let operationID: UUID
     let completion: BoundedAdapterStop
+}
+
+nonisolated final class AdapterCleanupCapacity: Sendable {
+    nonisolated static let shared = AdapterCleanupCapacity(limit: 64)
+    private let limit: Int
+    private let reservations = Mutex(Set<UUID>())
+
+    init(limit: Int) {
+        self.limit = max(1, limit)
+    }
+
+    fileprivate func reserve() -> AdapterCleanupPermit? {
+        let reservationID = UUID()
+        let accepted = reservations.withLock {
+            guard $0.count < limit else { return false }
+            $0.insert(reservationID)
+            return true
+        }
+        guard accepted else { return nil }
+        return AdapterCleanupPermit(
+            capacity: self,
+            reservationID: reservationID
+        )
+    }
+
+    fileprivate func release(_ reservationID: UUID) {
+        _ = reservations.withLock { $0.remove(reservationID) }
+    }
+
+    var reservedCount: Int {
+        reservations.withLock { $0.count }
+    }
+}
+
+nonisolated private final class AdapterCleanupPermit: Sendable {
+    private enum State: Sendable {
+        case reserved
+        case submitted(AdapterCleanupTicket)
+        case released
+    }
+
+    let reservationID: UUID
+    private let capacity: AdapterCleanupCapacity
+    private let state = Mutex(State.reserved)
+
+    init(capacity: AdapterCleanupCapacity, reservationID: UUID) {
+        self.capacity = capacity
+        self.reservationID = reservationID
+    }
+
+    func beginSubmission(_ proposed: AdapterCleanupTicket) -> (AdapterCleanupTicket, Bool) {
+        state.withLock {
+            switch $0 {
+            case .reserved:
+                $0 = .submitted(proposed)
+                return (proposed, true)
+            case .submitted(let existing):
+                return (existing, false)
+            case .released:
+                return (proposed, false)
+            }
+        }
+    }
+
+    func release() {
+        let shouldRelease = state.withLock {
+            guard case .released = $0 else {
+                $0 = .released
+                return true
+            }
+            return false
+        }
+        if shouldRelease { capacity.release(reservationID) }
+    }
+
+    deinit {
+        let shouldRelease = state.withLock {
+            guard case .reserved = $0 else { return false }
+            $0 = .released
+            return true
+        }
+        if shouldRelease { capacity.release(reservationID) }
+    }
 }
 
 private actor AdapterStopCountdown {
@@ -602,24 +698,32 @@ private actor AdapterStopCountdown {
 
 private actor AdapterCleanupSupervisor {
     nonisolated static let shared = AdapterCleanupSupervisor()
-    nonisolated static let capacity = 64
     private var operations: [UUID: Task<Void, Never>] = [:]
 
     func submit(
         _ session: any AgentAdapterSession,
+        permit: AdapterCleanupPermit,
         deadline: ContinuousClock.Instant
-    ) -> AdapterCleanupTicket? {
-        guard operations.count < Self.capacity else { return nil }
-        let operationID = UUID()
-        let completion = BoundedAdapterStop()
+    ) -> AdapterCleanupTicket {
+        let proposed = AdapterCleanupTicket(
+            operationID: permit.reservationID,
+            completion: BoundedAdapterStop()
+        )
+        let (ticket, isNew) = permit.beginSubmission(proposed)
+        guard isNew else { return ticket }
         let supervisor = self
         let task = Task.detached {
             await session.stop(deadline: deadline)
-            await completion.complete()
-            await supervisor.finished(operationID)
+            permit.release()
+            await ticket.completion.complete()
+            await supervisor.finished(ticket.operationID)
         }
-        operations[operationID] = task
-        return AdapterCleanupTicket(completion: completion)
+        operations[ticket.operationID] = task
+        return ticket
+    }
+
+    func cancel(_ ticket: AdapterCleanupTicket) {
+        operations[ticket.operationID]?.cancel()
     }
 
     private func finished(_ operationID: UUID) {
@@ -636,6 +740,7 @@ nonisolated private struct CoreBoundAdapterSession: AgentAdapterSession {
     let sink: ValidatingAgentEventSink
     let underlying: any AgentAdapterSession
     let authorityLease: OneShotAuthorityLease
+    let cleanupPermit: AdapterCleanupPermit
 
     func start() async throws {
         guard await state.beginStart() else {
@@ -682,13 +787,12 @@ nonisolated private struct CoreBoundAdapterSession: AgentAdapterSession {
             )
             let ticket = await AdapterCleanupSupervisor.shared.submit(
                 underlying,
+                permit: cleanupPermit,
                 deadline: deadline
             )
-            let adapterWait = ticket.map { ticket in
-                Task.detached {
-                    await ticket.completion.wait()
-                    await countdown.arrive()
-                }
+            let adapterWait = Task.detached {
+                await ticket.completion.wait()
+                await countdown.arrive()
             }
             let drainWait = Task.detached {
                 await state.waitUntilDrained()
@@ -703,7 +807,8 @@ nonisolated private struct CoreBoundAdapterSession: AgentAdapterSession {
                 await boundedWork.complete()
             }
             await boundedWork.wait()
-            adapterWait?.cancel()
+            await AdapterCleanupSupervisor.shared.cancel(ticket)
+            adapterWait.cancel()
             drainWait.cancel()
             timeout.cancel()
             await state.revoke()
@@ -757,10 +862,12 @@ nonisolated struct AgentAdapterRegistry: Sendable {
     private let presentations: [AgentID: AgentPresentationDescriptor]
     private let adapters: [AdapterID: (AdapterDescriptor, any AgentAdapterFactory)]
     private let registryID: UUID
+    private let cleanupCapacity: AdapterCleanupCapacity
 
     init(
         compiledPresentations: [AgentPresentationDescriptor],
-        compiledAdapters: [(AdapterDescriptor, any AgentAdapterFactory)]
+        compiledAdapters: [(AdapterDescriptor, any AgentAdapterFactory)],
+        cleanupCapacity: AdapterCleanupCapacity = .shared
     ) throws {
         guard compiledPresentations.count <= 128, compiledAdapters.count <= 128 else {
             throw AdapterRegistrationError.tooManyEntries
@@ -799,6 +906,7 @@ nonisolated struct AgentAdapterRegistry: Sendable {
         presentations = presentationMap
         adapters = adapterMap
         registryID = UUID()
+        self.cleanupCapacity = cleanupCapacity
     }
 
     private func factory(for contract: NegotiatedAdapterContract) throws -> any AgentAdapterFactory {
@@ -825,6 +933,9 @@ nonisolated struct AgentAdapterRegistry: Sendable {
                   checkpoint.sourceContract == contract else {
                 throw AdapterSessionError.checkpointMismatch
             }
+        }
+        guard let cleanupPermit = cleanupCapacity.reserve() else {
+            throw AdapterSessionError.cleanupCapacityUnavailable
         }
         let authorityGate = checkpoint?.gate ?? contract.freshSessionGate
         let reservationID = UUID()
@@ -866,7 +977,8 @@ nonisolated struct AgentAdapterRegistry: Sendable {
                 state: state,
                 sink: sink,
                 underlying: session,
-                authorityLease: authorityLease
+                authorityLease: authorityLease,
+                cleanupPermit: cleanupPermit
             )
         } catch {
             await state.failStart()

--- a/Pine/Agent/Adapters/AdapterValidation.swift
+++ b/Pine/Agent/Adapters/AdapterValidation.swift
@@ -99,7 +99,7 @@ nonisolated struct AdapterResumeCheckpoint: Sendable, CustomStringConvertible,
 }
 
 // swiftlint:disable:next private_over_fileprivate
-nonisolated fileprivate actor CheckpointConsumptionGate {
+fileprivate actor CheckpointConsumptionGate {
     private var consumed = false
     func consume() -> Bool {
         guard !consumed else { return false }
@@ -118,7 +118,7 @@ nonisolated private enum SourceActivationResult: Equatable, Sendable {
     case committed, cancelled, rejected
 }
 
-nonisolated private actor SourceSessionState {
+private actor SourceSessionState {
     private enum Lifecycle { case ready, starting, flushing, active, retired }
     private var lifecycle = Lifecycle.ready
     private var highestAdmittedSequence: UInt64
@@ -220,7 +220,7 @@ nonisolated private actor SourceSessionState {
     }
 }
 
-nonisolated private actor ValidatingAgentEventSink: AgentEventSink {
+private actor ValidatingAgentEventSink: AgentEventSink {
     typealias Downstream = @Sendable (ValidatedAgentEvent) async -> AdapterIngestOutcome
     private let contract: NegotiatedAdapterContract
     private let namespace: SourceNamespace

--- a/Pine/Agent/Adapters/AdapterValidation.swift
+++ b/Pine/Agent/Adapters/AdapterValidation.swift
@@ -598,7 +598,7 @@ nonisolated private struct AdapterCleanupTicket: Sendable {
 }
 
 nonisolated final class AdapterCleanupCapacity: Sendable {
-    nonisolated static let shared = AdapterCleanupCapacity(limit: 64)
+    nonisolated static let shared = AdapterCleanupCapacity(limit: 1_024)
     private let limit: Int
     private let reservations = Mutex(Set<UUID>())
 
@@ -731,54 +731,77 @@ private actor AdapterCleanupSupervisor {
     }
 }
 
-nonisolated private struct CoreBoundAdapterSession: AgentAdapterSession {
-    let contract: NegotiatedAdapterContract
-    let registryID: UUID
-    let namespace: SourceNamespace
-    let attempt: SourceAttempt
+nonisolated private final class CoreBoundSessionLifetime: Sendable {
+    nonisolated private static let abandonmentGrace = Duration.seconds(5)
     let state: SourceSessionState
-    let sink: ValidatingAgentEventSink
     let underlying: any AgentAdapterSession
-    let authorityLease: OneShotAuthorityLease
     let cleanupPermit: AdapterCleanupPermit
 
-    func start() async throws {
-        guard await state.beginStart() else {
-            throw AdapterSessionError.invalidLifecycle
-        }
-        do { try await underlying.start() } catch {
-            await state.failStart()
-            throw error
-        }
-        switch await sink.activate() {
-        case .committed:
-            return
-        case .cancelled:
-            throw CancellationError()
-        case .rejected:
-            throw AdapterSessionError.invalidLifecycle
-        }
+    init(
+        state: SourceSessionState,
+        underlying: any AgentAdapterSession,
+        cleanupPermit: AdapterCleanupPermit
+    ) {
+        self.state = state
+        self.underlying = underlying
+        self.cleanupPermit = cleanupPermit
     }
 
     func stop(deadline: ContinuousClock.Instant) async {
+        await Self.performStop(
+            state: state,
+            underlying: underlying,
+            cleanupPermit: cleanupPermit,
+            deadline: deadline
+        )
+    }
+
+    deinit {
+        let state = state
+        let underlying = underlying
+        let cleanupPermit = cleanupPermit
+        let deadline = ContinuousClock.now.advanced(by: Self.abandonmentGrace)
+        Task.detached {
+            await CoreBoundSessionLifetime.performStop(
+                state: state,
+                underlying: underlying,
+                cleanupPermit: cleanupPermit,
+                deadline: deadline
+            )
+        }
+    }
+
+    nonisolated private static func performStop(
+        state: SourceSessionState,
+        underlying: any AgentAdapterSession,
+        cleanupPermit: AdapterCleanupPermit,
+        deadline: ContinuousClock.Instant
+    ) async {
         let directive = await state.beginStop()
         let sharedCompletion: BoundedAdapterStop
         switch directive {
         case .start(let completion):
             sharedCompletion = completion
-            startSharedCleanup(completion: completion, deadline: deadline)
+            startSharedCleanup(
+                state: state,
+                underlying: underlying,
+                cleanupPermit: cleanupPermit,
+                completion: completion,
+                deadline: deadline
+            )
         case .wait(let completion):
             sharedCompletion = completion
         }
         await waitForSharedCleanup(sharedCompletion, deadline: deadline)
     }
 
-    private func startSharedCleanup(
+    nonisolated private static func startSharedCleanup(
+        state: SourceSessionState,
+        underlying: any AgentAdapterSession,
+        cleanupPermit: AdapterCleanupPermit,
         completion: BoundedAdapterStop,
         deadline: ContinuousClock.Instant
     ) {
-        let state = state
-        let underlying = underlying
         Task.detached {
             let boundedWork = BoundedAdapterStop()
             let countdown = AdapterStopCountdown(
@@ -816,7 +839,7 @@ nonisolated private struct CoreBoundAdapterSession: AgentAdapterSession {
         }
     }
 
-    private func waitForSharedCleanup(
+    nonisolated private static func waitForSharedCleanup(
         _ sharedCompletion: BoundedAdapterStop,
         deadline: ContinuousClock.Instant
     ) async {
@@ -836,6 +859,40 @@ nonisolated private struct CoreBoundAdapterSession: AgentAdapterSession {
         await localCompletion.wait()
         sharedWait.cancel()
         timeout.cancel()
+    }
+}
+
+nonisolated private struct CoreBoundAdapterSession: AgentAdapterSession {
+    let contract: NegotiatedAdapterContract
+    let registryID: UUID
+    let namespace: SourceNamespace
+    let attempt: SourceAttempt
+    let sink: ValidatingAgentEventSink
+    let authorityLease: OneShotAuthorityLease
+    let lifetime: CoreBoundSessionLifetime
+
+    var state: SourceSessionState { lifetime.state }
+
+    func start() async throws {
+        guard await lifetime.state.beginStart() else {
+            throw AdapterSessionError.invalidLifecycle
+        }
+        do { try await lifetime.underlying.start() } catch {
+            await lifetime.state.failStart()
+            throw error
+        }
+        switch await sink.activate() {
+        case .committed:
+            return
+        case .cancelled:
+            throw CancellationError()
+        case .rejected:
+            throw AdapterSessionError.invalidLifecycle
+        }
+    }
+
+    func stop(deadline: ContinuousClock.Instant) async {
+        await lifetime.stop(deadline: deadline)
     }
 }
 
@@ -969,16 +1026,19 @@ nonisolated struct AgentAdapterRegistry: Sendable {
             guard session.contract == contract else {
                 throw AdapterSessionError.contractMismatch
             }
+            let lifetime = CoreBoundSessionLifetime(
+                state: state,
+                underlying: session,
+                cleanupPermit: cleanupPermit
+            )
             return CoreBoundAdapterSession(
                 contract: contract,
                 registryID: registryID,
                 namespace: namespace,
                 attempt: attempt,
-                state: state,
                 sink: sink,
-                underlying: session,
                 authorityLease: authorityLease,
-                cleanupPermit: cleanupPermit
+                lifetime: lifetime
             )
         } catch {
             await state.failStart()

--- a/PineTests/AgentAdapterContractTests.swift
+++ b/PineTests/AgentAdapterContractTests.swift
@@ -479,7 +479,7 @@ struct AgentAdapterContractTests {
             ), ContractTestFactory(id: factoryID, probeResult: probeResult))]
         )
         let offer = try await registry.probe(adapterID: adapterID)
-        return try registry.negotiate(
+        return try await registry.negotiate(
             offer: offer,
             policy: AdapterNegotiationPolicy(
                 allowedVersions: versions,

--- a/PineTests/AgentAdapterContractTests.swift
+++ b/PineTests/AgentAdapterContractTests.swift
@@ -1,0 +1,486 @@
+import Foundation
+import Testing
+@testable import Pine
+
+nonisolated private struct ContractTestFactory: AgentAdapterFactory {
+    let id: AdapterFactoryID
+    func probe() async throws -> AdapterProbeResult { throw AdapterProbeError.unavailable(.permanent) }
+    func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession {
+        throw AdapterSessionError.launchFailed(.permanent)
+    }
+}
+
+@Suite("Agent adapter core contract")
+struct AgentAdapterContractTests {
+    @Test func identifiersRequireValidation() throws {
+        #expect(throws: AdapterValueError.self) { _ = try AgentID(validating: "CODEX") }
+        #expect(throws: AdapterValueError.self) { _ = try AgentID(validating: "cоdex") } // Cyrillic o
+        #expect(throws: AdapterValueError.self) { _ = try AgentID(validating: "claudeCode") }
+        #expect(throws: AdapterValueError.self) { _ = try AgentID(validating: String(repeating: "a", count: 97)) }
+        #expect(try AgentID(validating: "codex").value == "codex")
+    }
+
+    @Test func textAndAliasesRejectSpoofs() throws {
+        #expect(throws: AdapterValueError.self) { _ = try ExecutableAlias(validating: "../codex") }
+        #expect(throws: AdapterValueError.self) { _ = try ExecutableAlias(validating: "Codex") }
+        #expect(throws: AdapterValueError.self) {
+            _ = try AgentPresentationDescriptor(
+                agentID: AgentID(validating: "user:x"), displayName: "safe\u{202E}txt",
+                executableAliases: [], style: .generic
+            )
+        }
+    }
+
+    @Test func userRegistrationIsNamespaced() throws {
+        let registration = try UserAgentPresentationRegistration(
+            identifier: "local", displayName: "Local", executableAliases: ["local-agent"]
+        )
+        let presentation = try registration.normalized()
+        #expect(presentation.agentID.value == "user:local")
+        let keys = Set(Mirror(reflecting: registration).children.compactMap(\.label))
+        #expect(keys == ["identifier", "displayName", "executableAliases"])
+    }
+
+    @Test func legacyCatalogRoundTripsAndCollisions() throws {
+        let values = ["claudeCode", "codex", "aider", "copilot", "pi", "generic:Local Tool"]
+        let catalog = try LegacyAgentMigrationCatalog(stableIdentifiers: values)
+        for value in values {
+            let migration = try #require(catalog.lookup(stableIdentifier: value))
+            #expect(migration.originalStableIdentifier == value)
+            #expect(catalog.lookup(agentID: migration.canonicalAgentID)?.originalStableIdentifier == value)
+        }
+        #expect(catalog.lookup(stableIdentifier: "codex")?.canonicalAgentID.value == "codex")
+        #expect(try LegacyAgentMigrationCatalog(stableIdentifiers: values)
+            .lookup(stableIdentifier: "generic:Local Tool")?.canonicalAgentID
+            == catalog.lookup(stableIdentifier: "generic:Local Tool")?.canonicalAgentID)
+        for malformed in ["", "unknown", "generic:", "generic:\u{202E}bad", String(repeating: "x", count: 257)] {
+            #expect(throws: LegacyMigrationError.self) {
+                _ = try LegacyAgentMigrationCatalog(stableIdentifiers: [malformed])
+            }
+        }
+        for malformedGeneric in ["generic:", "generic:\u{202E}bad", "generic:bad\u{200B}"] {
+            #expect(throws: LegacyMigrationError.malformedIdentifier) {
+                _ = try LegacyAgentMigrationCatalog(stableIdentifiers: [malformedGeneric])
+            }
+        }
+        #expect(throws: LegacyMigrationError.duplicateOriginalIdentifier) {
+            _ = try LegacyAgentMigrationCatalog(stableIdentifiers: ["codex", "codex"])
+        }
+        #expect(throws: LegacyMigrationError.canonicalCollision) {
+            let duplicate = try AgentID(validating: "generic:duplicate")
+            try LegacyAgentMigrationCatalog.validateCanonicalUniqueness([duplicate, duplicate])
+        }
+    }
+
+    @Test func profilesValidateDependencies() throws {
+        let profile = try fixtureProfile()
+        #expect(profile.deterministicWireValues == profile.deterministicWireValues.sorted())
+        #expect(throws: AdapterProfileError.missingDependency) {
+            _ = try fixtureProfile(signals: [.init(scope: .item, phase: .started)])
+        }
+        #expect(throws: AdapterProfileError.replayRequiresOrdering) {
+            _ = try fixtureProfile(replay: .sourceCursor, ordering: .unordered)
+        }
+        #expect(throws: AdapterProfileError.transportAuthenticationMismatch) {
+            _ = try AdapterCapabilityProfile(
+                transport: .ownedStandardIO,
+                lifecycle: AdapterLifecycleCapabilities(
+                    signals: [.init(scope: .session, phase: .started)], evidence: []
+                ),
+                delivery: AdapterDeliverySemantics(ordering: .ordered, minimumAuthentication: .authenticatedPeer)
+            )
+        }
+        #expect(throws: AdapterProfileError.missingDependency) {
+            _ = try fixtureProfile(evidence: [.fileChange])
+        }
+    }
+
+    @Test func piAndCodexLifecyclePairsDoNotCross() throws {
+        let pi = try fixtureContract(profile: fixtureProfile(signals: [
+            .init(scope: .run, phase: .succeeded), .init(scope: .session, phase: .settled)
+        ]))
+        let codex = try fixtureContract(profile: fixtureProfile(signals: [
+            .init(scope: .session, phase: .started), .init(scope: .turn, phase: .succeeded),
+            .init(scope: .item, phase: .started)
+        ]))
+        for (contract, accepted, rejected) in [
+            (pi, (AdapterLifecycleScope.run, AdapterLifecyclePhase.succeeded),
+             (AdapterLifecycleScope.session, AdapterLifecyclePhase.succeeded)),
+            (pi, (.session, .settled), (.run, .settled)),
+            (codex, (.turn, .succeeded), (.session, .succeeded)),
+            (codex, (.item, .started), (.item, .succeeded))
+        ] {
+            let valid = try CandidateLifecycleEvent(scope: accepted.0, phase: accepted.1, reference: nil)
+            try AdapterCandidateEvent.lifecycle(valid).validate(against: contract)
+            let invalid = try CandidateLifecycleEvent(scope: rejected.0, phase: rejected.1, reference: nil)
+            #expect(throws: AdapterCandidateError.capabilityOverreach) {
+                try AdapterCandidateEvent.lifecycle(invalid).validate(against: contract)
+            }
+        }
+    }
+
+    @Test func candidatesAreCapabilityBound() throws {
+        let contract = try fixtureContract(profile: fixtureProfile(signals: [
+            .init(scope: .session, phase: .started),
+            .init(scope: .turn, phase: .waitingForQuestion)
+        ]))
+        let question = try CandidateAttentionEvent(
+            scope: .turn, phase: .waitingForQuestion,
+            request: VendorReference(role: .request, value: "r1"),
+            context: VendorReference(role: .turn, value: "turn-1")
+        )
+        try AdapterCandidateEvent.question(question).validate(against: contract)
+        #expect(throws: AdapterCandidateError.capabilityOverreach) {
+            let approval = try CandidateAttentionEvent(
+                scope: .turn, phase: .waitingForApproval,
+                request: VendorReference(role: .request, value: "r2")
+            )
+            try AdapterCandidateEvent.approval(approval).validate(against: contract)
+        }
+        #expect(throws: AdapterCandidateError.capabilityOverreach) {
+            let tool = try CandidateToolEvent(
+                phase: .started, category: .read,
+                toolCall: VendorReference(role: .toolCall, value: "t1"), fileChanges: []
+            )
+            try AdapterCandidateEvent.tool(tool).validate(against: contract)
+        }
+        try AdapterCandidateEvent.processExited(status: 0).validate(against: contract)
+        let completed = try CandidateLifecycleEvent(scope: .turn, phase: .succeeded, reference: nil)
+        #expect(throws: AdapterCandidateError.capabilityOverreach) {
+            try AdapterCandidateEvent.lifecycle(completed).validate(against: contract)
+        }
+    }
+
+    @Test func attentionRequiresExactScopePhaseAndRoles() throws {
+        let contract = try fixtureContract(profile: fixtureProfile(signals: [
+            .init(scope: .session, phase: .waitingForQuestion),
+            .init(scope: .turn, phase: .waitingForQuestion),
+            .init(scope: .turn, phase: .waitingForApproval)
+        ]))
+        let request = try VendorReference(role: .request, value: "request")
+        let turn = try VendorReference(role: .turn, value: "turn")
+        let validQuestion = try CandidateAttentionEvent(
+            scope: .turn, phase: .waitingForQuestion, request: request, context: turn
+        )
+        try AdapterCandidateEvent.question(validQuestion).validate(against: contract)
+        let wrongScope = try CandidateAttentionEvent(scope: .item, phase: .waitingForQuestion, request: request)
+        #expect(throws: AdapterCandidateError.capabilityOverreach) {
+            try AdapterCandidateEvent.question(wrongScope).validate(against: contract)
+        }
+        let approval = try CandidateAttentionEvent(scope: .turn, phase: .waitingForApproval, request: request)
+        #expect(throws: AdapterCandidateError.capabilityOverreach) {
+            try AdapterCandidateEvent.question(approval).validate(against: contract)
+        }
+        #expect(throws: AdapterCandidateError.capabilityOverreach) {
+            try AdapterCandidateEvent.approval(validQuestion).validate(against: contract)
+        }
+        #expect(throws: AdapterCandidateError.contradictoryEvent) {
+            _ = try CandidateAttentionEvent(
+                scope: .turn, phase: .waitingForQuestion, request: request,
+                context: VendorReference(role: .conversation, value: "wrong-context")
+            )
+        }
+        #expect(throws: AdapterCandidateError.contradictoryEvent) {
+            _ = try CandidateAttentionEvent(
+                scope: .turn, phase: .started,
+                request: request
+            )
+        }
+        for phase in [AdapterLifecyclePhase.waitingForQuestion, .waitingForApproval] {
+            #expect(throws: AdapterCandidateError.contradictoryEvent) {
+                _ = try CandidateLifecycleEvent(scope: .turn, phase: phase, reference: turn)
+            }
+        }
+    }
+
+    @Test func candidateValuesAreBounded() throws {
+        for path in ["", ".", "..", "/tmp/x", "a//b", "a/./b", "a/../b", "a\0b"] {
+            #expect(throws: AdapterCandidateError.invalidRelativePath) {
+                _ = try CandidateFileChange(operation: .modify, relativePath: path)
+            }
+        }
+        for path in ["safe/evil\u{202E}txt", "safe/zero\u{200B}width"] {
+            #expect(throws: AdapterCandidateError.invalidRelativePath) {
+                _ = try CandidateFileChange(operation: .modify, relativePath: path)
+            }
+        }
+        let hash = String(repeating: "a", count: 64)
+        let identity = try ClaimedContentIdentity(sha256: hash, byteCount: 42)
+        #expect(identity.byteCount == 42)
+        #expect(throws: AdapterCandidateError.invalidContentIdentity) {
+            _ = try ClaimedContentIdentity(sha256: "sha256:\(hash)", byteCount: 1)
+        }
+        #expect(throws: AdapterCandidateError.invalidContentIdentity) {
+            _ = try ClaimedContentIdentity(sha256: hash, byteCount: 1_099_511_627_777)
+        }
+        let reference = try VendorReference(role: .event, value: "secret-value")
+        #expect(reference.description == "<redacted:event>")
+        #expect(reference.rawValue == "secret-value")
+        let resume = try AdapterResumePosition("opaque-cursor")
+        #expect(resume.description == "<redacted:resume-position>")
+        #expect(resume.rawValue == "opaque-cursor")
+        #expect(throws: AdapterValueError.self) {
+            _ = try AdapterResumePosition(String(repeating: "x", count: 257))
+        }
+        #expect(try DetectedVendorVersion("1.2.3").value == "1.2.3")
+        #expect(throws: AdapterValueError.self) {
+            _ = try VendorReference(role: .event, value: String(repeating: "x", count: 257))
+        }
+        for hostile in [" 1.2.3", "1.2.3 ", "1\u{202E}.2", "1\u{200B}.2"] {
+            #expect(throws: AdapterValueError.self) { _ = try DetectedVendorVersion(hostile) }
+        }
+        #expect(try DetectedVendorVersion("e\u{301}").value == "é")
+    }
+
+    @Test func fileChangeBatchesAreCoherent() throws {
+        let call = try VendorReference(role: .toolCall, value: "call")
+        let change = try CandidateFileChange(operation: .modify, relativePath: "Sources/File.swift")
+        #expect(throws: AdapterCandidateError.contradictoryEvent) {
+            _ = try CandidateToolEvent(phase: .succeeded, category: .fileChange, toolCall: call, fileChanges: [])
+        }
+        let alias = try CandidateFileChange(operation: .modify, relativePath: "sources/file.swift")
+        #expect(throws: AdapterCandidateError.contradictoryEvent) {
+            _ = try CandidateToolEvent(
+                phase: .succeeded, category: .fileChange, toolCall: call, fileChanges: [change, alias]
+            )
+        }
+        for path in ["Sources/Fíle.swift", "Sources/Ｆile.swift"] {
+            let first = try CandidateFileChange(operation: .modify, relativePath: "Sources/File.swift")
+            let folded = try CandidateFileChange(operation: .modify, relativePath: path)
+            #expect(throws: AdapterCandidateError.contradictoryEvent) {
+                _ = try CandidateToolEvent(
+                    phase: .succeeded, category: .fileChange,
+                    toolCall: call, fileChanges: [first, folded]
+                )
+            }
+        }
+        let rename = try CandidateFileChange(
+            operation: .rename, relativePath: "old.swift", destinationRelativePath: "OLD.swift"
+        )
+        #expect(throws: AdapterCandidateError.contradictoryEvent) {
+            _ = try CandidateToolEvent(
+                phase: .succeeded, category: .fileChange, toolCall: call, fileChanges: [rename]
+            )
+        }
+        for pair in [
+            ("dir", "dir/file"), ("dir/file", "dir"),
+            ("Dir", "dir/file"), ("dír", "dir/file"), ("dir", "DÍR/file"), ("ｄｉｒ", "dir/file")
+        ] {
+            let first = try CandidateFileChange(operation: .modify, relativePath: pair.0)
+            let second = try CandidateFileChange(operation: .modify, relativePath: pair.1)
+            #expect(throws: AdapterCandidateError.contradictoryEvent) {
+                _ = try CandidateToolEvent(
+                    phase: .succeeded, category: .fileChange, toolCall: call,
+                    fileChanges: [first, second]
+                )
+            }
+        }
+        let tool = try CandidateToolEvent(
+            phase: .succeeded, category: .read, toolCall: call, fileChanges: [change]
+        )
+        let toolOnly = try fixtureContract(profile: fixtureProfile(evidence: [.tool]))
+        #expect(throws: AdapterCandidateError.capabilityOverreach) {
+            try AdapterCandidateEvent.tool(tool).validate(against: toolOnly)
+        }
+        let categoryEvent = try CandidateToolEvent(
+            phase: .succeeded, category: .fileChange, toolCall: call, fileChanges: [change]
+        )
+        #expect(throws: AdapterCandidateError.capabilityOverreach) {
+            try AdapterCandidateEvent.tool(categoryEvent).validate(against: toolOnly)
+        }
+        let both = try fixtureContract(profile: fixtureProfile(evidence: [.tool, .fileChange]))
+        try AdapterCandidateEvent.tool(tool).validate(against: both)
+    }
+
+    @Test func sourcePositionFollowsProfile() throws {
+        let ordered = try fixtureContract(profile: fixtureProfile())
+        let sequence = try AdapterSourcePosition(sourceSequence: 1)
+        try AdapterCandidate(event: .processExited(status: nil), sourcePosition: sequence).validate(against: ordered)
+        #expect(throws: AdapterCandidateError.missingSourceSequence) {
+            try AdapterCandidate(event: .processExited(status: nil)).validate(against: ordered)
+        }
+        let replay = try fixtureContract(profile: fixtureProfile(replay: .sourceCursor))
+        #expect(throws: AdapterCandidateError.incompleteReplayPosition) {
+            try AdapterCandidate(event: .processExited(status: nil), sourcePosition: sequence).validate(against: replay)
+        }
+        for incomplete in [
+            try AdapterSourcePosition(resumePosition: AdapterResumePosition("cursor-1"), sourceSequence: 1),
+            try AdapterSourcePosition(
+                sourceEvent: VendorReference(role: .event, value: "event-1"), sourceSequence: 1
+            ),
+            try AdapterSourcePosition(
+                sourceEvent: VendorReference(role: .event, value: "event-1"),
+                resumePosition: AdapterResumePosition("cursor-1")
+            )
+        ] {
+            #expect(throws: AdapterCandidateError.incompleteReplayPosition) {
+                try AdapterCandidate(event: .processExited(status: nil), sourcePosition: incomplete)
+                    .validate(against: replay)
+            }
+        }
+        let cursor = try AdapterSourcePosition(
+            sourceEvent: VendorReference(role: .event, value: "event-1"),
+            resumePosition: AdapterResumePosition("cursor-1"), sourceSequence: 1
+        )
+        try AdapterCandidate(event: .processExited(status: nil), sourcePosition: cursor).validate(against: replay)
+        #expect(throws: AdapterCandidateError.forbiddenReplayPosition) {
+            try AdapterCandidate(event: .processExited(status: nil), sourcePosition: cursor).validate(against: ordered)
+        }
+        #expect(throws: AdapterCandidateError.invalidSourcePosition) {
+            _ = try AdapterSourcePosition(sourceEvent: VendorReference(role: .request, value: "wrong"))
+        }
+        #expect(throws: AdapterCandidateError.invalidSourcePosition) {
+            _ = try AdapterSourcePosition(sourceSequence: 0)
+        }
+        let unordered = try fixtureContract(profile: fixtureProfile(ordering: .unordered))
+        #expect(throws: AdapterCandidateError.forbiddenSourceSequence) {
+            try AdapterCandidate(event: .processExited(status: nil), sourcePosition: sequence)
+                .validate(against: unordered)
+        }
+    }
+
+    @Test func opaqueValuesRedactAllDiagnostics() throws {
+        let reference = try VendorReference(role: .event, value: "reference-canary")
+        let resume = try AdapterResumePosition("resume-canary")
+        let nested = try AdapterSourcePosition(
+            sourceEvent: reference, resumePosition: resume, sourceSequence: 1
+        )
+        for output in [
+            String(reflecting: reference), dumped(reference), String(reflecting: resume), dumped(resume),
+            String(reflecting: nested), dumped(nested)
+        ] {
+            #expect(!output.contains("reference-canary"))
+            #expect(!output.contains("resume-canary"))
+        }
+    }
+
+    @Test func probeResultsAreConstructivelyBounded() throws {
+        let version = try DetectedVendorVersion("1.0")
+        let profile = try fixtureProfile()
+        _ = try AdapterProbeResult(
+            detectedVendorVersion: version, detectedSchema: nil, offeredProfiles: [profile]
+        )
+        #expect(throws: AdapterProbeError.malformedResponse) {
+            _ = try AdapterProbeResult(
+                detectedVendorVersion: version, detectedSchema: nil, offeredProfiles: [profile, profile]
+            )
+        }
+        #expect(throws: AdapterProbeError.malformedResponse) {
+            _ = try AdapterProbeResult(
+                detectedVendorVersion: version, detectedSchema: nil,
+                offeredProfiles: Array(repeating: profile, count: 17)
+            )
+        }
+    }
+
+    @Test func candidatesHaveNoAuthorityContext() throws {
+        let source = try AdapterSourcePosition(
+            sourceEvent: VendorReference(role: .event, value: "event"),
+            resumePosition: AdapterResumePosition("cursor"), sourceSequence: 1
+        )
+        let timestamp = try TimestampHint(secondsSince1970: 1, durationMilliseconds: 2)
+        let lifecycle = try CandidateLifecycleEvent(
+            scope: .turn, phase: .working, reference: VendorReference(role: .turn, value: "turn")
+        )
+        let attention = try CandidateAttentionEvent(
+            scope: .turn, phase: .waitingForQuestion,
+            request: VendorReference(role: .request, value: "request"),
+            context: VendorReference(role: .turn, value: "turn")
+        )
+        let identity = try ClaimedContentIdentity(sha256: String(repeating: "a", count: 64), byteCount: 1)
+        let change = try CandidateFileChange(
+            operation: .rename, relativePath: "old.swift", destinationRelativePath: "new.swift",
+            before: identity, after: identity
+        )
+        let tool = try CandidateToolEvent(
+            phase: .succeeded, category: .fileChange,
+            toolCall: VendorReference(role: .toolCall, value: "tool"), fileChanges: [change]
+        )
+        let candidates = [
+            AdapterCandidate(event: .lifecycle(lifecycle), timestampHint: timestamp, sourcePosition: source),
+            AdapterCandidate(event: .question(attention), timestampHint: timestamp, sourcePosition: source),
+            AdapterCandidate(event: .approval(try CandidateAttentionEvent(
+                scope: .turn, phase: .waitingForApproval,
+                request: VendorReference(role: .request, value: "approval"), context: attention.context
+            )), timestampHint: timestamp, sourcePosition: source),
+            AdapterCandidate(event: .tool(tool), timestampHint: timestamp, sourcePosition: source),
+            AdapterCandidate(event: .processExited(status: 1), timestampHint: timestamp, sourcePosition: source)
+        ]
+        for candidate in candidates { assertNoForbiddenAuthority(candidate) }
+    }
+
+    private func fixtureProfile(
+        signals: Set<AdapterLifecycleCapabilities.Signal> = [
+            .init(scope: .session, phase: .settled), .init(scope: .turn, phase: .started)
+        ],
+        evidence: Set<AdapterEvidence> = [],
+        replay: AdapterReplay = .none,
+        ordering: AdapterOrdering = .ordered
+    ) throws -> AdapterCapabilityProfile {
+        try AdapterCapabilityProfile(
+            transport: .ownedStandardIO,
+            lifecycle: AdapterLifecycleCapabilities(signals: signals, evidence: evidence),
+            delivery: AdapterDeliverySemantics(
+                replay: replay, ordering: ordering, minimumAuthentication: .ownedChildPipe
+            )
+        )
+    }
+
+    private func fixtureContract(profile: AdapterCapabilityProfile) throws -> NegotiatedAdapterContract {
+        let agentID = try AgentID(validating: "codex")
+        let adapterID = try AdapterID(validating: "pine:codex")
+        let factoryID = try AdapterFactoryID(validating: "pine.codex.factory")
+        let presentation = try AgentPresentationDescriptor(
+            agentID: agentID, displayName: "Codex",
+            executableAliases: [ExecutableAlias(validating: "codex")], style: .codex
+        )
+        let version = PineAdapterContractVersion(major: 1, minor: 0)
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [presentation],
+            compiledAdapters: [(AdapterDescriptor(
+                adapterID: adapterID, agentID: agentID, factoryID: factoryID,
+                contractVersions: PineAdapterContractVersionRange(minimum: version, maximum: version),
+                maximumProfiles: [profile]
+            ), ContractTestFactory(id: factoryID))]
+        )
+        return try registry.negotiate(
+            adapterID: adapterID, offeredProfiles: [profile],
+            offeredVersions: PineAdapterContractVersionRange(minimum: version, maximum: version),
+            policy: AdapterNegotiationPolicy(
+                allowedVersions: PineAdapterContractVersionRange(minimum: version, maximum: version),
+                transportPreference: [profile.transport], acceptedAuthentication: [profile.minimumAuthentication]
+            )
+        )
+    }
+
+    private func dumped<T>(_ value: T) -> String {
+        var output = ""
+        dump(value, to: &output)
+        return output
+    }
+
+    private func assertNoForbiddenAuthority(_ value: Any) {
+        let forbidden = [
+            "credential", "authenticationcontext", "task", "project", "worktree", "pane", "tab", "terminal",
+            "pid", "processgeneration", "route", "trust", "provenance", "command", "args", "environment",
+            "env", "output", "transcript", "filecontent", "contents"
+        ]
+        func inspect(_ value: Any) {
+            let mirror = Mirror(reflecting: value)
+            let typeName = String(reflecting: type(of: value)).lowercased()
+            let forbiddenTypes = [
+                "credential", "authenticationcontext", "taskid", "projectid", "worktreeid", "paneid", "tabid",
+                "terminal", "processgeneration", "routeauthority", "trustauthority", "provenanceauthority",
+                "pid", "command", "arguments", "environment", "output", "transcript", "filecontents"
+            ]
+            #expect(!forbiddenTypes.contains { typeName.contains($0) })
+            for child in mirror.children {
+                let label = (child.label ?? "").lowercased()
+                if label == "$defaultactor" { continue }
+                #expect(!forbidden.contains { label.contains($0) })
+                inspect(child.value)
+            }
+        }
+        inspect(value)
+    }
+}

--- a/PineTests/AgentAdapterContractTests.swift
+++ b/PineTests/AgentAdapterContractTests.swift
@@ -4,7 +4,8 @@ import Testing
 
 nonisolated private struct ContractTestFactory: AgentAdapterFactory {
     let id: AdapterFactoryID
-    func probe() async throws -> AdapterProbeResult { throw AdapterProbeError.unavailable(.permanent) }
+    let probeResult: AdapterProbeResult
+    func probe() async throws -> AdapterProbeResult { probeResult }
     func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession {
         throw AdapterSessionError.launchFailed(.permanent)
     }
@@ -95,11 +96,11 @@ struct AgentAdapterContractTests {
         }
     }
 
-    @Test func piAndCodexLifecyclePairsDoNotCross() throws {
-        let pi = try fixtureContract(profile: fixtureProfile(signals: [
+    @Test func piAndCodexLifecyclePairsDoNotCross() async throws {
+        let pi = try await fixtureContract(profile: fixtureProfile(signals: [
             .init(scope: .run, phase: .succeeded), .init(scope: .session, phase: .settled)
         ]))
-        let codex = try fixtureContract(profile: fixtureProfile(signals: [
+        let codex = try await fixtureContract(profile: fixtureProfile(signals: [
             .init(scope: .session, phase: .started), .init(scope: .turn, phase: .succeeded),
             .init(scope: .item, phase: .started)
         ]))
@@ -119,8 +120,8 @@ struct AgentAdapterContractTests {
         }
     }
 
-    @Test func candidatesAreCapabilityBound() throws {
-        let contract = try fixtureContract(profile: fixtureProfile(signals: [
+    @Test func candidatesAreCapabilityBound() async throws {
+        let contract = try await fixtureContract(profile: fixtureProfile(signals: [
             .init(scope: .session, phase: .started),
             .init(scope: .turn, phase: .waitingForQuestion)
         ]))
@@ -151,8 +152,8 @@ struct AgentAdapterContractTests {
         }
     }
 
-    @Test func attentionRequiresExactScopePhaseAndRoles() throws {
-        let contract = try fixtureContract(profile: fixtureProfile(signals: [
+    @Test func attentionRequiresExactScopePhaseAndRoles() async throws {
+        let contract = try await fixtureContract(profile: fixtureProfile(signals: [
             .init(scope: .session, phase: .waitingForQuestion),
             .init(scope: .turn, phase: .waitingForQuestion),
             .init(scope: .turn, phase: .waitingForApproval)
@@ -232,7 +233,7 @@ struct AgentAdapterContractTests {
         #expect(try DetectedVendorVersion("e\u{301}").value == "é")
     }
 
-    @Test func fileChangeBatchesAreCoherent() throws {
+    @Test func fileChangeBatchesAreCoherent() async throws {
         let call = try VendorReference(role: .toolCall, value: "call")
         let change = try CandidateFileChange(operation: .modify, relativePath: "Sources/File.swift")
         #expect(throws: AdapterCandidateError.contradictoryEvent) {
@@ -278,7 +279,7 @@ struct AgentAdapterContractTests {
         let tool = try CandidateToolEvent(
             phase: .succeeded, category: .read, toolCall: call, fileChanges: [change]
         )
-        let toolOnly = try fixtureContract(profile: fixtureProfile(evidence: [.tool]))
+        let toolOnly = try await fixtureContract(profile: fixtureProfile(evidence: [.tool]))
         #expect(throws: AdapterCandidateError.capabilityOverreach) {
             try AdapterCandidateEvent.tool(tool).validate(against: toolOnly)
         }
@@ -288,18 +289,18 @@ struct AgentAdapterContractTests {
         #expect(throws: AdapterCandidateError.capabilityOverreach) {
             try AdapterCandidateEvent.tool(categoryEvent).validate(against: toolOnly)
         }
-        let both = try fixtureContract(profile: fixtureProfile(evidence: [.tool, .fileChange]))
+        let both = try await fixtureContract(profile: fixtureProfile(evidence: [.tool, .fileChange]))
         try AdapterCandidateEvent.tool(tool).validate(against: both)
     }
 
-    @Test func sourcePositionFollowsProfile() throws {
-        let ordered = try fixtureContract(profile: fixtureProfile())
+    @Test func sourcePositionFollowsProfile() async throws {
+        let ordered = try await fixtureContract(profile: fixtureProfile())
         let sequence = try AdapterSourcePosition(sourceSequence: 1)
         try AdapterCandidate(event: .processExited(status: nil), sourcePosition: sequence).validate(against: ordered)
         #expect(throws: AdapterCandidateError.missingSourceSequence) {
             try AdapterCandidate(event: .processExited(status: nil)).validate(against: ordered)
         }
-        let replay = try fixtureContract(profile: fixtureProfile(replay: .sourceCursor))
+        let replay = try await fixtureContract(profile: fixtureProfile(replay: .sourceCursor))
         #expect(throws: AdapterCandidateError.incompleteReplayPosition) {
             try AdapterCandidate(event: .processExited(status: nil), sourcePosition: sequence).validate(against: replay)
         }
@@ -332,7 +333,7 @@ struct AgentAdapterContractTests {
         #expect(throws: AdapterCandidateError.invalidSourcePosition) {
             _ = try AdapterSourcePosition(sourceSequence: 0)
         }
-        let unordered = try fixtureContract(profile: fixtureProfile(ordering: .unordered))
+        let unordered = try await fixtureContract(profile: fixtureProfile(ordering: .unordered))
         #expect(throws: AdapterCandidateError.forbiddenSourceSequence) {
             try AdapterCandidate(event: .processExited(status: nil), sourcePosition: sequence)
                 .validate(against: unordered)
@@ -358,17 +359,44 @@ struct AgentAdapterContractTests {
         let version = try DetectedVendorVersion("1.0")
         let profile = try fixtureProfile()
         _ = try AdapterProbeResult(
-            detectedVendorVersion: version, detectedSchema: nil, offeredProfiles: [profile]
+            detectedVendorVersion: version,
+            detectedSchema: nil,
+            offeredProfiles: [profile],
+            offeredContractVersions: PineAdapterContractVersionRange(
+                minimum: PineAdapterContractVersion(major: 1, minor: 0),
+                maximum: PineAdapterContractVersion(major: 1, minor: 1)
+            )
         )
         #expect(throws: AdapterProbeError.malformedResponse) {
             _ = try AdapterProbeResult(
-                detectedVendorVersion: version, detectedSchema: nil, offeredProfiles: [profile, profile]
+                detectedVendorVersion: version,
+                detectedSchema: nil,
+                offeredProfiles: [profile, profile],
+                offeredContractVersions: PineAdapterContractVersionRange(
+                    minimum: PineAdapterContractVersion(major: 1, minor: 0),
+                    maximum: PineAdapterContractVersion(major: 1, minor: 1)
+                )
             )
         }
         #expect(throws: AdapterProbeError.malformedResponse) {
             _ = try AdapterProbeResult(
                 detectedVendorVersion: version, detectedSchema: nil,
-                offeredProfiles: Array(repeating: profile, count: 17)
+                offeredProfiles: Array(repeating: profile, count: 17),
+                offeredContractVersions: PineAdapterContractVersionRange(
+                    minimum: PineAdapterContractVersion(major: 1, minor: 0),
+                    maximum: PineAdapterContractVersion(major: 1, minor: 1)
+                )
+            )
+        }
+        #expect(throws: AdapterProbeError.malformedResponse) {
+            _ = try AdapterProbeResult(
+                detectedVendorVersion: version,
+                detectedSchema: nil,
+                offeredProfiles: [profile],
+                offeredContractVersions: PineAdapterContractVersionRange(
+                    minimum: PineAdapterContractVersion(major: 2, minor: 0),
+                    maximum: PineAdapterContractVersion(major: 1, minor: 0)
+                )
             )
         }
     }
@@ -426,7 +454,7 @@ struct AgentAdapterContractTests {
         )
     }
 
-    private func fixtureContract(profile: AdapterCapabilityProfile) throws -> NegotiatedAdapterContract {
+    private func fixtureContract(profile: AdapterCapabilityProfile) async throws -> NegotiatedAdapterContract {
         let agentID = try AgentID(validating: "codex")
         let adapterID = try AdapterID(validating: "pine:codex")
         let factoryID = try AdapterFactoryID(validating: "pine.codex.factory")
@@ -435,19 +463,26 @@ struct AgentAdapterContractTests {
             executableAliases: [ExecutableAlias(validating: "codex")], style: .codex
         )
         let version = PineAdapterContractVersion(major: 1, minor: 0)
+        let versions = PineAdapterContractVersionRange(minimum: version, maximum: version)
+        let probeResult = try AdapterProbeResult(
+            detectedVendorVersion: DetectedVendorVersion("test-vendor-1.0"),
+            detectedSchema: nil,
+            offeredProfiles: [profile],
+            offeredContractVersions: versions
+        )
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [presentation],
             compiledAdapters: [(AdapterDescriptor(
                 adapterID: adapterID, agentID: agentID, factoryID: factoryID,
-                contractVersions: PineAdapterContractVersionRange(minimum: version, maximum: version),
+                contractVersions: versions,
                 maximumProfiles: [profile]
-            ), ContractTestFactory(id: factoryID))]
+            ), ContractTestFactory(id: factoryID, probeResult: probeResult))]
         )
+        let offer = try await registry.probe(adapterID: adapterID)
         return try registry.negotiate(
-            adapterID: adapterID, offeredProfiles: [profile],
-            offeredVersions: PineAdapterContractVersionRange(minimum: version, maximum: version),
+            offer: offer,
             policy: AdapterNegotiationPolicy(
-                allowedVersions: PineAdapterContractVersionRange(minimum: version, maximum: version),
+                allowedVersions: versions,
                 transportPreference: [profile.transport], acceptedAuthentication: [profile.minimumAuthentication]
             )
         )

--- a/PineTests/AgentAdapterRegistryTests.swift
+++ b/PineTests/AgentAdapterRegistryTests.swift
@@ -326,56 +326,73 @@ struct AgentAdapterRegistryTests {
         _ = replacement
     }
 
-    @Test func cleanupCapacityIsReservedBeforeExposureAndReleasedOnAbandonment() async throws {
-        let setup = try fixtures()
-        let descriptor = setup.adapters[0].0
-        let recorder = FactoryRecorder()
-        let capacity = AdapterCleanupCapacity(limit: 1)
-        let registry = try AgentAdapterRegistry(
-            compiledPresentations: [setup.presentation],
-            compiledAdapters: [(descriptor, RecordingFactory(
-                id: descriptor.factoryID,
-                recorder: recorder,
-                probeResult: try probeResult(
-                    profile: setup.profile,
-                    versions: descriptor.contractVersions
-                )
-            ))],
-            cleanupCapacity: capacity
-        )
-        let firstContract = try await negotiate(
-            registry,
-            adapterID: descriptor.adapterID,
-            profile: setup.profile
-        )
-        let secondContract = try await negotiate(
-            registry,
-            adapterID: descriptor.adapterID,
-            profile: setup.profile
-        )
-        var first: (any AgentAdapterSession)? = try await registry.makeSession(
-            contract: firstContract,
-            resumeFrom: nil
-        ) { _ in .accepted }
-        #expect(first != nil)
-        #expect(capacity.reservedCount == 1)
-        await #expect(throws: AdapterSessionError.cleanupCapacityUnavailable) {
-            _ = try await registry.makeSession(
-                contract: secondContract,
+    @Test func abandonmentBeforeOrAfterStartRunsExactlyOneCleanup() async throws {
+        for startsBeforeAbandonment in [false, true] {
+            let setup = try fixtures()
+            let descriptor = setup.adapters[0].0
+            let recorder = FactoryRecorder()
+            let stopHold = StopHold()
+            let capacity = AdapterCleanupCapacity(limit: 1)
+            let registry = try AgentAdapterRegistry(
+                compiledPresentations: [setup.presentation],
+                compiledAdapters: [(descriptor, StopTestFactory(
+                    id: descriptor.factoryID,
+                    probeResult: try probeResult(
+                        profile: setup.profile,
+                        versions: descriptor.contractVersions
+                    ),
+                    stopHold: stopHold,
+                    recorder: recorder
+                ))],
+                cleanupCapacity: capacity
+            )
+            let abandonedContract = try await negotiate(
+                registry,
+                adapterID: descriptor.adapterID,
+                profile: setup.profile
+            )
+            let replacementContract = try await negotiate(
+                registry,
+                adapterID: descriptor.adapterID,
+                profile: setup.profile
+            )
+            var abandoned: (any AgentAdapterSession)? = try await registry.makeSession(
+                contract: abandonedContract,
                 resumeFrom: nil
             ) { _ in .accepted }
-        }
+            if startsBeforeAbandonment, let session = abandoned {
+                try await session.start()
+            }
+            #expect(capacity.reservedCount == 1)
+            abandoned = nil
 
-        first = nil
-        #expect(capacity.reservedCount == 0)
-        var replacement: (any AgentAdapterSession)? = try await registry.makeSession(
-            contract: secondContract,
-            resumeFrom: nil
-        ) { _ in .accepted }
-        #expect(replacement != nil)
-        #expect(capacity.reservedCount == 1)
-        replacement = nil
-        #expect(capacity.reservedCount == 0)
+            await stopHold.waitUntilArrived()
+            #expect(await stopHold.callCount == 1)
+            #expect(capacity.reservedCount == 1)
+            await #expect(throws: AdapterSessionError.cleanupCapacityUnavailable) {
+                _ = try await registry.makeSession(
+                    contract: replacementContract,
+                    resumeFrom: nil
+                ) { _ in .accepted }
+            }
+
+            await stopHold.release()
+            await stopHold.waitUntilFinished()
+            for _ in 0..<10_000 where capacity.reservedCount != 0 {
+                await Task.yield()
+            }
+            #expect(capacity.reservedCount == 0)
+
+            let replacement = try await registry.makeSession(
+                contract: replacementContract,
+                resumeFrom: nil
+            ) { _ in .accepted }
+            await replacement.stop(
+                deadline: ContinuousClock.now.advanced(by: .seconds(1))
+            )
+            #expect(await stopHold.callCount == 2)
+            #expect(capacity.reservedCount == 0)
+        }
     }
 
     @Test func continuationGateResolvesEveryRegistrationCancellationOrdering() async {
@@ -403,6 +420,18 @@ struct AgentAdapterRegistryTests {
         registeredBeforeResolution.resolve()
         await registeredTask.value
         #expect(registeredBeforeResolution.isResolved)
+
+        let cancelledAfterRegistration = AsyncContinuationGate()
+        let cancellationTask = Task { await cancelledAfterRegistration.wait() }
+        for _ in 0..<1_000 where !cancelledAfterRegistration.hasRegisteredWaiter {
+            await Task.yield()
+        }
+        #expect(cancelledAfterRegistration.hasRegisteredWaiter)
+        cancellationTask.cancel()
+        await cancellationTask.value
+        cancelledAfterRegistration.resolve()
+        cancelledAfterRegistration.resolve()
+        #expect(cancelledAfterRegistration.isResolved)
 
         for _ in 0..<128 {
             let raced = AsyncContinuationGate()
@@ -1540,14 +1569,189 @@ struct AgentAdapterRegistryTests {
         #expect(await stopHold.observedCancellationAtExit == true)
         #expect(capacity.reservedCount == 0)
 
-        var replacement: (any AgentAdapterSession)? = try await registry.makeSession(
+        let replacement = try await registry.makeSession(
             contract: replacementContract,
             resumeFrom: nil
         ) { _ in .accepted }
-        #expect(replacement != nil)
         #expect(capacity.reservedCount == 1)
-        replacement = nil
+        await replacement.stop(
+            deadline: ContinuousClock.now.advanced(by: .seconds(1))
+        )
         #expect(capacity.reservedCount == 0)
+    }
+
+    @Test func cancellationIgnoringCleanupRetainsCapacityUntilActualExit() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let hold = IgnoringStopHold()
+        let capacity = AdapterCleanupCapacity(limit: 1)
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, IgnoringStopTestFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                ),
+                hold: hold
+            ))],
+            cleanupCapacity: capacity
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let replacementContract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let session = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .milliseconds(200))
+        let stopTask = Task {
+            await session.stop(deadline: deadline)
+            return clock.now
+        }
+        let watchdog = Task {
+            try? await clock.sleep(until: deadline.advanced(by: .seconds(2)))
+            await hold.release()
+        }
+
+        await hold.waitUntilArrived()
+        let returnedAt = await stopTask.value
+        #expect(returnedAt <= deadline.advanced(by: .seconds(1)))
+        #expect(capacity.reservedCount == 1)
+        await #expect(throws: AdapterSessionError.cleanupCapacityUnavailable) {
+            _ = try await registry.makeSession(
+                contract: replacementContract,
+                resumeFrom: nil
+            ) { _ in .accepted }
+        }
+
+        await hold.release()
+        await hold.waitUntilFinished()
+        watchdog.cancel()
+        #expect(await hold.observedCancellationAtExit == true)
+        for _ in 0..<10_000 where capacity.reservedCount != 0 {
+            await Task.yield()
+        }
+        #expect(capacity.reservedCount == 0)
+
+        let replacement = try await registry.makeSession(
+            contract: replacementContract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        await replacement.stop(
+            deadline: ContinuousClock.now.advanced(by: .seconds(1))
+        )
+        #expect(await hold.callCount == 2)
+        #expect(capacity.reservedCount == 0)
+    }
+
+    @Test func laterShortStopKeepsInitiatingLongCleanupAlive() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let hold = StopHold()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, StopTestFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                ),
+                stopHold: hold
+            ))]
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let session = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        let clock = ContinuousClock()
+        let longDeadline = clock.now.advanced(by: .seconds(2))
+        let longStop = Task {
+            await session.stop(deadline: longDeadline)
+            return clock.now
+        }
+        await hold.waitUntilArrived()
+
+        let shortDeadline = clock.now.advanced(by: .milliseconds(200))
+        let shortStop = Task {
+            await session.stop(deadline: shortDeadline)
+            return clock.now
+        }
+        let shortReturnedAt = await shortStop.value
+        #expect(shortReturnedAt <= shortDeadline.advanced(by: .seconds(1)))
+        #expect(await hold.callCount == 1)
+        #expect(await hold.observedCancellationAtExit == nil)
+
+        await hold.release()
+        let longReturnedAt = await longStop.value
+        await hold.waitUntilFinished()
+        #expect(longReturnedAt <= longDeadline.advanced(by: .seconds(1)))
+        #expect(await hold.observedCancellationAtExit == false)
+    }
+
+    @Test func initiatingShortStopCancelsSharedCleanupForLongFollower() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let hold = StopHold()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, StopTestFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                ),
+                stopHold: hold
+            ))]
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let session = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        let clock = ContinuousClock()
+        let shortDeadline = clock.now.advanced(by: .milliseconds(200))
+        let shortStop = Task {
+            await session.stop(deadline: shortDeadline)
+            return clock.now
+        }
+        await hold.waitUntilArrived()
+        let longDeadline = clock.now.advanced(by: .seconds(2))
+        let longStop = Task {
+            await session.stop(deadline: longDeadline)
+            return clock.now
+        }
+        let watchdog = Task {
+            try? await clock.sleep(until: shortDeadline.advanced(by: .seconds(2)))
+            await hold.release()
+        }
+
+        let shortReturnedAt = await shortStop.value
+        let longReturnedAt = await longStop.value
+        await hold.waitUntilFinished()
+        watchdog.cancel()
+        await hold.release()
+        #expect(shortReturnedAt <= shortDeadline.advanced(by: .seconds(1)))
+        #expect(longReturnedAt <= shortDeadline.advanced(by: .seconds(1)))
+        #expect(await hold.callCount == 1)
+        #expect(await hold.observedCancellationAtExit == true)
     }
 
     @Test func stopPreservesAcceptedOutcomeForAlreadyAdmittedDelivery() async throws {
@@ -2160,6 +2364,30 @@ nonisolated private struct CancellationIgnoringResumeFactory: AgentAdapterFactor
     }
 }
 
+nonisolated private struct IgnoringStopTestFactory: AgentAdapterFactory {
+    let id: AdapterFactoryID
+    let probeResult: AdapterProbeResult
+    let hold: IgnoringStopHold
+
+    func probe() async throws -> AdapterProbeResult { probeResult }
+
+    func makeSession(
+        _ request: AgentAdapterSessionRequest
+    ) async throws -> any AgentAdapterSession {
+        IgnoringStopTestSession(contract: request.contract, hold: hold)
+    }
+}
+
+nonisolated private struct IgnoringStopTestSession: AgentAdapterSession {
+    let contract: NegotiatedAdapterContract
+    let hold: IgnoringStopHold
+
+    func start() async throws {}
+    func stop(deadline: ContinuousClock.Instant) async {
+        await hold.wait()
+    }
+}
+
 nonisolated private struct StopTestFactory: AgentAdapterFactory {
     let id: AdapterFactoryID
     let probeResult: AdapterProbeResult
@@ -2215,6 +2443,41 @@ private actor StopHold {
 
     func release() async {
         await releaseSignal.signal()
+    }
+}
+
+private actor IgnoringStopHold {
+    private let arrival = TestSignal()
+    private let finished = TestSignal()
+    private var released = false
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+    private(set) var observedCancellationAtExit: Bool?
+    private(set) var callCount = 0
+
+    func wait() async {
+        callCount += 1
+        await arrival.signal()
+        if !released {
+            await withCheckedContinuation { releaseWaiters.append($0) }
+        }
+        observedCancellationAtExit = Task.isCancelled
+        await finished.signal()
+    }
+
+    func waitUntilArrived() async {
+        await arrival.wait()
+    }
+
+    func waitUntilFinished() async {
+        await finished.wait()
+    }
+
+    func release() {
+        guard !released else { return }
+        released = true
+        let retained = releaseWaiters
+        releaseWaiters.removeAll(keepingCapacity: false)
+        retained.forEach { $0.resume() }
     }
 }
 

--- a/PineTests/AgentAdapterRegistryTests.swift
+++ b/PineTests/AgentAdapterRegistryTests.swift
@@ -189,7 +189,7 @@ struct AgentAdapterRegistryTests {
         )
 
         let offer = try await registry.probe(adapterID: firstDescriptor.adapterID)
-        let contract = try registry.negotiate(offer: offer, policy: policy())
+        let contract = try await registry.negotiate(offer: offer, policy: policy())
         _ = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .accepted }
 
         #expect(contract.adapterID == firstDescriptor.adapterID)
@@ -229,13 +229,68 @@ struct AgentAdapterRegistryTests {
         )
 
         let foreignOffer = try await firstRegistry.probe(adapterID: descriptor.adapterID)
-        #expect(throws: AdapterNegotiationError.offerMismatch) {
-            _ = try secondRegistry.negotiate(offer: foreignOffer, policy: policy())
+        await #expect(throws: AdapterNegotiationError.offerMismatch) {
+            _ = try await secondRegistry.negotiate(offer: foreignOffer, policy: policy())
         }
         #expect(await firstRecorder.probeCalls == 1)
         #expect(await firstRecorder.sessionCalls == 0)
         #expect(await secondRecorder.probeCalls == 0)
         #expect(await secondRecorder.sessionCalls == 0)
+    }
+
+    @Test func registryOfferCanBeNegotiatedOnlyOnce() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: FactoryRecorder(),
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                )
+            ))]
+        )
+        let offer = try await registry.probe(adapterID: descriptor.adapterID)
+
+        _ = try await registry.negotiate(offer: offer, policy: policy())
+        await #expect(throws: AdapterNegotiationError.offerMismatch) {
+            _ = try await registry.negotiate(offer: offer, policy: policy())
+        }
+    }
+
+    @Test func negotiatedContractAuthorizesOnlyOneFreshSession() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: FactoryRecorder(),
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                )
+            ))]
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let first = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+
+        await #expect(throws: AdapterSessionError.contractAlreadyConsumed) {
+            _ = try await registry.makeSession(
+                contract: contract,
+                resumeFrom: nil
+            ) { _ in .accepted }
+        }
+        _ = first
     }
 
     @Test func strictSubsetProbeOfferNegotiatesAndActivates() async throws {
@@ -269,7 +324,7 @@ struct AgentAdapterRegistryTests {
         )
 
         let offer = try await registry.probe(adapterID: descriptor.adapterID)
-        let contract = try registry.negotiate(
+        let contract = try await registry.negotiate(
             offer: offer,
             policy: AdapterNegotiationPolicy(
                 allowedVersions: range(1, 1, 1, 8),
@@ -300,8 +355,8 @@ struct AgentAdapterRegistryTests {
             ))]
         )
         let versionOffer = try await versionRegistry.probe(adapterID: descriptor.adapterID)
-        #expect(throws: AdapterNegotiationError.noCommonVersion) {
-            _ = try versionRegistry.negotiate(offer: versionOffer, policy: policy())
+        await #expect(throws: AdapterNegotiationError.noCommonVersion) {
+            _ = try await versionRegistry.negotiate(offer: versionOffer, policy: policy())
         }
         #expect(await versionRecorder.probeCalls == 1)
         #expect(await versionRecorder.sessionCalls == 0)
@@ -323,8 +378,8 @@ struct AgentAdapterRegistryTests {
             ))]
         )
         let profileOffer = try await profileRegistry.probe(adapterID: descriptor.adapterID)
-        #expect(throws: AdapterNegotiationError.offeredProfileExceedsMaximum) {
-            _ = try profileRegistry.negotiate(offer: profileOffer, policy: policy())
+        await #expect(throws: AdapterNegotiationError.offeredProfileExceedsMaximum) {
+            _ = try await profileRegistry.negotiate(offer: profileOffer, policy: policy())
         }
         #expect(await profileRecorder.probeCalls == 1)
         #expect(await profileRecorder.sessionCalls == 0)
@@ -463,8 +518,8 @@ struct AgentAdapterRegistryTests {
             acceptedAuthentication: [.authenticatedPeer]
         )
         let offer = try await registry.probe(adapterID: setup.adapters[0].0.adapterID)
-        #expect(throws: AdapterNegotiationError.noCommonProfile) {
-            _ = try registry.negotiate(offer: offer, policy: forbiddenPolicy)
+        await #expect(throws: AdapterNegotiationError.noCommonProfile) {
+            _ = try await registry.negotiate(offer: offer, policy: forbiddenPolicy)
         }
     }
 
@@ -490,16 +545,16 @@ struct AgentAdapterRegistryTests {
             ))]
         )
         let versionOffer = try await registry.probe(adapterID: descriptor.adapterID)
-        #expect(throws: AdapterNegotiationError.noCommonVersion) {
-            _ = try registry.negotiate(offer: versionOffer, policy: policy())
+        await #expect(throws: AdapterNegotiationError.noCommonVersion) {
+            _ = try await registry.negotiate(offer: versionOffer, policy: policy())
         }
         let emptyOffer = try await registry.probe(adapterID: descriptor.adapterID)
-        #expect(throws: AdapterNegotiationError.noCommonProfile) {
-            _ = try registry.negotiate(offer: emptyOffer, policy: policy())
+        await #expect(throws: AdapterNegotiationError.noCommonProfile) {
+            _ = try await registry.negotiate(offer: emptyOffer, policy: policy())
         }
         let validOffer = try await registry.probe(adapterID: descriptor.adapterID)
-        #expect(throws: AdapterNegotiationError.invalidPolicyRange) {
-            _ = try registry.negotiate(
+        await #expect(throws: AdapterNegotiationError.invalidPolicyRange) {
+            _ = try await registry.negotiate(
                 offer: validOffer,
                 policy: AdapterNegotiationPolicy(
                     allowedVersions: range(2, 0, 1, 0),
@@ -522,11 +577,12 @@ struct AgentAdapterRegistryTests {
                 probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions)
             ))]
         )
-        let contract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
-        let first = try await registry.makeSession(contract: contract, resumeFrom: nil) { event in
+        let firstContract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let secondContract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let first = try await registry.makeSession(contract: firstContract, resumeFrom: nil) { event in
             await recorder.capture(event); return .accepted
         }
-        let second = try await registry.makeSession(contract: contract, resumeFrom: nil) { event in
+        let second = try await registry.makeSession(contract: secondContract, resumeFrom: nil) { event in
             await recorder.capture(event); return .accepted
         }
         try await first.start()
@@ -543,7 +599,7 @@ struct AgentAdapterRegistryTests {
             #expect(!output.contains("event-1"))
         }
         #expect(Array(Mirror(reflecting: checkpoint).children).count == 1)
-        let resumed = try await registry.makeSession(contract: contract, resumeFrom: checkpoint) { event in
+        let resumed = try await registry.makeSession(contract: firstContract, resumeFrom: checkpoint) { event in
             await recorder.capture(event)
             return .accepted
         }
@@ -624,7 +680,7 @@ struct AgentAdapterRegistryTests {
         let outcomes = await recorder.startOutcomes
         #expect(outcomes.count == limit + 1)
         #expect(outcomes.prefix(limit).allSatisfy { $0 == .bufferedUntilActivation })
-        #expect(outcomes.last == .droppedInvalid)
+        #expect(outcomes.last == .retryAfterActivation)
         #expect(await recorder.capturedCount == limit)
         let retry = AdapterCandidate(
             event: .processExited(status: nil),
@@ -672,7 +728,7 @@ struct AgentAdapterRegistryTests {
         let startTask = Task { try await session.start() }
         await completions.waitUntilArrived(1)
         let postCommit = try candidate(sequence: 2)
-        #expect(await recorder.ingest(postCommit) == .droppedInvalid)
+        #expect(await recorder.ingest(postCommit) == .retryAfterActivation)
 
         await completions.release(1)
         try await startTask.value
@@ -952,8 +1008,11 @@ struct AgentAdapterRegistryTests {
                 probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions)
             ))]
         )
-        let contract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
-        let dropped = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .droppedInvalid }
+        let droppedContract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let dropped = try await registry.makeSession(
+            contract: droppedContract,
+            resumeFrom: nil
+        ) { _ in .droppedInvalid }
         try await dropped.start()
         await #expect(throws: AdapterSessionError.checkpointUnavailable) {
             _ = try await registry.makeCheckpoint(for: dropped)
@@ -963,14 +1022,22 @@ struct AgentAdapterRegistryTests {
             _ = try await registry.makeCheckpoint(for: dropped)
         }
 
-        let revoked = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .revoked }
+        let revokedContract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let revoked = try await registry.makeSession(
+            contract: revokedContract,
+            resumeFrom: nil
+        ) { _ in .revoked }
         try await revoked.start()
         #expect(await recorder.ingest(try candidate(sequence: 2), sinkIndex: 1) == .revoked)
         await #expect(throws: AdapterSessionError.checkpointUnavailable) {
             _ = try await registry.makeCheckpoint(for: revoked)
         }
 
-        let accepted = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .accepted }
+        let acceptedContract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let accepted = try await registry.makeSession(
+            contract: acceptedContract,
+            resumeFrom: nil
+        ) { _ in .accepted }
         try await accepted.start()
         #expect(await recorder.ingest(try candidate(sequence: 7), sinkIndex: 2) == .accepted)
         _ = try await registry.makeCheckpoint(for: accepted)
@@ -1062,6 +1129,191 @@ struct AgentAdapterRegistryTests {
         #expect(await recorder.calls == 2)
     }
 
+    @Test func failedResumeConstructionRollsBackCheckpointReservation() async throws {
+        let setup = try fixtures(replay: .sourceCursor)
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let resumeFailure = ResumeFailureController()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RetryableResumeFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                ),
+                recorder: recorder,
+                resumeFailure: resumeFailure
+            ))]
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let source = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        try await source.start()
+        #expect(await recorder.ingest(try candidate(sequence: 1)) == .accepted)
+        let checkpoint = try await registry.makeCheckpoint(for: source)
+
+        await #expect(throws: AdapterSessionError.launchFailed(.transient)) {
+            _ = try await registry.makeSession(
+                contract: contract,
+                resumeFrom: checkpoint
+            ) { _ in .accepted }
+        }
+        let failedStart = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: checkpoint
+        ) { _ in .accepted }
+        await #expect(throws: AdapterSessionError.launchFailed(.transient)) {
+            try await failedStart.start()
+        }
+        let resumed = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: checkpoint
+        ) { _ in .accepted }
+        try await resumed.start()
+        await #expect(throws: AdapterSessionError.checkpointAlreadyConsumed) {
+            _ = try await registry.makeSession(
+                contract: contract,
+                resumeFrom: checkpoint
+            ) { _ in .accepted }
+        }
+        #expect(await recorder.calls == 4)
+    }
+
+    @Test func stopRunsOutsideCallerCancellation() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let stopHold = StopHold()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, StopTestFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                ),
+                stopHold: stopHold
+            ))]
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let session = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+
+        let stopTask = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            await session.stop(
+                deadline: ContinuousClock.now.advanced(by: .seconds(5))
+            )
+        }
+        await stopHold.waitUntilArrived()
+        await stopHold.release()
+        await stopTask.value
+        #expect(await stopHold.observedCallerCancellation == false)
+    }
+
+    @Test func stopReturnsByDeadlineWhenAdapterDoesNotCooperate() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let stopHold = StopHold()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, StopTestFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                ),
+                stopHold: stopHold
+            ))]
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let session = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        let completion = TestSignal()
+        let deadline = ContinuousClock.now.advanced(by: .milliseconds(200))
+        let stopTask = Task {
+            await session.stop(deadline: deadline)
+            await completion.signal()
+        }
+
+        await stopHold.waitUntilArrived()
+        try await ContinuousClock().sleep(
+            until: deadline.advanced(by: .seconds(1))
+        )
+        let returnedByDeadline = await completion.signalled
+        await stopHold.release()
+        await stopTask.value
+        #expect(returnedByDeadline)
+    }
+
+    @Test func stopPreservesAcceptedOutcomeForAlreadyAdmittedDelivery() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let completions = CompletionController()
+        let stopHold = StopHold()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, StopTestFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                ),
+                stopHold: stopHold,
+                recorder: recorder
+            ))]
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let session = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { event in
+            await completions.wait(
+                sequence: event.candidate.sourcePosition?.sourceSequence
+            )
+            return .accepted
+        }
+        try await session.start()
+
+        let admitted = Task { await recorder.ingest(try candidate(sequence: 1)) }
+        await completions.waitUntilArrived(1)
+        let stopTask = Task {
+            await session.stop(
+                deadline: ContinuousClock.now.advanced(by: .seconds(5))
+            )
+        }
+        await stopHold.waitUntilArrived()
+        await stopHold.release()
+        #expect(await recorder.ingest(try candidate(sequence: 2)) == .revoked)
+        await completions.release(1)
+
+        #expect(try await admitted.value == .accepted)
+        await stopTask.value
+    }
+
     @Test func checkpointBindingsAndResumeBaselineFailClosed() async throws {
         let setup = try fixtures(twoAdapters: true, replay: .sourceCursor)
         let recorder = FactoryRecorder()
@@ -1145,12 +1397,12 @@ struct AgentAdapterRegistryTests {
         let checkpoint = try await registry.makeCheckpoint(for: source)
 
         let olderOffer = try await registry.probe(adapterID: descriptor.adapterID)
-        let olderVersion = try registry.negotiate(offer: olderOffer, policy: policy())
+        let olderVersion = try await registry.negotiate(offer: olderOffer, policy: policy())
         await #expect(throws: AdapterSessionError.checkpointMismatch) {
             _ = try await registry.makeSession(contract: olderVersion, resumeFrom: checkpoint) { _ in .accepted }
         }
         let alternateOffer = try await registry.probe(adapterID: descriptor.adapterID)
-        let alternateProfile = try registry.negotiate(
+        let alternateProfile = try await registry.negotiate(
             offer: alternateOffer,
             policy: AdapterNegotiationPolicy(
                 allowedVersions: range(1, 0, 1, 4),
@@ -1204,7 +1456,7 @@ struct AgentAdapterRegistryTests {
         var selections: [NegotiatedAdapterContract] = []
         for _ in permutations {
             let offer = try await completeRegistry.probe(adapterID: descriptor.adapterID)
-            selections.append(try completeRegistry.negotiate(
+            selections.append(try await completeRegistry.negotiate(
                 offer: offer,
                 policy: AdapterNegotiationPolicy(
                     allowedVersions: range(1, 0, 1, 4),
@@ -1237,8 +1489,8 @@ struct AgentAdapterRegistryTests {
             ))]
         )
         let offer = try await registry.probe(adapterID: descriptor.adapterID)
-        #expect(throws: AdapterNegotiationError.offeredProfileExceedsMaximum) {
-            _ = try registry.negotiate(offer: offer, policy: policy())
+        await #expect(throws: AdapterNegotiationError.offeredProfileExceedsMaximum) {
+            _ = try await registry.negotiate(offer: offer, policy: policy())
         }
     }
 
@@ -1291,7 +1543,7 @@ struct AgentAdapterRegistryTests {
         _ registry: AgentAdapterRegistry, adapterID: AdapterID, profile: AdapterCapabilityProfile
     ) async throws -> NegotiatedAdapterContract {
         let offer = try await registry.probe(adapterID: adapterID)
-        return try registry.negotiate(
+        return try await registry.negotiate(
             offer: offer,
             policy: AdapterNegotiationPolicy(
                 allowedVersions: range(1, 0, 1, 8), transportPreference: [profile.transport],
@@ -1462,12 +1714,109 @@ nonisolated private struct ProbeCancellingFactory: AgentAdapterFactory {
     }
 }
 
+private actor ResumeFailureController {
+    enum Behavior: Sendable { case failConstruction, failStart, succeed }
+    private var attempt = 0
+
+    func nextBehavior() -> Behavior {
+        attempt += 1
+        switch attempt {
+        case 1: return .failConstruction
+        case 2: return .failStart
+        default: return .succeed
+        }
+    }
+}
+
+nonisolated private struct RetryableResumeFactory: AgentAdapterFactory {
+    let id: AdapterFactoryID
+    let probeResult: AdapterProbeResult
+    let recorder: FactoryRecorder
+    let resumeFailure: ResumeFailureController
+
+    func probe() async throws -> AdapterProbeResult { probeResult }
+
+    func makeSession(
+        _ request: AgentAdapterSessionRequest
+    ) async throws -> any AgentAdapterSession {
+        await recorder.record(request: request)
+        if request.resumeFrom != nil {
+            switch await resumeFailure.nextBehavior() {
+            case .failConstruction:
+                throw AdapterSessionError.launchFailed(.transient)
+            case .failStart:
+                return RegistryTestSession(
+                    contract: request.contract,
+                    startFailure: .launchFailed(.transient)
+                )
+            case .succeed:
+                break
+            }
+        }
+        return RegistryTestSession(contract: request.contract)
+    }
+}
+
+nonisolated private struct StopTestFactory: AgentAdapterFactory {
+    let id: AdapterFactoryID
+    let probeResult: AdapterProbeResult
+    let stopHold: StopHold
+    var recorder: FactoryRecorder? = nil
+
+    func probe() async throws -> AdapterProbeResult { probeResult }
+
+    func makeSession(
+        _ request: AgentAdapterSessionRequest
+    ) async throws -> any AgentAdapterSession {
+        if let recorder { await recorder.record(request: request) }
+        return StopTestSession(contract: request.contract, stopHold: stopHold)
+    }
+}
+
+nonisolated private struct StopTestSession: AgentAdapterSession {
+    let contract: NegotiatedAdapterContract
+    let stopHold: StopHold
+
+    func start() async throws {}
+    func stop(deadline: ContinuousClock.Instant) async {
+        await stopHold.wait()
+    }
+}
+
+private actor StopHold {
+    private let arrival = TestSignal()
+    private var released = false
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+    private(set) var observedCallerCancellation: Bool?
+
+    func wait() async {
+        observedCallerCancellation = Task.isCancelled
+        await arrival.signal()
+        guard !released else { return }
+        await withCheckedContinuation { releaseWaiters.append($0) }
+    }
+
+    func waitUntilArrived() async {
+        await arrival.wait()
+    }
+
+    func release() {
+        guard !released else { return }
+        released = true
+        let retained = releaseWaiters
+        releaseWaiters.removeAll(keepingCapacity: false)
+        retained.forEach { $0.resume() }
+    }
+}
+
 private actor TestSignal {
     private var isSignalled = false
     private var nextWaiterID: UInt64 = 0
     private var waiters: [UInt64: CheckedContinuation<Void, Never>] = [:]
     private var cancelledBeforeRegistration = Set<UInt64>()
     private var resolvedBeforeCancellation = Set<UInt64>()
+
+    var signalled: Bool { isSignalled }
 
     func wait() async {
         guard !isSignalled, !Task.isCancelled else { return }

--- a/PineTests/AgentAdapterRegistryTests.swift
+++ b/PineTests/AgentAdapterRegistryTests.swift
@@ -326,6 +326,95 @@ struct AgentAdapterRegistryTests {
         _ = replacement
     }
 
+    @Test func cleanupCapacityIsReservedBeforeExposureAndReleasedOnAbandonment() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let capacity = AdapterCleanupCapacity(limit: 1)
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                )
+            ))],
+            cleanupCapacity: capacity
+        )
+        let firstContract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let secondContract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        var first: (any AgentAdapterSession)? = try await registry.makeSession(
+            contract: firstContract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        #expect(first != nil)
+        #expect(capacity.reservedCount == 1)
+        await #expect(throws: AdapterSessionError.cleanupCapacityUnavailable) {
+            _ = try await registry.makeSession(
+                contract: secondContract,
+                resumeFrom: nil
+            ) { _ in .accepted }
+        }
+
+        first = nil
+        #expect(capacity.reservedCount == 0)
+        var replacement: (any AgentAdapterSession)? = try await registry.makeSession(
+            contract: secondContract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        #expect(replacement != nil)
+        #expect(capacity.reservedCount == 1)
+        replacement = nil
+        #expect(capacity.reservedCount == 0)
+    }
+
+    @Test func continuationGateResolvesEveryRegistrationCancellationOrdering() async {
+        let resolvedBeforeRegistration = AsyncContinuationGate()
+        resolvedBeforeRegistration.resolve()
+        resolvedBeforeRegistration.resolve()
+        await resolvedBeforeRegistration.wait()
+        #expect(resolvedBeforeRegistration.isResolved)
+
+        let cancelledBeforeRegistration = AsyncContinuationGate()
+        let cancelledTask = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            await cancelledBeforeRegistration.wait()
+        }
+        await cancelledTask.value
+        #expect(cancelledBeforeRegistration.isResolved)
+
+        let registeredBeforeResolution = AsyncContinuationGate()
+        let registeredTask = Task { await registeredBeforeResolution.wait() }
+        for _ in 0..<1_000 where !registeredBeforeResolution.hasRegisteredWaiter {
+            await Task.yield()
+        }
+        #expect(registeredBeforeResolution.hasRegisteredWaiter)
+        registeredBeforeResolution.resolve()
+        registeredBeforeResolution.resolve()
+        await registeredTask.value
+        #expect(registeredBeforeResolution.isResolved)
+
+        for _ in 0..<128 {
+            let raced = AsyncContinuationGate()
+            let task = Task { await raced.wait() }
+            task.cancel()
+            raced.resolve()
+            raced.resolve()
+            await task.value
+            #expect(raced.isResolved)
+        }
+    }
+
     @Test func strictSubsetProbeOfferNegotiatesAndActivates() async throws {
         let setup = try fixtures()
         let base = setup.adapters[0].0
@@ -1400,10 +1489,11 @@ struct AgentAdapterRegistryTests {
         #expect(await stopHold.observedCallerCancellation == false)
     }
 
-    @Test func stopReturnsByDeadlineWhenAdapterDoesNotCooperate() async throws {
+    @Test func stopCancelsCooperativeCleanupAtDeadlineAndReleasesCapacity() async throws {
         let setup = try fixtures()
         let descriptor = setup.adapters[0].0
         let stopHold = StopHold()
+        let capacity = AdapterCleanupCapacity(limit: 1)
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
             compiledAdapters: [(descriptor, StopTestFactory(
@@ -1413,9 +1503,15 @@ struct AgentAdapterRegistryTests {
                     versions: descriptor.contractVersions
                 ),
                 stopHold: stopHold
-            ))]
+            ))],
+            cleanupCapacity: capacity
         )
         let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let replacementContract = try await negotiate(
             registry,
             adapterID: descriptor.adapterID,
             profile: setup.profile
@@ -1437,9 +1533,21 @@ struct AgentAdapterRegistryTests {
 
         await stopHold.waitUntilArrived()
         let returnedAt = await stopTask.value
+        await stopHold.waitUntilFinished()
         watchdog.cancel()
         await stopHold.release()
         #expect(returnedAt <= deadline.advanced(by: .seconds(1)))
+        #expect(await stopHold.observedCancellationAtExit == true)
+        #expect(capacity.reservedCount == 0)
+
+        var replacement: (any AgentAdapterSession)? = try await registry.makeSession(
+            contract: replacementContract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        #expect(replacement != nil)
+        #expect(capacity.reservedCount == 1)
+        replacement = nil
+        #expect(capacity.reservedCount == 0)
     }
 
     @Test func stopPreservesAcceptedOutcomeForAlreadyAdmittedDelivery() async throws {
@@ -2081,7 +2189,9 @@ nonisolated private struct StopTestSession: AgentAdapterSession {
 private actor StopHold {
     private let arrival = TestSignal()
     private let releaseSignal = TestSignal()
+    private let finished = TestSignal()
     private(set) var observedCallerCancellation: Bool?
+    private(set) var observedCancellationAtExit: Bool?
     private(set) var callCount = 0
 
     func wait() async {
@@ -2091,10 +2201,16 @@ private actor StopHold {
         }
         await arrival.signal()
         await releaseSignal.wait()
+        observedCancellationAtExit = Task.isCancelled
+        await finished.signal()
     }
 
     func waitUntilArrived() async {
         await arrival.wait()
+    }
+
+    func waitUntilFinished() async {
+        await finished.wait()
     }
 
     func release() async {

--- a/PineTests/AgentAdapterRegistryTests.swift
+++ b/PineTests/AgentAdapterRegistryTests.swift
@@ -4,13 +4,79 @@ import Testing
 nonisolated private struct RegistryTestFactory: AgentAdapterFactory {
     let id: AdapterFactoryID
     let failure: AdapterFailureDisposition
-    init(id: AdapterFactoryID, failure: AdapterFailureDisposition = .permanent) {
+    let probeResult: AdapterProbeResult?
+    init(
+        id: AdapterFactoryID,
+        failure: AdapterFailureDisposition = .permanent,
+        probeResult: AdapterProbeResult? = nil
+    ) {
         self.id = id
         self.failure = failure
+        self.probeResult = probeResult
     }
-    func probe() async throws -> AdapterProbeResult { throw AdapterProbeError.unavailable(.permanent) }
+    func probe() async throws -> AdapterProbeResult {
+        guard let probeResult else { throw AdapterProbeError.unavailable(.permanent) }
+        return probeResult
+    }
     func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession {
         throw AdapterSessionError.launchFailed(failure)
+    }
+}
+
+nonisolated private struct AuthorityTestFactory: AgentAdapterFactory {
+    let id: AdapterFactoryID
+    let probeResult: AdapterProbeResult?
+    let probeFailure: AdapterProbeError?
+    let sessionFailure: AdapterSessionError?
+    let recorder: AuthorityFactoryRecorder
+
+    func probe() async throws -> AdapterProbeResult {
+        await recorder.recordProbe()
+        if let probeFailure { throw probeFailure }
+        return try #require(probeResult)
+    }
+
+    func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession {
+        await recorder.recordSession(contract: request.contract)
+        if let sessionFailure { throw sessionFailure }
+        return RegistryTestSession(contract: request.contract)
+    }
+}
+
+private actor AuthorityFactoryRecorder {
+    private(set) var probeCalls = 0
+    private(set) var sessionCalls = 0
+    private(set) var sessionContract: NegotiatedAdapterContract?
+
+    func recordProbe() { probeCalls += 1 }
+    func recordSession(contract: NegotiatedAdapterContract) {
+        sessionCalls += 1
+        sessionContract = contract
+    }
+}
+
+private actor ProbeResultSequence {
+    private var results: [AdapterProbeResult]
+    private var index = 0
+
+    init(_ results: [AdapterProbeResult]) { self.results = results }
+
+    func next() throws -> AdapterProbeResult {
+        guard results.indices.contains(index) else { throw AdapterProbeError.malformedResponse }
+        defer { index += 1 }
+        return results[index]
+    }
+}
+
+nonisolated private struct SequencedRecordingFactory: AgentAdapterFactory {
+    let id: AdapterFactoryID
+    let probes: ProbeResultSequence
+    let sessionRecorder: FactoryRecorder?
+
+    func probe() async throws -> AdapterProbeResult { try await probes.next() }
+    func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession {
+        await sessionRecorder?.record(request: request)
+        return RegistryTestSession(contract: request.contract)
     }
 }
 
@@ -67,15 +133,221 @@ nonisolated private struct RegistryTestSession: AgentAdapterSession {
     func stop(deadline: ContinuousClock.Instant) async {}
 }
 
-@Suite("Agent adapter compiled registry")
+@Suite("Agent adapter compiled registry", .timeLimit(.minutes(1)))
 struct AgentAdapterRegistryTests {
+    @Test func unavailableProbeCannotBeBypassedByEquivalentCallerResult() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let equivalentRawResult = try probeResult(
+            profile: setup.profile,
+            versions: descriptor.contractVersions
+        )
+        let recorder = AuthorityFactoryRecorder()
+        let factory = AuthorityTestFactory(
+            id: descriptor.factoryID,
+            probeResult: nil,
+            probeFailure: .unavailable(.permanent),
+            sessionFailure: nil,
+            recorder: recorder
+        )
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, factory)]
+        )
+
+        await #expect(throws: AdapterProbeError.unavailable(.permanent)) {
+            _ = try await registry.probe(adapterID: descriptor.adapterID)
+        }
+        #expect(equivalentRawResult.offeredProfiles == [setup.profile])
+        #expect(await recorder.probeCalls == 1)
+        #expect(await recorder.sessionCalls == 0)
+    }
+
+    @Test func offerBindsExactRegisteredFactoryThroughSessionCreation() async throws {
+        let setup = try fixtures(twoAdapters: true)
+        let firstDescriptor = setup.adapters[0].0
+        let secondDescriptor = setup.adapters[1].0
+        let firstRecorder = AuthorityFactoryRecorder()
+        let secondRecorder = AuthorityFactoryRecorder()
+        let firstFactory = AuthorityTestFactory(
+            id: firstDescriptor.factoryID,
+            probeResult: try probeResult(profile: setup.profile, versions: range(1, 1, 1, 3)),
+            probeFailure: nil,
+            sessionFailure: nil,
+            recorder: firstRecorder
+        )
+        let secondFactory = AuthorityTestFactory(
+            id: secondDescriptor.factoryID,
+            probeResult: try probeResult(profile: setup.profile, versions: range(1, 0, 1, 4)),
+            probeFailure: nil,
+            sessionFailure: .launchFailed(.permanent),
+            recorder: secondRecorder
+        )
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(firstDescriptor, firstFactory), (secondDescriptor, secondFactory)]
+        )
+
+        let offer = try await registry.probe(adapterID: firstDescriptor.adapterID)
+        let contract = try registry.negotiate(offer: offer, policy: policy())
+        _ = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .accepted }
+
+        #expect(contract.adapterID == firstDescriptor.adapterID)
+        #expect(contract.factoryID == firstDescriptor.factoryID)
+        #expect(await firstRecorder.probeCalls == 1)
+        #expect(await firstRecorder.sessionCalls == 1)
+        #expect(await firstRecorder.sessionContract == contract)
+        #expect(await secondRecorder.probeCalls == 0)
+        #expect(await secondRecorder.sessionCalls == 0)
+    }
+
+    @Test func foreignRegistryOfferIsRejectedBeforeFactoryInvocation() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let firstRecorder = AuthorityFactoryRecorder()
+        let secondRecorder = AuthorityFactoryRecorder()
+        let result = try probeResult(profile: setup.profile, versions: descriptor.contractVersions)
+        let firstRegistry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, AuthorityTestFactory(
+                id: descriptor.factoryID,
+                probeResult: result,
+                probeFailure: nil,
+                sessionFailure: nil,
+                recorder: firstRecorder
+            ))]
+        )
+        let secondRegistry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, AuthorityTestFactory(
+                id: descriptor.factoryID,
+                probeResult: result,
+                probeFailure: nil,
+                sessionFailure: nil,
+                recorder: secondRecorder
+            ))]
+        )
+
+        let foreignOffer = try await firstRegistry.probe(adapterID: descriptor.adapterID)
+        #expect(throws: AdapterNegotiationError.offerMismatch) {
+            _ = try secondRegistry.negotiate(offer: foreignOffer, policy: policy())
+        }
+        #expect(await firstRecorder.probeCalls == 1)
+        #expect(await firstRecorder.sessionCalls == 0)
+        #expect(await secondRecorder.probeCalls == 0)
+        #expect(await secondRecorder.sessionCalls == 0)
+    }
+
+    @Test func strictSubsetProbeOfferNegotiatesAndActivates() async throws {
+        let setup = try fixtures()
+        let base = setup.adapters[0].0
+        let maximum = try AdapterCapabilityProfile(
+            transport: .ownedStandardIO,
+            lifecycle: AdapterLifecycleCapabilities(
+                signals: lifecycleSignals().union([.init(scope: .turn, phase: .working)]),
+                evidence: [.tool]
+            ),
+            delivery: AdapterDeliverySemantics(ordering: .ordered, minimumAuthentication: .ownedChildPipe)
+        )
+        let descriptor = AdapterDescriptor(
+            adapterID: base.adapterID,
+            agentID: base.agentID,
+            factoryID: base.factoryID,
+            contractVersions: range(1, 0, 1, 9),
+            maximumProfiles: [maximum]
+        )
+        let recorder = AuthorityFactoryRecorder()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, AuthorityTestFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(profile: setup.profile, versions: range(1, 2, 1, 4)),
+                probeFailure: nil,
+                sessionFailure: nil,
+                recorder: recorder
+            ))]
+        )
+
+        let offer = try await registry.probe(adapterID: descriptor.adapterID)
+        let contract = try registry.negotiate(
+            offer: offer,
+            policy: AdapterNegotiationPolicy(
+                allowedVersions: range(1, 1, 1, 8),
+                transportPreference: [.ownedStandardIO],
+                acceptedAuthentication: [.ownedChildPipe]
+            )
+        )
+        _ = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .accepted }
+
+        #expect(contract.version == PineAdapterContractVersion(major: 1, minor: 4))
+        #expect(contract.profile == setup.profile)
+        #expect(await recorder.probeCalls == 1)
+        #expect(await recorder.sessionCalls == 1)
+    }
+
+    @Test func unsupportedProbeVersionAndProfileOverreachFailBeforeFactoryInvocation() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let versionRecorder = AuthorityFactoryRecorder()
+        let versionRegistry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, AuthorityTestFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(profile: setup.profile, versions: range(2, 0, 2, 1)),
+                probeFailure: nil,
+                sessionFailure: nil,
+                recorder: versionRecorder
+            ))]
+        )
+        let versionOffer = try await versionRegistry.probe(adapterID: descriptor.adapterID)
+        #expect(throws: AdapterNegotiationError.noCommonVersion) {
+            _ = try versionRegistry.negotiate(offer: versionOffer, policy: policy())
+        }
+        #expect(await versionRecorder.probeCalls == 1)
+        #expect(await versionRecorder.sessionCalls == 0)
+
+        let excessive = try AdapterCapabilityProfile(
+            transport: .ownedStandardIO,
+            lifecycle: AdapterLifecycleCapabilities(signals: lifecycleSignals(), evidence: [.tool]),
+            delivery: AdapterDeliverySemantics(ordering: .ordered, minimumAuthentication: .ownedChildPipe)
+        )
+        let profileRecorder = AuthorityFactoryRecorder()
+        let profileRegistry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, AuthorityTestFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(profile: excessive, versions: descriptor.contractVersions),
+                probeFailure: nil,
+                sessionFailure: nil,
+                recorder: profileRecorder
+            ))]
+        )
+        let profileOffer = try await profileRegistry.probe(adapterID: descriptor.adapterID)
+        #expect(throws: AdapterNegotiationError.offeredProfileExceedsMaximum) {
+            _ = try profileRegistry.negotiate(offer: profileOffer, policy: policy())
+        }
+        #expect(await profileRecorder.probeCalls == 1)
+        #expect(await profileRecorder.sessionCalls == 0)
+    }
+
+    @Test func unknownAdapterProbeFailsWithoutFactoryInvocation() async throws {
+        let setup = try fixtures()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation], compiledAdapters: setup.adapters
+        )
+
+        await #expect(throws: AdapterProbeError.unknownAdapter) {
+            _ = try await registry.probe(adapterID: AdapterID(validating: "pine:unknown"))
+        }
+    }
+
     @Test func exactFactoryMembership() async throws {
         let setup = try fixtures(twoAdapters: true)
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation], compiledAdapters: setup.adapters
         )
-        let first = try negotiate(registry, adapterID: setup.adapters[0].0.adapterID, profile: setup.profile)
-        let second = try negotiate(registry, adapterID: setup.adapters[1].0.adapterID, profile: setup.profile)
+        let first = try await negotiate(registry, adapterID: setup.adapters[0].0.adapterID, profile: setup.profile)
+        let second = try await negotiate(registry, adapterID: setup.adapters[1].0.adapterID, profile: setup.profile)
         #expect(first.agentID == second.agentID)
         await #expect(throws: AdapterSessionError.launchFailed(.permanent)) {
             _ = try await registry.makeSession(contract: first, resumeFrom: nil) { _ in .accepted }
@@ -181,56 +453,59 @@ struct AgentAdapterRegistryTests {
         }
     }
 
-    @Test func negotiationEnforcesSecurity() throws {
+    @Test func negotiationEnforcesSecurity() async throws {
         let setup = try fixtures()
         let registry = try AgentAdapterRegistry(compiledPresentations: [setup.presentation], compiledAdapters: setup.adapters)
-        let contract = try negotiate(registry, adapterID: setup.adapters[0].0.adapterID, profile: setup.profile)
+        let contract = try await negotiate(registry, adapterID: setup.adapters[0].0.adapterID, profile: setup.profile)
         #expect(contract.version == PineAdapterContractVersion(major: 1, minor: 4))
         let forbiddenPolicy = AdapterNegotiationPolicy(
             allowedVersions: range(1, 0, 1, 4), transportPreference: [.ownedStandardIO],
             acceptedAuthentication: [.authenticatedPeer]
         )
+        let offer = try await registry.probe(adapterID: setup.adapters[0].0.adapterID)
         #expect(throws: AdapterNegotiationError.noCommonProfile) {
-            _ = try registry.negotiate(
-                adapterID: setup.adapters[0].0.adapterID, offeredProfiles: [setup.profile],
-                offeredVersions: range(1, 1, 1, 9), policy: forbiddenPolicy
-            )
+            _ = try registry.negotiate(offer: offer, policy: forbiddenPolicy)
         }
     }
 
-    @Test func negotiationRejectsInvalidAndEmptyOffers() throws {
+    @Test func negotiationRejectsInvalidPolicyAndEmptyOffers() async throws {
         let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let probes = ProbeResultSequence([
+            try probeResult(profile: setup.profile, versions: range(2, 0, 2, 1)),
+            try AdapterProbeResult(
+                detectedVendorVersion: DetectedVendorVersion("test-vendor-1.0"),
+                detectedSchema: nil,
+                offeredProfiles: [],
+                offeredContractVersions: descriptor.contractVersions
+            ),
+            try probeResult(profile: setup.profile, versions: descriptor.contractVersions)
+        ])
         let registry = try AgentAdapterRegistry(
-            compiledPresentations: [setup.presentation], compiledAdapters: setup.adapters
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, SequencedRecordingFactory(
+                id: descriptor.factoryID,
+                probes: probes,
+                sessionRecorder: nil
+            ))]
         )
-        let adapterID = setup.adapters[0].0.adapterID
+        let versionOffer = try await registry.probe(adapterID: descriptor.adapterID)
         #expect(throws: AdapterNegotiationError.noCommonVersion) {
-            _ = try registry.negotiate(
-                adapterID: adapterID, offeredProfiles: [setup.profile],
-                offeredVersions: range(2, 0, 2, 1), policy: policy()
-            )
+            _ = try registry.negotiate(offer: versionOffer, policy: policy())
         }
+        let emptyOffer = try await registry.probe(adapterID: descriptor.adapterID)
         #expect(throws: AdapterNegotiationError.noCommonProfile) {
-            _ = try registry.negotiate(
-                adapterID: adapterID, offeredProfiles: [],
-                offeredVersions: range(1, 0, 1, 4), policy: policy()
-            )
+            _ = try registry.negotiate(offer: emptyOffer, policy: policy())
         }
+        let validOffer = try await registry.probe(adapterID: descriptor.adapterID)
         #expect(throws: AdapterNegotiationError.invalidPolicyRange) {
             _ = try registry.negotiate(
-                adapterID: adapterID, offeredProfiles: [setup.profile],
-                offeredVersions: range(1, 0, 1, 4),
+                offer: validOffer,
                 policy: AdapterNegotiationPolicy(
                     allowedVersions: range(2, 0, 1, 0),
                     transportPreference: [.ownedStandardIO],
                     acceptedAuthentication: [.ownedChildPipe]
                 )
-            )
-        }
-        #expect(throws: AdapterNegotiationError.invalidPolicyRange) {
-            _ = try registry.negotiate(
-                adapterID: adapterID, offeredProfiles: [setup.profile, setup.profile],
-                offeredVersions: range(1, 0, 1, 4), policy: policy()
             )
         }
     }
@@ -241,9 +516,13 @@ struct AgentAdapterRegistryTests {
         let descriptor = setup.adapters[0].0
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
-            compiledAdapters: [(descriptor, RecordingFactory(id: descriptor.factoryID, recorder: recorder))]
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions)
+            ))]
         )
-        let contract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let contract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
         let first = try await registry.makeSession(contract: contract, resumeFrom: nil) { event in
             await recorder.capture(event); return .accepted
         }
@@ -283,13 +562,14 @@ struct AgentAdapterRegistryTests {
         let factory = RecordingFactory(
             id: descriptor.factoryID,
             recorder: recorder,
+            probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions),
             emitDuringMake: true,
             emitDuringStart: true
         )
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation], compiledAdapters: [(descriptor, factory)]
         )
-        let contract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let contract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
         let session = try await registry.makeSession(contract: contract, resumeFrom: nil) { event in
             await recorder.capture(event)
             return .accepted
@@ -322,11 +602,12 @@ struct AgentAdapterRegistryTests {
             compiledAdapters: [(descriptor, RecordingFactory(
                 id: descriptor.factoryID,
                 recorder: recorder,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions),
                 emitDuringStart: true,
                 startEmissionCount: limit + 1
             ))]
         )
-        let contract = try negotiate(
+        let contract = try await negotiate(
             registry,
             adapterID: descriptor.adapterID,
             profile: setup.profile
@@ -355,6 +636,51 @@ struct AgentAdapterRegistryTests {
         #expect(await recorder.capturedCount == limit + 1)
     }
 
+    @Test func postCommitIngressCannotExtendActivationWatermark() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let completions = CompletionController()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                ),
+                emitDuringStart: true
+            ))]
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let session = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { event in
+            await completions.wait(
+                sequence: event.candidate.sourcePosition?.sourceSequence
+            )
+            await recorder.capture(event)
+            return .accepted
+        }
+
+        let startTask = Task { try await session.start() }
+        await completions.waitUntilArrived(1)
+        let postCommit = try candidate(sequence: 2)
+        #expect(await recorder.ingest(postCommit) == .droppedInvalid)
+
+        await completions.release(1)
+        try await startTask.value
+        #expect(await recorder.capturedCount == 1)
+        #expect(await recorder.ingest(postCommit) == .accepted)
+        #expect(await recorder.capturedCount == 2)
+    }
+
     @Test func postCommitRevocationDoesNotFailStart() async throws {
         let setup = try fixtures()
         let descriptor = setup.adapters[0].0
@@ -365,11 +691,12 @@ struct AgentAdapterRegistryTests {
             compiledAdapters: [(descriptor, RecordingFactory(
                 id: descriptor.factoryID,
                 recorder: recorder,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions),
                 emitDuringStart: true,
                 startEmissionCount: 2
             ))]
         )
-        let contract = try negotiate(
+        let contract = try await negotiate(
             registry,
             adapterID: descriptor.adapterID,
             profile: setup.profile
@@ -407,11 +734,12 @@ struct AgentAdapterRegistryTests {
             compiledAdapters: [(descriptor, RecordingFactory(
                 id: descriptor.factoryID,
                 recorder: recorder,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions),
                 emitDuringStart: true,
                 startHold: hold
             ))]
         )
-        let contract = try negotiate(
+        let contract = try await negotiate(
             registry,
             adapterID: descriptor.adapterID,
             profile: setup.profile
@@ -448,11 +776,12 @@ struct AgentAdapterRegistryTests {
             compiledAdapters: [(descriptor, RecordingFactory(
                 id: descriptor.factoryID,
                 recorder: recorder,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions),
                 emitDuringStart: true,
                 cancelBeforeReturning: true
             ))]
         )
-        let contract = try negotiate(
+        let contract = try await negotiate(
             registry,
             adapterID: descriptor.adapterID,
             profile: setup.profile
@@ -486,11 +815,12 @@ struct AgentAdapterRegistryTests {
             compiledAdapters: [(descriptor, RecordingFactory(
                 id: descriptor.factoryID,
                 recorder: recorder,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions),
                 startFailure: AdapterSessionError.launchFailed(.transient),
                 emitDuringStart: true
             ))]
         )
-        let contract = try negotiate(
+        let contract = try await negotiate(
             registry,
             adapterID: descriptor.adapterID,
             profile: setup.profile
@@ -516,11 +846,12 @@ struct AgentAdapterRegistryTests {
             compiledAdapters: [(descriptor, RecordingFactory(
                 id: descriptor.factoryID,
                 recorder: cancellationRecorder,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions),
                 emitDuringStart: true,
                 cancelDuringStart: true
             ))]
         )
-        let cancellationContract = try negotiate(
+        let cancellationContract = try await negotiate(
             cancellationRegistry,
             adapterID: descriptor.adapterID,
             profile: setup.profile
@@ -550,24 +881,30 @@ struct AgentAdapterRegistryTests {
         let failedRegistry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
             compiledAdapters: [(descriptor, RecordingFactory(
-                id: descriptor.factoryID, recorder: failedRecorder, failure: AdapterSessionError.launchFailed(.permanent)
+                id: descriptor.factoryID,
+                recorder: failedRecorder,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions),
+                failure: AdapterSessionError.launchFailed(.permanent)
             ))]
         )
-        let failedContract = try negotiate(failedRegistry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let failedContract = try await negotiate(failedRegistry, adapterID: descriptor.adapterID, profile: setup.profile)
         await #expect(throws: AdapterSessionError.launchFailed(.permanent)) {
             _ = try await failedRegistry.makeSession(contract: failedContract, resumeFrom: nil) { _ in .accepted }
         }
         #expect(await failedRecorder.ingest(try candidate(sequence: 1)) == .revoked)
 
         let mismatchRecorder = FactoryRecorder()
-        let mismatch = try mismatchContract(from: setup)
+        let mismatch = try await mismatchContract(from: setup)
         let mismatchRegistry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
             compiledAdapters: [(descriptor, RecordingFactory(
-                id: descriptor.factoryID, recorder: mismatchRecorder, returnedContract: mismatch
+                id: descriptor.factoryID,
+                recorder: mismatchRecorder,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions),
+                returnedContract: mismatch
             ))]
         )
-        let mismatchContract = try negotiate(mismatchRegistry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let mismatchContract = try await negotiate(mismatchRegistry, adapterID: descriptor.adapterID, profile: setup.profile)
         await #expect(throws: AdapterSessionError.contractMismatch) {
             _ = try await mismatchRegistry.makeSession(contract: mismatchContract, resumeFrom: nil) { _ in .accepted }
         }
@@ -579,11 +916,27 @@ struct AgentAdapterRegistryTests {
         let descriptor = setup.adapters[0].0
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
-            compiledAdapters: [(descriptor, CancellingFactory(id: descriptor.factoryID))]
+            compiledAdapters: [(descriptor, CancellingFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions)
+            ))]
         )
-        let contract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let contract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
         await #expect(throws: CancellationError.self) {
             _ = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .accepted }
+        }
+    }
+
+    @Test func probeCancellationPropagatesUnchanged() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, ProbeCancellingFactory(id: descriptor.factoryID))]
+        )
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await registry.probe(adapterID: descriptor.adapterID)
         }
     }
 
@@ -593,9 +946,13 @@ struct AgentAdapterRegistryTests {
         let descriptor = setup.adapters[0].0
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
-            compiledAdapters: [(descriptor, RecordingFactory(id: descriptor.factoryID, recorder: recorder))]
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions)
+            ))]
         )
-        let contract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let contract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
         let dropped = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .droppedInvalid }
         try await dropped.start()
         await #expect(throws: AdapterSessionError.checkpointUnavailable) {
@@ -628,9 +985,13 @@ struct AgentAdapterRegistryTests {
         let descriptor = setup.adapters[0].0
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
-            compiledAdapters: [(descriptor, RecordingFactory(id: descriptor.factoryID, recorder: recorder))]
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions)
+            ))]
         )
-        let contract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let contract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
         let session = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .accepted }
         try await session.start()
         await #expect(throws: AdapterSessionError.checkpointNotSupported) {
@@ -645,9 +1006,13 @@ struct AgentAdapterRegistryTests {
         let completions = CompletionController()
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
-            compiledAdapters: [(descriptor, RecordingFactory(id: descriptor.factoryID, recorder: recorder))]
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions)
+            ))]
         )
-        let contract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let contract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
         let session = try await registry.makeSession(contract: contract, resumeFrom: nil) { event in
             await completions.wait(sequence: event.candidate.sourcePosition?.sourceSequence)
             return .accepted
@@ -678,9 +1043,13 @@ struct AgentAdapterRegistryTests {
         let descriptor = setup.adapters[0].0
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
-            compiledAdapters: [(descriptor, RecordingFactory(id: descriptor.factoryID, recorder: recorder))]
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions)
+            ))]
         )
-        let contract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let contract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
         let source = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .accepted }
         try await source.start()
         #expect(await recorder.ingest(try candidate(sequence: 4)) == .accepted)
@@ -696,10 +1065,16 @@ struct AgentAdapterRegistryTests {
     @Test func checkpointBindingsAndResumeBaselineFailClosed() async throws {
         let setup = try fixtures(twoAdapters: true, replay: .sourceCursor)
         let recorder = FactoryRecorder()
-        let compiled = setup.adapters.map { ($0.0, RecordingFactory(id: $0.0.factoryID, recorder: recorder) as any AgentAdapterFactory) }
+        let compiled = try setup.adapters.map { descriptor, _ in
+            (descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions)
+            ) as any AgentAdapterFactory)
+        }
         let registry = try AgentAdapterRegistry(compiledPresentations: [setup.presentation], compiledAdapters: compiled)
-        let first = try negotiate(registry, adapterID: compiled[0].0.adapterID, profile: setup.profile)
-        let second = try negotiate(registry, adapterID: compiled[1].0.adapterID, profile: setup.profile)
+        let first = try await negotiate(registry, adapterID: compiled[0].0.adapterID, profile: setup.profile)
+        let second = try await negotiate(registry, adapterID: compiled[1].0.adapterID, profile: setup.profile)
         let source = try await registry.makeSession(contract: first, resumeFrom: nil) { _ in .accepted }
         try await source.start()
         #expect(await recorder.ingest(try candidate(sequence: 5)) == .accepted)
@@ -713,9 +1088,13 @@ struct AgentAdapterRegistryTests {
         let foreignRecorder = FactoryRecorder()
         let foreignRegistry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
-            compiledAdapters: [(compiled[0].0, RecordingFactory(id: compiled[0].0.factoryID, recorder: foreignRecorder))]
+            compiledAdapters: [(compiled[0].0, RecordingFactory(
+                id: compiled[0].0.factoryID,
+                recorder: foreignRecorder,
+                probeResult: try probeResult(profile: setup.profile, versions: compiled[0].0.contractVersions)
+            ))]
         )
-        let foreign = try negotiate(foreignRegistry, adapterID: compiled[0].0.adapterID, profile: setup.profile)
+        let foreign = try await negotiate(foreignRegistry, adapterID: compiled[0].0.adapterID, profile: setup.profile)
         await #expect(throws: AdapterSessionError.checkpointMismatch) {
             _ = try await foreignRegistry.makeSession(contract: foreign, resumeFrom: checkpoint) { _ in .accepted }
         }
@@ -746,29 +1125,33 @@ struct AgentAdapterRegistryTests {
             maximumProfiles: [setup.profile, alternate]
         )
         let recorder = FactoryRecorder()
+        let probes = ProbeResultSequence([
+            try probeResult(profile: setup.profile, versions: range(1, 0, 1, 4)),
+            try probeResult(profile: setup.profile, versions: range(1, 0, 1, 3)),
+            try probeResult(profile: alternate, versions: range(1, 0, 1, 4))
+        ])
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
-            compiledAdapters: [(expanded, RecordingFactory(id: descriptor.factoryID, recorder: recorder))]
+            compiledAdapters: [(expanded, SequencedRecordingFactory(
+                id: descriptor.factoryID,
+                probes: probes,
+                sessionRecorder: recorder
+            ))]
         )
-        let sourceContract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let sourceContract = try await negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
         let source = try await registry.makeSession(contract: sourceContract, resumeFrom: nil) { _ in .accepted }
         try await source.start()
         #expect(await recorder.ingest(try candidate(sequence: 1)) == .accepted)
         let checkpoint = try await registry.makeCheckpoint(for: source)
 
-        let olderVersion = try registry.negotiate(
-            adapterID: descriptor.adapterID,
-            offeredProfiles: [setup.profile],
-            offeredVersions: range(1, 0, 1, 3),
-            policy: policy()
-        )
+        let olderOffer = try await registry.probe(adapterID: descriptor.adapterID)
+        let olderVersion = try registry.negotiate(offer: olderOffer, policy: policy())
         await #expect(throws: AdapterSessionError.checkpointMismatch) {
             _ = try await registry.makeSession(contract: olderVersion, resumeFrom: checkpoint) { _ in .accepted }
         }
+        let alternateOffer = try await registry.probe(adapterID: descriptor.adapterID)
         let alternateProfile = try registry.negotiate(
-            adapterID: descriptor.adapterID,
-            offeredProfiles: [alternate],
-            offeredVersions: range(1, 0, 1, 4),
+            offer: alternateOffer,
             policy: AdapterNegotiationPolicy(
                 allowedVersions: range(1, 0, 1, 4),
                 transportPreference: [.authenticatedLocalIPC],
@@ -781,7 +1164,7 @@ struct AgentAdapterRegistryTests {
         #expect(await recorder.calls == 1)
     }
 
-    @Test func policyIgnoresOfferOrder() throws {
+    @Test func policyIgnoresOfferOrder() async throws {
         let setup = try fixtures()
         let local = try AdapterCapabilityProfile(
             transport: .authenticatedLocalIPC,
@@ -800,36 +1183,62 @@ struct AgentAdapterRegistryTests {
             adapterID: descriptor.adapterID, agentID: descriptor.agentID, factoryID: descriptor.factoryID,
             contractVersions: descriptor.contractVersions, maximumProfiles: [setup.profile, local, richerLocal]
         )
-        let completeRegistry = try AgentAdapterRegistry(
-            compiledPresentations: [setup.presentation], compiledAdapters: [(complete, setup.adapters[0].1)]
-        )
         let offers = [setup.profile, local, richerLocal]
         let permutations = [offers, Array(offers.reversed()), [local, setup.profile, richerLocal]]
-        let selections = try permutations.map { offered in
-            try completeRegistry.negotiate(
-                adapterID: descriptor.adapterID, offeredProfiles: Array(offered),
-                offeredVersions: range(1, 0, 1, 4),
+        let probes = try permutations.map { offered in
+            try AdapterProbeResult(
+                detectedVendorVersion: DetectedVendorVersion("test-vendor-1.0"),
+                detectedSchema: nil,
+                offeredProfiles: Array(offered),
+                offeredContractVersions: range(1, 0, 1, 4)
+            )
+        }
+        let completeRegistry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(complete, SequencedRecordingFactory(
+                id: descriptor.factoryID,
+                probes: ProbeResultSequence(probes),
+                sessionRecorder: nil
+            ))]
+        )
+        var selections: [NegotiatedAdapterContract] = []
+        for _ in permutations {
+            let offer = try await completeRegistry.probe(adapterID: descriptor.adapterID)
+            selections.append(try completeRegistry.negotiate(
+                offer: offer,
                 policy: AdapterNegotiationPolicy(
                     allowedVersions: range(1, 0, 1, 4),
                     transportPreference: [.authenticatedLocalIPC, .ownedStandardIO],
                     acceptedAuthentication: [.ownedChildPipe, .authenticatedPeer]
                 )
-            )
+            ))
         }
         #expect(selections.allSatisfy { $0 == selections[0] })
         #expect(selections[0].profile.transport == .authenticatedLocalIPC)
     }
 
-    @Test func escalationFails() throws {
+    @Test func escalationFails() async throws {
         let setup = try fixtures()
-        let registry = try AgentAdapterRegistry(compiledPresentations: [setup.presentation], compiledAdapters: setup.adapters)
+        let descriptor = setup.adapters[0].0
         let excessive = try AdapterCapabilityProfile(
             transport: .ownedStandardIO,
             lifecycle: AdapterLifecycleCapabilities(signals: lifecycleSignals(), evidence: [.tool]),
             delivery: AdapterDeliverySemantics(ordering: .ordered, minimumAuthentication: .ownedChildPipe)
         )
+        let recorder = AuthorityFactoryRecorder()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, AuthorityTestFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(profile: excessive, versions: descriptor.contractVersions),
+                probeFailure: nil,
+                sessionFailure: nil,
+                recorder: recorder
+            ))]
+        )
+        let offer = try await registry.probe(adapterID: descriptor.adapterID)
         #expect(throws: AdapterNegotiationError.offeredProfileExceedsMaximum) {
-            _ = try negotiate(registry, adapterID: setup.adapters[0].0.adapterID, profile: excessive)
+            _ = try registry.negotiate(offer: offer, policy: policy())
         }
     }
 
@@ -856,10 +1265,14 @@ struct AgentAdapterRegistryTests {
         )
         func pair(_ suffix: String) throws -> (AdapterDescriptor, any AgentAdapterFactory) {
             let factoryID = try AdapterFactoryID(validating: "pine.codex.\(suffix).factory")
-            return (AdapterDescriptor(
+            let descriptor = AdapterDescriptor(
                 adapterID: try AdapterID(validating: "pine:codex:\(suffix)"), agentID: agent, factoryID: factoryID,
                 contractVersions: range(1, 0, 1, 4), maximumProfiles: [profile]
-            ), RegistryTestFactory(id: factoryID))
+            )
+            return (descriptor, RegistryTestFactory(
+                id: factoryID,
+                probeResult: try probeResult(profile: profile, versions: descriptor.contractVersions)
+            ))
         }
         return (presentation, twoAdapters ? [try pair("stdio"), try pair("rpc")] : [try pair("stdio")], profile)
     }
@@ -867,21 +1280,22 @@ struct AgentAdapterRegistryTests {
     private func mismatchContract(from setup: (
         presentation: AgentPresentationDescriptor,
         adapters: [(AdapterDescriptor, any AgentAdapterFactory)], profile: AdapterCapabilityProfile
-    )) throws -> NegotiatedAdapterContract {
+    )) async throws -> NegotiatedAdapterContract {
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation], compiledAdapters: setup.adapters
         )
-        return try negotiate(registry, adapterID: setup.adapters[1].0.adapterID, profile: setup.profile)
+        return try await negotiate(registry, adapterID: setup.adapters[1].0.adapterID, profile: setup.profile)
     }
 
     private func negotiate(
         _ registry: AgentAdapterRegistry, adapterID: AdapterID, profile: AdapterCapabilityProfile
-    ) throws -> NegotiatedAdapterContract {
-        try registry.negotiate(
-            adapterID: adapterID, offeredProfiles: [profile], offeredVersions: range(1, 1, 1, 9),
+    ) async throws -> NegotiatedAdapterContract {
+        let offer = try await registry.probe(adapterID: adapterID)
+        return try registry.negotiate(
+            offer: offer,
             policy: AdapterNegotiationPolicy(
-                allowedVersions: range(1, 0, 1, 8), transportPreference: [.ownedStandardIO],
-                acceptedAuthentication: [.ownedChildPipe]
+                allowedVersions: range(1, 0, 1, 8), transportPreference: [profile.transport],
+                acceptedAuthentication: [profile.minimumAuthentication]
             )
         )
     }
@@ -898,6 +1312,18 @@ struct AgentAdapterRegistryTests {
             allowedVersions: range(1, 0, 1, 4),
             transportPreference: [.ownedStandardIO],
             acceptedAuthentication: [.ownedChildPipe]
+        )
+    }
+
+    private func probeResult(
+        profile: AdapterCapabilityProfile,
+        versions: PineAdapterContractVersionRange
+    ) throws -> AdapterProbeResult {
+        try AdapterProbeResult(
+            detectedVendorVersion: DetectedVendorVersion("test-vendor-1.0"),
+            detectedSchema: nil,
+            offeredProfiles: [profile],
+            offeredContractVersions: versions
         )
     }
 
@@ -933,6 +1359,7 @@ struct AgentAdapterRegistryTests {
 nonisolated private struct RecordingFactory: AgentAdapterFactory {
     let id: AdapterFactoryID
     let recorder: FactoryRecorder
+    let probeResult: AdapterProbeResult
     var emitDuringMake = false
     var failure: AdapterSessionError?
     var returnedContract: NegotiatedAdapterContract?
@@ -942,7 +1369,7 @@ nonisolated private struct RecordingFactory: AgentAdapterFactory {
     var cancelDuringStart = false
     var cancelBeforeReturning = false
     var startHold: StartHold?
-    func probe() async throws -> AdapterProbeResult { throw AdapterProbeError.unavailable(.permanent) }
+    func probe() async throws -> AdapterProbeResult { probeResult }
     func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession {
         await recorder.record(request: request)
         if emitDuringMake {
@@ -1020,52 +1447,115 @@ nonisolated private struct MismatchingFactory: AgentAdapterFactory {
 
 nonisolated private struct CancellingFactory: AgentAdapterFactory {
     let id: AdapterFactoryID
-    func probe() async throws -> AdapterProbeResult { throw CancellationError() }
+    let probeResult: AdapterProbeResult
+    func probe() async throws -> AdapterProbeResult { probeResult }
     func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession {
         throw CancellationError()
     }
 }
 
-private actor StartHold {
-    private var arrived = false
-    private var released = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+nonisolated private struct ProbeCancellingFactory: AgentAdapterFactory {
+    let id: AdapterFactoryID
+    func probe() async throws -> AdapterProbeResult { throw CancellationError() }
+    func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession {
+        throw AdapterSessionError.launchFailed(.permanent)
+    }
+}
+
+private actor TestSignal {
+    private var isSignalled = false
+    private var nextWaiterID: UInt64 = 0
+    private var waiters: [UInt64: CheckedContinuation<Void, Never>] = [:]
+    private var cancelledBeforeRegistration = Set<UInt64>()
+    private var resolvedBeforeCancellation = Set<UInt64>()
 
     func wait() async {
-        arrived = true
-        guard !released else { return }
-        await withCheckedContinuation { waiters.append($0) }
+        guard !isSignalled, !Task.isCancelled else { return }
+        nextWaiterID += 1
+        let waiterID = nextWaiterID
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if isSignalled || Task.isCancelled
+                    || cancelledBeforeRegistration.remove(waiterID) != nil {
+                    resolvedBeforeCancellation.insert(waiterID)
+                    continuation.resume()
+                } else {
+                    waiters[waiterID] = continuation
+                }
+            }
+        } onCancel: {
+            Task { await self.cancel(waiterID) }
+        }
+    }
+
+    func signal() {
+        guard !isSignalled else { return }
+        isSignalled = true
+        let retained = Array(waiters.values)
+        waiters.removeAll(keepingCapacity: false)
+        cancelledBeforeRegistration.removeAll(keepingCapacity: false)
+        resolvedBeforeCancellation.removeAll(keepingCapacity: false)
+        retained.forEach { $0.resume() }
+    }
+
+    private func cancel(_ waiterID: UInt64) {
+        guard !isSignalled else { return }
+        if resolvedBeforeCancellation.remove(waiterID) != nil { return }
+        if let waiter = waiters.removeValue(forKey: waiterID) {
+            waiter.resume()
+        } else {
+            cancelledBeforeRegistration.insert(waiterID)
+        }
+    }
+}
+
+private actor StartHold {
+    private let arrival = TestSignal()
+    private let releaseSignal = TestSignal()
+
+    func wait() async {
+        await arrival.signal()
+        await releaseSignal.wait()
     }
 
     func waitUntilArrived() async {
-        while !arrived { await Task.yield() }
+        await arrival.wait()
     }
 
-    func release() {
-        released = true
-        waiters.forEach { $0.resume() }
-        waiters.removeAll(keepingCapacity: false)
+    func release() async {
+        await releaseSignal.signal()
     }
 }
 
 private actor CompletionController {
-    private var arrived = Set<UInt64>()
-    private var released = Set<UInt64>()
-    private var continuations: [UInt64: [CheckedContinuation<Void, Never>]] = [:]
+    private var arrivals: [UInt64: TestSignal] = [:]
+    private var releases: [UInt64: TestSignal] = [:]
 
     func wait(sequence: UInt64?) async {
         guard let sequence else { return }
-        arrived.insert(sequence)
-        guard !released.contains(sequence) else { return }
-        await withCheckedContinuation { continuations[sequence, default: []].append($0) }
+        let arrival = signal(for: sequence, in: &arrivals)
+        let release = signal(for: sequence, in: &releases)
+        await arrival.signal()
+        await release.wait()
     }
 
     func waitUntilArrived(_ sequence: UInt64) async {
-        while !arrived.contains(sequence) { await Task.yield() }
+        let arrival = signal(for: sequence, in: &arrivals)
+        await arrival.wait()
     }
 
-    func release(_ sequence: UInt64) {
-        released.insert(sequence)
-        continuations.removeValue(forKey: sequence)?.forEach { $0.resume() }
+    func release(_ sequence: UInt64) async {
+        let release = signal(for: sequence, in: &releases)
+        await release.signal()
+    }
+
+    private func signal(
+        for sequence: UInt64,
+        in signals: inout [UInt64: TestSignal]
+    ) -> TestSignal {
+        if let existing = signals[sequence] { return existing }
+        let created = TestSignal()
+        signals[sequence] = created
+        return created
     }
 }

--- a/PineTests/AgentAdapterRegistryTests.swift
+++ b/PineTests/AgentAdapterRegistryTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Pine
 
@@ -1110,19 +1111,25 @@ struct AgentAdapterRegistryTests {
 
         let mismatchRecorder = FactoryRecorder()
         let mismatch = try await mismatchContract(from: setup)
+        let mismatchStopHold = StopHold()
         let mismatchRegistry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
             compiledAdapters: [(descriptor, RecordingFactory(
                 id: descriptor.factoryID,
                 recorder: mismatchRecorder,
                 probeResult: try probeResult(profile: setup.profile, versions: descriptor.contractVersions),
-                returnedContract: mismatch
+                returnedContract: mismatch,
+                returnedStopHold: mismatchStopHold
             ))]
         )
         let mismatchContract = try await negotiate(mismatchRegistry, adapterID: descriptor.adapterID, profile: setup.profile)
         await #expect(throws: AdapterSessionError.contractMismatch) {
             _ = try await mismatchRegistry.makeSession(contract: mismatchContract, resumeFrom: nil) { _ in .accepted }
         }
+        await mismatchStopHold.waitUntilArrived()
+        #expect(await mismatchStopHold.callCount == 1)
+        await mismatchStopHold.release()
+        await mismatchStopHold.waitUntilFinished()
         #expect(await mismatchRecorder.ingest(try candidate(sequence: 1)) == .revoked)
     }
 
@@ -1378,6 +1385,7 @@ struct AgentAdapterRegistryTests {
         let descriptor = setup.adapters[0].0
         let recorder = FactoryRecorder()
         let cancellation = IgnoredFactoryCancellation()
+        let rejectedStopHold = StopHold()
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
             compiledAdapters: [(descriptor, CancellationIgnoringResumeFactory(
@@ -1387,7 +1395,8 @@ struct AgentAdapterRegistryTests {
                     profile: setup.profile,
                     versions: descriptor.contractVersions
                 ),
-                cancellation: cancellation
+                cancellation: cancellation,
+                rejectedStopHold: rejectedStopHold
             ))]
         )
         let contract = try await negotiate(
@@ -1414,6 +1423,10 @@ struct AgentAdapterRegistryTests {
         await #expect(throws: CancellationError.self) {
             _ = try await cancelledConstruction.value
         }
+        await rejectedStopHold.waitUntilArrived()
+        #expect(await rejectedStopHold.callCount == 1)
+        await rejectedStopHold.release()
+        await rejectedStopHold.waitUntilFinished()
 
         let resumed = try await registry.makeSession(
             contract: contract,
@@ -1427,6 +1440,7 @@ struct AgentAdapterRegistryTests {
         let descriptor = setup.adapters[0].0
         let recorder = FactoryRecorder()
         let completions = CompletionController()
+        let startHold = StartHold()
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
             compiledAdapters: [(descriptor, RecordingFactory(
@@ -1435,7 +1449,8 @@ struct AgentAdapterRegistryTests {
                 probeResult: try probeResult(
                     profile: setup.profile,
                     versions: descriptor.contractVersions
-                )
+                ),
+                startHold: startHold
             ))]
         )
         let contract = try await negotiate(
@@ -1452,8 +1467,10 @@ struct AgentAdapterRegistryTests {
             )
             return .accepted
         }
-        #expect(await recorder.ingest(try candidate(sequence: 1)) == .bufferedUntilActivation)
         let startTask = Task { try await session.start() }
+        await startHold.waitUntilArrived()
+        #expect(await recorder.ingest(try candidate(sequence: 1)) == .bufferedUntilActivation)
+        await startHold.release()
         await completions.waitUntilArrived(1)
 
         let stopTask = Task {
@@ -1523,6 +1540,7 @@ struct AgentAdapterRegistryTests {
         let descriptor = setup.adapters[0].0
         let stopHold = StopHold()
         let capacity = AdapterCleanupCapacity(limit: 1)
+        let manualDeadline = ManualDeadlineSleeper()
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
             compiledAdapters: [(descriptor, StopTestFactory(
@@ -1533,7 +1551,10 @@ struct AgentAdapterRegistryTests {
                 ),
                 stopHold: stopHold
             ))],
-            cleanupCapacity: capacity
+            cleanupCapacity: capacity,
+            deadlineSleeper: AdapterDeadlineSleeper { deadline in
+                await manualDeadline.sleep(until: deadline)
+            }
         )
         let contract = try await negotiate(
             registry,
@@ -1549,23 +1570,21 @@ struct AgentAdapterRegistryTests {
             contract: contract,
             resumeFrom: nil
         ) { _ in .accepted }
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .milliseconds(200))
+        let deadline = ContinuousClock.now.advanced(by: .seconds(1))
+        let returned = TestSignal()
         let stopTask = Task {
             await session.stop(deadline: deadline)
-            return clock.now
-        }
-        let watchdog = Task {
-            try? await clock.sleep(until: deadline.advanced(by: .seconds(2)))
-            await stopHold.release()
+            await returned.signal()
         }
 
         await stopHold.waitUntilArrived()
-        let returnedAt = await stopTask.value
+        await manualDeadline.waitUntilWaiterCount(2)
+        #expect(await manualDeadline.waiterCount >= 2)
+        #expect(await returned.signalled == false)
+        await manualDeadline.advance(to: deadline)
+        await stopTask.value
         await stopHold.waitUntilFinished()
-        watchdog.cancel()
         await stopHold.release()
-        #expect(returnedAt <= deadline.advanced(by: .seconds(1)))
         #expect(await stopHold.observedCancellationAtExit == true)
         #expect(capacity.reservedCount == 0)
 
@@ -1585,6 +1604,7 @@ struct AgentAdapterRegistryTests {
         let descriptor = setup.adapters[0].0
         let hold = IgnoringStopHold()
         let capacity = AdapterCleanupCapacity(limit: 1)
+        let manualDeadline = ManualDeadlineSleeper()
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
             compiledAdapters: [(descriptor, IgnoringStopTestFactory(
@@ -1595,7 +1615,10 @@ struct AgentAdapterRegistryTests {
                 ),
                 hold: hold
             ))],
-            cleanupCapacity: capacity
+            cleanupCapacity: capacity,
+            deadlineSleeper: AdapterDeadlineSleeper { deadline in
+                await manualDeadline.sleep(until: deadline)
+            }
         )
         let contract = try await negotiate(
             registry,
@@ -1611,20 +1634,18 @@ struct AgentAdapterRegistryTests {
             contract: contract,
             resumeFrom: nil
         ) { _ in .accepted }
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .milliseconds(200))
+        let deadline = ContinuousClock.now.advanced(by: .seconds(1))
+        let returned = TestSignal()
         let stopTask = Task {
             await session.stop(deadline: deadline)
-            return clock.now
-        }
-        let watchdog = Task {
-            try? await clock.sleep(until: deadline.advanced(by: .seconds(2)))
-            await hold.release()
+            await returned.signal()
         }
 
         await hold.waitUntilArrived()
-        let returnedAt = await stopTask.value
-        #expect(returnedAt <= deadline.advanced(by: .seconds(1)))
+        await manualDeadline.waitUntilWaiterCount(2)
+        #expect(await returned.signalled == false)
+        await manualDeadline.advance(to: deadline)
+        await stopTask.value
         #expect(capacity.reservedCount == 1)
         await #expect(throws: AdapterSessionError.cleanupCapacityUnavailable) {
             _ = try await registry.makeSession(
@@ -1635,7 +1656,6 @@ struct AgentAdapterRegistryTests {
 
         await hold.release()
         await hold.waitUntilFinished()
-        watchdog.cancel()
         #expect(await hold.observedCancellationAtExit == true)
         for _ in 0..<10_000 where capacity.reservedCount != 0 {
             await Task.yield()
@@ -1657,6 +1677,7 @@ struct AgentAdapterRegistryTests {
         let setup = try fixtures()
         let descriptor = setup.adapters[0].0
         let hold = StopHold()
+        let manualDeadline = ManualDeadlineSleeper()
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
             compiledAdapters: [(descriptor, StopTestFactory(
@@ -1666,7 +1687,10 @@ struct AgentAdapterRegistryTests {
                     versions: descriptor.contractVersions
                 ),
                 stopHold: hold
-            ))]
+            ))],
+            deadlineSleeper: AdapterDeadlineSleeper { deadline in
+                await manualDeadline.sleep(until: deadline)
+            }
         )
         let contract = try await negotiate(
             registry,
@@ -1677,28 +1701,34 @@ struct AgentAdapterRegistryTests {
             contract: contract,
             resumeFrom: nil
         ) { _ in .accepted }
-        let clock = ContinuousClock()
-        let longDeadline = clock.now.advanced(by: .seconds(2))
+        let base = ContinuousClock.now
+        let shortDeadline = base.advanced(by: .seconds(1))
+        let longDeadline = base.advanced(by: .seconds(2))
+        let longReturned = TestSignal()
         let longStop = Task {
             await session.stop(deadline: longDeadline)
-            return clock.now
+            await longReturned.signal()
         }
         await hold.waitUntilArrived()
+        await manualDeadline.waitUntilWaiterCount(2)
 
-        let shortDeadline = clock.now.advanced(by: .milliseconds(200))
+        let shortReturned = TestSignal()
         let shortStop = Task {
             await session.stop(deadline: shortDeadline)
-            return clock.now
+            await shortReturned.signal()
         }
-        let shortReturnedAt = await shortStop.value
-        #expect(shortReturnedAt <= shortDeadline.advanced(by: .seconds(1)))
+        await manualDeadline.waitUntilWaiterCount(3)
+        #expect(await shortReturned.signalled == false)
+        #expect(await longReturned.signalled == false)
+        await manualDeadline.advance(to: shortDeadline)
+        await shortStop.value
+        #expect(await longReturned.signalled == false)
         #expect(await hold.callCount == 1)
         #expect(await hold.observedCancellationAtExit == nil)
 
         await hold.release()
-        let longReturnedAt = await longStop.value
+        await longStop.value
         await hold.waitUntilFinished()
-        #expect(longReturnedAt <= longDeadline.advanced(by: .seconds(1)))
         #expect(await hold.observedCancellationAtExit == false)
     }
 
@@ -1706,6 +1736,7 @@ struct AgentAdapterRegistryTests {
         let setup = try fixtures()
         let descriptor = setup.adapters[0].0
         let hold = StopHold()
+        let manualDeadline = ManualDeadlineSleeper()
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
             compiledAdapters: [(descriptor, StopTestFactory(
@@ -1715,7 +1746,10 @@ struct AgentAdapterRegistryTests {
                     versions: descriptor.contractVersions
                 ),
                 stopHold: hold
-            ))]
+            ))],
+            deadlineSleeper: AdapterDeadlineSleeper { deadline in
+                await manualDeadline.sleep(until: deadline)
+            }
         )
         let contract = try await negotiate(
             registry,
@@ -1726,30 +1760,30 @@ struct AgentAdapterRegistryTests {
             contract: contract,
             resumeFrom: nil
         ) { _ in .accepted }
-        let clock = ContinuousClock()
-        let shortDeadline = clock.now.advanced(by: .milliseconds(200))
+        let base = ContinuousClock.now
+        let shortDeadline = base.advanced(by: .seconds(1))
+        let longDeadline = base.advanced(by: .seconds(2))
+        let shortReturned = TestSignal()
         let shortStop = Task {
             await session.stop(deadline: shortDeadline)
-            return clock.now
+            await shortReturned.signal()
         }
         await hold.waitUntilArrived()
-        let longDeadline = clock.now.advanced(by: .seconds(2))
+        await manualDeadline.waitUntilWaiterCount(2)
+        let longReturned = TestSignal()
         let longStop = Task {
             await session.stop(deadline: longDeadline)
-            return clock.now
+            await longReturned.signal()
         }
-        let watchdog = Task {
-            try? await clock.sleep(until: shortDeadline.advanced(by: .seconds(2)))
-            await hold.release()
-        }
+        await manualDeadline.waitUntilWaiterCount(3)
+        #expect(await shortReturned.signalled == false)
+        #expect(await longReturned.signalled == false)
 
-        let shortReturnedAt = await shortStop.value
-        let longReturnedAt = await longStop.value
+        await manualDeadline.advance(to: shortDeadline)
+        await shortStop.value
+        await longStop.value
         await hold.waitUntilFinished()
-        watchdog.cancel()
         await hold.release()
-        #expect(shortReturnedAt <= shortDeadline.advanced(by: .seconds(1)))
-        #expect(longReturnedAt <= shortDeadline.advanced(by: .seconds(1)))
         #expect(await hold.callCount == 1)
         #expect(await hold.observedCancellationAtExit == true)
     }
@@ -1817,6 +1851,7 @@ struct AgentAdapterRegistryTests {
         let recorder = FactoryRecorder()
         let completions = CompletionController()
         let stopHold = StopHold()
+        let manualDeadline = ManualDeadlineSleeper()
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
             compiledAdapters: [(descriptor, StopTestFactory(
@@ -1827,7 +1862,10 @@ struct AgentAdapterRegistryTests {
                 ),
                 stopHold: stopHold,
                 recorder: recorder
-            ))]
+            ))],
+            deadlineSleeper: AdapterDeadlineSleeper { deadline in
+                await manualDeadline.sleep(until: deadline)
+            }
         )
         let contract = try await negotiate(
             registry,
@@ -1853,20 +1891,133 @@ struct AgentAdapterRegistryTests {
         let current = Task { await recorder.ingest(try candidate(sequence: 2)) }
         await completions.waitUntilArrived(2)
         let stopReturned = TestSignal()
+        let deadline = ContinuousClock.now.advanced(by: .seconds(5))
         let stopTask = Task {
-            await session.stop(
-                deadline: ContinuousClock.now.advanced(by: .seconds(5))
-            )
+            await session.stop(deadline: deadline)
             await stopReturned.signal()
         }
         await stopHold.waitUntilArrived()
         await stopHold.release()
+        await manualDeadline.waitUntilWaiterCount(2)
         #expect(await recorder.ingest(try candidate(sequence: 3)) == .revoked)
-        #expect(await signal(stopReturned, arrivesWithin: .milliseconds(200)) == false)
+        #expect(await stopReturned.signalled == false)
 
         await completions.release(2)
         #expect(try await current.value == .accepted)
         await stopTask.value
+    }
+
+    @Test func checkpointWaitsForPredecessorCleanupBeforeResume() async throws {
+        let setup = try fixtures(replay: .sourceCursor)
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let stopHold = StopHold()
+        let manualDeadline = ManualDeadlineSleeper()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, StopTestFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                ),
+                stopHold: stopHold,
+                recorder: recorder
+            ))],
+            deadlineSleeper: AdapterDeadlineSleeper { deadline in
+                await manualDeadline.sleep(until: deadline)
+            }
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let source = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        try await source.start()
+        #expect(await recorder.ingest(try candidate(sequence: 1)) == .accepted)
+
+        let checkpointReady = TestSignal()
+        let checkpointTask = Task {
+            let checkpoint = try await registry.makeCheckpoint(for: source)
+            await checkpointReady.signal()
+            return checkpoint
+        }
+        await stopHold.waitUntilArrived()
+        await manualDeadline.waitUntilWaiterCount(2)
+        #expect(await checkpointReady.signalled == false)
+        #expect(await recorder.calls == 1)
+
+        await stopHold.release()
+        let checkpoint = try await checkpointTask.value
+        await stopHold.waitUntilFinished()
+        #expect(await stopHold.callCount == 1)
+
+        let resumed = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: checkpoint
+        ) { _ in .accepted }
+        try await resumed.start()
+        #expect(await recorder.calls == 2)
+    }
+
+    @Test func checkpointStaysPendingWhileCancellationIgnoringPredecessorLives() async throws {
+        let setup = try fixtures(replay: .sourceCursor)
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let stopHold = IgnoringStopHold()
+        let manualDeadline = ManualDeadlineSleeper()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, IgnoringStopTestFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                ),
+                hold: stopHold,
+                recorder: recorder
+            ))],
+            deadlineSleeper: AdapterDeadlineSleeper { deadline in
+                await manualDeadline.sleep(until: deadline)
+            }
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let source = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        try await source.start()
+        #expect(await recorder.ingest(try candidate(sequence: 1)) == .accepted)
+
+        let timedOutCheckpoint = Task {
+            try await registry.makeCheckpoint(for: source)
+        }
+        await stopHold.waitUntilArrived()
+        await manualDeadline.waitUntilWaiterCount(2)
+        let registeredDeadline = try #require(await manualDeadline.earliestDeadline)
+        await manualDeadline.advance(to: registeredDeadline)
+        await #expect(throws: AdapterSessionError.checkpointUnavailable) {
+            _ = try await timedOutCheckpoint.value
+        }
+        #expect(await recorder.calls == 1)
+
+        await stopHold.release()
+        await stopHold.waitUntilFinished()
+        let checkpoint = try await registry.makeCheckpoint(for: source)
+        let resumed = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: checkpoint
+        ) { _ in .accepted }
+        try await resumed.start()
+        #expect(await recorder.calls == 2)
     }
 
     @Test func checkpointBindingsAndResumeBaselineFailClosed() async throws {
@@ -2176,6 +2327,7 @@ nonisolated private struct RecordingFactory: AgentAdapterFactory {
     var cancelDuringStart = false
     var cancelBeforeReturning = false
     var startHold: StartHold?
+    var returnedStopHold: StopHold?
     func probe() async throws -> AdapterProbeResult { probeResult }
     func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession {
         await recorder.record(request: request)
@@ -2186,6 +2338,12 @@ nonisolated private struct RecordingFactory: AgentAdapterFactory {
             ))
         }
         if let failure { throw failure }
+        if let returnedStopHold {
+            return StopTestSession(
+                contract: returnedContract ?? request.contract,
+                stopHold: returnedStopHold
+            )
+        }
         return RegistryTestSession(
             contract: returnedContract ?? request.contract,
             startFailure: startFailure,
@@ -2275,7 +2433,7 @@ nonisolated private struct CancellationIgnoringProbeFactory: AgentAdapterFactory
     let cancellation: IgnoredFactoryCancellation
 
     func probe() async throws -> AdapterProbeResult {
-        await cancellation.ignoreOnce()
+        _ = await cancellation.ignoreOnce()
         return probeResult
     }
 
@@ -2331,13 +2489,14 @@ private actor IgnoredFactoryCancellation {
     private let entered = TestSignal()
     private var attempts = 0
 
-    func ignoreOnce() async {
+    func ignoreOnce() async -> Bool {
         attempts += 1
-        guard attempts == 1 else { return }
+        guard attempts == 1 else { return false }
         await entered.signal()
         while !Task.isCancelled {
             await Task.yield()
         }
+        return true
     }
 
     func waitUntilEntered() async {
@@ -2350,6 +2509,7 @@ nonisolated private struct CancellationIgnoringResumeFactory: AgentAdapterFactor
     let recorder: FactoryRecorder
     let probeResult: AdapterProbeResult
     let cancellation: IgnoredFactoryCancellation
+    var rejectedStopHold: StopHold? = nil
 
     func probe() async throws -> AdapterProbeResult { probeResult }
 
@@ -2358,7 +2518,13 @@ nonisolated private struct CancellationIgnoringResumeFactory: AgentAdapterFactor
     ) async throws -> any AgentAdapterSession {
         await recorder.record(request: request)
         if request.resumeFrom != nil {
-            await cancellation.ignoreOnce()
+            let ignored = await cancellation.ignoreOnce()
+            if ignored, let rejectedStopHold {
+                return StopTestSession(
+                    contract: request.contract,
+                    stopHold: rejectedStopHold
+                )
+            }
         }
         return RegistryTestSession(contract: request.contract)
     }
@@ -2368,13 +2534,15 @@ nonisolated private struct IgnoringStopTestFactory: AgentAdapterFactory {
     let id: AdapterFactoryID
     let probeResult: AdapterProbeResult
     let hold: IgnoringStopHold
+    var recorder: FactoryRecorder? = nil
 
     func probe() async throws -> AdapterProbeResult { probeResult }
 
     func makeSession(
         _ request: AgentAdapterSessionRequest
     ) async throws -> any AgentAdapterSession {
-        IgnoringStopTestSession(contract: request.contract, hold: hold)
+        if let recorder { await recorder.record(request: request) }
+        return IgnoringStopTestSession(contract: request.contract, hold: hold)
     }
 }
 
@@ -2481,23 +2649,45 @@ private actor IgnoringStopHold {
     }
 }
 
-nonisolated private func signal(
-    _ signal: TestSignal,
-    arrivesWithin duration: Duration
-) async -> Bool {
-    await withTaskGroup(of: Bool.self) { group in
-        group.addTask {
-            await signal.wait()
-            return true
-        }
-        group.addTask {
-            try? await Task.sleep(for: duration)
-            return false
-        }
-        let first = await group.next() ?? false
-        group.cancelAll()
-        return first
+private actor ManualDeadlineSleeper {
+    private struct Waiter {
+        let deadline: ContinuousClock.Instant
+        let gate: AsyncContinuationGate
     }
+
+    private var advancedThrough: ContinuousClock.Instant?
+    private var waiters: [UUID: Waiter] = [:]
+
+    func sleep(until deadline: ContinuousClock.Instant) async {
+        if let advancedThrough, deadline <= advancedThrough { return }
+        let waiterID = UUID()
+        let gate = AsyncContinuationGate()
+        waiters[waiterID] = Waiter(deadline: deadline, gate: gate)
+        await gate.wait()
+        waiters.removeValue(forKey: waiterID)
+    }
+
+    func advance(to instant: ContinuousClock.Instant) {
+        if let advancedThrough, advancedThrough >= instant { return }
+        advancedThrough = instant
+        let ready = waiters.filter { $0.value.deadline <= instant }
+        for (waiterID, waiter) in ready {
+            waiters.removeValue(forKey: waiterID)
+            waiter.gate.resolve()
+        }
+    }
+
+    func waitUntilWaiterCount(_ expected: Int) async {
+        for _ in 0..<10_000 where waiters.count < expected {
+            await Task.yield()
+        }
+    }
+
+    var earliestDeadline: ContinuousClock.Instant? {
+        waiters.values.map(\.deadline).min()
+    }
+
+    var waiterCount: Int { waiters.count }
 }
 
 private actor TestSignal {

--- a/PineTests/AgentAdapterRegistryTests.swift
+++ b/PineTests/AgentAdapterRegistryTests.swift
@@ -770,7 +770,7 @@ struct AgentAdapterRegistryTests {
         #expect(await recorder.capturedCount == 2)
     }
 
-    @Test func postCommitRevocationDoesNotFailStart() async throws {
+    @Test func postCommitCancellationFailsStartWithoutReopeningAuthority() async throws {
         let setup = try fixtures()
         let descriptor = setup.adapters[0].0
         let recorder = FactoryRecorder()
@@ -804,13 +804,21 @@ struct AgentAdapterRegistryTests {
         await completions.waitUntilArrived(2)
         startTask.cancel()
         await completions.release(2)
-        try await startTask.value
+        await #expect(throws: CancellationError.self) {
+            try await startTask.value
+        }
         #expect(await recorder.capturedCount == 2)
         let afterRevocation = AdapterCandidate(
             event: .processExited(status: nil),
             sourcePosition: try AdapterSourcePosition(sourceSequence: 3)
         )
         #expect(await recorder.ingest(afterRevocation) == .revoked)
+        await #expect(throws: AdapterSessionError.contractAlreadyConsumed) {
+            _ = try await registry.makeSession(
+                contract: contract,
+                resumeFrom: nil
+            ) { _ in .accepted }
+        }
     }
 
     @Test func preCommitTaskCancellationDiscardsStartBuffer() async throws {
@@ -1029,6 +1037,34 @@ struct AgentAdapterRegistryTests {
         }
     }
 
+    @Test func registryRejectsProbeResultAfterCallerCancellation() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let cancellation = IgnoredFactoryCancellation()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, CancellationIgnoringProbeFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                ),
+                cancellation: cancellation
+            ))]
+        )
+        let cancelledProbe = Task {
+            try await registry.probe(adapterID: descriptor.adapterID)
+        }
+        await cancellation.waitUntilEntered()
+        cancelledProbe.cancel()
+        await #expect(throws: CancellationError.self) {
+            _ = try await cancelledProbe.value
+        }
+
+        let offer = try await registry.probe(adapterID: descriptor.adapterID)
+        _ = try await registry.negotiate(offer: offer, policy: policy())
+    }
+
     @Test func checkpointRequiresNewAcceptedReplayPosition() async throws {
         let setup = try fixtures(replay: .sourceCursor)
         let recorder = FactoryRecorder()
@@ -1223,7 +1259,7 @@ struct AgentAdapterRegistryTests {
         let setup = try fixtures(replay: .sourceCursor)
         let descriptor = setup.adapters[0].0
         let recorder = FactoryRecorder()
-        let cancellation = IgnoredResumeCancellation()
+        let cancellation = IgnoredFactoryCancellation()
         let registry = try AgentAdapterRegistry(
             compiledPresentations: [setup.presentation],
             compiledAdapters: [(descriptor, CancellationIgnoringResumeFactory(
@@ -1921,6 +1957,21 @@ nonisolated private struct ProbeCancellingFactory: AgentAdapterFactory {
     }
 }
 
+nonisolated private struct CancellationIgnoringProbeFactory: AgentAdapterFactory {
+    let id: AdapterFactoryID
+    let probeResult: AdapterProbeResult
+    let cancellation: IgnoredFactoryCancellation
+
+    func probe() async throws -> AdapterProbeResult {
+        await cancellation.ignoreOnce()
+        return probeResult
+    }
+
+    func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession {
+        RegistryTestSession(contract: request.contract)
+    }
+}
+
 private actor ResumeFailureController {
     enum Behavior: Sendable { case failConstruction, failStart, succeed }
     private var attempt = 0
@@ -1964,7 +2015,7 @@ nonisolated private struct RetryableResumeFactory: AgentAdapterFactory {
     }
 }
 
-private actor IgnoredResumeCancellation {
+private actor IgnoredFactoryCancellation {
     private let entered = TestSignal()
     private var attempts = 0
 
@@ -1986,7 +2037,7 @@ nonisolated private struct CancellationIgnoringResumeFactory: AgentAdapterFactor
     let id: AdapterFactoryID
     let recorder: FactoryRecorder
     let probeResult: AdapterProbeResult
-    let cancellation: IgnoredResumeCancellation
+    let cancellation: IgnoredFactoryCancellation
 
     func probe() async throws -> AdapterProbeResult { probeResult }
 

--- a/PineTests/AgentAdapterRegistryTests.swift
+++ b/PineTests/AgentAdapterRegistryTests.swift
@@ -870,22 +870,24 @@ struct AgentAdapterRegistryTests {
             contract: contract,
             resumeFrom: nil
         ) { event in
-            await completions.wait(
-                sequence: event.candidate.sourcePosition?.sourceSequence
-            )
+            if event.candidate.sourcePosition?.sourceSequence == 1 {
+                await completions.wait(sequence: 1)
+            }
             await recorder.capture(event)
             return .accepted
         }
 
         let startTask = Task { try await session.start() }
         await completions.waitUntilArrived(1)
-        let postCommit = try candidate(sequence: 2)
-        #expect(await recorder.ingest(postCommit) == .retryAfterActivation)
+        let postCommit = try orderedCandidate(sequence: 2)
+        let activationOutcome = await recorder.ingest(postCommit)
+        #expect(activationOutcome == .retryAfterActivation)
 
         await completions.release(1)
         try await startTask.value
         #expect(await recorder.capturedCount == 1)
-        #expect(await recorder.ingest(postCommit) == .accepted)
+        let activeOutcome = await recorder.ingest(postCommit)
+        #expect(activeOutcome == .accepted)
         #expect(await recorder.capturedCount == 2)
     }
 
@@ -1469,7 +1471,7 @@ struct AgentAdapterRegistryTests {
         }
         let startTask = Task { try await session.start() }
         await startHold.waitUntilArrived()
-        #expect(await recorder.ingest(try candidate(sequence: 1)) == .bufferedUntilActivation)
+        #expect(await recorder.ingest(try orderedCandidate(sequence: 1)) == .bufferedUntilActivation)
         await startHold.release()
         await completions.waitUntilArrived(1)
 
@@ -1480,7 +1482,7 @@ struct AgentAdapterRegistryTests {
         }
         var closingOutcome = AdapterIngestOutcome.retryAfterActivation
         for _ in 0..<1_000 where closingOutcome != .revoked {
-            closingOutcome = await recorder.ingest(try candidate(sequence: 2))
+            closingOutcome = await recorder.ingest(try orderedCandidate(sequence: 2))
             await Task.yield()
         }
         #expect(closingOutcome == .revoked)
@@ -1822,7 +1824,7 @@ struct AgentAdapterRegistryTests {
         }
         try await session.start()
 
-        let admitted = Task { await recorder.ingest(try candidate(sequence: 1)) }
+        let admitted = Task { await recorder.ingest(try orderedCandidate(sequence: 1)) }
         await completions.waitUntilArrived(1)
         let firstStop = Task {
             await session.stop(
@@ -1836,7 +1838,7 @@ struct AgentAdapterRegistryTests {
         }
         await stopHold.waitUntilArrived()
         await stopHold.release()
-        #expect(await recorder.ingest(try candidate(sequence: 2)) == .revoked)
+        #expect(await recorder.ingest(try orderedCandidate(sequence: 2)) == .revoked)
         await completions.release(1)
 
         #expect(try await admitted.value == .accepted)
@@ -1883,12 +1885,12 @@ struct AgentAdapterRegistryTests {
         }
         try await session.start()
 
-        let earlier = Task { await recorder.ingest(try candidate(sequence: 1)) }
+        let earlier = Task { await recorder.ingest(try orderedCandidate(sequence: 1)) }
         await completions.waitUntilArrived(1)
         await completions.release(1)
         #expect(try await earlier.value == .accepted)
 
-        let current = Task { await recorder.ingest(try candidate(sequence: 2)) }
+        let current = Task { await recorder.ingest(try orderedCandidate(sequence: 2)) }
         await completions.waitUntilArrived(2)
         let stopReturned = TestSignal()
         let deadline = ContinuousClock.now.advanced(by: .seconds(5))
@@ -1899,7 +1901,7 @@ struct AgentAdapterRegistryTests {
         await stopHold.waitUntilArrived()
         await stopHold.release()
         await manualDeadline.waitUntilWaiterCount(2)
-        #expect(await recorder.ingest(try candidate(sequence: 3)) == .revoked)
+        #expect(await recorder.ingest(try orderedCandidate(sequence: 3)) == .revoked)
         #expect(await stopReturned.signalled == false)
 
         await completions.release(2)
@@ -2171,7 +2173,9 @@ struct AgentAdapterRegistryTests {
                 )
             ))
         }
-        #expect(selections.allSatisfy { $0 == selections[0] })
+        #expect(selections.allSatisfy {
+            $0.version == selections[0].version && $0.profile == selections[0].profile
+        })
         #expect(selections[0].profile.transport == .authenticatedLocalIPC)
     }
 
@@ -2297,6 +2301,13 @@ struct AgentAdapterRegistryTests {
                 resumePosition: AdapterResumePosition("cursor-\(sequence)"),
                 sourceSequence: sequence
             )
+        )
+    }
+
+    private func orderedCandidate(sequence: UInt64) throws -> AdapterCandidate {
+        AdapterCandidate(
+            event: .processExited(status: nil),
+            sourcePosition: try AdapterSourcePosition(sourceSequence: sequence)
         )
     }
 

--- a/PineTests/AgentAdapterRegistryTests.swift
+++ b/PineTests/AgentAdapterRegistryTests.swift
@@ -1,0 +1,1071 @@
+import Testing
+@testable import Pine
+
+nonisolated private struct RegistryTestFactory: AgentAdapterFactory {
+    let id: AdapterFactoryID
+    let failure: AdapterFailureDisposition
+    init(id: AdapterFactoryID, failure: AdapterFailureDisposition = .permanent) {
+        self.id = id
+        self.failure = failure
+    }
+    func probe() async throws -> AdapterProbeResult { throw AdapterProbeError.unavailable(.permanent) }
+    func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession {
+        throw AdapterSessionError.launchFailed(failure)
+    }
+}
+
+nonisolated private struct RegistryTestSession: AgentAdapterSession {
+    let contract: NegotiatedAdapterContract
+    var startFailure: AdapterSessionError?
+    var startSink: (any AgentEventSink)?
+    var startRecorder: FactoryRecorder?
+    var emitDuringStart = false
+    var startEmissionCount = 1
+    var cancelDuringStart = false
+    var cancelBeforeReturning = false
+    var startHold: StartHold?
+    init(
+        contract: NegotiatedAdapterContract,
+        startFailure: AdapterSessionError? = nil,
+        startSink: (any AgentEventSink)? = nil,
+        startRecorder: FactoryRecorder? = nil,
+        emitDuringStart: Bool = false,
+        startEmissionCount: Int = 1,
+        cancelDuringStart: Bool = false,
+        cancelBeforeReturning: Bool = false,
+        startHold: StartHold? = nil
+    ) {
+        self.contract = contract
+        self.startFailure = startFailure
+        self.startSink = startSink
+        self.startRecorder = startRecorder
+        self.emitDuringStart = emitDuringStart
+        self.startEmissionCount = startEmissionCount
+        self.cancelDuringStart = cancelDuringStart
+        self.cancelBeforeReturning = cancelBeforeReturning
+        self.startHold = startHold
+    }
+    func start() async throws {
+        if emitDuringStart, startEmissionCount > 0, let startSink {
+            for sequence in 1...startEmissionCount {
+                let outcome = await startSink.ingest(AdapterCandidate(
+                    event: .processExited(status: nil),
+                    sourcePosition: try AdapterSourcePosition(
+                        sourceSequence: UInt64(sequence)
+                    )
+                ))
+                await startRecorder?.recordStartOutcome(outcome)
+            }
+        }
+        await startHold?.wait()
+        if cancelDuringStart { throw CancellationError() }
+        if cancelBeforeReturning {
+            withUnsafeCurrentTask { $0?.cancel() }
+        }
+        if let startFailure { throw startFailure }
+    }
+    func stop(deadline: ContinuousClock.Instant) async {}
+}
+
+@Suite("Agent adapter compiled registry")
+struct AgentAdapterRegistryTests {
+    @Test func exactFactoryMembership() async throws {
+        let setup = try fixtures(twoAdapters: true)
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation], compiledAdapters: setup.adapters
+        )
+        let first = try negotiate(registry, adapterID: setup.adapters[0].0.adapterID, profile: setup.profile)
+        let second = try negotiate(registry, adapterID: setup.adapters[1].0.adapterID, profile: setup.profile)
+        #expect(first.agentID == second.agentID)
+        await #expect(throws: AdapterSessionError.launchFailed(.permanent)) {
+            _ = try await registry.makeSession(contract: first, resumeFrom: nil) { _ in .accepted }
+        }
+        await #expect(throws: AdapterSessionError.launchFailed(.permanent)) {
+            _ = try await registry.makeSession(contract: second, resumeFrom: nil) { _ in .accepted }
+        }
+    }
+
+    @Test func registryCollisionsFailClosed() throws {
+        let setup = try fixtures()
+        let wrong = RegistryTestFactory(id: try AdapterFactoryID(validating: "wrong.factory"))
+        #expect(throws: AdapterRegistrationError.descriptorMismatch) {
+            _ = try AgentAdapterRegistry(
+                compiledPresentations: [setup.presentation], compiledAdapters: [(setup.adapters[0].0, wrong)]
+            )
+        }
+        let collisionA = try AgentPresentationDescriptor(
+            agentID: AgentID(validating: "custom-a"), displayName: "Custom A",
+            executableAliases: [ExecutableAlias(validating: "local-agent")], style: .generic
+        )
+        let collisionB = try AgentPresentationDescriptor(
+            agentID: AgentID(validating: "custom-b"), displayName: "Custom B",
+            executableAliases: [ExecutableAlias(validating: "local-agent")], style: .generic
+        )
+        #expect(throws: AdapterRegistrationError.aliasCollision) {
+            _ = try AgentAdapterRegistry(compiledPresentations: [collisionA, collisionB], compiledAdapters: [])
+        }
+        let wrongStyle = try AgentPresentationDescriptor(
+            agentID: AgentID(validating: "codex"), displayName: "Codex",
+            executableAliases: [ExecutableAlias(validating: "codex")], style: .pi
+        )
+        #expect(throws: AdapterRegistrationError.invalidBuiltInPresentation) {
+            _ = try AgentAdapterRegistry(compiledPresentations: [wrongStyle], compiledAdapters: [])
+        }
+        let omittedBuiltInHijack = try AgentPresentationDescriptor(
+            agentID: AgentID(validating: "custom-agent"), displayName: "Custom",
+            executableAliases: [ExecutableAlias(validating: "pi")], style: .generic
+        )
+        #expect(throws: AdapterRegistrationError.aliasCollision) {
+            _ = try AgentAdapterRegistry(compiledPresentations: [omittedBuiltInHijack], compiledAdapters: [])
+        }
+        for (index, alias) in ["claude", "codex", "aider", "github-copilot-cli", "copilot", "pi"].enumerated() {
+            let hostile = try AgentPresentationDescriptor(
+                agentID: AgentID(validating: "custom-\(index)"), displayName: "Custom",
+                executableAliases: [ExecutableAlias(validating: alias)], style: .generic
+            )
+            #expect(throws: AdapterRegistrationError.aliasCollision) {
+                _ = try AgentAdapterRegistry(compiledPresentations: [hostile], compiledAdapters: [])
+            }
+        }
+        for builtInID in ["claudeCode", "codex", "aider", "copilot", "pi"] {
+            let malformed = try AgentPresentationDescriptor(
+                agentID: AgentID(migratingLegacyStableIdentifier: builtInID), displayName: "Impostor",
+                executableAliases: [], style: .generic
+            )
+            #expect(throws: AdapterRegistrationError.invalidBuiltInPresentation) {
+                _ = try AgentAdapterRegistry(compiledPresentations: [malformed], compiledAdapters: [])
+            }
+        }
+        let custom = try AgentPresentationDescriptor(
+            agentID: AgentID(validating: "custom-agent"), displayName: "Custom",
+            executableAliases: [ExecutableAlias(validating: "custom-agent")], style: .generic
+        )
+        _ = try AgentAdapterRegistry(compiledPresentations: [custom], compiledAdapters: [])
+        let descriptor = setup.adapters[0].0
+        let duplicateProfiles = AdapterDescriptor(
+            adapterID: descriptor.adapterID, agentID: descriptor.agentID, factoryID: descriptor.factoryID,
+            contractVersions: descriptor.contractVersions,
+            maximumProfiles: [setup.profile, setup.profile]
+        )
+        #expect(throws: AdapterRegistrationError.duplicateProfile) {
+            _ = try AgentAdapterRegistry(
+                compiledPresentations: [setup.presentation],
+                compiledAdapters: [(duplicateProfiles, setup.adapters[0].1)]
+            )
+        }
+    }
+
+    @Test func userAliasCollisionFails() throws {
+        let setup = try fixtures()
+        let registry = try AgentAdapterRegistry(compiledPresentations: [setup.presentation], compiledAdapters: setup.adapters)
+        let hostile = try UserAgentPresentationRegistration(
+            identifier: "codex-lookalike", displayName: "Codex", executableAliases: ["codex"]
+        )
+        #expect(throws: AdapterRegistrationError.aliasCollision) {
+            _ = try registry.validatedUserPresentations([hostile])
+        }
+        let emptyRegistry = try AgentAdapterRegistry(compiledPresentations: [], compiledAdapters: [])
+        #expect(throws: AdapterRegistrationError.aliasCollision) {
+            _ = try emptyRegistry.validatedUserPresentations([hostile])
+        }
+    }
+
+    @Test func duplicateUserAliasFails() throws {
+        let setup = try fixtures()
+        let registry = try AgentAdapterRegistry(compiledPresentations: [setup.presentation], compiledAdapters: setup.adapters)
+        #expect(throws: AdapterRegistrationError.duplicateAlias) {
+            let input = try UserAgentPresentationRegistration(
+                identifier: "local", displayName: "Local", executableAliases: ["local", "local"]
+            )
+            _ = try registry.validatedUserPresentations([input])
+        }
+    }
+
+    @Test func negotiationEnforcesSecurity() throws {
+        let setup = try fixtures()
+        let registry = try AgentAdapterRegistry(compiledPresentations: [setup.presentation], compiledAdapters: setup.adapters)
+        let contract = try negotiate(registry, adapterID: setup.adapters[0].0.adapterID, profile: setup.profile)
+        #expect(contract.version == PineAdapterContractVersion(major: 1, minor: 4))
+        let forbiddenPolicy = AdapterNegotiationPolicy(
+            allowedVersions: range(1, 0, 1, 4), transportPreference: [.ownedStandardIO],
+            acceptedAuthentication: [.authenticatedPeer]
+        )
+        #expect(throws: AdapterNegotiationError.noCommonProfile) {
+            _ = try registry.negotiate(
+                adapterID: setup.adapters[0].0.adapterID, offeredProfiles: [setup.profile],
+                offeredVersions: range(1, 1, 1, 9), policy: forbiddenPolicy
+            )
+        }
+    }
+
+    @Test func negotiationRejectsInvalidAndEmptyOffers() throws {
+        let setup = try fixtures()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation], compiledAdapters: setup.adapters
+        )
+        let adapterID = setup.adapters[0].0.adapterID
+        #expect(throws: AdapterNegotiationError.noCommonVersion) {
+            _ = try registry.negotiate(
+                adapterID: adapterID, offeredProfiles: [setup.profile],
+                offeredVersions: range(2, 0, 2, 1), policy: policy()
+            )
+        }
+        #expect(throws: AdapterNegotiationError.noCommonProfile) {
+            _ = try registry.negotiate(
+                adapterID: adapterID, offeredProfiles: [],
+                offeredVersions: range(1, 0, 1, 4), policy: policy()
+            )
+        }
+        #expect(throws: AdapterNegotiationError.invalidPolicyRange) {
+            _ = try registry.negotiate(
+                adapterID: adapterID, offeredProfiles: [setup.profile],
+                offeredVersions: range(1, 0, 1, 4),
+                policy: AdapterNegotiationPolicy(
+                    allowedVersions: range(2, 0, 1, 0),
+                    transportPreference: [.ownedStandardIO],
+                    acceptedAuthentication: [.ownedChildPipe]
+                )
+            )
+        }
+        #expect(throws: AdapterNegotiationError.invalidPolicyRange) {
+            _ = try registry.negotiate(
+                adapterID: adapterID, offeredProfiles: [setup.profile, setup.profile],
+                offeredVersions: range(1, 0, 1, 4), policy: policy()
+            )
+        }
+    }
+
+    @Test func namespacesAreFreshAndResumePreservesLogicalSource() async throws {
+        let setup = try fixtures(replay: .sourceCursor)
+        let recorder = FactoryRecorder()
+        let descriptor = setup.adapters[0].0
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(id: descriptor.factoryID, recorder: recorder))]
+        )
+        let contract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let first = try await registry.makeSession(contract: contract, resumeFrom: nil) { event in
+            await recorder.capture(event); return .accepted
+        }
+        let second = try await registry.makeSession(contract: contract, resumeFrom: nil) { event in
+            await recorder.capture(event); return .accepted
+        }
+        try await first.start()
+        try await second.start()
+        let firstEvent = try await recorder.emit(candidate(sequence: 1))
+        let secondEvent = try await recorder.emit(candidate(sequence: 1), sinkIndex: 1)
+        #expect(!firstEvent.hasSameLogicalSource(as: secondEvent))
+        #expect(firstEvent.hasSameLogicalSource(as: first))
+        #expect(secondEvent.hasSameLogicalSource(as: second))
+
+        let checkpoint = try await registry.makeCheckpoint(for: first)
+        for output in [String(describing: checkpoint), String(reflecting: checkpoint), dumped(checkpoint)] {
+            #expect(!output.contains("cursor-1"))
+            #expect(!output.contains("event-1"))
+        }
+        #expect(Array(Mirror(reflecting: checkpoint).children).count == 1)
+        let resumed = try await registry.makeSession(contract: contract, resumeFrom: checkpoint) { event in
+            await recorder.capture(event)
+            return .accepted
+        }
+        try await resumed.start()
+        let resumedEvent = try await recorder.emit(candidate(sequence: 2), sinkIndex: 2)
+        #expect(resumedEvent.hasSameLogicalSource(as: firstEvent))
+        #expect(!resumedEvent.hasSameAttempt(as: firstEvent))
+        #expect(resumedEvent.hasSameLogicalSource(as: resumed))
+        #expect(resumedEvent.hasSameAttempt(as: resumed))
+    }
+
+    @Test func preStartEmissionIsRevokedAndActiveSinkIsWrapped() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let factory = RecordingFactory(
+            id: descriptor.factoryID,
+            recorder: recorder,
+            emitDuringMake: true,
+            emitDuringStart: true
+        )
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation], compiledAdapters: [(descriptor, factory)]
+        )
+        let contract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let session = try await registry.makeSession(contract: contract, resumeFrom: nil) { event in
+            await recorder.capture(event)
+            return .accepted
+        }
+        #expect(await recorder.lastEvent == nil)
+        try await session.start()
+        #expect(await recorder.startOutcome == .bufferedUntilActivation)
+        #expect(await recorder.lastEvent != nil)
+        await #expect(throws: AdapterSessionError.invalidLifecycle) {
+            try await session.start()
+        }
+        let activeCandidate = AdapterCandidate(
+            event: .processExited(status: nil),
+            sourcePosition: try AdapterSourcePosition(sourceSequence: 2)
+        )
+        #expect(await recorder.ingest(activeCandidate) == .accepted)
+        let emitted = try #require(await recorder.lastEvent)
+        #expect(emitted.hasSameLogicalSource(as: session))
+        await session.stop(deadline: .now)
+        #expect(await recorder.ingest(try candidate(sequence: 3)) == .revoked)
+    }
+
+    @Test func startBufferIsBoundedAndRejectedSequenceCanRetry() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let limit = AgentAdapterRegistry.startBufferLimit
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                emitDuringStart: true,
+                startEmissionCount: limit + 1
+            ))]
+        )
+        let contract = try negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let session = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { event in
+            await recorder.capture(event)
+            return .accepted
+        }
+        try await session.start()
+
+        let outcomes = await recorder.startOutcomes
+        #expect(outcomes.count == limit + 1)
+        #expect(outcomes.prefix(limit).allSatisfy { $0 == .bufferedUntilActivation })
+        #expect(outcomes.last == .droppedInvalid)
+        #expect(await recorder.capturedCount == limit)
+        let retry = AdapterCandidate(
+            event: .processExited(status: nil),
+            sourcePosition: try AdapterSourcePosition(
+                sourceSequence: UInt64(limit + 1)
+            )
+        )
+        #expect(await recorder.ingest(retry) == .accepted)
+        #expect(await recorder.capturedCount == limit + 1)
+    }
+
+    @Test func postCommitRevocationDoesNotFailStart() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let completions = CompletionController()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                emitDuringStart: true,
+                startEmissionCount: 2
+            ))]
+        )
+        let contract = try negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let session = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { event in
+            let sequence = event.candidate.sourcePosition?.sourceSequence
+            await completions.wait(sequence: sequence)
+            await recorder.capture(event)
+            return .accepted
+        }
+        await completions.release(1)
+        let startTask = Task { try await session.start() }
+        await completions.waitUntilArrived(2)
+        startTask.cancel()
+        await completions.release(2)
+        try await startTask.value
+        #expect(await recorder.capturedCount == 2)
+        let afterRevocation = AdapterCandidate(
+            event: .processExited(status: nil),
+            sourcePosition: try AdapterSourcePosition(sourceSequence: 3)
+        )
+        #expect(await recorder.ingest(afterRevocation) == .revoked)
+    }
+
+    @Test func preCommitTaskCancellationDiscardsStartBuffer() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let hold = StartHold()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                emitDuringStart: true,
+                startHold: hold
+            ))]
+        )
+        let contract = try negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let session = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { event in
+            await recorder.capture(event)
+            return .accepted
+        }
+        let startTask = Task { try await session.start() }
+        await hold.waitUntilArrived()
+        startTask.cancel()
+        await hold.release()
+        await #expect(throws: CancellationError.self) {
+            try await startTask.value
+        }
+        #expect(await recorder.startOutcome == .bufferedUntilActivation)
+        #expect(await recorder.capturedCount == 0)
+        let discarded = AdapterCandidate(
+            event: .processExited(status: nil),
+            sourcePosition: try AdapterSourcePosition(sourceSequence: 1)
+        )
+        #expect(await recorder.ingest(discarded) == .revoked)
+    }
+
+    @Test func cancellationAtActivationBoundaryLosesToNoCommit() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                emitDuringStart: true,
+                cancelBeforeReturning: true
+            ))]
+        )
+        let contract = try negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let session = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { event in
+            await recorder.capture(event)
+            return .accepted
+        }
+        let startTask = Task { try await session.start() }
+        await #expect(throws: CancellationError.self) {
+            try await startTask.value
+        }
+        #expect(await recorder.startOutcome == .bufferedUntilActivation)
+        #expect(await recorder.capturedCount == 0)
+        let discarded = AdapterCandidate(
+            event: .processExited(status: nil),
+            sourcePosition: try AdapterSourcePosition(sourceSequence: 1)
+        )
+        #expect(await recorder.ingest(discarded) == .revoked)
+    }
+
+    @Test func lifecycleRejectsRestartAndRevokesFailedStartSink() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                startFailure: AdapterSessionError.launchFailed(.transient),
+                emitDuringStart: true
+            ))]
+        )
+        let contract = try negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let failed = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        #expect(await recorder.ingest(try candidate(sequence: 1)) == .revoked)
+        await #expect(throws: AdapterSessionError.launchFailed(.transient)) {
+            try await failed.start()
+        }
+        #expect(await recorder.startOutcome == .bufferedUntilActivation)
+        #expect(await recorder.lastEvent == nil)
+        #expect(await recorder.ingest(try candidate(sequence: 1)) == .revoked)
+        await #expect(throws: AdapterSessionError.invalidLifecycle) {
+            try await failed.start()
+        }
+
+        let cancellationRecorder = FactoryRecorder()
+        let cancellationRegistry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: cancellationRecorder,
+                emitDuringStart: true,
+                cancelDuringStart: true
+            ))]
+        )
+        let cancellationContract = try negotiate(
+            cancellationRegistry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let cancelled = try await cancellationRegistry.makeSession(
+            contract: cancellationContract,
+            resumeFrom: nil
+        ) { event in
+            await cancellationRecorder.capture(event)
+            return .accepted
+        }
+        await #expect(throws: CancellationError.self) {
+            try await cancelled.start()
+        }
+        #expect(await cancellationRecorder.startOutcome == .bufferedUntilActivation)
+        #expect(await cancellationRecorder.lastEvent == nil)
+        #expect(
+            await cancellationRecorder.ingest(try candidate(sequence: 1))
+                == .revoked
+        )
+    }
+
+    @Test func failureAndMismatchRevokeRetainedSink() async throws {
+        let setup = try fixtures(twoAdapters: true)
+        let descriptor = setup.adapters[0].0
+        let failedRecorder = FactoryRecorder()
+        let failedRegistry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID, recorder: failedRecorder, failure: AdapterSessionError.launchFailed(.permanent)
+            ))]
+        )
+        let failedContract = try negotiate(failedRegistry, adapterID: descriptor.adapterID, profile: setup.profile)
+        await #expect(throws: AdapterSessionError.launchFailed(.permanent)) {
+            _ = try await failedRegistry.makeSession(contract: failedContract, resumeFrom: nil) { _ in .accepted }
+        }
+        #expect(await failedRecorder.ingest(try candidate(sequence: 1)) == .revoked)
+
+        let mismatchRecorder = FactoryRecorder()
+        let mismatch = try mismatchContract(from: setup)
+        let mismatchRegistry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID, recorder: mismatchRecorder, returnedContract: mismatch
+            ))]
+        )
+        let mismatchContract = try negotiate(mismatchRegistry, adapterID: descriptor.adapterID, profile: setup.profile)
+        await #expect(throws: AdapterSessionError.contractMismatch) {
+            _ = try await mismatchRegistry.makeSession(contract: mismatchContract, resumeFrom: nil) { _ in .accepted }
+        }
+        #expect(await mismatchRecorder.ingest(try candidate(sequence: 1)) == .revoked)
+    }
+
+    @Test func factoryCancellationPropagatesUnchanged() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, CancellingFactory(id: descriptor.factoryID))]
+        )
+        let contract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        await #expect(throws: CancellationError.self) {
+            _ = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .accepted }
+        }
+    }
+
+    @Test func checkpointRequiresNewAcceptedReplayPosition() async throws {
+        let setup = try fixtures(replay: .sourceCursor)
+        let recorder = FactoryRecorder()
+        let descriptor = setup.adapters[0].0
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(id: descriptor.factoryID, recorder: recorder))]
+        )
+        let contract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let dropped = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .droppedInvalid }
+        try await dropped.start()
+        await #expect(throws: AdapterSessionError.checkpointUnavailable) {
+            _ = try await registry.makeCheckpoint(for: dropped)
+        }
+        #expect(await recorder.ingest(try candidate(sequence: 1)) == .droppedInvalid)
+        await #expect(throws: AdapterSessionError.checkpointUnavailable) {
+            _ = try await registry.makeCheckpoint(for: dropped)
+        }
+
+        let revoked = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .revoked }
+        try await revoked.start()
+        #expect(await recorder.ingest(try candidate(sequence: 2), sinkIndex: 1) == .revoked)
+        await #expect(throws: AdapterSessionError.checkpointUnavailable) {
+            _ = try await registry.makeCheckpoint(for: revoked)
+        }
+
+        let accepted = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .accepted }
+        try await accepted.start()
+        #expect(await recorder.ingest(try candidate(sequence: 7), sinkIndex: 2) == .accepted)
+        _ = try await registry.makeCheckpoint(for: accepted)
+        await #expect(throws: AdapterSessionError.checkpointUnavailable) {
+            _ = try await registry.makeCheckpoint(for: accepted)
+        }
+    }
+
+    @Test func checkpointIsUnavailableForNoReplayContract() async throws {
+        let setup = try fixtures()
+        let recorder = FactoryRecorder()
+        let descriptor = setup.adapters[0].0
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(id: descriptor.factoryID, recorder: recorder))]
+        )
+        let contract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let session = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .accepted }
+        try await session.start()
+        await #expect(throws: AdapterSessionError.checkpointNotSupported) {
+            _ = try await registry.makeCheckpoint(for: session)
+        }
+    }
+
+    @Test func monotonicAdmissionAndConcurrentCompletionDoNotRegress() async throws {
+        let setup = try fixtures(replay: .sourceCursor)
+        let recorder = FactoryRecorder()
+        let descriptor = setup.adapters[0].0
+        let completions = CompletionController()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(id: descriptor.factoryID, recorder: recorder))]
+        )
+        let contract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let session = try await registry.makeSession(contract: contract, resumeFrom: nil) { event in
+            await completions.wait(sequence: event.candidate.sourcePosition?.sourceSequence)
+            return .accepted
+        }
+        try await session.start()
+        let secondCandidate = try candidate(sequence: 2)
+        let thirdCandidate = try candidate(sequence: 3)
+        async let second = recorder.ingest(secondCandidate)
+        await completions.waitUntilArrived(2)
+        await #expect(throws: AdapterSessionError.checkpointUnavailable) {
+            _ = try await registry.makeCheckpoint(for: session)
+        }
+        async let third = recorder.ingest(thirdCandidate)
+        await completions.waitUntilArrived(3)
+        await completions.release(3)
+        #expect(await third == .accepted)
+        await completions.release(2)
+        #expect(await second == .accepted)
+        #expect(await recorder.ingest(try candidate(sequence: 3)) == .droppedInvalid)
+        #expect(await recorder.ingest(try candidate(sequence: 1)) == .droppedInvalid)
+        let checkpoint = try await registry.makeCheckpoint(for: session)
+        #expect(checkpoint.lastSourceSequence == 3)
+    }
+
+    @Test func checkpointIsOneShotAndRejectedBeforeFactoryInvocation() async throws {
+        let setup = try fixtures(replay: .sourceCursor)
+        let recorder = FactoryRecorder()
+        let descriptor = setup.adapters[0].0
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(id: descriptor.factoryID, recorder: recorder))]
+        )
+        let contract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let source = try await registry.makeSession(contract: contract, resumeFrom: nil) { _ in .accepted }
+        try await source.start()
+        #expect(await recorder.ingest(try candidate(sequence: 4)) == .accepted)
+        let checkpoint = try await registry.makeCheckpoint(for: source)
+        #expect(await recorder.ingest(try candidate(sequence: 5)) == .revoked)
+        async let first = canResume(registry, contract: contract, checkpoint: checkpoint)
+        async let second = canResume(registry, contract: contract, checkpoint: checkpoint)
+        let outcomes = (await first, await second)
+        #expect(outcomes.0 != outcomes.1)
+        #expect(await recorder.calls == 2)
+    }
+
+    @Test func checkpointBindingsAndResumeBaselineFailClosed() async throws {
+        let setup = try fixtures(twoAdapters: true, replay: .sourceCursor)
+        let recorder = FactoryRecorder()
+        let compiled = setup.adapters.map { ($0.0, RecordingFactory(id: $0.0.factoryID, recorder: recorder) as any AgentAdapterFactory) }
+        let registry = try AgentAdapterRegistry(compiledPresentations: [setup.presentation], compiledAdapters: compiled)
+        let first = try negotiate(registry, adapterID: compiled[0].0.adapterID, profile: setup.profile)
+        let second = try negotiate(registry, adapterID: compiled[1].0.adapterID, profile: setup.profile)
+        let source = try await registry.makeSession(contract: first, resumeFrom: nil) { _ in .accepted }
+        try await source.start()
+        #expect(await recorder.ingest(try candidate(sequence: 5)) == .accepted)
+        let checkpoint = try await registry.makeCheckpoint(for: source)
+        #expect(await recorder.ingest(try candidate(sequence: 6)) == .revoked)
+        await #expect(throws: AdapterSessionError.checkpointMismatch) {
+            _ = try await registry.makeSession(contract: second, resumeFrom: checkpoint) { _ in .accepted }
+        }
+        #expect(await recorder.calls == 1)
+
+        let foreignRecorder = FactoryRecorder()
+        let foreignRegistry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(compiled[0].0, RecordingFactory(id: compiled[0].0.factoryID, recorder: foreignRecorder))]
+        )
+        let foreign = try negotiate(foreignRegistry, adapterID: compiled[0].0.adapterID, profile: setup.profile)
+        await #expect(throws: AdapterSessionError.checkpointMismatch) {
+            _ = try await foreignRegistry.makeSession(contract: foreign, resumeFrom: checkpoint) { _ in .accepted }
+        }
+        #expect(await foreignRecorder.calls == 0)
+
+        let resumed = try await registry.makeSession(contract: first, resumeFrom: checkpoint) { _ in .accepted }
+        try await resumed.start()
+        #expect(await recorder.ingest(try candidate(sequence: 5), sinkIndex: 1) == .droppedInvalid)
+        #expect(await recorder.ingest(try candidate(sequence: 6), sinkIndex: 1) == .accepted)
+        #expect((try await registry.makeCheckpoint(for: resumed)).lastSourceSequence == 6)
+    }
+
+    @Test func checkpointRejectsDifferentVersionAndProfileBeforeFactory() async throws {
+        let setup = try fixtures(replay: .sourceCursor)
+        let descriptor = setup.adapters[0].0
+        let alternate = try AdapterCapabilityProfile(
+            transport: .authenticatedLocalIPC,
+            lifecycle: AdapterLifecycleCapabilities(signals: lifecycleSignals(), evidence: []),
+            delivery: AdapterDeliverySemantics(
+                replay: .sourceCursor, ordering: .ordered, minimumAuthentication: .authenticatedPeer
+            )
+        )
+        let expanded = AdapterDescriptor(
+            adapterID: descriptor.adapterID,
+            agentID: descriptor.agentID,
+            factoryID: descriptor.factoryID,
+            contractVersions: descriptor.contractVersions,
+            maximumProfiles: [setup.profile, alternate]
+        )
+        let recorder = FactoryRecorder()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(expanded, RecordingFactory(id: descriptor.factoryID, recorder: recorder))]
+        )
+        let sourceContract = try negotiate(registry, adapterID: descriptor.adapterID, profile: setup.profile)
+        let source = try await registry.makeSession(contract: sourceContract, resumeFrom: nil) { _ in .accepted }
+        try await source.start()
+        #expect(await recorder.ingest(try candidate(sequence: 1)) == .accepted)
+        let checkpoint = try await registry.makeCheckpoint(for: source)
+
+        let olderVersion = try registry.negotiate(
+            adapterID: descriptor.adapterID,
+            offeredProfiles: [setup.profile],
+            offeredVersions: range(1, 0, 1, 3),
+            policy: policy()
+        )
+        await #expect(throws: AdapterSessionError.checkpointMismatch) {
+            _ = try await registry.makeSession(contract: olderVersion, resumeFrom: checkpoint) { _ in .accepted }
+        }
+        let alternateProfile = try registry.negotiate(
+            adapterID: descriptor.adapterID,
+            offeredProfiles: [alternate],
+            offeredVersions: range(1, 0, 1, 4),
+            policy: AdapterNegotiationPolicy(
+                allowedVersions: range(1, 0, 1, 4),
+                transportPreference: [.authenticatedLocalIPC],
+                acceptedAuthentication: [.authenticatedPeer]
+            )
+        )
+        await #expect(throws: AdapterSessionError.checkpointMismatch) {
+            _ = try await registry.makeSession(contract: alternateProfile, resumeFrom: checkpoint) { _ in .accepted }
+        }
+        #expect(await recorder.calls == 1)
+    }
+
+    @Test func policyIgnoresOfferOrder() throws {
+        let setup = try fixtures()
+        let local = try AdapterCapabilityProfile(
+            transport: .authenticatedLocalIPC,
+            lifecycle: AdapterLifecycleCapabilities(signals: lifecycleSignals(), evidence: []),
+            delivery: AdapterDeliverySemantics(ordering: .ordered, minimumAuthentication: .authenticatedPeer)
+        )
+        let descriptor = setup.adapters[0].0
+        let richerLocal = try AdapterCapabilityProfile(
+            transport: .authenticatedLocalIPC,
+            lifecycle: AdapterLifecycleCapabilities(
+                signals: lifecycleSignals().union([.init(scope: .turn, phase: .working)]), evidence: []
+            ),
+            delivery: AdapterDeliverySemantics(ordering: .ordered, minimumAuthentication: .authenticatedPeer)
+        )
+        let complete = AdapterDescriptor(
+            adapterID: descriptor.adapterID, agentID: descriptor.agentID, factoryID: descriptor.factoryID,
+            contractVersions: descriptor.contractVersions, maximumProfiles: [setup.profile, local, richerLocal]
+        )
+        let completeRegistry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation], compiledAdapters: [(complete, setup.adapters[0].1)]
+        )
+        let offers = [setup.profile, local, richerLocal]
+        let permutations = [offers, Array(offers.reversed()), [local, setup.profile, richerLocal]]
+        let selections = try permutations.map { offered in
+            try completeRegistry.negotiate(
+                adapterID: descriptor.adapterID, offeredProfiles: Array(offered),
+                offeredVersions: range(1, 0, 1, 4),
+                policy: AdapterNegotiationPolicy(
+                    allowedVersions: range(1, 0, 1, 4),
+                    transportPreference: [.authenticatedLocalIPC, .ownedStandardIO],
+                    acceptedAuthentication: [.ownedChildPipe, .authenticatedPeer]
+                )
+            )
+        }
+        #expect(selections.allSatisfy { $0 == selections[0] })
+        #expect(selections[0].profile.transport == .authenticatedLocalIPC)
+    }
+
+    @Test func escalationFails() throws {
+        let setup = try fixtures()
+        let registry = try AgentAdapterRegistry(compiledPresentations: [setup.presentation], compiledAdapters: setup.adapters)
+        let excessive = try AdapterCapabilityProfile(
+            transport: .ownedStandardIO,
+            lifecycle: AdapterLifecycleCapabilities(signals: lifecycleSignals(), evidence: [.tool]),
+            delivery: AdapterDeliverySemantics(ordering: .ordered, minimumAuthentication: .ownedChildPipe)
+        )
+        #expect(throws: AdapterNegotiationError.offeredProfileExceedsMaximum) {
+            _ = try negotiate(registry, adapterID: setup.adapters[0].0.adapterID, profile: excessive)
+        }
+    }
+
+    private func dumped<T>(_ value: T) -> String {
+        var output = ""
+        dump(value, to: &output)
+        return output
+    }
+
+    private func fixtures(twoAdapters: Bool = false, replay: AdapterReplay = .none) throws -> (
+        presentation: AgentPresentationDescriptor,
+        adapters: [(AdapterDescriptor, any AgentAdapterFactory)], profile: AdapterCapabilityProfile
+    ) {
+        let agent = try AgentID(validating: "codex")
+        let presentation = try AgentPresentationDescriptor(
+            agentID: agent, displayName: "Codex", executableAliases: [ExecutableAlias(validating: "codex")], style: .codex
+        )
+        let profile = try AdapterCapabilityProfile(
+            transport: .ownedStandardIO,
+            lifecycle: AdapterLifecycleCapabilities(signals: lifecycleSignals(), evidence: []),
+            delivery: AdapterDeliverySemantics(
+                replay: replay, ordering: .ordered, minimumAuthentication: .ownedChildPipe
+            )
+        )
+        func pair(_ suffix: String) throws -> (AdapterDescriptor, any AgentAdapterFactory) {
+            let factoryID = try AdapterFactoryID(validating: "pine.codex.\(suffix).factory")
+            return (AdapterDescriptor(
+                adapterID: try AdapterID(validating: "pine:codex:\(suffix)"), agentID: agent, factoryID: factoryID,
+                contractVersions: range(1, 0, 1, 4), maximumProfiles: [profile]
+            ), RegistryTestFactory(id: factoryID))
+        }
+        return (presentation, twoAdapters ? [try pair("stdio"), try pair("rpc")] : [try pair("stdio")], profile)
+    }
+
+    private func mismatchContract(from setup: (
+        presentation: AgentPresentationDescriptor,
+        adapters: [(AdapterDescriptor, any AgentAdapterFactory)], profile: AdapterCapabilityProfile
+    )) throws -> NegotiatedAdapterContract {
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation], compiledAdapters: setup.adapters
+        )
+        return try negotiate(registry, adapterID: setup.adapters[1].0.adapterID, profile: setup.profile)
+    }
+
+    private func negotiate(
+        _ registry: AgentAdapterRegistry, adapterID: AdapterID, profile: AdapterCapabilityProfile
+    ) throws -> NegotiatedAdapterContract {
+        try registry.negotiate(
+            adapterID: adapterID, offeredProfiles: [profile], offeredVersions: range(1, 1, 1, 9),
+            policy: AdapterNegotiationPolicy(
+                allowedVersions: range(1, 0, 1, 8), transportPreference: [.ownedStandardIO],
+                acceptedAuthentication: [.ownedChildPipe]
+            )
+        )
+    }
+
+    private func range(_ minMajor: UInt16, _ minMinor: UInt16, _ maxMajor: UInt16, _ maxMinor: UInt16) -> PineAdapterContractVersionRange {
+        PineAdapterContractVersionRange(
+            minimum: PineAdapterContractVersion(major: minMajor, minor: minMinor),
+            maximum: PineAdapterContractVersion(major: maxMajor, minor: maxMinor)
+        )
+    }
+
+    private func policy() -> AdapterNegotiationPolicy {
+        AdapterNegotiationPolicy(
+            allowedVersions: range(1, 0, 1, 4),
+            transportPreference: [.ownedStandardIO],
+            acceptedAuthentication: [.ownedChildPipe]
+        )
+    }
+
+    private func lifecycleSignals() -> Set<AdapterLifecycleCapabilities.Signal> {
+        [.init(scope: .session, phase: .settled), .init(scope: .turn, phase: .started)]
+    }
+
+    private func candidate(sequence: UInt64) throws -> AdapterCandidate {
+        AdapterCandidate(
+            event: .processExited(status: nil),
+            sourcePosition: try AdapterSourcePosition(
+                sourceEvent: VendorReference(role: .event, value: "event-\(sequence)"),
+                resumePosition: AdapterResumePosition("cursor-\(sequence)"),
+                sourceSequence: sequence
+            )
+        )
+    }
+
+    private func canResume(
+        _ registry: AgentAdapterRegistry,
+        contract: NegotiatedAdapterContract,
+        checkpoint: AdapterResumeCheckpoint
+    ) async -> Bool {
+        do {
+            _ = try await registry.makeSession(contract: contract, resumeFrom: checkpoint) { _ in .accepted }
+            return true
+        } catch {
+            return false
+        }
+    }
+}
+
+nonisolated private struct RecordingFactory: AgentAdapterFactory {
+    let id: AdapterFactoryID
+    let recorder: FactoryRecorder
+    var emitDuringMake = false
+    var failure: AdapterSessionError?
+    var returnedContract: NegotiatedAdapterContract?
+    var startFailure: AdapterSessionError?
+    var emitDuringStart = false
+    var startEmissionCount = 1
+    var cancelDuringStart = false
+    var cancelBeforeReturning = false
+    var startHold: StartHold?
+    func probe() async throws -> AdapterProbeResult { throw AdapterProbeError.unavailable(.permanent) }
+    func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession {
+        await recorder.record(request: request)
+        if emitDuringMake {
+            _ = await request.sink.ingest(AdapterCandidate(
+                event: .processExited(status: nil),
+                sourcePosition: try AdapterSourcePosition(sourceSequence: 1)
+            ))
+        }
+        if let failure { throw failure }
+        return RegistryTestSession(
+            contract: returnedContract ?? request.contract,
+            startFailure: startFailure,
+            startSink: request.sink,
+            startRecorder: recorder,
+            emitDuringStart: emitDuringStart,
+            startEmissionCount: startEmissionCount,
+            cancelDuringStart: cancelDuringStart,
+            cancelBeforeReturning: cancelBeforeReturning,
+            startHold: startHold
+        )
+    }
+}
+
+private actor FactoryRecorder {
+    private(set) var contract: NegotiatedAdapterContract?
+    private(set) var sequence: UInt64?
+    private(set) var calls = 0
+    private(set) var cursor: String?
+    private(set) var event: String?
+    private(set) var sinks: [any AgentEventSink] = []
+    private(set) var lastEvent: ValidatedAgentEvent?
+    private(set) var startOutcome: AdapterIngestOutcome?
+    private(set) var startOutcomes: [AdapterIngestOutcome] = []
+    private(set) var capturedCount = 0
+
+    func record(request: AgentAdapterSessionRequest) {
+        calls += 1
+        contract = request.contract
+        sequence = request.resumeFrom?.lastSourceSequence
+        cursor = request.resumeFrom?.resumePosition.rawValue
+        event = request.resumeFrom?.lastSourceEvent.rawValue
+        sinks.append(request.sink)
+    }
+
+    func ingest(_ candidate: AdapterCandidate, sinkIndex: Int = 0) async -> AdapterIngestOutcome {
+        guard sinks.indices.contains(sinkIndex) else { return .revoked }
+        return await sinks[sinkIndex].ingest(candidate)
+    }
+
+    func emit(_ candidate: AdapterCandidate, sinkIndex: Int = 0) async throws -> ValidatedAgentEvent {
+        lastEvent = nil
+        guard await ingest(candidate, sinkIndex: sinkIndex) == .accepted,
+              let lastEvent else { throw AdapterSessionError.checkpointUnavailable }
+        return lastEvent
+    }
+
+    func capture(_ event: ValidatedAgentEvent) {
+        lastEvent = event
+        capturedCount += 1
+    }
+    func recordStartOutcome(_ outcome: AdapterIngestOutcome) {
+        startOutcome = outcome
+        startOutcomes.append(outcome)
+    }
+}
+
+nonisolated private struct MismatchingFactory: AgentAdapterFactory {
+    let id: AdapterFactoryID
+    let returnedContract: NegotiatedAdapterContract
+    func probe() async throws -> AdapterProbeResult { throw AdapterProbeError.unavailable(.permanent) }
+    func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession {
+        RegistryTestSession(contract: returnedContract)
+    }
+}
+
+nonisolated private struct CancellingFactory: AgentAdapterFactory {
+    let id: AdapterFactoryID
+    func probe() async throws -> AdapterProbeResult { throw CancellationError() }
+    func makeSession(_ request: AgentAdapterSessionRequest) async throws -> any AgentAdapterSession {
+        throw CancellationError()
+    }
+}
+
+private actor StartHold {
+    private var arrived = false
+    private var released = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        arrived = true
+        guard !released else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func waitUntilArrived() async {
+        while !arrived { await Task.yield() }
+    }
+
+    func release() {
+        released = true
+        waiters.forEach { $0.resume() }
+        waiters.removeAll(keepingCapacity: false)
+    }
+}
+
+private actor CompletionController {
+    private var arrived = Set<UInt64>()
+    private var released = Set<UInt64>()
+    private var continuations: [UInt64: [CheckedContinuation<Void, Never>]] = [:]
+
+    func wait(sequence: UInt64?) async {
+        guard let sequence else { return }
+        arrived.insert(sequence)
+        guard !released.contains(sequence) else { return }
+        await withCheckedContinuation { continuations[sequence, default: []].append($0) }
+    }
+
+    func waitUntilArrived(_ sequence: UInt64) async {
+        while !arrived.contains(sequence) { await Task.yield() }
+    }
+
+    func release(_ sequence: UInt64) {
+        released.insert(sequence)
+        continuations.removeValue(forKey: sequence)?.forEach { $0.resume() }
+    }
+}

--- a/PineTests/AgentAdapterRegistryTests.swift
+++ b/PineTests/AgentAdapterRegistryTests.swift
@@ -293,6 +293,39 @@ struct AgentAdapterRegistryTests {
         _ = first
     }
 
+    @Test func abandonedFreshSessionRollsAuthorityBackSynchronously() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: FactoryRecorder(),
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                )
+            ))]
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        var abandoned: (any AgentAdapterSession)? = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        #expect(abandoned != nil)
+        abandoned = nil
+
+        let replacement = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        _ = replacement
+    }
+
     @Test func strictSubsetProbeOfferNegotiatesAndActivates() async throws {
         let setup = try fixtures()
         let base = setup.adapters[0].0
@@ -1186,6 +1219,114 @@ struct AgentAdapterRegistryTests {
         #expect(await recorder.calls == 4)
     }
 
+    @Test func registryRejectsFactoryResultAfterConstructionCancellation() async throws {
+        let setup = try fixtures(replay: .sourceCursor)
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let cancellation = IgnoredResumeCancellation()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, CancellationIgnoringResumeFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                ),
+                cancellation: cancellation
+            ))]
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let source = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { _ in .accepted }
+        try await source.start()
+        #expect(await recorder.ingest(try candidate(sequence: 1)) == .accepted)
+        let checkpoint = try await registry.makeCheckpoint(for: source)
+
+        let cancelledConstruction = Task {
+            try await registry.makeSession(
+                contract: contract,
+                resumeFrom: checkpoint
+            ) { _ in .accepted }
+        }
+        await cancellation.waitUntilEntered()
+        cancelledConstruction.cancel()
+        await #expect(throws: CancellationError.self) {
+            _ = try await cancelledConstruction.value
+        }
+
+        let resumed = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: checkpoint
+        ) { _ in .accepted }
+        try await resumed.start()
+    }
+
+    @Test func stopAfterActivationCommitCannotReopenFreshAuthority() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let completions = CompletionController()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, RecordingFactory(
+                id: descriptor.factoryID,
+                recorder: recorder,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                )
+            ))]
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let session = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { event in
+            await completions.wait(
+                sequence: event.candidate.sourcePosition?.sourceSequence
+            )
+            return .accepted
+        }
+        #expect(await recorder.ingest(try candidate(sequence: 1)) == .bufferedUntilActivation)
+        let startTask = Task { try await session.start() }
+        await completions.waitUntilArrived(1)
+
+        let stopTask = Task {
+            await session.stop(
+                deadline: ContinuousClock.now.advanced(by: .seconds(5))
+            )
+        }
+        var closingOutcome = AdapterIngestOutcome.retryAfterActivation
+        for _ in 0..<1_000 where closingOutcome != .revoked {
+            closingOutcome = await recorder.ingest(try candidate(sequence: 2))
+            await Task.yield()
+        }
+        #expect(closingOutcome == .revoked)
+        await #expect(throws: AdapterSessionError.contractAlreadyConsumed) {
+            _ = try await registry.makeSession(
+                contract: contract,
+                resumeFrom: nil
+            ) { _ in .accepted }
+        }
+
+        await completions.release(1)
+        await #expect(throws: AdapterSessionError.invalidLifecycle) {
+            try await startTask.value
+        }
+        await stopTask.value
+    }
+
     @Test func stopRunsOutsideCallerCancellation() async throws {
         let setup = try fixtures()
         let descriptor = setup.adapters[0].0
@@ -1247,21 +1388,22 @@ struct AgentAdapterRegistryTests {
             contract: contract,
             resumeFrom: nil
         ) { _ in .accepted }
-        let completion = TestSignal()
-        let deadline = ContinuousClock.now.advanced(by: .milliseconds(200))
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .milliseconds(200))
         let stopTask = Task {
             await session.stop(deadline: deadline)
-            await completion.signal()
+            return clock.now
+        }
+        let watchdog = Task {
+            try? await clock.sleep(until: deadline.advanced(by: .seconds(2)))
+            await stopHold.release()
         }
 
         await stopHold.waitUntilArrived()
-        try await ContinuousClock().sleep(
-            until: deadline.advanced(by: .seconds(1))
-        )
-        let returnedByDeadline = await completion.signalled
+        let returnedAt = await stopTask.value
+        watchdog.cancel()
         await stopHold.release()
-        await stopTask.value
-        #expect(returnedByDeadline)
+        #expect(returnedAt <= deadline.advanced(by: .seconds(1)))
     }
 
     @Test func stopPreservesAcceptedOutcomeForAlreadyAdmittedDelivery() async throws {
@@ -1300,7 +1442,12 @@ struct AgentAdapterRegistryTests {
 
         let admitted = Task { await recorder.ingest(try candidate(sequence: 1)) }
         await completions.waitUntilArrived(1)
-        let stopTask = Task {
+        let firstStop = Task {
+            await session.stop(
+                deadline: ContinuousClock.now.advanced(by: .seconds(5))
+            )
+        }
+        let secondStop = Task {
             await session.stop(
                 deadline: ContinuousClock.now.advanced(by: .seconds(5))
             )
@@ -1311,6 +1458,66 @@ struct AgentAdapterRegistryTests {
         await completions.release(1)
 
         #expect(try await admitted.value == .accepted)
+        await firstStop.value
+        await secondStop.value
+        #expect(await stopHold.callCount == 1)
+    }
+
+    @Test func stopWaitsForCurrentInFlightWorkAfterAnEarlierDrain() async throws {
+        let setup = try fixtures()
+        let descriptor = setup.adapters[0].0
+        let recorder = FactoryRecorder()
+        let completions = CompletionController()
+        let stopHold = StopHold()
+        let registry = try AgentAdapterRegistry(
+            compiledPresentations: [setup.presentation],
+            compiledAdapters: [(descriptor, StopTestFactory(
+                id: descriptor.factoryID,
+                probeResult: try probeResult(
+                    profile: setup.profile,
+                    versions: descriptor.contractVersions
+                ),
+                stopHold: stopHold,
+                recorder: recorder
+            ))]
+        )
+        let contract = try await negotiate(
+            registry,
+            adapterID: descriptor.adapterID,
+            profile: setup.profile
+        )
+        let session = try await registry.makeSession(
+            contract: contract,
+            resumeFrom: nil
+        ) { event in
+            await completions.wait(
+                sequence: event.candidate.sourcePosition?.sourceSequence
+            )
+            return .accepted
+        }
+        try await session.start()
+
+        let earlier = Task { await recorder.ingest(try candidate(sequence: 1)) }
+        await completions.waitUntilArrived(1)
+        await completions.release(1)
+        #expect(try await earlier.value == .accepted)
+
+        let current = Task { await recorder.ingest(try candidate(sequence: 2)) }
+        await completions.waitUntilArrived(2)
+        let stopReturned = TestSignal()
+        let stopTask = Task {
+            await session.stop(
+                deadline: ContinuousClock.now.advanced(by: .seconds(5))
+            )
+            await stopReturned.signal()
+        }
+        await stopHold.waitUntilArrived()
+        await stopHold.release()
+        #expect(await recorder.ingest(try candidate(sequence: 3)) == .revoked)
+        #expect(await signal(stopReturned, arrivesWithin: .milliseconds(200)) == false)
+
+        await completions.release(2)
+        #expect(try await current.value == .accepted)
         await stopTask.value
     }
 
@@ -1757,6 +1964,43 @@ nonisolated private struct RetryableResumeFactory: AgentAdapterFactory {
     }
 }
 
+private actor IgnoredResumeCancellation {
+    private let entered = TestSignal()
+    private var attempts = 0
+
+    func ignoreOnce() async {
+        attempts += 1
+        guard attempts == 1 else { return }
+        await entered.signal()
+        while !Task.isCancelled {
+            await Task.yield()
+        }
+    }
+
+    func waitUntilEntered() async {
+        await entered.wait()
+    }
+}
+
+nonisolated private struct CancellationIgnoringResumeFactory: AgentAdapterFactory {
+    let id: AdapterFactoryID
+    let recorder: FactoryRecorder
+    let probeResult: AdapterProbeResult
+    let cancellation: IgnoredResumeCancellation
+
+    func probe() async throws -> AdapterProbeResult { probeResult }
+
+    func makeSession(
+        _ request: AgentAdapterSessionRequest
+    ) async throws -> any AgentAdapterSession {
+        await recorder.record(request: request)
+        if request.resumeFrom != nil {
+            await cancellation.ignoreOnce()
+        }
+        return RegistryTestSession(contract: request.contract)
+    }
+}
+
 nonisolated private struct StopTestFactory: AgentAdapterFactory {
     let id: AdapterFactoryID
     let probeResult: AdapterProbeResult
@@ -1785,27 +2029,44 @@ nonisolated private struct StopTestSession: AgentAdapterSession {
 
 private actor StopHold {
     private let arrival = TestSignal()
-    private var released = false
-    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+    private let releaseSignal = TestSignal()
     private(set) var observedCallerCancellation: Bool?
+    private(set) var callCount = 0
 
     func wait() async {
-        observedCallerCancellation = Task.isCancelled
+        callCount += 1
+        if observedCallerCancellation == nil {
+            observedCallerCancellation = Task.isCancelled
+        }
         await arrival.signal()
-        guard !released else { return }
-        await withCheckedContinuation { releaseWaiters.append($0) }
+        await releaseSignal.wait()
     }
 
     func waitUntilArrived() async {
         await arrival.wait()
     }
 
-    func release() {
-        guard !released else { return }
-        released = true
-        let retained = releaseWaiters
-        releaseWaiters.removeAll(keepingCapacity: false)
-        retained.forEach { $0.resume() }
+    func release() async {
+        await releaseSignal.signal()
+    }
+}
+
+nonisolated private func signal(
+    _ signal: TestSignal,
+    arrivesWithin duration: Duration
+) async -> Bool {
+    await withTaskGroup(of: Bool.self) { group in
+        group.addTask {
+            await signal.wait()
+            return true
+        }
+        group.addTask {
+            try? await Task.sleep(for: duration)
+            return false
+        }
+        let first = await group.next() ?? false
+        group.cancelAll()
+        return first
     }
 }
 

--- a/docs/agent-adapter-core.md
+++ b/docs/agent-adapter-core.md
@@ -128,10 +128,11 @@ Every async throwing factory/session seam propagates `CancellationError`
 unchanged, and core checks cancellation again after an untrusted probe or session
 factory returns. `stop(deadline:)` first closes admission, then starts at most one
 shared adapter cleanup per session and supervises the current set of already
-admitted deliveries outside caller cancellation. Concurrent callers share that
-cleanup while retaining their own return deadlines. Stop preserves the actual
-downstream outcome for work admitted before closing and cancels the supervised
-adapter task at the initiating deadline. Cleanup capacity is reserved before a
+admitted deliveries outside caller cancellation. Concurrent callers and
+last-copy abandonment share that same single-flight cleanup; abandonment uses a
+bounded core-owned deadline. Stop preserves the actual downstream outcome for
+work admitted before closing and cancels the supervised adapter task at the
+initiating deadline. Cleanup capacity is reserved before a
 core-bound session is exposed; construction fails with
 `cleanupCapacityUnavailable` when no permit remains. A cleanup that ignores
 cancellation keeps its pre-reserved process-wide quarantine slot until it exits,

--- a/docs/agent-adapter-core.md
+++ b/docs/agent-adapter-core.md
@@ -125,10 +125,13 @@ security boundary. Strict duplicate-key, integer-token, nesting, source-envelope
 and schema parsing belong to the future authenticated framed-ingress slice.
 
 Every async throwing factory/session seam propagates `CancellationError`
-unchanged, and core checks cancellation again after an untrusted factory returns.
-`stop(deadline:)` first closes admission, then starts at most one shared adapter
-cleanup per session and supervises the current set of already admitted deliveries
-outside caller cancellation. Concurrent callers share that cleanup while retaining
-their own return deadlines. Stop preserves the actual downstream outcome for work
-admitted before closing and cancels unfinished cleanup at the initiating deadline.
-It does not claim forced termination when an implementation ignores cancellation.
+unchanged, and core checks cancellation again after an untrusted probe or session
+factory returns. `stop(deadline:)` first closes admission, then starts at most one
+shared adapter cleanup per session and supervises the current set of already
+admitted deliveries outside caller cancellation. Concurrent callers share that
+cleanup while retaining their own return deadlines. Stop preserves the actual
+downstream outcome for work admitted before closing and cancels unfinished cleanup
+at the initiating deadline.
+An adapter cleanup that ignores cancellation remains explicitly tracked in a
+fixed-capacity process-wide quarantine; saturation does not launch additional
+unbounded cleanup tasks. This slice does not claim forced in-process termination.

--- a/docs/agent-adapter-core.md
+++ b/docs/agent-adapter-core.md
@@ -25,14 +25,19 @@ versions, and bounded capability profiles. Each profile describes exactly one
 transport, explicit lifecycle scope/phase pairs, coherent tool/file-change
 evidence, replay, ordering, and a minimum core-derived authentication
 requirement. V1 exposes no control operations. Raw factories and their maximum
-capabilities stay private to the registry. Negotiation selects the highest
-policy-allowed version and one whole offered profile within the compiled
-maximum. Only the minting registry constructs and wraps sessions: it rejects
-foreign contracts, checkpoints for no-replay profiles, and checkpoints not
-bound to the exact minting registry, negotiated contract, and source-session
-namespace. It passes its exact contract and core-owned validating sink to the
-exact factory, and rejects a returned session whose contract differs before it
-can escape.
+capabilities stay private to the registry. The unskippable authority flow is:
+registered factory probe → registry-minted opaque offer → policy negotiation →
+registry-bound contract → exact registered factory session. A raw probe result
+cannot authorize negotiation, and an offer from another registry is rejected
+before any factory invocation. Negotiation derives offered profiles and Pine
+contract versions only from the exact stored factory's probe result, then
+selects the highest policy-allowed version and one whole offered profile within
+the compiled maximum. Only the minting registry constructs and wraps sessions:
+it rejects foreign contracts, checkpoints for no-replay profiles, and
+checkpoints not bound to the exact minting registry, negotiated contract, and
+source-session namespace. It passes its exact contract and core-owned validating
+sink to the exact factory, and rejects a returned session whose contract differs
+before it can escape.
 
 The **candidate plane** contains discriminated, non-authoritative lifecycle,
 question, approval, tool, file-change, process-exit, timestamp, and vendor
@@ -59,7 +64,10 @@ a failed start. During `start()` they hold only a core-bounded number of
 already-validated candidates
 and return the distinct `bufferedUntilActivation` outcome. After underlying
 startup succeeds, core checks cancellation and commits activation in one
-synchronous actor transition before draining that buffer. Failure or
+synchronous actor transition, freezing exactly that finite batch before
+draining it. Ingress during the drain is rejected without advancing source
+ordering, so it cannot extend startup and the same sequence can retry after the
+session becomes active. Failure or
 cancellation before the commit discards
 it without publication; downstream revocation or cancellation after the commit
 may retire the live session, but cannot retroactively turn `start()` into a

--- a/docs/agent-adapter-core.md
+++ b/docs/agent-adapter-core.md
@@ -61,7 +61,8 @@ The adapter-facing payload contains the opaque vendor
 cursor plus the last accepted source event identity and sequence; the private
 binding contains no credential, task, project, terminal, process, or routing
 authority. Resume reserves the checkpoint exclusively before factory invocation,
-commits its one-shot consumption only after a contract-matching session activates,
+commits its one-shot consumption at the core-owned activation boundary immediately
+before any frozen startup candidate can reach downstream,
 and rolls the reservation back on construction failure, failed start,
 cancellation, stop-before-start, or abandoned construction. It requires
 the same registry and exact negotiated contract before the payload reaches a
@@ -74,11 +75,11 @@ synchronous actor transition, freezing exactly that finite batch before
 draining it. Ingress during the drain is rejected without advancing source
 ordering, so it cannot extend startup and receives the explicit
 `retryAfterActivation` outcome rather than a permanent-invalid result. The same
-sequence can retry after the session becomes active. Failure or
-cancellation before the commit discards
-it without publication; downstream revocation or cancellation after the commit
-may retire the live session, but cannot retroactively turn `start()` into a
-failed transaction. Minting a checkpoint
+sequence can retry after the session becomes active. Failure or cancellation
+before the commit discards the reservation without publication. Stop,
+downstream revocation, or cancellation after the commit may make `start()` fail,
+but cannot reopen the consumed authority after buffered publication has become
+possible. Minting a checkpoint
 requires an active session with no in-flight downstream delivery and atomically
 retires the source sink, so the original and
 resumed attempts cannot fork one logical source sequence. The logical source
@@ -124,8 +125,10 @@ security boundary. Strict duplicate-key, integer-token, nesting, source-envelope
 and schema parsing belong to the future authenticated framed-ingress slice.
 
 Every async throwing factory/session seam propagates `CancellationError`
-unchanged. `stop(deadline:)` first closes admission, then supervises already
-admitted deliveries and adapter cleanup outside caller cancellation. It returns
-when both finish or the shared deadline expires, preserves the actual downstream
-outcome for work admitted before closing, and then cancels unfinished cleanup.
+unchanged, and core checks cancellation again after an untrusted factory returns.
+`stop(deadline:)` first closes admission, then starts at most one shared adapter
+cleanup per session and supervises the current set of already admitted deliveries
+outside caller cancellation. Concurrent callers share that cleanup while retaining
+their own return deadlines. Stop preserves the actual downstream outcome for work
+admitted before closing and cancels unfinished cleanup at the initiating deadline.
 It does not claim forced termination when an implementation ignores cancellation.

--- a/docs/agent-adapter-core.md
+++ b/docs/agent-adapter-core.md
@@ -1,0 +1,113 @@
+# Agent adapter core boundary
+
+This first #1303 slice defines pure contracts and validation only. It has no
+production ingress and is independently reviewable from #1302.
+
+## Three planes
+
+The **presentation plane** contains a stable agent ID, normalized display text,
+exact executable aliases, and a data-driven style token. One migration catalog
+preserves Pine's five exact legacy built-in identifiers and retains each generic
+legacy identifier alongside a deterministic SHA-256-derived canonical ID.
+All five built-in IDs and executable aliases are globally reserved even when a
+compiled caller omits a built-in record; supplied built-ins are also checked
+against the complete core-owned catalog. A separate bounded
+programmatic user registration accepts only presentation and aliases, namespaces
+the ID, and normalizes to generic, inference-only presentation. It cannot name
+an adapter, factory, authentication, capability, command, or provenance.
+
+This slice deliberately provides no JSON registration decoder. A future bounded
+configuration loader must limit total bytes before allocation or decoding and
+reject duplicate JSON keys.
+
+The **compiled adapter plane** contains adapter and factory IDs, Pine contract
+versions, and bounded capability profiles. Each profile describes exactly one
+transport, explicit lifecycle scope/phase pairs, coherent tool/file-change
+evidence, replay, ordering, and a minimum core-derived authentication
+requirement. V1 exposes no control operations. Raw factories and their maximum
+capabilities stay private to the registry. Negotiation selects the highest
+policy-allowed version and one whole offered profile within the compiled
+maximum. Only the minting registry constructs and wraps sessions: it rejects
+foreign contracts, checkpoints for no-replay profiles, and checkpoints not
+bound to the exact minting registry, negotiated contract, and source-session
+namespace. It passes its exact contract and core-owned validating sink to the
+exact factory, and rejects a returned session whose contract differs before it
+can escape.
+
+The **candidate plane** contains discriminated, non-authoritative lifecycle,
+question, approval, tool, file-change, process-exit, timestamp, and vendor
+reference hints. Questions and approvals carry an exact lifecycle scope,
+matching attention phase, request reference, and only an optional context
+reference whose role must match that scope. Explicit pairs prevent Pi run
+completion and session settlement, or Codex thread/turn/item phases, from
+authorizing one another.
+Source sequences start at 1. Ordered delivery requires them; unordered profiles
+reject producer sequences rather than silently inventing monotonic semantics.
+Source-cursor replay requires one structurally
+complete source position containing an event identity, resume cursor, and
+positive source sequence; no-replay profiles reject event/cursor positions.
+A checkpoint cannot be caller-constructed. The registry derives its redacted
+internal envelope from the latest complete replay position accepted through one
+core-wrapped source session; callers cannot supply a position to checkpoint.
+The adapter-facing payload contains the opaque vendor
+cursor plus the last accepted source event identity and sequence; the private
+binding contains no credential, task, project, terminal, process, or routing
+authority. Resume uses the checkpoint itself as one-shot authority and requires
+the same registry and exact negotiated contract before the payload reaches a
+factory. Session sinks reject input before `start()`, after `stop()`, and after
+a failed start. During `start()` they hold only a core-bounded number of
+already-validated candidates
+and return the distinct `bufferedUntilActivation` outcome. After underlying
+startup succeeds, core checks cancellation and commits activation in one
+synchronous actor transition before draining that buffer. Failure or
+cancellation before the commit discards
+it without publication; downstream revocation or cancellation after the commit
+may retire the live session, but cannot retroactively turn `start()` into a
+failed transaction. Minting a checkpoint
+requires an active session with no in-flight downstream delivery and atomically
+retires the source sink, so the original and
+resumed attempts cannot fork one logical source sequence. The logical source
+namespace survives resume while each construction
+gets a distinct attempt identity. A core-owned session actor drops duplicate,
+lower, and stale source sequences before routing and advances checkpoint state
+only after downstream acceptance, without regressing when accepted outcomes
+complete out of order. Core later stamps its own journal sequence. Candidate
+paths and hashes remain untrusted. File-change
+batches reject exact and component-prefix path overlaps after conservative case,
+width, and diacritic reduction. Accepted paths preserve their exact filesystem
+spelling, but paths containing bidi, control, or default-ignorable scalars are
+rejected at candidate construction and are never exposed as safe presentation.
+Pine must recompute identity beneath a credential-bound, no-follow root before trust.
+Vendor references, resume positions, and checkpoints are bounded, non-Codable,
+and redacted from description, debug description, and reflection. Process exit
+is not successful agent completion.
+
+## Authority and deferred work
+
+Pine creates and lifecycle-binds a session-contract validating sink before the
+factory is invoked. Its adapter-facing API is only `ingest(_ candidate:)`; core
+wraps validated events with opaque source namespace and attempt identity before
+forwarding. Factory failure, returned-contract mismatch, start failure, and stop
+revoke the sink.
+Adapter DTOs contain no authentication context, credential, task, project,
+worktree, terminal, process generation, replay watermark, trust, or routing
+field. Those are server-side facts and depend on #1302's durable identity and
+routing work.
+
+This commit does **not** complete #1303. It does not prove executable identity,
+no-follow/stat/signature/hash verification, socket or peer security, HMAC,
+credential storage, hook install,
+command execution, rate limiting, replay persistence,
+production supervision, crash/hang enforcement, task routing, or vendor
+integration.
+Factories are pre-bound instances supplied by a future supervised loader; probe
+neither searches PATH nor verifies executable identity. Runtime root containment
+and forced process teardown remain deferred.
+
+This slice defines no JSON or frame decoder and therefore no byte-allocation
+security boundary. Strict duplicate-key, integer-token, nesting, source-envelope,
+and schema parsing belong to the future authenticated framed-ingress slice.
+
+Every async throwing factory/session seam propagates `CancellationError`
+unchanged. `stop(deadline:)` attempts bounded cleanup independently of caller
+cancellation and does not claim forced termination.

--- a/docs/agent-adapter-core.md
+++ b/docs/agent-adapter-core.md
@@ -130,8 +130,10 @@ factory returns. `stop(deadline:)` first closes admission, then starts at most o
 shared adapter cleanup per session and supervises the current set of already
 admitted deliveries outside caller cancellation. Concurrent callers share that
 cleanup while retaining their own return deadlines. Stop preserves the actual
-downstream outcome for work admitted before closing and cancels unfinished cleanup
-at the initiating deadline.
-An adapter cleanup that ignores cancellation remains explicitly tracked in a
-fixed-capacity process-wide quarantine; saturation does not launch additional
-unbounded cleanup tasks. This slice does not claim forced in-process termination.
+downstream outcome for work admitted before closing and cancels the supervised
+adapter task at the initiating deadline. Cleanup capacity is reserved before a
+core-bound session is exposed; construction fails with
+`cleanupCapacityUnavailable` when no permit remains. A cleanup that ignores
+cancellation keeps its pre-reserved process-wide quarantine slot until it exits,
+so quarantine remains bounded without denying cleanup to an already-issued
+session. This slice does not claim forced in-process termination.

--- a/docs/agent-adapter-core.md
+++ b/docs/agent-adapter-core.md
@@ -28,8 +28,11 @@ requirement. V1 exposes no control operations. Raw factories and their maximum
 capabilities stay private to the registry. The unskippable authority flow is:
 registered factory probe → registry-minted opaque offer → policy negotiation →
 registry-bound contract → exact registered factory session. A raw probe result
-cannot authorize negotiation, and an offer from another registry is rejected
-before any factory invocation. Negotiation derives offered profiles and Pine
+cannot authorize negotiation, copied offers share one registry-owned one-shot
+gate, and an offer from another registry is rejected before any factory
+invocation. The resulting contract is bound to that probe generation and carries
+one fresh-session authority; resume instead requires a one-shot checkpoint.
+Negotiation derives offered profiles and Pine
 contract versions only from the exact stored factory's probe result, then
 selects the highest policy-allowed version and one whole offered profile within
 the compiled maximum. Only the minting registry constructs and wraps sessions:
@@ -57,7 +60,10 @@ core-wrapped source session; callers cannot supply a position to checkpoint.
 The adapter-facing payload contains the opaque vendor
 cursor plus the last accepted source event identity and sequence; the private
 binding contains no credential, task, project, terminal, process, or routing
-authority. Resume uses the checkpoint itself as one-shot authority and requires
+authority. Resume reserves the checkpoint exclusively before factory invocation,
+commits its one-shot consumption only after a contract-matching session activates,
+and rolls the reservation back on construction failure, failed start,
+cancellation, stop-before-start, or abandoned construction. It requires
 the same registry and exact negotiated contract before the payload reaches a
 factory. Session sinks reject input before `start()`, after `stop()`, and after
 a failed start. During `start()` they hold only a core-bounded number of
@@ -66,8 +72,9 @@ and return the distinct `bufferedUntilActivation` outcome. After underlying
 startup succeeds, core checks cancellation and commits activation in one
 synchronous actor transition, freezing exactly that finite batch before
 draining it. Ingress during the drain is rejected without advancing source
-ordering, so it cannot extend startup and the same sequence can retry after the
-session becomes active. Failure or
+ordering, so it cannot extend startup and receives the explicit
+`retryAfterActivation` outcome rather than a permanent-invalid result. The same
+sequence can retry after the session becomes active. Failure or
 cancellation before the commit discards
 it without publication; downstream revocation or cancellation after the commit
 may retire the live session, but cannot retroactively turn `start()` into a
@@ -117,5 +124,8 @@ security boundary. Strict duplicate-key, integer-token, nesting, source-envelope
 and schema parsing belong to the future authenticated framed-ingress slice.
 
 Every async throwing factory/session seam propagates `CancellationError`
-unchanged. `stop(deadline:)` attempts bounded cleanup independently of caller
-cancellation and does not claim forced termination.
+unchanged. `stop(deadline:)` first closes admission, then supervises already
+admitted deliveries and adapter cleanup outside caller cancellation. It returns
+when both finish or the shared deadline expires, preserves the actual downstream
+outcome for work admitted before closing, and then cancels unfinished cleanup.
+It does not claim forced termination when an implementation ignores cancellation.


### PR DESCRIPTION
## Summary

Adds the vendor-neutral foundation for Pine agent adapters without coupling terminal or future Inbox UI to vendor-specific switches.

- defines adapter identifiers, capabilities, descriptors, and event models;
- adds registry and factory contracts with generic fallback behavior;
- validates adapter offers, capability/version declarations, event scope, trust, redaction, and monotonic ordering;
- documents the core architecture and trust boundaries;
- adds contract and registry tests.

## Current status

**Draft:** candidate `f6d557a138a66127d20976299e892bd760c4f463` closes all findings and suggestions from the exact-SHA review of `dcb38a574a411b84d8cbc06e8a600dff29e7d083` while preserving the earlier authority and activation fixes:

1. all session copies share a reference-owned lifetime box; explicit stop and last-copy abandonment enter the same single-flight cleanup;
2. abandonment before or after start retains its permit until the supervised underlying stop actually exits;
3. cancellation-ignoring cleanup remains quarantined and blocks replacement until explicit release;
4. distinct long/short concurrent stop orderings prove independent caller deadlines and initiating-ticket selection;
5. continuation tests deterministically cover cancellation after registration as well as every earlier ordering.

Linux-available parsing, strict-concurrency probes, SwiftLint, repository guards, and the focused activation-watermark regression pass. Native macOS/Xcode CI remains required.

This PR is logically sequenced after #1302 but is based directly on `main` so its CI can run independently.

## Verification available from Linux

- `git diff --check`
- `check_nonisolated.py`: OK
- `check-no-post-under-inout.py`: PASS
- focused Swift 6 strict-concurrency review/probes completed for the candidate lineage

Native macOS/Xcode tests remain required in CI.

Part of #1303
