### PR TITLE
fix(agent): surface background agent work via Dock badge, guard, and foreground banners

### DIFF
--- a/Pine/Agent/AgentNotificationController.swift
+++ b/Pine/Agent/AgentNotificationController.swift
@@ -47,6 +47,20 @@ final class SystemAgentNotificationCenter: NSObject,
     static let openActionIdentifier = "pine.agent.open"
     static let muteActionIdentifier = "pine.agent.mute"
 
+    /// Presentation options requested while Pine is frontmost. The system
+    /// default suppresses banners for the active app, so without
+    /// ``userNotificationCenter(_:willPresent:withCompletionHandler:)`` the
+    /// notifications a backgrounded project produced accumulate unseen in
+    /// Notification Center and surface as a burst once Pine stops being
+    /// frontmost (#1355).
+    ///
+    /// Suppression of an already-visible route stays with
+    /// `AgentNotificationController.process`, which skips delivery entirely
+    /// when `isPresented(taskID)` is true; that path never reaches
+    /// `willPresent`. The options here therefore always request the full set.
+    nonisolated static let foregroundPresentationOptions:
+        UNNotificationPresentationOptions = [.banner, .list, .sound]
+
     var responseHandler: ((AgentNotificationResponseAction) -> Void)?
     private let center: UNUserNotificationCenter
 
@@ -102,6 +116,15 @@ final class SystemAgentNotificationCenter: NSObject,
             content: content,
             trigger: nil
         ))
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler:
+            @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler(Self.foregroundPresentationOptions)
     }
 
     nonisolated func userNotificationCenter(

--- a/Pine/Agent/AgentPresenceController.swift
+++ b/Pine/Agent/AgentPresenceController.swift
@@ -1,0 +1,185 @@
+//
+//  AgentPresenceController.swift
+//  Pine
+//
+//  App-level visibility for background agent work (#1355).
+//
+//  Closing a project window backgrounds the project but keeps its terminals
+//  and agents alive (`ProjectRegistry.closeProjectWindow`). Without a surface
+//  that survives the last window, "I closed everything" silently becomes a
+//  lie. This controller drives three macOS-visible signals from the same
+//  `AgentTaskRegistry` mutation stream that feeds the per-window Agent Inbox
+//  badge (#1337):
+//
+//    1. `NSApp.dockTile.badgeLabel` — the live agent-run count.
+//    2. The sudden-termination guard — balanced across run start/stop cycles.
+//
+//  The Dock menu entries are built by `AppDelegate.applicationDockMenu`,
+//  which reads the same registry through ``liveTasks(for:)`` below.
+//
+
+import AppKit
+import Foundation
+
+/// Testable side-effect seam for the Dock tile and the sudden-termination
+/// guard. The production implementation touches `NSApp` and `ProcessInfo`;
+/// tests inject a recording double to assert balanced calls and the exact
+/// badge value without depending on AppKit state.
+@MainActor
+protocol AgentPresenceApplier: AnyObject {
+    /// Sets the Dock badge to the live agent-run count. `0` clears it.
+    func setDockBadge(count: Int)
+    /// Disables sudden termination while at least one agent run is live and
+    /// re-enables it when the last one ends. Calls must stay balanced.
+    func setSuddenTerminationDisabled(_ disabled: Bool)
+}
+
+/// Production applier: writes `NSApp.dockTile.badgeLabel` and toggles the
+/// sudden-termination guard on `ProcessInfo`. Both are main-thread surfaces.
+@MainActor
+final class AppKitAgentPresenceApplier: AgentPresenceApplier {
+    func setDockBadge(count: Int) {
+        // `badgeLabel` is `String?`. Setting `nil` removes the badge; a numeric
+        // string renders as the red Dock counter. Assigning the property
+        // redisplays the tile, so no explicit `display()` is required.
+        NSApp.dockTile.badgeLabel = count > 0 ? String(count) : nil
+    }
+
+    func setSuddenTerminationDisabled(_ disabled: Bool) {
+        // Pine does not opt into sudden termination via Info.plist
+        // (`NSSupportsSuddenTermination`), so these calls are forward-
+        // compatible protection rather than an active toggle today: if Pine
+        // ever enables it (or a system heuristic considers it), live agents
+        // are never killed at logout/restart without the quit handshake.
+        // The controller keeps its own bookkeeping so the paired calls always
+        // balance to the agent-run lifecycle, never to each mutation.
+        if disabled {
+            ProcessInfo.processInfo.disableSuddenTermination()
+        } else {
+            ProcessInfo.processInfo.enableSuddenTermination()
+        }
+    }
+}
+
+/// Drives app-level visibility for background agent work from a single
+/// `AgentTaskRegistry` observer.
+///
+/// One mutation rebuilds the live-run count and applies both signals in a
+/// single pass. The live-run definition matches the Inbox `working` section
+/// (`AgentInboxSnapshot`): `lifecycle == .active` with a live latest run,
+/// regardless of window state, so a backgrounded project is still counted.
+@MainActor
+final class AgentPresenceController {
+    private let registry: AgentTaskRegistry
+    private let applier: any AgentPresenceApplier
+    private var observerToken: UUID?
+    private var isRunning = false
+    // `-1` forces the first pass to publish even when the initial count is 0.
+    private var lastLiveCount = -1
+    private var suddenTerminationDisabled = false
+
+    init(
+        registry: AgentTaskRegistry,
+        applier: any AgentPresenceApplier = AppKitAgentPresenceApplier()
+    ) {
+        self.registry = registry
+        self.applier = applier
+    }
+
+    func start() {
+        guard !isRunning else { return }
+        isRunning = true
+        observerToken = registry.addTaskChangeObserver { [weak self] _, tasks in
+            self?.apply(tasks: tasks)
+        }
+        // Seed the initial state so a relaunch with durable, still-live tasks
+        // re-arms the badge and guard without waiting for the next mutation.
+        apply(tasks: registry.tasks)
+    }
+
+    func stop() {
+        guard isRunning else { return }
+        isRunning = false
+        if let observerToken { registry.removeTaskChangeObserver(observerToken) }
+        observerToken = nil
+        // Restore the baseline so a stop/start cycle never leaves the guard
+        // disabled or a stale badge on the Dock.
+        if suddenTerminationDisabled {
+            suddenTerminationDisabled = false
+            applier.setSuddenTerminationDisabled(false)
+        }
+        if lastLiveCount != 0 {
+            lastLiveCount = 0
+            applier.setDockBadge(count: 0)
+        }
+        lastLiveCount = -1
+    }
+
+    /// Pure projection: the number of agent runs currently executing across
+    /// every project, including backgrounded ones. Mirrors the Inbox
+    /// `working` section exactly so the Dock badge and the Inbox agree.
+    nonisolated static func liveAgentRunCount(_ tasks: [AgentTask]) -> Int {
+        tasks.count { task in
+            task.lifecycle == .active && task.runs.last?.liveness == .live
+        }
+    }
+
+    /// Pure projection of the live agent tasks the Dock menu should list, in
+    /// the same newest-first order the Inbox `working` section renders, capped
+    /// so an extreme fleet does not overflow the Dock menu.
+    nonisolated static func liveTasks(
+        for tasks: [AgentTask],
+        limit: Int = 10
+    ) -> [AgentTask] {
+        let live = tasks.filter {
+            $0.lifecycle == .active && $0.runs.last?.liveness == .live
+        }
+        let sorted = live.sorted(by: Self.rowPrecedes)
+        return sorted.count > limit ? Array(sorted.prefix(limit)) : sorted
+    }
+
+    /// Dock menu title for a live agent task: agent name, objective, and the
+    /// owning project's display name. Proper nouns are not localized, matching
+    /// `recentProjectDisplayTitle`, so the title reads the same in any locale.
+    /// `@MainActor` because `AgentDescriptor.agentType` resolves through the
+    /// compatibility catalog on the main actor.
+    static func dockMenuAgentTitle(for task: AgentTask) -> String {
+        let agent = task.descriptor.agentType.displayName
+        let projectName = URL(
+            fileURLWithPath: task.project.canonicalProjectPath
+        ).lastPathComponent
+        let trimmedTitle = task.title?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmedTitle, !trimmedTitle.isEmpty {
+            return "\(agent) — \(trimmedTitle) — \(projectName)"
+        }
+        return "\(agent) — \(projectName)"
+    }
+
+    private func apply(tasks: [AgentTask]) {
+        guard isRunning else { return }
+        let count = Self.liveAgentRunCount(tasks)
+        guard count != lastLiveCount else { return }
+        lastLiveCount = count
+        applier.setDockBadge(count: count)
+        // Disable exactly once on the 0→1 transition and re-enable exactly
+        // once when the last run ends. The controller's own boolean keeps the
+        // `ProcessInfo` reference count balanced across any sequence of
+        // start/stop/mutation, independent of how many mutations fire.
+        let shouldDisable = count > 0
+        if shouldDisable != suddenTerminationDisabled {
+            suddenTerminationDisabled = shouldDisable
+            applier.setSuddenTerminationDisabled(shouldDisable)
+        }
+    }
+
+    /// Sorts live tasks newest-first by run start, then by stable id, matching
+    /// `AgentInboxSnapshot.rowPrecedes` so the Dock list and the Inbox read in
+    /// the same order.
+    private nonisolated static func rowPrecedes(_ lhs: AgentTask, _ rhs: AgentTask) -> Bool {
+        let lhsStarted = lhs.runs.last?.startedAt ?? lhs.createdAt
+        let rhsStarted = rhs.runs.last?.startedAt ?? rhs.createdAt
+        if lhsStarted != rhsStarted { return lhsStarted > rhsStarted }
+        return lhs.id.uuidString < rhs.id.uuidString
+    }
+}

--- a/Pine/Agent/AgentPresenceController.swift
+++ b/Pine/Agent/AgentPresenceController.swift
@@ -176,7 +176,7 @@ final class AgentPresenceController {
     /// Sorts live tasks newest-first by run start, then by stable id, matching
     /// `AgentInboxSnapshot.rowPrecedes` so the Dock list and the Inbox read in
     /// the same order.
-    private nonisolated static func rowPrecedes(_ lhs: AgentTask, _ rhs: AgentTask) -> Bool {
+    nonisolated private static func rowPrecedes(_ lhs: AgentTask, _ rhs: AgentTask) -> Bool {
         let lhsStarted = lhs.runs.last?.startedAt ?? lhs.createdAt
         let rhsStarted = rhs.runs.last?.startedAt ?? rhs.createdAt
         if lhsStarted != rhsStarted { return lhsStarted > rhsStarted }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -874,6 +874,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         }
     )
 
+    /// Application-wide visibility for background agent work: the Dock badge
+    /// and a balanced sudden-termination guard (#1355). Driven from the same
+    /// `AgentTaskRegistry` stream as the per-window Inbox badge (#1337), so
+    /// the count includes backgrounded projects whose windows have closed.
+    lazy var agentPresence = AgentPresenceController(
+        registry: registry.agentTasks
+    )
+
     // MARK: - Quick terminal (#1113)
 
     /// Owner of the global drop-down terminal session + its system-wide hotkey.
@@ -1222,6 +1230,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSWindow.allowsAutomaticWindowTabbing = false
         agentNotifications.start()
+        agentPresence.start()
 
         // The key-down half is routed through the single precedence monitor
         // below; this installs Control-release and owner-window cancellation.
@@ -1747,8 +1756,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
 
     func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
         let menu = NSMenu()
+
+        // Live agent runs are reachable with no window open (#1355). Each
+        // entry opens the Agent Inbox, the single surface that resumes,
+        // navigates, and dismisses a backgrounded task. Per-task terminal
+        // focus from the Dock is a follow-up.
+        let liveTasks = AgentPresenceController.liveTasks(for: registry.agentTasks.tasks)
+        for task in liveTasks {
+            let item = NSMenuItem(
+                title: AgentPresenceController.dockMenuAgentTitle(for: task),
+                action: #selector(dockMenuOpenAgentTask(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.representedObject = task.id
+            menu.addItem(item)
+        }
+        if !liveTasks.isEmpty {
+            menu.addItem(.separator())
+        }
+
         let projects = Array(registry.recentProjects.prefix(10))
-        guard !projects.isEmpty else { return nil }
         for url in projects {
             let title = ProjectRegistry.recentProjectDisplayTitle(for: url)
             let item = NSMenuItem(title: title, action: #selector(dockMenuOpenProject(_:)), keyEquivalent: "")
@@ -1756,7 +1784,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             item.representedObject = url
             menu.addItem(item)
         }
-        return menu
+        return menu.items.isEmpty ? nil : menu
     }
 
     @objc func dockMenuOpenProject(_ sender: NSMenuItem) {
@@ -1764,8 +1792,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         requestOpenRecentProject(url)
     }
 
+    @objc func dockMenuOpenAgentTask(_ sender: NSMenuItem) {
+        // The represented taskID is captured for a future per-task focus
+        // path; today every entry routes to the Inbox so a background agent
+        // is reachable the instant Pine has no open window.
+        showAgentInbox()
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         agentNotifications.stop()
+        agentPresence.stop()
         // Save sessions before terminating processes.
         for (_, pm) in registry.openProjects {
             pm.finalizeAgentSessionsForHistory()
@@ -1824,7 +1860,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             let shouldTerminate = await confirmApplicationTermination()
             terminationDecisionTask = nil
             isTerminating = shouldTerminate
-            if shouldTerminate { agentNotifications.stop() }
+            if shouldTerminate {
+                agentNotifications.stop()
+                agentPresence.stop()
+            }
             reply(shouldTerminate)
         }
         return .terminateLater

--- a/PineTests/AgentPresenceTests.swift
+++ b/PineTests/AgentPresenceTests.swift
@@ -1,0 +1,214 @@
+//
+//  AgentPresenceTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+import UserNotifications
+@testable import Pine
+
+@MainActor
+struct AgentPresenceTests {
+    // MARK: - Dock badge + sudden-termination guard (#1355)
+
+    @Test("Dock badge tracks the live-run count, including backgrounded projects")
+    func badgeTracksLiveRunCount() {
+        let registry = AgentTaskRegistry()
+        let applier = RecordingAgentPresenceApplier()
+        let controller = AgentPresenceController(
+            registry: registry,
+            applier: applier
+        )
+        controller.start()
+        // start() seeds the empty baseline: badge cleared, guard untouched.
+        #expect(applier.badgeCounts == [0])
+        #expect(applier.suddenTerminationCalls.isEmpty)
+
+        // A backgrounded project (window closed → availability .background)
+        // is still executing and must still be counted, so closing every
+        // window never makes live agents invisible.
+        let backgrounded = makeTask(seed: 1, availability: .background)
+        let live = makeTask(seed: 2)
+        registry.setTasksForTesting([backgrounded, live])
+
+        #expect(applier.badgeCounts.last == 2)
+        #expect(applier.suddenTerminationCalls == [true])
+
+        // The last run ending clears the badge and re-enables termination.
+        registry.setTasksForTesting([])
+        #expect(applier.badgeCounts.last == 0)
+        #expect(applier.suddenTerminationCalls == [true, false])
+        controller.stop()
+    }
+
+    @Test("sudden-termination guard stays balanced across run and controller cycles")
+    func suddenTerminationBalanced() {
+        let registry = AgentTaskRegistry()
+        let applier = RecordingAgentPresenceApplier()
+        let controller = AgentPresenceController(
+            registry: registry,
+            applier: applier
+        )
+        controller.start()
+
+        // 0 -> 1 -> 0 -> 1, then stop.
+        registry.setTasksForTesting([makeTask(seed: 1)])
+        registry.setTasksForTesting([])
+        registry.setTasksForTesting([makeTask(seed: 2)])
+        controller.stop()
+
+        let calls = applier.suddenTerminationCalls
+        // Every disable is paired with a later enable — balanced to the run
+        // lifecycle, never to each mutation.
+        #expect(calls.filter { $0 }.count == calls.filter { !$0 }.count)
+        // Disables first, ends enabled, strictly alternating.
+        #expect(calls.first == true)
+        #expect(calls.last == false)
+        #expect(zip(calls, calls.dropFirst()).allSatisfy { $0.0 != $0.1 })
+        // A redundant mutation (same count) never reaches the applier.
+        #expect(applier.badgeCounts.filter { $0 == 1 }.count == 2)
+        // stop() always restores the baseline.
+        #expect(applier.badgeCounts.last == 0)
+    }
+
+    @Test("identical live-run counts do not re-publish the badge")
+    func noRedundantPublish() {
+        let registry = AgentTaskRegistry()
+        let applier = RecordingAgentPresenceApplier()
+        let controller = AgentPresenceController(
+            registry: registry,
+            applier: applier
+        )
+        controller.start()
+
+        // Two distinct tasks, same live count → badge published once for 1.
+        registry.setTasksForTesting([makeTask(seed: 1)])
+        registry.setTasksForTesting([makeTask(seed: 2)])
+        #expect(applier.badgeCounts == [0, 1])
+        #expect(applier.suddenTerminationCalls == [true])
+        controller.stop()
+    }
+
+    // MARK: - Foreground notification presentation (#1355, gap 3)
+
+    @Test("foreground notifications request banner, list, and sound while frontmost")
+    func willPresentRequestsBanner() {
+        let options = SystemAgentNotificationCenter.foregroundPresentationOptions
+        #expect(options.contains(.banner))
+        #expect(options.contains(.list))
+        #expect(options.contains(.sound))
+    }
+
+    // MARK: - Dock menu projection (#1355)
+
+    @Test("Dock menu lists only live runs, newest-first, with a stable title")
+    func dockMenuProjection() {
+        let older = makeTask(seed: 1, title: "Older task")
+        let newer = makeTask(seed: 2, title: "Newer task")
+        let terminated = makeTask(
+            seed: 3,
+            liveness: .terminated,
+            lifecycle: .paused,
+            title: "Ended"
+        )
+        let tasks = [older, newer, terminated]
+
+        #expect(AgentPresenceController.liveAgentRunCount(tasks) == 2)
+
+        let live = AgentPresenceController.liveTasks(for: tasks)
+        #expect(live.map(\.id) == [newer.id, older.id])
+        #expect(!live.contains { $0.id == terminated.id })
+
+        let titled = AgentPresenceController.dockMenuAgentTitle(for: newer)
+        // agent — objective — project
+        #expect(titled.components(separatedBy: " — ").count == 3)
+        #expect(titled.contains("Codex"))
+        #expect(titled.contains("Newer task"))
+        #expect(titled.contains("presence-demo"))
+
+        // No objective collapses to agent — project only.
+        let untitled = AgentPresenceController.dockMenuAgentTitle(
+            for: makeTask(seed: 4, title: nil)
+        )
+        #expect(untitled.components(separatedBy: " — ").count == 2)
+        #expect(untitled.contains("Codex"))
+        #expect(untitled.contains("presence-demo"))
+
+        // A large fleet is capped so the Dock menu cannot overflow.
+        let fleet = (1...25).map { makeTask(seed: $0) }
+        #expect(AgentPresenceController.liveTasks(for: fleet).count == 10)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeTask(
+        seed: Int,
+        agentType: AgentType = .codex,
+        state: AgentRunState = .executing,
+        liveness: AgentRunLiveness = .live,
+        lifecycle: AgentTaskLifecycle = .active,
+        availability: AgentTaskRouteAvailability = .available,
+        title: String? = "Review tests",
+        project: String = "/tmp/presence-demo"
+    ) -> AgentTask {
+        let route = AgentTaskRoute(
+            paneID: uuid(seed),
+            tabID: uuid(seed + 1),
+            terminalID: uuid(seed + 1),
+            availability: availability
+        )
+        let started = Date(timeIntervalSince1970: TimeInterval(1_000 + seed))
+        let context = AgentTaskBridgeContext(
+            project: AgentTaskProjectIdentity(
+                canonicalProjectPath: project,
+                canonicalWorktreePath: project
+            ),
+            route: route,
+            origin: .discoveredInTerminal,
+            observedAt: started
+        )
+        var task = AgentTask(
+            descriptor: AgentDescriptor(agentType: agentType),
+            context: context,
+            title: title
+        )
+        task.lifecycle = lifecycle
+        task.runs = [AgentTaskRun(AgentTaskRunInput(
+            id: uuid(seed + 100),
+            terminalID: route.terminalID,
+            process: AgentProcessEvidence(
+                processIdentifier: Int32(seed),
+                processGeneration: UInt64(seed),
+                startIdentifier: "presence-\(seed)",
+                observedStartedAt: started,
+                startIsAuthoritative: true
+            ),
+            status: AgentTaskRunStatus(
+                state: state,
+                liveness: liveness,
+                observedAt: started
+            )
+        ))]
+        return task
+    }
+
+    private func uuid(_ seed: Int) -> UUID {
+        let suffix = String(format: "%012llX", UInt64(seed))
+        return UUID(uuidString: "00000000-0000-0000-0000-\(suffix)") ?? UUID()
+    }
+}
+
+@MainActor
+private final class RecordingAgentPresenceApplier: AgentPresenceApplier {
+    private(set) var badgeCounts: [Int] = []
+    private(set) var suddenTerminationCalls: [Bool] = []
+
+    func setDockBadge(count: Int) {
+        badgeCounts.append(count)
+    }
+
+    func setSuddenTerminationDisabled(_ disabled: Bool) {
+        suddenTerminationCalls.append(disabled)
+    }
+}


### PR DESCRIPTION
Closes #1355.

## Summary

Closing a project window backgrounds the project but keeps its terminals and agents alive (`ProjectRegistry.closeProjectWindow`). With every window closed the user believed Pine was idle while agents kept executing. This PR closes the three concrete gaps from the issue, all driven from the same `AgentTaskRegistry` mutation stream that feeds the per-window Agent Inbox badge (#1337):

1. **Dock badge.** `NSApp.dockTile.badgeLabel` now shows the live agent-run count (including backgrounded projects) and clears at zero. New `AgentPresenceController` observes the registry and applies the badge in a single pass per mutation.
2. **Sudden-termination guard.** `ProcessInfo.disableSuddenTermination()` is balanced across run start/stop cycles — disabled on the 0→1 transition, re-enabled when the last run ends — so logout/restart cannot kill agents without the quit handshake. The controller's own bookkeeping keeps the paired calls balanced regardless of how many mutations fire.
3. **Foreground banners.** `SystemAgentNotificationCenter` now implements `userNotificationCenter(_:willPresent:withCompletionHandler:)` returning `[.banner, .list, .sound]`. Suppression of an already-visible route stays with the existing `isPresented` check in `AgentNotificationController.process`, so that path never reaches `willPresent`.

The **Dock menu** also lists live agent runs (capped, newest-first, matching the Inbox `working` section order) so a background agent is reachable with no window open; each entry opens the Agent Inbox. Per-task terminal focus from the Dock is recorded as a follow-up.

The sudden-termination calls are forward-compatible protection: Pine does not opt into sudden termination via `NSSupportsSuddenTermination` in `Info.plist`, so they are inert today but correct and protective the moment that ever changes.

## Files changed

- `Pine/Agent/AgentPresenceController.swift` *(new)* — `AgentPresenceApplier` protocol, `AppKitAgentPresenceApplier`, `AgentPresenceController`, plus pure projections (`liveAgentRunCount`, `liveTasks`, `dockMenuAgentTitle`).
- `Pine/Agent/AgentNotificationController.swift` — `foregroundPresentationOptions` + `willPresent` delegate method on `SystemAgentNotificationCenter`.
- `Pine/PineApp.swift` — instantiate/start/stop `AgentPresenceController`; live-agent entries in `applicationDockMenu(_:)`.
- `PineTests/AgentPresenceTests.swift` *(new)* — 6 tests.

## How to verify

- `xcodebuild build` (Xcode-beta, macOS 27 SDK) — **BUILD SUCCEEDED**.
- `AgentPresenceTests` + `AgentNotificationTests` — **13/13 pass**.
- `AgentInboxTests` — **10/10 pass** (no regression in the shared snapshot/projection path).
- SwiftLint — 0 violations on all touched files.

## Manual follow-ups (not in scope)

- Launch Pine, start an agent, close the project window → Dock badge should show `1`; reopen → badge clears when the run ends.
- Trigger an agent notification while Pine is frontmost → banner should now appear immediately instead of batching into Notification Center.
- Per-task terminal focus from the Dock menu entry (today every entry opens the Inbox).
