### PR TITLE
feat(agent): add evidence-based completion briefs

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -255,6 +255,10 @@ nonisolated enum AccessibilityID {
     static let agentHistoryRevertButton = "agentHistoryRevertButton"
     static let agentHistoryUndoUnavailable = "agentHistoryUndoUnavailable"
     static let agentHistoryRevertedBadge = "agentHistoryRevertedBadge"
+    static let agentCompletionBrief = "agentCompletionBrief"
+    static let agentCompletionShowButton = "agentCompletionShowButton"
+    static let agentCompletionReviewChanges =
+        "agentCompletionReviewChanges"
     static let agentHistoryRecoveryNotice = "agentHistoryRecoveryNotice"
     static func agentHistoryRecoveryRecord(_ name: String) -> String {
         "agentHistoryRecoveryRecord_\(name)"

--- a/Pine/Agent/AgentCompletionBrief.swift
+++ b/Pine/Agent/AgentCompletionBrief.swift
@@ -1,0 +1,472 @@
+//
+//  AgentCompletionBrief.swift
+//  Pine
+//
+//  Evidence-first completion summaries for finished agent work (#1308).
+//
+
+import Foundation
+
+/// Attribution shown beside every completion-brief fact.
+///
+/// The cases are deliberately not ordered. In particular, several inferred
+/// observations never combine into a verified claim.
+nonisolated enum AgentCompletionEvidenceLevel: String, Sendable, Equatable {
+    case verified
+    case inferred
+    case ambiguous
+    case observed
+    case agentReported
+}
+
+nonisolated enum AgentCompletionChangeKind: String, Sendable, Equatable {
+    case modified
+    case created
+    case deleted
+    case renamed
+    case unknown
+}
+
+nonisolated struct AgentCompletionDiffStatistics: Sendable, Equatable {
+    let addedLineCount: Int
+    let removedLineCount: Int
+}
+
+nonisolated struct AgentCompletionChange: Identifiable, Sendable, Equatable {
+    var id: String { relativePath }
+
+    let relativePath: String
+    let kind: AgentCompletionChangeKind
+    let statistics: AgentCompletionDiffStatistics?
+    let attribution: AgentCompletionEvidenceLevel
+    let hasOverlappingEdits: Bool
+    let hasVerifiedDiff: Bool
+}
+
+nonisolated enum AgentCompletionCommandKind: String, Sendable, Equatable {
+    case command
+    case build
+    case test
+}
+
+nonisolated enum AgentCompletionCommandOutcome: Sendable, Equatable {
+    case succeeded
+    case failed(exitStatus: Int32)
+    case unknown
+}
+
+nonisolated struct AgentCompletionCommand: Identifiable, Sendable, Equatable {
+    let id: UUID
+    let command: String
+    let kind: AgentCompletionCommandKind
+    let outcome: AgentCompletionCommandOutcome
+    let attribution: AgentCompletionEvidenceLevel
+    let source: String
+}
+
+nonisolated enum AgentCompletionGap: Sendable, Equatable {
+    case provenanceUnavailable
+    case provenanceRecoveredWithLoss
+    case noVerifiedChanges
+    case noStructuredCommands
+    case noVerifiedTests
+    case diffStatisticsUnavailable(paths: [String])
+    case overlappingEdits(paths: [String])
+}
+
+nonisolated struct AgentCompletionNarrative: Sendable, Equatable {
+    let text: String
+    let attribution: AgentCompletionEvidenceLevel
+
+    init(text: String) {
+        self.text = text
+        attribution = .agentReported
+    }
+}
+
+/// Read-only links. Their targets are resolved again by the presentation
+/// layer; neither value grants terminal access or mutation authority.
+nonisolated struct AgentCompletionEvidenceLinks: Sendable, Equatable {
+    let terminalID: UUID?
+    let diffPaths: [String]
+}
+
+nonisolated struct AgentCompletionBrief: Sendable, Equatable, Identifiable {
+    let id: UUID
+    let sessionID: UUID
+    let agentTypeRaw: String
+    let startedAt: Date
+    let endedAt: Date?
+    let changes: [AgentCompletionChange]
+    let commands: [AgentCompletionCommand]
+    let gaps: [AgentCompletionGap]
+    let narrative: AgentCompletionNarrative?
+    let links: AgentCompletionEvidenceLinks
+
+    var verifiedTestCount: Int {
+        commands.lazy.filter {
+            $0.kind == .test
+                && $0.attribution == .verified
+                && $0.outcome == .succeeded
+        }.count
+    }
+}
+
+/// Bounded inputs used by the pure builder. Integrity travels together with
+/// the provenance rows so a recovered or unavailable journal cannot be
+/// presented as complete evidence.
+@MainActor
+struct AgentCompletionBriefEvidence: Equatable {
+    let provenanceIntegrity: AgentEventStoreIntegrity?
+    let events: [StoredAgentEvent]
+    let activities: [AgentAction]
+    let verifiedUndoPreview: AgentHistoryUndoPreviewModel?
+    let agentReportedNarrative: String?
+    let overlappingPaths: Set<String>
+
+    init(
+        provenanceIntegrity: AgentEventStoreIntegrity? = nil,
+        events: [StoredAgentEvent] = [],
+        activities: [AgentAction] = [],
+        verifiedUndoPreview: AgentHistoryUndoPreviewModel? = nil,
+        agentReportedNarrative: String? = nil,
+        overlappingPaths: Set<String> = []
+    ) {
+        self.provenanceIntegrity = provenanceIntegrity
+        self.events = events
+        self.activities = activities
+        self.verifiedUndoPreview = verifiedUndoPreview
+        self.agentReportedNarrative = agentReportedNarrative
+        self.overlappingPaths = overlappingPaths
+    }
+}
+
+@MainActor
+enum AgentCompletionBriefBuilder {
+    private static let maximumEventCount = 10_000
+    private static let maximumActivityCount = 10_000
+    private static let maximumNarrativeBytes = 64 * 1_024
+
+    static func build(
+        entry: AgentHistoryEntry,
+        evidence: AgentCompletionBriefEvidence
+    ) -> AgentCompletionBrief {
+        let events = Array(evidence.events.lazy
+            .filter { $0.envelope.sessionID == entry.sessionID }
+            .prefix(maximumEventCount))
+        let activities = Array(evidence.activities.lazy
+            .filter { $0.attribution.contains(sessionID: entry.sessionID) }
+            .prefix(maximumActivityCount))
+        var previewByPath: [String: AgentHistoryUndoPreviewOperation] = [:]
+        for operation in evidence.verifiedUndoPreview?.operations ?? []
+        where previewByPath[operation.relativePath] == nil {
+            previewByPath[operation.relativePath] = operation
+        }
+        let verifiedKinds = verifiedChangeKinds(entry.verifiedChangeSet)
+        let eventPaths = events.compactMap { record -> String? in
+            guard case .fileChange(let change) = record.envelope.payload else {
+                return nil
+            }
+            return change.relativePath
+        }
+        var activityPathsByID: [UUID: String] = [:]
+        for action in activities where activityPathsByID[action.id] == nil {
+            activityPathsByID[action.id] = action.fileURL.flatMap {
+                relativePath(for: $0, entry: entry, events: events)
+            }
+        }
+        let activityPaths = activities.compactMap { activityPathsByID[$0.id] }
+        let allPaths = stableUnique(
+            entry.affectedFiles
+                + verifiedKinds.keys
+                + eventPaths
+                + activityPaths
+        )
+        let overlapPaths = overlappingPaths(
+            explicit: evidence.overlappingPaths,
+            activities: activities,
+            pathsByActivityID: activityPathsByID
+        )
+
+        let changes = allPaths.map { path in
+            let preview = previewByPath[path]
+            return AgentCompletionChange(
+                relativePath: path,
+                kind: verifiedKinds[path] ?? changeKind(from: preview),
+                statistics: preview.map { operation in
+                    // The preview is an inverse. Lines removed by the inverse
+                    // were added by the agent, and vice versa.
+                    AgentCompletionDiffStatistics(
+                        addedLineCount: operation.removedLineCount,
+                        removedLineCount: operation.addedLineCount
+                    )
+                },
+                attribution: attribution(
+                    path: path,
+                    entry: entry,
+                    events: events,
+                    activities: activities,
+                    pathsByActivityID: activityPathsByID
+                ),
+                hasOverlappingEdits: overlapPaths.contains(path),
+                hasVerifiedDiff: preview != nil
+            )
+        }
+
+        let commands = structuredCommands(events)
+            + observedCommands(activities, excluding: events)
+        var gaps = integrityGaps(evidence.provenanceIntegrity)
+        if !changes.contains(where: { $0.attribution == .verified }) {
+            gaps.append(.noVerifiedChanges)
+        }
+        if !commands.contains(where: { $0.attribution == .verified }) {
+            gaps.append(.noStructuredCommands)
+        }
+        if !commands.contains(where: {
+            $0.kind == .test && $0.attribution == .verified
+        }) {
+            gaps.append(.noVerifiedTests)
+        }
+        let pathsWithoutStats = changes.compactMap {
+            $0.statistics == nil ? $0.relativePath : nil
+        }
+        if !pathsWithoutStats.isEmpty {
+            gaps.append(.diffStatisticsUnavailable(paths: pathsWithoutStats))
+        }
+        let orderedOverlapPaths = allPaths.filter(overlapPaths.contains)
+        if !orderedOverlapPaths.isEmpty {
+            gaps.append(.overlappingEdits(paths: orderedOverlapPaths))
+        }
+
+        let narrative = boundedNarrative(evidence.agentReportedNarrative)
+            .map(AgentCompletionNarrative.init)
+        let terminalID = events.first?.envelope.process.terminalID
+
+        return AgentCompletionBrief(
+            id: entry.id,
+            sessionID: entry.sessionID,
+            agentTypeRaw: entry.agentTypeRaw,
+            startedAt: entry.startedAt,
+            endedAt: entry.endedAt,
+            changes: changes,
+            commands: commands,
+            gaps: gaps,
+            narrative: narrative,
+            links: AgentCompletionEvidenceLinks(
+                terminalID: terminalID,
+                diffPaths: changes.filter(\.hasVerifiedDiff).map(\.relativePath)
+            )
+        )
+    }
+
+    private static func verifiedChangeKinds(
+        _ changeSet: VerifiedAgentChangeSet?
+    ) -> [String: AgentCompletionChangeKind] {
+        guard let changeSet else { return [:] }
+        var result: [String: AgentCompletionChangeKind] = [:]
+        for change in changeSet.changes {
+            let kind: AgentCompletionChangeKind = switch change.operation {
+            case .modify: .modified
+            case .create: .created
+            case .delete: .deleted
+            case .rename: .renamed
+            case .symlink, .unsupported: .unknown
+            }
+            if result[change.relativePath] == nil {
+                result[change.relativePath] = kind
+            }
+        }
+        return result
+    }
+
+    private static func changeKind(
+        from preview: AgentHistoryUndoPreviewOperation?
+    ) -> AgentCompletionChangeKind {
+        guard let preview else { return .unknown }
+        return switch preview.kind {
+        case .restoreModifiedFile: .modified
+        case .removeCreatedFile: .created
+        case .restoreDeletedFile: .deleted
+        }
+    }
+
+    private static func attribution(
+        path: String,
+        entry: AgentHistoryEntry,
+        events: [StoredAgentEvent],
+        activities: [AgentAction],
+        pathsByActivityID: [UUID: String]
+    ) -> AgentCompletionEvidenceLevel {
+        if entry.attribution == .verified,
+           entry.verifiedChangeSet?.changes.contains(where: {
+               $0.relativePath == path
+           }) == true {
+            return .verified
+        }
+        let pathEvents = events.filter { record in
+            guard case .fileChange(let change) = record.envelope.payload else {
+                return false
+            }
+            return change.relativePath == path
+        }
+        if pathEvents.contains(where: {
+            $0.envelope.source == .explicitAgentEvent
+                && $0.envelope.trustLevel == .verified
+        }) {
+            return .verified
+        }
+        let pathActions = activities.filter {
+            pathsByActivityID[$0.id] == path
+        }
+        if pathActions.contains(where: {
+            if case .ambiguous = $0.attribution { return true }
+            return false
+        }) {
+            return .ambiguous
+        }
+        if !pathActions.isEmpty || entry.affectedFiles.contains(path) {
+            return .inferred
+        }
+        return .observed
+    }
+
+    private static func structuredCommands(
+        _ events: [StoredAgentEvent]
+    ) -> [AgentCompletionCommand] {
+        events.compactMap { record in
+            guard case .commandResult(let result) = record.envelope.payload else {
+                return nil
+            }
+            let isVerified = record.envelope.source == .explicitAgentEvent
+                && record.envelope.trustLevel == .verified
+            return AgentCompletionCommand(
+                id: record.envelope.id,
+                command: result.command,
+                kind: commandKind(result.command),
+                outcome: result.exitStatus == 0
+                    ? .succeeded
+                    : .failed(exitStatus: result.exitStatus),
+                attribution: isVerified ? .verified : .inferred,
+                source: record.envelope.source.stableIdentifier
+            )
+        }
+    }
+
+    private static func observedCommands(
+        _ activities: [AgentAction],
+        excluding events: [StoredAgentEvent]
+    ) -> [AgentCompletionCommand] {
+        let structuredCommands = Set(events.compactMap { record -> String? in
+            guard case .commandResult(let result) = record.envelope.payload else {
+                return nil
+            }
+            return result.command
+        })
+        return activities.compactMap { action in
+            guard action.kind == .command,
+                  !structuredCommands.contains(action.summary) else {
+                return nil
+            }
+            return AgentCompletionCommand(
+                id: action.id,
+                command: action.summary,
+                kind: commandKind(action.summary),
+                outcome: .unknown,
+                attribution: activityEvidence(action.attribution),
+                source: "activity"
+            )
+        }
+    }
+
+    private static func activityEvidence(
+        _ attribution: AgentActionAttribution
+    ) -> AgentCompletionEvidenceLevel {
+        switch attribution {
+        case .verified: .verified
+        case .inferred, .session: .inferred
+        case .ambiguous: .ambiguous
+        }
+    }
+
+    private static func commandKind(
+        _ command: String
+    ) -> AgentCompletionCommandKind {
+        let normalized = command.lowercased()
+        let testMarkers = [
+            "xcodebuild test", "swift test", "npm test", "npm run test",
+            "pnpm test", "yarn test", "cargo test", "go test", "pytest"
+        ]
+        if testMarkers.contains(where: normalized.contains) {
+            return .test
+        }
+        let buildMarkers = [
+            "xcodebuild build", "swift build", "npm run build",
+            "pnpm build", "yarn build", "cargo build", "go build"
+        ]
+        if buildMarkers.contains(where: normalized.contains) {
+            return .build
+        }
+        return .command
+    }
+
+    private static func integrityGaps(
+        _ integrity: AgentEventStoreIntegrity?
+    ) -> [AgentCompletionGap] {
+        switch integrity {
+        case .healthy: []
+        case .recovered: [.provenanceRecoveredWithLoss]
+        case .unavailable, nil: [.provenanceUnavailable]
+        }
+    }
+
+    private static func overlappingPaths(
+        explicit: Set<String>,
+        activities: [AgentAction],
+        pathsByActivityID: [UUID: String]
+    ) -> Set<String> {
+        var result = explicit
+        for action in activities {
+            guard case .ambiguous = action.attribution,
+                  let path = pathsByActivityID[action.id] else { continue }
+            result.insert(path)
+        }
+        return result
+    }
+
+    private static func relativePath(
+        for fileURL: URL,
+        entry: AgentHistoryEntry,
+        events: [StoredAgentEvent]
+    ) -> String? {
+        if let root = events.first?.envelope.location.worktreePath {
+            let path = fileURL.standardizedFileURL.path
+            let prefix = root.hasSuffix("/") ? root : root + "/"
+            if path.hasPrefix(prefix) {
+                return String(path.dropFirst(prefix.count))
+            }
+        }
+        return entry.affectedFiles.first {
+            URL(fileURLWithPath: $0).lastPathComponent
+                == fileURL.lastPathComponent
+        }
+    }
+
+    private static func stableUnique(_ paths: [String]) -> [String] {
+        var seen: Set<String> = []
+        return paths.filter { path in
+            AgentHistoryUndoPreflight.isCanonicalRelativePath(path)
+                && seen.insert(path).inserted
+        }
+    }
+
+    private static func boundedNarrative(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.utf8.count <= maximumNarrativeBytes,
+              !trimmed.utf8.contains(0) else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Pine/Agent/AgentCompletionBriefView.swift
+++ b/Pine/Agent/AgentCompletionBriefView.swift
@@ -1,0 +1,256 @@
+//
+//  AgentCompletionBriefView.swift
+//  Pine
+//
+//  Read-only evidence summary for a completed agent session (#1308).
+//
+
+import SwiftUI
+
+struct AgentCompletionBriefView: View {
+    @Environment(\.locale) private var locale
+    let brief: AgentCompletionBrief
+    let onReviewChanges: (() -> Void)?
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    changesSection
+                    verificationSection
+                    commandsSection
+                    gapsSection
+                    narrativeSection
+                }
+                .padding(16)
+            }
+        }
+        .frame(minWidth: 560, idealWidth: 680, minHeight: 420)
+        .accessibilityIdentifier(AccessibilityID.agentCompletionBrief)
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "checkmark.seal")
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(Strings.agentCompletionTitle)
+                    .font(.headline)
+                Text(verbatim: brief.agentTypeRaw)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button {
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+                    .font(.system(size: 16))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(Strings.dialogCancel)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 11)
+    }
+
+    private var changesSection: some View {
+        briefSection(Strings.agentCompletionChanges) {
+            if brief.changes.isEmpty {
+                Text(Strings.agentCompletionNoChanges)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(brief.changes) { change in
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Image(systemName: changeIcon(change.kind))
+                            .frame(width: 14)
+                            .foregroundStyle(.secondary)
+                        Text(verbatim: change.relativePath)
+                            .font(.system(.body, design: .monospaced))
+                            .textSelection(.enabled)
+                        Spacer()
+                        if let statistics = change.statistics {
+                            Text(verbatim:
+                                "+\(statistics.addedLineCount) −\(statistics.removedLineCount)"
+                            )
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                        }
+                        evidenceBadge(change.attribution)
+                    }
+                    if change.hasOverlappingEdits {
+                        Label(
+                            Strings.agentCompletionOverlap,
+                            systemImage: "exclamationmark.triangle.fill"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                    }
+                }
+            }
+            if !brief.links.diffPaths.isEmpty, let onReviewChanges {
+                Button(Strings.agentHistoryReviewChangesButton) {
+                    onReviewChanges()
+                }
+                .accessibilityIdentifier(
+                    AccessibilityID.agentCompletionReviewChanges
+                )
+            }
+        }
+    }
+
+    private var verificationSection: some View {
+        briefSection(Strings.agentCompletionVerification) {
+            Label {
+                Text(verbatim: Strings.agentCompletionVerifiedTests(
+                    brief.verifiedTestCount,
+                    locale: locale
+                ))
+            } icon: {
+                Image(systemName: brief.verifiedTestCount > 0
+                    ? "checkmark.circle.fill"
+                    : "questionmark.circle")
+            }
+            .foregroundStyle(brief.verifiedTestCount > 0 ? .green : .secondary)
+        }
+    }
+
+    private var commandsSection: some View {
+        briefSection(Strings.agentCompletionCommands) {
+            if brief.commands.isEmpty {
+                Text(Strings.agentCompletionNoCommands)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(brief.commands) { command in
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: outcomeIcon(command.outcome))
+                            .foregroundStyle(outcomeColor(command.outcome))
+                            .frame(width: 14)
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(verbatim: command.command)
+                                .font(.system(.body, design: .monospaced))
+                                .textSelection(.enabled)
+                            HStack(spacing: 6) {
+                                evidenceBadge(command.attribution)
+                                Text(verbatim: command.source)
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var gapsSection: some View {
+        if !brief.gaps.isEmpty {
+            briefSection(Strings.agentCompletionGaps) {
+                ForEach(Array(brief.gaps.enumerated()), id: \.offset) { _, gap in
+                    Label {
+                        Text(verbatim: gapText(gap))
+                    } icon: {
+                        Image(systemName: "info.circle")
+                    }
+                    .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var narrativeSection: some View {
+        if let narrative = brief.narrative {
+            briefSection(Strings.agentCompletionAgentReport) {
+                evidenceBadge(narrative.attribution)
+                Text(verbatim: narrative.text)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private func briefSection<Content: View>(
+        _ title: LocalizedStringKey,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func evidenceBadge(
+        _ level: AgentCompletionEvidenceLevel
+    ) -> some View {
+        Text(verbatim: evidenceText(level))
+            .font(.caption2.weight(.medium))
+            .foregroundStyle(level == .verified ? .green : .secondary)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(.quaternary, in: Capsule())
+    }
+
+    private func evidenceText(_ level: AgentCompletionEvidenceLevel) -> String {
+        switch level {
+        case .verified: Strings.agentActivityAttributionVerified
+        case .inferred: Strings.agentActivityAttributionInferred
+        case .ambiguous: Strings.agentActivityAttributionAmbiguous
+        case .observed: Strings.agentCompletionObserved(locale: locale)
+        case .agentReported: Strings.agentCompletionAgentReported(locale: locale)
+        }
+    }
+
+    private func gapText(_ gap: AgentCompletionGap) -> String {
+        switch gap {
+        case .provenanceUnavailable:
+            Strings.agentCompletionGapProvenance(locale: locale)
+        case .provenanceRecoveredWithLoss:
+            Strings.agentCompletionGapRecovered(locale: locale)
+        case .noVerifiedChanges:
+            Strings.agentCompletionGapChanges(locale: locale)
+        case .noStructuredCommands:
+            Strings.agentCompletionGapCommands(locale: locale)
+        case .noVerifiedTests:
+            Strings.agentCompletionGapTests(locale: locale)
+        case .diffStatisticsUnavailable(let paths):
+            Strings.agentCompletionGapStatistics(paths.count, locale: locale)
+        case .overlappingEdits(let paths):
+            Strings.agentCompletionGapOverlaps(paths.count, locale: locale)
+        }
+    }
+
+    private func changeIcon(_ kind: AgentCompletionChangeKind) -> String {
+        switch kind {
+        case .modified: "pencil"
+        case .created: "plus.circle"
+        case .deleted: "minus.circle"
+        case .renamed: "arrow.right"
+        case .unknown: "questionmark.circle"
+        }
+    }
+
+    private func outcomeIcon(_ outcome: AgentCompletionCommandOutcome) -> String {
+        switch outcome {
+        case .succeeded: "checkmark.circle.fill"
+        case .failed: "xmark.circle.fill"
+        case .unknown: "questionmark.circle"
+        }
+    }
+
+    private func outcomeColor(
+        _ outcome: AgentCompletionCommandOutcome
+    ) -> Color {
+        switch outcome {
+        case .succeeded: .green
+        case .failed: .red
+        case .unknown: .secondary
+        }
+    }
+}

--- a/Pine/Agent/AgentHistoryView.swift
+++ b/Pine/Agent/AgentHistoryView.swift
@@ -51,7 +51,18 @@ struct AgentHistoryRow: Identifiable, Equatable {
 /// no side effects — so it can be snapshotted with stub rows.
 struct AgentHistoryList: View {
     let rows: [AgentHistoryRow]
+    let onOpenBrief: ((AgentHistoryRow) -> Void)?
     let onRevert: (AgentHistoryRow) -> Void
+
+    init(
+        rows: [AgentHistoryRow],
+        onOpenBrief: ((AgentHistoryRow) -> Void)? = nil,
+        onRevert: @escaping (AgentHistoryRow) -> Void
+    ) {
+        self.rows = rows
+        self.onOpenBrief = onOpenBrief
+        self.onRevert = onRevert
+    }
 
     var body: some View {
         if rows.isEmpty {
@@ -64,7 +75,11 @@ struct AgentHistoryList: View {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     ForEach(rows) { row in
-                        AgentHistoryRowView(row: row, onRevert: onRevert)
+                        AgentHistoryRowView(
+                            row: row,
+                            onOpenBrief: onOpenBrief,
+                            onRevert: onRevert
+                        )
                         if row.id != rows.last?.id {
                             Divider()
                         }
@@ -80,6 +95,7 @@ struct AgentHistoryList: View {
 /// revert status/action.
 struct AgentHistoryRowView: View {
     let row: AgentHistoryRow
+    let onOpenBrief: ((AgentHistoryRow) -> Void)?
     let onRevert: (AgentHistoryRow) -> Void
 
     var body: some View {
@@ -102,6 +118,21 @@ struct AgentHistoryRowView: View {
             }
 
             Spacer()
+
+            if let onOpenBrief {
+                Button {
+                    onOpenBrief(row)
+                } label: {
+                    Label(
+                        Strings.agentCompletionShowButton,
+                        systemImage: "doc.text.magnifyingglass"
+                    )
+                }
+                .controlSize(.small)
+                .accessibilityIdentifier(
+                    AccessibilityID.agentCompletionShowButton
+                )
+            }
 
             if row.reverted {
                 Text(Strings.agentHistoryRevertedBadge)
@@ -143,7 +174,7 @@ struct AgentHistoryRowView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .contain)
     }
 
     /// "HH:mm – HH:mm" range, or a single time when no end is recorded.
@@ -165,8 +196,20 @@ struct AgentHistoryView: View {
     @Environment(\.locale) private var locale
     @Bindable var store: AgentHistoryStore
     @Binding var isPresented: Bool
+    let activities: [AgentAction]?
     @State private var reviewTarget: AgentHistoryEntry?
+    @State private var completionBrief: AgentCompletionBrief?
     @State private var revertResult: AgentHistoryRevertResult?
+
+    init(
+        store: AgentHistoryStore,
+        isPresented: Binding<Bool>,
+        activities: [AgentAction]? = nil
+    ) {
+        self.store = store
+        _isPresented = isPresented
+        self.activities = activities
+    }
 
     private var rows: [AgentHistoryRow] {
         store.entries.reversed().map { entry in
@@ -186,9 +229,15 @@ struct AgentHistoryView: View {
                 )
                 Divider()
             }
-            AgentHistoryList(rows: rows) { row in
-                openReview(for: row)
-            }
+            AgentHistoryList(
+                rows: rows,
+                onOpenBrief: activities == nil ? nil : { row in
+                    openCompletionBrief(for: row)
+                },
+                onRevert: { row in
+                    openReview(for: row)
+                }
+            )
             if let revertResult {
                 Divider()
                 resultBanner(revertResult)
@@ -211,6 +260,15 @@ struct AgentHistoryView: View {
                 revertResult = result
             }
         }
+        .sheet(item: $completionBrief) { brief in
+            AgentCompletionBriefView(
+                brief: brief,
+                onReviewChanges: brief.links.diffPaths.isEmpty ? nil : {
+                    openReviewFromCompletionBrief(brief)
+                },
+                onDismiss: { completionBrief = nil }
+            )
+        }
     }
 
     /// Opens the verified undo review sheet for the entry behind a row.
@@ -224,6 +282,42 @@ struct AgentHistoryView: View {
             return
         }
         reviewTarget = entry
+    }
+
+    private func openCompletionBrief(for row: AgentHistoryRow) {
+        guard let entry = store.entries.first(where: { $0.id == row.id }) else {
+            return
+        }
+        let activities = activities ?? []
+        Task { @MainActor in
+            let preview = await store.prepareVerifiedUndoPreview(for: entry)
+            let previewModel: AgentHistoryUndoPreviewModel? = switch preview {
+            case .available(let model): model
+            case .unavailable: nil
+            }
+            guard store.entries.contains(where: { $0.id == entry.id }) else {
+                return
+            }
+            completionBrief = AgentCompletionBriefBuilder.build(
+                entry: entry,
+                evidence: AgentCompletionBriefEvidence(
+                    activities: activities,
+                    verifiedUndoPreview: previewModel
+                )
+            )
+        }
+    }
+
+    private func openReviewFromCompletionBrief(
+        _ brief: AgentCompletionBrief
+    ) {
+        completionBrief = nil
+        guard let entry = store.entries.first(where: { $0.id == brief.id }) else {
+            return
+        }
+        DispatchQueue.main.async {
+            reviewTarget = entry
+        }
     }
 
     private var sheetHeader: some View {

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchEngine.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchEngine.swift
@@ -719,6 +719,196 @@ nonisolated enum VerifiedPatchEngine {
         )
     }
 
+    /// Produces a bounded selection from a fully prepared inverse.
+    ///
+    /// This is still display/simulation data, not filesystem authority. A
+    /// live coordinator must revalidate the complete owner-private evidence,
+    /// root, HEAD, index, and selected path descriptors before one atomic
+    /// transaction. Unselected operations are accepted by omission and are
+    /// never rewritten, staged, checked out, or discarded.
+    static func prepareSelection(
+        _ selections: [VerifiedPatchReviewSelection],
+        from prepared: PreparedInverse
+    ) -> Result<VerifiedPreparedSelection, VerifiedPatchSelectionFailure> {
+        do {
+            try validatePrepared(prepared)
+        } catch {
+            return .failure(.invalidPreparedInverse)
+        }
+        guard !selections.isEmpty else {
+            return .failure(.emptySelection)
+        }
+        guard selections.count <= VerifiedPatchLimits.maximumOperationCount else {
+            return .failure(.resourceLimitExceeded)
+        }
+
+        var seen: Set<VerifiedPatchOperationID> = []
+        var selectedOperations: [VerifiedPreparedInverseOperation] = []
+        for selection in selections {
+            let operationID: VerifiedPatchOperationID = switch selection {
+            case .operation(let id): id
+            case .hunks(let id, _): id
+            }
+            guard seen.insert(operationID).inserted else {
+                return .failure(.duplicateOperation(operationID))
+            }
+            guard let operation = prepared.operations.first(where: {
+                $0.operationID == operationID
+            }) else {
+                return .failure(.unknownOperation(operationID))
+            }
+            switch selection {
+            case .operation:
+                selectedOperations.append(operation)
+            case .hunks(_, let indices):
+                switch selectedTextOperation(
+                    operation,
+                    indices: indices
+                ) {
+                case .success(let selected):
+                    selectedOperations.append(selected)
+                case .failure(let failure):
+                    return .failure(failure)
+                }
+            }
+        }
+        return .success(VerifiedPreparedSelection(
+            prepared: prepared,
+            selections: selections,
+            operations: selectedOperations
+        ))
+    }
+
+    /// Recomputes the selection, checks its exact prepared shape, and applies
+    /// it to a fresh value snapshot atomically. A stale selected path fails;
+    /// concurrent changes to unselected paths are preserved byte-for-byte.
+    static func applySelection(
+        _ selection: VerifiedPreparedSelection,
+        currentSnapshot: VerifiedPatchWorkspaceSnapshot
+    ) -> VerifiedCheckedSelectionResult {
+        do {
+            try validateSnapshot(currentSnapshot)
+        } catch {
+            return .conflicted([VerifiedPatchConflict(
+                operationID: nil,
+                path: nil,
+                reason: .invalidCurrentSnapshot
+            )])
+        }
+        let rebuilt: VerifiedPreparedSelection
+        switch prepareSelection(
+            selection.selections,
+            from: selection.prepared
+        ) {
+        case .failure(let failure):
+            return .invalid(failure)
+        case .success(let value):
+            rebuilt = value
+        }
+        guard rebuilt == selection else {
+            return .invalid(.invalidPreparedInverse)
+        }
+
+        for operation in selection.operations {
+            for expectation in operation.expectations {
+                guard currentSnapshot.files[expectation.path]
+                        == expectation.state else {
+                    return .conflicted([VerifiedPatchConflict(
+                        operationID: operation.operationID,
+                        path: expectation.path,
+                        reason: .snapshotChangedAfterPreparation
+                    )])
+                }
+            }
+        }
+        var transformed = currentSnapshot.files
+        for operation in selection.operations {
+            for result in operation.results {
+                transformed[result.path] = result.state
+            }
+        }
+        let finalSnapshot = VerifiedPatchWorkspaceSnapshot(files: transformed)
+        do {
+            try validateSnapshot(finalSnapshot)
+        } catch {
+            return .conflicted([VerifiedPatchConflict(
+                operationID: nil,
+                path: nil,
+                reason: .resourceLimitExceeded
+            )])
+        }
+        return .applied(
+            snapshot: finalSnapshot,
+            previews: selection.operations.map(\.preview)
+        )
+    }
+
+    private static func selectedTextOperation(
+        _ operation: VerifiedPreparedInverseOperation,
+        indices: Set<Int>
+    ) -> Result<VerifiedPreparedInverseOperation, VerifiedPatchSelectionFailure> {
+        guard operation.mode == .checkedText else {
+            return .failure(.hunkSelectionRequiresCheckedText(
+                operation.operationID
+            ))
+        }
+        guard !indices.isEmpty else {
+            return .failure(.emptyHunkSelection(operation.operationID))
+        }
+        let sortedIndices = indices.sorted()
+        for index in sortedIndices where
+            !operation.resolvedTextHunks.indices.contains(index) {
+            return .failure(.invalidHunkIndex(
+                operationID: operation.operationID,
+                index: index
+            ))
+        }
+        guard operation.expectations.count == 1,
+              operation.results.count == 1,
+              let current = operation.expectations[0].state,
+              current.kind == .regularFile else {
+            return .failure(.invalidPreparedInverse)
+        }
+        let hunks = sortedIndices.map { operation.resolvedTextHunks[$0] }
+        guard let content = VerifiedTextPatch.applyingPreparedHunks(
+            hunks,
+            to: current.content
+        ) else {
+            return .failure(.resourceLimitExceeded)
+        }
+        let result = VerifiedPatchFileState(
+            content: content,
+            kind: current.kind,
+            posixMode: current.posixMode
+        )
+        let originalPreview = operation.preview
+        guard originalPreview.hunks.count
+                == operation.resolvedTextHunks.count else {
+            return .failure(.invalidPreparedInverse)
+        }
+        let preview = VerifiedInverseOperationPreview(
+            operationID: originalPreview.operationID,
+            kind: .applyTextHunks,
+            sourcePath: originalPreview.sourcePath,
+            destinationPath: originalPreview.destinationPath,
+            expectedCurrent: current.stateIdentity,
+            result: result.stateIdentity,
+            hunks: sortedIndices.map { originalPreview.hunks[$0] }
+        )
+        return .success(VerifiedPreparedInverseOperation(
+            operationID: operation.operationID,
+            kind: operation.kind,
+            mode: .checkedText,
+            expectations: operation.expectations,
+            results: [VerifiedPreparedPathResult(
+                path: operation.results[0].path,
+                state: result
+            )],
+            resolvedTextHunks: hunks,
+            preview: preview
+        ))
+    }
+
     /// Revalidates both authorship and nested journal audit evidence.
     ///
     /// Success is still not mutation authority. The caller must continue into

--- a/Pine/Agent/VerifiedChanges/VerifiedPatchModels.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedPatchModels.swift
@@ -588,6 +588,51 @@ nonisolated enum VerifiedCheckedInverseResult: Sendable, Equatable {
     case conflicted([VerifiedPatchConflict])
 }
 
+/// User-selected part of a prepared review.
+///
+/// Exact-state operations are selectable only as a whole. Checked-text
+/// modifications may instead select individual verified hunks. Acceptance is
+/// represented by omission: Pine mutates only explicit `.revert` selections.
+nonisolated enum VerifiedPatchReviewSelection: Sendable, Equatable {
+    case operation(VerifiedPatchOperationID)
+    case hunks(
+        operationID: VerifiedPatchOperationID,
+        indices: Set<Int>
+    )
+}
+
+nonisolated struct VerifiedPreparedSelection: Sendable, Equatable {
+    let prepared: PreparedInverse
+    let selections: [VerifiedPatchReviewSelection]
+    let operations: [VerifiedPreparedInverseOperation]
+}
+
+nonisolated enum VerifiedPatchSelectionFailure:
+    Error,
+    Sendable,
+    Equatable {
+    case invalidPreparedInverse
+    case emptySelection
+    case duplicateOperation(VerifiedPatchOperationID)
+    case unknownOperation(VerifiedPatchOperationID)
+    case hunkSelectionRequiresCheckedText(VerifiedPatchOperationID)
+    case emptyHunkSelection(VerifiedPatchOperationID)
+    case invalidHunkIndex(
+        operationID: VerifiedPatchOperationID,
+        index: Int
+    )
+    case resourceLimitExceeded
+}
+
+nonisolated enum VerifiedCheckedSelectionResult: Sendable, Equatable {
+    case applied(
+        snapshot: VerifiedPatchWorkspaceSnapshot,
+        previews: [VerifiedInverseOperationPreview]
+    )
+    case conflicted([VerifiedPatchConflict])
+    case invalid(VerifiedPatchSelectionFailure)
+}
+
 nonisolated enum VerifiedPatchValidationError: Error, Sendable, Equatable {
     case invalidWorkspaceIdentity
     case invalidReceipt

--- a/Pine/Agent/VerifiedChanges/VerifiedTextPatch.swift
+++ b/Pine/Agent/VerifiedChanges/VerifiedTextPatch.swift
@@ -298,6 +298,48 @@ nonisolated enum VerifiedTextPatch {
         return result
     }
 
+    /// Applies already-resolved, non-overlapping hunks to the exact current
+    /// bytes they were prepared against. This does no fuzzy matching: callers
+    /// must compare the current content identity immediately before use.
+    static func applyingPreparedHunks(
+        _ hunks: [VerifiedPreparedTextHunk],
+        to current: Data
+    ) -> Data? {
+        guard !hunks.isEmpty,
+              hunks.count <= VerifiedPatchLimits.maximumHunkCount,
+              isText(current) else {
+            return nil
+        }
+        var lines = lines(in: current)
+        let ordered = hunks.sorted {
+            $0.resolvedCurrentRange.lowerBound
+                < $1.resolvedCurrentRange.lowerBound
+        }
+        var previousUpperBound = 0
+        for hunk in ordered {
+            guard hunk.resolvedCurrentRange.lowerBound >= previousUpperBound,
+                  hunk.resolvedCurrentRange.lowerBound >= 0,
+                  hunk.resolvedCurrentRange.upperBound <= lines.count else {
+                return nil
+            }
+            previousUpperBound = hunk.resolvedCurrentRange.upperBound
+        }
+        for hunk in ordered.reversed() {
+            lines.replaceSubrange(
+                hunk.resolvedCurrentRange,
+                with: hunk.replacementLines
+            )
+        }
+        let byteCount = lines.reduce(0) { partial, line in
+            let sum = partial.addingReportingOverflow(line.count)
+            return sum.overflow ? Int.max : sum.partialValue
+        }
+        guard byteCount <= VerifiedPatchLimits.maximumFileByteCount else {
+            return nil
+        }
+        return lines.reduce(into: Data()) { $0.append($1) }
+    }
+
     private static func lcsCellCount(
         lhsCount: Int,
         rhsCount: Int

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -773,7 +773,11 @@ struct AgentHistoryPresenter: ViewModifier {
     func body(content: Content) -> some View {
         content
             .sheet(isPresented: $isPresented) {
-                AgentHistoryView(store: store, isPresented: $isPresented)
+                AgentHistoryView(
+                    store: store,
+                    isPresented: $isPresented,
+                    activities: projectManager.agentActivity.actions
+                )
             }
             .onReceive(NotificationCenter.default.publisher(for: .showAgentHistory)) { notification in
                 guard ContentView.shouldHandleTargetedCommand(

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -566,7 +566,1207 @@
         }
       }
     },
-    "agentHistory.emptyMessage": {
+    "agentCompletion.agentReport": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agentenbericht"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent report"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informe del agente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rapport de l’agent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェントの報告"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에이전트 보고"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relatório do agente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отчёт агента"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "智能体报告"
+          }
+        }
+      }
+    },
+    "agentCompletion.changes": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Änderungen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changes"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambios"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変更"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "변경 사항"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alterações"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Изменения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改"
+          }
+        }
+      }
+    },
+    "agentCompletion.commands": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Befehle und Prüfungen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commands and checks"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comandos y comprobaciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commandes et vérifications"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コマンドと確認"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "명령 및 확인"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comandos e verificações"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Команды и проверки"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令和检查"
+          }
+        }
+      }
+    },
+    "agentCompletion.evidence.agentReported": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vom Agenten gemeldet"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent-reported"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informado por el agente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signalé par l’agent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェント報告"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에이전트 보고"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relatado pelo agente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Со слов агента"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "智能体报告"
+          }
+        }
+      }
+    },
+    "agentCompletion.evidence.observed": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beobachtet"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observé"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "観測済み"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "관찰됨"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Observado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Наблюдалось"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已观察"
+          }
+        }
+      }
+    },
+    "agentCompletion.gap.changes": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Dateiänderungen haben eine verifizierte Zuordnung."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No file changes have verified attribution."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ningún cambio de archivo tiene atribución verificada."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune modification de fichier n’a d’attribution vérifiée."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証済みの帰属を持つファイル変更はありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검증된 귀속이 있는 파일 변경이 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma alteração de arquivo tem atribuição verificada."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет изменений файлов с подтверждённой атрибуцией."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有文件更改具有已验证归属。"
+          }
+        }
+      }
+    },
+    "agentCompletion.gap.commands": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Befehle haben strukturierte Nachweise."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No commands have structured evidence."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ningún comando tiene evidencia estructurada."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune commande ne dispose de preuves structurées."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "構造化された証拠を持つコマンドはありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "구조화된 증거가 있는 명령이 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum comando tem evidência estruturada."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет команд со структурированными доказательствами."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有命令具有结构化证据。"
+          }
+        }
+      }
+    },
+    "agentCompletion.gap.overlaps %lld": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld Dateien enthalten überlappende oder mehrdeutige Änderungen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld files have overlapping or ambiguous edits."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld archivos tienen ediciones superpuestas o ambiguas."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld fichiers ont des modifications qui se chevauchent ou sont ambiguës."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 個のファイルに重複または曖昧な編集があります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld개 파일에 겹치거나 모호한 편집이 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld arquivos têm edições sobrepostas ou ambíguas."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В %lld файлах есть пересекающиеся или неоднозначные правки."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 个文件存在重叠或不明确的编辑。"
+          }
+        }
+      }
+    },
+    "agentCompletion.gap.provenance": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Strukturierte Herkunftsdaten sind nicht verfügbar."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Structured provenance is unavailable."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La procedencia estructurada no está disponible."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La provenance structurée n’est pas disponible."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "構造化された来歴情報は利用できません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "구조화된 출처 정보를 사용할 수 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A proveniência estruturada não está disponível."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Структурированные данные о происхождении недоступны."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "结构化来源信息不可用。"
+          }
+        }
+      }
+    },
+    "agentCompletion.gap.recovered": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Herkunftsdaten wurden wiederhergestellt und können unvollständig sein."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provenance was recovered and may be incomplete."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La procedencia se recuperó y puede estar incompleta."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La provenance a été récupérée et peut être incomplète."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "来歴情報は復旧されましたが、不完全な可能性があります。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "출처 정보가 복구되었으며 불완전할 수 있습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A proveniência foi recuperada e pode estar incompleta."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Данные о происхождении восстановлены и могут быть неполными."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "来源信息已恢复，但可能不完整。"
+          }
+        }
+      }
+    },
+    "agentCompletion.gap.statistics %lld": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für %lld Dateien sind keine exakten Diff-Statistiken verfügbar."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exact diff statistics are unavailable for %lld files."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las estadísticas exactas del diff no están disponibles para %lld archivos."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les statistiques exactes du diff ne sont pas disponibles pour %lld fichiers."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 個のファイルでは正確な差分統計を利用できません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld개 파일의 정확한 diff 통계를 사용할 수 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As estatísticas exatas do diff não estão disponíveis para %lld arquivos."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для %lld файлов точная статистика diff недоступна."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 个文件无法获得精确差异统计。"
+          }
+        }
+      }
+    },
+    "agentCompletion.gap.tests": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein erfolgreicher Testlauf hat verifizierte Nachweise."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No successful test run has verified evidence."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ninguna ejecución de pruebas correcta tiene evidencia verificada."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune exécution de tests réussie ne dispose de preuves vérifiées."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証済みの証拠を持つ成功したテスト実行はありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검증된 증거가 있는 성공한 테스트 실행이 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma execução de teste bem-sucedida tem evidência verificada."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет успешных запусков тестов с подтверждёнными доказательствами."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有成功的测试运行具有已验证证据。"
+          }
+        }
+      }
+    },
+    "agentCompletion.gaps": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nachweislücken"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evidence gaps"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vacíos de evidencia"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lacunes des preuves"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "証拠の不足"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "증거 공백"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lacunas de evidência"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пробелы в доказательствах"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "证据缺口"
+          }
+        }
+      }
+    },
+    "agentCompletion.noChanges": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine zuordenbaren Dateiänderungen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No attributable file changes."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay cambios de archivo atribuibles."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune modification de fichier attribuable."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "帰属可能なファイル変更はありません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "귀속 가능한 파일 변경이 없습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma alteração de arquivo atribuível."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет атрибутируемых изменений файлов."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有可归属的文件更改。"
+          }
+        }
+      }
+    },
+    "agentCompletion.noCommands": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Befehlsnachweise aufgezeichnet."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No command evidence was recorded."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se registró evidencia de comandos."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune preuve de commande n’a été enregistrée."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コマンドの証拠は記録されていません。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "명령 증거가 기록되지 않았습니다."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma evidência de comando foi registrada."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Доказательства выполнения команд не записаны."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未记录命令证据。"
+          }
+        }
+      }
+    },
+    "agentCompletion.overlap": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überlappende oder mehrdeutige Bearbeiter"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Overlapping or ambiguous writers"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autores superpuestos o ambiguos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auteurs qui se chevauchent ou sont ambigus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重複または曖昧な編集者"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "겹치거나 모호한 작성자"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Autores sobrepostos ou ambíguos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пересекающиеся или неоднозначные авторы"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重叠或不明确的编辑者"
+          }
+        }
+      }
+    },
+    "agentCompletion.showButton": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abschlussbericht"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completion brief"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resumen de finalización"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rapport de fin"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了概要"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "완료 요약"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resumo da conclusão"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Итоговый отчёт"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成摘要"
+          }
+        }
+      }
+    },
+    "agentCompletion.title": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abschlussbericht des Agenten"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent Completion Brief"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resumen de finalización del agente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rapport de fin de l’agent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェント完了概要"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에이전트 완료 요약"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resumo da conclusão do agente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Итоговый отчёт агента"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "智能体完成摘要"
+          }
+        }
+      }
+    },
+    "agentCompletion.verification": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifizierung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verification"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérification"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검증"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificação"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "验证"
+          }
+        }
+      }
+    },
+    "agentCompletion.verifiedTests %lld": {
+      "comment": "Agent completion evidence brief (#1308).",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld verifizierte Testläufe"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld verified test runs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld ejecuciones de pruebas verificadas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld exécutions de tests vérifiées"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証済みテスト実行 %lld 件"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검증된 테스트 실행 %lld개"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld execuções de teste verificadas"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подтверждённых запусков тестов: %lld"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 次已验证测试运行"
+          }
+        }
+      }
+    },
+     "agentHistory.emptyMessage": {
       "comment": "Agent History: empty-state explanation (#1073).",
       "extractionState": "manual",
       "localizations": {

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -685,6 +685,130 @@ enum Strings {
     static let agentHistoryRevertButton: LocalizedStringKey = "agentHistory.revertButton"
     static let agentHistoryReviewChangesButton: LocalizedStringKey =
         "agentHistory.reviewChangesButton"
+    static let agentCompletionTitle: LocalizedStringKey =
+        "agentCompletion.title"
+    static let agentCompletionShowButton: LocalizedStringKey =
+        "agentCompletion.showButton"
+    static let agentCompletionChanges: LocalizedStringKey =
+        "agentCompletion.changes"
+    static let agentCompletionVerification: LocalizedStringKey =
+        "agentCompletion.verification"
+    static let agentCompletionCommands: LocalizedStringKey =
+        "agentCompletion.commands"
+    static let agentCompletionGaps: LocalizedStringKey =
+        "agentCompletion.gaps"
+    static let agentCompletionAgentReport: LocalizedStringKey =
+        "agentCompletion.agentReport"
+    static let agentCompletionNoChanges: LocalizedStringKey =
+        "agentCompletion.noChanges"
+    static let agentCompletionNoCommands: LocalizedStringKey =
+        "agentCompletion.noCommands"
+    static let agentCompletionOverlap: LocalizedStringKey =
+        "agentCompletion.overlap"
+
+    static func agentCompletionVerifiedTests(
+        _ count: Int,
+        locale: Locale = .current
+    ) -> String {
+        let format = localizedString(
+            forKey: "agentCompletion.verifiedTests %lld",
+            fallback: "%lld verified test runs",
+            locale: locale
+        )
+        return String(format: format, locale: locale, Int64(count))
+    }
+
+    static func agentCompletionObserved(locale: Locale = .current) -> String {
+        localizedString(
+            forKey: "agentCompletion.evidence.observed",
+            fallback: "Observed",
+            locale: locale
+        )
+    }
+
+    static func agentCompletionAgentReported(
+        locale: Locale = .current
+    ) -> String {
+        localizedString(
+            forKey: "agentCompletion.evidence.agentReported",
+            fallback: "Agent-reported",
+            locale: locale
+        )
+    }
+
+    static func agentCompletionGapProvenance(
+        locale: Locale = .current
+    ) -> String {
+        localizedString(
+            forKey: "agentCompletion.gap.provenance",
+            fallback: "Structured provenance is unavailable.",
+            locale: locale
+        )
+    }
+
+    static func agentCompletionGapRecovered(
+        locale: Locale = .current
+    ) -> String {
+        localizedString(
+            forKey: "agentCompletion.gap.recovered",
+            fallback: "Provenance was recovered and may be incomplete.",
+            locale: locale
+        )
+    }
+
+    static func agentCompletionGapChanges(
+        locale: Locale = .current
+    ) -> String {
+        localizedString(
+            forKey: "agentCompletion.gap.changes",
+            fallback: "No file changes have verified attribution.",
+            locale: locale
+        )
+    }
+
+    static func agentCompletionGapCommands(
+        locale: Locale = .current
+    ) -> String {
+        localizedString(
+            forKey: "agentCompletion.gap.commands",
+            fallback: "No commands have structured evidence.",
+            locale: locale
+        )
+    }
+
+    static func agentCompletionGapTests(
+        locale: Locale = .current
+    ) -> String {
+        localizedString(
+            forKey: "agentCompletion.gap.tests",
+            fallback: "No successful test run has verified evidence.",
+            locale: locale
+        )
+    }
+
+    static func agentCompletionGapStatistics(
+        _ count: Int,
+        locale: Locale = .current
+    ) -> String {
+        let format = localizedString(
+            forKey: "agentCompletion.gap.statistics %lld",
+            fallback: "Exact diff statistics are unavailable for %lld files.",
+            locale: locale
+        )
+        return String(format: format, locale: locale, Int64(count))
+    }
+
+    static func agentCompletionGapOverlaps(
+        _ count: Int,
+        locale: Locale = .current
+    ) -> String {
+        let format = localizedString(
+            forKey: "agentCompletion.gap.overlaps %lld",
+            fallback: "%lld files have overlapping or ambiguous edits.",
+            locale: locale
+        )
+        return String(format: format, locale: locale, Int64(count))
+    }
     static let agentHistoryUndoUnavailable: LocalizedStringKey = "agentHistory.undoUnavailable"
     static let agentHistoryUndoUnavailableReason: LocalizedStringKey = "agentHistory.undoUnavailableReason"
     static let agentHistoryRevertConfirmTitle: LocalizedStringKey = "agentHistory.revertConfirmTitle"

--- a/PineTests/AgentCompletionBriefTests.swift
+++ b/PineTests/AgentCompletionBriefTests.swift
@@ -1,0 +1,261 @@
+//
+//  AgentCompletionBriefTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Agent Completion Brief")
+@MainActor
+struct AgentCompletionBriefTests {
+    @Test("Terminal text never manufactures a verified test result")
+    func terminalTextIsNotVerified() {
+        let sessionID = id(1)
+        let action = AgentAction(
+            sessionID: sessionID,
+            agentType: .codex,
+            kind: .command,
+            status: .completed,
+            summary: "xcodebuild test -scheme Pine"
+        )
+
+        let brief = AgentCompletionBriefBuilder.build(
+            entry: history(sessionID: sessionID, paths: ["Pine/App.swift"]),
+            evidence: AgentCompletionBriefEvidence(activities: [action])
+        )
+
+        #expect(brief.commands.count == 1)
+        #expect(brief.commands[0].kind == .test)
+        #expect(brief.commands[0].outcome == .unknown)
+        #expect(brief.commands[0].attribution == .inferred)
+        #expect(brief.verifiedTestCount == 0)
+        #expect(brief.gaps.contains(.noVerifiedTests))
+    }
+
+    @Test("Structured exit status is retained with its verified source")
+    func structuredCommandResult() {
+        let sessionID = id(2)
+        let event = storedEvent(
+            sessionID: sessionID,
+            cursor: 1,
+            payload: .commandResult(AgentCommandResult(
+                command: "xcodebuild test -scheme Pine",
+                exitStatus: 0
+            ))
+        )
+
+        let brief = AgentCompletionBriefBuilder.build(
+            entry: history(sessionID: sessionID),
+            evidence: AgentCompletionBriefEvidence(
+                provenanceIntegrity: .healthy,
+                events: [event]
+            )
+        )
+
+        #expect(brief.commands.count == 1)
+        #expect(brief.commands[0].outcome == .succeeded)
+        #expect(brief.commands[0].attribution == .verified)
+        #expect(brief.commands[0].source == "explicitAgentEvent")
+        #expect(brief.verifiedTestCount == 1)
+        #expect(!brief.gaps.contains(.noStructuredCommands))
+        #expect(!brief.gaps.contains(.noVerifiedTests))
+    }
+
+    @Test("Completion statistics invert the checked undo preview")
+    func exactStatsAndNarrativeLabel() {
+        let sessionID = id(3)
+        let preview = AgentHistoryUndoPreviewModel(
+            historyEntryID: id(30),
+            operations: [previewOperation(
+                path: "Pine/App.swift",
+                inverseAdded: 2,
+                inverseRemoved: 5
+            )]
+        )
+
+        let brief = AgentCompletionBriefBuilder.build(
+            entry: history(
+                entryID: id(30),
+                sessionID: sessionID,
+                paths: ["Pine/App.swift"]
+            ),
+            evidence: AgentCompletionBriefEvidence(
+                verifiedUndoPreview: preview,
+                agentReportedNarrative: "Implemented the requested feature."
+            )
+        )
+
+        #expect(brief.changes.count == 1)
+        #expect(brief.changes[0].statistics == AgentCompletionDiffStatistics(
+            addedLineCount: 5,
+            removedLineCount: 2
+        ))
+        #expect(brief.changes[0].hasVerifiedDiff)
+        #expect(brief.narrative?.attribution == .agentReported)
+        #expect(brief.links.diffPaths == ["Pine/App.swift"])
+    }
+
+    @Test("Ambiguous writers remain ambiguous and disclose overlap")
+    func ambiguityAndOverlap() {
+        let sessionID = id(4)
+        let otherSessionID = id(5)
+        let root = URL(fileURLWithPath: "/tmp/project")
+        let action = AgentAction(
+            attribution: .ambiguous(candidates: [
+                AgentActionCandidate(sessionID: sessionID, agentType: .codex),
+                AgentActionCandidate(
+                    sessionID: otherSessionID,
+                    agentType: .claudeCode
+                )
+            ]),
+            kind: .fileWrite,
+            fileURL: root.appendingPathComponent("shared.swift"),
+            summary: "shared.swift"
+        )
+        let scopeEvent = storedEvent(
+            sessionID: sessionID,
+            cursor: 1,
+            payload: .none,
+            worktree: root.path
+        )
+
+        let brief = AgentCompletionBriefBuilder.build(
+            entry: history(
+                sessionID: sessionID,
+                paths: ["shared.swift"]
+            ),
+            evidence: AgentCompletionBriefEvidence(
+                provenanceIntegrity: .healthy,
+                events: [scopeEvent],
+                activities: [action]
+            )
+        )
+
+        #expect(brief.changes[0].attribution == .ambiguous)
+        #expect(brief.changes[0].hasOverlappingEdits)
+        #expect(brief.gaps.contains(.overlappingEdits(paths: ["shared.swift"])))
+    }
+
+    @Test("Recovered provenance and missing statistics are explicit gaps")
+    func unverifiableGaps() {
+        let report = AgentEventCorruptionReport(
+            kind: .truncatedFrame,
+            retainedRecordCount: 1,
+            discardedByteCount: 20,
+            quarantinedByteCount: 20,
+            quarantineFileName: "events.quarantine"
+        )
+        let brief = AgentCompletionBriefBuilder.build(
+            entry: history(sessionID: id(6), paths: ["unknown.bin"]),
+            evidence: AgentCompletionBriefEvidence(
+                provenanceIntegrity: .recovered(report)
+            )
+        )
+
+        #expect(brief.gaps.contains(.provenanceRecoveredWithLoss))
+        #expect(brief.gaps.contains(.noVerifiedChanges))
+        #expect(brief.gaps.contains(.diffStatisticsUnavailable(
+            paths: ["unknown.bin"]
+        )))
+    }
+
+    private func history(
+        entryID: UUID? = nil,
+        sessionID: UUID,
+        paths: [String] = []
+    ) -> AgentHistoryEntry {
+        AgentHistoryEntry(
+            id: entryID ?? id(20),
+            sessionID: sessionID,
+            agentTypeRaw: "codex",
+            startedAt: Date(timeIntervalSince1970: 100),
+            endedAt: Date(timeIntervalSince1970: 200),
+            affectedFiles: paths,
+            summary: "Observed completion"
+        )
+    }
+
+    private func storedEvent(
+        sessionID: UUID,
+        cursor: UInt64,
+        payload: AgentEventPayload,
+        worktree: String = "/tmp/project"
+    ) -> StoredAgentEvent {
+        StoredAgentEvent(
+            sequence: cursor,
+            envelope: AgentEventEnvelope(
+                id: id(Int(cursor) + 100),
+                projectID: id(90),
+                sessionID: sessionID,
+                agentTypeRaw: "codex",
+                process: AgentProcessIdentity(
+                    terminalID: id(91),
+                    processGeneration: 1
+                ),
+                location: AgentEventLocation(
+                    worktreePath: worktree,
+                    cwd: worktree
+                ),
+                cursorValue: cursor,
+                timestamp: Date(timeIntervalSince1970: 150),
+                source: .explicitAgentEvent,
+                trustLevel: .verified,
+                payload: payload
+            )
+        )
+    }
+
+    private func previewOperation(
+        path: String,
+        inverseAdded: Int,
+        inverseRemoved: Int
+    ) -> AgentHistoryUndoPreviewOperation {
+        var lines: [AgentHistoryUndoPreviewHunk.Line] = []
+        for index in 0..<inverseAdded {
+            lines.append(AgentHistoryUndoPreviewHunk.Line(
+                id: index,
+                kind: .add,
+                text: "+",
+                lineEnding: .lf
+            ))
+        }
+        for index in 0..<inverseRemoved {
+            lines.append(AgentHistoryUndoPreviewHunk.Line(
+                id: inverseAdded + index,
+                kind: .remove,
+                text: "-",
+                lineEnding: .lf
+            ))
+        }
+        return AgentHistoryUndoPreviewOperation(
+            id: path,
+            relativePath: path,
+            kind: .restoreModifiedFile,
+            contentRepresentation: .textual,
+            hunks: [AgentHistoryUndoPreviewHunk(
+                id: 0,
+                header: "@@ -1 +1 @@",
+                lines: lines
+            )],
+            expectedContentSHA256: String(repeating: "a", count: 64),
+            expectedByteCount: 1,
+            expectedPermissions: 0o644,
+            resultContentSHA256: String(repeating: "b", count: 64),
+            resultByteCount: 1,
+            resultPermissions: 0o644,
+            previewDevice: 1,
+            previewInode: 1
+        )
+    }
+
+    private func id(_ value: Int) -> UUID {
+        UUID(uuid: (
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0,
+            UInt8((value >> 8) & 0xff), UInt8(value & 0xff)
+        ))
+    }
+}

--- a/PineTests/VerifiedChanges/VerifiedPatchEngineTests.swift
+++ b/PineTests/VerifiedChanges/VerifiedPatchEngineTests.swift
@@ -1054,6 +1054,202 @@ struct VerifiedPatchPreparationTests {
     }
 }
 
+@Suite("Verified Patch Selection")
+struct VerifiedPatchSelectionTests {
+    @Test("One verified hunk reverts without touching accepted hunks")
+    func selectedHunk() throws {
+        let before = file("""
+        human-old
+        stable-0
+        stable-1
+        old-one
+        stable-a
+        stable-b
+        stable-c
+        stable-d
+        stable-e
+        old-two
+        stable-2
+        stable-3
+        """)
+        let after = file("""
+        human-old
+        stable-0
+        stable-1
+        agent-one
+        stable-a
+        stable-b
+        stable-c
+        stable-d
+        stable-e
+        agent-two
+        stable-2
+        stable-3
+        """)
+        let current = file("""
+        human-new
+        stable-0
+        stable-1
+        agent-one
+        stable-a
+        stable-b
+        stable-c
+        stable-d
+        stable-e
+        agent-two
+        stable-2
+        stable-3
+        """)
+        let patch = try singlePatch(before: before, after: after)
+        let prepared = try requirePrepared(
+            patch,
+            files: ["file.txt": current]
+        )
+        let operation = try #require(prepared.operations.first)
+        #expect(operation.mode == .checkedText)
+        #expect(operation.resolvedTextHunks.count == 2)
+
+        let selected = try #require(try? selection(
+            [.hunks(operationID: operation.operationID, indices: [0])],
+            from: prepared
+        ))
+        let outcome = VerifiedPatchEngine.applySelection(
+            selected,
+            currentSnapshot: snapshot(["file.txt": current])
+        )
+        guard case .applied(let result, let previews) = outcome else {
+            Issue.record("Expected selected hunk to apply")
+            return
+        }
+        #expect(text(try #require(result.files["file.txt"])) == """
+        human-new
+        stable-0
+        stable-1
+        old-one
+        stable-a
+        stable-b
+        stable-c
+        stable-d
+        stable-e
+        agent-two
+        stable-2
+        stable-3
+        """)
+        #expect(previews.count == 1)
+        #expect(previews[0].hunks.count == 1)
+    }
+
+    @Test("Concurrent edits to unselected paths are preserved")
+    func unselectedConcurrentPath() throws {
+        let after = file("agent\n")
+        let patch = try singlePatch(before: file("before\n"), after: after)
+        let prepared = try requirePrepared(
+            patch,
+            files: [
+                "file.txt": after,
+                "unrelated.txt": file("first\n")
+            ]
+        )
+        let operation = try #require(prepared.operations.first)
+        let selected = try #require(try? selection(
+            [.operation(operation.operationID)],
+            from: prepared
+        ))
+
+        let outcome = VerifiedPatchEngine.applySelection(
+            selected,
+            currentSnapshot: snapshot([
+                "file.txt": after,
+                "unrelated.txt": file("changed later\n")
+            ])
+        )
+        guard case .applied(let result, _) = outcome else {
+            Issue.record("Expected selection to preserve unrelated path")
+            return
+        }
+        #expect(text(try #require(result.files["file.txt"])) == "before\n")
+        #expect(text(try #require(result.files["unrelated.txt"])) == "changed later\n")
+    }
+
+    @Test("A stale selected path fails atomically")
+    func staleSelectedPath() throws {
+        let after = file("agent\n")
+        let patch = try singlePatch(before: file("before\n"), after: after)
+        let prepared = try requirePrepared(
+            patch,
+            files: ["file.txt": after]
+        )
+        let operation = try #require(prepared.operations.first)
+        let selected = try #require(try? selection(
+            [.operation(operation.operationID)],
+            from: prepared
+        ))
+
+        let outcome = VerifiedPatchEngine.applySelection(
+            selected,
+            currentSnapshot: snapshot([
+                "file.txt": file("changed after review\n")
+            ])
+        )
+        guard case .conflicted(let conflicts) = outcome else {
+            Issue.record("Expected stale selection conflict")
+            return
+        }
+        #expect(conflicts.count == 1)
+        #expect(conflicts[0].reason == .snapshotChangedAfterPreparation)
+    }
+
+    @Test("Exact, empty, duplicate, and unknown selections fail closed")
+    func invalidSelections() throws {
+        let after = file(Data([0x00, 0x01]))
+        let patch = try singlePatch(before: file(Data([0x02])), after: after)
+        let prepared = try requirePrepared(
+            patch,
+            files: ["file.txt": after]
+        )
+        let operation = try #require(prepared.operations.first)
+
+        #expect(selectionResult([], from: prepared) == .emptySelection)
+        #expect(selectionResult([
+            .operation(operation.operationID),
+            .operation(operation.operationID)
+        ], from: prepared) == .duplicateOperation(operation.operationID))
+        #expect(selectionResult([
+            .hunks(operationID: operation.operationID, indices: [0])
+        ], from: prepared) == .hunkSelectionRequiresCheckedText(
+            operation.operationID
+        ))
+
+        let unknownID = VerifiedPatchOperationID(
+            patchID: id(250),
+            transitionIDs: operation.operationID.transitionIDs
+        )
+        #expect(selectionResult([
+            .operation(unknownID)
+        ], from: prepared) == .unknownOperation(unknownID))
+    }
+
+    private func selection(
+        _ choices: [VerifiedPatchReviewSelection],
+        from prepared: PreparedInverse
+    ) throws -> VerifiedPreparedSelection {
+        switch VerifiedPatchEngine.prepareSelection(choices, from: prepared) {
+        case .success(let value): value
+        case .failure(let failure): throw failure
+        }
+    }
+
+    private func selectionResult(
+        _ choices: [VerifiedPatchReviewSelection],
+        from prepared: PreparedInverse
+    ) -> VerifiedPatchSelectionFailure? {
+        switch VerifiedPatchEngine.prepareSelection(choices, from: prepared) {
+        case .success: nil
+        case .failure(let failure): failure
+        }
+    }
+}
+
 @Suite("Verified Patch Budgets")
 struct VerifiedPatchBudgetTests {
     @Test("Per-file byte limit accepts limit and rejects +1")


### PR DESCRIPTION
Closes #1308

## Summary
- add an evidence-first completion brief to Agent History with exact changed paths, verified diff statistics, structured command outcomes, explicit evidence gaps, and separately labelled agent narrative
- never promote terminal text or heuristic activity into verified build/test claims
- add fail-closed selection of complete operations or individual checked-text hunks while preserving unrelated and unselected current state
- expose the brief through native keyboard-accessible controls and localize the new surface in all 9 supported languages

## Safety
- selected paths must still match the prepared snapshot; stale selected content conflicts atomically
- hunk selection is limited to previously resolved checked-text hunks and does no fuzzy matching
- empty, duplicate, unknown, malformed, and oversized selections fail closed
- this layer grants no filesystem, staging, checkout, or discard authority; the live coordinator must revalidate owner-private authority, root, HEAD, index, and descriptors

## Verification
- xcodebuild build: passed on macOS 27 beta / Xcode 27 beta, deployment target remains macOS 26.0
- AgentCompletionBriefTests + VerifiedPatchSelectionTests: 9 passed
- SwiftLint on all changed Swift files: 0 violations
- Localizable.xcstrings parsed and compiled by the build
- UI tests intentionally not run locally per maintainer request

## Stack
Base: #1323 (agent task recovery). Retarget to main after the lower stack lands.