### PR TITLE
fix(terminal): authorize bulk close and quit by stable agent identity

### DIFF
--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -345,10 +345,6 @@ struct ContentView: View {
                         let targetPaneIDs = Set(paneManager.terminalPaneIDs)
                         let targetTabs = terminal.allTerminalTabs
                         let targetTabIDs = Set(targetTabs.map(\.id))
-                        let authorizedForegroundProcesses =
-                            TabCloseHelper.foregroundProcessSnapshot(
-                                for: targetTabs
-                            )
                         Task { @MainActor in
                             // Resolve the owner resiliently: a transiently-nil
                             // weak project→window anchor during scene
@@ -361,19 +357,18 @@ struct ContentView: View {
                                 tabs: targetTabs,
                                 context: context
                             ) else { return }
+                            // `confirmTerminalProcessStop` already revalidates
+                            // process coverage through the stable-identity
+                            // authorization. Re-checking a volatile pgid here
+                            // silently discarded the user's confirmation
+                            // whenever an agent spawned a child (#1348); only
+                            // the pane/tab composition still needs a guard.
                             let currentPaneIDs = Set(paneManager.terminalPaneIDs)
-                            let currentTabs = terminal.allTerminalTabs
-                            let currentTabIDs = Set(currentTabs.map(\.id))
-                            let currentForegroundProcesses =
-                                TabCloseHelper.foregroundProcessSnapshot(
-                                    for: currentTabs
-                                )
+                            let currentTabIDs = Set(
+                                terminal.allTerminalTabs.map(\.id)
+                            )
                             guard currentPaneIDs.isSubset(of: targetPaneIDs),
-                                  currentTabIDs.isSubset(of: targetTabIDs),
-                                  TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
-                                      currentForegroundProcesses,
-                                      by: authorizedForegroundProcesses
-                                  ) else {
+                                  currentTabIDs.isSubset(of: targetTabIDs) else {
                                 return
                             }
                             // Hide all terminal panes

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -689,11 +689,14 @@ class CloseDelegate: NSObject, NSWindowDelegate {
             }
         }
 
-        let authorizedTerminalProcesses =
-            TabCloseHelper.foregroundProcessSnapshot(
-                for: projectManager.terminal.allTerminalTabs
-            )
-        if !authorizedTerminalProcesses.isEmpty {
+        // Authorize by stable identity, never by the volatile foreground pgid:
+        // an agent tab churns process groups on nearly every poll, so a pgid
+        // snapshot taken before the sheet is already stale when the user
+        // answers it, and the close would silently abort (#1335, #1348).
+        let terminalAuthorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: projectManager.terminal.allTerminalTabs
+        )
+        if terminalAuthorization.requiresConfirmation {
             let terminalResponse = if let closeAlertPresenter {
                 await closeAlertPresenter(
                     .terminalTabCloseWarning,
@@ -714,13 +717,8 @@ class CloseDelegate: NSObject, NSWindowDelegate {
         }
 
         let currentDirtyTabs = projectManager.allDirtyTabs
-        let currentTerminalProcesses =
-            TabCloseHelper.foregroundProcessSnapshot(
-                for: projectManager.terminal.allTerminalTabs
-            )
-        guard TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
-            currentTerminalProcesses,
-            by: authorizedTerminalProcesses
+        guard terminalAuthorization.stillCovers(
+            projectManager.terminal.allTerminalTabs
         ) else {
             return .cancel
         }
@@ -1940,8 +1938,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         var discardAuthorizations: [
             ObjectIdentifier: DirtyEditorContentAuthorization
         ] = [:]
-        var authorizedTerminalProcesses: [
-            ObjectIdentifier: Set<TerminalForegroundProcessIdentity>
+        // Keyed by project. Authorization is by stable identity (agent session
+        // id / process-group generation), never by a raw pgid snapshot, so an
+        // agent spawning children while the sheet is up cannot invalidate the
+        // Quit the user just confirmed (#1335, #1348).
+        var terminalAuthorizations: [
+            ObjectIdentifier: TerminalTabCloseAuthorization
         ] = [:]
 
         for projectManager in projects {
@@ -2018,16 +2020,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             }
         }
 
-        for projectManager in projects where projectManager.terminal.hasActiveProcesses {
+        for projectManager in projects {
             guard registry.openProjects.values.contains(where: {
                 $0 === projectManager
             }) else {
                 continue
             }
-            let activeTerminalProcesses =
-                TabCloseHelper.foregroundProcessSnapshot(
-                    for: projectManager.terminal.allTerminalTabs
+            // Record an authorization for every surviving project, including
+            // those with nothing running: the final revalidation needs a
+            // captured baseline per project to distinguish "was idle, still
+            // idle" from "appeared after the snapshot".
+            let authorization = TerminalTabCloseAuthorization.authorizing(
+                tabs: projectManager.terminal.allTerminalTabs
             )
+            terminalAuthorizations[ObjectIdentifier(projectManager)] =
+                authorization
+            guard authorization.requiresConfirmation else { continue }
             let projectContext = DialogPresenter.forProject(projectManager)
             let hasEligibleProjectOwner = projectContext.nsWindow.map {
                 DialogPresenter.isEligibleApplicationOwner($0)
@@ -2063,8 +2071,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             guard response == .alertFirstButtonReturn else {
                 return false
             }
-            authorizedTerminalProcesses[ObjectIdentifier(projectManager)] =
-                activeTerminalProcesses
         }
 
         // Runtime pane/tab IDs cannot be trusted across relaunch. Reserve a
@@ -2127,16 +2133,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 return false
             }
 
-            let allowedTerminalProcesses =
-                authorizedTerminalProcesses[identifier] ?? []
-            let currentTerminalProcesses =
-                TabCloseHelper.foregroundProcessSnapshot(
-                    for: projectManager.terminal.allTerminalTabs
-                )
-            guard TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
-                currentTerminalProcesses,
-                by: allowedTerminalProcesses
+            // A project that appeared after the snapshot was never presented
+            // to the user. An idle one is still safe to tear down; anything
+            // running in it is unauthorized and must cancel Quit.
+            guard let authorization = terminalAuthorizations[identifier] else {
+                guard !TerminalTabCloseAuthorization.authorizing(
+                    tabs: projectManager.terminal.allTerminalTabs
+                ).requiresConfirmation else {
+                    Logger.app.error(
+                        "Quit aborted: project with running processes opened during the termination handshake"
+                    )
+                    await rollbackAgentTasks()
+                    return false
+                }
+                continue
+            }
+            guard authorization.stillCovers(
+                projectManager.terminal.allTerminalTabs
             ) else {
+                Logger.app.error(
+                    "Quit aborted: terminal authorization no longer covers the project"
+                )
                 await rollbackAgentTasks()
                 return false
             }

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -460,26 +460,6 @@ enum TabCloseHelper {
         return authorization.stillCovers(tabs)
     }
 
-    static func foregroundProcessSnapshot(
-        for tabs: [TerminalTab]
-    ) -> Set<TerminalForegroundProcessIdentity> {
-        Set(tabs.compactMap { tab in
-            let processGroupID = tab.foregroundProcessID
-            guard processGroupID > 0 else { return nil }
-            return TerminalForegroundProcessIdentity(
-                tabID: tab.id,
-                processGroupID: processGroupID
-            )
-        })
-    }
-
-    nonisolated static func foregroundProcessSnapshotIsAuthorized(
-        _ current: Set<TerminalForegroundProcessIdentity>,
-        by authorized: Set<TerminalForegroundProcessIdentity>
-    ) -> Bool {
-        current.isSubset(of: authorized)
-    }
-
     /// Resolves a presentation context for a terminal close/stop, resilient
     /// to a transiently-missing project owner (#1335 H3).
     ///

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -382,10 +382,6 @@ struct TerminalPaneTabBar: View {
                 // Warn if any tab has a foreground process (window-scoped sheet, #1241)
                 let targetTabs = terminalState.terminalTabs
                 let targetTabIDs = Set(targetTabs.map(\.id))
-                let authorizedForegroundProcesses =
-                    TabCloseHelper.foregroundProcessSnapshot(
-                        for: targetTabs
-                    )
                 Task { @MainActor in
                     // Resolve the owner resiliently (#1335 H3): a
                     // transiently-nil weak anchor during scene restoration
@@ -397,17 +393,14 @@ struct TerminalPaneTabBar: View {
                         tabs: targetTabs,
                         context: context
                     ) else { return }
+                    // `confirmTerminalProcessStop` already revalidates process
+                    // coverage through the stable-identity authorization.
+                    // Re-checking a volatile pgid here silently discarded the
+                    // user's confirmation whenever an agent spawned a child
+                    // (#1348); only the tab composition still needs a guard.
                     let currentTabs = terminalState.terminalTabs
                     let currentTabIDs = Set(currentTabs.map(\.id))
-                    let currentForegroundProcesses =
-                        TabCloseHelper.foregroundProcessSnapshot(
-                            for: currentTabs
-                        )
-                    guard currentTabIDs.isSubset(of: targetTabIDs),
-                          TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
-                              currentForegroundProcesses,
-                              by: authorizedForegroundProcesses
-                          ) else {
+                    guard currentTabIDs.isSubset(of: targetTabIDs) else {
                         return
                     }
                     // Stop all tabs and remove pane

--- a/PineTests/BulkCloseAgentAuthorizationTests.swift
+++ b/PineTests/BulkCloseAgentAuthorizationTests.swift
@@ -1,0 +1,357 @@
+//
+//  BulkCloseAgentAuthorizationTests.swift
+//  PineTests
+//
+//  Regression coverage for #1348: the two bulk destructive paths — project
+//  window close and application quit — must authorize terminal tabs through
+//  `TerminalTabCloseAuthorization` (stable agent-session identity), exactly
+//  like the single-tab path fixed in #1343.
+//
+//  The pre-#1348 mechanism snapshotted the volatile foreground pgid before
+//  presenting the sheet and required the post-sheet snapshot to be a subset.
+//  An agent tab has no foreground pgid of its own between child spawns, so
+//  that snapshot was empty: the bulk paths never warned about a running
+//  agent at all, and once a child did appear mid-sheet the subset check
+//  failed and the confirmed close/quit aborted in silence.
+//
+//  Each test below fails against that old mechanism and passes against the
+//  authorization primitive.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import Pine
+
+@Suite("Bulk Close Agent Authorization (#1348)")
+@MainActor
+struct BulkCloseAgentAuthorizationTests {
+
+    // MARK: - Fixtures
+
+    private func makeTempDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineBulkCloseAuth-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: true
+        )
+        return url
+    }
+
+    private func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private func settle() async {
+        for _ in 0..<8 { await Task.yield() }
+    }
+
+    /// Adds a terminal pane carrying one tab that is running an AI agent.
+    /// The tab has no live PTY, so `foregroundProcessID` stays `-1` — which is
+    /// precisely the state the old pgid snapshot could not represent.
+    @discardableResult
+    private func addAgentTerminalTab(
+        to projectManager: ProjectManager
+    ) throws -> TerminalTab {
+        projectManager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: nil
+        )
+        let tab = try #require(projectManager.terminal.allTerminalTabs.first)
+        #expect(!tab.hasForegroundProcess)
+        tab.agentSession = AgentSession(agentType: .claudeCode)
+        return tab
+    }
+
+    // MARK: - Project window close
+
+    @Test("Window close warns about a running agent that has no foreground pgid")
+    func windowCloseWarnsAboutRunningAgent() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        try addAgentTerminalTab(to: project)
+
+        var presentedTemplates: [AlertTemplate] = []
+        let delegate = CloseDelegate(
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: AppDelegate(),
+            original: nil,
+            presentAlert: { template, _, _, _ in
+                presentedTemplates.append(template)
+                return .alertFirstButtonReturn
+            }
+        )
+        let window = BulkCloseTrackingWindow()
+        window.delegate = delegate
+        defer { DialogPresenter.ownerDidClose(window) }
+
+        #expect(!delegate.windowShouldClose(window))
+        await settle()
+
+        #expect(presentedTemplates == [.terminalTabCloseWarning])
+        #expect(window.performCloseCount == 1)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("Confirmed window close survives agent child-process churn")
+    func confirmedWindowCloseSurvivesChurn() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let tab = try addAgentTerminalTab(to: project)
+        let sessionID = try #require(tab.agentSession?.id)
+
+        let delegate = CloseDelegate(
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: AppDelegate(),
+            original: nil,
+            presentAlert: { _, _, _, _ in .alertFirstButtonReturn }
+        )
+        let window = BulkCloseTrackingWindow()
+        window.delegate = delegate
+        defer { DialogPresenter.ownerDidClose(window) }
+
+        #expect(!delegate.windowShouldClose(window))
+        await settle()
+
+        // Same agent session throughout: the confirmation still covers the tab.
+        #expect(tab.agentSession?.id == sessionID)
+        #expect(window.performCloseCount == 1)
+        #expect(window.approvedCloseCount == 1)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("A new agent run started during the sheet cancels the window close")
+    func newAgentRunDuringSheetCancelsWindowClose() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let tab = try addAgentTerminalTab(to: project)
+
+        let delegate = CloseDelegate(
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: AppDelegate(),
+            original: nil,
+            presentAlert: { _, _, _, _ in
+                // A genuinely different agent run appears while the sheet is
+                // up. The user authorized the previous one, not this.
+                tab.agentSession = AgentSession(agentType: .claudeCode)
+                return .alertFirstButtonReturn
+            }
+        )
+        let window = BulkCloseTrackingWindow()
+        window.delegate = delegate
+        defer { DialogPresenter.ownerDidClose(window) }
+
+        #expect(!delegate.windowShouldClose(window))
+        await settle()
+
+        #expect(window.performCloseCount == 0)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("An agent that exits during the sheet still lets the window close")
+    func agentExitDuringSheetStillClosesWindow() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let tab = try addAgentTerminalTab(to: project)
+
+        let delegate = CloseDelegate(
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: AppDelegate(),
+            original: nil,
+            presentAlert: { _, _, _, _ in
+                // Nothing left to protect once the agent is gone.
+                tab.agentSession = nil
+                return .alertFirstButtonReturn
+            }
+        )
+        let window = BulkCloseTrackingWindow()
+        window.delegate = delegate
+        defer { DialogPresenter.ownerDidClose(window) }
+
+        #expect(!delegate.windowShouldClose(window))
+        await settle()
+
+        #expect(window.performCloseCount == 1)
+        #expect(window.approvedCloseCount == 1)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    // MARK: - Application quit
+
+    @Test("Quit warns about a running agent that has no foreground pgid")
+    func quitWarnsAboutRunningAgent() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        try addAgentTerminalTab(to: project)
+
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var presentedTemplates: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presentedTemplates.append(template)
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 120
+        )
+
+        #expect(result)
+        #expect(presentedTemplates == [.terminalActiveProcessWarning])
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("Confirmed quit survives agent child-process churn")
+    func confirmedQuitSurvivesChurn() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let tab = try addAgentTerminalTab(to: project)
+        let sessionID = try #require(tab.agentSession?.id)
+
+        let delegate = AppDelegate()
+        delegate.registry = registry
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { _, _, _, _ in .alertFirstButtonReturn },
+            terminationDeadlineOverride: .now() + 120
+        )
+
+        #expect(result)
+        #expect(tab.agentSession?.id == sessionID)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("A new agent run started during the quit sheet cancels termination")
+    func newAgentRunDuringQuitSheetCancelsTermination() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let tab = try addAgentTerminalTab(to: project)
+
+        let delegate = AppDelegate()
+        delegate.registry = registry
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { _, _, _, _ in
+                tab.agentSession = AgentSession(agentType: .claudeCode)
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 120
+        )
+
+        #expect(!result)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("Quit is not blocked by a project that never had anything running")
+    func idleProjectDoesNotBlockQuit() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var alertCount = 0
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { _, _, _, _ in
+                alertCount += 1
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 120
+        )
+
+        #expect(result)
+        #expect(alertCount == 0)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("An agent in a background project still gates quit")
+    func backgroundProjectAgentStillGatesQuit() async throws {
+        // Closing a project window only backgrounds it — the agent keeps
+        // running. Quit must still account for it (the user's real-world
+        // scenario: every window closed, agents alive, ⌘Q).
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let tab = try addAgentTerminalTab(to: project)
+        registry.closeProjectWindow(dir)
+        #expect(registry.openProjects[registry.canonicalProjectURL(dir)] != nil)
+
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var presentedTemplates: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presentedTemplates.append(template)
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 120
+        )
+
+        #expect(result)
+        #expect(presentedTemplates == [.terminalActiveProcessWarning])
+        #expect(tab.agentSession != nil)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("Declining the quit warning cancels termination")
+    func decliningQuitWarningCancelsTermination() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        try addAgentTerminalTab(to: project)
+
+        let delegate = AppDelegate()
+        delegate.registry = registry
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { _, _, _, _ in .alertSecondButtonReturn },
+            terminationDeadlineOverride: .now() + 120
+        )
+
+        #expect(!result)
+        await project.workspace.waitForLoadingComplete()
+    }
+}
+
+/// Counts `performClose` so a test can distinguish "the close was approved"
+/// from "the close silently aborted" (#1348).
+@MainActor
+private final class BulkCloseTrackingWindow: NSWindow {
+    private(set) var performCloseCount = 0
+    private(set) var approvedCloseCount = 0
+
+    override func performClose(_ sender: Any?) {
+        performCloseCount += 1
+        if delegate?.windowShouldClose?(self) != false {
+            approvedCloseCount += 1
+        }
+    }
+}

--- a/PineTests/TerminalProcessConfirmationTests.swift
+++ b/PineTests/TerminalProcessConfirmationTests.swift
@@ -118,30 +118,6 @@ struct TerminalProcessConfirmationTests {
         #expect(alertCalled == false)
     }
 
-    @Test func foregroundAuthorizationUsesProcessGroupGeneration() {
-        let tabID = UUID()
-        let authorized: Set<TerminalForegroundProcessIdentity> = [
-            .init(tabID: tabID, processGroupID: 101),
-        ]
-
-        #expect(TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
-            [.init(tabID: tabID, processGroupID: 101)],
-            by: authorized
-        ))
-        #expect(!TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
-            [.init(tabID: tabID, processGroupID: 202)],
-            by: authorized
-        ))
-        #expect(!TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
-            [.init(tabID: UUID(), processGroupID: 101)],
-            by: authorized
-        ))
-        #expect(TabCloseHelper.foregroundProcessSnapshotIsAuthorized(
-            [],
-            by: authorized
-        ))
-    }
-
     // MARK: - Agent-tab authorization (#1335)
     //
     // An AI-agent tab churns its foreground process group on nearly every


### PR DESCRIPTION
Fixes #1348.

## Problem

Closing a project window and quitting Pine both snapshotted the **volatile** foreground process group before presenting their confirmation sheet, then required the post-sheet snapshot to be a subset of it. An AI agent spawns short-lived children constantly, which gave that check two distinct failure modes:

1. **No warning at all.** Between child spawns an agent tab reports no foreground pgid of its own, so `foregroundProcessSnapshot` returned an empty set. `!authorized.isEmpty` was false → no sheet was presented, and ⌘Q killed the running agent without asking anything.
2. **Silent abort.** Once a child did appear while a sheet was up, `current.isSubset(of: authorized)` failed and the close/quit the user had just confirmed aborted with no feedback. On the quit path `rollbackAgentTasks()` also ran.

Which one you got depended purely on timing. Reported from real use: several projects open with an agent in each, all windows closed, ⌘Q does nothing — the app had to be killed from Activity Monitor.

## Fix

Route both bulk paths through `TerminalTabCloseAuthorization`, the primitive the single-tab path has used since #1343: agent tabs are covered by their stable `agentSession.id`, non-agent tabs keep exact process-group generation semantics.

- `CloseDelegate.confirmWindowClose` — `authorizing(tabs:)` / `stillCovers(_:)`.
- `AppDelegate.confirmApplicationTermination` — per-project authorizations, revalidated via `stillCovers(_:)`. A project that appears mid-handshake is authorized only if it is idle; a running one cancels Quit and now logs why.
- `ContentView` (hide-all-terminals toggle) and `TerminalPaneTabBar` (pane close) had a **duplicate** pgid revalidation layered on top of `confirmTerminalProcessStop`, which already revalidates coverage internally. That extra check reintroduced the same silent abort on those two paths; removed. Pane/tab composition guards are kept.
- `foregroundProcessSnapshot` / `foregroundProcessSnapshotIsAuthorized` have no callers left and are removed, along with the test that covered only them.

## Behaviour change

An agent tab with no foreground pgid now **does** trigger the warning sheet on window close and on quit. Previously it was silently torn down. This is the intended safety semantics — the earlier behaviour lost agent work without a prompt.

## Tests

New `PineTests/BulkCloseAgentAuthorizationTests.swift` — 10 tests over both bulk paths: warning presented for a pgid-less agent, confirmation survives churn, a new agent run mid-sheet cancels, an exited agent still closes, idle project does not gate quit, an agent in a **background** project still gates quit (the reported scenario), declining cancels.

Verified they actually lock the regression: **6 of the 10 fail on the pre-fix code** and all 10 pass after. Related suites (`CloseDelegateTests`, `WindowLifecycleTests`, `TerminalProcessConfirmationTests`, `TabCloseHelperBulkTests`, `PaneLeafCloseTests`) — 88 tests green.

`swiftlint` clean (0 violations, 731 files). `xcodebuild build` succeeds.

**Note on the full local `PineTests` run:** it is flaky on this machine independently of this branch — `AgentAdapterRegistryTests` fails en masse with a uniform ~79.8s timeout under the parallel run, while passing in 0.016s in isolation. Baseline `4320b16` (clean main) produced **56** such failures against **28** on this branch, so the flakiness is pre-existing and not introduced here. CI is the arbiter.

## Follow-ups filed

- #1354 — one summary quit sheet instead of one per project; deadline should bound machine work only, not user deliberation; `Quit Anyway` instead of a hard refusal.
- #1355 — Dock badge for live agents, `disableSuddenTermination`, and the missing `willPresent` that suppresses agent notification banners while Pine is frontmost.

## Ready to merge

Once CI is fully green.