### PR TITLE
fix(marketing): hide terminal screenshot fixture

### DIFF
--- a/PineUITests/ScreenshotTests.swift
+++ b/PineUITests/ScreenshotTests.swift
@@ -147,7 +147,7 @@ final class ScreenshotTests: PineUITestCase {
 
     // MARK: - Terminal
 
-    func testMarketingShellFixtureIsProjectScopedAndCrossShell() throws {
+    func testMarketingShellFixtureStaysOutOfProjectAndCoversBothShells() throws {
         projectURL = try createTempProject(projectName: "Pine Demo")
         let projectURL = try XCTUnwrap(projectURL)
 
@@ -155,7 +155,13 @@ final class ScreenshotTests: PineUITestCase {
 
         XCTAssertEqual(
             configURL.deletingLastPathComponent().standardizedFileURL,
-            projectURL.standardizedFileURL
+            projectURL.deletingLastPathComponent().standardizedFileURL
+        )
+        XCTAssertFalse(
+            configURL.standardizedFileURL.path.hasPrefix(
+                projectURL.standardizedFileURL.path + "/"
+            ),
+            "Marketing shell fixtures must not appear in the project tree"
         )
         XCTAssertTrue(
             FileManager.default.fileExists(
@@ -209,10 +215,11 @@ final class ScreenshotTests: PineUITestCase {
     /// developer machines normally use zsh, so configure both login shells.
     @discardableResult
     private func configureMarketingShell(for projectURL: URL) throws -> URL {
-        let configURL = projectURL.appendingPathComponent(
-            ".pine-marketing-shell",
-            isDirectory: true
-        )
+        let configURL = projectURL.deletingLastPathComponent()
+            .appendingPathComponent(
+                ".pine-marketing-shell",
+                isDirectory: true
+            )
         try FileManager.default.createDirectory(at: configURL, withIntermediateDirectories: true)
 
         let zshConfiguration = #"""


### PR DESCRIPTION
## Summary

- move the deterministic bash/zsh fixture into the disposable test parent beside Pine Demo
- keep the stable pine@mac Pine Demo prompt without adding test-only content to the visible project tree
- strengthen the regression test to reject fixture paths nested under the project

## Testing

- Xcode 27 beta build-for-testing: succeeded
- SwiftLint strict on ScreenshotTests.swift: 0 violations
- UI shard validator: 222 tests, delta 2
- final rendered validation will run through the macOS 26 screenshot workflow after merge

Refs #1370
Closes #1375