### PR TITLE
fix(editor): wait for dialog owner before Open Folder panel

### DIFF
--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -182,9 +182,8 @@ extension ContentView {
 extension ContentView {
 
     func openNewProject() {
-        let context = DialogPresenter.forProject(projectManager)
         Task { @MainActor in
-            guard let url = await registry.openProjectViaPanel(context: context) else { return }
+            guard let url = await registry.openProjectViaPanel(for: projectManager) else { return }
             openWindow(value: url)
         }
     }

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -74,9 +74,12 @@ struct ContentView: View {
             .toolbar {
                 ToolbarItem {
                     Button {
-                        let context = DialogPresenter.forProject(projectManager)
                         Task { @MainActor in
-                            if let url = await registry.openProjectViaPanel(context: context) {
+                            // Wait for the project window to bind its dialog
+                            // owner before capturing the presentation context;
+                            // otherwise the panel silently aborts right after
+                            // the window appears or is replaced (#1344).
+                            if let url = await registry.openProjectViaPanel(for: projectManager) {
                                 openWindow(value: url)
                             }
                         }

--- a/Pine/DialogPresentationContext.swift
+++ b/Pine/DialogPresentationContext.swift
@@ -643,6 +643,7 @@ extension NSSavePanel {
     ) async -> NSApplication.ModalResponse {
         guard let capturedOwner = context.nsWindow,
               DialogPresenter.isEligibleApplicationOwner(capturedOwner) else {
+            Logger.app.debug("runSheet aborted: owner missing or ineligible (#1344)")
             return .abort
         }
         return await context.present(

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -322,6 +322,36 @@ final class ProjectRegistry: LSPSettingsObserver {
         return canonical
     }
 
+    /// Opens a project via folder picker, first waiting for the project
+    /// window to bind a dialog owner (#1344).
+    ///
+    /// Project scenes bind their AppKit owner asynchronously
+    /// (`WindowCloseInterceptor` → `DialogPresenter.register` →
+    /// `bindDialogOwnerWindow`), so callers that capture the presentation
+    /// context synchronously — e.g. the toolbar Open Folder button and the
+    /// `openNewProject()` duplicates — fire into a `nil` owner right after a
+    /// window appears or is replaced, and `NSSavePanel.runSheet` silently
+    /// aborts. This bounds the wait on `awaitDialogOwnerWindow`, then presents
+    /// the panel anchored to the freshly bound owner. Returns `nil` if the
+    /// owner never becomes eligible or the user cancels.
+    @discardableResult
+    func openProjectViaPanel(
+        for projectManager: ProjectManager,
+        maximumAttempts: Int = 80,
+        waitForNextAttempt: (@MainActor () async -> Void)? = nil,
+        isEligible: (@MainActor (NSWindow) -> Bool)? = nil
+    ) async -> URL? {
+        guard await projectManager.awaitDialogOwnerWindow(
+            maximumAttempts: maximumAttempts,
+            waitForNextAttempt: waitForNextAttempt,
+            isEligible: isEligible
+        ) != nil else {
+            return nil
+        }
+        let context = DialogPresenter.forProject(projectManager)
+        return await openProjectViaPanel(context: context)
+    }
+
     /// Closes the project window but keeps the ProjectManager alive. Terminal
     /// sessions and user tasks continue in the background; reopening the
     /// project restores access to their current state and output history.

--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -832,9 +832,8 @@ struct SidebarView: View {
 
     /// Opens a new project via folder picker in a new window.
     private func openNewProject() {
-        let context = DialogPresenter.forProject(projectManager)
         Task { @MainActor in
-            guard let url = await registry.openProjectViaPanel(context: context) else { return }
+            guard let url = await registry.openProjectViaPanel(for: projectManager) else { return }
             openWindow(value: url)
         }
     }

--- a/PineTests/DialogPresentationCoordinatorTests.swift
+++ b/PineTests/DialogPresentationCoordinatorTests.swift
@@ -397,6 +397,50 @@ struct DialogPresentationCoordinatorTests {
         DialogPresenter.ownerDidClose(window)
     }
 
+    @Test("NSSavePanel runSheet aborts without presenting for an ineligible owner (#1344)")
+    func savePanelAbortsForIneligibleOwner() async {
+        // Mirrors the NSAlert guard above. NSSavePanel.runSheet previously
+        // returned .abort silently for an unbound owner, leaving no trace that
+        // the Open Folder flow had fired into a missing dialog anchor.
+        let window = NSWindow()
+        let context = DialogPresentationContext(window: window)
+        let panel = NSSavePanel()
+
+        let response = await panel.runSheet(on: context)
+
+        #expect(response == .abort)
+        #expect(window.attachedSheet == nil)
+        DialogPresenter.ownerDidClose(window)
+    }
+
+    @Test("folder picker waits for the project owner to bind before presenting (#1344)")
+    func folderPickerWaitsForProjectOwner() async {
+        // The toolbar Open Folder button and the openNewProject() duplicates
+        // used to capture the presentation context synchronously and abort
+        // when the project window had not bound its owner yet. The
+        // owner-awaiting entry point must keep polling instead.
+        let registry = ProjectRegistry()
+        let projectManager = ProjectManager()
+        var waitCount = 0
+
+        let url = await registry.openProjectViaPanel(
+            for: projectManager,
+            maximumAttempts: 4,
+            waitForNextAttempt: {
+                waitCount += 1
+                await Task.yield()
+            },
+            // Owner never becomes eligible, so the panel is never reached;
+            // the only observable side effect is the bounded wait loop.
+            isEligible: { _ in false }
+        )
+
+        #expect(url == nil)
+        // Without the awaited-owner wait this would be 0 (immediate abort on
+        // a nil context), which is exactly the #1344 silent no-op regression.
+        #expect(waitCount == 4)
+    }
+
     @Test("application owner eligibility rejects hidden and miniaturized states")
     func applicationOwnerEligibility() {
         #expect(


### PR DESCRIPTION
## Summary

Fixes #1344.

The **Open Folder** toolbar button (and its `openNewProject()` duplicates) captured the dialog presentation context synchronously. Right after a project window appeared — or was replaced by SwiftUI scene restoration — the AppKit owner anchor (`dialogOwnerWindow`) was still `nil`, so `NSSavePanel.runSheet` hit its guard and returned `.abort`. No panel appeared, no error was logged: the button looked dead. This is an intermittent race; in steady state the binding exists and the button works.

## Changes

- **`ProjectRegistry.openProjectViaPanel(for:)`** (new) — centralizes the flow: it bounds a wait on `awaitDialogOwnerWindow` (≈2 s, same bounded retry the rest of the codebase uses), then captures the context and presents the panel anchored to the freshly bound owner. Eliminates the duplicated call sites.
- **`ContentView.swift`** (toolbar button), **`ContentView+Helpers.openNewProject()`**, **`SidebarView.openNewProject()`** — all three now route through the owner-awaiting entry point. The issue listed the first two; `SidebarView.openNewProject()` had the identical code and the same race, so it is fixed here too for consistency.
- **`DialogPresentationContext.swift`** — `NSSavePanel.runSheet` now logs on the missing/ineligible-owner abort (mirrors the existing `NSAlert.runSheet` log), closing the observability gap.

## Why a helper

Three call sites had byte-identical code. Extracting the owner-wait into `ProjectRegistry` removes the duplication and makes the pre-binding behavior unit-testable — the regression test below asserts the wait loop actually runs.

## Tests

`PineTests/DialogPresentationCoordinatorTests.swift`:

- **`folderPickerWaitsForProjectOwner`** — regression guard. Injects a bounded wait with an owner that never becomes eligible and asserts the wait loop ran (`waitCount == 4`). Verified to **fail without the fix** (`waitCount == 0`, immediate abort on a nil context) by temporarily disabling the await in the helper.
- **`savePanelAbortsForIneligibleOwner`** — contract test for the now-logging `NSSavePanel.runSheet` guard (mirrors the existing `hiddenOwnerFailsClosed` for `NSAlert`).

## Verification

- `swiftlint` on all touched files: **0 violations**.
- `PineTests/DialogPresentationCoordinatorTests` + `ProjectDialogOwnerReadinessTests`: **24 passed**.
- `PineTests/WindowLifecycleTests` + `ProjectManagerSessionTests` (touched-area neighbors): **passed**.
- Built with Xcode 27.0 (27A5218g) / macOS 27 SDK against the `macOS` destination. *(Xcode 26 baseline not exercised on this machine — only Xcode-beta is installed; CI covers both.)*

## Acceptance criteria (#1344)

- [x] Repeatedly opening a project and immediately clicking the Open Folder button now waits for the owner instead of aborting silently.
- [x] The shared entry point is bounded, so it cannot hang forever if the owner never binds.
- [x] `NSSavePanel.runSheet` logs on abort.
- [x] Unit tests cover the pre-binding case, including a regression that fails without the fix.

## Notes / follow-ups

- Manual UI verification (click the button in the first moments after a window appears, and after scene restoration) was not performed in this session — it is covered by the unit contract plus the existing window-lifecycle suites; a UI test is impractical here because `NSOpenPanel` presentation cannot be driven from `PineUITests` without a real folder picker.
- Not merging — leaving for the maintainer.