### PR TITLE
feat(agent): add five first-party detection adapters

### DIFF
--- a/Pine/Agent/Adapters/AdapterIdentifiers.swift
+++ b/Pine/Agent/Adapters/AdapterIdentifiers.swift
@@ -50,7 +50,10 @@ nonisolated struct AgentID: CanonicalAdapterIdentifier {
     }
 
     init(migratingLegacyStableIdentifier value: String) throws {
-        guard ["claudeCode", "codex", "aider", "copilot", "pi", "openCode", "gemini"].contains(value) else {
+        guard [
+            "claudeCode", "codex", "aider", "copilot", "pi", "openCode", "gemini",
+            "amp", "cursorAgent", "goose", "qwenCode", "crush",
+        ].contains(value) else {
             throw AdapterValueError.invalidCharacters("legacyAgentID")
         }
         self.value = value

--- a/Pine/Agent/Adapters/AdapterValidation.swift
+++ b/Pine/Agent/Adapters/AdapterValidation.swift
@@ -1288,7 +1288,12 @@ nonisolated enum AgentPresentationCatalog {
         "copilot": ("Copilot", .copilot, ["github-copilot-cli", "copilot"]),
         "pi": ("Pi", .pi, ["pi"]),
         "openCode": ("OpenCode", .generic, ["opencode"]),
-        "gemini": ("Gemini CLI", .generic, ["gemini"])
+        "gemini": ("Gemini CLI", .generic, ["gemini"]),
+        "amp": ("Amp", .generic, ["amp"]),
+        "cursorAgent": ("Cursor Agent", .generic, ["cursor-agent"]),
+        "goose": ("Goose", .generic, ["goose"]),
+        "qwenCode": ("Qwen Code", .generic, ["qwen"]),
+        "crush": ("Crush", .generic, ["crush"])
     ]
 
     static var builtInStableIdentifiers: Set<String> { Set(builtIns.keys) }

--- a/Pine/Agent/Adapters/FirstPartyAgentCompatibility.swift
+++ b/Pine/Agent/Adapters/FirstPartyAgentCompatibility.swift
@@ -109,6 +109,41 @@ nonisolated enum FirstPartyAgentCompatibilityCatalog {
             upstream: "https://github.com/google-gemini/gemini-cli",
             versions: ["0.53.1"]
         ),
+        reviewedRecord(
+            id: "amp",
+            name: "Amp",
+            aliases: ["amp"],
+            source: ("https://ampcode.com/manual", ["0.0.1785747753-g51f676"]),
+            interface: "--execute --stream-json / --stream-json-input"
+        ),
+        reviewedRecord(
+            id: "cursorAgent",
+            name: "Cursor Agent",
+            aliases: ["cursor-agent"],
+            source: ("https://docs.cursor.com/en/cli/overview", ["2026.07.23-e383d2b"]),
+            interface: "--print --output-format json|stream-json"
+        ),
+        reviewedRecord(
+            id: "goose",
+            name: "Goose",
+            aliases: ["goose"],
+            source: ("https://github.com/aaif-goose/goose", ["1.45.0"]),
+            interface: "ACP over stdio"
+        ),
+        reviewedRecord(
+            id: "qwenCode",
+            name: "Qwen Code",
+            aliases: ["qwen"],
+            source: ("https://github.com/QwenLM/qwen-code", ["0.21.4"]),
+            interface: "--output-format json|stream-json"
+        ),
+        reviewedRecord(
+            id: "crush",
+            name: "Crush",
+            aliases: ["crush"],
+            source: ("https://github.com/charmbracelet/crush", ["0.88.0"]),
+            interface: "experimental workspace SSE"
+        ),
     ]
 
     static func record(stableIdentifier: String) -> FirstPartyAgentCompatibilityRecord? {
@@ -140,6 +175,31 @@ nonisolated enum FirstPartyAgentCompatibilityCatalog {
             resumeCapability: .newSessionOnly,
             notificationAccuracy: .processTerminationOnly,
             limitations: "No documented structured event channel is enabled; attention and completion remain unverified."
+        )
+    }
+
+    private static func reviewedRecord(
+        id: String,
+        name: String,
+        aliases: Set<String>,
+        source: (upstream: String, versions: [String]),
+        interface: String
+    ) -> FirstPartyAgentCompatibilityRecord {
+        FirstPartyAgentCompatibilityRecord(
+            schemaVersion: schemaVersion,
+            stableIdentifier: id,
+            displayName: name,
+            executableAliases: aliases,
+            upstreamURL: source.upstream,
+            testedVersions: source.versions,
+            supportTier: .detected,
+            eventSource: .processSnapshot,
+            trustLevel: .observedProcessGeneration,
+            launchCapability: .manualTerminal,
+            resumeCapability: .newSessionOnly,
+            notificationAccuracy: .processTerminationOnly,
+            limitations: "Reviewed \(interface) is not enabled until Pine can authenticate and bind "
+                + "its transport; malformed, reordered, oversized, future-schema, and ambient events fail closed."
         )
     }
 }

--- a/Pine/Agent/AgentActivityStore.swift
+++ b/Pine/Agent/AgentActivityStore.swift
@@ -326,6 +326,16 @@ final class AgentActivityStore {
             "opencode"
         case .gemini:
             "gemini"
+        case .amp:
+            "amp"
+        case .cursorAgent:
+            "cursor-agent"
+        case .goose:
+            "goose"
+        case .qwenCode:
+            "qwen"
+        case .crush:
+            "crush"
         case .generic(let name):
             "generic:\(name)"
         }

--- a/Pine/Agent/AgentHistoryEntry.swift
+++ b/Pine/Agent/AgentHistoryEntry.swift
@@ -211,6 +211,11 @@ extension AgentType {
         case .pi: "pi"
         case .openCode: "openCode"
         case .gemini: "gemini"
+        case .amp: "amp"
+        case .cursorAgent: "cursorAgent"
+        case .goose: "goose"
+        case .qwenCode: "qwenCode"
+        case .crush: "crush"
         case .generic(let name): "generic:\(name)"
         }
     }
@@ -229,6 +234,11 @@ extension AgentType {
         case "pi": self = .pi
         case "openCode": self = .openCode
         case "gemini": self = .gemini
+        case "amp": self = .amp
+        case "cursorAgent": self = .cursorAgent
+        case "goose": self = .goose
+        case "qwenCode": self = .qwenCode
+        case "crush": self = .crush
         default:
             guard stableIdentifier.hasPrefix("generic:") else { return nil }
             let name = String(stableIdentifier.dropFirst("generic:".count))

--- a/Pine/Agent/AgentModels.swift
+++ b/Pine/Agent/AgentModels.swift
@@ -30,6 +30,16 @@ enum AgentType: Equatable, Sendable {
     case openCode
     /// Google Gemini CLI (`gemini`).
     case gemini
+    /// Sourcegraph Amp (`amp`).
+    case amp
+    /// Cursor Agent CLI (`cursor-agent`).
+    case cursorAgent
+    /// Goose (`goose`).
+    case goose
+    /// Qwen Code (`qwen`).
+    case qwenCode
+    /// Charmbracelet Crush (`crush`).
+    case crush
     /// Any other/unrecognised agent, identified by a free-form name.
     case generic(name: String)
 
@@ -43,6 +53,11 @@ enum AgentType: Equatable, Sendable {
         case .pi: "Pi"
         case .openCode: "OpenCode"
         case .gemini: "Gemini CLI"
+        case .amp: "Amp"
+        case .cursorAgent: "Cursor Agent"
+        case .goose: "Goose"
+        case .qwenCode: "Qwen Code"
+        case .crush: "Crush"
         case .generic(let name): name
         }
     }
@@ -69,6 +84,11 @@ enum AgentType: Equatable, Sendable {
         case .pi: .systemTeal
         case .openCode: .systemPink
         case .gemini: .systemIndigo
+        case .amp: .systemMint
+        case .cursorAgent: .systemCyan
+        case .goose: .systemYellow
+        case .qwenCode: .systemRed
+        case .crush: .systemBrown
         case .generic: .systemGray
         }
     }

--- a/Pine/Pine.help/Contents/Resources/de.lproj/index.html
+++ b/Pine/Pine.help/Contents/Resources/de.lproj/index.html
@@ -179,6 +179,7 @@
                 <p>Die Übergabe von Agent-Kontext ist optional und nur lesend. Pine sendet Ihren Code oder Ihre Terminalausgabe nirgendwohin ohne Ihr Zutun.</p>
             </div>
         </div>
+        <p>Pine erkennt Pi, Codex, Claude Code, OpenCode, Copilot, Aider, Gemini, Amp, Cursor Agent, Goose, Qwen Code und Crush anhand des exakten Programmnamens. Sofern die Matrix nichts anderes angibt, wird nur der Prozess erkannt.</p>
         <p><a href="https://github.com/batonogov/pine/blob/main/docs/agent-compatibility.md">Kompatibilitätsmatrix und aktuelle Einschränkungen der CLI-Agenten anzeigen.</a></p>
     </section>
 

--- a/Pine/Pine.help/Contents/Resources/en.lproj/index.html
+++ b/Pine/Pine.help/Contents/Resources/en.lproj/index.html
@@ -179,6 +179,7 @@
                 <p>Agent context handoff is opt-in and read-only. Pine never sends your code or terminal output anywhere without your action.</p>
             </div>
         </div>
+        <p>Pine recognizes Pi, Codex, Claude Code, OpenCode, Copilot, Aider, Gemini, Amp, Cursor Agent, Goose, Qwen Code, and Crush by exact executable name. Recognition is process-only unless the matrix explicitly says otherwise.</p>
         <p><a href="https://github.com/batonogov/pine/blob/main/docs/agent-compatibility.md">View the CLI agent compatibility matrix and current limitations.</a></p>
     </section>
 

--- a/Pine/Pine.help/Contents/Resources/es.lproj/index.html
+++ b/Pine/Pine.help/Contents/Resources/es.lproj/index.html
@@ -179,6 +179,7 @@
                 <p>La entrega de contexto del agente es opcional y de solo lectura. Pine nunca envía tu código ni la salida del terminal a ningún sitio sin tu acción.</p>
             </div>
         </div>
+        <p>Pine reconoce Pi, Codex, Claude Code, OpenCode, Copilot, Aider, Gemini, Amp, Cursor Agent, Goose, Qwen Code y Crush por el nombre exacto del ejecutable. Salvo que la matriz indique lo contrario, solo se reconoce el proceso.</p>
         <p><a href="https://github.com/batonogov/pine/blob/main/docs/agent-compatibility.md">Consulta la matriz de compatibilidad de agentes CLI y sus limitaciones actuales.</a></p>
     </section>
 

--- a/Pine/Pine.help/Contents/Resources/fr.lproj/index.html
+++ b/Pine/Pine.help/Contents/Resources/fr.lproj/index.html
@@ -179,6 +179,7 @@
                 <p>Le transfert de contexte à l'agent est optionnel et en lecture seule. Pine n'envoie jamais votre code ni la sortie du terminal nulle part sans votre action.</p>
             </div>
         </div>
+        <p>Pine reconnaît Pi, Codex, Claude Code, OpenCode, Copilot, Aider, Gemini, Amp, Cursor Agent, Goose, Qwen Code et Crush par le nom exact de l’exécutable. Sauf indication contraire dans la matrice, seule la présence du processus est reconnue.</p>
         <p><a href="https://github.com/batonogov/pine/blob/main/docs/agent-compatibility.md">Consultez la matrice de compatibilité des agents CLI et leurs limitations actuelles.</a></p>
     </section>
 

--- a/Pine/Pine.help/Contents/Resources/ja.lproj/index.html
+++ b/Pine/Pine.help/Contents/Resources/ja.lproj/index.html
@@ -179,6 +179,7 @@
                 <p>エージェントへのコンテキスト受け渡しは任意かつ読み取り専用です。操作なしにコードやターミナル出力を送信することはありません。</p>
             </div>
         </div>
+        <p>PineはPi、Codex、Claude Code、OpenCode、Copilot、Aider、Gemini、Amp、Cursor Agent、Goose、Qwen Code、Crushを実行ファイルの完全一致で認識します。マトリクスに明記されていない限り、認識はプロセスのみです。</p>
         <p><a href="https://github.com/batonogov/pine/blob/main/docs/agent-compatibility.md">CLIエージェントの互換性マトリクスと現在の制限事項を確認します。</a></p>
     </section>
 

--- a/Pine/Pine.help/Contents/Resources/ko.lproj/index.html
+++ b/Pine/Pine.help/Contents/Resources/ko.lproj/index.html
@@ -179,6 +179,7 @@
                 <p>에이전트 컨텍스트 전달은 선택 사항이며 읽기 전용입니다. Pine은 사용자의 조작 없이는 코드나 터미널 출력을 어디로도 보내지 않습니다.</p>
             </div>
         </div>
+        <p>Pine은 정확한 실행 파일 이름으로 Pi, Codex, Claude Code, OpenCode, Copilot, Aider, Gemini, Amp, Cursor Agent, Goose, Qwen Code 및 Crush를 인식합니다. 호환성 표에 달리 명시되지 않은 경우 프로세스만 인식합니다.</p>
         <p><a href="https://github.com/batonogov/pine/blob/main/docs/agent-compatibility.md">CLI 에이전트 호환성 표와 현재 제한 사항을 확인합니다.</a></p>
     </section>
 

--- a/Pine/Pine.help/Contents/Resources/pt-BR.lproj/index.html
+++ b/Pine/Pine.help/Contents/Resources/pt-BR.lproj/index.html
@@ -179,6 +179,7 @@
                 <p>A entrega de contexto ao agente é opcional e somente leitura. O Pine nunca envia seu código ou a saída do terminal a lugar algum sem sua ação.</p>
             </div>
         </div>
+        <p>O Pine reconhece Pi, Codex, Claude Code, OpenCode, Copilot, Aider, Gemini, Amp, Cursor Agent, Goose, Qwen Code e Crush pelo nome exato do executável. Salvo indicação contrária na matriz, apenas o processo é reconhecido.</p>
         <p><a href="https://github.com/batonogov/pine/blob/main/docs/agent-compatibility.md">Veja a matriz de compatibilidade dos agentes CLI e as limitações atuais.</a></p>
     </section>
 

--- a/Pine/Pine.help/Contents/Resources/ru.lproj/index.html
+++ b/Pine/Pine.help/Contents/Resources/ru.lproj/index.html
@@ -179,6 +179,7 @@
                 <p>Передача контекста агенту необязательна и доступна только для чтения. Pine никогда не отправляет ваш код или вывод терминала куда-либо без вашего действия.</p>
             </div>
         </div>
+        <p>Pine распознаёт Pi, Codex, Claude Code, OpenCode, Copilot, Aider, Gemini, Amp, Cursor Agent, Goose, Qwen Code и Crush по точному имени исполняемого файла. Если в матрице не указано иное, распознаётся только процесс.</p>
         <p><a href="https://github.com/batonogov/pine/blob/main/docs/agent-compatibility.md">Откройте матрицу совместимости CLI-агентов и список текущих ограничений.</a></p>
     </section>
 

--- a/Pine/Pine.help/Contents/Resources/zh-Hans.lproj/index.html
+++ b/Pine/Pine.help/Contents/Resources/zh-Hans.lproj/index.html
@@ -179,6 +179,7 @@
                 <p>代理上下文传递是可选且只读的。未经您的操作，Pine绝不会将您的代码或终端输出发送到任何地方。</p>
             </div>
         </div>
+        <p>Pine按可执行文件的精确名称识别Pi、Codex、Claude Code、OpenCode、Copilot、Aider、Gemini、Amp、Cursor Agent、Goose、Qwen Code和Crush。除非兼容性矩阵另有说明，否则只识别进程。</p>
         <p><a href="https://github.com/batonogov/pine/blob/main/docs/agent-compatibility.md">查看CLI代理兼容性矩阵和当前限制。</a></p>
     </section>
 

--- a/PineTests/AgentModelsTests.swift
+++ b/PineTests/AgentModelsTests.swift
@@ -22,6 +22,11 @@ struct AgentModelsTests {
         #expect(AgentType.pi.displayName == "Pi")
         #expect(AgentType.openCode.displayName == "OpenCode")
         #expect(AgentType.gemini.displayName == "Gemini CLI")
+        #expect(AgentType.amp.displayName == "Amp")
+        #expect(AgentType.cursorAgent.displayName == "Cursor Agent")
+        #expect(AgentType.goose.displayName == "Goose")
+        #expect(AgentType.qwenCode.displayName == "Qwen Code")
+        #expect(AgentType.crush.displayName == "Crush")
         #expect(AgentType.generic(name: "Custom").displayName == "Custom")
     }
 
@@ -35,13 +40,19 @@ struct AgentModelsTests {
         #expect(AgentType.pi.cliNames == ["pi"])
         #expect(AgentType.openCode.cliNames == ["opencode"])
         #expect(AgentType.gemini.cliNames == ["gemini"])
+        #expect(AgentType.amp.cliNames == ["amp"])
+        #expect(AgentType.cursorAgent.cliNames == ["cursor-agent"])
+        #expect(AgentType.goose.cliNames == ["goose"])
+        #expect(AgentType.qwenCode.cliNames == ["qwen"])
+        #expect(AgentType.crush.cliNames == ["crush"])
         // Generic agents have no known CLI names.
         #expect(AgentType.generic(name: "Custom").cliNames.isEmpty)
     }
 
     @Test func color_isDistinctAndNotClearPerAgent() {
         let agents: [AgentType] = [
-            .claudeCode, .codex, .aider, .copilot, .pi, .openCode, .gemini, .generic(name: "X"),
+            .claudeCode, .codex, .aider, .copilot, .pi, .openCode, .gemini,
+            .amp, .cursorAgent, .goose, .qwenCode, .crush, .generic(name: "X"),
         ]
 
         // Every case must resolve to a concrete, non-transparent color.
@@ -52,6 +63,7 @@ struct AgentModelsTests {
         // Known agents must return distinct colors so UI badges stay distinguishable.
         let known = [
             AgentType.claudeCode, .codex, .aider, .copilot, .pi, .openCode, .gemini,
+            .amp, .cursorAgent, .goose, .qwenCode, .crush,
         ]
         for i in known.indices {
             for j in (i + 1)..<known.count {
@@ -90,6 +102,14 @@ struct AgentModelsTests {
         #expect(AgentType.resolve(fromProcessName: "gemini") == .gemini)
     }
 
+    @Test func resolveReturnsExtendedFirstPartyAgentsForExactNames() {
+        #expect(AgentType.resolve(fromProcessName: "amp") == .amp)
+        #expect(AgentType.resolve(fromProcessName: "cursor-agent") == .cursorAgent)
+        #expect(AgentType.resolve(fromProcessName: "goose") == .goose)
+        #expect(AgentType.resolve(fromProcessName: "qwen") == .qwenCode)
+        #expect(AgentType.resolve(fromProcessName: "crush") == .crush)
+    }
+
     @Test func pi_isDistinctFromGenericNamedPi() {
         // .pi is a first-class case and must not collapse into a generic
         // agent whose free-form name happens to be "pi".
@@ -103,6 +123,11 @@ struct AgentModelsTests {
         #expect(AgentType.resolve(fromProcessName: "PI") == .pi)
         #expect(AgentType.resolve(fromProcessName: "OPENCODE") == .openCode)
         #expect(AgentType.resolve(fromProcessName: "GEMINI") == .gemini)
+        #expect(AgentType.resolve(fromProcessName: "AMP") == .amp)
+        #expect(AgentType.resolve(fromProcessName: "CURSOR-AGENT") == .cursorAgent)
+        #expect(AgentType.resolve(fromProcessName: "GOOSE") == .goose)
+        #expect(AgentType.resolve(fromProcessName: "QWEN") == .qwenCode)
+        #expect(AgentType.resolve(fromProcessName: "CRUSH") == .crush)
     }
 
     @Test func resolve_trimsWhitespace() {

--- a/PineTests/FirstPartyAgentCompatibilityTests.swift
+++ b/PineTests/FirstPartyAgentCompatibilityTests.swift
@@ -15,9 +15,29 @@ struct FirstPartyAgentCompatibilityTests {
         let commands: [String]
     }
 
+    private struct ProtocolReviewFixture: Decodable {
+        struct Agent: Decodable {
+            struct Case: Decodable {
+                let name: String
+                let inputBytes: Int
+                let wire: String
+            }
+
+            let stableIdentifier: String
+            let authority: String
+            let interface: String
+            let cases: [Case]
+        }
+
+        let schemaVersion: UInt16
+        let maximumEventBytes: Int
+        let sanitization: String
+        let agents: [Agent]
+    }
+
     @Test func catalogIsCompleteUniqueAndFailClosed() throws {
         let records = FirstPartyAgentCompatibilityCatalog.records
-        #expect(records.count == 7)
+        #expect(records.count == 12)
         #expect(Set(records.map(\.stableIdentifier)).count == records.count)
         #expect(records.allSatisfy { $0.schemaVersion == FirstPartyAgentCompatibilityCatalog.schemaVersion })
         #expect(records.allSatisfy { $0.supportTier == .detected })
@@ -38,6 +58,41 @@ struct FirstPartyAgentCompatibilityTests {
             for alias in record.executableAliases {
                 #expect(AgentPresentationCatalog.stableIdentifier(forExecutableAlias: alias) == record.stableIdentifier)
             }
+        }
+    }
+
+    @Test func reviewedStructuredInterfacesRemainFailClosed() throws {
+        let fixture = try loadProtocolReviewFixture()
+        #expect(fixture.schemaVersion == FirstPartyAgentCompatibilityCatalog.schemaVersion)
+        #expect(fixture.maximumEventBytes == 65_536)
+        #expect(fixture.sanitization.contains("credentials"))
+        #expect(Set(fixture.agents.map(\.stableIdentifier)) == [
+            "amp", "cursorAgent", "goose", "qwenCode", "crush",
+        ])
+
+        let requiredCases: [String: Set<String>] = [
+            "amp": ["documented-init", "documented-completion", "malformed", "reordered", "oversized", "future-schema"],
+            "cursorAgent": ["version", "json", "stream-json", "resume-explicit", "malformed", "oversized", "future-schema"],
+            "goose": ["negotiation", "ordering", "replay", "malformed", "oversized", "future-schema"],
+            "qwenCode": ["version", "process", "documented-stream", "malformed", "reordered", "oversized", "future-schema"],
+            "crush": ["session", "reconnect", "duplicate", "reordered", "malformed", "oversized", "future-schema"],
+        ]
+
+        for agent in fixture.agents {
+            let record = try #require(
+                FirstPartyAgentCompatibilityCatalog.record(stableIdentifier: agent.stableIdentifier)
+            )
+            #expect(record.supportTier == .detected)
+            #expect(record.eventSource == .processSnapshot)
+            #expect(record.trustLevel == .observedProcessGeneration)
+            #expect(record.launchCapability == .manualTerminal)
+            #expect(record.resumeCapability == .newSessionOnly)
+            #expect(agent.authority == "pine-launched-authenticated-transport-only")
+            #expect(!agent.interface.isEmpty)
+            #expect(Set(agent.cases.map(\.name)) == requiredCases[agent.stableIdentifier])
+            #expect(agent.cases.first { $0.name == "oversized" }?.inputBytes == fixture.maximumEventBytes + 1)
+            #expect(agent.cases.allSatisfy { !$0.wire.localizedCaseInsensitiveContains("token") })
+            #expect(agent.cases.allSatisfy { !$0.wire.localizedCaseInsensitiveContains("prompt") })
         }
     }
 
@@ -118,5 +173,13 @@ struct FirstPartyAgentCompatibilityTests {
             .appending(path: "Fixtures/AgentAdapters/process-v1.json")
         let data = try Data(contentsOf: fixtureURL)
         return try JSONDecoder().decode(Fixture.self, from: data)
+    }
+
+    private func loadProtocolReviewFixture() throws -> ProtocolReviewFixture {
+        let source = URL(fileURLWithPath: #filePath)
+        let fixtureURL = source.deletingLastPathComponent()
+            .appending(path: "Fixtures/AgentAdapters/protocol-review-v1.json")
+        let data = try Data(contentsOf: fixtureURL)
+        return try JSONDecoder().decode(ProtocolReviewFixture.self, from: data)
     }
 }

--- a/PineTests/Fixtures/AgentAdapters/process-v1.json
+++ b/PineTests/Fixtures/AgentAdapters/process-v1.json
@@ -37,6 +37,31 @@
       "stableIdentifier": "gemini",
       "testedVersion": "0.53.1",
       "commands": ["gemini", "node /opt/homebrew/bin/gemini.js"]
+    },
+    {
+      "stableIdentifier": "amp",
+      "testedVersion": "0.0.1785747753-g51f676",
+      "commands": ["amp", "/opt/homebrew/bin/amp"]
+    },
+    {
+      "stableIdentifier": "cursorAgent",
+      "testedVersion": "2026.07.23-e383d2b",
+      "commands": ["cursor-agent", "/usr/local/bin/cursor-agent"]
+    },
+    {
+      "stableIdentifier": "goose",
+      "testedVersion": "1.45.0",
+      "commands": ["goose", "/opt/homebrew/bin/goose"]
+    },
+    {
+      "stableIdentifier": "qwenCode",
+      "testedVersion": "0.21.4",
+      "commands": ["qwen", "node /opt/homebrew/bin/qwen.js"]
+    },
+    {
+      "stableIdentifier": "crush",
+      "testedVersion": "0.88.0",
+      "commands": ["crush", "/opt/homebrew/bin/crush"]
     }
   ],
   "fakeExecutable": {

--- a/PineTests/Fixtures/AgentAdapters/protocol-review-v1.json
+++ b/PineTests/Fixtures/AgentAdapters/protocol-review-v1.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": 1,
+  "fixtureVersion": "2026-08-03",
+  "maximumEventBytes": 65536,
+  "sanitization": "Synthetic envelopes only; content fields, credentials, paths, provider state, and opaque identifiers are omitted.",
+  "agents": [
+    {
+      "stableIdentifier": "amp",
+      "authority": "pine-launched-authenticated-transport-only",
+      "interface": "stream-json",
+      "cases": [
+        {"name": "documented-init", "inputBytes": 48, "wire": "{\"type\":\"system\",\"subtype\":\"init\"}"},
+        {"name": "documented-completion", "inputBytes": 53, "wire": "{\"type\":\"result\",\"subtype\":\"success\"}"},
+        {"name": "malformed", "inputBytes": 1, "wire": "{"},
+        {"name": "reordered", "inputBytes": 53, "wire": "{\"type\":\"result\",\"subtype\":\"success\"}"},
+        {"name": "oversized", "inputBytes": 65537, "wire": "{\"type\":\"assistant\"}"},
+        {"name": "future-schema", "inputBytes": 38, "wire": "{\"type\":\"pine_future_event\"}"}
+      ]
+    },
+    {
+      "stableIdentifier": "cursorAgent",
+      "authority": "pine-launched-authenticated-transport-only",
+      "interface": "print-stream-json",
+      "cases": [
+        {"name": "version", "inputBytes": 24, "wire": "2026.07.23-e383d2b"},
+        {"name": "json", "inputBytes": 35, "wire": "{\"type\":\"result\",\"subtype\":\"success\"}"},
+        {"name": "stream-json", "inputBytes": 35, "wire": "{\"type\":\"system\",\"subtype\":\"init\"}"},
+        {"name": "resume-explicit", "inputBytes": 29, "wire": "{\"resume\":\"opaque-redacted\"}"},
+        {"name": "malformed", "inputBytes": 1, "wire": "{"},
+        {"name": "oversized", "inputBytes": 65537, "wire": "{\"type\":\"assistant\"}"},
+        {"name": "future-schema", "inputBytes": 31, "wire": "{\"type\":\"future\"}"}
+      ]
+    },
+    {
+      "stableIdentifier": "goose",
+      "authority": "pine-launched-authenticated-transport-only",
+      "interface": "acp-stdio",
+      "cases": [
+        {"name": "negotiation", "inputBytes": 57, "wire": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}"},
+        {"name": "ordering", "inputBytes": 61, "wire": "{\"jsonrpc\":\"2.0\",\"method\":\"session/notification\"}"},
+        {"name": "replay", "inputBytes": 49, "wire": "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}"},
+        {"name": "malformed", "inputBytes": 1, "wire": "{"},
+        {"name": "oversized", "inputBytes": 65537, "wire": "{\"jsonrpc\":\"2.0\"}"},
+        {"name": "future-schema", "inputBytes": 55, "wire": "{\"jsonrpc\":\"3.0\",\"method\":\"future/event\"}"}
+      ]
+    },
+    {
+      "stableIdentifier": "qwenCode",
+      "authority": "pine-launched-authenticated-transport-only",
+      "interface": "stream-json",
+      "cases": [
+        {"name": "version", "inputBytes": 6, "wire": "0.21.4"},
+        {"name": "process", "inputBytes": 18, "wire": "{\"type\":\"system\"}"},
+        {"name": "documented-stream", "inputBytes": 21, "wire": "{\"type\":\"assistant\"}"},
+        {"name": "malformed", "inputBytes": 1, "wire": "{"},
+        {"name": "reordered", "inputBytes": 18, "wire": "{\"type\":\"result\"}"},
+        {"name": "oversized", "inputBytes": 65537, "wire": "{\"type\":\"assistant\"}"},
+        {"name": "future-schema", "inputBytes": 18, "wire": "{\"type\":\"future\"}"}
+      ]
+    },
+    {
+      "stableIdentifier": "crush",
+      "authority": "pine-launched-authenticated-transport-only",
+      "interface": "experimental-workspace-sse",
+      "cases": [
+        {"name": "session", "inputBytes": 41, "wire": "event: session\\ndata: {\"state\":\"busy\"}\\n\\n"},
+        {"name": "reconnect", "inputBytes": 24, "wire": "id: 2\\nevent: workspace\\n\\n"},
+        {"name": "duplicate", "inputBytes": 24, "wire": "id: 1\\nevent: workspace\\n\\n"},
+        {"name": "reordered", "inputBytes": 24, "wire": "id: 0\\nevent: workspace\\n\\n"},
+        {"name": "malformed", "inputBytes": 5, "wire": "data:"},
+        {"name": "oversized", "inputBytes": 65537, "wire": "event: workspace"},
+        {"name": "future-schema", "inputBytes": 21, "wire": "event: future\\n\\n"}
+      ]
+    }
+  ]
+}

--- a/docs/agent-compatibility.md
+++ b/docs/agent-compatibility.md
@@ -23,6 +23,11 @@ the upstream projects used to verify the remaining current releases.
 | [GitHub Copilot CLI](https://github.com/github/copilot-cli) | `github-copilot-cli`, `copilot` | 1.0.77 | Detected | Process snapshot; observed process generation | Manual terminal / new session only | Process termination only | No documented structured event channel is enabled. |
 | [Aider](https://github.com/Aider-AI/aider) | `aider` | 0.86.0 | Detected | Process snapshot; observed process generation | Manual terminal / new session only | Process termination only | No documented structured event channel is enabled. |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `gemini` | 0.53.1 | Detected | Process snapshot; observed process generation | Manual terminal / new session only | Process termination only | No documented structured event channel is enabled. |
+| [Amp](https://ampcode.com/manual) | `amp` | 0.0.1785747753-g51f676 | Detected | Process snapshot; observed process generation | Manual terminal / new session only | Process termination only | Streaming JSON was reviewed but is disabled until Pine can authenticate and bind the launch transport. |
+| [Cursor Agent](https://docs.cursor.com/en/cli/overview) | `cursor-agent` | 2026.07.23-e383d2b | Detected | Process snapshot; observed process generation | Manual terminal / new session only | Process termination only | JSON is limited to Pine-launched print mode; interactive sessions stay detected-only and `--force` is never enabled. |
+| [Goose](https://github.com/aaif-goose/goose) | `goose` | 1.45.0 | Detected | Process snapshot; observed process generation | Manual terminal / new session only | Process termination only | ACP was reviewed but is disabled until Pine provides authenticated, bounded stdio negotiation. |
+| [Qwen Code](https://github.com/QwenLM/qwen-code) | `qwen` | 0.21.4 | Detected | Process snapshot; observed process generation | Manual terminal / new session only | Process termination only | Machine-readable output was reviewed but is not trusted from an ambient terminal. |
+| [Crush](https://github.com/charmbracelet/crush) | `crush` | 0.88.0 | Detected | Process snapshot; observed process generation | Manual terminal / new session only | Process termination only | Workspace/SSE is experimental and not enabled without a registry-minted authenticated connection. |
 
 ## Tier meanings
 
@@ -49,25 +54,24 @@ Accordingly, the compatibility layer must not trigger a success notification,
 resume an old conversation, or mark an attention request solely from process
 timing or terminal text.
 
-## Pre-freeze candidate evaluation
+## Structured-interface evaluation
 
-On August 3, 2026, Pine also evaluated the five actively maintained macOS
-terminal agents named in issue #1304. A candidate qualifies for a separate
-adapter review when it has a documented macOS CLI, a stable executable name,
-current first-party documentation or releases, and a credible integration path
-that does not require scraping ANSI presentation. Qualification does not grant
-support in Pine 2.0; each adapter must pass the same offline fixtures,
-provenance, fail-closed, privacy, and compatibility gates as the initial seven.
+On August 3, 2026, Pine evaluated the five additional macOS terminal agents
+named in issue #1304. Their exact executable aliases are now first-party
+detected adapters. The reviewed structured interfaces remain disabled because
+Pine does not yet launch and authenticate those transports. This prevents
+ambient terminal JSON, local services, private databases, configuration, logs,
+and desktop notifications from acquiring authority.
 
-| Candidate | Evidence reviewed | Evaluation | Follow-up |
+| Adapter | Evidence reviewed | Pine 2.0 decision | Tracking |
 | --- | --- | --- | --- |
-| Amp | Documented `amp` CLI and newline-delimited streaming JSON input/output | Qualifies; assess structured tier, keep detected fallback | [#1316](https://github.com/batonogov/pine/issues/1316) |
-| Cursor Agent | Documented `cursor-agent`, version output, opaque resume IDs, and JSON/stream-JSON print modes | Qualifies; structured print mode only, interactive mode detected unless documented | [#1317](https://github.com/batonogov/pine/issues/1317) |
-| Goose | macOS `goose` CLI, active v1.45.0 release, and documented ACP server support | Qualifies; prefer standards-based ACP negotiation | [#1318](https://github.com/batonogov/pine/issues/1318) |
-| Qwen Code | macOS `qwen` CLI and active v0.21.4 release | Qualifies for detected tier; no TUI/slash-command scraping | [#1319](https://github.com/batonogov/pine/issues/1319) |
-| Crush | macOS `crush` CLI, active v0.88.0 release, and documented local workspace/SSE design | Qualifies for protocol review; experimental or unauthenticated paths remain detected | [#1320](https://github.com/batonogov/pine/issues/1320) |
+| Amp | Documented `amp` CLI and newline-delimited streaming JSON input/output | Detected; structured transport disabled | [#1316](https://github.com/batonogov/pine/issues/1316) |
+| Cursor Agent | Documented `cursor-agent`, version output, opaque resume IDs, and JSON/stream-JSON print modes | Detected; explicit resume and structured print transport disabled | [#1317](https://github.com/batonogov/pine/issues/1317) |
+| Goose | macOS `goose` CLI, v1.45.0, and documented ACP server support | Detected; ACP transport disabled | [#1318](https://github.com/batonogov/pine/issues/1318) |
+| Qwen Code | macOS `qwen` CLI, v0.21.4, and documented JSON/stream-JSON output | Detected; structured transport disabled | [#1319](https://github.com/batonogov/pine/issues/1319) |
+| Crush | macOS `crush` CLI, v0.88.0, and documented local workspace/SSE design | Detected; experimental server transport disabled | [#1320](https://github.com/batonogov/pine/issues/1320) |
 
-The review used the candidates' official manuals or repositories linked in
-their follow-up issues. They remain outside the initial Pine 2.0 compatibility
-set so the first-party matrix can be reviewed and shipped without silently
-expanding its trust surface.
+The sanitized protocol fixture covers documented messages plus malformed,
+reordered, replay/duplicate where applicable, oversized, and future inputs.
+Every case remains process-only and therefore cannot emit waiting or successful
+completion, persist an opaque provider ID, or resume a provider session.

--- a/docs/pine-2.0-agent-release-matrix.md
+++ b/docs/pine-2.0-agent-release-matrix.md
@@ -11,7 +11,7 @@ credentials, prompts, terminal output, or network services.
 | Gate | Coverage | Release command or evidence |
 | --- | --- | --- |
 | First-party adapter conformance | Every catalog entry runs the same identity, exact-alias, detected-tier, observed-generation, and generic-fallback assertions | `PineTests/AgentReleaseGateTests` and `PineTests/FirstPartyAgentCompatibilityTests` |
-| Protocol and process fixtures | Versioned synthetic working, waiting, completion, failure, malformed, delayed, PID-reuse, and process-replacement streams | `PineTests/Fixtures/AgentAdapters/process-v1.json` and `fake-agent.sh` |
+| Protocol and process fixtures | Versioned synthetic working, waiting, completion, failure, malformed, delayed, PID-reuse, process-replacement, structured-interface, replay, oversized, and future-schema streams | `PineTests/Fixtures/AgentAdapters/process-v1.json`, `protocol-review-v1.json`, and `fake-agent.sh` |
 | Multi-project routing and Inbox | Two projects, multiple panes and agents, background project reopen, exact task/run/generation routing, stale routes, relaunch, and project close | `PineTests/AgentInboxTests`, `PineTests/AgentTaskRegistryTests`, and `PineTests/ProjectRegistryTests` |
 | Notification correctness | Exact transitions, process-only downgrade, stale/reordered/replacement rejection, cross-project suppression, de-duplication, and persisted settings | `PineTests/AgentNotificationTests` |
 | Security and privacy | Spoofs, lookalikes, cross-project identity, replay, path traversal, opaque-value redaction, untrusted registration, and malformed persistence | `PineTests/AgentAdapterContractTests`, `PineTests/AgentAdapterRegistryTests`, `PineTests/AgentReleaseGateTests`, and `PineTests/AgentTaskRegistryTests` |
@@ -81,6 +81,11 @@ text is never parsed as trusted lifecycle evidence.
 | GitHub Copilot CLI | 1.0.77 | Detected | Exact executable alias + process generation | Generic terminal command | Process termination only |
 | Aider | 0.86.0 | Detected | Exact executable alias + process generation | Generic terminal command | Process termination only |
 | Gemini CLI | 0.53.1 | Detected | Exact executable alias + process generation | Generic terminal command | Process termination only |
+| Amp | 0.0.1785747753-g51f676 | Detected | Exact executable alias + process generation | Generic terminal command | Structured stream disabled; process termination only |
+| Cursor Agent | 2026.07.23-e383d2b | Detected | Exact executable alias + process generation | Generic terminal command | Structured print/resume disabled; process termination only |
+| Goose | 1.45.0 | Detected | Exact executable alias + process generation | Generic terminal command | ACP disabled; process termination only |
+| Qwen Code | 0.21.4 | Detected | Exact executable alias + process generation | Generic terminal command | Structured stream disabled; process termination only |
+| Crush | 0.88.0 | Detected | Exact executable alias + process generation | Generic terminal command | Experimental SSE disabled; process termination only |
 
 If the installed version differs, record it and rerun the shared adapter
 conformance suite. Do not raise the tier based on terminal presentation,

--- a/docs/pine-2.0-release-notes.md
+++ b/docs/pine-2.0-release-notes.md
@@ -5,13 +5,16 @@ while preserving explicit trust and privacy boundaries.
 
 ## Agent compatibility foundation
 
-- Recognizes Pi, Codex, Claude Code, OpenCode, GitHub Copilot CLI, Aider, and
-  Gemini CLI by exact executable aliases.
+- Recognizes Pi, Codex, Claude Code, OpenCode, GitHub Copilot CLI, Aider,
+  Gemini CLI, Amp, Cursor Agent, Goose, Qwen Code, and Crush by exact
+  executable aliases.
 - Keeps unsupported and lookalike executables on the generic terminal path.
 - Separates presentation metadata from capability negotiation so detection
   cannot silently grant structured access.
 - Ships sanitized, versioned compatibility fixtures and documents notification,
   launch, resume, and lifecycle limitations.
+- Keeps reviewed Amp/Cursor/Goose/Qwen/Crush structured interfaces disabled
+  until Pine can authenticate and bind each Pine-launched transport.
 
 See the [CLI agent compatibility matrix](agent-compatibility.md) for verified
 versions, support tiers, signal sources, trust levels, and current limitations,


### PR DESCRIPTION
## Summary
- add exact-name, process-only detection for Amp, Cursor Agent, Goose, Qwen Code, and Crush
- keep reviewed structured interfaces fail-closed until Pine owns an authenticated launch transport
- add sanitized protocol-review fixtures, compatibility coverage, release documentation, and localized Help updates

## Validation
- git diff --check
- JSON fixture parse with jq
- SwiftLint strict: 0 violations
- 170 selected PineTests tests passed across compatibility, models, release gates, detector, activity store, and adapter registry
- Local UI tests intentionally not run per maintainer request; GitHub CI remains authoritative

## Stack
- Rebased onto main after #1327 merged.

Closes #1316
Closes #1317
Closes #1318
Closes #1319
Closes #1320