### PR TITLE
fix(agent): close Pine 2.0 workflow regressions

### DIFF
--- a/Pine/Agent/AgentCompletionBrief.swift
+++ b/Pine/Agent/AgentCompletionBrief.swift
@@ -391,22 +391,7 @@ enum AgentCompletionBriefBuilder {
     private static func commandKind(
         _ command: String
     ) -> AgentCompletionCommandKind {
-        let normalized = command.lowercased()
-        let testMarkers = [
-            "xcodebuild test", "swift test", "npm test", "npm run test",
-            "pnpm test", "yarn test", "cargo test", "go test", "pytest"
-        ]
-        if testMarkers.contains(where: normalized.contains) {
-            return .test
-        }
-        let buildMarkers = [
-            "xcodebuild build", "swift build", "npm run build",
-            "pnpm build", "yarn build", "cargo build", "go build"
-        ]
-        if buildMarkers.contains(where: normalized.contains) {
-            return .build
-        }
-        return .command
+        AgentCompletionCommandClassifier.kind(for: command)
     }
 
     private static func integrityGaps(
@@ -468,5 +453,173 @@ enum AgentCompletionBriefBuilder {
             return nil
         }
         return trimmed
+    }
+}
+
+/// Conservative command-shape classification for evidence summaries.
+///
+/// The structured event authenticates who reported a command and its exit
+/// status; it does not turn arbitrary text inside that command into evidence
+/// that a test runner executed. Compound shell commands are deliberately left
+/// generic because their final status can be masked by a later segment.
+nonisolated private enum AgentCompletionCommandClassifier {
+    static func kind(for command: String) -> AgentCompletionCommandKind {
+        guard let words = shellWords(command),
+              let invocation = invocation(from: words) else {
+            return .command
+        }
+        if isTest(executable: invocation.executable, arguments: invocation.arguments) {
+            return .test
+        }
+        if isBuild(executable: invocation.executable, arguments: invocation.arguments) {
+            return .build
+        }
+        return .command
+    }
+
+    private static func invocation(
+        from words: [String]
+    ) -> (executable: String, arguments: [String])? {
+        var index = 0
+        while index < words.count, isEnvironmentAssignment(words[index]) {
+            index += 1
+        }
+        guard index < words.count else { return nil }
+
+        var executable = executableName(words[index])
+        if executable == "env" {
+            index += 1
+            while index < words.count,
+                  words[index] == "-i"
+                    || words[index] == "--ignore-environment"
+                    || words[index] == "--"
+                    || isEnvironmentAssignment(words[index]) {
+                index += 1
+            }
+            guard index < words.count else { return nil }
+            executable = executableName(words[index])
+        }
+        index += 1
+        return (executable, Array(words.dropFirst(index)))
+    }
+
+    private static func isTest(
+        executable: String,
+        arguments: [String]
+    ) -> Bool {
+        switch executable {
+        case "xcodebuild":
+            return arguments.contains("test")
+                || arguments.contains("test-without-building")
+        case "swift", "cargo", "go":
+            return arguments.first == "test"
+        case "npm", "pnpm", "yarn":
+            return packageScript(arguments, prefix: "test")
+        case "pytest", "pytest3":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isBuild(
+        executable: String,
+        arguments: [String]
+    ) -> Bool {
+        switch executable {
+        case "xcodebuild":
+            return arguments.contains("build")
+                || arguments.contains("build-for-testing")
+        case "swift", "cargo", "go":
+            return arguments.first == "build"
+        case "npm", "pnpm", "yarn":
+            return packageScript(arguments, prefix: "build")
+        default:
+            return false
+        }
+    }
+
+    private static func packageScript(
+        _ arguments: [String],
+        prefix: String
+    ) -> Bool {
+        guard let first = arguments.first else { return false }
+        if first == prefix || first.hasPrefix(prefix + ":") { return true }
+        guard first == "run", arguments.count > 1 else { return false }
+        let script = arguments[1]
+        return script == prefix || script.hasPrefix(prefix + ":")
+    }
+
+    private static func executableName(_ value: String) -> String {
+        value.split(separator: "/").last.map(String.init)?
+            .lowercased() ?? ""
+    }
+
+    private static func isEnvironmentAssignment(_ value: String) -> Bool {
+        guard let separator = value.firstIndex(of: "=") else { return false }
+        let name = value[..<separator]
+        guard let first = name.first,
+              first == "_" || first.isLetter else { return false }
+        return name.dropFirst().allSatisfy { $0 == "_" || $0.isLetter || $0.isNumber }
+    }
+
+    /// Returns one simple shell argv, or nil when quoting is malformed or the
+    /// command contains control operators whose aggregate exit status could
+    /// misrepresent the runner result.
+    private static func shellWords(_ command: String) -> [String]? {
+        var words: [String] = []
+        var word = ""
+        var wordStarted = false
+        var quote: Character?
+        var escaped = false
+
+        func finishWord() {
+            guard wordStarted else { return }
+            words.append(word.lowercased())
+            word = ""
+            wordStarted = false
+        }
+
+        for character in command {
+            if escaped {
+                word.append(character)
+                wordStarted = true
+                escaped = false
+                continue
+            }
+            if let activeQuote = quote {
+                if character == activeQuote {
+                    quote = nil
+                } else if activeQuote == "\"", character == "\\" {
+                    escaped = true
+                } else {
+                    word.append(character)
+                    wordStarted = true
+                }
+                continue
+            }
+            if character == "\\" {
+                escaped = true
+                wordStarted = true
+            } else if character == "'" || character == "\"" {
+                quote = character
+                wordStarted = true
+            } else if character == "#", !wordStarted {
+                break
+            } else if character == ";" || character == "|"
+                        || character == "&" || character == "\n"
+                        || character == "(" || character == ")" {
+                return nil
+            } else if character.isWhitespace {
+                finishWord()
+            } else {
+                word.append(character)
+                wordStarted = true
+            }
+        }
+
+        guard quote == nil, !escaped else { return nil }
+        finishWord()
+        return words
     }
 }

--- a/Pine/Agent/AgentInboxView.swift
+++ b/Pine/Agent/AgentInboxView.swift
@@ -169,8 +169,10 @@ struct AgentInboxView: View {
             if row.lifecycle != .active, row.liveness != .live {
                 if row.canRecover {
                     Divider()
-                    Button(Strings.agentInboxResumeSession) {
-                        recover(row.id, action: .resumeVendorSession)
+                    if registry.canOfferAgentTaskVendorResume(row.id) {
+                        Button(Strings.agentInboxResumeSession) {
+                            recover(row.id, action: .resumeVendorSession)
+                        }
                     }
                     Button(Strings.agentInboxNewSession) {
                         recover(row.id, action: .startNewSession)

--- a/Pine/Agent/AgentNotificationController.swift
+++ b/Pine/Agent/AgentNotificationController.swift
@@ -175,9 +175,15 @@ final class AgentNotificationController {
     @ObservationIgnored
     private let openTask: (AgentNotificationRouteIdentity) -> Void
     @ObservationIgnored
+    private let deliveryRetryDelays: [Duration]
+    @ObservationIgnored
     private var observerToken: UUID?
     @ObservationIgnored
     private var isRunning = false
+    @ObservationIgnored
+    private var pendingDeliveryIDs: Set<String> = []
+    @ObservationIgnored
+    private var deliveryTasks: [String: Task<Void, Never>] = [:]
 
     init(
         registry: AgentTaskRegistry,
@@ -187,6 +193,10 @@ final class AgentNotificationController {
             FirstPartyAgentCompatibilityCatalog.record(stableIdentifier: $0)?
                 .notificationAccuracy ?? .processTerminationOnly
         },
+        deliveryRetryDelays: [Duration] = [
+            .milliseconds(250),
+            .seconds(1),
+        ],
         isPresented: @escaping (UUID) -> Bool,
         openTask: @escaping (AgentNotificationRouteIdentity) -> Void
     ) {
@@ -194,6 +204,7 @@ final class AgentNotificationController {
         self.settings = settings
         self.delivery = delivery
         self.accuracy = accuracy
+        self.deliveryRetryDelays = deliveryRetryDelays
         self.isPresented = isPresented
         self.openTask = openTask
     }
@@ -217,6 +228,9 @@ final class AgentNotificationController {
         if let observerToken { registry.removeTaskChangeObserver(observerToken) }
         observerToken = nil
         delivery.responseHandler = nil
+        deliveryTasks.values.forEach { $0.cancel() }
+        deliveryTasks.removeAll()
+        pendingDeliveryIDs.removeAll()
     }
 
     func refreshAuthorizationStatus() async {
@@ -255,9 +269,45 @@ final class AgentNotificationController {
             guard let task = tasks[event.taskID],
                   settings.allows(event, task: task),
                   !isPresented(event.taskID),
-                  settings.claimDelivery(of: event.id) else { continue }
+                  !settings.hasDelivered(event.id),
+                  pendingDeliveryIDs.insert(event.id).inserted else { continue }
             let request = Self.request(for: event)
-            Task { try? await delivery.deliver(request) }
+            deliveryTasks[event.id] = Task { @MainActor [weak self] in
+                await self?.deliver(request, eventID: event.id)
+            }
+        }
+    }
+
+    private func deliver(
+        _ request: AgentNotificationRequest,
+        eventID: String
+    ) async {
+        defer {
+            pendingDeliveryIDs.remove(eventID)
+            deliveryTasks[eventID] = nil
+        }
+
+        let delays = [Duration.zero] + deliveryRetryDelays
+        for delay in delays {
+            guard isRunning,
+                  settings.isEnabled,
+                  authorizationStatus == .authorized,
+                  !Task.isCancelled else { return }
+            if delay > .zero {
+                do {
+                    try await ContinuousClock().sleep(for: delay)
+                } catch {
+                    return
+                }
+                guard isRunning, !Task.isCancelled else { return }
+            }
+            do {
+                try await delivery.deliver(request)
+                _ = settings.claimDelivery(of: eventID)
+                return
+            } catch {
+                continue
+            }
         }
     }
 

--- a/Pine/Agent/AgentNotificationSettings.swift
+++ b/Pine/Agent/AgentNotificationSettings.swift
@@ -99,6 +99,10 @@ final class AgentNotificationSettings {
         return true
     }
 
+    func hasDelivered(_ eventID: String) -> Bool {
+        deliveredEventIDs.contains(eventID)
+    }
+
     private func persist(_ values: Set<String>, key: String) {
         defaults.set(values.sorted(), forKey: key)
     }

--- a/Pine/Agent/AgentTaskRecovery.swift
+++ b/Pine/Agent/AgentTaskRecovery.swift
@@ -75,6 +75,30 @@ nonisolated struct AgentTaskRecoveryInspection: Equatable, Sendable {
 /// Pure recovery policy. Filesystem and process probing happen outside this
 /// type, which makes every failure and race outcome deterministic in tests.
 nonisolated enum AgentTaskRecoveryPlanner {
+    static func canOfferVendorResume(
+        task: AgentTask,
+        recipes: [AgentTaskResumeRecipe]
+    ) -> Bool {
+        guard task.lifecycle == .paused,
+              task.origin == .pineLaunched,
+              task.runs.last?.liveness != .live,
+              let identity = task.runs.last?.vendorIdentity,
+              isSafeOpaqueValue(identity.provider, maximumBytes: 128),
+              isSafeOpaqueValue(
+                  identity.opaqueIdentifier,
+                  maximumBytes: 1_024
+              ),
+              let recordedVersion = identity.executableVersion,
+              let executable = task.descriptor.launchExecutable?
+                .lowercased() else { return false }
+        return recipes.contains {
+            $0.provider == identity.provider
+                && $0.agentTypeIdentifier == task.descriptor.typeIdentifier
+                && $0.executableAliases.contains(executable)
+                && $0.supportedVersions.contains(recordedVersion)
+        }
+    }
+
     static func evaluate(
         task: AgentTask,
         action: AgentTaskRecoveryAction,
@@ -192,6 +216,13 @@ nonisolated struct AgentTaskRecoveryInspector: Sendable {
         self.resolver = resolver
         self.processRunner = processRunner
         self.recipes = recipes
+    }
+
+    func canOfferVendorResume(for task: AgentTask) -> Bool {
+        AgentTaskRecoveryPlanner.canOfferVendorResume(
+            task: task,
+            recipes: recipes
+        )
     }
 
     func inspect(

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -472,6 +472,12 @@ final class ProjectRegistry: LSPSettingsObserver {
         return true
     }
 
+    func canOfferAgentTaskVendorResume(_ taskID: UUID) -> Bool {
+        guard agentTasks.canResumeTask(taskID),
+              let task = agentTasks.task(for: taskID) else { return false }
+        return agentRecoveryInspector.canOfferVendorResume(for: task)
+    }
+
     /// Re-resolves a persisted route against current application ownership.
     /// No UI object is retained by the durable registry; every activation must
     /// cross this boundary immediately before use.

--- a/PineTests/AgentCompletionBriefTests.swift
+++ b/PineTests/AgentCompletionBriefTests.swift
@@ -64,6 +64,70 @@ struct AgentCompletionBriefTests {
         #expect(!brief.gaps.contains(.noVerifiedTests))
     }
 
+    @Test("Quoted runner names cannot manufacture a verified test result")
+    func quotedRunnerNameIsNotATest() {
+        let sessionID = id(21)
+        let decoys = [
+            "echo \"go test ./...\"",
+            "printf 'pytest\\n'",
+            "echo xcodebuild test",
+        ]
+        let events = decoys.enumerated().map { index, command in
+            storedEvent(
+                sessionID: sessionID,
+                cursor: UInt64(index + 1),
+                payload: .commandResult(AgentCommandResult(
+                    command: command,
+                    exitStatus: 0
+                ))
+            )
+        }
+
+        let brief = AgentCompletionBriefBuilder.build(
+            entry: history(sessionID: sessionID),
+            evidence: AgentCompletionBriefEvidence(
+                provenanceIntegrity: .healthy,
+                events: events
+            )
+        )
+
+        #expect(brief.commands.map(\.kind) == [.command, .command, .command])
+        #expect(brief.verifiedTestCount == 0)
+        #expect(brief.gaps.contains(.noVerifiedTests))
+    }
+
+    @Test("Simple runner invocations retain build and test classification")
+    func simpleRunnerInvocationsClassify() {
+        let sessionID = id(22)
+        let commands = [
+            "DEVELOPER_DIR=/Applications/Xcode.app /usr/bin/xcodebuild -project Pine.xcodeproj test",
+            "/usr/local/go/bin/go test ./...",
+            "npm run build",
+            "xcodebuild -scheme Pine build-for-testing",
+        ]
+        let events = commands.enumerated().map { index, command in
+            storedEvent(
+                sessionID: sessionID,
+                cursor: UInt64(index + 1),
+                payload: .commandResult(AgentCommandResult(
+                    command: command,
+                    exitStatus: 0
+                ))
+            )
+        }
+
+        let brief = AgentCompletionBriefBuilder.build(
+            entry: history(sessionID: sessionID),
+            evidence: AgentCompletionBriefEvidence(
+                provenanceIntegrity: .healthy,
+                events: events
+            )
+        )
+
+        #expect(brief.commands.map(\.kind) == [.test, .test, .build, .build])
+        #expect(brief.verifiedTestCount == 2)
+    }
+
     @Test("Completion statistics invert the checked undo preview")
     func exactStatsAndNarrativeLabel() {
         let sessionID = id(3)

--- a/PineTests/AgentNotificationTests.swift
+++ b/PineTests/AgentNotificationTests.swift
@@ -207,6 +207,84 @@ struct AgentNotificationTests {
         controller.stop()
     }
 
+    @Test("transient delivery failure retries before persisting deduplication")
+    func transientDeliveryFailureRetries() async throws {
+        let fixture = DefaultsFixture()
+        defer { fixture.cleanup() }
+        let settings = AgentNotificationSettings(defaults: fixture.defaults)
+        settings.setEnabled(true)
+        let registry = AgentTaskRegistry()
+        let delivery = RecordingAgentNotificationDelivery(status: .authorized)
+        delivery.failuresRemaining = 1
+        let controller = AgentNotificationController(
+            registry: registry,
+            settings: settings,
+            delivery: delivery,
+            deliveryRetryDelays: [.zero],
+            isPresented: { _ in false },
+            openTask: { _ in }
+        )
+        controller.start()
+        await controller.refreshAuthorizationStatus()
+
+        let session = makeSession(seed: 30)
+        registry.bridge(
+            session,
+            replacing: nil,
+            context: context(seed: 30, project: "/tmp/notify-retry")
+        )
+        session.applyLiveness(.terminated)
+        registry.refresh(sessions: [session])
+        await settle()
+
+        #expect(delivery.deliveryAttemptCount == 2)
+        let request = try #require(delivery.requests.first)
+        #expect(settings.hasDelivered(request.identifier))
+        controller.stop()
+    }
+
+    @Test("exhausted delivery remains eligible for the same event later")
+    func exhaustedDeliveryIsNotClaimed() async throws {
+        let fixture = DefaultsFixture()
+        defer { fixture.cleanup() }
+        let settings = AgentNotificationSettings(defaults: fixture.defaults)
+        settings.setEnabled(true)
+        let registry = AgentTaskRegistry()
+        let delivery = RecordingAgentNotificationDelivery(status: .authorized)
+        delivery.failuresRemaining = 2
+        let controller = AgentNotificationController(
+            registry: registry,
+            settings: settings,
+            delivery: delivery,
+            accuracy: { _ in .processTerminationOnly },
+            deliveryRetryDelays: [.zero],
+            isPresented: { _ in false },
+            openTask: { _ in }
+        )
+        controller.start()
+        await controller.refreshAuthorizationStatus()
+
+        let working = task(seed: 31, state: .executing)
+        var ended = working
+        update(&ended, state: .done, liveness: .terminated, offset: 1)
+        registry.setTasksForTesting([working])
+        registry.setTasksForTesting([ended])
+        await settle()
+
+        #expect(delivery.deliveryAttemptCount == 2)
+        #expect(delivery.requests.isEmpty)
+        #expect(settings.deliveredEventIDs.isEmpty)
+
+        registry.setTasksForTesting([working])
+        registry.setTasksForTesting([ended])
+        await settle()
+
+        #expect(delivery.deliveryAttemptCount == 3)
+        let request = try #require(delivery.requests.first)
+        #expect(settings.hasDelivered(request.identifier))
+        controller.stop()
+    }
+
     @Test("denied authorization disables delivery but remains reversible")
     func deniedAuthorization() async {
         let fixture = DefaultsFixture()
@@ -341,7 +419,9 @@ private final class RecordingAgentNotificationDelivery: AgentNotificationDeliver
     var responseHandler: ((AgentNotificationResponseAction) -> Void)?
     var status: AgentNotificationAuthorizationStatus
     var requestResult = false
+    var failuresRemaining = 0
     private(set) var requests: [AgentNotificationRequest] = []
+    private(set) var deliveryAttemptCount = 0
 
     init(status: AgentNotificationAuthorizationStatus) {
         self.status = status
@@ -351,11 +431,20 @@ private final class RecordingAgentNotificationDelivery: AgentNotificationDeliver
     func authorizationStatus() async -> AgentNotificationAuthorizationStatus { status }
     func requestAuthorization() async throws -> Bool { requestResult }
     func deliver(_ request: AgentNotificationRequest) async throws {
+        deliveryAttemptCount += 1
+        if failuresRemaining > 0 {
+            failuresRemaining -= 1
+            throw RecordingDeliveryError.transient
+        }
         requests.append(request)
     }
     func respond(_ action: AgentNotificationResponseAction) {
         responseHandler?(action)
     }
+}
+
+private enum RecordingDeliveryError: Error {
+    case transient
 }
 
 private final class DefaultsFixture {

--- a/PineTests/AgentTaskRecoveryTests.swift
+++ b/PineTests/AgentTaskRecoveryTests.swift
@@ -59,6 +59,42 @@ struct AgentTaskRecoveryTests {
         ) == .unavailable(.adapterUnavailable))
     }
 
+    @Test("Resume action is offered only for a statically supported paused task")
+    func resumeActionAvailability() {
+        let task = makeTask()
+        let recipe = AgentTaskResumeRecipe(
+            provider: "example",
+            agentTypeIdentifier: task.descriptor.typeIdentifier,
+            executableAliases: ["codex"],
+            supportedVersions: ["1.2.3"],
+            identifierArgumentPrefix: ["resume"],
+            identifierArgumentSuffix: []
+        )
+
+        #expect(!AgentTaskRecoveryPlanner.canOfferVendorResume(
+            task: task,
+            recipes: []
+        ))
+        #expect(AgentTaskRecoveryPlanner.canOfferVendorResume(
+            task: task,
+            recipes: [recipe]
+        ))
+
+        var completed = task
+        completed.lifecycle = .completed
+        #expect(!AgentTaskRecoveryPlanner.canOfferVendorResume(
+            task: completed,
+            recipes: [recipe]
+        ))
+
+        var live = task
+        live.runs[0].liveness = .live
+        #expect(!AgentTaskRecoveryPlanner.canOfferVendorResume(
+            task: live,
+            recipes: [recipe]
+        ))
+    }
+
     @Test("Opaque session ID remains one argv element without shell parsing")
     func opaqueIdentifierIsOneArgument() {
         let opaqueID = "session; touch /tmp/never-run $(whoami)"

--- a/PineUITests/WelcomeWindowTests.swift
+++ b/PineUITests/WelcomeWindowTests.swift
@@ -97,7 +97,7 @@ final class WelcomeWindowTests: PineUITestCase {
             "The first launch should create the durable recovery fixture"
         )
         firstLaunchRow.rightClick()
-        XCTAssertTrue(app.menuItems["Resume Session"].exists)
+        XCTAssertFalse(app.menuItems["Resume Session"].exists)
         XCTAssertTrue(app.menuItems["New Session"].exists)
         XCTAssertTrue(app.menuItems["Copy Objective"].exists)
         app.typeKey(.escape, modifierFlags: [])


### PR DESCRIPTION
## Summary

- retry transient notification delivery and persist deduplication only after success
- hide Resume Session unless the task and a reviewed vendor adapter support it
- classify verified build/test evidence from the executable and arguments instead of arbitrary substrings

## Testing

- strict SwiftLint over Pine, PineTests, and PineUITests
- 26 tests in AgentNotificationTests, AgentTaskRecoveryTests, and AgentCompletionBriefTests
- targeted AgentCompletionBriefTests after preserving build-for-testing classification
- PineUITests target builds locally; execution is delegated to CI because the local Xcode 27 beta runner was blocked by an active system authentication dialog

Closes #1365
Closes #1366
Closes #1367