### PR TITLE
feat(agent): isolate, compare, and hand off worktree tasks

### DIFF
--- a/Pine/Agent/AgentTaskComparison.swift
+++ b/Pine/Agent/AgentTaskComparison.swift
@@ -1,0 +1,216 @@
+//
+//  AgentTaskComparison.swift
+//  Pine
+//
+//  Fact-only comparison and explicit cross-agent handoff (#1309).
+//
+
+import Foundation
+
+nonisolated struct AgentTaskComparisonCandidate: Sendable, Equatable {
+    let taskID: UUID
+    let worktreePath: String
+    let agentTypeIdentifier: String
+    let changedFiles: [AgentCompletionChange]
+    let commands: [AgentCompletionCommand]
+    let evidenceGaps: [AgentCompletionGap]
+    let elapsedTime: TimeInterval?
+    let verifiedTestCount: Int
+    let failedCommandCount: Int
+    let agentReportedNarrative: AgentCompletionNarrative?
+}
+
+/// Side-by-side facts have no score, rank, recommendation, or winner field.
+/// Choosing a result is always a separate explicit user action.
+nonisolated struct AgentTaskComparison: Sendable, Equatable {
+    let objective: String?
+    let left: AgentTaskComparisonCandidate
+    let right: AgentTaskComparisonCandidate
+}
+
+nonisolated enum AgentTaskComparisonFailure: Error, Sendable, Equatable {
+    case sameTask
+    case differentProject
+    case briefDoesNotBelongToTask(UUID)
+}
+
+@MainActor
+enum AgentTaskComparisonBuilder {
+    static func build(
+        leftTask: AgentTask,
+        leftBrief: AgentCompletionBrief,
+        rightTask: AgentTask,
+        rightBrief: AgentCompletionBrief
+    ) -> Result<AgentTaskComparison, AgentTaskComparisonFailure> {
+        guard leftTask.id != rightTask.id else { return .failure(.sameTask) }
+        guard leftTask.project.canonicalProjectPath
+                == rightTask.project.canonicalProjectPath else {
+            return .failure(.differentProject)
+        }
+        guard brief(leftBrief, belongsTo: leftTask) else {
+            return .failure(.briefDoesNotBelongToTask(leftTask.id))
+        }
+        guard brief(rightBrief, belongsTo: rightTask) else {
+            return .failure(.briefDoesNotBelongToTask(rightTask.id))
+        }
+        let commonObjective = leftTask.objective == rightTask.objective
+            ? leftTask.objective
+            : nil
+        return .success(AgentTaskComparison(
+            objective: commonObjective,
+            left: candidate(task: leftTask, brief: leftBrief),
+            right: candidate(task: rightTask, brief: rightBrief)
+        ))
+    }
+
+    private static func brief(
+        _ brief: AgentCompletionBrief,
+        belongsTo task: AgentTask
+    ) -> Bool {
+        task.runs.contains { $0.id == brief.sessionID }
+            && task.descriptor.typeIdentifier == brief.agentTypeRaw
+    }
+
+    private static func candidate(
+        task: AgentTask,
+        brief: AgentCompletionBrief
+    ) -> AgentTaskComparisonCandidate {
+        let elapsed = brief.endedAt.map {
+            max(0, $0.timeIntervalSince(brief.startedAt))
+        }
+        return AgentTaskComparisonCandidate(
+            taskID: task.id,
+            worktreePath: task.project.canonicalWorktreePath,
+            agentTypeIdentifier: task.descriptor.typeIdentifier,
+            changedFiles: brief.changes,
+            commands: brief.commands,
+            evidenceGaps: brief.gaps,
+            elapsedTime: elapsed,
+            verifiedTestCount: brief.verifiedTestCount,
+            failedCommandCount: brief.commands.lazy.filter {
+                if case .failed = $0.outcome { return true }
+                return false
+            }.count,
+            agentReportedNarrative: brief.narrative
+        )
+    }
+}
+
+nonisolated struct AgentTaskHandoffRequest: Sendable, Equatable {
+    let sourceTaskID: UUID
+    let targetTaskID: UUID
+    let sourceCompletionBriefID: UUID
+    /// Fresh text authored by the user for this handoff. Pine never copies the
+    /// source task objective, credentials, environment, or transcript here.
+    let followUpObjective: String
+    let selectedEvidencePaths: [String]
+}
+
+nonisolated struct AgentTaskHandoffAttribution: Sendable, Equatable {
+    let relativePath: String
+    let sourceTaskID: UUID
+    let sourceSessionID: UUID
+    let originalEvidence: AgentCompletionEvidenceLevel
+}
+
+nonisolated struct AgentTaskHandoffPackage: Sendable, Equatable, Identifiable {
+    let id: UUID
+    let sourceTaskID: UUID
+    let targetTaskID: UUID
+    let sourceCompletionBriefID: UUID
+    let createdAt: Date
+    let followUpObjective: String
+    let priorAttribution: [AgentTaskHandoffAttribution]
+
+    /// Deliberate schema guarantee: there is no transcript, environment,
+    /// credential, command output, or copied agent narrative in this package.
+}
+
+nonisolated enum AgentTaskHandoffFailure: Error, Sendable, Equatable {
+    case sameTask
+    case taskMismatch
+    case differentProject
+    case sourceBriefMismatch
+    case invalidObjective
+    case invalidEvidencePath(String)
+    case evidencePathNotInBrief(String)
+    case resourceLimitExceeded
+}
+
+nonisolated enum AgentTaskHandoffPlanner {
+    private static let maximumObjectiveBytes = 64 * 1_024
+    private static let maximumEvidencePaths = 10_000
+
+    static func prepare(
+        request: AgentTaskHandoffRequest,
+        sourceTask: AgentTask,
+        targetTask: AgentTask,
+        sourceBrief: AgentCompletionBrief,
+        handoffID: UUID = UUID(),
+        createdAt: Date = Date()
+    ) -> Result<AgentTaskHandoffPackage, AgentTaskHandoffFailure> {
+        guard sourceTask.id != targetTask.id else { return .failure(.sameTask) }
+        guard request.sourceTaskID == sourceTask.id,
+              request.targetTaskID == targetTask.id else {
+            return .failure(.taskMismatch)
+        }
+        guard sourceTask.project.canonicalProjectPath
+                == targetTask.project.canonicalProjectPath else {
+            return .failure(.differentProject)
+        }
+        guard request.sourceCompletionBriefID == sourceBrief.id,
+              sourceTask.runs.contains(where: {
+                  $0.id == sourceBrief.sessionID
+              }) else {
+            return .failure(.sourceBriefMismatch)
+        }
+        let objective = request.followUpObjective.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        guard !objective.isEmpty,
+              objective.utf8.count <= maximumObjectiveBytes,
+              !objective.utf8.contains(0),
+              !objective.unicodeScalars.contains(where: {
+                  CharacterSet.controlCharacters.contains($0)
+                      && $0 != "\n" && $0 != "\t"
+              }) else {
+            return .failure(.invalidObjective)
+        }
+        guard request.selectedEvidencePaths.count <= maximumEvidencePaths else {
+            return .failure(.resourceLimitExceeded)
+        }
+
+        var changesByPath: [String: AgentCompletionChange] = [:]
+        for change in sourceBrief.changes
+        where changesByPath[change.relativePath] == nil {
+            changesByPath[change.relativePath] = change
+        }
+        var seen: Set<String> = []
+        var attributions: [AgentTaskHandoffAttribution] = []
+        for path in request.selectedEvidencePaths {
+            guard AgentHistoryUndoPreflight.isCanonicalRelativePath(path),
+                  seen.insert(path).inserted else {
+                return .failure(.invalidEvidencePath(path))
+            }
+            guard let change = changesByPath[path] else {
+                return .failure(.evidencePathNotInBrief(path))
+            }
+            attributions.append(AgentTaskHandoffAttribution(
+                relativePath: path,
+                sourceTaskID: sourceTask.id,
+                sourceSessionID: sourceBrief.sessionID,
+                originalEvidence: change.attribution
+            ))
+        }
+
+        return .success(AgentTaskHandoffPackage(
+            id: handoffID,
+            sourceTaskID: sourceTask.id,
+            targetTaskID: targetTask.id,
+            sourceCompletionBriefID: sourceBrief.id,
+            createdAt: createdAt,
+            followUpObjective: objective,
+            priorAttribution: attributions
+        ))
+    }
+}

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -564,11 +564,30 @@ final class AgentTaskRegistry {
     /// A closed project window leaves terminal processes alive in Pine's
     /// background project registry. Only route presentation changes.
     func setWindowOpen(_ isOpen: Bool, projectPath: String) {
+        setWindowOpen(isOpen) {
+            $0.canonicalProjectPath == projectPath
+        }
+    }
+
+    /// Updates only one project/worktree window. Multiple managed worktrees
+    /// deliberately share `canonicalProjectPath`, so closing one must not
+    /// background sibling agent runs.
+    func setWindowOpen(
+        _ isOpen: Bool,
+        project: AgentTaskProjectIdentity
+    ) {
+        setWindowOpen(isOpen) { $0 == project }
+    }
+
+    private func setWindowOpen(
+        _ isOpen: Bool,
+        matchesProject: (AgentTaskProjectIdentity) -> Bool
+    ) {
         expireClaims()
         guard !isTerminating else { return }
         var projects = Set<AgentTaskProjectIdentity>()
         for key in Array(pendingClaims.keys)
-        where key.project.canonicalProjectPath == projectPath {
+        where matchesProject(key.project) {
             guard var claim = pendingClaims[key] else { continue }
             if isOpen, claim.route.availability == .background {
                 claim.route.availability = .available
@@ -580,7 +599,7 @@ final class AgentTaskRegistry {
             pendingClaims[key] = claim
         }
         for (_, taskID) in taskIDByTerminal
-        where task(for: taskID)?.project.canonicalProjectPath == projectPath {
+        where task(for: taskID).map({ matchesProject($0.project) }) == true {
             guard let index = taskIndex(for: taskID) else { continue }
             let availability = tasks[index].route.availability
             if isOpen, availability == .background {

--- a/Pine/Agent/AgentWorktreeService.swift
+++ b/Pine/Agent/AgentWorktreeService.swift
@@ -1,0 +1,682 @@
+//
+//  AgentWorktreeService.swift
+//  Pine
+//
+//  Explicit, fail-closed Git worktree lifecycle for isolated agent tasks.
+//
+
+import CryptoKit
+import Darwin
+import Foundation
+
+nonisolated struct AgentWorktreeCreateRequest: Sendable, Equatable {
+    let taskID: UUID
+    let repositoryRoot: URL
+    let managedRoot: URL
+    let branchName: String
+    let startPoint: String
+}
+
+nonisolated struct AgentManagedWorktree: Sendable, Equatable {
+    let taskID: UUID
+    let repositoryRoot: URL
+    let managedRoot: URL
+    let worktreeRoot: URL
+    let branchName: String
+    let baseCommit: String
+}
+
+nonisolated enum AgentWorktreeCreateFailure: Error, Sendable, Equatable {
+    case invalidRepository
+    case unsafeManagedRoot
+    case managedRootInsideRepository
+    case invalidBranchName
+    case missingStartPoint
+    case destinationAlreadyExists(URL)
+    case primarySnapshotUnavailable
+    case gitRejected(String)
+    case creationInterrupted(URL)
+    case createdWorktreeInvalid(URL)
+    case primaryCheckoutChanged(URL)
+}
+
+nonisolated enum AgentWorktreeCreateResult: Sendable, Equatable {
+    case created(AgentManagedWorktree)
+    case failed(AgentWorktreeCreateFailure)
+}
+
+nonisolated struct AgentWorktreeRemovalInspection: Sendable, Equatable {
+    let worktree: AgentManagedWorktree
+    let dirtyPaths: [String]
+
+    var requiresDestructiveConfirmation: Bool { !dirtyPaths.isEmpty }
+}
+
+/// Exact, short-lived user intent. Presentation must show both `worktreeRoot`
+/// and every `dirtyPath`, plus the fact that uncommitted data may be lost,
+/// before constructing this value.
+nonisolated struct AgentWorktreeRemovalConfirmation: Sendable, Equatable {
+    let worktreeRoot: URL
+    let dirtyPaths: [String]
+    let acknowledgesUnrecoverableDataLoss: Bool
+}
+
+nonisolated enum AgentWorktreeRemovalFailure: Error, Sendable, Equatable {
+    case unsafeWorktree
+    case inspectionFailed
+    case confirmationRequired(AgentWorktreeRemovalInspection)
+    case confirmationMismatch
+    case gitRejected(String)
+    case removalInterrupted(URL)
+}
+
+nonisolated enum AgentWorktreeRemovalResult: Sendable, Equatable {
+    case removed
+    case failed(AgentWorktreeRemovalFailure)
+}
+
+nonisolated struct AgentWorktreeIntegrationPreview: Sendable, Equatable,
+    Identifiable {
+    let id: UUID
+    let worktree: AgentManagedWorktree
+    let sourceCommit: String
+    let targetRoot: URL
+    let targetHead: String
+    let targetBranch: String
+    let targetIndexDigest: String
+    let changedPaths: [String]
+    let conflictingPaths: [String]
+
+    var hasConflicts: Bool { !conflictingPaths.isEmpty }
+}
+
+nonisolated enum AgentWorktreeIntegrationPreviewFailure: Error, Sendable,
+    Equatable {
+    case unsafeWorktree
+    case sourceBranchChanged
+    case sourceWorktreeDirty([String])
+    case targetSnapshotUnavailable
+    case targetDetached
+    case targetCheckoutDirty([String])
+    case noChanges
+    case gitRejected(String)
+}
+
+nonisolated enum AgentWorktreeIntegrationPreviewResult: Sendable, Equatable {
+    case ready(AgentWorktreeIntegrationPreview)
+    case failed(AgentWorktreeIntegrationPreviewFailure)
+}
+
+/// Exact user approval of one immutable preview. Presentation must disclose
+/// the source commit, target branch and changed paths before creating it.
+nonisolated struct AgentWorktreeIntegrationConfirmation: Sendable, Equatable {
+    let previewID: UUID
+    let sourceCommit: String
+    let targetHead: String
+    let targetBranch: String
+    let changedPaths: [String]
+}
+
+nonisolated enum AgentWorktreeIntegrationFailure: Error, Sendable, Equatable {
+    case confirmationMismatch
+    case conflictsRequireResolution([String])
+    case sourceChanged
+    case targetChanged
+    case integrationInterrupted(URL)
+    case manualRecoveryRequired(String)
+}
+
+nonisolated enum AgentWorktreeIntegrationResult: Sendable, Equatable {
+    /// The source commit is staged and present in the target worktree, but is
+    /// deliberately not committed or pushed by Pine.
+    case integratedWithoutCommit
+    case failed(AgentWorktreeIntegrationFailure)
+}
+
+nonisolated struct AgentWorktreeGitRunner: Sendable {
+    let run: @Sendable ([String], URL) async -> GitCommandResult
+
+    static let live = AgentWorktreeGitRunner { arguments, directory in
+        await GitCommand.runAsync(arguments, at: directory)
+    }
+}
+
+/// Serializes Pine-managed worktree mutations and revalidates the primary
+/// checkout around every create. Git's own locks remain the cross-process
+/// authority; this actor prevents same-process races and ambiguous prompts.
+actor AgentWorktreeService {
+    private let runner: AgentWorktreeGitRunner
+    private let fileManager: FileManager
+    private var reservedDestinations: Set<String> = []
+
+    init(
+        runner: AgentWorktreeGitRunner = .live,
+        fileManager: FileManager = .default
+    ) {
+        self.runner = runner
+        self.fileManager = fileManager
+    }
+
+    func create(
+        _ request: AgentWorktreeCreateRequest
+    ) async -> AgentWorktreeCreateResult {
+        guard let repository = await canonicalRepository(
+            request.repositoryRoot
+        ) else {
+            return .failed(.invalidRepository)
+        }
+        guard let managedRoot = secureExistingDirectory(request.managedRoot)
+        else {
+            return .failed(.unsafeManagedRoot)
+        }
+        guard !isWithin(managedRoot, root: repository) else {
+            return .failed(.managedRootInsideRepository)
+        }
+        guard await isValidBranch(
+            request.branchName,
+            repository: repository
+        ) else {
+            return .failed(.invalidBranchName)
+        }
+        guard let baseCommit = await resolvedCommit(
+            request.startPoint,
+            repository: repository
+        ) else {
+            return .failed(.missingStartPoint)
+        }
+
+        let destination = managedRoot.appendingPathComponent(
+            request.taskID.uuidString.lowercased(),
+            isDirectory: true
+        ).standardizedFileURL
+        guard destination.deletingLastPathComponent() == managedRoot,
+              !fileManager.fileExists(atPath: destination.path) else {
+            return .failed(.destinationAlreadyExists(destination))
+        }
+        guard reservedDestinations.insert(destination.path).inserted else {
+            return .failed(.destinationAlreadyExists(destination))
+        }
+        defer { reservedDestinations.remove(destination.path) }
+        guard let before = await primarySnapshot(repository) else {
+            return .failed(.primarySnapshotUnavailable)
+        }
+
+        let result = await runner.run([
+            "worktree", "add", "--no-track", "-b", request.branchName,
+            "--", destination.path, baseCommit,
+        ], repository)
+        if result.timedOut || result.cancelled {
+            return .failed(.creationInterrupted(destination))
+        }
+        guard result.completedSuccessfully else {
+            return .failed(.gitRejected(diagnostic(result)))
+        }
+        guard let createdRoot = await canonicalRepository(destination),
+              createdRoot == destination.resolvingSymlinksInPath()
+                .standardizedFileURL else {
+            return .failed(.createdWorktreeInvalid(destination))
+        }
+        guard let after = await primarySnapshot(repository),
+              before == after else {
+            return .failed(.primaryCheckoutChanged(destination))
+        }
+
+        return .created(AgentManagedWorktree(
+            taskID: request.taskID,
+            repositoryRoot: repository,
+            managedRoot: managedRoot,
+            worktreeRoot: destination,
+            branchName: request.branchName,
+            baseCommit: baseCommit
+        ))
+    }
+
+    func inspectRemoval(
+        _ worktree: AgentManagedWorktree
+    ) async -> Result<AgentWorktreeRemovalInspection, AgentWorktreeRemovalFailure> {
+        guard secureManagedWorktree(worktree) else {
+            return .failure(.unsafeWorktree)
+        }
+        let result = await runner.run([
+            "status", "--porcelain=v1", "-z", "--untracked-files=all",
+        ], worktree.worktreeRoot)
+        guard result.succeeded else {
+            return .failure(.inspectionFailed)
+        }
+        return .success(AgentWorktreeRemovalInspection(
+            worktree: worktree,
+            dirtyPaths: Self.dirtyPaths(result.output)
+        ))
+    }
+
+    func remove(
+        _ worktree: AgentManagedWorktree,
+        confirmation: AgentWorktreeRemovalConfirmation? = nil
+    ) async -> AgentWorktreeRemovalResult {
+        let inspection: AgentWorktreeRemovalInspection
+        switch await inspectRemoval(worktree) {
+        case .failure(let failure): return .failed(failure)
+        case .success(let value): inspection = value
+        }
+
+        if inspection.requiresDestructiveConfirmation {
+            guard let confirmation else {
+                return .failed(.confirmationRequired(inspection))
+            }
+            guard confirmation.acknowledgesUnrecoverableDataLoss,
+                  confirmation.worktreeRoot.standardizedFileURL
+                    == worktree.worktreeRoot.standardizedFileURL,
+                  confirmation.dirtyPaths == inspection.dirtyPaths else {
+                return .failed(.confirmationMismatch)
+            }
+        } else if confirmation != nil {
+            return .failed(.confirmationMismatch)
+        }
+
+        var arguments = ["worktree", "remove"]
+        if inspection.requiresDestructiveConfirmation {
+            arguments.append("--force")
+        }
+        arguments += ["--", worktree.worktreeRoot.path]
+        let result = await runner.run(arguments, worktree.repositoryRoot)
+        if result.timedOut || result.cancelled {
+            return .failed(.removalInterrupted(worktree.worktreeRoot))
+        }
+        guard result.completedSuccessfully else {
+            return .failed(.gitRejected(diagnostic(result)))
+        }
+        return .removed
+    }
+
+    func previewIntegration(
+        _ worktree: AgentManagedWorktree,
+        previewID: UUID = UUID()
+    ) async -> AgentWorktreeIntegrationPreviewResult {
+        guard secureManagedWorktree(worktree) else {
+            return .failed(.unsafeWorktree)
+        }
+        guard let sourceCommit = await currentSourceCommit(worktree) else {
+            return .failed(.sourceBranchChanged)
+        }
+        let sourceStatus = await statusPaths(at: worktree.worktreeRoot)
+        guard let sourceStatus else {
+            return .failed(.gitRejected("Unable to inspect source worktree"))
+        }
+        guard sourceStatus.isEmpty else {
+            return .failed(.sourceWorktreeDirty(sourceStatus))
+        }
+        guard let target = await primarySnapshot(worktree.repositoryRoot) else {
+            return .failed(.targetSnapshotUnavailable)
+        }
+        guard let targetBranch = target.branch else {
+            return .failed(.targetDetached)
+        }
+        let targetDirtyPaths = Self.dirtyPaths(target.status)
+        guard targetDirtyPaths.isEmpty else {
+            return .failed(.targetCheckoutDirty(targetDirtyPaths))
+        }
+
+        let changes = await runner.run([
+            "diff", "--name-only", "-z",
+            "\(target.head)...\(sourceCommit)", "--",
+        ], worktree.repositoryRoot)
+        guard changes.succeeded else {
+            return .failed(.gitRejected(diagnostic(changes)))
+        }
+        let changedPaths = Self.canonicalNULPaths(changes.output)
+        guard !changedPaths.isEmpty else { return .failed(.noChanges) }
+
+        let merge = await runner.run([
+            "merge-tree", "--write-tree", "--name-only", "-z",
+            target.head, sourceCommit,
+        ], worktree.repositoryRoot)
+        guard !merge.timedOut,
+              !merge.cancelled,
+              merge.outputCaptureComplete,
+              merge.errorOutputCaptureComplete,
+              !merge.outputTruncated,
+              !merge.errorOutputTruncated,
+              merge.exitCode == 0 || merge.exitCode == 1 else {
+            return .failed(.gitRejected(diagnostic(merge)))
+        }
+        let conflicts = merge.exitCode == 1
+            ? Self.mergeTreeConflictPaths(merge.output)
+            : []
+        guard merge.exitCode == 0 || !conflicts.isEmpty else {
+            return .failed(.gitRejected("Git reported an unparseable conflict"))
+        }
+
+        return .ready(AgentWorktreeIntegrationPreview(
+            id: previewID,
+            worktree: worktree,
+            sourceCommit: sourceCommit,
+            targetRoot: worktree.repositoryRoot,
+            targetHead: target.head,
+            targetBranch: targetBranch,
+            targetIndexDigest: target.indexDigest,
+            changedPaths: changedPaths,
+            conflictingPaths: conflicts
+        ))
+    }
+
+    func integrate(
+        _ preview: AgentWorktreeIntegrationPreview,
+        confirmation: AgentWorktreeIntegrationConfirmation
+    ) async -> AgentWorktreeIntegrationResult {
+        guard confirmation.previewID == preview.id,
+              confirmation.sourceCommit == preview.sourceCommit,
+              confirmation.targetHead == preview.targetHead,
+              confirmation.targetBranch == preview.targetBranch,
+              confirmation.changedPaths == preview.changedPaths else {
+            return .failed(.confirmationMismatch)
+        }
+        guard !preview.hasConflicts else {
+            return .failed(.conflictsRequireResolution(
+                preview.conflictingPaths
+            ))
+        }
+        guard secureManagedWorktree(preview.worktree),
+              await currentSourceCommit(preview.worktree)
+                == preview.sourceCommit,
+              await statusPaths(at: preview.worktree.worktreeRoot)?.isEmpty
+                == true else {
+            return .failed(.sourceChanged)
+        }
+        guard let currentTarget = await primarySnapshot(preview.targetRoot),
+              currentTarget.head == preview.targetHead,
+              currentTarget.branch == preview.targetBranch,
+              currentTarget.indexDigest == preview.targetIndexDigest,
+              currentTarget.status.isEmpty else {
+            return .failed(.targetChanged)
+        }
+
+        let result = await runner.run([
+            "merge", "--no-commit", "--no-ff", "--no-edit",
+            preview.sourceCommit,
+        ], preview.targetRoot)
+        if result.timedOut || result.cancelled {
+            return .failed(.integrationInterrupted(preview.targetRoot))
+        }
+        guard result.completedSuccessfully else {
+            return .failed(.manualRecoveryRequired(diagnostic(result)))
+        }
+        return .integratedWithoutCommit
+    }
+
+    private func canonicalRepository(_ candidate: URL) async -> URL? {
+        guard let directory = secureExistingDirectory(candidate) else {
+            return nil
+        }
+        let result = await runner.run([
+            "rev-parse", "--path-format=absolute", "--show-toplevel",
+        ], directory)
+        guard result.succeeded,
+              let path = singleLine(result.output) else { return nil }
+        let canonical = URL(fileURLWithPath: path, isDirectory: true)
+            .resolvingSymlinksInPath().standardizedFileURL
+        return secureExistingDirectory(canonical)
+    }
+
+    private func isValidBranch(
+        _ branch: String,
+        repository: URL
+    ) async -> Bool {
+        guard !branch.isEmpty,
+              branch.utf8.count <= 255,
+              !branch.utf8.contains(0),
+              !branch.hasPrefix("-") else { return false }
+        return await runner.run(
+            ["check-ref-format", "--branch", branch],
+            repository
+        ).succeeded
+    }
+
+    private func resolvedCommit(
+        _ startPoint: String,
+        repository: URL
+    ) async -> String? {
+        guard !startPoint.isEmpty,
+              startPoint.utf8.count <= 1_024,
+              !startPoint.utf8.contains(0),
+              !startPoint.hasPrefix("-") else { return nil }
+        let result = await runner.run([
+            "rev-parse", "--verify", "--end-of-options",
+            "\(startPoint)^{commit}",
+        ], repository)
+        guard result.succeeded,
+              let commit = singleLine(result.output),
+              commit.count == 40,
+              commit.allSatisfy({ $0.isHexDigit }) else { return nil }
+        return commit.lowercased()
+    }
+
+    private func primarySnapshot(
+        _ repository: URL
+    ) async -> AgentWorktreePrimarySnapshot? {
+        let head = await runner.run(
+            ["rev-parse", "--verify", "HEAD"],
+            repository
+        )
+        let branch = await runner.run(
+            ["symbolic-ref", "--quiet", "HEAD"],
+            repository
+        )
+        let status = await runner.run([
+            "status", "--porcelain=v1", "-z", "--untracked-files=all",
+        ], repository)
+        let indexPath = await runner.run([
+            "rev-parse", "--path-format=absolute", "--git-path", "index",
+        ], repository)
+        guard head.succeeded,
+              status.succeeded,
+              indexPath.succeeded,
+              let headValue = singleLine(head.output),
+              let indexValue = singleLine(indexPath.output),
+              let digest = boundedDigest(URL(fileURLWithPath: indexValue)) else {
+            return nil
+        }
+        return AgentWorktreePrimarySnapshot(
+            head: headValue,
+            branch: branch.succeeded ? singleLine(branch.output) : nil,
+            status: status.output,
+            indexDigest: digest
+        )
+    }
+
+    private func currentSourceCommit(
+        _ worktree: AgentManagedWorktree
+    ) async -> String? {
+        let branch = await runner.run(
+            ["symbolic-ref", "--quiet", "HEAD"],
+            worktree.worktreeRoot
+        )
+        guard branch.succeeded,
+              singleLine(branch.output) == "refs/heads/\(worktree.branchName)"
+        else { return nil }
+        return await resolvedCommit("HEAD", repository: worktree.worktreeRoot)
+    }
+
+    private func statusPaths(at root: URL) async -> [String]? {
+        let status = await runner.run([
+            "status", "--porcelain=v1", "-z", "--untracked-files=all",
+        ], root)
+        guard status.succeeded else { return nil }
+        return Self.dirtyPaths(status.output)
+    }
+
+    private func boundedDigest(_ fileURL: URL) -> String? {
+        guard let attributes = try? fileManager.attributesOfItem(
+            atPath: fileURL.path
+        ), let size = attributes[.size] as? NSNumber,
+              size.int64Value >= 0,
+              size.int64Value <= 64 * 1_024 * 1_024,
+              let data = try? Data(contentsOf: fileURL, options: .mappedIfSafe)
+        else { return nil }
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    private func secureManagedWorktree(
+        _ worktree: AgentManagedWorktree
+    ) -> Bool {
+        guard let managedRoot = secureExistingDirectory(worktree.managedRoot),
+              let worktreeRoot = secureExistingDirectory(worktree.worktreeRoot),
+              managedRoot == worktree.managedRoot.standardizedFileURL,
+              worktreeRoot == worktree.worktreeRoot.standardizedFileURL,
+              worktreeRoot.deletingLastPathComponent() == managedRoot else {
+            return false
+        }
+        return isWithin(worktreeRoot, root: managedRoot)
+    }
+
+    /// Rejects every symlink component instead of merely resolving it. This
+    /// prevents a managed destination from silently moving between review and
+    /// mutation.
+    private func secureExistingDirectory(_ url: URL) -> URL? {
+        let supplied = url.standardizedFileURL
+        guard supplied.isFileURL,
+              supplied.path.hasPrefix("/"),
+              !supplied.path.utf8.contains(0),
+              !isSymbolicLink(supplied.path) else {
+            return nil
+        }
+        // `/var` and `/tmp` are Apple's stable system aliases into `/private`,
+        // and Foundation may return either spelling for temporary directories.
+        // Every other symlink component remains rejected.
+        guard pathComponentsContainNoSymlink(supplied.path) else {
+            return nil
+        }
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(
+            atPath: supplied.path,
+            isDirectory: &isDirectory
+        ), isDirectory.boolValue else { return nil }
+        return supplied
+    }
+
+    private func isSymbolicLink(_ path: String) -> Bool {
+        var info = stat()
+        return lstat(path, &info) == 0 && (info.st_mode & S_IFMT) == S_IFLNK
+    }
+
+    private func pathComponentsContainNoSymlink(_ path: String) -> Bool {
+        var current = ""
+        for component in URL(fileURLWithPath: path).pathComponents {
+            if component == "/" {
+                current = "/"
+                continue
+            }
+            current = URL(fileURLWithPath: current, isDirectory: true)
+                .appendingPathComponent(component).path
+            var info = stat()
+            guard lstat(current, &info) == 0 else { return false }
+            if (info.st_mode & S_IFMT) == S_IFLNK {
+                let destination = try? fileManager.destinationOfSymbolicLink(
+                    atPath: current
+                )
+                let isStableSystemAlias = (current, destination) == (
+                    "/var", "private/var"
+                ) || (current, destination) == ("/tmp", "private/tmp")
+                guard isStableSystemAlias else { return false }
+            }
+        }
+        return true
+    }
+
+    private func isWithin(_ candidate: URL, root: URL) -> Bool {
+        let candidatePath = candidate.standardizedFileURL.path
+        let rootPath = root.standardizedFileURL.path
+        return candidatePath == rootPath
+            || candidatePath.hasPrefix(rootPath.hasSuffix("/")
+                ? rootPath
+                : rootPath + "/")
+    }
+
+    private func singleLine(_ output: String) -> String? {
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              !trimmed.contains("\n"),
+              !trimmed.contains("\r"),
+              !trimmed.utf8.contains(0) else { return nil }
+        return trimmed
+    }
+
+    private func diagnostic(_ result: GitCommandResult) -> String {
+        let value = result.errorOutput.isEmpty
+            ? result.output
+            : result.errorOutput
+        return String(value.prefix(1_024))
+    }
+
+    private static func dirtyPaths(_ output: String) -> [String] {
+        var seen: Set<String> = []
+        var paths: [String] = []
+        let records = output.split(separator: "\0")
+        var index = records.startIndex
+        while index < records.endIndex {
+            let record = records[index]
+            guard record.utf8.count >= 4 else {
+                index = records.index(after: index)
+                continue
+            }
+            let status = record.prefix(2)
+            appendCanonicalPath(
+                String(record.dropFirst(3)),
+                seen: &seen,
+                paths: &paths
+            )
+            index = records.index(after: index)
+            if status.contains("R") || status.contains("C"),
+               index < records.endIndex {
+                appendCanonicalPath(
+                    String(records[index]),
+                    seen: &seen,
+                    paths: &paths
+                )
+                index = records.index(after: index)
+            }
+        }
+        return paths.sorted()
+    }
+
+    private static func appendCanonicalPath(
+        _ path: String,
+        seen: inout Set<String>,
+        paths: inout [String]
+    ) {
+        guard AgentHistoryUndoPreflight.isCanonicalRelativePath(path),
+              seen.insert(path).inserted else { return }
+        paths.append(path)
+    }
+
+    private static func canonicalNULPaths(_ output: String) -> [String] {
+        var seen: Set<String> = []
+        return output.split(separator: "\0").compactMap { rawPath in
+            let path = String(rawPath)
+            guard AgentHistoryUndoPreflight.isCanonicalRelativePath(path),
+                  seen.insert(path).inserted else { return nil }
+            return path
+        }.sorted()
+    }
+
+    private static func mergeTreeConflictPaths(_ output: String) -> [String] {
+        let fields = output.split(
+            separator: "\0",
+            omittingEmptySubsequences: false
+        )
+        // `merge-tree --write-tree --name-only -z` emits the tree object,
+        // followed by conflict paths, then an empty separator and messages.
+        guard fields.count > 2 else { return [] }
+        let pathFields = fields.dropFirst().prefix { !$0.isEmpty }
+        return canonicalNULPaths(pathFields.map(String.init).joined(
+            separator: "\0"
+        ))
+    }
+}
+
+nonisolated private struct AgentWorktreePrimarySnapshot: Equatable {
+    let head: String
+    let branch: String?
+    let status: String
+    let indexDigest: String
+}

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -981,9 +981,17 @@ final class ProjectManager {
             await workspace.openFolder(context: context)
         }
     }
-    func loadDirectory(url: URL) {
+    func loadDirectory(
+        url: URL,
+        agentTaskProject: AgentTaskProjectIdentity? = nil
+    ) {
         workspace.loadDirectory(url: url)
-        terminal.configureAgentTaskProject(url)
+        terminal.configureAgentTaskProject(
+            agentTaskProject ?? AgentTaskProjectIdentity(
+                canonicalProjectPath: url.path,
+                canonicalWorktreePath: url.path
+            )
+        )
         setupRecovery(projectURL: url)
         agentHistory.updateProjectRoot(url)
         synchronizeAgentHandoff(projectRoot: url)

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -54,6 +54,8 @@ final class ProjectRegistry: LSPSettingsObserver {
     @ObservationIgnored private let defaults: UserDefaults
     @ObservationIgnored private let fileManager: FileManager
     @ObservationIgnored private let agentRecoveryInspector: AgentTaskRecoveryInspector
+    @ObservationIgnored
+    private var agentTaskProjectsByRoot: [URL: AgentTaskProjectIdentity] = [:]
 
     /// Serializes settings lifecycle changes so rapid Apply/Reset operations
     /// cannot race each other across projects.
@@ -87,7 +89,68 @@ final class ProjectRegistry: LSPSettingsObserver {
     /// Returns nil if the directory no longer exists on disk.
     func projectManager(for projectURL: URL) -> ProjectManager? {
         let canonical = canonicalProjectURL(projectURL)
+        return projectManager(
+            forCanonicalWorktree: canonical,
+            identity: AgentTaskProjectIdentity(
+                canonicalProjectPath: canonical.path,
+                canonicalWorktreePath: canonical.path
+            )
+        )
+    }
+
+    /// Opens a Pine-managed worktree while retaining the owning repository as
+    /// the shared project scope. Sibling worktrees therefore remain comparable
+    /// without sharing terminal, task, event, checkpoint, or notification IDs.
+    func projectManager(for worktree: AgentManagedWorktree) -> ProjectManager? {
+        let repository = canonicalProjectURL(worktree.repositoryRoot)
+        let managedRoot = canonicalProjectURL(worktree.managedRoot)
+        let worktreeRoot = canonicalProjectURL(worktree.worktreeRoot)
+        guard repository == worktree.repositoryRoot.standardizedFileURL,
+              managedRoot == worktree.managedRoot.standardizedFileURL,
+              worktreeRoot == worktree.worktreeRoot.standardizedFileURL,
+              worktreeRoot.deletingLastPathComponent() == managedRoot else {
+            return nil
+        }
+        return projectManager(
+            forCanonicalWorktree: worktreeRoot,
+            identity: AgentTaskProjectIdentity(
+                canonicalProjectPath: repository.path,
+                canonicalWorktreePath: worktreeRoot.path
+            )
+        )
+    }
+
+    /// Reopens a persisted exact project/worktree scope after both paths have
+    /// been canonicalized again. This is used by Inbox navigation and recovery.
+    private func projectManager(
+        for identity: AgentTaskProjectIdentity
+    ) -> ProjectManager? {
+        let project = canonicalProjectURL(URL(
+            fileURLWithPath: identity.canonicalProjectPath,
+            isDirectory: true
+        ))
+        let worktree = canonicalProjectURL(URL(
+            fileURLWithPath: identity.canonicalWorktreePath,
+            isDirectory: true
+        ))
+        guard project.path == identity.canonicalProjectPath,
+              worktree.path == identity.canonicalWorktreePath else {
+            return nil
+        }
+        return projectManager(
+            forCanonicalWorktree: worktree,
+            identity: identity
+        )
+    }
+
+    private func projectManager(
+        forCanonicalWorktree canonical: URL,
+        identity: AgentTaskProjectIdentity
+    ) -> ProjectManager? {
         if let existing = openProjects[canonical] {
+            guard agentTaskProjectsByRoot[canonical] == identity else {
+                return nil
+            }
             // Verify directory still exists when reopening from background
             if backgroundProjects.contains(canonical) {
                 var isDir: ObjCBool = false
@@ -110,10 +173,11 @@ final class ProjectRegistry: LSPSettingsObserver {
                         }
                     }
                     openProjects.removeValue(forKey: canonical)
+                    agentTaskProjectsByRoot.removeValue(forKey: canonical)
                     backgroundProjects.remove(canonical)
                     agentTasks.setWindowOpen(
                         false,
-                        projectPath: canonical.path
+                        project: identity
                     )
                     existing.terminal.setAgentTaskWindowOpen(false)
                     recentProjects.removeAll { $0 == canonical }
@@ -121,7 +185,7 @@ final class ProjectRegistry: LSPSettingsObserver {
                     return nil
                 }
                 backgroundProjects.remove(canonical)
-                agentTasks.setWindowOpen(true, projectPath: canonical.path)
+                agentTasks.setWindowOpen(true, project: identity)
                 existing.terminal.setAgentTaskWindowOpen(true)
             }
             addToRecent(canonical)
@@ -135,17 +199,19 @@ final class ProjectRegistry: LSPSettingsObserver {
             saveRecentProjects()
             return nil
         }
-        let identity = AgentTaskProjectIdentity(
-            canonicalProjectPath: canonical.path,
-            canonicalWorktreePath: canonical.path
-        )
+        var isProjectDir: ObjCBool = false
+        guard fileManager.fileExists(
+            atPath: identity.canonicalProjectPath,
+            isDirectory: &isProjectDir
+        ), isProjectDir.boolValue else { return nil }
         agentTasks.registerProject(identity)
         let pm = ProjectManager(
             lspSettings: lspSettings,
             agentTaskRegistry: agentTasks
         )
-        pm.loadDirectory(url: canonical)
+        pm.loadDirectory(url: canonical, agentTaskProject: identity)
         openProjects[canonical] = pm
+        agentTaskProjectsByRoot[canonical] = identity
         addToRecent(canonical)
         #if DEBUG
         seedAgentRecoveryUITestFixture(
@@ -256,7 +322,9 @@ final class ProjectRegistry: LSPSettingsObserver {
         let canonical = canonicalProjectURL(url)
         guard openProjects[canonical] != nil else { return }
         backgroundProjects.insert(canonical)
-        agentTasks.setWindowOpen(false, projectPath: canonical.path)
+        if let identity = agentTaskProjectsByRoot[canonical] {
+            agentTasks.setWindowOpen(false, project: identity)
+        }
         openProjects[canonical]?.terminal.setAgentTaskWindowOpen(false)
     }
 
@@ -282,11 +350,12 @@ final class ProjectRegistry: LSPSettingsObserver {
                   runID: run.id
               ) else { return false }
         let projectURL = URL(
-            fileURLWithPath: task.project.canonicalProjectPath,
+            fileURLWithPath: task.project.canonicalWorktreePath,
             isDirectory: true
         ).standardizedFileURL
         guard !backgroundProjects.contains(projectURL),
               let manager = openProjects[projectURL],
+              agentTaskProjectsByRoot[projectURL] == task.project,
               manager.rootURL == projectURL,
               manager.paneManager.activePaneID.id == task.route.paneID,
               manager.paneManager.terminalState(
@@ -324,7 +393,7 @@ final class ProjectRegistry: LSPSettingsObserver {
                   runID: run.id
               ) else { return nil }
         let rawURL = URL(
-            fileURLWithPath: task.project.canonicalProjectPath,
+            fileURLWithPath: task.project.canonicalWorktreePath,
             isDirectory: true
         )
         let projectURL = await Task.detached {
@@ -345,8 +414,8 @@ final class ProjectRegistry: LSPSettingsObserver {
               ),
               !backgroundProjects.contains(projectURL),
               let manager = openProjects[projectURL],
+              agentTaskProjectsByRoot[projectURL] == task.project,
               manager.rootURL == projectURL,
-              projectURL.path == task.project.canonicalProjectPath,
               projectURL.path == task.project.canonicalWorktreePath else {
             return nil
         }
@@ -412,15 +481,14 @@ final class ProjectRegistry: LSPSettingsObserver {
         }
 
         let rawURL = URL(
-            fileURLWithPath: initialTask.project.canonicalProjectPath,
+            fileURLWithPath: initialTask.project.canonicalWorktreePath,
             isDirectory: true
         )
         let projectURL = await Task.detached {
             Self.canonicalProjectURL(rawURL)
         }.value
-        guard projectURL.path == initialTask.project.canonicalProjectPath,
-              projectURL.path == initialTask.project.canonicalWorktreePath,
-              let manager = projectManager(for: projectURL),
+        guard projectURL.path == initialTask.project.canonicalWorktreePath,
+              let manager = projectManager(for: initialTask.project),
               manager.rootURL == projectURL else {
             return .projectUnavailable
         }
@@ -497,7 +565,7 @@ final class ProjectRegistry: LSPSettingsObserver {
             Self.canonicalProjectURL(rawURL)
         }.value
         guard projectURL.path == initialTask.project.canonicalWorktreePath,
-              let manager = projectManager(for: projectURL),
+              let manager = projectManager(for: initialTask.project),
               manager.rootURL == projectURL else {
             return .projectUnavailable
         }
@@ -607,6 +675,7 @@ final class ProjectRegistry: LSPSettingsObserver {
               agentTasks.canResumeTask(task.id),
               !backgroundProjects.contains(projectURL),
               let manager = openProjects[projectURL],
+              agentTaskProjectsByRoot[projectURL] == task.project,
               manager.rootURL == projectURL,
               projectURL.path == task.project.canonicalWorktreePath else {
             return nil
@@ -715,6 +784,7 @@ final class ProjectRegistry: LSPSettingsObserver {
             pm.shutdownLanguageServers()
         }
         openProjects.removeAll()
+        agentTaskProjectsByRoot.removeAll()
         backgroundProjects.removeAll()
         detachedTaskCleanupProjects.removeAll()
         return true

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -76,14 +76,18 @@ final class TerminalManager {
         self.agentTaskRegistry = agentTaskRegistry
     }
 
-    /// Receives the already canonical root from `ProjectRegistry`; this method
-    /// performs no filesystem work on MainActor.
+    /// Receives an already validated identity from `ProjectRegistry`; this
+    /// method performs no filesystem work on MainActor.
+    func configureAgentTaskProject(_ project: AgentTaskProjectIdentity) {
+        agentTaskProject = project
+    }
+
     func configureAgentTaskProject(_ projectURL: URL) {
         let path = projectURL.standardizedFileURL.path
-        agentTaskProject = AgentTaskProjectIdentity(
+        configureAgentTaskProject(AgentTaskProjectIdentity(
             canonicalProjectPath: path,
             canonicalWorktreePath: path
-        )
+        ))
     }
 
     func setAgentTaskWindowOpen(_ isOpen: Bool) {

--- a/PineTests/AgentTaskComparisonTests.swift
+++ b/PineTests/AgentTaskComparisonTests.swift
@@ -1,0 +1,285 @@
+//
+//  AgentTaskComparisonTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Agent Task Comparison and Handoff")
+@MainActor
+struct AgentTaskComparisonTests {
+    @Test("Comparison keeps facts and narratives separate without ranking")
+    func comparisonIsFactOnly() throws {
+        let left = task(path: "/tmp/repo/left", objective: "Implement feature")
+        let right = task(path: "/tmp/repo/right", objective: "Implement feature")
+        let leftBrief = brief(
+            task: left,
+            path: "Pine/Left.swift",
+            verifiedTests: 1,
+            narrative: "I think this is best."
+        )
+        let rightBrief = brief(
+            task: right,
+            path: "Pine/Right.swift",
+            failedCommands: 1
+        )
+
+        let result = AgentTaskComparisonBuilder.build(
+            leftTask: left,
+            leftBrief: leftBrief,
+            rightTask: right,
+            rightBrief: rightBrief
+        )
+        let comparison = try success(result)
+
+        #expect(comparison.objective == "Implement feature")
+        #expect(comparison.left.changedFiles.map(\.relativePath)
+            == ["Pine/Left.swift"])
+        #expect(comparison.left.verifiedTestCount == 1)
+        #expect(comparison.left.agentReportedNarrative?.attribution
+            == .agentReported)
+        #expect(comparison.right.failedCommandCount == 1)
+        #expect(!Mirror(reflecting: comparison).children.contains {
+            $0.label == "winner" || $0.label == "recommendation"
+        })
+    }
+
+    @Test("Comparison rejects cross-project and mismatched session evidence")
+    func comparisonScopeValidation() {
+        let left = task(project: "/tmp/one", path: "/tmp/one/left")
+        let right = task(project: "/tmp/two", path: "/tmp/two/right")
+        let leftBrief = brief(task: left, path: "a.swift")
+        let rightBrief = brief(task: right, path: "b.swift")
+
+        #expect(AgentTaskComparisonBuilder.build(
+            leftTask: left,
+            leftBrief: leftBrief,
+            rightTask: right,
+            rightBrief: rightBrief
+        ) == .failure(.differentProject))
+
+        let sameProjectRight = task(
+            project: "/tmp/one",
+            path: "/tmp/one/right"
+        )
+        #expect(AgentTaskComparisonBuilder.build(
+            leftTask: left,
+            leftBrief: leftBrief,
+            rightTask: sameProjectRight,
+            rightBrief: rightBrief
+        ) == .failure(.briefDoesNotBelongToTask(sameProjectRight.id)))
+    }
+
+    @Test("Handoff copies only fresh user intent and attribution references")
+    func handoffDoesNotCopyTranscriptOrSecrets() throws {
+        let source = task(
+            path: "/tmp/repo/source",
+            objective: "SECRET source objective and full transcript"
+        )
+        let target = task(path: "/tmp/repo/target")
+        let sourceBrief = brief(
+            task: source,
+            path: "Pine/Feature.swift",
+            narrative: "SECRET agent narrative"
+        )
+        let request = AgentTaskHandoffRequest(
+            sourceTaskID: source.id,
+            targetTaskID: target.id,
+            sourceCompletionBriefID: sourceBrief.id,
+            followUpObjective: "  Review the verified change.  ",
+            selectedEvidencePaths: ["Pine/Feature.swift"]
+        )
+
+        let package = try handoff(AgentTaskHandoffPlanner.prepare(
+            request: request,
+            sourceTask: source,
+            targetTask: target,
+            sourceBrief: sourceBrief,
+            handoffID: id(40),
+            createdAt: Date(timeIntervalSince1970: 500)
+        ))
+
+        #expect(package.followUpObjective == "Review the verified change.")
+        #expect(package.priorAttribution == [AgentTaskHandoffAttribution(
+            relativePath: "Pine/Feature.swift",
+            sourceTaskID: source.id,
+            sourceSessionID: sourceBrief.sessionID,
+            originalEvidence: .verified
+        )])
+        let labels = Set(Mirror(reflecting: package).children.compactMap(\.label))
+        #expect(labels.isDisjoint(with: [
+            "transcript", "environment", "credentials", "narrative",
+            "commandOutput", "sourceObjective",
+        ]))
+        #expect(!package.followUpObjective.contains("SECRET"))
+    }
+
+    @Test("Handoff paths and objective fail closed")
+    func invalidHandoffFailsClosed() {
+        let source = task(path: "/tmp/repo/source")
+        let target = task(path: "/tmp/repo/target")
+        let sourceBrief = brief(task: source, path: "Pine/Feature.swift")
+
+        func request(
+            objective: String = "Review",
+            paths: [String]
+        ) -> AgentTaskHandoffRequest {
+            AgentTaskHandoffRequest(
+                sourceTaskID: source.id,
+                targetTaskID: target.id,
+                sourceCompletionBriefID: sourceBrief.id,
+                followUpObjective: objective,
+                selectedEvidencePaths: paths
+            )
+        }
+
+        #expect(AgentTaskHandoffPlanner.prepare(
+            request: request(paths: ["../escape"]),
+            sourceTask: source,
+            targetTask: target,
+            sourceBrief: sourceBrief
+        ) == .failure(.invalidEvidencePath("../escape")))
+        #expect(AgentTaskHandoffPlanner.prepare(
+            request: request(paths: ["unknown.swift"]),
+            sourceTask: source,
+            targetTask: target,
+            sourceBrief: sourceBrief
+        ) == .failure(.evidencePathNotInBrief("unknown.swift")))
+        #expect(AgentTaskHandoffPlanner.prepare(
+            request: request(
+                objective: "bad\u{0}objective",
+                paths: ["Pine/Feature.swift"]
+            ),
+            sourceTask: source,
+            targetTask: target,
+            sourceBrief: sourceBrief
+        ) == .failure(.invalidObjective))
+    }
+
+    private func task(
+        project: String = "/tmp/repo",
+        path: String,
+        objective: String? = nil
+    ) -> AgentTask {
+        var task = AgentTask(
+            descriptor: AgentDescriptor(agentType: .codex),
+            context: AgentTaskBridgeContext(
+                project: AgentTaskProjectIdentity(
+                    canonicalProjectPath: project,
+                    canonicalWorktreePath: path
+                ),
+                route: AgentTaskRoute(
+                    paneID: UUID(),
+                    tabID: UUID(),
+                    terminalID: UUID()
+                ),
+                origin: .pineLaunched,
+                observedAt: Date(timeIntervalSince1970: 100)
+            ),
+            objective: objective,
+            createdAt: Date(timeIntervalSince1970: 100)
+        )
+        let sessionID = UUID()
+        task.runs = [AgentTaskRun(AgentTaskRunInput(
+            id: sessionID,
+            terminalID: task.route.terminalID,
+            process: AgentProcessEvidence(
+                processIdentifier: 123,
+                processGeneration: 1,
+                startIdentifier: "start",
+                observedStartedAt: Date(timeIntervalSince1970: 100),
+                startIsAuthoritative: true
+            ),
+            status: AgentTaskRunStatus(
+                state: .done,
+                liveness: .terminated,
+                observedAt: Date(timeIntervalSince1970: 200)
+            )
+        ))]
+        return task
+    }
+
+    private func brief(
+        task: AgentTask,
+        path: String,
+        verifiedTests: Int = 0,
+        failedCommands: Int = 0,
+        narrative: String? = nil
+    ) -> AgentCompletionBrief {
+        var commands: [AgentCompletionCommand] = []
+        for _ in 0..<verifiedTests {
+            commands.append(AgentCompletionCommand(
+                id: UUID(),
+                command: "swift test",
+                kind: .test,
+                outcome: .succeeded,
+                attribution: .verified,
+                source: "explicitAgentEvent"
+            ))
+        }
+        for _ in 0..<failedCommands {
+            commands.append(AgentCompletionCommand(
+                id: UUID(),
+                command: "swift build",
+                kind: .build,
+                outcome: .failed(exitStatus: 1),
+                attribution: .verified,
+                source: "explicitAgentEvent"
+            ))
+        }
+        let sessionID = task.runs.first?.id ?? UUID()
+        return AgentCompletionBrief(
+            id: UUID(),
+            sessionID: sessionID,
+            agentTypeRaw: task.descriptor.typeIdentifier,
+            startedAt: Date(timeIntervalSince1970: 100),
+            endedAt: Date(timeIntervalSince1970: 200),
+            changes: [AgentCompletionChange(
+                relativePath: path,
+                kind: .modified,
+                statistics: AgentCompletionDiffStatistics(
+                    addedLineCount: 2,
+                    removedLineCount: 1
+                ),
+                attribution: .verified,
+                hasOverlappingEdits: false,
+                hasVerifiedDiff: true
+            )],
+            commands: commands,
+            gaps: [],
+            narrative: narrative.map(AgentCompletionNarrative.init),
+            links: AgentCompletionEvidenceLinks(
+                terminalID: task.route.terminalID,
+                diffPaths: [path]
+            )
+        )
+    }
+
+    private func success(
+        _ result: Result<AgentTaskComparison, AgentTaskComparisonFailure>
+    ) throws -> AgentTaskComparison {
+        switch result {
+        case .success(let comparison): comparison
+        case .failure(let failure): throw failure
+        }
+    }
+
+    private func handoff(
+        _ result: Result<AgentTaskHandoffPackage, AgentTaskHandoffFailure>
+    ) throws -> AgentTaskHandoffPackage {
+        switch result {
+        case .success(let package): package
+        case .failure(let failure): throw failure
+        }
+    }
+}
+
+private func id(_ value: Int) -> UUID {
+    UUID(uuid: (
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 1, UInt8(value)
+    ))
+}

--- a/PineTests/AgentWorktreeServiceTests.swift
+++ b/PineTests/AgentWorktreeServiceTests.swift
@@ -1,0 +1,532 @@
+//
+//  AgentWorktreeServiceTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Agent Worktree Service", .serialized)
+struct AgentWorktreeServiceTests {
+    @Test("Creation preserves primary branch, HEAD, index, and dirty state")
+    func createsWithoutContaminatingPrimaryCheckout() async throws {
+        let fixture = try WorktreeFixture()
+        try fixture.write("local.txt", "untracked\n")
+        let before = try fixture.primaryEvidence()
+        let service = AgentWorktreeService()
+
+        let result = await service.create(fixture.request(
+            taskID: id(1),
+            branch: "agent/task-one"
+        ))
+        let worktree = try created(result)
+
+        #expect(FileManager.default.fileExists(atPath: worktree.worktreeRoot.path))
+        #expect(try fixture.primaryEvidence() == before)
+        #expect(try fixture.git(
+            ["branch", "--show-current"],
+            at: worktree.worktreeRoot
+        ).trimmingCharacters(in: .whitespacesAndNewlines) == "agent/task-one")
+    }
+
+    @Test("Dirty and untracked data require exact destructive confirmation")
+    func dirtyRemovalRequiresExactConfirmation() async throws {
+        let fixture = try WorktreeFixture()
+        let service = AgentWorktreeService()
+        let worktree = try created(await service.create(fixture.request(
+            taskID: id(2),
+            branch: "agent/dirty"
+        )))
+        try Data("changed\n".utf8).write(
+            to: worktree.worktreeRoot.appendingPathComponent("tracked.txt")
+        )
+        try Data("new\n".utf8).write(
+            to: worktree.worktreeRoot.appendingPathComponent("untracked.txt")
+        )
+
+        let first = await service.remove(worktree)
+        guard case .failed(.confirmationRequired(let inspection)) = first else {
+            Issue.record("Expected an exact dirty-worktree confirmation")
+            return
+        }
+        #expect(inspection.dirtyPaths == ["tracked.txt", "untracked.txt"])
+        #expect(FileManager.default.fileExists(atPath: worktree.worktreeRoot.path))
+
+        let mismatched = AgentWorktreeRemovalConfirmation(
+            worktreeRoot: worktree.worktreeRoot,
+            dirtyPaths: ["tracked.txt"],
+            acknowledgesUnrecoverableDataLoss: true
+        )
+        #expect(await service.remove(
+            worktree,
+            confirmation: mismatched
+        ) == .failed(.confirmationMismatch))
+        #expect(FileManager.default.fileExists(atPath: worktree.worktreeRoot.path))
+
+        let confirmed = AgentWorktreeRemovalConfirmation(
+            worktreeRoot: inspection.worktree.worktreeRoot,
+            dirtyPaths: inspection.dirtyPaths,
+            acknowledgesUnrecoverableDataLoss: true
+        )
+        #expect(await service.remove(
+            worktree,
+            confirmation: confirmed
+        ) == .removed)
+        #expect(!FileManager.default.fileExists(atPath: worktree.worktreeRoot.path))
+    }
+
+    @Test("Invalid branches, missing refs, and symlink roots fail closed")
+    func invalidInputsFailClosed() async throws {
+        let fixture = try WorktreeFixture()
+        let service = AgentWorktreeService()
+
+        #expect(await service.create(fixture.request(
+            taskID: id(3),
+            branch: "../escape"
+        )) == .failed(.invalidBranchName))
+        #expect(await service.create(fixture.request(
+            taskID: id(4),
+            branch: "agent/missing",
+            startPoint: "refs/heads/does-not-exist"
+        )) == .failed(.missingStartPoint))
+
+        let symlink = fixture.root.appendingPathComponent("linked-root")
+        try FileManager.default.createSymbolicLink(
+            at: symlink,
+            withDestinationURL: fixture.managedRoot
+        )
+        let request = AgentWorktreeCreateRequest(
+            taskID: id(5),
+            repositoryRoot: fixture.repository,
+            managedRoot: symlink,
+            branchName: "agent/symlink",
+            startPoint: "HEAD"
+        )
+        #expect(await service.create(request) == .failed(.unsafeManagedRoot))
+    }
+
+    @Test("Concurrent duplicate creation has one winner")
+    func concurrentDuplicateCreation() async throws {
+        let fixture = try WorktreeFixture()
+        let service = AgentWorktreeService()
+        let request = fixture.request(
+            taskID: id(6),
+            branch: "agent/only-once"
+        )
+
+        async let first = service.create(request)
+        async let second = service.create(request)
+        let results = await [first, second]
+
+        #expect(results.filter {
+            if case .created = $0 { return true }
+            return false
+        }.count == 1)
+        #expect(results.filter {
+            if case .failed(.destinationAlreadyExists) = $0 { return true }
+            return false
+        }.count == 1)
+    }
+
+    @Test("A linked worktree can safely create another isolated worktree")
+    func linkedWorktreeRepositoryRoot() async throws {
+        let fixture = try WorktreeFixture()
+        let service = AgentWorktreeService()
+        let first = try created(await service.create(fixture.request(
+            taskID: id(7),
+            branch: "agent/first"
+        )))
+
+        let nestedManagedRoot = fixture.root.appendingPathComponent(
+            "second-managed",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: nestedManagedRoot,
+            withIntermediateDirectories: false
+        )
+        let second = await service.create(AgentWorktreeCreateRequest(
+            taskID: id(8),
+            repositoryRoot: first.worktreeRoot,
+            managedRoot: nestedManagedRoot,
+            branchName: "agent/second",
+            startPoint: "HEAD"
+        ))
+
+        #expect(try created(second).branchName == "agent/second")
+    }
+
+    @Test("Preview is read-only and integration requires exact approval")
+    func integrationIsPreviewedAndExplicit() async throws {
+        let fixture = try WorktreeFixture()
+        let service = AgentWorktreeService()
+        let worktree = try created(await service.create(fixture.request(
+            taskID: id(9),
+            branch: "agent/integrate"
+        )))
+        try fixture.write("tracked.txt", "agent result\n", at: worktree.worktreeRoot)
+        _ = try fixture.git(["add", "--", "tracked.txt"], at: worktree.worktreeRoot)
+        _ = try fixture.git(
+            ["commit", "-m", "agent result"],
+            at: worktree.worktreeRoot
+        )
+        let before = try fixture.primaryEvidence()
+        let beforeHead = try fixture.git(["rev-parse", "HEAD"])
+
+        let preview = try ready(await service.previewIntegration(
+            worktree,
+            previewID: id(10)
+        ))
+        #expect(preview.changedPaths == ["tracked.txt"])
+        #expect(!preview.hasConflicts)
+        #expect(try fixture.primaryEvidence() == before)
+
+        let mismatch = AgentWorktreeIntegrationConfirmation(
+            previewID: preview.id,
+            sourceCommit: preview.sourceCommit,
+            targetHead: preview.targetHead,
+            targetBranch: preview.targetBranch,
+            changedPaths: []
+        )
+        #expect(await service.integrate(
+            preview,
+            confirmation: mismatch
+        ) == .failed(.confirmationMismatch))
+        #expect(try fixture.primaryEvidence() == before)
+
+        let confirmation = AgentWorktreeIntegrationConfirmation(
+            previewID: preview.id,
+            sourceCommit: preview.sourceCommit,
+            targetHead: preview.targetHead,
+            targetBranch: preview.targetBranch,
+            changedPaths: preview.changedPaths
+        )
+        #expect(await service.integrate(
+            preview,
+            confirmation: confirmation
+        ) == .integratedWithoutCommit)
+        #expect(try fixture.git(["rev-parse", "HEAD"]) == beforeHead)
+        #expect(try String(contentsOf: fixture.repository.appendingPathComponent(
+            "tracked.txt"
+        ), encoding: .utf8) == "agent result\n")
+    }
+
+    @Test("Conflicts are previewed without touching the primary checkout")
+    func conflictsFailBeforeIntegration() async throws {
+        let fixture = try WorktreeFixture()
+        let service = AgentWorktreeService()
+        let worktree = try created(await service.create(fixture.request(
+            taskID: id(11),
+            branch: "agent/conflict"
+        )))
+        try fixture.write("tracked.txt", "agent side\n", at: worktree.worktreeRoot)
+        _ = try fixture.git(["add", "--", "tracked.txt"], at: worktree.worktreeRoot)
+        _ = try fixture.git(
+            ["commit", "-m", "agent side"],
+            at: worktree.worktreeRoot
+        )
+        try fixture.write("tracked.txt", "primary side\n")
+        _ = try fixture.git(["add", "--", "tracked.txt"])
+        _ = try fixture.git(["commit", "-m", "primary side"])
+        let before = try fixture.primaryEvidence()
+
+        let preview = try ready(await service.previewIntegration(
+            worktree,
+            previewID: id(12)
+        ))
+        #expect(preview.conflictingPaths == ["tracked.txt"])
+        #expect(try fixture.primaryEvidence() == before)
+        let confirmation = AgentWorktreeIntegrationConfirmation(
+            previewID: preview.id,
+            sourceCommit: preview.sourceCommit,
+            targetHead: preview.targetHead,
+            targetBranch: preview.targetBranch,
+            changedPaths: preview.changedPaths
+        )
+        #expect(await service.integrate(
+            preview,
+            confirmation: confirmation
+        ) == .failed(.conflictsRequireResolution(["tracked.txt"])))
+        #expect(try fixture.primaryEvidence() == before)
+    }
+
+    @Test("Interrupted creation is reported without guessing cleanup")
+    func interruptedCreationIsRecoverable() async throws {
+        let fixture = try WorktreeFixture()
+        let runner = AgentWorktreeGitRunner { arguments, directory in
+            if arguments.starts(with: ["worktree", "add"]) {
+                return interruptedGitResult()
+            }
+            return await GitCommand.runAsync(arguments, at: directory)
+        }
+        let service = AgentWorktreeService(runner: runner)
+        let request = fixture.request(
+            taskID: id(13),
+            branch: "agent/interrupted"
+        )
+        let result = await service.create(request)
+        guard case .failed(.creationInterrupted(let path)) = result else {
+            Issue.record("Expected interrupted creation, received \(result)")
+            return
+        }
+        #expect(path.lastPathComponent == id(13).uuidString.lowercased())
+        #expect(!FileManager.default.fileExists(atPath: path.path))
+    }
+
+    @Test("Sibling worktrees keep independent simultaneous task identities")
+    @MainActor
+    func siblingWorktreesHaveIndependentTaskScopes() async throws {
+        let fixture = try WorktreeFixture()
+        let service = AgentWorktreeService()
+        let left = try created(await service.create(fixture.request(
+            taskID: id(14),
+            branch: "agent/left"
+        )))
+        let right = try created(await service.create(fixture.request(
+            taskID: id(15),
+            branch: "agent/right"
+        )))
+        let storage = fixture.root.appendingPathComponent("task-metadata")
+        let taskRegistry = AgentTaskRegistry(persistence: AgentTaskMetadataStore(
+            storageRoot: storage
+        ))
+        let suiteName = "AgentWorktreeServiceTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let projects = ProjectRegistry(
+            defaults: defaults,
+            agentTasks: taskRegistry
+        )
+        let leftManager = try #require(projects.projectManager(for: left))
+        let rightManager = try #require(projects.projectManager(for: right))
+        _ = await taskRegistry.flushPersistence()
+
+        let leftTab = try terminalTab(in: leftManager, at: left.worktreeRoot)
+        let rightTab = try terminalTab(in: rightManager, at: right.worktreeRoot)
+        let leftContext = try #require(
+            leftManager.terminal.agentTaskContext(for: leftTab)
+        )
+        let rightContext = try #require(
+            rightManager.terminal.agentTaskContext(for: rightTab)
+        )
+        #expect(leftContext.project.canonicalProjectPath
+            == rightContext.project.canonicalProjectPath)
+        #expect(leftContext.project.canonicalWorktreePath
+            != rightContext.project.canonicalWorktreePath)
+        #expect(leftContext.route.terminalID != rightContext.route.terminalID)
+
+        let descriptor = AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        )
+        let leftReservation = try reservation(
+            leftManager.terminal.prepareAgentLaunch(
+                in: leftTab,
+                descriptor: descriptor,
+                objective: "Implement the same objective"
+            )
+        )
+        let rightReservation = try reservation(
+            rightManager.terminal.prepareAgentLaunch(
+                in: rightTab,
+                descriptor: descriptor,
+                objective: "Implement the same objective"
+            )
+        )
+        #expect(leftReservation.taskID != rightReservation.taskID)
+        #expect(taskRegistry.tasks.count == 2)
+
+        #expect(taskRegistry.armLaunch(leftReservation))
+        #expect(taskRegistry.armLaunch(rightReservation))
+        leftManager.terminal.bridgeAgentSession(
+            session(id: id(16), processIdentifier: 1_316),
+            replacing: nil,
+            in: leftTab,
+            reservation: leftReservation
+        )
+        rightManager.terminal.bridgeAgentSession(
+            session(id: id(17), processIdentifier: 1_317),
+            replacing: nil,
+            in: rightTab,
+            reservation: rightReservation
+        )
+
+        projects.closeProjectWindow(left.worktreeRoot)
+        #expect(taskRegistry.task(for: leftReservation.taskID)?
+            .route.availability == .background)
+        #expect(taskRegistry.task(for: rightReservation.taskID)?
+            .route.availability == .available)
+    }
+
+    private func created(
+        _ result: AgentWorktreeCreateResult
+    ) throws -> AgentManagedWorktree {
+        guard case .created(let worktree) = result else {
+            Issue.record("Expected worktree creation, received \(result)")
+            throw WorktreeFixtureError.commandFailed
+        }
+        return worktree
+    }
+
+    private func ready(
+        _ result: AgentWorktreeIntegrationPreviewResult
+    ) throws -> AgentWorktreeIntegrationPreview {
+        guard case .ready(let preview) = result else {
+            Issue.record("Expected integration preview, received \(result)")
+            throw WorktreeFixtureError.commandFailed
+        }
+        return preview
+    }
+
+    @MainActor
+    private func terminalTab(
+        in manager: ProjectManager,
+        at workingDirectory: URL
+    ) throws -> TerminalTab {
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: workingDirectory
+        )
+        return try #require(
+            manager.paneManager.terminalState(for: pane)?.activeTab
+        )
+    }
+
+    private func reservation(
+        _ result: AgentTaskLaunchResult
+    ) throws -> AgentTaskLaunchReservation {
+        guard case .reserved(let reservation) = result else {
+            Issue.record("Expected launch reservation, received \(result)")
+            throw WorktreeFixtureError.commandFailed
+        }
+        return reservation
+    }
+
+    @MainActor
+    private func session(
+        id: UUID,
+        processIdentifier: Int32
+    ) -> AgentSession {
+        let startedAt = Date()
+        let session = AgentSession(
+            id: id,
+            agentType: .codex,
+            state: .executing,
+            startedAt: startedAt
+        )
+        _ = session.bindProcessEvidence(AgentProcessEvidence(
+            processIdentifier: processIdentifier,
+            processGeneration: 1,
+            startIdentifier: "worktree-\(processIdentifier)",
+            observedStartedAt: startedAt,
+            startIsAuthoritative: true
+        ))
+        return session
+    }
+}
+
+private enum WorktreeFixtureError: Error {
+    case commandFailed
+}
+
+private final class WorktreeFixture {
+    let root: URL
+    let repository: URL
+    let managedRoot: URL
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "PineAgentWorktree-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        repository = root.appendingPathComponent("repository", isDirectory: true)
+        managedRoot = root.appendingPathComponent("managed", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: repository,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: managedRoot,
+            withIntermediateDirectories: false
+        )
+        _ = try git(["init", "-b", "main"], at: repository)
+        _ = try git(["config", "user.email", "pine-tests@example.invalid"])
+        _ = try git(["config", "user.name", "Pine Tests"])
+        try write("tracked.txt", "base\n")
+        _ = try git(["add", "--", "tracked.txt"])
+        _ = try git(["commit", "-m", "base"])
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func request(
+        taskID: UUID,
+        branch: String,
+        startPoint: String = "HEAD"
+    ) -> AgentWorktreeCreateRequest {
+        AgentWorktreeCreateRequest(
+            taskID: taskID,
+            repositoryRoot: repository,
+            managedRoot: managedRoot,
+            branchName: branch,
+            startPoint: startPoint
+        )
+    }
+
+    func write(
+        _ relativePath: String,
+        _ content: String,
+        at directory: URL? = nil
+    ) throws {
+        guard let data = content.data(using: .utf8) else {
+            throw WorktreeFixtureError.commandFailed
+        }
+        try data.write(to: (directory ?? repository).appendingPathComponent(
+            relativePath
+        ))
+    }
+
+    func primaryEvidence() throws -> [String] {
+        [
+            try git(["branch", "--show-current"]),
+            try git(["rev-parse", "HEAD"]),
+            try git(["status", "--porcelain=v1", "-z"]),
+            try git(["ls-files", "--stage"]),
+        ]
+    }
+
+    @discardableResult
+    func git(_ arguments: [String], at directory: URL? = nil) throws -> String {
+        let result = GitCommand.run(arguments, at: directory ?? repository)
+        guard result.succeeded else {
+            throw WorktreeFixtureError.commandFailed
+        }
+        return result.output
+    }
+}
+
+private func id(_ value: Int) -> UUID {
+    UUID(uuid: (
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, UInt8(value)
+    ))
+}
+
+nonisolated private func interruptedGitResult() -> GitCommandResult {
+    GitCommandResult(
+        output: "",
+        errorOutput: "",
+        exitCode: -1,
+        timedOut: true,
+        cancelled: false,
+        outputTruncated: false,
+        errorOutputTruncated: false,
+        outputCaptureComplete: true,
+        errorOutputCaptureComplete: true,
+        outputReadError: nil,
+        errorOutputReadError: nil
+    )
+}


### PR DESCRIPTION
Closes #1309

## Summary
- add fail-closed Pine-managed Git worktree creation, inspection, explicit removal, preview, and integration
- preserve shared repository scope while isolating worktree task, terminal, event, checkpoint, and notification identities
- add fact-only side-by-side comparison and bounded provenance-preserving handoff packages
- make project navigation and window availability worktree-aware

## Safety
- validates canonical repositories, refs, branches, containment, symlinks, and concurrent destinations
- never force-removes dirty or untracked worktrees without an exact path list and data-loss acknowledgement
- leaves the primary checkout, index, branch, commit, and push state unchanged until exact integration approval
- never copies transcripts, environment, credentials, command output, or agent narrative into handoff packages

## Verification
- SwiftLint: 0 violations
- AgentTaskComparisonTests + AgentWorktreeServiceTests: 13 passed
- ProjectRegistryTests + AgentTaskRegistryTests: 91 passed
- local UI/XCUITest execution intentionally deferred at maintainer request