### PR TITLE
fix(agent): Agent Inbox window polish — focus ring, duplicate title, RU label

### DIFF
--- a/Pine/Agent/AgentInboxView.swift
+++ b/Pine/Agent/AgentInboxView.swift
@@ -23,11 +23,12 @@ struct AgentInboxView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                Label(Strings.agentInboxTitle, systemImage: MenuIcons.agentInbox)
-                    .font(.title2.weight(.semibold))
-                Spacer()
-                if let navigationMessage {
+            // The window title bar already names the Agent Inbox; show a
+            // transient banner only when a navigation/recovery message is
+            // active (#1339 — removed the duplicate in-window header label).
+            if let navigationMessage {
+                HStack {
+                    Spacer()
                     Label(navigationMessage, systemImage: "exclamationmark.triangle")
                         .font(.caption)
                         .foregroundStyle(.orange)
@@ -35,10 +36,10 @@ struct AgentInboxView: View {
                             AccessibilityID.agentInboxNavigationStatus
                         )
                 }
-            }
-            .padding()
+                .padding()
 
-            Divider()
+                Divider()
+            }
 
             if snapshot.isEmpty {
                 ContentUnavailableView {
@@ -53,6 +54,7 @@ struct AgentInboxView: View {
         .frame(minWidth: 420, idealWidth: 720, minHeight: 360, idealHeight: 560)
         .focusable()
         .focused($hasKeyboardFocus)
+        .focusEffectDisabled()
         .onAppear {
             synchronizeSelection()
             hasKeyboardFocus = true

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -31951,7 +31951,7 @@
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Входящие агентов"
+            "value": "Входящие от агентов"
           }
         },
         "zh-Hans": {


### PR DESCRIPTION
Fixes #1339

Three small Agent Inbox window chrome defects found while dogfooding Pine 2.0.

## A. Blue focus ring around the whole window content
`AgentInboxView` marked the entire root `VStack` as `.focusable()` + `.focused()`, which drew the system focus ring around the whole window content when key. Keyboard navigation (arrow keys / Return) needs the container to be focusable to receive key events, so this keeps `.focusable()` and adds `.focusEffectDisabled()` (macOS 26+, the deployment target) to suppress the ring while preserving navigation.

## B. Duplicate "Agent Inbox" title
The in-window header `Label` reused the same localization key (`menu.agentInbox`) as the window title bar, so the title appeared twice. Removed the duplicate header label. The transient navigation/recovery status banner is preserved — it is now rendered only while a message is active, together with its `Divider`.

## C. RU label reads wrong
`Входящие агентов` parses as "agents who entered" rather than the agents' inbox. Changed the `ru` value of `menu.agentInbox` to `Входящие от агентов`. This is a single-line targeted text edit in `Localizable.xcstrings` — **no** `json.dump` re-serialization (Xcode non-standard formatting preserved).

## Verification
- `swiftlint` clean on the changed view.
- `xcodebuild build` → **BUILD SUCCEEDED** (Xcode-beta, macOS 27).
- `PineTests/AgentInboxTests` (7 tests) → **TEST SUCCEEDED**.
- `git diff --stat Pine/Localizable.xcstrings` → single-line change, no whitespace noise.
- `PineApp.swift` and `Strings.swift` untouched.

## Snapshot test
Not added. `AgentInboxView` renders `Text(row.startedAt, style: .timer)` — a continuously self-updating elapsed-time string — plus `@FocusState` set active in `.onAppear`, neither of which is pixel-stable under the `NSHostingView`-based snapshot harness (no frozen-clock injection). Forcing a snapshot would be flaky; relying on the build + unit tests + the visual diff instead. The header-removal and focus-ring changes are small and reviewable directly in the diff.

## Files
- `Pine/Agent/AgentInboxView.swift`
- `Pine/Localizable.xcstrings` (RU value only)
