### PR TITLE
fix: make application quit bounded, atomic, and user-visible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,17 +245,54 @@ How the maintainer works day-to-day. Documents intent and handoff conventions fo
 - **Explicit confirmation required** for: merging a PR, and anything in the destructive-command list in `AGENTS.md` (deletions, force-pushes, infrastructure changes).
 - Agents should run unit tests themselves — no need to ask first.
 
+### Independent review gate
+
+Every implementation must pass an independent, fresh-context review before
+its first push and before a PR is opened. This keeps expensive macOS and UI
+runners from testing a candidate that has not cleared adversarial review.
+Green CI remains necessary, but it does not replace that review.
+
+1. **Review the local candidate diff before push.** Once implementation and
+   regression tests are stable, review the complete local diff against its
+   intended base (`main...HEAD`, plus any staged or unstaged changes). Run at
+   least three read-only reviewer subagents with distinct lenses: (a)
+   correctness and architecture, (b) concurrency, security, and lifecycle
+   races, and (c) tests, UX, localization, and OS compatibility. Reviewers
+   must read the issue acceptance criteria and must not edit files.
+2. **Demand actionable findings.** Each finding includes severity, exact
+   file/line references, a concrete failure sequence or reproduction, and the
+   smallest safe fix. A clean review explicitly lists the invariants checked;
+   a summary that merely restates the diff does not count.
+3. **Synthesize and verify.** The parent agent deduplicates findings, validates
+   them against the code, and adds a regression test before or with each fix.
+   All confirmed P0, P1, and P2 findings must be resolved before merge. Record
+   low-risk coverage gaps or P3 findings in the PR or a follow-up issue when
+   they are intentionally deferred.
+4. **Fix on the same local branch.** Add follow-up commits; never amend or
+   force-push. Repeat the independent review/fix loop until reviewers return
+   no unresolved P0-P2 findings, then rerun the relevant local checks.
+5. **Push and open the PR only after review clears.** Summarize reviewer
+   angles, findings, dispositions, and local verification in the PR body.
+   Run the full required CI once the PR exists. An agent with explicit merge
+   authorization must not invoke merge until the pre-push review gate remains
+   clean and every required CI check is green.
+6. **Recover visibly from a premature merge.** If review was skipped before
+   merge, or a post-merge review finds a P0-P2 defect, reopen the source issue,
+   create a short-lived follow-up branch from current `main`, add regression
+   tests and fixes, repeat review plus CI, and close the issue only after the
+   follow-up PR is green and merged.
+
 ### Milestone orchestration with subagents
 
 For a milestone with multiple issues, the maintainer (or a parent agent) orchestrates implementation across subagents instead of doing all the work in one session. Used for parallelizable issues, large features, or when strict adversarial review is wanted. The full loop runs inside the agent; the human only merges at the end.
 
 Flow:
 1. **Scope first.** Read every issue in the milestone end-to-end, identify shared files, and note dependencies (`blocked-by`, or an explicit "depends on #X" in the body). Order implementation and merge accordingly.
-2. **One issue = one worker = one PR.** Delegate each issue to a worker subagent in an isolated worktree (`worktree: true`). Each worker creates its own branch and opens its own PR against `main`. Pass each worker explicit permissions in the task (which `git` / `gh` / `xcodebuild` commands are allowed) and an `acceptance` contract with `verify` commands and `stopRules` (notably: never merge, never force-push, never amend).
+2. **One issue = one worker = one candidate branch.** Delegate each issue to a worker subagent in an isolated worktree (`worktree: true`). Each worker creates its own local branch, commits the candidate, runs local verification, and reports it for review without pushing or opening a PR. Pass each worker explicit permissions in the task and an `acceptance` contract with `verify` commands and `stopRules` (notably: never push, never open a PR, never merge, never force-push, never amend before review clears).
 3. **Respect cross-issue boundaries.** Tell each worker exactly which files/branches it may touch so sibling PRs stay mergeable (e.g. add a dedicated accumulator field per branch instead of repurposing a shared one). When an issue depends on siblings not yet merged, the dependent worker merges those sibling branches into its own branch and documents it in the PR body — GitHub auto-shrinks the diff once the siblings land.
-4. **Strict review from fresh context.** Once PRs are open, run fresh-context `reviewer` subagents with distinct angles (e.g. correctness/regressions, tests/validation) against the actual diff. Reviewers are read-only — they must not edit.
-5. **Fix on the existing branch.** Synthesize reviewer findings and hand them to a fix-worker that checks out the **existing** PR branch and adds a follow-up commit. Never amend, force-push, or open a new branch for fixes. Repeat the review/fix loop until reviewers return a clean verdict (typically ~2 rounds).
-6. **Verify before handoff.** Confirm every PR is `MERGEABLE` and **fully green** — every required CI check passing, no exceptions. Pending checks must be explicitly noted. There is no "red but mergeable" state: branch protection blocks the merge button on any failing check, so a red PR is not ready regardless of why it failed. State the merge order.
+4. **Strict review from fresh context before push.** Run fresh-context `reviewer` subagents with distinct angles against each complete local candidate diff. Reviewers are read-only — they must not edit.
+5. **Fix before opening the PR.** Synthesize reviewer findings and hand them to a fix-worker that checks out the **existing local candidate branch** and adds a follow-up commit. Never amend, force-push, or open a new branch for fixes. Repeat the review/fix loop until reviewers return a clean verdict (typically ~2 rounds).
+6. **Publish and verify after review.** Only now push each reviewed branch and open its PR. Confirm every PR is `MERGEABLE` and **fully green** — every required CI check passing, no exceptions. Pending checks must be explicitly noted. There is no "red but mergeable" state: branch protection blocks the merge button on any failing check, so a red PR is not ready regardless of why it failed. State the merge order.
 7. **Never merge.** The agent opens and reviews PRs; only the human merges them.
 
 Operational notes:

--- a/Pine/Agent/AgentDetectionCoordinator.swift
+++ b/Pine/Agent/AgentDetectionCoordinator.swift
@@ -112,13 +112,28 @@ nonisolated final class AgentDetectionCoordinator {
     }
 
     @MainActor func stop() {
-        guard isRunning else { return }
+        guard suspendPolling() else { return }
+        terminalManager?.markAgentEvidenceUnavailable()
+        clearAllTabSessions()
+    }
+
+    /// Stops polling for the final termination snapshot without changing the
+    /// tab-local session identities that an already granted close authorization
+    /// covers. The normal ``stop()`` path still clears those sessions.
+    @MainActor func suspendForTermination() {
+        _ = suspendPolling()
+    }
+
+    /// Invalidates the active generation before cancelling its timer so an
+    /// already captured background result cannot mutate state after suspension.
+    @MainActor @discardableResult
+    private func suspendPolling() -> Bool {
+        guard isRunning else { return false }
         isRunning = false
         lifecycleGate.end()
         timer?.cancel()
         timer = nil
-        terminalManager?.markAgentEvidenceUnavailable()
-        clearAllTabSessions()
+        return true
     }
 
     deinit {

--- a/Pine/Agent/AgentTaskMetadataStore.swift
+++ b/Pine/Agent/AgentTaskMetadataStore.swift
@@ -1935,6 +1935,12 @@ actor AgentTaskMetadataStore: AgentTaskPersisting {
               task.lifecycle != .completed,
               task.attention != .completed,
               task.attention != .failed,
+              task.launchInterruption == nil
+                || (task.origin == .pineLaunched
+                    && task.runs.isEmpty
+                    && task.lifecycle == .paused
+                    && task.route.availability == .missing
+                    && task.attention == .none),
               validOptionalDate(task.completedAt),
               task.runs.allSatisfy(validateRun),
               validateChronology(task) else {

--- a/Pine/Agent/AgentTaskModels.swift
+++ b/Pine/Agent/AgentTaskModels.swift
@@ -116,6 +116,13 @@ nonisolated enum AgentTaskAttention: String, Codable, Sendable {
     case failed
 }
 
+/// Honest durable state for a Pine-owned launch that reached the PTY but was
+/// interrupted by application termination before detector evidence arrived.
+/// No PID, process generation, or start time is inferred for this marker.
+nonisolated enum AgentTaskLaunchInterruption: String, Codable, Sendable {
+    case acknowledgedBeforeVerification
+}
+
 /// A run's last reported state, kept separate from evidence freshness.
 nonisolated enum AgentRunState: String, Codable, Sendable {
     case idle
@@ -314,6 +321,7 @@ nonisolated struct AgentTask: Codable, Equatable, Sendable, Identifiable {
     var attention: AgentTaskAttention
     var title: String?
     var objective: String?
+    var launchInterruption: AgentTaskLaunchInterruption?
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -331,6 +339,7 @@ nonisolated struct AgentTask: Codable, Equatable, Sendable, Identifiable {
         case attention
         case title
         case objective
+        case launchInterruption
     }
 
     init(
@@ -356,6 +365,7 @@ nonisolated struct AgentTask: Codable, Equatable, Sendable, Identifiable {
         attention = .none
         self.title = title
         self.objective = objective
+        launchInterruption = nil
     }
 }
 

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -95,6 +95,8 @@ final class AgentTaskRegistry {
     @ObservationIgnored
     private var terminationDecisionClaimRemaining: [UUID: Duration] = [:]
     @ObservationIgnored
+    private var acknowledgedWriteClaimRemaining: [UUID: Duration] = [:]
+    @ObservationIgnored
     private var terminationClaimRemaining: [UUID: Duration] = [:]
     @ObservationIgnored
     private var registeredProjects = Set<AgentTaskProjectIdentity>()
@@ -735,6 +737,9 @@ final class AgentTaskRegistry {
         } else if let remaining =
                     terminationDecisionClaimRemaining[reservation.token] {
             deadlineIsValid = remaining > .zero
+        } else if let remaining =
+                    acknowledgedWriteClaimRemaining[reservation.token] {
+            deadlineIsValid = remaining > .zero
         } else {
             deadlineIsValid = monotonicNow() < claim.deadline
         }
@@ -756,6 +761,48 @@ final class AgentTaskRegistry {
         return true
     }
 
+    /// Holds an exact launch claim while Pine waits for its PTY write to be
+    /// acknowledged. The bounded lease resumes only after the write settles;
+    /// a concurrent Quit decision composes with this hold instead of replacing
+    /// it.
+    func pauseLaunchExpirationForAcknowledgedWrite(
+        _ reservation: AgentTaskLaunchReservation
+    ) -> Bool {
+        if !isTerminating { expireClaims() }
+        guard let key = pendingClaimKeyByToken[reservation.token],
+              let claim = pendingClaims[key],
+              claim.taskID == reservation.taskID else { return false }
+        let now = monotonicNow()
+        let remaining = terminationClaimRemaining[reservation.token]
+            ?? terminationDecisionClaimRemaining[reservation.token]
+            ?? acknowledgedWriteClaimRemaining[reservation.token]
+            ?? max(.zero, now.duration(to: claim.deadline))
+        guard remaining > .zero else { return false }
+        acknowledgedWriteClaimRemaining[reservation.token] = remaining
+        claimExpiryTasks.removeValue(forKey: reservation.token)?.cancel()
+        return true
+    }
+
+    func resumeLaunchExpirationAfterAcknowledgedWrite(
+        _ reservation: AgentTaskLaunchReservation
+    ) {
+        guard let remaining = acknowledgedWriteClaimRemaining
+                .removeValue(forKey: reservation.token),
+              let key = pendingClaimKeyByToken[reservation.token],
+              var claim = pendingClaims[key],
+              claim.taskID == reservation.taskID else { return }
+        if isTerminating {
+            terminationClaimRemaining[reservation.token] =
+                terminationClaimRemaining[reservation.token] ?? remaining
+            return
+        }
+        guard terminationDecisionClaimRemaining[reservation.token] == nil else {
+            return
+        }
+        claim.deadline = monotonicNow().advanced(by: remaining)
+        installClaim(claim, key: key)
+    }
+
     /// Pauses the bounded reservation lease while the user considers Quit.
     /// Human deliberation is intentionally unbounded, but the exact launch
     /// that caused the prompt must remain claimable until that decision is
@@ -775,7 +822,8 @@ final class AgentTaskRegistry {
             }
             let remaining = terminationDecisionClaimRemaining[
                 reservation.token
-            ] ?? max(.zero, now.duration(to: claim.deadline))
+            ] ?? acknowledgedWriteClaimRemaining[reservation.token]
+                ?? max(.zero, now.duration(to: claim.deadline))
             guard remaining > .zero else { return false }
             remainingByToken[reservation.token] = remaining
         }
@@ -800,6 +848,9 @@ final class AgentTaskRegistry {
                   let key = pendingClaimKeyByToken[reservation.token],
                   var claim = pendingClaims[key],
                   claim.taskID == reservation.taskID else {
+                continue
+            }
+            guard acknowledgedWriteClaimRemaining[reservation.token] == nil else {
                 continue
             }
             claim.deadline = now.advanced(by: remaining)
@@ -971,6 +1022,7 @@ final class AgentTaskRegistry {
         for claim in pendingClaims.values {
             terminationClaimRemaining[claim.token] =
                 terminationDecisionClaimRemaining[claim.token]
+                ?? acknowledgedWriteClaimRemaining[claim.token]
                 ?? max(.zero, now.duration(to: claim.deadline))
             claimExpiryTasks.removeValue(forKey: claim.token)?.cancel()
         }
@@ -1093,6 +1145,9 @@ final class AgentTaskRegistry {
         for key in Array(pendingClaims.keys) {
             guard var claim = pendingClaims[key],
                   let remaining = terminationClaimRemaining[claim.token] else {
+                continue
+            }
+            guard acknowledgedWriteClaimRemaining[claim.token] == nil else {
                 continue
             }
             claim.deadline = now.advanced(by: remaining)
@@ -1619,6 +1674,7 @@ final class AgentTaskRegistry {
         guard let claim = pendingClaims.removeValue(forKey: key) else { return }
         pendingClaimKeyByToken[claim.token] = nil
         terminationDecisionClaimRemaining[claim.token] = nil
+        acknowledgedWriteClaimRemaining[claim.token] = nil
         terminationClaimRemaining[claim.token] = nil
         claimExpiryTasks.removeValue(forKey: claim.token)?.cancel()
     }
@@ -1647,7 +1703,8 @@ final class AgentTaskRegistry {
     private func expireClaims() {
         let now = monotonicNow()
         let expired: [AgentTaskTerminalKey] = pendingClaims.compactMap { key, claim in
-            guard terminationDecisionClaimRemaining[claim.token] == nil else {
+            guard terminationDecisionClaimRemaining[claim.token] == nil,
+                  acknowledgedWriteClaimRemaining[claim.token] == nil else {
                 return nil
             }
             return claim.deadline <= now ? key : nil

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -140,6 +140,8 @@ final class AgentTaskRegistry {
     @ObservationIgnored
     private var claimExpiryTasks: [UUID: Task<Void, Never>] = [:]
     @ObservationIgnored
+    private var rollbackPersistenceRetryTask: Task<Void, Never>?
+    @ObservationIgnored
     private let monotonicNow: @Sendable () -> ContinuousClock.Instant
     @ObservationIgnored
     private let claimTTL: Duration
@@ -878,6 +880,8 @@ final class AgentTaskRegistry {
     /// This is not task completion and does not manufacture user attention.
     func prepareForApplicationTermination(at timestamp: Date = Date()) {
         guard !isTerminating else { return }
+        rollbackPersistenceRetryTask?.cancel()
+        rollbackPersistenceRetryTask = nil
         expireClaims()
         isTerminating = true
         let now = monotonicNow()
@@ -946,6 +950,9 @@ final class AgentTaskRegistry {
         // Runtime admission and bounded claim expiry are restored regardless.
         isRollingBackApplicationTermination = false
         finishTerminationCancellation()
+        if !rollbackWasSaved {
+            scheduleRollbackPersistenceRetry()
+        }
         return rollbackWasSaved
     }
 
@@ -989,6 +996,43 @@ final class AgentTaskRegistry {
             installClaim(claim, key: key)
         }
         terminationClaimRemaining.removeAll(keepingCapacity: true)
+    }
+
+    /// A failed bounded rollback must thaw the live application, but the
+    /// restored snapshot remains dirty until it is actually durable. Retry in
+    /// the background with bounded backoff so a later crash cannot indefinitely
+    /// reload the paused/missing termination snapshot.
+    private func scheduleRollbackPersistenceRetry() {
+        rollbackPersistenceRetryTask?.cancel()
+        rollbackPersistenceRetryTask = Task { @MainActor [weak self] in
+            var delay = Duration.milliseconds(100)
+            while !Task.isCancelled {
+                guard let self else { return }
+                let retryable = dirtyProjects.filter {
+                    registeredProjects.contains($0)
+                        && !quarantinedProjects.contains($0)
+                        && !unpersistableDirtyProjects.contains($0)
+                }
+                guard !retryable.isEmpty else {
+                    rollbackPersistenceRetryTask = nil
+                    return
+                }
+                persistenceRetryBlocked.subtract(retryable)
+                retryable.forEach(scheduleSaveIfReady)
+                if await flushPersistence(
+                    maximumDuration: min(flushTotal, .seconds(2))
+                ) == .saved {
+                    rollbackPersistenceRetryTask = nil
+                    return
+                }
+                do {
+                    try await ContinuousClock().sleep(for: delay)
+                } catch {
+                    return
+                }
+                delay = min(delay * 2, .seconds(5))
+            }
+        }
     }
 
     /// Waits for loads and every queued save, with a five-second total and

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -13,10 +13,9 @@ nonisolated private struct AgentTaskTerminalKey: Hashable, Sendable {
     let terminalID: UUID
 }
 
-nonisolated struct AgentTaskLaunchReservation: Equatable, Sendable {
+nonisolated struct AgentTaskLaunchReservation: Hashable, Sendable {
     let taskID: UUID
     fileprivate let token: UUID
-
 }
 
 nonisolated enum AgentTaskLaunchResult: Equatable, Sendable {
@@ -131,6 +130,10 @@ final class AgentTaskRegistry {
     private let publicationFence: AgentTaskPublicationFence
     @ObservationIgnored
     private var isTerminating = false
+    /// Window availability changes remain admissible while the rollback
+    /// snapshot is being reconciled and durably flushed. Every other agent
+    /// admission path stays frozen by `isTerminating`.
+    private var isRollingBackApplicationTermination = false
     @ObservationIgnored
     private var terminationRollback:
         [UUID: AgentTaskTerminationRollback] = [:]
@@ -754,8 +757,18 @@ final class AgentTaskRegistry {
         _ isOpen: Bool,
         matchesProject: (AgentTaskProjectIdentity) -> Bool
     ) {
-        expireClaims()
-        guard !isTerminating else { return }
+        if isTerminating {
+            guard isRollingBackApplicationTermination else { return }
+        } else {
+            expireClaims()
+        }
+        applyWindowOpen(isOpen, matchesProject: matchesProject)
+    }
+
+    private func applyWindowOpen(
+        _ isOpen: Bool,
+        matchesProject: (AgentTaskProjectIdentity) -> Bool
+    ) {
         var projects = Set<AgentTaskProjectIdentity>()
         for key in Array(pendingClaims.keys)
         where matchesProject(key.project) {
@@ -907,14 +920,31 @@ final class AgentTaskRegistry {
     func cancelApplicationTerminationAndFlush(
         maximumDuration: Duration? = nil
     ) async -> Bool {
+        await cancelApplicationTerminationAndFlush(
+            reconcilingWindowOpen: [:],
+            maximumDuration: maximumDuration
+        )
+    }
+
+    func cancelApplicationTerminationAndFlush(
+        reconcilingWindowOpen windowOpenByProject: [
+            AgentTaskProjectIdentity: Bool
+        ],
+        maximumDuration: Duration? = nil
+    ) async -> Bool {
         guard isTerminating else { return true }
+        isRollingBackApplicationTermination = true
         restoreTerminationSnapshot()
+        for (project, isOpen) in windowOpenByProject {
+            applyWindowOpen(isOpen) { $0 == project }
+        }
         let rollbackWasSaved = await flushPersistence(
             maximumDuration: maximumDuration
         ) == .saved
         // A failed durability barrier is surfaced to the caller, but it must
         // never leave the still-running application in termination mode.
         // Runtime admission and bounded claim expiry are restored regardless.
+        isRollingBackApplicationTermination = false
         finishTerminationCancellation()
         return rollbackWasSaved
     }
@@ -923,6 +953,7 @@ final class AgentTaskRegistry {
     func cancelApplicationTermination() {
         guard isTerminating else { return }
         restoreTerminationSnapshot()
+        isRollingBackApplicationTermination = false
         finishTerminationCancellation()
     }
     #endif

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -26,6 +26,7 @@ nonisolated enum AgentTaskLaunchResult: Equatable, Sendable {
 
 nonisolated private enum AgentTaskClaimKind: Sendable {
     case initialLaunch
+    case interruptedInitialLaunch
     case resume(previousRunID: UUID)
 }
 
@@ -54,6 +55,7 @@ nonisolated private struct AgentTaskTerminationRollback: Sendable {
     let liveness: AgentRunLiveness?
     let attention: AgentTaskAttention
     let updatedAt: Date
+    let launchInterruption: AgentTaskLaunchInterruption?
 }
 
 /// Application-lifetime durable task ownership. The registry is MainActor so
@@ -141,6 +143,9 @@ final class AgentTaskRegistry {
     private var claimExpiryTasks: [UUID: Task<Void, Never>] = [:]
     @ObservationIgnored
     private var rollbackPersistenceRetryTask: Task<Void, Never>?
+    @ObservationIgnored
+    private var rollbackPersistenceRetryProjects =
+        Set<AgentTaskProjectIdentity>()
     @ObservationIgnored
     private let monotonicNow: @Sendable () -> ContinuousClock.Instant
     @ObservationIgnored
@@ -406,6 +411,7 @@ final class AgentTaskRegistry {
         tasks[index].lifecycle = .dismissed
         tasks[index].attention = .none
         tasks[index].isUnread = false
+        tasks[index].launchInterruption = nil
         tasks[index].updatedAt = max(tasks[index].updatedAt, timestamp)
         markDirty(tasks[index].project)
         return true
@@ -669,12 +675,20 @@ final class AgentTaskRegistry {
               validLaunchRoute(context.route),
               tasks[index].project == context.project,
               isResumableTask(at: index),
-              let prior = tasks[index].runs.last,
               pendingClaims[terminalKey(context)] == nil,
               taskIDByTerminal[terminalKey(context)] == nil else {
             return .rejected
         }
-        let previousRunID = prior.id
+        let kind: AgentTaskClaimKind
+        if let previousRunID = tasks[index].runs.last?.id {
+            kind = .resume(previousRunID: previousRunID)
+        } else {
+            guard tasks[index].launchInterruption
+                    == .acknowledgedBeforeVerification else {
+                return .rejected
+            }
+            kind = .interruptedInitialLaunch
+        }
         let reservation = AgentTaskLaunchReservation(
             taskID: taskID,
             token: UUID()
@@ -685,7 +699,7 @@ final class AgentTaskRegistry {
             project: context.project,
             route: context.route,
             descriptor: tasks[index].descriptor,
-            kind: .resume(previousRunID: previousRunID),
+            kind: kind,
             expectedRunCount: tasks[index].runs.count,
             generationFloor: boundary.generationFloor,
             launchBoundary: normalizedLaunchBoundary(boundary.capturedAt),
@@ -894,6 +908,13 @@ final class AgentTaskRegistry {
             claimExpiryTasks.removeValue(forKey: claim.token)?.cancel()
         }
         var changedProjects = Set<AgentTaskProjectIdentity>()
+        let acknowledgedInitialTaskIDs = Set(
+            pendingClaims.values.compactMap { claim -> UUID? in
+                guard case .initialLaunch = claim.kind,
+                      claim.state == .armed else { return nil }
+                return claim.taskID
+            }
+        )
         for taskIndex in tasks.indices {
             let runIndex = tasks[taskIndex].runs.indices.last
             terminationRollback[tasks[taskIndex].id] = AgentTaskTerminationRollback(
@@ -901,8 +922,14 @@ final class AgentTaskRegistry {
                 availability: tasks[taskIndex].route.availability,
                 liveness: runIndex.map { tasks[taskIndex].runs[$0].liveness },
                 attention: tasks[taskIndex].attention,
-                updatedAt: tasks[taskIndex].updatedAt
+                updatedAt: tasks[taskIndex].updatedAt,
+                launchInterruption: tasks[taskIndex].launchInterruption
             )
+            if acknowledgedInitialTaskIDs.contains(tasks[taskIndex].id),
+               tasks[taskIndex].runs.isEmpty {
+                tasks[taskIndex].launchInterruption =
+                    .acknowledgedBeforeVerification
+            }
             tasks[taskIndex].route.availability = .missing
             if let runIndex,
                tasks[taskIndex].runs[runIndex].liveness == .live {
@@ -938,7 +965,7 @@ final class AgentTaskRegistry {
     ) async -> Bool {
         guard isTerminating else { return true }
         isRollingBackApplicationTermination = true
-        restoreTerminationSnapshot()
+        _ = restoreTerminationSnapshot(trackingPersistence: true)
         for (project, isOpen) in windowOpenByProject {
             applyWindowOpen(isOpen) { $0 == project }
         }
@@ -951,7 +978,7 @@ final class AgentTaskRegistry {
         isRollingBackApplicationTermination = false
         finishTerminationCancellation()
         if !rollbackWasSaved {
-            scheduleRollbackPersistenceRetry()
+            ensureRollbackPersistenceRetryScheduled()
         }
         return rollbackWasSaved
     }
@@ -959,13 +986,15 @@ final class AgentTaskRegistry {
     #if DEBUG
     func cancelApplicationTermination() {
         guard isTerminating else { return }
-        restoreTerminationSnapshot()
+        _ = restoreTerminationSnapshot(trackingPersistence: false)
         isRollingBackApplicationTermination = false
         finishTerminationCancellation()
     }
     #endif
 
-    private func restoreTerminationSnapshot() {
+    private func restoreTerminationSnapshot(
+        trackingPersistence: Bool
+    ) -> Set<AgentTaskProjectIdentity> {
         var restoredProjects = Set<AgentTaskProjectIdentity>()
         for index in tasks.indices {
             if let rollback = terminationRollback[tasks[index].id] {
@@ -973,6 +1002,8 @@ final class AgentTaskRegistry {
                 tasks[index].route.availability = rollback.availability
                 tasks[index].attention = rollback.attention
                 tasks[index].updatedAt = rollback.updatedAt
+                tasks[index].launchInterruption =
+                    rollback.launchInterruption
                 if let runIndex = tasks[index].runs.indices.last,
                    let liveness = rollback.liveness {
                     tasks[index].runs[runIndex].liveness = liveness
@@ -980,7 +1011,11 @@ final class AgentTaskRegistry {
                 restoredProjects.insert(tasks[index].project)
             }
         }
+        if trackingPersistence {
+            rollbackPersistenceRetryProjects.formUnion(restoredProjects)
+        }
         restoredProjects.forEach(markDirty)
+        return restoredProjects
     }
 
     private func finishTerminationCancellation() {
@@ -1002,13 +1037,14 @@ final class AgentTaskRegistry {
     /// restored snapshot remains dirty until it is actually durable. Retry in
     /// the background with bounded backoff so a later crash cannot indefinitely
     /// reload the paused/missing termination snapshot.
-    private func scheduleRollbackPersistenceRetry() {
-        rollbackPersistenceRetryTask?.cancel()
+    private func ensureRollbackPersistenceRetryScheduled() {
+        guard rollbackPersistenceRetryTask == nil,
+              !rollbackPersistenceRetryProjects.isEmpty else { return }
         rollbackPersistenceRetryTask = Task { @MainActor [weak self] in
             var delay = Duration.milliseconds(100)
             while !Task.isCancelled {
                 guard let self else { return }
-                let retryable = dirtyProjects.filter {
+                let retryable = rollbackPersistenceRetryProjects.filter {
                     registeredProjects.contains($0)
                         && !quarantinedProjects.contains($0)
                         && !unpersistableDirtyProjects.contains($0)
@@ -1021,7 +1057,8 @@ final class AgentTaskRegistry {
                 retryable.forEach(scheduleSaveIfReady)
                 if await flushPersistence(
                     maximumDuration: min(flushTotal, .seconds(2))
-                ) == .saved {
+                ) == .saved,
+                   rollbackPersistenceRetryProjects.isEmpty {
                     rollbackPersistenceRetryTask = nil
                     return
                 }
@@ -1107,7 +1144,8 @@ final class AgentTaskRegistry {
         var stagedInterruptedTaskIDs = Set<UUID>()
         for loadedTask in result.tasks {
             if loadedTask.origin == .pineLaunched,
-               loadedTask.runs.isEmpty {
+               loadedTask.runs.isEmpty,
+               loadedTask.launchInterruption == nil {
                 needsNormalizedSave = true
                 continue
             }
@@ -1274,6 +1312,7 @@ final class AgentTaskRegistry {
         ))
         task.route = context.route
         task.runs.append(run)
+        task.launchInterruption = nil
         task.lifecycle = liveness == .terminated ? .paused : .active
         if liveness == .terminated {
             task.route.availability = .missing
@@ -1422,6 +1461,10 @@ final class AgentTaskRegistry {
         case .initialLaunch:
             return task.runs.isEmpty
                 && task.route.terminalID == claim.route.terminalID
+        case .interruptedInitialLaunch:
+            return task.runs.isEmpty
+                && task.launchInterruption
+                    == .acknowledgedBeforeVerification
         case .resume(let previousRunID):
             guard let previous = task.runs.last else { return false }
             let generationIsValid = previous.terminalID != context.route.terminalID
@@ -1592,18 +1635,21 @@ final class AgentTaskRegistry {
             return
         }
         persistenceSequence += 1
-        let pendingInitialTaskIDs = Set<UUID>(
+        let pendingUnverifiedTaskIDs = Set<UUID>(
             pendingClaims.values.compactMap { claim in
-                guard case .initialLaunch = claim.kind else { return nil }
+                guard case .initialLaunch = claim.kind,
+                      task(for: claim.taskID)?.launchInterruption == nil else {
+                    return nil
+                }
                 return claim.taskID
             }
         )
-        // A Pine-owned task is not durable until authoritative process
-        // evidence appends its first run. This covers both pre-ACK dormant and
-        // post-ACK armed claims, including snapshots taken during Quit.
+        // Dormant launch intent is runtime-only. During Quit, an armed launch
+        // instead carries an honest interruption marker with no fabricated
+        // process evidence and must survive the application relaunch.
         let snapshot = tasks.filter {
             $0.project == project
-                && !pendingInitialTaskIDs.contains($0.id)
+                && !pendingUnverifiedTaskIDs.contains($0.id)
         }
         let store = persistence
         let revision = persistenceRevision[project]
@@ -1661,11 +1707,16 @@ final class AgentTaskRegistry {
                     persistenceRetryBlocked.insert(project)
                 } else {
                     persistenceRetryBlocked.remove(project)
+                    rollbackPersistenceRetryProjects.remove(project)
                 }
             }
             if ownsTail {
                 let pendingProjects = Array(dirtyProjects)
                 pendingProjects.forEach(scheduleSaveIfReady)
+            }
+            if rollbackPersistenceRetryProjects.contains(project),
+               rollbackPersistenceRetryTask == nil {
+                ensureRollbackPersistenceRetryScheduled()
             }
         }
     }
@@ -1846,8 +1897,11 @@ final class AgentTaskRegistry {
               let executable = task.descriptor.launchExecutable,
               task.descriptor.agentType.cliNames.contains(executable),
               !executable.contains(where: { $0.isWhitespace }),
-              let tail = task.runs.last,
-              resumableTail(tail, taskID: task.id) else {
+              (task.launchInterruption == .acknowledgedBeforeVerification
+                && task.runs.isEmpty
+                || task.runs.last.map {
+                    resumableTail($0, taskID: task.id)
+                } == true) else {
             return false
         }
         return !pendingClaims.values.contains { $0.taskID == task.id }

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -93,6 +93,8 @@ final class AgentTaskRegistry {
     @ObservationIgnored
     private var pendingClaimKeyByToken: [UUID: AgentTaskTerminalKey] = [:]
     @ObservationIgnored
+    private var terminationDecisionClaimRemaining: [UUID: Duration] = [:]
+    @ObservationIgnored
     private var terminationClaimRemaining: [UUID: Duration] = [:]
     @ObservationIgnored
     private var registeredProjects = Set<AgentTaskProjectIdentity>()
@@ -730,13 +732,79 @@ final class AgentTaskRegistry {
         if isTerminating {
             deadlineIsValid = terminationClaimRemaining[reservation.token]
                 .map { $0 > .zero } ?? false
+        } else if let remaining =
+                    terminationDecisionClaimRemaining[reservation.token] {
+            deadlineIsValid = remaining > .zero
         } else {
             deadlineIsValid = monotonicNow() < claim.deadline
         }
         guard deadlineIsValid else { return false }
         claim.state = .armed
         pendingClaims[key] = claim
+        // A PTY write may settle after Quit has already captured its rollback
+        // snapshot and started the first persistence pass. Record that exact
+        // acknowledgement immediately; the post-settlement persistence barrier
+        // must include this newer revision before AppKit may terminate Pine.
+        if isTerminating,
+           case .initialLaunch = claim.kind,
+           let index = taskIndex(for: claim.taskID),
+           tasks[index].runs.isEmpty,
+           tasks[index].launchInterruption == nil {
+            tasks[index].launchInterruption = .acknowledgedBeforeVerification
+            markDirty(tasks[index].project)
+        }
         return true
+    }
+
+    /// Pauses the bounded reservation lease while the user considers Quit.
+    /// Human deliberation is intentionally unbounded, but the exact launch
+    /// that caused the prompt must remain claimable until that decision is
+    /// either cancelled or transferred into the termination transaction.
+    func pauseLaunchExpirationForTerminationDecision(
+        _ reservations: Set<AgentTaskLaunchReservation>
+    ) -> Bool {
+        guard !isTerminating else { return false }
+        expireClaims()
+        let now = monotonicNow()
+        var remainingByToken: [UUID: Duration] = [:]
+        for reservation in reservations {
+            guard let key = pendingClaimKeyByToken[reservation.token],
+                  let claim = pendingClaims[key],
+                  claim.taskID == reservation.taskID else {
+                return false
+            }
+            let remaining = terminationDecisionClaimRemaining[
+                reservation.token
+            ] ?? max(.zero, now.duration(to: claim.deadline))
+            guard remaining > .zero else { return false }
+            remainingByToken[reservation.token] = remaining
+        }
+        for (token, remaining) in remainingByToken {
+            terminationDecisionClaimRemaining[token] = remaining
+            claimExpiryTasks.removeValue(forKey: token)?.cancel()
+        }
+        return true
+    }
+
+    /// Restores the lease after a cancelled Quit. The original remaining
+    /// duration is rebased from now, so time spent reading a native sheet does
+    /// not manufacture a claim expiry.
+    func resumeLaunchExpirationAfterTerminationDecision(
+        _ reservations: Set<AgentTaskLaunchReservation>
+    ) {
+        guard !isTerminating else { return }
+        let now = monotonicNow()
+        for reservation in reservations {
+            guard let remaining = terminationDecisionClaimRemaining
+                    .removeValue(forKey: reservation.token),
+                  let key = pendingClaimKeyByToken[reservation.token],
+                  var claim = pendingClaims[key],
+                  claim.taskID == reservation.taskID else {
+                continue
+            }
+            claim.deadline = now.advanced(by: remaining)
+            installClaim(claim, key: key)
+        }
     }
 
     func cancelLaunch(_ reservation: AgentTaskLaunchReservation) {
@@ -901,12 +969,12 @@ final class AgentTaskRegistry {
         let now = monotonicNow()
         terminationClaimRemaining.removeAll(keepingCapacity: true)
         for claim in pendingClaims.values {
-            terminationClaimRemaining[claim.token] = max(
-                .zero,
-                now.duration(to: claim.deadline)
-            )
+            terminationClaimRemaining[claim.token] =
+                terminationDecisionClaimRemaining[claim.token]
+                ?? max(.zero, now.duration(to: claim.deadline))
             claimExpiryTasks.removeValue(forKey: claim.token)?.cancel()
         }
+        terminationDecisionClaimRemaining.removeAll(keepingCapacity: true)
         var changedProjects = Set<AgentTaskProjectIdentity>()
         let acknowledgedInitialTaskIDs = Set(
             pendingClaims.values.compactMap { claim -> UUID? in
@@ -1550,6 +1618,7 @@ final class AgentTaskRegistry {
     private func removeClaim(for key: AgentTaskTerminalKey) {
         guard let claim = pendingClaims.removeValue(forKey: key) else { return }
         pendingClaimKeyByToken[claim.token] = nil
+        terminationDecisionClaimRemaining[claim.token] = nil
         terminationClaimRemaining[claim.token] = nil
         claimExpiryTasks.removeValue(forKey: claim.token)?.cancel()
     }
@@ -1577,8 +1646,11 @@ final class AgentTaskRegistry {
 
     private func expireClaims() {
         let now = monotonicNow()
-        let expired = pendingClaims.compactMap { key, claim in
-            claim.deadline <= now ? key : nil
+        let expired: [AgentTaskTerminalKey] = pendingClaims.compactMap { key, claim in
+            guard terminationDecisionClaimRemaining[claim.token] == nil else {
+                return nil
+            }
+            return claim.deadline <= now ? key : nil
         }
         expired.forEach(cancelClaim)
     }

--- a/Pine/DialogPresentationContext.swift
+++ b/Pine/DialogPresentationContext.swift
@@ -23,6 +23,17 @@ enum DialogRequestKey: Hashable {
     )
 }
 
+/// Controls what a queued request does while a framework-owned sheet occupies
+/// its captured window. Most commands use the bounded policy so a forgotten
+/// SwiftUI sheet cannot wedge a window's queue forever. Application
+/// termination is different: these sheets collect a human decision, so a
+/// generic presentation timeout must not silently turn that decision into a
+/// cancellation.
+enum DialogPresentationWaitPolicy {
+    case bounded
+    case waitUntilOwnerAvailable
+}
+
 extension DialogRequestKey {
     /// Concise, privacy-safe representation for `os_log` diagnostics (#1335).
     var logDescription: String {
@@ -53,6 +64,7 @@ final class WindowDialogCoordinator {
     private final class Request {
         let id: UUID
         let deduplicationKey: DialogRequestKey?
+        let waitPolicy: DialogPresentationWaitPolicy
         let start: Start
         let cancel: Cancel
         var continuation: CheckedContinuation<NSApplication.ModalResponse, Never>?
@@ -61,11 +73,13 @@ final class WindowDialogCoordinator {
         init(
             id: UUID,
             deduplicationKey: DialogRequestKey?,
+            waitPolicy: DialogPresentationWaitPolicy,
             start: @escaping Start,
             cancel: @escaping Cancel
         ) {
             self.id = id
             self.deduplicationKey = deduplicationKey
+            self.waitPolicy = waitPolicy
             self.start = start
             self.cancel = cancel
         }
@@ -90,8 +104,9 @@ final class WindowDialogCoordinator {
     private(set) var isOwnerClosed = false
 
     /// Polls the owner while a queued request is blocked by a foreign
-    /// (framework/SwiftUI) sheet, and bounds how long a queued request may
-    /// wait so the queue can never wedge permanently (#1335 H2).
+    /// (framework/SwiftUI) sheet. Ordinary requests have a bounded wait;
+    /// termination decisions keep polling until their human-owned surface is
+    /// available or the owner itself closes (#1335 H2, #1354).
     private let watchdogInterval: TimeInterval
     private let watchdogMaxAttempts: Int
     private var queuedWatchdog: Task<Void, Never>?
@@ -179,6 +194,7 @@ final class WindowDialogCoordinator {
     /// `.abort`; a dialog is never promoted to an application-modal window.
     func present(
         deduplicationKey: DialogRequestKey? = nil,
+        waitPolicy: DialogPresentationWaitPolicy = .bounded,
         start: @escaping Start,
         cancel: @escaping Cancel
     ) async -> NSApplication.ModalResponse {
@@ -206,6 +222,7 @@ final class WindowDialogCoordinator {
                 let request = Request(
                     id: requestID,
                     deduplicationKey: deduplicationKey,
+                    waitPolicy: waitPolicy,
                     start: start,
                     cancel: cancel
                 )
@@ -291,8 +308,8 @@ final class WindowDialogCoordinator {
 
     /// Arms the foreign-sheet watchdog for the front queued request. Polls the
     /// owner on `watchdogInterval`; once the foreign sheet clears the queued
-    /// request is presented, and after `watchdogMaxAttempts` the front request
-    /// is resolved as `.abort` so the queue can never wedge permanently.
+    /// request is presented. After `watchdogMaxAttempts`, ordinary requests
+    /// resolve as `.abort`; termination requests begin another polling period.
     private func armQueuedPresentationWatchdog() {
         guard queuedWatchdog == nil else { return }
         let interval = watchdogInterval
@@ -311,9 +328,19 @@ final class WindowDialogCoordinator {
                 self.presentNextIfPossible()
                 if Task.isCancelled { return }
             }
-            // Bound elapsed with the foreign sheet still attached: resolve the
-            // front request so the queue is not wedged forever.
+            // Bound elapsed with the foreign sheet still attached. Ordinary
+            // requests abort so the queue cannot wedge forever. A Quit
+            // decision deliberately keeps polling: human deliberation and an
+            // already-visible framework sheet are outside the machine-work
+            // termination budget.
             guard let self else { return }
+            if self.queuedRequests.first?.waitPolicy
+                == .waitUntilOwnerAvailable {
+                Logger.app.debug("termination dialog still waiting for an attached foreign sheet; continuing to poll")
+                self.queuedWatchdog = nil
+                self.armQueuedPresentationWatchdog()
+                return
+            }
             Logger.app.debug("queued request aborted after watchdog bound — owner still has an attached foreign sheet (#1335 H2)")
             self.abortFrontQueuedRequest()
         }
@@ -360,13 +387,19 @@ final class WindowDialogCoordinator {
 @MainActor
 struct DialogPresentationContext {
     fileprivate let coordinator: WindowDialogCoordinator?
+    private let waitPolicy: DialogPresentationWaitPolicy
 
     init(window: NSWindow?) {
         coordinator = window.map { DialogPresenter.coordinator(for: $0) }
+        waitPolicy = .bounded
     }
 
-    fileprivate init(coordinator: WindowDialogCoordinator?) {
+    fileprivate init(
+        coordinator: WindowDialogCoordinator?,
+        waitPolicy: DialogPresentationWaitPolicy = .bounded
+    ) {
         self.coordinator = coordinator
+        self.waitPolicy = waitPolicy
     }
 
     /// A deliberately unavailable owner. Presentation against this context
@@ -379,6 +412,16 @@ struct DialogPresentationContext {
         coordinator?.ownerWindowForPresentation
     }
 
+    /// Returns the same captured authority with a Quit-specific queue policy.
+    /// Owner closure still resolves `.abort`; only the generic foreign-sheet
+    /// watchdog is disabled so the caller can rebind a genuinely lost owner.
+    func waitingUntilOwnerAvailable() -> DialogPresentationContext {
+        DialogPresentationContext(
+            coordinator: coordinator,
+            waitPolicy: .waitUntilOwnerAvailable
+        )
+    }
+
     func present(
         deduplicationKey: DialogRequestKey? = nil,
         start: @escaping WindowDialogCoordinator.Start,
@@ -387,6 +430,7 @@ struct DialogPresentationContext {
         guard let coordinator else { return .abort }
         return await coordinator.present(
             deduplicationKey: deduplicationKey,
+            waitPolicy: waitPolicy,
             start: start,
             cancel: cancel
         )

--- a/Pine/EditorTab.swift
+++ b/Pine/EditorTab.swift
@@ -67,12 +67,22 @@ struct EditorTab: Identifiable, Hashable {
     var content: String {
         didSet { contentVersion &+= 1 }
     }
-    var savedContent: String
+    /// Last content known to be durable on disk. Every baseline replacement
+    /// advances `persistenceGeneration`, fencing delayed filesystem callbacks
+    /// from regressing a newer successful save or reload.
+    var savedContent: String {
+        didSet { persistenceGeneration &+= 1 }
+    }
     var kind: TabKind
 
     /// Monotonic counter incremented on every content mutation.
     /// Used for O(1) change detection instead of O(n) string comparison.
     private(set) var contentVersion: UInt64 = 0
+
+    /// Monotonic counter incremented whenever the durable-content baseline is
+    /// replaced. Unlike `contentVersion`, this advances even when a successful
+    /// save writes text identical to the current buffer.
+    private(set) var persistenceGeneration: UInt64 = 0
 
     // Per-tab editor state — preserved across tab switches.
     var cursorPosition: Int = 0
@@ -212,6 +222,7 @@ struct EditorTab: Identifiable, Hashable {
         copy.isPinned = source.isPinned
         copy.cachedHighlightResult = source.cachedHighlightResult
         copy.encoding = source.encoding
+        copy.persistenceGeneration = source.persistenceGeneration
         copy.recomputeContentCaches()
         return copy
     }

--- a/Pine/Extensibility/UserTaskRunStore.swift
+++ b/Pine/Extensibility/UserTaskRunStore.swift
@@ -13,6 +13,20 @@
 
 import Foundation
 
+/// Stable execution identities covered by one explicit shutdown decision.
+/// A later run of the same configured task receives a new run ID and is not
+/// covered by this authorization.
+@MainActor
+struct UserTaskExecutionAuthorization: Equatable {
+    fileprivate let executionIDs: Set<UUID>
+
+    init(executionIDs: Set<UUID> = []) {
+        self.executionIDs = executionIDs
+    }
+
+    var requiresConfirmation: Bool { !executionIDs.isEmpty }
+}
+
 nonisolated private enum UserTaskCompletionWaiter {
     static func wait(
         for handles: [UserTaskCancellation],
@@ -272,22 +286,67 @@ final class UserTaskRunStore {
         }
     }
 
-    /// Cancels and waits for every active run using one shared absolute
-    /// deadline.
-    ///
-    /// Cancellation ownership is snapshotted on the main actor, but the
-    /// blocking process waits run on a background queue. This keeps project
-    /// reopening and AppKit's asynchronous termination handshake responsive
-    /// while the runner reaps direct children and finishes bounded cleanup.
-    @discardableResult
-    func shutdownAll(until deadline: DispatchTime) async -> Bool {
-        requestShutdown()
+    /// Captures every execution for which this store still owns process or
+    /// cleanup responsibility. This intentionally includes more than the
+    /// visible active-run array.
+    func captureShutdownAuthorization() -> UserTaskExecutionAuthorization {
         pruneResolvedCleanupOwnership()
-        let ownershipIDs = executionOwnershipRunIDs
+        return UserTaskExecutionAuthorization(
+            executionIDs: executionOwnershipRunIDs
+        )
+    }
+
+    /// New execution ownership is never covered by an older user decision.
+    func shutdownAuthorizationStillCovers(
+        _ authorization: UserTaskExecutionAuthorization
+    ) -> Bool {
+        pruneResolvedCleanupOwnership()
+        return executionOwnershipRunIDs.isSubset(
+            of: authorization.executionIDs
+        )
+    }
+
+    /// Requests cancellation only for executions named by the authorization.
+    /// The all-or-nothing preflight prevents partial cancellation if any new
+    /// execution appeared before this method reached the MainActor.
+    @discardableResult
+    func requestShutdown(
+        authorizedBy authorization: UserTaskExecutionAuthorization
+    ) -> Bool {
+        guard shutdownAuthorizationStillCovers(authorization) else {
+            return false
+        }
+        for run in runs
+        where authorization.executionIDs.contains(run.id)
+            && run.state.isActive
+            && run.state != .cancelling {
+            if let handle = cancellationHandles[run.id] {
+                if handle.cancel() {
+                    run.markCancelling()
+                }
+            } else {
+                pendingCancellationRunIDs.insert(run.id)
+            }
+        }
+        return true
+    }
+
+    /// Waits only for the execution generations the user authorized. A new
+    /// run appearing while the wait is suspended is left untouched and makes
+    /// the shutdown fail closed.
+    @discardableResult
+    func waitForShutdown(
+        authorizedBy authorization: UserTaskExecutionAuthorization,
+        until deadline: DispatchTime
+    ) async -> Bool {
+        pruneResolvedCleanupOwnership()
+        let ownedAuthorizedIDs = executionOwnershipRunIDs.intersection(
+            authorization.executionIDs
+        )
         var handles: [UserTaskCancellation] = []
         var ownsEveryExecution = true
 
-        for id in ownershipIDs {
+        for id in ownedAuthorizedIDs {
             if let handle = cancellationHandles[id] {
                 handles.append(handle)
             } else {
@@ -299,12 +358,12 @@ final class UserTaskRunStore {
             for: handles,
             until: deadline
         )
-        let hasNewExecutionOwnership =
-            !executionOwnershipRunIDs.subtracting(ownershipIDs).isEmpty
-        let capturedExecutionsCompleted =
-            ownsEveryExecution && handlesCompleted
-        let allCompleted =
-            capturedExecutionsCompleted && !hasNewExecutionOwnership
+        let hasUnauthorizedExecution = !executionOwnershipRunIDs.isSubset(
+            of: authorization.executionIDs
+        )
+        let allCompleted = ownsEveryExecution
+            && handlesCompleted
+            && !hasUnauthorizedExecution
 
         if allCompleted {
             runs.removeAll()
@@ -313,6 +372,25 @@ final class UserTaskRunStore {
             unresolvedCleanupRunIDs.removeAll()
         }
         return allCompleted
+    }
+
+    /// Cancels and waits for every active run using one shared absolute
+    /// deadline.
+    ///
+    /// Cancellation ownership is snapshotted on the main actor, but the
+    /// blocking process waits run on a background queue. This keeps project
+    /// reopening and AppKit's asynchronous termination handshake responsive
+    /// while the runner reaps direct children and finishes bounded cleanup.
+    @discardableResult
+    func shutdownAll(until deadline: DispatchTime) async -> Bool {
+        let authorization = captureShutdownAuthorization()
+        guard requestShutdown(authorizedBy: authorization) else {
+            return false
+        }
+        return await waitForShutdown(
+            authorizedBy: authorization,
+            until: deadline
+        )
     }
 
     /// Whether teardown can release this store without dropping ownership of

--- a/Pine/Extensibility/UserTaskRunStore.swift
+++ b/Pine/Extensibility/UserTaskRunStore.swift
@@ -19,9 +19,14 @@ import Foundation
 @MainActor
 struct UserTaskExecutionAuthorization: Equatable {
     fileprivate let executionIDs: Set<UUID>
+    fileprivate let launchGeneration: UUID?
 
-    init(executionIDs: Set<UUID> = []) {
+    init(
+        executionIDs: Set<UUID> = [],
+        launchGeneration: UUID? = nil
+    ) {
         self.executionIDs = executionIDs
+        self.launchGeneration = launchGeneration
     }
 
     var requiresConfirmation: Bool { !executionIDs.isEmpty }
@@ -76,6 +81,10 @@ final class UserTaskRunStore {
     /// been released. This also covers the short race before a late handle is
     /// published on the main queue.
     private var unresolvedCleanupRunIDs: Set<UUID> = []
+    /// Changes for every accepted invocation and deliberately survives run
+    /// cleanup, so a transient late execution cannot disappear between Quit
+    /// authorization checks.
+    private var launchGeneration: UUID?
     private let maximumRuns: Int
     private let maximumRetainedOutputBytes: Int
 
@@ -95,6 +104,7 @@ final class UserTaskRunStore {
     /// progress. Returns the run so the caller can drive its state.
     @discardableResult
     func start(_ run: UserTaskRun) -> UserTaskRun {
+        launchGeneration = UUID()
         runs.insert(run, at: 0)
         isOutputVisible = true
         trimToCapacity()
@@ -292,7 +302,8 @@ final class UserTaskRunStore {
     func captureShutdownAuthorization() -> UserTaskExecutionAuthorization {
         pruneResolvedCleanupOwnership()
         return UserTaskExecutionAuthorization(
-            executionIDs: executionOwnershipRunIDs
+            executionIDs: executionOwnershipRunIDs,
+            launchGeneration: launchGeneration
         )
     }
 
@@ -301,7 +312,8 @@ final class UserTaskRunStore {
         _ authorization: UserTaskExecutionAuthorization
     ) -> Bool {
         pruneResolvedCleanupOwnership()
-        return executionOwnershipRunIDs.isSubset(
+        return launchGeneration == authorization.launchGeneration
+            && executionOwnershipRunIDs.isSubset(
             of: authorization.executionIDs
         )
     }
@@ -358,9 +370,11 @@ final class UserTaskRunStore {
             for: handles,
             until: deadline
         )
-        let hasUnauthorizedExecution = !executionOwnershipRunIDs.isSubset(
-            of: authorization.executionIDs
-        )
+        let hasUnauthorizedExecution =
+            launchGeneration != authorization.launchGeneration
+            || !executionOwnershipRunIDs.isSubset(
+                of: authorization.executionIDs
+            )
         let allCompleted = ownsEveryExecution
             && handlesCompleted
             && !hasUnauthorizedExecution

--- a/Pine/Extensibility/UserTaskRunStore.swift
+++ b/Pine/Extensibility/UserTaskRunStore.swift
@@ -85,6 +85,14 @@ final class UserTaskRunStore {
     /// cleanup, so a transient late execution cannot disappear between Quit
     /// authorization checks.
     private var launchGeneration: UUID?
+    /// Changes whenever runner ownership publishes or replaces a handle.
+    /// A wait cannot prepare a handle that changed while it was suspended.
+    private var cancellationRegistrationGeneration: UUID?
+    /// A successful wait is only the prepare phase of application-wide
+    /// shutdown. History and execution ownership remain intact until every
+    /// project store has prepared and the registry commits them together.
+    private var preparedShutdownAuthorization:
+        UserTaskExecutionAuthorization?
     private let maximumRuns: Int
     private let maximumRetainedOutputBytes: Int
 
@@ -104,6 +112,7 @@ final class UserTaskRunStore {
     /// progress. Returns the run so the caller can drive its state.
     @discardableResult
     func start(_ run: UserTaskRun) -> UserTaskRun {
+        preparedShutdownAuthorization = nil
         launchGeneration = UUID()
         runs.insert(run, at: 0)
         isOutputVisible = true
@@ -118,6 +127,8 @@ final class UserTaskRunStore {
         _ handle: UserTaskCancellation,
         forRunID id: UUID
     ) {
+        preparedShutdownAuthorization = nil
+        cancellationRegistrationGeneration = UUID()
         let cancellationWasPending =
             pendingCancellationRunIDs.remove(id) != nil
         if unresolvedCleanupRunIDs.contains(id) {
@@ -325,6 +336,7 @@ final class UserTaskRunStore {
     func requestShutdown(
         authorizedBy authorization: UserTaskExecutionAuthorization
     ) -> Bool {
+        preparedShutdownAuthorization = nil
         guard shutdownAuthorizationStillCovers(authorization) else {
             return false
         }
@@ -343,15 +355,19 @@ final class UserTaskRunStore {
         return true
     }
 
-    /// Waits only for the execution generations the user authorized. A new
-    /// run appearing while the wait is suspended is left untouched and makes
-    /// the shutdown fail closed.
+    /// Waits only for the execution generations the user authorized. This is
+    /// the prepare phase: a successful wait retains runs, output, and cleanup
+    /// ownership until the caller commits after every owner has prepared. A
+    /// new run appearing while the wait is suspended is left untouched and
+    /// makes the shutdown fail closed.
     @discardableResult
     func waitForShutdown(
         authorizedBy authorization: UserTaskExecutionAuthorization,
         until deadline: DispatchTime
     ) async -> Bool {
+        preparedShutdownAuthorization = nil
         pruneResolvedCleanupOwnership()
+        let registrationGeneration = cancellationRegistrationGeneration
         let ownedAuthorizedIDs = executionOwnershipRunIDs.intersection(
             authorization.executionIDs
         )
@@ -372,6 +388,7 @@ final class UserTaskRunStore {
         )
         let hasUnauthorizedExecution =
             launchGeneration != authorization.launchGeneration
+            || cancellationRegistrationGeneration != registrationGeneration
             || !executionOwnershipRunIDs.isSubset(
                 of: authorization.executionIDs
             )
@@ -380,12 +397,32 @@ final class UserTaskRunStore {
             && !hasUnauthorizedExecution
 
         if allCompleted {
-            runs.removeAll()
-            cancellationHandles.removeAll()
-            pendingCancellationRunIDs.removeAll()
-            unresolvedCleanupRunIDs.removeAll()
+            preparedShutdownAuthorization = authorization
         }
         return allCompleted
+    }
+
+    /// Revalidates a successful prepare phase immediately before commit.
+    /// Callers must perform this check for every store without suspension,
+    /// then commit every prepared store without suspension.
+    func shutdownIsPreparedForCommit(
+        authorizedBy authorization: UserTaskExecutionAuthorization
+    ) -> Bool {
+        preparedShutdownAuthorization == authorization
+            && shutdownAuthorizationStillCovers(authorization)
+    }
+
+    /// Commits a previously revalidated prepare phase. There must be no
+    /// suspension between the all-owner preflight and this mutation.
+    func commitPreparedShutdown(
+        authorizedBy authorization: UserTaskExecutionAuthorization
+    ) {
+        precondition(preparedShutdownAuthorization == authorization)
+        runs.removeAll()
+        cancellationHandles.removeAll()
+        pendingCancellationRunIDs.removeAll()
+        unresolvedCleanupRunIDs.removeAll()
+        preparedShutdownAuthorization = nil
     }
 
     /// Cancels and waits for every active run using one shared absolute
@@ -401,10 +438,14 @@ final class UserTaskRunStore {
         guard requestShutdown(authorizedBy: authorization) else {
             return false
         }
-        return await waitForShutdown(
+        guard await waitForShutdown(
             authorizedBy: authorization,
             until: deadline
-        )
+        ), shutdownIsPreparedForCommit(authorizedBy: authorization) else {
+            return false
+        }
+        commitPreparedShutdown(authorizedBy: authorization)
+        return true
     }
 
     /// Whether teardown can release this store without dropping ownership of

--- a/Pine/ExternalFileFormatter.swift
+++ b/Pine/ExternalFileFormatter.swift
@@ -3,6 +3,7 @@
 //  Pine
 //
 
+import Darwin
 import Foundation
 
 /// Result of running an external process.
@@ -35,85 +36,327 @@ nonisolated func runRealProcess(
     timeout: TimeInterval
 ) -> ProcessRunResult {
     precondition(!Thread.isMainThread, "runRealProcess() must not be called on the main thread")
-
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: executablePath)
-    process.arguments = arguments
-
-    let stdinPipe = Pipe()
-    let stdoutPipe = Pipe()
-    let stderrPipe = Pipe()
-    process.standardInput = stdinPipe
-    process.standardOutput = stdoutPipe
-    process.standardError = stderrPipe
-
-    do {
-        try process.run()
-
-        // Write stdin content and close
-        if let data = stdin.data(using: .utf8) {
-            stdinPipe.fileHandleForWriting.write(data)
-        }
-        stdinPipe.fileHandleForWriting.closeFile()
-
-        // Schedule timeout with thread-safe flag via NSLock
-        // (GCD serial queue .sync crashes under Swift 6 cooperative threading
-        //  because swift_task_checkIsolatedSwift triggers dispatch_assert_queue)
-        let timedOutLock = NSLock()
-        nonisolated(unsafe) var timedOutValue = false
-
-        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
-        timer.schedule(deadline: .now() + timeout)
-        timer.setEventHandler {
-            timedOutLock.lock()
-            timedOutValue = true
-            timedOutLock.unlock()
-            if process.isRunning {
-                process.terminate()
-            }
-        }
-        timer.resume()
-
-        // Read both pipes concurrently in separate threads to avoid
-        // deadlock when stderr pipe buffer fills up (64KB)
-        let readGroup = DispatchGroup()
-        nonisolated(unsafe) var outData = Data()
-        nonisolated(unsafe) var errData = Data()
-
-        readGroup.enter()
-        DispatchQueue.global().async {
-            outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-            readGroup.leave()
-        }
-
-        readGroup.enter()
-        DispatchQueue.global().async {
-            errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-            readGroup.leave()
-        }
-
-        readGroup.wait()
-        process.waitUntilExit()
-        timer.cancel()
-
-        timedOutLock.lock()
-        let didTimeout = timedOutValue
-        timedOutLock.unlock()
-
-        return ProcessRunResult(
-            stdout: String(bytes: outData, encoding: .utf8) ?? "",
-            stderr: String(bytes: errData, encoding: .utf8) ?? "",
-            exitCode: process.terminationStatus,
-            timedOut: didTimeout
-        )
-    } catch {
+    guard timeout.isFinite, timeout > 0 else {
         return ProcessRunResult(
             stdout: "",
-            stderr: error.localizedDescription,
+            stderr: "Process deadline expired",
             exitCode: -1,
-            timedOut: false
+            timedOut: true
         )
     }
+    return runSpawnedProcess(
+        executablePath: executablePath,
+        arguments: arguments,
+        stdin: Data(stdin.utf8),
+        timeout: timeout
+    )
+}
+
+nonisolated private func runSpawnedProcess(
+    executablePath: String,
+    arguments: [String],
+    stdin: Data,
+    timeout: TimeInterval
+) -> ProcessRunResult {
+    var inputPipe = [Int32](repeating: -1, count: 2)
+    var outputPipe = [Int32](repeating: -1, count: 2)
+    var errorPipe = [Int32](repeating: -1, count: 2)
+    guard Darwin.pipe(&inputPipe) == 0,
+          Darwin.pipe(&outputPipe) == 0,
+          Darwin.pipe(&errorPipe) == 0 else {
+        closeDescriptors(inputPipe + outputPipe + errorPipe)
+        return processLaunchFailure(errno)
+    }
+
+    var fileActions: posix_spawn_file_actions_t?
+    var attributes: posix_spawnattr_t?
+    guard posix_spawn_file_actions_init(&fileActions) == 0,
+          posix_spawnattr_init(&attributes) == 0 else {
+        closeDescriptors(inputPipe + outputPipe + errorPipe)
+        return processLaunchFailure(errno)
+    }
+    defer {
+        posix_spawn_file_actions_destroy(&fileActions)
+        posix_spawnattr_destroy(&attributes)
+    }
+
+    let childMappings = [
+        (inputPipe[0], STDIN_FILENO),
+        (outputPipe[1], STDOUT_FILENO),
+        (errorPipe[1], STDERR_FILENO),
+    ]
+    for (source, destination) in childMappings {
+        guard posix_spawn_file_actions_adddup2(
+            &fileActions,
+            source,
+            destination
+        ) == 0 else {
+            closeDescriptors(inputPipe + outputPipe + errorPipe)
+            return processLaunchFailure(errno)
+        }
+    }
+    for descriptor in inputPipe + outputPipe + errorPipe {
+        guard posix_spawn_file_actions_addclose(
+            &fileActions,
+            descriptor
+        ) == 0 else {
+            closeDescriptors(inputPipe + outputPipe + errorPipe)
+            return processLaunchFailure(errno)
+        }
+    }
+    guard posix_spawnattr_setflags(
+        &attributes,
+        Int16(POSIX_SPAWN_SETPGROUP)
+    ) == 0,
+          posix_spawnattr_setpgroup(&attributes, 0) == 0 else {
+        closeDescriptors(inputPipe + outputPipe + errorPipe)
+        return processLaunchFailure(errno)
+    }
+
+    let environment = ProcessInfo.processInfo.environment.map {
+        "\($0.key)=\($0.value)"
+    }
+    var childPID: pid_t = 0
+    let spawnResult = withMutableCStringArray(
+        [executablePath] + arguments
+    ) { argumentVector in
+        withMutableCStringArray(environment) { environmentVector in
+            posix_spawn(
+                &childPID,
+                executablePath,
+                &fileActions,
+                &attributes,
+                argumentVector,
+                environmentVector
+            )
+        }
+    }
+    guard spawnResult == 0 else {
+        closeDescriptors(inputPipe + outputPipe + errorPipe)
+        return processLaunchFailure(spawnResult)
+    }
+
+    Darwin.close(inputPipe[0])
+    Darwin.close(outputPipe[1])
+    Darwin.close(errorPipe[1])
+    var inputDescriptor = inputPipe[1]
+    var outputDescriptor = outputPipe[0]
+    var errorDescriptor = errorPipe[0]
+    setNonblocking(inputDescriptor)
+    setNonblocking(outputDescriptor)
+    setNonblocking(errorDescriptor)
+    _ = Darwin.fcntl(inputDescriptor, F_SETNOSIGPIPE, 1)
+
+    let start = DispatchTime.now().uptimeNanoseconds
+    let budget = UInt64(timeout * 1_000_000_000)
+    let hardDeadline = start &+ budget
+    let grace = min(100_000_000, max(10_000_000, budget / 5))
+    let softDeadline = hardDeadline &- grace
+    var sentTermination = false
+    var didTimeOut = false
+    var processStatus: Int32?
+    var inputOffset = 0
+    var output = Data()
+    var errors = Data()
+
+    while true {
+        reapIfExited(childPID, status: &processStatus)
+        drainPipe(&outputDescriptor, into: &output)
+        drainPipe(&errorDescriptor, into: &errors)
+        writePipe(
+            &inputDescriptor,
+            data: stdin,
+            offset: &inputOffset
+        )
+        if processStatus != nil,
+           outputDescriptor < 0,
+           errorDescriptor < 0 {
+            break
+        }
+
+        let now = DispatchTime.now().uptimeNanoseconds
+        if !sentTermination, now >= softDeadline {
+            didTimeOut = true
+            sentTermination = true
+            closeDescriptor(&inputDescriptor)
+            _ = Darwin.kill(-childPID, SIGTERM)
+        }
+        if now >= hardDeadline {
+            didTimeOut = true
+            _ = Darwin.kill(-childPID, SIGKILL)
+            closeDescriptor(&inputDescriptor)
+            closeDescriptor(&outputDescriptor)
+            closeDescriptor(&errorDescriptor)
+            reapIfExited(childPID, status: &processStatus)
+            if processStatus == nil {
+                let reapingPID = childPID
+                DispatchQueue.global(qos: .utility).async {
+                    var status: Int32 = 0
+                    while Darwin.waitpid(reapingPID, &status, 0) < 0,
+                          errno == EINTR {}
+                }
+            }
+            break
+        }
+
+        var pollDescriptors = makePollDescriptors(
+            input: inputDescriptor,
+            wantsInput: inputOffset < stdin.count,
+            output: outputDescriptor,
+            error: errorDescriptor
+        )
+        let nextBoundary = sentTermination ? hardDeadline : softDeadline
+        let remaining = nextBoundary > now ? nextBoundary - now : 0
+        let waitMilliseconds = Int32(
+            min(10, max(1, remaining / 1_000_000))
+        )
+        _ = Darwin.poll(
+            &pollDescriptors,
+            nfds_t(pollDescriptors.count),
+            waitMilliseconds
+        )
+    }
+
+    closeDescriptor(&inputDescriptor)
+    closeDescriptor(&outputDescriptor)
+    closeDescriptor(&errorDescriptor)
+    return ProcessRunResult(
+        stdout: String(bytes: output, encoding: .utf8) ?? "",
+        stderr: String(bytes: errors, encoding: .utf8) ?? "",
+        exitCode: processStatus.map(processExitCode) ?? -1,
+        timedOut: didTimeOut
+    )
+}
+
+nonisolated private func withMutableCStringArray<Result>(
+    _ strings: [String],
+    body: (UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) -> Result
+) -> Result {
+    let allocated = strings.map { strdup($0) }
+    defer { allocated.forEach { free($0) } }
+    var pointers = allocated
+    pointers.append(nil)
+    return pointers.withUnsafeMutableBufferPointer { buffer in
+        guard let baseAddress = buffer.baseAddress else {
+            preconditionFailure("CString vector must contain its terminator")
+        }
+        return body(baseAddress)
+    }
+}
+
+nonisolated private func makePollDescriptors(
+    input: Int32,
+    wantsInput: Bool,
+    output: Int32,
+    error: Int32
+) -> [pollfd] {
+    var descriptors: [pollfd] = []
+    if input >= 0, wantsInput {
+        descriptors.append(pollfd(fd: input, events: Int16(POLLOUT), revents: 0))
+    }
+    if output >= 0 {
+        descriptors.append(pollfd(fd: output, events: Int16(POLLIN), revents: 0))
+    }
+    if error >= 0 {
+        descriptors.append(pollfd(fd: error, events: Int16(POLLIN), revents: 0))
+    }
+    return descriptors
+}
+
+nonisolated private func setNonblocking(_ descriptor: Int32) {
+    let flags = Darwin.fcntl(descriptor, F_GETFL)
+    if flags >= 0 {
+        _ = Darwin.fcntl(descriptor, F_SETFL, flags | O_NONBLOCK)
+    }
+}
+
+nonisolated private func writePipe(
+    _ descriptor: inout Int32,
+    data: Data,
+    offset: inout Int
+) {
+    guard descriptor >= 0 else { return }
+    if offset >= data.count {
+        closeDescriptor(&descriptor)
+        return
+    }
+    let result = data.withUnsafeBytes { bytes in
+        guard let baseAddress = bytes.baseAddress else { return -1 }
+        return Darwin.write(
+            descriptor,
+            baseAddress.advanced(by: offset),
+            bytes.count - offset
+        )
+    }
+    if result > 0 {
+        offset += result
+    } else if result < 0, errno != EINTR, errno != EAGAIN {
+        closeDescriptor(&descriptor)
+    }
+}
+
+nonisolated private func drainPipe(
+    _ descriptor: inout Int32,
+    into data: inout Data
+) {
+    guard descriptor >= 0 else { return }
+    var buffer = [UInt8](repeating: 0, count: 16_384)
+    while true {
+        let count = Darwin.read(descriptor, &buffer, buffer.count)
+        if count > 0 {
+            data.append(buffer, count: count)
+        } else if count == 0 {
+            closeDescriptor(&descriptor)
+            return
+        } else if errno == EINTR {
+            continue
+        } else if errno == EAGAIN {
+            return
+        } else {
+            closeDescriptor(&descriptor)
+            return
+        }
+    }
+}
+
+nonisolated private func reapIfExited(
+    _ processID: pid_t,
+    status: inout Int32?
+) {
+    guard status == nil else { return }
+    var candidate: Int32 = 0
+    let result = Darwin.waitpid(processID, &candidate, WNOHANG)
+    if result == processID {
+        status = candidate
+    }
+}
+
+nonisolated private func processExitCode(_ status: Int32) -> Int32 {
+    let signal = status & 0x7f
+    return signal == 0 ? (status >> 8) & 0xff : 128 + signal
+}
+
+nonisolated private func closeDescriptors(_ descriptors: [Int32]) {
+    for descriptor in descriptors where descriptor >= 0 {
+        Darwin.close(descriptor)
+    }
+}
+
+nonisolated private func closeDescriptor(_ descriptor: inout Int32) {
+    guard descriptor >= 0 else { return }
+    Darwin.close(descriptor)
+    descriptor = -1
+}
+
+nonisolated private func processLaunchFailure(
+    _ code: Int32
+) -> ProcessRunResult {
+    ProcessRunResult(
+        stdout: "",
+        stderr: String(cString: strerror(code)),
+        exitCode: -1,
+        timedOut: false
+    )
 }
 
 /// A file formatter that delegates to an external CLI tool via stdin/stdout.

--- a/Pine/ExternalFileFormatter.swift
+++ b/Pine/ExternalFileFormatter.swift
@@ -7,11 +7,46 @@ import Darwin
 import Foundation
 
 /// Result of running an external process.
-struct ProcessRunResult: Sendable {
+nonisolated struct ProcessRunResult: Sendable {
     let stdout: String
     let stderr: String
     let exitCode: Int32
     let timedOut: Bool
+    let outputLimitExceeded: Bool
+
+    init(
+        stdout: String,
+        stderr: String,
+        exitCode: Int32,
+        timedOut: Bool,
+        outputLimitExceeded: Bool = false
+    ) {
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exitCode = exitCode
+        self.timedOut = timedOut
+        self.outputLimitExceeded = outputLimitExceeded
+    }
+}
+
+/// Byte limits applied while capturing a subprocess's output. Formatters only
+/// operate on Pine's in-memory document contents, so these bounds comfortably
+/// cover normal and large-file edits while preventing a broken tool from
+/// consuming memory without limit.
+nonisolated struct ProcessOutputLimits: Sendable {
+    let stdoutBytes: Int
+    let stderrBytes: Int
+
+    static let formatter = ProcessOutputLimits(
+        stdoutBytes: 16 * 1_024 * 1_024,
+        stderrBytes: 1 * 1_024 * 1_024
+    )
+}
+
+nonisolated private final class ExternalProcessSpawnLock: @unchecked Sendable {
+    static let shared = ExternalProcessSpawnLock()
+
+    let value = NSLock()
 }
 
 /// Signature for running an external process. Closure-based so tests can inject
@@ -48,7 +83,36 @@ nonisolated func runRealProcess(
         executablePath: executablePath,
         arguments: arguments,
         stdin: Data(stdin.utf8),
-        timeout: timeout
+        timeout: timeout,
+        outputLimits: .formatter
+    )
+}
+
+/// Internal overload used by focused process-runner tests to exercise output
+/// and deadline boundaries without allocating the production-sized limits.
+@Sendable
+nonisolated func runRealProcess(
+    executablePath: String,
+    arguments: [String],
+    stdin: String,
+    timeout: TimeInterval,
+    outputLimits: ProcessOutputLimits
+) -> ProcessRunResult {
+    precondition(!Thread.isMainThread, "runRealProcess() must not be called on the main thread")
+    guard timeout.isFinite, timeout > 0 else {
+        return ProcessRunResult(
+            stdout: "",
+            stderr: "Process deadline expired",
+            exitCode: -1,
+            timedOut: true
+        )
+    }
+    return runSpawnedProcess(
+        executablePath: executablePath,
+        arguments: arguments,
+        stdin: Data(stdin.utf8),
+        timeout: timeout,
+        outputLimits: outputLimits
     )
 }
 
@@ -56,16 +120,53 @@ nonisolated private func runSpawnedProcess(
     executablePath: String,
     arguments: [String],
     stdin: Data,
-    timeout: TimeInterval
+    timeout: TimeInterval,
+    outputLimits: ProcessOutputLimits
 ) -> ProcessRunResult {
+    let start = DispatchTime.now().uptimeNanoseconds
+    let requestedNanoseconds = timeout * 1_000_000_000
+    let maximumBudget = UInt64.max - start
+    let budget = requestedNanoseconds >= Double(maximumBudget)
+        ? maximumBudget
+        : UInt64(requestedNanoseconds)
+    let hardDeadline = start + budget
+    let desiredGrace = min(100_000_000, max(10_000_000, budget / 5))
+    let grace = min(budget, desiredGrace)
+    let softDeadline = hardDeadline - grace
+
+    // `pipe2(O_CLOEXEC)` is atomic, but only available on macOS 27. The
+    // deployment-target fallback serializes Pine's process runners across the
+    // short pipe()+fcntl()+spawn window. CLOEXEC_DEFAULT below additionally
+    // prevents unrelated descriptors from entering this child on both OSes.
+    let requiresSpawnLock: Bool
+    if #available(macOS 27.0, *) {
+        requiresSpawnLock = false
+    } else {
+        requiresSpawnLock = true
+    }
+    if requiresSpawnLock {
+        ExternalProcessSpawnLock.shared.value.lock()
+    }
+    var holdsSpawnLock = requiresSpawnLock
+    defer {
+        if holdsSpawnLock {
+            ExternalProcessSpawnLock.shared.value.unlock()
+        }
+    }
+
     var inputPipe = [Int32](repeating: -1, count: 2)
     var outputPipe = [Int32](repeating: -1, count: 2)
     var errorPipe = [Int32](repeating: -1, count: 2)
-    guard Darwin.pipe(&inputPipe) == 0,
-          Darwin.pipe(&outputPipe) == 0,
-          Darwin.pipe(&errorPipe) == 0 else {
+    let inputPipeResult = makeCloseOnExecPipe(&inputPipe)
+    let outputPipeResult = inputPipeResult == 0
+        ? makeCloseOnExecPipe(&outputPipe)
+        : inputPipeResult
+    let errorPipeResult = outputPipeResult == 0
+        ? makeCloseOnExecPipe(&errorPipe)
+        : outputPipeResult
+    guard errorPipeResult == 0 else {
         closeDescriptors(inputPipe + outputPipe + errorPipe)
-        return processLaunchFailure(errno)
+        return processLaunchFailure(errorPipeResult)
     }
 
     var fileActions: posix_spawn_file_actions_t?
@@ -106,7 +207,7 @@ nonisolated private func runSpawnedProcess(
     }
     guard posix_spawnattr_setflags(
         &attributes,
-        Int16(POSIX_SPAWN_SETPGROUP)
+        Int16(POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_CLOEXEC_DEFAULT)
     ) == 0,
           posix_spawnattr_setpgroup(&attributes, 0) == 0 else {
         closeDescriptors(inputPipe + outputPipe + errorPipe)
@@ -136,6 +237,11 @@ nonisolated private func runSpawnedProcess(
         return processLaunchFailure(spawnResult)
     }
 
+    if holdsSpawnLock {
+        ExternalProcessSpawnLock.shared.value.unlock()
+        holdsSpawnLock = false
+    }
+
     Darwin.close(inputPipe[0])
     Darwin.close(outputPipe[1])
     Darwin.close(errorPipe[1])
@@ -147,13 +253,10 @@ nonisolated private func runSpawnedProcess(
     setNonblocking(errorDescriptor)
     _ = Darwin.fcntl(inputDescriptor, F_SETNOSIGPIPE, 1)
 
-    let start = DispatchTime.now().uptimeNanoseconds
-    let budget = UInt64(timeout * 1_000_000_000)
-    let hardDeadline = start &+ budget
-    let grace = min(100_000_000, max(10_000_000, budget / 5))
-    let softDeadline = hardDeadline &- grace
     var sentTermination = false
+    var terminationDeadline = hardDeadline
     var didTimeOut = false
+    var outputLimitExceeded = false
     var processStatus: Int32?
     var inputOffset = 0
     var output = Data()
@@ -161,13 +264,39 @@ nonisolated private func runSpawnedProcess(
 
     while true {
         reapIfExited(childPID, status: &processStatus)
-        drainPipe(&outputDescriptor, into: &output)
-        drainPipe(&errorDescriptor, into: &errors)
+        let drainDeadline = sentTermination ? terminationDeadline : softDeadline
+        let outputDrain = drainPipe(
+            &outputDescriptor,
+            into: &output,
+            byteLimit: max(0, outputLimits.stdoutBytes),
+            deadline: drainDeadline
+        )
+        let errorDrain = drainPipe(
+            &errorDescriptor,
+            into: &errors,
+            byteLimit: max(0, outputLimits.stderrBytes),
+            deadline: drainDeadline
+        )
         writePipe(
             &inputDescriptor,
             data: stdin,
             offset: &inputOffset
         )
+        if outputDrain == .limitExceeded || errorDrain == .limitExceeded {
+            outputLimitExceeded = true
+            closeDescriptor(&inputDescriptor)
+            closeDescriptor(&outputDescriptor)
+            closeDescriptor(&errorDescriptor)
+            if !sentTermination {
+                sentTermination = true
+                let now = DispatchTime.now().uptimeNanoseconds
+                terminationDeadline = min(
+                    hardDeadline,
+                    addingWithoutOverflow(now, grace)
+                )
+                _ = Darwin.kill(-childPID, SIGTERM)
+            }
+        }
         if processStatus != nil,
            outputDescriptor < 0,
            errorDescriptor < 0 {
@@ -178,11 +307,14 @@ nonisolated private func runSpawnedProcess(
         if !sentTermination, now >= softDeadline {
             didTimeOut = true
             sentTermination = true
+            terminationDeadline = hardDeadline
             closeDescriptor(&inputDescriptor)
             _ = Darwin.kill(-childPID, SIGTERM)
         }
-        if now >= hardDeadline {
-            didTimeOut = true
+        if sentTermination, now >= terminationDeadline {
+            if !outputLimitExceeded {
+                didTimeOut = true
+            }
             _ = Darwin.kill(-childPID, SIGKILL)
             closeDescriptor(&inputDescriptor)
             closeDescriptor(&outputDescriptor)
@@ -205,7 +337,7 @@ nonisolated private func runSpawnedProcess(
             output: outputDescriptor,
             error: errorDescriptor
         )
-        let nextBoundary = sentTermination ? hardDeadline : softDeadline
+        let nextBoundary = sentTermination ? terminationDeadline : softDeadline
         let remaining = nextBoundary > now ? nextBoundary - now : 0
         let waitMilliseconds = Int32(
             min(10, max(1, remaining / 1_000_000))
@@ -224,8 +356,38 @@ nonisolated private func runSpawnedProcess(
         stdout: String(bytes: output, encoding: .utf8) ?? "",
         stderr: String(bytes: errors, encoding: .utf8) ?? "",
         exitCode: processStatus.map(processExitCode) ?? -1,
-        timedOut: didTimeOut
+        timedOut: didTimeOut,
+        outputLimitExceeded: outputLimitExceeded
     )
+}
+
+nonisolated private func makeCloseOnExecPipe(
+    _ descriptors: inout [Int32]
+) -> Int32 {
+    if #available(macOS 27.0, *) {
+        return Darwin.pipe2(&descriptors, O_CLOEXEC) == 0 ? 0 : errno
+    }
+
+    guard Darwin.pipe(&descriptors) == 0 else { return errno }
+    for descriptor in descriptors {
+        let flags = Darwin.fcntl(descriptor, F_GETFD)
+        guard flags >= 0,
+              Darwin.fcntl(descriptor, F_SETFD, flags | FD_CLOEXEC) == 0 else {
+            let failure = errno
+            closeDescriptors(descriptors)
+            descriptors = [-1, -1]
+            return failure
+        }
+    }
+    return 0
+}
+
+nonisolated private func addingWithoutOverflow(
+    _ lhs: UInt64,
+    _ rhs: UInt64
+) -> UInt64 {
+    let (value, overflow) = lhs.addingReportingOverflow(rhs)
+    return overflow ? UInt64.max : value
 }
 
 nonisolated private func withMutableCStringArray<Result>(
@@ -295,28 +457,59 @@ nonisolated private func writePipe(
     }
 }
 
+nonisolated private enum PipeDrainResult: Equatable {
+    case drained
+    case deadlineReached
+    case limitExceeded
+}
+
 nonisolated private func drainPipe(
     _ descriptor: inout Int32,
-    into data: inout Data
-) {
-    guard descriptor >= 0 else { return }
+    into data: inout Data,
+    byteLimit: Int,
+    deadline: UInt64
+) -> PipeDrainResult {
+    guard descriptor >= 0 else { return .drained }
     var buffer = [UInt8](repeating: 0, count: 16_384)
-    while true {
-        let count = Darwin.read(descriptor, &buffer, buffer.count)
+    // A fixed quantum prevents a continuously-writing child from monopolizing
+    // this loop. The monotonic check before every read enforces the same
+    // deadline even when the pipe never reaches EAGAIN.
+    var remainingQuantum = 64 * 1_024
+    while remainingQuantum > 0 {
+        guard DispatchTime.now().uptimeNanoseconds < deadline else {
+            return .deadlineReached
+        }
+        let remainingCapacity = max(0, byteLimit - data.count)
+        let overflowDetectingCapacity = remainingCapacity == Int.max
+            ? Int.max
+            : remainingCapacity + 1
+        let requestedCount = min(
+            min(buffer.count, remainingQuantum),
+            overflowDetectingCapacity
+        )
+        let count = Darwin.read(descriptor, &buffer, requestedCount)
         if count > 0 {
-            data.append(buffer, count: count)
+            let acceptedCount = min(count, remainingCapacity)
+            if acceptedCount > 0 {
+                data.append(buffer, count: acceptedCount)
+            }
+            if count > remainingCapacity {
+                return .limitExceeded
+            }
+            remainingQuantum -= count
         } else if count == 0 {
             closeDescriptor(&descriptor)
-            return
+            return .drained
         } else if errno == EINTR {
             continue
         } else if errno == EAGAIN {
-            return
+            return .drained
         } else {
             closeDescriptor(&descriptor)
-            return
+            return .drained
         }
     }
+    return .drained
 }
 
 nonisolated private func reapIfExited(
@@ -477,6 +670,7 @@ nonisolated final class ExternalFileFormatter: FileFormatter, Sendable {
 
         // Fall back to original on any failure
         guard !result.timedOut,
+              !result.outputLimitExceeded,
               result.exitCode == 0,
               !result.stdout.isEmpty else {
             return content

--- a/Pine/ExternalFileFormatter.swift
+++ b/Pine/ExternalFileFormatter.swift
@@ -49,6 +49,11 @@ nonisolated private final class ExternalProcessSpawnLock: @unchecked Sendable {
     let value = NSLock()
 }
 
+private typealias Pipe2Function = @convention(c) (
+    UnsafeMutablePointer<Int32>?,
+    Int32
+) -> Int32
+
 /// Signature for running an external process. Closure-based so tests can inject
 /// behaviour without implementing a protocol — there is only ever one real impl.
 typealias ProcessRunner = @Sendable (
@@ -134,16 +139,12 @@ nonisolated private func runSpawnedProcess(
     let grace = min(budget, desiredGrace)
     let softDeadline = hardDeadline - grace
 
-    // `pipe2(O_CLOEXEC)` is atomic, but only available on macOS 27. The
-    // deployment-target fallback serializes Pine's process runners across the
-    // short pipe()+fcntl()+spawn window. CLOEXEC_DEFAULT below additionally
-    // prevents unrelated descriptors from entering this child on both OSes.
-    let requiresSpawnLock: Bool
-    if #available(macOS 27.0, *) {
-        requiresSpawnLock = false
-    } else {
-        requiresSpawnLock = true
-    }
+    // `pipe2(O_CLOEXEC)` is atomic, but its declaration is absent from the
+    // macOS 26 SDK. Resolve the macOS 27 symbol dynamically so this source
+    // continues to compile with Xcode 26. The fallback serializes Pine's
+    // process runners across the short pipe()+fcntl()+spawn window.
+    let pipe2 = resolvedPipe2()
+    let requiresSpawnLock = pipe2 == nil
     if requiresSpawnLock {
         ExternalProcessSpawnLock.shared.value.lock()
     }
@@ -157,12 +158,12 @@ nonisolated private func runSpawnedProcess(
     var inputPipe = [Int32](repeating: -1, count: 2)
     var outputPipe = [Int32](repeating: -1, count: 2)
     var errorPipe = [Int32](repeating: -1, count: 2)
-    let inputPipeResult = makeCloseOnExecPipe(&inputPipe)
+    let inputPipeResult = makeCloseOnExecPipe(&inputPipe, pipe2: pipe2)
     let outputPipeResult = inputPipeResult == 0
-        ? makeCloseOnExecPipe(&outputPipe)
+        ? makeCloseOnExecPipe(&outputPipe, pipe2: pipe2)
         : inputPipeResult
     let errorPipeResult = outputPipeResult == 0
-        ? makeCloseOnExecPipe(&errorPipe)
+        ? makeCloseOnExecPipe(&errorPipe, pipe2: pipe2)
         : outputPipeResult
     guard errorPipeResult == 0 else {
         closeDescriptors(inputPipe + outputPipe + errorPipe)
@@ -263,7 +264,13 @@ nonisolated private func runSpawnedProcess(
     var errors = Data()
 
     while true {
-        reapIfExited(childPID, status: &processStatus)
+        let streamsAreClosed = outputDescriptor < 0 && errorDescriptor < 0
+        if formatterShouldAttemptReap(
+            terminationStarted: sentTermination,
+            streamsAreClosed: streamsAreClosed
+        ) {
+            reapIfExited(childPID, status: &processStatus)
+        }
         let drainDeadline = sentTermination ? terminationDeadline : softDeadline
         let outputDrain = drainPipe(
             &outputDescriptor,
@@ -362,10 +369,14 @@ nonisolated private func runSpawnedProcess(
 }
 
 nonisolated private func makeCloseOnExecPipe(
-    _ descriptors: inout [Int32]
+    _ descriptors: inout [Int32],
+    pipe2: Pipe2Function?
 ) -> Int32 {
-    if #available(macOS 27.0, *) {
-        return Darwin.pipe2(&descriptors, O_CLOEXEC) == 0 ? 0 : errno
+    if let pipe2 {
+        let result = descriptors.withUnsafeMutableBufferPointer { buffer in
+            pipe2(buffer.baseAddress, O_CLOEXEC)
+        }
+        return result == 0 ? 0 : errno
     }
 
     guard Darwin.pipe(&descriptors) == 0 else { return errno }
@@ -380,6 +391,28 @@ nonisolated private func makeCloseOnExecPipe(
         }
     }
     return 0
+}
+
+/// Returns the atomic macOS 27 pipe creator without making Xcode 26 resolve a
+/// declaration that does not exist in its SDK.
+nonisolated private func resolvedPipe2() -> Pipe2Function? {
+    guard #available(macOS 27.0, *),
+          let handle = Darwin.dlopen(nil, RTLD_LAZY | RTLD_LOCAL) else {
+        return nil
+    }
+    defer { Darwin.dlclose(handle) }
+    guard let symbol = Darwin.dlsym(handle, "pipe2") else { return nil }
+    return unsafeBitCast(symbol, to: Pipe2Function.self)
+}
+
+/// Consuming a zombie releases its PID/PGID for reuse. During termination the
+/// group leader must therefore remain unreaped until after Pine has sent its
+/// final group signal, even when a descendant keeps a captured pipe open.
+nonisolated func formatterShouldAttemptReap(
+    terminationStarted: Bool,
+    streamsAreClosed: Bool
+) -> Bool {
+    !terminationStarted && streamsAreClosed
 }
 
 nonisolated private func addingWithoutOverflow(

--- a/Pine/ExternalFileFormatter.swift
+++ b/Pine/ExternalFileFormatter.swift
@@ -199,9 +199,19 @@ nonisolated final class ExternalFileFormatter: FileFormatter, Sendable {
     }
 
     func format(_ content: String, url: URL) -> String {
+        format(content, url: url, maximumDuration: timeout)
+    }
+
+    func format(
+        _ content: String,
+        url: URL,
+        maximumDuration: TimeInterval
+    ) -> String {
         guard let executablePath = toolPath else {
             return content
         }
+        let effectiveTimeout = min(timeout, maximumDuration)
+        guard effectiveTimeout > 0 else { return content }
 
         // Dispatch to a background queue so runRealProcess's main-thread
         // precondition is satisfied. The caller (trySaveTab) runs on main;
@@ -216,7 +226,7 @@ nonisolated final class ExternalFileFormatter: FileFormatter, Sendable {
                 executablePath,
                 self.arguments,
                 content,
-                self.timeout
+                effectiveTimeout
             )
             group.leave()
         }

--- a/Pine/FileFormatter.swift
+++ b/Pine/FileFormatter.swift
@@ -14,13 +14,32 @@ import Foundation
 ///   be parsed, so save never blocks on malformed files.
 /// - **Sandbox-friendly** — pure-Swift formatters should not spawn external binaries.
 ///   For external tools, use `ExternalFileFormatter` which handles Process lifecycle.
-protocol FileFormatter: Sendable {
+nonisolated protocol FileFormatter: Sendable {
     /// Returns true when this formatter should be applied to the given file URL.
     func canFormat(url: URL) -> Bool
 
     /// Returns a formatted copy of `content`, or the original on any failure.
     /// The `url` is provided for blocklist checks and filename-based decisions.
     func format(_ content: String, url: URL) -> String
+
+    /// Deadline-aware variant used by application termination. Pure formatters
+    /// inherit the synchronous default; external formatters override it so the
+    /// child-process timeout never exceeds Quit's remaining shared budget.
+    func format(
+        _ content: String,
+        url: URL,
+        maximumDuration: TimeInterval
+    ) -> String
+}
+
+nonisolated extension FileFormatter {
+    func format(
+        _ content: String,
+        url: URL,
+        maximumDuration: TimeInterval
+    ) -> String {
+        format(content, url: url)
+    }
 }
 
 /// Formats JSON with 2-space indentation. Preserves the original text on
@@ -30,7 +49,7 @@ protocol FileFormatter: Sendable {
 /// `1.0` may become `1`, scientific notation changes form, and integers
 /// above 2^53 lose precision. Files with these patterns are skipped until
 /// a proper tokenizer-based formatter is written.
-struct JSONFileFormatter: FileFormatter {
+nonisolated struct JSONFileFormatter: FileFormatter {
     /// Files that must never be reformatted because their key order carries
     /// semantic meaning (npm, TypeScript, Composer, VS Code workspaces).
     private static let blocklist: Set<String> = [
@@ -87,7 +106,7 @@ struct JSONFileFormatter: FileFormatter {
 
 /// Formats YAML via `prettier --parser yaml`. Skips lock files and large files
 /// to avoid corrupting dependency trees or blocking the UI.
-struct YAMLFileFormatter: FileFormatter, Sendable {
+nonisolated struct YAMLFileFormatter: FileFormatter, Sendable {
     /// Lock files that must never be reformatted — reformatting changes
     /// content hashes and breaks dependency resolution.
     private static let blocklist: Set<String> = [
@@ -143,11 +162,26 @@ struct YAMLFileFormatter: FileFormatter, Sendable {
         guard content.utf8.count < Self.maxFormatSize else { return content }
         return formatter.format(content, url: url)
     }
+
+    func format(
+        _ content: String,
+        url: URL,
+        maximumDuration: TimeInterval
+    ) -> String {
+        let filename = url.lastPathComponent.lowercased()
+        if Self.blocklist.contains(filename) { return content }
+        guard content.utf8.count < Self.maxFormatSize else { return content }
+        return formatter.format(
+            content,
+            url: url,
+            maximumDuration: maximumDuration
+        )
+    }
 }
 
 /// Creates an HCL formatter that delegates to `terraform fmt -` or `tofu fmt -`.
 /// Prefers `terraform` when both are installed; gracefully no-ops when neither is found.
-enum HCLFileFormatter {
+nonisolated enum HCLFileFormatter {
     static func resolve(
         processRunner: @escaping ProcessRunner = runRealProcess,
         resolver: ExternalToolResolver = .fromEnvironment()
@@ -182,7 +216,7 @@ enum HCLFileFormatter {
 /// Formats shell scripts via `shfmt -i 2 -ci -bn`. Handles `.sh`, `.bash`, `.zsh` extensions
 /// and detects shell shebangs (`#!/bin/sh`, `#!/bin/bash`, `#!/usr/bin/env bash`, etc.)
 /// in extensionless files. Gracefully no-ops when `shfmt` is not installed.
-struct ShellFileFormatter: FileFormatter, Sendable {
+nonisolated struct ShellFileFormatter: FileFormatter, Sendable {
     /// Shell file extensions (lowercase, without dot).
     private static let shellExtensions: Set<String> = ["sh", "bash", "zsh"]
 
@@ -265,6 +299,24 @@ struct ShellFileFormatter: FileFormatter, Sendable {
         return formatter.format(content, url: url)
     }
 
+    func format(
+        _ content: String,
+        url: URL,
+        maximumDuration: TimeInterval
+    ) -> String {
+        guard content.utf8.count < Self.maxFormatSize else { return content }
+
+        let ext = url.pathExtension.lowercased()
+        if ext.isEmpty, !hasShellShebang(content) {
+            return content
+        }
+        return formatter.format(
+            content,
+            url: url,
+            maximumDuration: maximumDuration
+        )
+    }
+
     /// Checks whether the content starts with a shell shebang line.
     private func hasShellShebang(_ content: String) -> Bool {
         guard content.hasPrefix("#!") else { return false }
@@ -278,7 +330,7 @@ struct ShellFileFormatter: FileFormatter, Sendable {
 
 /// Composes an ordered list of formatters, applying the first whose `canFormat` returns
 /// true. The empty registry is a no-op — safe default for files with no known formatter.
-struct FileFormatterRegistry: Sendable {
+nonisolated struct FileFormatterRegistry: Sendable {
     let formatters: [FileFormatter]
 
     /// Default registry. Ships a pure-Swift JSON formatter. External tool formatters
@@ -298,6 +350,21 @@ struct FileFormatterRegistry: Sendable {
     func format(content: String, url: URL) -> String {
         for formatter in formatters where formatter.canFormat(url: url) {
             return formatter.format(content, url: url)
+        }
+        return content
+    }
+
+    func format(
+        content: String,
+        url: URL,
+        maximumDuration: TimeInterval
+    ) -> String {
+        for formatter in formatters where formatter.canFormat(url: url) {
+            return formatter.format(
+                content,
+                url: url,
+                maximumDuration: maximumDuration
+            )
         }
         return content
     }

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -11370,61 +11370,61 @@
       }
     },
     "quit.summary.message %lld": {
-      "comment": "App-wide Quit summary. The value is the number of projects requiring review.",
+      "comment": "App-wide Quit summary. The value is the number of projects or global terminal areas requiring review.",
       "extractionState": "manual",
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Zu prüfende Projekte: %lld.\n\nPrüfen Sie jedes Projekt vor dem Beenden, oder beenden Sie trotzdem, um ungesicherte Änderungen zu verwerfen und laufende Arbeiten zu stoppen."
+            "value": "Zu prüfende Elemente: %lld.\n\nPrüfen Sie jedes Element vor dem Beenden, oder beenden Sie trotzdem, um ungesicherte Änderungen zu verwerfen und laufende Arbeiten zu stoppen."
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Projects requiring attention: %lld.\n\nReview each project before quitting, or quit anyway to discard unsaved changes and stop running work."
+            "value": "Items requiring attention: %lld.\n\nReview each item before quitting, or quit anyway to discard unsaved changes and stop running work."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Proyectos que requieren atención: %lld.\n\nRevisa cada proyecto antes de salir o sal de todas formas para descartar los cambios sin guardar y detener el trabajo en curso."
+            "value": "Elementos que requieren atención: %lld.\n\nRevisa cada elemento antes de salir o sal de todas formas para descartar los cambios sin guardar y detener el trabajo en curso."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Projets nécessitant votre attention : %lld.\n\nVérifiez chaque projet avant de quitter, ou quittez quand même pour ignorer les modifications non enregistrées et arrêter le travail en cours."
+            "value": "Éléments nécessitant votre attention : %lld.\n\nVérifiez chaque élément avant de quitter, ou quittez quand même pour ignorer les modifications non enregistrées et arrêter le travail en cours."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "確認が必要なプロジェクト：%lld。\n\n終了前に各プロジェクトを確認するか、保存されていない変更を破棄して実行中の作業を停止し、そのまま終了してください。"
+            "value": "確認が必要な項目：%lld。\n\n終了前に各項目を確認するか、保存されていない変更を破棄して実行中の作業を停止し、そのまま終了してください。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "검토가 필요한 프로젝트: %lld.\n\n종료하기 전에 각 프로젝트를 검토하거나, 저장되지 않은 변경 사항을 버리고 실행 중인 작업을 중지한 후 종료하세요."
+            "value": "검토가 필요한 항목: %lld.\n\n종료하기 전에 각 항목을 검토하거나, 저장되지 않은 변경 사항을 버리고 실행 중인 작업을 중지한 후 종료하세요."
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Projetos que precisam de atenção: %lld.\n\nRevise cada projeto antes de sair ou saia mesmo assim para descartar alterações não salvas e interromper o trabalho em execução."
+            "value": "Itens que precisam de atenção: %lld.\n\nRevise cada item antes de sair ou saia mesmo assim para descartar alterações não salvas e interromper o trabalho em execução."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Проектов, требующих внимания: %lld.\n\nПроверьте каждый проект перед выходом или выйдите всё равно, чтобы отбросить несохранённые изменения и остановить выполняющуюся работу."
+            "value": "Объектов, требующих внимания: %lld.\n\nПроверьте каждый объект перед выходом или выйдите всё равно, чтобы отбросить несохранённые изменения и остановить выполняющуюся работу."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "需要检查的项目：%lld。\n\n退出前请检查每个项目，或仍然退出以丢弃未保存的更改并停止正在运行的工作。"
+            "value": "需要检查的事项：%lld。\n\n退出前请检查每个事项，或仍然退出以丢弃未保存的更改并停止正在运行的工作。"
           }
         }
       }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -1894,6 +1894,24 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         return deadline.uptimeNanoseconds - now
     }
 
+    /// Reserves a durable rollback slice before any termination mutation.
+    /// Long budgets retain the existing 28s/2s policy; short budgets split in
+    /// half instead of silently proceeding with no rollback barrier.
+    nonisolated static func terminationBudgetSplit(
+        availableNanoseconds: UInt64
+    ) -> (forwardNanoseconds: UInt64, rollbackNanoseconds: UInt64)? {
+        guard availableNanoseconds >= 2 else { return nil }
+        let rollbackNanoseconds = min(
+            2_000_000_000,
+            availableNanoseconds / 2
+        )
+        guard rollbackNanoseconds > 0 else { return nil }
+        return (
+            availableNanoseconds - rollbackNanoseconds,
+            rollbackNanoseconds
+        )
+    }
+
     private func valueBeforeTerminationDeadline<Value: Sendable>(
         _ deadline: DispatchTime,
         deadlineObserver: @escaping @Sendable () -> Void,
@@ -1934,6 +1952,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         presentAlert: TerminationAlertPresenter? = nil,
         saveAll: TerminationSaveAll? = nil,
         applicationContext: DialogPresentationContext? = nil,
+        terminationFailureContext: (@MainActor () -> DialogPresentationContext)? = nil,
         terminationDeadlineOverride: DispatchTime? = nil,
         terminationDeadlineObserver: @escaping @Sendable () -> Void = {}
     ) async -> Bool {
@@ -1965,6 +1984,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 )
             }
         )
+        let preflightUserTaskAuthorization =
+            registry.captureUserTaskShutdownAuthorization()
         let attentionProjectCount = projects.filter {
             !$0.allDirtyTabs.isEmpty
                 || preflightTerminalAuthorizations[
@@ -1973,7 +1994,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 || $0.hasOutstandingUserTaskExecution
         }.count
         let requiresAttention = attentionProjectCount > 0
-            || registry.hasOutstandingUserTaskExecution
+            || preflightUserTaskAuthorization.requiresConfirmation
         let needsNativeDecision = presentAlert == nil
             && requiresAttention
         if applicationContext == nil, needsNativeDecision {
@@ -2002,9 +2023,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         }
 
         func presentTerminationFailure() async {
+            let context: DialogPresentationContext
+            if let terminationFailureContext {
+                context = terminationFailureContext()
+            } else if presentAlert == nil {
+                // A clean preflight may never have created or restored an
+                // owner. Resolve one lazily only after machine work fails.
+                prepareApplicationDialogOwner()
+                context = DialogPresenter.forApplicationWindow()
+            } else {
+                context = fallbackContext
+            }
             _ = await presentTerminationAlert(
                 .applicationQuitFailure,
-                context: fallbackContext,
+                context: context,
                 title: Strings.applicationQuitFailureTitle,
                 message: Strings.applicationQuitFailureMessage
             )
@@ -2021,9 +2053,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             ObjectIdentifier: TerminalTabCloseAuthorization
         ] = [:]
         var saveRequests: [(ProjectManager, DialogPresentationContext)] = []
+        var preparedSavePlans: [
+            ObjectIdentifier: ProjectManager.PreparedPaneSavePlan
+        ] = [:]
         var quitAnyway = false
         var reviewIndividually = false
-        var mayShutdownUserTasks = false
+        var userTaskAuthorization = preflightUserTaskAuthorization
 
         if requiresAttention {
             let response = await presentTerminationAlert(
@@ -2039,7 +2074,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 reviewIndividually = true
             case .alertSecondButtonReturn:
                 quitAnyway = true
-                mayShutdownUserTasks = true
             default:
                 return false
             }
@@ -2117,7 +2151,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 }
             }
 
-            if registry.hasOutstandingUserTaskExecution {
+            let displayedUserTaskAuthorization =
+                registry.captureUserTaskShutdownAuthorization()
+            if displayedUserTaskAuthorization.requiresConfirmation {
                 let response = await presentTerminationAlert(
                     .activeUserTasksPreventQuit,
                     context: fallbackContext,
@@ -2127,8 +2163,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 guard response == .alertFirstButtonReturn else {
                     return false
                 }
-                mayShutdownUserTasks = true
             }
+            userTaskAuthorization = displayedUserTaskAuthorization
         } else {
             // No suspension point occurred after the empty preflight, so this
             // captures the same idle baseline for final revalidation.
@@ -2140,27 +2176,61 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             }
         }
 
+        // Collect every Save-As destination before rebasing the duration.
+        // These native panels are human decisions, not bounded machine work.
+        if saveAll == nil {
+            for (projectManager, context) in saveRequests {
+                switch await projectManager.prepareSaveAllPaneTabs(
+                    context: context
+                ) {
+                case .ready(let plan):
+                    preparedSavePlans[ObjectIdentifier(projectManager)] = plan
+                case .cancelledByUser:
+                    return false
+                case .invalidated:
+                    await presentTerminationFailure()
+                    return false
+                }
+            }
+        }
+
         // Rebase the captured duration only after the final human response.
         let terminationDeadline = DispatchTime.now() + .nanoseconds(
             Int(clamping: workBudgetNanoseconds)
         )
 
         for (projectManager, context) in saveRequests {
-            let didSave = await valueBeforeTerminationDeadline(
+            let saveResult = await valueBeforeTerminationDeadline(
                 terminationDeadline,
                 deadlineObserver: terminationDeadlineObserver,
                 onTimeout: {},
                 operation: {
                     if let saveAll {
                         return await saveAll(projectManager, context)
+                            ? PreparedPaneSaveCommitResult.saved
+                            : PreparedPaneSaveCommitResult.invalidated
                     }
-                    return await projectManager.saveAllPaneTabs(context: context)
+                    guard let plan = preparedSavePlans[
+                        ObjectIdentifier(projectManager)
+                    ] else {
+                        return .invalidated
+                    }
+                    return projectManager.commitPreparedSaveAllPaneTabs(plan)
                 }
             )
-            guard didSave == true else {
-                if didSave == nil {
-                    await presentTerminationFailure()
-                }
+            switch saveResult {
+            case .saved:
+                break
+            case .failed(let message):
+                _ = await presentTerminationAlert(
+                    .fileOperationErrorCritical,
+                    context: context,
+                    title: Strings.fileOperationErrorTitle,
+                    message: message
+                )
+                return false
+            case .invalidated, nil:
+                await presentTerminationFailure()
                 return false
             }
         }
@@ -2168,17 +2238,28 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         // Runtime pane/tab IDs cannot be trusted across relaunch. Reserve a
         // rollback slice before freezing so every failed Quit can durably
         // restore the pre-handshake snapshot within the same absolute budget.
-        let rollbackReserve: Duration = .seconds(2)
-        guard let availablePersistenceTime = remainingTerminationDuration(
-            until: terminationDeadline
-        ), availablePersistenceTime > .zero else {
+        let nowNanoseconds = DispatchTime.now().uptimeNanoseconds
+        guard nowNanoseconds < terminationDeadline.uptimeNanoseconds,
+              let budgetSplit = Self.terminationBudgetSplit(
+                  availableNanoseconds:
+                      terminationDeadline.uptimeNanoseconds - nowNanoseconds
+              ) else {
             terminationDeadlineObserver()
             await presentTerminationFailure()
             return false
         }
-        let effectiveRollbackReserve = availablePersistenceTime > rollbackReserve
-            ? rollbackReserve
-            : .zero
+        let forwardDeadline = DispatchTime(
+            uptimeNanoseconds:
+                terminationDeadline.uptimeNanoseconds
+                    - budgetSplit.rollbackNanoseconds
+        )
+
+        guard registry.userTaskShutdownAuthorizationStillCovers(
+            userTaskAuthorization
+        ) else {
+            await presentTerminationFailure()
+            return false
+        }
         registry.freezeAgentTasksForTermination()
         registry.agentTasks.prepareForApplicationTermination()
         func rollbackAgentTasks() async {
@@ -2194,8 +2275,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 return
             }
         }
-        let persistenceBudget = availablePersistenceTime
-            - effectiveRollbackReserve
+        guard let persistenceBudget = remainingTerminationDuration(
+            until: forwardDeadline
+        ) else {
+            await rollbackAgentTasks()
+            await presentTerminationFailure()
+            return false
+        }
         guard await registry.agentTasks.flushPersistence(
             maximumDuration: persistenceBudget
         ) == .saved else {
@@ -2242,7 +2328,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     return false
                 }
             }
-            return true
+            return registry.userTaskShutdownAuthorizationStillCovers(
+                userTaskAuthorization
+            )
         }
 
         guard destructiveAuthorizationsStillCoverCurrentState() else {
@@ -2252,21 +2340,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         }
 
         if registry.hasOutstandingUserTaskExecution {
-            guard mayShutdownUserTasks else {
-                await rollbackAgentTasks()
-                await presentTerminationFailure()
-                return false
-            }
-            let reserveNanoseconds: UInt64 =
-                effectiveRollbackReserve == rollbackReserve
-                ? 2_000_000_000
-                : 0
-            let taskShutdownDeadline = DispatchTime(
-                uptimeNanoseconds:
-                    terminationDeadline.uptimeNanoseconds - reserveNanoseconds
-            )
             guard await registry.shutdownUserTasks(
-                until: taskShutdownDeadline
+                authorizedBy: userTaskAuthorization,
+                until: forwardDeadline
             ) else {
                 await rollbackAgentTasks()
                 await presentTerminationFailure()

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -1963,11 +1963,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             .sorted { $0.key.path.localizedStandardCompare($1.key.path) == .orderedAscending }
             .map(\.value)
         var terminationCommitted = false
+        var heldAgentLaunchAuthorizations: [
+            (TerminalManager, PineAgentLaunchAuthorization)
+        ] = []
         registry.freezeAutoSaveForTermination()
         defer {
             if terminationCommitted {
                 registry.finishAutoSaveTerminationFreeze()
             } else {
+                for (terminal, authorization) in
+                        heldAgentLaunchAuthorizations.reversed() {
+                    terminal.cancelAuthorizedAgentLaunchTerminationDecision(
+                        authorization
+                    )
+                }
                 registry.cancelAutoSaveTerminationFreeze()
             }
         }
@@ -2003,16 +2012,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         )
         let preflightUserTaskAuthorization =
             registry.captureUserTaskShutdownAuthorization()
-        let attentionProjectCount = projects.filter {
-            !$0.allDirtyTabs.isEmpty
+        let attentionProjectIDs = Set(projects.compactMap { projectManager in
+            let identifier = ObjectIdentifier(projectManager)
+            return !projectManager.allDirtyTabs.isEmpty
                 || preflightTerminalAuthorizations[
-                    ObjectIdentifier($0)
+                    identifier
                 ]?.requiresConfirmation == true
                 || preflightAgentLaunchAuthorizations[
-                    ObjectIdentifier($0)
+                    identifier
                 ]?.requiresConfirmation == true
-                || $0.hasOutstandingUserTaskExecution
-        }.count
+                || projectManager.hasOutstandingUserTaskExecution
+                ? identifier
+                : nil
+        }).union(preflightUserTaskAuthorization.confirmingOwnerIDs)
+        let attentionProjectCount = attentionProjectIDs.count
         let requiresAttention = attentionProjectCount > 0
             || preflightUserTaskAuthorization.requiresConfirmation
         let needsNativeDecision = presentAlert == nil
@@ -2128,9 +2141,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         /// Machine failures are never user cancellation. Require the sole OK
         /// response as proof that AppKit displayed the explanation. `.abort`
         /// means presentation authority was lost, so retry on a freshly
-        /// resolved project/application owner. The fixed attempt bound avoids
-        /// recursive or infinite retry if the application cannot retain any
-        /// owner at all.
+        /// resolved project/application owner. There is deliberately no retry
+        /// count: returning from a machine failure without ever showing its
+        /// explanation would misreport presentation loss as user cancellation.
         @discardableResult
         func presentTerminationFailure(
             _ template: AlertTemplate = .applicationQuitFailure,
@@ -2138,15 +2151,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             title: String = Strings.applicationQuitFailureTitle,
             message: String = Strings.applicationQuitFailureMessage
         ) async -> Bool {
-            let maximumAttempts = 3
-            for attempt in 0..<maximumAttempts {
+            while !Task.isCancelled {
                 let context = resolveTerminationFailureContext(
                     preferredProject: preferredProject
                 )
                 if presentAlert == nil, !hasEligibleOwner(context) {
                     prepareApplicationDialogOwner()
-                    if attempt + 1 < maximumAttempts {
-                        await Task.yield()
+                    do {
+                        try await Task.sleep(for: .milliseconds(25))
+                    } catch {
+                        return false
                     }
                     continue
                 }
@@ -2165,12 +2179,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 if presentAlert == nil {
                     prepareApplicationDialogOwner()
                 }
-                if attempt + 1 < maximumAttempts {
-                    await Task.yield()
+                do {
+                    try await Task.sleep(for: .milliseconds(25))
+                } catch {
+                    return false
                 }
             }
             Logger.app.critical(
-                "Quit failure explanation could not be displayed after bounded owner rebinding"
+                "Quit failure explanation was cancelled before acknowledgement"
             )
             return false
         }
@@ -2243,6 +2259,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         var reviewIndividually = false
         var userTaskAuthorization = preflightUserTaskAuthorization
 
+        // Pin every Pine launch that contributed to the preflight before the
+        // first sheet suspends. Claim TTL bounds detector convergence, not the
+        // amount of time a person may spend considering Quit.
+        for projectManager in projects {
+            let authorization = preflightAgentLaunchAuthorizations[
+                ObjectIdentifier(projectManager)
+            ] ?? projectManager.terminal
+                .capturePineAgentLaunchAuthorization()
+            guard projectManager.terminal
+                    .pauseAuthorizedAgentLaunchesForTerminationDecision(
+                        authorization
+                    ) else {
+                await presentTerminationFailure()
+                return false
+            }
+            heldAgentLaunchAuthorizations.append((
+                projectManager.terminal,
+                authorization
+            ))
+        }
+
         if requiresAttention {
             guard let response = await presentTerminationDecision(
                 .applicationQuitSummary,
@@ -2310,6 +2347,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 terminalAuthorizations[identifier] = authorization
                 let launchAuthorization = projectManager.terminal
                     .capturePineAgentLaunchAuthorization()
+                guard projectManager.terminal
+                        .pauseAuthorizedAgentLaunchesForTerminationDecision(
+                            launchAuthorization
+                        ) else {
+                    await presentTerminationFailure()
+                    return false
+                }
+                heldAgentLaunchAuthorizations.append((
+                    projectManager.terminal,
+                    launchAuthorization
+                ))
                 agentLaunchAuthorizations[identifier] = launchAuthorization
                 guard authorization.requiresConfirmation
                         || launchAuthorization.requiresConfirmation else {
@@ -2355,6 +2403,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
 
         // Collect every Save-As destination before rebasing the duration.
         // These native panels are human decisions, not bounded machine work.
+        var destinationURLs: [URL] = []
+        var unplannedOpenURLs: [URL] = []
+        var plannedDestinationsByTabID: [UUID: URL] = [:]
         if saveAll == nil {
             for projectManager in saveRequests {
                 let context = resolveFreshDecisionContext(
@@ -2384,7 +2435,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             // chosen in one project must not alias another prepared save or a
             // clean/open tab in any project, otherwise two clean buffers can
             // claim one final on-disk value.
-            let destinationURLs = preparedSavePlans.values.flatMap(
+            destinationURLs = preparedSavePlans.values.flatMap(
                 \.standardizedDestinationURLs
             )
             let plannedTabIDs = preparedSavePlans.values.reduce(
@@ -2392,26 +2443,77 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             ) { result, plan in
                 result.formUnion(plan.plannedTabIDs)
             }
-            let unplannedOpenURLs = Set(
+            unplannedOpenURLs = Array(Set(
                 registry.openProjects.values.flatMap(\.allTabs).compactMap {
                     plannedTabIDs.contains($0.id)
                         ? nil
                         : $0.fileURL?.standardizedFileURL
                 }
-            )
-            guard destinationURLs.count == Set(destinationURLs).count,
-                  destinationURLs.allSatisfy({
-                      !unplannedOpenURLs.contains($0)
-                  }) else {
-                await presentTerminationFailure()
-                return false
+            ))
+            for plan in preparedSavePlans.values {
+                plannedDestinationsByTabID.merge(
+                    plan.plannedDestinationURLsByTabID,
+                    uniquingKeysWith: { current, _ in current }
+                )
             }
         }
+
+        // Capture one app-wide ownership fence only after every human choice.
+        // Planned Save As backing transitions are the sole allowed inventory
+        // mutation until Quit either commits or rolls back.
+        let saveInventoryAuthorization = registry
+            .captureApplicationTerminationSaveInventory(
+                allowingSaveAs: plannedDestinationsByTabID
+            )
 
         // Rebase the captured duration only after the final human response.
         let terminationDeadline = DispatchTime.now() + .nanoseconds(
             Int(clamping: workBudgetNanoseconds)
         )
+
+        if saveAll == nil {
+            let aliasResult = await TerminationFileAliasResolver.capture(
+                destinationURLs + unplannedOpenURLs,
+                until: terminationDeadline
+            )
+            guard registry.applicationTerminationSaveInventoryStillMatches(
+                saveInventoryAuthorization
+            ) else {
+                await presentTerminationFailure()
+                return false
+            }
+            switch aliasResult {
+            case .captured(let identities):
+                let destinationIdentities = Array(
+                    identities.prefix(destinationURLs.count)
+                )
+                let openIdentities = Set(
+                    identities.dropFirst(destinationURLs.count)
+                )
+                guard destinationIdentities.count == destinationURLs.count,
+                      Set(destinationIdentities).count
+                        == destinationIdentities.count,
+                      destinationIdentities.allSatisfy({
+                          !openIdentities.contains($0)
+                      }) else {
+                    await presentTerminationFailure()
+                    return false
+                }
+            case .failed:
+                await presentTerminationFailure()
+                return false
+            case .timedOut:
+                terminationDeadlineObserver()
+                await presentTerminationFailure()
+                return false
+            }
+        }
+
+        func saveInventoryStillAuthorized() -> Bool {
+            registry.applicationTerminationSaveInventoryStillMatches(
+                saveInventoryAuthorization
+            )
+        }
 
         func cleanupPreparedTerminationSaves() {
             for (identifier, plan) in preparedTerminationSavePlans {
@@ -2425,6 +2527,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
 
         if let saveAll {
             for projectManager in saveRequests {
+                guard saveInventoryStillAuthorized() else {
+                    await presentTerminationFailure()
+                    return false
+                }
                 let context = resolveFreshDecisionContext(
                     preferredProject: projectManager
                 )
@@ -2438,14 +2544,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                             : PreparedPaneSaveCommitResult.invalidated
                     }
                 )
-                guard saveResult == .saved else {
+                guard saveInventoryStillAuthorized(),
+                      saveResult == .saved else {
                     await presentTerminationFailure()
                     return false
                 }
             }
         } else {
             for projectManager in saveRequests {
-                guard let plan = preparedSavePlans[
+                guard saveInventoryStillAuthorized(),
+                      let plan = preparedSavePlans[
                     ObjectIdentifier(projectManager)
                 ] else {
                     cleanupPreparedTerminationSaves()
@@ -2457,6 +2565,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                         plan,
                         until: terminationDeadline
                     )
+                guard saveInventoryStillAuthorized() else {
+                    cleanupPreparedTerminationSaves()
+                    await presentTerminationFailure()
+                    return false
+                }
                 switch stageResult {
                 case .ready:
                     guard let stagedPlan else {
@@ -2493,14 +2606,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             // authorized inode before a RENAME_EXCL install, closing the
             // remaining pathname race without displacing a replacement.
             for projectManager in saveRequests {
-                guard let plan = preparedTerminationSavePlans[
+                guard saveInventoryStillAuthorized(),
+                      let plan = preparedTerminationSavePlans[
                     ObjectIdentifier(projectManager)
-                ],
-                      await projectManager
-                        .terminationSaveDestinationsStillMatch(
-                            plan,
-                            until: terminationDeadline
-                        ) else {
+                ] else {
+                    cleanupPreparedTerminationSaves()
+                    await presentTerminationFailure()
+                    return false
+                }
+                let destinationsStillMatch = await projectManager
+                    .terminationSaveDestinationsStillMatch(
+                        plan,
+                        until: terminationDeadline
+                    )
+                guard saveInventoryStillAuthorized(),
+                      destinationsStillMatch else {
                     cleanupPreparedTerminationSaves()
                     await presentTerminationFailure()
                     return false
@@ -2508,18 +2628,28 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             }
 
             for projectManager in saveRequests {
-                guard let plan = preparedTerminationSavePlans[
+                guard saveInventoryStillAuthorized(),
+                      let plan = preparedTerminationSavePlans[
                     ObjectIdentifier(projectManager)
                 ] else {
                     cleanupPreparedTerminationSaves()
                     await presentTerminationFailure()
                     return false
                 }
-                switch await projectManager
+                let commitResult = await projectManager
                     .commitStagedSaveAllPaneTabsForTermination(
                         plan,
-                        until: terminationDeadline
-                    ) {
+                        until: terminationDeadline,
+                        inventoryStillAuthorized:
+                            saveInventoryStillAuthorized
+                    )
+                guard saveInventoryStillAuthorized()
+                        || commitResult == .invalidated else {
+                    cleanupPreparedTerminationSaves()
+                    await presentTerminationFailure()
+                    return false
+                }
+                switch commitResult {
                 case .saved:
                     preparedTerminationSavePlans.removeValue(
                         forKey: ObjectIdentifier(projectManager)
@@ -2601,6 +2731,37 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             return false
         }
 
+        // A preflight-covered PTY write may acknowledge while the first save
+        // is in flight. Wait for every such write, then flush again so a late
+        // `acknowledgedBeforeVerification` marker (or a failed-write deletion)
+        // is durably newer than that first snapshot.
+        for projectManager in projects {
+            let identifier = ObjectIdentifier(projectManager)
+            guard let authorization = agentLaunchAuthorizations[identifier]
+            else { continue }
+            guard await projectManager.terminal
+                    .waitForAuthorizedAgentLaunchSettlement(
+                        authorization,
+                        until: forwardDeadline
+                    ) else {
+                await rollbackAgentTasks()
+                await presentTerminationFailure()
+                return false
+            }
+        }
+        guard let postSettlementPersistenceBudget =
+                remainingTerminationDuration(until: forwardDeadline),
+              await registry.agentTasks.flushPersistence(
+                  maximumDuration: postSettlementPersistenceBudget
+              ) == .saved else {
+            Logger.app.error(
+                "Post-settlement agent task metadata did not reach a clean persistence barrier"
+            )
+            await rollbackAgentTasks()
+            await presentTerminationFailure()
+            return false
+        }
+
         func destructiveAuthorizationsStillCoverCurrentState() -> Bool {
             for projectManager in registry.openProjects.values {
                 let identifier = ObjectIdentifier(projectManager)
@@ -2632,8 +2793,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     }
                     continue
                 }
+                let currentLaunchAuthorization = projectManager.terminal
+                    .capturePineAgentLaunchAuthorization()
                 guard authorization.stillCovers(
-                    projectManager.terminal.allTerminalTabs
+                    projectManager.terminal.allTerminalTabs,
+                    pineAgentLaunches: agentLaunchAuthorizations[identifier],
+                    currentPineAgentLaunches: currentLaunchAuthorization
                 ) else {
                     Logger.app.error(
                         "Quit aborted: terminal authorization no longer covers the project"
@@ -2643,8 +2808,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 guard let launchAuthorization =
                         agentLaunchAuthorizations[identifier],
                       launchAuthorization.stillCovers(
-                          projectManager.terminal
-                              .capturePineAgentLaunchAuthorization()
+                          currentLaunchAuthorization
                       ) else {
                     Logger.app.error(
                         "Quit aborted: Pine agent-launch authorization no longer covers the project"

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -2034,28 +2034,36 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             } ?? false
         }
 
+        func terminationContext(
+            _ context: DialogPresentationContext
+        ) -> DialogPresentationContext {
+            context.waitingUntilOwnerAvailable()
+        }
+
         func resolveFreshApplicationContext() -> DialogPresentationContext {
-            if let applicationContext {
+            if let applicationContext, applicationContext.nsWindow != nil {
                 // An injected presenter may intentionally use an off-screen
                 // synthetic owner. Native sheets still require live eligibility.
                 if presentAlert != nil || hasEligibleOwner(applicationContext) {
-                    return applicationContext
+                    return terminationContext(applicationContext)
                 }
             }
             let currentContext = DialogPresenter.forApplicationWindow()
             if hasEligibleOwner(currentContext) {
-                return currentContext
+                return terminationContext(currentContext)
             }
             if presentAlert == nil {
                 // The previously captured owner may have closed while another
                 // project sheet was up. Restore/create a discoverable owner at
                 // the point of use rather than reusing that stale authority.
                 prepareApplicationDialogOwner()
-                return DialogPresenter.forApplicationWindow()
+                return terminationContext(
+                    DialogPresenter.forApplicationWindow()
+                )
             }
             // Injected presenters do not require a native owner. Preserve their
             // explicit context while still preferring a live replacement above.
-            return applicationContext ?? fallbackContext
+            return terminationContext(applicationContext ?? fallbackContext)
         }
 
         func resolveFreshDecisionContext(
@@ -2066,7 +2074,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     preferredProject
                 )
                 if hasEligibleOwner(projectContext) {
-                    return projectContext
+                    return terminationContext(projectContext)
                 }
             }
             return resolveFreshApplicationContext()
@@ -2097,28 +2105,74 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 )
                 if let window = projectContext.nsWindow,
                    DialogPresenter.isEligibleApplicationOwner(window) {
-                    return projectContext
+                    return terminationContext(projectContext)
                 }
             }
             if let terminationFailureContext {
-                return terminationFailureContext()
+                let context = terminationFailureContext()
+                if presentAlert != nil || hasEligibleOwner(context) {
+                    return terminationContext(context)
+                }
             }
             if presentAlert == nil {
                 // A clean preflight may never have created or restored an
                 // owner. Resolve one lazily only after machine work fails.
                 prepareApplicationDialogOwner()
-                return DialogPresenter.forApplicationWindow()
+                return terminationContext(
+                    DialogPresenter.forApplicationWindow()
+                )
             }
-            return fallbackContext
+            return resolveFreshApplicationContext()
         }
 
-        func presentTerminationFailure() async {
-            _ = await presentTerminationAlert(
-                .applicationQuitFailure,
-                context: resolveTerminationFailureContext(),
-                title: Strings.applicationQuitFailureTitle,
-                message: Strings.applicationQuitFailureMessage
+        /// Machine failures are never user cancellation. Require the sole OK
+        /// response as proof that AppKit displayed the explanation. `.abort`
+        /// means presentation authority was lost, so retry on a freshly
+        /// resolved project/application owner. The fixed attempt bound avoids
+        /// recursive or infinite retry if the application cannot retain any
+        /// owner at all.
+        @discardableResult
+        func presentTerminationFailure(
+            _ template: AlertTemplate = .applicationQuitFailure,
+            preferredProject: ProjectManager? = nil,
+            title: String = Strings.applicationQuitFailureTitle,
+            message: String = Strings.applicationQuitFailureMessage
+        ) async -> Bool {
+            let maximumAttempts = 3
+            for attempt in 0..<maximumAttempts {
+                let context = resolveTerminationFailureContext(
+                    preferredProject: preferredProject
+                )
+                if presentAlert == nil, !hasEligibleOwner(context) {
+                    prepareApplicationDialogOwner()
+                    if attempt + 1 < maximumAttempts {
+                        await Task.yield()
+                    }
+                    continue
+                }
+                let response = await presentTerminationAlert(
+                    template,
+                    context: context,
+                    title: title,
+                    message: message
+                )
+                if response == .alertFirstButtonReturn {
+                    return true
+                }
+                Logger.app.error(
+                    "Quit failure explanation lost its dialog owner; retrying on a fresh owner"
+                )
+                if presentAlert == nil {
+                    prepareApplicationDialogOwner()
+                }
+                if attempt + 1 < maximumAttempts {
+                    await Task.yield()
+                }
+            }
+            Logger.app.critical(
+                "Quit failure explanation could not be displayed after bounded owner rebinding"
             )
+            return false
         }
 
         func presentTerminationDecision(
@@ -2127,26 +2181,42 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             title: String,
             message: String
         ) async -> NSApplication.ModalResponse? {
-            let context = resolveFreshDecisionContext(
-                preferredProject: preferredProject
-            )
-            guard presentAlert != nil || hasEligibleOwner(context) else {
-                await presentTerminationFailure()
-                return nil
+            let maximumAttempts = 3
+            for attempt in 0..<maximumAttempts {
+                let context = resolveFreshDecisionContext(
+                    preferredProject: preferredProject
+                )
+                if presentAlert == nil, !hasEligibleOwner(context) {
+                    prepareApplicationDialogOwner()
+                    if attempt + 1 < maximumAttempts {
+                        await Task.yield()
+                    }
+                    continue
+                }
+                let response = await presentTerminationAlert(
+                    template,
+                    context: context,
+                    title: title,
+                    message: message
+                )
+                // User cancellation has a template-specific button response.
+                // `.abort` is presentation loss and must rebind instead of
+                // being mistaken for that user decision.
+                if response != .abort {
+                    return response
+                }
+                Logger.app.error(
+                    "Quit decision lost its dialog owner; retrying on a fresh owner"
+                )
+                if presentAlert == nil {
+                    prepareApplicationDialogOwner()
+                }
+                if attempt + 1 < maximumAttempts {
+                    await Task.yield()
+                }
             }
-            let response = await presentTerminationAlert(
-                template,
-                context: context,
-                title: title,
-                message: message
-            )
-            // Native `.abort` means the sheet lost its captured owner; Cancel
-            // has its own button response and must remain the only silent exit.
-            if presentAlert == nil, response == .abort {
-                await presentTerminationFailure()
-                return nil
-            }
-            return response
+            await presentTerminationFailure()
+            return nil
         }
 
         var discardAuthorizations: [
@@ -2399,11 +2469,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     ] = stagedPlan
                 case .failed(let message):
                     cleanupPreparedTerminationSaves()
-                    _ = await presentTerminationAlert(
+                    await presentTerminationFailure(
                         .fileOperationErrorCritical,
-                        context: resolveTerminationFailureContext(
-                            preferredProject: projectManager
-                        ),
+                        preferredProject: projectManager,
                         title: Strings.fileOperationErrorTitle,
                         message: message
                     )
@@ -2421,14 +2489,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             }
 
             // Validate every target before the first destructive install. The
-            // atomic installer repeats the check and displaces existing files
-            // with RENAME_SWAP to close the remaining pathname race.
+            // atomic installer repeats the check and quarantines the exact
+            // authorized inode before a RENAME_EXCL install, closing the
+            // remaining pathname race without displacing a replacement.
             for projectManager in saveRequests {
                 guard let plan = preparedTerminationSavePlans[
                     ObjectIdentifier(projectManager)
                 ],
                       await projectManager
-                        .terminationSaveDestinationsStillMatch(plan) else {
+                        .terminationSaveDestinationsStillMatch(
+                            plan,
+                            until: terminationDeadline
+                        ) else {
                     cleanupPreparedTerminationSaves()
                     await presentTerminationFailure()
                     return false
@@ -2454,11 +2526,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     )
                 case .failed(let message):
                     cleanupPreparedTerminationSaves()
-                    _ = await presentTerminationAlert(
+                    await presentTerminationFailure(
                         .fileOperationErrorCritical,
-                        context: resolveTerminationFailureContext(
-                            preferredProject: projectManager
-                        ),
+                        preferredProject: projectManager,
                         title: Strings.fileOperationErrorTitle,
                         message: message
                     )

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -2515,14 +2515,58 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             )
         }
 
-        func cleanupPreparedTerminationSaves() {
+        func cleanupPreparedTerminationSaves() async -> [URL] {
+            var retainedArtifacts: [URL] = []
             for (identifier, plan) in preparedTerminationSavePlans {
                 guard let projectManager = projects.first(where: {
                     ObjectIdentifier($0) == identifier
                 }) else { continue }
-                projectManager.cleanupTerminationSavePlan(plan)
+                let result = await projectManager.cleanupTerminationSavePlan(
+                    plan,
+                    until: terminationDeadline
+                )
+                if case .failed(let message, let retained) = result {
+                    Logger.app.error(
+                        "Termination save cleanup failed: \(message, privacy: .public)"
+                    )
+                    retainedArtifacts.append(contentsOf: retained)
+                }
             }
             preparedTerminationSavePlans.removeAll()
+            return Array(Set(retainedArtifacts)).sorted {
+                $0.path < $1.path
+            }
+        }
+
+        func presentSaveFailure(
+            preferredProject: ProjectManager? = nil,
+            internalMessage: String? = nil,
+            retainedArtifacts additionalRetainedArtifacts: [URL] = []
+        ) async {
+            if let internalMessage {
+                Logger.app.error(
+                    "Termination save failed: \(internalMessage, privacy: .public)"
+                )
+            }
+            let cleanedRetainedArtifacts =
+                await cleanupPreparedTerminationSaves()
+            let retainedArtifacts = Array(Set(
+                additionalRetainedArtifacts + cleanedRetainedArtifacts
+            )).sorted { $0.path < $1.path }
+            let retainedPaths = retainedArtifacts.map(\.path).joined(
+                separator: "\n"
+            )
+            let message = retainedPaths.isEmpty
+                ? Strings.applicationQuitFailureMessage
+                : Strings.applicationQuitFailureMessage
+                    + "\n\n"
+                    + retainedPaths
+            await presentTerminationFailure(
+                .fileOperationErrorCritical,
+                preferredProject: preferredProject,
+                title: Strings.fileOperationErrorTitle,
+                message: message
+            )
         }
 
         if let saveAll {
@@ -2556,8 +2600,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                       let plan = preparedSavePlans[
                     ObjectIdentifier(projectManager)
                 ] else {
-                    cleanupPreparedTerminationSaves()
-                    await presentTerminationFailure()
+                    await presentSaveFailure(
+                        preferredProject: projectManager
+                    )
                     return false
                 }
                 let (stageResult, stagedPlan) = await projectManager
@@ -2566,37 +2611,39 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                         until: terminationDeadline
                     )
                 guard saveInventoryStillAuthorized() else {
-                    cleanupPreparedTerminationSaves()
-                    await presentTerminationFailure()
+                    await presentSaveFailure(
+                        preferredProject: projectManager
+                    )
                     return false
                 }
                 switch stageResult {
                 case .ready:
                     guard let stagedPlan else {
-                        cleanupPreparedTerminationSaves()
-                        await presentTerminationFailure()
+                        await presentSaveFailure(
+                            preferredProject: projectManager
+                        )
                         return false
                     }
                     preparedTerminationSavePlans[
                         ObjectIdentifier(projectManager)
                     ] = stagedPlan
-                case .failed(let message):
-                    cleanupPreparedTerminationSaves()
-                    await presentTerminationFailure(
-                        .fileOperationErrorCritical,
+                case .failed(let message, let retainedArtifacts):
+                    await presentSaveFailure(
                         preferredProject: projectManager,
-                        title: Strings.fileOperationErrorTitle,
-                        message: message
+                        internalMessage: message,
+                        retainedArtifacts: retainedArtifacts
                     )
                     return false
                 case .invalidated:
-                    cleanupPreparedTerminationSaves()
-                    await presentTerminationFailure()
+                    await presentSaveFailure(
+                        preferredProject: projectManager
+                    )
                     return false
                 case .timedOut:
                     terminationDeadlineObserver()
-                    cleanupPreparedTerminationSaves()
-                    await presentTerminationFailure()
+                    await presentSaveFailure(
+                        preferredProject: projectManager
+                    )
                     return false
                 }
             }
@@ -2610,8 +2657,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                       let plan = preparedTerminationSavePlans[
                     ObjectIdentifier(projectManager)
                 ] else {
-                    cleanupPreparedTerminationSaves()
-                    await presentTerminationFailure()
+                    await presentSaveFailure(
+                        preferredProject: projectManager
+                    )
                     return false
                 }
                 let destinationsStillMatch = await projectManager
@@ -2621,8 +2669,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     )
                 guard saveInventoryStillAuthorized(),
                       destinationsStillMatch else {
-                    cleanupPreparedTerminationSaves()
-                    await presentTerminationFailure()
+                    await presentSaveFailure(
+                        preferredProject: projectManager
+                    )
                     return false
                 }
             }
@@ -2632,8 +2681,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                       let plan = preparedTerminationSavePlans[
                     ObjectIdentifier(projectManager)
                 ] else {
-                    cleanupPreparedTerminationSaves()
-                    await presentTerminationFailure()
+                    await presentSaveFailure(
+                        preferredProject: projectManager
+                    )
                     return false
                 }
                 let commitResult = await projectManager
@@ -2645,8 +2695,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     )
                 guard saveInventoryStillAuthorized()
                         || commitResult == .invalidated else {
-                    cleanupPreparedTerminationSaves()
-                    await presentTerminationFailure()
+                    await presentSaveFailure(
+                        preferredProject: projectManager
+                    )
                     return false
                 }
                 switch commitResult {
@@ -2654,23 +2705,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     preparedTerminationSavePlans.removeValue(
                         forKey: ObjectIdentifier(projectManager)
                     )
-                case .failed(let message):
-                    cleanupPreparedTerminationSaves()
-                    await presentTerminationFailure(
-                        .fileOperationErrorCritical,
+                case .failed(let message, let retainedArtifacts):
+                    await presentSaveFailure(
                         preferredProject: projectManager,
-                        title: Strings.fileOperationErrorTitle,
-                        message: message
+                        internalMessage: message,
+                        retainedArtifacts: retainedArtifacts
                     )
                     return false
                 case .invalidated:
-                    cleanupPreparedTerminationSaves()
-                    await presentTerminationFailure()
+                    await presentSaveFailure(
+                        preferredProject: projectManager
+                    )
                     return false
                 case .timedOut:
                     terminationDeadlineObserver()
-                    cleanupPreparedTerminationSaves()
-                    await presentTerminationFailure()
+                    await presentSaveFailure(
+                        preferredProject: projectManager
+                    )
                     return false
                 }
             }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -1157,7 +1157,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         }
         switch DialogPresenter.applicationOwnerPlan(for: ownerStates) {
         case .keepExisting:
-            return
+            guard let index = ownerStates.firstIndex(of: .eligible),
+                  windows.indices.contains(index) else {
+                ensureWelcomeVisible()
+                return
+            }
+            windows[index].makeKeyAndOrderFront(nil)
+            NSApp.activate()
         case let .restore(index):
             guard windows.indices.contains(index) else {
                 ensureWelcomeVisible()
@@ -1944,6 +1950,44 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         }
     }
 
+    private func presentLateTerminationSaveFailure(
+        preferredProject: ProjectManager?,
+        internalMessage: String,
+        retainedArtifacts: [URL]
+    ) async {
+        Logger.app.error(
+            "Late termination save failure: \(internalMessage, privacy: .public)"
+        )
+        let paths = Array(Set(retainedArtifacts)).sorted {
+            $0.path < $1.path
+        }.map(\.path).joined(separator: "\n")
+        let message = Strings.applicationQuitFailureMessage
+            + (paths.isEmpty ? "" : "\n\n" + paths)
+        while !Task.isCancelled {
+            prepareApplicationDialogOwner()
+            let projectContext = preferredProject.map {
+                DialogPresenter.forProject($0)
+            }
+            let context: DialogPresentationContext
+            if let projectContext,
+               let window = projectContext.nsWindow,
+               DialogPresenter.isEligibleApplicationOwner(window) {
+                context = projectContext.waitingUntilOwnerAvailable()
+            } else {
+                context = DialogPresenter.forApplicationWindow()
+                    .waitingUntilOwnerAvailable()
+            }
+            let response = await AlertTemplate.fileOperationErrorCritical
+                .runSheet(
+                    on: context,
+                    messageText: Strings.fileOperationErrorTitle,
+                    informativeText: message
+                )
+            if response == .alertFirstButtonReturn { return }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+    }
+
     /// Presents one application-wide Quit summary. The safe Review path walks
     /// project-owned sheets only after the user opts in; Quit Anyway captures
     /// stable discard/process authorizations in one step. The 30-second clock
@@ -1962,6 +2006,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         let projects = registry.openProjects
             .sorted { $0.key.path.localizedStandardCompare($1.key.path) == .orderedAscending }
             .map(\.value)
+        for project in projects {
+            project.terminationSaveLateFailureHandler = { [weak self, weak project] message, retainedArtifacts in
+                Task { @MainActor in
+                    await self?.presentLateTerminationSaveFailure(
+                        preferredProject: project,
+                        internalMessage: message,
+                        retainedArtifacts: retainedArtifacts
+                    )
+                }
+            }
+        }
         var terminationCommitted = false
         var heldAgentLaunchAuthorizations: [
             (TerminalManager, PineAgentLaunchAuthorization)
@@ -2515,7 +2570,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             )
         }
 
-        func cleanupPreparedTerminationSaves() async -> [URL] {
+        func cleanupPreparedTerminationSaves(
+            excluding protectedArtifacts: [URL] = []
+        ) async -> [URL] {
             var retainedArtifacts: [URL] = []
             for (identifier, plan) in preparedTerminationSavePlans {
                 guard let projectManager = projects.first(where: {
@@ -2523,6 +2580,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 }) else { continue }
                 let result = await projectManager.cleanupTerminationSavePlan(
                     plan,
+                    excluding: protectedArtifacts,
                     until: terminationDeadline
                 )
                 if case .failed(let message, let retained) = result {
@@ -2549,7 +2607,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 )
             }
             let cleanedRetainedArtifacts =
-                await cleanupPreparedTerminationSaves()
+                await cleanupPreparedTerminationSaves(
+                    excluding: additionalRetainedArtifacts
+                )
             let retainedArtifacts = Array(Set(
                 additionalRetainedArtifacts + cleanedRetainedArtifacts
             )).sorted { $0.path < $1.path }
@@ -2693,18 +2753,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                         inventoryStillAuthorized:
                             saveInventoryStillAuthorized
                     )
-                guard saveInventoryStillAuthorized()
-                        || commitResult == .invalidated else {
-                    await presentSaveFailure(
-                        preferredProject: projectManager
-                    )
-                    return false
-                }
+                // ProjectManager owns cleanup/reconciliation once commit
+                // starts. Do not retry one-shot cleanup through obsolete
+                // staging paths in the app-level failure presenter.
+                preparedTerminationSavePlans.removeValue(
+                    forKey: ObjectIdentifier(projectManager)
+                )
                 switch commitResult {
                 case .saved:
-                    preparedTerminationSavePlans.removeValue(
-                        forKey: ObjectIdentifier(projectManager)
-                    )
+                    guard saveInventoryStillAuthorized() else {
+                        await presentSaveFailure(
+                            preferredProject: projectManager
+                        )
+                        return false
+                    }
                 case .failed(let message, let retainedArtifacts):
                     await presentSaveFailure(
                         preferredProject: projectManager,

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -836,6 +836,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         ProjectManager,
         DialogPresentationContext
     ) async -> Bool
+    typealias TerminationAliasCapture = @Sendable (
+        [URL],
+        DispatchTime
+    ) async -> TerminationFileAliasCaptureResult
 
     /// Pure feed configuration shared by the Sparkle delegate callback and
     /// tests. Keeping this seam independent from `updaterController` prevents
@@ -1998,7 +2002,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         applicationContext: DialogPresentationContext? = nil,
         terminationFailureContext: (@MainActor () -> DialogPresentationContext)? = nil,
         terminationDeadlineOverride: DispatchTime? = nil,
-        terminationDeadlineObserver: @escaping @Sendable () -> Void = {}
+        terminationDeadlineObserver: @escaping @Sendable () -> Void = {},
+        terminationAliasCapture: @escaping TerminationAliasCapture = { urls, deadline in
+            await TerminationFileAliasResolver.capture(
+                urls,
+                until: deadline
+            )
+        }
     ) async -> Bool {
         let workBudgetNanoseconds = terminationWorkBudgetNanoseconds(
             overriding: terminationDeadlineOverride
@@ -2526,10 +2536,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             Int(clamping: workBudgetNanoseconds)
         )
 
+        let saveAliasURLs = destinationURLs + unplannedOpenURLs
+        var saveAliasAuthorization: [TerminationFileAliasIdentity]?
         if saveAll == nil {
-            let aliasResult = await TerminationFileAliasResolver.capture(
-                destinationURLs + unplannedOpenURLs,
-                until: terminationDeadline
+            let aliasResult = await terminationAliasCapture(
+                saveAliasURLs,
+                terminationDeadline
             )
             guard registry.applicationTerminationSaveInventoryStillMatches(
                 saveInventoryAuthorization
@@ -2539,6 +2551,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             }
             switch aliasResult {
             case .captured(let identities):
+                saveAliasAuthorization = identities
                 let destinationIdentities = Array(
                     identities.prefix(destinationURLs.count)
                 )
@@ -2706,6 +2719,37 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     )
                     return false
                 }
+            }
+
+            // Staging can suspend long enough for a previously missing target
+            // parent to be replaced by a symlink. Re-capture the complete
+            // app-wide alias vector before the first install; from this point
+            // every staged plan pins its exact parent directory inode.
+            guard let saveAliasAuthorization else {
+                await presentSaveFailure()
+                return false
+            }
+            let currentAliases = await terminationAliasCapture(
+                saveAliasURLs,
+                terminationDeadline
+            )
+            guard saveInventoryStillAuthorized() else {
+                await presentSaveFailure()
+                return false
+            }
+            switch currentAliases {
+            case .captured(let identities):
+                guard identities == saveAliasAuthorization else {
+                    await presentSaveFailure()
+                    return false
+                }
+            case .failed:
+                await presentSaveFailure()
+                return false
+            case .timedOut:
+                terminationDeadlineObserver()
+                await presentSaveFailure()
+                return false
             }
 
             // Validate every target before the first destructive install. The

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -1962,6 +1962,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         let projects = registry.openProjects
             .sorted { $0.key.path.localizedStandardCompare($1.key.path) == .orderedAscending }
             .map(\.value)
+        var terminationCommitted = false
+        registry.freezeAutoSaveForTermination()
+        defer {
+            if terminationCommitted {
+                registry.finishAutoSaveTerminationFreeze()
+            } else {
+                registry.cancelAutoSaveTerminationFreeze()
+            }
+        }
         let preflightTerminalAuthorizations = Dictionary(
             uniqueKeysWithValues: projects.map {
                 (
@@ -2017,6 +2026,52 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         let fallbackContext = applicationContext
             ?? DialogPresenter.forApplicationWindow()
 
+        func hasEligibleOwner(
+            _ context: DialogPresentationContext
+        ) -> Bool {
+            context.nsWindow.map {
+                DialogPresenter.isEligibleApplicationOwner($0)
+            } ?? false
+        }
+
+        func resolveFreshApplicationContext() -> DialogPresentationContext {
+            if let applicationContext {
+                // An injected presenter may intentionally use an off-screen
+                // synthetic owner. Native sheets still require live eligibility.
+                if presentAlert != nil || hasEligibleOwner(applicationContext) {
+                    return applicationContext
+                }
+            }
+            let currentContext = DialogPresenter.forApplicationWindow()
+            if hasEligibleOwner(currentContext) {
+                return currentContext
+            }
+            if presentAlert == nil {
+                // The previously captured owner may have closed while another
+                // project sheet was up. Restore/create a discoverable owner at
+                // the point of use rather than reusing that stale authority.
+                prepareApplicationDialogOwner()
+                return DialogPresenter.forApplicationWindow()
+            }
+            // Injected presenters do not require a native owner. Preserve their
+            // explicit context while still preferring a live replacement above.
+            return applicationContext ?? fallbackContext
+        }
+
+        func resolveFreshDecisionContext(
+            preferredProject: ProjectManager? = nil
+        ) -> DialogPresentationContext {
+            if let preferredProject {
+                let projectContext = DialogPresenter.forProject(
+                    preferredProject
+                )
+                if hasEligibleOwner(projectContext) {
+                    return projectContext
+                }
+            }
+            return resolveFreshApplicationContext()
+        }
+
         func presentTerminationAlert(
             _ template: AlertTemplate,
             context: DialogPresentationContext,
@@ -2066,6 +2121,34 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             )
         }
 
+        func presentTerminationDecision(
+            _ template: AlertTemplate,
+            preferredProject: ProjectManager? = nil,
+            title: String,
+            message: String
+        ) async -> NSApplication.ModalResponse? {
+            let context = resolveFreshDecisionContext(
+                preferredProject: preferredProject
+            )
+            guard presentAlert != nil || hasEligibleOwner(context) else {
+                await presentTerminationFailure()
+                return nil
+            }
+            let response = await presentTerminationAlert(
+                template,
+                context: context,
+                title: title,
+                message: message
+            )
+            // Native `.abort` means the sheet lost its captured owner; Cancel
+            // has its own button response and must remain the only silent exit.
+            if presentAlert == nil, response == .abort {
+                await presentTerminationFailure()
+                return nil
+            }
+            return response
+        }
+
         var discardAuthorizations: [
             ObjectIdentifier: DirtyEditorContentAuthorization
         ] = [:]
@@ -2079,7 +2162,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         var agentLaunchAuthorizations: [
             ObjectIdentifier: PineAgentLaunchAuthorization
         ] = [:]
-        var saveRequests: [(ProjectManager, DialogPresentationContext)] = []
+        var saveRequests: [ProjectManager] = []
         var preparedSavePlans: [
             ObjectIdentifier: ProjectManager.PreparedPaneSavePlan
         ] = [:]
@@ -2091,14 +2174,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         var userTaskAuthorization = preflightUserTaskAuthorization
 
         if requiresAttention {
-            let response = await presentTerminationAlert(
+            guard let response = await presentTerminationDecision(
                 .applicationQuitSummary,
-                context: fallbackContext,
                 title: Strings.applicationQuitSummaryTitle,
                 message: Strings.applicationQuitSummaryMessage(
                     max(attentionProjectCount, 1)
                 )
-            )
+            ) else { return false }
             switch response {
             case .alertFirstButtonReturn:
                 reviewIndividually = true
@@ -2123,27 +2205,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 }) else {
                     continue
                 }
-                let projectContext = DialogPresenter.forProject(projectManager)
-                let hasEligibleProjectOwner = projectContext.nsWindow.map {
-                    DialogPresenter.isEligibleApplicationOwner($0)
-                } ?? false
-                let context = hasEligibleProjectOwner
-                    ? projectContext
-                    : fallbackContext
                 let dirty = projectManager.allDirtyTabs
                 guard !dirty.isEmpty else { continue }
 
                 let fileList = dirty.map { "  • \($0.fileName)" }
                     .joined(separator: "\n")
-                let response = await presentTerminationAlert(
+                guard let response = await presentTerminationDecision(
                     .unsavedChangesBulk,
-                    context: context,
+                    preferredProject: projectManager,
                     title: Strings.unsavedChangesTitle,
                     message: Strings.unsavedChangesListMessage(fileList)
-                )
+                ) else { return false }
                 switch response {
                 case .alertFirstButtonReturn:
-                    saveRequests.append((projectManager, context))
+                    saveRequests.append(projectManager)
                 case .alertSecondButtonReturn:
                     discardAuthorizations[ObjectIdentifier(projectManager)] =
                         DirtyEditorContentAuthorization(tabs: dirty)
@@ -2170,19 +2245,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                         || launchAuthorization.requiresConfirmation else {
                     continue
                 }
-                let projectContext = DialogPresenter.forProject(projectManager)
-                let hasEligibleProjectOwner = projectContext.nsWindow.map {
-                    DialogPresenter.isEligibleApplicationOwner($0)
-                } ?? false
-                let context = hasEligibleProjectOwner
-                    ? projectContext
-                    : fallbackContext
-                let response = await presentTerminationAlert(
+                guard let response = await presentTerminationDecision(
                     .terminalActiveProcessWarning,
-                    context: context,
+                    preferredProject: projectManager,
                     title: Strings.terminalActiveProcessWarningTitle,
                     message: Strings.terminalActiveProcessWarningMessage
-                )
+                ) else { return false }
                 guard response == .alertFirstButtonReturn else {
                     return false
                 }
@@ -2191,12 +2259,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             let displayedUserTaskAuthorization =
                 registry.captureUserTaskShutdownAuthorization()
             if displayedUserTaskAuthorization.requiresConfirmation {
-                let response = await presentTerminationAlert(
+                guard let response = await presentTerminationDecision(
                     .activeUserTasksPreventQuit,
-                    context: fallbackContext,
                     title: Strings.activeUserTasksPreventQuitTitle,
                     message: Strings.activeUserTasksPreventQuitMessage
-                )
+                ) else { return false }
                 guard response == .alertFirstButtonReturn else {
                     return false
                 }
@@ -2219,18 +2286,55 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         // Collect every Save-As destination before rebasing the duration.
         // These native panels are human decisions, not bounded machine work.
         if saveAll == nil {
-            for (projectManager, context) in saveRequests {
+            for projectManager in saveRequests {
+                let context = resolveFreshDecisionContext(
+                    preferredProject: projectManager
+                )
+                guard presentAlert != nil || hasEligibleOwner(context) else {
+                    await presentTerminationFailure()
+                    return false
+                }
                 switch await projectManager.prepareSaveAllPaneTabs(
                     context: context
                 ) {
                 case .ready(let plan):
                     preparedSavePlans[ObjectIdentifier(projectManager)] = plan
                 case .cancelledByUser:
+                    if presentAlert == nil, !hasEligibleOwner(context) {
+                        await presentTerminationFailure()
+                    }
                     return false
                 case .invalidated:
                     await presentTerminationFailure()
                     return false
                 }
+            }
+
+            // Save All is one application-wide transaction. A destination
+            // chosen in one project must not alias another prepared save or a
+            // clean/open tab in any project, otherwise two clean buffers can
+            // claim one final on-disk value.
+            let destinationURLs = preparedSavePlans.values.flatMap(
+                \.standardizedDestinationURLs
+            )
+            let plannedTabIDs = preparedSavePlans.values.reduce(
+                into: Set<UUID>()
+            ) { result, plan in
+                result.formUnion(plan.plannedTabIDs)
+            }
+            let unplannedOpenURLs = Set(
+                registry.openProjects.values.flatMap(\.allTabs).compactMap {
+                    plannedTabIDs.contains($0.id)
+                        ? nil
+                        : $0.fileURL?.standardizedFileURL
+                }
+            )
+            guard destinationURLs.count == Set(destinationURLs).count,
+                  destinationURLs.allSatisfy({
+                      !unplannedOpenURLs.contains($0)
+                  }) else {
+                await presentTerminationFailure()
+                return false
             }
         }
 
@@ -2250,7 +2354,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         }
 
         if let saveAll {
-            for (projectManager, context) in saveRequests {
+            for projectManager in saveRequests {
+                let context = resolveFreshDecisionContext(
+                    preferredProject: projectManager
+                )
                 let saveResult = await valueBeforeTerminationDeadline(
                     terminationDeadline,
                     deadlineObserver: terminationDeadlineObserver,
@@ -2267,7 +2374,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 }
             }
         } else {
-            for (projectManager, _) in saveRequests {
+            for projectManager in saveRequests {
                 guard let plan = preparedSavePlans[
                     ObjectIdentifier(projectManager)
                 ] else {
@@ -2313,7 +2420,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 }
             }
 
-            for (projectManager, _) in saveRequests {
+            // Validate every target before the first destructive install. The
+            // atomic installer repeats the check and displaces existing files
+            // with RENAME_SWAP to close the remaining pathname race.
+            for projectManager in saveRequests {
+                guard let plan = preparedTerminationSavePlans[
+                    ObjectIdentifier(projectManager)
+                ],
+                      await projectManager
+                        .terminationSaveDestinationsStillMatch(plan) else {
+                    cleanupPreparedTerminationSaves()
+                    await presentTerminationFailure()
+                    return false
+                }
+            }
+
+            for projectManager in saveRequests {
                 guard let plan = preparedTerminationSavePlans[
                     ObjectIdentifier(projectManager)
                 ] else {
@@ -2321,7 +2443,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     await presentTerminationFailure()
                     return false
                 }
-                switch projectManager
+                switch await projectManager
                     .commitStagedSaveAllPaneTabsForTermination(
                         plan,
                         until: terminationDeadline
@@ -2342,6 +2464,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     )
                     return false
                 case .invalidated:
+                    cleanupPreparedTerminationSaves()
+                    await presentTerminationFailure()
+                    return false
+                case .timedOut:
+                    terminationDeadlineObserver()
                     cleanupPreparedTerminationSaves()
                     await presentTerminationFailure()
                     return false
@@ -2466,6 +2593,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             return false
         }
 
+        var preparedUserTaskShutdown = false
         if registry.hasOutstandingUserTaskExecution {
             guard await registry.shutdownUserTasks(
                 authorizedBy: userTaskAuthorization,
@@ -2475,6 +2603,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 await presentTerminationFailure()
                 return false
             }
+            preparedUserTaskShutdown = true
         }
 
         // Task cleanup suspends off-main. Revalidate destructive state once
@@ -2485,8 +2614,26 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             return false
         }
 
+        guard !preparedUserTaskShutdown
+                || registry.userTaskShutdownIsPreparedForCommit(
+                    userTaskAuthorization
+                ) else {
+            await rollbackAgentTasks()
+            await presentTerminationFailure()
+            return false
+        }
+
         // Two-phase destructive commit: no project is mutated until every
-        // project/terminal authorization and task-ownership checks above pass.
+        // project/terminal/task and editor authorization above passes.
+        for projectManager in registry.openProjects.values {
+            let identifier = ObjectIdentifier(projectManager)
+            if let authorization = discardAuthorizations[identifier],
+               !projectManager.canCommitDiscard(authorization) {
+                await rollbackAgentTasks()
+                await presentTerminationFailure()
+                return false
+            }
+        }
         for projectManager in registry.openProjects.values {
             let identifier = ObjectIdentifier(projectManager)
             if let authorization = discardAuthorizations[identifier],
@@ -2499,7 +2646,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 return false
             }
         }
+        if preparedUserTaskShutdown,
+           !registry.commitPreparedUserTaskShutdown(
+                userTaskAuthorization
+           ) {
+            Logger.app.critical(
+                "Prepared user-task shutdown changed during synchronous commit"
+            )
+            await rollbackAgentTasks()
+            await presentTerminationFailure()
+            return false
+        }
 
+        terminationCommitted = true
         return true
     }
 }

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -2055,6 +2055,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 )
             }
         )
+        let preflightQuickTerminalAuthorization =
+            TerminalTabCloseAuthorization.authorizing(
+                tabs: quickTerminalCoordinator.paneState.terminalTabs
+            )
         let preflightAgentLaunchAuthorizations = Dictionary(
             uniqueKeysWithValues: projects.map {
                 (
@@ -2090,8 +2094,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 ? identifier
                 : nil
         }).union(preflightUserTaskAuthorization.confirmingOwnerIDs)
-        let attentionProjectCount = attentionProjectIDs.count
-        let requiresAttention = attentionProjectCount > 0
+        let attentionItemCount = attentionProjectIDs.count
+            + (preflightQuickTerminalAuthorization.requiresConfirmation ? 1 : 0)
+        let requiresAttention = attentionItemCount > 0
             || preflightUserTaskAuthorization.requiresConfirmation
         let needsNativeDecision = presentAlert == nil
             && requiresAttention
@@ -2310,6 +2315,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         var terminalAuthorizations: [
             ObjectIdentifier: TerminalTabCloseAuthorization
         ] = [:]
+        var quickTerminalAuthorization: TerminalTabCloseAuthorization?
         var agentLaunchAuthorizations: [
             ObjectIdentifier: PineAgentLaunchAuthorization
         ] = [:]
@@ -2350,7 +2356,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 .applicationQuitSummary,
                 title: Strings.applicationQuitSummaryTitle,
                 message: Strings.applicationQuitSummaryMessage(
-                    max(attentionProjectCount, 1)
+                    max(attentionItemCount, 1)
                 )
             ) else { return false }
             switch response {
@@ -2369,6 +2375,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             // while the sheet is open still fail closed during revalidation.
             discardAuthorizations = preflightDiscardAuthorizations
             terminalAuthorizations = preflightTerminalAuthorizations
+            quickTerminalAuthorization = preflightQuickTerminalAuthorization
             agentLaunchAuthorizations = preflightAgentLaunchAuthorizations
         } else if reviewIndividually {
             for projectManager in projects {
@@ -2439,6 +2446,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 }
             }
 
+            let currentQuickTerminalAuthorization =
+                TerminalTabCloseAuthorization.authorizing(
+                    tabs: quickTerminalCoordinator.paneState.terminalTabs
+                )
+            quickTerminalAuthorization = currentQuickTerminalAuthorization
+            if currentQuickTerminalAuthorization.requiresConfirmation {
+                guard let response = await presentTerminationDecision(
+                    .terminalActiveProcessWarning,
+                    title: Strings.terminalActiveProcessWarningTitle,
+                    message: Strings.terminalActiveProcessWarningMessage
+                ) else { return false }
+                guard response == .alertFirstButtonReturn else {
+                    return false
+                }
+            }
+
             let displayedUserTaskAuthorization =
                 registry.captureUserTaskShutdownAuthorization()
             if displayedUserTaskAuthorization.requiresConfirmation {
@@ -2464,6 +2487,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     projectManager.terminal
                         .capturePineAgentLaunchAuthorization()
             }
+            quickTerminalAuthorization =
+                TerminalTabCloseAuthorization.authorizing(
+                    tabs: quickTerminalCoordinator.paneState.terminalTabs
+                )
         }
 
         // Collect every Save-As destination before rebasing the duration.
@@ -2972,6 +2999,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     )
                     return false
                 }
+            }
+            guard let quickTerminalAuthorization,
+                  quickTerminalAuthorization.stillCovers(
+                      quickTerminalCoordinator.paneState.terminalTabs
+                  ) else {
+                Logger.app.error(
+                    "Quit aborted: Quick Terminal authorization no longer covers its running processes"
+                )
+                return false
             }
             return registry.userTaskShutdownAuthorizationStillCovers(
                 userTaskAuthorization

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -1972,6 +1972,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 )
             }
         )
+        let preflightAgentLaunchAuthorizations = Dictionary(
+            uniqueKeysWithValues: projects.map {
+                (
+                    ObjectIdentifier($0),
+                    $0.terminal.capturePineAgentLaunchAuthorization()
+                )
+            }
+        )
         let preflightDiscardAuthorizations: [
             ObjectIdentifier: DirtyEditorContentAuthorization
         ] = Dictionary(
@@ -1989,6 +1997,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         let attentionProjectCount = projects.filter {
             !$0.allDirtyTabs.isEmpty
                 || preflightTerminalAuthorizations[
+                    ObjectIdentifier($0)
+                ]?.requiresConfirmation == true
+                || preflightAgentLaunchAuthorizations[
                     ObjectIdentifier($0)
                 ]?.requiresConfirmation == true
                 || $0.hasOutstandingUserTaskExecution
@@ -2022,21 +2033,34 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             )
         }
 
-        func presentTerminationFailure() async {
-            let context: DialogPresentationContext
+        func resolveTerminationFailureContext(
+            preferredProject: ProjectManager? = nil
+        ) -> DialogPresentationContext {
+            if let preferredProject {
+                let projectContext = DialogPresenter.forProject(
+                    preferredProject
+                )
+                if let window = projectContext.nsWindow,
+                   DialogPresenter.isEligibleApplicationOwner(window) {
+                    return projectContext
+                }
+            }
             if let terminationFailureContext {
-                context = terminationFailureContext()
-            } else if presentAlert == nil {
+                return terminationFailureContext()
+            }
+            if presentAlert == nil {
                 // A clean preflight may never have created or restored an
                 // owner. Resolve one lazily only after machine work fails.
                 prepareApplicationDialogOwner()
-                context = DialogPresenter.forApplicationWindow()
-            } else {
-                context = fallbackContext
+                return DialogPresenter.forApplicationWindow()
             }
+            return fallbackContext
+        }
+
+        func presentTerminationFailure() async {
             _ = await presentTerminationAlert(
                 .applicationQuitFailure,
-                context: context,
+                context: resolveTerminationFailureContext(),
                 title: Strings.applicationQuitFailureTitle,
                 message: Strings.applicationQuitFailureMessage
             )
@@ -2052,9 +2076,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         var terminalAuthorizations: [
             ObjectIdentifier: TerminalTabCloseAuthorization
         ] = [:]
+        var agentLaunchAuthorizations: [
+            ObjectIdentifier: PineAgentLaunchAuthorization
+        ] = [:]
         var saveRequests: [(ProjectManager, DialogPresentationContext)] = []
         var preparedSavePlans: [
             ObjectIdentifier: ProjectManager.PreparedPaneSavePlan
+        ] = [:]
+        var preparedTerminationSavePlans: [
+            ObjectIdentifier: ProjectManager.PreparedTerminationPaneSavePlan
         ] = [:]
         var quitAnyway = false
         var reviewIndividually = false
@@ -2085,6 +2115,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             // while the sheet is open still fail closed during revalidation.
             discardAuthorizations = preflightDiscardAuthorizations
             terminalAuthorizations = preflightTerminalAuthorizations
+            agentLaunchAuthorizations = preflightAgentLaunchAuthorizations
         } else if reviewIndividually {
             for projectManager in projects {
                 guard registry.openProjects.values.contains(where: {
@@ -2132,7 +2163,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     tabs: projectManager.terminal.allTerminalTabs
                 )
                 terminalAuthorizations[identifier] = authorization
-                guard authorization.requiresConfirmation else { continue }
+                let launchAuthorization = projectManager.terminal
+                    .capturePineAgentLaunchAuthorization()
+                agentLaunchAuthorizations[identifier] = launchAuthorization
+                guard authorization.requiresConfirmation
+                        || launchAuthorization.requiresConfirmation else {
+                    continue
+                }
                 let projectContext = DialogPresenter.forProject(projectManager)
                 let hasEligibleProjectOwner = projectContext.nsWindow.map {
                     DialogPresenter.isEligibleApplicationOwner($0)
@@ -2173,6 +2210,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                     TerminalTabCloseAuthorization.authorizing(
                         tabs: projectManager.terminal.allTerminalTabs
                     )
+                agentLaunchAuthorizations[ObjectIdentifier(projectManager)] =
+                    projectManager.terminal
+                        .capturePineAgentLaunchAuthorization()
             }
         }
 
@@ -2199,39 +2239,113 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             Int(clamping: workBudgetNanoseconds)
         )
 
-        for (projectManager, context) in saveRequests {
-            let saveResult = await valueBeforeTerminationDeadline(
-                terminationDeadline,
-                deadlineObserver: terminationDeadlineObserver,
-                onTimeout: {},
-                operation: {
-                    if let saveAll {
-                        return await saveAll(projectManager, context)
+        func cleanupPreparedTerminationSaves() {
+            for (identifier, plan) in preparedTerminationSavePlans {
+                guard let projectManager = projects.first(where: {
+                    ObjectIdentifier($0) == identifier
+                }) else { continue }
+                projectManager.cleanupTerminationSavePlan(plan)
+            }
+            preparedTerminationSavePlans.removeAll()
+        }
+
+        if let saveAll {
+            for (projectManager, context) in saveRequests {
+                let saveResult = await valueBeforeTerminationDeadline(
+                    terminationDeadline,
+                    deadlineObserver: terminationDeadlineObserver,
+                    onTimeout: {},
+                    operation: {
+                        await saveAll(projectManager, context)
                             ? PreparedPaneSaveCommitResult.saved
                             : PreparedPaneSaveCommitResult.invalidated
                     }
-                    guard let plan = preparedSavePlans[
-                        ObjectIdentifier(projectManager)
-                    ] else {
-                        return .invalidated
-                    }
-                    return projectManager.commitPreparedSaveAllPaneTabs(plan)
-                }
-            )
-            switch saveResult {
-            case .saved:
-                break
-            case .failed(let message):
-                _ = await presentTerminationAlert(
-                    .fileOperationErrorCritical,
-                    context: context,
-                    title: Strings.fileOperationErrorTitle,
-                    message: message
                 )
-                return false
-            case .invalidated, nil:
-                await presentTerminationFailure()
-                return false
+                guard saveResult == .saved else {
+                    await presentTerminationFailure()
+                    return false
+                }
+            }
+        } else {
+            for (projectManager, _) in saveRequests {
+                guard let plan = preparedSavePlans[
+                    ObjectIdentifier(projectManager)
+                ] else {
+                    cleanupPreparedTerminationSaves()
+                    await presentTerminationFailure()
+                    return false
+                }
+                let (stageResult, stagedPlan) = await projectManager
+                    .stagePreparedSaveAllPaneTabsForTermination(
+                        plan,
+                        until: terminationDeadline
+                    )
+                switch stageResult {
+                case .ready:
+                    guard let stagedPlan else {
+                        cleanupPreparedTerminationSaves()
+                        await presentTerminationFailure()
+                        return false
+                    }
+                    preparedTerminationSavePlans[
+                        ObjectIdentifier(projectManager)
+                    ] = stagedPlan
+                case .failed(let message):
+                    cleanupPreparedTerminationSaves()
+                    _ = await presentTerminationAlert(
+                        .fileOperationErrorCritical,
+                        context: resolveTerminationFailureContext(
+                            preferredProject: projectManager
+                        ),
+                        title: Strings.fileOperationErrorTitle,
+                        message: message
+                    )
+                    return false
+                case .invalidated:
+                    cleanupPreparedTerminationSaves()
+                    await presentTerminationFailure()
+                    return false
+                case .timedOut:
+                    terminationDeadlineObserver()
+                    cleanupPreparedTerminationSaves()
+                    await presentTerminationFailure()
+                    return false
+                }
+            }
+
+            for (projectManager, _) in saveRequests {
+                guard let plan = preparedTerminationSavePlans[
+                    ObjectIdentifier(projectManager)
+                ] else {
+                    cleanupPreparedTerminationSaves()
+                    await presentTerminationFailure()
+                    return false
+                }
+                switch projectManager
+                    .commitStagedSaveAllPaneTabsForTermination(
+                        plan,
+                        until: terminationDeadline
+                    ) {
+                case .saved:
+                    preparedTerminationSavePlans.removeValue(
+                        forKey: ObjectIdentifier(projectManager)
+                    )
+                case .failed(let message):
+                    cleanupPreparedTerminationSaves()
+                    _ = await presentTerminationAlert(
+                        .fileOperationErrorCritical,
+                        context: resolveTerminationFailureContext(
+                            preferredProject: projectManager
+                        ),
+                        title: Strings.fileOperationErrorTitle,
+                        message: message
+                    )
+                    return false
+                case .invalidated:
+                    cleanupPreparedTerminationSaves()
+                    await presentTerminationFailure()
+                    return false
+                }
             }
         }
 
@@ -2263,11 +2377,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         registry.freezeAgentTasksForTermination()
         registry.agentTasks.prepareForApplicationTermination()
         func rollbackAgentTasks() async {
-            let remaining = remainingTerminationDuration(
-                until: terminationDeadline
-            ) ?? .zero
             guard await registry.cancelAgentTaskTermination(
-                maximumDuration: remaining
+                until: terminationDeadline
             ) else {
                 Logger.app.error(
                     "Agent task rollback did not reach a clean persistence barrier"
@@ -2309,9 +2420,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 // presented. An idle one is safe; running work is not.
                 guard let authorization = terminalAuthorizations[identifier]
                 else {
-                    guard !TerminalTabCloseAuthorization.authorizing(
+                    let currentTerminalAuthorization =
+                        TerminalTabCloseAuthorization.authorizing(
                         tabs: projectManager.terminal.allTerminalTabs
-                    ).requiresConfirmation else {
+                    )
+                    let currentLaunchAuthorization = projectManager.terminal
+                        .capturePineAgentLaunchAuthorization()
+                    guard !currentTerminalAuthorization.requiresConfirmation,
+                          !currentLaunchAuthorization.requiresConfirmation else {
                         Logger.app.error(
                             "Quit aborted: project with running processes opened during the termination handshake"
                         )
@@ -2324,6 +2440,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 ) else {
                     Logger.app.error(
                         "Quit aborted: terminal authorization no longer covers the project"
+                    )
+                    return false
+                }
+                guard let launchAuthorization =
+                        agentLaunchAuthorizations[identifier],
+                      launchAuthorization.stillCovers(
+                          projectManager.terminal
+                              .capturePineAgentLaunchAuthorization()
+                      ) else {
+                    Logger.app.error(
+                        "Quit aborted: Pine agent-launch authorization no longer covers the project"
                     )
                     return false
                 }

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -23,11 +23,45 @@ nonisolated enum TerminationPaneSaveStageResult: Sendable {
     case timedOut
 }
 
+nonisolated private final class TerminationInstallAwaitResolver:
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<
+        TerminationSaveInstallResult,
+        Never
+    >?
+
+    init(
+        _ continuation: CheckedContinuation<
+            TerminationSaveInstallResult,
+            Never
+        >
+    ) {
+        self.continuation = continuation
+    }
+
+    @discardableResult
+    func resolve(_ result: TerminationSaveInstallResult) -> Bool {
+        let continuation = lock.withLock {
+            let continuation = self.continuation
+            self.continuation = nil
+            return continuation
+        }
+        guard let continuation else { return false }
+        continuation.resume(returning: result)
+        return true
+    }
+}
+
 /// Thin coordinator that owns the workspace, terminal, and tab managers.
 /// Passed via environment so views can access all sub-managers.
 @MainActor
 @Observable
 final class ProjectManager {
+    private static let terminationInstallDeadlineQueue = DispatchQueue(
+        label: "com.pine.project.termination-install-deadline",
+        qos: .userInteractive
+    )
     typealias SaveDestinationChooser = @MainActor (
         _ tab: EditorTab,
         _ projectRoot: URL?,
@@ -42,7 +76,6 @@ final class ProjectManager {
         let tabManager: TabManager
         let tab: EditorTab
         var destination: URL?
-        var expectedDestinationState: TerminationDestinationState?
     }
 
     struct PreparedPaneSavePlan {
@@ -118,6 +151,8 @@ final class ProjectManager {
     @ObservationIgnored
     private var dialogOperationGeneration = 0
     @ObservationIgnored
+    private var isAutoSaveFrozenForTermination = false
+    @ObservationIgnored
     private(set) lazy var paneManager = PaneManager(existingTabManager: primaryTabManager)
     /// Test seam and single native Save-panel implementation for Save,
     /// Save As, Save All, close-window, and Quit paths.
@@ -149,9 +184,15 @@ final class ProjectManager {
     }
     @ObservationIgnored
     var terminationSaveInstaller: @Sendable (
-        TerminationStagedSave
-    ) async -> TerminationSaveInstallResult = { staged in
-        await TerminationSaveCoordinator.install(staged)
+        TerminationStagedSave,
+        DispatchTime,
+        @escaping @Sendable (TerminationSaveInstallResult) -> Void
+    ) async -> TerminationSaveInstallResult = { staged, deadline, lateCompletion in
+        await TerminationSaveCoordinator.install(
+            staged,
+            until: deadline,
+            lateCompletion: lateCompletion
+        )
     }
 
     /// Returns the TabManager for the currently focused pane.
@@ -176,18 +217,24 @@ final class ProjectManager {
     }
 
     func freezeAutoSaveForTermination() {
+        guard !isAutoSaveFrozenForTermination else { return }
+        isAutoSaveFrozenForTermination = true
         paneManager.allTabManagers.forEach {
             $0.freezeAutoSaveForTermination()
         }
     }
 
     func cancelAutoSaveTerminationFreeze() {
+        guard isAutoSaveFrozenForTermination else { return }
+        isAutoSaveFrozenForTermination = false
         paneManager.allTabManagers.forEach {
             $0.cancelAutoSaveTerminationFreeze()
         }
     }
 
     func finishAutoSaveTerminationFreeze() {
+        guard isAutoSaveFrozenForTermination else { return }
+        isAutoSaveFrozenForTermination = false
         paneManager.allTabManagers.forEach {
             $0.finishAutoSaveTerminationFreeze()
         }
@@ -266,8 +313,7 @@ final class ProjectManager {
                 return PlannedTabSave(
                     tabManager: tabManager,
                     tab: tab,
-                    destination: nil,
-                    expectedDestinationState: nil
+                    destination: nil
                 )
             }
         }
@@ -278,23 +324,6 @@ final class ProjectManager {
             $0.tab.kind == .text && !$0.tab.isTruncated
         }) else {
             return .invalidated
-        }
-
-        // Capture already-backed destinations before any Save As panel can
-        // suspend. Staging and install later reject an external write or
-        // pathname replacement instead of overwriting it silently.
-        for index in savePlan.indices {
-            guard let destination = savePlan[index].tab.fileURL else {
-                continue
-            }
-            do {
-                savePlan[index].expectedDestinationState = try await
-                    TerminationSaveCoordinator.captureDestinationState(
-                        at: destination
-                    )
-            } catch {
-                return .invalidated
-            }
         }
 
         // Collect every untitled destination before the first disk write.
@@ -310,14 +339,6 @@ final class ProjectManager {
                 return .cancelledByUser
             }
             savePlan[index].destination = destination
-            do {
-                savePlan[index].expectedDestinationState = try await
-                    TerminationSaveCoordinator.captureDestinationState(
-                        at: destination
-                    )
-            } catch {
-                return .invalidated
-            }
         }
 
         // A panel may suspend long enough for a tab to close, become saved,
@@ -427,18 +448,40 @@ final class ProjectManager {
         guard preparedSavePlanStillValid(plan) else {
             return (.invalidated, nil)
         }
-        let requests = plan.entries.compactMap { planned
+        let destinations = plan.entries.compactMap { planned in
+            planned.destination ?? planned.tab.fileURL
+        }
+        guard destinations.count == plan.entries.count else {
+            return (.invalidated, nil)
+        }
+        let destinationStates: [TerminationDestinationState]
+        switch await TerminationSaveCoordinator.captureDestinationStates(
+            at: destinations,
+            until: deadline
+        ) {
+        case .captured(let captured):
+            destinationStates = captured
+        case .failed(let message):
+            return (.failed(message: message), nil)
+        case .timedOut:
+            return (.timedOut, nil)
+        }
+        guard destinationStates.count == plan.entries.count,
+              preparedSavePlanStillValid(plan) else {
+            return (.invalidated, nil)
+        }
+        let requests = zip(plan.entries, destinationStates).compactMap { pair
             -> TerminationSaveRequest? in
+            let (planned, expectedDestinationState) = pair
             guard let destination = planned.destination
-                    ?? planned.tab.fileURL,
-                  let expectedDestinationState =
-                    planned.expectedDestinationState else {
+                    ?? planned.tab.fileURL else {
                 return nil
             }
             let settings = planned.tabManager.editorSettings
             return TerminationSaveRequest(
                 tabID: planned.tab.id,
                 contentVersion: planned.tab.contentVersion,
+                persistenceGeneration: planned.tab.persistenceGeneration,
                 content: planned.tab.content,
                 originalURL: planned.tab.fileURL,
                 destination: destination,
@@ -476,10 +519,12 @@ final class ProjectManager {
     }
 
     func terminationSaveDestinationsStillMatch(
-        _ plan: PreparedTerminationPaneSavePlan
+        _ plan: PreparedTerminationPaneSavePlan,
+        until deadline: DispatchTime
     ) async -> Bool {
         await TerminationSaveCoordinator.destinationStatesAreCurrent(
-            plan.staged
+            plan.staged,
+            until: deadline
         )
     }
 
@@ -501,6 +546,8 @@ final class ProjectManager {
                   return staged.request.tabID == entry.tab.id
                       && staged.request.contentVersion
                           == entry.tab.contentVersion
+                      && staged.request.persistenceGeneration
+                          == entry.tab.persistenceGeneration
                       && staged.request.content == entry.tab.content
                       && staged.request.originalURL == entry.tab.fileURL
                       && staged.request.destination == destination
@@ -524,29 +571,58 @@ final class ProjectManager {
                 )
                 return .invalidated
             }
-            switch await terminationSaveInstaller(staged) {
+            let lateCompletion: @Sendable (
+                TerminationSaveInstallResult
+            ) -> Void = { [tabManager = entry.tabManager] result in
+                guard case .installed(let metadata) = result else { return }
+                Task { @MainActor in
+                    guard tabManager.tabs.first(where: {
+                        $0.id == staged.request.tabID
+                    })?.persistenceGeneration
+                        == staged.request.persistenceGeneration else {
+                        return
+                    }
+                    guard tabManager.reconcileTerminationStagedSave(
+                        request: staged.request,
+                        savedContent: staged.preparedContent,
+                        metadata: metadata
+                    ) else {
+                        Logger.app.critical(
+                            "Late termination save model reconciliation failed"
+                        )
+                        return
+                    }
+                }
+            }
+            switch await awaitTerminationSaveInstall(
+                staged,
+                until: deadline,
+                lateCompletion: lateCompletion
+            ) {
             case .failed(let message):
                 cleanupTerminationStagedSaves(
                     Array(plan.staged.dropFirst(index))
                 )
                 return .failed(message: message)
-            case .installed:
-                break
-            }
-            // The install allowed MainActor reentrancy. Preserve any edit
-            // made while the syscall was in flight as dirty against the exact
-            // content that is now durable on disk.
-            guard entry.tabManager.reconcileTerminationStagedSave(
-                request: staged.request,
-                savedContent: staged.preparedContent
-            ) else {
-                Logger.app.critical(
-                    "Termination save model changed during atomic commit"
-                )
+            case .installed(let metadata):
+                guard entry.tabManager.reconcileTerminationStagedSave(
+                    request: staged.request,
+                    savedContent: staged.preparedContent,
+                    metadata: metadata
+                ) else {
+                    Logger.app.critical(
+                        "Termination save model changed during atomic commit"
+                    )
+                    cleanupTerminationStagedSaves(
+                        Array(plan.staged.dropFirst(index + 1))
+                    )
+                    return .invalidated
+                }
+            case .timedOut:
                 cleanupTerminationStagedSaves(
-                    Array(plan.staged.dropFirst(index + 1))
+                    Array(plan.staged.dropFirst(index))
                 )
-                return .invalidated
+                return .timedOut
             }
             if DispatchTime.now().uptimeNanoseconds
                     >= deadline.uptimeNanoseconds {
@@ -557,6 +633,40 @@ final class ProjectManager {
             }
         }
         return .saved
+    }
+
+    private func awaitTerminationSaveInstall(
+        _ staged: TerminationStagedSave,
+        until deadline: DispatchTime,
+        lateCompletion: @escaping @Sendable (
+            TerminationSaveInstallResult
+        ) -> Void
+    ) async -> TerminationSaveInstallResult {
+        guard DispatchTime.now().uptimeNanoseconds
+                < deadline.uptimeNanoseconds else {
+            return .timedOut
+        }
+        let installer = terminationSaveInstaller
+        return await withCheckedContinuation { continuation in
+            let resolver = TerminationInstallAwaitResolver(continuation)
+            let operationTask = Task {
+                let result = await installer(
+                    staged,
+                    deadline,
+                    lateCompletion
+                )
+                if !resolver.resolve(result) {
+                    lateCompletion(result)
+                }
+            }
+            Self.terminationInstallDeadlineQueue.asyncAfter(
+                deadline: deadline
+            ) {
+                if resolver.resolve(.timedOut) {
+                    operationTask.cancel()
+                }
+            }
+        }
     }
 
     func cleanupTerminationSavePlan(
@@ -586,6 +696,8 @@ final class ProjectManager {
             && current.kind == .text
             && !current.isTruncated
             && current.contentVersion == planned.tab.contentVersion
+            && current.persistenceGeneration
+                == planned.tab.persistenceGeneration
             && current.content == planned.tab.content
             && current.fileURL == planned.tab.fileURL
     }
@@ -611,6 +723,8 @@ final class ProjectManager {
                       && !current.isTruncated
                       && current.fileURL == planned.tab.fileURL
                       && current.contentVersion == planned.tab.contentVersion
+                      && current.persistenceGeneration
+                          == planned.tab.persistenceGeneration
                       && current.content == planned.tab.content
               }) else {
             return false
@@ -1083,6 +1197,9 @@ final class ProjectManager {
     /// created later by pane splits or session restoration.
     private func configureEditorTabManager(_ tabManager: TabManager) {
         tabManager.recoveryManager = recoveryManager
+        if isAutoSaveFrozenForTermination {
+            tabManager.freezeAutoSaveForTermination()
+        }
         tabManager.dialogContextProvider = { [weak self] in
             guard let self else { return .unscoped }
             return DialogPresenter.forProject(self)

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -213,35 +213,27 @@ nonisolated enum PreparedPaneSaveCommitResult: Sendable, Equatable {
     case saved
     case invalidated
     case timedOut
-    case failed(message: String)
+    case failed(message: String, retainedArtifacts: [URL])
 }
 
 nonisolated enum TerminationPaneSaveStageResult: Sendable {
     case ready
     case invalidated
-    case failed(message: String)
+    case failed(message: String, retainedArtifacts: [URL])
     case timedOut
 }
 
-nonisolated private final class TerminationInstallAwaitResolver:
+nonisolated private final class TerminationAwaitResolver<Result: Sendable>:
     @unchecked Sendable {
     private let lock = NSLock()
-    private var continuation: CheckedContinuation<
-        TerminationSaveInstallResult,
-        Never
-    >?
+    private var continuation: CheckedContinuation<Result, Never>?
 
-    init(
-        _ continuation: CheckedContinuation<
-            TerminationSaveInstallResult,
-            Never
-        >
-    ) {
+    init(_ continuation: CheckedContinuation<Result, Never>) {
         self.continuation = continuation
     }
 
     @discardableResult
-    func resolve(_ result: TerminationSaveInstallResult) -> Bool {
+    func resolve(_ result: Result) -> Bool {
         let continuation = lock.withLock {
             let continuation = self.continuation
             self.continuation = nil
@@ -420,6 +412,12 @@ final class ProjectManager {
             until: deadline,
             lateCompletion: lateCompletion
         )
+    }
+    @ObservationIgnored
+    var terminationSaveCleaner: @Sendable (
+        [TerminationStagedSave]
+    ) -> TerminationSaveCleanupResult = {
+        TerminationSaveCoordinator.cleanup($0)
     }
 
     /// Returns the TabManager for the currently focused pane.
@@ -683,7 +681,10 @@ final class ProjectManager {
                         return .invalidated
                     }
                 } catch {
-                    return .failed(message: error.localizedDescription)
+                    return .failed(
+                        message: error.localizedDescription,
+                        retainedArtifacts: []
+                    )
                 }
             } else {
                 guard let index = planned.tabManager.tabs.firstIndex(where: {
@@ -696,7 +697,10 @@ final class ProjectManager {
                         return .invalidated
                     }
                 } catch {
-                    return .failed(message: error.localizedDescription)
+                    return .failed(
+                        message: error.localizedDescription,
+                        retainedArtifacts: []
+                    )
                 }
             }
         }
@@ -730,7 +734,10 @@ final class ProjectManager {
         case .captured(let captured):
             destinationStates = captured
         case .failed(let message):
-            return (.failed(message: message), nil)
+            return (
+                .failed(message: message, retainedArtifacts: []),
+                nil
+            )
         case .timedOut:
             return (.timedOut, nil)
         }
@@ -779,8 +786,14 @@ final class ProjectManager {
                     staged: staged
                 )
             )
-        case .failed(let message):
-            return (.failed(message: message), nil)
+        case .failed(let message, let retainedArtifacts):
+            return (
+                .failed(
+                    message: message,
+                    retainedArtifacts: retainedArtifacts
+                ),
+                nil
+            )
         case .timedOut:
             return (.timedOut, nil)
         }
@@ -822,7 +835,7 @@ final class ProjectManager {
                       && staged.request.originalURL == entry.tab.fileURL
                       && staged.request.destination == destination
               }) else {
-            cleanupTerminationSavePlan(plan)
+            _ = await cleanupTerminationSavePlan(plan, until: deadline)
             return .invalidated
         }
 
@@ -830,15 +843,17 @@ final class ProjectManager {
             let (entry, staged) = pair
             guard DispatchTime.now().uptimeNanoseconds
                     < deadline.uptimeNanoseconds else {
-                cleanupTerminationStagedSaves(
-                    Array(plan.staged.dropFirst(index))
+                _ = await cleanupTerminationStagedSaves(
+                    Array(plan.staged.dropFirst(index)),
+                    until: deadline
                 )
                 return .timedOut
             }
             guard inventoryStillAuthorized(),
                   preparedEntryStillValid(entry) else {
-                cleanupTerminationStagedSaves(
-                    Array(plan.staged.dropFirst(index))
+                _ = await cleanupTerminationStagedSaves(
+                    Array(plan.staged.dropFirst(index)),
+                    until: deadline
                 )
                 return .invalidated
             }
@@ -873,14 +888,25 @@ final class ProjectManager {
             let inventoryWasAuthorizedAfterInstall =
                 inventoryStillAuthorized()
             switch installResult {
-            case .failed(let message):
-                cleanupTerminationStagedSaves(
-                    Array(plan.staged.dropFirst(index))
+            case .failed(let message, let retainedArtifacts):
+                let cleanupResult = await cleanupTerminationStagedSaves(
+                    Array(plan.staged.dropFirst(index)),
+                    until: deadline
                 )
+                let cleanupArtifacts: [URL]
+                if case .failed(_, let artifacts) = cleanupResult {
+                    cleanupArtifacts = artifacts
+                } else {
+                    cleanupArtifacts = []
+                }
                 guard inventoryWasAuthorizedAfterInstall else {
                     return .invalidated
                 }
-                return .failed(message: message)
+                return .failed(
+                    message: message,
+                    retainedArtifacts:
+                        Array(Set(retainedArtifacts + cleanupArtifacts))
+                )
             case .installed(let metadata):
                 guard entry.tabManager.reconcileTerminationStagedSave(
                     request: staged.request,
@@ -890,21 +916,24 @@ final class ProjectManager {
                     Logger.app.critical(
                         "Termination save model changed during atomic commit"
                     )
-                    cleanupTerminationStagedSaves(
-                        Array(plan.staged.dropFirst(index + 1))
+                    _ = await cleanupTerminationStagedSaves(
+                        Array(plan.staged.dropFirst(index + 1)),
+                        until: deadline
                     )
                     return .invalidated
                 }
                 guard inventoryWasAuthorizedAfterInstall,
                       inventoryStillAuthorized() else {
-                    cleanupTerminationStagedSaves(
-                        Array(plan.staged.dropFirst(index + 1))
+                    _ = await cleanupTerminationStagedSaves(
+                        Array(plan.staged.dropFirst(index + 1)),
+                        until: deadline
                     )
                     return .invalidated
                 }
             case .timedOut:
-                cleanupTerminationStagedSaves(
-                    Array(plan.staged.dropFirst(index))
+                _ = await cleanupTerminationStagedSaves(
+                    Array(plan.staged.dropFirst(index)),
+                    until: deadline
                 )
                 guard inventoryWasAuthorizedAfterInstall else {
                     return .invalidated
@@ -913,8 +942,9 @@ final class ProjectManager {
             }
             if DispatchTime.now().uptimeNanoseconds
                     >= deadline.uptimeNanoseconds {
-                cleanupTerminationStagedSaves(
-                    Array(plan.staged.dropFirst(index + 1))
+                _ = await cleanupTerminationStagedSaves(
+                    Array(plan.staged.dropFirst(index + 1)),
+                    until: deadline
                 )
                 return .timedOut
             }
@@ -935,7 +965,7 @@ final class ProjectManager {
         }
         let installer = terminationSaveInstaller
         return await withCheckedContinuation { continuation in
-            let resolver = TerminationInstallAwaitResolver(continuation)
+            let resolver = TerminationAwaitResolver(continuation)
             let operationTask = Task {
                 let result = await installer(
                     staged,
@@ -957,16 +987,39 @@ final class ProjectManager {
     }
 
     func cleanupTerminationSavePlan(
-        _ plan: PreparedTerminationPaneSavePlan
-    ) {
-        cleanupTerminationStagedSaves(plan.staged)
+        _ plan: PreparedTerminationPaneSavePlan,
+        until deadline: DispatchTime
+    ) async -> TerminationSaveCleanupResult {
+        await cleanupTerminationStagedSaves(plan.staged, until: deadline)
     }
 
     private func cleanupTerminationStagedSaves(
-        _ staged: [TerminationStagedSave]
-    ) {
-        Task.detached(priority: .utility) {
-            TerminationSaveCoordinator.cleanup(staged)
+        _ staged: [TerminationStagedSave],
+        until deadline: DispatchTime
+    ) async -> TerminationSaveCleanupResult {
+        guard !staged.isEmpty else { return .cleaned }
+        let retainedArtifacts = staged.map(\.stagingURL)
+        let timedOut = TerminationSaveCleanupResult.failed(
+            message: "Termination save cleanup exceeded its deadline",
+            retainedArtifacts: retainedArtifacts
+        )
+        guard DispatchTime.now().uptimeNanoseconds
+                < deadline.uptimeNanoseconds else {
+            return timedOut
+        }
+        let cleaner = terminationSaveCleaner
+        return await withCheckedContinuation { continuation in
+            let resolver = TerminationAwaitResolver(continuation)
+            let operationTask = Task.detached(priority: .utility) {
+                resolver.resolve(cleaner(staged))
+            }
+            Self.terminationInstallDeadlineQueue.asyncAfter(
+                deadline: deadline
+            ) {
+                if resolver.resolve(timedOut) {
+                    operationTask.cancel()
+                }
+            }
         }
     }
 
@@ -1048,7 +1101,7 @@ final class ProjectManager {
             return true
         case .invalidated, .timedOut:
             return false
-        case .failed(let message):
+        case .failed(let message, _):
             _ = await AlertTemplate.fileOperationErrorCritical.runSheet(
                 on: context,
                 messageText: Strings.fileOperationErrorTitle,

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -6,8 +6,208 @@
 //
 
 import AppKit
+import Darwin
 import os
 import SwiftUI
+
+nonisolated struct TerminationFileAliasIdentity: Hashable, Sendable {
+    private enum Storage: Hashable, Sendable {
+        case existing(device: UInt64, inode: UInt64)
+        case missing(
+            ancestorDevice: UInt64,
+            ancestorInode: UInt64,
+            normalizedSuffix: [String]
+        )
+    }
+
+    private let storage: Storage
+
+    fileprivate static func existing(
+        device: UInt64,
+        inode: UInt64
+    ) -> Self {
+        Self(storage: .existing(device: device, inode: inode))
+    }
+
+    fileprivate static func missing(
+        ancestorDevice: UInt64,
+        ancestorInode: UInt64,
+        normalizedSuffix: [String]
+    ) -> Self {
+        Self(storage: .missing(
+            ancestorDevice: ancestorDevice,
+            ancestorInode: ancestorInode,
+            normalizedSuffix: normalizedSuffix
+        ))
+    }
+}
+
+nonisolated enum TerminationFileAliasCaptureResult: Sendable {
+    case captured([TerminationFileAliasIdentity])
+    case failed(message: String)
+    case timedOut
+}
+
+nonisolated private final class TerminationFileAliasCaptureResolver:
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<
+        TerminationFileAliasCaptureResult,
+        Never
+    >?
+
+    init(
+        _ continuation: CheckedContinuation<
+            TerminationFileAliasCaptureResult,
+            Never
+        >
+    ) {
+        self.continuation = continuation
+    }
+
+    @discardableResult
+    func resolve(_ result: TerminationFileAliasCaptureResult) -> Bool {
+        let continuation = lock.withLock {
+            let continuation = self.continuation
+            self.continuation = nil
+            return continuation
+        }
+        guard let continuation else { return false }
+        continuation.resume(returning: result)
+        return true
+    }
+}
+
+/// Resolves filesystem aliases away from the main actor. Existing paths use
+/// their device/inode identity, so hard links, symlinks, and case aliases
+/// compare equal. Missing paths are keyed below their nearest existing
+/// ancestor using the volume's case behavior and canonical Unicode spelling.
+nonisolated enum TerminationFileAliasResolver {
+    private static let workQueue = DispatchQueue(
+        label: "com.pine.termination-file-alias",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+    private static let deadlineQueue = DispatchQueue(
+        label: "com.pine.termination-file-alias-deadline",
+        qos: .userInteractive
+    )
+
+    static func capture(
+        _ urls: [URL],
+        until deadline: DispatchTime
+    ) async -> TerminationFileAliasCaptureResult {
+        guard DispatchTime.now().uptimeNanoseconds
+                < deadline.uptimeNanoseconds else {
+            return .timedOut
+        }
+        return await withCheckedContinuation { continuation in
+            let resolver = TerminationFileAliasCaptureResolver(continuation)
+            workQueue.async {
+                let result: TerminationFileAliasCaptureResult
+                do {
+                    let identities = try urls.map {
+                        try identity(
+                            at: $0,
+                            deadlineNanoseconds: deadline.uptimeNanoseconds
+                        )
+                    }
+                    result = .captured(identities)
+                } catch let error as TerminationFileAliasError
+                where error == .timedOut {
+                    result = .timedOut
+                } catch {
+                    result = .failed(message: error.localizedDescription)
+                }
+                resolver.resolve(result)
+            }
+            deadlineQueue.asyncAfter(deadline: deadline) {
+                resolver.resolve(.timedOut)
+            }
+        }
+    }
+
+    private enum TerminationFileAliasError: Error {
+        case timedOut
+    }
+
+    private static func identity(
+        at originalURL: URL,
+        deadlineNanoseconds: UInt64
+    ) throws -> TerminationFileAliasIdentity {
+        try checkDeadline(deadlineNanoseconds)
+        var currentURL = originalURL.standardizedFileURL
+        var missingComponents: [String] = []
+
+        while true {
+            try checkDeadline(deadlineNanoseconds)
+            var status = stat()
+            let descriptor = Darwin.open(
+                currentURL.path,
+                O_RDONLY | O_NONBLOCK | O_CLOEXEC
+            )
+            if descriptor >= 0 {
+                defer { Darwin.close(descriptor) }
+                guard Darwin.fstat(descriptor, &status) == 0 else {
+                    throw NSError(
+                        domain: NSPOSIXErrorDomain,
+                        code: Int(errno)
+                    )
+                }
+                if missingComponents.isEmpty {
+                    return .existing(
+                        device: UInt64(status.st_dev),
+                        inode: UInt64(status.st_ino)
+                    )
+                }
+                let resourceValues = try currentURL.resourceValues(
+                    forKeys: [.volumeSupportsCaseSensitiveNamesKey]
+                )
+                guard let isCaseSensitive = resourceValues
+                    .volumeSupportsCaseSensitiveNames else {
+                    throw CocoaError(.fileReadUnknown)
+                }
+                let suffix = missingComponents.reversed().map {
+                    normalize($0, caseSensitive: isCaseSensitive)
+                }
+                return .missing(
+                    ancestorDevice: UInt64(status.st_dev),
+                    ancestorInode: UInt64(status.st_ino),
+                    normalizedSuffix: suffix
+                )
+            }
+            guard errno == ENOENT else {
+                throw NSError(
+                    domain: NSPOSIXErrorDomain,
+                    code: Int(errno)
+                )
+            }
+            let parentURL = currentURL.deletingLastPathComponent()
+            guard parentURL.path != currentURL.path else {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            missingComponents.append(currentURL.lastPathComponent)
+            currentURL = parentURL
+        }
+    }
+
+    private static func normalize(
+        _ component: String,
+        caseSensitive: Bool
+    ) -> String {
+        let canonical = component.precomposedStringWithCanonicalMapping
+        guard !caseSensitive else { return canonical }
+        return canonical.lowercased(
+            with: Locale(identifier: "en_US_POSIX")
+        )
+    }
+
+    private static func checkDeadline(_ deadlineNanoseconds: UInt64) throws {
+        guard DispatchTime.now().uptimeNanoseconds < deadlineNanoseconds else {
+            throw TerminationFileAliasError.timedOut
+        }
+    }
+}
 
 nonisolated enum PreparedPaneSaveCommitResult: Sendable, Equatable {
     case saved
@@ -78,6 +278,24 @@ final class ProjectManager {
         var destination: URL?
     }
 
+    struct TerminationOpenTabInventory: Equatable {
+        fileprivate struct Entry: Hashable {
+            let tabManager: ObjectIdentifier
+            let tabID: UUID
+            let originalFileURL: URL?
+            let authorizedSaveAsURL: URL?
+
+            func authorizes(_ tab: EditorTab) -> Bool {
+                let liveURL = tab.fileURL?.standardizedFileURL
+                return liveURL == originalFileURL
+                    || liveURL == authorizedSaveAsURL
+            }
+        }
+
+        fileprivate let tabManagers: Set<ObjectIdentifier>
+        fileprivate let entries: Set<Entry>
+    }
+
     struct PreparedPaneSavePlan {
         fileprivate let entries: [PlannedTabSave]
         fileprivate let dirtyAuthorization: DirtyEditorContentAuthorization
@@ -91,6 +309,15 @@ final class ProjectManager {
 
         var plannedTabIDs: Set<UUID> {
             Set(entries.map(\.tab.id))
+        }
+
+        var plannedDestinationURLsByTabID: [UUID: URL] {
+            Dictionary(uniqueKeysWithValues: entries.compactMap { planned in
+                guard let destination = planned.destination else {
+                    return nil
+                }
+                return (planned.tab.id, destination.standardizedFileURL)
+            })
         }
     }
 
@@ -214,6 +441,47 @@ final class ProjectManager {
     /// All dirty tabs across all panes.
     var allDirtyTabs: [EditorTab] {
         paneManager.tabManagers.values.flatMap(\.dirtyTabs)
+    }
+
+    func captureTerminationOpenTabInventory(
+        allowingSaveAs destinationsByTabID: [UUID: URL]
+    ) -> TerminationOpenTabInventory {
+        let tabManagers = paneManager.allTabManagers
+        return TerminationOpenTabInventory(
+            tabManagers: Set(tabManagers.map(ObjectIdentifier.init)),
+            entries: Set(tabManagers.flatMap { tabManager in
+                tabManager.tabs.map { tab in
+                    TerminationOpenTabInventory.Entry(
+                        tabManager: ObjectIdentifier(tabManager),
+                        tabID: tab.id,
+                        originalFileURL: tab.fileURL?.standardizedFileURL,
+                        authorizedSaveAsURL:
+                            destinationsByTabID[tab.id]?.standardizedFileURL
+                    )
+                }
+            })
+        )
+    }
+
+    func terminationOpenTabInventoryStillMatches(
+        _ inventory: TerminationOpenTabInventory
+    ) -> Bool {
+        let tabManagers = paneManager.allTabManagers
+        guard Set(tabManagers.map(ObjectIdentifier.init))
+                == inventory.tabManagers else {
+            return false
+        }
+        let liveTabs = tabManagers.flatMap { tabManager in
+            tabManager.tabs.map { (ObjectIdentifier(tabManager), $0) }
+        }
+        guard liveTabs.count == inventory.entries.count else { return false }
+        return liveTabs.allSatisfy { tabManagerID, tab in
+            inventory.entries.contains { entry in
+                entry.tabManager == tabManagerID
+                    && entry.tabID == tab.id
+                    && entry.authorizes(tab)
+            }
+        }
     }
 
     func freezeAutoSaveForTermination() {
@@ -534,11 +802,13 @@ final class ProjectManager {
     /// completes before a timeout is reported.
     func commitStagedSaveAllPaneTabsForTermination(
         _ plan: PreparedTerminationPaneSavePlan,
-        until deadline: DispatchTime
+        until deadline: DispatchTime,
+        inventoryStillAuthorized: @MainActor () -> Bool = { true }
     ) async -> PreparedPaneSaveCommitResult {
         let source = plan.source
         guard DispatchTime.now().uptimeNanoseconds
                 < deadline.uptimeNanoseconds,
+              inventoryStillAuthorized(),
               preparedSavePlanStillValid(source),
               plan.staged.count == source.entries.count,
               zip(source.entries, plan.staged).allSatisfy({ entry, staged in
@@ -565,7 +835,8 @@ final class ProjectManager {
                 )
                 return .timedOut
             }
-            guard preparedEntryStillValid(entry) else {
+            guard inventoryStillAuthorized(),
+                  preparedEntryStillValid(entry) else {
                 cleanupTerminationStagedSaves(
                     Array(plan.staged.dropFirst(index))
                 )
@@ -594,15 +865,21 @@ final class ProjectManager {
                     }
                 }
             }
-            switch await awaitTerminationSaveInstall(
+            let installResult = await awaitTerminationSaveInstall(
                 staged,
                 until: deadline,
                 lateCompletion: lateCompletion
-            ) {
+            )
+            let inventoryWasAuthorizedAfterInstall =
+                inventoryStillAuthorized()
+            switch installResult {
             case .failed(let message):
                 cleanupTerminationStagedSaves(
                     Array(plan.staged.dropFirst(index))
                 )
+                guard inventoryWasAuthorizedAfterInstall else {
+                    return .invalidated
+                }
                 return .failed(message: message)
             case .installed(let metadata):
                 guard entry.tabManager.reconcileTerminationStagedSave(
@@ -618,10 +895,20 @@ final class ProjectManager {
                     )
                     return .invalidated
                 }
+                guard inventoryWasAuthorizedAfterInstall,
+                      inventoryStillAuthorized() else {
+                    cleanupTerminationStagedSaves(
+                        Array(plan.staged.dropFirst(index + 1))
+                    )
+                    return .invalidated
+                }
             case .timedOut:
                 cleanupTerminationStagedSaves(
                     Array(plan.staged.dropFirst(index))
                 )
+                guard inventoryWasAuthorizedAfterInstall else {
+                    return .invalidated
+                }
                 return .timedOut
             }
             if DispatchTime.now().uptimeNanoseconds

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -419,6 +419,16 @@ final class ProjectManager {
     ) -> TerminationSaveCleanupResult = {
         TerminationSaveCoordinator.cleanup($0)
     }
+    @ObservationIgnored
+    var terminationSaveLateFailureHandler: @Sendable (
+        String,
+        [URL]
+    ) -> Void = { message, retainedArtifacts in
+        let paths = retainedArtifacts.map(\.path).joined(separator: ",")
+        Logger.app.error(
+            "Late termination save failure: \(message, privacy: .public); retained=\(paths, privacy: .public)"
+        )
+    }
 
     /// Returns the TabManager for the currently focused pane.
     /// Falls back to the primary ``primaryTabManager`` when no editor pane is active.
@@ -774,9 +784,15 @@ final class ProjectManager {
         guard requests.count == plan.entries.count else {
             return (.invalidated, nil)
         }
+        let lateFailureHandler = terminationSaveLateFailureHandler
         switch await TerminationSaveCoordinator.stage(
             requests,
-            until: deadline
+            until: deadline,
+            lateCompletion: { result in
+                guard case .failed(let message, let retainedArtifacts) = result,
+                      !retainedArtifacts.isEmpty else { return }
+                lateFailureHandler(message, retainedArtifacts)
+            }
         ) {
         case .ready(let staged):
             return (
@@ -835,7 +851,13 @@ final class ProjectManager {
                       && staged.request.originalURL == entry.tab.fileURL
                       && staged.request.destination == destination
               }) else {
-            _ = await cleanupTerminationSavePlan(plan, until: deadline)
+            let cleanup = await cleanupTerminationSavePlan(
+                plan,
+                until: deadline
+            )
+            if let failure = terminationCleanupFailure(cleanup) {
+                return failure
+            }
             return .invalidated
         }
 
@@ -843,25 +865,37 @@ final class ProjectManager {
             let (entry, staged) = pair
             guard DispatchTime.now().uptimeNanoseconds
                     < deadline.uptimeNanoseconds else {
-                _ = await cleanupTerminationStagedSaves(
+                let cleanup = await cleanupTerminationStagedSaves(
                     Array(plan.staged.dropFirst(index)),
                     until: deadline
                 )
+                if let failure = terminationCleanupFailure(cleanup) {
+                    return failure
+                }
                 return .timedOut
             }
             guard inventoryStillAuthorized(),
                   preparedEntryStillValid(entry) else {
-                _ = await cleanupTerminationStagedSaves(
+                let cleanup = await cleanupTerminationStagedSaves(
                     Array(plan.staged.dropFirst(index)),
                     until: deadline
                 )
+                if let failure = terminationCleanupFailure(cleanup) {
+                    return failure
+                }
                 return .invalidated
             }
+            let tabManager = entry.tabManager
+            let lateFailureHandler = terminationSaveLateFailureHandler
             let lateCompletion: @Sendable (
                 TerminationSaveInstallResult
-            ) -> Void = { [tabManager = entry.tabManager] result in
-                guard case .installed(let metadata) = result else { return }
-                Task { @MainActor in
+            ) -> Void = { result in
+                switch result {
+                case .failed(let message, let retainedArtifacts):
+                    guard !retainedArtifacts.isEmpty else { return }
+                    lateFailureHandler(message, retainedArtifacts)
+                case .installed(let metadata):
+                    Task { @MainActor in
                     guard tabManager.tabs.first(where: {
                         $0.id == staged.request.tabID
                     })?.persistenceGeneration
@@ -878,6 +912,9 @@ final class ProjectManager {
                         )
                         return
                     }
+                    }
+                case .timedOut:
+                    break
                 }
             }
             let installResult = await awaitTerminationSaveInstall(
@@ -891,16 +928,14 @@ final class ProjectManager {
             case .failed(let message, let retainedArtifacts):
                 let cleanupResult = await cleanupTerminationStagedSaves(
                     Array(plan.staged.dropFirst(index)),
-                    until: deadline
+                    until: deadline,
+                    excluding: retainedArtifacts
                 )
                 let cleanupArtifacts: [URL]
                 if case .failed(_, let artifacts) = cleanupResult {
                     cleanupArtifacts = artifacts
                 } else {
                     cleanupArtifacts = []
-                }
-                guard inventoryWasAuthorizedAfterInstall else {
-                    return .invalidated
                 }
                 return .failed(
                     message: message,
@@ -916,25 +951,34 @@ final class ProjectManager {
                     Logger.app.critical(
                         "Termination save model changed during atomic commit"
                     )
-                    _ = await cleanupTerminationStagedSaves(
+                    let cleanup = await cleanupTerminationStagedSaves(
                         Array(plan.staged.dropFirst(index + 1)),
                         until: deadline
                     )
+                    if let failure = terminationCleanupFailure(cleanup) {
+                        return failure
+                    }
                     return .invalidated
                 }
                 guard inventoryWasAuthorizedAfterInstall,
                       inventoryStillAuthorized() else {
-                    _ = await cleanupTerminationStagedSaves(
+                    let cleanup = await cleanupTerminationStagedSaves(
                         Array(plan.staged.dropFirst(index + 1)),
                         until: deadline
                     )
+                    if let failure = terminationCleanupFailure(cleanup) {
+                        return failure
+                    }
                     return .invalidated
                 }
             case .timedOut:
-                _ = await cleanupTerminationStagedSaves(
+                let cleanup = await cleanupTerminationStagedSaves(
                     Array(plan.staged.dropFirst(index)),
                     until: deadline
                 )
+                if let failure = terminationCleanupFailure(cleanup) {
+                    return failure
+                }
                 guard inventoryWasAuthorizedAfterInstall else {
                     return .invalidated
                 }
@@ -942,10 +986,13 @@ final class ProjectManager {
             }
             if DispatchTime.now().uptimeNanoseconds
                     >= deadline.uptimeNanoseconds {
-                _ = await cleanupTerminationStagedSaves(
+                let cleanup = await cleanupTerminationStagedSaves(
                     Array(plan.staged.dropFirst(index + 1)),
                     until: deadline
                 )
+                if let failure = terminationCleanupFailure(cleanup) {
+                    return failure
+                }
                 return .timedOut
             }
         }
@@ -988,20 +1035,35 @@ final class ProjectManager {
 
     func cleanupTerminationSavePlan(
         _ plan: PreparedTerminationPaneSavePlan,
+        excluding retainedArtifacts: [URL] = [],
         until deadline: DispatchTime
     ) async -> TerminationSaveCleanupResult {
-        await cleanupTerminationStagedSaves(plan.staged, until: deadline)
+        await cleanupTerminationStagedSaves(
+            plan.staged,
+            until: deadline,
+            excluding: retainedArtifacts
+        )
     }
 
     private func cleanupTerminationStagedSaves(
         _ staged: [TerminationStagedSave],
-        until deadline: DispatchTime
+        until deadline: DispatchTime,
+        excluding retainedArtifacts: [URL] = []
     ) async -> TerminationSaveCleanupResult {
-        guard !staged.isEmpty else { return .cleaned }
-        let retainedArtifacts = staged.map(\.stagingURL)
+        let protectedPaths = Set(retainedArtifacts.map {
+            $0.resolvingSymlinksInPath().standardizedFileURL.path
+        })
+        let cleanupCandidates = staged.filter {
+            !protectedPaths.contains(
+                $0.stagingURL.resolvingSymlinksInPath()
+                    .standardizedFileURL.path
+            )
+        }
+        guard !cleanupCandidates.isEmpty else { return .cleaned }
+        let timedOutArtifacts = cleanupCandidates.map(\.stagingURL)
         let timedOut = TerminationSaveCleanupResult.failed(
             message: "Termination save cleanup exceeded its deadline",
-            retainedArtifacts: retainedArtifacts
+            retainedArtifacts: timedOutArtifacts
         )
         guard DispatchTime.now().uptimeNanoseconds
                 < deadline.uptimeNanoseconds else {
@@ -1011,7 +1073,7 @@ final class ProjectManager {
         return await withCheckedContinuation { continuation in
             let resolver = TerminationAwaitResolver(continuation)
             let operationTask = Task.detached(priority: .utility) {
-                resolver.resolve(cleaner(staged))
+                resolver.resolve(cleaner(cleanupCandidates))
             }
             Self.terminationInstallDeadlineQueue.asyncAfter(
                 deadline: deadline
@@ -1021,6 +1083,18 @@ final class ProjectManager {
                 }
             }
         }
+    }
+
+    private func terminationCleanupFailure(
+        _ result: TerminationSaveCleanupResult
+    ) -> PreparedPaneSaveCommitResult? {
+        guard case .failed(let message, let retainedArtifacts) = result else {
+            return nil
+        }
+        return .failed(
+            message: message,
+            retainedArtifacts: retainedArtifacts
+        )
     }
 
     private func preparedEntryStillValid(_ planned: PlannedTabSave) -> Bool {

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -8,6 +8,12 @@
 import AppKit
 import SwiftUI
 
+nonisolated enum PreparedPaneSaveCommitResult: Sendable, Equatable {
+    case saved
+    case invalidated
+    case failed(message: String)
+}
+
 /// Thin coordinator that owns the workspace, terminal, and tab managers.
 /// Passed via environment so views can access all sub-managers.
 @MainActor
@@ -23,10 +29,21 @@ final class ProjectManager {
         _ context: DialogPresentationContext
     ) async -> URL?
 
-    private struct PlannedTabSave {
+    fileprivate struct PlannedTabSave {
         let tabManager: TabManager
         let tab: EditorTab
         var destination: URL?
+    }
+
+    struct PreparedPaneSavePlan {
+        fileprivate let entries: [PlannedTabSave]
+        fileprivate let dirtyAuthorization: DirtyEditorContentAuthorization
+    }
+
+    enum PaneSavePreparationResult {
+        case ready(PreparedPaneSavePlan)
+        case cancelledByUser
+        case invalidated
     }
 
     let workspace = WorkspaceManager()
@@ -185,9 +202,11 @@ final class ProjectManager {
         return true
     }
 
-    /// Window-scoped save-all used by close and termination decisions.
-    @discardableResult
-    func saveAllPaneTabs(context: DialogPresentationContext) async -> Bool {
+    /// Collects all human Save-As decisions without writing any file. Quit
+    /// performs this phase before starting its bounded machine-work clock.
+    func prepareSaveAllPaneTabs(
+        context: DialogPresentationContext
+    ) async -> PaneSavePreparationResult {
         var savePlan = paneManager.allTabManagers.flatMap { tabManager in
             tabManager.tabs.compactMap { tab -> PlannedTabSave? in
                 guard tab.isDirty else { return nil }
@@ -204,7 +223,7 @@ final class ProjectManager {
         guard savePlan.allSatisfy({
             $0.tab.kind == .text && !$0.tab.isTruncated
         }) else {
-            return false
+            return .invalidated
         }
 
         // Collect every untitled destination before the first disk write.
@@ -217,7 +236,7 @@ final class ProjectManager {
                 workspace.rootURL,
                 context
             ) else {
-                return false
+                return .cancelledByUser
             }
             savePlan[index].destination = destination
         }
@@ -235,8 +254,9 @@ final class ProjectManager {
                 && current.kind == .text
                 && !current.isTruncated
                 && current.fileURL == planned.tab.fileURL
+                && current.content == planned.tab.content
         }) else {
-            return false
+            return .invalidated
         }
 
         let effectiveDestinations = savePlan.compactMap { planned in
@@ -246,7 +266,7 @@ final class ProjectManager {
         guard effectiveDestinations.count == savePlan.count,
               Set(effectiveDestinations).count
                 == effectiveDestinations.count else {
-            return false
+            return .invalidated
         }
 
         // An untitled Save-As target must not alias a file already open in
@@ -266,39 +286,108 @@ final class ProjectManager {
         guard newDestinations.allSatisfy({
             !unplannedOpenDestinations.contains($0)
         }) else {
-            return false
+            return .invalidated
         }
 
-        for planned in savePlan {
+        return .ready(PreparedPaneSavePlan(
+            entries: savePlan,
+            dirtyAuthorization: DirtyEditorContentAuthorization(
+                tabs: allDirtyTabs
+            )
+        ))
+    }
+
+    /// Commits an already prepared Save All plan without presenting UI or
+    /// suspending. The whole plan is revalidated before the first write.
+    func commitPreparedSaveAllPaneTabs(
+        _ plan: PreparedPaneSavePlan
+    ) -> PreparedPaneSaveCommitResult {
+        guard plan.dirtyAuthorization.covers(allDirtyTabs),
+              plan.entries.allSatisfy({ planned in
+                  guard let current = planned.tabManager.tabs.first(where: {
+                      $0.id == planned.tab.id
+                  }) else {
+                      return false
+                  }
+                  return current.isDirty
+                      && current.kind == .text
+                      && !current.isTruncated
+                      && current.fileURL == planned.tab.fileURL
+                      && current.content == planned.tab.content
+              }) else {
+            return .invalidated
+        }
+
+        let effectiveDestinations = plan.entries.compactMap { planned in
+            (planned.destination ?? planned.tab.fileURL)?
+                .standardizedFileURL
+        }
+        guard effectiveDestinations.count == plan.entries.count,
+              Set(effectiveDestinations).count
+                == effectiveDestinations.count else {
+            return .invalidated
+        }
+        let plannedTabIDs = Set(plan.entries.map(\.tab.id))
+        let unplannedOpenDestinations = Set(
+            allTabs.compactMap { tab -> URL? in
+                guard !plannedTabIDs.contains(tab.id) else { return nil }
+                return tab.fileURL?.standardizedFileURL
+            }
+        )
+        guard plan.entries.compactMap(\.destination).allSatisfy({
+            !unplannedOpenDestinations.contains($0.standardizedFileURL)
+        }) else {
+            return .invalidated
+        }
+
+        for planned in plan.entries {
             if let destination = planned.destination {
                 do {
                     guard try planned.tabManager.saveTabAs(
                         tabID: planned.tab.id,
                         to: destination
                     ) else {
-                        return false
+                        return .invalidated
                     }
                 } catch {
-                    _ = await AlertTemplate.fileOperationErrorCritical
-                        .runSheet(
-                            on: context,
-                            messageText: Strings.fileOperationErrorTitle,
-                            informativeText: error.localizedDescription
-                        )
-                    return false
+                    return .failed(message: error.localizedDescription)
                 }
             } else {
-                guard await saveTab(
-                    tabID: planned.tab.id,
-                    in: planned.tabManager,
-                    forceSaveAs: false,
-                    context: context
-                ) else {
-                    return false
+                guard let index = planned.tabManager.tabs.firstIndex(where: {
+                    $0.id == planned.tab.id
+                }) else {
+                    return .invalidated
+                }
+                do {
+                    guard try planned.tabManager.trySaveTab(at: index) else {
+                        return .invalidated
+                    }
+                } catch {
+                    return .failed(message: error.localizedDescription)
                 }
             }
         }
-        return true
+        return .saved
+    }
+
+    /// Window-scoped save-all used by close and menu decisions.
+    @discardableResult
+    func saveAllPaneTabs(context: DialogPresentationContext) async -> Bool {
+        let prepared = await prepareSaveAllPaneTabs(context: context)
+        guard case .ready(let plan) = prepared else { return false }
+        switch commitPreparedSaveAllPaneTabs(plan) {
+        case .saved:
+            return true
+        case .invalidated:
+            return false
+        case .failed(let message):
+            _ = await AlertTemplate.fileOperationErrorCritical.runSheet(
+                on: context,
+                messageText: Strings.fileOperationErrorTitle,
+                informativeText: message
+            )
+            return false
+        }
     }
 
     /// Resolves the editor pane a native File command should keep targeting
@@ -1335,6 +1424,35 @@ final class ProjectManager {
     /// and tasks alive.
     func requestUserTaskShutdown() {
         taskRunStore.requestShutdown()
+    }
+
+    func captureUserTaskShutdownAuthorization()
+        -> UserTaskExecutionAuthorization {
+        taskRunStore.captureShutdownAuthorization()
+    }
+
+    func userTaskShutdownAuthorizationStillCovers(
+        _ authorization: UserTaskExecutionAuthorization
+    ) -> Bool {
+        taskRunStore.shutdownAuthorizationStillCovers(authorization)
+    }
+
+    @discardableResult
+    func requestUserTaskShutdown(
+        authorizedBy authorization: UserTaskExecutionAuthorization
+    ) -> Bool {
+        taskRunStore.requestShutdown(authorizedBy: authorization)
+    }
+
+    @discardableResult
+    func waitForUserTaskShutdown(
+        authorizedBy authorization: UserTaskExecutionAuthorization,
+        until deadline: DispatchTime
+    ) async -> Bool {
+        await taskRunStore.waitForShutdown(
+            authorizedBy: authorization,
+            until: deadline
+        )
     }
 
     /// Waits for project-owned user tasks only until the shared absolute

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -6,12 +6,20 @@
 //
 
 import AppKit
+import os
 import SwiftUI
 
 nonisolated enum PreparedPaneSaveCommitResult: Sendable, Equatable {
     case saved
     case invalidated
     case failed(message: String)
+}
+
+nonisolated enum TerminationPaneSaveStageResult: Sendable {
+    case ready
+    case invalidated
+    case failed(message: String)
+    case timedOut
 }
 
 /// Thin coordinator that owns the workspace, terminal, and tab managers.
@@ -38,6 +46,11 @@ final class ProjectManager {
     struct PreparedPaneSavePlan {
         fileprivate let entries: [PlannedTabSave]
         fileprivate let dirtyAuthorization: DirtyEditorContentAuthorization
+    }
+
+    struct PreparedTerminationPaneSavePlan {
+        fileprivate let source: PreparedPaneSavePlan
+        fileprivate let staged: [TerminationStagedSave]
     }
 
     enum PaneSavePreparationResult {
@@ -207,6 +220,9 @@ final class ProjectManager {
     func prepareSaveAllPaneTabs(
         context: DialogPresentationContext
     ) async -> PaneSavePreparationResult {
+        let dirtyAuthorization = DirtyEditorContentAuthorization(
+            tabs: allDirtyTabs
+        )
         var savePlan = paneManager.allTabManagers.flatMap { tabManager in
             tabManager.tabs.compactMap { tab -> PlannedTabSave? in
                 guard tab.isDirty else { return nil }
@@ -244,7 +260,8 @@ final class ProjectManager {
         // A panel may suspend long enough for a tab to close, become saved,
         // change backing, or become truncated. Revalidate every captured
         // identity before committing any member of the plan.
-        guard savePlan.allSatisfy({ planned in
+        guard dirtyAuthorization.covers(allDirtyTabs),
+              savePlan.allSatisfy({ planned in
             guard let current = planned.tabManager.tabs.first(where: {
                 $0.id == planned.tab.id
             }) else {
@@ -291,9 +308,7 @@ final class ProjectManager {
 
         return .ready(PreparedPaneSavePlan(
             entries: savePlan,
-            dirtyAuthorization: DirtyEditorContentAuthorization(
-                tabs: allDirtyTabs
-            )
+            dirtyAuthorization: dirtyAuthorization
         ))
     }
 
@@ -302,41 +317,7 @@ final class ProjectManager {
     func commitPreparedSaveAllPaneTabs(
         _ plan: PreparedPaneSavePlan
     ) -> PreparedPaneSaveCommitResult {
-        guard plan.dirtyAuthorization.covers(allDirtyTabs),
-              plan.entries.allSatisfy({ planned in
-                  guard let current = planned.tabManager.tabs.first(where: {
-                      $0.id == planned.tab.id
-                  }) else {
-                      return false
-                  }
-                  return current.isDirty
-                      && current.kind == .text
-                      && !current.isTruncated
-                      && current.fileURL == planned.tab.fileURL
-                      && current.content == planned.tab.content
-              }) else {
-            return .invalidated
-        }
-
-        let effectiveDestinations = plan.entries.compactMap { planned in
-            (planned.destination ?? planned.tab.fileURL)?
-                .standardizedFileURL
-        }
-        guard effectiveDestinations.count == plan.entries.count,
-              Set(effectiveDestinations).count
-                == effectiveDestinations.count else {
-            return .invalidated
-        }
-        let plannedTabIDs = Set(plan.entries.map(\.tab.id))
-        let unplannedOpenDestinations = Set(
-            allTabs.compactMap { tab -> URL? in
-                guard !plannedTabIDs.contains(tab.id) else { return nil }
-                return tab.fileURL?.standardizedFileURL
-            }
-        )
-        guard plan.entries.compactMap(\.destination).allSatisfy({
-            !unplannedOpenDestinations.contains($0.standardizedFileURL)
-        }) else {
+        guard preparedSavePlanStillValid(plan) else {
             return .invalidated
         }
 
@@ -368,6 +349,199 @@ final class ProjectManager {
             }
         }
         return .saved
+    }
+
+    /// Stages every potentially slow formatter and data write away from the
+    /// main actor. Staging files live beside their destinations so the later
+    /// commit is a same-volume atomic replacement.
+    func stagePreparedSaveAllPaneTabsForTermination(
+        _ plan: PreparedPaneSavePlan,
+        until deadline: DispatchTime
+    ) async -> (
+        TerminationPaneSaveStageResult,
+        PreparedTerminationPaneSavePlan?
+    ) {
+        guard preparedSavePlanStillValid(plan) else {
+            return (.invalidated, nil)
+        }
+        let requests = plan.entries.compactMap { planned
+            -> TerminationSaveRequest? in
+            guard let destination = planned.destination
+                    ?? planned.tab.fileURL else {
+                return nil
+            }
+            let settings = planned.tabManager.editorSettings
+            return TerminationSaveRequest(
+                tabID: planned.tab.id,
+                contentVersion: planned.tab.contentVersion,
+                content: planned.tab.content,
+                originalURL: planned.tab.fileURL,
+                destination: destination,
+                encodingRawValue: planned.tab.encoding.rawValue,
+                settings: EditorSaveSettingsSnapshot(
+                    insertFinalNewline: settings.insertFinalNewline,
+                    stripTrailingWhitespace:
+                        settings.stripTrailingWhitespace,
+                    formatOnSave: settings.formatOnSave
+                ),
+                formatters: planned.tabManager.fileFormatters
+            )
+        }
+        guard requests.count == plan.entries.count else {
+            return (.invalidated, nil)
+        }
+        switch await TerminationSaveCoordinator.stage(
+            requests,
+            until: deadline
+        ) {
+        case .ready(let staged):
+            return (
+                .ready,
+                PreparedTerminationPaneSavePlan(
+                    source: plan,
+                    staged: staged
+                )
+            )
+        case .failed(let message):
+            return (.failed(message: message), nil)
+        case .timedOut:
+            return (.timedOut, nil)
+        }
+    }
+
+    /// Performs only the short atomic-replacement and model-update half of a
+    /// staged termination save. Once the first replacement begins there is no
+    /// competing timeout task that can report failure while later files keep
+    /// mutating behind the user's back.
+    func commitStagedSaveAllPaneTabsForTermination(
+        _ plan: PreparedTerminationPaneSavePlan,
+        until deadline: DispatchTime
+    ) -> PreparedPaneSaveCommitResult {
+        let source = plan.source
+        guard DispatchTime.now().uptimeNanoseconds
+                < deadline.uptimeNanoseconds,
+              preparedSavePlanStillValid(source),
+              plan.staged.count == source.entries.count,
+              zip(source.entries, plan.staged).allSatisfy({ entry, staged in
+                  let destination = entry.destination ?? entry.tab.fileURL
+                  return staged.request.tabID == entry.tab.id
+                      && staged.request.contentVersion
+                          == entry.tab.contentVersion
+                      && staged.request.content == entry.tab.content
+                      && staged.request.originalURL == entry.tab.fileURL
+                      && staged.request.destination == destination
+              }) else {
+            cleanupTerminationSavePlan(plan)
+            return .invalidated
+        }
+
+        for (index, pair) in zip(source.entries, plan.staged).enumerated() {
+            let (entry, staged) = pair
+            do {
+                guard TerminationSaveCoordinator
+                    .stagingIdentityIsCurrent(staged) else {
+                    throw CocoaError(.fileReadCorruptFile)
+                }
+                try Self.atomicallyInstallStagedSave(staged)
+            } catch {
+                cleanupTerminationStagedSaves(
+                    Array(plan.staged.dropFirst(index))
+                )
+                return .failed(message: error.localizedDescription)
+            }
+            guard entry.tabManager.applyTerminationStagedSave(
+                request: staged.request,
+                savedContent: staged.preparedContent
+            ) else {
+                // No suspension occurs between validation and this update, so
+                // reaching this branch is an internal invariant violation.
+                Logger.app.critical(
+                    "Termination save model changed during atomic commit"
+                )
+                return .invalidated
+            }
+        }
+        return .saved
+    }
+
+    func cleanupTerminationSavePlan(
+        _ plan: PreparedTerminationPaneSavePlan
+    ) {
+        cleanupTerminationStagedSaves(plan.staged)
+    }
+
+    private func cleanupTerminationStagedSaves(
+        _ staged: [TerminationStagedSave]
+    ) {
+        Task.detached(priority: .utility) {
+            TerminationSaveCoordinator.cleanup(staged)
+        }
+    }
+
+    private static func atomicallyInstallStagedSave(
+        _ staged: TerminationStagedSave
+    ) throws {
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: staged.request.destination.path) {
+            _ = try fileManager.replaceItemAt(
+                staged.request.destination,
+                withItemAt: staged.stagingURL,
+                backupItemName: nil,
+                options: []
+            )
+        } else {
+            try fileManager.moveItem(
+                at: staged.stagingURL,
+                to: staged.request.destination
+            )
+        }
+    }
+
+    private func preparedSavePlanStillValid(
+        _ plan: PreparedPaneSavePlan
+    ) -> Bool {
+        let liveTabManagers = paneManager.allTabManagers
+        guard plan.dirtyAuthorization.covers(allDirtyTabs),
+              plan.entries.allSatisfy({ planned in
+                  guard liveTabManagers.contains(where: {
+                      $0 === planned.tabManager
+                  }) else {
+                      return false
+                  }
+                  guard let current = planned.tabManager.tabs.first(where: {
+                      $0.id == planned.tab.id
+                  }) else {
+                      return false
+                  }
+                  return current.isDirty
+                      && current.kind == .text
+                      && !current.isTruncated
+                      && current.fileURL == planned.tab.fileURL
+                      && current.contentVersion == planned.tab.contentVersion
+                      && current.content == planned.tab.content
+              }) else {
+            return false
+        }
+
+        let effectiveDestinations = plan.entries.compactMap { planned in
+            (planned.destination ?? planned.tab.fileURL)?
+                .standardizedFileURL
+        }
+        guard effectiveDestinations.count == plan.entries.count,
+              Set(effectiveDestinations).count
+                == effectiveDestinations.count else {
+            return false
+        }
+        let plannedTabIDs = Set(plan.entries.map(\.tab.id))
+        let unplannedOpenDestinations = Set(
+            allTabs.compactMap { tab -> URL? in
+                guard !plannedTabIDs.contains(tab.id) else { return nil }
+                return tab.fileURL?.standardizedFileURL
+            }
+        )
+        return plan.entries.compactMap(\.destination).allSatisfy {
+            !unplannedOpenDestinations.contains($0.standardizedFileURL)
+        }
     }
 
     /// Window-scoped save-all used by close and menu decisions.

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -1060,20 +1060,29 @@ final class ProjectManager {
             )
         }
         guard !cleanupCandidates.isEmpty else { return .cleaned }
-        let timedOutArtifacts = cleanupCandidates.map(\.stagingURL)
         let timedOut = TerminationSaveCleanupResult.failed(
             message: "Termination save cleanup exceeded its deadline",
-            retainedArtifacts: timedOutArtifacts
+            retainedArtifacts: []
         )
         guard DispatchTime.now().uptimeNanoseconds
                 < deadline.uptimeNanoseconds else {
             return timedOut
         }
         let cleaner = terminationSaveCleaner
+        let lateFailureHandler = terminationSaveLateFailureHandler
         return await withCheckedContinuation { continuation in
             let resolver = TerminationAwaitResolver(continuation)
             let operationTask = Task.detached(priority: .utility) {
-                resolver.resolve(cleaner(cleanupCandidates))
+                let result = cleaner(cleanupCandidates)
+                guard !resolver.resolve(result),
+                      case .failed(
+                          let message,
+                          let retainedArtifacts
+                      ) = result,
+                      !retainedArtifacts.isEmpty else {
+                    return
+                }
+                lateFailureHandler(message, retainedArtifacts)
             }
             Self.terminationInstallDeadlineQueue.asyncAfter(
                 deadline: deadline

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -926,8 +926,15 @@ final class ProjectManager {
                 inventoryStillAuthorized()
             switch installResult {
             case .failed(let message, let retainedArtifacts):
+                // A typed retained artifact belongs to the current install
+                // transaction even when its parent directory moved and its
+                // display URL no longer matches the original staging URL.
+                // Preserve that staged identity and clean only later entries.
+                let cleanupStartIndex = retainedArtifacts.isEmpty
+                    ? index
+                    : index + 1
                 let cleanupResult = await cleanupTerminationStagedSaves(
-                    Array(plan.staged.dropFirst(index)),
+                    Array(plan.staged.dropFirst(cleanupStartIndex)),
                     until: deadline,
                     excluding: retainedArtifacts
                 )

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -12,6 +12,7 @@ import SwiftUI
 nonisolated enum PreparedPaneSaveCommitResult: Sendable, Equatable {
     case saved
     case invalidated
+    case timedOut
     case failed(message: String)
 }
 
@@ -41,11 +42,23 @@ final class ProjectManager {
         let tabManager: TabManager
         let tab: EditorTab
         var destination: URL?
+        var expectedDestinationState: TerminationDestinationState?
     }
 
     struct PreparedPaneSavePlan {
         fileprivate let entries: [PlannedTabSave]
         fileprivate let dirtyAuthorization: DirtyEditorContentAuthorization
+
+        var standardizedDestinationURLs: [URL] {
+            entries.compactMap { planned in
+                (planned.destination ?? planned.tab.fileURL)?
+                    .standardizedFileURL
+            }
+        }
+
+        var plannedTabIDs: Set<UUID> {
+            Set(entries.map(\.tab.id))
+        }
     }
 
     struct PreparedTerminationPaneSavePlan {
@@ -134,6 +147,12 @@ final class ProjectManager {
         }
         return panel.url
     }
+    @ObservationIgnored
+    var terminationSaveInstaller: @Sendable (
+        TerminationStagedSave
+    ) async -> TerminationSaveInstallResult = { staged in
+        await TerminationSaveCoordinator.install(staged)
+    }
 
     /// Returns the TabManager for the currently focused pane.
     /// Falls back to the primary ``primaryTabManager`` when no editor pane is active.
@@ -154,6 +173,24 @@ final class ProjectManager {
     /// All dirty tabs across all panes.
     var allDirtyTabs: [EditorTab] {
         paneManager.tabManagers.values.flatMap(\.dirtyTabs)
+    }
+
+    func freezeAutoSaveForTermination() {
+        paneManager.allTabManagers.forEach {
+            $0.freezeAutoSaveForTermination()
+        }
+    }
+
+    func cancelAutoSaveTerminationFreeze() {
+        paneManager.allTabManagers.forEach {
+            $0.cancelAutoSaveTerminationFreeze()
+        }
+    }
+
+    func finishAutoSaveTerminationFreeze() {
+        paneManager.allTabManagers.forEach {
+            $0.finishAutoSaveTerminationFreeze()
+        }
     }
 
     /// Validates an exact dirty-buffer authorization across every editor
@@ -229,7 +266,8 @@ final class ProjectManager {
                 return PlannedTabSave(
                     tabManager: tabManager,
                     tab: tab,
-                    destination: nil
+                    destination: nil,
+                    expectedDestinationState: nil
                 )
             }
         }
@@ -240,6 +278,23 @@ final class ProjectManager {
             $0.tab.kind == .text && !$0.tab.isTruncated
         }) else {
             return .invalidated
+        }
+
+        // Capture already-backed destinations before any Save As panel can
+        // suspend. Staging and install later reject an external write or
+        // pathname replacement instead of overwriting it silently.
+        for index in savePlan.indices {
+            guard let destination = savePlan[index].tab.fileURL else {
+                continue
+            }
+            do {
+                savePlan[index].expectedDestinationState = try await
+                    TerminationSaveCoordinator.captureDestinationState(
+                        at: destination
+                    )
+            } catch {
+                return .invalidated
+            }
         }
 
         // Collect every untitled destination before the first disk write.
@@ -255,6 +310,14 @@ final class ProjectManager {
                 return .cancelledByUser
             }
             savePlan[index].destination = destination
+            do {
+                savePlan[index].expectedDestinationState = try await
+                    TerminationSaveCoordinator.captureDestinationState(
+                        at: destination
+                    )
+            } catch {
+                return .invalidated
+            }
         }
 
         // A panel may suspend long enough for a tab to close, become saved,
@@ -367,7 +430,9 @@ final class ProjectManager {
         let requests = plan.entries.compactMap { planned
             -> TerminationSaveRequest? in
             guard let destination = planned.destination
-                    ?? planned.tab.fileURL else {
+                    ?? planned.tab.fileURL,
+                  let expectedDestinationState =
+                    planned.expectedDestinationState else {
                 return nil
             }
             let settings = planned.tabManager.editorSettings
@@ -377,6 +442,7 @@ final class ProjectManager {
                 content: planned.tab.content,
                 originalURL: planned.tab.fileURL,
                 destination: destination,
+                expectedDestinationState: expectedDestinationState,
                 encodingRawValue: planned.tab.encoding.rawValue,
                 settings: EditorSaveSettingsSnapshot(
                     insertFinalNewline: settings.insertFinalNewline,
@@ -409,14 +475,22 @@ final class ProjectManager {
         }
     }
 
-    /// Performs only the short atomic-replacement and model-update half of a
-    /// staged termination save. Once the first replacement begins there is no
-    /// competing timeout task that can report failure while later files keep
-    /// mutating behind the user's back.
+    func terminationSaveDestinationsStillMatch(
+        _ plan: PreparedTerminationPaneSavePlan
+    ) async -> Bool {
+        await TerminationSaveCoordinator.destinationStatesAreCurrent(
+            plan.staged
+        )
+    }
+
+    /// Installs staged files serially off-main. The deadline is checked before
+    /// every install and after every in-flight atomic syscall. An individual
+    /// rename cannot be interrupted safely, so its model reconciliation always
+    /// completes before a timeout is reported.
     func commitStagedSaveAllPaneTabsForTermination(
         _ plan: PreparedTerminationPaneSavePlan,
         until deadline: DispatchTime
-    ) -> PreparedPaneSaveCommitResult {
+    ) async -> PreparedPaneSaveCommitResult {
         let source = plan.source
         guard DispatchTime.now().uptimeNanoseconds
                 < deadline.uptimeNanoseconds,
@@ -437,28 +511,49 @@ final class ProjectManager {
 
         for (index, pair) in zip(source.entries, plan.staged).enumerated() {
             let (entry, staged) = pair
-            do {
-                guard TerminationSaveCoordinator
-                    .stagingIdentityIsCurrent(staged) else {
-                    throw CocoaError(.fileReadCorruptFile)
-                }
-                try Self.atomicallyInstallStagedSave(staged)
-            } catch {
+            guard DispatchTime.now().uptimeNanoseconds
+                    < deadline.uptimeNanoseconds else {
                 cleanupTerminationStagedSaves(
                     Array(plan.staged.dropFirst(index))
                 )
-                return .failed(message: error.localizedDescription)
+                return .timedOut
             }
-            guard entry.tabManager.applyTerminationStagedSave(
+            guard preparedEntryStillValid(entry) else {
+                cleanupTerminationStagedSaves(
+                    Array(plan.staged.dropFirst(index))
+                )
+                return .invalidated
+            }
+            switch await terminationSaveInstaller(staged) {
+            case .failed(let message):
+                cleanupTerminationStagedSaves(
+                    Array(plan.staged.dropFirst(index))
+                )
+                return .failed(message: message)
+            case .installed:
+                break
+            }
+            // The install allowed MainActor reentrancy. Preserve any edit
+            // made while the syscall was in flight as dirty against the exact
+            // content that is now durable on disk.
+            guard entry.tabManager.reconcileTerminationStagedSave(
                 request: staged.request,
                 savedContent: staged.preparedContent
             ) else {
-                // No suspension occurs between validation and this update, so
-                // reaching this branch is an internal invariant violation.
                 Logger.app.critical(
                     "Termination save model changed during atomic commit"
                 )
+                cleanupTerminationStagedSaves(
+                    Array(plan.staged.dropFirst(index + 1))
+                )
                 return .invalidated
+            }
+            if DispatchTime.now().uptimeNanoseconds
+                    >= deadline.uptimeNanoseconds {
+                cleanupTerminationStagedSaves(
+                    Array(plan.staged.dropFirst(index + 1))
+                )
+                return .timedOut
             }
         }
         return .saved
@@ -478,23 +573,21 @@ final class ProjectManager {
         }
     }
 
-    private static func atomicallyInstallStagedSave(
-        _ staged: TerminationStagedSave
-    ) throws {
-        let fileManager = FileManager.default
-        if fileManager.fileExists(atPath: staged.request.destination.path) {
-            _ = try fileManager.replaceItemAt(
-                staged.request.destination,
-                withItemAt: staged.stagingURL,
-                backupItemName: nil,
-                options: []
-            )
-        } else {
-            try fileManager.moveItem(
-                at: staged.stagingURL,
-                to: staged.request.destination
-            )
+    private func preparedEntryStillValid(_ planned: PlannedTabSave) -> Bool {
+        guard paneManager.allTabManagers.contains(where: {
+            $0 === planned.tabManager
+        }),
+              let current = planned.tabManager.tabs.first(where: {
+                  $0.id == planned.tab.id
+              }) else {
+            return false
         }
+        return current.isDirty
+            && current.kind == .text
+            && !current.isTruncated
+            && current.contentVersion == planned.tab.contentVersion
+            && current.content == planned.tab.content
+            && current.fileURL == planned.tab.fileURL
     }
 
     private func preparedSavePlanStillValid(
@@ -552,7 +645,7 @@ final class ProjectManager {
         switch commitPreparedSaveAllPaneTabs(plan) {
         case .saved:
             return true
-        case .invalidated:
+        case .invalidated, .timedOut:
             return false
         case .failed(let message):
             _ = await AlertTemplate.fileOperationErrorCritical.runSheet(
@@ -1626,6 +1719,22 @@ final class ProjectManager {
         await taskRunStore.waitForShutdown(
             authorizedBy: authorization,
             until: deadline
+        )
+    }
+
+    func userTaskShutdownIsPreparedForCommit(
+        authorizedBy authorization: UserTaskExecutionAuthorization
+    ) -> Bool {
+        taskRunStore.shutdownIsPreparedForCommit(
+            authorizedBy: authorization
+        )
+    }
+
+    func commitPreparedUserTaskShutdown(
+        authorizedBy authorization: UserTaskExecutionAuthorization
+    ) {
+        taskRunStore.commitPreparedShutdown(
+            authorizedBy: authorization
         )
     }
 

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -12,10 +12,10 @@ import SwiftUI
 
 nonisolated struct TerminationFileAliasIdentity: Hashable, Sendable {
     private enum Storage: Hashable, Sendable {
-        case existing(device: UInt64, inode: UInt64)
+        case existing(device: dev_t, inode: ino_t)
         case missing(
-            ancestorDevice: UInt64,
-            ancestorInode: UInt64,
+            ancestorDevice: dev_t,
+            ancestorInode: ino_t,
             normalizedSuffix: [String]
         )
     }
@@ -23,15 +23,15 @@ nonisolated struct TerminationFileAliasIdentity: Hashable, Sendable {
     private let storage: Storage
 
     fileprivate static func existing(
-        device: UInt64,
-        inode: UInt64
+        device: dev_t,
+        inode: ino_t
     ) -> Self {
         Self(storage: .existing(device: device, inode: inode))
     }
 
     fileprivate static func missing(
-        ancestorDevice: UInt64,
-        ancestorInode: UInt64,
+        ancestorDevice: dev_t,
+        ancestorInode: ino_t,
         normalizedSuffix: [String]
     ) -> Self {
         Self(storage: .missing(
@@ -156,8 +156,8 @@ nonisolated enum TerminationFileAliasResolver {
                 }
                 if missingComponents.isEmpty {
                     return .existing(
-                        device: UInt64(status.st_dev),
-                        inode: UInt64(status.st_ino)
+                        device: status.st_dev,
+                        inode: status.st_ino
                     )
                 }
                 let resourceValues = try currentURL.resourceValues(
@@ -171,8 +171,8 @@ nonisolated enum TerminationFileAliasResolver {
                     normalize($0, caseSensitive: isCaseSensitive)
                 }
                 return .missing(
-                    ancestorDevice: UInt64(status.st_dev),
-                    ancestorInode: UInt64(status.st_ino),
+                    ancestorDevice: status.st_dev,
+                    ancestorInode: status.st_ino,
                     normalizedSuffix: suffix
                 )
             }

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -35,6 +35,24 @@ struct UserTaskShutdownAuthorization {
     var requiresConfirmation: Bool {
         byOwner.values.contains { $0.requiresConfirmation }
     }
+
+    var confirmingOwnerIDs: Set<ObjectIdentifier> {
+        Set(byOwner.compactMap { owner, authorization in
+            authorization.requiresConfirmation ? owner : nil
+        })
+    }
+}
+
+/// Stable application-wide ownership fence for Quit's machine save phase.
+/// Planned Save As tabs may move from their original backing to the one
+/// destination chosen by the user; every other project, pane manager, tab,
+/// and backing URL must remain identical until the transaction completes.
+@MainActor
+struct TerminationSaveInventoryAuthorization {
+    fileprivate let projectsByRoot: [URL: ObjectIdentifier]
+    fileprivate let tabsByProject: [
+        ObjectIdentifier: ProjectManager.TerminationOpenTabInventory
+    ]
 }
 
 /// Manages open projects and recent project history.
@@ -803,6 +821,43 @@ final class ProjectRegistry: LSPSettingsObserver {
         openProjects.values.forEach { $0.freezeAutoSaveForTermination() }
         detachedTaskCleanupProjects.values.forEach {
             $0.freezeAutoSaveForTermination()
+        }
+    }
+
+    func captureApplicationTerminationSaveInventory(
+        allowingSaveAs destinationsByTabID: [UUID: URL]
+    ) -> TerminationSaveInventoryAuthorization {
+        let projectsByRoot = openProjects.mapValues(ObjectIdentifier.init)
+        return TerminationSaveInventoryAuthorization(
+            projectsByRoot: projectsByRoot,
+            tabsByProject: Dictionary(uniqueKeysWithValues: openProjects
+                .values.map { projectManager in
+                    (
+                        ObjectIdentifier(projectManager),
+                        projectManager.captureTerminationOpenTabInventory(
+                            allowingSaveAs: destinationsByTabID
+                        )
+                    )
+                })
+        )
+    }
+
+    func applicationTerminationSaveInventoryStillMatches(
+        _ authorization: TerminationSaveInventoryAuthorization
+    ) -> Bool {
+        guard openProjects.mapValues(ObjectIdentifier.init)
+                == authorization.projectsByRoot else {
+            return false
+        }
+        return openProjects.values.allSatisfy { projectManager in
+            guard let inventory = authorization.tabsByProject[
+                ObjectIdentifier(projectManager)
+            ] else {
+                return false
+            }
+            return projectManager.terminationOpenTabInventoryStillMatches(
+                inventory
+            )
         }
     }
 

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -24,6 +24,19 @@ nonisolated enum AgentInboxRecoveryResult: Equatable, Sendable {
     case launchRejected
 }
 
+/// App-wide snapshot of the exact user-task executions covered by one Quit
+/// decision, keyed by their owning ProjectManager identity.
+@MainActor
+struct UserTaskShutdownAuthorization {
+    fileprivate let byOwner: [
+        ObjectIdentifier: UserTaskExecutionAuthorization
+    ]
+
+    var requiresConfirmation: Bool {
+        byOwner.values.contains { $0.requiresConfirmation }
+    }
+}
+
 /// Manages open projects and recent project history.
 /// Each project directory maps to a single ProjectManager instance.
 @MainActor
@@ -81,6 +94,10 @@ final class ProjectRegistry: LSPSettingsObserver {
     /// cannot race each other across projects.
     @ObservationIgnored
     private var lspSettingsChangeTask: Task<Void, Never>?
+    /// Prevents a ProjectManager from being created without a matching agent
+    /// metadata registration while that registry has frozen admission.
+    @ObservationIgnored
+    private(set) var isProjectAdmissionFrozenForTermination = false
 
     init(
         lspSettings: LSPSettings = .shared,
@@ -237,6 +254,7 @@ final class ProjectRegistry: LSPSettingsObserver {
             atPath: identity.canonicalProjectPath,
             isDirectory: &isProjectDir
         ), isProjectDir.boolValue else { return nil }
+        guard !isProjectAdmissionFrozenForTermination else { return nil }
         agentTasks.registerProject(identity)
         let pm = ProjectManager(
             lspSettings: lspSettings,
@@ -765,6 +783,7 @@ final class ProjectRegistry: LSPSettingsObserver {
     }
 
     func freezeAgentTasksForTermination() {
+        isProjectAdmissionFrozenForTermination = true
         for manager in openProjects.values {
             manager.terminal.freezeAgentTasksForTermination()
         }
@@ -780,12 +799,21 @@ final class ProjectRegistry: LSPSettingsObserver {
         let rollbackWasSaved = await agentTasks.cancelApplicationTerminationAndFlush(
             maximumDuration: maximumDuration
         )
-        for manager in openProjects.values {
+        for (url, manager) in openProjects {
+            let isWindowOpen = !backgroundProjects.contains(url)
+            if let identity = agentTaskProjectsByRoot[url] {
+                agentTasks.setWindowOpen(
+                    isWindowOpen,
+                    project: identity
+                )
+            }
+            manager.terminal.setAgentTaskWindowOpen(isWindowOpen)
             manager.terminal.cancelAgentTaskTermination()
         }
         for manager in detachedTaskCleanupProjects.values {
             manager.terminal.cancelAgentTaskTermination()
         }
+        isProjectAdmissionFrozenForTermination = false
         return rollbackWasSaved
     }
 
@@ -797,21 +825,72 @@ final class ProjectRegistry: LSPSettingsObserver {
         userTaskOwners.contains { $0.hasOutstandingUserTaskExecution }
     }
 
+    func captureUserTaskShutdownAuthorization()
+        -> UserTaskShutdownAuthorization {
+        UserTaskShutdownAuthorization(byOwner: Dictionary(
+            uniqueKeysWithValues: userTaskOwners.map { projectManager in
+                (
+                    ObjectIdentifier(projectManager),
+                    projectManager.captureUserTaskShutdownAuthorization()
+                )
+            }
+        ))
+    }
+
+    func userTaskShutdownAuthorizationStillCovers(
+        _ authorization: UserTaskShutdownAuthorization
+    ) -> Bool {
+        userTaskOwners.allSatisfy { projectManager in
+            let captured = authorization.byOwner[
+                ObjectIdentifier(projectManager)
+            ] ?? UserTaskExecutionAuthorization()
+            return projectManager.userTaskShutdownAuthorizationStillCovers(
+                captured
+            )
+        }
+    }
+
     /// Cancels and waits for all project-owned user tasks against one shared
     /// absolute deadline. Blocking process waits happen off the main actor.
     @discardableResult
-    func shutdownUserTasks(until deadline: DispatchTime) async -> Bool {
+    func shutdownUserTasks(
+        authorizedBy authorization: UserTaskShutdownAuthorization,
+        until deadline: DispatchTime
+    ) async -> Bool {
         // Snapshot before the first suspension point. Main-actor reentrancy may
         // otherwise mutate the registry while an iterator is held across an
         // `await`.
         let projectManagers = userTaskOwners
-        for projectManager in projectManagers {
-            projectManager.requestUserTaskShutdown()
+        guard projectManagers.allSatisfy({ projectManager in
+            let captured = authorization.byOwner[
+                ObjectIdentifier(projectManager)
+            ] ?? UserTaskExecutionAuthorization()
+            return projectManager.userTaskShutdownAuthorizationStillCovers(
+                captured
+            )
+        }) else {
+            return false
         }
         for projectManager in projectManagers {
-            _ = await projectManager.shutdownUserTasks(
+            let captured = authorization.byOwner[
+                ObjectIdentifier(projectManager)
+            ] ?? UserTaskExecutionAuthorization()
+            guard projectManager.requestUserTaskShutdown(
+                authorizedBy: captured
+            ) else {
+                return false
+            }
+        }
+        var allCompleted = true
+        for projectManager in projectManagers {
+            let captured = authorization.byOwner[
+                ObjectIdentifier(projectManager)
+            ] ?? UserTaskExecutionAuthorization()
+            let didComplete = await projectManager.waitForUserTaskShutdown(
+                authorizedBy: captured,
                 until: deadline
             )
+            allCompleted = allCompleted && didComplete
         }
 
         detachedTaskCleanupProjects = detachedTaskCleanupProjects.filter {
@@ -821,9 +900,19 @@ final class ProjectRegistry: LSPSettingsObserver {
         // A project or task may have appeared while process waits ran off the
         // main actor. Treat that as an incomplete shutdown so Quit fails
         // closed instead of dropping its execution ownership.
-        return !userTaskOwners.contains(where: {
+        return allCompleted && !userTaskOwners.contains(where: {
             $0.hasOutstandingUserTaskExecution
         })
+    }
+
+    /// Legacy project-teardown entry point. Its snapshot is captured at the
+    /// call boundary, so it cannot cancel executions created after an await.
+    @discardableResult
+    func shutdownUserTasks(until deadline: DispatchTime) async -> Bool {
+        await shutdownUserTasks(
+            authorizedBy: captureUserTaskShutdownAuthorization(),
+            until: deadline
+        )
     }
 
     /// Fully destroys all project managers after task cleanup has completed.

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -98,6 +98,8 @@ final class ProjectRegistry: LSPSettingsObserver {
     /// metadata registration while that registry has frozen admission.
     @ObservationIgnored
     private(set) var isProjectAdmissionFrozenForTermination = false
+    @ObservationIgnored
+    private var isAutoSaveFrozenForTermination = false
 
     init(
         lspSettings: LSPSettings = .shared,
@@ -260,6 +262,9 @@ final class ProjectRegistry: LSPSettingsObserver {
             lspSettings: lspSettings,
             agentTaskRegistry: agentTasks
         )
+        if isAutoSaveFrozenForTermination {
+            pm.freezeAutoSaveForTermination()
+        }
         pm.loadDirectory(url: canonical, agentTaskProject: identity)
         openProjects[canonical] = pm
         agentTaskProjectsByRoot[canonical] = identity
@@ -792,6 +797,37 @@ final class ProjectRegistry: LSPSettingsObserver {
         }
     }
 
+    func freezeAutoSaveForTermination() {
+        guard !isAutoSaveFrozenForTermination else { return }
+        isAutoSaveFrozenForTermination = true
+        openProjects.values.forEach { $0.freezeAutoSaveForTermination() }
+        detachedTaskCleanupProjects.values.forEach {
+            $0.freezeAutoSaveForTermination()
+        }
+    }
+
+    func cancelAutoSaveTerminationFreeze() {
+        guard isAutoSaveFrozenForTermination else { return }
+        isAutoSaveFrozenForTermination = false
+        openProjects.values.forEach {
+            $0.cancelAutoSaveTerminationFreeze()
+        }
+        detachedTaskCleanupProjects.values.forEach {
+            $0.cancelAutoSaveTerminationFreeze()
+        }
+    }
+
+    func finishAutoSaveTerminationFreeze() {
+        guard isAutoSaveFrozenForTermination else { return }
+        isAutoSaveFrozenForTermination = false
+        openProjects.values.forEach {
+            $0.finishAutoSaveTerminationFreeze()
+        }
+        detachedTaskCleanupProjects.values.forEach {
+            $0.finishAutoSaveTerminationFreeze()
+        }
+    }
+
     @discardableResult
     func cancelAgentTaskTermination(
         maximumDuration: Duration? = nil
@@ -912,14 +948,65 @@ final class ProjectRegistry: LSPSettingsObserver {
             allCompleted = allCompleted && didComplete
         }
 
+        // Waiting is only the prepare phase. Revalidate every original owner
+        // and every owner admitted during a suspension before clearing any
+        // store, so one later timeout or launch cannot erase an earlier
+        // owner's runs and output when application shutdown rolls back.
+        guard allCompleted,
+              projectManagers.allSatisfy({ projectManager in
+                  let captured = authorization.byOwner[
+                      ObjectIdentifier(projectManager)
+                  ] ?? UserTaskExecutionAuthorization()
+                  return projectManager
+                      .userTaskShutdownIsPreparedForCommit(
+                          authorizedBy: captured
+                      )
+              }),
+              userTaskShutdownAuthorizationStillCovers(authorization) else {
+            return false
+        }
+
+        // Application Quit performs its final dirty/terminal authorization
+        // recheck after this prepare phase. It commits every prepared store
+        // only after that global check succeeds.
+        return true
+    }
+
+    func userTaskShutdownIsPreparedForCommit(
+        _ authorization: UserTaskShutdownAuthorization
+    ) -> Bool {
+        userTaskOwners.allSatisfy { projectManager in
+            let captured = authorization.byOwner[
+                ObjectIdentifier(projectManager)
+            ] ?? UserTaskExecutionAuthorization()
+            return projectManager.userTaskShutdownIsPreparedForCommit(
+                authorizedBy: captured
+            )
+        } && userTaskShutdownAuthorizationStillCovers(authorization)
+    }
+
+    @discardableResult
+    func commitPreparedUserTaskShutdown(
+        _ authorization: UserTaskShutdownAuthorization
+    ) -> Bool {
+        guard userTaskShutdownIsPreparedForCommit(authorization) else {
+            return false
+        }
+        // No suspension is allowed between the aggregate preflight above and
+        // the last commit below. Main-actor isolation makes this one global
+        // commit boundary for all prepared project stores.
+        for projectManager in userTaskOwners {
+            let captured = authorization.byOwner[
+                ObjectIdentifier(projectManager)
+            ] ?? UserTaskExecutionAuthorization()
+            projectManager.commitPreparedUserTaskShutdown(
+                authorizedBy: captured
+            )
+        }
         detachedTaskCleanupProjects = detachedTaskCleanupProjects.filter {
             $0.value.hasOutstandingUserTaskExecution
         }
-
-        // A project or task may have appeared while process waits ran off the
-        // main actor. Treat that as an incomplete shutdown so Quit fails
-        // closed instead of dropping its execution ownership.
-        return allCompleted && !userTaskOwners.contains(where: {
+        return !userTaskOwners.contains(where: {
             $0.hasOutstandingUserTaskExecution
         })
     }
@@ -928,10 +1015,12 @@ final class ProjectRegistry: LSPSettingsObserver {
     /// call boundary, so it cannot cancel executions created after an await.
     @discardableResult
     func shutdownUserTasks(until deadline: DispatchTime) async -> Bool {
-        await shutdownUserTasks(
-            authorizedBy: captureUserTaskShutdownAuthorization(),
+        let authorization = captureUserTaskShutdownAuthorization()
+        guard await shutdownUserTasks(
+            authorizedBy: authorization,
             until: deadline
-        )
+        ) else { return false }
+        return commitPreparedUserTaskShutdown(authorization)
     }
 
     /// Fully destroys all project managers after task cleanup has completed.

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -796,17 +796,19 @@ final class ProjectRegistry: LSPSettingsObserver {
     func cancelAgentTaskTermination(
         maximumDuration: Duration? = nil
     ) async -> Bool {
-        let rollbackWasSaved = await agentTasks.cancelApplicationTerminationAndFlush(
-            maximumDuration: maximumDuration
+        let windowOpenByProject = Dictionary(
+            agentTaskProjectsByRoot.map { url, identity in
+                (identity, !backgroundProjects.contains(url))
+            },
+            uniquingKeysWith: { _, latest in latest }
         )
+        let rollbackWasSaved = await agentTasks
+            .cancelApplicationTerminationAndFlush(
+                reconcilingWindowOpen: windowOpenByProject,
+                maximumDuration: maximumDuration
+            )
         for (url, manager) in openProjects {
             let isWindowOpen = !backgroundProjects.contains(url)
-            if let identity = agentTaskProjectsByRoot[url] {
-                agentTasks.setWindowOpen(
-                    isWindowOpen,
-                    project: identity
-                )
-            }
             manager.terminal.setAgentTaskWindowOpen(isWindowOpen)
             manager.terminal.cancelAgentTaskTermination()
         }
@@ -815,6 +817,23 @@ final class ProjectRegistry: LSPSettingsObserver {
         }
         isProjectAdmissionFrozenForTermination = false
         return rollbackWasSaved
+    }
+
+    @discardableResult
+    func cancelAgentTaskTermination(
+        until deadline: DispatchTime
+    ) async -> Bool {
+        let now = DispatchTime.now().uptimeNanoseconds
+        let remaining: Duration = if now < deadline.uptimeNanoseconds {
+            .nanoseconds(
+                Int64(clamping: deadline.uptimeNanoseconds - now)
+            )
+        } else {
+            .zero
+        }
+        return await cancelAgentTaskTermination(
+            maximumDuration: remaining
+        )
     }
 
     /// Whether any open or detached project still owns a user-task execution.

--- a/Pine/String+TrailingWhitespace.swift
+++ b/Pine/String+TrailingWhitespace.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-extension String {
+nonisolated extension String {
     /// Returns a copy with trailing whitespace (spaces and tabs) removed from every line.
     /// Preserves line endings (LF, CRLF) and empty lines.
     func trailingWhitespaceStripped() -> String {

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -2035,8 +2035,8 @@ enum Strings {
         String(localized: "quit.summary.title")
     }
 
-    static func applicationQuitSummaryMessage(_ projectCount: Int) -> String {
-        String(localized: "quit.summary.message \(projectCount)")
+    static func applicationQuitSummaryMessage(_ itemCount: Int) -> String {
+        String(localized: "quit.summary.message \(itemCount)")
     }
 
     static var applicationQuitReview: String {

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -85,12 +85,17 @@ struct TerminalTabCloseAuthorization {
     /// was visible is always covered (nothing remains to protect).
     func stillCovers(_ tabs: [TerminalTab]) -> Bool {
         for tab in tabs {
-            // A tab with nothing to protect at authorization time (idle
-            // shell, no agent session, no foreground process) is absent from
-            // `coverage`. It has nothing to re-check, so skip it — otherwise a
-            // mixed idle+active bulk close set would be silently aborted
-            // right after the user confirmed (#1335 review finding).
-            guard let captured = coverage[tab.id] else { continue }
+            // Idle tabs are absent from `coverage`, but they remain safe only
+            // while they are still idle. A foreground process or agent that
+            // appears after the prompt is a new destructive generation and
+            // must not inherit the earlier authorization.
+            guard let captured = coverage[tab.id] else {
+                guard tab.agentSession == nil,
+                      tab.foregroundProcessID <= 0 else {
+                    return false
+                }
+                continue
+            }
             switch captured {
             case .agentSession(let sessionID):
                 // Same agent session: covered (pgid churn is normal agent

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -142,9 +142,21 @@ struct TerminalTabCloseAuthorization {
                     return false
                 }
             case .foregroundProcess(let identity):
-                // A newly detected agent is a different kind of destructive
-                // work even if its process-group observation is not ready yet.
-                guard tab.agentSession == nil else { return false }
+                // A foreground job may settle into the agent session launched
+                // by the exact Pine reservation already covered by this Quit
+                // decision. No detected-agent label, process-group reuse, or
+                // unrelated session may inherit that authorization.
+                if tab.agentSession != nil {
+                    guard let pineAgentLaunches,
+                          let currentPineAgentLaunches,
+                          pineAgentLaunches.coversLaunch(
+                              in: tab.id,
+                              current: currentPineAgentLaunches
+                          ) else {
+                        return false
+                    }
+                    continue
+                }
                 let current = tab.foregroundProcessID
                 // Process exited: covered. A new non-zero process group is a
                 // new, unauthorized generation.

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -23,8 +23,9 @@ nonisolated struct TerminalForegroundProcessIdentity: Hashable, Sendable {
 }
 
 nonisolated struct TerminalProcessStartIdentity: Hashable, Sendable {
-    let seconds: Int64
-    let microseconds: Int32
+    let processID: pid_t
+    let seconds: UInt64
+    let microseconds: UInt64
 }
 
 /// Per-tab coverage captured when a destructive terminal close/stop is
@@ -71,11 +72,15 @@ struct TerminalTabCloseAuthorization {
         for tab in tabs {
             if let sessionID = tab.agentSession?.id {
                 coverage[tab.id] = .agentSession(sessionID: sessionID)
-            } else if tab.foregroundProcessID > 0 {
+            } else {
+                let processGroupID = tab.foregroundProcessID
+                guard processGroupID > 0 else { continue }
                 let identity = TerminalForegroundProcessIdentity(
                     tabID: tab.id,
-                    processGroupID: tab.foregroundProcessID,
-                    startIdentity: tab.foregroundProcessStartIdentity
+                    processGroupID: processGroupID,
+                    startIdentity: tab.foregroundProcessIdentity(
+                        in: processGroupID
+                    )
                 )
                 coverage[tab.id] = .foregroundProcess(identity)
                 foregroundIdentities.insert(identity)
@@ -146,7 +151,10 @@ struct TerminalTabCloseAuthorization {
                 if current > 0 {
                     guard current == identity.processGroupID,
                           let capturedStart = identity.startIdentity,
-                          tab.foregroundProcessStartIdentity == capturedStart
+                          tab.foregroundProcessIdentityStillMatches(
+                              capturedStart,
+                              in: current
+                          )
                     else { return false }
                 }
             }

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -26,6 +26,38 @@ nonisolated struct TerminalProcessStartIdentity: Hashable, Sendable {
     let processID: pid_t
     let seconds: UInt64
     let microseconds: UInt64
+
+    init(
+        processID: pid_t,
+        seconds: UInt64,
+        microseconds: UInt64
+    ) {
+        self.processID = processID
+        self.seconds = seconds
+        self.microseconds = microseconds
+    }
+
+    init?(processEvidence: AgentProcessEvidence) {
+        guard processEvidence.startIsAuthoritative,
+              let processID = processEvidence.processIdentifier,
+              processID > 1 else { return nil }
+        let interval = processEvidence.observedStartedAt.timeIntervalSince1970
+        guard interval.isFinite, interval >= 0 else { return nil }
+        var seconds = UInt64(interval.rounded(.down))
+        var microseconds = UInt64(
+            ((interval - Double(seconds)) * 1_000_000).rounded()
+        )
+        if microseconds == 1_000_000 {
+            guard seconds < UInt64.max else { return nil }
+            seconds += 1
+            microseconds = 0
+        }
+        self.init(
+            processID: processID,
+            seconds: seconds,
+            microseconds: microseconds
+        )
+    }
 }
 
 /// Per-tab coverage captured when a destructive terminal close/stop is
@@ -39,8 +71,13 @@ nonisolated enum TerminalTabCloseCoverage: Hashable, Sendable {
     /// generation. A new process group in the same tab is a new
     /// authorization generation (existing safety semantics).
     case foregroundProcess(TerminalForegroundProcessIdentity)
-    /// An agent tab is covered by its stable agent-session identity.
-    case agentSession(sessionID: UUID)
+    /// An agent tab is covered by its stable session id plus the immutable OS
+    /// process-start witness that backs that run. Foreground child churn is
+    /// covered only while this exact agent generation remains alive.
+    case agentSession(
+        sessionID: UUID,
+        processIdentity: TerminalProcessStartIdentity?
+    )
 }
 
 /// Snapshot of the destructive-process coverage authorized for a set of
@@ -70,8 +107,13 @@ struct TerminalTabCloseAuthorization {
         var coverage: [UUID: TerminalTabCloseCoverage] = [:]
         var foregroundIdentities: Set<TerminalForegroundProcessIdentity> = []
         for tab in tabs {
-            if let sessionID = tab.agentSession?.id {
-                coverage[tab.id] = .agentSession(sessionID: sessionID)
+            if let session = tab.agentSession {
+                coverage[tab.id] = .agentSession(
+                    sessionID: session.id,
+                    processIdentity: session.processEvidence.flatMap(
+                        TerminalProcessStartIdentity.init(processEvidence:)
+                    )
+                )
             } else {
                 let processGroupID = tab.foregroundProcessID
                 guard processGroupID > 0 else { continue }
@@ -124,6 +166,7 @@ struct TerminalTabCloseAuthorization {
                           let currentPineAgentLaunches,
                           pineAgentLaunches.coversLaunch(
                               in: tab.id,
+                              settledSessionID: tab.agentSession?.id,
                               current: currentPineAgentLaunches
                           ) else {
                         return false
@@ -132,12 +175,20 @@ struct TerminalTabCloseAuthorization {
                 continue
             }
             switch captured {
-            case .agentSession(let sessionID):
+            case .agentSession(let sessionID, let processIdentity):
                 // Same agent session: covered (pgid churn is normal agent
-                // behaviour). Once it exits, only a genuinely idle tab is
-                // covered; a replacement foreground job is a new generation.
+                // behaviour) only while the agent's exact OS generation is
+                // still alive. Once it exits, only a genuinely idle tab is
+                // covered; a replacement foreground job is new work.
                 if let currentSession = tab.agentSession {
                     guard currentSession.id == sessionID else { return false }
+                    if tab.foregroundProcessID > 0 {
+                        guard processIdentity.map({
+                            tab.agentProcessIdentityStillMatches($0)
+                        }) == true else {
+                            return false
+                        }
+                    }
                 } else if tab.foregroundProcessID > 0 {
                     return false
                 }
@@ -168,6 +219,7 @@ struct TerminalTabCloseAuthorization {
                           let currentPineAgentLaunches,
                           pineAgentLaunches.coversLaunch(
                               in: tab.id,
+                              settledSessionID: tab.agentSession?.id,
                               current: currentPineAgentLaunches
                           ) else {
                         return false

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -144,9 +144,26 @@ struct TerminalTabCloseAuthorization {
             case .foregroundProcess(let identity):
                 // A foreground job may settle into the agent session launched
                 // by the exact Pine reservation already covered by this Quit
-                // decision. No detected-agent label, process-group reuse, or
-                // unrelated session may inherit that authorization.
+                // decision. A manually launched job may also be labelled as
+                // an agent while the dialog is open; its exact process witness
+                // remains the authority in that case.
+                let current = tab.foregroundProcessID
+                let sameForegroundGeneration = current > 0
+                    && current == identity.processGroupID
+                    && identity.startIdentity.map {
+                        tab.foregroundProcessIdentityStillMatches(
+                            $0,
+                            in: current
+                        )
+                    } == true
                 if tab.agentSession != nil {
+                    let sessionMatchesForegroundWitness =
+                        tab.agentSession?.processEvidence?.processIdentifier
+                            == identity.startIdentity?.processID
+                    if sameForegroundGeneration,
+                       sessionMatchesForegroundWitness {
+                        continue
+                    }
                     guard let pineAgentLaunches,
                           let currentPineAgentLaunches,
                           pineAgentLaunches.coversLaunch(
@@ -157,17 +174,10 @@ struct TerminalTabCloseAuthorization {
                     }
                     continue
                 }
-                let current = tab.foregroundProcessID
                 // Process exited: covered. A new non-zero process group is a
                 // new, unauthorized generation.
-                if current > 0 {
-                    guard current == identity.processGroupID,
-                          let capturedStart = identity.startIdentity,
-                          tab.foregroundProcessIdentityStillMatches(
-                              capturedStart,
-                              in: current
-                          )
-                    else { return false }
+                if current > 0, !sameForegroundGeneration {
+                    return false
                 }
             }
         }

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -19,6 +19,12 @@ import AppKit
 nonisolated struct TerminalForegroundProcessIdentity: Hashable, Sendable {
     let tabID: UUID
     let processGroupID: Int32
+    let startIdentity: TerminalProcessStartIdentity?
+}
+
+nonisolated struct TerminalProcessStartIdentity: Hashable, Sendable {
+    let seconds: Int64
+    let microseconds: Int32
 }
 
 /// Per-tab coverage captured when a destructive terminal close/stop is
@@ -68,7 +74,8 @@ struct TerminalTabCloseAuthorization {
             } else if tab.foregroundProcessID > 0 {
                 let identity = TerminalForegroundProcessIdentity(
                     tabID: tab.id,
-                    processGroupID: tab.foregroundProcessID
+                    processGroupID: tab.foregroundProcessID,
+                    startIdentity: tab.foregroundProcessStartIdentity
                 )
                 coverage[tab.id] = .foregroundProcess(identity)
                 foregroundIdentities.insert(identity)
@@ -136,8 +143,11 @@ struct TerminalTabCloseAuthorization {
                 let current = tab.foregroundProcessID
                 // Process exited: covered. A new non-zero process group is a
                 // new, unauthorized generation.
-                if current > 0, current != identity.processGroupID {
-                    return false
+                if current > 0 {
+                    guard current == identity.processGroupID,
+                          let capturedStart = identity.startIdentity,
+                          tab.foregroundProcessStartIdentity == capturedStart
+                    else { return false }
                 }
             }
         }

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -84,15 +84,38 @@ struct TerminalTabCloseAuthorization {
     /// captured at authorization time. A process that exited while the sheet
     /// was visible is always covered (nothing remains to protect).
     func stillCovers(_ tabs: [TerminalTab]) -> Bool {
+        stillCovers(
+            tabs,
+            pineAgentLaunches: nil,
+            currentPineAgentLaunches: nil
+        )
+    }
+
+    /// Composes foreground-process coverage with Pine's exact launch
+    /// reservation. An idle tab may legitimately become foreground while the
+    /// Quit sheet is visible when that same launch was already part of the
+    /// prompt; unrelated jobs still fail closed.
+    func stillCovers(
+        _ tabs: [TerminalTab],
+        pineAgentLaunches: PineAgentLaunchAuthorization?,
+        currentPineAgentLaunches: PineAgentLaunchAuthorization?
+    ) -> Bool {
         for tab in tabs {
             // Idle tabs are absent from `coverage`, but they remain safe only
             // while they are still idle. A foreground process or agent that
-            // appears after the prompt is a new destructive generation and
-            // must not inherit the earlier authorization.
+            // appears after the prompt must be the exact Pine launch separately
+            // captured by that same prompt; raw foreground identity is not
+            // sufficient to inherit authorization.
             guard let captured = coverage[tab.id] else {
-                guard tab.agentSession == nil,
-                      tab.foregroundProcessID <= 0 else {
-                    return false
+                if tab.agentSession != nil || tab.foregroundProcessID > 0 {
+                    guard let pineAgentLaunches,
+                          let currentPineAgentLaunches,
+                          pineAgentLaunches.coversLaunch(
+                              in: tab.id,
+                              current: currentPineAgentLaunches
+                          ) else {
+                        return false
+                    }
                 }
                 continue
             }

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -99,11 +99,17 @@ struct TerminalTabCloseAuthorization {
             switch captured {
             case .agentSession(let sessionID):
                 // Same agent session: covered (pgid churn is normal agent
-                // behaviour). The agent having exited (session cleared) is
-                // also covered — there is nothing left to protect.
-                guard tab.agentSession?.id == sessionID
-                    || tab.agentSession == nil else { return false }
+                // behaviour). Once it exits, only a genuinely idle tab is
+                // covered; a replacement foreground job is a new generation.
+                if let currentSession = tab.agentSession {
+                    guard currentSession.id == sessionID else { return false }
+                } else if tab.foregroundProcessID > 0 {
+                    return false
+                }
             case .foregroundProcess(let identity):
+                // A newly detected agent is a different kind of destructive
+                // work even if its process-group observation is not ready yet.
+                guard tab.agentSession == nil else { return false }
                 let current = tab.foregroundProcessID
                 // Process exited: covered. A new non-zero process group is a
                 // new, unauthorized generation.

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -899,7 +899,8 @@ final class TabManager {
     @discardableResult
     func applyTerminationStagedSave(
         request: TerminationSaveRequest,
-        savedContent: String
+        savedContent: String,
+        metadata: TerminationInstalledFileMetadata
     ) -> Bool {
         guard let index = tabs.firstIndex(where: {
             $0.id == request.tabID
@@ -908,6 +909,8 @@ final class TabManager {
               tabs[index].kind == .text,
               !tabs[index].isTruncated,
               tabs[index].contentVersion == request.contentVersion,
+              tabs[index].persistenceGeneration
+                == request.persistenceGeneration,
               tabs[index].content == request.content,
               tabs[index].fileURL == request.originalURL else {
             return false
@@ -917,8 +920,8 @@ final class TabManager {
         tabs[index].content = savedContent
         tabs[index].url = request.destination
         tabs[index].savedContent = savedContent
-        tabs[index].lastModDate = modDate(for: request.destination)
-        tabs[index].fileSizeBytes = fileSize(url: request.destination)
+        tabs[index].lastModDate = metadata.modificationDate
+        tabs[index].fileSizeBytes = metadata.size
         if contentChanged {
             tabs[index].cachedHighlightResult = nil
             tabs[index].recomputeContentCaches()
@@ -946,13 +949,16 @@ final class TabManager {
     @discardableResult
     func reconcileTerminationStagedSave(
         request: TerminationSaveRequest,
-        savedContent: String
+        savedContent: String,
+        metadata: TerminationInstalledFileMetadata
     ) -> Bool {
         guard let index = tabs.firstIndex(where: {
             $0.id == request.tabID
         }),
               tabs[index].kind == .text,
               !tabs[index].isTruncated,
+              tabs[index].persistenceGeneration
+                == request.persistenceGeneration,
               tabs[index].fileURL == request.originalURL else {
             return false
         }
@@ -967,8 +973,8 @@ final class TabManager {
         }
         tabs[index].url = request.destination
         tabs[index].savedContent = savedContent
-        tabs[index].lastModDate = modDate(for: request.destination)
-        tabs[index].fileSizeBytes = fileSize(url: request.destination)
+        tabs[index].lastModDate = metadata.modificationDate
+        tabs[index].fileSizeBytes = metadata.size
         if !requestIsStillCurrent {
             tabs[index].recomputeContentCaches()
         }

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -892,6 +892,54 @@ final class TabManager {
         return outcome.saved
     }
 
+    /// Applies the model half of a termination save after its destination was
+    /// atomically replaced from an off-main staged file. No formatter or file
+    /// write is performed here, so Quit never waits for those operations on
+    /// the main actor.
+    @discardableResult
+    func applyTerminationStagedSave(
+        request: TerminationSaveRequest,
+        savedContent: String
+    ) -> Bool {
+        guard let index = tabs.firstIndex(where: {
+            $0.id == request.tabID
+        }),
+              tabs[index].isDirty,
+              tabs[index].kind == .text,
+              !tabs[index].isTruncated,
+              tabs[index].contentVersion == request.contentVersion,
+              tabs[index].content == request.content,
+              tabs[index].fileURL == request.originalURL else {
+            return false
+        }
+        let contentChanged = savedContent != tabs[index].content
+        let backingChanged = tabs[index].fileURL != request.destination
+        tabs[index].content = savedContent
+        tabs[index].url = request.destination
+        tabs[index].savedContent = savedContent
+        tabs[index].lastModDate = modDate(for: request.destination)
+        tabs[index].fileSizeBytes = fileSize(url: request.destination)
+        if contentChanged {
+            tabs[index].cachedHighlightResult = nil
+            tabs[index].recomputeContentCaches()
+        }
+        recoveryManager?.deleteRecoveryFile(for: request.tabID)
+        if backingChanged {
+            onTabInventoryChanged?()
+        }
+        if contentChanged {
+            NotificationCenter.default.post(
+                name: .tabReloadedFromDisk,
+                object: nil,
+                userInfo: [
+                    "url": request.destination,
+                    "text": savedContent,
+                ]
+            )
+        }
+        return true
+    }
+
     // MARK: - Reorder & Pin
 
     /// Removes a tab for an in-window pane transfer.

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -940,6 +940,59 @@ final class TabManager {
         return true
     }
 
+    /// Reconciles a staged save whose atomic install ran off-main. If the
+    /// buffer was edited while the syscall was in flight, the new edit stays
+    /// visible and dirty while `savedContent` becomes the truthful disk base.
+    @discardableResult
+    func reconcileTerminationStagedSave(
+        request: TerminationSaveRequest,
+        savedContent: String
+    ) -> Bool {
+        guard let index = tabs.firstIndex(where: {
+            $0.id == request.tabID
+        }),
+              tabs[index].kind == .text,
+              !tabs[index].isTruncated,
+              tabs[index].fileURL == request.originalURL else {
+            return false
+        }
+        let requestIsStillCurrent =
+            tabs[index].contentVersion == request.contentVersion
+            && tabs[index].content == request.content
+        let backingChanged = tabs[index].fileURL != request.destination
+        if requestIsStillCurrent {
+            tabs[index].content = savedContent
+            tabs[index].cachedHighlightResult = nil
+            tabs[index].recomputeContentCaches()
+        }
+        tabs[index].url = request.destination
+        tabs[index].savedContent = savedContent
+        tabs[index].lastModDate = modDate(for: request.destination)
+        tabs[index].fileSizeBytes = fileSize(url: request.destination)
+        if !requestIsStillCurrent {
+            tabs[index].recomputeContentCaches()
+        }
+        if tabs[index].isDirty {
+            recoveryManager?.scheduleSnapshot()
+        } else {
+            recoveryManager?.deleteRecoveryFile(for: request.tabID)
+        }
+        if backingChanged {
+            onTabInventoryChanged?()
+        }
+        if requestIsStillCurrent && savedContent != request.content {
+            NotificationCenter.default.post(
+                name: .tabReloadedFromDisk,
+                object: nil,
+                userInfo: [
+                    "url": request.destination,
+                    "text": savedContent,
+                ]
+            )
+        }
+        return true
+    }
+
     // MARK: - Reorder & Pin
 
     /// Removes a tab for an in-window pane transfer.
@@ -1201,6 +1254,7 @@ final class TabManager {
     // MARK: - Auto-save
 
     private let autoSaveCoordinator = TabAutoSave()
+    private var autoSaveFrozenForTermination = false
     nonisolated static let autoSaveKey = TabAutoSave.autoSaveKey
     var isAutoSaving: Bool { autoSaveCoordinator.isSaving }
     var autoSaveDelay: TimeInterval { autoSaveCoordinator.delay }
@@ -1213,7 +1267,8 @@ final class TabManager {
     }
 
     private func scheduleAutoSave(for tabID: UUID) {
-        guard let index = tabs.firstIndex(where: { $0.id == tabID }),
+        guard !autoSaveFrozenForTermination,
+              let index = tabs.firstIndex(where: { $0.id == tabID }),
               let fileURL = tabs[index].fileURL,
               FileManager.default.isWritableFile(atPath: fileURL.path) else {
             return
@@ -1236,6 +1291,28 @@ final class TabManager {
     var hasScheduledAutoSave: Bool { autoSaveCoordinator.hasScheduledSave }
     func hasScheduledAutoSave(for tabID: UUID) -> Bool {
         autoSaveCoordinator.hasScheduledSave(for: tabID)
+    }
+
+    /// Prevents a pending or newly scheduled debounce from turning a user's
+    /// explicit Quit/Don't Save decision into an implicit save while the
+    /// asynchronous termination handshake is in progress.
+    func freezeAutoSaveForTermination() {
+        autoSaveFrozenForTermination = true
+        autoSaveCoordinator.cancel()
+    }
+
+    func cancelAutoSaveTerminationFreeze() {
+        guard autoSaveFrozenForTermination else { return }
+        autoSaveFrozenForTermination = false
+        guard isAutoSaveEnabled else { return }
+        for tab in tabs where tab.isDirty {
+            scheduleAutoSave(for: tab.id)
+        }
+    }
+
+    func finishAutoSaveTerminationFreeze() {
+        autoSaveFrozenForTermination = false
+        autoSaveCoordinator.cancel()
     }
 
     // MARK: - Markdown preview

--- a/Pine/Tabs/TabFormatter.swift
+++ b/Pine/Tabs/TabFormatter.swift
@@ -7,6 +7,12 @@
 
 import Foundation
 
+nonisolated struct EditorSaveSettingsSnapshot: Sendable {
+    let insertFinalNewline: Bool
+    let stripTrailingWhitespace: Bool
+    let formatOnSave: Bool
+}
+
 /// Applies all enabled save-time transformations in the canonical order:
 /// 1. Language-aware formatter (e.g. JSON pretty-print), when `formatOnSave` is on
 ///    and a formatter claims this file type.
@@ -23,9 +29,37 @@ enum TabFormatter {
         settings: EditorSettings,
         formatters: FileFormatterRegistry
     ) -> String {
+        contentPreparedForSave(
+            content,
+            url: url,
+            settings: EditorSaveSettingsSnapshot(
+                insertFinalNewline: settings.insertFinalNewline,
+                stripTrailingWhitespace: settings.stripTrailingWhitespace,
+                formatOnSave: settings.formatOnSave
+            ),
+            formatters: formatters,
+            formatterMaximumDuration: nil
+        )
+    }
+
+    nonisolated static func contentPreparedForSave(
+        _ content: String,
+        url: URL,
+        settings: EditorSaveSettingsSnapshot,
+        formatters: FileFormatterRegistry,
+        formatterMaximumDuration: TimeInterval?
+    ) -> String {
         var result = content
         if settings.formatOnSave {
-            result = formatters.format(content: result, url: url)
+            if let formatterMaximumDuration {
+                result = formatters.format(
+                    content: result,
+                    url: url,
+                    maximumDuration: formatterMaximumDuration
+                )
+            } else {
+                result = formatters.format(content: result, url: url)
+            }
         }
         if settings.stripTrailingWhitespace {
             result = result.trailingWhitespaceStripped()

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -22,11 +22,33 @@ nonisolated struct PineAgentLaunchIdentity: Hashable, Sendable {
 @MainActor
 struct PineAgentLaunchAuthorization {
     fileprivate let identities: Set<PineAgentLaunchIdentity>
+    fileprivate let settledTaskIDsByTerminal: [UUID: UUID]
 
     var requiresConfirmation: Bool { !identities.isEmpty }
 
     func stillCovers(_ current: PineAgentLaunchAuthorization) -> Bool {
         current.identities.isSubset(of: identities)
+    }
+
+    /// Covers an idle-to-foreground transition only when the current terminal
+    /// still carries the exact Pine reservation captured by the user's Quit
+    /// decision. A raw tab id or a newly observed process group is insufficient.
+    func coversLaunch(
+        in terminalID: UUID,
+        current: PineAgentLaunchAuthorization
+    ) -> Bool {
+        current.identities.contains { identity in
+            identity.terminalID == terminalID
+                && identities.contains(identity)
+        } || identities.contains { identity in
+            identity.terminalID == terminalID
+                && current.settledTaskIDsByTerminal[terminalID]
+                    == identity.reservation.taskID
+        }
+    }
+
+    fileprivate var reservations: Set<AgentTaskLaunchReservation> {
+        Set(identities.map(\.reservation))
     }
 }
 
@@ -202,6 +224,15 @@ final class TerminalManager {
     func capturePineAgentLaunchAuthorization()
         -> PineAgentLaunchAuthorization {
         var identities = Set<PineAgentLaunchIdentity>()
+        let staleReservationTerminalIDs = launchReservations.compactMap { terminalID, reservation in
+            agentTaskRegistry?.isLaunchPending(reservation) == true
+                ? nil
+                : terminalID
+        }
+        for terminalID in staleReservationTerminalIDs {
+            launchReservations[terminalID] = nil
+            acknowledgedAgentLaunches[terminalID] = nil
+        }
         for (terminalID, reservation) in launchReservations {
             identities.insert(PineAgentLaunchIdentity(
                 terminalID: terminalID,
@@ -220,7 +251,70 @@ final class TerminalManager {
                 reservation: reservation
             ))
         }
-        return PineAgentLaunchAuthorization(identities: identities)
+        var settledTaskIDsByTerminal: [UUID: UUID] = [:]
+        for tab in allTerminalTabs {
+            guard let sessionID = tab.agentSession?.id,
+                  let taskID = agentTaskRegistry?
+                    .taskID(forSessionID: sessionID) else {
+                continue
+            }
+            settledTaskIDsByTerminal[tab.id] = taskID
+        }
+        return PineAgentLaunchAuthorization(
+            identities: identities,
+            settledTaskIDsByTerminal: settledTaskIDsByTerminal
+        )
+    }
+
+    /// Pins every exact launch covered by the preflight while the user reads
+    /// Quit sheets. The registry retains the claim's remaining lease rather
+    /// than charging unbounded human decision time against a short TTL.
+    func pauseAuthorizedAgentLaunchesForTerminationDecision(
+        _ authorization: PineAgentLaunchAuthorization
+    ) -> Bool {
+        agentTaskRegistry?.pauseLaunchExpirationForTerminationDecision(
+            authorization.reservations
+        ) ?? authorization.reservations.isEmpty
+    }
+
+    /// Releases a cancelled Quit's lease and drops acknowledgement-only UI
+    /// state. Armed reservations remain represented by `launchReservations`;
+    /// an acknowledgement whose durable claim disappeared must not continue
+    /// authorizing later destructive actions.
+    func cancelAuthorizedAgentLaunchTerminationDecision(
+        _ authorization: PineAgentLaunchAuthorization
+    ) {
+        agentTaskRegistry?.resumeLaunchExpirationAfterTerminationDecision(
+            authorization.reservations
+        )
+        acknowledgedAgentLaunches.removeAll()
+    }
+
+    /// Waits for every exact PTY write covered by the user's decision to
+    /// settle. Pine performs another persistence barrier after this returns,
+    /// so a late successful acknowledgement cannot be killed without its
+    /// durable interruption marker.
+    func waitForAuthorizedAgentLaunchSettlement(
+        _ authorization: PineAgentLaunchAuthorization,
+        until deadline: DispatchTime
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        while authorization.identities.contains(where: { identity in
+            launchWritesInFlight[identity.terminalID] == identity.reservation
+        }) {
+            let now = DispatchTime.now().uptimeNanoseconds
+            guard now < deadline.uptimeNanoseconds else { return false }
+            let remaining = deadline.uptimeNanoseconds - now
+            do {
+                try await clock.sleep(for: .nanoseconds(Int64(clamping: min(
+                    remaining,
+                    5_000_000
+                ))))
+            } catch {
+                return false
+            }
+        }
+        return true
     }
 
     /// Captures the detector boundary and reserves durable identity for the
@@ -379,6 +473,9 @@ final class TerminalManager {
         if launchReservations[tab.id] == reservation {
             launchReservations[tab.id] = nil
         }
+        if acknowledgedAgentLaunches[tab.id] == reservation {
+            acknowledgedAgentLaunches[tab.id] = nil
+        }
         agentTaskRegistry?.cancelLaunch(reservation)
     }
 
@@ -469,6 +566,7 @@ final class TerminalManager {
     func cancelAgentTaskTermination() {
         guard agentTaskCallbacksFrozen else { return }
         agentTaskCallbacksFrozen = false
+        acknowledgedAgentLaunches.removeAll()
         if paneManager?.allTerminalTabs.isEmpty == false {
             if let agentCoordinator {
                 agentCoordinator.start()

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -46,17 +46,22 @@ struct PineAgentLaunchAuthorization {
     /// decision. A raw tab id or a newly observed process group is insufficient.
     func coversLaunch(
         in terminalID: UUID,
+        settledSessionID: UUID?,
         current: PineAgentLaunchAuthorization
     ) -> Bool {
         let authorizedLaunches = identities.union(
             settledIdentities.map(\.launch)
         )
+        if let settledSessionID {
+            return current.settledIdentities.contains { settled in
+                settled.launch.terminalID == terminalID
+                    && settled.sessionID == settledSessionID
+                    && authorizedLaunches.contains(settled.launch)
+            }
+        }
         return current.identities.contains { identity in
             identity.terminalID == terminalID
                 && authorizedLaunches.contains(identity)
-        } || current.settledIdentities.contains { settled in
-            settled.launch.terminalID == terminalID
-                && authorizedLaunches.contains(settled.launch)
         }
     }
 

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -14,6 +14,22 @@ nonisolated enum AgentTaskRecoveryLaunchResult: Equatable, Sendable {
     case rejected
 }
 
+nonisolated struct PineAgentLaunchIdentity: Hashable, Sendable {
+    let terminalID: UUID
+    let reservation: AgentTaskLaunchReservation
+}
+
+@MainActor
+struct PineAgentLaunchAuthorization {
+    fileprivate let identities: Set<PineAgentLaunchIdentity>
+
+    var requiresConfirmation: Bool { !identities.isEmpty }
+
+    func stillCovers(_ current: PineAgentLaunchAuthorization) -> Bool {
+        current.identities.isSubset(of: identities)
+    }
+}
+
 @MainActor
 @Observable
 final class TerminalManager {
@@ -49,7 +65,15 @@ final class TerminalManager {
     @ObservationIgnored
     private var launchReservations: [UUID: AgentTaskLaunchReservation] = [:]
     @ObservationIgnored
-    private var launchWritesInFlight: Set<UUID> = []
+    private var launchWritesInFlight: [
+        UUID: AgentTaskLaunchReservation
+    ] = [:]
+    /// A successful PTY write remains destructive work even when its durable
+    /// claim expires or cannot be armed before detector evidence arrives.
+    @ObservationIgnored
+    private var acknowledgedAgentLaunches: [
+        UUID: AgentTaskLaunchReservation
+    ] = [:]
 
     /// `true` once agent-detection polling has started. Read-only diagnostic /
     /// test hook. Delegates to the coordinator's `isRunning` so it correctly
@@ -102,6 +126,7 @@ final class TerminalManager {
             ) {
                 agentTaskRegistry?.cancelLaunch(reservation)
             }
+            self?.acknowledgedAgentLaunches.removeValue(forKey: terminalID)
             agentTaskRegistry?.markTerminalClosed(
                 terminalID: terminalID,
                 project: project
@@ -170,7 +195,32 @@ final class TerminalManager {
         if let ownedReservation,
            !agentTaskRegistry.isLaunchPending(ownedReservation) {
             launchReservations[tab.id] = nil
+            acknowledgedAgentLaunches[tab.id] = nil
         }
+    }
+
+    func capturePineAgentLaunchAuthorization()
+        -> PineAgentLaunchAuthorization {
+        var identities = Set<PineAgentLaunchIdentity>()
+        for (terminalID, reservation) in launchReservations {
+            identities.insert(PineAgentLaunchIdentity(
+                terminalID: terminalID,
+                reservation: reservation
+            ))
+        }
+        for (terminalID, reservation) in launchWritesInFlight {
+            identities.insert(PineAgentLaunchIdentity(
+                terminalID: terminalID,
+                reservation: reservation
+            ))
+        }
+        for (terminalID, reservation) in acknowledgedAgentLaunches {
+            identities.insert(PineAgentLaunchIdentity(
+                terminalID: terminalID,
+                reservation: reservation
+            ))
+        }
+        return PineAgentLaunchAuthorization(identities: identities)
     }
 
     /// Captures the detector boundary and reserves durable identity for the
@@ -251,6 +301,10 @@ final class TerminalManager {
         agentTaskCallbacksFrozen
     }
 
+    var hasAcknowledgedAgentLaunchForTesting: Bool {
+        !acknowledgedAgentLaunches.isEmpty
+    }
+
     func launchAgentCommandForTesting(
         _ command: String,
         descriptor: AgentDescriptor,
@@ -281,7 +335,7 @@ final class TerminalManager {
                 ? .sentWithoutReservation
                 : .rejected
         }
-        guard !launchWritesInFlight.contains(tab.id) else {
+        guard launchWritesInFlight[tab.id] == nil else {
             return .rejected
         }
         if let existing = launchReservations[tab.id],
@@ -297,13 +351,14 @@ final class TerminalManager {
         guard case .reserved(let reservation) = result else {
             return .rejected
         }
-        launchWritesInFlight.insert(tab.id)
+        launchWritesInFlight[tab.id] = reservation
         let acknowledged = await acknowledgedWrite()
-        launchWritesInFlight.remove(tab.id)
+        launchWritesInFlight[tab.id] = nil
         guard acknowledged else {
             cancelAgentLaunch(reservation, in: tab)
             return .rejected
         }
+        acknowledgedAgentLaunches[tab.id] = reservation
         guard launchReservations[tab.id] == reservation,
               agentTaskRegistry?.armLaunch(reservation) == true else {
             cancelAgentLaunch(reservation, in: tab)
@@ -336,18 +391,19 @@ final class TerminalManager {
               let task = agentTaskRegistry.task(for: taskID),
               task.descriptor.launchExecutable == command,
               Self.exactAgentLaunchDescriptor(for: command) == task.descriptor,
-              !launchWritesInFlight.contains(tab.id) else {
+              launchWritesInFlight[tab.id] == nil else {
             return .rejected
         }
         let result = prepareAgentResume(taskID: taskID, in: tab)
         guard case .reserved(let reservation) = result else { return result }
-        launchWritesInFlight.insert(tab.id)
+        launchWritesInFlight[tab.id] = reservation
         let acknowledged = await tab.sendTextAcknowledged(command + "\n")
-        launchWritesInFlight.remove(tab.id)
+        launchWritesInFlight[tab.id] = nil
         guard acknowledged else {
             cancelAgentLaunch(reservation, in: tab)
             return .rejected
         }
+        acknowledgedAgentLaunches[tab.id] = reservation
         guard launchReservations[tab.id] == reservation,
               agentTaskRegistry.armLaunch(reservation) else {
             cancelAgentLaunch(reservation, in: tab)

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -445,9 +445,18 @@ final class TerminalManager {
         guard case .reserved(let reservation) = result else {
             return .rejected
         }
+        guard agentTaskRegistry?.pauseLaunchExpirationForAcknowledgedWrite(
+            reservation
+        ) == true else {
+            cancelAgentLaunch(reservation, in: tab)
+            return .rejected
+        }
         launchWritesInFlight[tab.id] = reservation
         let acknowledged = await acknowledgedWrite()
         launchWritesInFlight[tab.id] = nil
+        agentTaskRegistry?.resumeLaunchExpirationAfterAcknowledgedWrite(
+            reservation
+        )
         guard acknowledged else {
             cancelAgentLaunch(reservation, in: tab)
             return .rejected
@@ -493,9 +502,18 @@ final class TerminalManager {
         }
         let result = prepareAgentResume(taskID: taskID, in: tab)
         guard case .reserved(let reservation) = result else { return result }
+        guard agentTaskRegistry.pauseLaunchExpirationForAcknowledgedWrite(
+            reservation
+        ) else {
+            cancelAgentLaunch(reservation, in: tab)
+            return .rejected
+        }
         launchWritesInFlight[tab.id] = reservation
         let acknowledged = await tab.sendTextAcknowledged(command + "\n")
         launchWritesInFlight[tab.id] = nil
+        agentTaskRegistry.resumeLaunchExpirationAfterAcknowledgedWrite(
+            reservation
+        )
         guard acknowledged else {
             cancelAgentLaunch(reservation, in: tab)
             return .rejected

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -19,15 +19,26 @@ nonisolated struct PineAgentLaunchIdentity: Hashable, Sendable {
     let reservation: AgentTaskLaunchReservation
 }
 
+nonisolated struct PineAgentSettledLaunchIdentity: Hashable, Sendable {
+    let launch: PineAgentLaunchIdentity
+    let sessionID: UUID
+}
+
 @MainActor
 struct PineAgentLaunchAuthorization {
     fileprivate let identities: Set<PineAgentLaunchIdentity>
-    fileprivate let settledTaskIDsByTerminal: [UUID: UUID]
+    fileprivate let settledIdentities: Set<PineAgentSettledLaunchIdentity>
 
     var requiresConfirmation: Bool { !identities.isEmpty }
 
     func stillCovers(_ current: PineAgentLaunchAuthorization) -> Bool {
-        current.identities.isSubset(of: identities)
+        let authorizedLaunches = identities.union(
+            settledIdentities.map(\.launch)
+        )
+        return current.identities.isSubset(of: authorizedLaunches)
+            && current.settledIdentities.allSatisfy {
+                authorizedLaunches.contains($0.launch)
+            }
     }
 
     /// Covers an idle-to-foreground transition only when the current terminal
@@ -37,13 +48,15 @@ struct PineAgentLaunchAuthorization {
         in terminalID: UUID,
         current: PineAgentLaunchAuthorization
     ) -> Bool {
-        current.identities.contains { identity in
+        let authorizedLaunches = identities.union(
+            settledIdentities.map(\.launch)
+        )
+        return current.identities.contains { identity in
             identity.terminalID == terminalID
-                && identities.contains(identity)
-        } || identities.contains { identity in
-            identity.terminalID == terminalID
-                && current.settledTaskIDsByTerminal[terminalID]
-                    == identity.reservation.taskID
+                && authorizedLaunches.contains(identity)
+        } || current.settledIdentities.contains { settled in
+            settled.launch.terminalID == terminalID
+                && authorizedLaunches.contains(settled.launch)
         }
     }
 
@@ -95,6 +108,13 @@ final class TerminalManager {
     @ObservationIgnored
     private var acknowledgedAgentLaunches: [
         UUID: AgentTaskLaunchReservation
+    ] = [:]
+    /// Exact reservation-to-session lineage retained after the registry
+    /// consumes a launch claim. A durable task id can span many resumes and
+    /// is therefore never sufficient destructive authorization by itself.
+    @ObservationIgnored
+    private var settledAgentLaunches: [
+        UUID: PineAgentSettledLaunchIdentity
     ] = [:]
 
     /// `true` once agent-detection polling has started. Read-only diagnostic /
@@ -149,6 +169,7 @@ final class TerminalManager {
                 agentTaskRegistry?.cancelLaunch(reservation)
             }
             self?.acknowledgedAgentLaunches.removeValue(forKey: terminalID)
+            self?.settledAgentLaunches.removeValue(forKey: terminalID)
             agentTaskRegistry?.markTerminalClosed(
                 terminalID: terminalID,
                 project: project
@@ -200,6 +221,9 @@ final class TerminalManager {
               let base = agentTaskContext(for: tab),
               let agentTaskRegistry else { return }
         let ownedReservation = reservation ?? launchReservations[tab.id]
+        if settledAgentLaunches[tab.id]?.sessionID != session.id {
+            settledAgentLaunches[tab.id] = nil
+        }
         let context = AgentTaskBridgeContext(
             project: base.project,
             route: base.route,
@@ -214,6 +238,18 @@ final class TerminalManager {
             context: context,
             reservation: ownedReservation
         )
+        if let ownedReservation,
+           !agentTaskRegistry.isLaunchPending(ownedReservation),
+           agentTaskRegistry.taskID(forSessionID: session.id)
+                == ownedReservation.taskID {
+            settledAgentLaunches[tab.id] = PineAgentSettledLaunchIdentity(
+                launch: PineAgentLaunchIdentity(
+                    terminalID: tab.id,
+                    reservation: ownedReservation
+                ),
+                sessionID: session.id
+            )
+        }
         if let ownedReservation,
            !agentTaskRegistry.isLaunchPending(ownedReservation) {
             launchReservations[tab.id] = nil
@@ -251,18 +287,25 @@ final class TerminalManager {
                 reservation: reservation
             ))
         }
-        var settledTaskIDsByTerminal: [UUID: UUID] = [:]
-        for tab in allTerminalTabs {
-            guard let sessionID = tab.agentSession?.id,
-                  let taskID = agentTaskRegistry?
-                    .taskID(forSessionID: sessionID) else {
-                continue
+        let tabsByID = Dictionary(
+            uniqueKeysWithValues: allTerminalTabs.map { ($0.id, $0) }
+        )
+        let staleSettledTerminalIDs = settledAgentLaunches.compactMap { terminalID, settled in
+            guard let tab = tabsByID[terminalID],
+                  tab.agentSession?.id == settled.sessionID,
+                  agentTaskRegistry?.taskID(
+                      forSessionID: settled.sessionID
+                  ) == settled.launch.reservation.taskID else {
+                return terminalID
             }
-            settledTaskIDsByTerminal[tab.id] = taskID
+            return nil
+        }
+        for terminalID in staleSettledTerminalIDs {
+            settledAgentLaunches[terminalID] = nil
         }
         return PineAgentLaunchAuthorization(
             identities: identities,
-            settledTaskIDsByTerminal: settledTaskIDsByTerminal
+            settledIdentities: Set(settledAgentLaunches.values)
         )
     }
 

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -463,7 +463,7 @@ final class TerminalManager {
     func freezeAgentTasksForTermination() {
         guard !agentTaskCallbacksFrozen else { return }
         agentTaskCallbacksFrozen = true
-        agentCoordinator?.stop()
+        agentCoordinator?.suspendForTermination()
     }
 
     func cancelAgentTaskTermination() {

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -12,10 +12,21 @@ import SwiftTerm
 import os
 
 nonisolated enum AcknowledgedPTYWriter {
+    struct DescriptorIdentity: Equatable, Sendable {
+        let device: UInt64
+        let inode: UInt64
+        let fileType: UInt16
+    }
+
     static func write(_ bytes: [UInt8], to borrowedDescriptor: Int32) async -> Bool {
-        await write(
+        guard let expectedIdentity = descriptorIdentity(borrowedDescriptor),
+              let descriptor = acquireDescriptor(
+                  borrowedDescriptor,
+                  expectedIdentity: expectedIdentity
+              ) else { return false }
+        return await write(
             bytes,
-            to: borrowedDescriptor,
+            toOwnedDescriptor: descriptor,
             didAcquireDescriptor: {}
         )
     }
@@ -26,9 +37,14 @@ nonisolated enum AcknowledgedPTYWriter {
         to borrowedDescriptor: Int32,
         didAcquireDescriptor: @escaping @Sendable () -> Void
     ) async -> Bool {
-        await write(
+        guard let expectedIdentity = descriptorIdentity(borrowedDescriptor),
+              let descriptor = acquireDescriptor(
+                  borrowedDescriptor,
+                  expectedIdentity: expectedIdentity
+              ) else { return false }
+        return await write(
             bytes,
-            to: borrowedDescriptor,
+            toOwnedDescriptor: descriptor,
             didAcquireDescriptor: didAcquireDescriptor
         )
     }
@@ -41,17 +57,44 @@ nonisolated enum AcknowledgedPTYWriter {
         error == 0 && remainingByteCount == 0
     }
 
-    private static func write(
-        _ bytes: [UInt8],
-        to borrowedDescriptor: Int32,
-        didAcquireDescriptor: @escaping @Sendable () -> Void
-    ) async -> Bool {
+    static func descriptorIdentity(
+        _ descriptor: Int32
+    ) -> DescriptorIdentity? {
+        var status = stat()
+        guard Darwin.fstat(descriptor, &status) == 0 else { return nil }
+        return DescriptorIdentity(
+            device: UInt64(status.st_dev),
+            inode: UInt64(status.st_ino),
+            fileType: UInt16(status.st_mode & S_IFMT)
+        )
+    }
+
+    static func acquireDescriptor(
+        _ borrowedDescriptor: Int32,
+        expectedIdentity: DescriptorIdentity
+    ) -> Int32? {
+        guard descriptorIdentity(borrowedDescriptor) == expectedIdentity else {
+            return nil
+        }
         let descriptor = Darwin.fcntl(
             borrowedDescriptor,
             F_DUPFD_CLOEXEC,
             0
         )
-        guard descriptor >= 0 else { return false }
+        guard descriptor >= 0 else { return nil }
+        guard descriptorIdentity(borrowedDescriptor) == expectedIdentity,
+              descriptorIdentity(descriptor) == expectedIdentity else {
+            Darwin.close(descriptor)
+            return nil
+        }
+        return descriptor
+    }
+
+    static func write(
+        _ bytes: [UInt8],
+        toOwnedDescriptor descriptor: Int32,
+        didAcquireDescriptor: @escaping @Sendable () -> Void
+    ) async -> Bool {
         defer { Darwin.close(descriptor) }
         didAcquireDescriptor()
         let data = bytes.withUnsafeBytes { DispatchData(bytes: $0) }
@@ -1708,6 +1751,8 @@ final class TerminalTab: Identifiable, Hashable {
     private let shellSettings: ShellSettings
     private let agentHandoffSettings: AgentHandoffSettings
     private var processStarted = false
+    private var acknowledgedPTYIdentity:
+        AcknowledgedPTYWriter.DescriptorIdentity?
     private var workingDirectory: URL?
     private var initialProcess: TerminalInitialProcess?
 
@@ -1960,6 +2005,9 @@ final class TerminalTab: Identifiable, Hashable {
             execName: nil,
             currentDirectory: dir
         )
+        acknowledgedPTYIdentity = AcknowledgedPTYWriter.descriptorIdentity(
+            terminalView.process.childfd
+        )
     }
 
     func stop() {
@@ -1969,6 +2017,7 @@ final class TerminalTab: Identifiable, Hashable {
         }
         guard !isTerminated else { return }
         isTerminated = true
+        acknowledgedPTYIdentity = nil
         terminalView.terminate()
     }
 
@@ -1978,6 +2027,7 @@ final class TerminalTab: Identifiable, Hashable {
             onLifecycleEnded?(id)
         }
         isTerminated = true
+        acknowledgedPTYIdentity = nil
     }
 
     /// Forces SwiftTerm to mark the entire visible buffer as dirty and asks
@@ -2068,6 +2118,8 @@ final class TerminalTab: Identifiable, Hashable {
     /// running. Used by `AgentDetectionCoordinator` (#951).
     #if DEBUG
     var foregroundProcessIDOverrideForTesting: Int32?
+    var foregroundStartOverrideForTesting:
+        TerminalProcessStartIdentity?
     #endif
 
     var foregroundProcessID: Int32 {
@@ -2083,6 +2135,33 @@ final class TerminalTab: Identifiable, Hashable {
         let shellPid = terminalView.process.shellPid
         guard foregroundPgid > 0, foregroundPgid != shellPid else { return -1 }
         return foregroundPgid
+    }
+
+    var foregroundProcessStartIdentity: TerminalProcessStartIdentity? {
+        let processGroupID = foregroundProcessID
+        guard processGroupID > 0 else { return nil }
+        #if DEBUG
+        if foregroundProcessIDOverrideForTesting != nil {
+            return foregroundStartOverrideForTesting
+                ?? TerminalProcessStartIdentity(seconds: 0, microseconds: 0)
+        }
+        #endif
+        var info = proc_bsdinfo()
+        let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.size)
+        guard proc_pidinfo(
+            processGroupID,
+            PROC_PIDTBSDINFO,
+            0,
+            &info,
+            expectedSize
+        ) == expectedSize,
+              info.pbi_pid == UInt32(processGroupID) else {
+            return nil
+        }
+        return TerminalProcessStartIdentity(
+            seconds: Int64(info.pbi_start_tvsec),
+            microseconds: Int32(info.pbi_start_tvusec)
+        )
     }
 
     // MARK: - Search
@@ -2194,10 +2273,19 @@ final class TerminalTab: Identifiable, Hashable {
     /// while the write is pending without redirecting bytes after descriptor reuse.
     func sendTextAcknowledged(_ text: String) async -> Bool {
         guard isProcessRunning else { return false }
-        let descriptor = terminalView.process.childfd
-        guard descriptor >= 0 else { return false }
+        let borrowedDescriptor = terminalView.process.childfd
+        guard borrowedDescriptor >= 0,
+              let acknowledgedPTYIdentity,
+              let descriptor = AcknowledgedPTYWriter.acquireDescriptor(
+                  borrowedDescriptor,
+                  expectedIdentity: acknowledgedPTYIdentity
+              ) else { return false }
         let bytes = Array(text.utf8)
-        return await AcknowledgedPTYWriter.write(bytes, to: descriptor)
+        return await AcknowledgedPTYWriter.write(
+            bytes,
+            toOwnedDescriptor: descriptor,
+            didAcquireDescriptor: {}
+        )
     }
 
     static func == (lhs: TerminalTab, rhs: TerminalTab) -> Bool { lhs.id == rhs.id }

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -13,9 +13,12 @@ import os
 
 nonisolated enum AcknowledgedPTYWriter {
     struct DescriptorIdentity: Equatable, Sendable {
-        let device: UInt64
-        let inode: UInt64
-        let fileType: UInt16
+        // Preserve Darwin's native signedness. PTY device identifiers may use
+        // the high bit of `dev_t`; a checked conversion to UInt64 traps on
+        // those perfectly valid descriptors (notably on macOS 27).
+        let device: dev_t
+        let inode: ino_t
+        let fileType: mode_t
     }
 
     static func write(_ bytes: [UInt8], to borrowedDescriptor: Int32) async -> Bool {
@@ -63,9 +66,9 @@ nonisolated enum AcknowledgedPTYWriter {
         var status = stat()
         guard Darwin.fstat(descriptor, &status) == 0 else { return nil }
         return DescriptorIdentity(
-            device: UInt64(status.st_dev),
-            inode: UInt64(status.st_ino),
-            fileType: UInt16(status.st_mode & S_IFMT)
+            device: status.st_dev,
+            inode: status.st_ino,
+            fileType: status.st_mode & S_IFMT
         )
     }
 
@@ -2137,30 +2140,69 @@ final class TerminalTab: Identifiable, Hashable {
         return foregroundPgid
     }
 
-    var foregroundProcessStartIdentity: TerminalProcessStartIdentity? {
-        let processGroupID = foregroundProcessID
-        guard processGroupID > 0 else { return nil }
+    func foregroundProcessIdentity(
+        in processGroupID: pid_t
+    ) -> TerminalProcessStartIdentity? {
+        guard processGroupID > 1 else { return nil }
         #if DEBUG
         if foregroundProcessIDOverrideForTesting != nil {
             return foregroundStartOverrideForTesting
-                ?? TerminalProcessStartIdentity(seconds: 0, microseconds: 0)
         }
         #endif
-        var info = proc_bsdinfo()
-        let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.size)
-        guard proc_pidinfo(
-            processGroupID,
-            PROC_PIDTBSDINFO,
-            0,
-            &info,
-            expectedSize
-        ) == expectedSize,
-              info.pbi_pid == UInt32(processGroupID) else {
+
+        let processIDs: [pid_t]
+        switch UserTaskProcessInspector.processIDs(inGroup: processGroupID) {
+        case .known(let members):
+            // Prefer the leader while it exists, but retain a concrete live
+            // member as the generation witness after a pipeline's leader has
+            // exited and been reaped.
+            processIDs = Array(Set(members + [processGroupID])).sorted {
+                if $0 == processGroupID { return true }
+                if $1 == processGroupID { return false }
+                return $0 < $1
+            }
+        case .unknown:
+            processIDs = [processGroupID]
+        }
+
+        return processIDs.lazy.compactMap { processID in
+            Self.processIdentity(
+                processID: processID,
+                processGroupID: processGroupID
+            )
+        }.first
+    }
+
+    func foregroundProcessIdentityStillMatches(
+        _ identity: TerminalProcessStartIdentity,
+        in processGroupID: pid_t
+    ) -> Bool {
+        #if DEBUG
+        if foregroundProcessIDOverrideForTesting != nil {
+            return foregroundStartOverrideForTesting == identity
+        }
+        #endif
+        return Self.processIdentity(
+            processID: identity.processID,
+            processGroupID: processGroupID
+        ) == identity
+    }
+
+    nonisolated private static func processIdentity(
+        processID: pid_t,
+        processGroupID: pid_t
+    ) -> TerminalProcessStartIdentity? {
+        guard processID > 1,
+              Darwin.getpgid(processID) == processGroupID,
+              let identity = UserTaskProcessInspector.identity(for: processID),
+              Darwin.getpgid(processID) == processGroupID,
+              UserTaskProcessInspector.identity(for: processID) == identity else {
             return nil
         }
         return TerminalProcessStartIdentity(
-            seconds: Int64(info.pbi_start_tvsec),
-            microseconds: Int32(info.pbi_start_tvusec)
+            processID: identity.processID,
+            seconds: identity.startSeconds,
+            microseconds: identity.startMicroseconds
         )
     }
 

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -11,102 +11,144 @@ import SwiftUI
 import SwiftTerm
 import os
 
-nonisolated enum AcknowledgedPTYWriter {
-    struct DescriptorIdentity: Equatable, Sendable {
-        // Preserve Darwin's native signedness. PTY device identifiers may use
-        // the high bit of `dev_t`; a checked conversion to UInt64 traps on
-        // those perfectly valid descriptors (notably on macOS 27).
-        let device: dev_t
-        let inode: ino_t
-        let fileType: mode_t
-    }
+/// Owns the exact PTY open-file description Pine received from SwiftTerm.
+///
+/// A `(device, inode, file type)` snapshot is not a lifetime token: after
+/// SwiftTerm closes its public `childfd`, another PTY can reuse both the file
+/// descriptor and the same `stat` values. Duplicating once, immediately after
+/// `startProcess`, pins the original open-file description instead. Every
+/// acknowledged write is then duplicated from this Pine-owned descriptor,
+/// never from SwiftTerm's later, borrowed integer.
+nonisolated final class PinePTYDescriptorLease: @unchecked Sendable {
+    final class WriteDescriptor: @unchecked Sendable {
+        let rawValue: Int32
+        private let owner: PinePTYDescriptorLease
+        private let lock = NSLock()
+        private var isFinished = false
 
-    static func write(_ bytes: [UInt8], to borrowedDescriptor: Int32) async -> Bool {
-        guard let expectedIdentity = descriptorIdentity(borrowedDescriptor),
-              let descriptor = acquireDescriptor(
-                  borrowedDescriptor,
-                  expectedIdentity: expectedIdentity
-              ) else { return false }
-        return await write(
-            bytes,
-            toOwnedDescriptor: descriptor,
-            didAcquireDescriptor: {}
-        )
-    }
-
-    #if DEBUG
-    static func writeForTesting(
-        _ bytes: [UInt8],
-        to borrowedDescriptor: Int32,
-        didAcquireDescriptor: @escaping @Sendable () -> Void
-    ) async -> Bool {
-        guard let expectedIdentity = descriptorIdentity(borrowedDescriptor),
-              let descriptor = acquireDescriptor(
-                  borrowedDescriptor,
-                  expectedIdentity: expectedIdentity
-              ) else { return false }
-        return await write(
-            bytes,
-            toOwnedDescriptor: descriptor,
-            didAcquireDescriptor: didAcquireDescriptor
-        )
-    }
-    #endif
-
-    static func acknowledgesCompletion(
-        error: Int32,
-        remainingByteCount: Int
-    ) -> Bool {
-        error == 0 && remainingByteCount == 0
-    }
-
-    static func descriptorIdentity(
-        _ descriptor: Int32
-    ) -> DescriptorIdentity? {
-        var status = stat()
-        guard Darwin.fstat(descriptor, &status) == 0 else { return nil }
-        return DescriptorIdentity(
-            device: status.st_dev,
-            inode: status.st_ino,
-            fileType: status.st_mode & S_IFMT
-        )
-    }
-
-    static func acquireDescriptor(
-        _ borrowedDescriptor: Int32,
-        expectedIdentity: DescriptorIdentity
-    ) -> Int32? {
-        guard descriptorIdentity(borrowedDescriptor) == expectedIdentity else {
-            return nil
+        fileprivate init(
+            rawValue: Int32,
+            owner: PinePTYDescriptorLease
+        ) {
+            self.rawValue = rawValue
+            self.owner = owner
         }
+
+        func finish() {
+            lock.lock()
+            guard !isFinished else {
+                lock.unlock()
+                return
+            }
+            isFinished = true
+            lock.unlock()
+            owner.releaseWriteDescriptor(rawValue)
+        }
+
+        deinit {
+            finish()
+        }
+    }
+
+    private let lock = NSLock()
+    private var ownedDescriptor: Int32 = -1
+    private var writeDescriptors: Set<Int32> = []
+    private var isInvalidated = false
+
+    /// Pins the borrowed descriptor exactly once for this terminal lifecycle.
+    /// The duplicate happens synchronously before `startIfNeeded()` returns.
+    func acquire(borrowing borrowedDescriptor: Int32) -> Bool {
+        guard borrowedDescriptor >= 0 else { return false }
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isInvalidated, ownedDescriptor < 0 else { return false }
         let descriptor = Darwin.fcntl(
             borrowedDescriptor,
             F_DUPFD_CLOEXEC,
             0
         )
-        guard descriptor >= 0 else { return nil }
-        guard descriptorIdentity(borrowedDescriptor) == expectedIdentity,
-              descriptorIdentity(descriptor) == expectedIdentity else {
-            Darwin.close(descriptor)
-            return nil
-        }
-        return descriptor
+        guard descriptor >= 0 else { return false }
+        ownedDescriptor = descriptor
+        return true
     }
 
+    /// Duplicates only the Pine-owned lease, synchronously, before an async
+    /// write can suspend. The returned token closes exactly once even when
+    /// terminal teardown invalidates all outstanding writes first.
+    func acquireWriteDescriptor() -> WriteDescriptor? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isInvalidated, ownedDescriptor >= 0 else { return nil }
+        let descriptor = Darwin.fcntl(
+            ownedDescriptor,
+            F_DUPFD_CLOEXEC,
+            0
+        )
+        guard descriptor >= 0 else { return nil }
+        writeDescriptors.insert(descriptor)
+        return WriteDescriptor(rawValue: descriptor, owner: self)
+    }
+
+    /// Closes the persistent lease and rejects new writes before SwiftTerm
+    /// terminates its process. An already-acquired write descriptor remains
+    /// owned until its DispatchIO completion: closing it early would let the
+    /// integer be reused and recreate the very ABA write-redirection hazard
+    /// this lease prevents. Those small launch writes are the only bounded
+    /// lifetime by which Pine can extend the PTY master after invalidation.
+    func invalidate() {
+        lock.lock()
+        guard !isInvalidated else {
+            lock.unlock()
+            return
+        }
+        isInvalidated = true
+        let descriptor = ownedDescriptor
+        ownedDescriptor = -1
+        lock.unlock()
+
+        if descriptor >= 0 {
+            Darwin.close(descriptor)
+        }
+    }
+
+    #if DEBUG
+    var isActiveForTesting: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !isInvalidated && ownedDescriptor >= 0
+    }
+    #endif
+
+    private func releaseWriteDescriptor(_ descriptor: Int32) {
+        lock.lock()
+        let wasOwned = writeDescriptors.remove(descriptor) != nil
+        lock.unlock()
+        if wasOwned {
+            Darwin.close(descriptor)
+        }
+    }
+
+    deinit {
+        invalidate()
+    }
+}
+
+nonisolated enum AcknowledgedPTYWriter {
+    /// The caller acquires the exact descriptor synchronously on MainActor;
+    /// the I/O itself is deliberately nonisolated because DispatchIO invokes
+    /// its completion on the supplied background queue.
     static func write(
         _ bytes: [UInt8],
-        toOwnedDescriptor descriptor: Int32,
-        didAcquireDescriptor: @escaping @Sendable () -> Void
+        to descriptor: PinePTYDescriptorLease.WriteDescriptor
     ) async -> Bool {
-        defer { Darwin.close(descriptor) }
-        didAcquireDescriptor()
         let data = bytes.withUnsafeBytes { DispatchData(bytes: $0) }
         return await withCheckedContinuation { continuation in
             DispatchIO.write(
-                toFileDescriptor: descriptor,
+                toFileDescriptor: descriptor.rawValue,
                 data: data,
                 runningHandlerOn: DispatchQueue.global(qos: .userInitiated)
             ) { remaining, error in
+                descriptor.finish()
                 continuation.resume(returning:
                     AcknowledgedPTYWriter.acknowledgesCompletion(
                         error: error,
@@ -116,6 +158,14 @@ nonisolated enum AcknowledgedPTYWriter {
             }
         }
     }
+
+    static func acknowledgesCompletion(
+        error: Int32,
+        remainingByteCount: Int
+    ) -> Bool {
+        error == 0 && remainingByteCount == 0
+    }
+
 }
 
 /// Pine-specific terminal view wrapper.
@@ -1754,8 +1804,10 @@ final class TerminalTab: Identifiable, Hashable {
     private let shellSettings: ShellSettings
     private let agentHandoffSettings: AgentHandoffSettings
     private var processStarted = false
-    private var acknowledgedPTYIdentity:
-        AcknowledgedPTYWriter.DescriptorIdentity?
+    /// Stable Pine-owned duplicate of SwiftTerm's master PTY. The holder has
+    /// its own lock so nonisolated `deinit` can close it safely as a final
+    /// lifecycle backstop.
+    private let acknowledgedPTYLease = PinePTYDescriptorLease()
     private var workingDirectory: URL?
     private var initialProcess: TerminalInitialProcess?
 
@@ -1844,6 +1896,7 @@ final class TerminalTab: Identifiable, Hashable {
     }
 
     deinit {
+        acknowledgedPTYLease.invalidate()
         if let themeChangeObserver {
             themeNotificationCenter.removeObserver(themeChangeObserver)
         }
@@ -2008,8 +2061,8 @@ final class TerminalTab: Identifiable, Hashable {
             execName: nil,
             currentDirectory: dir
         )
-        acknowledgedPTYIdentity = AcknowledgedPTYWriter.descriptorIdentity(
-            terminalView.process.childfd
+        _ = acknowledgedPTYLease.acquire(
+            borrowing: terminalView.process.childfd
         )
     }
 
@@ -2020,7 +2073,7 @@ final class TerminalTab: Identifiable, Hashable {
         }
         guard !isTerminated else { return }
         isTerminated = true
-        acknowledgedPTYIdentity = nil
+        acknowledgedPTYLease.invalidate()
         terminalView.terminate()
     }
 
@@ -2030,7 +2083,7 @@ final class TerminalTab: Identifiable, Hashable {
             onLifecycleEnded?(id)
         }
         isTerminated = true
-        acknowledgedPTYIdentity = nil
+        acknowledgedPTYLease.invalidate()
     }
 
     /// Forces SwiftTerm to mark the entire visible buffer as dirty and asks
@@ -2314,21 +2367,21 @@ final class TerminalTab: Identifiable, Hashable {
     /// reports that every byte was accepted. SwiftTerm may close its descriptor
     /// while the write is pending without redirecting bytes after descriptor reuse.
     func sendTextAcknowledged(_ text: String) async -> Bool {
-        guard isProcessRunning else { return false }
-        let borrowedDescriptor = terminalView.process.childfd
-        guard borrowedDescriptor >= 0,
-              let acknowledgedPTYIdentity,
-              let descriptor = AcknowledgedPTYWriter.acquireDescriptor(
-                  borrowedDescriptor,
-                  expectedIdentity: acknowledgedPTYIdentity
-              ) else { return false }
+        guard isProcessRunning,
+              let descriptor = acknowledgedPTYLease
+                .acquireWriteDescriptor() else { return false }
         let bytes = Array(text.utf8)
         return await AcknowledgedPTYWriter.write(
             bytes,
-            toOwnedDescriptor: descriptor,
-            didAcquireDescriptor: {}
+            to: descriptor
         )
     }
+
+    #if DEBUG
+    var hasAcknowledgedPTYLeaseForTesting: Bool {
+        acknowledgedPTYLease.isActiveForTesting
+    }
+    #endif
 
     static func == (lhs: TerminalTab, rhs: TerminalTab) -> Bool { lhs.id == rhs.id }
     func hash(into hasher: inout Hasher) { hasher.combine(id) }

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -2066,7 +2066,16 @@ final class TerminalTab: Identifiable, Hashable {
     /// The process group ID of the foreground process in this terminal, or
     /// `-1` if the shell itself is in the foreground or the process is not
     /// running. Used by `AgentDetectionCoordinator` (#951).
+    #if DEBUG
+    var foregroundProcessIDOverrideForTesting: Int32?
+    #endif
+
     var foregroundProcessID: Int32 {
+        #if DEBUG
+        if let foregroundProcessIDOverrideForTesting {
+            return foregroundProcessIDOverrideForTesting
+        }
+        #endif
         guard isProcessRunning else { return -1 }
         let fd = terminalView.process.childfd
         guard fd >= 0 else { return -1 }

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -2176,6 +2176,8 @@ final class TerminalTab: Identifiable, Hashable {
     var foregroundProcessIDOverrideForTesting: Int32?
     var foregroundStartOverrideForTesting:
         TerminalProcessStartIdentity?
+    var agentProcessIdentityResolverForTesting:
+        ((pid_t) -> TerminalProcessStartIdentity?)?
     #endif
 
     var foregroundProcessID: Int32 {
@@ -2239,6 +2241,24 @@ final class TerminalTab: Identifiable, Hashable {
             processID: identity.processID,
             processGroupID: processGroupID
         ) == identity
+    }
+
+    func agentProcessIdentityStillMatches(
+        _ identity: TerminalProcessStartIdentity
+    ) -> Bool {
+        #if DEBUG
+        if let agentProcessIdentityResolverForTesting {
+            return agentProcessIdentityResolverForTesting(
+                identity.processID
+            ) == identity
+        }
+        #endif
+        guard let current = UserTaskProcessInspector.identity(
+            for: identity.processID
+        ) else { return false }
+        return current.processID == identity.processID
+            && current.startSeconds == identity.seconds
+            && current.startMicroseconds == identity.microseconds
     }
 
     nonisolated private static func processIdentity(

--- a/Pine/TerminationSaveCoordinator.swift
+++ b/Pine/TerminationSaveCoordinator.swift
@@ -151,6 +151,12 @@ nonisolated enum TerminationSaveCoordinator {
         let metadata: TerminationInstalledFileMetadata
     }
 
+    private struct PublishedSwapRollback {
+        let stagingLeaf: String
+        let destinationLeaf: String
+        let displacedStatus: stat
+    }
+
     private static let deadlineQueue = DispatchQueue(
         label: "com.pine.termination-save-deadline",
         qos: .userInteractive
@@ -164,7 +170,10 @@ nonisolated enum TerminationSaveCoordinator {
 
     static func stage(
         _ requests: [TerminationSaveRequest],
-        until deadline: DispatchTime
+        until deadline: DispatchTime,
+        lateCompletion: @escaping @Sendable (
+            TerminationSaveStageResult
+        ) -> Void = { _ in }
     ) async -> TerminationSaveStageResult {
         let deadlineNanoseconds = deadline.uptimeNanoseconds
         guard DispatchTime.now().uptimeNanoseconds < deadlineNanoseconds else {
@@ -177,8 +186,18 @@ nonisolated enum TerminationSaveCoordinator {
                     requests,
                     deadlineNanoseconds: deadlineNanoseconds
                 )
-                if !resolver.resolve(result), case .ready(let staged) = result {
-                    cleanup(staged)
+                guard !resolver.resolve(result) else { return }
+                switch result {
+                case .ready(let staged):
+                    if case .failed(let message, let retainedArtifacts) =
+                        cleanup(staged) {
+                        lateCompletion(.failed(
+                            message: message,
+                            retainedArtifacts: retainedArtifacts
+                        ))
+                    }
+                case .failed, .timedOut:
+                    lateCompletion(result)
                 }
             }
             deadlineQueue.asyncAfter(deadline: deadline) {
@@ -315,7 +334,15 @@ nonisolated enum TerminationSaveCoordinator {
                     )
                     result = .installed(metadata: staged.installedMetadata)
                 } catch is CancellationError {
-                    result = .timedOut
+                    switch cleanup([staged]) {
+                    case .cleaned:
+                        result = .timedOut
+                    case .failed(let message, let retainedArtifacts):
+                        result = .failed(
+                            message: message,
+                            retainedArtifacts: retainedArtifacts
+                        )
+                    }
                 } catch {
                     result = .failed(
                         message: error.localizedDescription,
@@ -418,15 +445,18 @@ nonisolated enum TerminationSaveCoordinator {
             }
             return .ready(staged)
         } catch {
-            if case .failed(let message, let retainedArtifacts) = cleanup(staged) {
+            let errorArtifacts = retainedArtifacts(from: error)
+            if case .failed(let message, let cleanupArtifacts) = cleanup(staged) {
                 return .failed(
-                    message: message,
-                    retainedArtifacts: retainedArtifacts
+                    message: error.localizedDescription + "\n" + message,
+                    retainedArtifacts: Array(Set(
+                        errorArtifacts + cleanupArtifacts
+                    ))
                 )
             }
             return .failed(
                 message: error.localizedDescription,
-                retainedArtifacts: []
+                retainedArtifacts: errorArtifacts
             )
         }
     }
@@ -633,10 +663,27 @@ nonisolated enum TerminationSaveCoordinator {
 
         let expected = staged.request.expectedDestinationState
         if expected.exists {
-            let quarantineLeaf = ".pine-save-recovery-\(UUID().uuidString)"
-            let quarantineURL = parentURL.appendingPathComponent(quarantineLeaf)
             beforeDestinationQuarantine?()
             try checkDeadline(deadlineNanoseconds)
+            try verifyPinnedParentPath(
+                staged,
+                descriptor: parentDescriptor,
+                retainedLeaf: stagingLeaf
+            )
+            guard try stagingDescriptorIsAuthorized(
+                stagingDescriptor,
+                staged: staged,
+                deadlineNanoseconds: deadlineNanoseconds
+            ) else {
+                throw retainedRecoveryError(
+                    at: retainedArtifactURL(
+                        parentDescriptor: parentDescriptor,
+                        leaf: stagingLeaf,
+                        fallback: staged.stagingURL
+                    ),
+                    reason: "The staged save changed before publication"
+                )
+            }
             let destinationDescriptor = Darwin.openat(
                 parentDescriptor,
                 destinationLeaf,
@@ -653,44 +700,39 @@ nonisolated enum TerminationSaveCoordinator {
                       parentDescriptor: parentDescriptor,
                       leaf: destinationLeaf,
                       status: immediateSnapshot.status
-                  ) else {
+            ) else {
                 throw CocoaError(.fileWriteFileExists)
             }
-            guard renameExclusive(
+            try verifyPinnedParentPath(
+                staged,
+                descriptor: parentDescriptor,
+                retainedLeaf: stagingLeaf
+            )
+            guard renameSwap(
                 parentDescriptor: parentDescriptor,
-                source: destinationLeaf,
-                destination: quarantineLeaf
+                first: stagingLeaf,
+                second: destinationLeaf
             ) == 0 else {
                 throw posixError()
             }
-            var stagingWasPublished = false
             do {
                 try synchronizeDirectory(parentDescriptor)
+                afterDestinationPublication?()
                 let displacedSnapshot = try destinationSnapshot(
                     destinationDescriptor,
                     deadlineNanoseconds: deadlineNanoseconds
                 )
                 guard authorizedContentAndMetadataMatch(
-                    displacedSnapshot.state,
-                    expected: expected
-                ),
+                          displacedSnapshot.state,
+                          expected: immediateSnapshot.state
+                      ),
                       pathMatches(
                           parentDescriptor: parentDescriptor,
-                          leaf: quarantineLeaf,
+                          leaf: stagingLeaf,
                           status: displacedSnapshot.status
                       ) else {
                     throw CocoaError(.fileWriteFileExists)
                 }
-                try checkDeadline(deadlineNanoseconds)
-                guard renameExclusive(
-                    parentDescriptor: parentDescriptor,
-                    source: stagingLeaf,
-                    destination: destinationLeaf
-                ) == 0 else {
-                    throw posixError()
-                }
-                stagingWasPublished = true
-                afterDestinationPublication?()
                 try applyExistingDestinationMetadata(
                     from: destinationDescriptor,
                     status: displacedSnapshot.status,
@@ -700,67 +742,102 @@ nonisolated enum TerminationSaveCoordinator {
                     stagingDescriptor,
                     expected: expected,
                     deadlineNanoseconds: deadlineNanoseconds
+                ),
+                      try installedContentMatches(
+                          stagingDescriptor,
+                          staged: staged,
+                          deadlineNanoseconds: deadlineNanoseconds
+                      ),
+                      regularFileMatches(
+                          parentDescriptor: parentDescriptor,
+                          leaf: destinationLeaf,
+                          device: staged.stagingDevice,
+                          inode: staged.stagingInode
+                      )
+                else {
+                    throw CocoaError(.fileWriteFileExists)
+                }
+                try verifyPinnedParentPath(
+                    staged,
+                    descriptor: parentDescriptor,
+                    retainedLeaf: stagingLeaf
+                )
+                beforeRecoveryCleanup?()
+                try verifyPinnedParentPath(
+                    staged,
+                    descriptor: parentDescriptor,
+                    retainedLeaf: stagingLeaf
+                )
+                guard regularFileMatches(
+                    parentDescriptor: parentDescriptor,
+                    leaf: destinationLeaf,
+                    device: staged.stagingDevice,
+                    inode: staged.stagingInode
                 ) else {
+                    throw CocoaError(.fileWriteFileExists)
+                }
+                let cleanupSnapshot = try destinationSnapshot(
+                    destinationDescriptor,
+                    deadlineNanoseconds: deadlineNanoseconds
+                )
+                guard cleanupSnapshot.state == displacedSnapshot.state,
+                      pathMatches(
+                          parentDescriptor: parentDescriptor,
+                          leaf: stagingLeaf,
+                          status: cleanupSnapshot.status
+                      )
+                else {
                     throw CocoaError(.fileWriteFileExists)
                 }
             } catch {
                 let installError = error
-                if stagingWasPublished {
-                    try rollbackPublishedStaging(
-                        staged,
-                        stagingDescriptor: stagingDescriptor,
-                        parentDescriptor: parentDescriptor,
-                        quarantineLeaf: quarantineLeaf
-                    )
-                } else {
-                    var stagingSecurityError: Error?
-                    do {
-                        try resecureStaging(
-                            stagingDescriptor,
-                            at: staged.stagingURL
-                        )
-                    } catch {
-                        stagingSecurityError = error
-                    }
-                    try restoreOrRetainRecovery(
-                        parentDescriptor: parentDescriptor,
-                        quarantineLeaf: quarantineLeaf,
+                try rollbackPublishedSwap(
+                    staged,
+                    stagingDescriptor: stagingDescriptor,
+                    parentDescriptor: parentDescriptor,
+                    rollback: PublishedSwapRollback(
+                        stagingLeaf: stagingLeaf,
                         destinationLeaf: destinationLeaf,
-                        destinationURL: staged.request.destination
+                        displacedStatus: immediateSnapshot.status
                     )
-                    if let stagingSecurityError {
-                        throw stagingSecurityError
-                    }
-                }
-                throw installError
-            }
-            do {
-                try synchronizeDirectory(parentDescriptor)
-            } catch {
+                )
                 throw retainedRecoveryError(
-                    at: quarantineURL,
-                    reason: "The saved destination was installed, but its "
-                        + "directory entry could not be made durable"
+                    at: retainedArtifactURL(
+                        parentDescriptor: parentDescriptor,
+                        leaf: stagingLeaf,
+                        fallback: staged.stagingURL
+                    ),
+                    reason: installError.localizedDescription
                 )
             }
-            guard regularFileMatches(
-                parentDescriptor: parentDescriptor,
-                leaf: destinationLeaf,
-                device: staged.stagingDevice,
-                inode: staged.stagingInode
-            ) else {
-                throw retainedRecoveryError(at: quarantineURL)
-            }
-            beforeRecoveryCleanup?()
             switch removeEntryIfMatches(
                 parentDescriptor: parentDescriptor,
                 parentURL: parentURL,
-                leaf: quarantineLeaf,
+                leaf: stagingLeaf,
                 device: expected.device,
                 inode: expected.inode
             ) {
             case .removed:
-                break
+                try verifyPinnedParentPath(
+                    staged,
+                    descriptor: parentDescriptor,
+                    retainedLeaf: destinationLeaf
+                )
+                guard regularFileMatches(
+                    parentDescriptor: parentDescriptor,
+                    leaf: destinationLeaf,
+                    device: staged.stagingDevice,
+                    inode: staged.stagingInode
+                ) else {
+                    throw retainedRecoveryError(
+                        at: retainedArtifactURL(
+                            parentDescriptor: parentDescriptor,
+                            leaf: destinationLeaf,
+                            fallback: staged.request.destination
+                        ),
+                        reason: "The installed save moved before completion"
+                    )
+                }
             case .failed(let message, let retainedURL):
                 if let retainedURL {
                     throw retainedRecoveryError(
@@ -775,6 +852,25 @@ nonisolated enum TerminationSaveCoordinator {
             }
         } else {
             try checkDeadline(deadlineNanoseconds)
+            try verifyPinnedParentPath(
+                staged,
+                descriptor: parentDescriptor,
+                retainedLeaf: stagingLeaf
+            )
+            guard try stagingDescriptorIsAuthorized(
+                stagingDescriptor,
+                staged: staged,
+                deadlineNanoseconds: deadlineNanoseconds
+            ) else {
+                throw retainedRecoveryError(
+                    at: retainedArtifactURL(
+                        parentDescriptor: parentDescriptor,
+                        leaf: stagingLeaf,
+                        fallback: staged.stagingURL
+                    ),
+                    reason: "The staged save changed before publication"
+                )
+            }
             var destinationStatus = stat()
             guard Darwin.fstatat(
                 parentDescriptor,
@@ -807,6 +903,25 @@ nonisolated enum TerminationSaveCoordinator {
                     leaf: destinationLeaf,
                     device: staged.stagingDevice,
                     inode: staged.stagingInode
+                ),
+                      try installedContentMatches(
+                          stagingDescriptor,
+                          staged: staged,
+                          deadlineNanoseconds: deadlineNanoseconds
+                      )
+                else {
+                    throw CocoaError(.fileWriteFileExists)
+                }
+                try verifyPinnedParentPath(
+                    staged,
+                    descriptor: parentDescriptor,
+                    retainedLeaf: destinationLeaf
+                )
+                guard regularFileMatches(
+                    parentDescriptor: parentDescriptor,
+                    leaf: destinationLeaf,
+                    device: staged.stagingDevice,
+                    inode: staged.stagingInode
                 ) else {
                     throw CocoaError(.fileWriteFileExists)
                 }
@@ -820,7 +935,14 @@ nonisolated enum TerminationSaveCoordinator {
                     stagingLeaf: stagingLeaf,
                     destinationLeaf: destinationLeaf
                 )
-                throw installError
+                throw retainedRecoveryError(
+                    at: retainedArtifactURL(
+                        parentDescriptor: parentDescriptor,
+                        leaf: stagingLeaf,
+                        fallback: staged.stagingURL
+                    ),
+                    reason: installError.localizedDescription
+                )
             }
         }
     }
@@ -851,6 +973,71 @@ nonisolated enum TerminationSaveCoordinator {
         return descriptor
     }
 
+    private static func verifyPinnedParentPath(
+        _ staged: TerminationStagedSave,
+        descriptor: Int32,
+        retainedLeaf: String
+    ) throws {
+        let expectedURL = staged.request.destination.deletingLastPathComponent()
+        let verificationDescriptor = Darwin.open(
+            expectedURL.path,
+            O_RDONLY | O_DIRECTORY | O_CLOEXEC
+        )
+        var pinnedStatus = stat()
+        var verificationStatus = stat()
+        let matches = verificationDescriptor >= 0
+            && Darwin.fstat(descriptor, &pinnedStatus) == 0
+            && Darwin.fstat(verificationDescriptor, &verificationStatus) == 0
+            && (verificationStatus.st_mode & S_IFMT) == S_IFDIR
+            && verificationStatus.st_dev == pinnedStatus.st_dev
+            && verificationStatus.st_ino == pinnedStatus.st_ino
+            && UInt64(verificationStatus.st_dev) == staged.parentDevice
+            && UInt64(verificationStatus.st_ino) == staged.parentInode
+        if verificationDescriptor >= 0 {
+            Darwin.close(verificationDescriptor)
+        }
+        guard matches else {
+            throw retainedRecoveryError(
+                at: retainedArtifactURL(
+                    parentDescriptor: descriptor,
+                    leaf: retainedLeaf,
+                    fallback: expectedURL.appendingPathComponent(retainedLeaf)
+                ),
+                reason: "The save directory moved during atomic installation"
+            )
+        }
+    }
+
+    private static func retainedArtifactURL(
+        parentDescriptor: Int32,
+        leaf: String,
+        fallback: URL
+    ) -> URL {
+        var path = [CChar](
+            repeating: 0,
+            count: 4 * Int(MAXPATHLEN)
+        )
+        guard let handle = Darwin.dlopen(nil, RTLD_LAZY | RTLD_LOCAL) else {
+            return fallback
+        }
+        defer { Darwin.dlclose(handle) }
+        guard let symbol = Darwin.dlsym(handle, "fcntl") else {
+            return fallback
+        }
+        typealias FcntlPath = @convention(c) (
+            Int32,
+            Int32,
+            UnsafeMutableRawPointer?
+        ) -> Int32
+        let fcntlPath = unsafeBitCast(symbol, to: FcntlPath.self)
+        let result = path.withUnsafeMutableBytes { buffer in
+            fcntlPath(parentDescriptor, F_GETPATH, buffer.baseAddress)
+        }
+        guard result == 0 else { return fallback }
+        return URL(fileURLWithPath: String(cString: path))
+            .appendingPathComponent(leaf)
+    }
+
     private static func withVerifiedParentDirectory<Result>(
         of url: URL,
         staged: TerminationStagedSave,
@@ -879,65 +1066,61 @@ nonisolated enum TerminationSaveCoordinator {
         )
     }
 
-    private static func restoreOrRetainRecovery(
+    private static func renameSwap(
         parentDescriptor: Int32,
-        quarantineLeaf: String,
-        destinationLeaf: String,
-        destinationURL: URL
-    ) throws {
-        guard renameExclusive(
-            parentDescriptor: parentDescriptor,
-            source: quarantineLeaf,
-            destination: destinationLeaf
-        ) == 0 else {
-            let recoveryURL = destinationURL
-                .deletingLastPathComponent()
-                .appendingPathComponent(quarantineLeaf)
-            throw retainedRecoveryError(at: recoveryURL)
-        }
-        try synchronizeDirectory(parentDescriptor)
+        first: String,
+        second: String
+    ) -> Int32 {
+        Darwin.renameatx_np(
+            parentDescriptor,
+            first,
+            parentDescriptor,
+            second,
+            UInt32(RENAME_SWAP)
+        )
     }
 
-    private static func rollbackPublishedStaging(
+    private static func rollbackPublishedSwap(
         _ staged: TerminationStagedSave,
         stagingDescriptor: Int32,
         parentDescriptor: Int32,
-        quarantineLeaf: String
+        rollback: PublishedSwapRollback
     ) throws {
-        let stagingLeaf = staged.stagingURL.lastPathComponent
-        let destinationLeaf = staged.request.destination.lastPathComponent
-        let recoveryURL = staged.request.destination
-            .deletingLastPathComponent()
-            .appendingPathComponent(quarantineLeaf)
+        let stagingLeaf = rollback.stagingLeaf
+        let destinationLeaf = rollback.destinationLeaf
+        let actualStagingURL = retainedArtifactURL(
+            parentDescriptor: parentDescriptor,
+            leaf: stagingLeaf,
+            fallback: staged.stagingURL
+        )
+        let actualDestinationURL = retainedArtifactURL(
+            parentDescriptor: parentDescriptor,
+            leaf: destinationLeaf,
+            fallback: staged.request.destination
+        )
         guard regularFileMatches(
             parentDescriptor: parentDescriptor,
             leaf: destinationLeaf,
             device: staged.stagingDevice,
             inode: staged.stagingInode
         ),
-              renameExclusive(
+              pathMatches(
                   parentDescriptor: parentDescriptor,
-                  source: destinationLeaf,
-                  destination: stagingLeaf
+                  leaf: stagingLeaf,
+                  status: rollback.displacedStatus
+              ),
+              renameSwap(
+                  parentDescriptor: parentDescriptor,
+                  first: stagingLeaf,
+                  second: destinationLeaf
               ) == 0 else {
-            throw retainedRecoveryError(at: recoveryURL)
+            throw retainedRecoveryError(
+                at: [actualDestinationURL, actualStagingURL],
+                reason: "The atomic save swap could not be rolled back"
+            )
         }
-
-        var stagingSecurityError: Error?
-        do {
-            try resecureStaging(stagingDescriptor, at: staged.stagingURL)
-        } catch {
-            stagingSecurityError = error
-        }
-        try restoreOrRetainRecovery(
-            parentDescriptor: parentDescriptor,
-            quarantineLeaf: quarantineLeaf,
-            destinationLeaf: destinationLeaf,
-            destinationURL: staged.request.destination
-        )
-        if let stagingSecurityError {
-            throw stagingSecurityError
-        }
+        try resecureStaging(stagingDescriptor, at: actualStagingURL)
+        try synchronizeDirectory(parentDescriptor)
     }
 
     private static func rollbackPublishedNewDestination(
@@ -968,13 +1151,21 @@ nonisolated enum TerminationSaveCoordinator {
         at recoveryURL: URL,
         reason: String = "A concurrent file replacement was retained"
     ) -> NSError {
-        NSError(
+        retainedRecoveryError(at: [recoveryURL], reason: reason)
+    }
+
+    private static func retainedRecoveryError(
+        at recoveryURLs: [URL],
+        reason: String
+    ) -> NSError {
+        let paths = recoveryURLs.map(\.path).joined(separator: "\n")
+        return NSError(
             domain: NSCocoaErrorDomain,
             code: CocoaError.fileWriteUnknown.rawValue,
             userInfo: [
                 NSLocalizedDescriptionKey:
-                    "\(reason) at \(recoveryURL.path)",
-                "PineTerminationRetainedArtifactURLs": [recoveryURL],
+                    "\(reason)\n\(paths)",
+                "PineTerminationRetainedArtifactURLs": recoveryURLs,
             ]
         )
     }
@@ -1371,6 +1562,34 @@ nonisolated enum TerminationSaveCoordinator {
                 descriptor,
                 deadlineNanoseconds: deadlineNanoseconds
             ) == expected.extendedMetadataDigest
+    }
+
+    private static func installedContentMatches(
+        _ descriptor: Int32,
+        staged: TerminationStagedSave,
+        deadlineNanoseconds: UInt64
+    ) throws -> Bool {
+        var before = stat()
+        guard Darwin.fstat(descriptor, &before) == 0,
+              UInt64(before.st_dev) == staged.stagingDevice,
+              UInt64(before.st_ino) == staged.stagingInode else {
+            throw posixError()
+        }
+        let digest = try contentDigest(
+            descriptor,
+            deadlineNanoseconds: deadlineNanoseconds
+        )
+        var after = stat()
+        guard Darwin.fstat(descriptor, &after) == 0,
+              stableStatus(before, after) else {
+            return false
+        }
+        return Int(after.st_size) == staged.installedMetadata.size
+            && Int(after.st_mtimespec.tv_sec)
+                == staged.installedMetadata.modificationSeconds
+            && Int(after.st_mtimespec.tv_nsec)
+                == staged.installedMetadata.modificationNanoseconds
+            && digest == staged.stagingContentDigest
     }
 
     private static func applyMissingDestinationMetadata(

--- a/Pine/TerminationSaveCoordinator.swift
+++ b/Pine/TerminationSaveCoordinator.swift
@@ -14,9 +14,42 @@ nonisolated struct TerminationSaveRequest: Sendable {
     let content: String
     let originalURL: URL?
     let destination: URL
+    let expectedDestinationState: TerminationDestinationState
     let encodingRawValue: UInt
     let settings: EditorSaveSettingsSnapshot
     let formatters: FileFormatterRegistry
+}
+
+/// Filesystem identity authorized when the user finished choosing a Save As
+/// destination (or when an already-backed dirty tab entered Save All).
+/// Comparing timestamps as well as inode identity catches in-place external
+/// writes while staging is in progress.
+nonisolated struct TerminationDestinationState: Sendable, Equatable {
+    let device: UInt64
+    let inode: UInt64
+    let size: Int64
+    let permissions: UInt32
+    let ownerID: UInt32
+    let groupID: UInt32
+    let modificationSeconds: Int
+    let modificationNanoseconds: Int
+    let changeSeconds: Int
+    let changeNanoseconds: Int
+
+    static let missing = TerminationDestinationState(
+        device: 0,
+        inode: 0,
+        size: -1,
+        permissions: 0,
+        ownerID: 0,
+        groupID: 0,
+        modificationSeconds: 0,
+        modificationNanoseconds: 0,
+        changeSeconds: 0,
+        changeNanoseconds: 0
+    )
+
+    var exists: Bool { size >= 0 }
 }
 
 nonisolated struct TerminationStagedSave: Sendable {
@@ -31,6 +64,11 @@ nonisolated enum TerminationSaveStageResult: Sendable {
     case ready([TerminationStagedSave])
     case failed(message: String)
     case timedOut
+}
+
+nonisolated enum TerminationSaveInstallResult: Sendable {
+    case installed
+    case failed(message: String)
 }
 
 nonisolated private final class TerminationSaveStageResolver:
@@ -96,8 +134,50 @@ nonisolated enum TerminationSaveCoordinator {
 
     static func cleanup(_ staged: [TerminationStagedSave]) {
         for item in staged {
-            try? FileManager.default.removeItem(at: item.stagingURL)
+            unlinkRegularFile(
+                at: item.stagingURL,
+                device: item.stagingDevice,
+                inode: item.stagingInode
+            )
         }
+    }
+
+    static func captureDestinationState(
+        at url: URL
+    ) async throws -> TerminationDestinationState {
+        try await Task.detached(priority: .userInitiated) {
+            try destinationState(at: url)
+        }.value
+    }
+
+    static func destinationStatesAreCurrent(
+        _ staged: [TerminationStagedSave]
+    ) async -> Bool {
+        await Task.detached(priority: .userInitiated) {
+            staged.allSatisfy { item in
+                destinationStateMatches(
+                    item.request.expectedDestinationState,
+                    at: item.request.destination
+                )
+            }
+        }.value
+    }
+
+    /// Installs exactly the staged inode. Existing destinations are swapped
+    /// atomically so the displaced inode can be compared with the state the
+    /// user authorized; missing destinations use RENAME_EXCL. This closes the
+    /// pathname race between a preflight lstat and rename.
+    static func install(
+        _ staged: TerminationStagedSave
+    ) async -> TerminationSaveInstallResult {
+        await Task.detached(priority: .userInitiated) {
+            do {
+                try installSynchronously(staged)
+                return .installed
+            } catch {
+                return .failed(message: error.localizedDescription)
+            }
+        }.value
     }
 
     static func stagingIdentityIsCurrent(
@@ -128,6 +208,12 @@ nonisolated enum TerminationSaveCoordinator {
                     cleanup(staged)
                     return .timedOut
                 }
+                guard destinationStateMatches(
+                    request.expectedDestinationState,
+                    at: request.destination
+                ) else {
+                    throw CocoaError(.fileWriteFileExists)
+                }
                 let remainingSeconds = TimeInterval(
                     deadlineNanoseconds - now
                 ) / 1_000_000_000
@@ -155,7 +241,8 @@ nonisolated enum TerminationSaveCoordinator {
                 }
                 let staging = try writeStagingFile(
                     data,
-                    beside: request.destination
+                    beside: request.destination,
+                    preservingPermissions: request.expectedDestinationState
                 )
                 staged.append(TerminationStagedSave(
                     request: request,
@@ -180,7 +267,8 @@ nonisolated enum TerminationSaveCoordinator {
 
     private static func writeStagingFile(
         _ data: Data,
-        beside destination: URL
+        beside destination: URL,
+        preservingPermissions destinationState: TerminationDestinationState
     ) throws -> (url: URL, device: UInt64, inode: UInt64) {
         let stagingURL = destination
             .deletingLastPathComponent()
@@ -191,7 +279,7 @@ nonisolated enum TerminationSaveCoordinator {
         let descriptor = Darwin.open(
             stagingURL.path,
             O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
-            S_IRUSR | S_IWUSR
+            S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
         )
         guard descriptor >= 0 else {
             throw posixError()
@@ -225,6 +313,27 @@ nonisolated enum TerminationSaveCoordinator {
                 written += result
             }
         }
+        if destinationState.exists {
+            let metadataFlags = copyfile_flags_t(
+                COPYFILE_ACL
+                    | COPYFILE_XATTR
+                    | COPYFILE_NOFOLLOW
+            )
+            guard Darwin.copyfile(
+                destination.path,
+                stagingURL.path,
+                nil,
+                metadataFlags
+            ) == 0 else {
+                throw posixError()
+            }
+            guard Darwin.fchmod(
+                descriptor,
+                mode_t(destinationState.permissions)
+            ) == 0 else {
+                throw posixError()
+            }
+        }
         guard Darwin.fsync(descriptor) == 0 else {
             throw posixError()
         }
@@ -243,5 +352,188 @@ nonisolated enum TerminationSaveCoordinator {
 
     private static func posixError() -> NSError {
         NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+    }
+
+    private static func destinationState(
+        at url: URL
+    ) throws -> TerminationDestinationState {
+        var status = stat()
+        if Darwin.lstat(url.path, &status) != 0 {
+            if errno == ENOENT { return .missing }
+            throw posixError()
+        }
+        guard (status.st_mode & S_IFMT) == S_IFREG else {
+            throw CocoaError(.fileWriteInvalidFileName)
+        }
+        return TerminationDestinationState(
+            device: UInt64(status.st_dev),
+            inode: UInt64(status.st_ino),
+            size: status.st_size,
+            permissions: UInt32(status.st_mode & 0o7777),
+            ownerID: status.st_uid,
+            groupID: status.st_gid,
+            modificationSeconds: Int(status.st_mtimespec.tv_sec),
+            modificationNanoseconds: Int(status.st_mtimespec.tv_nsec),
+            changeSeconds: Int(status.st_ctimespec.tv_sec),
+            changeNanoseconds: Int(status.st_ctimespec.tv_nsec)
+        )
+    }
+
+    private static func destinationStateMatches(
+        _ expected: TerminationDestinationState,
+        at url: URL
+    ) -> Bool {
+        do {
+            return try destinationState(at: url) == expected
+        } catch let error as NSError
+        where error.domain == NSPOSIXErrorDomain
+                && error.code == Int(ENOENT) {
+            return !expected.exists
+        } catch {
+            return false
+        }
+    }
+
+    private static func installSynchronously(
+        _ staged: TerminationStagedSave
+    ) throws {
+        guard stagingIdentityIsCurrent(staged) else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        let expected = staged.request.expectedDestinationState
+        if expected.exists {
+            guard destinationStateMatches(
+                expected,
+                at: staged.request.destination
+            ) else {
+                throw CocoaError(.fileWriteFileExists)
+            }
+            guard rename(
+                staged.stagingURL,
+                staged.request.destination,
+                flags: UInt32(RENAME_SWAP)
+            ) == 0 else {
+                throw posixError()
+            }
+
+            let displacedMatches = displacedStateMatchesAfterSwap(
+                expected,
+                at: staged.stagingURL
+            )
+            let installedMatches = regularFileMatches(
+                at: staged.request.destination,
+                device: staged.stagingDevice,
+                inode: staged.stagingInode
+            )
+            guard displacedMatches, installedMatches else {
+                // Roll back only while both pathnames still hold the two
+                // inodes produced by our swap. An external replacement after
+                // the swap must never be displaced by a blind second swap.
+                let displacedIdentityIsExpected = regularFileMatches(
+                    at: staged.stagingURL,
+                    device: expected.device,
+                    inode: expected.inode
+                )
+                let installedIdentityIsOurs = regularFileMatches(
+                    at: staged.request.destination,
+                    device: staged.stagingDevice,
+                    inode: staged.stagingInode
+                )
+                if displacedIdentityIsExpected, installedIdentityIsOurs {
+                    _ = rename(
+                        staged.stagingURL,
+                        staged.request.destination,
+                        flags: UInt32(RENAME_SWAP)
+                    )
+                }
+                throw CocoaError(.fileWriteUnknown)
+            }
+            unlinkRegularFile(
+                at: staged.stagingURL,
+                device: expected.device,
+                inode: expected.inode
+            )
+        } else {
+            guard rename(
+                staged.stagingURL,
+                staged.request.destination,
+                flags: UInt32(RENAME_EXCL)
+            ) == 0 else {
+                throw posixError()
+            }
+            guard regularFileMatches(
+                at: staged.request.destination,
+                device: staged.stagingDevice,
+                inode: staged.stagingInode
+            ) else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+        }
+    }
+
+    private static func rename(
+        _ source: URL,
+        _ destination: URL,
+        flags: UInt32
+    ) -> Int32 {
+        source.path.withCString { sourcePath in
+            destination.path.withCString { destinationPath in
+                Darwin.renameatx_np(
+                    AT_FDCWD,
+                    sourcePath,
+                    AT_FDCWD,
+                    destinationPath,
+                    flags
+                )
+            }
+        }
+    }
+
+    private static func regularFileMatches(
+        at url: URL,
+        device: UInt64,
+        inode: UInt64
+    ) -> Bool {
+        var status = stat()
+        guard Darwin.lstat(url.path, &status) == 0,
+              (status.st_mode & S_IFMT) == S_IFREG else {
+            return false
+        }
+        return UInt64(status.st_dev) == device
+            && UInt64(status.st_ino) == inode
+    }
+
+    /// A rename updates the inode change time even though the file itself was
+    /// not edited. Compare every authorized property that survives the swap;
+    /// the strict pre-swap check above still includes ctime.
+    private static func displacedStateMatchesAfterSwap(
+        _ expected: TerminationDestinationState,
+        at url: URL
+    ) -> Bool {
+        guard let current = try? destinationState(at: url) else {
+            return false
+        }
+        return current.device == expected.device
+            && current.inode == expected.inode
+            && current.size == expected.size
+            && current.permissions == expected.permissions
+            && current.ownerID == expected.ownerID
+            && current.groupID == expected.groupID
+            && current.modificationSeconds == expected.modificationSeconds
+            && current.modificationNanoseconds
+                == expected.modificationNanoseconds
+    }
+
+    private static func unlinkRegularFile(
+        at url: URL,
+        device: UInt64,
+        inode: UInt64
+    ) {
+        guard regularFileMatches(
+            at: url,
+            device: device,
+            inode: inode
+        ) else { return }
+        _ = Darwin.unlink(url.path)
     }
 }

--- a/Pine/TerminationSaveCoordinator.swift
+++ b/Pine/TerminationSaveCoordinator.swift
@@ -763,19 +763,30 @@ nonisolated enum TerminationSaveCoordinator {
                     retainedLeaf: stagingLeaf
                 )
                 beforeRecoveryCleanup?()
+                guard try installedMetadataMatches(
+                    stagingDescriptor,
+                    expected: expected,
+                    deadlineNanoseconds: deadlineNanoseconds
+                ),
+                      try installedContentMatches(
+                          stagingDescriptor,
+                          staged: staged,
+                          deadlineNanoseconds: deadlineNanoseconds
+                      ),
+                      regularFileMatches(
+                          parentDescriptor: parentDescriptor,
+                          leaf: destinationLeaf,
+                          device: staged.stagingDevice,
+                          inode: staged.stagingInode
+                      )
+                else {
+                    throw CocoaError(.fileWriteFileExists)
+                }
                 try verifyPinnedParentPath(
                     staged,
                     descriptor: parentDescriptor,
                     retainedLeaf: stagingLeaf
                 )
-                guard regularFileMatches(
-                    parentDescriptor: parentDescriptor,
-                    leaf: destinationLeaf,
-                    device: staged.stagingDevice,
-                    inode: staged.stagingInode
-                ) else {
-                    throw CocoaError(.fileWriteFileExists)
-                }
                 let cleanupSnapshot = try destinationSnapshot(
                     destinationDescriptor,
                     deadlineNanoseconds: deadlineNanoseconds
@@ -892,6 +903,7 @@ nonisolated enum TerminationSaveCoordinator {
                 throw installError
             }
             do {
+                try synchronizeDirectory(parentDescriptor)
                 afterDestinationPublication?()
                 try applyMissingDestinationMetadata(
                     parentDescriptor: parentDescriptor,
@@ -1108,6 +1120,33 @@ nonisolated enum TerminationSaveCoordinator {
                   parentDescriptor: parentDescriptor,
                   leaf: stagingLeaf,
                   status: rollback.displacedStatus
+              ) else {
+            throw retainedRecoveryError(
+                at: [actualDestinationURL, actualStagingURL],
+                reason: "The atomic save swap could not be rolled back"
+            )
+        }
+        do {
+            try resecureStaging(
+                stagingDescriptor,
+                at: actualDestinationURL
+            )
+        } catch {
+            throw retainedRecoveryError(
+                at: [actualDestinationURL, actualStagingURL],
+                reason: error.localizedDescription
+            )
+        }
+        guard regularFileMatches(
+            parentDescriptor: parentDescriptor,
+            leaf: destinationLeaf,
+            device: staged.stagingDevice,
+            inode: staged.stagingInode
+        ),
+              pathMatches(
+                  parentDescriptor: parentDescriptor,
+                  leaf: stagingLeaf,
+                  status: rollback.displacedStatus
               ),
               renameSwap(
                   parentDescriptor: parentDescriptor,
@@ -1119,8 +1158,14 @@ nonisolated enum TerminationSaveCoordinator {
                 reason: "The atomic save swap could not be rolled back"
             )
         }
-        try resecureStaging(stagingDescriptor, at: actualStagingURL)
-        try synchronizeDirectory(parentDescriptor)
+        do {
+            try synchronizeDirectory(parentDescriptor)
+        } catch {
+            throw retainedRecoveryError(
+                at: [actualDestinationURL, actualStagingURL],
+                reason: error.localizedDescription
+            )
+        }
     }
 
     private static func rollbackPublishedNewDestination(
@@ -1130,6 +1175,25 @@ nonisolated enum TerminationSaveCoordinator {
         stagingLeaf: String,
         destinationLeaf: String
     ) throws {
+        let actualStagingURL = retainedArtifactURL(
+            parentDescriptor: parentDescriptor,
+            leaf: stagingLeaf,
+            fallback: staged.stagingURL
+        )
+        let actualDestinationURL = retainedArtifactURL(
+            parentDescriptor: parentDescriptor,
+            leaf: destinationLeaf,
+            fallback: staged.request.destination
+        )
+        guard regularFileMatches(
+            parentDescriptor: parentDescriptor,
+            leaf: destinationLeaf,
+            device: staged.stagingDevice,
+            inode: staged.stagingInode
+        ) else {
+            throw retainedRecoveryError(at: actualDestinationURL)
+        }
+        try resecureStaging(stagingDescriptor, at: actualDestinationURL)
         guard regularFileMatches(
             parentDescriptor: parentDescriptor,
             leaf: destinationLeaf,
@@ -1141,10 +1205,16 @@ nonisolated enum TerminationSaveCoordinator {
                   source: destinationLeaf,
                   destination: stagingLeaf
               ) == 0 else {
-            throw retainedRecoveryError(at: staged.request.destination)
+            throw retainedRecoveryError(at: actualDestinationURL)
         }
-        try resecureStaging(stagingDescriptor, at: staged.stagingURL)
-        try synchronizeDirectory(parentDescriptor)
+        do {
+            try synchronizeDirectory(parentDescriptor)
+        } catch {
+            throw retainedRecoveryError(
+                at: actualStagingURL,
+                reason: error.localizedDescription
+            )
+        }
     }
 
     private static func retainedRecoveryError(

--- a/Pine/TerminationSaveCoordinator.swift
+++ b/Pine/TerminationSaveCoordinator.swift
@@ -5,6 +5,7 @@
 //  Bounded, off-main staging for application-termination saves.
 //
 
+import CryptoKit
 import Darwin
 import Foundation
 
@@ -36,6 +37,8 @@ nonisolated struct TerminationDestinationState: Sendable, Equatable {
     let modificationNanoseconds: Int
     let changeSeconds: Int
     let changeNanoseconds: Int
+    let contentDigest: Data
+    let extendedMetadataDigest: Data
 
     static let missing = TerminationDestinationState(
         device: 0,
@@ -47,7 +50,9 @@ nonisolated struct TerminationDestinationState: Sendable, Equatable {
         modificationSeconds: 0,
         modificationNanoseconds: 0,
         changeSeconds: 0,
-        changeNanoseconds: 0
+        changeNanoseconds: 0,
+        contentDigest: Data(),
+        extendedMetadataDigest: Data()
     )
 
     var exists: Bool { size >= 0 }
@@ -61,6 +66,7 @@ nonisolated struct TerminationStagedSave: Sendable {
     let stagingInode: UInt64
     let parentDevice: UInt64
     let parentInode: UInt64
+    let stagingContentDigest: Data
     let installedMetadata: TerminationInstalledFileMetadata
 }
 
@@ -87,6 +93,11 @@ nonisolated enum TerminationSaveInstallResult: Sendable {
     case installed(metadata: TerminationInstalledFileMetadata)
     case failed(message: String)
     case timedOut
+}
+
+nonisolated enum TerminationSaveCleanupResult: Sendable, Equatable {
+    case cleaned
+    case failed(message: String, retainedArtifacts: [URL])
 }
 
 nonisolated enum TerminationDestinationCaptureResult: Sendable {
@@ -120,12 +131,23 @@ nonisolated private final class TerminationDeadlineResolver<Result: Sendable>:
 nonisolated enum TerminationSaveCoordinator {
     typealias InstallHook = @Sendable () -> Void
 
+    private enum ArtifactRemovalResult {
+        case removed
+        case failed(message: String, retainedURL: URL?)
+    }
+
+    private struct DestinationDescriptorSnapshot {
+        let state: TerminationDestinationState
+        let status: stat
+    }
+
     private struct StagingFile {
         let url: URL
         let device: UInt64
         let inode: UInt64
         let parentDevice: UInt64
         let parentInode: UInt64
+        let contentDigest: Data
         let metadata: TerminationInstalledFileMetadata
     }
 
@@ -133,6 +155,12 @@ nonisolated enum TerminationSaveCoordinator {
         label: "com.pine.termination-save-deadline",
         qos: .userInteractive
     )
+    /// macOS 27 recreates this provenance marker immediately after a
+    /// successful `fremovexattr`. It is kernel-managed launch provenance, not
+    /// destination metadata, and carries no staged document bytes.
+    private static let privateStagingSystemXattrs = Set([
+        "com.apple.provenance",
+    ])
 
     static func stage(
         _ requests: [TerminationSaveRequest],
@@ -161,10 +189,30 @@ nonisolated enum TerminationSaveCoordinator {
         }
     }
 
-    static func cleanup(_ staged: [TerminationStagedSave]) {
+    @discardableResult
+    static func cleanup(
+        _ staged: [TerminationStagedSave]
+    ) -> TerminationSaveCleanupResult {
+        var failures: [String] = []
+        var retainedArtifacts: [URL] = []
         for item in staged {
-            removeStagingFileIfMatches(item)
+            switch removeStagingFileIfMatches(item) {
+            case .removed:
+                break
+            case .failed(let message, let retainedURL):
+                failures.append(message)
+                if let retainedURL {
+                    retainedArtifacts.append(retainedURL)
+                }
+            }
         }
+        guard failures.isEmpty else {
+            return .failed(
+                message: failures.joined(separator: "\n"),
+                retainedArtifacts: retainedArtifacts
+            )
+        }
+        return .cleaned
     }
 
     static func captureDestinationStates(
@@ -180,9 +228,17 @@ nonisolated enum TerminationSaveCoordinator {
             let operationTask = Task.detached(priority: .userInitiated) {
                 let result: TerminationDestinationCaptureResult
                 do {
+                    let deadlineNanoseconds = deadline.uptimeNanoseconds
                     result = .captured(
-                        try urls.map(destinationState(at:))
+                        try urls.map {
+                            try destinationState(
+                                at: $0,
+                                deadlineNanoseconds: deadlineNanoseconds
+                            )
+                        }
                     )
+                } catch is CancellationError {
+                    result = .timedOut
                 } catch {
                     result = .failed(message: error.localizedDescription)
                 }
@@ -211,7 +267,8 @@ nonisolated enum TerminationSaveCoordinator {
                     guard !Task.isCancelled else { return false }
                     return destinationStateMatches(
                         item.request.expectedDestinationState,
-                        at: item.request.destination
+                        at: item.request.destination,
+                        deadlineNanoseconds: deadline.uptimeNanoseconds
                     )
                 }
                 _ = resolver.resolve(matches)
@@ -232,6 +289,7 @@ nonisolated enum TerminationSaveCoordinator {
         _ staged: TerminationStagedSave,
         until deadline: DispatchTime,
         beforeDestinationQuarantine: InstallHook? = nil,
+        beforeRecoveryCleanup: InstallHook? = nil,
         lateCompletion: @escaping @Sendable (
             TerminationSaveInstallResult
         ) -> Void = { _ in }
@@ -249,7 +307,8 @@ nonisolated enum TerminationSaveCoordinator {
                         staged,
                         deadlineNanoseconds: deadlineNanoseconds,
                         beforeDestinationQuarantine:
-                            beforeDestinationQuarantine
+                            beforeDestinationQuarantine,
+                        beforeRecoveryCleanup: beforeRecoveryCleanup
                     )
                     result = .installed(metadata: staged.installedMetadata)
                 } catch is CancellationError {
@@ -293,17 +352,16 @@ nonisolated enum TerminationSaveCoordinator {
         do {
             for request in requests {
                 guard !Task.isCancelled else {
-                    cleanup(staged)
-                    return .timedOut
+                    return stageCancellationResult(staged)
                 }
                 let now = DispatchTime.now().uptimeNanoseconds
                 guard now < deadlineNanoseconds else {
-                    cleanup(staged)
-                    return .timedOut
+                    return stageCancellationResult(staged)
                 }
                 guard destinationStateMatches(
                     request.expectedDestinationState,
-                    at: request.destination
+                    at: request.destination,
+                    deadlineNanoseconds: deadlineNanoseconds
                 ) else {
                     throw CocoaError(.fileWriteFileExists)
                 }
@@ -320,8 +378,7 @@ nonisolated enum TerminationSaveCoordinator {
                 guard !Task.isCancelled,
                       DispatchTime.now().uptimeNanoseconds
                         < deadlineNanoseconds else {
-                    cleanup(staged)
-                    return .timedOut
+                    return stageCancellationResult(staged)
                 }
                 let encoding = String.Encoding(
                     rawValue: request.encodingRawValue
@@ -334,8 +391,7 @@ nonisolated enum TerminationSaveCoordinator {
                 }
                 let staging = try writeStagingFile(
                     data,
-                    beside: request.destination,
-                    preservingPermissions: request.expectedDestinationState
+                    beside: request.destination
                 )
                 staged.append(TerminationStagedSave(
                     request: request,
@@ -345,26 +401,36 @@ nonisolated enum TerminationSaveCoordinator {
                     stagingInode: staging.inode,
                     parentDevice: staging.parentDevice,
                     parentInode: staging.parentInode,
+                    stagingContentDigest: staging.contentDigest,
                     installedMetadata: staging.metadata
                 ))
             }
             guard !Task.isCancelled,
                   DispatchTime.now().uptimeNanoseconds
                     < deadlineNanoseconds else {
-                cleanup(staged)
-                return .timedOut
+                return stageCancellationResult(staged)
             }
             return .ready(staged)
         } catch {
-            cleanup(staged)
+            if case .failed(let message, _) = cleanup(staged) {
+                return .failed(message: message)
+            }
             return .failed(message: error.localizedDescription)
         }
     }
 
+    private static func stageCancellationResult(
+        _ staged: [TerminationStagedSave]
+    ) -> TerminationSaveStageResult {
+        if case .failed(let message, _) = cleanup(staged) {
+            return .failed(message: message)
+        }
+        return .timedOut
+    }
+
     private static func writeStagingFile(
         _ data: Data,
-        beside destination: URL,
-        preservingPermissions destinationState: TerminationDestinationState
+        beside destination: URL
     ) throws -> StagingFile {
         let stagingURL = destination
             .deletingLastPathComponent()
@@ -401,99 +467,77 @@ nonisolated enum TerminationSaveCoordinator {
             Darwin.close(descriptor)
             throw posixError()
         }
-        var keepFile = false
-        defer {
-            Darwin.close(descriptor)
-            if !keepFile {
-                removeEntryIfMatches(
+        defer { Darwin.close(descriptor) }
+
+        do {
+            try makeDescriptorPrivate(descriptor)
+            try data.withUnsafeBytes { rawBuffer in
+                guard let baseAddress = rawBuffer.baseAddress else { return }
+                var written = 0
+                while written < rawBuffer.count {
+                    if Task.isCancelled {
+                        throw CancellationError()
+                    }
+                    let result = Darwin.write(
+                        descriptor,
+                        baseAddress.advanced(by: written),
+                        rawBuffer.count - written
+                    )
+                    if result < 0, errno == EINTR {
+                        continue
+                    }
+                    guard result > 0 else {
+                        throw posixError()
+                    }
+                    written += result
+                }
+            }
+            guard Darwin.fsync(descriptor) == 0 else {
+                throw posixError()
+            }
+            var status = stat()
+            guard Darwin.fstat(descriptor, &status) == 0,
+                  (status.st_mode & S_IFMT) == S_IFREG else {
+                throw posixError()
+            }
+            return StagingFile(
+                url: stagingURL,
+                device: UInt64(status.st_dev),
+                inode: UInt64(status.st_ino),
+                parentDevice: UInt64(parentStatus.st_dev),
+                parentInode: UInt64(parentStatus.st_ino),
+                contentDigest: Data(SHA256.hash(data: data)),
+                metadata: TerminationInstalledFileMetadata(
+                    size: Int(clamping: status.st_size),
+                    modificationSeconds: Int(status.st_mtimespec.tv_sec),
+                    modificationNanoseconds: Int(status.st_mtimespec.tv_nsec)
+                )
+            )
+        } catch {
+            let stagingError = error
+            switch removeEntryIfMatches(
                     parentDescriptor: parentDescriptor,
+                    parentURL: parentURL,
                     leaf: stagingLeaf,
                     device: UInt64(openedStatus.st_dev),
                     inode: UInt64(openedStatus.st_ino)
+            ) {
+            case .removed:
+                throw stagingError
+            case .failed(let message, let retainedURL):
+                if let retainedURL {
+                    throw retainedRecoveryError(
+                        at: retainedURL,
+                        reason: message
+                    )
+                }
+                throw NSError(
+                    domain: NSCocoaErrorDomain,
+                    code: CocoaError.fileWriteUnknown.rawValue,
+                    userInfo: [NSLocalizedDescriptionKey: message]
                 )
             }
         }
-
-        try data.withUnsafeBytes { rawBuffer in
-            guard let baseAddress = rawBuffer.baseAddress else { return }
-            var written = 0
-            while written < rawBuffer.count {
-                if Task.isCancelled {
-                    throw CancellationError()
-                }
-                let result = Darwin.write(
-                    descriptor,
-                    baseAddress.advanced(by: written),
-                    rawBuffer.count - written
-                )
-                if result < 0, errno == EINTR {
-                    continue
-                }
-                guard result > 0 else {
-                    throw posixError()
-                }
-                written += result
-            }
-        }
-        if destinationState.exists {
-            let sourceDescriptor = Darwin.openat(
-                parentDescriptor,
-                destination.lastPathComponent,
-                O_RDONLY | O_CLOEXEC | O_NOFOLLOW
-            )
-            guard sourceDescriptor >= 0 else { throw posixError() }
-            defer { Darwin.close(sourceDescriptor) }
-            var sourceStatus = stat()
-            guard Darwin.fstat(sourceDescriptor, &sourceStatus) == 0,
-                  state(sourceStatus, matches: destinationState) else {
-                throw CocoaError(.fileWriteFileExists)
-            }
-            let metadataFlags = copyfile_flags_t(
-                COPYFILE_ACL
-                    | COPYFILE_XATTR
-            )
-            guard Darwin.fcopyfile(
-                sourceDescriptor,
-                descriptor,
-                nil,
-                metadataFlags
-            ) == 0 else {
-                throw posixError()
-            }
-            guard Darwin.fchmod(
-                descriptor,
-                mode_t(destinationState.permissions)
-            ) == 0 else {
-                throw posixError()
-            }
-        } else {
-            // Staging remains owner-only until all bytes are durable. New
-            // files receive Pine's normal 0644 document mode only afterward.
-            guard Darwin.fchmod(descriptor, 0o644) == 0 else {
-                throw posixError()
-            }
-        }
-        guard Darwin.fsync(descriptor) == 0 else {
-            throw posixError()
-        }
-        var status = stat()
-        guard Darwin.fstat(descriptor, &status) == 0,
-              (status.st_mode & S_IFMT) == S_IFREG else {
-            throw posixError()
-        }
-        keepFile = true
-        return StagingFile(
-            url: stagingURL,
-            device: UInt64(status.st_dev),
-            inode: UInt64(status.st_ino),
-            parentDevice: UInt64(parentStatus.st_dev),
-            parentInode: UInt64(parentStatus.st_ino),
-            metadata: TerminationInstalledFileMetadata(
-                size: Int(clamping: status.st_size),
-                modificationSeconds: Int(status.st_mtimespec.tv_sec),
-                modificationNanoseconds: Int(status.st_mtimespec.tv_nsec)
-            )
-        )
     }
 
     private static func posixError() -> NSError {
@@ -501,36 +545,41 @@ nonisolated enum TerminationSaveCoordinator {
     }
 
     private static func destinationState(
-        at url: URL
+        at url: URL,
+        deadlineNanoseconds: UInt64
     ) throws -> TerminationDestinationState {
-        var status = stat()
-        if Darwin.lstat(url.path, &status) != 0 {
+        try checkDeadline(deadlineNanoseconds)
+        let descriptor = Darwin.open(
+            url.path,
+            O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW
+        )
+        if descriptor < 0 {
             if errno == ENOENT { return .missing }
             throw posixError()
         }
-        guard (status.st_mode & S_IFMT) == S_IFREG else {
-            throw CocoaError(.fileWriteInvalidFileName)
-        }
-        return TerminationDestinationState(
-            device: UInt64(status.st_dev),
-            inode: UInt64(status.st_ino),
-            size: status.st_size,
-            permissions: UInt32(status.st_mode & 0o7777),
-            ownerID: status.st_uid,
-            groupID: status.st_gid,
-            modificationSeconds: Int(status.st_mtimespec.tv_sec),
-            modificationNanoseconds: Int(status.st_mtimespec.tv_nsec),
-            changeSeconds: Int(status.st_ctimespec.tv_sec),
-            changeNanoseconds: Int(status.st_ctimespec.tv_nsec)
+        defer { Darwin.close(descriptor) }
+        let snapshot = try destinationSnapshot(
+            descriptor,
+            deadlineNanoseconds: deadlineNanoseconds
         )
+        var live = stat()
+        guard Darwin.lstat(url.path, &live) == 0,
+              sameObject(snapshot.status, live) else {
+            throw CocoaError(.fileWriteFileExists)
+        }
+        return snapshot.state
     }
 
     private static func destinationStateMatches(
         _ expected: TerminationDestinationState,
-        at url: URL
+        at url: URL,
+        deadlineNanoseconds: UInt64
     ) -> Bool {
         do {
-            return try destinationState(at: url) == expected
+            return try destinationState(
+                at: url,
+                deadlineNanoseconds: deadlineNanoseconds
+            ) == expected
         } catch let error as NSError
         where error.domain == NSPOSIXErrorDomain
                 && error.code == Int(ENOENT) {
@@ -543,17 +592,25 @@ nonisolated enum TerminationSaveCoordinator {
     private static func installSynchronously(
         _ staged: TerminationStagedSave,
         deadlineNanoseconds: UInt64,
-        beforeDestinationQuarantine: InstallHook?
+        beforeDestinationQuarantine: InstallHook?,
+        beforeRecoveryCleanup: InstallHook?
     ) throws {
         let parentDescriptor = try openVerifiedParentDirectory(for: staged)
         defer { Darwin.close(parentDescriptor) }
+        let parentURL = staged.request.destination.deletingLastPathComponent()
         let stagingLeaf = staged.stagingURL.lastPathComponent
         let destinationLeaf = staged.request.destination.lastPathComponent
-        guard regularFileMatches(
-            parentDescriptor: parentDescriptor,
-            leaf: stagingLeaf,
-            device: staged.stagingDevice,
-            inode: staged.stagingInode
+        let stagingDescriptor = Darwin.openat(
+            parentDescriptor,
+            stagingLeaf,
+            O_RDWR | O_CLOEXEC | O_NOFOLLOW
+        )
+        guard stagingDescriptor >= 0 else { throw posixError() }
+        defer { Darwin.close(stagingDescriptor) }
+        guard try stagingDescriptorIsAuthorized(
+            stagingDescriptor,
+            staged: staged,
+            deadlineNanoseconds: deadlineNanoseconds
         ) else {
             throw CocoaError(.fileReadCorruptFile)
         }
@@ -561,11 +618,27 @@ nonisolated enum TerminationSaveCoordinator {
         let expected = staged.request.expectedDestinationState
         if expected.exists {
             let quarantineLeaf = ".pine-save-recovery-\(UUID().uuidString)"
+            let quarantineURL = parentURL.appendingPathComponent(quarantineLeaf)
             beforeDestinationQuarantine?()
-            guard !Task.isCancelled,
-                  DispatchTime.now().uptimeNanoseconds
-                    < deadlineNanoseconds else {
-                throw CancellationError()
+            try checkDeadline(deadlineNanoseconds)
+            let destinationDescriptor = Darwin.openat(
+                parentDescriptor,
+                destinationLeaf,
+                O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW
+            )
+            guard destinationDescriptor >= 0 else { throw posixError() }
+            defer { Darwin.close(destinationDescriptor) }
+            let immediateSnapshot = try destinationSnapshot(
+                destinationDescriptor,
+                deadlineNanoseconds: deadlineNanoseconds
+            )
+            guard immediateSnapshot.state == expected,
+                  pathMatches(
+                      parentDescriptor: parentDescriptor,
+                      leaf: destinationLeaf,
+                      status: immediateSnapshot.status
+                  ) else {
+                throw CocoaError(.fileWriteFileExists)
             }
             guard renameExclusive(
                 parentDescriptor: parentDescriptor,
@@ -574,30 +647,134 @@ nonisolated enum TerminationSaveCoordinator {
             ) == 0 else {
                 throw posixError()
             }
-
-            guard displacedStateMatchesAfterRename(
-                expected,
-                parentDescriptor: parentDescriptor,
-                leaf: quarantineLeaf
-            ) else {
+            do {
+                try synchronizeDirectory(parentDescriptor)
+                let displacedSnapshot = try destinationSnapshot(
+                    destinationDescriptor,
+                    deadlineNanoseconds: deadlineNanoseconds
+                )
+                guard authorizedContentAndMetadataMatch(
+                    displacedSnapshot.state,
+                    expected: expected
+                ),
+                      pathMatches(
+                          parentDescriptor: parentDescriptor,
+                          leaf: quarantineLeaf,
+                          status: displacedSnapshot.status
+                      ) else {
+                    throw CocoaError(.fileWriteFileExists)
+                }
+                try applyExistingDestinationMetadata(
+                    from: destinationDescriptor,
+                    status: displacedSnapshot.status,
+                    to: stagingDescriptor
+                )
+                guard try installedMetadataMatches(
+                    stagingDescriptor,
+                    expected: expected,
+                    deadlineNanoseconds: deadlineNanoseconds
+                ) else {
+                    throw CocoaError(.fileWriteFileExists)
+                }
+                try checkDeadline(deadlineNanoseconds)
+                guard renameExclusive(
+                    parentDescriptor: parentDescriptor,
+                    source: stagingLeaf,
+                    destination: destinationLeaf
+                ) == 0 else {
+                    throw posixError()
+                }
+            } catch {
+                let installError = error
+                var stagingSecurityError: Error?
+                do {
+                    try resecureStaging(
+                        stagingDescriptor,
+                        at: staged.stagingURL
+                    )
+                } catch {
+                    stagingSecurityError = error
+                }
                 try restoreOrRetainRecovery(
                     parentDescriptor: parentDescriptor,
                     quarantineLeaf: quarantineLeaf,
                     destinationLeaf: destinationLeaf,
                     destinationURL: staged.request.destination
                 )
-                throw CocoaError(.fileWriteFileExists)
+                if let stagingSecurityError {
+                    throw stagingSecurityError
+                }
+                throw installError
             }
-            guard !Task.isCancelled,
-                  DispatchTime.now().uptimeNanoseconds
-                    < deadlineNanoseconds else {
-                try restoreOrRetainRecovery(
-                    parentDescriptor: parentDescriptor,
-                    quarantineLeaf: quarantineLeaf,
-                    destinationLeaf: destinationLeaf,
-                    destinationURL: staged.request.destination
+            do {
+                try synchronizeDirectory(parentDescriptor)
+            } catch {
+                throw retainedRecoveryError(
+                    at: quarantineURL,
+                    reason: "The saved destination was installed, but its "
+                        + "directory entry could not be made durable"
                 )
-                throw CancellationError()
+            }
+            guard regularFileMatches(
+                parentDescriptor: parentDescriptor,
+                leaf: destinationLeaf,
+                device: staged.stagingDevice,
+                inode: staged.stagingInode
+            ) else {
+                throw retainedRecoveryError(at: quarantineURL)
+            }
+            beforeRecoveryCleanup?()
+            switch removeEntryIfMatches(
+                parentDescriptor: parentDescriptor,
+                parentURL: parentURL,
+                leaf: quarantineLeaf,
+                device: expected.device,
+                inode: expected.inode
+            ) {
+            case .removed:
+                break
+            case .failed(let message, let retainedURL):
+                if let retainedURL {
+                    throw retainedRecoveryError(
+                        at: retainedURL,
+                        reason: message
+                    )
+                }
+                throw CocoaError(
+                    .fileWriteUnknown,
+                    userInfo: [NSLocalizedDescriptionKey: message]
+                )
+            }
+        } else {
+            try checkDeadline(deadlineNanoseconds)
+            let permissions = try probeCreationPermissions(
+                parentDescriptor: parentDescriptor,
+                parentURL: parentURL
+            )
+            guard Darwin.fchmod(
+                stagingDescriptor,
+                mode_t(permissions)
+            ) == 0 else {
+                let installError = posixError()
+                try resecureStaging(stagingDescriptor, at: staged.stagingURL)
+                throw installError
+            }
+            guard Darwin.fsync(stagingDescriptor) == 0 else {
+                let installError = posixError()
+                try resecureStaging(stagingDescriptor, at: staged.stagingURL)
+                throw installError
+            }
+            try checkDeadline(deadlineNanoseconds)
+            var destinationStatus = stat()
+            guard Darwin.fstatat(
+                parentDescriptor,
+                destinationLeaf,
+                &destinationStatus,
+                AT_SYMLINK_NOFOLLOW
+            ) != 0,
+                  errno == ENOENT else {
+                try resecureStaging(stagingDescriptor, at: staged.stagingURL)
+                throw CocoaError(.fileWriteFileExists)
             }
             guard renameExclusive(
                 parentDescriptor: parentDescriptor,
@@ -605,48 +782,8 @@ nonisolated enum TerminationSaveCoordinator {
                 destination: destinationLeaf
             ) == 0 else {
                 let installError = posixError()
-                try restoreOrRetainRecovery(
-                    parentDescriptor: parentDescriptor,
-                    quarantineLeaf: quarantineLeaf,
-                    destinationLeaf: destinationLeaf,
-                    destinationURL: staged.request.destination
-                )
+                try resecureStaging(stagingDescriptor, at: staged.stagingURL)
                 throw installError
-            }
-
-            // If another actor immediately replaces the installed inode,
-            // fail closed and retain the authorized original for recovery.
-            // The editor remains dirty instead of claiming that the external
-            // bytes currently at the destination are our saved content.
-            guard regularFileMatches(
-                parentDescriptor: parentDescriptor,
-                leaf: destinationLeaf,
-                device: staged.stagingDevice,
-                inode: staged.stagingInode
-            ) else {
-                let recoveryURL = staged.request.destination
-                    .deletingLastPathComponent()
-                    .appendingPathComponent(quarantineLeaf)
-                throw retainedRecoveryError(at: recoveryURL)
-            }
-            removeEntryIfMatches(
-                parentDescriptor: parentDescriptor,
-                leaf: quarantineLeaf,
-                device: expected.device,
-                inode: expected.inode
-            )
-        } else {
-            guard !Task.isCancelled,
-                  DispatchTime.now().uptimeNanoseconds
-                    < deadlineNanoseconds else {
-                throw CancellationError()
-            }
-            guard renameExclusive(
-                parentDescriptor: parentDescriptor,
-                source: stagingLeaf,
-                destination: destinationLeaf
-            ) == 0 else {
-                throw posixError()
             }
             guard regularFileMatches(
                 parentDescriptor: parentDescriptor,
@@ -656,6 +793,7 @@ nonisolated enum TerminationSaveCoordinator {
             ) else {
                 throw CocoaError(.fileWriteFileExists)
             }
+            try synchronizeDirectory(parentDescriptor)
         }
     }
 
@@ -729,64 +867,448 @@ nonisolated enum TerminationSaveCoordinator {
                 .appendingPathComponent(quarantineLeaf)
             throw retainedRecoveryError(at: recoveryURL)
         }
+        try synchronizeDirectory(parentDescriptor)
     }
 
-    private static func retainedRecoveryError(at recoveryURL: URL) -> NSError {
+    private static func retainedRecoveryError(
+        at recoveryURL: URL,
+        reason: String = "A concurrent file replacement was retained"
+    ) -> NSError {
         NSError(
             domain: NSCocoaErrorDomain,
             code: CocoaError.fileWriteUnknown.rawValue,
             userInfo: [
                 NSLocalizedDescriptionKey:
-                    "A concurrent file replacement was retained at "
-                    + recoveryURL.path,
+                    "\(reason) at \(recoveryURL.path)",
             ]
         )
     }
 
-    private static func displacedStateMatchesAfterRename(
-        _ expected: TerminationDestinationState,
-        parentDescriptor: Int32,
-        leaf: String
-    ) -> Bool {
-        var status = stat()
-        guard Darwin.fstatat(
-            parentDescriptor,
-            leaf,
-            &status,
-            AT_SYMLINK_NOFOLLOW
-        ) == 0 else {
-            return false
+    private static func checkDeadline(_ deadlineNanoseconds: UInt64) throws {
+        guard !Task.isCancelled,
+              DispatchTime.now().uptimeNanoseconds < deadlineNanoseconds else {
+            throw CancellationError()
         }
-        return UInt64(status.st_dev) == expected.device
-            && UInt64(status.st_ino) == expected.inode
-            && status.st_size == expected.size
-            && UInt32(status.st_mode & 0o7777) == expected.permissions
-            && status.st_uid == expected.ownerID
-            && status.st_gid == expected.groupID
-            && Int(status.st_mtimespec.tv_sec)
-                == expected.modificationSeconds
-            && Int(status.st_mtimespec.tv_nsec)
-                == expected.modificationNanoseconds
     }
 
-    private static func state(
-        _ status: stat,
-        matches expected: TerminationDestinationState
+    private static func destinationSnapshot(
+        _ descriptor: Int32,
+        deadlineNanoseconds: UInt64
+    ) throws -> DestinationDescriptorSnapshot {
+        try checkDeadline(deadlineNanoseconds)
+        var before = stat()
+        guard Darwin.fstat(descriptor, &before) == 0,
+              (before.st_mode & S_IFMT) == S_IFREG else {
+            throw CocoaError(.fileWriteInvalidFileName)
+        }
+        let contentDigest = try contentDigest(
+            descriptor,
+            deadlineNanoseconds: deadlineNanoseconds
+        )
+        let metadataDigest = try extendedMetadataDigest(
+            descriptor,
+            deadlineNanoseconds: deadlineNanoseconds
+        )
+        var after = stat()
+        guard Darwin.fstat(descriptor, &after) == 0,
+              stableStatus(before, after) else {
+            throw CocoaError(.fileWriteFileExists)
+        }
+        return DestinationDescriptorSnapshot(
+            state: TerminationDestinationState(
+                device: UInt64(after.st_dev),
+                inode: UInt64(after.st_ino),
+                size: after.st_size,
+                permissions: UInt32(after.st_mode & 0o7777),
+                ownerID: after.st_uid,
+                groupID: after.st_gid,
+                modificationSeconds: Int(after.st_mtimespec.tv_sec),
+                modificationNanoseconds: Int(after.st_mtimespec.tv_nsec),
+                changeSeconds: Int(after.st_ctimespec.tv_sec),
+                changeNanoseconds: Int(after.st_ctimespec.tv_nsec),
+                contentDigest: contentDigest,
+                extendedMetadataDigest: metadataDigest
+            ),
+            status: after
+        )
+    }
+
+    private static func contentDigest(
+        _ descriptor: Int32,
+        deadlineNanoseconds: UInt64
+    ) throws -> Data {
+        var hasher = SHA256()
+        var offset: off_t = 0
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            try checkDeadline(deadlineNanoseconds)
+            let count = buffer.withUnsafeMutableBytes { rawBuffer in
+                Darwin.pread(
+                    descriptor,
+                    rawBuffer.baseAddress,
+                    rawBuffer.count,
+                    offset
+                )
+            }
+            if count < 0, errno == EINTR { continue }
+            guard count >= 0 else { throw posixError() }
+            guard count > 0 else { break }
+            hasher.update(data: Data(buffer.prefix(count)))
+            offset += off_t(count)
+        }
+        return Data(hasher.finalize())
+    }
+
+    private static func extendedMetadataDigest(
+        _ descriptor: Int32,
+        deadlineNanoseconds: UInt64
+    ) throws -> Data {
+        var hasher = SHA256()
+        let names = try extendedAttributeNames(descriptor).sorted()
+        for name in names {
+            try checkDeadline(deadlineNanoseconds)
+            updateDigest(&hasher, with: Data(name.utf8))
+            updateDigest(
+                &hasher,
+                with: try extendedAttributeValue(descriptor, name: name)
+            )
+        }
+        updateDigest(&hasher, with: try extendedACLData(descriptor))
+        return Data(hasher.finalize())
+    }
+
+    private static func updateDigest(
+        _ hasher: inout SHA256,
+        with data: Data
+    ) {
+        var length = UInt64(data.count).bigEndian
+        withUnsafeBytes(of: &length) { bytes in
+            hasher.update(data: Data(bytes))
+        }
+        hasher.update(data: data)
+    }
+
+    private static func extendedAttributeNames(
+        _ descriptor: Int32
+    ) throws -> [String] {
+        let required = Darwin.flistxattr(descriptor, nil, 0, 0)
+        guard required >= 0 else { throw posixError() }
+        guard required > 0 else { return [] }
+        var bytes = [CChar](repeating: 0, count: required)
+        let count = bytes.withUnsafeMutableBufferPointer { buffer in
+            Darwin.flistxattr(descriptor, buffer.baseAddress, buffer.count, 0)
+        }
+        guard count >= 0 else { throw posixError() }
+        let raw = bytes.prefix(count).map(UInt8.init(bitPattern:))
+        var names: [String] = []
+        var start = raw.startIndex
+        for index in raw.indices where raw[index] == 0 {
+            guard index > start,
+                  let name = String(
+                      bytes: raw[start..<index],
+                      encoding: .utf8
+                  ) else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+            names.append(name)
+            start = raw.index(after: index)
+        }
+        guard start == raw.endIndex else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        return names
+    }
+
+    private static func extendedAttributeValue(
+        _ descriptor: Int32,
+        name: String
+    ) throws -> Data {
+        let required = name.withCString {
+            Darwin.fgetxattr(descriptor, $0, nil, 0, 0, 0)
+        }
+        guard required >= 0 else { throw posixError() }
+        var data = Data(count: required)
+        let count = data.withUnsafeMutableBytes { buffer in
+            name.withCString {
+                Darwin.fgetxattr(
+                    descriptor,
+                    $0,
+                    buffer.baseAddress,
+                    buffer.count,
+                    0,
+                    0
+                )
+            }
+        }
+        guard count == required else { throw posixError() }
+        return data
+    }
+
+    private static func extendedACLData(_ descriptor: Int32) throws -> Data {
+        errno = 0
+        guard let acl = Darwin.acl_get_fd_np(
+            descriptor,
+            ACL_TYPE_EXTENDED
+        ) else {
+            guard errno == 0 || errno == ENOENT else { throw posixError() }
+            return Data()
+        }
+        defer { Darwin.acl_free(UnsafeMutableRawPointer(acl)) }
+        var length: ssize_t = 0
+        guard let text = Darwin.acl_to_text(acl, &length) else {
+            throw posixError()
+        }
+        defer { Darwin.acl_free(UnsafeMutableRawPointer(text)) }
+        return Data(bytes: text, count: length)
+    }
+
+    private static func stableStatus(_ lhs: stat, _ rhs: stat) -> Bool {
+        lhs.st_dev == rhs.st_dev
+            && lhs.st_ino == rhs.st_ino
+            && lhs.st_mode == rhs.st_mode
+            && lhs.st_nlink == rhs.st_nlink
+            && lhs.st_uid == rhs.st_uid
+            && lhs.st_gid == rhs.st_gid
+            && lhs.st_size == rhs.st_size
+            && lhs.st_mtimespec.tv_sec == rhs.st_mtimespec.tv_sec
+            && lhs.st_mtimespec.tv_nsec == rhs.st_mtimespec.tv_nsec
+            && lhs.st_ctimespec.tv_sec == rhs.st_ctimespec.tv_sec
+            && lhs.st_ctimespec.tv_nsec == rhs.st_ctimespec.tv_nsec
+    }
+
+    private static func sameObject(_ lhs: stat, _ rhs: stat) -> Bool {
+        lhs.st_dev == rhs.st_dev
+            && lhs.st_ino == rhs.st_ino
+            && (lhs.st_mode & S_IFMT) == (rhs.st_mode & S_IFMT)
+    }
+
+    private static func pathMatches(
+        parentDescriptor: Int32,
+        leaf: String,
+        status: stat
     ) -> Bool {
-        (status.st_mode & S_IFMT) == S_IFREG
-            && UInt64(status.st_dev) == expected.device
-            && UInt64(status.st_ino) == expected.inode
-            && status.st_size == expected.size
-            && UInt32(status.st_mode & 0o7777) == expected.permissions
+        var live = stat()
+        return Darwin.fstatat(
+            parentDescriptor,
+            leaf,
+            &live,
+            AT_SYMLINK_NOFOLLOW
+        ) == 0 && sameObject(status, live)
+    }
+
+    private static func authorizedContentAndMetadataMatch(
+        _ actual: TerminationDestinationState,
+        expected: TerminationDestinationState
+    ) -> Bool {
+        actual.device == expected.device
+            && actual.inode == expected.inode
+            && actual.size == expected.size
+            && actual.permissions == expected.permissions
+            && actual.ownerID == expected.ownerID
+            && actual.groupID == expected.groupID
+            && actual.modificationSeconds == expected.modificationSeconds
+            && actual.modificationNanoseconds
+                == expected.modificationNanoseconds
+            && actual.contentDigest == expected.contentDigest
+            && actual.extendedMetadataDigest
+                == expected.extendedMetadataDigest
+    }
+
+    private static func stagingDescriptorIsAuthorized(
+        _ descriptor: Int32,
+        staged: TerminationStagedSave,
+        deadlineNanoseconds: UInt64
+    ) throws -> Bool {
+        var status = stat()
+        guard Darwin.fstat(descriptor, &status) == 0,
+              (status.st_mode & S_IFMT) == S_IFREG,
+              UInt64(status.st_dev) == staged.stagingDevice,
+              UInt64(status.st_ino) == staged.stagingInode,
+              status.st_uid == Darwin.getuid(),
+              status.st_nlink == 1,
+              (status.st_mode & 0o7777) == 0o600,
+              try privateStagingXattrsAreSafe(descriptor),
+              try descriptorHasNoExtendedACL(descriptor) else {
+            return false
+        }
+        return try contentDigest(
+            descriptor,
+            deadlineNanoseconds: deadlineNanoseconds
+        ) == staged.stagingContentDigest
+    }
+
+    private static func descriptorHasNoExtendedACL(
+        _ descriptor: Int32
+    ) throws -> Bool {
+        errno = 0
+        guard let acl = Darwin.acl_get_fd_np(
+            descriptor,
+            ACL_TYPE_EXTENDED
+        ) else {
+            guard errno == 0 || errno == ENOENT else { throw posixError() }
+            return true
+        }
+        defer { Darwin.acl_free(UnsafeMutableRawPointer(acl)) }
+        var entry: acl_entry_t?
+        let result = Darwin.acl_get_entry(
+            acl,
+            Int32(ACL_FIRST_ENTRY.rawValue),
+            &entry
+        )
+        guard result >= 0 else { throw posixError() }
+        return result == 0
+    }
+
+    private static func makeDescriptorPrivate(_ descriptor: Int32) throws {
+        guard Darwin.fchmod(descriptor, mode_t(0o600)) == 0 else {
+            throw posixError()
+        }
+        for name in try extendedAttributeNames(descriptor)
+        where !privateStagingSystemXattrs.contains(name) {
+            let result = name.withCString {
+                Darwin.fremovexattr(descriptor, $0, 0)
+            }
+            guard result == 0 || errno == ENOATTR else { throw posixError() }
+        }
+        if !(try descriptorHasNoExtendedACL(descriptor)) {
+            try deleteExtendedACL(from: descriptor)
+        }
+        guard try privateStagingXattrsAreSafe(descriptor),
+              try descriptorHasNoExtendedACL(descriptor) else {
+            throw CocoaError(.fileWriteNoPermission)
+        }
+    }
+
+    private static func privateStagingXattrsAreSafe(
+        _ descriptor: Int32
+    ) throws -> Bool {
+        try extendedAttributeNames(descriptor).allSatisfy {
+            privateStagingSystemXattrs.contains($0)
+        }
+    }
+
+    /// `acl_delete_fd_np` is a public libSystem symbol on every supported
+    /// macOS release, but the Swift Darwin overlay does not import it. Resolve
+    /// that exact descriptor-based API dynamically so ACL removal stays free
+    /// of pathname races.
+    private static func deleteExtendedACL(from descriptor: Int32) throws {
+        guard let handle = Darwin.dlopen(nil, RTLD_LAZY | RTLD_LOCAL) else {
+            throw posixError()
+        }
+        defer { Darwin.dlclose(handle) }
+        guard let symbol = Darwin.dlsym(handle, "acl_delete_fd_np") else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        typealias DeleteACL = @convention(c) (
+            Int32,
+            acl_type_t
+        ) -> Int32
+        let deleteACL = unsafeBitCast(symbol, to: DeleteACL.self)
+        guard deleteACL(descriptor, ACL_TYPE_EXTENDED) == 0
+                || errno == ENOENT else {
+            throw posixError()
+        }
+    }
+
+    private static func resecureStaging(
+        _ descriptor: Int32,
+        at stagingURL: URL
+    ) throws {
+        do {
+            try makeDescriptorPrivate(descriptor)
+            guard Darwin.fsync(descriptor) == 0 else { throw posixError() }
+        } catch {
+            throw retainedRecoveryError(
+                at: stagingURL,
+                reason: "Staged save bytes could not be resecured"
+            )
+        }
+    }
+
+    private static func applyExistingDestinationMetadata(
+        from sourceDescriptor: Int32,
+        status: stat,
+        to destinationDescriptor: Int32
+    ) throws {
+        guard Darwin.fchown(
+            destinationDescriptor,
+            status.st_uid,
+            status.st_gid
+        ) == 0 else {
+            throw posixError()
+        }
+        let metadataFlags = copyfile_flags_t(COPYFILE_ACL | COPYFILE_XATTR)
+        guard Darwin.fcopyfile(
+            sourceDescriptor,
+            destinationDescriptor,
+            nil,
+            metadataFlags
+        ) == 0,
+              Darwin.fchmod(
+                  destinationDescriptor,
+                  mode_t(status.st_mode & 0o7777)
+              ) == 0,
+              Darwin.fsync(destinationDescriptor) == 0 else {
+            throw posixError()
+        }
+    }
+
+    private static func installedMetadataMatches(
+        _ descriptor: Int32,
+        expected: TerminationDestinationState,
+        deadlineNanoseconds: UInt64
+    ) throws -> Bool {
+        var status = stat()
+        guard Darwin.fstat(descriptor, &status) == 0 else {
+            throw posixError()
+        }
+        return try UInt32(status.st_mode & 0o7777) == expected.permissions
             && status.st_uid == expected.ownerID
             && status.st_gid == expected.groupID
-            && Int(status.st_mtimespec.tv_sec)
-                == expected.modificationSeconds
-            && Int(status.st_mtimespec.tv_nsec)
-                == expected.modificationNanoseconds
-            && Int(status.st_ctimespec.tv_sec) == expected.changeSeconds
-            && Int(status.st_ctimespec.tv_nsec)
-                == expected.changeNanoseconds
+            && extendedMetadataDigest(
+                descriptor,
+                deadlineNanoseconds: deadlineNanoseconds
+            ) == expected.extendedMetadataDigest
+    }
+
+    private static func probeCreationPermissions(
+        parentDescriptor: Int32,
+        parentURL: URL
+    ) throws -> UInt32 {
+        let leaf = ".pine-save-mode-\(UUID().uuidString).tmp"
+        let descriptor = Darwin.openat(
+            parentDescriptor,
+            leaf,
+            O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
+            mode_t(0o666)
+        )
+        guard descriptor >= 0 else { throw posixError() }
+        var status = stat()
+        let captured = Darwin.fstat(descriptor, &status) == 0
+        Darwin.close(descriptor)
+        guard captured else { throw posixError() }
+        switch removeEntryIfMatches(
+            parentDescriptor: parentDescriptor,
+            parentURL: parentURL,
+            leaf: leaf,
+            device: UInt64(status.st_dev),
+            inode: UInt64(status.st_ino)
+        ) {
+        case .removed:
+            return UInt32(status.st_mode & 0o666)
+        case .failed(let message, let retainedURL):
+            if let retainedURL {
+                throw retainedRecoveryError(at: retainedURL, reason: message)
+            }
+            throw CocoaError(
+                .fileWriteUnknown,
+                userInfo: [NSLocalizedDescriptionKey: message]
+            )
+        }
+    }
+
+    private static func synchronizeDirectory(_ descriptor: Int32) throws {
+        guard Darwin.fsync(descriptor) == 0 else { throw posixError() }
     }
 
     private static func regularFileMatches(
@@ -811,18 +1333,23 @@ nonisolated enum TerminationSaveCoordinator {
 
     private static func removeStagingFileIfMatches(
         _ staged: TerminationStagedSave
-    ) {
-        _ = withVerifiedParentDirectory(
+    ) -> ArtifactRemovalResult {
+        let result = withVerifiedParentDirectory(
             of: staged.stagingURL,
             staged: staged
         ) { parentDescriptor, stagingLeaf in
             removeEntryIfMatches(
                 parentDescriptor: parentDescriptor,
+                parentURL: staged.stagingURL.deletingLastPathComponent(),
                 leaf: stagingLeaf,
                 device: staged.stagingDevice,
                 inode: staged.stagingInode
             )
         }
+        return result ?? .failed(
+            message: "Could not verify the staged-save directory",
+            retainedURL: staged.stagingURL
+        )
     }
 
     /// Move-first cleanup prevents a pathname substitution from being blindly
@@ -830,29 +1357,66 @@ nonisolated enum TerminationSaveCoordinator {
     /// concurrently reappeared, the entry remains under the recovery name.
     private static func removeEntryIfMatches(
         parentDescriptor: Int32,
+        parentURL: URL,
         leaf: String,
         device: UInt64,
         inode: UInt64
-    ) {
+    ) -> ArtifactRemovalResult {
         let cleanupLeaf = ".pine-save-cleanup-\(UUID().uuidString)"
+        let originalURL = parentURL.appendingPathComponent(leaf)
+        let cleanupURL = parentURL.appendingPathComponent(cleanupLeaf)
         guard renameExclusive(
             parentDescriptor: parentDescriptor,
             source: leaf,
             destination: cleanupLeaf
-        ) == 0 else { return }
+        ) == 0 else {
+            if errno == ENOENT { return .removed }
+            return .failed(
+                message: "Could not quarantine an artifact before cleanup",
+                retainedURL: originalURL
+            )
+        }
+        do {
+            try synchronizeDirectory(parentDescriptor)
+        } catch {
+            return .failed(
+                message: "Could not make artifact quarantine durable",
+                retainedURL: cleanupURL
+            )
+        }
         guard regularFileMatches(
             parentDescriptor: parentDescriptor,
             leaf: cleanupLeaf,
             device: device,
             inode: inode
         ) else {
-            _ = renameExclusive(
+            let restored = renameExclusive(
                 parentDescriptor: parentDescriptor,
                 source: cleanupLeaf,
                 destination: leaf
+            ) == 0
+            if restored {
+                try? synchronizeDirectory(parentDescriptor)
+            }
+            return .failed(
+                message: "An artifact changed identity during cleanup",
+                retainedURL: restored ? originalURL : cleanupURL
             )
-            return
         }
-        _ = Darwin.unlinkat(parentDescriptor, cleanupLeaf, 0)
+        guard Darwin.unlinkat(parentDescriptor, cleanupLeaf, 0) == 0 else {
+            return .failed(
+                message: "Could not unlink a quarantined artifact",
+                retainedURL: cleanupURL
+            )
+        }
+        do {
+            try synchronizeDirectory(parentDescriptor)
+            return .removed
+        } catch {
+            return .failed(
+                message: "Artifact removal could not be made durable",
+                retainedURL: nil
+            )
+        }
     }
 }

--- a/Pine/TerminationSaveCoordinator.swift
+++ b/Pine/TerminationSaveCoordinator.swift
@@ -11,6 +11,7 @@ import Foundation
 nonisolated struct TerminationSaveRequest: Sendable {
     let tabID: UUID
     let contentVersion: UInt64
+    let persistenceGeneration: UInt64
     let content: String
     let originalURL: URL?
     let destination: URL
@@ -20,8 +21,8 @@ nonisolated struct TerminationSaveRequest: Sendable {
     let formatters: FileFormatterRegistry
 }
 
-/// Filesystem identity authorized when the user finished choosing a Save As
-/// destination (or when an already-backed dirty tab entered Save All).
+/// Filesystem identity captured under Quit's machine-work deadline after the
+/// user finished choosing every Save As destination.
 /// Comparing timestamps as well as inode identity catches in-place external
 /// writes while staging is in progress.
 nonisolated struct TerminationDestinationState: Sendable, Equatable {
@@ -58,6 +59,22 @@ nonisolated struct TerminationStagedSave: Sendable {
     let preparedContent: String
     let stagingDevice: UInt64
     let stagingInode: UInt64
+    let parentDevice: UInt64
+    let parentInode: UInt64
+    let installedMetadata: TerminationInstalledFileMetadata
+}
+
+nonisolated struct TerminationInstalledFileMetadata: Sendable {
+    let size: Int
+    let modificationSeconds: Int
+    let modificationNanoseconds: Int
+
+    var modificationDate: Date {
+        Date(
+            timeIntervalSince1970: TimeInterval(modificationSeconds)
+                + TimeInterval(modificationNanoseconds) / 1_000_000_000
+        )
+    }
 }
 
 nonisolated enum TerminationSaveStageResult: Sendable {
@@ -67,27 +84,28 @@ nonisolated enum TerminationSaveStageResult: Sendable {
 }
 
 nonisolated enum TerminationSaveInstallResult: Sendable {
-    case installed
+    case installed(metadata: TerminationInstalledFileMetadata)
     case failed(message: String)
+    case timedOut
 }
 
-nonisolated private final class TerminationSaveStageResolver:
+nonisolated enum TerminationDestinationCaptureResult: Sendable {
+    case captured([TerminationDestinationState])
+    case failed(message: String)
+    case timedOut
+}
+
+nonisolated private final class TerminationDeadlineResolver<Result: Sendable>:
     @unchecked Sendable {
     private let lock = NSLock()
-    private var continuation:
-        CheckedContinuation<TerminationSaveStageResult, Never>?
+    private var continuation: CheckedContinuation<Result, Never>?
 
-    init(
-        _ continuation: CheckedContinuation<
-            TerminationSaveStageResult,
-            Never
-        >
-    ) {
+    init(_ continuation: CheckedContinuation<Result, Never>) {
         self.continuation = continuation
     }
 
     @discardableResult
-    func resolve(_ result: TerminationSaveStageResult) -> Bool {
+    func resolve(_ result: Result) -> Bool {
         let continuation = lock.withLock {
             let continuation = self.continuation
             self.continuation = nil
@@ -100,6 +118,17 @@ nonisolated private final class TerminationSaveStageResolver:
 }
 
 nonisolated enum TerminationSaveCoordinator {
+    typealias InstallHook = @Sendable () -> Void
+
+    private struct StagingFile {
+        let url: URL
+        let device: UInt64
+        let inode: UInt64
+        let parentDevice: UInt64
+        let parentInode: UInt64
+        let metadata: TerminationInstalledFileMetadata
+    }
+
     private static let deadlineQueue = DispatchQueue(
         label: "com.pine.termination-save-deadline",
         qos: .userInteractive
@@ -114,7 +143,7 @@ nonisolated enum TerminationSaveCoordinator {
             return .timedOut
         }
         return await withCheckedContinuation { continuation in
-            let resolver = TerminationSaveStageResolver(continuation)
+            let resolver = TerminationDeadlineResolver(continuation)
             let operationTask = Task.detached(priority: .userInitiated) {
                 let result = stageSynchronously(
                     requests,
@@ -134,62 +163,126 @@ nonisolated enum TerminationSaveCoordinator {
 
     static func cleanup(_ staged: [TerminationStagedSave]) {
         for item in staged {
-            unlinkRegularFile(
-                at: item.stagingURL,
-                device: item.stagingDevice,
-                inode: item.stagingInode
-            )
+            removeStagingFileIfMatches(item)
         }
     }
 
-    static func captureDestinationState(
-        at url: URL
-    ) async throws -> TerminationDestinationState {
-        try await Task.detached(priority: .userInitiated) {
-            try destinationState(at: url)
-        }.value
+    static func captureDestinationStates(
+        at urls: [URL],
+        until deadline: DispatchTime
+    ) async -> TerminationDestinationCaptureResult {
+        guard DispatchTime.now().uptimeNanoseconds
+                < deadline.uptimeNanoseconds else {
+            return .timedOut
+        }
+        return await withCheckedContinuation { continuation in
+            let resolver = TerminationDeadlineResolver(continuation)
+            let operationTask = Task.detached(priority: .userInitiated) {
+                let result: TerminationDestinationCaptureResult
+                do {
+                    result = .captured(
+                        try urls.map(destinationState(at:))
+                    )
+                } catch {
+                    result = .failed(message: error.localizedDescription)
+                }
+                _ = resolver.resolve(result)
+            }
+            deadlineQueue.asyncAfter(deadline: deadline) {
+                if resolver.resolve(.timedOut) {
+                    operationTask.cancel()
+                }
+            }
+        }
     }
 
     static func destinationStatesAreCurrent(
-        _ staged: [TerminationStagedSave]
+        _ staged: [TerminationStagedSave],
+        until deadline: DispatchTime
     ) async -> Bool {
-        await Task.detached(priority: .userInitiated) {
-            staged.allSatisfy { item in
-                destinationStateMatches(
-                    item.request.expectedDestinationState,
-                    at: item.request.destination
-                )
+        guard DispatchTime.now().uptimeNanoseconds
+                < deadline.uptimeNanoseconds else {
+            return false
+        }
+        return await withCheckedContinuation { continuation in
+            let resolver = TerminationDeadlineResolver(continuation)
+            let operationTask = Task.detached(priority: .userInitiated) {
+                let matches = staged.allSatisfy { item in
+                    guard !Task.isCancelled else { return false }
+                    return destinationStateMatches(
+                        item.request.expectedDestinationState,
+                        at: item.request.destination
+                    )
+                }
+                _ = resolver.resolve(matches)
             }
-        }.value
+            deadlineQueue.asyncAfter(deadline: deadline) {
+                if resolver.resolve(false) {
+                    operationTask.cancel()
+                }
+            }
+        }
     }
 
-    /// Installs exactly the staged inode. Existing destinations are swapped
-    /// atomically so the displaced inode can be compared with the state the
-    /// user authorized; missing destinations use RENAME_EXCL. This closes the
-    /// pathname race between a preflight lstat and rename.
+    /// Runs the installer away from the main actor and bounds the caller's
+    /// wait by the shared Quit deadline. If an already-started filesystem
+    /// syscall completes after that boundary, `lateCompletion` lets the model
+    /// owner reconcile the durable result instead of losing track of it.
     static func install(
-        _ staged: TerminationStagedSave
+        _ staged: TerminationStagedSave,
+        until deadline: DispatchTime,
+        beforeDestinationQuarantine: InstallHook? = nil,
+        lateCompletion: @escaping @Sendable (
+            TerminationSaveInstallResult
+        ) -> Void = { _ in }
     ) async -> TerminationSaveInstallResult {
-        await Task.detached(priority: .userInitiated) {
-            do {
-                try installSynchronously(staged)
-                return .installed
-            } catch {
-                return .failed(message: error.localizedDescription)
+        let deadlineNanoseconds = deadline.uptimeNanoseconds
+        guard DispatchTime.now().uptimeNanoseconds < deadlineNanoseconds else {
+            return .timedOut
+        }
+        return await withCheckedContinuation { continuation in
+            let resolver = TerminationDeadlineResolver(continuation)
+            let operationTask = Task.detached(priority: .userInitiated) {
+                let result: TerminationSaveInstallResult
+                do {
+                    try installSynchronously(
+                        staged,
+                        deadlineNanoseconds: deadlineNanoseconds,
+                        beforeDestinationQuarantine:
+                            beforeDestinationQuarantine
+                    )
+                    result = .installed(metadata: staged.installedMetadata)
+                } catch is CancellationError {
+                    result = .timedOut
+                } catch {
+                    result = .failed(message: error.localizedDescription)
+                }
+                if !resolver.resolve(result) {
+                    lateCompletion(result)
+                }
             }
-        }.value
+            deadlineQueue.asyncAfter(deadline: deadline) {
+                if resolver.resolve(.timedOut) {
+                    operationTask.cancel()
+                }
+            }
+        }
     }
 
     static func stagingIdentityIsCurrent(
         _ staged: TerminationStagedSave
     ) -> Bool {
-        var status = stat()
-        guard Darwin.lstat(staged.stagingURL.path, &status) == 0,
-              (status.st_mode & S_IFMT) == S_IFREG else {
-            return false
-        }
-        return UInt64(status.st_dev) == staged.stagingDevice
-            && UInt64(status.st_ino) == staged.stagingInode
+        withVerifiedParentDirectory(
+            of: staged.stagingURL,
+            staged: staged
+        ) { parentDescriptor, stagingLeaf in
+            regularFileMatches(
+                parentDescriptor: parentDescriptor,
+                leaf: stagingLeaf,
+                device: staged.stagingDevice,
+                inode: staged.stagingInode
+            )
+        } ?? false
     }
 
     private static func stageSynchronously(
@@ -249,7 +342,10 @@ nonisolated enum TerminationSaveCoordinator {
                     stagingURL: staging.url,
                     preparedContent: prepared,
                     stagingDevice: staging.device,
-                    stagingInode: staging.inode
+                    stagingInode: staging.inode,
+                    parentDevice: staging.parentDevice,
+                    parentInode: staging.parentInode,
+                    installedMetadata: staging.metadata
                 ))
             }
             guard !Task.isCancelled,
@@ -269,26 +365,52 @@ nonisolated enum TerminationSaveCoordinator {
         _ data: Data,
         beside destination: URL,
         preservingPermissions destinationState: TerminationDestinationState
-    ) throws -> (url: URL, device: UInt64, inode: UInt64) {
+    ) throws -> StagingFile {
         let stagingURL = destination
             .deletingLastPathComponent()
             .appendingPathComponent(
                 ".pine-save-\(UUID().uuidString).tmp",
                 isDirectory: false
             )
-        let descriptor = Darwin.open(
-            stagingURL.path,
+        let parentURL = destination.deletingLastPathComponent()
+        let parentDescriptor = Darwin.open(
+            parentURL.path,
+            O_RDONLY | O_DIRECTORY | O_CLOEXEC
+        )
+        guard parentDescriptor >= 0 else { throw posixError() }
+        defer { Darwin.close(parentDescriptor) }
+
+        var parentStatus = stat()
+        guard Darwin.fstat(parentDescriptor, &parentStatus) == 0,
+              (parentStatus.st_mode & S_IFMT) == S_IFDIR else {
+            throw posixError()
+        }
+        let stagingLeaf = stagingURL.lastPathComponent
+        let descriptor = Darwin.openat(
+            parentDescriptor,
+            stagingLeaf,
             O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
-            S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
+            S_IRUSR | S_IWUSR
         )
         guard descriptor >= 0 else {
+            throw posixError()
+        }
+        var openedStatus = stat()
+        guard Darwin.fstat(descriptor, &openedStatus) == 0,
+              (openedStatus.st_mode & S_IFMT) == S_IFREG else {
+            Darwin.close(descriptor)
             throw posixError()
         }
         var keepFile = false
         defer {
             Darwin.close(descriptor)
             if !keepFile {
-                Darwin.unlink(stagingURL.path)
+                removeEntryIfMatches(
+                    parentDescriptor: parentDescriptor,
+                    leaf: stagingLeaf,
+                    device: UInt64(openedStatus.st_dev),
+                    inode: UInt64(openedStatus.st_ino)
+                )
             }
         }
 
@@ -314,14 +436,25 @@ nonisolated enum TerminationSaveCoordinator {
             }
         }
         if destinationState.exists {
+            let sourceDescriptor = Darwin.openat(
+                parentDescriptor,
+                destination.lastPathComponent,
+                O_RDONLY | O_CLOEXEC | O_NOFOLLOW
+            )
+            guard sourceDescriptor >= 0 else { throw posixError() }
+            defer { Darwin.close(sourceDescriptor) }
+            var sourceStatus = stat()
+            guard Darwin.fstat(sourceDescriptor, &sourceStatus) == 0,
+                  state(sourceStatus, matches: destinationState) else {
+                throw CocoaError(.fileWriteFileExists)
+            }
             let metadataFlags = copyfile_flags_t(
                 COPYFILE_ACL
                     | COPYFILE_XATTR
-                    | COPYFILE_NOFOLLOW
             )
-            guard Darwin.copyfile(
-                destination.path,
-                stagingURL.path,
+            guard Darwin.fcopyfile(
+                sourceDescriptor,
+                descriptor,
                 nil,
                 metadataFlags
             ) == 0 else {
@@ -331,6 +464,12 @@ nonisolated enum TerminationSaveCoordinator {
                 descriptor,
                 mode_t(destinationState.permissions)
             ) == 0 else {
+                throw posixError()
+            }
+        } else {
+            // Staging remains owner-only until all bytes are durable. New
+            // files receive Pine's normal 0644 document mode only afterward.
+            guard Darwin.fchmod(descriptor, 0o644) == 0 else {
                 throw posixError()
             }
         }
@@ -343,10 +482,17 @@ nonisolated enum TerminationSaveCoordinator {
             throw posixError()
         }
         keepFile = true
-        return (
-            stagingURL,
-            UInt64(status.st_dev),
-            UInt64(status.st_ino)
+        return StagingFile(
+            url: stagingURL,
+            device: UInt64(status.st_dev),
+            inode: UInt64(status.st_ino),
+            parentDevice: UInt64(parentStatus.st_dev),
+            parentInode: UInt64(parentStatus.st_ino),
+            metadata: TerminationInstalledFileMetadata(
+                size: Int(clamping: status.st_size),
+                modificationSeconds: Int(status.st_mtimespec.tv_sec),
+                modificationNanoseconds: Int(status.st_mtimespec.tv_nsec)
+            )
         )
     }
 
@@ -395,107 +541,267 @@ nonisolated enum TerminationSaveCoordinator {
     }
 
     private static func installSynchronously(
-        _ staged: TerminationStagedSave
+        _ staged: TerminationStagedSave,
+        deadlineNanoseconds: UInt64,
+        beforeDestinationQuarantine: InstallHook?
     ) throws {
-        guard stagingIdentityIsCurrent(staged) else {
+        let parentDescriptor = try openVerifiedParentDirectory(for: staged)
+        defer { Darwin.close(parentDescriptor) }
+        let stagingLeaf = staged.stagingURL.lastPathComponent
+        let destinationLeaf = staged.request.destination.lastPathComponent
+        guard regularFileMatches(
+            parentDescriptor: parentDescriptor,
+            leaf: stagingLeaf,
+            device: staged.stagingDevice,
+            inode: staged.stagingInode
+        ) else {
             throw CocoaError(.fileReadCorruptFile)
         }
+
         let expected = staged.request.expectedDestinationState
         if expected.exists {
-            guard destinationStateMatches(
-                expected,
-                at: staged.request.destination
-            ) else {
-                throw CocoaError(.fileWriteFileExists)
+            let quarantineLeaf = ".pine-save-recovery-\(UUID().uuidString)"
+            beforeDestinationQuarantine?()
+            guard !Task.isCancelled,
+                  DispatchTime.now().uptimeNanoseconds
+                    < deadlineNanoseconds else {
+                throw CancellationError()
             }
-            guard rename(
-                staged.stagingURL,
-                staged.request.destination,
-                flags: UInt32(RENAME_SWAP)
+            guard renameExclusive(
+                parentDescriptor: parentDescriptor,
+                source: destinationLeaf,
+                destination: quarantineLeaf
             ) == 0 else {
                 throw posixError()
             }
 
-            let displacedMatches = displacedStateMatchesAfterSwap(
+            guard displacedStateMatchesAfterRename(
                 expected,
-                at: staged.stagingURL
-            )
-            let installedMatches = regularFileMatches(
-                at: staged.request.destination,
+                parentDescriptor: parentDescriptor,
+                leaf: quarantineLeaf
+            ) else {
+                try restoreOrRetainRecovery(
+                    parentDescriptor: parentDescriptor,
+                    quarantineLeaf: quarantineLeaf,
+                    destinationLeaf: destinationLeaf,
+                    destinationURL: staged.request.destination
+                )
+                throw CocoaError(.fileWriteFileExists)
+            }
+            guard !Task.isCancelled,
+                  DispatchTime.now().uptimeNanoseconds
+                    < deadlineNanoseconds else {
+                try restoreOrRetainRecovery(
+                    parentDescriptor: parentDescriptor,
+                    quarantineLeaf: quarantineLeaf,
+                    destinationLeaf: destinationLeaf,
+                    destinationURL: staged.request.destination
+                )
+                throw CancellationError()
+            }
+            guard renameExclusive(
+                parentDescriptor: parentDescriptor,
+                source: stagingLeaf,
+                destination: destinationLeaf
+            ) == 0 else {
+                let installError = posixError()
+                try restoreOrRetainRecovery(
+                    parentDescriptor: parentDescriptor,
+                    quarantineLeaf: quarantineLeaf,
+                    destinationLeaf: destinationLeaf,
+                    destinationURL: staged.request.destination
+                )
+                throw installError
+            }
+
+            // If another actor immediately replaces the installed inode,
+            // fail closed and retain the authorized original for recovery.
+            // The editor remains dirty instead of claiming that the external
+            // bytes currently at the destination are our saved content.
+            guard regularFileMatches(
+                parentDescriptor: parentDescriptor,
+                leaf: destinationLeaf,
                 device: staged.stagingDevice,
                 inode: staged.stagingInode
-            )
-            guard displacedMatches, installedMatches else {
-                // Roll back only while both pathnames still hold the two
-                // inodes produced by our swap. An external replacement after
-                // the swap must never be displaced by a blind second swap.
-                let displacedIdentityIsExpected = regularFileMatches(
-                    at: staged.stagingURL,
-                    device: expected.device,
-                    inode: expected.inode
-                )
-                let installedIdentityIsOurs = regularFileMatches(
-                    at: staged.request.destination,
-                    device: staged.stagingDevice,
-                    inode: staged.stagingInode
-                )
-                if displacedIdentityIsExpected, installedIdentityIsOurs {
-                    _ = rename(
-                        staged.stagingURL,
-                        staged.request.destination,
-                        flags: UInt32(RENAME_SWAP)
-                    )
-                }
-                throw CocoaError(.fileWriteUnknown)
+            ) else {
+                let recoveryURL = staged.request.destination
+                    .deletingLastPathComponent()
+                    .appendingPathComponent(quarantineLeaf)
+                throw retainedRecoveryError(at: recoveryURL)
             }
-            unlinkRegularFile(
-                at: staged.stagingURL,
+            removeEntryIfMatches(
+                parentDescriptor: parentDescriptor,
+                leaf: quarantineLeaf,
                 device: expected.device,
                 inode: expected.inode
             )
         } else {
-            guard rename(
-                staged.stagingURL,
-                staged.request.destination,
-                flags: UInt32(RENAME_EXCL)
+            guard !Task.isCancelled,
+                  DispatchTime.now().uptimeNanoseconds
+                    < deadlineNanoseconds else {
+                throw CancellationError()
+            }
+            guard renameExclusive(
+                parentDescriptor: parentDescriptor,
+                source: stagingLeaf,
+                destination: destinationLeaf
             ) == 0 else {
                 throw posixError()
             }
             guard regularFileMatches(
-                at: staged.request.destination,
+                parentDescriptor: parentDescriptor,
+                leaf: destinationLeaf,
                 device: staged.stagingDevice,
                 inode: staged.stagingInode
             ) else {
-                throw CocoaError(.fileWriteUnknown)
+                throw CocoaError(.fileWriteFileExists)
             }
         }
     }
 
-    private static func rename(
-        _ source: URL,
-        _ destination: URL,
-        flags: UInt32
-    ) -> Int32 {
-        source.path.withCString { sourcePath in
-            destination.path.withCString { destinationPath in
-                Darwin.renameatx_np(
-                    AT_FDCWD,
-                    sourcePath,
-                    AT_FDCWD,
-                    destinationPath,
-                    flags
-                )
-            }
+    private static func openVerifiedParentDirectory(
+        for staged: TerminationStagedSave
+    ) throws -> Int32 {
+        let stagingParent = staged.stagingURL.deletingLastPathComponent()
+        let destinationParent = staged.request.destination
+            .deletingLastPathComponent()
+        guard stagingParent.standardizedFileURL
+                == destinationParent.standardizedFileURL else {
+            throw CocoaError(.fileWriteInvalidFileName)
         }
+        let descriptor = Darwin.open(
+            destinationParent.path,
+            O_RDONLY | O_DIRECTORY | O_CLOEXEC
+        )
+        guard descriptor >= 0 else { throw posixError() }
+        var status = stat()
+        guard Darwin.fstat(descriptor, &status) == 0,
+              (status.st_mode & S_IFMT) == S_IFDIR,
+              UInt64(status.st_dev) == staged.parentDevice,
+              UInt64(status.st_ino) == staged.parentInode else {
+            Darwin.close(descriptor)
+            throw CocoaError(.fileWriteInvalidFileName)
+        }
+        return descriptor
+    }
+
+    private static func withVerifiedParentDirectory<Result>(
+        of url: URL,
+        staged: TerminationStagedSave,
+        _ body: (Int32, String) -> Result
+    ) -> Result? {
+        guard url.deletingLastPathComponent().standardizedFileURL
+                == staged.stagingURL.deletingLastPathComponent()
+                    .standardizedFileURL,
+              let descriptor = try? openVerifiedParentDirectory(for: staged)
+        else { return nil }
+        defer { Darwin.close(descriptor) }
+        return body(descriptor, url.lastPathComponent)
+    }
+
+    private static func renameExclusive(
+        parentDescriptor: Int32,
+        source: String,
+        destination: String
+    ) -> Int32 {
+        Darwin.renameatx_np(
+            parentDescriptor,
+            source,
+            parentDescriptor,
+            destination,
+            UInt32(RENAME_EXCL)
+        )
+    }
+
+    private static func restoreOrRetainRecovery(
+        parentDescriptor: Int32,
+        quarantineLeaf: String,
+        destinationLeaf: String,
+        destinationURL: URL
+    ) throws {
+        guard renameExclusive(
+            parentDescriptor: parentDescriptor,
+            source: quarantineLeaf,
+            destination: destinationLeaf
+        ) == 0 else {
+            let recoveryURL = destinationURL
+                .deletingLastPathComponent()
+                .appendingPathComponent(quarantineLeaf)
+            throw retainedRecoveryError(at: recoveryURL)
+        }
+    }
+
+    private static func retainedRecoveryError(at recoveryURL: URL) -> NSError {
+        NSError(
+            domain: NSCocoaErrorDomain,
+            code: CocoaError.fileWriteUnknown.rawValue,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "A concurrent file replacement was retained at "
+                    + recoveryURL.path,
+            ]
+        )
+    }
+
+    private static func displacedStateMatchesAfterRename(
+        _ expected: TerminationDestinationState,
+        parentDescriptor: Int32,
+        leaf: String
+    ) -> Bool {
+        var status = stat()
+        guard Darwin.fstatat(
+            parentDescriptor,
+            leaf,
+            &status,
+            AT_SYMLINK_NOFOLLOW
+        ) == 0 else {
+            return false
+        }
+        return UInt64(status.st_dev) == expected.device
+            && UInt64(status.st_ino) == expected.inode
+            && status.st_size == expected.size
+            && UInt32(status.st_mode & 0o7777) == expected.permissions
+            && status.st_uid == expected.ownerID
+            && status.st_gid == expected.groupID
+            && Int(status.st_mtimespec.tv_sec)
+                == expected.modificationSeconds
+            && Int(status.st_mtimespec.tv_nsec)
+                == expected.modificationNanoseconds
+    }
+
+    private static func state(
+        _ status: stat,
+        matches expected: TerminationDestinationState
+    ) -> Bool {
+        (status.st_mode & S_IFMT) == S_IFREG
+            && UInt64(status.st_dev) == expected.device
+            && UInt64(status.st_ino) == expected.inode
+            && status.st_size == expected.size
+            && UInt32(status.st_mode & 0o7777) == expected.permissions
+            && status.st_uid == expected.ownerID
+            && status.st_gid == expected.groupID
+            && Int(status.st_mtimespec.tv_sec)
+                == expected.modificationSeconds
+            && Int(status.st_mtimespec.tv_nsec)
+                == expected.modificationNanoseconds
+            && Int(status.st_ctimespec.tv_sec) == expected.changeSeconds
+            && Int(status.st_ctimespec.tv_nsec)
+                == expected.changeNanoseconds
     }
 
     private static func regularFileMatches(
-        at url: URL,
+        parentDescriptor: Int32,
+        leaf: String,
         device: UInt64,
         inode: UInt64
     ) -> Bool {
         var status = stat()
-        guard Darwin.lstat(url.path, &status) == 0,
+        guard Darwin.fstatat(
+            parentDescriptor,
+            leaf,
+            &status,
+            AT_SYMLINK_NOFOLLOW
+        ) == 0,
               (status.st_mode & S_IFMT) == S_IFREG else {
             return false
         }
@@ -503,37 +809,50 @@ nonisolated enum TerminationSaveCoordinator {
             && UInt64(status.st_ino) == inode
     }
 
-    /// A rename updates the inode change time even though the file itself was
-    /// not edited. Compare every authorized property that survives the swap;
-    /// the strict pre-swap check above still includes ctime.
-    private static func displacedStateMatchesAfterSwap(
-        _ expected: TerminationDestinationState,
-        at url: URL
-    ) -> Bool {
-        guard let current = try? destinationState(at: url) else {
-            return false
+    private static func removeStagingFileIfMatches(
+        _ staged: TerminationStagedSave
+    ) {
+        _ = withVerifiedParentDirectory(
+            of: staged.stagingURL,
+            staged: staged
+        ) { parentDescriptor, stagingLeaf in
+            removeEntryIfMatches(
+                parentDescriptor: parentDescriptor,
+                leaf: stagingLeaf,
+                device: staged.stagingDevice,
+                inode: staged.stagingInode
+            )
         }
-        return current.device == expected.device
-            && current.inode == expected.inode
-            && current.size == expected.size
-            && current.permissions == expected.permissions
-            && current.ownerID == expected.ownerID
-            && current.groupID == expected.groupID
-            && current.modificationSeconds == expected.modificationSeconds
-            && current.modificationNanoseconds
-                == expected.modificationNanoseconds
     }
 
-    private static func unlinkRegularFile(
-        at url: URL,
+    /// Move-first cleanup prevents a pathname substitution from being blindly
+    /// unlinked. A mismatched entry is restored exclusively; if that path has
+    /// concurrently reappeared, the entry remains under the recovery name.
+    private static func removeEntryIfMatches(
+        parentDescriptor: Int32,
+        leaf: String,
         device: UInt64,
         inode: UInt64
     ) {
+        let cleanupLeaf = ".pine-save-cleanup-\(UUID().uuidString)"
+        guard renameExclusive(
+            parentDescriptor: parentDescriptor,
+            source: leaf,
+            destination: cleanupLeaf
+        ) == 0 else { return }
         guard regularFileMatches(
-            at: url,
+            parentDescriptor: parentDescriptor,
+            leaf: cleanupLeaf,
             device: device,
             inode: inode
-        ) else { return }
-        _ = Darwin.unlink(url.path)
+        ) else {
+            _ = renameExclusive(
+                parentDescriptor: parentDescriptor,
+                source: cleanupLeaf,
+                destination: leaf
+            )
+            return
+        }
+        _ = Darwin.unlinkat(parentDescriptor, cleanupLeaf, 0)
     }
 }

--- a/Pine/TerminationSaveCoordinator.swift
+++ b/Pine/TerminationSaveCoordinator.swift
@@ -27,7 +27,7 @@ nonisolated struct TerminationSaveRequest: Sendable {
 /// Comparing timestamps as well as inode identity catches in-place external
 /// writes while staging is in progress.
 nonisolated struct TerminationDestinationState: Sendable, Equatable {
-    let device: UInt64
+    let device: UInt32
     let inode: UInt64
     let size: Int64
     let permissions: UInt32
@@ -58,14 +58,42 @@ nonisolated struct TerminationDestinationState: Sendable, Equatable {
     var exists: Bool { size >= 0 }
 }
 
+/// Keeps the exact staging directory reachable even if another process renames
+/// it before Quit either installs or removes the staged save. Directory file
+/// descriptors remain bound to the directory inode across namespace moves.
+nonisolated final class TerminationParentDirectoryLease: @unchecked Sendable {
+    private let descriptor: Int32
+
+    init(duplicating descriptor: Int32) throws {
+        let duplicate = Darwin.fcntl(descriptor, F_DUPFD_CLOEXEC, 0)
+        guard duplicate >= 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        self.descriptor = duplicate
+    }
+
+    deinit {
+        Darwin.close(descriptor)
+    }
+
+    func duplicateDescriptor() throws -> Int32 {
+        let duplicate = Darwin.fcntl(descriptor, F_DUPFD_CLOEXEC, 0)
+        guard duplicate >= 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        return duplicate
+    }
+}
+
 nonisolated struct TerminationStagedSave: Sendable {
     let request: TerminationSaveRequest
     let stagingURL: URL
     let preparedContent: String
-    let stagingDevice: UInt64
+    let stagingDevice: UInt32
     let stagingInode: UInt64
-    let parentDevice: UInt64
+    let parentDevice: UInt32
     let parentInode: UInt64
+    let parentDirectoryLease: TerminationParentDirectoryLease
     let stagingContentDigest: Data
     let installedMetadata: TerminationInstalledFileMetadata
 }
@@ -131,6 +159,13 @@ nonisolated private final class TerminationDeadlineResolver<Result: Sendable>:
 nonisolated enum TerminationSaveCoordinator {
     typealias InstallHook = @Sendable () -> Void
 
+    /// `dev_t` is signed in Darwin's Swift overlay even though every bit is
+    /// part of the filesystem identity. Preserve that representation without
+    /// a checked signed-to-unsigned conversion, which traps for high-bit IDs.
+    static func deviceIdentityBits(_ device: dev_t) -> UInt32 {
+        UInt32(bitPattern: device)
+    }
+
     private enum ArtifactRemovalResult {
         case removed
         case failed(message: String, retainedURL: URL?)
@@ -143,12 +178,39 @@ nonisolated enum TerminationSaveCoordinator {
 
     private struct StagingFile {
         let url: URL
-        let device: UInt64
+        let device: UInt32
         let inode: UInt64
-        let parentDevice: UInt64
+        let parentDevice: UInt32
         let parentInode: UInt64
+        let parentDirectoryLease: TerminationParentDirectoryLease
         let contentDigest: Data
         let metadata: TerminationInstalledFileMetadata
+    }
+
+    private struct InstalledDescriptorMetadata: Equatable {
+        let permissions: UInt32
+        let ownerID: UInt32
+        let groupID: UInt32
+        let extendedMetadataDigest: Data
+    }
+
+    private enum ExpectedInstalledMetadata {
+        case existing(TerminationDestinationState)
+        case captured(InstalledDescriptorMetadata)
+    }
+
+    private struct InstallHooks {
+        let beforeDestinationQuarantine: InstallHook?
+        let afterDestinationPublication: InstallHook?
+        let beforeRecoveryCleanup: InstallHook?
+        let beforeFinalInstalledFence: InstallHook?
+    }
+
+    private struct FinalInstalledFileVerification {
+        let stagingDescriptor: Int32
+        let parentDescriptor: Int32
+        let destinationLeaf: String
+        let expectedMetadata: ExpectedInstalledMetadata
     }
 
     private struct PublishedSwapRollback {
@@ -310,6 +372,7 @@ nonisolated enum TerminationSaveCoordinator {
         beforeDestinationQuarantine: InstallHook? = nil,
         afterDestinationPublication: InstallHook? = nil,
         beforeRecoveryCleanup: InstallHook? = nil,
+        beforeFinalInstalledFence: InstallHook? = nil,
         lateCompletion: @escaping @Sendable (
             TerminationSaveInstallResult
         ) -> Void = { _ in }
@@ -326,11 +389,15 @@ nonisolated enum TerminationSaveCoordinator {
                     try installSynchronously(
                         staged,
                         deadlineNanoseconds: deadlineNanoseconds,
-                        beforeDestinationQuarantine:
-                            beforeDestinationQuarantine,
-                        afterDestinationPublication:
-                            afterDestinationPublication,
-                        beforeRecoveryCleanup: beforeRecoveryCleanup
+                        hooks: InstallHooks(
+                            beforeDestinationQuarantine:
+                                beforeDestinationQuarantine,
+                            afterDestinationPublication:
+                                afterDestinationPublication,
+                            beforeRecoveryCleanup: beforeRecoveryCleanup,
+                            beforeFinalInstalledFence:
+                                beforeFinalInstalledFence
+                        )
                     )
                     result = .installed(metadata: staged.installedMetadata)
                 } catch is CancellationError {
@@ -434,6 +501,7 @@ nonisolated enum TerminationSaveCoordinator {
                     stagingInode: staging.inode,
                     parentDevice: staging.parentDevice,
                     parentInode: staging.parentInode,
+                    parentDirectoryLease: staging.parentDirectoryLease,
                     stagingContentDigest: staging.contentDigest,
                     installedMetadata: staging.metadata
                 ))
@@ -547,10 +615,13 @@ nonisolated enum TerminationSaveCoordinator {
             }
             return StagingFile(
                 url: stagingURL,
-                device: UInt64(status.st_dev),
+                device: deviceIdentityBits(status.st_dev),
                 inode: UInt64(status.st_ino),
-                parentDevice: UInt64(parentStatus.st_dev),
+                parentDevice: deviceIdentityBits(parentStatus.st_dev),
                 parentInode: UInt64(parentStatus.st_ino),
+                parentDirectoryLease: try TerminationParentDirectoryLease(
+                    duplicating: parentDescriptor
+                ),
                 contentDigest: Data(SHA256.hash(data: data)),
                 metadata: TerminationInstalledFileMetadata(
                     size: Int(clamping: status.st_size),
@@ -562,9 +633,9 @@ nonisolated enum TerminationSaveCoordinator {
             let stagingError = error
             switch removeEntryIfMatches(
                     parentDescriptor: parentDescriptor,
-                    parentURL: parentURL,
+                    fallbackParentURL: parentURL,
                     leaf: stagingLeaf,
-                    device: UInt64(openedStatus.st_dev),
+                    device: deviceIdentityBits(openedStatus.st_dev),
                     inode: UInt64(openedStatus.st_ino)
             ) {
             case .removed:
@@ -637,9 +708,7 @@ nonisolated enum TerminationSaveCoordinator {
     private static func installSynchronously(
         _ staged: TerminationStagedSave,
         deadlineNanoseconds: UInt64,
-        beforeDestinationQuarantine: InstallHook?,
-        afterDestinationPublication: InstallHook?,
-        beforeRecoveryCleanup: InstallHook?
+        hooks: InstallHooks
     ) throws {
         let parentDescriptor = try openVerifiedParentDirectory(for: staged)
         defer { Darwin.close(parentDescriptor) }
@@ -663,7 +732,7 @@ nonisolated enum TerminationSaveCoordinator {
 
         let expected = staged.request.expectedDestinationState
         if expected.exists {
-            beforeDestinationQuarantine?()
+            hooks.beforeDestinationQuarantine?()
             try checkDeadline(deadlineNanoseconds)
             try verifyPinnedParentPath(
                 staged,
@@ -717,7 +786,7 @@ nonisolated enum TerminationSaveCoordinator {
             }
             do {
                 try synchronizeDirectory(parentDescriptor)
-                afterDestinationPublication?()
+                hooks.afterDestinationPublication?()
                 let displacedSnapshot = try destinationSnapshot(
                     destinationDescriptor,
                     deadlineNanoseconds: deadlineNanoseconds
@@ -762,7 +831,7 @@ nonisolated enum TerminationSaveCoordinator {
                     descriptor: parentDescriptor,
                     retainedLeaf: stagingLeaf
                 )
-                beforeRecoveryCleanup?()
+                hooks.beforeRecoveryCleanup?()
                 guard try installedMetadataMatches(
                     stagingDescriptor,
                     expected: expected,
@@ -823,32 +892,23 @@ nonisolated enum TerminationSaveCoordinator {
             }
             switch removeEntryIfMatches(
                 parentDescriptor: parentDescriptor,
-                parentURL: parentURL,
+                fallbackParentURL: parentURL,
                 leaf: stagingLeaf,
                 device: expected.device,
                 inode: expected.inode
             ) {
             case .removed:
-                try verifyPinnedParentPath(
+                hooks.beforeFinalInstalledFence?()
+                try verifyFinalInstalledFile(
                     staged,
-                    descriptor: parentDescriptor,
-                    retainedLeaf: destinationLeaf
+                    verification: FinalInstalledFileVerification(
+                        stagingDescriptor: stagingDescriptor,
+                        parentDescriptor: parentDescriptor,
+                        destinationLeaf: destinationLeaf,
+                        expectedMetadata: .existing(expected)
+                    ),
+                    deadlineNanoseconds: deadlineNanoseconds
                 )
-                guard regularFileMatches(
-                    parentDescriptor: parentDescriptor,
-                    leaf: destinationLeaf,
-                    device: staged.stagingDevice,
-                    inode: staged.stagingInode
-                ) else {
-                    throw retainedRecoveryError(
-                        at: retainedArtifactURL(
-                            parentDescriptor: parentDescriptor,
-                            leaf: destinationLeaf,
-                            fallback: staged.request.destination
-                        ),
-                        reason: "The installed save moved before completion"
-                    )
-                }
             case .failed(let message, let retainedURL):
                 if let retainedURL {
                     throw retainedRecoveryError(
@@ -902,13 +962,15 @@ nonisolated enum TerminationSaveCoordinator {
                 try resecureStaging(stagingDescriptor, at: staged.stagingURL)
                 throw installError
             }
+            let installedMetadata: InstalledDescriptorMetadata
             do {
                 try synchronizeDirectory(parentDescriptor)
-                afterDestinationPublication?()
-                try applyMissingDestinationMetadata(
+                hooks.afterDestinationPublication?()
+                installedMetadata = try applyMissingDestinationMetadata(
                     parentDescriptor: parentDescriptor,
                     parentURL: parentURL,
-                    destinationDescriptor: stagingDescriptor
+                    destinationDescriptor: stagingDescriptor,
+                    deadlineNanoseconds: deadlineNanoseconds
                 )
                 guard regularFileMatches(
                     parentDescriptor: parentDescriptor,
@@ -940,22 +1002,48 @@ nonisolated enum TerminationSaveCoordinator {
                 try synchronizeDirectory(parentDescriptor)
             } catch {
                 let installError = error
-                try rollbackPublishedNewDestination(
-                    staged,
-                    stagingDescriptor: stagingDescriptor,
+                do {
+                    try rollbackPublishedNewDestination(
+                        staged,
+                        stagingDescriptor: stagingDescriptor,
+                        parentDescriptor: parentDescriptor,
+                        stagingLeaf: stagingLeaf,
+                        destinationLeaf: destinationLeaf
+                    )
+                } catch {
+                    let retainedURLs = uniqueRecoveryURLs(
+                        retainedArtifacts(from: installError)
+                            + retainedArtifacts(from: error)
+                    )
+                    throw retainedRecoveryError(
+                        at: retainedURLs,
+                        reason: installError.localizedDescription
+                            + "\n" + error.localizedDescription
+                    )
+                }
+                let recoveryURL = retainedArtifactURL(
                     parentDescriptor: parentDescriptor,
-                    stagingLeaf: stagingLeaf,
-                    destinationLeaf: destinationLeaf
+                    leaf: stagingLeaf,
+                    fallback: staged.stagingURL
                 )
                 throw retainedRecoveryError(
-                    at: retainedArtifactURL(
-                        parentDescriptor: parentDescriptor,
-                        leaf: stagingLeaf,
-                        fallback: staged.stagingURL
+                    at: uniqueRecoveryURLs(
+                        retainedArtifacts(from: installError) + [recoveryURL]
                     ),
                     reason: installError.localizedDescription
                 )
             }
+            hooks.beforeFinalInstalledFence?()
+            try verifyFinalInstalledFile(
+                staged,
+                verification: FinalInstalledFileVerification(
+                    stagingDescriptor: stagingDescriptor,
+                    parentDescriptor: parentDescriptor,
+                    destinationLeaf: destinationLeaf,
+                    expectedMetadata: .captured(installedMetadata)
+                ),
+                deadlineNanoseconds: deadlineNanoseconds
+            )
         }
     }
 
@@ -969,15 +1057,12 @@ nonisolated enum TerminationSaveCoordinator {
                 == destinationParent.standardizedFileURL else {
             throw CocoaError(.fileWriteInvalidFileName)
         }
-        let descriptor = Darwin.open(
-            destinationParent.path,
-            O_RDONLY | O_DIRECTORY | O_CLOEXEC
-        )
-        guard descriptor >= 0 else { throw posixError() }
+        let descriptor = try staged.parentDirectoryLease
+            .duplicateDescriptor()
         var status = stat()
         guard Darwin.fstat(descriptor, &status) == 0,
               (status.st_mode & S_IFMT) == S_IFDIR,
-              UInt64(status.st_dev) == staged.parentDevice,
+              deviceIdentityBits(status.st_dev) == staged.parentDevice,
               UInt64(status.st_ino) == staged.parentInode else {
             Darwin.close(descriptor)
             throw CocoaError(.fileWriteInvalidFileName)
@@ -1003,7 +1088,8 @@ nonisolated enum TerminationSaveCoordinator {
             && (verificationStatus.st_mode & S_IFMT) == S_IFDIR
             && verificationStatus.st_dev == pinnedStatus.st_dev
             && verificationStatus.st_ino == pinnedStatus.st_ino
-            && UInt64(verificationStatus.st_dev) == staged.parentDevice
+            && deviceIdentityBits(verificationStatus.st_dev)
+                == staged.parentDevice
             && UInt64(verificationStatus.st_ino) == staged.parentInode
         if verificationDescriptor >= 0 {
             Darwin.close(verificationDescriptor)
@@ -1025,16 +1111,26 @@ nonisolated enum TerminationSaveCoordinator {
         leaf: String,
         fallback: URL
     ) -> URL {
+        currentArtifactURL(
+            parentDescriptor: parentDescriptor,
+            leaf: leaf
+        ) ?? fallback
+    }
+
+    private static func currentArtifactURL(
+        parentDescriptor: Int32,
+        leaf: String
+    ) -> URL? {
         var path = [CChar](
             repeating: 0,
             count: 4 * Int(MAXPATHLEN)
         )
         guard let handle = Darwin.dlopen(nil, RTLD_LAZY | RTLD_LOCAL) else {
-            return fallback
+            return nil
         }
         defer { Darwin.dlclose(handle) }
         guard let symbol = Darwin.dlsym(handle, "fcntl") else {
-            return fallback
+            return nil
         }
         typealias FcntlPath = @convention(c) (
             Int32,
@@ -1045,8 +1141,13 @@ nonisolated enum TerminationSaveCoordinator {
         let result = path.withUnsafeMutableBytes { buffer in
             fcntlPath(parentDescriptor, F_GETPATH, buffer.baseAddress)
         }
-        guard result == 0 else { return fallback }
-        return URL(fileURLWithPath: String(cString: path))
+        guard result == 0 else { return nil }
+        let terminator = path.firstIndex(of: 0) ?? path.endIndex
+        let pathBytes = path[..<terminator].map(UInt8.init(bitPattern:))
+        guard let currentPath = String(bytes: pathBytes, encoding: .utf8) else {
+            return nil
+        }
+        return URL(fileURLWithPath: currentPath)
             .appendingPathComponent(leaf)
     }
 
@@ -1055,12 +1156,17 @@ nonisolated enum TerminationSaveCoordinator {
         staged: TerminationStagedSave,
         _ body: (Int32, String) -> Result
     ) -> Result? {
-        guard url.deletingLastPathComponent().standardizedFileURL
-                == staged.stagingURL.deletingLastPathComponent()
-                    .standardizedFileURL,
-              let descriptor = try? openVerifiedParentDirectory(for: staged)
-        else { return nil }
+        guard url.lastPathComponent == staged.stagingURL.lastPathComponent,
+              let descriptor = try? staged.parentDirectoryLease
+                .duplicateDescriptor() else { return nil }
         defer { Darwin.close(descriptor) }
+        var status = stat()
+        guard Darwin.fstat(descriptor, &status) == 0,
+              (status.st_mode & S_IFMT) == S_IFDIR,
+              deviceIdentityBits(status.st_dev) == staged.parentDevice,
+              UInt64(status.st_ino) == staged.parentInode else {
+            return nil
+        }
         return body(descriptor, url.lastPathComponent)
     }
 
@@ -1247,6 +1353,13 @@ nonisolated enum TerminationSaveCoordinator {
         ] as? [URL] ?? []
     }
 
+    private static func uniqueRecoveryURLs(_ urls: [URL]) -> [URL] {
+        var paths = Set<String>()
+        return urls.filter {
+            paths.insert($0.standardizedFileURL.path).inserted
+        }
+    }
+
     private static func checkDeadline(_ deadlineNanoseconds: UInt64) throws {
         guard !Task.isCancelled,
               DispatchTime.now().uptimeNanoseconds < deadlineNanoseconds else {
@@ -1279,7 +1392,7 @@ nonisolated enum TerminationSaveCoordinator {
         }
         return DestinationDescriptorSnapshot(
             state: TerminationDestinationState(
-                device: UInt64(after.st_dev),
+                device: deviceIdentityBits(after.st_dev),
                 inode: UInt64(after.st_ino),
                 size: after.st_size,
                 permissions: UInt32(after.st_mode & 0o7777),
@@ -1485,7 +1598,7 @@ nonisolated enum TerminationSaveCoordinator {
         var status = stat()
         guard Darwin.fstat(descriptor, &status) == 0,
               (status.st_mode & S_IFMT) == S_IFREG,
-              UInt64(status.st_dev) == staged.stagingDevice,
+              deviceIdentityBits(status.st_dev) == staged.stagingDevice,
               UInt64(status.st_ino) == staged.stagingInode,
               status.st_uid == Darwin.getuid(),
               status.st_nlink == 1,
@@ -1634,6 +1747,91 @@ nonisolated enum TerminationSaveCoordinator {
             ) == expected.extendedMetadataDigest
     }
 
+    private static func installedMetadataSnapshot(
+        _ descriptor: Int32,
+        deadlineNanoseconds: UInt64
+    ) throws -> InstalledDescriptorMetadata {
+        var status = stat()
+        guard Darwin.fstat(descriptor, &status) == 0 else {
+            throw posixError()
+        }
+        return InstalledDescriptorMetadata(
+            permissions: UInt32(status.st_mode & 0o7777),
+            ownerID: status.st_uid,
+            groupID: status.st_gid,
+            extendedMetadataDigest: try extendedMetadataDigest(
+                descriptor,
+                deadlineNanoseconds: deadlineNanoseconds
+            )
+        )
+    }
+
+    private static func verifyFinalInstalledFile(
+        _ staged: TerminationStagedSave,
+        verification: FinalInstalledFileVerification,
+        deadlineNanoseconds: UInt64
+    ) throws {
+        do {
+            try verifyPinnedParentPath(
+                staged,
+                descriptor: verification.parentDescriptor,
+                retainedLeaf: verification.destinationLeaf
+            )
+            var before = stat()
+            guard Darwin.fstat(
+                verification.stagingDescriptor,
+                &before
+            ) == 0 else {
+                throw posixError()
+            }
+            let metadataMatches: Bool
+            switch verification.expectedMetadata {
+            case .existing(let expected):
+                metadataMatches = try installedMetadataMatches(
+                    verification.stagingDescriptor,
+                    expected: expected,
+                    deadlineNanoseconds: deadlineNanoseconds
+                )
+            case .captured(let expected):
+                metadataMatches = try installedMetadataSnapshot(
+                    verification.stagingDescriptor,
+                    deadlineNanoseconds: deadlineNanoseconds
+                ) == expected
+            }
+            let contentMatches = try installedContentMatches(
+                verification.stagingDescriptor,
+                staged: staged,
+                deadlineNanoseconds: deadlineNanoseconds
+            )
+            var after = stat()
+            guard metadataMatches,
+                  contentMatches,
+                  Darwin.fstat(
+                      verification.stagingDescriptor,
+                      &after
+                  ) == 0,
+                  stableStatus(before, after),
+                  regularFileMatches(
+                      parentDescriptor: verification.parentDescriptor,
+                      leaf: verification.destinationLeaf,
+                      device: staged.stagingDevice,
+                      inode: staged.stagingInode
+                  ) else {
+                throw CocoaError(.fileWriteFileExists)
+            }
+        } catch {
+            throw retainedRecoveryError(
+                at: retainedArtifactURL(
+                    parentDescriptor: verification.parentDescriptor,
+                    leaf: verification.destinationLeaf,
+                    fallback: staged.request.destination
+                ),
+                reason: "The final installed save could not be verified: "
+                    + error.localizedDescription
+            )
+        }
+    }
+
     private static func installedContentMatches(
         _ descriptor: Int32,
         staged: TerminationStagedSave,
@@ -1641,7 +1839,7 @@ nonisolated enum TerminationSaveCoordinator {
     ) throws -> Bool {
         var before = stat()
         guard Darwin.fstat(descriptor, &before) == 0,
-              UInt64(before.st_dev) == staged.stagingDevice,
+              deviceIdentityBits(before.st_dev) == staged.stagingDevice,
               UInt64(before.st_ino) == staged.stagingInode else {
             throw posixError()
         }
@@ -1665,8 +1863,9 @@ nonisolated enum TerminationSaveCoordinator {
     private static func applyMissingDestinationMetadata(
         parentDescriptor: Int32,
         parentURL: URL,
-        destinationDescriptor: Int32
-    ) throws {
+        destinationDescriptor: Int32,
+        deadlineNanoseconds: UInt64
+    ) throws -> InstalledDescriptorMetadata {
         let leaf = ".pine-save-mode-\(UUID().uuidString).tmp"
         let probeDescriptor = Darwin.openat(
             parentDescriptor,
@@ -1712,9 +1911,9 @@ nonisolated enum TerminationSaveCoordinator {
 
         let removal = removeEntryIfMatches(
             parentDescriptor: parentDescriptor,
-            parentURL: parentURL,
+            fallbackParentURL: parentURL,
             leaf: leaf,
-            device: UInt64(status.st_dev),
+            device: deviceIdentityBits(status.st_dev),
             inode: UInt64(status.st_ino)
         )
         switch removal {
@@ -1722,7 +1921,17 @@ nonisolated enum TerminationSaveCoordinator {
             break
         case .failed(let message, let retainedURL):
             if let retainedURL {
-                throw retainedRecoveryError(at: retainedURL, reason: message)
+                let metadataArtifacts = metadataError.map {
+                    retainedArtifacts(from: $0)
+                } ?? []
+                throw retainedRecoveryError(
+                    at: uniqueRecoveryURLs(
+                        metadataArtifacts + [retainedURL]
+                    ),
+                    reason: metadataError.map {
+                        $0.localizedDescription + "\n" + message
+                    } ?? message
+                )
             }
             throw CocoaError(
                 .fileWriteUnknown,
@@ -1732,6 +1941,10 @@ nonisolated enum TerminationSaveCoordinator {
         if let metadataError {
             throw metadataError
         }
+        return try installedMetadataSnapshot(
+            destinationDescriptor,
+            deadlineNanoseconds: deadlineNanoseconds
+        )
     }
 
     private static func synchronizeDirectory(_ descriptor: Int32) throws {
@@ -1741,7 +1954,7 @@ nonisolated enum TerminationSaveCoordinator {
     private static func regularFileMatches(
         parentDescriptor: Int32,
         leaf: String,
-        device: UInt64,
+        device: UInt32,
         inode: UInt64
     ) -> Bool {
         var status = stat()
@@ -1754,7 +1967,7 @@ nonisolated enum TerminationSaveCoordinator {
               (status.st_mode & S_IFMT) == S_IFREG else {
             return false
         }
-        return UInt64(status.st_dev) == device
+        return deviceIdentityBits(status.st_dev) == device
             && UInt64(status.st_ino) == inode
     }
 
@@ -1765,9 +1978,14 @@ nonisolated enum TerminationSaveCoordinator {
             of: staged.stagingURL,
             staged: staged
         ) { parentDescriptor, stagingLeaf in
-            removeEntryIfMatches(
+            let originalParentURL = staged.stagingURL
+                .deletingLastPathComponent()
+            return removeEntryIfMatches(
                 parentDescriptor: parentDescriptor,
-                parentURL: staged.stagingURL.deletingLastPathComponent(),
+                fallbackParentURL: directoryPathMatches(
+                    parentDescriptor: parentDescriptor,
+                    url: originalParentURL
+                ) ? originalParentURL : nil,
                 leaf: stagingLeaf,
                 device: staged.stagingDevice,
                 inode: staged.stagingInode
@@ -1775,8 +1993,20 @@ nonisolated enum TerminationSaveCoordinator {
         }
         return result ?? .failed(
             message: "Could not verify the staged-save directory",
-            retainedURL: staged.stagingURL
+            retainedURL: nil
         )
+    }
+
+    private static func directoryPathMatches(
+        parentDescriptor: Int32,
+        url: URL
+    ) -> Bool {
+        var pinnedStatus = stat()
+        var pathStatus = stat()
+        return Darwin.fstat(parentDescriptor, &pinnedStatus) == 0
+            && Darwin.lstat(url.path, &pathStatus) == 0
+            && (pathStatus.st_mode & S_IFMT) == S_IFDIR
+            && sameObject(pinnedStatus, pathStatus)
     }
 
     /// Move-first cleanup prevents a pathname substitution from being blindly
@@ -1784,14 +2014,16 @@ nonisolated enum TerminationSaveCoordinator {
     /// concurrently reappeared, the entry remains under the recovery name.
     private static func removeEntryIfMatches(
         parentDescriptor: Int32,
-        parentURL: URL,
+        fallbackParentURL: URL?,
         leaf: String,
-        device: UInt64,
+        device: UInt32,
         inode: UInt64
     ) -> ArtifactRemovalResult {
         let cleanupLeaf = ".pine-save-cleanup-\(UUID().uuidString)"
-        let originalURL = parentURL.appendingPathComponent(leaf)
-        let cleanupURL = parentURL.appendingPathComponent(cleanupLeaf)
+        let fallbackOriginalURL = fallbackParentURL?.appendingPathComponent(leaf)
+        let fallbackCleanupURL = fallbackParentURL?.appendingPathComponent(
+            cleanupLeaf
+        )
         guard renameExclusive(
             parentDescriptor: parentDescriptor,
             source: leaf,
@@ -1800,7 +2032,10 @@ nonisolated enum TerminationSaveCoordinator {
             if errno == ENOENT { return .removed }
             return .failed(
                 message: "Could not quarantine an artifact before cleanup",
-                retainedURL: originalURL
+                retainedURL: currentArtifactURL(
+                    parentDescriptor: parentDescriptor,
+                    leaf: leaf
+                ) ?? fallbackOriginalURL
             )
         }
         do {
@@ -1808,7 +2043,10 @@ nonisolated enum TerminationSaveCoordinator {
         } catch {
             return .failed(
                 message: "Could not make artifact quarantine durable",
-                retainedURL: cleanupURL
+                retainedURL: currentArtifactURL(
+                    parentDescriptor: parentDescriptor,
+                    leaf: cleanupLeaf
+                ) ?? fallbackCleanupURL
             )
         }
         guard regularFileMatches(
@@ -1827,13 +2065,19 @@ nonisolated enum TerminationSaveCoordinator {
             }
             return .failed(
                 message: "An artifact changed identity during cleanup",
-                retainedURL: restored ? originalURL : cleanupURL
+                retainedURL: currentArtifactURL(
+                    parentDescriptor: parentDescriptor,
+                    leaf: restored ? leaf : cleanupLeaf
+                ) ?? (restored ? fallbackOriginalURL : fallbackCleanupURL)
             )
         }
         guard Darwin.unlinkat(parentDescriptor, cleanupLeaf, 0) == 0 else {
             return .failed(
                 message: "Could not unlink a quarantined artifact",
-                retainedURL: cleanupURL
+                retainedURL: currentArtifactURL(
+                    parentDescriptor: parentDescriptor,
+                    leaf: cleanupLeaf
+                ) ?? fallbackCleanupURL
             )
         }
         do {

--- a/Pine/TerminationSaveCoordinator.swift
+++ b/Pine/TerminationSaveCoordinator.swift
@@ -1,0 +1,247 @@
+//
+//  TerminationSaveCoordinator.swift
+//  Pine
+//
+//  Bounded, off-main staging for application-termination saves.
+//
+
+import Darwin
+import Foundation
+
+nonisolated struct TerminationSaveRequest: Sendable {
+    let tabID: UUID
+    let contentVersion: UInt64
+    let content: String
+    let originalURL: URL?
+    let destination: URL
+    let encodingRawValue: UInt
+    let settings: EditorSaveSettingsSnapshot
+    let formatters: FileFormatterRegistry
+}
+
+nonisolated struct TerminationStagedSave: Sendable {
+    let request: TerminationSaveRequest
+    let stagingURL: URL
+    let preparedContent: String
+    let stagingDevice: UInt64
+    let stagingInode: UInt64
+}
+
+nonisolated enum TerminationSaveStageResult: Sendable {
+    case ready([TerminationStagedSave])
+    case failed(message: String)
+    case timedOut
+}
+
+nonisolated private final class TerminationSaveStageResolver:
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation:
+        CheckedContinuation<TerminationSaveStageResult, Never>?
+
+    init(
+        _ continuation: CheckedContinuation<
+            TerminationSaveStageResult,
+            Never
+        >
+    ) {
+        self.continuation = continuation
+    }
+
+    @discardableResult
+    func resolve(_ result: TerminationSaveStageResult) -> Bool {
+        let continuation = lock.withLock {
+            let continuation = self.continuation
+            self.continuation = nil
+            return continuation
+        }
+        guard let continuation else { return false }
+        continuation.resume(returning: result)
+        return true
+    }
+}
+
+nonisolated enum TerminationSaveCoordinator {
+    private static let deadlineQueue = DispatchQueue(
+        label: "com.pine.termination-save-deadline",
+        qos: .userInteractive
+    )
+
+    static func stage(
+        _ requests: [TerminationSaveRequest],
+        until deadline: DispatchTime
+    ) async -> TerminationSaveStageResult {
+        let deadlineNanoseconds = deadline.uptimeNanoseconds
+        guard DispatchTime.now().uptimeNanoseconds < deadlineNanoseconds else {
+            return .timedOut
+        }
+        return await withCheckedContinuation { continuation in
+            let resolver = TerminationSaveStageResolver(continuation)
+            let operationTask = Task.detached(priority: .userInitiated) {
+                let result = stageSynchronously(
+                    requests,
+                    deadlineNanoseconds: deadlineNanoseconds
+                )
+                if !resolver.resolve(result), case .ready(let staged) = result {
+                    cleanup(staged)
+                }
+            }
+            deadlineQueue.asyncAfter(deadline: deadline) {
+                if resolver.resolve(.timedOut) {
+                    operationTask.cancel()
+                }
+            }
+        }
+    }
+
+    static func cleanup(_ staged: [TerminationStagedSave]) {
+        for item in staged {
+            try? FileManager.default.removeItem(at: item.stagingURL)
+        }
+    }
+
+    static func stagingIdentityIsCurrent(
+        _ staged: TerminationStagedSave
+    ) -> Bool {
+        var status = stat()
+        guard Darwin.lstat(staged.stagingURL.path, &status) == 0,
+              (status.st_mode & S_IFMT) == S_IFREG else {
+            return false
+        }
+        return UInt64(status.st_dev) == staged.stagingDevice
+            && UInt64(status.st_ino) == staged.stagingInode
+    }
+
+    private static func stageSynchronously(
+        _ requests: [TerminationSaveRequest],
+        deadlineNanoseconds: UInt64
+    ) -> TerminationSaveStageResult {
+        var staged: [TerminationStagedSave] = []
+        do {
+            for request in requests {
+                guard !Task.isCancelled else {
+                    cleanup(staged)
+                    return .timedOut
+                }
+                let now = DispatchTime.now().uptimeNanoseconds
+                guard now < deadlineNanoseconds else {
+                    cleanup(staged)
+                    return .timedOut
+                }
+                let remainingSeconds = TimeInterval(
+                    deadlineNanoseconds - now
+                ) / 1_000_000_000
+                let prepared = TabFormatter.contentPreparedForSave(
+                    request.content,
+                    url: request.destination,
+                    settings: request.settings,
+                    formatters: request.formatters,
+                    formatterMaximumDuration: remainingSeconds
+                )
+                guard !Task.isCancelled,
+                      DispatchTime.now().uptimeNanoseconds
+                        < deadlineNanoseconds else {
+                    cleanup(staged)
+                    return .timedOut
+                }
+                let encoding = String.Encoding(
+                    rawValue: request.encodingRawValue
+                )
+                guard let data = prepared.data(
+                    using: encoding,
+                    allowLossyConversion: false
+                ) else {
+                    throw CocoaError(.fileWriteInapplicableStringEncoding)
+                }
+                let staging = try writeStagingFile(
+                    data,
+                    beside: request.destination
+                )
+                staged.append(TerminationStagedSave(
+                    request: request,
+                    stagingURL: staging.url,
+                    preparedContent: prepared,
+                    stagingDevice: staging.device,
+                    stagingInode: staging.inode
+                ))
+            }
+            guard !Task.isCancelled,
+                  DispatchTime.now().uptimeNanoseconds
+                    < deadlineNanoseconds else {
+                cleanup(staged)
+                return .timedOut
+            }
+            return .ready(staged)
+        } catch {
+            cleanup(staged)
+            return .failed(message: error.localizedDescription)
+        }
+    }
+
+    private static func writeStagingFile(
+        _ data: Data,
+        beside destination: URL
+    ) throws -> (url: URL, device: UInt64, inode: UInt64) {
+        let stagingURL = destination
+            .deletingLastPathComponent()
+            .appendingPathComponent(
+                ".pine-save-\(UUID().uuidString).tmp",
+                isDirectory: false
+            )
+        let descriptor = Darwin.open(
+            stagingURL.path,
+            O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
+            S_IRUSR | S_IWUSR
+        )
+        guard descriptor >= 0 else {
+            throw posixError()
+        }
+        var keepFile = false
+        defer {
+            Darwin.close(descriptor)
+            if !keepFile {
+                Darwin.unlink(stagingURL.path)
+            }
+        }
+
+        try data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return }
+            var written = 0
+            while written < rawBuffer.count {
+                if Task.isCancelled {
+                    throw CancellationError()
+                }
+                let result = Darwin.write(
+                    descriptor,
+                    baseAddress.advanced(by: written),
+                    rawBuffer.count - written
+                )
+                if result < 0, errno == EINTR {
+                    continue
+                }
+                guard result > 0 else {
+                    throw posixError()
+                }
+                written += result
+            }
+        }
+        guard Darwin.fsync(descriptor) == 0 else {
+            throw posixError()
+        }
+        var status = stat()
+        guard Darwin.fstat(descriptor, &status) == 0,
+              (status.st_mode & S_IFMT) == S_IFREG else {
+            throw posixError()
+        }
+        keepFile = true
+        return (
+            stagingURL,
+            UInt64(status.st_dev),
+            UInt64(status.st_ino)
+        )
+    }
+
+    private static func posixError() -> NSError {
+        NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+    }
+}

--- a/Pine/TerminationSaveCoordinator.swift
+++ b/Pine/TerminationSaveCoordinator.swift
@@ -85,13 +85,13 @@ nonisolated struct TerminationInstalledFileMetadata: Sendable {
 
 nonisolated enum TerminationSaveStageResult: Sendable {
     case ready([TerminationStagedSave])
-    case failed(message: String)
+    case failed(message: String, retainedArtifacts: [URL])
     case timedOut
 }
 
 nonisolated enum TerminationSaveInstallResult: Sendable {
     case installed(metadata: TerminationInstalledFileMetadata)
-    case failed(message: String)
+    case failed(message: String, retainedArtifacts: [URL])
     case timedOut
 }
 
@@ -289,6 +289,7 @@ nonisolated enum TerminationSaveCoordinator {
         _ staged: TerminationStagedSave,
         until deadline: DispatchTime,
         beforeDestinationQuarantine: InstallHook? = nil,
+        afterDestinationPublication: InstallHook? = nil,
         beforeRecoveryCleanup: InstallHook? = nil,
         lateCompletion: @escaping @Sendable (
             TerminationSaveInstallResult
@@ -308,13 +309,18 @@ nonisolated enum TerminationSaveCoordinator {
                         deadlineNanoseconds: deadlineNanoseconds,
                         beforeDestinationQuarantine:
                             beforeDestinationQuarantine,
+                        afterDestinationPublication:
+                            afterDestinationPublication,
                         beforeRecoveryCleanup: beforeRecoveryCleanup
                     )
                     result = .installed(metadata: staged.installedMetadata)
                 } catch is CancellationError {
                     result = .timedOut
                 } catch {
-                    result = .failed(message: error.localizedDescription)
+                    result = .failed(
+                        message: error.localizedDescription,
+                        retainedArtifacts: retainedArtifacts(from: error)
+                    )
                 }
                 if !resolver.resolve(result) {
                     lateCompletion(result)
@@ -412,18 +418,27 @@ nonisolated enum TerminationSaveCoordinator {
             }
             return .ready(staged)
         } catch {
-            if case .failed(let message, _) = cleanup(staged) {
-                return .failed(message: message)
+            if case .failed(let message, let retainedArtifacts) = cleanup(staged) {
+                return .failed(
+                    message: message,
+                    retainedArtifacts: retainedArtifacts
+                )
             }
-            return .failed(message: error.localizedDescription)
+            return .failed(
+                message: error.localizedDescription,
+                retainedArtifacts: []
+            )
         }
     }
 
     private static func stageCancellationResult(
         _ staged: [TerminationStagedSave]
     ) -> TerminationSaveStageResult {
-        if case .failed(let message, _) = cleanup(staged) {
-            return .failed(message: message)
+        if case .failed(let message, let retainedArtifacts) = cleanup(staged) {
+            return .failed(
+                message: message,
+                retainedArtifacts: retainedArtifacts
+            )
         }
         return .timedOut
     }
@@ -593,6 +608,7 @@ nonisolated enum TerminationSaveCoordinator {
         _ staged: TerminationStagedSave,
         deadlineNanoseconds: UInt64,
         beforeDestinationQuarantine: InstallHook?,
+        afterDestinationPublication: InstallHook?,
         beforeRecoveryCleanup: InstallHook?
     ) throws {
         let parentDescriptor = try openVerifiedParentDirectory(for: staged)
@@ -647,6 +663,7 @@ nonisolated enum TerminationSaveCoordinator {
             ) == 0 else {
                 throw posixError()
             }
+            var stagingWasPublished = false
             do {
                 try synchronizeDirectory(parentDescriptor)
                 let displacedSnapshot = try destinationSnapshot(
@@ -664,6 +681,16 @@ nonisolated enum TerminationSaveCoordinator {
                       ) else {
                     throw CocoaError(.fileWriteFileExists)
                 }
+                try checkDeadline(deadlineNanoseconds)
+                guard renameExclusive(
+                    parentDescriptor: parentDescriptor,
+                    source: stagingLeaf,
+                    destination: destinationLeaf
+                ) == 0 else {
+                    throw posixError()
+                }
+                stagingWasPublished = true
+                afterDestinationPublication?()
                 try applyExistingDestinationMetadata(
                     from: destinationDescriptor,
                     status: displacedSnapshot.status,
@@ -676,33 +703,34 @@ nonisolated enum TerminationSaveCoordinator {
                 ) else {
                     throw CocoaError(.fileWriteFileExists)
                 }
-                try checkDeadline(deadlineNanoseconds)
-                guard renameExclusive(
-                    parentDescriptor: parentDescriptor,
-                    source: stagingLeaf,
-                    destination: destinationLeaf
-                ) == 0 else {
-                    throw posixError()
-                }
             } catch {
                 let installError = error
-                var stagingSecurityError: Error?
-                do {
-                    try resecureStaging(
-                        stagingDescriptor,
-                        at: staged.stagingURL
+                if stagingWasPublished {
+                    try rollbackPublishedStaging(
+                        staged,
+                        stagingDescriptor: stagingDescriptor,
+                        parentDescriptor: parentDescriptor,
+                        quarantineLeaf: quarantineLeaf
                     )
-                } catch {
-                    stagingSecurityError = error
-                }
-                try restoreOrRetainRecovery(
-                    parentDescriptor: parentDescriptor,
-                    quarantineLeaf: quarantineLeaf,
-                    destinationLeaf: destinationLeaf,
-                    destinationURL: staged.request.destination
-                )
-                if let stagingSecurityError {
-                    throw stagingSecurityError
+                } else {
+                    var stagingSecurityError: Error?
+                    do {
+                        try resecureStaging(
+                            stagingDescriptor,
+                            at: staged.stagingURL
+                        )
+                    } catch {
+                        stagingSecurityError = error
+                    }
+                    try restoreOrRetainRecovery(
+                        parentDescriptor: parentDescriptor,
+                        quarantineLeaf: quarantineLeaf,
+                        destinationLeaf: destinationLeaf,
+                        destinationURL: staged.request.destination
+                    )
+                    if let stagingSecurityError {
+                        throw stagingSecurityError
+                    }
                 }
                 throw installError
             }
@@ -747,24 +775,6 @@ nonisolated enum TerminationSaveCoordinator {
             }
         } else {
             try checkDeadline(deadlineNanoseconds)
-            let permissions = try probeCreationPermissions(
-                parentDescriptor: parentDescriptor,
-                parentURL: parentURL
-            )
-            guard Darwin.fchmod(
-                stagingDescriptor,
-                mode_t(permissions)
-            ) == 0 else {
-                let installError = posixError()
-                try resecureStaging(stagingDescriptor, at: staged.stagingURL)
-                throw installError
-            }
-            guard Darwin.fsync(stagingDescriptor) == 0 else {
-                let installError = posixError()
-                try resecureStaging(stagingDescriptor, at: staged.stagingURL)
-                throw installError
-            }
-            try checkDeadline(deadlineNanoseconds)
             var destinationStatus = stat()
             guard Darwin.fstatat(
                 parentDescriptor,
@@ -785,15 +795,33 @@ nonisolated enum TerminationSaveCoordinator {
                 try resecureStaging(stagingDescriptor, at: staged.stagingURL)
                 throw installError
             }
-            guard regularFileMatches(
-                parentDescriptor: parentDescriptor,
-                leaf: destinationLeaf,
-                device: staged.stagingDevice,
-                inode: staged.stagingInode
-            ) else {
-                throw CocoaError(.fileWriteFileExists)
+            do {
+                afterDestinationPublication?()
+                try applyMissingDestinationMetadata(
+                    parentDescriptor: parentDescriptor,
+                    parentURL: parentURL,
+                    destinationDescriptor: stagingDescriptor
+                )
+                guard regularFileMatches(
+                    parentDescriptor: parentDescriptor,
+                    leaf: destinationLeaf,
+                    device: staged.stagingDevice,
+                    inode: staged.stagingInode
+                ) else {
+                    throw CocoaError(.fileWriteFileExists)
+                }
+                try synchronizeDirectory(parentDescriptor)
+            } catch {
+                let installError = error
+                try rollbackPublishedNewDestination(
+                    staged,
+                    stagingDescriptor: stagingDescriptor,
+                    parentDescriptor: parentDescriptor,
+                    stagingLeaf: stagingLeaf,
+                    destinationLeaf: destinationLeaf
+                )
+                throw installError
             }
-            try synchronizeDirectory(parentDescriptor)
         }
     }
 
@@ -870,6 +898,72 @@ nonisolated enum TerminationSaveCoordinator {
         try synchronizeDirectory(parentDescriptor)
     }
 
+    private static func rollbackPublishedStaging(
+        _ staged: TerminationStagedSave,
+        stagingDescriptor: Int32,
+        parentDescriptor: Int32,
+        quarantineLeaf: String
+    ) throws {
+        let stagingLeaf = staged.stagingURL.lastPathComponent
+        let destinationLeaf = staged.request.destination.lastPathComponent
+        let recoveryURL = staged.request.destination
+            .deletingLastPathComponent()
+            .appendingPathComponent(quarantineLeaf)
+        guard regularFileMatches(
+            parentDescriptor: parentDescriptor,
+            leaf: destinationLeaf,
+            device: staged.stagingDevice,
+            inode: staged.stagingInode
+        ),
+              renameExclusive(
+                  parentDescriptor: parentDescriptor,
+                  source: destinationLeaf,
+                  destination: stagingLeaf
+              ) == 0 else {
+            throw retainedRecoveryError(at: recoveryURL)
+        }
+
+        var stagingSecurityError: Error?
+        do {
+            try resecureStaging(stagingDescriptor, at: staged.stagingURL)
+        } catch {
+            stagingSecurityError = error
+        }
+        try restoreOrRetainRecovery(
+            parentDescriptor: parentDescriptor,
+            quarantineLeaf: quarantineLeaf,
+            destinationLeaf: destinationLeaf,
+            destinationURL: staged.request.destination
+        )
+        if let stagingSecurityError {
+            throw stagingSecurityError
+        }
+    }
+
+    private static func rollbackPublishedNewDestination(
+        _ staged: TerminationStagedSave,
+        stagingDescriptor: Int32,
+        parentDescriptor: Int32,
+        stagingLeaf: String,
+        destinationLeaf: String
+    ) throws {
+        guard regularFileMatches(
+            parentDescriptor: parentDescriptor,
+            leaf: destinationLeaf,
+            device: staged.stagingDevice,
+            inode: staged.stagingInode
+        ),
+              renameExclusive(
+                  parentDescriptor: parentDescriptor,
+                  source: destinationLeaf,
+                  destination: stagingLeaf
+              ) == 0 else {
+            throw retainedRecoveryError(at: staged.request.destination)
+        }
+        try resecureStaging(stagingDescriptor, at: staged.stagingURL)
+        try synchronizeDirectory(parentDescriptor)
+    }
+
     private static func retainedRecoveryError(
         at recoveryURL: URL,
         reason: String = "A concurrent file replacement was retained"
@@ -880,8 +974,16 @@ nonisolated enum TerminationSaveCoordinator {
             userInfo: [
                 NSLocalizedDescriptionKey:
                     "\(reason) at \(recoveryURL.path)",
+                "PineTerminationRetainedArtifactURLs": [recoveryURL],
             ]
         )
+    }
+
+    private static func retainedArtifacts(from error: Error) -> [URL] {
+        let nsError = error as NSError
+        return nsError.userInfo[
+            "PineTerminationRetainedArtifactURLs"
+        ] as? [URL] ?? []
     }
 
     private static func checkDeadline(_ deadlineNanoseconds: UInt64) throws {
@@ -1271,31 +1373,64 @@ nonisolated enum TerminationSaveCoordinator {
             ) == expected.extendedMetadataDigest
     }
 
-    private static func probeCreationPermissions(
+    private static func applyMissingDestinationMetadata(
         parentDescriptor: Int32,
-        parentURL: URL
-    ) throws -> UInt32 {
+        parentURL: URL,
+        destinationDescriptor: Int32
+    ) throws {
         let leaf = ".pine-save-mode-\(UUID().uuidString).tmp"
-        let descriptor = Darwin.openat(
+        let probeDescriptor = Darwin.openat(
             parentDescriptor,
             leaf,
             O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
             mode_t(0o666)
         )
-        guard descriptor >= 0 else { throw posixError() }
+        guard probeDescriptor >= 0 else { throw posixError() }
+        defer { Darwin.close(probeDescriptor) }
         var status = stat()
-        let captured = Darwin.fstat(descriptor, &status) == 0
-        Darwin.close(descriptor)
-        guard captured else { throw posixError() }
-        switch removeEntryIfMatches(
+        guard Darwin.fstat(probeDescriptor, &status) == 0 else {
+            throw posixError()
+        }
+        let expectedACL = try extendedACLData(probeDescriptor)
+        var metadataError: Error?
+        do {
+            guard Darwin.fcopyfile(
+                probeDescriptor,
+                destinationDescriptor,
+                nil,
+                copyfile_flags_t(COPYFILE_ACL)
+            ) == 0,
+                  Darwin.fchmod(
+                      destinationDescriptor,
+                      mode_t(status.st_mode & 0o7777)
+                  ) == 0,
+                  Darwin.fsync(destinationDescriptor) == 0 else {
+                throw posixError()
+            }
+            var installedStatus = stat()
+            guard Darwin.fstat(destinationDescriptor, &installedStatus) == 0,
+                  installedStatus.st_uid == status.st_uid,
+                  installedStatus.st_gid == status.st_gid,
+                  (installedStatus.st_mode & 0o7777)
+                    == (status.st_mode & 0o7777),
+                  try extendedACLData(destinationDescriptor) == expectedACL
+            else {
+                throw CocoaError(.fileWriteNoPermission)
+            }
+        } catch {
+            metadataError = error
+        }
+
+        let removal = removeEntryIfMatches(
             parentDescriptor: parentDescriptor,
             parentURL: parentURL,
             leaf: leaf,
             device: UInt64(status.st_dev),
             inode: UInt64(status.st_ino)
-        ) {
+        )
+        switch removal {
         case .removed:
-            return UInt32(status.st_mode & 0o666)
+            break
         case .failed(let message, let retainedURL):
             if let retainedURL {
                 throw retainedRecoveryError(at: retainedURL, reason: message)
@@ -1304,6 +1439,9 @@ nonisolated enum TerminationSaveCoordinator {
                 .fileWriteUnknown,
                 userInfo: [NSLocalizedDescriptionKey: message]
             )
+        }
+        if let metadataError {
+            throw metadataError
         }
     }
 

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -1415,6 +1415,197 @@ struct AgentTaskRegistryTests {
         #expect(projects.projectManager(for: admittedProject) != nil)
     }
 
+    @Test("preflight launch lease survives unbounded Quit decision")
+    func preflightLaunchLeaseSurvivesHumanDecision() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let store = ScriptedAgentTaskStore()
+        let taskRegistry = AgentTaskRegistry(
+            persistence: store,
+            claimTTL: .milliseconds(10)
+        )
+        let projects = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projects.projectManager(for: fixture.project)
+        )
+        #expect(await taskRegistry.flushPersistence() == .saved)
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let tab = try #require(
+            manager.paneManager.terminalState(for: pane)?.terminalTabs.first
+        )
+        let descriptor = AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        )
+        guard case .reserved(let reservation) = await manager.terminal
+                .launchAgentCommandForTesting(
+                    "codex",
+                    descriptor: descriptor,
+                    in: tab,
+                    acknowledgedWrite: { true }
+                ) else {
+            Issue.record("launch was not reserved")
+            return
+        }
+        let delegate = AppDelegate()
+        delegate.registry = projects
+
+        let didQuit = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                #expect(template == .applicationQuitSummary)
+                try? await Task.sleep(for: .milliseconds(75))
+                return .alertSecondButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(didQuit)
+        #expect(taskRegistry.isLaunchPending(reservation))
+        #expect(
+            taskRegistry.task(for: reservation.taskID)?.launchInterruption
+                == .acknowledgedBeforeVerification
+        )
+        #expect(await store.savedTaskCounts().last == 1)
+        await manager.workspace.waitForLoadingComplete()
+    }
+
+    @Test("cancelled Quit restores launch lease and clears acknowledgement")
+    func cancelledQuitRestoresLeaseAndClearsAcknowledgement() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let taskRegistry = AgentTaskRegistry(
+            persistence: ScriptedAgentTaskStore(),
+            claimTTL: .milliseconds(20)
+        )
+        let projects = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projects.projectManager(for: fixture.project)
+        )
+        #expect(await taskRegistry.flushPersistence() == .saved)
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let tab = try #require(
+            manager.paneManager.terminalState(for: pane)?.terminalTabs.first
+        )
+        let descriptor = AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        )
+        guard case .reserved(let reservation) = await manager.terminal
+                .launchAgentCommandForTesting(
+                    "codex",
+                    descriptor: descriptor,
+                    in: tab,
+                    acknowledgedWrite: { true }
+                ) else {
+            Issue.record("launch was not reserved")
+            return
+        }
+        let delegate = AppDelegate()
+        delegate.registry = projects
+
+        let didQuit = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                #expect(template == .applicationQuitSummary)
+                try? await Task.sleep(for: .milliseconds(75))
+                return .alertThirdButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(!didQuit)
+        #expect(!manager.terminal.hasAcknowledgedAgentLaunchForTesting)
+        #expect(taskRegistry.isLaunchPending(reservation))
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while taskRegistry.isLaunchPending(reservation), clock.now < deadline {
+            try await clock.sleep(for: .milliseconds(5))
+        }
+        #expect(!taskRegistry.isLaunchPending(reservation))
+        #expect(
+            !manager.terminal.capturePineAgentLaunchAuthorization()
+                .requiresConfirmation
+        )
+        await manager.workspace.waitForLoadingComplete()
+    }
+
+    @Test("late in-flight acknowledgement gets a post-settlement durable flush")
+    func lateAcknowledgementGetsPostSettlementFlush() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let store = ScriptedAgentTaskStore(suspendFirstSave: true)
+        let taskRegistry = AgentTaskRegistry(persistence: store)
+        let projects = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projects.projectManager(for: fixture.project)
+        )
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let tab = try #require(
+            manager.paneManager.terminalState(for: pane)?.terminalTabs.first
+        )
+        let descriptor = AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        )
+        let writeGate = AgentLaunchWriteGate()
+        let launchTask = Task { @MainActor in
+            await manager.terminal.launchAgentCommandForTesting(
+                "codex",
+                descriptor: descriptor,
+                in: tab
+            ) {
+                await writeGate.waitForCompletion()
+            }
+        }
+        #expect(await writeGate.waitUntilStarted())
+        let delegate = AppDelegate()
+        delegate.registry = projects
+        var releaseTask: Task<Void, Never>?
+
+        let didQuit = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                #expect(template == .applicationQuitSummary)
+                releaseTask = Task { @MainActor in
+                    #expect(await store.waitForFirstSave())
+                    writeGate.finish(true)
+                    let clock = ContinuousClock()
+                    let deadline = clock.now.advanced(by: .seconds(1))
+                    while !manager.terminal
+                            .hasAcknowledgedAgentLaunchForTesting,
+                          clock.now < deadline {
+                        await Task.yield()
+                    }
+                    #expect(
+                        manager.terminal
+                            .hasAcknowledgedAgentLaunchForTesting
+                    )
+                    await store.releaseFirstSave()
+                }
+                return .alertSecondButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        await releaseTask?.value
+        guard case .reserved(let reservation) = await launchTask.value else {
+            Issue.record("late acknowledgement lost its reservation")
+            return
+        }
+        #expect(didQuit)
+        #expect(
+            taskRegistry.task(for: reservation.taskID)?.launchInterruption
+                == .acknowledgedBeforeVerification
+        )
+        #expect(await store.savedTaskCounts().last == 1)
+        #expect(await store.saveCallCount() >= 2)
+        await manager.workspace.waitForLoadingComplete()
+    }
+
     @Test("in-flight Pine launch alone contributes Quit attention")
     func inFlightPineLaunchContributesQuitAttention() async throws {
         let fixture = try PersistenceFixture()

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -456,7 +456,12 @@ struct AgentTaskRegistryTests {
             return
         }
 
-        try await ContinuousClock().sleep(for: .milliseconds(50))
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while registry.task(for: reservation.taskID) != nil,
+              clock.now < deadline {
+            try await clock.sleep(for: .milliseconds(5))
+        }
         #expect(registry.task(for: reservation.taskID) == nil)
     }
 
@@ -1388,7 +1393,12 @@ struct AgentTaskRegistryTests {
             Issue.record("first reservation was rejected")
             return
         }
-        try await ContinuousClock().sleep(for: .milliseconds(10))
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while taskRegistry.isLaunchPending(expired),
+              clock.now < deadline {
+            try await clock.sleep(for: .milliseconds(5))
+        }
         #expect(!taskRegistry.isLaunchPending(expired))
 
         guard case .reserved = manager.terminal.prepareAgentLaunch(
@@ -2010,8 +2020,9 @@ struct AgentTaskRegistryTests {
         )
         registry.registerProject(identity)
         #expect(await registry.flushPersistence() == .saved)
+        let session = makeSession(pid: 1_493, generation: 1)
         registry.bridge(
-            makeSession(pid: 1_493, generation: 1),
+            session,
             replacing: nil,
             context: context(project: identity, routeSeed: 153)
         )
@@ -2024,6 +2035,20 @@ struct AgentTaskRegistryTests {
             maximumDuration: .milliseconds(100)
         )
         #expect(!didPersistRollback)
+        await store.setSaveResult(.saved(taskCount: 1))
+        let clock = ContinuousClock()
+        let retryDeadline = clock.now.advanced(by: .seconds(2))
+        while await store.publishedAvailabilityHistory(
+            forSessionID: session.id
+        ).last != .available,
+              clock.now < retryDeadline {
+            try? await clock.sleep(for: .milliseconds(10))
+        }
+        #expect(
+            await store.publishedAvailabilityHistory(
+                forSessionID: session.id
+            ).last == .available
+        )
         let replacement = makeSession(pid: 1_494, generation: 2)
         registry.bridge(
             replacement,
@@ -2447,8 +2472,8 @@ struct AgentTaskRegistryTests {
         let identity = project("/tmp/pine-agent-post-publication-timeout")
         let registry = AgentTaskRegistry(
             persistence: store,
-            flushTotal: .milliseconds(25),
-            flushTail: .milliseconds(5)
+            flushTotal: .milliseconds(250),
+            flushTail: .milliseconds(50)
         )
         registry.registerProject(identity)
         #expect(await registry.flushPersistence() == .saved)

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -5,6 +5,7 @@
 //  Durable cross-project agent task identity and persistence (issue #1302).
 //
 
+import AppKit
 import Foundation
 import Testing
 @testable import Pine
@@ -1212,6 +1213,157 @@ struct AgentTaskRegistryTests {
         #expect(taskRegistry.taskID(forSessionID: launched.id) == reservation.taskID)
     }
 
+    @Test("late acknowledged Pine launch invalidates Quit Anyway")
+    func lateAcknowledgedPineLaunchInvalidatesQuitAnyway() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let store = ScriptedAgentTaskStore(suspendFirstSave: true)
+        let taskRegistry = AgentTaskRegistry(persistence: store)
+        let projects = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projects.projectManager(for: fixture.project)
+        )
+        _ = try #require(manager.createUntitledFile())
+        manager.primaryTabManager.autoSavePreferenceProvider = { false }
+        manager.primaryTabManager.updateContent("keep this dirty buffer")
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let state = try #require(
+            manager.paneManager.terminalState(for: pane)
+        )
+        let tab = try #require(state.terminalTabs.first)
+        let descriptor = AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        )
+        let writeGate = AgentLaunchWriteGate()
+        var launchTask: Task<AgentTaskLaunchResult, Never>?
+        var releaseTask: Task<Void, Never>?
+        var presented: [AlertTemplate] = []
+        let delegate = AppDelegate()
+        delegate.registry = projects
+
+        let didQuit = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presented.append(template)
+                if template == .applicationQuitSummary {
+                    launchTask = Task { @MainActor in
+                        await manager.terminal
+                            .launchAgentCommandForTesting(
+                                "codex",
+                                descriptor: descriptor,
+                                in: tab
+                            ) {
+                                await writeGate.waitForCompletion()
+                            }
+                    }
+                    #expect(await writeGate.waitUntilStarted())
+                    releaseTask = Task { @MainActor in
+                        #expect(await store.waitForFirstSave())
+                        #expect(manager.terminal.agentCallbacksFrozenForTesting)
+                        writeGate.finish(true)
+                        let clock = ContinuousClock()
+                        let deadline = clock.now.advanced(by: .seconds(2))
+                        while !manager.terminal
+                            .hasAcknowledgedAgentLaunchForTesting,
+                              clock.now < deadline {
+                            await Task.yield()
+                        }
+                        #expect(
+                            manager.terminal
+                                .hasAcknowledgedAgentLaunchForTesting
+                        )
+                        await store.releaseFirstSave()
+                    }
+                    return .alertSecondButtonReturn
+                }
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        await releaseTask?.value
+        let optionalLaunchResult = await launchTask?.value
+        guard let launchResult = optionalLaunchResult,
+              case .reserved(let reservation) = launchResult else {
+            let detail = String(describing: optionalLaunchResult)
+            Issue.record(
+                "late acknowledged launch lost its reservation: \(detail)"
+            )
+            return
+        }
+        #expect(!didQuit)
+        #expect(
+            presented == [
+                .applicationQuitSummary,
+                .applicationQuitFailure,
+            ]
+        )
+        #expect(manager.hasUnsavedChanges)
+        #expect(taskRegistry.isLaunchPending(reservation))
+        #expect(!manager.terminal.agentCallbacksFrozenForTesting)
+        #expect(!projects.isProjectAdmissionFrozenForTermination)
+
+        let admittedProject = fixture.root.appendingPathComponent(
+            "admitted-after-late-launch",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: admittedProject,
+            withIntermediateDirectories: false
+        )
+        #expect(projects.projectManager(for: admittedProject) != nil)
+    }
+
+    @Test("in-flight Pine launch alone contributes Quit attention")
+    func inFlightPineLaunchContributesQuitAttention() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let projects = ProjectRegistry()
+        let manager = try #require(
+            projects.projectManager(for: fixture.project)
+        )
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let state = try #require(
+            manager.paneManager.terminalState(for: pane)
+        )
+        let tab = try #require(state.terminalTabs.first)
+        let descriptor = AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        )
+        let writeGate = AgentLaunchWriteGate()
+        let launchTask = Task { @MainActor in
+            await manager.terminal.launchAgentCommandForTesting(
+                "codex",
+                descriptor: descriptor,
+                in: tab
+            ) {
+                await writeGate.waitForCompletion()
+            }
+        }
+        #expect(await writeGate.waitUntilStarted())
+        let delegate = AppDelegate()
+        delegate.registry = projects
+        var presented: [AlertTemplate] = []
+
+        let didQuit = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presented.append(template)
+                return .alertThirdButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        writeGate.finish(false)
+        #expect(await launchTask.value == .rejected)
+        #expect(!didQuit)
+        #expect(presented == [.applicationQuitSummary])
+    }
+
     @Test("expired local reservation permits a new terminal launch")
     func expiredTerminalReservationCanBeReplaced() async throws {
         let fixture = try PersistenceFixture()
@@ -1915,6 +2067,15 @@ struct AgentTaskRegistryTests {
         #expect(!didPersistRollback)
         #expect(!manager.terminal.agentCallbacksFrozenForTesting)
         #expect(!projects.isProjectAdmissionFrozenForTermination)
+        let admittedProject = fixture.root.appendingPathComponent(
+            "admitted-after-failed-rollback",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: admittedProject,
+            withIntermediateDirectories: false
+        )
+        #expect(projects.projectManager(for: admittedProject) != nil)
     }
 
     @Test("rollback reconciles a window closed during termination freeze")
@@ -1949,6 +2110,11 @@ struct AgentTaskRegistryTests {
         #expect(await projects.cancelAgentTaskTermination())
         #expect(agentTasks.task(forSessionID: session.id)?.route.availability
                 == .background)
+        #expect(
+            await store.publishedAvailabilityHistory(
+                forSessionID: session.id
+            ).last == .background
+        )
     }
 
     @Test("rollback reconciles a background window reopened during freeze")
@@ -1986,6 +2152,11 @@ struct AgentTaskRegistryTests {
         #expect(await projects.cancelAgentTaskTermination())
         #expect(agentTasks.task(forSessionID: session.id)?.route.availability
                 == .available)
+        #expect(
+            await store.publishedAvailabilityHistory(
+                forSessionID: session.id
+            ).last == .available
+        )
     }
 
     @Test("one rejected project cannot starve another project save")
@@ -3561,6 +3732,16 @@ private actor ScriptedAgentTaskStore: AgentTaskPersisting {
 
     func savedTaskCounts() -> [Int] {
         publishedSnapshots.map(\.count)
+    }
+
+    func publishedAvailabilityHistory(
+        forSessionID sessionID: UUID
+    ) -> [AgentTaskRouteAvailability] {
+        publishedSnapshots.compactMap { snapshot in
+            snapshot.first(where: { task in
+                task.runs.contains(where: { $0.id == sessionID })
+            })?.route.availability
+        }
     }
 
     func saveCallCount() -> Int {

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -952,7 +952,7 @@ struct AgentTaskRegistryTests {
         manager.terminal.cancelAgentLaunch(in: tab)
     }
 
-    @Test("stale successful PTY acknowledgement cannot arm launch authority")
+    @Test("cancelled successful PTY acknowledgement cannot arm launch authority")
     func staleAcknowledgementCannotArmLaunchAuthority() async throws {
         let fixture = try PersistenceFixture()
         defer { fixture.cleanup() }
@@ -996,7 +996,7 @@ struct AgentTaskRegistryTests {
             in: tab
         )
         #expect(taskRegistry.task(for: dormantTaskID)?.runs.isEmpty == true)
-        try await ContinuousClock().sleep(for: .milliseconds(100))
+        manager.terminal.cancelAgentLaunch(in: tab)
         #expect(taskRegistry.task(for: dormantTaskID) == nil)
 
         var duplicateWriteCalled = false
@@ -1455,10 +1455,16 @@ struct AgentTaskRegistryTests {
         let didQuit = await delegate.confirmApplicationTermination(
             presentAlert: { template, _, _, _ in
                 #expect(template == .applicationQuitSummary)
+                guard template == .applicationQuitSummary else {
+                    return .alertFirstButtonReturn
+                }
                 try? await Task.sleep(for: .milliseconds(75))
                 return .alertSecondButtonReturn
             },
-            terminationDeadlineOverride: .now() + 5
+            // This test exercises an unbounded human decision, not the
+            // machine-work timeout. Leave enough headroom for unrelated
+            // AppKit panel tests that can temporarily occupy MainActor.
+            terminationDeadlineOverride: .now() + 120
         )
 
         #expect(didQuit)
@@ -1469,6 +1475,50 @@ struct AgentTaskRegistryTests {
         )
         #expect(await store.savedTaskCounts().last == 1)
         await manager.workspace.waitForLoadingComplete()
+    }
+
+    @Test("acknowledged PTY write pins the exact launch lease")
+    func acknowledgedWritePinsLaunchLease() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let taskRegistry = AgentTaskRegistry(
+            persistence: ScriptedAgentTaskStore(),
+            claimTTL: .milliseconds(10)
+        )
+        let projects = ProjectRegistry(agentTasks: taskRegistry)
+        let manager = try #require(
+            projects.projectManager(for: fixture.project)
+        )
+        let pane = manager.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: fixture.project
+        )
+        let tab = try #require(
+            manager.paneManager.terminalState(for: pane)?.terminalTabs.first
+        )
+        let descriptor = AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        )
+
+        let result = await manager.terminal.launchAgentCommandForTesting(
+            "codex",
+            descriptor: descriptor,
+            in: tab,
+            acknowledgedWrite: {
+                try? await Task.sleep(for: .milliseconds(75))
+                return true
+            }
+        )
+
+        guard case .reserved(let reservation) = result else {
+            Issue.record("A successful delayed write must keep its reservation")
+            return
+        }
+        #expect(taskRegistry.isLaunchPending(reservation))
+        #expect(
+            manager.terminal.capturePineAgentLaunchAuthorization()
+                .requiresConfirmation
+        )
     }
 
     @Test("cancelled Quit restores launch lease and clears acknowledgement")

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -1374,7 +1374,8 @@ struct AgentTaskRegistryTests {
             limits: limits
         )
         let registry = AgentTaskRegistry()
-        let identity = project(fixture.project.path)
+        let canonical = ProjectRegistry.canonicalProjectURL(fixture.project)
+        let identity = project(canonical.path)
         let sharedContext = context(
             project: identity,
             routeSeed: 110,
@@ -1900,6 +1901,7 @@ struct AgentTaskRegistryTests {
             context: context(project: identity, routeSeed: 155)
         )
         #expect(await agentTasks.flushPersistence() == .saved)
+        #expect(await agentTasks.flushPersistence() == .saved)
         projects.freezeAgentTasksForTermination()
         #expect(manager.terminal.agentCallbacksFrozenForTesting)
         agentTasks.prepareForApplicationTermination()
@@ -1912,6 +1914,78 @@ struct AgentTaskRegistryTests {
 
         #expect(!didPersistRollback)
         #expect(!manager.terminal.agentCallbacksFrozenForTesting)
+        #expect(!projects.isProjectAdmissionFrozenForTermination)
+    }
+
+    @Test("rollback reconciles a window closed during termination freeze")
+    func rollbackReconcilesCloseDuringFreeze() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let canonical = ProjectRegistry.canonicalProjectURL(fixture.project)
+        let identity = project(canonical.path)
+        let store = ScriptedAgentTaskStore()
+        let agentTasks = AgentTaskRegistry(
+            persistence: store,
+            flushTotal: .seconds(120),
+            flushTail: .seconds(120)
+        )
+        let projects = ProjectRegistry(agentTasks: agentTasks)
+        _ = try #require(projects.projectManager(for: fixture.project))
+        let session = makeSession(pid: 1_497, generation: 1)
+        agentTasks.bridge(
+            session,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 156)
+        )
+        #expect(await agentTasks.flushPersistence() == .saved)
+        #expect(agentTasks.task(forSessionID: session.id)?.route.availability
+                == .available)
+
+        projects.freezeAgentTasksForTermination()
+        agentTasks.prepareForApplicationTermination()
+        #expect(await agentTasks.flushPersistence() == .saved)
+        projects.closeProjectWindow(fixture.project)
+
+        #expect(await projects.cancelAgentTaskTermination())
+        #expect(agentTasks.task(forSessionID: session.id)?.route.availability
+                == .background)
+    }
+
+    @Test("rollback reconciles a background window reopened during freeze")
+    func rollbackReconcilesReopenDuringFreeze() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let canonical = ProjectRegistry.canonicalProjectURL(fixture.project)
+        let identity = project(canonical.path)
+        let store = ScriptedAgentTaskStore()
+        let agentTasks = AgentTaskRegistry(
+            persistence: store,
+            flushTotal: .seconds(120),
+            flushTail: .seconds(120)
+        )
+        let projects = ProjectRegistry(agentTasks: agentTasks)
+        let manager = try #require(
+            projects.projectManager(for: fixture.project)
+        )
+        let session = makeSession(pid: 1_498, generation: 1)
+        agentTasks.bridge(
+            session,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 157)
+        )
+        #expect(await agentTasks.flushPersistence() == .saved)
+        projects.closeProjectWindow(fixture.project)
+        #expect(agentTasks.task(forSessionID: session.id)?.route.availability
+                == .background)
+
+        projects.freezeAgentTasksForTermination()
+        agentTasks.prepareForApplicationTermination()
+        #expect(await agentTasks.flushPersistence() == .saved)
+        #expect(projects.projectManager(for: fixture.project) === manager)
+
+        #expect(await projects.cancelAgentTaskTermination())
+        #expect(agentTasks.task(forSessionID: session.id)?.route.availability
+                == .available)
     }
 
     @Test("one rejected project cannot starve another project save")

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -1116,8 +1116,8 @@ struct AgentTaskRegistryTests {
         #expect(await store.savedTaskCounts().last == 0)
     }
 
-    @Test("acknowledged initial launch is not published before observation")
-    func armedInitialLaunchIsNotPersisted() async throws {
+    @Test("acknowledged launch becomes durable only when Quit interrupts it")
+    func armedInitialLaunchPersistsOnlyAsQuitInterruption() async throws {
         let identity = project("/tmp/pine-agent-armed-persistence")
         let store = ScriptedAgentTaskStore()
         let registry = AgentTaskRegistry(persistence: store)
@@ -1148,13 +1148,107 @@ struct AgentTaskRegistryTests {
 
         registry.prepareForApplicationTermination()
         #expect(await registry.flushPersistence() == .saved)
-        #expect(await store.savedTaskCounts().last == 0)
+        #expect(await store.savedTaskCounts().last == 1)
+        let interrupted = try #require(registry.task(for: reservation.taskID))
+        #expect(interrupted.runs.isEmpty)
+        #expect(
+            interrupted.launchInterruption
+                == .acknowledgedBeforeVerification
+        )
         #expect(await registry.cancelApplicationTerminationAndFlush())
         #expect(await store.savedTaskCounts().last == 0)
+        #expect(
+            registry.task(for: reservation.taskID)?.launchInterruption == nil
+        )
 
         registry.cancelLaunch(reservation)
         #expect(await registry.flushPersistence() == .saved)
         #expect(await store.savedTaskCounts().last == 0)
+    }
+
+    @Test("Quit-interrupted acknowledged launch reloads without fake evidence")
+    func acknowledgedLaunchInterruptionSurvivesRelaunch() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        let writer = AgentTaskRegistry(persistence: store)
+        writer.registerProject(identity)
+        #expect(await writer.flushPersistence() == .saved)
+        let launchContext = context(
+            project: identity,
+            routeSeed: 672,
+            origin: .pineLaunched
+        )
+        guard case .reserved(let launch) = writer.preparePineLaunch(
+            descriptor: AgentDescriptor(
+                agentType: .claudeCode,
+                launchExecutable: "claude"
+            ),
+            context: launchContext,
+            title: "Interrupted launch",
+            objective: nil
+        ) else {
+            Issue.record("reservation was rejected")
+            return
+        }
+        #expect(writer.armLaunch(launch))
+
+        writer.prepareForApplicationTermination()
+        #expect(await writer.flushPersistence() == .saved)
+        let stored = try #require(await store.load(project: identity).tasks.first)
+        #expect(stored.id == launch.taskID)
+        #expect(stored.runs.isEmpty)
+        #expect(
+            stored.launchInterruption == .acknowledgedBeforeVerification
+        )
+
+        let reader = AgentTaskRegistry(persistence: store)
+        reader.registerProject(identity)
+        #expect(await reader.flushPersistence() == .saved)
+        let reloaded = try #require(reader.task(for: launch.taskID))
+        #expect(reloaded.runs.isEmpty)
+        #expect(
+            reloaded.launchInterruption == .acknowledgedBeforeVerification
+        )
+        #expect(reader.canResumeTask(launch.taskID))
+        #expect(
+            AgentInboxSnapshot(tasks: reader.tasks).rows.first?.canRecover
+                == true
+        )
+
+        let resumeContext = context(
+            project: identity,
+            routeSeed: 673,
+            origin: .pineLaunched
+        )
+        guard case .reserved(let resume) = reader.prepareResume(
+            taskID: launch.taskID,
+            context: resumeContext
+        ) else {
+            Issue.record("interrupted launch was not resumable")
+            return
+        }
+        #expect(reader.armLaunch(resume))
+        let observed = makeSession(
+            pid: 1_496,
+            generation: 7,
+            preciseStartedAt: Date().addingTimeInterval(1),
+            agentType: .claudeCode
+        )
+        reader.bridge(
+            observed,
+            replacing: nil,
+            context: resumeContext,
+            reservation: resume
+        )
+
+        let verified = try #require(reader.task(for: launch.taskID))
+        #expect(verified.launchInterruption == nil)
+        #expect(verified.runs.map(\.id) == [observed.id])
+        #expect(verified.runs.first?.process.processGeneration == 7)
+        #expect(verified.runs.first?.process.startIdentifier != nil)
+        #expect(verified.runs.first?.process.startIsAuthoritative == true)
     }
 
     @Test("successful launch acknowledgement survives Quit rollback")
@@ -1700,11 +1794,41 @@ struct AgentTaskRegistryTests {
         activeWithoutRun.route.availability = .missing
         #expect(await store.save(tasks: [activeWithoutRun], project: identity)
             == .saved(taskCount: 1))
+        activeWithoutRun.launchInterruption =
+            .acknowledgedBeforeVerification
+        #expect(await store.save(tasks: [activeWithoutRun], project: identity)
+            == .rejected(.invalidMetadata))
+
+        var interruptedPineLaunch = AgentTask(
+            descriptor: AgentDescriptor(
+                agentType: .claudeCode,
+                launchExecutable: "claude"
+            ),
+            context: context(
+                project: identity,
+                routeSeed: 212,
+                origin: .pineLaunched
+            )
+        )
+        interruptedPineLaunch.lifecycle = .paused
+        interruptedPineLaunch.route.availability = .missing
+        interruptedPineLaunch.launchInterruption =
+            .acknowledgedBeforeVerification
+        #expect(
+            await store.save(
+                tasks: [interruptedPineLaunch],
+                project: identity
+            ) == .saved(taskCount: 1)
+        )
 
         let registry = AgentTaskRegistry()
         let session = makeSession(pid: 2_211, generation: 1)
         registry.bridge(session, replacing: nil, context: discovered)
         var task = try #require(registry.tasks.first)
+        task.launchInterruption = .acknowledgedBeforeVerification
+        #expect(await store.save(tasks: [task], project: identity)
+            == .rejected(.invalidMetadata))
+        task.launchInterruption = nil
         task.attention = .waitingInput
         #expect(await store.save(tasks: [task], project: identity)
             == .rejected(.invalidMetadata))
@@ -2056,6 +2180,43 @@ struct AgentTaskRegistryTests {
             context: context(project: identity, routeSeed: 154)
         )
         #expect(registry.task(forSessionID: replacement.id) != nil)
+    }
+
+    @Test("zero-budget rollback retries after a late rejected quit tail")
+    func rollbackRetrySurvivesLateRejectedTerminationTail() async throws {
+        let identity = project("/tmp/pine-agent-rollback-tail-race")
+        let store = RollbackTailRaceAgentTaskStore()
+        let registry = AgentTaskRegistry(
+            persistence: store,
+            flushTotal: .seconds(120),
+            flushTail: .seconds(120)
+        )
+        registry.registerProject(identity)
+        #expect(await registry.flushPersistence() == .saved)
+        let session = makeSession(pid: 1_495, generation: 1)
+        registry.bridge(
+            session,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 154)
+        )
+        #expect(await registry.flushPersistence() == .saved)
+
+        registry.prepareForApplicationTermination()
+        #expect(await store.waitForSuspendedTerminationSave())
+        #expect(
+            await registry.cancelApplicationTerminationAndFlush(
+                maximumDuration: .zero
+            ) == false
+        )
+
+        await store.releaseTerminationSaveAsRejected()
+        #expect(await store.waitForRestoredSave())
+        #expect(
+            await store.publishedAvailabilityHistory(
+                forSessionID: session.id
+            ).last == .available
+        )
+        #expect(await registry.flushPersistence() == .saved)
     }
 
     @Test("failed durable rollback still thaws project terminal callbacks")
@@ -3788,5 +3949,86 @@ private actor ScriptedAgentTaskStore: AgentTaskPersisting {
             }
         }
         return completedSaves >= expected
+    }
+}
+
+private actor RollbackTailRaceAgentTaskStore: AgentTaskPersisting {
+    private var saveCallCount = 0
+    private var terminationSaveContinuation: CheckedContinuation<Void, Never>?
+    private var publishedSnapshots: [[AgentTask]] = []
+
+    func load(
+        project: AgentTaskProjectIdentity
+    ) async -> AgentTaskMetadataLoadResult {
+        AgentTaskMetadataLoadResult(status: .missing, tasks: [])
+    }
+
+    func save(
+        tasks: [AgentTask],
+        project: AgentTaskProjectIdentity,
+        authorization: AgentTaskPublicationAuthorization?
+    ) async -> AgentTaskMetadataSaveResult {
+        saveCallCount += 1
+        let call = saveCallCount
+        if call == 2 {
+            await withCheckedContinuation { continuation in
+                terminationSaveContinuation = continuation
+            }
+            return .rejected(.ioFailure)
+        }
+        let decision: AgentTaskPublicationDecision
+        if let authorization {
+            decision = authorization.publishForTesting {
+                publishedSnapshots.append(tasks)
+                return true
+            }
+        } else {
+            publishedSnapshots.append(tasks)
+            decision = .published
+        }
+        switch decision {
+        case .published:
+            return .saved(taskCount: tasks.count)
+        case .failed:
+            return .rejected(.transientIO)
+        case .superseded:
+            return .rejected(.superseded)
+        }
+    }
+
+    func waitForSuspendedTerminationSave() async -> Bool {
+        await waitUntil { saveCallCount >= 2 }
+    }
+
+    func releaseTerminationSaveAsRejected() {
+        terminationSaveContinuation?.resume()
+        terminationSaveContinuation = nil
+    }
+
+    func waitForRestoredSave() async -> Bool {
+        await waitUntil { saveCallCount >= 3 }
+    }
+
+    func publishedAvailabilityHistory(
+        forSessionID sessionID: UUID
+    ) -> [AgentTaskRouteAvailability] {
+        publishedSnapshots.compactMap { snapshot in
+            snapshot.first(where: { task in
+                task.runs.contains(where: { $0.id == sessionID })
+            })?.route.availability
+        }
+    }
+
+    private func waitUntil(_ condition: () -> Bool) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while !condition(), clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
+        }
+        return condition()
     }
 }

--- a/PineTests/BulkCloseAgentAuthorizationTests.swift
+++ b/PineTests/BulkCloseAgentAuthorizationTests.swift
@@ -230,6 +230,42 @@ struct BulkCloseAgentAuthorizationTests {
         await project.workspace.waitForLoadingComplete()
     }
 
+    @Test("Foreground transition accepts the same manually launched agent")
+    func foregroundTransitionAcceptsSameManualAgent() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: dir)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        let capturedStart = TerminalProcessStartIdentity(
+            processID: 4_242,
+            seconds: 10,
+            microseconds: 20
+        )
+        tab.foregroundProcessIDOverrideForTesting = 4_242
+        tab.foregroundStartOverrideForTesting = capturedStart
+        let authorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: [tab]
+        )
+
+        tab.agentSession = detectedSession(
+            agentType: .codex,
+            processID: 4_242,
+            generation: 10
+        )
+
+        #expect(authorization.stillCovers([tab]))
+
+        tab.foregroundStartOverrideForTesting = TerminalProcessStartIdentity(
+            processID: capturedStart.processID,
+            seconds: capturedStart.seconds + 1,
+            microseconds: capturedStart.microseconds
+        )
+        #expect(!authorization.stillCovers([tab]))
+        await project.workspace.waitForLoadingComplete()
+    }
+
     @Test("Foreground transition rejects an unrelated detected agent")
     func foregroundTransitionRejectsUnrelatedAgent() async throws {
         let dir = try makeTempDirectory()

--- a/PineTests/BulkCloseAgentAuthorizationTests.swift
+++ b/PineTests/BulkCloseAgentAuthorizationTests.swift
@@ -23,11 +23,17 @@ import Foundation
 import Testing
 @testable import Pine
 
-@Suite("Bulk Close Agent Authorization (#1348)")
+@Suite("Bulk Close Agent Authorization (#1348)", .serialized)
 @MainActor
 struct BulkCloseAgentAuthorizationTests {
 
     // MARK: - Fixtures
+
+    private func makeRegistry() -> ProjectRegistry {
+        ProjectRegistry(agentTasks: AgentTaskRegistry(
+            persistence: BulkCloseAgentTaskStore()
+        ))
+    }
 
     private func makeTempDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
@@ -69,7 +75,7 @@ struct BulkCloseAgentAuthorizationTests {
     func windowCloseWarnsAboutRunningAgent() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         try addAgentTerminalTab(to: project)
 
@@ -101,7 +107,7 @@ struct BulkCloseAgentAuthorizationTests {
     func confirmedWindowCloseSurvivesChurn() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         let tab = try addAgentTerminalTab(to: project)
         let sessionID = try #require(tab.agentSession?.id)
@@ -132,7 +138,7 @@ struct BulkCloseAgentAuthorizationTests {
     func newAgentRunDuringSheetCancelsWindowClose() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         let tab = try addAgentTerminalTab(to: project)
 
@@ -164,7 +170,7 @@ struct BulkCloseAgentAuthorizationTests {
     func agentExitDuringSheetStillClosesWindow() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         let tab = try addAgentTerminalTab(to: project)
 
@@ -202,7 +208,7 @@ struct BulkCloseAgentAuthorizationTests {
             cleanup(firstDirectory)
             cleanup(secondDirectory)
         }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let firstProject = try #require(
             registry.projectManager(for: firstDirectory)
         )
@@ -243,7 +249,7 @@ struct BulkCloseAgentAuthorizationTests {
             cleanup(activeDirectory)
             cleanup(idleDirectory)
         }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let activeProject = try #require(
             registry.projectManager(for: activeDirectory)
         )
@@ -290,7 +296,7 @@ struct BulkCloseAgentAuthorizationTests {
     func confirmedQuitSurvivesChurn() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         let tab = try addAgentTerminalTab(to: project)
         let sessionID = try #require(tab.agentSession?.id)
@@ -312,7 +318,7 @@ struct BulkCloseAgentAuthorizationTests {
     func newAgentRunDuringQuitSheetCancelsTermination() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         let tab = try addAgentTerminalTab(to: project)
 
@@ -346,7 +352,7 @@ struct BulkCloseAgentAuthorizationTests {
     func idleProjectDoesNotBlockQuit() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
 
@@ -374,7 +380,7 @@ struct BulkCloseAgentAuthorizationTests {
         // scenario: every window closed, agents alive, ⌘Q).
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         let tab = try addAgentTerminalTab(to: project)
         registry.closeProjectWindow(dir)
@@ -402,7 +408,7 @@ struct BulkCloseAgentAuthorizationTests {
     func decliningQuitWarningCancelsTermination() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         try addAgentTerminalTab(to: project)
 
@@ -416,6 +422,22 @@ struct BulkCloseAgentAuthorizationTests {
 
         #expect(!result)
         await project.workspace.waitForLoadingComplete()
+    }
+}
+
+private actor BulkCloseAgentTaskStore: AgentTaskPersisting {
+    func load(
+        project: AgentTaskProjectIdentity
+    ) async -> AgentTaskMetadataLoadResult {
+        AgentTaskMetadataLoadResult(status: .missing, tasks: [])
+    }
+
+    func save(
+        tasks: [AgentTask],
+        project: AgentTaskProjectIdentity,
+        authorization: AgentTaskPublicationAuthorization?
+    ) async -> AgentTaskMetadataSaveResult {
+        .saved(taskCount: tasks.count)
     }
 }
 

--- a/PineTests/BulkCloseAgentAuthorizationTests.swift
+++ b/PineTests/BulkCloseAgentAuthorizationTests.swift
@@ -381,6 +381,7 @@ struct BulkCloseAgentAuthorizationTests {
         tab.agentSession = firstSession
         #expect(firstAuthorization.coversLaunch(
             in: tab.id,
+            settledSessionID: firstSession.id,
             current: project.terminal.capturePineAgentLaunchAuthorization()
         ))
 
@@ -418,8 +419,118 @@ struct BulkCloseAgentAuthorizationTests {
         #expect(!firstAuthorization.stillCovers(current))
         #expect(!firstAuthorization.coversLaunch(
             in: tab.id,
+            settledSessionID: secondSession.id,
             current: current
         ))
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("Pending Pine launch does not authorize an unrelated detected agent")
+    func pendingLaunchRejectsUnrelatedDetectedAgent() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let pane = project.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: dir
+        )
+        let tab = try #require(
+            project.paneManager.terminalState(for: pane)?.terminalTabs.first
+        )
+        let terminalAuthorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: [tab]
+        )
+        guard case .reserved = await project.terminal
+                .launchAgentCommandForTesting(
+                    "codex",
+                    descriptor: AgentDescriptor(
+                        agentType: .codex,
+                        launchExecutable: "codex"
+                    ),
+                    in: tab,
+                    acknowledgedWrite: { true }
+                ) else {
+            Issue.record("Pine launch was not reserved")
+            return
+        }
+        let launchAuthorization = project.terminal
+            .capturePineAgentLaunchAuthorization()
+        let unrelated = detectedSession(
+            agentType: .claudeCode,
+            processID: 8_222,
+            generation: 11
+        )
+
+        // The implicit bridge attempts to consume the pending Codex
+        // reservation for this terminal, but the incompatible Claude session
+        // must not inherit that authorization while the claim remains live.
+        project.terminal.bridgeAgentSession(
+            unrelated,
+            replacing: nil,
+            in: tab
+        )
+        tab.agentSession = unrelated
+        let current = project.terminal.capturePineAgentLaunchAuthorization()
+
+        #expect(current.requiresConfirmation)
+        #expect(!terminalAuthorization.stillCovers(
+            [tab],
+            pineAgentLaunches: launchAuthorization,
+            currentPineAgentLaunches: current
+        ))
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("Stale agent session does not authorize a replacement foreground job")
+    func staleAgentSessionRejectsReplacementForegroundJob() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let pane = project.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: dir
+        )
+        let tab = try #require(
+            project.paneManager.terminalState(for: pane)?.terminalTabs.first
+        )
+        let startedAt = Date(timeIntervalSince1970: 10.000_020)
+        let session = AgentSession(
+            agentType: .codex,
+            startedAt: startedAt
+        )
+        _ = session.bindProcessEvidence(AgentProcessEvidence(
+            processIdentifier: 8_111,
+            processGeneration: 10,
+            startIdentifier: "generation-10",
+            observedStartedAt: startedAt,
+            startIsAuthoritative: true
+        ))
+        let processIdentity = TerminalProcessStartIdentity(
+            processID: 8_111,
+            seconds: 10,
+            microseconds: 20
+        )
+        tab.agentSession = session
+        tab.foregroundProcessIDOverrideForTesting = 8_111
+        tab.agentProcessIdentityResolverForTesting = { _ in processIdentity }
+        let authorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: [tab]
+        )
+
+        #expect(authorization.stillCovers([tab]))
+
+        // Detection is frozen during the machine phase, so the old session
+        // object can remain after its process exits. A new foreground job in
+        // the same PTY is independent work and must fail closed.
+        tab.agentProcessIdentityResolverForTesting = { _ in nil }
+        tab.foregroundProcessIDOverrideForTesting = 9_999
+        tab.foregroundStartOverrideForTesting = TerminalProcessStartIdentity(
+            processID: 9_999,
+            seconds: processIdentity.seconds + 1,
+            microseconds: processIdentity.microseconds
+        )
+
+        #expect(!authorization.stillCovers([tab]))
         await project.workspace.waitForLoadingComplete()
     }
 
@@ -551,6 +662,112 @@ struct BulkCloseAgentAuthorizationTests {
     }
 
     // MARK: - Application quit
+
+    @Test("Hidden Quick Terminal foreground work gates application quit")
+    func hiddenQuickTerminalForegroundWorkGatesQuit() async {
+        let delegate = AppDelegate()
+        delegate.registry = makeRegistry()
+        let tab = delegate.quickTerminalCoordinator.paneState.addTab(
+            workingDirectory: nil
+        )
+        tab.foregroundProcessIDOverrideForTesting = 8_111
+        tab.foregroundStartOverrideForTesting = TerminalProcessStartIdentity(
+            processID: 8_111,
+            seconds: 10,
+            microseconds: 20
+        )
+        var presented: [AlertTemplate] = []
+        var summaryMessage: String?
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, message in
+                presented.append(template)
+                if template == .applicationQuitSummary {
+                    summaryMessage = message
+                }
+                return .alertSecondButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(result)
+        #expect(presented == [.applicationQuitSummary])
+        #expect(summaryMessage == Strings.applicationQuitSummaryMessage(1))
+    }
+
+    @Test("Review asks separately before stopping Quick Terminal work")
+    func reviewConfirmsQuickTerminalForegroundWork() async {
+        let delegate = AppDelegate()
+        delegate.registry = makeRegistry()
+        let tab = delegate.quickTerminalCoordinator.paneState.addTab(
+            workingDirectory: nil
+        )
+        tab.foregroundProcessIDOverrideForTesting = 8_111
+        tab.foregroundStartOverrideForTesting = TerminalProcessStartIdentity(
+            processID: 8_111,
+            seconds: 10,
+            microseconds: 20
+        )
+        var presented: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presented.append(template)
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(result)
+        #expect(
+            presented == [
+                .applicationQuitSummary,
+                .terminalActiveProcessWarning,
+            ]
+        )
+    }
+
+    @Test("Quick Terminal job started during summary cancels quit")
+    func quickTerminalJobStartedDuringSummaryCancelsQuit() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        try addAgentTerminalTab(to: project)
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        let tab = delegate.quickTerminalCoordinator.paneState.addTab(
+            workingDirectory: nil
+        )
+        var presented: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presented.append(template)
+                if template == .applicationQuitSummary {
+                    tab.foregroundProcessIDOverrideForTesting = 8_222
+                    tab.foregroundStartOverrideForTesting =
+                        TerminalProcessStartIdentity(
+                            processID: 8_222,
+                            seconds: 11,
+                            microseconds: 20
+                        )
+                    return .alertSecondButtonReturn
+                }
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(!result)
+        #expect(
+            presented == [
+                .applicationQuitSummary,
+                .applicationQuitFailure,
+            ]
+        )
+        await project.workspace.waitForLoadingComplete()
+    }
 
     @Test("Quit summarizes agents from multiple projects in one alert")
     func quitSummarizesAgentsAcrossProjects() async throws {

--- a/PineTests/BulkCloseAgentAuthorizationTests.swift
+++ b/PineTests/BulkCloseAgentAuthorizationTests.swift
@@ -339,6 +339,90 @@ struct BulkCloseAgentAuthorizationTests {
         await project.workspace.waitForLoadingComplete()
     }
 
+    @Test("Settled launch authorization rejects same-task reservation replay")
+    func settledLaunchRejectsSameTaskReservationReplay() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let pane = project.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: dir
+        )
+        let tab = try #require(
+            project.paneManager.terminalState(for: pane)?.terminalTabs.first
+        )
+        let descriptor = AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        )
+        guard case .reserved(let firstReservation) = await project.terminal
+                .launchAgentCommandForTesting(
+                    "codex",
+                    descriptor: descriptor,
+                    in: tab,
+                    acknowledgedWrite: { true }
+                ) else {
+            Issue.record("First launch was not reserved")
+            return
+        }
+        let firstAuthorization = project.terminal
+            .capturePineAgentLaunchAuthorization()
+        let firstSession = detectedSession(
+            agentType: .codex,
+            processID: 8_111,
+            generation: 10
+        )
+        project.terminal.bridgeAgentSession(
+            firstSession,
+            replacing: nil,
+            in: tab,
+            reservation: firstReservation
+        )
+        tab.agentSession = firstSession
+        #expect(firstAuthorization.coversLaunch(
+            in: tab.id,
+            current: project.terminal.capturePineAgentLaunchAuthorization()
+        ))
+
+        firstSession.applyLiveness(.terminated)
+        firstSession.state = .done
+        project.terminal.bridgeAgentSession(
+            firstSession,
+            replacing: firstSession,
+            in: tab
+        )
+        guard case .reserved(let secondReservation) = project.terminal
+                .prepareAgentResume(
+                    taskID: firstReservation.taskID,
+                    in: tab
+                ) else {
+            Issue.record("Second launch was not reserved")
+            return
+        }
+        #expect(secondReservation != firstReservation)
+        #expect(registry.agentTasks.armLaunch(secondReservation))
+        let secondSession = detectedSession(
+            agentType: .codex,
+            processID: 8_222,
+            generation: 11
+        )
+        project.terminal.bridgeAgentSession(
+            secondSession,
+            replacing: firstSession,
+            in: tab,
+            reservation: secondReservation
+        )
+        tab.agentSession = secondSession
+        let current = project.terminal.capturePineAgentLaunchAuthorization()
+
+        #expect(!firstAuthorization.stillCovers(current))
+        #expect(!firstAuthorization.coversLaunch(
+            in: tab.id,
+            current: current
+        ))
+        await project.workspace.waitForLoadingComplete()
+    }
+
     @Test("Window close warns about a running agent that has no foreground pgid")
     func windowCloseWarnsAboutRunningAgent() async throws {
         let dir = try makeTempDirectory()

--- a/PineTests/BulkCloseAgentAuthorizationTests.swift
+++ b/PineTests/BulkCloseAgentAuthorizationTests.swift
@@ -292,6 +292,104 @@ struct BulkCloseAgentAuthorizationTests {
         await idleProject.workspace.waitForLoadingComplete()
     }
 
+    @Test("Idle terminal accepts the exact Pine launch authorized by Quit")
+    func idleTerminalAcceptsExactAuthorizedPineLaunch() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let pane = project.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: dir
+        )
+        let tab = try #require(
+            project.paneManager.terminalState(for: pane)?.terminalTabs.first
+        )
+        #expect(tab.foregroundProcessID <= 0)
+        let descriptor = AgentDescriptor(
+            agentType: .codex,
+            launchExecutable: "codex"
+        )
+        let gate = BulkCloseAgentLaunchGate()
+        let launchTask = Task { @MainActor in
+            await project.terminal.launchAgentCommandForTesting(
+                "codex",
+                descriptor: descriptor,
+                in: tab
+            ) {
+                await gate.waitForCompletion()
+            }
+        }
+        #expect(await gate.waitUntilStarted())
+        let delegate = AppDelegate()
+        delegate.registry = registry
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                #expect(template == .applicationQuitSummary)
+                gate.finish(true)
+                guard case .reserved = await launchTask.value else {
+                    Issue.record("authorized Pine launch was not armed")
+                    return .alertThirdButtonReturn
+                }
+                tab.foregroundProcessIDOverrideForTesting = 8_111
+                return .alertSecondButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(result)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("Idle terminal rejects an unrelated new foreground process")
+    func idleTerminalRejectsUnrelatedForegroundProcess() async throws {
+        let activeDirectory = try makeTempDirectory()
+        let idleDirectory = try makeTempDirectory()
+        defer {
+            cleanup(activeDirectory)
+            cleanup(idleDirectory)
+        }
+        let registry = makeRegistry()
+        let activeProject = try #require(
+            registry.projectManager(for: activeDirectory)
+        )
+        let idleProject = try #require(
+            registry.projectManager(for: idleDirectory)
+        )
+        try addAgentTerminalTab(to: activeProject)
+        let pane = idleProject.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: idleDirectory
+        )
+        let idleTab = try #require(
+            idleProject.paneManager.terminalState(for: pane)?.terminalTabs.first
+        )
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var presented: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presented.append(template)
+                if template == .applicationQuitSummary {
+                    idleTab.foregroundProcessIDOverrideForTesting = 8_222
+                    return .alertSecondButtonReturn
+                }
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(!result)
+        #expect(
+            presented == [
+                .applicationQuitSummary,
+                .applicationQuitFailure,
+            ]
+        )
+        await activeProject.workspace.waitForLoadingComplete()
+        await idleProject.workspace.waitForLoadingComplete()
+    }
+
     @Test("Confirmed quit survives agent child-process churn")
     func confirmedQuitSurvivesChurn() async throws {
         let dir = try makeTempDirectory()
@@ -438,6 +536,43 @@ private actor BulkCloseAgentTaskStore: AgentTaskPersisting {
         authorization: AgentTaskPublicationAuthorization?
     ) async -> AgentTaskMetadataSaveResult {
         .saved(taskCount: tasks.count)
+    }
+}
+
+@MainActor
+private final class BulkCloseAgentLaunchGate {
+    private var started = false
+    private var completion: Bool?
+
+    func waitForCompletion() async -> Bool {
+        started = true
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while completion == nil, clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
+        }
+        return completion ?? false
+    }
+
+    func waitUntilStarted() async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+        while !started, clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
+        }
+        return started
+    }
+
+    func finish(_ result: Bool) {
+        completion = result
     }
 }
 

--- a/PineTests/BulkCloseAgentAuthorizationTests.swift
+++ b/PineTests/BulkCloseAgentAuthorizationTests.swift
@@ -53,6 +53,26 @@ struct BulkCloseAgentAuthorizationTests {
         for _ in 0..<8 { await Task.yield() }
     }
 
+    private func detectedSession(
+        agentType: AgentType,
+        processID: Int32,
+        generation: UInt64
+    ) -> AgentSession {
+        let startedAt = Date().addingTimeInterval(1)
+        let session = AgentSession(
+            agentType: agentType,
+            startedAt: startedAt
+        )
+        _ = session.bindProcessEvidence(AgentProcessEvidence(
+            processIdentifier: processID,
+            processGeneration: generation,
+            startIdentifier: "generation-\(generation)",
+            observedStartedAt: startedAt,
+            startIsAuthoritative: true
+        ))
+        return session
+    }
+
     /// Adds a terminal pane carrying one tab that is running an AI agent.
     /// The tab has no live PTY, so `foregroundProcessID` stays `-1` — which is
     /// precisely the state the old pgid snapshot could not represent.
@@ -145,6 +165,141 @@ struct BulkCloseAgentAuthorizationTests {
 
         #expect(authorization.requiresConfirmation)
         #expect(!authorization.stillCovers([tab]))
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("Foreground transition accepts the exact settled Pine agent task")
+    func foregroundTransitionAcceptsExactSettledAgent() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: dir)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        tab.foregroundProcessIDOverrideForTesting = 4_242
+        tab.foregroundStartOverrideForTesting = TerminalProcessStartIdentity(
+            processID: 4_242,
+            seconds: 10,
+            microseconds: 20
+        )
+        let gate = BulkCloseAgentLaunchGate()
+        let launchTask = Task { @MainActor in
+            await project.terminal.launchAgentCommandForTesting(
+                "codex",
+                descriptor: AgentDescriptor(
+                    agentType: .codex,
+                    launchExecutable: "codex"
+                ),
+                in: tab
+            ) {
+                await gate.waitForCompletion()
+            }
+        }
+        try #require(await gate.waitUntilStarted())
+        let terminalAuthorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: [tab]
+        )
+        let launchAuthorization = project.terminal
+            .capturePineAgentLaunchAuthorization()
+
+        gate.finish(true)
+        guard case .reserved(let reservation) = await launchTask.value else {
+            Issue.record("Pine launch was not reserved")
+            return
+        }
+        let session = detectedSession(
+            agentType: .codex,
+            processID: 8_111,
+            generation: 10
+        )
+        project.terminal.bridgeAgentSession(
+            session,
+            replacing: nil,
+            in: tab,
+            reservation: reservation
+        )
+        tab.agentSession = session
+        let currentLaunchAuthorization = project.terminal
+            .capturePineAgentLaunchAuthorization()
+
+        #expect(terminalAuthorization.stillCovers(
+            [tab],
+            pineAgentLaunches: launchAuthorization,
+            currentPineAgentLaunches: currentLaunchAuthorization
+        ))
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("Foreground transition rejects an unrelated detected agent")
+    func foregroundTransitionRejectsUnrelatedAgent() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: dir)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        tab.foregroundProcessIDOverrideForTesting = 4_242
+        tab.foregroundStartOverrideForTesting = TerminalProcessStartIdentity(
+            processID: 4_242,
+            seconds: 10,
+            microseconds: 20
+        )
+        let gate = BulkCloseAgentLaunchGate()
+        let launchTask = Task { @MainActor in
+            await project.terminal.launchAgentCommandForTesting(
+                "codex",
+                descriptor: AgentDescriptor(
+                    agentType: .codex,
+                    launchExecutable: "codex"
+                ),
+                in: tab
+            ) {
+                await gate.waitForCompletion()
+            }
+        }
+        try #require(await gate.waitUntilStarted())
+        let terminalAuthorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: [tab]
+        )
+        let launchAuthorization = project.terminal
+            .capturePineAgentLaunchAuthorization()
+
+        gate.finish(true)
+        guard case .reserved(let reservation) = await launchTask.value else {
+            Issue.record("Pine launch was not reserved")
+            return
+        }
+        let launched = detectedSession(
+            agentType: .codex,
+            processID: 8_111,
+            generation: 10
+        )
+        project.terminal.bridgeAgentSession(
+            launched,
+            replacing: nil,
+            in: tab,
+            reservation: reservation
+        )
+        launched.applyLiveness(.terminated)
+        let unrelated = detectedSession(
+            agentType: .claudeCode,
+            processID: 8_222,
+            generation: 11
+        )
+        project.terminal.bridgeAgentSession(
+            unrelated,
+            replacing: launched,
+            in: tab
+        )
+        tab.agentSession = unrelated
+        let currentLaunchAuthorization = project.terminal
+            .capturePineAgentLaunchAuthorization()
+
+        #expect(!terminalAuthorization.stillCovers(
+            [tab],
+            pineAgentLaunches: launchAuthorization,
+            currentPineAgentLaunches: currentLaunchAuthorization
+        ))
         await project.workspace.waitForLoadingComplete()
     }
 

--- a/PineTests/BulkCloseAgentAuthorizationTests.swift
+++ b/PineTests/BulkCloseAgentAuthorizationTests.swift
@@ -81,6 +81,7 @@ struct BulkCloseAgentAuthorizationTests {
         let tab = try #require(project.terminal.allTerminalTabs.first)
         tab.foregroundProcessIDOverrideForTesting = 4_242
         tab.foregroundStartOverrideForTesting = TerminalProcessStartIdentity(
+            processID: 4_242,
             seconds: 10,
             microseconds: 20
         )
@@ -89,10 +90,60 @@ struct BulkCloseAgentAuthorizationTests {
         )
 
         tab.foregroundStartOverrideForTesting = TerminalProcessStartIdentity(
+            processID: 4_242,
             seconds: 11,
             microseconds: 20
         )
 
+        #expect(!authorization.stillCovers([tab]))
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("Leaderless foreground group retains an exact live member witness")
+    func leaderlessForegroundGroupIsAuthorizedByMember() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        tab.foregroundProcessIDOverrideForTesting = 4_242
+        let member = TerminalProcessStartIdentity(
+            processID: 5_252,
+            seconds: 10,
+            microseconds: 20
+        )
+        tab.foregroundStartOverrideForTesting = member
+        let authorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: [tab]
+        )
+
+        #expect(authorization.stillCovers([tab]))
+
+        tab.foregroundStartOverrideForTesting = TerminalProcessStartIdentity(
+            processID: member.processID,
+            seconds: member.seconds + 1,
+            microseconds: member.microseconds
+        )
+        #expect(!authorization.stillCovers([tab]))
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test("Unavailable foreground member identity fails closed")
+    func unavailableForegroundMemberIdentityFailsClosed() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        tab.foregroundProcessIDOverrideForTesting = 4_242
+        tab.foregroundStartOverrideForTesting = nil
+        let authorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: [tab]
+        )
+
+        #expect(authorization.requiresConfirmation)
         #expect(!authorization.stillCovers([tab]))
         await project.workspace.waitForLoadingComplete()
     }

--- a/PineTests/BulkCloseAgentAuthorizationTests.swift
+++ b/PineTests/BulkCloseAgentAuthorizationTests.swift
@@ -215,10 +215,14 @@ struct BulkCloseAgentAuthorizationTests {
         let delegate = AppDelegate()
         delegate.registry = registry
         var presentedTemplates: [AlertTemplate] = []
+        var summaryMessage: String?
 
         let result = await delegate.confirmApplicationTermination(
-            presentAlert: { template, _, _, _ in
+            presentAlert: { template, _, _, message in
                 presentedTemplates.append(template)
+                if template == .applicationQuitSummary {
+                    summaryMessage = message
+                }
                 return .alertSecondButtonReturn
             },
             terminationDeadlineOverride: .now() + 120
@@ -226,8 +230,60 @@ struct BulkCloseAgentAuthorizationTests {
 
         #expect(result)
         #expect(presentedTemplates == [.applicationQuitSummary])
+        #expect(summaryMessage == Strings.applicationQuitSummaryMessage(2))
         await firstProject.workspace.waitForLoadingComplete()
         await secondProject.workspace.waitForLoadingComplete()
+    }
+
+    @Test("Idle terminal becoming an agent during summary cancels quit")
+    func idleTerminalBecomingAgentDuringSummaryCancelsQuit() async throws {
+        let activeDirectory = try makeTempDirectory()
+        let idleDirectory = try makeTempDirectory()
+        defer {
+            cleanup(activeDirectory)
+            cleanup(idleDirectory)
+        }
+        let registry = ProjectRegistry()
+        let activeProject = try #require(
+            registry.projectManager(for: activeDirectory)
+        )
+        let idleProject = try #require(
+            registry.projectManager(for: idleDirectory)
+        )
+        try addAgentTerminalTab(to: activeProject)
+        idleProject.paneManager.createTerminalPaneAtBottom(
+            workingDirectory: nil
+        )
+        let idleTab = try #require(
+            idleProject.terminal.allTerminalTabs.first
+        )
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var presentedTemplates: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presentedTemplates.append(template)
+                if template == .applicationQuitSummary {
+                    idleTab.agentSession = AgentSession(
+                        agentType: .claudeCode
+                    )
+                    return .alertSecondButtonReturn
+                }
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 120
+        )
+
+        #expect(!result)
+        #expect(
+            presentedTemplates == [
+                .applicationQuitSummary,
+                .applicationQuitFailure,
+            ]
+        )
+        await activeProject.workspace.waitForLoadingComplete()
+        await idleProject.workspace.waitForLoadingComplete()
     }
 
     @Test("Confirmed quit survives agent child-process churn")

--- a/PineTests/BulkCloseAgentAuthorizationTests.swift
+++ b/PineTests/BulkCloseAgentAuthorizationTests.swift
@@ -71,6 +71,32 @@ struct BulkCloseAgentAuthorizationTests {
 
     // MARK: - Project window close
 
+    @Test("Reused foreground PGID is a new authorization generation")
+    func reusedForegroundPGIDIsRejected() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        tab.foregroundProcessIDOverrideForTesting = 4_242
+        tab.foregroundStartOverrideForTesting = TerminalProcessStartIdentity(
+            seconds: 10,
+            microseconds: 20
+        )
+        let authorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: [tab]
+        )
+
+        tab.foregroundStartOverrideForTesting = TerminalProcessStartIdentity(
+            seconds: 11,
+            microseconds: 20
+        )
+
+        #expect(!authorization.stillCovers([tab]))
+        await project.workspace.waitForLoadingComplete()
+    }
+
     @Test("Window close warns about a running agent that has no foreground pgid")
     func windowCloseWarnsAboutRunningAgent() async throws {
         let dir = try makeTempDirectory()

--- a/PineTests/DialogPresentationCoordinatorTests.swift
+++ b/PineTests/DialogPresentationCoordinatorTests.swift
@@ -744,6 +744,59 @@ struct DialogPresentationCoordinatorTests {
         #expect(await response.value == .abort)
         #expect(!started)
     }
+
+    @Test("a termination request outlives the generic foreign-sheet watchdog")
+    func terminationRequestWaitsPastWatchdogBound() async {
+        let owner = makeVisibleWindow()
+        let foreignSheet = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 120),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let coordinator = WindowDialogCoordinator(
+            ownerWindow: owner,
+            notificationCenter: NotificationCenter(),
+            watchdogInterval: 0.01,
+            watchdogMaxAttempts: 3
+        )
+        var started = false
+        var completion: ((NSApplication.ModalResponse) -> Void)?
+        defer {
+            coordinator.ownerDidClose()
+            owner.orderOut(nil)
+        }
+
+        owner.beginSheet(foreignSheet) { _ in }
+        let response = Task {
+            await coordinator.present(
+                waitPolicy: .waitUntilOwnerAvailable,
+                start: { _, callback in
+                    started = true
+                    completion = callback
+                },
+                cancel: { _ in }
+            )
+        }
+
+        // Cross several watchdog bounds. A human Quit decision must remain
+        // queued instead of turning the framework sheet into a silent abort.
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(!started)
+
+        owner.endSheet(foreignSheet, returnCode: .cancel)
+        for _ in 0..<100 {
+            if started { break }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(started)
+        if let completion {
+            completion(.alertFirstButtonReturn)
+        } else {
+            coordinator.ownerDidClose()
+        }
+        #expect(await response.value == .alertFirstButtonReturn)
+    }
 }
 
 @Suite("Dialog flow regressions")

--- a/PineTests/ExternalFileFormatterTests.swift
+++ b/PineTests/ExternalFileFormatterTests.swift
@@ -3,12 +3,13 @@
 //  PineTests
 //
 
+import Darwin
 import Foundation
 import Testing
 
 @testable import Pine
 
-@Suite("ExternalFileFormatter")
+@Suite("ExternalFileFormatter", .serialized)
 struct ExternalFileFormatterTests {
 
     /// Helper to create a formatter with a mock tool path (bypasses real PATH resolution).
@@ -171,6 +172,142 @@ struct ExternalFileFormatterTests {
         #expect(elapsed < 0.5)
     }
 
+    @Test("Continuous stdout cannot evade the monotonic timeout")
+    func continuousOutputHonorsTimeout() {
+        let semaphore = DispatchSemaphore(value: 0)
+        nonisolated(unsafe) var result: ProcessRunResult?
+        nonisolated(unsafe) var elapsed: TimeInterval = 0
+
+        DispatchQueue.global().async {
+            let start = Date()
+            result = runRealProcess(
+                executablePath: "/usr/bin/awk",
+                arguments: [
+                    "BEGIN { while (1) print \"0123456789abcdef0123456789abcdef\" }",
+                ],
+                stdin: "",
+                timeout: 0.05,
+                outputLimits: ProcessOutputLimits(
+                    stdoutBytes: 32 * 1_024 * 1_024,
+                    stderrBytes: 1_024
+                )
+            )
+            elapsed = Date().timeIntervalSince(start)
+            semaphore.signal()
+        }
+
+        #expect(semaphore.wait(timeout: .now() + 1) == .success)
+        #expect(result?.timedOut == true)
+        #expect(result?.outputLimitExceeded == false)
+        #expect(elapsed < 0.5)
+    }
+
+    @Test("Output cap terminates a producer and reports explicit failure")
+    func outputCapFailsWithoutReturningTruncatedOutput() {
+        let semaphore = DispatchSemaphore(value: 0)
+        nonisolated(unsafe) var result: ProcessRunResult?
+        nonisolated(unsafe) var elapsed: TimeInterval = 0
+
+        DispatchQueue.global().async {
+            let start = Date()
+            result = runRealProcess(
+                executablePath: "/usr/bin/yes",
+                arguments: [],
+                stdin: "",
+                timeout: 1,
+                outputLimits: ProcessOutputLimits(
+                    stdoutBytes: 32 * 1_024,
+                    stderrBytes: 1_024
+                )
+            )
+            elapsed = Date().timeIntervalSince(start)
+            semaphore.signal()
+        }
+
+        #expect(semaphore.wait(timeout: .now() + 1) == .success)
+        #expect(result?.outputLimitExceeded == true)
+        #expect(result?.timedOut == false)
+        #expect(result?.stdout.utf8.count == 32 * 1_024)
+        #expect(elapsed < 0.5)
+    }
+
+    @Test("Stderr has an independent bounded capture cap")
+    func stderrCapTerminatesProducer() {
+        let semaphore = DispatchSemaphore(value: 0)
+        nonisolated(unsafe) var result: ProcessRunResult?
+
+        DispatchQueue.global().async {
+            result = runRealProcess(
+                executablePath: "/bin/sh",
+                arguments: ["-c", "exec /usr/bin/yes >&2"],
+                stdin: "",
+                timeout: 1,
+                outputLimits: ProcessOutputLimits(
+                    stdoutBytes: 1_024,
+                    stderrBytes: 8 * 1_024
+                )
+            )
+            semaphore.signal()
+        }
+
+        #expect(semaphore.wait(timeout: .now() + 1) == .success)
+        #expect(result?.outputLimitExceeded == true)
+        #expect(result?.timedOut == false)
+        #expect(result?.stderr.utf8.count == 8 * 1_024)
+    }
+
+    @Test("Spawn closes unrelated inheritable descriptors")
+    func spawnDoesNotInheritUnrelatedDescriptor() throws {
+        let descriptor = Darwin.open("/dev/null", O_RDONLY)
+        #expect(descriptor >= 0)
+        guard descriptor >= 0 else { return }
+        defer { Darwin.close(descriptor) }
+
+        let descriptorFlags = Darwin.fcntl(descriptor, F_GETFD)
+        #expect(descriptorFlags >= 0)
+        guard descriptorFlags >= 0 else { return }
+        #expect(Darwin.fcntl(
+            descriptor,
+            F_SETFD,
+            descriptorFlags & ~FD_CLOEXEC
+        ) == 0)
+
+        let semaphore = DispatchSemaphore(value: 0)
+        nonisolated(unsafe) var result: ProcessRunResult?
+        DispatchQueue.global().async {
+            result = runRealProcess(
+                executablePath: "/bin/sh",
+                arguments: [
+                    "-c",
+                    "if test -e /dev/fd/\(descriptor); then printf leaked; else printf closed; fi",
+                ],
+                stdin: "",
+                timeout: 1
+            )
+            semaphore.signal()
+        }
+
+        #expect(semaphore.wait(timeout: .now() + 2) == .success)
+        #expect(result?.exitCode == 0)
+        #expect(result?.stdout == "closed")
+    }
+
+    @Test("Formatter rejects output explicitly marked as overflowed")
+    func formatterRejectsOverflowedOutput() {
+        let runner = MockProcessRunner(
+            stdout: "truncated",
+            stderr: "",
+            exitCode: 0,
+            outputLimitExceeded: true
+        )
+        let formatter = makeFormatter(runner: runner)
+
+        #expect(formatter.format(
+            "original",
+            url: URL(fileURLWithPath: "/tmp/main.tf")
+        ) == "original")
+    }
+
     // MARK: - Registry integration
 
     @Test("ExternalFileFormatter works in FileFormatterRegistry")
@@ -205,6 +342,7 @@ nonisolated final class MockProcessRunner: @unchecked Sendable {
     let exitCode: Int32
     let error: Error?
     let simulateTimeout: Bool
+    let outputLimitExceeded: Bool
     private(set) var lastStdinContent: String?
 
     init(
@@ -212,13 +350,15 @@ nonisolated final class MockProcessRunner: @unchecked Sendable {
         stderr: String = "",
         exitCode: Int32 = 0,
         error: Error? = nil,
-        simulateTimeout: Bool = false
+        simulateTimeout: Bool = false,
+        outputLimitExceeded: Bool = false
     ) {
         self.stdout = stdout
         self.stderr = stderr
         self.exitCode = exitCode
         self.error = error
         self.simulateTimeout = simulateTimeout
+        self.outputLimitExceeded = outputLimitExceeded
     }
 
     func run(
@@ -234,6 +374,12 @@ nonisolated final class MockProcessRunner: @unchecked Sendable {
         if simulateTimeout {
             return ProcessRunResult(stdout: "", stderr: "timed out", exitCode: -1, timedOut: true)
         }
-        return ProcessRunResult(stdout: stdout, stderr: stderr, exitCode: exitCode, timedOut: false)
+        return ProcessRunResult(
+            stdout: stdout,
+            stderr: stderr,
+            exitCode: exitCode,
+            timedOut: false,
+            outputLimitExceeded: outputLimitExceeded
+        )
     }
 }

--- a/PineTests/ExternalFileFormatterTests.swift
+++ b/PineTests/ExternalFileFormatterTests.swift
@@ -145,6 +145,32 @@ struct ExternalFileFormatterTests {
         #expect(result == "hello world")
     }
 
+    @Test("Timeout kills a TERM-ignoring process group and closes pipes")
+    func timeoutKillsProcessGroup() {
+        let semaphore = DispatchSemaphore(value: 0)
+        nonisolated(unsafe) var result: ProcessRunResult?
+        nonisolated(unsafe) var elapsed: TimeInterval = 0
+
+        DispatchQueue.global().async {
+            let start = Date()
+            result = runRealProcess(
+                executablePath: "/bin/sh",
+                arguments: [
+                    "-c",
+                    "trap '' TERM; sleep 10 & wait",
+                ],
+                stdin: "",
+                timeout: 0.2
+            )
+            elapsed = Date().timeIntervalSince(start)
+            semaphore.signal()
+        }
+
+        #expect(semaphore.wait(timeout: .now() + 1) == .success)
+        #expect(result?.timedOut == true)
+        #expect(elapsed < 0.5)
+    }
+
     // MARK: - Registry integration
 
     @Test("ExternalFileFormatter works in FileFormatterRegistry")

--- a/PineTests/ExternalFileFormatterTests.swift
+++ b/PineTests/ExternalFileFormatterTests.swift
@@ -172,6 +172,26 @@ struct ExternalFileFormatterTests {
         #expect(elapsed < 0.5)
     }
 
+    @Test("Formatter preserves the process-group leader until its final signal")
+    func formatterReapsOnlyAfterSafeBoundary() {
+        #expect(formatterShouldAttemptReap(
+            terminationStarted: false,
+            streamsAreClosed: true
+        ))
+        #expect(!formatterShouldAttemptReap(
+            terminationStarted: false,
+            streamsAreClosed: false
+        ))
+        #expect(!formatterShouldAttemptReap(
+            terminationStarted: true,
+            streamsAreClosed: true
+        ))
+        #expect(!formatterShouldAttemptReap(
+            terminationStarted: true,
+            streamsAreClosed: false
+        ))
+    }
+
     @Test("Continuous stdout cannot evade the monotonic timeout")
     func continuousOutputHonorsTimeout() {
         let semaphore = DispatchSemaphore(value: 0)

--- a/PineTests/ProjectManagerTerminationAutoSaveTests.swift
+++ b/PineTests/ProjectManagerTerminationAutoSaveTests.swift
@@ -1,0 +1,48 @@
+//
+//  ProjectManagerTerminationAutoSaveTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Project Manager Termination Auto-Save Tests", .serialized)
+@MainActor
+struct ProjectManagerTerminationAutoSaveTests {
+    @Test("editor managers created during Quit inherit the auto-save freeze")
+    func newEditorManagerInheritsTerminationFreeze() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("late-pane.swift")
+        try "original".write(to: file, atomically: true, encoding: .utf8)
+
+        let project = ProjectManager()
+        let initialPane = project.paneManager.activePaneID
+        project.freezeAutoSaveForTermination()
+        let newPane = try #require(project.paneManager.splitPane(
+            initialPane,
+            axis: .horizontal
+        ))
+        let tabs = try #require(project.paneManager.tabManager(for: newPane))
+        tabs.openTab(url: file)
+        tabs.autoSavePreferenceProvider = { true }
+        tabs.setAutoSaveDelay(0.05)
+        tabs.updateContent("must remain unsaved during Quit")
+
+        #expect(tabs.activeTab?.isDirty == true)
+        #expect(!tabs.hasScheduledAutoSave)
+        #expect(try String(contentsOf: file, encoding: .utf8) == "original")
+
+        project.cancelAutoSaveTerminationFreeze()
+        #expect(tabs.hasScheduledAutoSave)
+        tabs.cancelAutoSave()
+        #expect(try String(contentsOf: file, encoding: .utf8) == "original")
+    }
+}

--- a/PineTests/ProjectRegistryTests.swift
+++ b/PineTests/ProjectRegistryTests.swift
@@ -90,6 +90,22 @@ struct ProjectRegistryTests {
         #expect(pm2 == nil)
     }
 
+    @Test func terminationFreezeBlocksNewProjectAdmissionUntilRollback() async throws {
+        let tempDir = try makeTempDirectory()
+        defer { cleanup(tempDir) }
+        let registry = ProjectRegistry()
+
+        registry.freezeAgentTasksForTermination()
+
+        #expect(registry.isProjectAdmissionFrozenForTermination)
+        #expect(registry.projectManager(for: tempDir) == nil)
+        #expect(registry.openProjects.isEmpty)
+
+        #expect(await registry.cancelAgentTaskTermination())
+        #expect(!registry.isProjectAdmissionFrozenForTermination)
+        #expect(registry.projectManager(for: tempDir) != nil)
+    }
+
     // MARK: - Close
 
     @Test func closeProjectKeepsInOpenProjectsAsBackground() throws {

--- a/PineTests/ProjectRegistryTests.swift
+++ b/PineTests/ProjectRegistryTests.swift
@@ -260,6 +260,78 @@ struct ProjectRegistryTests {
         #expect(registry.destroyAllProjects())
     }
 
+    @Test func aggregatedTaskShutdownFailureRetainsEveryOwner() async throws {
+        let firstDirectory = try makeTempDirectory()
+        let secondDirectory = try makeTempDirectory()
+        defer {
+            cleanup(firstDirectory)
+            cleanup(secondDirectory)
+        }
+
+        let registry = ProjectRegistry()
+        let first = try #require(
+            registry.projectManager(for: firstDirectory)
+        )
+        let second = try #require(
+            registry.projectManager(for: secondDirectory)
+        )
+        let history = first.taskRunStore.start(
+            makeTaskRun(id: "retained-history")
+        )
+        first.taskRunStore.finishRun(
+            id: history.id,
+            outcome: makeTaskOutcome(id: "retained-history"),
+            cancelled: false
+        )
+        let firstActive = first.taskRunStore.start(
+            makeTaskRun(id: "first-active")
+        )
+        let secondActive = second.taskRunStore.start(
+            makeTaskRun(id: "second-active")
+        )
+        let completedProbe = ProjectTaskCancellationProbe()
+        let timedOutProbe = ProjectTaskCancellationProbe(waitResult: false)
+        first.taskRunStore.registerCancellation(
+            completedProbe.makeCancellation(),
+            forRunID: firstActive.id
+        )
+        second.taskRunStore.registerCancellation(
+            timedOutProbe.makeCancellation(),
+            forRunID: secondActive.id
+        )
+
+        let authorization = registry.captureUserTaskShutdownAuthorization()
+        let didShutdown = await registry.shutdownUserTasks(
+            authorizedBy: authorization,
+            until: .now()
+        )
+
+        #expect(!didShutdown)
+        #expect(completedProbe.cancellationCount == 1)
+        #expect(completedProbe.waitCount == 1)
+        #expect(timedOutProbe.cancellationCount == 1)
+        #expect(timedOutProbe.waitCount == 1)
+        #expect(first.taskRunStore.run(forID: firstActive.id) === firstActive)
+        #expect(first.taskRunStore.run(forID: history.id) === history)
+        #expect(history.combinedOutput == "done")
+        #expect(
+            second.taskRunStore.run(forID: secondActive.id) === secondActive
+        )
+        #expect(first.hasOutstandingUserTaskExecution)
+        #expect(second.hasOutstandingUserTaskExecution)
+
+        first.taskRunStore.finishRun(
+            id: firstActive.id,
+            outcome: makeTaskOutcome(id: "first-active"),
+            cancelled: true
+        )
+        second.taskRunStore.finishRun(
+            id: secondActive.id,
+            outcome: makeTaskOutcome(id: "second-active"),
+            cancelled: true
+        )
+    }
+
     // MARK: - Recent projects
 
     @Test func recentProjectsAddedOnOpen() throws {

--- a/PineTests/TerminalManagerCoordinatorTests.swift
+++ b/PineTests/TerminalManagerCoordinatorTests.swift
@@ -192,6 +192,32 @@ struct TerminalManagerCoordinatorTests {
         #expect(terminal.isAgentDetectionPolling)
     }
 
+    @Test func terminationFreezePreservesAgentAuthorization() throws {
+        let paneManager = PaneManager()
+        let terminal = TerminalManager(
+            agentDetectionProcessRunner: Self.noOpProcessRunner
+        )
+        terminal.paneManager = paneManager
+
+        terminal.createTerminalTab(
+            relativeTo: paneManager.activePaneID,
+            workingDirectory: nil
+        )
+        #expect(terminal.isAgentDetectionPolling)
+
+        let tab = try #require(terminal.allTerminalTabs.first)
+        let session = AgentSession(agentType: .claudeCode)
+        tab.agentSession = session
+        tab.foregroundProcessIDOverrideForTesting = 42
+        let authorization = TerminalTabCloseAuthorization.authorizing(tabs: [tab])
+
+        terminal.freezeAgentTasksForTermination()
+
+        #expect(!terminal.isAgentDetectionPolling)
+        #expect(tab.agentSession === session)
+        #expect(authorization.stillCovers([tab]))
+    }
+
     @Test func startTerminals_bootsAgentDetection() {
         let paneManager = PaneManager()
         let terminal = TerminalManager(agentDetectionProcessRunner: Self.noOpProcessRunner)

--- a/PineTests/TerminalManagerCoordinatorTests.swift
+++ b/PineTests/TerminalManagerCoordinatorTests.swift
@@ -206,9 +206,27 @@ struct TerminalManagerCoordinatorTests {
         #expect(terminal.isAgentDetectionPolling)
 
         let tab = try #require(terminal.allTerminalTabs.first)
-        let session = AgentSession(agentType: .claudeCode)
+        let startedAt = Date(timeIntervalSince1970: 10.000_020)
+        let session = AgentSession(
+            agentType: .claudeCode,
+            startedAt: startedAt
+        )
+        _ = session.bindProcessEvidence(AgentProcessEvidence(
+            processIdentifier: 42,
+            processGeneration: 10,
+            startIdentifier: "generation-10",
+            observedStartedAt: startedAt,
+            startIsAuthoritative: true
+        ))
         tab.agentSession = session
         tab.foregroundProcessIDOverrideForTesting = 42
+        tab.agentProcessIdentityResolverForTesting = { processID in
+            TerminalProcessStartIdentity(
+                processID: processID,
+                seconds: 10,
+                microseconds: 20
+            )
+        }
         let authorization = TerminalTabCloseAuthorization.authorizing(tabs: [tab])
 
         terminal.freezeAgentTasksForTermination()

--- a/PineTests/TerminalProcessConfirmationTests.swift
+++ b/PineTests/TerminalProcessConfirmationTests.swift
@@ -265,4 +265,30 @@ struct TerminalProcessConfirmationTests {
 
         #expect(!authorization.stillCovers([original, added]))
     }
+
+    @Test func agentReplacedByForegroundProcessInvalidatesAuthorization() {
+        let tab = TerminalTab(name: "Claude")
+        tab.agentSession = AgentSession(agentType: .claudeCode)
+        let authorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: [tab]
+        )
+
+        tab.agentSession = nil
+        tab.foregroundProcessIDOverrideForTesting = 42
+
+        #expect(!authorization.stillCovers([tab]))
+    }
+
+    @Test func foregroundProcessReplacedByAgentInvalidatesAuthorization() {
+        let tab = TerminalTab(name: "Shell")
+        tab.foregroundProcessIDOverrideForTesting = 41
+        let authorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: [tab]
+        )
+
+        tab.foregroundProcessIDOverrideForTesting = 0
+        tab.agentSession = AgentSession(agentType: .claudeCode)
+
+        #expect(!authorization.stillCovers([tab]))
+    }
 }

--- a/PineTests/TerminalProcessConfirmationTests.swift
+++ b/PineTests/TerminalProcessConfirmationTests.swift
@@ -243,4 +243,26 @@ struct TerminalProcessConfirmationTests {
         // Tab order in the re-check must not matter.
         #expect(authorization.stillCovers([agentTab, idleTab]))
     }
+
+    @Test func idleTabBecomingAgentInvalidatesAuthorization() {
+        let tab = TerminalTab(name: "Shell")
+        let authorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: [tab]
+        )
+
+        tab.agentSession = AgentSession(agentType: .claudeCode)
+
+        #expect(!authorization.stillCovers([tab]))
+    }
+
+    @Test func newlyAddedAgentTabInvalidatesAuthorization() {
+        let original = TerminalTab(name: "Shell")
+        let authorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: [original]
+        )
+        let added = TerminalTab(name: "Claude")
+        added.agentSession = AgentSession(agentType: .claudeCode)
+
+        #expect(!authorization.stillCovers([original, added]))
+    }
 }

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -35,36 +35,29 @@ struct TerminalTabTests {
         #expect(tab1 != tab2)
     }
 
-    @Test("acknowledged PTY write retains its descriptor identity")
+    @Test("acknowledged PTY write retains its owned descriptor")
+    @MainActor
     func acknowledgedWriteOwnsDescriptor() async throws {
         var pipeDescriptors: [Int32] = [-1, -1]
         try #require(Darwin.pipe(&pipeDescriptors) == 0)
         let readDescriptor = pipeDescriptors[0]
         let borrowedDescriptor = pipeDescriptors[1]
         defer { Darwin.close(readDescriptor) }
+        let lease = PinePTYDescriptorLease()
+        try #require(lease.acquire(borrowing: borrowedDescriptor))
+        let writeDescriptor = try #require(
+            lease.acquireWriteDescriptor()
+        )
         let temporaryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
         defer { try? FileManager.default.removeItem(at: temporaryURL) }
-        let acquired = DispatchSemaphore(value: 0)
-        let release = DispatchSemaphore(value: 0)
         let expected = Array("resume\n".utf8)
-        let writeTask = Task.detached {
-            await AcknowledgedPTYWriter.writeForTesting(
+        let writeTask = Task {
+            await AcknowledgedPTYWriter.write(
                 expected,
-                to: borrowedDescriptor
-            ) {
-                acquired.signal()
-                _ = release.wait(timeout: .now() + 2)
-            }
+                to: writeDescriptor
+            )
         }
-        let didAcquire = await withCheckedContinuation { continuation in
-            DispatchQueue.global().async {
-                continuation.resume(
-                    returning: acquired.wait(timeout: .now() + 1) == .success
-                )
-            }
-        }
-        try #require(didAcquire)
         Darwin.close(borrowedDescriptor)
         let replacement = Darwin.open(
             temporaryURL.path,
@@ -81,7 +74,6 @@ struct TerminalTabTests {
             reusedDescriptor = borrowedDescriptor
         }
         defer { Darwin.close(reusedDescriptor) }
-        release.signal()
 
         #expect(await writeTask.value)
         var received = [UInt8](repeating: 0, count: expected.count)
@@ -91,6 +83,7 @@ struct TerminalTabTests {
         #expect(readCount == expected.count)
         #expect(received == expected)
         #expect((try? Data(contentsOf: temporaryURL)).map(\.isEmpty) == true)
+        lease.invalidate()
     }
 
     @Test("partial and failed PTY completions are never acknowledged")
@@ -115,75 +108,145 @@ struct TerminalTabTests {
         )
     }
 
-    @Test("reused borrowed PTY descriptor is rejected before duplication")
-    func reusedBorrowedDescriptorIsRejected() throws {
-        var pipeDescriptors: [Int32] = [-1, -1]
-        try #require(Darwin.pipe(&pipeDescriptors) == 0)
-        let readDescriptor = pipeDescriptors[0]
-        let borrowedDescriptor = pipeDescriptors[1]
-        defer { Darwin.close(readDescriptor) }
-        let expectedIdentity = try #require(
-            AcknowledgedPTYWriter.descriptorIdentity(borrowedDescriptor)
-        )
-        Darwin.close(borrowedDescriptor)
-        let temporaryURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-        defer { try? FileManager.default.removeItem(at: temporaryURL) }
-        let replacement = Darwin.open(
-            temporaryURL.path,
-            O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC,
-            mode_t(0o600)
-        )
-        try #require(replacement >= 0)
-        let reusedDescriptor: Int32
-        if replacement == borrowedDescriptor {
-            reusedDescriptor = replacement
-        } else {
-            try #require(Darwin.dup2(replacement, borrowedDescriptor) >= 0)
-            Darwin.close(replacement)
-            reusedDescriptor = borrowedDescriptor
-        }
-        defer { Darwin.close(reusedDescriptor) }
-
-        #expect(AcknowledgedPTYWriter.acquireDescriptor(
-            reusedDescriptor,
-            expectedIdentity: expectedIdentity
-        ) == nil)
-    }
-
-    @Test("PTY descriptor identity preserves native signed device values")
-    func ptyDescriptorIdentityAcceptsSignedDevice() throws {
-        var controllerDescriptor: Int32 = -1
-        var peerDescriptor: Int32 = -1
+    @Test("owned PTY lease survives a real close-and-reopen ABA")
+    @MainActor
+    func ownedPTYLeaseRejectsBorrowedDescriptorABA() async throws {
+        var originalController: Int32 = -1
+        var originalPeer: Int32 = -1
         try #require(Darwin.openpty(
-            &controllerDescriptor,
-            &peerDescriptor,
+            &originalController,
+            &originalPeer,
             nil,
             nil,
             nil
         ) == 0)
-        defer {
-            Darwin.close(controllerDescriptor)
-            Darwin.close(peerDescriptor)
+        var originalSettings = termios()
+        try #require(Darwin.tcgetattr(originalPeer, &originalSettings) == 0)
+        Darwin.cfmakeraw(&originalSettings)
+        try #require(Darwin.tcsetattr(
+            originalPeer,
+            TCSANOW,
+            &originalSettings
+        ) == 0)
+        // Keep the test's observation end alive after the writer completion
+        // closes the final production-owned descriptor. Without this anchor,
+        // PTY HUP is allowed to discard unread input before the assertion can
+        // inspect which peer received it.
+        let originalLifetimeAnchor = Darwin.fcntl(
+            originalController,
+            F_DUPFD_CLOEXEC,
+            0
+        )
+        try #require(originalLifetimeAnchor >= 0)
+        let lease = PinePTYDescriptorLease()
+        try #require(lease.acquire(borrowing: originalController))
+        // This is the synchronous pre-suspension duplicate used by the real
+        // send path. It must outlive invalidation until DispatchIO completes.
+        let writeDescriptor = try #require(
+            lease.acquireWriteDescriptor()
+        )
+        lease.invalidate()
+
+        let reusedDescriptor = originalController
+        Darwin.close(originalController)
+        originalController = -1
+
+        var replacementController: Int32 = -1
+        var replacementPeer: Int32 = -1
+        try #require(Darwin.openpty(
+            &replacementController,
+            &replacementPeer,
+            nil,
+            nil,
+            nil
+        ) == 0)
+        if replacementController != reusedDescriptor {
+            try #require(Darwin.dup2(
+                replacementController,
+                reusedDescriptor
+            ) == reusedDescriptor)
+            Darwin.close(replacementController)
+            replacementController = reusedDescriptor
         }
+        defer {
+            lease.invalidate()
+            if originalController >= 0 {
+                Darwin.close(originalController)
+            }
+            Darwin.close(originalLifetimeAnchor)
+            Darwin.close(originalPeer)
+            Darwin.close(replacementController)
+            Darwin.close(replacementPeer)
+        }
+        var replacementSettings = termios()
+        try #require(Darwin.tcgetattr(
+            replacementPeer,
+            &replacementSettings
+        ) == 0)
+        Darwin.cfmakeraw(&replacementSettings)
+        try #require(Darwin.tcsetattr(
+            replacementPeer,
+            TCSANOW,
+            &replacementSettings
+        ) == 0)
+        _ = Darwin.fcntl(originalPeer, F_SETFL, O_NONBLOCK)
+        _ = Darwin.fcntl(replacementPeer, F_SETFL, O_NONBLOCK)
 
-        let controllerIdentity = try #require(
-            AcknowledgedPTYWriter.descriptorIdentity(controllerDescriptor)
-        )
-        let peerIdentity = try #require(
-            AcknowledgedPTYWriter.descriptorIdentity(peerDescriptor)
-        )
-        #expect(controllerIdentity.fileType == mode_t(S_IFCHR))
-        #expect(peerIdentity.fileType == mode_t(S_IFCHR))
+        // The borrowed integer now names a different real PTY, while the
+        // already-acquired write remains pinned to the original open-file
+        // description even though terminal teardown invalidated the lease.
+        let expected = Array("original".utf8)
+        #expect(await AcknowledgedPTYWriter.write(
+            expected,
+            to: writeDescriptor
+        ))
 
-        // This value exercised the checked-conversion trap independently of
-        // which PTY device number a particular macOS runtime assigns.
-        let signedIdentity = AcknowledgedPTYWriter.DescriptorIdentity(
-            device: dev_t(-1),
-            inode: ino_t(1),
-            fileType: mode_t(S_IFCHR)
+        var received = [UInt8](repeating: 0, count: expected.count)
+        let readDeadline = DispatchTime.now() + 1
+        var readCount = -1
+        repeat {
+            readCount = received.withUnsafeMutableBytes { bytes in
+                Darwin.read(originalPeer, bytes.baseAddress, bytes.count)
+            }
+            // Darwin PTY peers may transiently report a zero-length read
+            // while the master remains open; only actual bytes complete the
+            // observation.
+            if readCount > 0 { break }
+            Darwin.usleep(1_000)
+        } while DispatchTime.now() < readDeadline
+        #expect(readCount == expected.count)
+        #expect(received == expected)
+
+        var unexpected = [UInt8](repeating: 0, count: expected.count)
+        let unexpectedCount = unexpected.withUnsafeMutableBytes { bytes in
+            Darwin.read(replacementPeer, bytes.baseAddress, bytes.count)
+        }
+        #expect(unexpectedCount <= 0)
+        if unexpectedCount == -1 {
+            #expect(errno == EAGAIN || errno == EWOULDBLOCK)
+        }
+    }
+
+    @Test("invalidating a PTY lease lets an outstanding write close exactly once")
+    func invalidatingPTYLeasePreservesOutstandingWriteOwnership() throws {
+        var pipeDescriptors: [Int32] = [-1, -1]
+        try #require(Darwin.pipe(&pipeDescriptors) == 0)
+        defer { Darwin.close(pipeDescriptors[0]) }
+        defer { Darwin.close(pipeDescriptors[1]) }
+        let lease = PinePTYDescriptorLease()
+        try #require(lease.acquire(borrowing: pipeDescriptors[1]))
+        let writeDescriptor = try #require(
+            lease.acquireWriteDescriptor()
         )
-        #expect(signedIdentity.device == -1)
+        lease.invalidate()
+        #expect(!lease.isActiveForTesting)
+        #expect(Darwin.fcntl(writeDescriptor.rawValue, F_GETFD) >= 0)
+        writeDescriptor.finish()
+        #expect(Darwin.fcntl(writeDescriptor.rawValue, F_GETFD) == -1)
+        #expect(errno == EBADF)
+        // A second completion/deinit path cannot close a later occupant of
+        // the same descriptor integer.
+        writeDescriptor.finish()
     }
 
     @Test("foreground identity falls back to a live process-group member")
@@ -277,10 +340,15 @@ struct TerminalTabTests {
     @Test @MainActor func showTabAddsTerminalView() {
         let container = TerminalContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
         let tab = TerminalTab(name: "test")
+        defer { tab.stop() }
         container.showTab(tab)
         #expect(container.subviews.contains(tab.terminalView))
         #expect(container.subviews.contains { $0 is TerminalScrollInterceptor })
         #expect(container.subviews.count == 2)
+        // Exact regression for the macOS-27 crash stack: showTab ->
+        // startIfNeeded must pin the real SwiftTerm PTY without converting
+        // signed `stat` fields or trapping on the main thread.
+        #expect(tab.hasAcknowledgedPTYLeaseForTesting)
     }
 
     @Test @MainActor func showSameTabTwiceIsNoOp() {

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -115,6 +115,42 @@ struct TerminalTabTests {
         )
     }
 
+    @Test("reused borrowed PTY descriptor is rejected before duplication")
+    func reusedBorrowedDescriptorIsRejected() throws {
+        var pipeDescriptors: [Int32] = [-1, -1]
+        try #require(Darwin.pipe(&pipeDescriptors) == 0)
+        let readDescriptor = pipeDescriptors[0]
+        let borrowedDescriptor = pipeDescriptors[1]
+        defer { Darwin.close(readDescriptor) }
+        let expectedIdentity = try #require(
+            AcknowledgedPTYWriter.descriptorIdentity(borrowedDescriptor)
+        )
+        Darwin.close(borrowedDescriptor)
+        let temporaryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: temporaryURL) }
+        let replacement = Darwin.open(
+            temporaryURL.path,
+            O_RDWR | O_CREAT | O_TRUNC | O_CLOEXEC,
+            mode_t(0o600)
+        )
+        try #require(replacement >= 0)
+        let reusedDescriptor: Int32
+        if replacement == borrowedDescriptor {
+            reusedDescriptor = replacement
+        } else {
+            try #require(Darwin.dup2(replacement, borrowedDescriptor) >= 0)
+            Darwin.close(replacement)
+            reusedDescriptor = borrowedDescriptor
+        }
+        defer { Darwin.close(reusedDescriptor) }
+
+        #expect(AcknowledgedPTYWriter.acquireDescriptor(
+            reusedDescriptor,
+            expectedIdentity: expectedIdentity
+        ) == nil)
+    }
+
     @Test @MainActor func terminalTabHashable() {
         let tab = TerminalTab(name: "test")
         var set: Set<TerminalTab> = [tab, tab]

--- a/PineTests/TerminalTabTests.swift
+++ b/PineTests/TerminalTabTests.swift
@@ -151,6 +151,86 @@ struct TerminalTabTests {
         ) == nil)
     }
 
+    @Test("PTY descriptor identity preserves native signed device values")
+    func ptyDescriptorIdentityAcceptsSignedDevice() throws {
+        var controllerDescriptor: Int32 = -1
+        var peerDescriptor: Int32 = -1
+        try #require(Darwin.openpty(
+            &controllerDescriptor,
+            &peerDescriptor,
+            nil,
+            nil,
+            nil
+        ) == 0)
+        defer {
+            Darwin.close(controllerDescriptor)
+            Darwin.close(peerDescriptor)
+        }
+
+        let controllerIdentity = try #require(
+            AcknowledgedPTYWriter.descriptorIdentity(controllerDescriptor)
+        )
+        let peerIdentity = try #require(
+            AcknowledgedPTYWriter.descriptorIdentity(peerDescriptor)
+        )
+        #expect(controllerIdentity.fileType == mode_t(S_IFCHR))
+        #expect(peerIdentity.fileType == mode_t(S_IFCHR))
+
+        // This value exercised the checked-conversion trap independently of
+        // which PTY device number a particular macOS runtime assigns.
+        let signedIdentity = AcknowledgedPTYWriter.DescriptorIdentity(
+            device: dev_t(-1),
+            inode: ino_t(1),
+            fileType: mode_t(S_IFCHR)
+        )
+        #expect(signedIdentity.device == -1)
+    }
+
+    @Test("foreground identity falls back to a live process-group member")
+    @MainActor
+    func leaderlessForegroundGroupUsesLiveMember() throws {
+        let subprocess = try UserTaskSubprocess(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            command: "trap '' HUP; sleep 30 & wait",
+            workingDirectory: nil
+        )
+        let processGroupID = subprocess.processGroup.identifier
+        var didReapLeader = false
+        defer {
+            _ = Darwin.kill(-processGroupID, SIGKILL)
+            if !didReapLeader {
+                _ = subprocess.waitForExit()
+            }
+        }
+
+        let memberDeadline = DispatchTime.now() + 2
+        var memberIDs: [pid_t] = []
+        repeat {
+            if case .known(let processIDs) =
+                UserTaskProcessInspector.processIDs(inGroup: processGroupID) {
+                memberIDs = processIDs.filter { $0 != processGroupID }
+            }
+            if !memberIDs.isEmpty { break }
+            Darwin.usleep(10_000)
+        } while DispatchTime.now() < memberDeadline
+        try #require(!memberIDs.isEmpty)
+
+        try #require(Darwin.kill(processGroupID, SIGKILL) == 0)
+        _ = subprocess.waitForExit()
+        didReapLeader = true
+
+        let tab = TerminalTab(name: "leaderless group")
+        let identity = try #require(
+            tab.foregroundProcessIdentity(in: processGroupID)
+        )
+        #expect(identity.processID != processGroupID)
+        #expect(memberIDs.contains(identity.processID))
+        #expect(tab.foregroundProcessIdentityStillMatches(
+            identity,
+            in: processGroupID
+        ))
+    }
+
     @Test @MainActor func terminalTabHashable() {
         let tab = TerminalTab(name: "test")
         var set: Set<TerminalTab> = [tab, tab]

--- a/PineTests/TerminationSaveCoordinatorSecurityTests.swift
+++ b/PineTests/TerminationSaveCoordinatorSecurityTests.swift
@@ -399,6 +399,76 @@ struct TerminationSaveCoordinatorSecurityTests {
             try String(contentsOf: staged.stagingURL, encoding: .utf8)
                 == "external replacement"
         )
+        #expect(
+            (try fileStatus(at: staged.stagingURL).st_mode & 0o7777) == 0o600
+        )
+        #expect(try extendedACLText(at: staged.stagingURL) == "")
+        #expect(
+            Set(try extendedAttributeNames(at: staged.stagingURL))
+                .isSubset(of: ["com.apple.provenance"])
+        )
+    }
+
+    @Test func preCleanupContentMutationRollsBackPrivately() async throws {
+        let directory = try makeDirectory()
+        defer { remove(directory) }
+        let destination = directory.appendingPathComponent("cleanup-raced.txt")
+        try Data("authorized original".utf8).write(to: destination)
+        #expect(Darwin.chmod(destination.path, mode_t(0o644)) == 0)
+        try setExtendedAttribute(
+            at: destination,
+            name: "com.pine.tests.public",
+            value: Data("public metadata".utf8)
+        )
+        let staged = try await stage(
+            content: "pine staged bytes",
+            destination: destination
+        )
+
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: .now() + 5,
+            beforeRecoveryCleanup: {
+                let descriptor = Darwin.open(
+                    destination.path,
+                    O_WRONLY | O_TRUNC | O_CLOEXEC
+                )
+                guard descriptor >= 0 else { return }
+                defer { Darwin.close(descriptor) }
+                let bytes = Data("late external bytes".utf8)
+                _ = bytes.withUnsafeBytes {
+                    Darwin.write(descriptor, $0.baseAddress, $0.count)
+                }
+            }
+        )
+
+        guard case .failed(_, let retainedArtifacts) = result else {
+            Issue.record("A pre-cleanup mutation must fail closed")
+            return
+        }
+        #expect(retainedArtifacts.contains(staged.stagingURL))
+        #expect(
+            try String(contentsOf: destination, encoding: .utf8)
+                == "authorized original"
+        )
+        #expect(
+            try extendedAttribute(
+                at: destination,
+                name: "com.pine.tests.public"
+            ) == Data("public metadata".utf8)
+        )
+        #expect(
+            try String(contentsOf: staged.stagingURL, encoding: .utf8)
+                == "late external bytes"
+        )
+        #expect(
+            (try fileStatus(at: staged.stagingURL).st_mode & 0o7777) == 0o600
+        )
+        #expect(try extendedACLText(at: staged.stagingURL) == "")
+        #expect(
+            Set(try extendedAttributeNames(at: staged.stagingURL))
+                .isSubset(of: ["com.apple.provenance"])
+        )
     }
 
     @Test func displacedOriginalMutationIsRetainedInsteadOfDeleted() async throws {
@@ -475,6 +545,14 @@ struct TerminationSaveCoordinatorSecurityTests {
         #expect(
             try String(contentsOf: staged.stagingURL, encoding: .utf8)
                 == "external new bytes"
+        )
+        #expect(
+            (try fileStatus(at: staged.stagingURL).st_mode & 0o7777) == 0o600
+        )
+        #expect(try extendedACLText(at: staged.stagingURL) == "")
+        #expect(
+            Set(try extendedAttributeNames(at: staged.stagingURL))
+                .isSubset(of: ["com.apple.provenance"])
         )
     }
 

--- a/PineTests/TerminationSaveCoordinatorSecurityTests.swift
+++ b/PineTests/TerminationSaveCoordinatorSecurityTests.swift
@@ -1,0 +1,376 @@
+//
+//  TerminationSaveCoordinatorSecurityTests.swift
+//  PineTests
+//
+
+import Darwin
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Termination Save Coordinator Security Tests", .serialized)
+struct TerminationSaveCoordinatorSecurityTests {
+    @Test func publicDestinationDoesNotWidenStagingBeforeInstall() async throws {
+        let directory = try makeDirectory()
+        defer { remove(directory) }
+        let destination = directory.appendingPathComponent("public.txt")
+        try Data("old public bytes".utf8).write(to: destination)
+        #expect(Darwin.chmod(destination.path, mode_t(0o644)) == 0)
+
+        let staged = try await stage(
+            content: "private unsaved bytes",
+            destination: destination
+        )
+        defer { _ = TerminationSaveCoordinator.cleanup([staged]) }
+
+        let status = try fileStatus(at: staged.stagingURL)
+        #expect((status.st_mode & 0o7777) == 0o600)
+        #expect(
+            Set(try extendedAttributeNames(at: staged.stagingURL))
+                .isSubset(of: ["com.apple.provenance"])
+        )
+        #expect(
+            try String(contentsOf: destination, encoding: .utf8)
+                == "old public bytes"
+        )
+    }
+
+    @Test func missingDestinationHonorsRestrictiveUmask() async throws {
+        let previousMask = Darwin.umask(mode_t(0o077))
+        defer { _ = Darwin.umask(previousMask) }
+        let directory = try makeDirectory()
+        defer { remove(directory) }
+        let destination = directory.appendingPathComponent("new.txt")
+
+        let staged = try await stage(
+            content: "new private file",
+            destination: destination
+        )
+        #expect((try fileStatus(at: staged.stagingURL).st_mode & 0o7777) == 0o600)
+
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: .now() + 5
+        )
+
+        guard case .installed = result else {
+            Issue.record("Expected the missing destination to install: \(result)")
+            return
+        }
+        #expect((try fileStatus(at: destination).st_mode & 0o7777) == 0o600)
+        #expect(
+            try String(contentsOf: destination, encoding: .utf8)
+                == "new private file"
+        )
+    }
+
+    @Test func existingDestinationPreservesOwnerModeAndXattrs() async throws {
+        let directory = try makeDirectory()
+        defer { remove(directory) }
+        let destination = directory.appendingPathComponent("existing.txt")
+        try Data("old bytes".utf8).write(to: destination)
+        #expect(Darwin.chmod(destination.path, mode_t(0o640)) == 0)
+        try setExtendedAttribute(
+            at: destination,
+            name: "com.pine.tests.preserved",
+            value: Data("metadata".utf8)
+        )
+        let original = try fileStatus(at: destination)
+        let staged = try await stage(
+            content: "replacement bytes",
+            destination: destination
+        )
+
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: .now() + 5
+        )
+
+        guard case .installed = result else {
+            Issue.record("Expected existing destination to install: \(result)")
+            return
+        }
+        let installed = try fileStatus(at: destination)
+        #expect(installed.st_uid == original.st_uid)
+        #expect(installed.st_gid == original.st_gid)
+        #expect((installed.st_mode & 0o7777) == 0o640)
+        #expect(
+            try extendedAttribute(
+                at: destination,
+                name: "com.pine.tests.preserved"
+            ) == Data("metadata".utf8)
+        )
+    }
+
+    @Test func restoredMtimeContentAndXattrRaceIsRejectedWithoutLoss() async throws {
+        let directory = try makeDirectory()
+        defer { remove(directory) }
+        let destination = directory.appendingPathComponent("raced.txt")
+        try Data("authorized".utf8).write(to: destination)
+        let modificationDate = try #require(
+            FileManager.default.attributesOfItem(atPath: destination.path)[
+                .modificationDate
+            ] as? Date
+        )
+        let staged = try await stage(
+            content: "pine save!",
+            destination: destination
+        )
+
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: .now() + 5,
+            beforeDestinationQuarantine: {
+                try? Data("externally".utf8).write(to: destination)
+                try? setExtendedAttribute(
+                    at: destination,
+                    name: "com.pine.tests.raced",
+                    value: Data("changed".utf8)
+                )
+                try? FileManager.default.setAttributes(
+                    [.modificationDate: modificationDate],
+                    ofItemAtPath: destination.path
+                )
+            }
+        )
+
+        guard case .failed = result else {
+            Issue.record("Expected the external change fence to reject the race")
+            return
+        }
+        #expect(
+            try String(contentsOf: destination, encoding: .utf8)
+                == "externally"
+        )
+        #expect(
+            try extendedAttribute(
+                at: destination,
+                name: "com.pine.tests.raced"
+            ) == Data("changed".utf8)
+        )
+        #expect(TerminationSaveCoordinator.stagingIdentityIsCurrent(staged))
+    }
+
+    @Test func stagingCleanupFailureReturnsRetainedArtifact() async throws {
+        let directory = try makeDirectory()
+        defer { remove(directory) }
+        let destination = directory.appendingPathComponent("cleanup.txt")
+        let staged = try await stage(
+            content: "still private",
+            destination: destination
+        )
+        #expect(Darwin.chmod(directory.path, mode_t(0o500)) == 0)
+        let result = TerminationSaveCoordinator.cleanup([staged])
+        #expect(Darwin.chmod(directory.path, mode_t(0o700)) == 0)
+
+        guard case .failed(_, let retainedArtifacts) = result else {
+            Issue.record("Expected cleanup to return a typed failure")
+            return
+        }
+        #expect(retainedArtifacts.contains(staged.stagingURL))
+        #expect(FileManager.default.fileExists(atPath: staged.stagingURL.path))
+        #expect(TerminationSaveCoordinator.cleanup([staged]) == .cleaned)
+    }
+
+    @Test func installedDestinationReportsRetainedRecoveryFailure() async throws {
+        let directory = try makeDirectory()
+        defer { remove(directory) }
+        let destination = directory.appendingPathComponent("recovery.txt")
+        try Data("authorized original".utf8).write(to: destination)
+        let staged = try await stage(
+            content: "installed new bytes",
+            destination: destination
+        )
+
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: .now() + 5,
+            beforeRecoveryCleanup: {
+                _ = Darwin.chmod(directory.path, mode_t(0o500))
+            }
+        )
+        #expect(Darwin.chmod(directory.path, mode_t(0o700)) == 0)
+
+        guard case .failed(let message) = result else {
+            Issue.record("Expected recovery cleanup failure after install")
+            return
+        }
+        #expect(message.contains(".pine-save-recovery-"))
+        #expect(
+            try String(contentsOf: destination, encoding: .utf8)
+                == "installed new bytes"
+        )
+        let recovery = try FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        ).first { $0.lastPathComponent.hasPrefix(".pine-save-recovery-") }
+        let recoveryURL = try #require(recovery)
+        #expect(
+            try String(contentsOf: recoveryURL, encoding: .utf8)
+                == "authorized original"
+        )
+    }
+
+    private func stage(
+        content: String,
+        destination: URL
+    ) async throws -> TerminationStagedSave {
+        let state: TerminationDestinationState
+        switch await TerminationSaveCoordinator.captureDestinationStates(
+            at: [destination],
+            until: .now() + 5
+        ) {
+        case .captured(let states):
+            state = try #require(states.first)
+        case .failed(let message):
+            Issue.record("Could not capture destination: \(message)")
+            throw CocoaError(.fileReadUnknown)
+        case .timedOut:
+            Issue.record("Destination capture timed out")
+            throw CancellationError()
+        }
+        let request = TerminationSaveRequest(
+            tabID: UUID(),
+            contentVersion: 1,
+            persistenceGeneration: 1,
+            content: content,
+            originalURL: state.exists ? destination : nil,
+            destination: destination,
+            expectedDestinationState: state,
+            encodingRawValue: String.Encoding.utf8.rawValue,
+            settings: EditorSaveSettingsSnapshot(
+                insertFinalNewline: false,
+                stripTrailingWhitespace: false,
+                formatOnSave: false
+            ),
+            formatters: FileFormatterRegistry(formatters: [])
+        )
+        switch await TerminationSaveCoordinator.stage(
+            [request],
+            until: .now() + 5
+        ) {
+        case .ready(let staged):
+            return try #require(staged.first)
+        case .failed(let message):
+            Issue.record("Could not stage save: \(message)")
+            throw CocoaError(.fileWriteUnknown)
+        case .timedOut:
+            Issue.record("Staging timed out")
+            throw CancellationError()
+        }
+    }
+
+    private func makeDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PineTerminationSecurity-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        return directory
+    }
+
+    private func remove(_ url: URL) {
+        _ = Darwin.chmod(url.path, mode_t(0o700))
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private func fileStatus(at url: URL) throws -> stat {
+        var status = stat()
+        guard Darwin.lstat(url.path, &status) == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        return status
+    }
+
+    private func extendedAttributeNames(at url: URL) throws -> [String] {
+        let required = Darwin.listxattr(
+            url.path,
+            nil,
+            0,
+            XATTR_NOFOLLOW
+        )
+        guard required >= 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        guard required > 0 else { return [] }
+        var bytes = [CChar](repeating: 0, count: required)
+        let count = Darwin.listxattr(
+            url.path,
+            &bytes,
+            bytes.count,
+            XATTR_NOFOLLOW
+        )
+        guard count >= 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        let raw = bytes.prefix(count).map(UInt8.init(bitPattern:))
+        var names: [String] = []
+        var start = raw.startIndex
+        for index in raw.indices where raw[index] == 0 {
+            guard index > start,
+                  let name = String(
+                      bytes: raw[start..<index],
+                      encoding: .utf8
+                  ) else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+            names.append(name)
+            start = raw.index(after: index)
+        }
+        guard start == raw.endIndex else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        return names
+    }
+
+    nonisolated private func setExtendedAttribute(
+        at url: URL,
+        name: String,
+        value: Data
+    ) throws {
+        let result = value.withUnsafeBytes { buffer in
+            name.withCString {
+                Darwin.setxattr(
+                    url.path,
+                    $0,
+                    buffer.baseAddress,
+                    buffer.count,
+                    0,
+                    XATTR_NOFOLLOW
+                )
+            }
+        }
+        guard result == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+    }
+
+    private func extendedAttribute(at url: URL, name: String) throws -> Data {
+        let required = name.withCString {
+            Darwin.getxattr(url.path, $0, nil, 0, 0, XATTR_NOFOLLOW)
+        }
+        guard required >= 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        var value = Data(count: required)
+        let count = value.withUnsafeMutableBytes { buffer in
+            name.withCString {
+                Darwin.getxattr(
+                    url.path,
+                    $0,
+                    buffer.baseAddress,
+                    buffer.count,
+                    0,
+                    XATTR_NOFOLLOW
+                )
+            }
+        }
+        guard count == required else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        return value
+    }
+}

--- a/PineTests/TerminationSaveCoordinatorSecurityTests.swift
+++ b/PineTests/TerminationSaveCoordinatorSecurityTests.swift
@@ -22,8 +22,6 @@ struct TerminationSaveCoordinatorSecurityTests {
             content: "private unsaved bytes",
             destination: destination
         )
-        defer { _ = TerminationSaveCoordinator.cleanup([staged]) }
-
         let status = try fileStatus(at: staged.stagingURL)
         #expect((status.st_mode & 0o7777) == 0o600)
         #expect(
@@ -34,13 +32,36 @@ struct TerminationSaveCoordinatorSecurityTests {
             try String(contentsOf: destination, encoding: .utf8)
                 == "old public bytes"
         )
+
+        nonisolated(unsafe) var publicationWasPrivate = false
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: .now() + 5,
+            afterDestinationPublication: {
+                let live = try? fileStatus(at: destination)
+                publicationWasPrivate = live.map {
+                    ($0.st_mode & 0o7777) == 0o600
+                } == true
+                    && !FileManager.default.fileExists(
+                        atPath: staged.stagingURL.path
+                    )
+                    && (try? extendedACLText(at: destination)) == ""
+            }
+        )
+
+        guard case .installed = result else {
+            Issue.record("Expected existing destination install: \(result)")
+            return
+        }
+        #expect(publicationWasPrivate)
     }
 
-    @Test func missingDestinationHonorsRestrictiveUmask() async throws {
-        let previousMask = Darwin.umask(mode_t(0o077))
-        defer { _ = Darwin.umask(previousMask) }
+    @Test func missingDestinationMatchesNormalCreationMode() async throws {
         let directory = try makeDirectory()
         defer { remove(directory) }
+        let baseline = directory.appendingPathComponent("baseline.txt")
+        try Data().write(to: baseline)
+        let baselineMode = try fileStatus(at: baseline).st_mode & 0o7777
         let destination = directory.appendingPathComponent("new.txt")
 
         let staged = try await stage(
@@ -58,11 +79,40 @@ struct TerminationSaveCoordinatorSecurityTests {
             Issue.record("Expected the missing destination to install: \(result)")
             return
         }
-        #expect((try fileStatus(at: destination).st_mode & 0o7777) == 0o600)
+        #expect(
+            (try fileStatus(at: destination).st_mode & 0o7777)
+                == baselineMode
+        )
         #expect(
             try String(contentsOf: destination, encoding: .utf8)
                 == "new private file"
         )
+    }
+
+    @Test func missingDestinationPreservesInheritedDirectoryACL() async throws {
+        let directory = try makeDirectory()
+        defer { remove(directory) }
+        try addInheritedReadACL(to: directory)
+        let baseline = directory.appendingPathComponent("baseline.txt")
+        try Data().write(to: baseline)
+        let expectedACL = try extendedACLText(at: baseline)
+        #expect(!expectedACL.isEmpty)
+
+        let destination = directory.appendingPathComponent("new.txt")
+        let staged = try await stage(
+            content: "inherited policy",
+            destination: destination
+        )
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: .now() + 5
+        )
+
+        guard case .installed = result else {
+            Issue.record("Expected inherited-ACL install: \(result)")
+            return
+        }
+        #expect(try extendedACLText(at: destination) == expectedACL)
     }
 
     @Test func existingDestinationPreservesOwnerModeAndXattrs() async throws {
@@ -192,7 +242,7 @@ struct TerminationSaveCoordinatorSecurityTests {
         )
         #expect(Darwin.chmod(directory.path, mode_t(0o700)) == 0)
 
-        guard case .failed(let message) = result else {
+        guard case .failed(let message, let retainedArtifacts) = result else {
             Issue.record("Expected recovery cleanup failure after install")
             return
         }
@@ -206,6 +256,10 @@ struct TerminationSaveCoordinatorSecurityTests {
             includingPropertiesForKeys: nil
         ).first { $0.lastPathComponent.hasPrefix(".pine-save-recovery-") }
         let recoveryURL = try #require(recovery)
+        #expect(
+            retainedArtifacts.map { $0.resolvingSymlinksInPath() }
+                == [recoveryURL.resolvingSymlinksInPath()]
+        )
         #expect(
             try String(contentsOf: recoveryURL, encoding: .utf8)
                 == "authorized original"
@@ -252,7 +306,7 @@ struct TerminationSaveCoordinatorSecurityTests {
         ) {
         case .ready(let staged):
             return try #require(staged.first)
-        case .failed(let message):
+        case .failed(let message, _):
             Issue.record("Could not stage save: \(message)")
             throw CocoaError(.fileWriteUnknown)
         case .timedOut:
@@ -277,7 +331,7 @@ struct TerminationSaveCoordinatorSecurityTests {
         try? FileManager.default.removeItem(at: url)
     }
 
-    private func fileStatus(at url: URL) throws -> stat {
+    nonisolated private func fileStatus(at url: URL) throws -> stat {
         var status = stat()
         guard Darwin.lstat(url.path, &status) == 0 else {
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
@@ -372,5 +426,44 @@ struct TerminationSaveCoordinatorSecurityTests {
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
         }
         return value
+    }
+
+    nonisolated private func addInheritedReadACL(to directory: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/chmod")
+        process.arguments = [
+            "+a",
+            "everyone allow read,file_inherit",
+            directory.path,
+        ]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw CocoaError(.fileWriteNoPermission)
+        }
+    }
+
+    nonisolated private func extendedACLText(at url: URL) throws -> String {
+        errno = 0
+        guard let acl = Darwin.acl_get_file(url.path, ACL_TYPE_EXTENDED) else {
+            guard errno == 0 || errno == ENOENT else {
+                throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+            }
+            return ""
+        }
+        defer { Darwin.acl_free(UnsafeMutableRawPointer(acl)) }
+        var length: ssize_t = 0
+        guard let text = Darwin.acl_to_text(acl, &length) else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        defer { Darwin.acl_free(UnsafeMutableRawPointer(text)) }
+        let bytes = UnsafeBufferPointer(
+            start: text,
+            count: Int(length)
+        ).map { UInt8(bitPattern: $0) }
+        guard let result = String(bytes: bytes, encoding: .utf8) else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        return result
     }
 }

--- a/PineTests/TerminationSaveCoordinatorSecurityTests.swift
+++ b/PineTests/TerminationSaveCoordinatorSecurityTests.swift
@@ -11,6 +11,15 @@ import Testing
 
 @Suite("Termination Save Coordinator Security Tests", .serialized)
 struct TerminationSaveCoordinatorSecurityTests {
+    @Test func signedDeviceIdentityPreservesHighBitPattern() {
+        let highBitDevice = dev_t(bitPattern: UInt32(0x8000_0000))
+
+        #expect(
+            TerminationSaveCoordinator.deviceIdentityBits(highBitDevice)
+                == 0x8000_0000
+        )
+    }
+
     @Test func publicDestinationDoesNotWidenStagingBeforeInstall() async throws {
         let directory = try makeDirectory()
         defer { remove(directory) }
@@ -222,6 +231,41 @@ struct TerminationSaveCoordinatorSecurityTests {
         #expect(retainedArtifacts.contains(staged.stagingURL))
         #expect(FileManager.default.fileExists(atPath: staged.stagingURL.path))
         #expect(TerminationSaveCoordinator.cleanup([staged]) == .cleaned)
+    }
+
+    @Test func cleanupTracksStagingDirectoryAcrossRename() async throws {
+        let container = try makeDirectory()
+        defer { remove(container) }
+        let directory = container.appendingPathComponent("project")
+        let movedDirectory = container.appendingPathComponent("project-moved")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: false
+        )
+        let staged = try await stage(
+            content: "private bytes in a moved directory",
+            destination: directory.appendingPathComponent("moved.txt")
+        )
+        try FileManager.default.moveItem(at: directory, to: movedDirectory)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: false
+        )
+
+        #expect(TerminationSaveCoordinator.cleanup([staged]) == .cleaned)
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: movedDirectory.appendingPathComponent(
+                    staged.stagingURL.lastPathComponent
+                ).path
+            )
+        )
+        #expect(
+            try FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: nil
+            ).isEmpty
+        )
     }
 
     @Test func installedDestinationReportsRetainedRecoveryFailure() async throws {
@@ -471,6 +515,36 @@ struct TerminationSaveCoordinatorSecurityTests {
         )
     }
 
+    @Test func postCleanupMutationFailsWithExactDestination() async throws {
+        let directory = try makeDirectory()
+        defer { remove(directory) }
+        let destination = directory.appendingPathComponent("final-raced.txt")
+        try Data("authorized original".utf8).write(to: destination)
+        let staged = try await stage(
+            content: "pine installed bytes",
+            destination: destination
+        )
+
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: .now() + 5,
+            beforeFinalInstalledFence: {
+                overwrite(destination, with: "post-cleanup external bytes")
+            }
+        )
+
+        guard case .failed(_, let retainedArtifacts) = result else {
+            Issue.record("A post-cleanup mutation must not be reported installed")
+            return
+        }
+        #expect(retainedArtifacts == [destination])
+        #expect(
+            try String(contentsOf: destination, encoding: .utf8)
+                == "post-cleanup external bytes"
+        )
+        #expect(!FileManager.default.fileExists(atPath: staged.stagingURL.path))
+    }
+
     @Test func displacedOriginalMutationIsRetainedInsteadOfDeleted() async throws {
         let directory = try makeDirectory()
         defer { remove(directory) }
@@ -556,6 +630,34 @@ struct TerminationSaveCoordinatorSecurityTests {
         )
     }
 
+    @Test func finalNewDestinationMutationReportsExactDestination() async throws {
+        let directory = try makeDirectory()
+        defer { remove(directory) }
+        let destination = directory.appendingPathComponent("new-final-raced.txt")
+        let staged = try await stage(
+            content: "pine new bytes",
+            destination: destination
+        )
+
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: .now() + 5,
+            beforeFinalInstalledFence: {
+                overwrite(destination, with: "late external new bytes")
+            }
+        )
+
+        guard case .failed(_, let retainedArtifacts) = result else {
+            Issue.record("A final new-file mutation must fail closed")
+            return
+        }
+        #expect(retainedArtifacts == [destination])
+        #expect(
+            try String(contentsOf: destination, encoding: .utf8)
+                == "late external new bytes"
+        )
+    }
+
     private func stage(
         content: String,
         destination: URL
@@ -627,6 +729,18 @@ struct TerminationSaveCoordinatorSecurityTests {
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
         }
         return status
+    }
+
+    nonisolated private func overwrite(_ url: URL, with content: String) {
+        let descriptor = Darwin.open(
+            url.path,
+            O_WRONLY | O_TRUNC | O_CLOEXEC
+        )
+        guard descriptor >= 0 else { return }
+        defer { Darwin.close(descriptor) }
+        _ = Data(content.utf8).withUnsafeBytes {
+            Darwin.write(descriptor, $0.baseAddress, $0.count)
+        }
     }
 
     private func extendedAttributeNames(at url: URL) throws -> [String] {

--- a/PineTests/TerminationSaveCoordinatorSecurityTests.swift
+++ b/PineTests/TerminationSaveCoordinatorSecurityTests.swift
@@ -42,9 +42,10 @@ struct TerminationSaveCoordinatorSecurityTests {
                 publicationWasPrivate = live.map {
                     ($0.st_mode & 0o7777) == 0o600
                 } == true
-                    && !FileManager.default.fileExists(
-                        atPath: staged.stagingURL.path
-                    )
+                    && (try? String(
+                        contentsOf: staged.stagingURL,
+                        encoding: .utf8
+                    )) == "old public bytes"
                     && (try? extendedACLText(at: destination)) == ""
             }
         )
@@ -246,7 +247,7 @@ struct TerminationSaveCoordinatorSecurityTests {
             Issue.record("Expected recovery cleanup failure after install")
             return
         }
-        #expect(message.contains(".pine-save-recovery-"))
+        #expect(message.contains(".pine-save-"))
         #expect(
             try String(contentsOf: destination, encoding: .utf8)
                 == "installed new bytes"
@@ -254,7 +255,7 @@ struct TerminationSaveCoordinatorSecurityTests {
         let recovery = try FileManager.default.contentsOfDirectory(
             at: directory,
             includingPropertiesForKeys: nil
-        ).first { $0.lastPathComponent.hasPrefix(".pine-save-recovery-") }
+        ).first { $0.lastPathComponent.hasPrefix(".pine-save-") }
         let recoveryURL = try #require(recovery)
         #expect(
             retainedArtifacts.map { $0.resolvingSymlinksInPath() }
@@ -263,6 +264,217 @@ struct TerminationSaveCoordinatorSecurityTests {
         #expect(
             try String(contentsOf: recoveryURL, encoding: .utf8)
                 == "authorized original"
+        )
+    }
+
+    @Test func movedParentDirectoryCannotProduceFalseInstalledResult() async throws {
+        let container = try makeDirectory()
+        defer { remove(container) }
+        let directory = container.appendingPathComponent("project")
+        let movedDirectory = container.appendingPathComponent("project-moved")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: false
+        )
+        let destination = directory.appendingPathComponent("moved.txt")
+        try Data("authorized original".utf8).write(to: destination)
+        let staged = try await stage(
+            content: "pine staged bytes",
+            destination: destination
+        )
+
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: .now() + 5,
+            beforeDestinationQuarantine: {
+                try? FileManager.default.moveItem(
+                    at: directory,
+                    to: movedDirectory
+                )
+                try? FileManager.default.createDirectory(
+                    at: directory,
+                    withIntermediateDirectories: false
+                )
+            }
+        )
+
+        guard case .failed(_, let retainedArtifacts) = result else {
+            Issue.record("A moved parent must fail the installation")
+            return
+        }
+        #expect(!retainedArtifacts.isEmpty)
+        #expect(
+            try String(
+                contentsOf: movedDirectory.appendingPathComponent("moved.txt"),
+                encoding: .utf8
+            ) == "authorized original"
+        )
+        #expect(!FileManager.default.fileExists(atPath: destination.path))
+    }
+
+    @Test func parentMovedAfterPublicationCannotProduceFalseInstalledResult() async throws {
+        let container = try makeDirectory()
+        defer { remove(container) }
+        let directory = container.appendingPathComponent("project")
+        let movedDirectory = container.appendingPathComponent("project-moved")
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: false
+        )
+        let destination = directory.appendingPathComponent("moved-late.txt")
+        try Data("authorized original".utf8).write(to: destination)
+        let staged = try await stage(
+            content: "pine staged bytes",
+            destination: destination
+        )
+
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: .now() + 5,
+            beforeRecoveryCleanup: {
+                try? FileManager.default.moveItem(
+                    at: directory,
+                    to: movedDirectory
+                )
+                try? FileManager.default.createDirectory(
+                    at: directory,
+                    withIntermediateDirectories: false
+                )
+            }
+        )
+
+        guard case .failed(_, let retainedArtifacts) = result else {
+            Issue.record("A late parent move must fail the installation")
+            return
+        }
+        #expect(!retainedArtifacts.isEmpty)
+        #expect(
+            try String(
+                contentsOf: movedDirectory.appendingPathComponent(
+                    "moved-late.txt"
+                ),
+                encoding: .utf8
+            ) == "authorized original"
+        )
+        #expect(!FileManager.default.fileExists(atPath: destination.path))
+    }
+
+    @Test func publishedContentMutationIsNeverReportedInstalled() async throws {
+        let directory = try makeDirectory()
+        defer { remove(directory) }
+        let destination = directory.appendingPathComponent("published.txt")
+        try Data("authorized original".utf8).write(to: destination)
+        let staged = try await stage(
+            content: "pine staged bytes",
+            destination: destination
+        )
+
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: .now() + 5,
+            afterDestinationPublication: {
+                let descriptor = Darwin.open(
+                    destination.path,
+                    O_WRONLY | O_TRUNC | O_CLOEXEC
+                )
+                guard descriptor >= 0 else { return }
+                defer { Darwin.close(descriptor) }
+                let bytes = Data("external replacement".utf8)
+                _ = bytes.withUnsafeBytes {
+                    Darwin.write(descriptor, $0.baseAddress, $0.count)
+                }
+            }
+        )
+
+        guard case .failed(_, let retainedArtifacts) = result else {
+            Issue.record("A published-content mutation must fail closed")
+            return
+        }
+        #expect(!retainedArtifacts.isEmpty)
+        #expect(
+            try String(contentsOf: destination, encoding: .utf8)
+                == "authorized original"
+        )
+        #expect(
+            try String(contentsOf: staged.stagingURL, encoding: .utf8)
+                == "external replacement"
+        )
+    }
+
+    @Test func displacedOriginalMutationIsRetainedInsteadOfDeleted() async throws {
+        let directory = try makeDirectory()
+        defer { remove(directory) }
+        let destination = directory.appendingPathComponent("borrowed-fd.txt")
+        try Data("authorized original".utf8).write(to: destination)
+        let descriptor = Darwin.open(destination.path, O_RDWR | O_CLOEXEC)
+        let liveDescriptor = try #require(descriptor >= 0 ? descriptor : nil)
+        defer { Darwin.close(liveDescriptor) }
+        let staged = try await stage(
+            content: "pine staged bytes",
+            destination: destination
+        )
+
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: .now() + 5,
+            afterDestinationPublication: {
+                _ = Darwin.ftruncate(liveDescriptor, 0)
+                _ = Data("external through old fd".utf8).withUnsafeBytes {
+                    Darwin.write(liveDescriptor, $0.baseAddress, $0.count)
+                }
+            }
+        )
+
+        guard case .failed(_, let retainedArtifacts) = result else {
+            Issue.record("A displaced-original mutation must fail closed")
+            return
+        }
+        #expect(!retainedArtifacts.isEmpty)
+        #expect(
+            try String(contentsOf: destination, encoding: .utf8)
+                == "external through old fd"
+        )
+        #expect(
+            try String(contentsOf: staged.stagingURL, encoding: .utf8)
+                == "pine staged bytes"
+        )
+    }
+
+    @Test func newDestinationMutationFailsWithoutFalseCleanSuccess() async throws {
+        let directory = try makeDirectory()
+        defer { remove(directory) }
+        let destination = directory.appendingPathComponent("new-raced.txt")
+        let staged = try await stage(
+            content: "pine new bytes",
+            destination: destination
+        )
+
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: .now() + 5,
+            afterDestinationPublication: {
+                let descriptor = Darwin.open(
+                    destination.path,
+                    O_WRONLY | O_TRUNC | O_CLOEXEC
+                )
+                guard descriptor >= 0 else { return }
+                defer { Darwin.close(descriptor) }
+                let bytes = Data("external new bytes".utf8)
+                _ = bytes.withUnsafeBytes {
+                    Darwin.write(descriptor, $0.baseAddress, $0.count)
+                }
+            }
+        )
+
+        guard case .failed(_, let retainedArtifacts) = result else {
+            Issue.record("A raced new destination must fail closed")
+            return
+        }
+        #expect(!retainedArtifacts.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: destination.path))
+        #expect(
+            try String(contentsOf: staged.stagingURL, encoding: .utf8)
+                == "external new bytes"
         )
     }
 

--- a/PineTests/UserTaskRunStoreTests.swift
+++ b/PineTests/UserTaskRunStoreTests.swift
@@ -401,6 +401,48 @@ struct UserTaskRunStoreTests {
         #expect(store.runs.isEmpty)
     }
 
+    @Test("Prepared shutdown retains a late finish until commit")
+    func preparedShutdownRetainsLateFinish() async {
+        let store = UserTaskRunStore()
+        let run = store.start(makeRun())
+        let waits = CancellationCounter()
+        store.registerCancellation(
+            UserTaskCancellation(
+                terminate: { true },
+                waitForCompletion: { _ in
+                    waits.increment()
+                    return true
+                }
+            ),
+            forRunID: run.id
+        )
+        let authorization = store.captureShutdownAuthorization()
+
+        #expect(store.requestShutdown(authorizedBy: authorization))
+        #expect(await store.waitForShutdown(
+            authorizedBy: authorization,
+            until: .now()
+        ))
+        #expect(waits.value == 1)
+        #expect(store.run(forID: run.id) === run)
+        #expect(store.cancellationHandleCount == 1)
+
+        #expect(store.finishRun(
+            id: run.id,
+            outcome: outcome(exitCode: SIGTERM, stdout: "late output"),
+            cancelled: true
+        ))
+        #expect(run.state == .cancelled)
+        #expect(run.stdout == "late output")
+        #expect(store.shutdownIsPreparedForCommit(
+            authorizedBy: authorization
+        ))
+
+        store.commitPreparedShutdown(authorizedBy: authorization)
+        #expect(store.runs.isEmpty)
+        #expect(!store.hasOutstandingExecutionOwnership)
+    }
+
     @Test("Shutdown timeout retains cancelling run and its handle")
     func shutdownTimeoutRetainsOwnership() async {
         let store = UserTaskRunStore()

--- a/PineTests/UserTaskRunStoreTests.swift
+++ b/PineTests/UserTaskRunStoreTests.swift
@@ -522,7 +522,11 @@ struct UserTaskRunStoreTests {
             try? await Task.sleep(for: .milliseconds(5))
         }
         let lateRun = store.start(makeRun(taskID: "late"))
-        store.registerCancellation(.noop, forRunID: lateRun.id)
+        let lateCancellation = CancellationCounter()
+        store.registerCancellation(
+            makeCancellation(counter: lateCancellation),
+            forRunID: lateRun.id
+        )
         gate.release()
 
         let didShutdown = await shutdown.value
@@ -530,7 +534,30 @@ struct UserTaskRunStoreTests {
         #expect(store.run(forID: first.id) != nil)
         #expect(store.run(forID: lateRun.id) === lateRun)
         #expect(lateRun.state == .pending)
+        #expect(lateCancellation.value == 0)
         #expect(store.hasOutstandingExecutionOwnership)
+    }
+
+    @Test("A replacement run does not inherit an older shutdown decision")
+    func replacementRunDoesNotInheritShutdownAuthorization() {
+        let store = UserTaskRunStore()
+        let first = store.start(makeRun(taskID: "same-task"))
+        let authorization = store.captureShutdownAuthorization()
+        #expect(store.finishRun(
+            id: first.id,
+            outcome: outcome(exitCode: 0),
+            cancelled: false
+        ))
+        let replacement = store.start(makeRun(taskID: "same-task"))
+        let replacementCancellation = CancellationCounter()
+        store.registerCancellation(
+            makeCancellation(counter: replacementCancellation),
+            forRunID: replacement.id
+        )
+
+        #expect(!store.requestShutdown(authorizedBy: authorization))
+        #expect(replacementCancellation.value == 0)
+        #expect(replacement.state == .pending)
     }
 
     @Test("Elapsed time advances while active and freezes at completion")

--- a/PineTests/UserTaskRunStoreTests.swift
+++ b/PineTests/UserTaskRunStoreTests.swift
@@ -521,6 +521,7 @@ struct UserTaskRunStoreTests {
         for _ in 0..<200 where !gate.didStartWaiting {
             try? await Task.sleep(for: .milliseconds(5))
         }
+        #expect(gate.didStartWaiting)
         let lateRun = store.start(makeRun(taskID: "late"))
         let lateCancellation = CancellationCounter()
         store.registerCancellation(
@@ -536,6 +537,47 @@ struct UserTaskRunStoreTests {
         #expect(lateRun.state == .pending)
         #expect(lateCancellation.value == 0)
         #expect(store.hasOutstandingExecutionOwnership)
+    }
+
+    @Test("A transient late run still invalidates shutdown authorization")
+    func transientLateRunInvalidatesShutdownAuthorization() async {
+        let store = UserTaskRunStore()
+        let first = store.start(makeRun(taskID: "first"))
+        let gate = ShutdownWaitGate()
+        store.registerCancellation(
+            UserTaskCancellation(
+                terminate: { true },
+                waitForCompletion: { deadline in
+                    gate.waitForRelease(until: deadline)
+                }
+            ),
+            forRunID: first.id
+        )
+        let shutdown = Task { @MainActor in
+            await store.shutdownAll(until: .now() + 2)
+        }
+        defer { gate.release() }
+
+        for _ in 0..<200 where !gate.didStartWaiting {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(gate.didStartWaiting)
+        let lateRun = store.start(makeRun(taskID: "transient-late"))
+        let lateCancellation = CancellationCounter()
+        store.registerCancellation(
+            makeCancellation(counter: lateCancellation),
+            forRunID: lateRun.id
+        )
+        #expect(store.finishRun(
+            id: lateRun.id,
+            outcome: outcome(exitCode: 0),
+            cancelled: false
+        ))
+        gate.release()
+
+        #expect(!(await shutdown.value))
+        #expect(lateCancellation.value == 0)
+        #expect(lateRun.state == .succeeded)
     }
 
     @Test("A replacement run does not inherit an older shutdown decision")

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -452,6 +452,125 @@ struct WindowLifecycleTests {
         await second.workspace.waitForLoadingComplete()
     }
 
+    @Test func quitDecisionRetriesAfterProjectOwnerCloses() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        updateContent("// keep after owner closes", in: project)
+
+        let oldWindow = NSWindow()
+        let newWindow = NSWindow()
+        oldWindow.orderFront(nil)
+        let applicationContext = DialogPresenter.register(
+            window: oldWindow,
+            projectManager: project
+        )
+        defer {
+            for window in [oldWindow, newWindow] {
+                DialogPresenter.ownerDidClose(window)
+                window.orderOut(nil)
+            }
+        }
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var unsavedPromptOwners: [NSWindow?] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, context, _, _ in
+                if template == .applicationQuitSummary {
+                    return .alertFirstButtonReturn
+                }
+                #expect(template == .unsavedChangesBulk)
+                unsavedPromptOwners.append(context.nsWindow)
+                if unsavedPromptOwners.count == 1 {
+                    DialogPresenter.ownerDidClose(oldWindow)
+                    oldWindow.orderOut(nil)
+                    newWindow.orderFront(nil)
+                    DialogPresenter.register(
+                        window: newWindow,
+                        projectManager: project
+                    )
+                    return .abort
+                }
+                return .alertThirdButtonReturn
+            },
+            applicationContext: applicationContext,
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(!result)
+        #expect(unsavedPromptOwners.count == 2)
+        #expect(unsavedPromptOwners[0] === oldWindow)
+        #expect(unsavedPromptOwners[1] === newWindow)
+        #expect(project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func quitFailureRetriesUntilAcknowledgementIsDisplayed() async {
+        let delegate = AppDelegate()
+        delegate.registry = makeRegistry()
+        let oldWindow = NSWindow()
+        let newWindow = NSWindow()
+        let oldContext = DialogPresentationContext(window: oldWindow)
+        let newContext = DialogPresentationContext(window: newWindow)
+        defer {
+            DialogPresenter.ownerDidClose(oldWindow)
+            DialogPresenter.ownerDidClose(newWindow)
+        }
+        var contextResolutionCount = 0
+        var presentedOwners: [NSWindow?] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, context, _, _ in
+                #expect(template == .applicationQuitFailure)
+                presentedOwners.append(context.nsWindow)
+                if presentedOwners.count == 1 {
+                    DialogPresenter.ownerDidClose(oldWindow)
+                    return .abort
+                }
+                return .alertFirstButtonReturn
+            },
+            terminationFailureContext: {
+                defer { contextResolutionCount += 1 }
+                return contextResolutionCount == 0
+                    ? oldContext
+                    : newContext
+            },
+            terminationDeadlineOverride: .now()
+        )
+
+        #expect(!result)
+        #expect(contextResolutionCount == 2)
+        #expect(presentedOwners.count == 2)
+        #expect(presentedOwners[0] === oldWindow)
+        #expect(presentedOwners[1] === newWindow)
+    }
+
+    @Test func quitFailureOwnerRetriesAreBounded() async {
+        let delegate = AppDelegate()
+        delegate.registry = makeRegistry()
+        let owner = NSWindow()
+        let context = DialogPresentationContext(window: owner)
+        defer { DialogPresenter.ownerDidClose(owner) }
+        var presentationCount = 0
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                #expect(template == .applicationQuitFailure)
+                presentationCount += 1
+                return .abort
+            },
+            terminationFailureContext: { context },
+            terminationDeadlineOverride: .now()
+        )
+
+        #expect(!result)
+        #expect(presentationCount == 3)
+    }
+
     @Test func saveAsUsesReplacementProjectOwnerAfterReview() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
@@ -527,6 +646,7 @@ struct WindowLifecycleTests {
         }
         let oldWindow = NSWindow()
         let newWindow = NSWindow()
+        let replacementFailureWindow = NSWindow()
         oldWindow.orderFront(nil)
         let oldContext = DialogPresenter.register(
             window: oldWindow,
@@ -535,13 +655,15 @@ struct WindowLifecycleTests {
         defer {
             DialogPresenter.ownerDidClose(oldWindow)
             DialogPresenter.ownerDidClose(newWindow)
+            DialogPresenter.ownerDidClose(replacementFailureWindow)
             oldWindow.orderOut(nil)
             newWindow.orderOut(nil)
+            replacementFailureWindow.orderOut(nil)
         }
         let delegate = AppDelegate()
         delegate.registry = registry
         var presented: [AlertTemplate] = []
-        var errorOwner: NSWindow?
+        var errorOwners: [NSWindow?] = []
 
         let result = await delegate.confirmApplicationTermination(
             presentAlert: { template, context, _, _ in
@@ -556,7 +678,17 @@ struct WindowLifecycleTests {
                     )
                 }
                 if template == .fileOperationErrorCritical {
-                    errorOwner = context.nsWindow
+                    errorOwners.append(context.nsWindow)
+                    if errorOwners.count == 1 {
+                        DialogPresenter.ownerDidClose(newWindow)
+                        newWindow.orderOut(nil)
+                        replacementFailureWindow.orderFront(nil)
+                        DialogPresenter.register(
+                            window: replacementFailureWindow,
+                            projectManager: project
+                        )
+                        return .abort
+                    }
                 }
                 return .alertFirstButtonReturn
             },
@@ -570,9 +702,12 @@ struct WindowLifecycleTests {
                 .applicationQuitSummary,
                 .unsavedChangesBulk,
                 .fileOperationErrorCritical,
+                .fileOperationErrorCritical,
             ]
         )
-        #expect(errorOwner === newWindow)
+        #expect(errorOwners.count == 2)
+        #expect(errorOwners[0] === newWindow)
+        #expect(errorOwners[1] === replacementFailureWindow)
         #expect(project.hasUnsavedChanges)
         await project.workspace.waitForLoadingComplete()
     }
@@ -958,8 +1093,12 @@ struct WindowLifecycleTests {
         )
         let stagedPlan = try #require(staged.1)
         let installer = DelayedTerminationInstallerProbe()
-        project.terminationSaveInstaller = { staged in
-            await installer.install(staged)
+        project.terminationSaveInstaller = { staged, deadline, lateCompletion in
+            await installer.install(
+                staged,
+                until: deadline,
+                lateCompletion: lateCompletion
+            )
         }
 
         let result = await project.commitStagedSaveAllPaneTabsForTermination(
@@ -971,7 +1110,7 @@ struct WindowLifecycleTests {
         #expect(installer.installCount == 1)
         #expect(
             try String(contentsOf: firstURL, encoding: .utf8)
-                == "// first dirty\n"
+                == "// first.swift"
         )
         #expect(
             try String(contentsOf: secondURL, encoding: .utf8)
@@ -981,8 +1120,89 @@ struct WindowLifecycleTests {
             atPath: firstURL.path
         )
         #expect(firstAttributes[.posixPermissions] as? Int == 0o750)
-        #expect(tabs.tabs.first(where: { $0.fileURL == firstURL })?.isDirty == false)
+        #expect(tabs.tabs.first(where: { $0.fileURL == firstURL })?.isDirty == true)
         #expect(tabs.tabs.first(where: { $0.fileURL == secondURL })?.isDirty == true)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func lateTerminationInstallDoesNotRegressNewerSave() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let tabs = project.primaryTabManager
+        tabs.autoSavePreferenceProvider = { false }
+        tabs.openTab(url: file)
+        tabs.updateContent("// captured by termination")
+        let prepared = await project.prepareSaveAllPaneTabs(
+            context: .unscoped
+        )
+        guard case .ready(let plan) = prepared else {
+            Issue.record("Expected a ready save plan")
+            return
+        }
+        let staged = await project.stagePreparedSaveAllPaneTabsForTermination(
+            plan,
+            until: .now() + 5
+        )
+        let stagedPlan = try #require(staged.1)
+        let installer = PausedInstalledTerminationInstallerProbe()
+        defer { installer.release() }
+        project.terminationSaveInstaller = { staged, deadline, lateCompletion in
+            await installer.install(
+                staged,
+                until: deadline,
+                lateCompletion: lateCompletion
+            )
+        }
+        let commit = Task {
+            await project.commitStagedSaveAllPaneTabsForTermination(
+                stagedPlan,
+                until: .now() + .milliseconds(250)
+            )
+        }
+        #expect(await installer.waitUntilInstalled())
+
+        let result = await commit.value
+        #expect(result == .timedOut)
+        #expect(
+            try String(contentsOf: file, encoding: .utf8)
+                == "// captured by termination\n"
+        )
+
+        let newerContent = "// saved after timeout"
+        tabs.updateContent(newerContent)
+        let index = try #require(tabs.tabs.firstIndex(where: {
+            $0.fileURL == file
+        }))
+        #expect(try tabs.trySaveTab(at: index))
+        let savedTab = try #require(tabs.tabs.first(where: {
+            $0.fileURL == file
+        }))
+        let persistedContent = savedTab.content
+        #expect(persistedContent.hasPrefix(newerContent))
+        #expect(savedTab.savedContent == persistedContent)
+        let savedGeneration = savedTab.persistenceGeneration
+        let savedModificationDate = savedTab.lastModDate
+        let savedFileSize = savedTab.fileSizeBytes
+
+        installer.release()
+        #expect(await installer.waitUntilReturned())
+        await settle()
+
+        let reconciledTab = try #require(tabs.tabs.first(where: {
+            $0.fileURL == file
+        }))
+        #expect(reconciledTab.content == persistedContent)
+        #expect(reconciledTab.savedContent == persistedContent)
+        #expect(reconciledTab.persistenceGeneration == savedGeneration)
+        #expect(reconciledTab.lastModDate == savedModificationDate)
+        #expect(reconciledTab.fileSizeBytes == savedFileSize)
+        #expect(!reconciledTab.isDirty)
+        #expect(
+            try String(contentsOf: file, encoding: .utf8) == persistedContent
+        )
         await project.workspace.waitForLoadingComplete()
     }
 
@@ -1041,6 +1261,60 @@ struct WindowLifecycleTests {
         #expect(project.primaryTabManager.activeTab?.content ==
                 "// captured dirty")
         #expect(project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func concurrentReplacementBeforeQuarantineIsRestored() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        updateContent("// captured dirty", in: project)
+
+        let prepared = await project.prepareSaveAllPaneTabs(
+            context: .unscoped
+        )
+        guard case .ready(let plan) = prepared else {
+            Issue.record("Expected a ready termination save plan")
+            return
+        }
+        let staged = await project.stagePreparedSaveAllPaneTabsForTermination(
+            plan,
+            until: .now() + 5
+        )
+        let stagedPlan = try #require(staged.1)
+        project.terminationSaveInstaller = { staged, deadline, lateCompletion in
+            await TerminationSaveCoordinator.install(
+                staged,
+                until: deadline,
+                beforeDestinationQuarantine: {
+                    try? FileManager.default.removeItem(at: file)
+                    try? Data("external replacement".utf8).write(to: file)
+                },
+                lateCompletion: lateCompletion
+            )
+        }
+
+        let result = await project.commitStagedSaveAllPaneTabsForTermination(
+            stagedPlan,
+            until: .now() + 5
+        )
+
+        guard case .failed = result else {
+            Issue.record("Expected the raced install to fail")
+            return
+        }
+        #expect(
+            try String(contentsOf: file, encoding: .utf8)
+                == "external replacement"
+        )
+        #expect(project.hasUnsavedChanges)
+        let recoveryArtifacts = try FileManager.default
+            .contentsOfDirectory(atPath: dir.path)
+            .filter { $0.hasPrefix(".pine-save-recovery-") }
+        #expect(recoveryArtifacts.isEmpty)
         await project.workspace.waitForLoadingComplete()
     }
 
@@ -1763,11 +2037,92 @@ nonisolated private final class DelayedTerminationInstallerProbe:
     var installCount: Int { lock.withLock { installs } }
 
     func install(
-        _ staged: TerminationStagedSave
+        _: TerminationStagedSave,
+        until _: DispatchTime,
+        lateCompletion _: @escaping @Sendable (
+            TerminationSaveInstallResult
+        ) -> Void
     ) async -> TerminationSaveInstallResult {
         lock.withLock { installs += 1 }
         try? await Task.sleep(for: .milliseconds(100))
-        return await TerminationSaveCoordinator.install(staged)
+        return .failed(message: "The outer deadline did not win")
+    }
+}
+
+nonisolated private final class PausedInstalledTerminationInstallerProbe:
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+    private var released = false
+    private var installed = false
+    private var returned = false
+
+    var didInstall: Bool { lock.withLock { installed } }
+    var didReturn: Bool { lock.withLock { returned } }
+
+    func install(
+        _ staged: TerminationStagedSave,
+        until deadline: DispatchTime,
+        lateCompletion: @escaping @Sendable (
+            TerminationSaveInstallResult
+        ) -> Void
+    ) async -> TerminationSaveInstallResult {
+        let result = await TerminationSaveCoordinator.install(
+            staged,
+            until: deadline,
+            lateCompletion: lateCompletion
+        )
+        guard case .installed = result else { return result }
+        lock.withLock { installed = true }
+        await withCheckedContinuation { continuation in
+            let resumeImmediately = lock.withLock {
+                if released { return true }
+                releaseContinuation = continuation
+                return false
+            }
+            if resumeImmediately {
+                continuation.resume()
+            }
+        }
+        lock.withLock { returned = true }
+        return result
+    }
+
+    func release() {
+        let continuation = lock.withLock {
+            released = true
+            defer { releaseContinuation = nil }
+            return releaseContinuation
+        }
+        continuation?.resume()
+    }
+
+    func waitUntilInstalled(
+        maximumDuration: Duration = .seconds(5)
+    ) async -> Bool {
+        await wait(until: { self.didInstall }, maximumDuration: maximumDuration)
+    }
+
+    func waitUntilReturned(
+        maximumDuration: Duration = .seconds(5)
+    ) async -> Bool {
+        await wait(until: { self.didReturn }, maximumDuration: maximumDuration)
+    }
+
+    private func wait(
+        until condition: () -> Bool,
+        maximumDuration: Duration
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: maximumDuration)
+        while !condition(), clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
+        }
+        return condition()
     }
 }
 

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -1092,6 +1092,83 @@ struct WindowLifecycleTests {
         await project.workspace.waitForLoadingComplete()
     }
 
+    @Test func applicationSaveRejectsAliasCreatedAfterInitialFence() async throws {
+        let saveRoot = try makeTempDirectory()
+        let observerRoot = try makeTempDirectory()
+        defer { cleanup(saveRoot); cleanup(observerRoot) }
+        let destinationParent = saveRoot.appendingPathComponent(
+            "redirected",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: destinationParent,
+            withIntermediateDirectories: false
+        )
+        let observedFile = try makeTempFile(
+            in: observerRoot,
+            name: "shared.swift"
+        )
+        let destination = destinationParent.appendingPathComponent(
+            observedFile.lastPathComponent
+        )
+        let registry = makeRegistry()
+        let savingProject = try #require(
+            registry.projectManager(for: saveRoot)
+        )
+        let observingProject = try #require(
+            registry.projectManager(for: observerRoot)
+        )
+        observingProject.primaryTabManager.openTab(url: observedFile)
+        _ = try #require(savingProject.createUntitledFile())
+        updateContent("// must remain untitled", in: savingProject)
+        savingProject.saveDestinationChooser = { _, _, _ in destination }
+        let aliasCapture = TerminationAliasMutationProbe {
+            do {
+                try FileManager.default.removeItem(at: destinationParent)
+                try FileManager.default.createSymbolicLink(
+                    at: destinationParent,
+                    withDestinationURL: observerRoot
+                )
+                return nil
+            } catch {
+                return error.localizedDescription
+            }
+        }
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var presented: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presented.append(template)
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5,
+            terminationAliasCapture: { urls, deadline in
+                await aliasCapture.capture(urls, until: deadline)
+            }
+        )
+
+        #expect(aliasCapture.mutationError == nil)
+        #expect(aliasCapture.captureCount == 2)
+        #expect(!result)
+        #expect(
+            try String(contentsOf: observedFile, encoding: .utf8)
+                == "// shared.swift"
+        )
+        let untitled = try #require(savingProject.allTabs.first(where: {
+            $0.fileURL == nil
+        }))
+        #expect(untitled.content == "// must remain untitled")
+        #expect(untitled.isDirty)
+        #expect(observingProject.allTabs.first(where: {
+            $0.fileURL == observedFile
+        })?.isDirty == false)
+        #expect(presented.last == .fileOperationErrorCritical)
+        await savingProject.workspace.waitForLoadingComplete()
+        await observingProject.workspace.waitForLoadingComplete()
+    }
+
     @Test func laterOpenTabStopsFutureTerminationInstall() async throws {
         let saveRoot = try makeTempDirectory()
         let observerRoot = try makeTempDirectory()
@@ -2423,6 +2500,40 @@ nonisolated private final class TerminationDeadlineProbe: @unchecked Sendable {
             recordedElapsedNanoseconds =
                 DispatchTime.now().uptimeNanoseconds - started
         }
+    }
+}
+
+nonisolated private final class TerminationAliasMutationProbe:
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private let mutation: @Sendable () -> String?
+    private var captures = 0
+    private var recordedMutationError: String?
+
+    init(mutation: @escaping @Sendable () -> String?) {
+        self.mutation = mutation
+    }
+
+    var captureCount: Int { lock.withLock { captures } }
+    var mutationError: String? { lock.withLock { recordedMutationError } }
+
+    func capture(
+        _ urls: [URL],
+        until deadline: DispatchTime
+    ) async -> TerminationFileAliasCaptureResult {
+        let result = await TerminationFileAliasResolver.capture(
+            urls,
+            until: deadline
+        )
+        let shouldMutate = lock.withLock {
+            captures += 1
+            return captures == 1
+        }
+        if shouldMutate {
+            let error = mutation()
+            lock.withLock { recordedMutationError = error }
+        }
+        return result
     }
 }
 

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -9,9 +9,15 @@ import Testing
 
 @testable import Pine
 
-@Suite("Window Lifecycle Tests")
+@Suite("Window Lifecycle Tests", .serialized)
 @MainActor
 struct WindowLifecycleTests {
+    private func makeRegistry() -> ProjectRegistry {
+        ProjectRegistry(agentTasks: AgentTaskRegistry(
+            persistence: WindowLifecycleAgentTaskStore()
+        ))
+    }
+
     private func settle() async {
         for _ in 0..<8 {
             await Task.yield()
@@ -49,7 +55,7 @@ struct WindowLifecycleTests {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
 
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         _ = registry.projectManager(for: dir)
 
         let delegate = AppDelegate()
@@ -72,7 +78,7 @@ struct WindowLifecycleTests {
         let dir2 = try makeTempDirectory()
         defer { cleanup(dir1); cleanup(dir2) }
 
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         _ = registry.projectManager(for: dir1)
         _ = registry.projectManager(for: dir2)
 
@@ -96,7 +102,7 @@ struct WindowLifecycleTests {
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
 
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let pm = try #require(registry.projectManager(for: dir))
         pm.primaryTabManager.openTab(url: file)
 
@@ -125,7 +131,7 @@ struct WindowLifecycleTests {
         let file1 = try makeTempFile(in: dir1, name: "a.swift")
         let file2 = try makeTempFile(in: dir2, name: "b.swift")
 
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let pm1 = try #require(registry.projectManager(for: dir1))
         let pm2 = try #require(registry.projectManager(for: dir2))
         pm1.primaryTabManager.openTab(url: file1)
@@ -149,7 +155,7 @@ struct WindowLifecycleTests {
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
 
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
         updateContent("// dirty", in: project)
@@ -188,7 +194,7 @@ struct WindowLifecycleTests {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let destination = dir.appendingPathComponent("saved.swift")
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         _ = try #require(project.createUntitledFile())
         updateContent("// saved after a slow panel", in: project)
@@ -225,7 +231,7 @@ struct WindowLifecycleTests {
     @Test func cancellingQuitSavePanelDoesNotShowMachineFailure() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         _ = try #require(project.createUntitledFile())
         updateContent("// keep", in: project)
@@ -258,7 +264,7 @@ struct WindowLifecycleTests {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let destination = dir.appendingPathComponent("first.swift")
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         _ = try #require(project.createUntitledFile())
         updateContent("// first dirty", in: project)
@@ -302,7 +308,7 @@ struct WindowLifecycleTests {
         }
         let firstFile = try makeTempFile(in: firstDirectory, name: "first.swift")
         let secondFile = try makeTempFile(in: secondDirectory, name: "second.swift")
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let first = try #require(registry.projectManager(for: firstDirectory))
         let second = try #require(registry.projectManager(for: secondDirectory))
         first.primaryTabManager.openTab(url: firstFile)
@@ -337,7 +343,7 @@ struct WindowLifecycleTests {
 
     @Test func cleanPreflightFailureResolvesOwnerLazily() async {
         let delegate = AppDelegate()
-        delegate.registry = ProjectRegistry()
+        delegate.registry = makeRegistry()
         let owner = NSWindow()
         let expectedContext = DialogPresentationContext(window: owner)
         defer { DialogPresenter.ownerDidClose(owner) }
@@ -364,10 +370,155 @@ struct WindowLifecycleTests {
         #expect(presentedOwner === owner)
     }
 
+    @Test func laterReviewPromptUsesReplacementProjectOwner() async throws {
+        let root = try makeTempDirectory()
+        defer { cleanup(root) }
+        let firstDirectory = root.appendingPathComponent("a-first")
+        let secondDirectory = root.appendingPathComponent("b-second")
+        try FileManager.default.createDirectory(
+            at: firstDirectory,
+            withIntermediateDirectories: false
+        )
+        try FileManager.default.createDirectory(
+            at: secondDirectory,
+            withIntermediateDirectories: false
+        )
+        let firstFile = try makeTempFile(in: firstDirectory, name: "first.swift")
+        let secondFile = try makeTempFile(in: secondDirectory, name: "second.swift")
+        let registry = makeRegistry()
+        let first = try #require(registry.projectManager(for: firstDirectory))
+        let second = try #require(registry.projectManager(for: secondDirectory))
+        first.primaryTabManager.openTab(url: firstFile)
+        second.primaryTabManager.openTab(url: secondFile)
+        updateContent("// first dirty", in: first)
+        updateContent("// second dirty", in: second)
+
+        let firstWindow = NSWindow()
+        let oldSecondWindow = NSWindow()
+        let newSecondWindow = NSWindow()
+        firstWindow.orderFront(nil)
+        oldSecondWindow.orderFront(nil)
+        let applicationContext = DialogPresenter.register(
+            window: firstWindow,
+            projectManager: first
+        )
+        DialogPresenter.register(
+            window: oldSecondWindow,
+            projectManager: second
+        )
+        defer {
+            for window in [firstWindow, oldSecondWindow, newSecondWindow] {
+                DialogPresenter.ownerDidClose(window)
+                window.orderOut(nil)
+            }
+        }
+
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var reviewPromptCount = 0
+        var laterPromptOwner: NSWindow?
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, context, _, _ in
+                if template == .applicationQuitSummary {
+                    return .alertFirstButtonReturn
+                }
+                #expect(template == .unsavedChangesBulk)
+                reviewPromptCount += 1
+                if reviewPromptCount == 1 {
+                    #expect(context.nsWindow === firstWindow)
+                    DialogPresenter.ownerDidClose(oldSecondWindow)
+                    oldSecondWindow.orderOut(nil)
+                    newSecondWindow.orderFront(nil)
+                    DialogPresenter.register(
+                        window: newSecondWindow,
+                        projectManager: second
+                    )
+                    return .alertSecondButtonReturn
+                }
+                laterPromptOwner = context.nsWindow
+                return .alertThirdButtonReturn
+            },
+            applicationContext: applicationContext,
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(!result)
+        #expect(reviewPromptCount == 2)
+        #expect(laterPromptOwner === newSecondWindow)
+        #expect(first.hasUnsavedChanges)
+        #expect(second.hasUnsavedChanges)
+        await first.workspace.waitForLoadingComplete()
+        await second.workspace.waitForLoadingComplete()
+    }
+
+    @Test func saveAsUsesReplacementProjectOwnerAfterReview() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        _ = try #require(project.createUntitledFile())
+        updateContent("// keep unsaved", in: project)
+
+        let oldWindow = NSWindow()
+        let newWindow = NSWindow()
+        oldWindow.orderFront(nil)
+        let oldContext = DialogPresenter.register(
+            window: oldWindow,
+            projectManager: project
+        )
+        defer {
+            for window in [oldWindow, newWindow] {
+                DialogPresenter.ownerDidClose(window)
+                window.orderOut(nil)
+            }
+        }
+        var saveAsOwner: NSWindow?
+        var saveAsCount = 0
+        project.saveDestinationChooser = { _, _, context in
+            saveAsCount += 1
+            saveAsOwner = context.nsWindow
+            return nil
+        }
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var presented: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presented.append(template)
+                if template == .unsavedChangesBulk {
+                    DialogPresenter.ownerDidClose(oldWindow)
+                    oldWindow.orderOut(nil)
+                    newWindow.orderFront(nil)
+                    DialogPresenter.register(
+                        window: newWindow,
+                        projectManager: project
+                    )
+                }
+                return .alertFirstButtonReturn
+            },
+            applicationContext: oldContext,
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(!result)
+        #expect(
+            presented == [
+                .applicationQuitSummary,
+                .unsavedChangesBulk,
+            ]
+        )
+        #expect(saveAsCount == 1)
+        #expect(saveAsOwner === newWindow)
+        #expect(project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
     @Test func detailedQuitSaveFailureUsesReboundProjectOwner() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         _ = try #require(project.createUntitledFile())
         updateContent("// cannot stage", in: project)
@@ -447,7 +598,7 @@ struct WindowLifecycleTests {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
         updateContent("// dirty", in: project)
@@ -484,7 +635,7 @@ struct WindowLifecycleTests {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
         updateContent("// dirty", in: project)
@@ -525,7 +676,7 @@ struct WindowLifecycleTests {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
         updateContent("// dirty before timeout", in: project)
@@ -575,7 +726,7 @@ struct WindowLifecycleTests {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
         updateContent("// captured dirty", in: project)
@@ -628,7 +779,7 @@ struct WindowLifecycleTests {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         let tabManager = project.primaryTabManager
         tabManager.openTab(url: file)
@@ -652,7 +803,7 @@ struct WindowLifecycleTests {
         let stagedPlan = try #require(staged.1)
 
         project.paneManager.removePane(project.paneManager.activePaneID)
-        let result = project.commitStagedSaveAllPaneTabsForTermination(
+        let result = await project.commitStagedSaveAllPaneTabsForTermination(
             stagedPlan,
             until: .now() + 5
         )
@@ -664,11 +815,182 @@ struct WindowLifecycleTests {
         await project.workspace.waitForLoadingComplete()
     }
 
+    @Test func applicationSaveRejectsCrossProjectDestinationAlias() async throws {
+        let firstRoot = try makeTempDirectory()
+        let secondRoot = try makeTempDirectory()
+        defer { cleanup(firstRoot); cleanup(secondRoot) }
+        let destination = firstRoot.appendingPathComponent("shared.swift")
+        let registry = makeRegistry()
+        let first = try #require(registry.projectManager(for: firstRoot))
+        let second = try #require(registry.projectManager(for: secondRoot))
+        _ = try #require(first.createUntitledFile())
+        _ = try #require(second.createUntitledFile())
+        updateContent("// first", in: first)
+        updateContent("// second", in: second)
+        first.saveDestinationChooser = { _, _, _ in destination }
+        second.saveDestinationChooser = { _, _, _ in destination }
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var presented: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presented.append(template)
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(!result)
+        #expect(!FileManager.default.fileExists(atPath: destination.path))
+        #expect(first.hasUnsavedChanges)
+        #expect(second.hasUnsavedChanges)
+        #expect(presented.last == .applicationQuitFailure)
+        await first.workspace.waitForLoadingComplete()
+        await second.workspace.waitForLoadingComplete()
+    }
+
+    @Test func destinationCreatedDuringStagingIsNotOverwritten() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let destination = dir.appendingPathComponent("created.swift")
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        _ = try #require(project.createUntitledFile())
+        updateContent("// captured dirty", in: project)
+        project.saveDestinationChooser = { _, _, _ in destination }
+        let probe = BlockingFormatterProbe()
+        defer { probe.release() }
+        let suiteName = "WindowLifecycleTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settings = EditorSettings(defaults: defaults)
+        settings.formatOnSave = true
+        project.primaryTabManager.editorSettings = settings
+        project.primaryTabManager.fileFormatters = FileFormatterRegistry(
+            formatters: [probe.formatter()]
+        )
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        let quit = Task { @MainActor in
+            await delegate.confirmApplicationTermination(
+                presentAlert: { _, _, _, _ in .alertFirstButtonReturn },
+                terminationDeadlineOverride: .now() + 5
+            )
+        }
+
+        #expect(await probe.waitUntilStarted())
+        try "external".write(
+            to: destination,
+            atomically: false,
+            encoding: .utf8
+        )
+        probe.release()
+        let result = await quit.value
+
+        #expect(!result)
+        #expect(
+            try String(contentsOf: destination, encoding: .utf8)
+                == "external"
+        )
+        #expect(project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func quitAnywayCancelsPendingAutoSaveBeforeDecision() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let tabs = project.primaryTabManager
+        tabs.openTab(url: file)
+        tabs.autoSavePreferenceProvider = { true }
+        tabs.setAutoSaveDelay(0.05)
+        tabs.updateContent("// must be discarded")
+        #expect(tabs.hasScheduledAutoSave)
+        let delegate = AppDelegate()
+        delegate.registry = registry
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                #expect(template == .applicationQuitSummary)
+                try? await Task.sleep(for: .milliseconds(200))
+                return .alertSecondButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(result)
+        #expect(try String(contentsOf: file, encoding: .utf8) == "// test.swift")
+        #expect(tabs.activeTab?.content == "// test.swift")
+        #expect(!tabs.hasScheduledAutoSave)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func stagedCommitStopsBeforeNextFileAfterDeadline() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let firstURL = try makeTempFile(in: dir, name: "first.swift")
+        let secondURL = try makeTempFile(in: dir, name: "second.swift")
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o750],
+            ofItemAtPath: firstURL.path
+        )
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let tabs = project.primaryTabManager
+        tabs.autoSavePreferenceProvider = { false }
+        tabs.openTab(url: firstURL)
+        tabs.updateContent("// first dirty")
+        tabs.openTab(url: secondURL)
+        tabs.updateContent("// second dirty")
+        let prepared = await project.prepareSaveAllPaneTabs(
+            context: .unscoped
+        )
+        guard case .ready(let plan) = prepared else {
+            Issue.record("Expected a ready save plan")
+            return
+        }
+        let staged = await project.stagePreparedSaveAllPaneTabsForTermination(
+            plan,
+            until: .now() + 5
+        )
+        let stagedPlan = try #require(staged.1)
+        let installer = DelayedTerminationInstallerProbe()
+        project.terminationSaveInstaller = { staged in
+            await installer.install(staged)
+        }
+
+        let result = await project.commitStagedSaveAllPaneTabsForTermination(
+            stagedPlan,
+            until: .now() + .milliseconds(50)
+        )
+
+        #expect(result == .timedOut)
+        #expect(installer.installCount == 1)
+        #expect(
+            try String(contentsOf: firstURL, encoding: .utf8)
+                == "// first dirty\n"
+        )
+        #expect(
+            try String(contentsOf: secondURL, encoding: .utf8)
+                == "// second.swift"
+        )
+        let firstAttributes = try FileManager.default.attributesOfItem(
+            atPath: firstURL.path
+        )
+        #expect(firstAttributes[.posixPermissions] as? Int == 0o750)
+        #expect(tabs.tabs.first(where: { $0.fileURL == firstURL })?.isDirty == false)
+        #expect(tabs.tabs.first(where: { $0.fileURL == secondURL })?.isDirty == true)
+        await project.workspace.waitForLoadingComplete()
+    }
+
     @Test func replacedStagingFileIsRejectedBeforeInstall() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
         updateContent("// captured dirty", in: project)
@@ -702,7 +1024,7 @@ struct WindowLifecycleTests {
             encoding: .utf8
         )
 
-        let result = project.commitStagedSaveAllPaneTabsForTermination(
+        let result = await project.commitStagedSaveAllPaneTabsForTermination(
             stagedPlan,
             until: .now() + 5
         )
@@ -712,6 +1034,10 @@ struct WindowLifecycleTests {
             return
         }
         #expect(try String(contentsOf: file, encoding: .utf8) == "// test.swift")
+        #expect(
+            try String(contentsOf: stagingURL, encoding: .utf8)
+                == "substituted"
+        )
         #expect(project.primaryTabManager.activeTab?.content ==
                 "// captured dirty")
         #expect(project.hasUnsavedChanges)
@@ -723,7 +1049,7 @@ struct WindowLifecycleTests {
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
 
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
         updateContent("// dirty", in: project)
@@ -762,7 +1088,7 @@ struct WindowLifecycleTests {
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
 
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
         updateContent("// first dirty state", in: project)
@@ -801,7 +1127,7 @@ struct WindowLifecycleTests {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
         updateContent("// discarded", in: project)
@@ -834,7 +1160,7 @@ struct WindowLifecycleTests {
         }
         let firstFile = try makeTempFile(in: firstDirectory, name: "first.swift")
         let secondFile = try makeTempFile(in: secondDirectory, name: "second.swift")
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let firstProject = try #require(
             registry.projectManager(for: firstDirectory)
         )
@@ -876,7 +1202,7 @@ struct WindowLifecycleTests {
     @Test func quitFailureIsVisibleWhenUserTaskCleanupDoesNotFinish() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         let run = project.taskRunStore.start(makeTaskRun(id: "active"))
         let probe = TerminationTaskProbe(waitResult: false)
@@ -923,7 +1249,7 @@ struct WindowLifecycleTests {
     @Test func quitAnywayStopsUserTaskAndQuits() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         let run = project.taskRunStore.start(makeTaskRun(id: "active"))
         let probe = TerminationTaskProbe(waitResult: true)
@@ -950,11 +1276,63 @@ struct WindowLifecycleTests {
         #expect(registry.destroyAllProjects())
     }
 
+    @Test func lateDirtyStateRetainsPreparedUserTaskHistory() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        let run = project.taskRunStore.start(makeTaskRun(id: "active"))
+        let probe = BlockingTerminationTaskProbe()
+        project.taskRunStore.registerCancellation(
+            probe.makeCancellation(),
+            forRunID: run.id
+        )
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var presentedTemplates: [AlertTemplate] = []
+
+        let quit = Task { @MainActor in
+            await delegate.confirmApplicationTermination(
+                presentAlert: { template, _, _, _ in
+                    presentedTemplates.append(template)
+                    return template == .applicationQuitSummary
+                        ? .alertSecondButtonReturn
+                        : .alertFirstButtonReturn
+                },
+                terminationDeadlineOverride: .now() + 5
+            )
+        }
+
+        #expect(await probe.waitUntilStarted())
+        project.primaryTabManager.updateContent("// late dirty")
+        probe.release()
+        let result = await quit.value
+
+        #expect(!result)
+        #expect(
+            presentedTemplates == [
+                .applicationQuitSummary,
+                .applicationQuitFailure,
+            ]
+        )
+        #expect(project.taskRunStore.runs.contains(where: { $0.id == run.id }))
+        #expect(project.hasOutstandingUserTaskExecution)
+        #expect(project.hasUnsavedChanges)
+        project.taskRunStore.finishRun(
+            id: run.id,
+            outcome: makeTaskOutcome(id: "active"),
+            cancelled: true
+        )
+        await project.workspace.waitForLoadingComplete()
+    }
+
     @Test func taskStartedDuringQuitDoesNotCommitDiscard() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
         updateContent("// keep after refused quit", in: project)
@@ -1007,7 +1385,7 @@ struct WindowLifecycleTests {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
         project.primaryTabManager.openTab(url: file)
         updateContent("// keep late task", in: project)
@@ -1084,7 +1462,7 @@ struct WindowLifecycleTests {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
 
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let pm = ProjectManager()
         let delegate = AppDelegate()
         let window = NSWindow()
@@ -1109,7 +1487,7 @@ struct WindowLifecycleTests {
         defer { cleanup(dir) }
         let file = try makeTempFile(in: dir)
 
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let pm = ProjectManager()
         pm.primaryTabManager.openTab(url: file)
 
@@ -1137,7 +1515,7 @@ struct WindowLifecycleTests {
         let file1 = try makeTempFile(in: dir, name: "a.swift")
         let file2 = try makeTempFile(in: dir, name: "b.swift")
 
-        let registry = ProjectRegistry()
+        let registry = makeRegistry()
         let pm = ProjectManager()
         pm.primaryTabManager.openTab(url: file1)
         pm.primaryTabManager.openTab(url: file2)
@@ -1293,6 +1671,23 @@ struct WindowLifecycleTests {
     }
 }
 
+private actor WindowLifecycleAgentTaskStore:
+    AgentTaskPersisting {
+    func load(
+        project: AgentTaskProjectIdentity
+    ) async -> AgentTaskMetadataLoadResult {
+        AgentTaskMetadataLoadResult(status: .missing, tasks: [])
+    }
+
+    func save(
+        tasks: [AgentTask],
+        project: AgentTaskProjectIdentity,
+        authorization: AgentTaskPublicationAuthorization?
+    ) async -> AgentTaskMetadataSaveResult {
+        .saved(taskCount: tasks.count)
+    }
+}
+
 nonisolated private final class TerminationDeadlineProbe: @unchecked Sendable {
     private let lock = NSLock()
     private let started = DispatchTime.now().uptimeNanoseconds
@@ -1345,7 +1740,7 @@ nonisolated private final class BlockingFormatterProbe: @unchecked Sendable {
     }
 
     func waitUntilStarted(
-        maximumDuration: Duration = .seconds(2)
+        maximumDuration: Duration = .seconds(5)
     ) async -> Bool {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: maximumDuration)
@@ -1357,6 +1752,22 @@ nonisolated private final class BlockingFormatterProbe: @unchecked Sendable {
             }
         }
         return didStart
+    }
+}
+
+nonisolated private final class DelayedTerminationInstallerProbe:
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private var installs = 0
+
+    var installCount: Int { lock.withLock { installs } }
+
+    func install(
+        _ staged: TerminationStagedSave
+    ) async -> TerminationSaveInstallResult {
+        lock.withLock { installs += 1 }
+        try? await Task.sleep(for: .milliseconds(100))
+        return await TerminationSaveCoordinator.install(staged)
     }
 }
 
@@ -1393,5 +1804,44 @@ nonisolated private final class TerminationTaskProbe: @unchecked Sendable {
                 return waitResult
             }
         )
+    }
+}
+
+nonisolated private final class BlockingTerminationTaskProbe:
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private var started = false
+
+    var didStart: Bool { lock.withLock { started } }
+
+    func makeCancellation() -> UserTaskCancellation {
+        UserTaskCancellation(
+            terminate: { true },
+            waitForCompletion: { [self] _ in
+                lock.withLock { started = true }
+                releaseSemaphore.wait()
+                return true
+            }
+        )
+    }
+
+    func release() {
+        releaseSemaphore.signal()
+    }
+
+    func waitUntilStarted(
+        maximumDuration: Duration = .seconds(5)
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: maximumDuration)
+        while !didStart, clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
+        }
+        return didStart
     }
 }

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -1325,6 +1325,77 @@ struct WindowLifecycleTests {
         await project.workspace.waitForLoadingComplete()
     }
 
+    @Test func movedParentRetainedSaveSurvivesProjectCleanup() async throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let saveDirectory = directory.appendingPathComponent("sources")
+        let movedDirectory = directory.appendingPathComponent("sources-moved")
+        try FileManager.default.createDirectory(
+            at: saveDirectory,
+            withIntermediateDirectories: false
+        )
+        let file = try makeTempFile(in: saveDirectory, name: "moved.swift")
+        let registry = makeRegistry()
+        let project = try #require(
+            registry.projectManager(for: directory)
+        )
+        project.primaryTabManager.openTab(url: file)
+        updateContent("// retained dirty bytes", in: project)
+        let prepared = await project.prepareSaveAllPaneTabs(
+            context: .unscoped
+        )
+        guard case .ready(let plan) = prepared else {
+            Issue.record("Expected a ready save plan")
+            return
+        }
+        let staged = await project.stagePreparedSaveAllPaneTabsForTermination(
+            plan,
+            until: .now() + 5
+        )
+        let stagedPlan = try #require(staged.1)
+        let stagingProbe = TerminationStagingLeafProbe()
+        project.terminationSaveInstaller = { staged, deadline, lateCompletion in
+            stagingProbe.record(staged)
+            return await TerminationSaveCoordinator.install(
+                staged,
+                until: deadline,
+                beforeDestinationQuarantine: {
+                    try? FileManager.default.moveItem(
+                        at: saveDirectory,
+                        to: movedDirectory
+                    )
+                    try? FileManager.default.createDirectory(
+                        at: saveDirectory,
+                        withIntermediateDirectories: false
+                    )
+                },
+                lateCompletion: lateCompletion
+            )
+        }
+
+        let result = await project
+            .commitStagedSaveAllPaneTabsForTermination(
+                stagedPlan,
+                until: .now() + 5
+            )
+
+        guard case .failed(_, let retainedArtifacts) = result else {
+            Issue.record("Expected the moved parent install to fail closed")
+            return
+        }
+        #expect(!retainedArtifacts.isEmpty)
+        let movedArtifact = movedDirectory.appendingPathComponent(
+            try #require(stagingProbe.leaf)
+        )
+        #expect(FileManager.default.fileExists(atPath: movedArtifact.path))
+        #expect(
+            try String(contentsOf: movedArtifact, encoding: .utf8)
+                .contains("// retained dirty bytes")
+        )
+        #expect(project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
     @Test func stagedCommitStopsBeforeNextFileAfterDeadline() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
@@ -2465,6 +2536,20 @@ struct WindowLifecycleTests {
             exitCode: 0,
             timedOut: false
         )
+    }
+}
+
+nonisolated private final class TerminationStagingLeafProbe:
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedLeaf: String?
+
+    var leaf: String? { lock.withLock { recordedLeaf } }
+
+    func record(_ staged: TerminationStagedSave) {
+        lock.withLock {
+            recordedLeaf = staged.stagingURL.lastPathComponent
+        }
     }
 }
 

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -1292,14 +1292,11 @@ struct WindowLifecycleTests {
         )
 
         guard case .failed(let message, let retainedArtifacts) = result else {
-            Issue.record("Expected deadline cleanup to retain both staged files")
+            Issue.record("Expected deadline cleanup failure")
             return
         }
         #expect(message == "Termination save cleanup exceeded its deadline")
-        #expect(retainedArtifacts.count == 2)
-        #expect(retainedArtifacts.allSatisfy {
-            $0.lastPathComponent.hasPrefix(".pine-save-")
-        })
+        #expect(retainedArtifacts.isEmpty)
         #expect(installer.installCount == 1)
         #expect(
             try String(contentsOf: firstURL, encoding: .utf8)
@@ -1315,6 +1312,132 @@ struct WindowLifecycleTests {
         #expect(firstAttributes[.posixPermissions] as? Int == 0o750)
         #expect(tabs.tabs.first(where: { $0.fileURL == firstURL })?.isDirty == true)
         #expect(tabs.tabs.first(where: { $0.fileURL == secondURL })?.isDirty == true)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func cleanupTimeoutDoesNotClaimArtifactThatWorkerLaterDeletes() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        updateContent("// captured dirty", in: project)
+        let prepared = await project.prepareSaveAllPaneTabs(
+            context: .unscoped
+        )
+        guard case .ready(let plan) = prepared else {
+            Issue.record("Expected a ready save plan")
+            return
+        }
+        let staged = await project.stagePreparedSaveAllPaneTabsForTermination(
+            plan,
+            until: .now() + 5
+        )
+        let stagedPlan = try #require(staged.1)
+        let cleaner = BlockingTerminationCleanerProbe { staged in
+            TerminationSaveCoordinator.cleanup(staged)
+        }
+        project.terminationSaveCleaner = { staged in
+            cleaner.clean(staged)
+        }
+
+        let cleanupTask = Task {
+            await project.cleanupTerminationSavePlan(
+                stagedPlan,
+                until: .now() + .milliseconds(50)
+            )
+        }
+        #expect(await cleaner.waitUntilStarted())
+        let result = await cleanupTask.value
+
+        guard case .failed(let message, let retainedArtifacts) = result else {
+            Issue.record("Expected cleanup deadline failure")
+            cleaner.release()
+            return
+        }
+        #expect(message == "Termination save cleanup exceeded its deadline")
+        #expect(retainedArtifacts.isEmpty)
+        cleaner.release()
+        #expect(await cleaner.waitUntilReturned())
+        #expect(cleaner.stagingURLs.allSatisfy {
+            !FileManager.default.fileExists(atPath: $0.path)
+        })
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func cleanupTimeoutReportsActualLateRetainedArtifact() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let retainedArtifact = dir.appendingPathComponent(
+            ".pine-save-cleanup-retained"
+        )
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        updateContent("// captured dirty", in: project)
+        let prepared = await project.prepareSaveAllPaneTabs(
+            context: .unscoped
+        )
+        guard case .ready(let plan) = prepared else {
+            Issue.record("Expected a ready save plan")
+            return
+        }
+        let staged = await project.stagePreparedSaveAllPaneTabsForTermination(
+            plan,
+            until: .now() + 5
+        )
+        let stagedPlan = try #require(staged.1)
+        let cleaner = BlockingTerminationCleanerProbe { staged in
+            guard let stagingURL = staged.first?.stagingURL else {
+                return .cleaned
+            }
+            do {
+                try FileManager.default.moveItem(
+                    at: stagingURL,
+                    to: retainedArtifact
+                )
+                return .failed(
+                    message: "late cleanup retained recovery",
+                    retainedArtifacts: [retainedArtifact]
+                )
+            } catch {
+                return .failed(
+                    message: error.localizedDescription,
+                    retainedArtifacts: []
+                )
+            }
+        }
+        let report = TerminationLateFailureReportProbe()
+        project.terminationSaveCleaner = { staged in
+            cleaner.clean(staged)
+        }
+        project.terminationSaveLateFailureHandler = { message, artifacts in
+            report.record(message: message, artifacts: artifacts)
+        }
+
+        let cleanupTask = Task {
+            await project.cleanupTerminationSavePlan(
+                stagedPlan,
+                until: .now() + .milliseconds(50)
+            )
+        }
+        #expect(await cleaner.waitUntilStarted())
+        let result = await cleanupTask.value
+        guard case .failed(_, let retainedArtifacts) = result else {
+            Issue.record("Expected cleanup deadline failure")
+            cleaner.release()
+            return
+        }
+        #expect(retainedArtifacts.isEmpty)
+
+        cleaner.release()
+        #expect(await cleaner.waitUntilReturned())
+        #expect(await report.waitUntilRecorded())
+        #expect(report.message == "late cleanup retained recovery")
+        #expect(report.artifacts == [retainedArtifact])
+        #expect(FileManager.default.fileExists(atPath: retainedArtifact.path))
         await project.workspace.waitForLoadingComplete()
     }
 
@@ -1359,15 +1482,11 @@ struct WindowLifecycleTests {
 
         let result = await commit.value
         guard case .failed(let message, let retainedArtifacts) = result else {
-            Issue.record("Expected timed-out cleanup to report its retained inode")
+            Issue.record("Expected timed-out cleanup failure")
             return
         }
         #expect(message == "Termination save cleanup exceeded its deadline")
-        #expect(retainedArtifacts.count == 1)
-        #expect(
-            retainedArtifacts.first?.lastPathComponent
-                .hasPrefix(".pine-save-") == true
-        )
+        #expect(retainedArtifacts.isEmpty)
         #expect(
             try String(contentsOf: file, encoding: .utf8)
                 == "// captured by termination\n"
@@ -2376,6 +2495,111 @@ nonisolated private final class DelayedTerminationInstallerProbe:
             message: "The outer deadline did not win",
             retainedArtifacts: []
         )
+    }
+}
+
+nonisolated private final class BlockingTerminationCleanerProbe:
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private let cleanup: @Sendable (
+        [TerminationStagedSave]
+    ) -> TerminationSaveCleanupResult
+    private var started = false
+    private var returned = false
+    private var recordedStagingURLs: [URL] = []
+
+    var stagingURLs: [URL] { lock.withLock { recordedStagingURLs } }
+
+    init(
+        cleanup: @escaping @Sendable (
+            [TerminationStagedSave]
+        ) -> TerminationSaveCleanupResult
+    ) {
+        self.cleanup = cleanup
+    }
+
+    func clean(
+        _ staged: [TerminationStagedSave]
+    ) -> TerminationSaveCleanupResult {
+        lock.withLock {
+            recordedStagingURLs = staged.map(\.stagingURL)
+            started = true
+        }
+        releaseSemaphore.wait()
+        let result = cleanup(staged)
+        lock.withLock { returned = true }
+        return result
+    }
+
+    func release() {
+        releaseSemaphore.signal()
+    }
+
+    func waitUntilStarted(
+        maximumDuration: Duration = .seconds(5)
+    ) async -> Bool {
+        await wait(
+            until: { self.lock.withLock { self.started } },
+            maximumDuration: maximumDuration
+        )
+    }
+
+    func waitUntilReturned(
+        maximumDuration: Duration = .seconds(5)
+    ) async -> Bool {
+        await wait(
+            until: { self.lock.withLock { self.returned } },
+            maximumDuration: maximumDuration
+        )
+    }
+
+    private func wait(
+        until condition: () -> Bool,
+        maximumDuration: Duration
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: maximumDuration)
+        while !condition(), clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
+        }
+        return condition()
+    }
+}
+
+nonisolated private final class TerminationLateFailureReportProbe:
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedMessage: String?
+    private var recordedArtifacts: [URL] = []
+
+    var message: String? { lock.withLock { recordedMessage } }
+    var artifacts: [URL] { lock.withLock { recordedArtifacts } }
+
+    func record(message: String, artifacts: [URL]) {
+        lock.withLock {
+            recordedMessage = message
+            recordedArtifacts = artifacts
+        }
+    }
+
+    func waitUntilRecorded(
+        maximumDuration: Duration = .seconds(5)
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: maximumDuration)
+        while message == nil, clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
+        }
+        return message != nil
     }
 }
 

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -254,6 +254,45 @@ struct WindowLifecycleTests {
         await project.workspace.waitForLoadingComplete()
     }
 
+    @Test func newDirtyTabDuringQuitSavePanelInvalidatesPlan() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let destination = dir.appendingPathComponent("first.swift")
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        _ = try #require(project.createUntitledFile())
+        updateContent("// first dirty", in: project)
+        project.saveDestinationChooser = { _, _, _ in
+            _ = project.createUntitledFile()
+            project.activeTabManager.autoSavePreferenceProvider = { false }
+            project.activeTabManager.updateContent("// created during panel")
+            return destination
+        }
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var presentedTemplates: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presentedTemplates.append(template)
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(!result)
+        #expect(
+            presentedTemplates == [
+                .applicationQuitSummary,
+                .unsavedChangesBulk,
+                .applicationQuitFailure,
+            ]
+        )
+        #expect(!FileManager.default.fileExists(atPath: destination.path))
+        #expect(project.allDirtyTabs.count == 2)
+        await project.workspace.waitForLoadingComplete()
+    }
+
     @Test func multipleSlowReviewPromptsDoNotConsumeMachineDeadline() async throws {
         let firstDirectory = try makeTempDirectory()
         let secondDirectory = try makeTempDirectory()
@@ -325,6 +364,68 @@ struct WindowLifecycleTests {
         #expect(presentedOwner === owner)
     }
 
+    @Test func detailedQuitSaveFailureUsesReboundProjectOwner() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        _ = try #require(project.createUntitledFile())
+        updateContent("// cannot stage", in: project)
+        project.saveDestinationChooser = { _, _, _ in
+            dir.appendingPathComponent("missing-parent/file.swift")
+        }
+        let oldWindow = NSWindow()
+        let newWindow = NSWindow()
+        oldWindow.orderFront(nil)
+        let oldContext = DialogPresenter.register(
+            window: oldWindow,
+            projectManager: project
+        )
+        defer {
+            DialogPresenter.ownerDidClose(oldWindow)
+            DialogPresenter.ownerDidClose(newWindow)
+            oldWindow.orderOut(nil)
+            newWindow.orderOut(nil)
+        }
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var presented: [AlertTemplate] = []
+        var errorOwner: NSWindow?
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, context, _, _ in
+                presented.append(template)
+                if template == .unsavedChangesBulk {
+                    DialogPresenter.ownerDidClose(oldWindow)
+                    oldWindow.orderOut(nil)
+                    newWindow.orderFront(nil)
+                    DialogPresenter.register(
+                        window: newWindow,
+                        projectManager: project
+                    )
+                }
+                if template == .fileOperationErrorCritical {
+                    errorOwner = context.nsWindow
+                }
+                return .alertFirstButtonReturn
+            },
+            applicationContext: oldContext,
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(!result)
+        #expect(
+            presented == [
+                .applicationQuitSummary,
+                .unsavedChangesBulk,
+                .fileOperationErrorCritical,
+            ]
+        )
+        #expect(errorOwner === newWindow)
+        #expect(project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
     @Test func terminationBudgetAlwaysReservesRollback() {
         let long = AppDelegate.terminationBudgetSplit(
             availableNanoseconds: 30_000_000_000
@@ -370,7 +471,10 @@ struct WindowLifecycleTests {
 
         let elapsed = DispatchTime.now().uptimeNanoseconds - started
         #expect(result)
-        #expect(elapsed >= 600_000_000)
+        // ContinuousClock sleeps may wake within their platform tolerance;
+        // the assertion only needs to prove the 500 ms machine budget did
+        // not cap the user's decision time.
+        #expect(elapsed >= 550_000_000)
         #expect(deadlineProbe.elapsedNanoseconds == nil)
         #expect(!project.hasUnsavedChanges)
         await project.workspace.waitForLoadingComplete()
@@ -413,6 +517,203 @@ struct WindowLifecycleTests {
         #expect(
             deadlineProbe.elapsedNanoseconds.map { $0 < 1_000_000_000 } == true
         )
+        #expect(project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func realQuitSaveTimeoutLeavesTargetAndTabUntouched() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        updateContent("// dirty before timeout", in: project)
+        let probe = BlockingFormatterProbe()
+        defer { probe.release() }
+        let suiteName = "WindowLifecycleTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settings = EditorSettings(defaults: defaults)
+        settings.formatOnSave = true
+        project.primaryTabManager.editorSettings = settings
+        project.primaryTabManager.fileFormatters = FileFormatterRegistry(
+            formatters: [probe.formatter()]
+        )
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        let deadlineProbe = TerminationDeadlineProbe()
+        var presented: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presented.append(template)
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + .milliseconds(100),
+            terminationDeadlineObserver: deadlineProbe.record
+        )
+
+        #expect(!result)
+        #expect(probe.didStart)
+        #expect(deadlineProbe.elapsedNanoseconds != nil)
+        #expect(
+            presented == [
+                .applicationQuitSummary,
+                .unsavedChangesBulk,
+                .applicationQuitFailure,
+            ]
+        )
+        #expect(try String(contentsOf: file, encoding: .utf8) == "// test.swift")
+        #expect(project.primaryTabManager.activeTab?.content ==
+                "// dirty before timeout")
+        #expect(project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func editBackDuringQuitSaveStagingInvalidatesGeneration() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        updateContent("// captured dirty", in: project)
+        let probe = BlockingFormatterProbe()
+        defer { probe.release() }
+        let suiteName = "WindowLifecycleTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let settings = EditorSettings(defaults: defaults)
+        settings.formatOnSave = true
+        project.primaryTabManager.editorSettings = settings
+        project.primaryTabManager.fileFormatters = FileFormatterRegistry(
+            formatters: [probe.formatter()]
+        )
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var presented: [AlertTemplate] = []
+        let quit = Task { @MainActor in
+            await delegate.confirmApplicationTermination(
+                presentAlert: { template, _, _, _ in
+                    presented.append(template)
+                    return .alertFirstButtonReturn
+                },
+                terminationDeadlineOverride: .now() + 5
+            )
+        }
+
+        #expect(await probe.waitUntilStarted())
+        project.primaryTabManager.updateContent("// edited during staging")
+        project.primaryTabManager.updateContent("// captured dirty")
+        probe.release()
+        let result = await quit.value
+
+        #expect(!result)
+        #expect(
+            presented == [
+                .applicationQuitSummary,
+                .unsavedChangesBulk,
+                .applicationQuitFailure,
+            ]
+        )
+        #expect(try String(contentsOf: file, encoding: .utf8) == "// test.swift")
+        #expect(project.primaryTabManager.activeTab?.content ==
+                "// captured dirty")
+        #expect(project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func paneReplacementInvalidatesStagedTerminationSave() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        let tabManager = project.primaryTabManager
+        tabManager.openTab(url: file)
+        updateContent("// captured dirty", in: project)
+
+        let prepared = await project.prepareSaveAllPaneTabs(
+            context: .unscoped
+        )
+        guard case .ready(let plan) = prepared else {
+            Issue.record("Expected a ready termination save plan")
+            return
+        }
+        let staged = await project.stagePreparedSaveAllPaneTabsForTermination(
+            plan,
+            until: .now() + 5
+        )
+        guard case .ready = staged.0 else {
+            Issue.record("Expected staged termination save artifacts")
+            return
+        }
+        let stagedPlan = try #require(staged.1)
+
+        project.paneManager.removePane(project.paneManager.activePaneID)
+        let result = project.commitStagedSaveAllPaneTabsForTermination(
+            stagedPlan,
+            until: .now() + 5
+        )
+
+        #expect(result == .invalidated)
+        #expect(try String(contentsOf: file, encoding: .utf8) == "// test.swift")
+        #expect(tabManager.activeTab?.content == "// captured dirty")
+        #expect(tabManager.activeTab?.isDirty == true)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func replacedStagingFileIsRejectedBeforeInstall() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        updateContent("// captured dirty", in: project)
+
+        let prepared = await project.prepareSaveAllPaneTabs(
+            context: .unscoped
+        )
+        guard case .ready(let plan) = prepared else {
+            Issue.record("Expected a ready termination save plan")
+            return
+        }
+        let staged = await project.stagePreparedSaveAllPaneTabsForTermination(
+            plan,
+            until: .now() + 5
+        )
+        guard case .ready = staged.0 else {
+            Issue.record("Expected staged termination save artifacts")
+            return
+        }
+        let stagedPlan = try #require(staged.1)
+        let stagingURL = try #require(
+            FileManager.default.contentsOfDirectory(
+                at: dir,
+                includingPropertiesForKeys: nil
+            ).first(where: { $0.lastPathComponent.hasPrefix(".pine-save-") })
+        )
+        try FileManager.default.removeItem(at: stagingURL)
+        try "substituted".write(
+            to: stagingURL,
+            atomically: false,
+            encoding: .utf8
+        )
+
+        let result = project.commitStagedSaveAllPaneTabsForTermination(
+            stagedPlan,
+            until: .now() + 5
+        )
+
+        guard case .failed = result else {
+            Issue.record("Expected substituted staging file to fail")
+            return
+        }
+        #expect(try String(contentsOf: file, encoding: .utf8) == "// test.swift")
+        #expect(project.primaryTabManager.activeTab?.content ==
+                "// captured dirty")
         #expect(project.hasUnsavedChanges)
         await project.workspace.waitForLoadingComplete()
     }
@@ -1007,6 +1308,55 @@ nonisolated private final class TerminationDeadlineProbe: @unchecked Sendable {
             recordedElapsedNanoseconds =
                 DispatchTime.now().uptimeNanoseconds - started
         }
+    }
+}
+
+nonisolated private final class BlockingFormatterProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private var started = false
+
+    var didStart: Bool {
+        lock.withLock { started }
+    }
+
+    func formatter() -> ExternalFileFormatter {
+        ExternalFileFormatter(
+            toolPath: "/usr/bin/false",
+            toolName: "blocking-test-formatter",
+            extensions: ["swift"],
+            arguments: [],
+            processRunner: { [self] _, _, input, _ in
+                lock.withLock { started = true }
+                releaseSemaphore.wait()
+                return ProcessRunResult(
+                    stdout: input,
+                    stderr: "",
+                    exitCode: 0,
+                    timedOut: false
+                )
+            },
+            timeout: 30
+        )
+    }
+
+    func release() {
+        releaseSemaphore.signal()
+    }
+
+    func waitUntilStarted(
+        maximumDuration: Duration = .seconds(2)
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: maximumDuration)
+        while !didStart, clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
+        }
+        return didStart
     }
 }
 

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -549,7 +549,7 @@ struct WindowLifecycleTests {
         #expect(presentedOwners[1] === newWindow)
     }
 
-    @Test func quitFailureOwnerRetriesAreBounded() async {
+    @Test func quitFailureRetriesPastFourLostOwnersUntilAcknowledged() async {
         let delegate = AppDelegate()
         delegate.registry = makeRegistry()
         let owner = NSWindow()
@@ -561,14 +561,16 @@ struct WindowLifecycleTests {
             presentAlert: { template, _, _, _ in
                 #expect(template == .applicationQuitFailure)
                 presentationCount += 1
-                return .abort
+                return presentationCount <= 4
+                    ? .abort
+                    : .alertFirstButtonReturn
             },
             terminationFailureContext: { context },
             terminationDeadlineOverride: .now()
         )
 
         #expect(!result)
-        #expect(presentationCount == 3)
+        #expect(presentationCount == 5)
     }
 
     @Test func saveAsUsesReplacementProjectOwnerAfterReview() async throws {
@@ -983,6 +985,124 @@ struct WindowLifecycleTests {
         #expect(presented.last == .applicationQuitFailure)
         await first.workspace.waitForLoadingComplete()
         await second.workspace.waitForLoadingComplete()
+    }
+
+    @Test func applicationSaveRejectsCaseAliasedOpenFile() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let volumeValues = try dir.resourceValues(
+            forKeys: [.volumeSupportsCaseSensitiveNamesKey]
+        )
+        guard volumeValues.volumeSupportsCaseSensitiveNames == false else {
+            return
+        }
+        let openFile = try makeTempFile(in: dir, name: "shared.swift")
+        let aliasedDestination = dir.appendingPathComponent("SHARED.swift")
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: openFile)
+        _ = try #require(project.createUntitledFile())
+        updateContent("// must remain untitled", in: project)
+        project.saveDestinationChooser = { _, _, _ in aliasedDestination }
+        let delegate = AppDelegate()
+        delegate.registry = registry
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { _, _, _, _ in .alertFirstButtonReturn },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(!result)
+        #expect(
+            try String(contentsOf: openFile, encoding: .utf8)
+                == "// shared.swift"
+        )
+        let untitled = try #require(project.allTabs.first(where: {
+            $0.fileURL == nil
+        }))
+        #expect(untitled.content == "// must remain untitled")
+        #expect(untitled.isDirty)
+        #expect(project.allTabs.first(where: { $0.fileURL == openFile })?
+            .isDirty == false)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func laterOpenTabStopsFutureTerminationInstall() async throws {
+        let saveRoot = try makeTempDirectory()
+        let observerRoot = try makeTempDirectory()
+        defer { cleanup(saveRoot); cleanup(observerRoot) }
+        let firstDestination = try makeTempFile(
+            in: saveRoot,
+            name: "first.swift"
+        )
+        let laterDestination = try makeTempFile(
+            in: saveRoot,
+            name: "later.swift"
+        )
+        let registry = makeRegistry()
+        let savingProject = try #require(
+            registry.projectManager(for: saveRoot)
+        )
+        let observingProject = try #require(
+            registry.projectManager(for: observerRoot)
+        )
+        _ = try #require(savingProject.createUntitledFile())
+        updateContent("// first captured", in: savingProject)
+        _ = try #require(savingProject.createUntitledFile())
+        updateContent("// later captured", in: savingProject)
+        var destinationIndex = 0
+        let destinations = [firstDestination, laterDestination]
+        savingProject.saveDestinationChooser = { _, _, _ in
+            defer { destinationIndex += 1 }
+            return destinations[destinationIndex]
+        }
+        let installer = FirstTerminationInstallGate()
+        defer { installer.release() }
+        savingProject.terminationSaveInstaller = { staged, deadline, lateCompletion in
+            await installer.install(
+                staged,
+                until: deadline,
+                lateCompletion: lateCompletion
+            )
+        }
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        let quit = Task { @MainActor in
+            await delegate.confirmApplicationTermination(
+                presentAlert: { _, _, _, _ in .alertFirstButtonReturn },
+                terminationDeadlineOverride: .now() + 5
+            )
+        }
+
+        #expect(await installer.waitUntilStarted())
+        observingProject.primaryTabManager.openTab(url: laterDestination)
+        installer.release()
+        let result = await quit.value
+
+        #expect(!result)
+        #expect(installer.installCount == 1)
+        #expect(
+            try String(contentsOf: firstDestination, encoding: .utf8)
+                == "// first captured\n"
+        )
+        #expect(
+            try String(contentsOf: laterDestination, encoding: .utf8)
+                == "// later.swift"
+        )
+        #expect(savingProject.allTabs.first(where: {
+            $0.fileURL == firstDestination
+        })?.isDirty == false)
+        let unsavedLater = try #require(savingProject.allTabs.first(where: {
+            $0.fileURL == nil && $0.content == "// later captured"
+        }))
+        #expect(unsavedLater.isDirty)
+        let observed = try #require(observingProject.allTabs.first(where: {
+            $0.fileURL == laterDestination
+        }))
+        #expect(!observed.isDirty)
+        #expect(observed.content == "// later.swift")
+        await savingProject.workspace.waitForLoadingComplete()
+        await observingProject.workspace.waitForLoadingComplete()
     }
 
     @Test func destinationCreatedDuringStagingIsNotOverwritten() async throws {
@@ -1520,6 +1640,69 @@ struct WindowLifecycleTests {
         #expect(registry.destroyAllProjects())
     }
 
+    @Test func quitSummaryCountsEveryDetachedTaskOwner() async throws {
+        let firstDirectory = try makeTempDirectory()
+        let secondDirectory = try makeTempDirectory()
+        defer {
+            cleanup(firstDirectory)
+            cleanup(secondDirectory)
+        }
+        let registry = makeRegistry()
+        let firstProject = try #require(
+            registry.projectManager(for: firstDirectory)
+        )
+        let secondProject = try #require(
+            registry.projectManager(for: secondDirectory)
+        )
+        let firstRun = firstProject.taskRunStore.start(
+            makeTaskRun(id: "first-detached")
+        )
+        let secondRun = secondProject.taskRunStore.start(
+            makeTaskRun(id: "second-detached")
+        )
+        firstProject.taskRunStore.registerCancellation(
+            TerminationTaskProbe(waitResult: false).makeCancellation(),
+            forRunID: firstRun.id
+        )
+        secondProject.taskRunStore.registerCancellation(
+            TerminationTaskProbe(waitResult: false).makeCancellation(),
+            forRunID: secondRun.id
+        )
+        registry.closeProjectWindow(firstDirectory)
+        registry.closeProjectWindow(secondDirectory)
+        cleanup(firstDirectory)
+        cleanup(secondDirectory)
+        #expect(registry.projectManager(for: firstDirectory) == nil)
+        #expect(registry.projectManager(for: secondDirectory) == nil)
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var summaryMessage: String?
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, message in
+                #expect(template == .applicationQuitSummary)
+                summaryMessage = message
+                return .alertThirdButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(!result)
+        #expect(summaryMessage == Strings.applicationQuitSummaryMessage(2))
+        firstProject.taskRunStore.finishRun(
+            id: firstRun.id,
+            outcome: makeTaskOutcome(id: "first-detached"),
+            cancelled: true
+        )
+        secondProject.taskRunStore.finishRun(
+            id: secondRun.id,
+            outcome: makeTaskOutcome(id: "second-detached"),
+            cancelled: true
+        )
+        await settle()
+        #expect(registry.destroyAllProjects())
+    }
+
     @Test func quitAnywayStopsUserTaskAndQuits() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
@@ -2046,6 +2229,73 @@ nonisolated private final class DelayedTerminationInstallerProbe:
         lock.withLock { installs += 1 }
         try? await Task.sleep(for: .milliseconds(100))
         return .failed(message: "The outer deadline did not win")
+    }
+}
+
+nonisolated private final class FirstTerminationInstallGate:
+    @unchecked Sendable {
+    private let lock = NSLock()
+    private var installs = 0
+    private var firstInstallStarted = false
+    private var released = false
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    var installCount: Int { lock.withLock { installs } }
+
+    func install(
+        _ staged: TerminationStagedSave,
+        until deadline: DispatchTime,
+        lateCompletion: @escaping @Sendable (
+            TerminationSaveInstallResult
+        ) -> Void
+    ) async -> TerminationSaveInstallResult {
+        let shouldWait = lock.withLock {
+            installs += 1
+            guard installs == 1 else { return false }
+            firstInstallStarted = true
+            return true
+        }
+        if shouldWait {
+            await withCheckedContinuation { continuation in
+                let resumeImmediately = lock.withLock {
+                    if released { return true }
+                    releaseContinuation = continuation
+                    return false
+                }
+                if resumeImmediately {
+                    continuation.resume()
+                }
+            }
+        }
+        return await TerminationSaveCoordinator.install(
+            staged,
+            until: deadline,
+            lateCompletion: lateCompletion
+        )
+    }
+
+    func release() {
+        let continuation = lock.withLock {
+            released = true
+            defer { releaseContinuation = nil }
+            return releaseContinuation
+        }
+        continuation?.resume()
+    }
+
+    func waitUntilStarted(
+        maximumDuration: Duration = .seconds(5)
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: maximumDuration)
+        while !lock.withLock({ firstInstallStarted }), clock.now < deadline {
+            do {
+                try await clock.sleep(for: .milliseconds(1))
+            } catch {
+                return false
+            }
+        }
+        return lock.withLock { firstInstallStarted }
     }
 }
 

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -734,13 +734,16 @@ struct WindowLifecycleTests {
         project.primaryTabManager.openTab(url: file)
         updateContent("// unsaved cleanup bytes", in: project)
         project.terminationSaveInstaller = { _, _, _ in
-            .failed(
+            return .failed(
                 message: "internal unlocalized installer detail",
                 retainedArtifacts: []
             )
         }
+        nonisolated(unsafe) var cleanupAttempts = 0
         project.terminationSaveCleaner = { _ in
-            .failed(
+            cleanupAttempts += 1
+            guard cleanupAttempts == 1 else { return .cleaned }
+            return .failed(
                 message: "internal unlocalized cleanup detail",
                 retainedArtifacts: [retainedArtifact]
             )
@@ -771,6 +774,7 @@ struct WindowLifecycleTests {
             + "\n\n"
             + retainedArtifact.path)
         #expect(!(failureMessage?.contains("unlocalized") ?? true))
+        #expect(cleanupAttempts == 1)
         #expect(project.hasUnsavedChanges)
         await project.workspace.waitForLoadingComplete()
     }
@@ -1287,7 +1291,15 @@ struct WindowLifecycleTests {
             until: .now() + .milliseconds(50)
         )
 
-        #expect(result == .timedOut)
+        guard case .failed(let message, let retainedArtifacts) = result else {
+            Issue.record("Expected deadline cleanup to retain both staged files")
+            return
+        }
+        #expect(message == "Termination save cleanup exceeded its deadline")
+        #expect(retainedArtifacts.count == 2)
+        #expect(retainedArtifacts.allSatisfy {
+            $0.lastPathComponent.hasPrefix(".pine-save-")
+        })
         #expect(installer.installCount == 1)
         #expect(
             try String(contentsOf: firstURL, encoding: .utf8)
@@ -1346,7 +1358,16 @@ struct WindowLifecycleTests {
         #expect(await installer.waitUntilInstalled())
 
         let result = await commit.value
-        #expect(result == .timedOut)
+        guard case .failed(let message, let retainedArtifacts) = result else {
+            Issue.record("Expected timed-out cleanup to report its retained inode")
+            return
+        }
+        #expect(message == "Termination save cleanup exceeded its deadline")
+        #expect(retainedArtifacts.count == 1)
+        #expect(
+            retainedArtifacts.first?.lastPathComponent
+                .hasPrefix(".pine-save-") == true
+        )
         #expect(
             try String(contentsOf: file, encoding: .utf8)
                 == "// captured by termination\n"
@@ -1384,6 +1405,56 @@ struct WindowLifecycleTests {
         #expect(
             try String(contentsOf: file, encoding: .utf8) == persistedContent
         )
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func lateTerminationFailureReportsActualRetainedPath() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let retainedArtifact = dir.appendingPathComponent(
+            ".pine-save-late-retained"
+        )
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        updateContent("// captured dirty", in: project)
+        let prepared = await project.prepareSaveAllPaneTabs(
+            context: .unscoped
+        )
+        guard case .ready(let plan) = prepared else {
+            Issue.record("Expected a ready termination save plan")
+            return
+        }
+        let staged = await project.stagePreparedSaveAllPaneTabsForTermination(
+            plan,
+            until: .now() + 5
+        )
+        let stagedPlan = try #require(staged.1)
+        nonisolated(unsafe) var reportedArtifacts: [URL] = []
+        project.terminationSaveLateFailureHandler = { _, retainedArtifacts in
+            reportedArtifacts = retainedArtifacts
+        }
+        project.terminationSaveInstaller = { _, _, _ in
+            try? await Task.sleep(for: .milliseconds(100))
+            return .failed(
+                message: "late retained recovery",
+                retainedArtifacts: [retainedArtifact]
+            )
+        }
+
+        let result = await project.commitStagedSaveAllPaneTabsForTermination(
+            stagedPlan,
+            until: .now() + .milliseconds(25)
+        )
+        try? await Task.sleep(for: .milliseconds(150))
+
+        guard case .failed = result else {
+            Issue.record("Deadline cleanup should fail with retained staging")
+            return
+        }
+        #expect(reportedArtifacts == [retainedArtifact])
+        #expect(project.hasUnsavedChanges)
         await project.workspace.waitForLoadingComplete()
     }
 
@@ -2169,6 +2240,18 @@ struct WindowLifecycleTests {
         #expect(welcome.isVisible)
     }
 
+    @Test func existingQuitOwnerIsRaisedBeforeNativePresentation() {
+        let delegate = AppDelegate()
+        let owner = TrackingApplicationOwnerWindow()
+        owner.orderFront(nil)
+        owner.resetTracking()
+        defer { owner.orderOut(nil) }
+
+        delegate.prepareApplicationDialogOwner(windows: [owner])
+
+        #expect(owner.makeKeyAndOrderFrontCount == 1)
+    }
+
     private func makeTaskRun(id: String) -> UserTaskRun {
         UserTaskRun(
             taskID: id,
@@ -2437,6 +2520,20 @@ nonisolated private final class PausedInstalledTerminationInstallerProbe:
             }
         }
         return condition()
+    }
+}
+
+@MainActor
+private final class TrackingApplicationOwnerWindow: NSWindow {
+    private(set) var makeKeyAndOrderFrontCount = 0
+
+    override func makeKeyAndOrderFront(_ sender: Any?) {
+        makeKeyAndOrderFrontCount += 1
+        super.makeKeyAndOrderFront(sender)
+    }
+
+    func resetTracking() {
+        makeKeyAndOrderFrontCount = 0
     }
 }
 

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -176,11 +176,170 @@ struct WindowLifecycleTests {
             presentedTemplates == [
                 .applicationQuitSummary,
                 .unsavedChangesBulk,
+                .applicationQuitFailure,
             ]
         )
         #expect(saveAttempts == 1)
         #expect(project.hasUnsavedChanges)
         await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func saveAsDeliberationDoesNotConsumeMachineDeadline() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let destination = dir.appendingPathComponent("saved.swift")
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        _ = try #require(project.createUntitledFile())
+        updateContent("// saved after a slow panel", in: project)
+        project.saveDestinationChooser = { _, _, _ in
+            try? await Task.sleep(for: .milliseconds(600))
+            return destination
+        }
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        let deadlineProbe = TerminationDeadlineProbe()
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                switch template {
+                case .applicationQuitSummary, .unsavedChangesBulk:
+                    return .alertFirstButtonReturn
+                default:
+                    Issue.record("Unexpected Quit alert: \(template)")
+                    return .abort
+                }
+            },
+            terminationDeadlineOverride: .now() + .milliseconds(500),
+            terminationDeadlineObserver: deadlineProbe.record
+        )
+
+        #expect(result)
+        #expect(deadlineProbe.elapsedNanoseconds == nil)
+        #expect(try String(contentsOf: destination, encoding: .utf8) ==
+                "// saved after a slow panel\n")
+        #expect(!project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func cancellingQuitSavePanelDoesNotShowMachineFailure() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        _ = try #require(project.createUntitledFile())
+        updateContent("// keep", in: project)
+        project.saveDestinationChooser = { _, _, _ in nil }
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var presentedTemplates: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presentedTemplates.append(template)
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(!result)
+        #expect(
+            presentedTemplates == [
+                .applicationQuitSummary,
+                .unsavedChangesBulk,
+            ]
+        )
+        #expect(project.hasUnsavedChanges)
+        #expect(project.primaryTabManager.activeTab?.fileURL == nil)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func multipleSlowReviewPromptsDoNotConsumeMachineDeadline() async throws {
+        let firstDirectory = try makeTempDirectory()
+        let secondDirectory = try makeTempDirectory()
+        defer {
+            cleanup(firstDirectory)
+            cleanup(secondDirectory)
+        }
+        let firstFile = try makeTempFile(in: firstDirectory, name: "first.swift")
+        let secondFile = try makeTempFile(in: secondDirectory, name: "second.swift")
+        let registry = ProjectRegistry()
+        let first = try #require(registry.projectManager(for: firstDirectory))
+        let second = try #require(registry.projectManager(for: secondDirectory))
+        first.primaryTabManager.openTab(url: firstFile)
+        second.primaryTabManager.openTab(url: secondFile)
+        updateContent("// first dirty", in: first)
+        updateContent("// second dirty", in: second)
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        let deadlineProbe = TerminationDeadlineProbe()
+        var projectPromptCount = 0
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                if template == .applicationQuitSummary {
+                    return .alertFirstButtonReturn
+                }
+                #expect(template == .unsavedChangesBulk)
+                projectPromptCount += 1
+                try? await Task.sleep(for: .milliseconds(300))
+                return .alertSecondButtonReturn
+            },
+            terminationDeadlineOverride: .now() + .milliseconds(500),
+            terminationDeadlineObserver: deadlineProbe.record
+        )
+
+        #expect(result)
+        #expect(projectPromptCount == 2)
+        #expect(deadlineProbe.elapsedNanoseconds == nil)
+        await first.workspace.waitForLoadingComplete()
+        await second.workspace.waitForLoadingComplete()
+    }
+
+    @Test func cleanPreflightFailureResolvesOwnerLazily() async {
+        let delegate = AppDelegate()
+        delegate.registry = ProjectRegistry()
+        let owner = NSWindow()
+        let expectedContext = DialogPresentationContext(window: owner)
+        defer { DialogPresenter.ownerDidClose(owner) }
+        var contextResolutionCount = 0
+        var presentedOwner: NSWindow?
+        var presentedTemplates: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, context, _, _ in
+                presentedTemplates.append(template)
+                presentedOwner = context.nsWindow
+                return .alertFirstButtonReturn
+            },
+            terminationFailureContext: {
+                contextResolutionCount += 1
+                return expectedContext
+            },
+            terminationDeadlineOverride: .now()
+        )
+
+        #expect(!result)
+        #expect(contextResolutionCount == 1)
+        #expect(presentedTemplates == [.applicationQuitFailure])
+        #expect(presentedOwner === owner)
+    }
+
+    @Test func terminationBudgetAlwaysReservesRollback() {
+        let long = AppDelegate.terminationBudgetSplit(
+            availableNanoseconds: 30_000_000_000
+        )
+        #expect(long?.forwardNanoseconds == 28_000_000_000)
+        #expect(long?.rollbackNanoseconds == 2_000_000_000)
+
+        let short = AppDelegate.terminationBudgetSplit(
+            availableNanoseconds: 100_000_000
+        )
+        #expect(short?.forwardNanoseconds == 50_000_000)
+        #expect(short?.rollbackNanoseconds == 50_000_000)
+        #expect(AppDelegate.terminationBudgetSplit(
+            availableNanoseconds: 1
+        ) == nil)
     }
 
     @Test func terminationDeadlineDoesNotBoundHumanDeliberation() async throws {
@@ -198,17 +357,20 @@ struct WindowLifecycleTests {
 
         let result = await delegate.confirmApplicationTermination(
             presentAlert: { template, _, _, _ in
-                #expect(template == .applicationQuitSummary)
-                try? await Task.sleep(for: .milliseconds(150))
-                return .alertSecondButtonReturn
+                if template == .applicationQuitSummary {
+                    try? await Task.sleep(for: .milliseconds(600))
+                    return .alertSecondButtonReturn
+                }
+                Issue.record("Unexpected Quit alert: \(template)")
+                return .abort
             },
-            terminationDeadlineOverride: .now() + .milliseconds(100),
+            terminationDeadlineOverride: .now() + .milliseconds(500),
             terminationDeadlineObserver: deadlineProbe.record
         )
 
         let elapsed = DispatchTime.now().uptimeNanoseconds - started
         #expect(result)
-        #expect(elapsed >= 150_000_000)
+        #expect(elapsed >= 600_000_000)
         #expect(deadlineProbe.elapsedNanoseconds == nil)
         #expect(!project.hasUnsavedChanges)
         await project.workspace.waitForLoadingComplete()
@@ -432,7 +594,7 @@ struct WindowLifecycleTests {
                     ? .alertSecondButtonReturn
                     : .alertFirstButtonReturn
             },
-            terminationDeadlineOverride: .now() + 5
+            terminationDeadlineOverride: .now() + 120
         )
 
         #expect(!result)
@@ -476,7 +638,7 @@ struct WindowLifecycleTests {
                 #expect(template == .applicationQuitSummary)
                 return .alertSecondButtonReturn
             },
-            terminationDeadlineOverride: .now() + 5
+            terminationDeadlineOverride: .now() + 120
         )
 
         #expect(result)
@@ -535,6 +697,58 @@ struct WindowLifecycleTests {
         project.taskRunStore.finishRun(
             id: activeRun.id,
             outcome: makeTaskOutcome(id: "late-active"),
+            cancelled: false
+        )
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func taskStartedAfterQuitAnywayIsNotCancelled() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = ProjectRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        updateContent("// keep late task", in: project)
+        let probe = TerminationTaskProbe(waitResult: true)
+        var lateRun: UserTaskRun?
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var presentedTemplates: [AlertTemplate] = []
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                presentedTemplates.append(template)
+                if template == .applicationQuitSummary {
+                    let run = project.taskRunStore.start(
+                        makeTaskRun(id: "late-after-summary")
+                    )
+                    project.taskRunStore.registerCancellation(
+                        probe.makeCancellation(),
+                        forRunID: run.id
+                    )
+                    lateRun = run
+                    return .alertSecondButtonReturn
+                }
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(!result)
+        #expect(
+            presentedTemplates == [
+                .applicationQuitSummary,
+                .applicationQuitFailure,
+            ]
+        )
+        #expect(probe.cancellationCount == 0)
+        #expect(probe.waitCount == 0)
+        #expect(project.hasUnsavedChanges)
+        let run = try #require(lateRun)
+        project.taskRunStore.finishRun(
+            id: run.id,
+            outcome: makeTaskOutcome(id: "late-after-summary"),
             cancelled: false
         )
         await project.workspace.waitForLoadingComplete()

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -666,9 +666,10 @@ struct WindowLifecycleTests {
         delegate.registry = registry
         var presented: [AlertTemplate] = []
         var errorOwners: [NSWindow?] = []
+        var errorMessages: [String] = []
 
         let result = await delegate.confirmApplicationTermination(
-            presentAlert: { template, context, _, _ in
+            presentAlert: { template, context, _, message in
                 presented.append(template)
                 if template == .unsavedChangesBulk {
                     DialogPresenter.ownerDidClose(oldWindow)
@@ -681,6 +682,7 @@ struct WindowLifecycleTests {
                 }
                 if template == .fileOperationErrorCritical {
                     errorOwners.append(context.nsWindow)
+                    errorMessages.append(message)
                     if errorOwners.count == 1 {
                         DialogPresenter.ownerDidClose(newWindow)
                         newWindow.orderOut(nil)
@@ -710,6 +712,65 @@ struct WindowLifecycleTests {
         #expect(errorOwners.count == 2)
         #expect(errorOwners[0] === newWindow)
         #expect(errorOwners[1] === replacementFailureWindow)
+        #expect(errorMessages == [
+            Strings.applicationQuitFailureMessage,
+            Strings.applicationQuitFailureMessage,
+        ])
+        #expect(project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
+    @Test func quitSaveCleanupFailureShowsRetainedArtifact() async throws {
+        let directory = try makeTempDirectory()
+        defer { cleanup(directory) }
+        let file = try makeTempFile(in: directory, name: "cleanup.swift")
+        let retainedArtifact = directory.appendingPathComponent(
+            ".pine-save-retained.tmp"
+        )
+        let registry = makeRegistry()
+        let project = try #require(
+            registry.projectManager(for: directory)
+        )
+        project.primaryTabManager.openTab(url: file)
+        updateContent("// unsaved cleanup bytes", in: project)
+        project.terminationSaveInstaller = { _, _, _ in
+            .failed(
+                message: "internal unlocalized installer detail",
+                retainedArtifacts: []
+            )
+        }
+        project.terminationSaveCleaner = { _ in
+            .failed(
+                message: "internal unlocalized cleanup detail",
+                retainedArtifacts: [retainedArtifact]
+            )
+        }
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var presented: [AlertTemplate] = []
+        var failureMessage: String?
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, message in
+                presented.append(template)
+                if template == .fileOperationErrorCritical {
+                    failureMessage = message
+                }
+                return .alertFirstButtonReturn
+            },
+            terminationDeadlineOverride: .now() + 5
+        )
+
+        #expect(!result)
+        #expect(presented == [
+            .applicationQuitSummary,
+            .unsavedChangesBulk,
+            .fileOperationErrorCritical,
+        ])
+        #expect(failureMessage == Strings.applicationQuitFailureMessage
+            + "\n\n"
+            + retainedArtifact.path)
+        #expect(!(failureMessage?.contains("unlocalized") ?? true))
         #expect(project.hasUnsavedChanges)
         await project.workspace.waitForLoadingComplete()
     }
@@ -849,7 +910,7 @@ struct WindowLifecycleTests {
             presented == [
                 .applicationQuitSummary,
                 .unsavedChangesBulk,
-                .applicationQuitFailure,
+                .fileOperationErrorCritical,
             ]
         )
         #expect(try String(contentsOf: file, encoding: .utf8) == "// test.swift")
@@ -902,7 +963,7 @@ struct WindowLifecycleTests {
             presented == [
                 .applicationQuitSummary,
                 .unsavedChangesBulk,
-                .applicationQuitFailure,
+                .fileOperationErrorCritical,
             ]
         )
         #expect(try String(contentsOf: file, encoding: .utf8) == "// test.swift")
@@ -2228,7 +2289,10 @@ nonisolated private final class DelayedTerminationInstallerProbe:
     ) async -> TerminationSaveInstallResult {
         lock.withLock { installs += 1 }
         try? await Task.sleep(for: .milliseconds(100))
-        return .failed(message: "The outer deadline did not win")
+        return .failed(
+            message: "The outer deadline did not win",
+            retainedArtifacts: []
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

- replace per-project Quit sheets with one application-wide Review / Quit Anyway / Cancel summary
- keep human deliberation outside the machine deadline and surface every machine-phase refusal in a native failure sheet
- include dirty editors, project terminals, Quick Terminal sessions, Pine-launched agents, and user tasks in generation-bound preflight and final revalidation
- stage Save All / Save As work and commit it through an atomic, crash-conscious filesystem transaction with retained-artifact reporting
- settle and durably persist agent/task interruption state before destructive teardown
- harden external formatter process execution, deadlines, output caps, and descriptor isolation
- fix the two reported macOS 27 traps by owning PTY descriptors across asynchronous writes and keeping DispatchIO callbacks nonisolated

## Safety properties

- no editor discard or terminal/task teardown occurs until every project and global terminal authorization passes twice
- new or replacement process generations fail closed instead of inheriting an earlier confirmation
- cancelled or failed Quit restores task/agent leases and keeps dirty editor state truthful
- save rollback preserves private permissions and reports any recovery artifact that could not be removed safely

## Validation

- strict SwiftLint: 0 violations
- xcodebuild build and build-for-testing succeeded with deployment target macOS 26.0 under Xcode 27 beta
- 70 focused terminal, agent-authorization, coordinator, and Quick Terminal tests passed
- 56 WindowLifecycleTests passed
- TerminationSaveCoordinatorSecurityTests and ExternalFileFormatterTests passed
- both exact TerminalTab crash-stack regressions passed sequentially
- git diff --check passed

A macOS 26 runtime was not available in this environment; compatibility was build-checked against the retained 26.0 deployment target.

Fixes #1354