### PR TITLE
fix(agent): add CPU-time hysteresis to stop waiting-input flip-flop

### DIFF
--- a/Pine/Agent/AgentDetector.swift
+++ b/Pine/Agent/AgentDetector.swift
@@ -39,8 +39,12 @@ nonisolated struct DetectedProcess: Sendable, Equatable {
     let cwd: URL?
     /// Cumulative CPU time in seconds (from `ps -eo ... cputime=`). Used by
     /// `AgentDetector.processSnapshotDidUpdate(_:)` to refine
-    /// `.idle` → `.executing` / `.waitingInput`: a session whose CPU time
-    /// stopped advancing between two snapshots is idle at a prompt (#1112).
+    /// `.idle` → `.executing` / `.waitingInput`. A CPU-time advance promotes a
+    /// session to `.executing`; only
+    /// `AgentDetector.waitingInputFlatPollThreshold` consecutive flat polls
+    /// (no CPU growth) downgrade it to `.waitingInput` (#1112, #1338).
+    /// Network-bound LLM agents barely burn CPU while blocked on an API
+    /// response, so a single flat poll must not read as "idle at a prompt".
     /// `nil` when the snapshot did not carry CPU time (legacy parse path,
     /// unit tests) — the detector leaves the state untouched in that case.
     let cpuTime: Int?
@@ -108,6 +112,20 @@ final class AgentDetector {
     /// `processSnapshotDidUpdate(_:)` to refine state. Cleared in `markDone`
     /// so pid reuse starts a fresh baseline (#1112).
     private var lastCpuTimeByPID: [Int32: Int] = [:]
+
+    /// Consecutive CPU-flat polls seen for each tracked pid. A session is only
+    /// downgraded to `.waitingInput` once this reaches
+    /// `waitingInputFlatPollThreshold`, so a busy-but-network-bound agent is
+    /// not flipped by a single flat poll (#1338). Reset to 0 on a CPU advance
+    /// and purged in `markDone` alongside `lastCpuTimeByPID`.
+    private var flatPollCountByPID: [Int32: Int] = [:]
+
+    /// Number of consecutive CPU-flat polls required before a tracked session
+    /// is downgraded from `.executing` / `.idle` to `.waitingInput`. At the
+    /// default 2-second detection poll interval this is roughly six seconds
+    /// of inactivity, which absorbs the network-bound thinking pauses of LLM
+    /// agents (#1338).
+    static let waitingInputFlatPollThreshold = 3
 
     /// Stable process-start value seen for each tracked pid.
     private var startIdentifierByPID: [Int32: String] = [:]
@@ -263,9 +281,23 @@ final class AgentDetector {
                 }
                 if let cpu = process.cpuTime {
                     if let previousCPU, existing.state != .done {
-                        existing.state = cpu > previousCPU
-                            ? .executing
-                            : .waitingInput
+                        if cpu > previousCPU {
+                            // A CPU advance means real local work: promote to
+                            // `.executing` and clear the flat-poll streak.
+                            existing.state = .executing
+                            flatPollCountByPID[process.pid] = 0
+                        } else {
+                            // CPU did not advance. Network-bound LLM agents
+                            // sleep while waiting on an API response, so a
+                            // single flat poll must not read as "idle at a
+                            // prompt" — require a sustained streak before
+                            // downgrading to `.waitingInput` (#1338).
+                            let flatCount = (flatPollCountByPID[process.pid] ?? 0) + 1
+                            flatPollCountByPID[process.pid] = flatCount
+                            if flatCount >= Self.waitingInputFlatPollThreshold {
+                                existing.state = .waitingInput
+                            }
+                        }
                     }
                     lastCpuTimeByPID[process.pid] = cpu
                 }
@@ -343,6 +375,7 @@ final class AgentDetector {
     private func markDone(pid: Int32) -> UUID? {
         guard let session = sessionsByPID.removeValue(forKey: pid) else { return nil }
         lastCpuTimeByPID.removeValue(forKey: pid)
+        flatPollCountByPID.removeValue(forKey: pid)
         startIdentifierByPID.removeValue(forKey: pid)
         preciseStartByPID.removeValue(forKey: pid)
         livenessTracker.recordTermination(of: session)

--- a/PineTests/AgentAttentionStateTests.swift
+++ b/PineTests/AgentAttentionStateTests.swift
@@ -44,10 +44,14 @@ struct AgentAttentionStateTests {
         detector.processSnapshotDidUpdate([
             DetectedProcess(pid: 100, command: "codex", cpuTime: 12),
         ])
-        // Next poll: CPU time unchanged — agent is idle at a prompt.
-        detector.processSnapshotDidUpdate([
-            DetectedProcess(pid: 100, command: "codex", cpuTime: 12),
-        ])
+        // CPU time unchanged across polls — agent is idle at a prompt. The
+        // detector now requires `waitingInputFlatPollThreshold` consecutive
+        // flat polls before downgrading (#1338 hysteresis), so drive that many.
+        for _ in 0..<AgentDetector.waitingInputFlatPollThreshold {
+            detector.processSnapshotDidUpdate([
+                DetectedProcess(pid: 100, command: "codex", cpuTime: 12),
+            ])
+        }
         #expect(detector.detectedSessions[0].state == .waitingInput)
     }
 
@@ -62,9 +66,13 @@ struct AgentAttentionStateTests {
         ])
         #expect(detector.detectedSessions[0].state == .executing)
 
-        detector.processSnapshotDidUpdate([
-            DetectedProcess(pid: 100, command: "claude", cpuTime: 3),
-        ])
+        // A single flat poll no longer flips to .waitingInput (#1338
+        // hysteresis); drive the threshold count of flat polls to reach it.
+        for _ in 0..<AgentDetector.waitingInputFlatPollThreshold {
+            detector.processSnapshotDidUpdate([
+                DetectedProcess(pid: 100, command: "claude", cpuTime: 3),
+            ])
+        }
         #expect(detector.detectedSessions[0].state == .waitingInput)
 
         detector.processSnapshotDidUpdate([

--- a/PineTests/AgentDetectorTests.swift
+++ b/PineTests/AgentDetectorTests.swift
@@ -1007,6 +1007,183 @@ struct AgentDetectorTests {
         #expect(detector.detectedSessions.count == 3)
     }
 
+    // MARK: - CPU-time hysteresis (#1338)
+
+    @Test func executingAgentStaysExecutingForFlatPollsBelowThreshold() throws {
+        // A busy-but-network-bound agent barely burns CPU while waiting on an
+        // API response. Flat polls below the threshold must NOT downgrade an
+        // executing session to .waitingInput (#1338).
+        let threshold = AgentDetector.waitingInputFlatPollThreshold
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 700, command: "claude", cpuTime: 100),
+        ])
+        let session = try #require(detector.session(forPID: 700))
+
+        // A CPU advance promotes to .executing.
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 700, command: "claude", cpuTime: 110),
+        ])
+        #expect(session.state == .executing)
+
+        // (threshold - 1) flat polls: still executing.
+        for _ in 0..<(threshold - 1) {
+            detector.processSnapshotDidUpdate([
+                DetectedProcess(pid: 700, command: "claude", cpuTime: 110),
+            ])
+        }
+        #expect(session.state == .executing)
+    }
+
+    @Test func flatCpuAtThresholdDowngradesToWaitingInput() throws {
+        // Only a sustained flat streak (threshold consecutive polls) justifies
+        // reading a session as idle at a prompt.
+        let threshold = AgentDetector.waitingInputFlatPollThreshold
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 701, command: "claude", cpuTime: 100),
+        ])
+        let session = try #require(detector.session(forPID: 701))
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 701, command: "claude", cpuTime: 110),
+        ])
+        #expect(session.state == .executing)
+
+        for _ in 0..<threshold {
+            detector.processSnapshotDidUpdate([
+                DetectedProcess(pid: 701, command: "claude", cpuTime: 110),
+            ])
+        }
+        #expect(session.state == .waitingInput)
+    }
+
+    @Test func cpuAdvanceResetsFlatPollCounter() throws {
+        // A single CPU tick must reset the flat-poll streak and re-promote to
+        // .executing, so the streak restarts from zero.
+        let threshold = AgentDetector.waitingInputFlatPollThreshold
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 702, command: "claude", cpuTime: 100),
+        ])
+        let session = try #require(detector.session(forPID: 702))
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 702, command: "claude", cpuTime: 110),
+        ])
+        #expect(session.state == .executing)
+
+        // Build a near-threshold streak.
+        for _ in 0..<(threshold - 1) {
+            detector.processSnapshotDidUpdate([
+                DetectedProcess(pid: 702, command: "claude", cpuTime: 110),
+            ])
+        }
+        #expect(session.state == .executing)
+
+        // One CPU tick resets the streak.
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 702, command: "claude", cpuTime: 120),
+        ])
+        #expect(session.state == .executing)
+
+        // After the reset, (threshold - 1) flat polls must NOT downgrade —
+        // they would if the counter had not been cleared.
+        for _ in 0..<(threshold - 1) {
+            detector.processSnapshotDidUpdate([
+                DetectedProcess(pid: 702, command: "claude", cpuTime: 120),
+            ])
+        }
+        #expect(session.state == .executing)
+    }
+
+    @Test func idleAgentNeedsThresholdFlatPollsBeforeWaitingInput() throws {
+        // A freshly detected (.idle) session is also protected by hysteresis:
+        // it is not flipped to .waitingInput on the first flat poll.
+        let threshold = AgentDetector.waitingInputFlatPollThreshold
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 703, command: "claude", cpuTime: 50),
+        ])
+        let session = try #require(detector.session(forPID: 703))
+        #expect(session.state == .idle)
+
+        for _ in 0..<(threshold - 1) {
+            detector.processSnapshotDidUpdate([
+                DetectedProcess(pid: 703, command: "claude", cpuTime: 50),
+            ])
+        }
+        #expect(session.state == .idle)
+
+        // Reaching the threshold downgrades to .waitingInput.
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 703, command: "claude", cpuTime: 50),
+        ])
+        #expect(session.state == .waitingInput)
+    }
+
+    @Test func doneSessionIsNeverDowngradedToWaitingInput() throws {
+        // A terminated (.done) session is disassociated from its pid, so it is
+        // never refined again. Pin that it keeps .done instead of being flipped
+        // to .waitingInput when the recycled pid reports flat CPU evidence.
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 704, command: "claude", cpuTime: 5),
+        ])
+        let session = try #require(detector.session(forPID: 704))
+
+        detector.processSnapshotDidUpdate([])
+        #expect(session.state == .done)
+
+        // Recycle the pid with flat CPU; the old session must stay .done.
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 704, command: "claude", cpuTime: 5),
+        ])
+        #expect(session.state == .done)
+        let recycled = try #require(detector.session(forPID: 704))
+        #expect(recycled !== session)
+        #expect(recycled.state == .idle)
+    }
+
+    @Test func flatPollCounterIsPurgedOnTermination() throws {
+        // The flat-poll streak must not leak across pid reuse: a recycled
+        // session tolerates (threshold - 1) flat polls without flipping.
+        let threshold = AgentDetector.waitingInputFlatPollThreshold
+        let detector = AgentDetector()
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 705, command: "claude", cpuTime: 10),
+        ])
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 705, command: "claude", cpuTime: 12),
+        ])
+        let done = detector.detectedSessions[0]
+        #expect(done.state == .executing)
+
+        // Build a near-threshold streak, then terminate.
+        for _ in 0..<(threshold - 1) {
+            detector.processSnapshotDidUpdate([
+                DetectedProcess(pid: 705, command: "claude", cpuTime: 12),
+            ])
+        }
+        #expect(done.state == .executing)
+        detector.processSnapshotDidUpdate([])
+        #expect(done.state == .done)
+
+        // Recycle.
+        detector.processSnapshotDidUpdate([
+            DetectedProcess(pid: 705, command: "claude", cpuTime: 10),
+        ])
+        let recycled = try #require(detector.session(forPID: 705))
+        #expect(recycled !== done)
+
+        // (threshold - 1) flat polls must NOT downgrade the fresh session —
+        // they would if the stale streak had leaked across termination.
+        for _ in 0..<(threshold - 1) {
+            detector.processSnapshotDidUpdate([
+                DetectedProcess(pid: 705, command: "claude", cpuTime: 10),
+            ])
+        }
+        #expect(recycled.state != .waitingInput)
+    }
+
     private func stamp(
         _ wallTime: Date,
         uptime: TimeInterval,


### PR DESCRIPTION
## Summary

Fixes #1338.

`AgentDetector` classified an agent session as `.waitingInput` from a **single** CPU-flat poll. Network-bound LLM agents (Claude Code, Codex, …) barely burn CPU while blocked on an API response, so every 2 s poll that did not catch a CPU tick flipped the agent to `.waitingInput` → `.needsAttention`, then back to `.executing` on the next poll. The attention list flickered and cried wolf.

## Root cause

`AgentDetector.processSnapshotDidUpdate` refined state with one hysteresis-free comparison:

```swift
if let previousCPU, existing.state != .done {
    existing.state = cpu > previousCPU ? .executing : .waitingInput
}
```

No hysteresis: one flat poll was enough to downgrade to `.waitingInput`. The doc comment even encoded the wrong assumption ("a session whose CPU time stopped advancing between two snapshots is idle at a prompt").

## Change

Add a per-pid flat-poll counter and require **N consecutive flat polls** before downgrading, per the issue's recommended smallest-safe-fix:

- New `flatPollCountByPID: [Int32: Int]` + `static let waitingInputFlatPollThreshold = 3` (~6 s at the 2 s poll interval).
- `cpu > previousCPU` → `.executing`, counter reset to **0** (single tick re-promotes).
- flat poll → increment counter; downgrade to `.waitingInput` only once it reaches the threshold; otherwise leave the state untouched.
- `.done` guard preserved (a finished session is never downgraded).
- Counter is purged in `markDone` alongside `lastCpuTimeByPID`, so pid reuse starts a fresh streak.
- Updated the stale doc comment to describe the hysteresis.

The attention/inbox layers (`AgentTaskRegistry`, `AgentInboxModels`) are untouched — this is purely the detector signal source.

## Validation

- `swiftlint` clean (0 violations).
- `xcodebuild build` green (Xcode 27 beta / macOS 27 SDK).
- `AgentDetectorTests` — **69 tests pass** (63 existing + 6 new covering: flat-below-threshold stays executing, flat-at-threshold becomes waitingInput, single tick resets counter, idle hysteresis, `.done` exclusion, counter purge on termination).

## Notes

This is the upstream fix for the flicker reported in #1336 (inbox sort) — the companion sort-stability change is independent and tracked separately. The 2 s poll interval is unchanged (out of scope).
