### PR TITLE
feat(agent): add safe agent task recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,17 +511,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Shard 1 — Terminal (29 tests)
+          # Shard 1 — Terminal (31 tests)
           - shard-name: "Terminal"
             test-classes: >-
               -only-testing:PineUITests/TerminalTests
               -only-testing:PineUITests/TerminalMenuTests
-              -only-testing:PineUITests/AgentAttentionKeyboardUITests
-          # Shard 2 — Welcome & Session (30 tests)
+              -only-testing:PineUITests/SessionRestoreTests
+          # Shard 2 — Welcome & Session (31 tests)
           - shard-name: "Welcome & Session"
             test-classes: >-
               -only-testing:PineUITests/WelcomeWindowTests
-              -only-testing:PineUITests/SessionRestoreTests
+              -only-testing:PineUITests/AgentAttentionKeyboardUITests
               -only-testing:PineUITests/SidebarFolderClickTests
               -only-testing:PineUITests/NativeFileWindowMenuUITests
           # Shard 3 — Navigation (31 tests)

--- a/Pine/Agent/AgentInboxModels.swift
+++ b/Pine/Agent/AgentInboxModels.swift
@@ -44,6 +44,12 @@ nonisolated struct AgentInboxRow: Identifiable, Equatable, Sendable {
             && liveness == .live
             && routeAvailability != .missing
     }
+
+    var canRecover: Bool {
+        !canNavigateToLiveRun
+            && (lifecycle == .paused || lifecycle == .completed)
+            && liveness != .live
+    }
 }
 
 nonisolated struct AgentInboxSection: Identifiable, Equatable, Sendable {

--- a/Pine/Agent/AgentInboxView.swift
+++ b/Pine/Agent/AgentInboxView.swift
@@ -165,6 +165,26 @@ struct AgentInboxView: View {
                 )
             }
             if row.lifecycle != .active, row.liveness != .live {
+                if row.canRecover {
+                    Divider()
+                    Button(Strings.agentInboxResumeSession) {
+                        recover(row.id, action: .resumeVendorSession)
+                    }
+                    Button(Strings.agentInboxNewSession) {
+                        recover(row.id, action: .startNewSession)
+                    }
+                    if let objective = registry.agentTasks.task(
+                        for: row.id
+                    )?.objective {
+                        Button(Strings.agentInboxCopyObjective) {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(
+                                objective,
+                                forType: .string
+                            )
+                        }
+                    }
+                }
                 Divider()
                 Button(Strings.agentInboxDismiss, role: .destructive) {
                     _ = registry.agentTasks.dismissTask(row.id)
@@ -237,7 +257,35 @@ struct AgentInboxView: View {
 
     private func activateSelection() {
         guard let selectedTaskID else { return }
-        navigate(to: selectedTaskID)
+        if snapshot.rows.first(where: { $0.id == selectedTaskID })?
+            .canRecover == true {
+            recover(selectedTaskID, action: .startNewSession)
+        } else {
+            navigate(to: selectedTaskID)
+        }
+    }
+
+    private func recover(
+        _ taskID: UUID,
+        action: AgentTaskRecoveryAction
+    ) {
+        navigationMessage = nil
+        Task { @MainActor in
+            let result = await registry.recoverAgentTaskFromInbox(
+                taskID,
+                action: action,
+                openProjectWindow: { url in openWindow(value: url) }
+            )
+            switch result {
+            case .openedNewSession:
+                navigationMessage = Strings.agentInboxOpenedNewSession
+            case .resumed:
+                navigationMessage = Strings.agentInboxResumedSession
+            case .taskMissing, .projectUnavailable, .unavailable,
+                    .changedWhilePreparing, .launchRejected:
+                navigationMessage = Strings.agentInboxRecoveryUnavailable
+            }
+        }
     }
 
     private func navigate(to taskID: UUID) {

--- a/Pine/Agent/AgentTaskMetadataStore.swift
+++ b/Pine/Agent/AgentTaskMetadataStore.swift
@@ -16,6 +16,9 @@ nonisolated struct AgentTaskPersistenceLimits: Sendable {
     let maxFileBytes: Int
     let maxAgentIdentifierBytes: Int
     let maxProcessStartBytes: Int
+    let maxVendorProviderBytes: Int
+    let maxVendorIdentityBytes: Int
+    let maxExecutableVersionBytes: Int
     let maxTitleBytes: Int
     let maxObjectiveBytes: Int
 
@@ -31,6 +34,9 @@ nonisolated struct AgentTaskPersistenceLimits: Sendable {
         self.maxFileBytes = max(1_024, maxFileBytes)
         maxAgentIdentifierBytes = 128
         maxProcessStartBytes = 512
+        maxVendorProviderBytes = 128
+        maxVendorIdentityBytes = 1_024
+        maxExecutableVersionBytes = 256
         maxTitleBytes = 256
         maxObjectiveBytes = 2_048
     }
@@ -1951,6 +1957,20 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
               run.lastObservedAt >= run.startedAt,
               validOptionalDate(run.endedAt) else {
             return false
+        }
+        if let identity = run.vendorIdentity {
+            guard validText(
+                identity.provider,
+                maximum: limits.maxVendorProviderBytes,
+                allowsEmpty: false
+            ), validText(
+                identity.opaqueIdentifier,
+                maximum: limits.maxVendorIdentityBytes,
+                allowsEmpty: false
+            ), validOptionalText(
+                identity.executableVersion,
+                maximum: limits.maxExecutableVersionBytes
+            ) else { return false }
         }
         if let endedAt = run.endedAt, endedAt < run.startedAt {
             return false

--- a/Pine/Agent/AgentTaskModels.swift
+++ b/Pine/Agent/AgentTaskModels.swift
@@ -152,10 +152,27 @@ nonisolated enum AgentRunLiveness: String, Codable, Sendable {
 }
 
 /// Opaque vendor identity is an adapter hint, never Pine identity or authority.
-/// It is intentionally excluded from persisted `AgentTaskRun` metadata.
-nonisolated struct AgentVendorSessionIdentity: Equatable, Sendable {
+///
+/// It is persisted only in Pine's mode-0600 task metadata so a documented
+/// adapter can offer an explicit resume after restart. Presentation code must
+/// never render either value, and launch code must pass the identifier as one
+/// argument instead of interpolating it into a shell command.
+nonisolated struct AgentVendorSessionIdentity: Codable, Equatable, Sendable {
     let provider: String
     let opaqueIdentifier: String
+    /// Exact executable version observed when the adapter issued the identity.
+    /// A resume is rejected when the immediately re-probed version differs.
+    let executableVersion: String?
+
+    init(
+        provider: String,
+        opaqueIdentifier: String,
+        executableVersion: String? = nil
+    ) {
+        self.provider = provider
+        self.opaqueIdentifier = opaqueIdentifier
+        self.executableVersion = executableVersion
+    }
 }
 
 /// Process-start evidence that prevents PID reuse from extending an old run.
@@ -245,6 +262,7 @@ nonisolated struct AgentTaskRun: Codable, Equatable, Sendable, Identifiable {
         case startedAt
         case lastObservedAt
         case endedAt
+        case vendorIdentity
     }
 
     init(_ input: AgentTaskRunInput) {
@@ -271,7 +289,10 @@ nonisolated struct AgentTaskRun: Codable, Equatable, Sendable, Identifiable {
         startedAt = try values.decode(Date.self, forKey: .startedAt)
         lastObservedAt = try values.decode(Date.self, forKey: .lastObservedAt)
         endedAt = try values.decodeIfPresent(Date.self, forKey: .endedAt)
-        vendorIdentity = nil
+        vendorIdentity = try values.decodeIfPresent(
+            AgentVendorSessionIdentity.self,
+            forKey: .vendorIdentity
+        )
     }
 }
 

--- a/Pine/Agent/AgentTaskRecovery.swift
+++ b/Pine/Agent/AgentTaskRecovery.swift
@@ -1,0 +1,259 @@
+//
+//  AgentTaskRecovery.swift
+//  Pine
+//
+//  Explicit, capability-gated recovery for durable agent tasks (#1307).
+//
+
+import Foundation
+
+nonisolated enum AgentTaskRecoveryAction: Equatable, Sendable {
+    /// Continue a vendor conversation only through a documented adapter.
+    case resumeVendorSession
+    /// Open a fresh shell in the original worktree. This is never described as
+    /// continuing the previous vendor conversation.
+    case startNewSession
+}
+
+nonisolated enum AgentTaskRecoveryUnavailableReason: Equatable, Sendable {
+    case taskNotRecoverable
+    case projectMissing
+    case worktreeMissing
+    case executableMissing
+    case adapterUnavailable
+    case vendorIdentityMissing
+    case vendorIdentityInvalid
+    case versionProbeFailed
+    case versionChanged
+}
+
+/// An executable and argv are kept separate all the way to SwiftTerm. No
+/// recovery path constructs a shell command string.
+nonisolated struct AgentRecoveryProcess: Equatable, Sendable {
+    let executablePath: String
+    let arguments: [String]
+}
+
+nonisolated struct AgentTaskRecoveryPlan: Equatable, Sendable {
+    let taskID: UUID
+    let project: AgentTaskProjectIdentity
+    let action: AgentTaskRecoveryAction
+    let workingDirectory: URL
+    let process: AgentRecoveryProcess?
+    let objective: String?
+}
+
+nonisolated enum AgentTaskRecoveryEvaluation: Equatable, Sendable {
+    case ready(AgentTaskRecoveryPlan)
+    case unavailable(AgentTaskRecoveryUnavailableReason)
+}
+
+/// A reviewed adapter recipe. `identifierArgumentPrefix` and suffix are fixed
+/// data; the opaque ID is inserted as exactly one argv element.
+nonisolated struct AgentTaskResumeRecipe: Equatable, Sendable {
+    let provider: String
+    let agentTypeIdentifier: String
+    let executableAliases: Set<String>
+    let supportedVersions: Set<String>
+    let identifierArgumentPrefix: [String]
+    let identifierArgumentSuffix: [String]
+
+    func arguments(opaqueIdentifier: String) -> [String] {
+        identifierArgumentPrefix
+            + [opaqueIdentifier]
+            + identifierArgumentSuffix
+    }
+}
+
+nonisolated struct AgentTaskRecoveryInspection: Equatable, Sendable {
+    let projectExists: Bool
+    let worktreeExists: Bool
+    let resolvedExecutablePath: String?
+    let executableVersion: String?
+}
+
+/// Pure recovery policy. Filesystem and process probing happen outside this
+/// type, which makes every failure and race outcome deterministic in tests.
+nonisolated enum AgentTaskRecoveryPlanner {
+    static func evaluate(
+        task: AgentTask,
+        action: AgentTaskRecoveryAction,
+        inspection: AgentTaskRecoveryInspection,
+        recipes: [AgentTaskResumeRecipe]
+    ) -> AgentTaskRecoveryEvaluation {
+        guard task.runs.last?.liveness != .live else {
+            return .unavailable(.taskNotRecoverable)
+        }
+        guard inspection.projectExists else {
+            return .unavailable(.projectMissing)
+        }
+        guard inspection.worktreeExists else {
+            return .unavailable(.worktreeMissing)
+        }
+
+        let directory = URL(
+            fileURLWithPath: task.project.canonicalWorktreePath,
+            isDirectory: true
+        ).standardizedFileURL
+
+        switch action {
+        case .startNewSession:
+            guard task.lifecycle == .paused || task.lifecycle == .completed else {
+                return .unavailable(.taskNotRecoverable)
+            }
+            return .ready(AgentTaskRecoveryPlan(
+                taskID: task.id,
+                project: task.project,
+                action: action,
+                workingDirectory: directory,
+                process: nil,
+                objective: task.objective
+            ))
+
+        case .resumeVendorSession:
+            guard task.lifecycle == .paused,
+                  task.origin == .pineLaunched else {
+                return .unavailable(.taskNotRecoverable)
+            }
+            guard let identity = task.runs.last?.vendorIdentity else {
+                return .unavailable(.vendorIdentityMissing)
+            }
+            guard isSafeOpaqueValue(identity.provider, maximumBytes: 128),
+                  isSafeOpaqueValue(
+                      identity.opaqueIdentifier,
+                      maximumBytes: 1_024
+                  ) else {
+                return .unavailable(.vendorIdentityInvalid)
+            }
+            guard let executable = inspection.resolvedExecutablePath else {
+                return .unavailable(.executableMissing)
+            }
+            let executableName = URL(fileURLWithPath: executable)
+                .lastPathComponent.lowercased()
+            guard let recipe = recipes.first(where: {
+                $0.provider == identity.provider
+                    && $0.agentTypeIdentifier == task.descriptor.typeIdentifier
+                    && $0.executableAliases.contains(executableName)
+            }) else {
+                return .unavailable(.adapterUnavailable)
+            }
+            guard let version = inspection.executableVersion else {
+                return .unavailable(.versionProbeFailed)
+            }
+            guard let recordedVersion = identity.executableVersion else {
+                return .unavailable(.versionProbeFailed)
+            }
+            if recordedVersion != version {
+                return .unavailable(.versionChanged)
+            }
+            guard recipe.supportedVersions.contains(version) else {
+                return .unavailable(.versionChanged)
+            }
+            return .ready(AgentTaskRecoveryPlan(
+                taskID: task.id,
+                project: task.project,
+                action: action,
+                workingDirectory: directory,
+                process: AgentRecoveryProcess(
+                    executablePath: executable,
+                    arguments: recipe.arguments(
+                        opaqueIdentifier: identity.opaqueIdentifier
+                    )
+                ),
+                objective: task.objective
+            ))
+        }
+    }
+
+    private static func isSafeOpaqueValue(
+        _ value: String,
+        maximumBytes: Int
+    ) -> Bool {
+        !value.isEmpty
+            && value.utf8.count <= maximumBytes
+            && !value.unicodeScalars.contains(where: {
+                CharacterSet.controlCharacters.contains($0)
+            })
+    }
+}
+
+/// Production inspection is deliberately bounded. The planner is run again
+/// with these fresh values immediately before the user-requested launch.
+nonisolated struct AgentTaskRecoveryInspector: Sendable {
+    let resolver: ExternalToolResolver
+    let processRunner: ProcessRunner
+    let recipes: [AgentTaskResumeRecipe]
+
+    init(
+        resolver: ExternalToolResolver = .fromEnvironment(),
+        processRunner: @escaping ProcessRunner = runRealProcess,
+        recipes: [AgentTaskResumeRecipe] = []
+    ) {
+        self.resolver = resolver
+        self.processRunner = processRunner
+        self.recipes = recipes
+    }
+
+    func inspect(
+        task: AgentTask,
+        action: AgentTaskRecoveryAction
+    ) async -> AgentTaskRecoveryEvaluation {
+        let projectPath = task.project.canonicalProjectPath
+        let worktreePath = task.project.canonicalWorktreePath
+        let executableName = task.descriptor.launchExecutable
+        let resolver = resolver
+        let processRunner = processRunner
+
+        let inspection = await Task.detached(priority: .userInitiated) {
+            var isProjectDirectory: ObjCBool = false
+            var isWorktreeDirectory: ObjCBool = false
+            let fileManager = FileManager.default
+            let projectExists = fileManager.fileExists(
+                atPath: projectPath,
+                isDirectory: &isProjectDirectory
+            ) && isProjectDirectory.boolValue
+            let worktreeExists = fileManager.fileExists(
+                atPath: worktreePath,
+                isDirectory: &isWorktreeDirectory
+            ) && isWorktreeDirectory.boolValue
+
+            guard action == .resumeVendorSession,
+                  let executableName,
+                  let executable = resolver.resolve(tool: executableName),
+                  fileManager.isExecutableFile(atPath: executable) else {
+                return AgentTaskRecoveryInspection(
+                    projectExists: projectExists,
+                    worktreeExists: worktreeExists,
+                    resolvedExecutablePath: nil,
+                    executableVersion: nil
+                )
+            }
+            let result = processRunner(executable, ["--version"], "", 2)
+            let version: String?
+            if !result.timedOut, result.exitCode == 0 {
+                let output = result.stdout.isEmpty ? result.stderr : result.stdout
+                let candidate = output
+                    .split(whereSeparator: \Character.isNewline)
+                    .first
+                    .map(String.init)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                version = candidate?.isEmpty == false ? candidate : nil
+            } else {
+                version = nil
+            }
+            return AgentTaskRecoveryInspection(
+                projectExists: projectExists,
+                worktreeExists: worktreeExists,
+                resolvedExecutablePath: executable,
+                executableVersion: version
+            )
+        }.value
+
+        return AgentTaskRecoveryPlanner.evaluate(
+            task: task,
+            action: action,
+            inspection: inspection,
+            recipes: recipes
+        )
+    }
+}

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -31643,6 +31643,90 @@
         }
       }
     },
+    "agentInbox.copyObjective": {
+      "comment": "Copies the saved task objective without exposing terminal output.",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Ziel kopieren" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Copy Objective" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Copiar objetivo" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Copier l’objectif" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "目的をコピー" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "목표 복사" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Copiar objetivo" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Скопировать цель" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "复制目标" } }
+      }
+    },
+    "agentInbox.newSession": {
+      "comment": "Opens a fresh shell in the task worktree; it does not continue the vendor conversation.",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Neue Sitzung" } },
+        "en": { "stringUnit": { "state": "translated", "value": "New Session" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Nueva sesión" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Nouvelle session" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "新しいセッション" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "새 세션" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Nova sessão" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Новая сессия" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "新建会话" } }
+      }
+    },
+    "agentInbox.openedNewSession": {
+      "comment": "Confirms that recovery opened a fresh shell, not the previous vendor conversation.",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Neue Sitzung geöffnet" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Opened a new session" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Se abrió una sesión nueva" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Nouvelle session ouverte" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "新しいセッションを開きました" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "새 세션을 열었습니다" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Nova sessão aberta" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Открыта новая сессия" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已打开新会话" } }
+      }
+    },
+    "agentInbox.recoveryUnavailable": {
+      "comment": "Shown when task recovery fails validation without exposing sensitive details.",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Sichere Wiederherstellung nicht verfügbar" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Safe recovery is unavailable" } },
+        "es": { "stringUnit": { "state": "translated", "value": "La recuperación segura no está disponible" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "La récupération sécurisée est indisponible" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "安全な復元は利用できません" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "안전한 복구를 사용할 수 없습니다" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "A recuperação segura não está disponível" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Безопасное восстановление недоступно" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "安全恢复不可用" } }
+      }
+    },
+    "agentInbox.resumeSession": {
+      "comment": "Explicitly resumes a vendor conversation when a documented adapter validates it.",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Sitzung fortsetzen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Resume Session" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Reanudar sesión" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Reprendre la session" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "セッションを再開" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "세션 재개" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Retomar sessão" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Продолжить сессию" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "继续会话" } }
+      }
+    },
+    "agentInbox.resumedSession": {
+      "comment": "Confirms a validated vendor conversation resume.",
+      "localizations": {
+        "de": { "stringUnit": { "state": "translated", "value": "Sitzung fortgesetzt" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Session resumed" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Sesión reanudada" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Session reprise" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "セッションを再開しました" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "세션을 재개했습니다" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Sessão retomada" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Сессия продолжена" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "会话已继续" } }
+      }
+    },
     "agentInbox.routeUnavailable": {
       "comment": "Shown when an Inbox route cannot be verified.",
       "isCommentAutoGenerated": false,

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -1449,10 +1449,17 @@ final class PaneManager {
     /// Adds a terminal tab through the pane owner so creation and focus
     /// routing cannot disagree about the active pane.
     @discardableResult
-    func addTerminalTab(in paneID: PaneID, workingDirectory: URL?) -> TerminalTab? {
+    func addTerminalTab(
+        in paneID: PaneID,
+        workingDirectory: URL?,
+        initialProcess: TerminalInitialProcess? = nil
+    ) -> TerminalTab? {
         guard let terminalState = terminalStates[paneID] else { return nil }
         activePaneID = paneID
-        let tab = terminalState.addTab(workingDirectory: workingDirectory)
+        let tab = terminalState.addTab(
+            workingDirectory: workingDirectory,
+            initialProcess: initialProcess
+        )
         recordTabActivation(paneID: paneID, tabID: tab.id, contentType: .terminal)
         return tab
     }
@@ -1487,7 +1494,10 @@ final class PaneManager {
     /// Creates a terminal pane spanning the full width at the bottom of the editor area.
     /// Wraps the entire current root in a vertical split with the terminal below.
     @discardableResult
-    func createTerminalPaneAtBottom(workingDirectory: URL?) -> PaneID {
+    func createTerminalPaneAtBottom(
+        workingDirectory: URL?,
+        initialProcess: TerminalInitialProcess? = nil
+    ) -> PaneID {
         let newID = PaneID()
         let terminalLeaf = PaneNode.leaf(newID, .terminal)
         root = .split(.vertical, first: root, second: terminalLeaf, ratio: 0.6)
@@ -1495,7 +1505,10 @@ final class PaneManager {
         let state = makeTerminalPaneState(for: newID)
         terminalStates[newID] = state
         activePaneID = newID
-        state.addTab(workingDirectory: workingDirectory)
+        state.addTab(
+            workingDirectory: workingDirectory,
+            initialProcess: initialProcess
+        )
         return newID
     }
 

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -14,6 +14,16 @@ nonisolated enum AgentInboxNavigationResult: Equatable, Sendable {
     case routeStale
 }
 
+nonisolated enum AgentInboxRecoveryResult: Equatable, Sendable {
+    case openedNewSession(terminalID: UUID)
+    case resumed(terminalID: UUID)
+    case taskMissing
+    case projectUnavailable
+    case unavailable(AgentTaskRecoveryUnavailableReason)
+    case changedWhilePreparing
+    case launchRejected
+}
+
 /// Manages open projects and recent project history.
 /// Each project directory maps to a single ProjectManager instance.
 @MainActor
@@ -43,6 +53,7 @@ final class ProjectRegistry: LSPSettingsObserver {
     private static let maxRecentProjects = 10
     @ObservationIgnored private let defaults: UserDefaults
     @ObservationIgnored private let fileManager: FileManager
+    @ObservationIgnored private let agentRecoveryInspector: AgentTaskRecoveryInspector
 
     /// Serializes settings lifecycle changes so rapid Apply/Reset operations
     /// cannot race each other across projects.
@@ -54,6 +65,7 @@ final class ProjectRegistry: LSPSettingsObserver {
         defaults: UserDefaults = .standard,
         fileManager: FileManager = .default,
         agentTasks: AgentTaskRegistry = AgentTaskRegistry(),
+        agentRecoveryInspector: AgentTaskRecoveryInspector = AgentTaskRecoveryInspector(),
         clearRecentProjects: Bool = CommandLine.arguments.contains(
             "--clear-recent-projects"
         )
@@ -62,6 +74,7 @@ final class ProjectRegistry: LSPSettingsObserver {
         self.agentTasks = agentTasks
         self.defaults = defaults
         self.fileManager = fileManager
+        self.agentRecoveryInspector = agentRecoveryInspector
         if clearRecentProjects {
             defaults.removeObject(forKey: Self.recentProjectsKey)
         }
@@ -381,6 +394,110 @@ final class ProjectRegistry: LSPSettingsObserver {
         _ = agentTasks.setReviewed(true, taskID: taskID)
         activate()
         return .focused(route)
+    }
+
+    /// Recovers a durable task only after an explicit Inbox action. The task,
+    /// project binding, executable and adapter version are inspected again
+    /// after the project window is presented and immediately before launch.
+    func recoverAgentTaskFromInbox(
+        _ taskID: UUID,
+        action: AgentTaskRecoveryAction,
+        openProjectWindow: @escaping @MainActor (URL) -> Void,
+        waitUntilPresented: (@MainActor (ProjectManager) async -> Bool)? = nil,
+        activateApplication: (@MainActor (ProjectManager) -> Void)? = nil
+    ) async -> AgentInboxRecoveryResult {
+        guard let initialTask = agentTasks.task(for: taskID) else {
+            return .taskMissing
+        }
+        let rawURL = URL(
+            fileURLWithPath: initialTask.project.canonicalWorktreePath,
+            isDirectory: true
+        )
+        let projectURL = await Task.detached {
+            Self.canonicalProjectURL(rawURL)
+        }.value
+        guard projectURL.path == initialTask.project.canonicalWorktreePath,
+              let manager = projectManager(for: projectURL),
+              manager.rootURL == projectURL else {
+            return .projectUnavailable
+        }
+
+        if backgroundProjects.contains(projectURL) {
+            openProjectWindow(projectURL)
+        }
+        let presented = if let waitUntilPresented {
+            await waitUntilPresented(manager)
+        } else {
+            await manager.awaitDialogOwnerWindow() != nil
+        }
+        guard presented else { return .projectUnavailable }
+        guard agentTasks.task(for: taskID) == initialTask else {
+            return .changedWhilePreparing
+        }
+
+        let evaluation = await agentRecoveryInspector.inspect(
+            task: initialTask,
+            action: action
+        )
+        guard agentTasks.task(for: taskID) == initialTask else {
+            return .changedWhilePreparing
+        }
+        guard case .ready(let plan) = evaluation else {
+            if case .unavailable(let reason) = evaluation {
+                return .unavailable(reason)
+            }
+            return .launchRejected
+        }
+
+        let result = manager.terminal.launchAgentRecovery(plan)
+        let terminalID: UUID
+        switch result {
+        case .openedNewSession(let id):
+            terminalID = id
+        case .resumed(let id):
+            terminalID = id
+        case .rejected:
+            return .launchRejected
+        }
+        guard let route = resolveAgentRecoveryTerminal(
+            terminalID,
+            in: manager
+        ), manager.paneManager.selectTerminalTab(
+            route.tabID,
+            in: PaneID(id: route.paneID)
+        ) else { return .launchRejected }
+
+        if let activateApplication {
+            activateApplication(manager)
+        } else if let window = manager.dialogOwnerWindow {
+            if window.isMiniaturized { window.deminiaturize(nil) }
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate()
+        }
+        return switch result {
+        case .openedNewSession: .openedNewSession(terminalID: terminalID)
+        case .resumed: .resumed(terminalID: terminalID)
+        case .rejected: .launchRejected
+        }
+    }
+
+    private func resolveAgentRecoveryTerminal(
+        _ terminalID: UUID,
+        in manager: ProjectManager
+    ) -> AgentTaskRoute? {
+        var routes: [AgentTaskRoute] = []
+        for paneID in manager.paneManager.terminalPaneIDs {
+            guard manager.paneManager.terminalState(for: paneID)?
+                .terminalTabs.contains(where: { $0.id == terminalID }) == true else {
+                continue
+            }
+            routes.append(AgentTaskRoute(
+                paneID: paneID.id,
+                tabID: terminalID,
+                terminalID: terminalID
+            ))
+        }
+        return routes.count == 1 ? routes[0] : nil
     }
 
     private func matches(

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -147,8 +147,95 @@ final class ProjectRegistry: LSPSettingsObserver {
         pm.loadDirectory(url: canonical)
         openProjects[canonical] = pm
         addToRecent(canonical)
+        #if DEBUG
+        seedAgentRecoveryUITestFixture(
+            manager: pm,
+            project: identity
+        )
+        #endif
         return pm
     }
+
+    #if DEBUG
+    /// Creates a durable, terminated Pine-owned task only for the explicit
+    /// recovery XCUITest. A second launch loads the persisted card instead of
+    /// seeding another one, exercising the real restore boundary.
+    private func seedAgentRecoveryUITestFixture(
+        manager: ProjectManager,
+        project: AgentTaskProjectIdentity
+    ) {
+        guard ProcessInfo.processInfo.arguments.contains(
+            "--ui-test-agent-recovery"
+        ) else { return }
+        Task { @MainActor [weak self, weak manager] in
+            guard let self, let manager else { return }
+            _ = await agentTasks.flushPersistence(
+                maximumDuration: .seconds(2)
+            )
+            guard !agentTasks.tasks.contains(where: { $0.project == project }) else {
+                return
+            }
+            let paneID = manager.paneManager.createTerminalPaneAtBottom(
+                workingDirectory: manager.rootURL
+            )
+            manager.terminal.lastActiveTerminalPaneID = paneID
+            guard let tab = manager.paneManager.terminalState(for: paneID)?
+                .activeTab else { return }
+            let startedAt = Date()
+            let context = AgentTaskBridgeContext(
+                project: project,
+                route: AgentTaskRoute(
+                    paneID: paneID.id,
+                    tabID: tab.id,
+                    terminalID: tab.id
+                ),
+                origin: .pineLaunched,
+                observedAt: startedAt
+            )
+            let launch = agentTasks.preparePineLaunch(
+                descriptor: AgentDescriptor(
+                    agentType: .codex,
+                    launchExecutable: "codex"
+                ),
+                context: context,
+                title: "Recovery fixture",
+                objective: "Finish the Pine 2.0 release",
+                boundary: AgentTaskLaunchBoundary(
+                    generationFloor: 0,
+                    capturedAt: startedAt
+                )
+            )
+            guard case .reserved(let reservation) = launch,
+                  agentTasks.armLaunch(reservation) else { return }
+            let session = AgentSession(
+                id: UUID(
+                    uuidString: "00000000-0000-0000-0000-000000001307"
+                ) ?? UUID(),
+                agentType: .codex,
+                state: .executing,
+                startedAt: startedAt
+            )
+            _ = session.bindProcessEvidence(AgentProcessEvidence(
+                processIdentifier: 13_007,
+                processGeneration: 1,
+                startIdentifier: "ui-recovery-fixture",
+                observedStartedAt: startedAt,
+                startIsAuthoritative: true
+            ))
+            agentTasks.bridge(
+                session,
+                replacing: nil,
+                context: context,
+                reservation: reservation
+            )
+            session.applyLiveness(.terminated)
+            agentTasks.bridge(session, replacing: session, context: context)
+            _ = await agentTasks.flushPersistence(
+                maximumDuration: .seconds(2)
+            )
+        }
+    }
+    #endif
 
     /// Opens a project via folder picker. Returns the project URL if opened.
     @discardableResult

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -174,12 +174,13 @@ final class ProjectRegistry: LSPSettingsObserver {
                 return
             }
             let startedAt = Date()
+            let terminalID = UUID()
             let context = AgentTaskBridgeContext(
                 project: project,
                 route: AgentTaskRoute(
                     paneID: UUID(),
-                    tabID: UUID(),
-                    terminalID: UUID()
+                    tabID: terminalID,
+                    terminalID: terminalID
                 ),
                 origin: .pineLaunched,
                 observedAt: startedAt

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -149,7 +149,6 @@ final class ProjectRegistry: LSPSettingsObserver {
         addToRecent(canonical)
         #if DEBUG
         seedAgentRecoveryUITestFixture(
-            manager: pm,
             project: identity
         )
         #endif
@@ -161,33 +160,26 @@ final class ProjectRegistry: LSPSettingsObserver {
     /// recovery XCUITest. A second launch loads the persisted card instead of
     /// seeding another one, exercising the real restore boundary.
     private func seedAgentRecoveryUITestFixture(
-        manager: ProjectManager,
         project: AgentTaskProjectIdentity
     ) {
         guard ProcessInfo.processInfo.arguments.contains(
             "--ui-test-agent-recovery"
         ) else { return }
-        Task { @MainActor [weak self, weak manager] in
-            guard let self, let manager else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
             _ = await agentTasks.flushPersistence(
                 maximumDuration: .seconds(2)
             )
             guard !agentTasks.tasks.contains(where: { $0.project == project }) else {
                 return
             }
-            let paneID = manager.paneManager.createTerminalPaneAtBottom(
-                workingDirectory: manager.rootURL
-            )
-            manager.terminal.lastActiveTerminalPaneID = paneID
-            guard let tab = manager.paneManager.terminalState(for: paneID)?
-                .activeTab else { return }
             let startedAt = Date()
             let context = AgentTaskBridgeContext(
                 project: project,
                 route: AgentTaskRoute(
-                    paneID: paneID.id,
-                    tabID: tab.id,
-                    terminalID: tab.id
+                    paneID: UUID(),
+                    tabID: UUID(),
+                    terminalID: UUID()
                 ),
                 origin: .pineLaunched,
                 observedAt: startedAt

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -631,6 +631,18 @@ enum Strings {
     static let agentInboxDismiss: LocalizedStringKey = "agentInbox.dismiss"
     static let agentInboxRouteUnavailable: LocalizedStringKey =
         "agentInbox.routeUnavailable"
+    static let agentInboxResumeSession: LocalizedStringKey =
+        "agentInbox.resumeSession"
+    static let agentInboxNewSession: LocalizedStringKey =
+        "agentInbox.newSession"
+    static let agentInboxCopyObjective: LocalizedStringKey =
+        "agentInbox.copyObjective"
+    static let agentInboxOpenedNewSession: LocalizedStringKey =
+        "agentInbox.openedNewSession"
+    static let agentInboxResumedSession: LocalizedStringKey =
+        "agentInbox.resumedSession"
+    static let agentInboxRecoveryUnavailable: LocalizedStringKey =
+        "agentInbox.recoveryUnavailable"
 
     // MARK: - Agent notifications (#1306)
     static let agentNotificationsSettingsTitle: LocalizedStringKey =

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -8,6 +8,12 @@
 
 import SwiftUI
 
+nonisolated enum AgentTaskRecoveryLaunchResult: Equatable, Sendable {
+    case openedNewSession(terminalID: UUID)
+    case resumed(terminalID: UUID)
+    case rejected
+}
+
 @MainActor
 @Observable
 final class TerminalManager {
@@ -413,6 +419,73 @@ final class TerminalManager {
     }
 
     // MARK: - Tab creation
+
+    /// Applies a freshly inspected recovery plan. Vendor resume is reserved
+    /// and armed before SwiftUI can mount the tab and start its direct child.
+    /// A failed reservation removes the unstarted tab and leaves prior task
+    /// history untouched.
+    func launchAgentRecovery(
+        _ plan: AgentTaskRecoveryPlan
+    ) -> AgentTaskRecoveryLaunchResult {
+        guard let pm = paneManager,
+              let project = agentTaskProject,
+              project == plan.project,
+              project.canonicalWorktreePath
+                == plan.workingDirectory.standardizedFileURL.path else {
+            return .rejected
+        }
+        let initialProcess = plan.process.map {
+            TerminalInitialProcess(
+                executablePath: $0.executablePath,
+                arguments: $0.arguments
+            )
+        }
+        guard let (paneID, tab) = createTerminalTabForRecovery(
+            workingDirectory: plan.workingDirectory,
+            initialProcess: initialProcess
+        ) else { return .rejected }
+
+        switch plan.action {
+        case .startNewSession:
+            return .openedNewSession(terminalID: tab.id)
+        case .resumeVendorSession:
+            let result = prepareAgentResume(taskID: plan.taskID, in: tab)
+            guard case .reserved(let reservation) = result,
+                  agentTaskRegistry?.armLaunch(reservation) == true else {
+                cancelAgentLaunch(in: tab)
+                pm.terminalState(for: paneID)?.removeTab(id: tab.id)
+                return .rejected
+            }
+            return .resumed(terminalID: tab.id)
+        }
+    }
+
+    private func createTerminalTabForRecovery(
+        workingDirectory: URL,
+        initialProcess: TerminalInitialProcess?
+    ) -> (PaneID, TerminalTab)? {
+        guard let pm = paneManager else { return nil }
+        ensureAgentDetectionStarted()
+        if let paneID = lastActiveTerminalPaneID,
+           let state = pm.terminalState(for: paneID) {
+            let tab = state.addTab(
+                workingDirectory: workingDirectory,
+                initialProcess: initialProcess
+            )
+            pm.activePaneID = paneID
+            return (paneID, tab)
+        }
+        let paneID = pm.createTerminalPaneAtBottom(
+            workingDirectory: workingDirectory,
+            initialProcess: initialProcess
+        )
+        lastActiveTerminalPaneID = paneID
+        pm.pruneEmptyEditorLeaves()
+        guard let tab = pm.terminalState(for: paneID)?.activeTab else {
+            return nil
+        }
+        return (paneID, tab)
+    }
 
     /// Creates a terminal tab in the last-used terminal pane.
     /// If no terminal pane exists, creates one below the given editor pane.

--- a/Pine/TerminalPaneState.swift
+++ b/Pine/TerminalPaneState.swift
@@ -87,14 +87,20 @@ final class TerminalPaneState {
     }
 
     @discardableResult
-    func addTab(workingDirectory: URL?) -> TerminalTab {
+    func addTab(
+        workingDirectory: URL?,
+        initialProcess: TerminalInitialProcess? = nil
+    ) -> TerminalTab {
         let number = nextTabNumber
         nextTabNumber += 1
         let tab = TerminalTab(
             name: Strings.terminalNumberedName(number),
             themeSettings: themeSettings
         )
-        tab.configure(workingDirectory: workingDirectory)
+        tab.configure(
+            workingDirectory: workingDirectory,
+            initialProcess: initialProcess
+        )
         onTabCreated?(tab)
         terminalTabs.append(tab)
         activeTerminalID = tab.id

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -1628,6 +1628,14 @@ struct TerminalSearchMatch {
     let length: Int
 }
 
+/// Optional first child for a terminal tab. Keeping the executable and argv
+/// separate prevents recovery and extension launches from passing through a
+/// login shell or re-parsing opaque values.
+nonisolated struct TerminalInitialProcess: Equatable, Sendable {
+    let executablePath: String
+    let arguments: [String]
+}
+
 // MARK: - Модель вкладки терминала
 
 /// Одна вкладка терминала. Содержит SwiftTerm LocalProcessTerminalView.
@@ -1701,6 +1709,11 @@ final class TerminalTab: Identifiable, Hashable {
     private let agentHandoffSettings: AgentHandoffSettings
     private var processStarted = false
     private var workingDirectory: URL?
+    private var initialProcess: TerminalInitialProcess?
+
+    /// Value-only diagnostic used to prove that recovery keeps argv separate
+    /// before SwiftTerm starts the child.
+    var configuredInitialProcess: TerminalInitialProcess? { initialProcess }
 
     /// KVO observation token for `NSApp.effectiveAppearance` — re-applies
     /// palette and background when the user switches between light/dark mode.
@@ -1836,8 +1849,12 @@ final class TerminalTab: Identifiable, Hashable {
     }
 
     /// Сохраняет рабочую директорию для отложенного запуска
-    func configure(workingDirectory: URL?) {
+    func configure(
+        workingDirectory: URL?,
+        initialProcess: TerminalInitialProcess? = nil
+    ) {
         self.workingDirectory = workingDirectory
+        self.initialProcess = initialProcess
     }
 
     /// Builds the environment dictionary for the terminal child process.
@@ -1933,9 +1950,12 @@ final class TerminalTab: Identifiable, Hashable {
         let envStrings = env.map { "\($0.key)=\($0.value)" }
         let dir = resolveWorkingDirectory()
 
+        let executable = initialProcess?.executablePath
+            ?? shellSettings.resolvedShellPath
+        let arguments = initialProcess?.arguments ?? shellSettings.shellArgs
         terminalView.startProcess(
-            executable: shellSettings.resolvedShellPath,
-            args: shellSettings.shellArgs,
+            executable: executable,
+            args: arguments,
             environment: envStrings,
             execName: nil,
             currentDirectory: dir

--- a/PineTests/AgentInboxTests.swift
+++ b/PineTests/AgentInboxTests.swift
@@ -242,6 +242,87 @@ struct AgentInboxTests {
         )))
     }
 
+    @Test("explicit new session preserves history and routes one exact terminal")
+    func explicitNewSessionRecovery() async throws {
+        let fixture = try InboxProjectFixture()
+        defer { fixture.cleanup() }
+        let taskRegistry = AgentTaskRegistry()
+        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projectRegistry.projectManager(for: fixture.project)
+        )
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        manager.terminal.lastActiveTerminalPaneID = pane
+        let state = try #require(manager.paneManager.terminalState(for: pane))
+        let originalTab = try #require(state.activeTab)
+        let projectIdentity = project(fixture.project.standardizedFileURL.path)
+        let routeContext = AgentTaskBridgeContext(
+            project: projectIdentity,
+            route: AgentTaskRoute(
+                paneID: pane.id,
+                tabID: originalTab.id,
+                terminalID: originalTab.id
+            ),
+            origin: .pineLaunched,
+            observedAt: Date(timeIntervalSince1970: 50)
+        )
+        let descriptor = AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        )
+        let launch = taskRegistry.preparePineLaunch(
+            descriptor: descriptor,
+            context: routeContext,
+            title: "Recovery fixture",
+            objective: "Finish the release",
+            boundary: AgentTaskLaunchBoundary(
+                generationFloor: 50,
+                capturedAt: routeContext.observedAt
+            )
+        )
+        let reservation: AgentTaskLaunchReservation
+        guard case .reserved(let value) = launch else {
+            Issue.record("Expected Pine-owned launch reservation")
+            return
+        }
+        reservation = value
+        #expect(taskRegistry.armLaunch(reservation))
+        let session = makeSession(seed: 51, state: .executing)
+        taskRegistry.bridge(
+            session,
+            replacing: nil,
+            context: routeContext,
+            reservation: reservation
+        )
+        let taskID = try #require(taskRegistry.taskID(forSessionID: session.id))
+        session.applyLiveness(.terminated)
+        taskRegistry.bridge(
+            session,
+            replacing: session,
+            context: routeContext
+        )
+        let historicalTask = try #require(taskRegistry.task(for: taskID))
+        #expect(historicalTask.lifecycle == .paused)
+
+        let result = await projectRegistry.recoverAgentTaskFromInbox(
+            taskID,
+            action: .startNewSession,
+            openProjectWindow: { _ in },
+            waitUntilPresented: { _ in true },
+            activateApplication: { _ in }
+        )
+        guard case .openedNewSession(let terminalID) = result else {
+            Issue.record("Expected one fresh terminal")
+            return
+        }
+        #expect(state.terminalTabs.map(\.id) == [originalTab.id, terminalID])
+        #expect(state.activeTerminalID == terminalID)
+        #expect(state.pendingFocusTabID == terminalID)
+        #expect(taskRegistry.task(for: taskID) == historicalTask)
+    }
+
     private func makeTask(
         seed: Int,
         project path: String,

--- a/PineTests/AgentTaskRecoveryTests.swift
+++ b/PineTests/AgentTaskRecoveryTests.swift
@@ -1,0 +1,290 @@
+import Foundation
+import Testing
+@testable import Pine
+
+@MainActor
+struct AgentTaskRecoveryTests {
+    @Test("New session is an honest shell plan with the saved objective")
+    func newSessionPlan() throws {
+        let task = makeTask()
+        let result = AgentTaskRecoveryPlanner.evaluate(
+            task: task,
+            action: .startNewSession,
+            inspection: inspection(),
+            recipes: []
+        )
+        guard case .ready(let plan) = result else {
+            Issue.record("Expected a recoverable new session")
+            return
+        }
+        #expect(plan.action == .startNewSession)
+        #expect(plan.process == nil)
+        #expect(plan.objective == "Finish the release")
+        #expect(plan.workingDirectory.path == task.project.canonicalWorktreePath)
+    }
+
+    @Test("Missing and removed directories have distinct deterministic outcomes")
+    func directoryOutcomes() {
+        let task = makeTask()
+        #expect(AgentTaskRecoveryPlanner.evaluate(
+            task: task,
+            action: .startNewSession,
+            inspection: inspection(projectExists: false),
+            recipes: []
+        ) == .unavailable(.projectMissing))
+        #expect(AgentTaskRecoveryPlanner.evaluate(
+            task: task,
+            action: .startNewSession,
+            inspection: inspection(worktreeExists: false),
+            recipes: []
+        ) == .unavailable(.worktreeMissing))
+    }
+
+    @Test("Resume requires a documented adapter and persisted vendor identity")
+    func capabilityGate() {
+        var missingIdentity = makeTask()
+        missingIdentity.runs[0].vendorIdentity = nil
+        #expect(AgentTaskRecoveryPlanner.evaluate(
+            task: missingIdentity,
+            action: .resumeVendorSession,
+            inspection: inspection(),
+            recipes: []
+        ) == .unavailable(.vendorIdentityMissing))
+
+        #expect(AgentTaskRecoveryPlanner.evaluate(
+            task: makeTask(),
+            action: .resumeVendorSession,
+            inspection: inspection(),
+            recipes: []
+        ) == .unavailable(.adapterUnavailable))
+    }
+
+    @Test("Opaque session ID remains one argv element without shell parsing")
+    func opaqueIdentifierIsOneArgument() {
+        let opaqueID = "session; touch /tmp/never-run $(whoami)"
+        let task = makeTask(opaqueIdentifier: opaqueID)
+        let recipe = AgentTaskResumeRecipe(
+            provider: "example",
+            agentTypeIdentifier: task.descriptor.typeIdentifier,
+            executableAliases: ["codex"],
+            supportedVersions: ["1.2.3"],
+            identifierArgumentPrefix: ["resume", "--session"],
+            identifierArgumentSuffix: ["--no-update"]
+        )
+        let result = AgentTaskRecoveryPlanner.evaluate(
+            task: task,
+            action: .resumeVendorSession,
+            inspection: inspection(),
+            recipes: [recipe]
+        )
+        guard case .ready(let plan) = result else {
+            Issue.record("Expected documented resume plan")
+            return
+        }
+        #expect(plan.process?.executablePath == "/usr/local/bin/codex")
+        #expect(plan.process?.arguments == [
+            "resume", "--session", opaqueID, "--no-update",
+        ])
+    }
+
+    @Test("Executable and version changes fail closed")
+    func executableAndVersionChanges() {
+        let task = makeTask()
+        let recipe = AgentTaskResumeRecipe(
+            provider: "example",
+            agentTypeIdentifier: task.descriptor.typeIdentifier,
+            executableAliases: ["codex"],
+            supportedVersions: ["1.2.3"],
+            identifierArgumentPrefix: ["resume"],
+            identifierArgumentSuffix: []
+        )
+        #expect(AgentTaskRecoveryPlanner.evaluate(
+            task: task,
+            action: .resumeVendorSession,
+            inspection: inspection(executable: nil),
+            recipes: [recipe]
+        ) == .unavailable(.executableMissing))
+        #expect(AgentTaskRecoveryPlanner.evaluate(
+            task: task,
+            action: .resumeVendorSession,
+            inspection: inspection(version: "2.0.0"),
+            recipes: [recipe]
+        ) == .unavailable(.versionChanged))
+        #expect(AgentTaskRecoveryPlanner.evaluate(
+            task: task,
+            action: .resumeVendorSession,
+            inspection: inspection(version: nil),
+            recipes: [recipe]
+        ) == .unavailable(.versionProbeFailed))
+
+        var unversionedTask = task
+        unversionedTask.runs[0].vendorIdentity = AgentVendorSessionIdentity(
+            provider: "example",
+            opaqueIdentifier: "opaque-session-123"
+        )
+        #expect(AgentTaskRecoveryPlanner.evaluate(
+            task: unversionedTask,
+            action: .resumeVendorSession,
+            inspection: inspection(),
+            recipes: [recipe]
+        ) == .unavailable(.versionProbeFailed))
+    }
+
+    @Test("Control characters in persisted identity are rejected")
+    func invalidOpaqueIdentity() {
+        let task = makeTask(opaqueIdentifier: "session\nsecret")
+        #expect(AgentTaskRecoveryPlanner.evaluate(
+            task: task,
+            action: .resumeVendorSession,
+            inspection: inspection(),
+            recipes: []
+        ) == .unavailable(.vendorIdentityInvalid))
+    }
+
+    @Test("Completed tasks may start fresh but cannot resume a finished session")
+    func completedTaskRecoveryPolicy() {
+        var task = makeTask()
+        task.lifecycle = .completed
+        let recipe = AgentTaskResumeRecipe(
+            provider: "example",
+            agentTypeIdentifier: task.descriptor.typeIdentifier,
+            executableAliases: ["codex"],
+            supportedVersions: ["1.2.3"],
+            identifierArgumentPrefix: ["resume"],
+            identifierArgumentSuffix: []
+        )
+        #expect(AgentTaskRecoveryPlanner.evaluate(
+            task: task,
+            action: .resumeVendorSession,
+            inspection: inspection(),
+            recipes: [recipe]
+        ) == .unavailable(.taskNotRecoverable))
+        guard case .ready(let plan) = AgentTaskRecoveryPlanner.evaluate(
+            task: task,
+            action: .startNewSession,
+            inspection: inspection(),
+            recipes: []
+        ) else {
+            Issue.record("Expected completed task to allow a fresh session")
+            return
+        }
+        #expect(plan.process == nil)
+    }
+
+    @Test("Inspector revalidates an executable cached before it was removed")
+    func removedCachedExecutable() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineRecovery-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: root,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+        let executable = root.appendingPathComponent("codex")
+        try Data().write(to: executable)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: executable.path
+        )
+        let resolver = ExternalToolResolver(searchDirectories: [root.path])
+        #expect(resolver.resolve(tool: "codex") == executable.path)
+        try FileManager.default.removeItem(at: executable)
+
+        let inspector = AgentTaskRecoveryInspector(
+            resolver: resolver,
+            processRunner: { _, _, _, _ in
+                Issue.record("Removed executable must not be launched")
+                return ProcessRunResult(
+                    stdout: "",
+                    stderr: "",
+                    exitCode: 0,
+                    timedOut: false
+                )
+            },
+            recipes: []
+        )
+        #expect(await inspector.inspect(
+            task: makeTask(root: root.path),
+            action: .resumeVendorSession
+        ) == .unavailable(.executableMissing))
+    }
+
+    private func makeTask(
+        opaqueIdentifier: String = "opaque-session-123",
+        root: String = "/tmp/pine-recovery-project"
+    ) -> AgentTask {
+        let root = URL(fileURLWithPath: root)
+            .standardizedFileURL.path
+        let identity = AgentTaskProjectIdentity(
+            canonicalProjectPath: root,
+            canonicalWorktreePath: root
+        )
+        let route = AgentTaskRoute(
+            paneID: UUID(),
+            tabID: UUID(),
+            terminalID: UUID(),
+            availability: .missing
+        )
+        // Persisted routes always use the terminal identity for tab identity.
+        let validRoute = AgentTaskRoute(
+            paneID: route.paneID,
+            tabID: route.terminalID,
+            terminalID: route.terminalID,
+            availability: .missing
+        )
+        let context = AgentTaskBridgeContext(
+            project: identity,
+            route: validRoute,
+            origin: .pineLaunched,
+            observedAt: Date(timeIntervalSince1970: 100)
+        )
+        var task = AgentTask(
+            descriptor: AgentDescriptor(
+                agentType: .codex,
+                launchExecutable: "codex"
+            ),
+            context: context,
+            title: "Release",
+            objective: "Finish the release"
+        )
+        var run = AgentTaskRun(AgentTaskRunInput(
+            id: UUID(),
+            terminalID: validRoute.terminalID,
+            process: AgentProcessEvidence(
+                processIdentifier: nil,
+                processGeneration: 7,
+                startIdentifier: nil,
+                observedStartedAt: Date(timeIntervalSince1970: 100)
+            ),
+            status: AgentTaskRunStatus(
+                state: .done,
+                liveness: .terminated,
+                observedAt: Date(timeIntervalSince1970: 110)
+            )
+        ))
+        run.vendorIdentity = AgentVendorSessionIdentity(
+            provider: "example",
+            opaqueIdentifier: opaqueIdentifier,
+            executableVersion: "1.2.3"
+        )
+        task.runs = [run]
+        task.lifecycle = .paused
+        task.updatedAt = Date(timeIntervalSince1970: 110)
+        task.lastActivityAt = Date(timeIntervalSince1970: 110)
+        return task
+    }
+
+    private func inspection(
+        projectExists: Bool = true,
+        worktreeExists: Bool = true,
+        executable: String? = "/usr/local/bin/codex",
+        version: String? = "1.2.3"
+    ) -> AgentTaskRecoveryInspection {
+        AgentTaskRecoveryInspection(
+            projectExists: projectExists,
+            worktreeExists: worktreeExists,
+            resolvedExecutablePath: executable,
+            executableVersion: version
+        )
+    }
+}

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -1972,7 +1972,7 @@ struct AgentTaskRegistryTests {
         #expect(loaded.tasks.isEmpty)
     }
 
-    @Test("persisted metadata excludes session-private content")
+    @Test("persisted metadata excludes content and keeps bounded recovery identity")
     func persistencePrivacy() async throws {
         let fixture = try PersistenceFixture()
         defer { fixture.cleanup() }
@@ -2030,7 +2030,7 @@ struct AgentTaskRegistryTests {
         #expect(!persisted.contains(secretPrompt))
         #expect(!persisted.contains(terminalOutput))
         #expect(!persisted.contains(credential))
-        #expect(!persisted.contains(vendorCanary))
+        #expect(persisted.contains(vendorCanary))
         #expect(!persisted.contains("environment"))
         #expect(!persisted.contains("transcript"))
         #expect(!persisted.contains("prompt"))
@@ -2063,8 +2063,15 @@ struct AgentTaskRegistryTests {
         let run = try #require((task["runs"] as? [[String: Any]])?.first)
         #expect(Set(run.keys) == [
             "id", "lastObservedAt", "liveness", "process", "startedAt",
-            "state", "terminalID",
+            "state", "terminalID", "vendorIdentity",
         ])
+        let vendorIdentity = try #require(
+            run["vendorIdentity"] as? [String: Any]
+        )
+        #expect(Set(vendorIdentity.keys) == [
+            "opaqueIdentifier", "provider",
+        ])
+        #expect(vendorIdentity["opaqueIdentifier"] as? String == vendorCanary)
         let process = try #require(run["process"] as? [String: Any])
         #expect(Set(process.keys) == [
             "observedStartedAt", "processGeneration",
@@ -2072,7 +2079,7 @@ struct AgentTaskRegistryTests {
         let forbiddenKeys: Set<String> = [
             "prompt", "command", "arguments", "environment", "output",
             "transcript", "fileContents", "activitySummary", "credentials",
-            "vendorIdentity", "processIdentifier", "startIdentifier",
+            "processIdentifier", "startIdentifier",
         ]
         func assertNoForbiddenKeys(_ value: Any) {
             if let object = value as? [String: Any] {
@@ -2083,6 +2090,12 @@ struct AgentTaskRegistryTests {
             }
         }
         assertNoForbiddenKeys(root)
+
+        let loaded = await store.load(project: identity)
+        #expect(
+            loaded.tasks.first?.runs.first?.vendorIdentity
+                == privateTask.runs.first?.vendorIdentity
+        )
     }
 
     @Test("schema v1 metadata migrates to revisioned v2")

--- a/PineTests/TerminalPaneStateTests.swift
+++ b/PineTests/TerminalPaneStateTests.swift
@@ -24,6 +24,19 @@ struct TerminalPaneStateTests {
         #expect(state.activeTerminalID == tab.id)
     }
 
+    @Test func addTab_keepsDirectExecutableAndArgumentsSeparate() {
+        let state = TerminalPaneState()
+        let process = TerminalInitialProcess(
+            executablePath: "/usr/local/bin/agent",
+            arguments: ["resume", "opaque; $(never-evaluate)"]
+        )
+        let tab = state.addTab(
+            workingDirectory: URL(fileURLWithPath: "/tmp"),
+            initialProcess: process
+        )
+        #expect(tab.configuredInitialProcess == process)
+    }
+
     @Test func addMultipleTabs_activeIsLast() {
         let state = TerminalPaneState()
         _ = state.addTab(workingDirectory: nil)

--- a/PineUITests/WelcomeWindowTests.swift
+++ b/PineUITests/WelcomeWindowTests.swift
@@ -82,6 +82,55 @@ final class WelcomeWindowTests: PineUITestCase {
         XCTAssertTrue(app.scrollViews["sidebar"].exists)
     }
 
+    func testRecoveredTaskRequiresExplicitChoiceAndRoutesNewSession() throws {
+        let url = try createTempProject(
+            files: ["release.md": "# Pine 2.0\n"]
+        )
+        projectURLs.append(url)
+        app.launchArguments.append("--ui-test-agent-recovery")
+        launchWithProject(url)
+
+        openAgentInbox()
+        let firstLaunchRow = recoveryRow
+        XCTAssertTrue(
+            firstLaunchRow.waitForExistence(timeout: 8),
+            "The first launch should create the durable recovery fixture"
+        )
+        firstLaunchRow.rightClick()
+        XCTAssertTrue(app.menuItems["Resume Session"].exists)
+        XCTAssertTrue(app.menuItems["New Session"].exists)
+        XCTAssertTrue(app.menuItems["Copy Objective"].exists)
+        app.typeKey(.escape, modifierFlags: [])
+
+        app.terminate()
+        app.launch()
+        app.activate()
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+
+        openAgentInbox()
+        let restoredRow = recoveryRow
+        XCTAssertTrue(
+            restoredRow.waitForExistence(timeout: 8),
+            "The second launch should load the persisted recovery card"
+        )
+        restoredRow.rightClick()
+        let newSession = app.menuItems["New Session"]
+        XCTAssertTrue(newSession.waitForExistence(timeout: 3))
+        let terminal = app.buttons["terminalTab_Terminal 1"].firstMatch
+        XCTAssertFalse(
+            terminal.exists,
+            "Restoring task metadata must not launch a terminal automatically"
+        )
+        newSession.click()
+
+        XCTAssertTrue(terminal.waitForExistence(timeout: 5))
+        XCTAssertEqual(
+            app.buttons.matching(identifier: "terminalTab_Terminal 1").count,
+            1,
+            "One explicit recovery action must create one exact terminal"
+        )
+    }
+
     func testWelcomeWindowShowsPineTitle() throws {
         launchClean()
 
@@ -92,6 +141,24 @@ final class WelcomeWindowTests: PineUITestCase {
             NSPredicate(format: "value == 'Pine'")
         ).firstMatch
         XCTAssertTrue(pineTitle.exists, "Pine title should be visible in Welcome window")
+    }
+
+    private func openAgentInbox() {
+        clickMenuBarItem("View")
+        let inboxItem = app.menuBars.menuBarItems["View"]
+            .menus.menuItems["Agent Inbox"].firstMatch
+        XCTAssertTrue(inboxItem.waitForExistence(timeout: 3))
+        inboxItem.click()
+        XCTAssertTrue(
+            app.descendants(matching: .any)["agentInbox"]
+                .firstMatch.waitForExistence(timeout: 5)
+        )
+    }
+
+    private var recoveryRow: XCUIElement {
+        app.buttons.matching(
+            NSPredicate(format: "label CONTAINS 'Recovery fixture'")
+        ).firstMatch
     }
 
     // MARK: - P0: Open Folder → NSOpenPanel appears


### PR DESCRIPTION
## Summary
- persist bounded opaque vendor session identity in owner-private metadata
- offer explicit Resume Session and New Session recovery choices
- require a documented adapter recipe, exact executable version, and direct argv launch
- restore completed tasks across relaunch without stealing existing terminal history
- add recovery routing, security, persistence, and localization coverage

## Stack
Depends on the #1306 notification PR. Review the three commits unique to this PR.

## Validation
- 92 registry/recovery/terminal unit tests passed
- focused recovery and Inbox routing tests passed
- SwiftLint: 0 violations
- localization catalog parses successfully
- UI scenario added but its final rerun is intentionally deferred at the maintainer request

Closes #1307