### PR TITLE
fix(terminal): close-tab confirmation robustness for agent tabs

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -327,7 +327,6 @@ struct ContentView: View {
                     } else {
                         // Warn before stopping tabs with foreground processes.
                         // Presented as a window-scoped sheet (issue #1241).
-                        let context = DialogPresenter.forProject(projectManager)
                         let targetPaneIDs = Set(paneManager.terminalPaneIDs)
                         let targetTabs = terminal.allTerminalTabs
                         let targetTabIDs = Set(targetTabs.map(\.id))
@@ -336,6 +335,13 @@ struct ContentView: View {
                                 for: targetTabs
                             )
                         Task { @MainActor in
+                            // Resolve the owner resiliently: a transiently-nil
+                            // weak project→window anchor during scene
+                            // restoration must not silently abort the close
+                            // (#1335 H3).
+                            let context = await TabCloseHelper.terminalCloseContext(
+                                for: projectManager
+                            )
                             guard await TabCloseHelper.confirmTerminalProcessStop(
                                 tabs: targetTabs,
                                 context: context

--- a/Pine/DialogPresentationContext.swift
+++ b/Pine/DialogPresentationContext.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import os
 
 /// Identity for an in-flight destructive dialog workflow. A repeated user
 /// gesture with the same key is rejected while the original request is active
@@ -20,6 +21,18 @@ enum DialogRequestKey: Hashable {
         tabIDs: Set<UUID>,
         foregroundProcesses: Set<TerminalForegroundProcessIdentity>
     )
+}
+
+extension DialogRequestKey {
+    /// Concise, privacy-safe representation for `os_log` diagnostics (#1335).
+    var logDescription: String {
+        switch self {
+        case let .editorTabs(_, tabIDs):
+            return "editorTabs(\(tabIDs.count))"
+        case let .terminalTabs(tabIDs, foregroundProcesses):
+            return "terminalTabs(tabs:\(tabIDs.count), fg:\(foregroundProcesses.count))"
+        }
+    }
 }
 
 /// Serializes every native dialog belonging to one window.
@@ -76,6 +89,17 @@ final class WindowDialogCoordinator {
     private let onOwnerClose: () -> Void
     private(set) var isOwnerClosed = false
 
+    /// Polls the owner while a queued request is blocked by a foreign
+    /// (framework/SwiftUI) sheet, and bounds how long a queued request may
+    /// wait so the queue can never wedge permanently (#1335 H2).
+    private let watchdogInterval: TimeInterval
+    private let watchdogMaxAttempts: Int
+    private var queuedWatchdog: Task<Void, Never>?
+
+    /// Production watchdog cadence: re-check every 0.5 s for up to ~30 s.
+    static let defaultWatchdogInterval: TimeInterval = 0.5
+    static let defaultWatchdogMaxAttempts: Int = 60
+
     var pendingRequestCount: Int {
         queuedRequests.count + (activeRequest == nil ? 0 : 1)
     }
@@ -83,10 +107,14 @@ final class WindowDialogCoordinator {
     init(
         ownerWindow: NSWindow,
         notificationCenter: NotificationCenter = .default,
+        watchdogInterval: TimeInterval = WindowDialogCoordinator.defaultWatchdogInterval,
+        watchdogMaxAttempts: Int = WindowDialogCoordinator.defaultWatchdogMaxAttempts,
         onOwnerClose: @escaping () -> Void = {}
     ) {
         self.ownerWindow = ownerWindow
         self.notificationCenter = notificationCenter
+        self.watchdogInterval = watchdogInterval
+        self.watchdogMaxAttempts = watchdogMaxAttempts
         self.onOwnerClose = onOwnerClose
         closeObserver = notificationCenter.addObserver(
             forName: NSWindow.willCloseNotification,
@@ -167,6 +195,7 @@ final class WindowDialogCoordinator {
                     $0.deduplicationKey == deduplicationKey
                 })
             if isDuplicate {
+                Logger.app.debug("present aborted: duplicate request key \(deduplicationKey.logDescription, privacy: .public) (#1335 H1)")
                 return .abort
             }
         }
@@ -196,6 +225,7 @@ final class WindowDialogCoordinator {
     func ownerDidClose() {
         guard !isOwnerClosed else { return }
         isOwnerClosed = true
+        disarmQueuedPresentationWatchdog()
 
         if let activeRequest {
             self.activeRequest = nil
@@ -239,7 +269,15 @@ final class WindowDialogCoordinator {
         // SwiftUI and framework-owned sheets do not enter this coordinator.
         // Wait for them to finish instead of asking AppKit to attach a second
         // sheet to the same window.
-        guard ownerWindow.attachedSheet == nil else { return }
+        guard ownerWindow.attachedSheet == nil else {
+            // A foreign sheet may occupy the owner without emitting
+            // `didEndSheetNotification` (notably SwiftUI sheets). Without a
+            // watchdog a queued request could wait forever for a signal that
+            // never arrives, so poll the owner on a bounded cadence (#1335 H2).
+            armQueuedPresentationWatchdog()
+            return
+        }
+        disarmQueuedPresentationWatchdog()
 
         let request = queuedRequests.removeFirst()
         activeRequest = request
@@ -249,6 +287,51 @@ final class WindowDialogCoordinator {
                 self.finish(request, response: response)
             }
         }
+    }
+
+    /// Arms the foreign-sheet watchdog for the front queued request. Polls the
+    /// owner on `watchdogInterval`; once the foreign sheet clears the queued
+    /// request is presented, and after `watchdogMaxAttempts` the front request
+    /// is resolved as `.abort` so the queue can never wedge permanently.
+    private func armQueuedPresentationWatchdog() {
+        guard queuedWatchdog == nil else { return }
+        let interval = watchdogInterval
+        let maxAttempts = watchdogMaxAttempts
+        Logger.app.debug("queued request blocked by an attached foreign sheet; arming presentation watchdog (#1335 H2)")
+        queuedWatchdog = Task { @MainActor [weak self] in
+            for _ in 0..<maxAttempts {
+                if Task.isCancelled { return }
+                try? await Task.sleep(
+                    nanoseconds: UInt64(interval * 1_000_000_000)
+                )
+                guard let self, !self.isOwnerClosed else { return }
+                // Re-evaluate: if the foreign sheet cleared this starts the
+                // queued request (and disarms the watchdog). Otherwise it is
+                // a no-op and the loop keeps polling.
+                self.presentNextIfPossible()
+                if Task.isCancelled { return }
+            }
+            // Bound elapsed with the foreign sheet still attached: resolve the
+            // front request so the queue is not wedged forever.
+            guard let self else { return }
+            Logger.app.debug("queued request aborted after watchdog bound — owner still has an attached foreign sheet (#1335 H2)")
+            self.abortFrontQueuedRequest()
+        }
+    }
+
+    private func disarmQueuedPresentationWatchdog() {
+        queuedWatchdog?.cancel()
+        queuedWatchdog = nil
+    }
+
+    /// Resolves the front queued request as `.abort` and re-evaluates so any
+    /// remaining queued requests get their own bounded watchdog turn.
+    private func abortFrontQueuedRequest() {
+        disarmQueuedPresentationWatchdog()
+        guard !queuedRequests.isEmpty else { return }
+        let request = queuedRequests.removeFirst()
+        request.resolve(.abort)
+        presentNextIfPossible()
     }
 
     private func finish(
@@ -533,6 +616,7 @@ extension NSAlert {
     ) async -> NSApplication.ModalResponse {
         guard let capturedOwner = context.nsWindow,
               DialogPresenter.isEligibleApplicationOwner(capturedOwner) else {
+            Logger.app.debug("runSheet aborted: owner missing or ineligible (#1335 H3)")
             return .abort
         }
         return await context.present(

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -85,7 +85,12 @@ struct TerminalTabCloseAuthorization {
     /// was visible is always covered (nothing remains to protect).
     func stillCovers(_ tabs: [TerminalTab]) -> Bool {
         for tab in tabs {
-            guard let captured = coverage[tab.id] else { return false }
+            // A tab with nothing to protect at authorization time (idle
+            // shell, no agent session, no foreground process) is absent from
+            // `coverage`. It has nothing to re-check, so skip it — otherwise a
+            // mixed idle+active bulk close set would be silently aborted
+            // right after the user confirmed (#1335 review finding).
+            guard let captured = coverage[tab.id] else { continue }
             switch captured {
             case .agentSession(let sessionID):
                 // Same agent session: covered (pgid churn is normal agent

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -21,6 +21,91 @@ nonisolated struct TerminalForegroundProcessIdentity: Hashable, Sendable {
     let processGroupID: Int32
 }
 
+/// Per-tab coverage captured when a destructive terminal close/stop is
+/// authorized. An AI-agent tab (#1335) is covered by its stable
+/// agent-session identity rather than its volatile foreground process group:
+/// agents constantly spawn short-lived children, so the foreground pgid
+/// churns on nearly every poll and must not invalidate a confirmation the
+/// user already gave.
+nonisolated enum TerminalTabCloseCoverage: Hashable, Sendable {
+    /// A non-agent tab is covered by an exact foreground process-group
+    /// generation. A new process group in the same tab is a new
+    /// authorization generation (existing safety semantics).
+    case foregroundProcess(TerminalForegroundProcessIdentity)
+    /// An agent tab is covered by its stable agent-session identity.
+    case agentSession(sessionID: UUID)
+}
+
+/// Snapshot of the destructive-process coverage authorized for a set of
+/// terminal tabs. Re-checked after the user answers the confirmation sheet so
+/// a confirmation cannot be silently invalidated by the normal process-group
+/// churn of an AI-agent tab (#1335).
+@MainActor
+struct TerminalTabCloseAuthorization {
+    private let coverage: [UUID: TerminalTabCloseCoverage]
+    private let foregroundIdentities: Set<TerminalForegroundProcessIdentity>
+
+    /// `true` when at least one tab has a running agent session or foreground
+    /// process and therefore needs confirmation.
+    var requiresConfirmation: Bool { !coverage.isEmpty }
+
+    /// Deduplication key. Agent tabs contribute only their (stable) tab id —
+    /// never a volatile foreground pgid — so repeated close gestures on the
+    /// same agent tab collapse to one in-flight request.
+    var deduplicationKey: DialogRequestKey {
+        .terminalTabs(
+            tabIDs: Set(coverage.keys),
+            foregroundProcesses: foregroundIdentities
+        )
+    }
+
+    static func authorizing(tabs: [TerminalTab]) -> TerminalTabCloseAuthorization {
+        var coverage: [UUID: TerminalTabCloseCoverage] = [:]
+        var foregroundIdentities: Set<TerminalForegroundProcessIdentity> = []
+        for tab in tabs {
+            if let sessionID = tab.agentSession?.id {
+                coverage[tab.id] = .agentSession(sessionID: sessionID)
+            } else if tab.foregroundProcessID > 0 {
+                let identity = TerminalForegroundProcessIdentity(
+                    tabID: tab.id,
+                    processGroupID: tab.foregroundProcessID
+                )
+                coverage[tab.id] = .foregroundProcess(identity)
+                foregroundIdentities.insert(identity)
+            }
+        }
+        return TerminalTabCloseAuthorization(
+            coverage: coverage,
+            foregroundIdentities: foregroundIdentities
+        )
+    }
+
+    /// `true` when every authorized tab is still covered by the identity
+    /// captured at authorization time. A process that exited while the sheet
+    /// was visible is always covered (nothing remains to protect).
+    func stillCovers(_ tabs: [TerminalTab]) -> Bool {
+        for tab in tabs {
+            guard let captured = coverage[tab.id] else { return false }
+            switch captured {
+            case .agentSession(let sessionID):
+                // Same agent session: covered (pgid churn is normal agent
+                // behaviour). The agent having exited (session cleared) is
+                // also covered — there is nothing left to protect.
+                guard tab.agentSession?.id == sessionID
+                    || tab.agentSession == nil else { return false }
+            case .foregroundProcess(let identity):
+                let current = tab.foregroundProcessID
+                // Process exited: covered. A new non-zero process group is a
+                // new, unauthorized generation.
+                if current > 0, current != identity.processGroupID {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+}
+
 @MainActor
 enum TabCloseHelper {
 
@@ -354,21 +439,20 @@ enum TabCloseHelper {
         context: DialogPresentationContext = .unscoped,
         presentAlert: (@MainActor () async -> NSApplication.ModalResponse)? = nil
     ) async -> Bool {
-        let authorizedProcesses = foregroundProcessSnapshot(for: tabs)
-        guard !authorizedProcesses.isEmpty else { return true }
+        // An agent tab is authorized by its stable session identity rather
+        // than its volatile foreground pgid, so the normal child-process
+        // churn of an AI agent cannot silently abort a confirmation (#1335).
+        let authorization = TerminalTabCloseAuthorization.authorizing(tabs: tabs)
+        guard authorization.requiresConfirmation else { return true }
         guard await confirmTerminalStop(
             hasForegroundProcess: true,
             context: context,
-            deduplicationKey: .terminalTabs(
-                tabIDs: Set(tabs.map(\.id)),
-                foregroundProcesses: authorizedProcesses
-            ),
+            deduplicationKey: authorization.deduplicationKey,
             presentAlert: presentAlert
         ) else {
             return false
         }
-        return foregroundProcessSnapshot(for: tabs)
-            .isSubset(of: authorizedProcesses)
+        return authorization.stillCovers(tabs)
     }
 
     static func foregroundProcessSnapshot(
@@ -389,5 +473,31 @@ enum TabCloseHelper {
         by authorized: Set<TerminalForegroundProcessIdentity>
     ) -> Bool {
         current.isSubset(of: authorized)
+    }
+
+    /// Resolves a presentation context for a terminal close/stop, resilient
+    /// to a transiently-missing project owner (#1335 H3).
+    ///
+    /// `DialogPresenter.forProject` reads a weak project→window anchor that
+    /// can be `nil` for a brief moment during SwiftUI scene restoration. A
+    /// close captured at that instant would otherwise resolve to an unscoped
+    /// context and silently abort. This resolves the project owner, falls
+    /// back to the key project window, and retries once after a short
+    /// main-queue hop so a transient miss does not lose the close gesture.
+    static func terminalCloseContext(
+        for projectManager: ProjectManager?
+    ) async -> DialogPresentationContext {
+        func resolve() -> DialogPresentationContext {
+            guard let projectManager else { return .unscoped }
+            let projectContext = DialogPresenter.forProject(projectManager)
+            if projectContext.nsWindow != nil { return projectContext }
+            let keyContext = DialogPresenter.forKeyProject()
+            return keyContext.nsWindow != nil ? keyContext : projectContext
+        }
+
+        let first = resolve()
+        if first.nsWindow != nil { return first }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        return resolve()
     }
 }

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -41,12 +41,11 @@ struct TerminalPaneTabBar: View {
     }
 
     private func closeTerminalTabWithConfirmation(_ tab: TerminalTab) {
-        let context = if let projectManager {
-            DialogPresenter.forProject(projectManager)
-        } else {
-            DialogPresentationContext.unscoped
-        }
+        let project = projectManager
         Task { @MainActor in
+            // Resolve the owner inside the task, resilient to a transiently-
+            // nil weak anchor during SwiftUI scene restoration (#1335 H3).
+            let context = await TabCloseHelper.terminalCloseContext(for: project)
             guard await TabCloseHelper.confirmTerminalProcessStop(
                 tabs: [tab],
                 context: context

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -380,11 +380,6 @@ struct TerminalPaneTabBar: View {
             // Close terminal pane
             Button {
                 // Warn if any tab has a foreground process (window-scoped sheet, #1241)
-                let context = if let projectManager {
-                    DialogPresenter.forProject(projectManager)
-                } else {
-                    DialogPresentationContext.unscoped
-                }
                 let targetTabs = terminalState.terminalTabs
                 let targetTabIDs = Set(targetTabs.map(\.id))
                 let authorizedForegroundProcesses =
@@ -392,6 +387,12 @@ struct TerminalPaneTabBar: View {
                         for: targetTabs
                     )
                 Task { @MainActor in
+                    // Resolve the owner resiliently (#1335 H3): a
+                    // transiently-nil weak anchor during scene restoration
+                    // must not silently abort the close.
+                    let context = await TabCloseHelper.terminalCloseContext(
+                        for: projectManager
+                    )
                     guard await TabCloseHelper.confirmTerminalProcessStop(
                         tabs: targetTabs,
                         context: context

--- a/PineTests/DialogPresentationCoordinatorTests.swift
+++ b/PineTests/DialogPresentationCoordinatorTests.swift
@@ -602,6 +602,104 @@ struct DialogPresentationCoordinatorTests {
 
         #expect(events == ["first-start", "first-end", "second"])
     }
+
+    // MARK: - Foreign-sheet watchdog (#1335 H2)
+    //
+    // A foreign (framework/SwiftUI) sheet occupying the owner blocks a queued
+    // native request. SwiftUI sheets do not reliably emit
+    // `didEndSheetNotification`, so without a watchdog the request could wait
+    // forever for a signal that never arrives. The coordinator polls the
+    // owner on a bounded cadence and, once the foreign sheet clears, presents
+    // the queued request; after the bound it aborts so the queue can never
+    // wedge permanently.
+
+    @Test("queued request presents via watchdog when didEndSheet is not delivered")
+    func watchdogAdvancesBlockedRequestWithoutNotification() async {
+        let owner = makeVisibleWindow()
+        let foreignSheet = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 120),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        // Empty notification center: the coordinator never receives
+        // didEndSheet, so only the watchdog can advance the queued request.
+        let coordinator = WindowDialogCoordinator(
+            ownerWindow: owner,
+            notificationCenter: NotificationCenter(),
+            watchdogInterval: 0.01,
+            watchdogMaxAttempts: 500
+        )
+        var startCount = 0
+        var completion: ((NSApplication.ModalResponse) -> Void)?
+        defer {
+            coordinator.ownerDidClose()
+            owner.orderOut(nil)
+        }
+
+        owner.beginSheet(foreignSheet) { _ in }
+        let response = Task {
+            await coordinator.present(
+                start: { _, callback in
+                    startCount += 1
+                    completion = callback
+                },
+                cancel: { _ in }
+            )
+        }
+        await settle()
+        #expect(startCount == 0) // blocked by the foreign sheet
+
+        // End the foreign sheet. NSWindow posts didEndSheet to .default, which
+        // the coordinator does not observe here — only the watchdog re-checks.
+        owner.endSheet(foreignSheet, returnCode: .cancel)
+        for _ in 0..<2000 {
+            if startCount == 1 { break }
+            await Task.yield()
+        }
+        #expect(startCount == 1)
+
+        if let completion {
+            completion(.alertFirstButtonReturn)
+        } else {
+            coordinator.ownerDidClose()
+        }
+        #expect(await response.value == .alertFirstButtonReturn)
+    }
+
+    @Test("a request blocked past the watchdog bound aborts instead of hanging forever")
+    func blockedRequestAbortsAfterWatchdogBound() async {
+        let owner = makeVisibleWindow()
+        let foreignSheet = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 120),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let coordinator = WindowDialogCoordinator(
+            ownerWindow: owner,
+            notificationCenter: NotificationCenter(),
+            watchdogInterval: 0.01,
+            watchdogMaxAttempts: 3
+        )
+        var started = false
+        defer {
+            coordinator.ownerDidClose()
+            owner.orderOut(nil)
+        }
+
+        owner.beginSheet(foreignSheet) { _ in } // foreign sheet never ends
+        let response = Task {
+            await coordinator.present(
+                start: { _, _ in started = true },
+                cancel: { _ in }
+            )
+        }
+
+        // Bound is ~30 ms; the request must resolve (abort) rather than hang.
+        #expect(await response.value == .abort)
+        #expect(!started)
+    }
 }
 
 @Suite("Dialog flow regressions")

--- a/PineTests/TerminalProcessConfirmationTests.swift
+++ b/PineTests/TerminalProcessConfirmationTests.swift
@@ -245,4 +245,26 @@ struct TerminalProcessConfirmationTests {
             Issue.record("expected terminalTabs dedup key")
         }
     }
+
+    @Test func mixedIdleAndAgentTabs_idleTabDoesNotInvalidateConfirmation() {
+        // Bulk close (hide-all toggle / pane close) passes ALL terminal tabs
+        // — including idle shells — to `confirmTerminalProcessStop`. An idle
+        // tab (no agent session, no foreground process) is absent from
+        // `coverage`; it must NOT cause `stillCovers` to abort an otherwise-
+        // covered authorization, or every mixed idle+active bulk close would
+        // silently no-op right after the user confirmed (#1335 review finding).
+        let idleTab = TerminalTab(name: "Shell")
+        let agentTab = TerminalTab(name: "Claude")
+        agentTab.agentSession = AgentSession(agentType: .claudeCode)
+
+        let authorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: [idleTab, agentTab]
+        )
+
+        #expect(authorization.requiresConfirmation)
+        // The idle tab is skipped; the agent tab is still covered.
+        #expect(authorization.stillCovers([idleTab, agentTab]))
+        // Tab order in the re-check must not matter.
+        #expect(authorization.stillCovers([agentTab, idleTab]))
+    }
 }

--- a/PineTests/TerminalProcessConfirmationTests.swift
+++ b/PineTests/TerminalProcessConfirmationTests.swift
@@ -141,4 +141,108 @@ struct TerminalProcessConfirmationTests {
             by: authorized
         ))
     }
+
+    // MARK: - Agent-tab authorization (#1335)
+    //
+    // An AI-agent tab churns its foreground process group on nearly every
+    // poll (the agent spawns git/node/shell children). The close path must
+    // authorize such a tab by its stable agent-session identity rather than
+    // its volatile pgid, so the normal churn cannot silently abort a
+    // confirmation the user already gave.
+
+    @Test func agentTab_requiresConfirmation_evenWithoutForegroundPgid() {
+        let tab = TerminalTab(name: "Claude")
+        tab.agentSession = AgentSession(agentType: .claudeCode)
+
+        let authorization = TerminalTabCloseAuthorization.authorizing(tabs: [tab])
+
+        #expect(authorization.requiresConfirmation)
+    }
+
+    @Test func agentTab_userConfirms_proceeds() async {
+        let tab = TerminalTab(name: "Claude")
+        tab.agentSession = AgentSession(agentType: .claudeCode)
+        var alertCalled = false
+
+        let result = await TabCloseHelper.confirmTerminalProcessStop(
+            tabs: [tab],
+            presentAlert: {
+                alertCalled = true
+                return .alertFirstButtonReturn // "Close Terminal"
+            }
+        )
+
+        #expect(result == true)
+        #expect(alertCalled == true)
+    }
+
+    @Test func agentTab_userCancels_aborts() async {
+        let tab = TerminalTab(name: "Claude")
+        tab.agentSession = AgentSession(agentType: .claudeCode)
+
+        let result = await TabCloseHelper.confirmTerminalProcessStop(
+            tabs: [tab],
+            presentAlert: { .alertSecondButtonReturn } // "Cancel"
+        )
+
+        #expect(result == false)
+    }
+
+    @Test func agentTab_foregroundPgidChurn_doesNotInvalidateConfirmation() {
+        // A test TerminalTab has no real PTY, so foregroundProcessID stays
+        // negative regardless — exactly the situation during pgid churn where
+        // the foreground group is briefly not the agent's own. The same agent
+        // session remains, so the confirmation must still cover the tab.
+        let tab = TerminalTab(name: "Claude")
+        let session = AgentSession(agentType: .claudeCode)
+        tab.agentSession = session
+
+        let authorization = TerminalTabCloseAuthorization.authorizing(tabs: [tab])
+
+        #expect(authorization.stillCovers([tab]))
+    }
+
+    @Test func agentTab_differentAgentSession_invalidatesConfirmation() {
+        // A genuinely different agent run is a new authorization generation
+        // and must not be covered by the previous answer.
+        let tab = TerminalTab(name: "Claude")
+        tab.agentSession = AgentSession(agentType: .claudeCode)
+        let authorization = TerminalTabCloseAuthorization.authorizing(tabs: [tab])
+
+        tab.agentSession = AgentSession(agentType: .claudeCode) // new session id
+
+        #expect(!authorization.stillCovers([tab]))
+    }
+
+    @Test func agentTab_agentExited_isStillCovered() {
+        // If the agent exited while the sheet was visible, there is nothing
+        // left to protect — the tab is safe to close.
+        let tab = TerminalTab(name: "Claude")
+        tab.agentSession = AgentSession(agentType: .claudeCode)
+        let authorization = TerminalTabCloseAuthorization.authorizing(tabs: [tab])
+
+        tab.agentSession = nil
+
+        #expect(authorization.stillCovers([tab]))
+    }
+
+    @Test func agentTab_deduplicationKeyIsStableAcrossPgidChurn() {
+        // The dedup key for an agent tab carries no volatile foreground pgid,
+        // so two close gestures on the same agent tab collapse to one
+        // in-flight request even as the pgid churns between them.
+        let tab = TerminalTab(name: "Claude")
+        tab.agentSession = AgentSession(agentType: .claudeCode)
+
+        let first = TerminalTabCloseAuthorization.authorizing(tabs: [tab])
+        let second = TerminalTabCloseAuthorization.authorizing(tabs: [tab])
+
+        #expect(first.deduplicationKey == second.deduplicationKey)
+        // No volatile pgid is recorded for an agent tab.
+        switch first.deduplicationKey {
+        case .terminalTabs(_, let foregroundProcesses):
+            #expect(foregroundProcesses.isEmpty)
+        default:
+            Issue.record("expected terminalTabs dedup key")
+        }
+    }
 }


### PR DESCRIPTION
## Summary

A terminal tab running an AI agent **could not be closed while the agent was the foreground process**: clicking the ✕ produced no confirmation sheet, and the tab only closed after `Ctrl-C`. Blocks a primary action for Pine's core workload.

Fixes #1335.

> **Honesty note on root cause.** The exact field branch cannot be confirmed without a live repro (the sheet never appears, so there is nothing to inspect). Per the issue's own guidance, this PR implements **defensive robustness fixes that are correct for all three ranked hypotheses** (H1 pgid/dedup churn, H2 indefinite suspension on an attached sheet, H3 weak owner transiently nil), backed by mock-based regression tests, plus diagnostic `os_log` at each abort point so the maintainer can confirm the live branch from Console.app.

## Changes

- **H1 — agent-aware authorization (`TabCloseHelper`).** Agent tabs are now authorized by their **stable agent-session identity** rather than the volatile foreground pgid (`TerminalTabCloseAuthorization`). The normal child-process churn of an AI agent (spawning git/node/shell children) can no longer silently invalidate a confirmation the user already gave. The dedup key for an agent tab carries no pgid, so repeated close gestures collapse to one in-flight request.
- **H2 — bounded foreign-sheet watchdog (`WindowDialogCoordinator`).** While a queued request is blocked by a foreign (framework/SwiftUI) sheet, the coordinator arms a bounded watchdog that re-checks the owner on a cadence and presents once the sheet clears. SwiftUI sheets do not reliably emit `didEndSheetNotification`, so without this a request could wait forever. After the bound (~30 s in production) the front request is aborted so the queue can never wedge permanently.
- **H3 — owner-resolution resilience (`TabCloseHelper.terminalCloseContext`).** The terminal close path resolves its owner inside the `Task` with a key-window fallback and a one-shot main-queue retry, so a transiently-`nil` weak anchor during SwiftUI scene restoration no longer silently aborts the close.
- **Diagnostics.** `os.Logger` debug logging at the three abort points (`runSheet` owner-missing, `present` dedup-match, watchdog abort) keyed by request identity, so the live branch is identifiable from Console.

## Tests

New mock-based regression tests (no live agent/PTY required):
- Agent tab: requires confirmation even without a foreground pgid; user confirm → proceeds; cancel → aborts.
- Agent tab: foreground-pgid churn does **not** invalidate the confirmation; a different agent session **does**; an exited agent is still safe to close.
- Agent tab: dedup key is stable across pgid churn (no volatile pgid recorded).
- Watchdog: a blocked queued request **presents** once the foreign sheet clears even when `didEndSheetNotification` is not delivered.
- Watchdog: a request blocked past the bound **aborts** instead of hanging forever.
- Existing paths (no-process fast path, user-confirm → proceeds, pgid-generation authorization) remain unchanged.

## Verification

- `swiftlint` — 0 violations.
- `xcodebuild build` — succeeded.
- `xcodebuild test` — `TerminalProcessConfirmationTests`, `DialogPresentationCoordinatorTests`, `AlertTemplateTests`, `ProjectDialogOwnerReadinessTests`: **54 tests passed** (clean tree off `origin/main`).

## Residual risk / follow-up

- The exact live branch is unconfirmed pending the new diagnostics; these fixes are correct regardless of which path fires.
- The bulk terminal-close paths (`PineApp`, `ContentView`, `TerminalPaneTabBar` pane close) still use the pgid-based `foregroundProcessSnapshotIsAuthorized` directly. They are out of scope here (file boundaries) but could adopt `TerminalTabCloseAuthorization` later if agent-churn is observed there too.