### PR TITLE
test(agent): add Pine 2.0 release gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,7 @@ jobs:
             -skip-testing:PineTests/FuzzSymbolParserTests \
             -skip-testing:PineTests/FuzzConfigValidatorTests \
             -skip-testing:PineTests/FuzzGoToLineParserTests \
+            -skip-testing:PineTests/FuzzAgentBoundaryTests \
             -retry-tests-on-failure \
             -parallel-testing-enabled NO \
             -test-timeouts-enabled YES \
@@ -876,6 +877,7 @@ jobs:
             -only-testing:PineTests/FuzzSymbolParserTests \
             -only-testing:PineTests/FuzzConfigValidatorTests \
             -only-testing:PineTests/FuzzGoToLineParserTests \
+            -only-testing:PineTests/FuzzAgentBoundaryTests \
             -resultBundlePath FuzzResults.xcresult \
             CODE_SIGN_IDENTITY=- \
             CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -69,6 +69,7 @@ jobs:
             -only-testing:PineTests/FuzzSymbolParserTests \
             -only-testing:PineTests/FuzzConfigValidatorTests \
             -only-testing:PineTests/FuzzGoToLineParserTests \
+            -only-testing:PineTests/FuzzAgentBoundaryTests \
             -resultBundlePath FuzzResults.xcresult \
             CODE_SIGN_IDENTITY=- \
             CODE_SIGNING_ALLOWED=NO

--- a/PinePerformanceTests/AgentWorkflowPerformanceTests.swift
+++ b/PinePerformanceTests/AgentWorkflowPerformanceTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+import XCTest
+@testable import Pine
+
+@MainActor
+final class AgentWorkflowPerformanceTests: XCTestCase {
+    private let taskCount = 500
+
+    func testProcessPolling500Agents() {
+        let detector = AgentDetector(maxSessionHistory: 1_000)
+        let aliases = FirstPartyAgentCompatibilityCatalog.records
+            .compactMap { $0.executableAliases.sorted().first }
+        let processes = (0..<taskCount).map { index in
+            DetectedProcess(
+                pid: Int32(10_000 + index),
+                command: aliases[index % aliases.count],
+                cpuTime: index,
+                startIdentifier: "synthetic-\(index)"
+            )
+        }
+
+        assertUnderBudget(.seconds(1)) {
+            detector.processSnapshotDidUpdate(processes)
+        }
+        measure(metrics: [XCTClockMetric()]) {
+            detector.processSnapshotDidUpdate(processes)
+        }
+    }
+
+    func testEventEnvelopeIngestion1000Events() throws {
+        let events = (0..<1_000).map(makeEnvelope)
+        let data = try JSONEncoder().encode(events)
+
+        assertUnderBudget(.seconds(1)) {
+            _ = try? JSONDecoder().decode([AgentEventEnvelope].self, from: data)
+        }
+        measure(metrics: [XCTClockMetric()]) {
+            _ = try? JSONDecoder().decode([AgentEventEnvelope].self, from: data)
+        }
+    }
+
+    func testRegistryRefresh500Tasks() {
+        let registry = AgentTaskRegistry(
+            persistence: PerformanceAgentTaskStore(),
+            limits: AgentTaskPersistenceLimits(maxTasksPerProject: taskCount)
+        )
+        let sessions = (0..<taskCount).map(makeSession)
+        for (index, session) in sessions.enumerated() {
+            registry.bridge(
+                session,
+                replacing: nil,
+                context: makeContext(index)
+            )
+        }
+
+        assertUnderBudget(.seconds(1)) {
+            registry.refresh(sessions: sessions)
+        }
+        measure(metrics: [XCTClockMetric()]) {
+            registry.refresh(sessions: sessions)
+        }
+    }
+
+    func testInboxProjectionAndNotificationCoalescing500Tasks() {
+        let oldTasks = (0..<taskCount).map {
+            makeTask(index: $0, state: .executing, observedOffset: 0)
+        }
+        let newTasks = oldTasks.map { task in
+            var task = task
+            let observedAt = task.updatedAt.addingTimeInterval(1)
+            task.runs[task.runs.count - 1].state = .waitingInput
+            task.runs[task.runs.count - 1].lastObservedAt = observedAt
+            task.attention = .waitingInput
+            task.updatedAt = observedAt
+            task.lastActivityAt = observedAt
+            return task
+        }
+
+        assertUnderBudget(.seconds(1)) {
+            _ = AgentInboxSnapshot(tasks: newTasks)
+            _ = AgentNotificationTransitionResolver.events(
+                from: oldTasks,
+                to: newTasks,
+                accuracy: { _ in .verifiedLifecycleTransitions }
+            )
+        }
+        measure(metrics: [XCTClockMetric()]) {
+            _ = AgentInboxSnapshot(tasks: newTasks)
+            _ = AgentNotificationTransitionResolver.events(
+                from: oldTasks,
+                to: newTasks,
+                accuracy: { _ in .verifiedLifecycleTransitions }
+            )
+        }
+    }
+
+    private func assertUnderBudget(
+        _ budget: Duration,
+        operation: () -> Void
+    ) {
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+        operation()
+        XCTAssertLessThan(startedAt.duration(to: clock.now), budget)
+    }
+
+    private func makeEnvelope(_ index: Int) -> AgentEventEnvelope {
+        AgentEventEnvelope(
+            id: uuid(index),
+            projectID: uuid(index + 1_000),
+            sessionID: uuid(index + 2_000),
+            agentTypeRaw: "codex",
+            process: AgentProcessIdentity(
+                terminalID: uuid(index + 3_000),
+                processGeneration: UInt64(index + 1)
+            ),
+            location: AgentEventLocation(
+                worktreePath: "/tmp/project",
+                cwd: "/tmp/project"
+            ),
+            cursorValue: UInt64(index + 1),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            source: .terminalProcess,
+            trustLevel: .observed
+        )
+    }
+
+    private func makeSession(_ index: Int) -> AgentSession {
+        let startedAt = Date(timeIntervalSince1970: TimeInterval(index + 1))
+        let session = AgentSession(
+            id: uuid(index + 4_000),
+            agentType: .codex,
+            state: .executing,
+            startedAt: startedAt
+        )
+        XCTAssertTrue(session.bindProcessEvidence(AgentProcessEvidence(
+            processIdentifier: Int32(index + 20_000),
+            processGeneration: UInt64(index + 1),
+            startIdentifier: "synthetic-\(index)",
+            observedStartedAt: startedAt,
+            startIsAuthoritative: true
+        )))
+        return session
+    }
+
+    private func makeContext(_ index: Int) -> AgentTaskBridgeContext {
+        let terminalID = uuid(index + 5_000)
+        return AgentTaskBridgeContext(
+            project: AgentTaskProjectIdentity(
+                canonicalProjectPath: "/tmp/performance-project",
+                canonicalWorktreePath: "/tmp/performance-project"
+            ),
+            route: AgentTaskRoute(
+                paneID: uuid(index + 6_000),
+                tabID: terminalID,
+                terminalID: terminalID
+            ),
+            origin: .discoveredInTerminal,
+            observedAt: Date(timeIntervalSince1970: TimeInterval(index + 1))
+        )
+    }
+
+    private func makeTask(
+        index: Int,
+        state: AgentRunState,
+        observedOffset: TimeInterval
+    ) -> AgentTask {
+        let context = makeContext(index)
+        let observedAt = context.observedAt.addingTimeInterval(observedOffset)
+        var task = AgentTask(
+            descriptor: AgentDescriptor(agentType: .codex),
+            context: context,
+            title: "Synthetic task \(index)"
+        )
+        task.runs = [AgentTaskRun(AgentTaskRunInput(
+            id: uuid(index + 4_000),
+            terminalID: context.route.terminalID,
+            process: AgentProcessEvidence(
+                processIdentifier: Int32(index + 20_000),
+                processGeneration: UInt64(index + 1),
+                startIdentifier: "synthetic-\(index)",
+                observedStartedAt: context.observedAt,
+                startIsAuthoritative: true
+            ),
+            status: AgentTaskRunStatus(
+                state: state,
+                liveness: .live,
+                observedAt: observedAt
+            )
+        ))]
+        task.attention = state == .waitingInput ? .waitingInput : .none
+        task.updatedAt = observedAt
+        task.lastActivityAt = observedAt
+        return task
+    }
+
+    private func uuid(_ seed: Int) -> UUID {
+        guard let value = UUID(uuidString: String(
+            format: "00000000-0000-0000-0000-%012x",
+            seed
+        )) else {
+            preconditionFailure("Synthetic UUID seed must fit the fixture")
+        }
+        return value
+    }
+}
+
+private actor PerformanceAgentTaskStore: AgentTaskPersisting {
+    func save(
+        tasks: [AgentTask],
+        project: AgentTaskProjectIdentity,
+        authorization: AgentTaskPublicationAuthorization?
+    ) -> AgentTaskMetadataSaveResult {
+        .saved(taskCount: tasks.count)
+    }
+
+    func load(
+        project: AgentTaskProjectIdentity
+    ) -> AgentTaskMetadataLoadResult {
+        AgentTaskMetadataLoadResult(status: .missing, tasks: [])
+    }
+}

--- a/PinePerformanceTests/baselines.json
+++ b/PinePerformanceTests/baselines.json
@@ -277,6 +277,22 @@
         "SyntaxHighlighterPerformanceTests/testViewportHighlightVsFullHighlight5000Lines": {
             "baseline_seconds": 0.200,
             "description": "Viewport vs full highlight comparison for 5000 lines"
+        },
+        "AgentWorkflowPerformanceTests/testProcessPolling500Agents": {
+            "baseline_seconds": 1.000,
+            "description": "Reconcile one synthetic process poll containing 500 agents"
+        },
+        "AgentWorkflowPerformanceTests/testEventEnvelopeIngestion1000Events": {
+            "baseline_seconds": 1.000,
+            "description": "Decode 1000 bounded agent provenance envelopes"
+        },
+        "AgentWorkflowPerformanceTests/testRegistryRefresh500Tasks": {
+            "baseline_seconds": 1.000,
+            "description": "Refresh 500 durable agent task runs"
+        },
+        "AgentWorkflowPerformanceTests/testInboxProjectionAndNotificationCoalescing500Tasks": {
+            "baseline_seconds": 1.000,
+            "description": "Project and coalesce Inbox notification transitions for 500 tasks"
         }
     }
 }

--- a/PineTests/AgentReleaseGateTests.swift
+++ b/PineTests/AgentReleaseGateTests.swift
@@ -1,0 +1,220 @@
+import Foundation
+import Testing
+@testable import Pine
+
+@Suite("Pine 2.0 agent release gates", .serialized)
+struct AgentReleaseGateTests {
+    private struct Fixture: Decodable {
+        let schemaVersion: UInt16
+        let fixtureVersion: String
+        let sanitization: String
+        let agents: [AgentFixture]
+        let fakeExecutable: FakeExecutableFixture
+    }
+
+    private struct AgentFixture: Decodable {
+        let stableIdentifier: String
+        let testedVersion: String
+        let commands: [String]
+    }
+
+    private struct FakeExecutableFixture: Decodable {
+        let protocolVersion: UInt16
+        let scenarios: [Scenario]
+    }
+
+    private struct Scenario: Decodable {
+        let name: String
+        let expectedExitStatus: Int32
+        let expectedStates: [String]
+        let malformed: Bool?
+        let minimumDelayMilliseconds: Int?
+        let expectedGenerations: [UInt64]?
+        let expectedProcessIdentifiers: [Int32]?
+    }
+
+    private struct FakeEnvelope: Decodable {
+        let schemaVersion: UInt16
+        let scenario: String
+        let events: [FakeEvent]
+    }
+
+    private struct FakeEvent: Decodable {
+        let state: String
+        let pid: Int32
+        let generation: UInt64
+    }
+
+    private struct Execution {
+        let status: Int32
+        let output: Data
+        let errorOutput: String
+        let elapsed: Duration
+    }
+
+    @Test("every first-party adapter passes the same detected-tier contract")
+    func firstPartyConformanceAndFallback() throws {
+        let fixture = try loadFixture()
+        let fixtureIDs = Set(fixture.agents.map(\.stableIdentifier))
+        let records = FirstPartyAgentCompatibilityCatalog.records
+
+        #expect(fixture.schemaVersion == FirstPartyAgentCompatibilityCatalog.schemaVersion)
+        #expect(fixture.fakeExecutable.protocolVersion == fixture.schemaVersion)
+        #expect(fixtureIDs == Set(records.map(\.stableIdentifier)))
+
+        for record in records {
+            let agent = try #require(
+                fixture.agents.first { $0.stableIdentifier == record.stableIdentifier }
+            )
+            #expect(record.supportTier == .detected)
+            #expect(record.eventSource == .processSnapshot)
+            #expect(record.trustLevel == .observedProcessGeneration)
+            #expect(record.testedVersions.contains(agent.testedVersion))
+
+            for command in agent.commands {
+                let executable = AgentDetector.extractExecutableName(from: command)
+                #expect(
+                    AgentPresentationCatalog.stableIdentifier(
+                        forExecutableAlias: executable.lowercased()
+                    ) == record.stableIdentifier
+                )
+            }
+
+            for lookalike in record.executableAliases.map({ "\($0)-helper" }) {
+                let resolved = AgentType.resolve(fromProcessName: lookalike)
+                guard case .generic = resolved else {
+                    Issue.record("Expected generic fallback for \(lookalike)")
+                    continue
+                }
+            }
+        }
+    }
+
+    @Test("fake executable covers lifecycle, malformed, delayed, and replacement cases")
+    func fakeExecutableScenarios() throws {
+        let fixture = try loadFixture()
+        let names = Set(fixture.fakeExecutable.scenarios.map(\.name))
+        #expect(names == [
+            "working", "waiting", "completion", "failure", "malformed",
+            "delayed", "pid-reuse", "process-replacement",
+        ])
+
+        for scenario in fixture.fakeExecutable.scenarios {
+            let execution = try executeFakeAgent(scenario: scenario.name)
+            #expect(execution.status == scenario.expectedExitStatus)
+            #expect(execution.errorOutput.isEmpty)
+
+            if scenario.malformed == true {
+                #expect(throws: DecodingError.self) {
+                    _ = try JSONDecoder().decode(
+                        FakeEnvelope.self,
+                        from: execution.output
+                    )
+                }
+                continue
+            }
+
+            let envelope = try JSONDecoder().decode(
+                FakeEnvelope.self,
+                from: execution.output
+            )
+            #expect(envelope.schemaVersion == fixture.fakeExecutable.protocolVersion)
+            #expect(envelope.scenario == scenario.name)
+            #expect(envelope.events.map(\.state) == scenario.expectedStates)
+            if let expected = scenario.expectedGenerations {
+                #expect(envelope.events.map(\.generation) == expected)
+            }
+            if let expected = scenario.expectedProcessIdentifiers {
+                #expect(envelope.events.map(\.pid) == expected)
+            }
+            if let minimumDelayMilliseconds = scenario.minimumDelayMilliseconds {
+                #expect(
+                    execution.elapsed >= .milliseconds(minimumDelayMilliseconds)
+                )
+                #expect(execution.elapsed < .seconds(2))
+            }
+        }
+    }
+
+    @Test("fixtures and fake executable are offline and privacy bounded")
+    func offlineSanitizedFixture() throws {
+        let fixture = try loadFixture()
+        let fixtureData = try Data(contentsOf: fixtureURL)
+        let fixtureText = try #require(String(data: fixtureData, encoding: .utf8))
+        let scriptText = try String(contentsOf: fakeAgentURL, encoding: .utf8)
+        let combined = fixtureText + scriptText
+
+        #expect(!fixture.fixtureVersion.isEmpty)
+        #expect(fixture.sanitization.contains("no prompts"))
+        for forbidden in [
+            "api_key", "authorization:", "bearer ", "BEGIN PRIVATE KEY",
+            "/Users/", "$HOME", "curl ", "wget ", "nc ", "ssh ",
+        ] {
+            #expect(!combined.localizedCaseInsensitiveContains(forbidden))
+        }
+    }
+
+    @Test("hostile identifiers, paths, cursors, and manifests fail closed")
+    func securityCorpus() throws {
+        for identifier in ["../codex", "CODEX", "cоdex", "agent\u{202E}txt"] {
+            #expect(throws: Error.self) {
+                _ = try AgentID(validating: identifier)
+            }
+        }
+        for path in ["../secret", "/private/secret", "safe/../secret", "safe\u{0}file"] {
+            #expect(throws: AdapterCandidateError.invalidRelativePath) {
+                _ = try CandidateFileChange(operation: .modify, relativePath: path)
+            }
+        }
+        for cursor in ["", "cursor\nvalue", String(repeating: "x", count: 257)] {
+            #expect(throws: AdapterValueError.self) {
+                _ = try AdapterResumePosition(cursor)
+            }
+        }
+        #expect(throws: AdapterValueError.self) {
+            _ = try UserAgentPresentationRegistration(
+                identifier: "trusted", displayName: "Spoof\u{202E}txt",
+                executableAliases: ["codex"]
+            )
+        }
+    }
+
+    private var fixtureURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appending(path: "Fixtures/AgentAdapters/process-v1.json")
+    }
+
+    private var fakeAgentURL: URL {
+        fixtureURL.deletingLastPathComponent().appending(path: "fake-agent.sh")
+    }
+
+    private func loadFixture() throws -> Fixture {
+        try JSONDecoder().decode(Fixture.self, from: Data(contentsOf: fixtureURL))
+    }
+
+    private func executeFakeAgent(scenario: String) throws -> Execution {
+        let process = Process()
+        let output = Pipe()
+        let errorOutput = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [fakeAgentURL.path, scenario]
+        process.environment = ["LANG": "C", "PATH": "/usr/bin:/bin"]
+        process.standardOutput = output
+        process.standardError = errorOutput
+
+        let clock = ContinuousClock()
+        let startedAt = clock.now
+        try process.run()
+        process.waitUntilExit()
+        return Execution(
+            status: process.terminationStatus,
+            output: output.fileHandleForReading.readDataToEndOfFile(),
+            errorOutput: String(
+                data: errorOutput.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            ) ?? "",
+            elapsed: startedAt.duration(to: clock.now)
+        )
+    }
+}

--- a/PineTests/FirstPartyAgentCompatibilityTests.swift
+++ b/PineTests/FirstPartyAgentCompatibilityTests.swift
@@ -88,6 +88,10 @@ struct FirstPartyAgentCompatibilityTests {
             contentsOf: sourceRoot.appending(path: "docs/pine-2.0-release-notes.md"),
             encoding: .utf8
         )
+        let releaseMatrix = try String(
+            contentsOf: sourceRoot.appending(path: "docs/pine-2.0-agent-release-matrix.md"),
+            encoding: .utf8
+        )
 
         for record in FirstPartyAgentCompatibilityCatalog.records {
             #expect(matrix.contains(record.displayName))
@@ -99,6 +103,13 @@ struct FirstPartyAgentCompatibilityTests {
             #expect(matrix.contains("issues/\(followUp)"))
         }
         #expect(releaseNotes.contains("(agent-compatibility.md)"))
+        #expect(releaseNotes.contains("(pine-2.0-agent-release-matrix.md)"))
+        #expect(matrix.contains("(pine-2.0-agent-release-matrix.md)"))
+        #expect(releaseMatrix.contains("macOS 26"))
+        #expect(releaseMatrix.contains("macOS 27"))
+        for record in FirstPartyAgentCompatibilityCatalog.records {
+            #expect(releaseMatrix.contains(record.displayName))
+        }
     }
 
     private func loadFixture() throws -> Fixture {

--- a/PineTests/Fixtures/AgentAdapters/fake-agent.sh
+++ b/PineTests/Fixtures/AgentAdapters/fake-agent.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -eu
+
+scenario="${1:-}"
+
+case "$scenario" in
+  working)
+    printf '%s\n' '{"schemaVersion":1,"scenario":"working","events":[{"state":"started","pid":4100,"generation":1},{"state":"working","pid":4100,"generation":1}]}'
+    ;;
+  waiting)
+    printf '%s\n' '{"schemaVersion":1,"scenario":"waiting","events":[{"state":"started","pid":4100,"generation":1},{"state":"waiting","pid":4100,"generation":1}]}'
+    ;;
+  completion)
+    printf '%s\n' '{"schemaVersion":1,"scenario":"completion","events":[{"state":"started","pid":4100,"generation":1},{"state":"completed","pid":4100,"generation":1}]}'
+    ;;
+  failure)
+    printf '%s\n' '{"schemaVersion":1,"scenario":"failure","events":[{"state":"started","pid":4100,"generation":1},{"state":"failed","pid":4100,"generation":1}]}'
+    exit 17
+    ;;
+  malformed)
+    printf '%s\n' '{not-json'
+    ;;
+  delayed)
+    sleep 0.05
+    printf '%s\n' '{"schemaVersion":1,"scenario":"delayed","events":[{"state":"started","pid":4100,"generation":1},{"state":"working","pid":4100,"generation":1}]}'
+    ;;
+  pid-reuse)
+    printf '%s\n' '{"schemaVersion":1,"scenario":"pid-reuse","events":[{"state":"started","pid":4100,"generation":1},{"state":"replaced","pid":4100,"generation":2}]}'
+    ;;
+  process-replacement)
+    printf '%s\n' '{"schemaVersion":1,"scenario":"process-replacement","events":[{"state":"started","pid":4100,"generation":1},{"state":"replaced","pid":4200,"generation":2}]}'
+    ;;
+  *)
+    printf '%s\n' 'unsupported fake-agent scenario' >&2
+    exit 64
+    ;;
+esac

--- a/PineTests/Fixtures/AgentAdapters/process-v1.json
+++ b/PineTests/Fixtures/AgentAdapters/process-v1.json
@@ -1,5 +1,7 @@
 {
   "schemaVersion": 1,
+  "fixtureVersion": "2026-08-03",
+  "sanitization": "Synthetic commands and lifecycle events only; no prompts, output, credentials, home paths, or repository paths.",
   "agents": [
     {
       "stableIdentifier": "pi",
@@ -36,5 +38,54 @@
       "testedVersion": "0.53.1",
       "commands": ["gemini", "node /opt/homebrew/bin/gemini.js"]
     }
-  ]
+  ],
+  "fakeExecutable": {
+    "protocolVersion": 1,
+    "scenarios": [
+      {
+        "name": "working",
+        "expectedExitStatus": 0,
+        "expectedStates": ["started", "working"]
+      },
+      {
+        "name": "waiting",
+        "expectedExitStatus": 0,
+        "expectedStates": ["started", "waiting"]
+      },
+      {
+        "name": "completion",
+        "expectedExitStatus": 0,
+        "expectedStates": ["started", "completed"]
+      },
+      {
+        "name": "failure",
+        "expectedExitStatus": 17,
+        "expectedStates": ["started", "failed"]
+      },
+      {
+        "name": "malformed",
+        "expectedExitStatus": 0,
+        "expectedStates": [],
+        "malformed": true
+      },
+      {
+        "name": "delayed",
+        "expectedExitStatus": 0,
+        "expectedStates": ["started", "working"],
+        "minimumDelayMilliseconds": 25
+      },
+      {
+        "name": "pid-reuse",
+        "expectedExitStatus": 0,
+        "expectedStates": ["started", "replaced"],
+        "expectedGenerations": [1, 2]
+      },
+      {
+        "name": "process-replacement",
+        "expectedExitStatus": 0,
+        "expectedStates": ["started", "replaced"],
+        "expectedProcessIdentifiers": [4100, 4200]
+      }
+    ]
+  }
 }

--- a/PineTests/FuzzAgentBoundaryTests.swift
+++ b/PineTests/FuzzAgentBoundaryTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+@testable import Pine
+
+@Suite("Fuzz Agent Boundary Tests", .timeLimit(.minutes(2)))
+struct FuzzAgentBoundaryTests {
+    @Test func fuzzEventEnvelopeDecoder() {
+        var rng = SplitMix64(seed: 62)
+        let decoder = JSONDecoder()
+
+        for _ in 0..<100 {
+            let length = FuzzGen.randomLength(max: 8_192, rng: &rng)
+            let input = FuzzGen.randomBytes(count: length, rng: &rng)
+            _ = try? decoder.decode(
+                AgentEventEnvelope.self,
+                from: Data(input.utf8)
+            )
+        }
+    }
+
+    @Test func fuzzIdentifiersPathsAndOpaqueCursors() {
+        var rng = SplitMix64(seed: 63)
+
+        for _ in 0..<100 {
+            let length = FuzzGen.randomLength(max: 512, rng: &rng)
+            let value = FuzzGen.randomUnicode(count: length, rng: &rng)
+            _ = try? AgentID(validating: value)
+            _ = try? AdapterID(validating: value)
+            _ = try? ExecutableAlias(validating: value)
+            _ = try? VendorReference(role: .event, value: value)
+            _ = try? AdapterResumePosition(value)
+            _ = try? CandidateFileChange(
+                operation: .modify,
+                relativePath: value
+            )
+        }
+    }
+
+    @Test func fuzzUnknownTrustAndSourceNeverUpgrade() throws {
+        var rng = SplitMix64(seed: 64)
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        for index in 0..<100 {
+            let envelope = AgentEventEnvelope(
+                projectID: UUID(),
+                sessionID: UUID(),
+                agentTypeRaw: "codex",
+                process: AgentProcessIdentity(
+                    terminalID: UUID(),
+                    processGeneration: UInt64(index + 1)
+                ),
+                location: AgentEventLocation(
+                    worktreePath: "/tmp/project",
+                    cwd: "/tmp/project"
+                ),
+                cursorValue: UInt64(index + 1),
+                timestamp: Date(timeIntervalSince1970: 1_000),
+                source: .terminalProcess,
+                trustLevel: .observed
+            )
+            let data = try encoder.encode(envelope)
+            var object = try #require(
+                JSONSerialization.jsonObject(with: data) as? [String: Any]
+            )
+            object["source"] = FuzzGen.randomPrintable(
+                count: 24,
+                rng: &rng
+            )
+            object["trustLevel"] = "future-super-trust"
+            let hostile = try JSONSerialization.data(withJSONObject: object)
+            let decoded = try decoder.decode(
+                AgentEventEnvelope.self,
+                from: hostile
+            )
+
+            #expect(decoded.trustLevel != .verified)
+            #expect(!decoded.source.canEstablishVerifiedTrust)
+        }
+    }
+
+    @Test func opaqueDiagnosticsRemainRedactedUnderRandomInputs() throws {
+        var rng = SplitMix64(seed: 65)
+
+        for _ in 0..<100 {
+            var randomValue = FuzzGen.randomPrintable(
+                count: FuzzGen.randomLength(min: 1, max: 128, rng: &rng),
+                rng: &rng
+            )
+            randomValue.removeAll { $0.isNewline }
+            let value = "opaque-(randomValue)-value"
+            let reference = try VendorReference(role: .event, value: value)
+            let cursor = try AdapterResumePosition(value)
+
+            #expect(reference.description == "<redacted:event>")
+            #expect(reference.debugDescription == "<redacted:event>")
+            #expect(cursor.description == "<redacted:resume-position>")
+            #expect(cursor.debugDescription == "<redacted:resume-position>")
+        }
+    }
+}

--- a/PineTests/FuzzTestUtilities.swift
+++ b/PineTests/FuzzTestUtilities.swift
@@ -17,8 +17,9 @@ import Foundation
 // Seed  53–60: FuzzConfigValidatorTests (yamllint=53, shellcheck=54, terraform=55,
 //              hadolint=56, builtinYAML=57, dockerfile=58, shell=59, detector=60)
 // Seed  61:    FuzzGoToLineParserTests
+// Seed  62–65: FuzzAgentBoundaryTests (envelope=62, values=63, trust=64, redaction=65)
 //
-// Next available seed: 62
+// Next available seed: 66
 //
 // Iteration count: each random-input fuzz test runs 100 iterations. With the
 // deterministic SplitMix64 PRNG this still exercises ample edge cases while

--- a/docs/agent-compatibility.md
+++ b/docs/agent-compatibility.md
@@ -5,6 +5,10 @@ that Pine observed a supported executable in one of its terminal process
 trees. It does not mean that Pine can read a provider's private state, infer a
 successful completion, or resume a provider session.
 
+The executable release procedure, automated gate inventory, OS/renderer test
+matrix, and accessibility checklist live in the
+[Pine 2.0 agent release matrix](pine-2.0-agent-release-matrix.md).
+
 The checked-in catalog schema is version 1. The versions below were verified
 on August 3, 2026 against sanitized command-shape fixtures; Pi, Codex, and
 OpenCode were also checked against locally installed binaries. Links point to

--- a/docs/pine-2.0-agent-release-matrix.md
+++ b/docs/pine-2.0-agent-release-matrix.md
@@ -1,0 +1,112 @@
+# Pine 2.0 agent release matrix
+
+This matrix is the release gate for Pine's agent workflows. A row marked
+`Pending` blocks the Pine 2.0 release; it must not be converted to `Pass`
+without recording the exact environment and a human result. Automated tests
+use only checked-in synthetic data and must not read a user's agent config,
+credentials, prompts, terminal output, or network services.
+
+## Automated gates
+
+| Gate | Coverage | Release command or evidence |
+| --- | --- | --- |
+| First-party adapter conformance | Every catalog entry runs the same identity, exact-alias, detected-tier, observed-generation, and generic-fallback assertions | `PineTests/AgentReleaseGateTests` and `PineTests/FirstPartyAgentCompatibilityTests` |
+| Protocol and process fixtures | Versioned synthetic working, waiting, completion, failure, malformed, delayed, PID-reuse, and process-replacement streams | `PineTests/Fixtures/AgentAdapters/process-v1.json` and `fake-agent.sh` |
+| Multi-project routing and Inbox | Two projects, multiple panes and agents, background project reopen, exact task/run/generation routing, stale routes, relaunch, and project close | `PineTests/AgentInboxTests`, `PineTests/AgentTaskRegistryTests`, and `PineTests/ProjectRegistryTests` |
+| Notification correctness | Exact transitions, process-only downgrade, stale/reordered/replacement rejection, cross-project suppression, de-duplication, and persisted settings | `PineTests/AgentNotificationTests` |
+| Security and privacy | Spoofs, lookalikes, cross-project identity, replay, path traversal, opaque-value redaction, untrusted registration, and malformed persistence | `PineTests/AgentAdapterContractTests`, `PineTests/AgentAdapterRegistryTests`, `PineTests/AgentReleaseGateTests`, and `PineTests/AgentTaskRegistryTests` |
+| Fuzzing | Envelope decoding, identifiers, relative paths, cursors, future trust/source values, and diagnostic redaction | `PineTests/FuzzAgentBoundaryTests`; nightly and opt-in `fuzz` CI jobs |
+| Performance | Process polling, provenance-event decoding, durable registry refresh, Inbox projection, and notification transition coalescing | `PinePerformanceTests/AgentWorkflowPerformanceTests`; nightly performance workflow and checked-in budgets |
+| Accessibility logic | Keyboard selection, deterministic review behavior, localized announcements, and Reduce Motion animation policy | `PineTests/AgentKeyboardSelectionTests`, `PineTests/AgentInboxTests`, and `PineTests/AgentModelsTests` |
+| UI sharding | Every UI test class appears exactly once and shard counts differ by no more than three | `python3 .github/scripts/check_ui_test_shards.py --tests-dir PineUITests --workflow .github/workflows/ci.yml --max-delta 3` |
+
+The blocking unit-test job excludes only deterministic fuzz suites, which run
+nightly and when a PR has the `fuzz` label. No automated gate launches a real
+agent, uses a paid API, accesses live provider state, or requires network
+access.
+
+## Compatibility environments
+
+Record all four commands for every tested OS, even when the failure appears
+unrelated to the SDK:
+
+```sh
+sw_vers
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -version
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun --sdk macosx --show-sdk-version
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun --sdk macosx --show-sdk-build-version
+```
+
+The currently available macOS 27 beta machine was captured on August 3, 2026:
+
+```text
+ProductName:            macOS
+ProductVersion:         27.0
+BuildVersion:           26A5388g
+Xcode 27.0
+Build version 27A5218g
+SDK version:            27.0
+SDK build version:      26A5378i
+```
+
+Environment capture is not a manual product pass. Complete each row below on
+the named OS and attach the command output plus effective terminal renderer to
+the release PR.
+
+| OS | Terminal renderer | Agent detection and replacement | Inbox/review and notifications | Accessibility | Status |
+| --- | --- | --- | --- | --- | --- |
+| macOS 26.x | Default (Metal when available; record fallback) | Not run | Not run | Not run | Pending |
+| macOS 26.x | Forced CoreGraphics (`PINE_DISABLE_METAL=1`) | Not run | Not run | Not run | Pending |
+| macOS 27 current beta | Default (Metal when available; record fallback) | Not run | Not run | Not run | Pending |
+| macOS 27 current beta | Forced CoreGraphics (`PINE_DISABLE_METAL=1`) | Not run | Not run | Not run | Pending |
+
+For each renderer row, use two projects with at least two terminal panes and
+two simultaneous agents. Exercise working, waiting, completion, failure,
+terminal close, project-window close/reopen, application relaunch, PID reuse,
+and process replacement. Confirm every notification returns only to its exact
+task/run/generation and that a stale or replaced run never steals focus.
+
+## Adapter matrix
+
+These claims are deliberately conservative. Process observation is the
+supported mechanism and generic execution is the lower-tier fallback; terminal
+text is never parsed as trusted lifecycle evidence.
+
+| Adapter | Verified version | Tier | Mechanism | Required fallback | Limitation |
+| --- | --- | --- | --- | --- | --- |
+| Pi | 0.83.0 | Detected | Exact executable alias + process generation | Generic terminal command | Process termination only |
+| Codex | 0.146.0 | Detected | Exact executable alias + process generation | Generic terminal command | Process termination only |
+| Claude Code | 2.1.220 | Detected | Exact executable alias + process generation | Generic terminal command | Process termination only |
+| OpenCode | 1.18.10 | Detected | Exact executable alias + process generation | Generic terminal command | Process termination only |
+| GitHub Copilot CLI | 1.0.77 | Detected | Exact executable alias + process generation | Generic terminal command | Process termination only |
+| Aider | 0.86.0 | Detected | Exact executable alias + process generation | Generic terminal command | Process termination only |
+| Gemini CLI | 0.53.1 | Detected | Exact executable alias + process generation | Generic terminal command | Process termination only |
+
+If the installed version differs, record it and rerun the shared adapter
+conformance suite. Do not raise the tier based on terminal presentation,
+timing, an undocumented file, or an unauthenticated local endpoint.
+
+## Manual accessibility and privacy checklist
+
+- Use the keyboard to open the Agent Inbox, traverse every section and row,
+  open a task, mark it reviewed/unreviewed, and dismiss eligible history.
+- Repeat Inbox/review navigation with VoiceOver. Confirm labels include the
+  agent, project, state, freshness, and available action without exposing an
+  absolute path, prompt, command output, token, or opaque provider identifier.
+- Enable Reduce Motion and confirm attention indicators do not pulse and
+  navigation/review state changes remain immediate and understandable.
+- Exercise notification permission states: not determined, denied,
+  authorized, globally disabled, event disabled, agent disabled, project
+  disabled, task muted, duplicate delivery, and click-through after process
+  replacement.
+- With two projects open, verify the Inbox aggregates both while all review,
+  dismissal, navigation, and notification actions affect only the selected
+  exact task.
+- Inspect logs and crash reports for secrets, environment variables, home
+  paths, terminal output, prompts, and raw vendor session/cursor values.
+- Run `python3 .github/scripts/check_ui_test_shards.py --tests-dir PineUITests
+  --workflow .github/workflows/ci.yml --max-delta 3` after adding or moving any
+  UI test class.
+
+Record failures with the exact OS/Xcode/SDK evidence above, adapter version,
+support tier, mechanism, renderer, Mac model/chip, and display configuration.

--- a/docs/pine-2.0-release-notes.md
+++ b/docs/pine-2.0-release-notes.md
@@ -14,7 +14,9 @@ while preserving explicit trust and privacy boundaries.
   launch, resume, and lifecycle limitations.
 
 See the [CLI agent compatibility matrix](agent-compatibility.md) for verified
-versions, support tiers, signal sources, trust levels, and current limitations.
+versions, support tiers, signal sources, trust levels, and current limitations,
+and the [Pine 2.0 agent release matrix](pine-2.0-agent-release-matrix.md) for the
+automated gates and manual OS/renderer checklist.
 
 This document is a release-candidate draft. The final notes will also include
 the Agent Inbox, actionable notifications, durable resume, completion briefs,


### PR DESCRIPTION
## Summary
- add a shared first-party agent conformance suite plus versioned, sanitized offline fixtures and a fake agent executable
- add deterministic agent boundary fuzzing and performance coverage for polling, event ingestion, registry refresh, Inbox projection, and notification coalescing
- wire fuzz coverage into opt-in/nightly CI and document the Pine 2.0 OS, renderer, security, accessibility, and manual release matrix

## Validation
- selected AgentReleaseGate, compatibility, notification, and Inbox unit tests
- FuzzAgentBoundaryTests and compatibility documentation gate
- AgentWorkflowPerformanceTests
- SwiftLint strict: 0 violations
- fixture JSON, performance baseline JSON, and fake-agent shell validation
- UI shard validation: 37 classes / 218 tests, delta 2
- git diff --check

Local UI tests were not run per maintainer request. GitHub CI remains authoritative for UI shards.

Closes #1310