### PR TITLE
feat(agent): add actionable agent notifications

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -12,6 +12,9 @@ nonisolated enum AccessibilityID {
     static let agentHandoffReadOnlyContextToggle =
         "agentHandoffReadOnlyContextToggle"
     static let agentHandoffStatus = "agentHandoffStatus"
+    static let agentNotificationSettings = "agentNotificationSettings"
+    static let agentNotificationEnableButton = "agentNotificationEnableButton"
+    static let agentNotificationMainToggle = "agentNotificationMainToggle"
     static let generalFontSizeSlider = "generalFontSizeSlider"
     static let generalSettingsPane = "generalSettingsPane"
     static let keyBindingsSettingsPane = "keyBindingsSettingsPane"

--- a/Pine/Agent/AgentHandoffSettingsView.swift
+++ b/Pine/Agent/AgentHandoffSettingsView.swift
@@ -6,11 +6,14 @@
 //
 
 import SwiftUI
+import AppKit
 
 @MainActor
 struct PineSettingsView: View {
     let lspSettings: LSPSettings
     let handoffSettings: AgentHandoffSettings
+    let notificationController: AgentNotificationController
+    let agentTasks: AgentTaskRegistry
     let shellSettings: ShellSettings
     let editorSettings: EditorSettings
     let terminalThemeSettings: TerminalThemeSettings
@@ -22,6 +25,8 @@ struct PineSettingsView: View {
     init(
         lspSettings: LSPSettings,
         handoffSettings: AgentHandoffSettings,
+        notificationController: AgentNotificationController,
+        agentTasks: AgentTaskRegistry,
         shellSettings: ShellSettings,
         editorSettings: EditorSettings,
         terminalThemeSettings: TerminalThemeSettings = .shared,
@@ -29,6 +34,8 @@ struct PineSettingsView: View {
     ) {
         self.lspSettings = lspSettings
         self.handoffSettings = handoffSettings
+        self.notificationController = notificationController
+        self.agentTasks = agentTasks
         self.shellSettings = shellSettings
         self.editorSettings = editorSettings
         self.terminalThemeSettings = terminalThemeSettings
@@ -65,7 +72,11 @@ struct PineSettingsView: View {
                 }
                 .tag(SettingsPane.SettingsPaneID.languages)
 
-            AgentHandoffSettingsView(settings: handoffSettings)
+            AgentSettingsView(
+                handoffSettings: handoffSettings,
+                notificationController: notificationController,
+                agentTasks: agentTasks
+            )
                 .tabItem {
                     Label(
                         Strings.settingsAgentHandoffTab,
@@ -87,6 +98,203 @@ struct PineSettingsView: View {
     }
 
     nonisolated static let selectedPaneKey = "settings.selectedPane"
+}
+
+@MainActor
+private struct AgentSettingsView: View {
+    let handoffSettings: AgentHandoffSettings
+    let notificationController: AgentNotificationController
+    let agentTasks: AgentTaskRegistry
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 22) {
+                AgentNotificationSettingsView(
+                    controller: notificationController,
+                    agentTasks: agentTasks
+                )
+                Divider()
+                AgentHandoffSettingsView(settings: handoffSettings)
+                    .frame(height: 380)
+            }
+            .padding(20)
+        }
+        .frame(width: 720, height: 500)
+    }
+}
+
+@MainActor
+private struct AgentNotificationSettingsView: View {
+    let controller: AgentNotificationController
+    let agentTasks: AgentTaskRegistry
+
+    private var agentOptions: [(String, String)] {
+        let values = agentTasks.tasks.map {
+            ($0.descriptor.typeIdentifier, $0.descriptor.agentType.displayName)
+        }
+        return Dictionary(values, uniquingKeysWith: { current, _ in current })
+            .sorted { $0.value.localizedStandardCompare($1.value) == .orderedAscending }
+    }
+
+    private var projectOptions: [(String, String)] {
+        let values = agentTasks.tasks.map {
+            ($0.project.canonicalProjectPath, URL(fileURLWithPath: $0.project.canonicalProjectPath).lastPathComponent)
+        }
+        return Dictionary(values, uniquingKeysWith: { current, _ in current })
+            .sorted { $0.value.localizedStandardCompare($1.value) == .orderedAscending }
+    }
+
+    private var taskOptions: [(UUID, String)] {
+        agentTasks.tasks
+            .filter { $0.lifecycle != .dismissed }
+            .map { task in
+                let fallback = task.descriptor.agentType.displayName
+                return (task.id, task.title ?? fallback)
+            }
+            .sorted { $0.1.localizedStandardCompare($1.1) == .orderedAscending }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(Strings.agentNotificationsSettingsTitle)
+                .font(.title2.weight(.semibold))
+            Text(Strings.agentNotificationsPermissionExplanation)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            permissionControl
+
+            GroupBox(Strings.agentNotificationsEvents) {
+                VStack(alignment: .leading, spacing: 10) {
+                    eventToggle(.waitingInput, Strings.agentNotificationsWaiting)
+                    eventToggle(.failed, Strings.agentNotificationsFailed)
+                    eventToggle(.completed, Strings.agentNotificationsCompleted)
+                    eventToggle(.processEnded, Strings.agentNotificationsProcessEnded)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 4)
+            }
+            .disabled(!controller.settings.isEnabled)
+
+            if !agentOptions.isEmpty {
+                preferenceGroup(
+                    Strings.agentNotificationsAgents,
+                    options: agentOptions,
+                    isEnabled: { !controller.settings.disabledAgentIDs.contains($0) },
+                    setEnabled: controller.settings.setAgent
+                )
+            }
+            if !projectOptions.isEmpty {
+                preferenceGroup(
+                    Strings.agentNotificationsProjects,
+                    options: projectOptions,
+                    isEnabled: { !controller.settings.disabledProjectPaths.contains($0) },
+                    setEnabled: controller.settings.setProject
+                )
+            }
+            if !taskOptions.isEmpty {
+                GroupBox(Strings.agentNotificationsTasks) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(taskOptions, id: \.0) { taskID, displayName in
+                            Toggle(
+                                displayName,
+                                isOn: Binding(
+                                    get: {
+                                        !controller.settings.mutedTaskIDs.contains(taskID)
+                                    },
+                                    set: {
+                                        controller.settings.setTask(taskID, enabled: $0)
+                                    }
+                                )
+                            )
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 4)
+                }
+                .disabled(!controller.settings.isEnabled)
+            }
+
+            Text(Strings.agentNotificationsFocusHelp)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityIdentifier(AccessibilityID.agentNotificationSettings)
+        .task { await controller.refreshAuthorizationStatus() }
+    }
+
+    @ViewBuilder
+    private var permissionControl: some View {
+        switch controller.authorizationStatus {
+        case .notDetermined:
+            Button(Strings.agentNotificationsEnable) {
+                Task { await controller.requestAuthorization() }
+            }
+            .accessibilityIdentifier(AccessibilityID.agentNotificationEnableButton)
+        case .denied:
+            HStack {
+                Label(Strings.agentNotificationsDenied, systemImage: "bell.slash")
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button(Strings.agentNotificationsOpenSystemSettings) {
+                    guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else { return }
+                    NSWorkspace.shared.open(url)
+                }
+            }
+        case .authorized:
+            Toggle(
+                Strings.agentNotificationsMainToggle,
+                isOn: Binding(
+                    get: { controller.settings.isEnabled },
+                    set: {
+                        if $0 {
+                            controller.settings.setEnabled(true)
+                        } else {
+                            controller.disable()
+                        }
+                    }
+                )
+            )
+            .accessibilityIdentifier(AccessibilityID.agentNotificationMainToggle)
+        }
+    }
+
+    private func eventToggle(
+        _ kind: AgentNotificationEventKind,
+        _ title: LocalizedStringKey
+    ) -> some View {
+        Toggle(
+            title,
+            isOn: Binding(
+                get: { controller.settings.enabledEvents.contains(kind) },
+                set: { controller.settings.setEvent(kind, enabled: $0) }
+            )
+        )
+    }
+
+    private func preferenceGroup(
+        _ title: LocalizedStringKey,
+        options: [(String, String)],
+        isEnabled: @escaping (String) -> Bool,
+        setEnabled: @escaping (String, Bool) -> Void
+    ) -> some View {
+        GroupBox(title) {
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(options, id: \.0) { identifier, displayName in
+                    Toggle(
+                        displayName,
+                        isOn: Binding(
+                            get: { isEnabled(identifier) },
+                            set: { setEnabled(identifier, $0) }
+                        )
+                    )
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 4)
+        }
+        .disabled(!controller.settings.isEnabled)
+    }
 }
 
 /// Identifiers for the Settings scene panes (issue #337). The raw value is
@@ -169,7 +377,6 @@ struct AgentHandoffSettingsView: View {
             Spacer(minLength: 0)
         }
         .padding(20)
-        .frame(width: 720, height: 500)
     }
 
     private func handoffGuarantee(

--- a/Pine/Agent/AgentNotificationController.swift
+++ b/Pine/Agent/AgentNotificationController.swift
@@ -1,0 +1,273 @@
+//
+//  AgentNotificationController.swift
+//  Pine
+//
+
+import Foundation
+import UserNotifications
+
+nonisolated enum AgentNotificationAuthorizationStatus: Equatable, Sendable {
+    case notDetermined
+    case denied
+    case authorized
+}
+
+nonisolated struct AgentNotificationRequest: Equatable, Sendable {
+    let identifier: String
+    let title: String
+    let body: String
+    let categoryIdentifier: String
+    let userInfo: [String: String]
+}
+
+nonisolated struct AgentNotificationRouteIdentity: Equatable, Sendable {
+    let taskID: UUID
+    let runID: UUID
+    let processGeneration: UInt64
+}
+
+nonisolated enum AgentNotificationResponseAction: Equatable, Sendable {
+    case open(AgentNotificationRouteIdentity)
+    case mute(taskID: UUID)
+}
+
+@MainActor
+protocol AgentNotificationDelivering: AnyObject {
+    var responseHandler: ((AgentNotificationResponseAction) -> Void)? { get set }
+    func registerActions()
+    func authorizationStatus() async -> AgentNotificationAuthorizationStatus
+    func requestAuthorization() async throws -> Bool
+    func deliver(_ request: AgentNotificationRequest) async throws
+}
+
+@MainActor
+final class SystemAgentNotificationCenter: NSObject,
+    AgentNotificationDelivering, UNUserNotificationCenterDelegate {
+    static let categoryIdentifier = "pine.agent.task"
+    static let openActionIdentifier = "pine.agent.open"
+    static let muteActionIdentifier = "pine.agent.mute"
+
+    var responseHandler: ((AgentNotificationResponseAction) -> Void)?
+    private let center: UNUserNotificationCenter
+
+    init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+        super.init()
+    }
+
+    func registerActions() {
+        let open = UNNotificationAction(
+            identifier: Self.openActionIdentifier,
+            title: String(localized: "agentNotifications.action.open"),
+            options: [.foreground]
+        )
+        let mute = UNNotificationAction(
+            identifier: Self.muteActionIdentifier,
+            title: String(localized: "agentNotifications.action.mute")
+        )
+        center.setNotificationCategories([UNNotificationCategory(
+            identifier: Self.categoryIdentifier,
+            actions: [open, mute],
+            intentIdentifiers: []
+        )])
+        center.delegate = self
+    }
+
+    func authorizationStatus() async -> AgentNotificationAuthorizationStatus {
+        let settings = await center.notificationSettings()
+        switch settings.authorizationStatus {
+        case .notDetermined:
+            return .notDetermined
+        case .denied:
+            return .denied
+        case .authorized, .provisional, .ephemeral:
+            return .authorized
+        @unknown default:
+            return .denied
+        }
+    }
+
+    func requestAuthorization() async throws -> Bool {
+        try await center.requestAuthorization(options: [.alert, .sound])
+    }
+
+    func deliver(_ request: AgentNotificationRequest) async throws {
+        let content = UNMutableNotificationContent()
+        content.title = request.title
+        content.body = request.body
+        content.categoryIdentifier = request.categoryIdentifier
+        content.userInfo = request.userInfo
+        try await center.add(UNNotificationRequest(
+            identifier: request.identifier,
+            content: content,
+            trigger: nil
+        ))
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let actionIdentifier = response.actionIdentifier
+        let userInfo = response.notification.request.content.userInfo
+        let taskID = (userInfo["taskID"] as? String).flatMap(UUID.init(uuidString:))
+        let runID = (userInfo["runID"] as? String).flatMap(UUID.init(uuidString:))
+        let generation = (userInfo["generation"] as? String).flatMap(UInt64.init)
+        completionHandler()
+        Task { @MainActor [weak self] in
+            guard let taskID else { return }
+            switch actionIdentifier {
+            case Self.muteActionIdentifier:
+                self?.responseHandler?(.mute(taskID: taskID))
+            case Self.openActionIdentifier, UNNotificationDefaultActionIdentifier:
+                guard let runID, let generation else { return }
+                self?.responseHandler?(.open(AgentNotificationRouteIdentity(
+                    taskID: taskID,
+                    runID: runID,
+                    processGeneration: generation
+                )))
+            default:
+                break
+            }
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class AgentNotificationController {
+    private(set) var authorizationStatus: AgentNotificationAuthorizationStatus =
+        .notDetermined
+
+    let settings: AgentNotificationSettings
+    @ObservationIgnored
+    private let registry: AgentTaskRegistry
+    @ObservationIgnored
+    private let delivery: any AgentNotificationDelivering
+    @ObservationIgnored
+    private let accuracy: (String) -> FirstPartyAgentNotificationAccuracy
+    @ObservationIgnored
+    private let isPresented: (UUID) -> Bool
+    @ObservationIgnored
+    private let openTask: (AgentNotificationRouteIdentity) -> Void
+    @ObservationIgnored
+    private var observerToken: UUID?
+    @ObservationIgnored
+    private var isRunning = false
+
+    init(
+        registry: AgentTaskRegistry,
+        settings: AgentNotificationSettings,
+        delivery: any AgentNotificationDelivering = SystemAgentNotificationCenter(),
+        accuracy: @escaping (String) -> FirstPartyAgentNotificationAccuracy = {
+            FirstPartyAgentCompatibilityCatalog.record(stableIdentifier: $0)?
+                .notificationAccuracy ?? .processTerminationOnly
+        },
+        isPresented: @escaping (UUID) -> Bool,
+        openTask: @escaping (AgentNotificationRouteIdentity) -> Void
+    ) {
+        self.registry = registry
+        self.settings = settings
+        self.delivery = delivery
+        self.accuracy = accuracy
+        self.isPresented = isPresented
+        self.openTask = openTask
+    }
+
+    func start() {
+        guard !isRunning else { return }
+        isRunning = true
+        delivery.registerActions()
+        delivery.responseHandler = { [weak self] action in
+            self?.handle(action)
+        }
+        observerToken = registry.addTaskChangeObserver { [weak self] old, new in
+            self?.process(oldTasks: old, newTasks: new)
+        }
+        Task { await refreshAuthorizationStatus() }
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        isRunning = false
+        if let observerToken { registry.removeTaskChangeObserver(observerToken) }
+        observerToken = nil
+        delivery.responseHandler = nil
+    }
+
+    func refreshAuthorizationStatus() async {
+        authorizationStatus = await delivery.authorizationStatus()
+        if authorizationStatus == .denied { settings.setEnabled(false) }
+    }
+
+    @discardableResult
+    func requestAuthorization() async -> Bool {
+        do {
+            let granted = try await delivery.requestAuthorization()
+            authorizationStatus = granted ? .authorized : .denied
+            settings.setEnabled(granted)
+            return granted
+        } catch {
+            await refreshAuthorizationStatus()
+            settings.setEnabled(false)
+            return false
+        }
+    }
+
+    func disable() {
+        settings.setEnabled(false)
+    }
+
+    private func process(oldTasks: [AgentTask], newTasks: [AgentTask]) {
+        guard isRunning, settings.isEnabled,
+              authorizationStatus == .authorized else { return }
+        let events = AgentNotificationTransitionResolver.events(
+            from: oldTasks,
+            to: newTasks,
+            accuracy: accuracy
+        )
+        let tasks = Dictionary(uniqueKeysWithValues: newTasks.map { ($0.id, $0) })
+        for event in events {
+            guard let task = tasks[event.taskID],
+                  settings.allows(event, task: task),
+                  !isPresented(event.taskID),
+                  settings.claimDelivery(of: event.id) else { continue }
+            let request = Self.request(for: event)
+            Task { try? await delivery.deliver(request) }
+        }
+    }
+
+    private func handle(_ action: AgentNotificationResponseAction) {
+        switch action {
+        case .open(let identity): openTask(identity)
+        case .mute(let taskID): settings.muteTask(taskID)
+        }
+    }
+
+    static func request(for event: AgentNotificationEvent) -> AgentNotificationRequest {
+        let titleKey = switch event.kind {
+        case .waitingInput: "agentNotifications.event.waiting"
+        case .failed: "agentNotifications.event.failed"
+        case .completed: "agentNotifications.event.completed"
+        case .processEnded: "agentNotifications.event.processEnded"
+        }
+        let state = String(localized: String.LocalizationValue(titleKey))
+        let title = "\(event.agentName): \(state)"
+        let elapsed = Duration.seconds(
+            max(0, event.observedAt.timeIntervalSince(event.startedAt))
+        ).formatted(.units(allowed: [.hours, .minutes], width: .abbreviated))
+        let fields = [event.projectName, event.taskTitle, elapsed].compactMap { $0 }
+        return AgentNotificationRequest(
+            identifier: event.id,
+            title: title,
+            body: fields.joined(separator: " • "),
+            categoryIdentifier: SystemAgentNotificationCenter.categoryIdentifier,
+            userInfo: [
+                "taskID": event.taskID.uuidString,
+                "runID": event.runID.uuidString,
+                "generation": String(event.processGeneration),
+            ]
+        )
+    }
+}

--- a/Pine/Agent/AgentNotificationModels.swift
+++ b/Pine/Agent/AgentNotificationModels.swift
@@ -1,0 +1,133 @@
+//
+//  AgentNotificationModels.swift
+//  Pine
+//
+//  Privacy-bounded notification transitions for cross-project agent work.
+//
+
+import Foundation
+
+nonisolated enum AgentNotificationEventKind: String, CaseIterable, Sendable {
+    case waitingInput
+    case failed
+    case completed
+    case processEnded
+}
+
+/// A value-only event whose identifier contains stable opaque identity and no
+/// project path, command, prompt, output, or environment data.
+nonisolated struct AgentNotificationEvent: Equatable, Sendable, Identifiable {
+    let taskID: UUID
+    let runID: UUID
+    let processGeneration: UInt64
+    let kind: AgentNotificationEventKind
+    let observedAt: Date
+    let agentName: String
+    let projectName: String
+    let taskTitle: String?
+    let startedAt: Date
+
+    var id: String {
+        let milliseconds = Int64((observedAt.timeIntervalSince1970 * 1_000).rounded())
+        return [
+            "pine-agent", taskID.uuidString, runID.uuidString,
+            String(processGeneration), kind.rawValue, String(milliseconds),
+        ].joined(separator: ".")
+    }
+}
+
+enum AgentNotificationTransitionResolver {
+    static func events(
+        from oldTasks: [AgentTask],
+        to newTasks: [AgentTask],
+        accuracy: (String) -> FirstPartyAgentNotificationAccuracy
+    ) -> [AgentNotificationEvent] {
+        let previousByID = Dictionary(uniqueKeysWithValues: oldTasks.map { ($0.id, $0) })
+        return newTasks.compactMap { task in
+            guard let previous = previousByID[task.id],
+                  task.lifecycle != .dismissed,
+                  let oldRun = previous.runs.last,
+                  let newRun = task.runs.last,
+                  oldRun.id == newRun.id,
+                  oldRun.process.processGeneration == newRun.process.processGeneration,
+                  newRun.lastObservedAt >= oldRun.lastObservedAt,
+                  newRun.liveness != .stale,
+                  let kind = eventKind(
+                      previousTask: previous,
+                      task: task,
+                      previousRun: oldRun,
+                      run: newRun,
+                      accuracy: accuracy(task.descriptor.typeIdentifier)
+                  ) else {
+                return nil
+            }
+            return AgentNotificationEvent(
+                taskID: task.id,
+                runID: newRun.id,
+                processGeneration: newRun.process.processGeneration,
+                kind: kind,
+                observedAt: newRun.lastObservedAt,
+                agentName: safeDisplayName(for: task),
+                projectName: sanitizedProjectName(task.project.canonicalProjectPath),
+                taskTitle: sanitizedTitle(task.title),
+                startedAt: newRun.startedAt
+            )
+        }
+    }
+
+    private static func eventKind(
+        previousTask: AgentTask,
+        task: AgentTask,
+        previousRun: AgentTaskRun,
+        run: AgentTaskRun,
+        accuracy: FirstPartyAgentNotificationAccuracy
+    ) -> AgentNotificationEventKind? {
+        switch accuracy {
+        case .processTerminationOnly:
+            guard previousRun.liveness == .live,
+                  run.liveness == .terminated else { return nil }
+            return .processEnded
+        case .verifiedLifecycleTransitions:
+            if task.attention == .failed,
+               previousTask.attention != .failed {
+                return .failed
+            }
+            let isCompleted = task.attention == .completed
+                || task.lifecycle == .completed
+                || run.state == .done
+            let wasCompleted = previousTask.attention == .completed
+                || previousTask.lifecycle == .completed
+                || previousRun.state == .done
+            if isCompleted, !wasCompleted { return .completed }
+            if run.liveness == .live,
+               run.state == .waitingInput,
+               previousRun.state != .waitingInput {
+                return .waitingInput
+            }
+            return nil
+        }
+    }
+
+    private static func safeDisplayName(for task: AgentTask) -> String {
+        guard let record = FirstPartyAgentCompatibilityCatalog.record(
+            stableIdentifier: task.descriptor.typeIdentifier
+        ) else { return "Agent" }
+        return String(record.displayName.prefix(64))
+    }
+
+    private static func sanitizedProjectName(_ path: String) -> String {
+        let name = URL(fileURLWithPath: path).lastPathComponent
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+        return String(name.prefix(80))
+    }
+
+    private static func sanitizedTitle(_ title: String?) -> String? {
+        guard let title else { return nil }
+        let value = title
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : String(value.prefix(120))
+    }
+}

--- a/Pine/Agent/AgentNotificationSettings.swift
+++ b/Pine/Agent/AgentNotificationSettings.swift
@@ -1,0 +1,109 @@
+//
+//  AgentNotificationSettings.swift
+//  Pine
+//
+
+import Foundation
+
+@MainActor
+@Observable
+final class AgentNotificationSettings {
+    static let shared = AgentNotificationSettings(
+        defaults: PineSettingsDefaults.shared()
+    )
+
+    enum Keys {
+        static let enabled = "agentNotifications.enabled"
+        static let eventPrefix = "agentNotifications.event."
+        static let mutedTasks = "agentNotifications.mutedTasks"
+        static let disabledAgents = "agentNotifications.disabledAgents"
+        static let disabledProjects = "agentNotifications.disabledProjects"
+        static let deliveredEventIDs = "agentNotifications.deliveredEventIDs"
+    }
+
+    private let defaults: UserDefaults
+    private(set) var isEnabled: Bool
+    private(set) var enabledEvents: Set<AgentNotificationEventKind>
+    private(set) var mutedTaskIDs: Set<UUID>
+    private(set) var disabledAgentIDs: Set<String>
+    private(set) var disabledProjectPaths: Set<String>
+    private(set) var deliveredEventIDs: Set<String>
+    @ObservationIgnored
+    private var deliveredEventOrder: [String]
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+        isEnabled = (defaults.object(forKey: Keys.enabled) as? Bool) ?? false
+        enabledEvents = Set(AgentNotificationEventKind.allCases.filter { kind in
+            (defaults.object(forKey: Keys.eventPrefix + kind.rawValue) as? Bool)
+                ?? true
+        })
+        mutedTaskIDs = Self.uuidSet(defaults.stringArray(forKey: Keys.mutedTasks))
+        disabledAgentIDs = Set(defaults.stringArray(forKey: Keys.disabledAgents) ?? [])
+        disabledProjectPaths = Set(
+            defaults.stringArray(forKey: Keys.disabledProjects) ?? []
+        )
+        let eventOrder = Array(
+            (defaults.stringArray(forKey: Keys.deliveredEventIDs) ?? []).suffix(512)
+        )
+        deliveredEventOrder = eventOrder
+        deliveredEventIDs = Set(eventOrder)
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        isEnabled = enabled
+        defaults.set(enabled, forKey: Keys.enabled)
+    }
+
+    func setEvent(_ kind: AgentNotificationEventKind, enabled: Bool) {
+        if enabled { enabledEvents.insert(kind) } else { enabledEvents.remove(kind) }
+        defaults.set(enabled, forKey: Keys.eventPrefix + kind.rawValue)
+    }
+
+    func setAgent(_ identifier: String, enabled: Bool) {
+        if enabled { disabledAgentIDs.remove(identifier) } else { disabledAgentIDs.insert(identifier) }
+        persist(disabledAgentIDs, key: Keys.disabledAgents)
+    }
+
+    func setProject(_ path: String, enabled: Bool) {
+        if enabled { disabledProjectPaths.remove(path) } else { disabledProjectPaths.insert(path) }
+        persist(disabledProjectPaths, key: Keys.disabledProjects)
+    }
+
+    func muteTask(_ taskID: UUID) {
+        setTask(taskID, enabled: false)
+    }
+
+    func setTask(_ taskID: UUID, enabled: Bool) {
+        if enabled { mutedTaskIDs.remove(taskID) } else { mutedTaskIDs.insert(taskID) }
+        persist(Set(mutedTaskIDs.map(\.uuidString)), key: Keys.mutedTasks)
+    }
+
+    func allows(_ event: AgentNotificationEvent, task: AgentTask) -> Bool {
+        isEnabled
+            && enabledEvents.contains(event.kind)
+            && !mutedTaskIDs.contains(task.id)
+            && !disabledAgentIDs.contains(task.descriptor.typeIdentifier)
+            && !disabledProjectPaths.contains(task.project.canonicalProjectPath)
+    }
+
+    /// Returns true exactly once for a deterministic transition identifier.
+    func claimDelivery(of eventID: String) -> Bool {
+        guard deliveredEventIDs.insert(eventID).inserted else { return false }
+        deliveredEventOrder.append(eventID)
+        if deliveredEventOrder.count > 512 {
+            deliveredEventOrder.removeFirst(deliveredEventOrder.count - 384)
+            deliveredEventIDs = Set(deliveredEventOrder)
+        }
+        defaults.set(deliveredEventOrder, forKey: Keys.deliveredEventIDs)
+        return true
+    }
+
+    private func persist(_ values: Set<String>, key: String) {
+        defaults.set(values.sorted(), forKey: key)
+    }
+
+    private static func uuidSet(_ strings: [String]?) -> Set<UUID> {
+        Set((strings ?? []).compactMap(UUID.init(uuidString:)))
+    }
+}

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -64,7 +64,14 @@ nonisolated private struct AgentTaskTerminationRollback: Sendable {
 @MainActor
 @Observable
 final class AgentTaskRegistry {
-    private(set) var tasks: [AgentTask] = []
+    private(set) var tasks: [AgentTask] = [] {
+        didSet {
+            guard oldValue != tasks else { return }
+            for observer in Array(taskChangeObservers.values) {
+                observer(oldValue, tasks)
+            }
+        }
+    }
     private(set) var loadStatusByProject:
         [String: AgentTaskMetadataLoadStatus] = [:]
     private(set) var saveResultByProject:
@@ -139,6 +146,10 @@ final class AgentTaskRegistry {
     private let flushTail: Duration
     @ObservationIgnored
     private let abandonedPersistenceLimit = 2
+    @ObservationIgnored
+    private var taskChangeObservers: [
+        UUID: @MainActor ([AgentTask], [AgentTask]) -> Void
+    ] = [:]
 
     init(
         persistence: any AgentTaskPersisting = AgentTaskMetadataStore(),
@@ -163,6 +174,30 @@ final class AgentTaskRegistry {
 
     func task(for id: UUID) -> AgentTask? {
         tasks.first { $0.id == id }
+    }
+
+    func matchesNotificationRoute(
+        _ identity: AgentNotificationRouteIdentity
+    ) -> Bool {
+        guard let task = task(for: identity.taskID),
+              let run = task.runs.last else { return false }
+        return run.id == identity.runID
+            && run.process.processGeneration == identity.processGeneration
+    }
+
+    /// Observes ordered, value-only snapshots without exposing persistence or
+    /// terminal ownership internals. The returned token must be removed by the
+    /// application-lifetime consumer when it stops.
+    func addTaskChangeObserver(
+        _ observer: @escaping @MainActor ([AgentTask], [AgentTask]) -> Void
+    ) -> UUID {
+        let token = UUID()
+        taskChangeObservers[token] = observer
+        return token
+    }
+
+    func removeTaskChangeObserver(_ token: UUID) {
+        taskChangeObservers.removeValue(forKey: token)
     }
 
     /// Explicitly changes Inbox review state. Merely reading or rendering the

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -30762,6 +30762,227 @@
         }
       }
     },
+    "agentNotifications.action.mute": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Diesen Task stummschalten" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Mute This Task" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Silenciar esta tarea" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Désactiver cette tâche" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "このタスクをミュート" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이 작업 알림 끄기" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Silenciar esta tarefa" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Отключить для этой задачи" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "静音此任务" } }
+      }
+    },
+    "agentNotifications.action.open": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Sitzung öffnen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Open Session" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Abrir sesión" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Ouvrir la session" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "セッションを開く" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "세션 열기" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Abrir sessão" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Открыть сессию" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "打开会话" } }
+      }
+    },
+    "agentNotifications.agents": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Agenten" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Agents" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Agentes" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Agents" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "エージェント" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "에이전트" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Agentes" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Агенты" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "智能体" } }
+      }
+    },
+    "agentNotifications.event.completed": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Abgeschlossen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Completed" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Completada" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Terminée" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "完了" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "완료됨" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Concluída" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Завершено" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已完成" } }
+      }
+    },
+    "agentNotifications.event.failed": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Fehlgeschlagen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Failed" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Falló" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Échec" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "失敗" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "실패" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Falhou" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Ошибка" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "失败" } }
+      }
+    },
+    "agentNotifications.event.processEnded": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Prozess beendet" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Process ended" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Proceso finalizado" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Processus terminé" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "プロセス終了" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "프로세스 종료됨" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Processo encerrado" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Процесс завершён" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "进程已结束" } }
+      }
+    },
+    "agentNotifications.event.waiting": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Wartet auf Antwort" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Waiting for reply" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Esperando respuesta" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "En attente de réponse" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "返信待ち" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "응답 대기 중" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Aguardando resposta" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Ожидает ответа" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "等待回复" } }
+      }
+    },
+    "agentNotifications.events": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Ereignisse" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Events" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Eventos" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Événements" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "イベント" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이벤트" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Eventos" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "События" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "事件" } }
+      }
+    },
+    "agentNotifications.focusHelp": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Fokus und Systemeinstellungen können Hinweise verzögern oder ausblenden." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Focus and system notification settings may delay or hide alerts." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Concentración y los ajustes del sistema pueden retrasar u ocultar avisos." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Concentration et les réglages système peuvent retarder ou masquer les alertes." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "集中モードやシステム設定により通知が遅延または非表示になる場合があります。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "집중 모드 및 시스템 설정에 따라 알림이 지연되거나 숨겨질 수 있습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "O Foco e os ajustes do sistema podem atrasar ou ocultar alertas." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Фокусирование и системные настройки могут задерживать или скрывать уведомления." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "专注模式和系统通知设置可能会延迟或隐藏提醒。" } }
+      }
+    },
+    "agentNotifications.master": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Agentenmitteilungen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Agent notifications" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Notificaciones de agentes" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Notifications des agents" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "エージェント通知" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "에이전트 알림" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Notificações de agentes" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Уведомления агентов" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "智能体通知" } }
+      }
+    },
+    "agentNotifications.permission.denied": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Mitteilungen sind in den Systemeinstellungen deaktiviert." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Notifications are disabled in System Settings." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Las notificaciones están desactivadas en Ajustes del Sistema." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Les notifications sont désactivées dans Réglages Système." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "システム設定で通知が無効です。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "시스템 설정에서 알림이 비활성화되어 있습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "As notificações estão desativadas nos Ajustes do Sistema." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Уведомления отключены в Системных настройках." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "系统设置中已关闭通知。" } }
+      }
+    },
+    "agentNotifications.permission.enable": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Mitteilungen erlauben…" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Allow Notifications…" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Permitir notificaciones…" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Autoriser les notifications…" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "通知を許可…" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "알림 허용…" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Permitir notificações…" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Разрешить уведомления…" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "允许通知…" } }
+      }
+    },
+    "agentNotifications.permission.explanation": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Pine meldet nur bedeutsame Zustandswechsel, wenn die zugehörige Sitzung nicht sichtbar ist. Inhalte und Ausgaben werden nie eingeschlossen." } },
+        "en": { "stringUnit": { "state": "translated", "value": "Pine alerts only on meaningful state changes while the relevant session is not visible. Prompts and output are never included." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Pine avisa solo de cambios importantes cuando la sesión relevante no está visible. Nunca incluye solicitudes ni salida." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Pine signale uniquement les changements importants lorsque la session concernée n’est pas visible. Les requêtes et sorties ne sont jamais incluses." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Pine は関連セッションが表示されていない場合に重要な状態変化だけを通知します。プロンプトや出力は含まれません。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "Pine은 관련 세션이 보이지 않을 때 의미 있는 상태 변경만 알립니다. 프롬프트와 출력은 포함하지 않습니다." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "O Pine alerta apenas mudanças importantes quando a sessão relevante não está visível. Prompts e saídas nunca são incluídos." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Pine сообщает только о важных изменениях, когда нужная сессия не видна. Запросы и вывод никогда не включаются." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "仅当相关会话不可见时，Pine 才会提醒重要状态变化，且绝不包含提示或输出。" } }
+      }
+    },
+    "agentNotifications.permission.openSettings": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Systemeinstellungen öffnen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Open System Settings" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Abrir Ajustes del Sistema" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Ouvrir Réglages Système" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "システム設定を開く" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "시스템 설정 열기" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Abrir Ajustes do Sistema" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Открыть Системные настройки" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "打开系统设置" } }
+      }
+    },
+    "agentNotifications.projects": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Projekte" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Projects" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Proyectos" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Projets" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "プロジェクト" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "프로젝트" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Projetos" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Проекты" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "项目" } }
+      }
+    },
+    "agentNotifications.settings.title": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Agentenmitteilungen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Agent Notifications" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Notificaciones de agentes" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Notifications des agents" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "エージェント通知" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "에이전트 알림" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Notificações de agentes" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Уведомления агентов" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "智能体通知" } }
+      }
+    },
+    "agentNotifications.tasks": {
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Aufgaben" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Tasks" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Tareas" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Tâches" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "タスク" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "작업" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Tarefas" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Задачи" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "任务" } }
+      }
+    },
     "agentInbox.empty": {
       "comment": "Shown when the Agent Inbox has no tasks.",
       "isCommentAutoGenerated": false,

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -70,6 +70,8 @@ struct PineApp: App {
             PineSettingsView(
                 lspSettings: registry.lspSettings,
                 handoffSettings: .shared,
+                notificationController: appDelegate.agentNotifications,
+                agentTasks: registry.agentTasks,
                 shellSettings: .shared,
                 editorSettings: .shared
             )
@@ -862,6 +864,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
     /// Central project registry — created early so it's available for AppKit fallback.
     var registry = ProjectRegistry()
 
+    /// Application-wide, permission-gated agent notification coordinator.
+    lazy var agentNotifications = AgentNotificationController(
+        registry: registry.agentTasks,
+        settings: .shared,
+        isPresented: { [weak self] taskID in
+            self?.registry.isAgentTaskPresented(taskID) ?? false
+        },
+        openTask: { [weak self] identity in
+            self?.openAgentTaskFromNotification(identity)
+        }
+    )
+
     // MARK: - Quick terminal (#1113)
 
     /// Owner of the global drop-down terminal session + its system-wide hotkey.
@@ -907,6 +921,35 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
     func showAgentInbox() {
         openNamedWindow?("agent-inbox")
         NSApp.activate()
+    }
+
+    private func openAgentTaskFromNotification(
+        _ identity: AgentNotificationRouteIdentity
+    ) {
+        guard registry.agentTasks.matchesNotificationRoute(identity) else {
+            showAgentInbox()
+            return
+        }
+        guard openProjectWindow != nil else {
+            showAgentInbox()
+            return
+        }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let result = await registry.navigateToAgentTaskFromInbox(
+                identity.taskID,
+                openProjectWindow: { [weak self] url in
+                    self?.openProjectWindow?(url)
+                },
+                expectedNotificationRoute: identity
+            )
+            guard case .focused = result else {
+                // The explicit user action still lands on truthful durable
+                // history when the exact process generation is gone.
+                showAgentInbox()
+                return
+            }
+        }
     }
 
     /// Reference to the Welcome NSWindow, captured via WelcomeWindowCapture.
@@ -1180,6 +1223,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSWindow.allowsAutomaticWindowTabbing = false
+        agentNotifications.start()
 
         // The key-down half is routed through the single precedence monitor
         // below; this installs Control-release and owner-window cancellation.
@@ -1723,6 +1767,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        agentNotifications.stop()
         // Save sessions before terminating processes.
         for (_, pm) in registry.openProjects {
             pm.finalizeAgentSessionsForHistory()
@@ -1781,6 +1826,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             let shouldTerminate = await confirmApplicationTermination()
             terminationDecisionTask = nil
             isTerminating = shouldTerminate
+            if shouldTerminate { agentNotifications.stop() }
             reply(shouldTerminate)
         }
         return .terminateLater

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -173,6 +173,39 @@ final class ProjectRegistry: LSPSettingsObserver {
         closeProjectWindow(url)
     }
 
+    /// True only when the exact live terminal route is already visible in the
+    /// key project window. Merely having Pine active or the project open is not
+    /// enough to suppress a notification for another pane or terminal tab.
+    func isAgentTaskPresented(_ taskID: UUID) -> Bool {
+        guard let task = agentTasks.task(for: taskID),
+              task.lifecycle == .active,
+              task.route.availability == .available,
+              let run = task.runs.last,
+              run.liveness == .live,
+              run.endedAt == nil,
+              agentTasks.isExactLiveOwner(
+                  taskID: taskID,
+                  terminalID: task.route.terminalID,
+                  runID: run.id
+              ) else { return false }
+        let projectURL = URL(
+            fileURLWithPath: task.project.canonicalProjectPath,
+            isDirectory: true
+        ).standardizedFileURL
+        guard !backgroundProjects.contains(projectURL),
+              let manager = openProjects[projectURL],
+              manager.rootURL == projectURL,
+              manager.paneManager.activePaneID.id == task.route.paneID,
+              manager.paneManager.terminalState(
+                  for: PaneID(id: task.route.paneID)
+              )?.activeTerminalID == task.route.tabID,
+              let window = manager.dialogOwnerWindow,
+              window.isVisible,
+              window.isKeyWindow,
+              window.occlusionState.contains(.visible) else { return false }
+        return true
+    }
+
     /// Re-resolves a persisted route against current application ownership.
     /// No UI object is retained by the durable registry; every activation must
     /// cross this boundary immediately before use.
@@ -273,13 +306,15 @@ final class ProjectRegistry: LSPSettingsObserver {
         _ taskID: UUID,
         openProjectWindow: @escaping @MainActor (URL) -> Void,
         waitUntilPresented: (@MainActor (ProjectManager) async -> Bool)? = nil,
-        activateApplication: (@MainActor (ProjectManager) -> Void)? = nil
+        activateApplication: (@MainActor (ProjectManager) -> Void)? = nil,
+        expectedNotificationRoute: AgentNotificationRouteIdentity? = nil
     ) async -> AgentInboxNavigationResult {
         guard let initialTask = agentTasks.task(for: taskID) else {
             return .taskMissing
         }
         guard initialTask.lifecycle == .active,
-              initialTask.route.availability != .missing else {
+              initialTask.route.availability != .missing,
+              matches(initialTask, expectedNotificationRoute) else {
             return .routeStale
         }
 
@@ -315,6 +350,7 @@ final class ProjectRegistry: LSPSettingsObserver {
               let run = currentTask.runs.last,
               run.liveness == .live,
               run.endedAt == nil,
+              matches(currentTask, expectedNotificationRoute),
               agentTasks.isExactLiveOwner(
                   taskID: taskID,
                   terminalID: route.terminalID,
@@ -345,6 +381,17 @@ final class ProjectRegistry: LSPSettingsObserver {
         _ = agentTasks.setReviewed(true, taskID: taskID)
         activate()
         return .focused(route)
+    }
+
+    private func matches(
+        _ task: AgentTask,
+        _ expected: AgentNotificationRouteIdentity?
+    ) -> Bool {
+        guard let expected else { return true }
+        guard task.id == expected.taskID,
+              let run = task.runs.last else { return false }
+        return run.id == expected.runID
+            && run.process.processGeneration == expected.processGeneration
     }
 
     private func resolvePausedAgentTaskRoute(

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -632,6 +632,38 @@ enum Strings {
     static let agentInboxRouteUnavailable: LocalizedStringKey =
         "agentInbox.routeUnavailable"
 
+    // MARK: - Agent notifications (#1306)
+    static let agentNotificationsSettingsTitle: LocalizedStringKey =
+        "agentNotifications.settings.title"
+    static let agentNotificationsPermissionExplanation: LocalizedStringKey =
+        "agentNotifications.permission.explanation"
+    static let agentNotificationsEnable: LocalizedStringKey =
+        "agentNotifications.permission.enable"
+    static let agentNotificationsDenied: LocalizedStringKey =
+        "agentNotifications.permission.denied"
+    static let agentNotificationsOpenSystemSettings: LocalizedStringKey =
+        "agentNotifications.permission.openSettings"
+    static let agentNotificationsMainToggle: LocalizedStringKey =
+        "agentNotifications.master"
+    static let agentNotificationsEvents: LocalizedStringKey =
+        "agentNotifications.events"
+    static let agentNotificationsWaiting: LocalizedStringKey =
+        "agentNotifications.event.waiting"
+    static let agentNotificationsFailed: LocalizedStringKey =
+        "agentNotifications.event.failed"
+    static let agentNotificationsCompleted: LocalizedStringKey =
+        "agentNotifications.event.completed"
+    static let agentNotificationsProcessEnded: LocalizedStringKey =
+        "agentNotifications.event.processEnded"
+    static let agentNotificationsAgents: LocalizedStringKey =
+        "agentNotifications.agents"
+    static let agentNotificationsProjects: LocalizedStringKey =
+        "agentNotifications.projects"
+    static let agentNotificationsTasks: LocalizedStringKey =
+        "agentNotifications.tasks"
+    static let agentNotificationsFocusHelp: LocalizedStringKey =
+        "agentNotifications.focusHelp"
+
     // MARK: - Agent History & Undo (#1073)
     static let menuAgentHistory: LocalizedStringKey = "menu.agentHistory"
     static let agentHistoryTitle: LocalizedStringKey = "agentHistory.title"

--- a/PineTests/AgentInboxTests.swift
+++ b/PineTests/AgentInboxTests.swift
@@ -156,6 +156,52 @@ struct AgentInboxTests {
         ) == .routeStale)
     }
 
+    @Test("notification navigation rejects a replacement during window presentation")
+    func notificationNavigationRejectsReplacementRace() async throws {
+        let fixture = try InboxProjectFixture()
+        defer { fixture.cleanup() }
+        let taskRegistry = AgentTaskRegistry()
+        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let state = try #require(manager.paneManager.terminalState(for: pane))
+        let tab = try #require(state.terminalTabs.first)
+        let original = makeSession(seed: 45, state: .waitingInput)
+        manager.terminal.bridgeAgentSession(original, replacing: nil, in: tab)
+        tab.agentSession = original
+        let taskID = try #require(taskRegistry.taskID(forSessionID: original.id))
+        let identity = AgentNotificationRouteIdentity(
+            taskID: taskID,
+            runID: original.id,
+            processGeneration: 45
+        )
+
+        let result = await projectRegistry.navigateToAgentTaskFromInbox(
+            taskID,
+            openProjectWindow: { _ in },
+            waitUntilPresented: { _ in
+                original.applyLiveness(.terminated)
+                let replacement = makeSession(seed: 46, state: .executing)
+                manager.terminal.bridgeAgentSession(
+                    replacement,
+                    replacing: original,
+                    in: tab
+                )
+                tab.agentSession = replacement
+                return true
+            },
+            activateApplication: { _ in },
+            expectedNotificationRoute: identity
+        )
+
+        #expect(result == .routeStale)
+        #expect(taskRegistry.task(for: taskID)?.isUnread == true)
+    }
+
     @Test("background navigation reopens the exact project before resolving")
     func backgroundProjectNavigation() async throws {
         let fixture = try InboxProjectFixture()

--- a/PineTests/AgentNotificationTests.swift
+++ b/PineTests/AgentNotificationTests.swift
@@ -1,0 +1,373 @@
+//
+//  AgentNotificationTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+@testable import Pine
+
+@MainActor
+struct AgentNotificationTests {
+    @Test("verified waiting, failure, and completion transitions are actionable")
+    func verifiedTransitions() throws {
+        let working = task(seed: 1, state: .executing)
+
+        var waiting = working
+        update(&waiting, state: .waitingInput, offset: 1)
+        #expect(events(working, waiting, accuracy: .verifiedLifecycleTransitions).map(\.kind) == [.waitingInput])
+
+        var failed = waiting
+        failed.attention = .failed
+        update(&failed, state: .executing, offset: 2)
+        #expect(events(waiting, failed, accuracy: .verifiedLifecycleTransitions).map(\.kind) == [.failed])
+
+        var completed = working
+        completed.lifecycle = .completed
+        completed.attention = .completed
+        update(&completed, state: .done, liveness: .terminated, offset: 3)
+        #expect(events(working, completed, accuracy: .verifiedLifecycleTransitions).map(\.kind) == [.completed])
+    }
+
+    @Test("process-only adapters never invent attention or completion")
+    func processOnlyAccuracy() {
+        let working = task(seed: 2, state: .executing)
+        var waiting = working
+        update(&waiting, state: .waitingInput, offset: 1)
+        #expect(events(working, waiting, accuracy: .processTerminationOnly).isEmpty)
+
+        var ended = waiting
+        update(&ended, state: .done, liveness: .terminated, offset: 2)
+        #expect(events(waiting, ended, accuracy: .processTerminationOnly).map(\.kind) == [.processEnded])
+    }
+
+    @Test("duplicates, reordered evidence, stale evidence, and new generations are ignored")
+    func rejectsUntrustworthyTransitions() {
+        let original = task(seed: 3, state: .executing)
+        var unchanged = original
+        update(&unchanged, state: .executing, offset: 1)
+        #expect(events(original, unchanged, accuracy: .verifiedLifecycleTransitions).isEmpty)
+
+        var reordered = original
+        update(&reordered, state: .waitingInput, offset: -1)
+        #expect(events(original, reordered, accuracy: .verifiedLifecycleTransitions).isEmpty)
+
+        var stale = original
+        update(&stale, state: .waitingInput, liveness: .stale, offset: 1)
+        #expect(events(original, stale, accuracy: .verifiedLifecycleTransitions).isEmpty)
+
+        var replacement = original
+        replacement.runs[0].process = AgentProcessEvidence(
+            processIdentifier: 99,
+            processGeneration: 999,
+            startIdentifier: "replacement",
+            observedStartedAt: replacement.runs[0].startedAt,
+            startIsAuthoritative: true
+        )
+        update(&replacement, state: .waitingInput, offset: 1)
+        #expect(events(original, replacement, accuracy: .verifiedLifecycleTransitions).isEmpty)
+    }
+
+    @Test("notification identifiers and routing metadata contain opaque identity only")
+    func privacyBoundedRequest() throws {
+        let original = task(
+            seed: 4,
+            state: .executing,
+            project: "/private/secret/project",
+            title: "User title\ncontinued"
+        )
+        var waiting = original
+        update(&waiting, state: .waitingInput, offset: 60)
+        let event = try #require(events(
+            original,
+            waiting,
+            accuracy: .verifiedLifecycleTransitions
+        ).first)
+        let request = AgentNotificationController.request(for: event)
+
+        #expect(!request.identifier.contains("secret"))
+        #expect(!request.identifier.contains("project"))
+        #expect(request.body.contains("project"))
+        #expect(!request.body.contains("\n"))
+        #expect(Set(request.userInfo.keys) == ["taskID", "runID", "generation"])
+        #expect(!request.userInfo.values.contains { $0.contains("secret") })
+    }
+
+    @Test("notification navigation authority is bound to the exact run generation")
+    func exactNotificationRouteIdentity() throws {
+        let registry = AgentTaskRegistry()
+        let session = makeSession(seed: 42)
+        let routeContext = context(seed: 42, project: "/tmp/notify-route")
+        registry.bridge(session, replacing: nil, context: routeContext)
+        let taskID = try #require(registry.taskID(forSessionID: session.id))
+        #expect(registry.matchesNotificationRoute(AgentNotificationRouteIdentity(
+            taskID: taskID,
+            runID: session.id,
+            processGeneration: 42
+        )))
+        #expect(!registry.matchesNotificationRoute(AgentNotificationRouteIdentity(
+            taskID: taskID,
+            runID: session.id,
+            processGeneration: 43
+        )))
+        #expect(!registry.matchesNotificationRoute(AgentNotificationRouteIdentity(
+            taskID: taskID,
+            runID: UUID(),
+            processGeneration: 42
+        )))
+    }
+
+    @Test("preferences persist event, task, agent, and project controls")
+    func persistedPreferences() {
+        let fixture = DefaultsFixture()
+        defer { fixture.cleanup() }
+        let settings = AgentNotificationSettings(defaults: fixture.defaults)
+        let sample = task(seed: 5, state: .executing)
+        var ended = sample
+        update(&ended, state: .done, liveness: .terminated, offset: 2)
+        let event = events(sample, ended, accuracy: .processTerminationOnly)[0]
+
+        settings.setEnabled(true)
+        settings.setEvent(.completed, enabled: false)
+        settings.setAgent(sample.descriptor.typeIdentifier, enabled: false)
+        settings.setProject(sample.project.canonicalProjectPath, enabled: false)
+        settings.muteTask(sample.id)
+        #expect(!settings.allows(event, task: sample))
+        #expect(settings.claimDelivery(of: event.id))
+        #expect(!settings.claimDelivery(of: event.id))
+
+        let restored = AgentNotificationSettings(defaults: fixture.defaults)
+        #expect(restored.isEnabled)
+        #expect(!restored.enabledEvents.contains(.completed))
+        #expect(restored.mutedTaskIDs.contains(sample.id))
+        #expect(restored.disabledAgentIDs.contains(sample.descriptor.typeIdentifier))
+        #expect(restored.disabledProjectPaths.contains(sample.project.canonicalProjectPath))
+        #expect(!restored.claimDelivery(of: event.id))
+        restored.setTask(sample.id, enabled: true)
+        #expect(!AgentNotificationSettings(
+            defaults: fixture.defaults
+        ).mutedTaskIDs.contains(sample.id))
+    }
+
+    @Test("controller delivers across projects, suppresses the exact visible task, and deduplicates")
+    func multiProjectDeliveryAndSuppression() async throws {
+        let fixture = DefaultsFixture()
+        defer { fixture.cleanup() }
+        let settings = AgentNotificationSettings(defaults: fixture.defaults)
+        settings.setEnabled(true)
+        let registry = AgentTaskRegistry()
+        let delivery = RecordingAgentNotificationDelivery(status: .authorized)
+        var presented = Set<UUID>()
+        var opened: AgentNotificationRouteIdentity?
+        let controller = AgentNotificationController(
+            registry: registry,
+            settings: settings,
+            delivery: delivery,
+            isPresented: { presented.contains($0) },
+            openTask: { opened = $0 }
+        )
+        controller.start()
+        await controller.refreshAuthorizationStatus()
+
+        let first = makeSession(seed: 10)
+        let second = makeSession(seed: 20)
+        registry.bridge(first, replacing: nil, context: context(seed: 10, project: "/tmp/notify-a"))
+        registry.bridge(second, replacing: nil, context: context(seed: 20, project: "/tmp/notify-b"))
+        let firstTaskID = try #require(registry.taskID(forSessionID: first.id))
+        let expectedSecondTaskID = try #require(
+            registry.taskID(forSessionID: second.id)
+        )
+        presented.insert(firstTaskID)
+
+        first.applyLiveness(.terminated)
+        second.applyLiveness(.terminated)
+        registry.refresh(sessions: [first, second])
+        await settle()
+
+        #expect(delivery.requests.count == 1)
+        let deliveredTaskID = try #require(
+            delivery.requests.first?.userInfo["taskID"]
+        )
+        let secondTaskID = try #require(UUID(uuidString: deliveredTaskID))
+        #expect(secondTaskID == expectedSecondTaskID)
+
+        registry.refresh(sessions: [first, second])
+        await settle()
+        #expect(delivery.requests.count == 1)
+
+        let routeIdentity = AgentNotificationRouteIdentity(
+            taskID: secondTaskID,
+            runID: second.id,
+            processGeneration: 20
+        )
+        delivery.respond(.open(routeIdentity))
+        #expect(opened == routeIdentity)
+        delivery.respond(.mute(taskID: secondTaskID))
+        #expect(settings.mutedTaskIDs.contains(secondTaskID))
+        controller.stop()
+    }
+
+    @Test("denied authorization disables delivery but remains reversible")
+    func deniedAuthorization() async {
+        let fixture = DefaultsFixture()
+        defer { fixture.cleanup() }
+        let settings = AgentNotificationSettings(defaults: fixture.defaults)
+        settings.setEnabled(true)
+        let delivery = RecordingAgentNotificationDelivery(status: .denied)
+        let controller = AgentNotificationController(
+            registry: AgentTaskRegistry(),
+            settings: settings,
+            delivery: delivery,
+            isPresented: { _ in false },
+            openTask: { _ in }
+        )
+
+        await controller.refreshAuthorizationStatus()
+        #expect(controller.authorizationStatus == .denied)
+        #expect(!settings.isEnabled)
+
+        delivery.status = .authorized
+        delivery.requestResult = true
+        #expect(await controller.requestAuthorization())
+        #expect(settings.isEnabled)
+    }
+
+    private func events(
+        _ old: AgentTask,
+        _ new: AgentTask,
+        accuracy: FirstPartyAgentNotificationAccuracy
+    ) -> [AgentNotificationEvent] {
+        AgentNotificationTransitionResolver.events(
+            from: [old],
+            to: [new],
+            accuracy: { _ in accuracy }
+        )
+    }
+
+    private func task(
+        seed: Int,
+        state: AgentRunState,
+        project: String = "/tmp/notify-project",
+        title: String? = "Review tests"
+    ) -> AgentTask {
+        let context = context(seed: seed, project: project)
+        let started = Date(timeIntervalSince1970: TimeInterval(1_000 + seed))
+        var task = AgentTask(
+            descriptor: AgentDescriptor(agentType: .codex),
+            context: context,
+            title: title,
+            createdAt: started
+        )
+        task.runs = [AgentTaskRun(AgentTaskRunInput(
+            id: uuid(seed + 100),
+            terminalID: context.route.terminalID,
+            process: AgentProcessEvidence(
+                processIdentifier: Int32(seed),
+                processGeneration: UInt64(seed),
+                startIdentifier: "verified-\(seed)",
+                observedStartedAt: started,
+                startIsAuthoritative: true
+            ),
+            status: AgentTaskRunStatus(
+                state: state,
+                liveness: .live,
+                observedAt: started
+            )
+        ))]
+        task.updatedAt = started
+        task.lastActivityAt = started
+        return task
+    }
+
+    private func update(
+        _ task: inout AgentTask,
+        state: AgentRunState,
+        liveness: AgentRunLiveness = .live,
+        offset: TimeInterval
+    ) {
+        task.runs[0].state = state
+        task.runs[0].liveness = liveness
+        task.runs[0].lastObservedAt = task.runs[0].startedAt.addingTimeInterval(offset)
+        task.runs[0].endedAt = liveness == .terminated
+            ? task.runs[0].lastObservedAt
+            : nil
+        task.updatedAt = task.runs[0].lastObservedAt
+    }
+
+    private func makeSession(seed: Int) -> AgentSession {
+        let session = AgentSession(
+            agentType: .codex,
+            state: .executing,
+            startedAt: Date(timeIntervalSince1970: TimeInterval(seed))
+        )
+        _ = session.bindProcessEvidence(AgentProcessEvidence(
+            processIdentifier: Int32(seed),
+            processGeneration: UInt64(seed),
+            startIdentifier: "verified-session-\(seed)",
+            observedStartedAt: session.startedAt,
+            startIsAuthoritative: true
+        ))
+        return session
+    }
+
+    private func context(seed: Int, project: String) -> AgentTaskBridgeContext {
+        AgentTaskBridgeContext(
+            project: AgentTaskProjectIdentity(
+                canonicalProjectPath: project,
+                canonicalWorktreePath: project
+            ),
+            route: AgentTaskRoute(
+                paneID: uuid(seed),
+                tabID: uuid(seed + 1_000),
+                terminalID: uuid(seed + 1_000)
+            ),
+            origin: .discoveredInTerminal,
+            observedAt: Date(timeIntervalSince1970: TimeInterval(seed))
+        )
+    }
+
+    private func uuid(_ seed: Int) -> UUID {
+        let suffix = String(format: "%012llX", UInt64(seed))
+        return UUID(uuidString: "00000000-0000-0000-0000-\(suffix)") ?? UUID()
+    }
+
+    private func settle() async {
+        for _ in 0..<5 { await Task.yield() }
+    }
+}
+
+@MainActor
+private final class RecordingAgentNotificationDelivery: AgentNotificationDelivering {
+    var responseHandler: ((AgentNotificationResponseAction) -> Void)?
+    var status: AgentNotificationAuthorizationStatus
+    var requestResult = false
+    private(set) var requests: [AgentNotificationRequest] = []
+
+    init(status: AgentNotificationAuthorizationStatus) {
+        self.status = status
+    }
+
+    func registerActions() {}
+    func authorizationStatus() async -> AgentNotificationAuthorizationStatus { status }
+    func requestAuthorization() async throws -> Bool { requestResult }
+    func deliver(_ request: AgentNotificationRequest) async throws {
+        requests.append(request)
+    }
+    func respond(_ action: AgentNotificationResponseAction) {
+        responseHandler?(action)
+    }
+}
+
+private final class DefaultsFixture {
+    let suiteName = "AgentNotificationTests.\(UUID().uuidString)"
+    let defaults: UserDefaults
+
+    init() {
+        defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func cleanup() {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pine keeps CLI agents in the terminal and the code in view. It reflects agent ac
 ## Features
 
 - **Native macOS** — SwiftUI + AppKit, Liquid Glass UI, system text handling. No browser engine, no runtime
-- **Agent-aware workflow** — Detects supported CLI agents, marks active terminal tabs and attention states, and provides activity history with undo for agent changes
+- **Agent-aware workflow** — Tracks durable tasks across projects in Agent Inbox, routes back to the exact live session, and sends privacy-bounded notifications for verified events or detected process exits
 - **LSP code intelligence** — Diagnostics, completion, hover, go-to-definition, code actions, rename, and a Problems panel
 - **Syntax highlighting** — bundled grammars for Swift, TypeScript, Python, Go, Rust, Java, Kotlin, Ruby, C/C++, and more
 - **Split panes** — Drag tabs to edges to split horizontally or vertically. Drag between panes to move. Resize with divider

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,15 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pine — The Native macOS Code Editor for CLI Agent Workflows</title>
-    <meta name="description" content="Pine is a fast, native macOS code editor for working beside CLI agents. Split editor and terminal panes, live agent activity, LSP, Git context, and no Electron.">
+    <meta name="description" content="Pine is a native macOS code editor for CLI agents, with a cross-project Agent Inbox, private notifications, LSP, Git context, and no Electron.">
     <meta property="og:title" content="Pine — The Native macOS Code Editor for CLI Agent Workflows">
-    <meta property="og:description" content="Keep the agent in the terminal and the code in view. Native editor and terminal panes, live agent activity, LSP, and Git context.">
+    <meta property="og:description" content="Keep agents in the terminal and every task in view with a cross-project Inbox, private notifications, LSP, and Git context.">
     <meta property="og:image" content="https://raw.githubusercontent.com/batonogov/pine/main/assets/screenshot-editor.png">
     <meta property="og:url" content="https://batonogov.github.io/pine/">
     <meta property="og:type" content="website">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Pine — The Native macOS Code Editor for CLI Agent Workflows">
-    <meta name="twitter:description" content="Keep the agent in the terminal and the code in view. Native editor and terminal panes, live agent activity, LSP, and Git context.">
+    <meta name="twitter:description" content="Keep agents in the terminal and every task in view with a cross-project Inbox, private notifications, LSP, and Git context.">
     <meta name="twitter:image" content="https://raw.githubusercontent.com/batonogov/pine/main/assets/screenshot-editor.png">
     <meta name="theme-color" content="#07110d">
     <link rel="canonical" href="https://batonogov.github.io/pine/">
@@ -1132,7 +1132,7 @@
                     <article class="feature-card feature-wide">
                         <div class="feature-badge">01</div>
                         <h3 data-i18n="features.01title">See agent work as it happens.</h3>
-                        <p data-i18n="features.01desc">Detects supported CLI agents, marks active terminal tabs, surfaces attention states, and provides activity history with undo for agent changes.</p>
+                        <p data-i18n="features.01desc">Tracks durable tasks across projects in Agent Inbox, routes to the exact live session, and sends private notifications for verified events or detected process exits.</p>
                     </article>
                     <article class="feature-card">
                         <div class="feature-badge">02</div>
@@ -1302,7 +1302,7 @@
                 "features.title": "Everything needed to edit beside an agent.",
                 "features.desc": "Pine stays a focused code editor while making terminal-driven, agent-assisted work visible.",
                 "features.01title": "See agent work as it happens.",
-                "features.01desc": "Detects supported CLI agents, marks active terminal tabs, surfaces attention states, and provides activity history with undo for agent changes.",
+                "features.01desc": "Tracks durable tasks across projects in Agent Inbox, routes to the exact live session, and sends private notifications for verified events or detected process exits.",
                 "features.02title": "Edit with native speed and real code intelligence.",
                 "features.02desc": "Bundled language grammars, LSP diagnostics, completion, hover, go-to-definition, code actions, rename, symbols, folding, minimap, and project search.",
                 "features.03title": "Shape a workspace around the task.",
@@ -1344,11 +1344,11 @@
                 "install.shellNote": "Build from source with <code>xcodebuild -project Pine.xcodeproj -scheme Pine build</code> if you want the full native stack on your machine.",
                 "footer.text": "Pine is open source and built for macOS developers who work with code and CLI agents.",
                 "meta.title": "Pine — The Native macOS Code Editor for CLI Agent Workflows",
-                "meta.description": "Pine is a fast, native macOS code editor for working beside CLI agents. Split editor and terminal panes, live agent activity, LSP, Git context, and no Electron.",
+                "meta.description": "Pine is a native macOS code editor for CLI agents, with a cross-project Agent Inbox, private notifications, LSP, Git context, and no Electron.",
                 "meta.ogTitle": "Pine — The Native macOS Code Editor for CLI Agent Workflows",
-                "meta.ogDescription": "Keep the agent in the terminal and the code in view. Native editor and terminal panes, live agent activity, LSP, and Git context.",
+                "meta.ogDescription": "Keep agents in the terminal and every task in view with a cross-project Inbox, private notifications, LSP, and Git context.",
                 "meta.twitterTitle": "Pine — The Native macOS Code Editor for CLI Agent Workflows",
-                "meta.twitterDescription": "Keep the agent in the terminal and the code in view. Native editor and terminal panes, live agent activity, LSP, and Git context."
+                "meta.twitterDescription": "Keep agents in the terminal and every task in view with a cross-project Inbox, private notifications, LSP, and Git context."
             },
             ru: {
                 "nav.why": "Почему Pine",
@@ -1404,7 +1404,7 @@
                 "features.title": "Всё для работы рядом с агентом.",
                 "features.desc": "Pine остаётся сфокусированным редактором кода, но делает работу агентов из терминала видимой.",
                 "features.01title": "Видно, как агент работает прямо сейчас.",
-                "features.01desc": "Pine распознаёт поддерживаемых CLI-агентов, отмечает активные вкладки терминала, показывает запросы внимания и хранит историю действий с отменой изменений агента.",
+                "features.01desc": "Pine хранит задачи разных проектов во Входящих агентов, точно возвращает к активной сессии и отправляет приватные уведомления о проверенных событиях или завершении процесса.",
                 "features.02title": "Нативная скорость и полноценная работа с кодом.",
                 "features.02desc": "Встроенные грамматики языков, диагностика LSP, автодополнение, hover, переход к определению, code actions, переименование, символы, сворачивание, миникарта и поиск по проекту.",
                 "features.03title": "Рабочее пространство под конкретную задачу.",
@@ -1446,11 +1446,11 @@
                 "install.shellNote": "Если хочется полностью нативный стек на Mac, Pine можно собрать из исходников командой <code>xcodebuild -project Pine.xcodeproj -scheme Pine build</code>.",
                 "footer.text": "Pine — редактор с открытым исходным кодом для разработчиков macOS, которые работают с кодом и CLI-агентами.",
                 "meta.title": "Pine — нативный редактор кода для macOS и CLI-агентов",
-                "meta.description": "Pine — быстрый нативный редактор для работы рядом с CLI-агентами: панели редактора и терминала, активность агентов, LSP, Git-контекст и никакого Electron.",
+                "meta.description": "Pine — нативный редактор macOS для CLI-агентов: общие Входящие агентов, приватные уведомления, LSP, Git-контекст и никакого Electron.",
                 "meta.ogTitle": "Pine — нативный редактор кода для macOS и CLI-агентов",
-                "meta.ogDescription": "Агент остаётся в терминале, а код — перед глазами. Нативные панели, активность агентов, LSP и Git-контекст.",
+                "meta.ogDescription": "Агенты остаются в терминале, а все задачи — во Входящих разных проектов с приватными уведомлениями, LSP и Git-контекстом.",
                 "meta.twitterTitle": "Pine — нативный редактор кода для macOS и CLI-агентов",
-                "meta.twitterDescription": "Агент остаётся в терминале, а код — перед глазами. Нативные панели, активность агентов, LSP и Git-контекст."
+                "meta.twitterDescription": "Агенты остаются в терминале, а все задачи — во Входящих разных проектов с приватными уведомлениями, LSP и Git-контекстом."
             },
             de: {
                 "nav.why": "Warum Pine",
@@ -1506,7 +1506,7 @@
                 "features.title": "Alles für die Arbeit neben einem Agenten.",
                 "features.desc": "Pine bleibt ein fokussierter Code-Editor und macht zugleich terminalbasierte, agentengestützte Arbeit sichtbar.",
                 "features.01title": "Agentenarbeit in Echtzeit sehen.",
-                "features.01desc": "Erkennt unterstützte CLI-Agenten, markiert aktive Terminal-Tabs, zeigt Aufmerksamkeitszustände und bietet einen Aktivitätsverlauf mit Undo für Agentenänderungen.",
+                "features.01desc": "Verfolgt dauerhafte Aufgaben projektübergreifend im Agenten-Posteingang, führt zur exakten Live-Sitzung und sendet private Hinweise für verifizierte Ereignisse oder erkannte Prozessenden.",
                 "features.02title": "Native Geschwindigkeit und echte Code-Intelligenz.",
                 "features.02desc": "Mitgelieferte Sprachgrammatiken, LSP-Diagnosen, Vervollständigung, Hover, Definition, Code-Aktionen, Umbenennen, Symbole, Folding, Minimap und Projektsuche.",
                 "features.03title": "Arbeitsbereich passend zur Aufgabe.",
@@ -1548,11 +1548,11 @@
                 "install.shellNote": "Aus den Quellen bauen mit <code>xcodebuild -project Pine.xcodeproj -scheme Pine build</code>, wenn Sie den vollen nativen Stack auf Ihrem Mac wollen.",
                 "footer.text": "Pine ist Open Source und für macOS-Entwickler gebaut, die mit Code und CLI-Agenten arbeiten.",
                 "meta.title": "Pine — Nativer macOS-Code-Editor für CLI-Agenten",
-                "meta.description": "Pine ist ein schneller, nativer macOS-Code-Editor für die Arbeit mit CLI-Agenten: geteilte Editor- und Terminal-Bereiche, Agentenaktivität, LSP, Git-Kontext und kein Electron.",
+                "meta.description": "Pine ist ein nativer macOS-Code-Editor für CLI-Agenten mit projektübergreifendem Agenten-Posteingang, privaten Hinweisen, LSP, Git-Kontext und ohne Electron.",
                 "meta.ogTitle": "Pine — Nativer macOS-Code-Editor für CLI-Agenten",
-                "meta.ogDescription": "Agent im Terminal, Code im Blick. Native Bereiche, Agentenaktivität, LSP und Git-Kontext.",
+                "meta.ogDescription": "Agenten bleiben im Terminal, alle Aufgaben im projektübergreifenden Posteingang – mit privaten Hinweisen, LSP und Git-Kontext.",
                 "meta.twitterTitle": "Pine — Nativer macOS-Code-Editor für CLI-Agenten",
-                "meta.twitterDescription": "Agent im Terminal, Code im Blick. Native Bereiche, Agentenaktivität, LSP und Git-Kontext."
+                "meta.twitterDescription": "Agenten bleiben im Terminal, alle Aufgaben im projektübergreifenden Posteingang – mit privaten Hinweisen, LSP und Git-Kontext."
             },
             es: {
                 "nav.why": "Por qué Pine",
@@ -1608,7 +1608,7 @@
                 "features.title": "Todo lo necesario para editar junto a un agente.",
                 "features.desc": "Pine sigue siendo un editor de código enfocado y hace visible el trabajo con agentes desde la terminal.",
                 "features.01title": "Mira el trabajo del agente mientras ocurre.",
-                "features.01desc": "Detecta agentes CLI compatibles, marca pestañas activas de terminal, muestra estados de atención y ofrece historial de actividad con deshacer para cambios del agente.",
+                "features.01desc": "Mantiene tareas duraderas de varios proyectos en la Bandeja de agentes, vuelve a la sesión activa exacta y envía avisos privados de eventos verificados o cierres de proceso detectados.",
                 "features.02title": "Velocidad nativa e inteligencia de código real.",
                 "features.02desc": "Gramáticas de lenguaje incluidas, diagnósticos LSP, autocompletado, hover, definición, acciones de código, renombrado, símbolos, plegado, minimapa y búsqueda de proyecto.",
                 "features.03title": "Adapta el espacio de trabajo a la tarea.",
@@ -1650,11 +1650,11 @@
                 "install.shellNote": "Compila desde el código fuente con <code>xcodebuild -project Pine.xcodeproj -scheme Pine build</code> si quieres el stack nativo completo en tu Mac.",
                 "footer.text": "Pine es open source y está hecho para desarrolladores de macOS que trabajan con código y agentes CLI.",
                 "meta.title": "Pine — Editor nativo de macOS para agentes CLI",
-                "meta.description": "Pine es un editor nativo y rápido para trabajar junto a agentes CLI: paneles de editor y terminal, actividad de agentes, LSP, contexto Git y sin Electron.",
+                "meta.description": "Pine es un editor nativo de macOS para agentes CLI con Bandeja de agentes entre proyectos, avisos privados, LSP, contexto Git y sin Electron.",
                 "meta.ogTitle": "Pine — Editor nativo de macOS para agentes CLI",
-                "meta.ogDescription": "El agente en la terminal y el código a la vista. Paneles nativos, actividad de agentes, LSP y contexto Git.",
+                "meta.ogDescription": "Agentes en la terminal y todas las tareas en una bandeja entre proyectos, con avisos privados, LSP y contexto Git.",
                 "meta.twitterTitle": "Pine — Editor nativo de macOS para agentes CLI",
-                "meta.twitterDescription": "El agente en la terminal y el código a la vista. Paneles nativos, actividad de agentes, LSP y contexto Git."
+                "meta.twitterDescription": "Agentes en la terminal y todas las tareas en una bandeja entre proyectos, con avisos privados, LSP y contexto Git."
             },
             fr: {
                 "nav.why": "Pourquoi Pine",
@@ -1710,7 +1710,7 @@
                 "features.title": "Tout le nécessaire pour éditer aux côtés d'un agent.",
                 "features.desc": "Pine reste un éditeur de code focalisé tout en rendant visible le travail assisté par agents depuis le terminal.",
                 "features.01title": "Suivez le travail de l'agent en direct.",
-                "features.01desc": "Détecte les agents CLI compatibles, marque les onglets de terminal actifs, affiche les états d'attention et fournit un historique avec annulation des changements de l'agent.",
+                "features.01desc": "Suit les tâches durables de plusieurs projets dans la boîte des agents, revient à la session active exacte et envoie des alertes privées pour les événements vérifiés ou les fins de processus détectées.",
                 "features.02title": "Vitesse native et véritable intelligence du code.",
                 "features.02desc": "Grammaires de langage intégrées, diagnostics LSP, complétion, hover, définition, actions de code, renommage, symboles, pliage, minimap et recherche de projet.",
                 "features.03title": "Adaptez l'espace de travail à la tâche.",
@@ -1752,11 +1752,11 @@
                 "install.shellNote": "Compilez depuis les sources avec <code>xcodebuild -project Pine.xcodeproj -scheme Pine build</code> si vous voulez le stack natif complet sur votre Mac.",
                 "footer.text": "Pine est open source et conçu pour les développeurs macOS qui travaillent avec du code et des agents CLI.",
                 "meta.title": "Pine — Éditeur macOS natif pour les agents CLI",
-                "meta.description": "Pine est un éditeur macOS natif et rapide pour travailler avec des agents CLI : volets éditeur et terminal, activité des agents, LSP, contexte Git et sans Electron.",
+                "meta.description": "Pine est un éditeur macOS natif pour agents CLI avec boîte interprojets, alertes privées, LSP, contexte Git et sans Electron.",
                 "meta.ogTitle": "Pine — Éditeur macOS natif pour les agents CLI",
-                "meta.ogDescription": "L'agent dans le terminal, le code à l'écran. Volets natifs, activité des agents, LSP et contexte Git.",
+                "meta.ogDescription": "Les agents restent dans le terminal et toutes les tâches dans une boîte interprojets, avec alertes privées, LSP et contexte Git.",
                 "meta.twitterTitle": "Pine — Éditeur macOS natif pour les agents CLI",
-                "meta.twitterDescription": "L'agent dans le terminal, le code à l'écran. Volets natifs, activité des agents, LSP et contexte Git."
+                "meta.twitterDescription": "Les agents restent dans le terminal et toutes les tâches dans une boîte interprojets, avec alertes privées, LSP et contexte Git."
             },
             ja: {
                 "nav.why": "Pine とは",
@@ -1812,7 +1812,7 @@
                 "features.title": "エージェントの隣で編集するためのすべて。",
                 "features.desc": "Pine は集中できるコードエディタのまま、ターミナルで動くエージェントの作業を見える形にします。",
                 "features.01title": "エージェントの作業をリアルタイムで確認。",
-                "features.01desc": "対応 CLI エージェントを検出し、アクティブなターミナルタブと注意状態を示し、エージェント変更を取り消せる活動履歴を提供します。",
+                "features.01desc": "複数プロジェクトの永続タスクをエージェント受信箱で追跡し、正確なライブセッションへ戻り、検証済みイベントまたは検出したプロセス終了を安全に通知します。",
                 "features.02title": "ネイティブの速度と本物のコードインテリジェンス。",
                 "features.02desc": "同梱の言語文法、LSP 診断、補完、hover、定義ジャンプ、コードアクション、名前変更、シンボル、折りたたみ、ミニマップ、プロジェクト検索。",
                 "features.03title": "タスクに合わせてワークスペースを構成。",
@@ -1854,11 +1854,11 @@
                 "install.shellNote": "Mac でフルネイティブスタックが必要なら、<code>xcodebuild -project Pine.xcodeproj -scheme Pine build</code> でソースからビルドできます。",
                 "footer.text": "Pine は、コードと CLI エージェントで作業する macOS 開発者のためのオープンソースエディタです。",
                 "meta.title": "Pine — CLI エージェント向けネイティブ macOS エディタ",
-                "meta.description": "Pine は CLI エージェントと作業するための高速なネイティブ macOS エディタ。エディタとターミナルのペイン、エージェント活動、LSP、Git コンテキスト、Electron 不要。",
+                "meta.description": "Pine は CLI エージェント向けのネイティブ macOS エディタ。プロジェクト横断の受信箱、プライベート通知、LSP、Git コンテキストを備え、Electron は不要。",
                 "meta.ogTitle": "Pine — CLI エージェント向けネイティブ macOS エディタ",
-                "meta.ogDescription": "エージェントはターミナルに、コードは視界に。ネイティブペイン、エージェント活動、LSP、Git コンテキスト。",
+                "meta.ogDescription": "エージェントはターミナルに、全タスクはプロジェクト横断の受信箱に。プライベート通知、LSP、Git コンテキストを搭載。",
                 "meta.twitterTitle": "Pine — CLI エージェント向けネイティブ macOS エディタ",
-                "meta.twitterDescription": "エージェントはターミナルに、コードは視界に。ネイティブペイン、エージェント活動、LSP、Git コンテキスト。"
+                "meta.twitterDescription": "エージェントはターミナルに、全タスクはプロジェクト横断の受信箱に。プライベート通知、LSP、Git コンテキストを搭載。"
             },
             ko: {
                 "nav.why": "왜 Pine인가",
@@ -1914,7 +1914,7 @@
                 "features.title": "에이전트와 함께 편집하는 데 필요한 모든 것.",
                 "features.desc": "Pine은 집중된 코드 편집기로 남으면서 터미널 기반 에이전트 작업을 보이게 합니다.",
                 "features.01title": "에이전트 작업을 실시간으로 확인.",
-                "features.01desc": "지원되는 CLI 에이전트를 감지하고 활성 터미널 탭과 주의 상태를 표시하며 에이전트 변경을 되돌릴 수 있는 활동 기록을 제공합니다.",
+                "features.01desc": "여러 프로젝트의 지속 작업을 에이전트 받은편지함에서 추적하고 정확한 라이브 세션으로 돌아가며 검증된 이벤트나 감지된 프로세스 종료를 안전하게 알립니다.",
                 "features.02title": "네이티브 속도와 실제 코드 인텔리전스.",
                 "features.02desc": "번들 언어 문법, LSP 진단, 완성, hover, 정의 이동, 코드 액션, 이름 변경, 심볼, 폴딩, 미니맵, 프로젝트 검색.",
                 "features.03title": "작업에 맞게 워크스페이스 구성.",
@@ -1956,11 +1956,11 @@
                 "install.shellNote": "Mac에서 풀 네이티브 스택을 원하면 <code>xcodebuild -project Pine.xcodeproj -scheme Pine build</code>로 소스에서 빌드하세요.",
                 "footer.text": "Pine은 코드와 CLI 에이전트로 작업하는 macOS 개발자를 위한 오픈 소스 편집기입니다.",
                 "meta.title": "Pine — CLI 에이전트를 위한 네이티브 macOS 편집기",
-                "meta.description": "Pine은 CLI 에이전트와 함께 작업하는 빠른 네이티브 macOS 편집기입니다. 편집기와 터미널 패널, 에이전트 활동, LSP, Git 컨텍스트, Electron 없음.",
+                "meta.description": "Pine은 CLI 에이전트용 네이티브 macOS 편집기입니다. 프로젝트 간 받은편지함, 비공개 알림, LSP, Git 컨텍스트를 제공하며 Electron이 없습니다.",
                 "meta.ogTitle": "Pine — CLI 에이전트를 위한 네이티브 macOS 편집기",
-                "meta.ogDescription": "에이전트는 터미널에, 코드는 시야에. 네이티브 패널, 에이전트 활동, LSP, Git 컨텍스트.",
+                "meta.ogDescription": "에이전트는 터미널에, 모든 작업은 프로젝트 간 받은편지함에. 비공개 알림, LSP, Git 컨텍스트 제공.",
                 "meta.twitterTitle": "Pine — CLI 에이전트를 위한 네이티브 macOS 편집기",
-                "meta.twitterDescription": "에이전트는 터미널에, 코드는 시야에. 네이티브 패널, 에이전트 활동, LSP, Git 컨텍스트."
+                "meta.twitterDescription": "에이전트는 터미널에, 모든 작업은 프로젝트 간 받은편지함에. 비공개 알림, LSP, Git 컨텍스트 제공."
             },
             "pt-BR": {
                 "nav.why": "Por que Pine",
@@ -2016,7 +2016,7 @@
                 "features.title": "Tudo para editar ao lado de um agente.",
                 "features.desc": "Pine continua sendo um editor de código focado e torna visível o trabalho com agentes pelo terminal.",
                 "features.01title": "Veja o trabalho do agente em tempo real.",
-                "features.01desc": "Detecta agentes CLI compatíveis, marca abas ativas do terminal, mostra estados de atenção e oferece histórico com desfazer para mudanças do agente.",
+                "features.01desc": "Mantém tarefas duráveis de vários projetos na Caixa de agentes, volta à sessão ativa exata e envia alertas privados de eventos verificados ou encerramentos de processo detectados.",
                 "features.02title": "Velocidade nativa e inteligência de código real.",
                 "features.02desc": "Gramáticas de linguagem incluídas, diagnósticos LSP, completions, hover, definição, code actions, renomear, símbolos, folding, minimapa e busca no projeto.",
                 "features.03title": "Monte o espaço de trabalho para a tarefa.",
@@ -2058,11 +2058,11 @@
                 "install.shellNote": "Compile a partir do código-fonte com <code>xcodebuild -project Pine.xcodeproj -scheme Pine build</code> se quiser o stack nativo completo no seu Mac.",
                 "footer.text": "Pine é open source e feito para desenvolvedores macOS que trabalham com código e agentes CLI.",
                 "meta.title": "Pine — Editor macOS nativo para agentes CLI",
-                "meta.description": "Pine é um editor macOS nativo e rápido para trabalhar com agentes CLI: painéis de editor e terminal, atividade dos agentes, LSP, contexto Git e sem Electron.",
+                "meta.description": "Pine é um editor macOS nativo para agentes CLI com Caixa de agentes entre projetos, alertas privados, LSP, contexto Git e sem Electron.",
                 "meta.ogTitle": "Pine — Editor macOS nativo para agentes CLI",
-                "meta.ogDescription": "O agente no terminal e o código à vista. Painéis nativos, atividade dos agentes, LSP e contexto Git.",
+                "meta.ogDescription": "Agentes no terminal e todas as tarefas em uma caixa entre projetos, com alertas privados, LSP e contexto Git.",
                 "meta.twitterTitle": "Pine — Editor macOS nativo para agentes CLI",
-                "meta.twitterDescription": "O agente no terminal e o código à vista. Painéis nativos, atividade dos agentes, LSP e contexto Git."
+                "meta.twitterDescription": "Agentes no terminal e todas as tarefas em uma caixa entre projetos, com alertas privados, LSP e contexto Git."
             },
             "zh-Hans": {
                 "nav.why": "为什么选 Pine",
@@ -2118,7 +2118,7 @@
                 "features.title": "与代理并肩编辑所需的一切。",
                 "features.desc": "Pine 始终是专注的代码编辑器，同时让终端中的代理工作清晰可见。",
                 "features.01title": "实时查看代理的工作。",
-                "features.01desc": "检测支持的 CLI 代理，标记活跃终端标签页，显示注意状态，并提供可撤销代理更改的活动历史。",
+                "features.01desc": "在智能体收件箱中跟踪跨项目的持久任务，准确返回实时会话，并对已验证事件或检测到的进程结束发送私密通知。",
                 "features.02title": "原生速度与真正的代码智能。",
                 "features.02desc": "内置语言语法、LSP 诊断、补全、悬停、跳转定义、代码操作、重命名、符号、折叠、迷你地图和项目搜索。",
                 "features.03title": "围绕任务组织工作区。",
@@ -2160,11 +2160,11 @@
                 "install.shellNote": "如果你想要完整的原生技术栈，可以用 <code>xcodebuild -project Pine.xcodeproj -scheme Pine build</code> 从源码构建。",
                 "footer.text": "Pine 是为使用代码和 CLI 代理工作的 macOS 开发者打造的开源编辑器。",
                 "meta.title": "Pine — 面向 CLI 代理的原生 macOS 编辑器",
-                "meta.description": "Pine 是与 CLI 代理协作的快速原生 macOS 编辑器：编辑器与终端窗格、代理活动、LSP、Git 上下文，无 Electron。",
+                "meta.description": "Pine 是面向 CLI 智能体的原生 macOS 编辑器，提供跨项目收件箱、私密通知、LSP 和 Git 上下文，无 Electron。",
                 "meta.ogTitle": "Pine — 面向 CLI 代理的原生 macOS 编辑器",
-                "meta.ogDescription": "代理留在终端，代码始终可见。原生窗格、代理活动、LSP 和 Git 上下文。",
+                "meta.ogDescription": "智能体留在终端，所有任务集中于跨项目收件箱，并提供私密通知、LSP 和 Git 上下文。",
                 "meta.twitterTitle": "Pine — 面向 CLI 代理的原生 macOS 编辑器",
-                "meta.twitterDescription": "代理留在终端，代码始终可见。原生窗格、代理活动、LSP 和 Git 上下文。"
+                "meta.twitterDescription": "智能体留在终端，所有任务集中于跨项目收件箱，并提供私密通知、LSP 和 Git 上下文。"
             }
         };
 


### PR DESCRIPTION
## Summary
- add project-scoped completion, attention, and failure notifications
- route notification actions to the exact task and terminal when still valid
- keep notification settings explicit and privacy-preserving
- add localized presentation and focused tests

## Stack
Depends on the #1305 Agent Inbox PR. Review only the commit unique to this PR.

## Validation
- targeted unit tests
- SwiftLint

Closes #1306