### PR TITLE
fix(marketing): stabilize terminal screenshot prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,7 +519,7 @@ jobs:
             --workflow .github/workflows/ci.yml \
             --max-delta 3
 
-  # UI test shards — 7 parallel jobs, 29-32 tests each (delta 3).
+  # UI test shards — 7 parallel jobs, 31-33 tests each (delta 2).
   # To rebalance: count tests per class, redistribute so shards stay within ±3 tests.
   # List classes with: grep -r "func test" PineUITests/ | sed 's/:.*//' | sort | uniq -c | sort -rn
   ui-tests:
@@ -560,8 +560,7 @@ jobs:
               -only-testing:PineUITests/BranchSwitcherTests
               -only-testing:PineUITests/CheckForUpdatesTests
               -only-testing:PineUITests/SplitPaneRoutingUITests
-              -only-testing:PineUITests/UnsavedChangesUITests
-          # Shard 5 — Files & Save (30 tests)
+          # Shard 5 — Files & Save (33 tests)
           - shard-name: "Files & Save"
             test-classes: >-
               -only-testing:PineUITests/EditorSaveFlowTests
@@ -569,6 +568,7 @@ jobs:
               -only-testing:PineUITests/SidebarRenameTests
               -only-testing:PineUITests/SidebarFileOperationsTests
               -only-testing:PineUITests/UserTaskExecutionUITests
+              -only-testing:PineUITests/UnsavedChangesUITests
           # Shard 6 — Search & Panes (32 tests)
           - shard-name: "Search & Panes"
             test-classes: >-

--- a/PineUITests/ScreenshotTests.swift
+++ b/PineUITests/ScreenshotTests.swift
@@ -147,6 +147,30 @@ final class ScreenshotTests: PineUITestCase {
 
     // MARK: - Terminal
 
+    func testMarketingShellFixtureIsProjectScopedAndCrossShell() throws {
+        projectURL = try createTempProject(projectName: "Pine Demo")
+        let projectURL = try XCTUnwrap(projectURL)
+
+        let configURL = try configureMarketingShell(for: projectURL)
+
+        XCTAssertEqual(
+            configURL.deletingLastPathComponent().standardizedFileURL,
+            projectURL.standardizedFileURL
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: configURL.appendingPathComponent(".zshrc").path
+            )
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: configURL.appendingPathComponent(".bash_profile").path
+            )
+        )
+        XCTAssertEqual(app.launchEnvironment["PS1"], "pine@mac \\W $ ")
+        XCTAssertEqual(app.launchEnvironment["PROMPT"], "pine@mac %1~ %# ")
+    }
+
     func testCaptureTerminal() throws {
         projectURL = try createTempProject(files: [
             "main.swift": "print(\"Hello, Pine!\")\n"
@@ -180,21 +204,46 @@ final class ScreenshotTests: PineUITestCase {
         attachScreenshot(screenshot, name: "screenshot-terminal")
     }
 
-    /// Keeps personal dotfiles and temporary paths out of the marketing capture.
-    private func configureMarketingShell(for projectURL: URL) throws {
-        let configURL = projectURL.deletingLastPathComponent()
-            .appendingPathComponent("zsh", isDirectory: true)
+    /// Keeps personal dotfiles, runner identity, and temporary paths out of
+    /// the marketing capture. GitHub's macOS account may still use bash while
+    /// developer machines normally use zsh, so configure both login shells.
+    @discardableResult
+    private func configureMarketingShell(for projectURL: URL) throws -> URL {
+        let configURL = projectURL.appendingPathComponent(
+            ".pine-marketing-shell",
+            isDirectory: true
+        )
         try FileManager.default.createDirectory(at: configURL, withIntermediateDirectories: true)
-        let configuration = """
-        precmd() { print -Pn '\\e]0;Terminal 1\\a' }
-        PROMPT='%F{green}➜%f  %F{cyan}%1~%f '
-        """
-        try configuration.write(
+
+        let zshConfiguration = #"""
+        precmd() { print -Pn '\e]0;Terminal 1\a' }
+        PROMPT='%F{green}pine@mac%f %F{cyan}%1~%f %# '
+        """#
+        try zshConfiguration.write(
             to: configURL.appendingPathComponent(".zshrc"),
             atomically: true,
             encoding: .utf8
         )
+
+        let bashConfiguration = #"""
+        export BASH_SILENCE_DEPRECATION_WARNING=1
+        PROMPT_COMMAND='printf "\033]0;Terminal 1\007"'
+        PS1='\[\e[32m\]pine@mac\[\e[0m\] \[\e[36m\]\W\[\e[0m\] \$ '
+        """#
+        try bashConfiguration.write(
+            to: configURL.appendingPathComponent(".bash_profile"),
+            atomically: true,
+            encoding: .utf8
+        )
+
         app.launchEnvironment["ZDOTDIR"] = configURL.path
+        app.launchEnvironment["HOME"] = configURL.path
+        app.launchEnvironment["BASH_SILENCE_DEPRECATION_WARNING"] = "1"
+        // Environment fallbacks keep the prompt deterministic even if a
+        // runner-specific login shell skips its user startup file.
+        app.launchEnvironment["PS1"] = "pine@mac \\W $ "
+        app.launchEnvironment["PROMPT"] = "pine@mac %1~ %# "
+        return configURL
     }
 
     // MARK: - Sidebar (file tree)


### PR DESCRIPTION
## Summary

- configure deterministic bash and zsh login prompts for the terminal marketing capture
- keep shell fixtures inside the disposable Pine Demo project and provide environment fallbacks when startup files are skipped
- add a regression test for project scope, cross-shell coverage, and stable prompt values

## Testing

- Xcode 27 beta build-for-testing: succeeded
- SwiftLint strict on ScreenshotTests.swift: 0 violations
- bash scripts/tests/test-screenshot-workflow.sh
- local UI execution was blocked before test start by macOS LocalAuthentication -4; the macOS 26 screenshot workflow will provide the final rendered verification after merge

Refs #1370
Closes #1375