### PR TITLE
chore: prepare Pine 2.0 release candidate

### DIFF
--- a/docs/pine-2.0-release-notes.md
+++ b/docs/pine-2.0-release-notes.md
@@ -21,7 +21,52 @@ versions, support tiers, signal sources, trust levels, and current limitations,
 and the [Pine 2.0 agent release matrix](pine-2.0-agent-release-matrix.md) for the
 automated gates and manual OS/renderer checklist.
 
-This document is a release-candidate draft. The final notes will also include
-the Agent Inbox, actionable notifications, durable resume, completion briefs,
-isolated worktrees, and the final compatibility/security gate results after
-those release blockers land.
+## One Inbox across projects
+
+- Tracks durable agent tasks independently of transient process identifiers.
+- Aggregates waiting, failed, unread-completed, working, and historical tasks
+  from every open project in one keyboard-accessible window.
+- Routes back only to the exact live task generation; stale or historical
+  routes fail closed instead of focusing an unrelated terminal.
+
+## Actionable, private notifications
+
+- Delivers low-noise waiting, failure, and completion notifications with
+  per-event, per-agent, per-project, and per-task controls.
+- Reuses the Inbox routing authority, coalesces duplicates, and never embeds
+  prompts, terminal output, tokens, absolute paths, or vendor identifiers.
+- Distinguishes verified events from process-only exit detection in both the
+  UI and notification copy.
+
+## Recovery and verified review
+
+- Restores durable task metadata across project-window and application
+  relaunch without pretending that metadata restoration resumed a vendor
+  session.
+- Builds completion briefs that separate verified changes, test evidence,
+  inference, ambiguity, and agent-reported narrative.
+- Preserves unrelated work and staging state during checked undo, checkpoint,
+  comparison, and handoff operations, or refuses the operation safely.
+
+## Isolated worktree workflows
+
+- Creates explicit, repository-contained worktrees for parallel tasks without
+  silently moving the user's current checkout.
+- Supports deterministic comparison and bounded cross-agent handoff while
+  retaining Pine's existing Git and provenance safety rules.
+- Requires a deliberate user action for agent launch and destructive cleanup.
+
+## Compatibility and release validation
+
+- Keeps the macOS 26.0 deployment target and checks source compatibility with
+  the current macOS 27 beta SDK.
+- Adds shared offline adapter conformance, hostile-input fuzzing, multi-project
+  routing coverage, performance budgets, accessibility logic, and balanced UI
+  shards without requiring paid accounts or live model output.
+- Documents the required manual macOS 26/27 and Metal/CoreGraphics release
+  pass. A `Pending` row in the release matrix remains a release blocker and
+  must not be converted to `Pass` from automated evidence alone.
+
+Pine remains a native editor and terminal-first control plane: it does not
+embed a vendor chat, parse terminal presentation as trusted lifecycle data,
+upload transcripts, or autonomously schedule agents.


### PR DESCRIPTION
## Summary
- turn the Pine 2.0 notes from a placeholder into a complete release-candidate summary
- document Inbox, notifications, recovery, verified review, worktree, privacy, and compatibility boundaries
- request 2.0.0 explicitly through the commit and PR footer so Release Please does not publish this as a 1.x minor

## Validation
- git diff --check
- docs workflow is content-only (docs-check)
- canonical README and all 9 landing-page localizations already carry the Pine 2.0 positioning from the preceding stack

## Release boundary
The manual macOS 26/27 × Metal/CoreGraphics rows remain Pending and continue to block publication. This PR prepares the candidate; it does not fabricate manual evidence or publish a release.

## Stack
- Rebased onto main after #1328 merged.

Release-As: 2.0.0