### PR TITLE
chore(deps): bump SwiftTerm 1.15.0 → 1.16.0

### DIFF
--- a/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/migueldeicaza/SwiftTerm.git",
       "state" : {
-        "revision" : "dd2fb8ac5b861e7bf617c872895e338f38165648",
-        "version" : "1.15.0"
+        "revision" : "3917686ea5f5527c5451aaf371bd90bf3618aa71",
+        "version" : "1.16.0"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Bumps SwiftTerm from 1.15.0 to 1.16.0 (29 commits). SwiftTerm's `upToNextMajorVersion` requirement (`1.5.0..<2.0.0`) already permits 1.16.0, so this only touches `Package.resolved`.

Notable upstream changes in 1.16.0:
- Bidirectional text rendering (Arabic / Hebrew) via terminal-wg escapes
- Render Powerline separators as cell geometry
- Fix sixel crash; replace `abort()`/force-unwraps in `CircularList` with precondition checks (#609)
- Avoid force-casting `CTRun` font/color attributes (#610)
- Fix catastrophic backtracking in implicit link detection (#613)
- Fix cell width rounding (excess spacing) and cross-terminal hyperlink GC; make `TinyAtom` thread-safe (#611)
- Translate selections when rows move in place (#616)
- Ignore `DECCOLM` unless the application asks for it, like xterm (#618)

## What changed

- `Package.resolved`: `swiftterm` pin `1.15.0` → `1.16.0` (revision `dd2fb8a` → `3917686`).

No code changes required — Pine's SwiftTerm call sites compile unchanged against the new API surface.

## Verification

- `xcodebuild -resolvePackageDependencies` → Sparkle @ 2.9.5, SwiftTerm @ 1.16.0
- `xcodebuild build` (scheme `Pine`, platform macOS) → `** BUILD SUCCEEDED **` on SwiftTerm 1.16.0
- `swiftlint` → clean for source files (remaining warnings are pre-existing generated-file noise under `build/`)
- Terminal theme/palette unit tests → `Test run with 69 tests in 3 suites passed` (`TerminalThemeTests`, `TerminalPaletteTests`, `TerminalThemeSettingsTests`, `DigitalRainThemeTests`)

## Notes

- `useBrightColors = false` behavior (the 256-color index 8 → 0 collapse that drives the Nord-light ghost-text defect in #1350) is unchanged in 1.16.0; #1350 is unaffected by this bump and tracked separately.
- The local working tree had an accidental Sparkle downgrade (`2.9.5 → 2.9.4`) alongside this bump; it was reverted so the diff is SwiftTerm-only.
