### PR TITLE
chore(deps): bump Sparkle 2.9.4 → 2.9.5

### DIFF
--- a/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle.git",
       "state" : {
-        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
-        "version" : "2.9.4"
+        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
+        "version" : "2.9.5"
       }
     },
     {


### PR DESCRIPTION
## Summary
Bump Sparkle from 2.9.4 to 2.9.5. The only tracked change is `Package.resolved` (Sparkle entry `revision` + `version`).

Sparkle 2.9.5 ships a **high-complexity symlink security fix** (upstream [#2891](https://github.com/sparkle-project/Sparkle/pull/2891)) — it hardens the patching delta file against a symbolic link at the destination path. This is a more complete fix to the symlink issue first identified in 2.9.2.

Release notes: https://github.com/sparkle-project/Sparkle/releases/tag/2.9.5

Closes #1346.

## Changes
- `Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`: Sparkle `2.9.4` (`b6496a7…`) → `2.9.5` (`79bc9e8…`). No source edits — Sparkle's update surface used by Pine (#152) is unchanged.

## Verification
- [x] `xcodebuild -project Pine.xcodeproj -scheme Pine build` → **BUILD SUCCEEDED** with Xcode-beta, Sparkle.framework resolved and copied into `Pine.app/Contents/Frameworks`.
- [ ] CI (lint + unit tests + 7 UI shards) green.
- [ ] Auto-update flow sanity check before release (manual).

## Notes
- Patch-version bump only; no API changes, so no code or test changes are expected to be required.
- Not merging — leaving for human merge per project workflow.
