### PR TITLE
fix: aggregate quit confirmation across projects

### DIFF
--- a/Pine/AlertTemplate.swift
+++ b/Pine/AlertTemplate.swift
@@ -41,8 +41,14 @@ enum AlertTemplate: Sendable, Equatable {
     /// Quit / Cancel  — quitting the app with active terminal processes.
     case terminalActiveProcessWarning
 
-    /// OK — Quit is refused while a user task still owns an execution.
+    /// Review / Quit Anyway / Cancel — one app-wide summary for Quit.
+    case applicationQuitSummary
+
+    /// Quit Anyway / Cancel — stopping user tasks after opt-in review.
     case activeUserTasksPreventQuit
+
+    /// OK — machine work could not complete within the Quit budget.
+    case applicationQuitFailure
 
     // MARK: - External changes
 
@@ -231,7 +237,8 @@ extension AlertTemplate {
             return .critical
         case .unsavedChangesSingle, .unsavedChangesBulk,
              .terminalTabCloseWarning, .terminalActiveProcessWarning,
-             .activeUserTasksPreventQuit,
+             .applicationQuitSummary, .activeUserTasksPreventQuit,
+             .applicationQuitFailure,
              .externalModifyConflict, .fileDeletedSaveAs,
              .fileOperationErrorWarning, .largeFileWarning,
              .branchUncommittedChanges, .revertAllConfirmation:
@@ -250,7 +257,15 @@ extension AlertTemplate {
             return [Strings.terminalTabCloseWarningClose, Strings.dialogCancel]
         case .terminalActiveProcessWarning:
             return [Strings.terminalActiveProcessWarningQuit, Strings.dialogCancel]
+        case .applicationQuitSummary:
+            return [
+                Strings.applicationQuitReview,
+                Strings.applicationQuitAnyway,
+                Strings.dialogCancel,
+            ]
         case .activeUserTasksPreventQuit:
+            return [Strings.applicationQuitAnyway, Strings.dialogCancel]
+        case .applicationQuitFailure:
             return [Strings.dialogOK]
         case .externalModifyConflict:
             return [Strings.externalModifyReload, Strings.externalModifyKeep]
@@ -285,7 +300,11 @@ extension AlertTemplate {
             return [.destructive, [.default, .cancel]]
         case .terminalActiveProcessWarning:
             return [.destructive, [.default, .cancel]]
+        case .applicationQuitSummary:
+            return [.default, .destructive, .cancel]
         case .activeUserTasksPreventQuit:
+            return [.destructive, [.default, .cancel]]
+        case .applicationQuitFailure:
             return [.default]
         case .externalModifyConflict:
             // Reload discards local edits (destructive); Keep is the safe default.

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -11249,6 +11249,366 @@
         }
       }
     },
+    "quit.failure.message": {
+      "comment": "Alert message when Pine cannot safely finish bounded machine work during Quit.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine konnte den Zustand nicht sicher speichern oder laufende Arbeiten beenden. Prüfen Sie die betroffenen Projekte und versuchen Sie es erneut."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine couldn’t safely finish saving state or stopping running work. Review the affected projects and try again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine no pudo terminar de guardar el estado o detener el trabajo en curso de forma segura. Revisa los proyectos afectados e inténtalo de nuevo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine n’a pas pu terminer en toute sécurité l’enregistrement de l’état ou l’arrêt du travail en cours. Vérifiez les projets concernés et réessayez."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine は状態の保存または実行中の作業の停止を安全に完了できませんでした。対象のプロジェクトを確認して、もう一度お試しください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine이 상태 저장 또는 실행 중인 작업 중지를 안전하게 완료하지 못했습니다. 영향을 받는 프로젝트를 검토한 후 다시 시도하세요."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Pine não conseguiu concluir com segurança o salvamento do estado ou a interrupção do trabalho em execução. Revise os projetos afetados e tente novamente."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine не удалось безопасно завершить сохранение состояния или остановку выполняющейся работы. Проверьте затронутые проекты и повторите попытку."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine 无法安全地完成状态保存或停止正在运行的工作。请检查受影响的项目后重试。"
+          }
+        }
+      }
+    },
+    "quit.failure.title": {
+      "comment": "Alert title when bounded machine work prevents Quit from completing safely.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine konnte nicht beendet werden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine Couldn’t Quit"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine no pudo salir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine n’a pas pu quitter"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine を終了できませんでした"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine을 종료할 수 없음"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Pine não pôde sair"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось завершить Pine"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pine 无法退出"
+          }
+        }
+      }
+    },
+    "quit.summary.message %lld": {
+      "comment": "App-wide Quit summary. The value is the number of projects requiring review.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zu prüfende Projekte: %lld.\n\nPrüfen Sie jedes Projekt vor dem Beenden, oder beenden Sie trotzdem, um ungesicherte Änderungen zu verwerfen und laufende Arbeiten zu stoppen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Projects requiring attention: %lld.\n\nReview each project before quitting, or quit anyway to discard unsaved changes and stop running work."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proyectos que requieren atención: %lld.\n\nRevisa cada proyecto antes de salir o sal de todas formas para descartar los cambios sin guardar y detener el trabajo en curso."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Projets nécessitant votre attention : %lld.\n\nVérifiez chaque projet avant de quitter, ou quittez quand même pour ignorer les modifications non enregistrées et arrêter le travail en cours."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認が必要なプロジェクト：%lld。\n\n終了前に各プロジェクトを確認するか、保存されていない変更を破棄して実行中の作業を停止し、そのまま終了してください。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검토가 필요한 프로젝트: %lld.\n\n종료하기 전에 각 프로젝트를 검토하거나, 저장되지 않은 변경 사항을 버리고 실행 중인 작업을 중지한 후 종료하세요."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Projetos que precisam de atenção: %lld.\n\nRevise cada projeto antes de sair ou saia mesmo assim para descartar alterações não salvas e interromper o trabalho em execução."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проектов, требующих внимания: %lld.\n\nПроверьте каждый проект перед выходом или выйдите всё равно, чтобы отбросить несохранённые изменения и остановить выполняющуюся работу."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要检查的项目：%lld。\n\n退出前请检查每个项目，或仍然退出以丢弃未保存的更改并停止正在运行的工作。"
+          }
+        }
+      }
+    },
+    "quit.summary.quitAnyway": {
+      "comment": "Destructive button that quits while discarding changes and stopping running work.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trotzdem beenden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quit Anyway"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salir de todas formas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quitter quand même"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "そのまま終了"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "그래도 종료"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sair mesmo assim"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Всё равно выйти"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仍然退出"
+          }
+        }
+      }
+    },
+    "quit.summary.review": {
+      "comment": "Safe default button that reviews affected projects before Quit.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prüfen …"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revisar…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifier…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검토…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revisar…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查…"
+          }
+        }
+      }
+    },
+    "quit.summary.title": {
+      "comment": "Title of the single app-wide Quit summary.",
+      "extractionState": "manual",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vor dem Beenden prüfen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Review Before Quitting"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revisar antes de salir"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vérifier avant de quitter"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終了前に確認"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "종료 전 검토"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Revisar antes de sair"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка перед выходом"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出前检查"
+          }
+        }
+      }
+    },
     "recovery.discard": {
       "comment": "Button to discard recovered files after a crash.",
       "extractionState": "manual",
@@ -15414,61 +15774,61 @@
       }
     },
     "task.activePreventQuit.message": {
-      "comment": "Alert message explaining why Quit is refused while a user task owns an execution.",
+      "comment": "Alert message explaining that Quit Anyway stops active user tasks and waits for cleanup.",
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine kann nicht beendet werden, solange eine Benutzeraufgabe noch einen laufenden Prozess besitzt. Brechen Sie die Aufgabe ab und warten Sie, bis die Bereinigung abgeschlossen ist. Beenden Sie Pine anschließend erneut."
+            "value": "Beim Beenden werden aktive Benutzeraufgaben gestoppt und Pine wartet auf die Bereinigung ihrer Prozesse."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine cannot quit while a user task still owns a running process. Cancel the task and wait for cleanup to finish, then quit again."
+            "value": "Quitting will stop active user tasks and wait for their processes to finish cleanup."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine no puede salir mientras una tarea de usuario siga controlando un proceso en ejecución. Cancela la tarea y espera a que termine la limpieza; después, vuelve a salir."
+            "value": "Al salir se detendrán las tareas de usuario activas y Pine esperará a que sus procesos terminen la limpieza."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine ne peut pas quitter tant qu’une tâche utilisateur contrôle encore un processus en cours. Annulez la tâche et attendez la fin du nettoyage, puis quittez à nouveau."
+            "value": "Quitter arrêtera les tâches utilisateur actives et Pine attendra la fin du nettoyage de leurs processus."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ユーザータスクが実行中のプロセスを保持している間は Pine を終了できません。タスクをキャンセルし、クリーンアップの完了を待ってから、もう一度終了してください。"
+            "value": "終了するとアクティブなユーザータスクが停止され、Pine はそのプロセスのクリーンアップ完了を待ちます。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사용자 작업이 실행 중인 프로세스를 소유하고 있는 동안에는 Pine을 종료할 수 없습니다. 작업을 취소하고 정리가 끝날 때까지 기다린 후 다시 종료하세요."
+            "value": "종료하면 활성 사용자 작업이 중지되고 Pine은 해당 프로세스의 정리가 완료될 때까지 기다립니다."
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "O Pine não pode sair enquanto uma tarefa do usuário ainda controlar um processo em execução. Cancele a tarefa, aguarde a conclusão da limpeza e tente sair novamente."
+            "value": "Sair interromperá as tarefas de usuário ativas, e o Pine aguardará a conclusão da limpeza de seus processos."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pine не может завершить работу, пока пользовательская задача управляет запущенным процессом. Отмените задачу, дождитесь завершения очистки и повторите выход."
+            "value": "При выходе активные пользовательские задачи будут остановлены, а Pine дождётся завершения очистки их процессов."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "当用户任务仍拥有正在运行的进程时，Pine 无法退出。请取消该任务并等待清理完成，然后再次退出。"
+            "value": "退出将停止活跃的用户任务，Pine 会等待其进程完成清理。"
           }
         }
       }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -1882,6 +1882,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         )
     }
 
+    /// Captures the test override as a duration, then rebases it after the
+    /// final user decision. Human deliberation must never consume Quit's
+    /// bounded machine-work budget (#1354).
+    private func terminationWorkBudgetNanoseconds(
+        overriding deadline: DispatchTime?
+    ) -> UInt64 {
+        guard let deadline else { return 30_000_000_000 }
+        let now = DispatchTime.now().uptimeNanoseconds
+        guard now < deadline.uptimeNanoseconds else { return 0 }
+        return deadline.uptimeNanoseconds - now
+    }
+
     private func valueBeforeTerminationDeadline<Value: Sendable>(
         _ deadline: DispatchTime,
         deadlineObserver: @escaping @Sendable () -> Void,
@@ -1914,11 +1926,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         }
     }
 
-    /// Runs all quit decisions asynchronously on their owning project
-    /// windows. Background projects fall back to one captured visible
-    /// application window (normally Welcome); with no live owner, native
-    /// presentation returns `.abort` and cancels Quit. Save failures also
-    /// cancel Quit.
+    /// Presents one application-wide Quit summary. The safe Review path walks
+    /// project-owned sheets only after the user opts in; Quit Anyway captures
+    /// stable discard/process authorizations in one step. The 30-second clock
+    /// starts after all human decisions and bounds only machine work.
     func confirmApplicationTermination(
         presentAlert: TerminationAlertPresenter? = nil,
         saveAll: TerminationSaveAll? = nil,
@@ -1926,16 +1937,45 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         terminationDeadlineOverride: DispatchTime? = nil,
         terminationDeadlineObserver: @escaping @Sendable () -> Void = {}
     ) async -> Bool {
-        let terminationDeadline = terminationDeadlineOverride
-            ?? DispatchTime.now() + .seconds(30)
+        let workBudgetNanoseconds = terminationWorkBudgetNanoseconds(
+            overriding: terminationDeadlineOverride
+        )
         let projects = registry.openProjects
             .sorted { $0.key.path.localizedStandardCompare($1.key.path) == .orderedAscending }
             .map(\.value)
+        let preflightTerminalAuthorizations = Dictionary(
+            uniqueKeysWithValues: projects.map {
+                (
+                    ObjectIdentifier($0),
+                    TerminalTabCloseAuthorization.authorizing(
+                        tabs: $0.terminal.allTerminalTabs
+                    )
+                )
+            }
+        )
+        let preflightDiscardAuthorizations: [
+            ObjectIdentifier: DirtyEditorContentAuthorization
+        ] = Dictionary(
+            uniqueKeysWithValues: projects.compactMap { projectManager in
+                let dirty = projectManager.allDirtyTabs
+                guard !dirty.isEmpty else { return nil }
+                return (
+                    ObjectIdentifier(projectManager),
+                    DirtyEditorContentAuthorization(tabs: dirty)
+                )
+            }
+        )
+        let attentionProjectCount = projects.filter {
+            !$0.allDirtyTabs.isEmpty
+                || preflightTerminalAuthorizations[
+                    ObjectIdentifier($0)
+                ]?.requiresConfirmation == true
+                || $0.hasOutstandingUserTaskExecution
+        }.count
+        let requiresAttention = attentionProjectCount > 0
+            || registry.hasOutstandingUserTaskExecution
         let needsNativeDecision = presentAlert == nil
-            && (registry.hasOutstandingUserTaskExecution
-                || projects.contains {
-                    !$0.allDirtyTabs.isEmpty || $0.terminal.hasActiveProcesses
-                })
+            && requiresAttention
         if applicationContext == nil, needsNativeDecision {
             // Quit can arrive from the Dock while Pine is hidden or every
             // project is miniaturized. Restore/create a discoverable owner
@@ -1945,36 +1985,29 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         let fallbackContext = applicationContext
             ?? DialogPresenter.forApplicationWindow()
 
-        // A cancellable Quit cannot safely start TERM/KILL: a later save,
-        // metadata barrier, or authorization check may still fail, but a
-        // destroyed process cannot be rolled back. Keep execution ownership
-        // intact and require the user to cancel the task explicitly first.
-        if registry.hasOutstandingUserTaskExecution {
-            _ = await valueBeforeTerminationDeadline(
-                terminationDeadline,
-                deadlineObserver: terminationDeadlineObserver,
-                onTimeout: {
-                    guard let window = fallbackContext.nsWindow,
-                          let sheet = window.attachedSheet else { return }
-                    window.endSheet(sheet, returnCode: .abort)
-                },
-                operation: {
-                    if let presentAlert {
-                        return await presentAlert(
-                            .activeUserTasksPreventQuit,
-                            fallbackContext,
-                            Strings.activeUserTasksPreventQuitTitle,
-                            Strings.activeUserTasksPreventQuitMessage
-                        )
-                    }
-                    return await AlertTemplate.activeUserTasksPreventQuit.runSheet(
-                        on: fallbackContext,
-                        messageText: Strings.activeUserTasksPreventQuitTitle,
-                        informativeText: Strings.activeUserTasksPreventQuitMessage
-                    )
-                }
+        func presentTerminationAlert(
+            _ template: AlertTemplate,
+            context: DialogPresentationContext,
+            title: String,
+            message: String
+        ) async -> NSApplication.ModalResponse {
+            if let presentAlert {
+                return await presentAlert(template, context, title, message)
+            }
+            return await template.runSheet(
+                on: context,
+                messageText: title,
+                informativeText: message
             )
-            return false
+        }
+
+        func presentTerminationFailure() async {
+            _ = await presentTerminationAlert(
+                .applicationQuitFailure,
+                context: fallbackContext,
+                title: Strings.applicationQuitFailureTitle,
+                message: Strings.applicationQuitFailureMessage
+            )
         }
 
         var discardAuthorizations: [
@@ -1987,130 +2020,147 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         var terminalAuthorizations: [
             ObjectIdentifier: TerminalTabCloseAuthorization
         ] = [:]
+        var saveRequests: [(ProjectManager, DialogPresentationContext)] = []
+        var quitAnyway = false
+        var reviewIndividually = false
+        var mayShutdownUserTasks = false
 
-        for projectManager in projects {
-            guard registry.openProjects.values.contains(where: {
-                $0 === projectManager
-            }) else {
-                continue
-            }
-            let projectContext = DialogPresenter.forProject(projectManager)
-            let hasEligibleProjectOwner = projectContext.nsWindow.map {
-                DialogPresenter.isEligibleApplicationOwner($0)
-            } ?? false
-            let context = hasEligibleProjectOwner
-                ? projectContext
-                : fallbackContext
-            let dirty = projectManager.allDirtyTabs
-            guard !dirty.isEmpty else { continue }
-
-            let fileList = dirty.map { "  • \($0.fileName)" }.joined(separator: "\n")
-            let message = Strings.unsavedChangesListMessage(fileList)
-            let response = await valueBeforeTerminationDeadline(
-                terminationDeadline,
-                deadlineObserver: terminationDeadlineObserver,
-                onTimeout: {
-                    guard let window = context.nsWindow,
-                          let sheet = window.attachedSheet else { return }
-                    window.endSheet(sheet, returnCode: .abort)
-                },
-                operation: {
-                    if let presentAlert {
-                        return await presentAlert(
-                            .unsavedChangesBulk,
-                            context,
-                            Strings.unsavedChangesTitle,
-                            message
-                        )
-                    }
-                    return await AlertTemplate.unsavedChangesBulk.runSheet(
-                        on: context,
-                        messageText: Strings.unsavedChangesTitle,
-                        informativeText: message
-                    )
-                }
+        if requiresAttention {
+            let response = await presentTerminationAlert(
+                .applicationQuitSummary,
+                context: fallbackContext,
+                title: Strings.applicationQuitSummaryTitle,
+                message: Strings.applicationQuitSummaryMessage(
+                    max(attentionProjectCount, 1)
+                )
             )
-            guard let response else { return false }
             switch response {
             case .alertFirstButtonReturn:
-                let didSave = await valueBeforeTerminationDeadline(
-                    terminationDeadline,
-                    deadlineObserver: terminationDeadlineObserver,
-                    onTimeout: {
-                        guard let window = context.nsWindow,
-                              let sheet = window.attachedSheet else { return }
-                        window.endSheet(sheet, returnCode: .abort)
-                    },
-                    operation: {
-                        if let saveAll {
-                            return await saveAll(projectManager, context)
-                        }
-                        return await projectManager.saveAllPaneTabs(
-                            context: context
-                        )
-                    }
-                )
-                guard didSave == true else {
-                    return false
-                }
+                reviewIndividually = true
             case .alertSecondButtonReturn:
-                discardAuthorizations[ObjectIdentifier(projectManager)] =
-                    DirtyEditorContentAuthorization(tabs: dirty)
-                continue
+                quitAnyway = true
+                mayShutdownUserTasks = true
             default:
                 return false
             }
         }
 
-        for projectManager in projects {
-            guard registry.openProjects.values.contains(where: {
-                $0 === projectManager
-            }) else {
-                continue
+        if quitAnyway {
+            // The summary authorizes exactly the state that caused it to be
+            // presented. New dirty content or process generations that appear
+            // while the sheet is open still fail closed during revalidation.
+            discardAuthorizations = preflightDiscardAuthorizations
+            terminalAuthorizations = preflightTerminalAuthorizations
+        } else if reviewIndividually {
+            for projectManager in projects {
+                guard registry.openProjects.values.contains(where: {
+                    $0 === projectManager
+                }) else {
+                    continue
+                }
+                let projectContext = DialogPresenter.forProject(projectManager)
+                let hasEligibleProjectOwner = projectContext.nsWindow.map {
+                    DialogPresenter.isEligibleApplicationOwner($0)
+                } ?? false
+                let context = hasEligibleProjectOwner
+                    ? projectContext
+                    : fallbackContext
+                let dirty = projectManager.allDirtyTabs
+                guard !dirty.isEmpty else { continue }
+
+                let fileList = dirty.map { "  • \($0.fileName)" }
+                    .joined(separator: "\n")
+                let response = await presentTerminationAlert(
+                    .unsavedChangesBulk,
+                    context: context,
+                    title: Strings.unsavedChangesTitle,
+                    message: Strings.unsavedChangesListMessage(fileList)
+                )
+                switch response {
+                case .alertFirstButtonReturn:
+                    saveRequests.append((projectManager, context))
+                case .alertSecondButtonReturn:
+                    discardAuthorizations[ObjectIdentifier(projectManager)] =
+                        DirtyEditorContentAuthorization(tabs: dirty)
+                default:
+                    return false
+                }
             }
-            // Record an authorization for every surviving project, including
-            // those with nothing running: the final revalidation needs a
-            // captured baseline per project to distinguish "was idle, still
-            // idle" from "appeared after the snapshot".
-            let authorization = TerminalTabCloseAuthorization.authorizing(
-                tabs: projectManager.terminal.allTerminalTabs
-            )
-            terminalAuthorizations[ObjectIdentifier(projectManager)] =
-                authorization
-            guard authorization.requiresConfirmation else { continue }
-            let projectContext = DialogPresenter.forProject(projectManager)
-            let hasEligibleProjectOwner = projectContext.nsWindow.map {
-                DialogPresenter.isEligibleApplicationOwner($0)
-            } ?? false
-            let context = hasEligibleProjectOwner
-                ? projectContext
-                : fallbackContext
-            let response = await valueBeforeTerminationDeadline(
+
+            for projectManager in projects {
+                guard registry.openProjects.values.contains(where: {
+                    $0 === projectManager
+                }) else {
+                    continue
+                }
+                let identifier = ObjectIdentifier(projectManager)
+                let authorization = TerminalTabCloseAuthorization.authorizing(
+                    tabs: projectManager.terminal.allTerminalTabs
+                )
+                terminalAuthorizations[identifier] = authorization
+                guard authorization.requiresConfirmation else { continue }
+                let projectContext = DialogPresenter.forProject(projectManager)
+                let hasEligibleProjectOwner = projectContext.nsWindow.map {
+                    DialogPresenter.isEligibleApplicationOwner($0)
+                } ?? false
+                let context = hasEligibleProjectOwner
+                    ? projectContext
+                    : fallbackContext
+                let response = await presentTerminationAlert(
+                    .terminalActiveProcessWarning,
+                    context: context,
+                    title: Strings.terminalActiveProcessWarningTitle,
+                    message: Strings.terminalActiveProcessWarningMessage
+                )
+                guard response == .alertFirstButtonReturn else {
+                    return false
+                }
+            }
+
+            if registry.hasOutstandingUserTaskExecution {
+                let response = await presentTerminationAlert(
+                    .activeUserTasksPreventQuit,
+                    context: fallbackContext,
+                    title: Strings.activeUserTasksPreventQuitTitle,
+                    message: Strings.activeUserTasksPreventQuitMessage
+                )
+                guard response == .alertFirstButtonReturn else {
+                    return false
+                }
+                mayShutdownUserTasks = true
+            }
+        } else {
+            // No suspension point occurred after the empty preflight, so this
+            // captures the same idle baseline for final revalidation.
+            for projectManager in projects {
+                terminalAuthorizations[ObjectIdentifier(projectManager)] =
+                    TerminalTabCloseAuthorization.authorizing(
+                        tabs: projectManager.terminal.allTerminalTabs
+                    )
+            }
+        }
+
+        // Rebase the captured duration only after the final human response.
+        let terminationDeadline = DispatchTime.now() + .nanoseconds(
+            Int(clamping: workBudgetNanoseconds)
+        )
+
+        for (projectManager, context) in saveRequests {
+            let didSave = await valueBeforeTerminationDeadline(
                 terminationDeadline,
                 deadlineObserver: terminationDeadlineObserver,
-                onTimeout: {
-                    guard let window = context.nsWindow,
-                          let sheet = window.attachedSheet else { return }
-                    window.endSheet(sheet, returnCode: .abort)
-                },
+                onTimeout: {},
                 operation: {
-                    if let presentAlert {
-                        return await presentAlert(
-                            .terminalActiveProcessWarning,
-                            context,
-                            Strings.terminalActiveProcessWarningTitle,
-                            Strings.terminalActiveProcessWarningMessage
-                        )
+                    if let saveAll {
+                        return await saveAll(projectManager, context)
                     }
-                    return await AlertTemplate.terminalActiveProcessWarning.runSheet(
-                        on: context,
-                        messageText: Strings.terminalActiveProcessWarningTitle,
-                        informativeText: Strings.terminalActiveProcessWarningMessage
-                    )
+                    return await projectManager.saveAllPaneTabs(context: context)
                 }
             )
-            guard let response else { return false }
-            guard response == .alertFirstButtonReturn else {
+            guard didSave == true else {
+                if didSave == nil {
+                    await presentTerminationFailure()
+                }
                 return false
             }
         }
@@ -2121,9 +2171,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         let rollbackReserve: Duration = .seconds(2)
         guard let availablePersistenceTime = remainingTerminationDuration(
             until: terminationDeadline
-        ), availablePersistenceTime > rollbackReserve else {
+        ), availablePersistenceTime > .zero else {
+            terminationDeadlineObserver()
+            await presentTerminationFailure()
             return false
         }
+        let effectiveRollbackReserve = availablePersistenceTime > rollbackReserve
+            ? rollbackReserve
+            : .zero
         registry.freezeAgentTasksForTermination()
         registry.agentTasks.prepareForApplicationTermination()
         func rollbackAgentTasks() async {
@@ -2139,7 +2194,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 return
             }
         }
-        let persistenceBudget = availablePersistenceTime - rollbackReserve
+        let persistenceBudget = availablePersistenceTime
+            - effectiveRollbackReserve
         guard await registry.agentTasks.flushPersistence(
             maximumDuration: persistenceBudget
         ) == .saved else {
@@ -2147,58 +2203,83 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 "Agent task metadata did not reach a clean persistence barrier"
             )
             await rollbackAgentTasks()
+            await presentTerminationFailure()
             return false
         }
 
-        // Other project windows remain interactive while sheets and metadata
-        // waits are in flight. A task can therefore start after the initial
-        // refusal check; revalidate execution ownership after the final
-        // suspension point, before any editor discard is committed.
-        guard !registry.hasOutstandingUserTaskExecution else {
-            await rollbackAgentTasks()
-            return false
-        }
-
-        // Revalidate every destructive authorization after the final
-        // suspension point, immediately before committing Quit, so later
-        // edits/processes are never covered by an earlier answer.
-        for projectManager in registry.openProjects.values {
-            let identifier = ObjectIdentifier(projectManager)
-            let currentDirtyTabs = projectManager.allDirtyTabs
-            if let authorization = discardAuthorizations[identifier] {
-                guard authorization.covers(currentDirtyTabs) else {
-                    await rollbackAgentTasks()
+        func destructiveAuthorizationsStillCoverCurrentState() -> Bool {
+            for projectManager in registry.openProjects.values {
+                let identifier = ObjectIdentifier(projectManager)
+                let currentDirtyTabs = projectManager.allDirtyTabs
+                if let authorization = discardAuthorizations[identifier] {
+                    guard authorization.covers(currentDirtyTabs) else {
+                        return false
+                    }
+                } else if !currentDirtyTabs.isEmpty {
                     return false
                 }
-            } else if !currentDirtyTabs.isEmpty {
-                await rollbackAgentTasks()
-                return false
-            }
 
-            // A project that appeared after the snapshot was never presented
-            // to the user. An idle one is still safe to tear down; anything
-            // running in it is unauthorized and must cancel Quit.
-            guard let authorization = terminalAuthorizations[identifier] else {
-                guard !TerminalTabCloseAuthorization.authorizing(
-                    tabs: projectManager.terminal.allTerminalTabs
-                ).requiresConfirmation else {
+                // A project that appeared after the snapshot was never
+                // presented. An idle one is safe; running work is not.
+                guard let authorization = terminalAuthorizations[identifier]
+                else {
+                    guard !TerminalTabCloseAuthorization.authorizing(
+                        tabs: projectManager.terminal.allTerminalTabs
+                    ).requiresConfirmation else {
+                        Logger.app.error(
+                            "Quit aborted: project with running processes opened during the termination handshake"
+                        )
+                        return false
+                    }
+                    continue
+                }
+                guard authorization.stillCovers(
+                    projectManager.terminal.allTerminalTabs
+                ) else {
                     Logger.app.error(
-                        "Quit aborted: project with running processes opened during the termination handshake"
+                        "Quit aborted: terminal authorization no longer covers the project"
                     )
-                    await rollbackAgentTasks()
                     return false
                 }
-                continue
             }
-            guard authorization.stillCovers(
-                projectManager.terminal.allTerminalTabs
-            ) else {
-                Logger.app.error(
-                    "Quit aborted: terminal authorization no longer covers the project"
-                )
+            return true
+        }
+
+        guard destructiveAuthorizationsStillCoverCurrentState() else {
+            await rollbackAgentTasks()
+            await presentTerminationFailure()
+            return false
+        }
+
+        if registry.hasOutstandingUserTaskExecution {
+            guard mayShutdownUserTasks else {
                 await rollbackAgentTasks()
+                await presentTerminationFailure()
                 return false
             }
+            let reserveNanoseconds: UInt64 =
+                effectiveRollbackReserve == rollbackReserve
+                ? 2_000_000_000
+                : 0
+            let taskShutdownDeadline = DispatchTime(
+                uptimeNanoseconds:
+                    terminationDeadline.uptimeNanoseconds - reserveNanoseconds
+            )
+            guard await registry.shutdownUserTasks(
+                until: taskShutdownDeadline
+            ) else {
+                await rollbackAgentTasks()
+                await presentTerminationFailure()
+                return false
+            }
+        }
+
+        // Task cleanup suspends off-main. Revalidate destructive state once
+        // more before committing any editor discard.
+        guard destructiveAuthorizationsStillCoverCurrentState() else {
+            await rollbackAgentTasks()
+            await presentTerminationFailure()
+            return false
         }
 
         // Two-phase destructive commit: no project is mutated until every
@@ -2209,8 +2290,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                !projectManager.commitDiscard(
                    authorization,
                    postReloadNotifications: false
-               ) {
+                ) {
                 await rollbackAgentTasks()
+                await presentTerminationFailure()
                 return false
             }
         }

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -790,8 +790,9 @@ final class ProjectRegistry: LSPSettingsObserver {
     }
 
     /// Whether any open or detached project still owns a user-task execution.
-    /// Application termination uses this as a fail-closed preflight and final
-    /// revalidation; it never sends TERM/KILL as part of a cancellable Quit.
+    /// Application termination uses this for its aggregated preflight and
+    /// final revalidation. Only an explicit Quit Anyway decision authorizes
+    /// bounded TERM/KILL cleanup before project ownership is destroyed.
     var hasOutstandingUserTaskExecution: Bool {
         userTaskOwners.contains { $0.hasOutstandingUserTaskExecution }
     }

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -2031,6 +2031,30 @@ enum Strings {
         String(localized: "task.activePreventQuit.message")
     }
 
+    static var applicationQuitSummaryTitle: String {
+        String(localized: "quit.summary.title")
+    }
+
+    static func applicationQuitSummaryMessage(_ projectCount: Int) -> String {
+        String(localized: "quit.summary.message \(projectCount)")
+    }
+
+    static var applicationQuitReview: String {
+        String(localized: "quit.summary.review")
+    }
+
+    static var applicationQuitAnyway: String {
+        String(localized: "quit.summary.quitAnyway")
+    }
+
+    static var applicationQuitFailureTitle: String {
+        String(localized: "quit.failure.title")
+    }
+
+    static var applicationQuitFailureMessage: String {
+        String(localized: "quit.failure.message")
+    }
+
     static var terminalTabCloseWarningTitle: String {
         String(localized: "terminal.tabCloseWarning.title")
     }

--- a/PineTests/AlertTemplateTests.swift
+++ b/PineTests/AlertTemplateTests.swift
@@ -57,9 +57,31 @@ struct AlertTemplateTests {
         #expect(buttons[1].title == Strings.dialogCancel)
     }
 
-    @Test("activeUserTasksPreventQuit has one safe OK button")
+    @Test("applicationQuitSummary has Review / Quit Anyway / Cancel")
+    func applicationQuitSummaryButtons() {
+        let template = AlertTemplate.applicationQuitSummary
+        let alert = template.makeAlert(messageText: "Test")
+        let buttons = alert.buttons
+        #expect(buttons.count == 3)
+        #expect(buttons[0].title == Strings.applicationQuitReview)
+        #expect(buttons[1].title == Strings.applicationQuitAnyway)
+        #expect(buttons[2].title == Strings.dialogCancel)
+    }
+
+    @Test("activeUserTasksPreventQuit has Quit Anyway / Cancel")
     func activeUserTasksPreventQuitButtons() {
         let template = AlertTemplate.activeUserTasksPreventQuit
+        let alert = template.makeAlert(messageText: "Test")
+        let buttons = alert.buttons
+        #expect(buttons.count == 2)
+        #expect(buttons[0].title == Strings.applicationQuitAnyway)
+        #expect(buttons[1].title == Strings.dialogCancel)
+        #expect(alert.alertStyle == .warning)
+    }
+
+    @Test("applicationQuitFailure has one safe OK button")
+    func applicationQuitFailureButtons() {
+        let template = AlertTemplate.applicationQuitFailure
         let alert = template.makeAlert(messageText: "Test")
         let buttons = alert.buttons
         #expect(buttons.count == 1)
@@ -148,6 +170,9 @@ struct AlertTemplateTests {
             .unsavedChangesBulk,
             .terminalTabCloseWarning,
             .terminalActiveProcessWarning,
+            .applicationQuitSummary,
+            .activeUserTasksPreventQuit,
+            .applicationQuitFailure,
             .externalModifyConflict,
             .fileDeletedSaveAs,
             .largeFileWarning,
@@ -211,6 +236,24 @@ struct AlertTemplateTests {
                 defaultIndex: 1,
                 cancelIndex: 1,
                 destructiveIndices: [0]
+            ),
+            .init(
+                template: .applicationQuitSummary,
+                defaultIndex: 0,
+                cancelIndex: 2,
+                destructiveIndices: [1]
+            ),
+            .init(
+                template: .activeUserTasksPreventQuit,
+                defaultIndex: 1,
+                cancelIndex: 1,
+                destructiveIndices: [0]
+            ),
+            .init(
+                template: .applicationQuitFailure,
+                defaultIndex: 0,
+                cancelIndex: nil,
+                destructiveIndices: []
             ),
             .init(
                 template: .externalModifyConflict,

--- a/PineTests/BulkCloseAgentAuthorizationTests.swift
+++ b/PineTests/BulkCloseAgentAuthorizationTests.swift
@@ -194,13 +194,23 @@ struct BulkCloseAgentAuthorizationTests {
 
     // MARK: - Application quit
 
-    @Test("Quit warns about a running agent that has no foreground pgid")
-    func quitWarnsAboutRunningAgent() async throws {
-        let dir = try makeTempDirectory()
-        defer { cleanup(dir) }
+    @Test("Quit summarizes agents from multiple projects in one alert")
+    func quitSummarizesAgentsAcrossProjects() async throws {
+        let firstDirectory = try makeTempDirectory()
+        let secondDirectory = try makeTempDirectory()
+        defer {
+            cleanup(firstDirectory)
+            cleanup(secondDirectory)
+        }
         let registry = ProjectRegistry()
-        let project = try #require(registry.projectManager(for: dir))
-        try addAgentTerminalTab(to: project)
+        let firstProject = try #require(
+            registry.projectManager(for: firstDirectory)
+        )
+        let secondProject = try #require(
+            registry.projectManager(for: secondDirectory)
+        )
+        try addAgentTerminalTab(to: firstProject)
+        try addAgentTerminalTab(to: secondProject)
 
         let delegate = AppDelegate()
         delegate.registry = registry
@@ -209,14 +219,15 @@ struct BulkCloseAgentAuthorizationTests {
         let result = await delegate.confirmApplicationTermination(
             presentAlert: { template, _, _, _ in
                 presentedTemplates.append(template)
-                return .alertFirstButtonReturn
+                return .alertSecondButtonReturn
             },
             terminationDeadlineOverride: .now() + 120
         )
 
         #expect(result)
-        #expect(presentedTemplates == [.terminalActiveProcessWarning])
-        await project.workspace.waitForLoadingComplete()
+        #expect(presentedTemplates == [.applicationQuitSummary])
+        await firstProject.workspace.waitForLoadingComplete()
+        await secondProject.workspace.waitForLoadingComplete()
     }
 
     @Test("Confirmed quit survives agent child-process churn")
@@ -232,7 +243,7 @@ struct BulkCloseAgentAuthorizationTests {
         delegate.registry = registry
 
         let result = await delegate.confirmApplicationTermination(
-            presentAlert: { _, _, _, _ in .alertFirstButtonReturn },
+            presentAlert: { _, _, _, _ in .alertSecondButtonReturn },
             terminationDeadlineOverride: .now() + 120
         )
 
@@ -252,15 +263,26 @@ struct BulkCloseAgentAuthorizationTests {
         let delegate = AppDelegate()
         delegate.registry = registry
 
+        var presentedTemplates: [AlertTemplate] = []
         let result = await delegate.confirmApplicationTermination(
-            presentAlert: { _, _, _, _ in
-                tab.agentSession = AgentSession(agentType: .claudeCode)
+            presentAlert: { template, _, _, _ in
+                presentedTemplates.append(template)
+                if template == .applicationQuitSummary {
+                    tab.agentSession = AgentSession(agentType: .claudeCode)
+                    return .alertSecondButtonReturn
+                }
                 return .alertFirstButtonReturn
             },
             terminationDeadlineOverride: .now() + 120
         )
 
         #expect(!result)
+        #expect(
+            presentedTemplates == [
+                .applicationQuitSummary,
+                .applicationQuitFailure,
+            ]
+        )
         await project.workspace.waitForLoadingComplete()
     }
 
@@ -309,13 +331,13 @@ struct BulkCloseAgentAuthorizationTests {
         let result = await delegate.confirmApplicationTermination(
             presentAlert: { template, _, _, _ in
                 presentedTemplates.append(template)
-                return .alertFirstButtonReturn
+                return .alertSecondButtonReturn
             },
             terminationDeadlineOverride: .now() + 120
         )
 
         #expect(result)
-        #expect(presentedTemplates == [.terminalActiveProcessWarning])
+        #expect(presentedTemplates == [.applicationQuitSummary])
         #expect(tab.agentSession != nil)
         await project.workspace.waitForLoadingComplete()
     }
@@ -332,7 +354,7 @@ struct BulkCloseAgentAuthorizationTests {
         delegate.registry = registry
 
         let result = await delegate.confirmApplicationTermination(
-            presentAlert: { _, _, _, _ in .alertSecondButtonReturn },
+            presentAlert: { _, _, _, _ in .alertThirdButtonReturn },
             terminationDeadlineOverride: .now() + 120
         )
 

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -172,13 +172,18 @@ struct WindowLifecycleTests {
         )
 
         #expect(!result)
-        #expect(presentedTemplates == [.unsavedChangesBulk])
+        #expect(
+            presentedTemplates == [
+                .applicationQuitSummary,
+                .unsavedChangesBulk,
+            ]
+        )
         #expect(saveAttempts == 1)
         #expect(project.hasUnsavedChanges)
         await project.workspace.waitForLoadingComplete()
     }
 
-    @Test func terminationDeadlineBoundsHungAlertPresenter() async throws {
+    @Test func terminationDeadlineDoesNotBoundHumanDeliberation() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
@@ -189,17 +194,60 @@ struct WindowLifecycleTests {
         let delegate = AppDelegate()
         delegate.registry = registry
         let deadlineProbe = TerminationDeadlineProbe()
+        let started = DispatchTime.now().uptimeNanoseconds
 
         let result = await delegate.confirmApplicationTermination(
-            presentAlert: { _, _, _, _ in
-                try? await Task.sleep(for: .seconds(10))
+            presentAlert: { template, _, _, _ in
+                #expect(template == .applicationQuitSummary)
+                try? await Task.sleep(for: .milliseconds(150))
+                return .alertSecondButtonReturn
+            },
+            terminationDeadlineOverride: .now() + .milliseconds(100),
+            terminationDeadlineObserver: deadlineProbe.record
+        )
+
+        let elapsed = DispatchTime.now().uptimeNanoseconds - started
+        #expect(result)
+        #expect(elapsed >= 150_000_000)
+        #expect(deadlineProbe.elapsedNanoseconds == nil)
+        #expect(!project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func terminationDeadlineStillBoundsHungMachineWork() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        updateContent("// dirty", in: project)
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        let deadlineProbe = TerminationDeadlineProbe()
+        var presentedTemplates: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presentedTemplates.append(template)
                 return .alertFirstButtonReturn
+            },
+            saveAll: { _, _ in
+                try? await Task.sleep(for: .seconds(10))
+                return true
             },
             terminationDeadlineOverride: .now() + .milliseconds(25),
             terminationDeadlineObserver: deadlineProbe.record
         )
 
         #expect(!result)
+        #expect(
+            presentedTemplates == [
+                .applicationQuitSummary,
+                .unsavedChangesBulk,
+                .applicationQuitFailure,
+            ]
+        )
         #expect(
             deadlineProbe.elapsedNanoseconds.map { $0 < 1_000_000_000 } == true
         )
@@ -226,7 +274,8 @@ struct WindowLifecycleTests {
         var presentedOwner: NSWindow?
 
         let result = await delegate.confirmApplicationTermination(
-            presentAlert: { _, context, _, _ in
+            presentAlert: { template, context, _, _ in
+                #expect(template == .applicationQuitSummary)
                 presentedOwner = context.nsWindow
                 return .alertThirdButtonReturn
             },
@@ -259,12 +308,21 @@ struct WindowLifecycleTests {
         delegate.registry = registry
         let result = await delegate.confirmApplicationTermination(
             presentAlert: { template, _, _, _ in
-                #expect(template == .unsavedChangesBulk)
-                updateContent(
-                    "// changed while quit sheet was visible",
-                    in: project
-                )
-                return .alertSecondButtonReturn
+                switch template {
+                case .applicationQuitSummary:
+                    return .alertFirstButtonReturn
+                case .unsavedChangesBulk:
+                    updateContent(
+                        "// changed while quit sheet was visible",
+                        in: project
+                    )
+                    return .alertSecondButtonReturn
+                case .applicationQuitFailure:
+                    return .alertFirstButtonReturn
+                default:
+                    Issue.record("Unexpected Quit alert: \(template)")
+                    return .abort
+                }
             },
             terminationDeadlineOverride: .now() + 120
         )
@@ -291,7 +349,7 @@ struct WindowLifecycleTests {
 
         let result = await delegate.confirmApplicationTermination(
             presentAlert: { template, _, _, _ in
-                #expect(template == .unsavedChangesBulk)
+                #expect(template == .applicationQuitSummary)
                 return .alertSecondButtonReturn
             },
             terminationDeadlineOverride: .now() + 120
@@ -330,6 +388,9 @@ struct WindowLifecycleTests {
 
         let result = await delegate.confirmApplicationTermination(
             presentAlert: { template, _, _, _ in
+                if template == .applicationQuitSummary {
+                    return .alertFirstButtonReturn
+                }
                 #expect(template == .unsavedChangesBulk)
                 promptCount += 1
                 return promptCount == 1
@@ -349,7 +410,7 @@ struct WindowLifecycleTests {
         await secondProject.workspace.waitForLoadingComplete()
     }
 
-    @Test func quitRefusesWhileUserTaskOwnsExecution() async throws {
+    @Test func quitFailureIsVisibleWhenUserTaskCleanupDoesNotFinish() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let registry = ProjectRegistry()
@@ -367,15 +428,22 @@ struct WindowLifecycleTests {
         let result = await delegate.confirmApplicationTermination(
             presentAlert: { template, _, _, _ in
                 presentedTemplates.append(template)
-                return .alertFirstButtonReturn
+                return template == .applicationQuitSummary
+                    ? .alertSecondButtonReturn
+                    : .alertFirstButtonReturn
             },
-            terminationDeadlineOverride: .now() + 1
+            terminationDeadlineOverride: .now() + 5
         )
 
         #expect(!result)
-        #expect(presentedTemplates == [.activeUserTasksPreventQuit])
-        #expect(probe.cancellationCount == 0)
-        #expect(probe.waitCount == 0)
+        #expect(
+            presentedTemplates == [
+                .applicationQuitSummary,
+                .applicationQuitFailure,
+            ]
+        )
+        #expect(probe.cancellationCount == 1)
+        #expect(probe.waitCount == 1)
         #expect(project.hasOutstandingUserTaskExecution)
         #expect(registry.isProjectOpen(dir))
         #expect(!registry.destroyAllProjects())
@@ -389,7 +457,7 @@ struct WindowLifecycleTests {
         #expect(registry.destroyAllProjects())
     }
 
-    @Test func quitNeverKillsTaskWhoseCleanupWouldFitDeadline() async throws {
+    @Test func quitAnywayStopsUserTaskAndQuits() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let registry = ProjectRegistry()
@@ -405,24 +473,17 @@ struct WindowLifecycleTests {
 
         let result = await delegate.confirmApplicationTermination(
             presentAlert: { template, _, _, _ in
-                #expect(template == .activeUserTasksPreventQuit)
-                return .alertFirstButtonReturn
+                #expect(template == .applicationQuitSummary)
+                return .alertSecondButtonReturn
             },
-            terminationDeadlineOverride: .now() + 1
+            terminationDeadlineOverride: .now() + 5
         )
 
-        #expect(!result)
-        #expect(probe.cancellationCount == 0)
-        #expect(probe.waitCount == 0)
-        #expect(project.hasOutstandingUserTaskExecution)
-        #expect(project.taskRunStore.runs.count == 1)
-        #expect(!registry.destroyAllProjects())
-
-        project.taskRunStore.finishRun(
-            id: run.id,
-            outcome: makeTaskOutcome(id: "active"),
-            cancelled: false
-        )
+        #expect(result)
+        #expect(probe.cancellationCount == 1)
+        #expect(probe.waitCount == 1)
+        #expect(!project.hasOutstandingUserTaskExecution)
+        #expect(project.taskRunStore.runs.isEmpty)
         #expect(registry.destroyAllProjects())
     }
 
@@ -441,16 +502,25 @@ struct WindowLifecycleTests {
 
         let result = await delegate.confirmApplicationTermination(
             presentAlert: { template, _, _, _ in
-                #expect(template == .unsavedChangesBulk)
-                let started = project.taskRunStore.start(
-                    makeTaskRun(id: "late-active")
-                )
-                project.taskRunStore.registerCancellation(
-                    probe.makeCancellation(),
-                    forRunID: started.id
-                )
-                run = started
-                return .alertSecondButtonReturn
+                switch template {
+                case .applicationQuitSummary:
+                    return .alertFirstButtonReturn
+                case .unsavedChangesBulk:
+                    let started = project.taskRunStore.start(
+                        makeTaskRun(id: "late-active")
+                    )
+                    project.taskRunStore.registerCancellation(
+                        probe.makeCancellation(),
+                        forRunID: started.id
+                    )
+                    run = started
+                    return .alertSecondButtonReturn
+                case .activeUserTasksPreventQuit:
+                    return .alertSecondButtonReturn
+                default:
+                    Issue.record("Unexpected Quit alert: \(template)")
+                    return .abort
+                }
             },
             terminationDeadlineOverride: .now() + 2
         )


### PR DESCRIPTION
Closes #1354

Summary:
- show one application-wide Review / Quit Anyway / Cancel summary for multi-project quit
- start the bounded machine-work deadline only after the final human decision
- let Quit Anyway stop active user tasks while preserving fail-closed authorization checks
- localize the new quit flow across all supported locales

Tests:
- strict SwiftLint on all changed Swift files
- targeted WindowLifecycleTests, BulkCloseAgentAuthorizationTests, and AlertTemplateTests
- full PineTests: 635 passed, 1 skipped; two unrelated flaky tests passed on isolated rerun