### PR TITLE
chore: resolve remaining compiler warnings across Pine

### DIFF
--- a/Pine/EditorTabBar.swift
+++ b/Pine/EditorTabBar.swift
@@ -409,8 +409,7 @@ struct EditorTabBar: View {
                             paneManager.selectEditorTab(tab.id, in: paneID)
                         } label: {
                             Label {
-                                Text(tab.fileName)
-                                    + Text(tab.isDirty ? " \u{25CF}" : "")
+                                Text("\(tab.fileName)\(tab.isDirty ? " \u{25CF}" : "")")
                             } icon: {
                                 Image(systemName: tab.isPinned
                                       ? "pin.fill"

--- a/Pine/LSP/LSPClient.swift
+++ b/Pine/LSP/LSPClient.swift
@@ -319,11 +319,14 @@ nonisolated final class LSPTransport: @unchecked Sendable {
     /// Writes a framed JSON-RPC message to the server's stdin.
     /// No-op when the process is not running.
     func send(_ payload: [String: Any]) {
+        // Box as @unchecked Sendable so the payload can cross the
+        // nonisolated ioQueue boundary (see `deliver` / `SendableJSONBox`).
+        let box = SendableJSONBox(payload)
         ioQueue.async { [weak self] in
             guard let self,
                   let pipe = self.stdinPipe,
                   self.process?.isRunning == true else { return }
-            let framed = LSPMessageFraming.frame(payload)
+            let framed = LSPMessageFraming.frame(box.value)
             do {
                 try pipe.fileHandleForWriting.write(contentsOf: framed)
             } catch {
@@ -1349,7 +1352,10 @@ extension LSPClient: LSPClientProtocol {
 }
 
 /// Error wrapping a JSON-RPC error object.
-nonisolated struct LSPError: Error {
+nonisolated struct LSPError: Error, @unchecked Sendable {
+    // `@unchecked Sendable`: the `[String: Any]` JSON-RPC error object is not
+    // statically Sendable (`Any` cannot be), but it is a freshly decoded,
+    // effectively-immutable payload — same pattern as `SendableJSONBox`.
     let error: [String: Any]
 }
 

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -713,15 +713,21 @@ final class PaneManager {
     // they can be touched from `deinit`, which is nonisolated even on a
     // @MainActor class. All real reads/writes happen on the main thread.
 
+    // `@ObservationIgnored` + `nonisolated(unsafe)`: this is internal cleanup
+    // state, not UI-observable. Without `@ObservationIgnored` the `@Observable`
+    // macro manages the property and warns "`nonisolated(unsafe)` has no
+    // effect"; `nonisolated` alone is illegal on a mutable stored property.
+    // Excluded from observation so `nonisolated(unsafe)` takes effect and
+    // `deinit` can touch it.
     /// NSEvent monitor for mouse-up cleanup of drop overlays (in-app).
-    nonisolated(unsafe) private var mouseUpMonitor: Any?
+    @ObservationIgnored nonisolated(unsafe) private var mouseUpMonitor: Any?
 
     /// NSEvent monitor for mouse-up cleanup that fires even when the cursor
     /// is released outside the app window.
-    nonisolated(unsafe) private var globalMouseUpMonitor: Any?
+    @ObservationIgnored nonisolated(unsafe) private var globalMouseUpMonitor: Any?
 
     /// Notification observers for window/app deactivation cleanup.
-    nonisolated(unsafe) private var deactivationObservers: [NSObjectProtocol] = []
+    @ObservationIgnored nonisolated(unsafe) private var deactivationObservers: [NSObjectProtocol] = []
 
     /// Provider that returns `true` when the user is currently holding any
     /// mouse button down (i.e. a drag is potentially in progress).
@@ -764,23 +770,29 @@ final class PaneManager {
     /// Polling timer that periodically checks whether stale overlays should
     /// be cleared. Started lazily when an overlay first appears, stopped when
     /// none remain. ~120ms cadence keeps overhead negligible.
-    nonisolated(unsafe) private var staleDropPollTimer: Timer?
+    @ObservationIgnored nonisolated(unsafe) private var staleDropPollTimer: Timer?
 
     /// Starts the stale-overlay polling timer if not already running.
     /// Called by drop delegates whenever they set a drop zone.
     func startStaleDropPollingIfNeeded() {
         guard staleDropPollTimer == nil else { return }
         // Timer scheduled on the main run loop fires on the main thread, and
-        // PaneManager is @MainActor, so no extra DispatchQueue.main.async hop
-        // is needed inside the callback.
+        // PaneManager is @MainActor. `MainActor.assumeIsolated` asserts that
+        // main-thread invariant for the compiler so isolated members can be
+        // touched without a `DispatchQueue.main.async` hop. The non-Sendable
+        // `Timer` argument is kept out of the @MainActor closure and
+        // invalidated in the outer callback based on the returned flag.
         let timer = Timer.scheduledTimer(withTimeInterval: 0.12, repeats: true) { [weak self] t in
-            guard let self else { t.invalidate(); return }
-            if !self.hasActiveDropZones {
-                t.invalidate()
-                self.staleDropPollTimer = nil
-                return
+            let stop = MainActor.assumeIsolated {
+                guard let self else { return true }
+                if !self.hasActiveDropZones {
+                    self.staleDropPollTimer = nil
+                    return true
+                }
+                self.clearStaleDropZonesIfNoDragActive()
+                return false
             }
-            self.clearStaleDropZonesIfNoDragActive()
+            if stop { t.invalidate() }
         }
         staleDropPollTimer = timer
     }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -1699,7 +1699,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
            ) {
             window.makeKeyAndOrderFront(nil)
             NSApp.activate()
-            registry.projectManager(for: canonical)
+            // Touch the registered project manager (no-op side effect; result
+            // intentionally unused) so the Open Recent path mirrors the normal
+            // open path that resolves the manager for the canonical URL.
+            _ = registry.projectManager(for: canonical)
             hideWelcome()
             return true
         }

--- a/Pine/ToastManager.swift
+++ b/Pine/ToastManager.swift
@@ -37,7 +37,7 @@ struct ToastItem: Identifiable, Equatable {
 /// Posts a VoiceOver/screen-reader announcement. Extracted as a typealias so
 /// tests can inject a recorder without reaching into `NSAccessibility` (which
 /// is a no-op outside an app process). Always invoked on the main actor.
-typealias ToastAnnouncer = @Sendable (String) -> Void
+typealias ToastAnnouncer = @MainActor @Sendable (String) -> Void
 
 /// Manages a FIFO queue of toast notifications with auto-dismiss.
 @MainActor


### PR DESCRIPTION
Closes #1358

## Summary

Clears the remaining compiler warnings so Pine builds warning-free under the current Xcode beta. Five source-level fixes:

| File | Warning | Fix |
|---|---|---|
| `EditorTabBar.swift` | deprecated `Text + Text` concatenation | string interpolation `Text("\(fileName)\(...)")` |
| `LSPClient.swift` | non-Sendable `payload` captured in `@Sendable` ioQueue closure; `LSPError` stores non-Sendable `[String: Any]` | box payload in `SendableJSONBox` before the closure; mark `LSPError` `@unchecked Sendable` |
| `PaneManager.swift` | `nonisolated(unsafe)` has no effect on `@Observable`-managed properties; polling `Timer` touches main-actor members | mark drag-cleanup props `@ObservationIgnored` (internal cleanup state) so `nonisolated(unsafe)` takes effect for `deinit`; wrap timer callback in `MainActor.assumeIsolated`, keep non-Sendable `Timer` arg out of the @MainActor closure |
| `PineApp.swift` | unused result of `projectManager(for:)` | `_ =` (intentional no-op side effect in Open Recent) |
| `ToastManager.swift` | default `announce` closure references `NSApp` from a nonisolated context | make `ToastAnnouncer` `@MainActor @Sendable` (default closure already runs on the main actor) |

## Design notes

- The `PaneManager` fix required the most thought. The drag-cleanup properties (`mouseUpMonitor`, `globalMouseUpMonitor`, `deactivationObservers`, `staleDropPollTimer`) are internal cleanup state touched from `deinit` — they were never meant to drive UI observation. The compiler warned that `nonisolated(unsafe)` "has no effect" because the `@Observable` macro manages them, but the suggested alternative (`nonisolated`) is illegal on mutable stored properties. `@ObservationIgnored` is the semantically correct answer: it opts the properties out of observation tracking so `nonisolated(unsafe)` behaves as intended for `deinit` access.
- The polling `Timer` callback runs on the main run loop (already documented in the code), so `MainActor.assumeIsolated` asserts that invariant for the compiler rather than adding a real `DispatchQueue.main.async` hop. The non-Sendable `Timer` argument is kept out of the @MainActor closure and invalidated in the outer callback based on a returned flag.
- `ToastAnnouncer` was already documented as "always invoked on the main actor"; making it `@MainActor @Sendable` just encodes that in the type. Test-injected recorders inherit `@MainActor` from the assignment context.

## Verification

- `xcodebuild build` — **warning-free and error-free** in `Pine/` sources.
- `swiftlint lint` on all 5 touched files — 0 violations.
- `xcodebuild build-for-testing` — test target compiles clean (covers `ToastManagerTests`, `CLIInstallerTests`, `UserConfigurationAlertPresenterTests` which assign `announce`).
- `ToastManagerTests` — **20/20 passed**.

## Notes

- `LSPClient.swift:326` (`send` payload) did not appear in the first incremental build log but surfaced on the clean rebuild — it is fixed here.
- SwiftLint warnings on `build/.../Generated*.swift` are Xcode-generated files under `build/` (gitignored) and out of scope.

## When this is ready to merge

Already ready — build is warning-free, SwiftLint clean, relevant tests pass. Merging requires the human reviewer; CI must be fully green first.
