### PR TITLE
feat(help): add contextual recovery routes

### DIFF
--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -229,6 +229,9 @@ nonisolated enum AccessibilityID {
     static let problemsIndicator = "problemsIndicator"
     static let problemsPanel = "problemsPanel"
     static let problemsEmptyState = "problemsEmptyState"
+    static let problemsHelpButton = "problemsHelpButton"
+    static let problemsLanguageSettingsButton =
+        "problemsLanguageSettingsButton"
     static let agentStatusBarMenu = "agentStatusBarMenu"
 
     // MARK: - LSP completion popup (#1012)
@@ -248,7 +251,10 @@ nonisolated enum AccessibilityID {
     static let agentActivityKindMenu = "agentActivityKindMenu"
     static let agentActivityStatusMenu = "agentActivityStatusMenu"
     static let agentActivityAttributionMenu = "agentActivityAttributionMenu"
+    static let agentActivityHelpButton = "agentActivityHelpButton"
     static let agentActivityDetail = "agentActivityDetail"
+    static let agentActivityDetailHelpButton =
+        "agentActivityDetailHelpButton"
     static let agentActivityDetailCopy = "agentActivityDetailCopy"
     static let agentActivityDetailGoToTerminal = "agentActivityDetailGoToTerminal"
     static let agentActivityDetailOpenFile = "agentActivityDetailOpenFile"

--- a/Pine/Agent/AgentActivityView.swift
+++ b/Pine/Agent/AgentActivityView.swift
@@ -298,6 +298,13 @@ struct AgentActivityView: View {
                 .font(.headline)
                 .accessibilityIdentifier(AccessibilityID.agentActivityPanel)
             Spacer()
+            HelpLink(
+                anchor: PineHelp.Anchor.agents,
+                book: PineHelp.bookName
+            )
+            .accessibilityIdentifier(
+                AccessibilityID.agentActivityHelpButton
+            )
             Button(action: onClose) {
                 Image(systemName: "xmark.circle.fill")
                     .foregroundStyle(.secondary)
@@ -749,6 +756,13 @@ struct AgentActivityDetailView: View {
                 .lineLimit(2)
                 .accessibilityIdentifier(AccessibilityID.agentActivityDetail)
             Spacer()
+            HelpLink(
+                anchor: PineHelp.Anchor.agents,
+                book: PineHelp.bookName
+            )
+            .accessibilityIdentifier(
+                AccessibilityID.agentActivityDetailHelpButton
+            )
             Button(action: onClose) {
                 Image(systemName: "xmark.circle.fill")
                     .foregroundStyle(.secondary)

--- a/Pine/LSP/ProblemsPanelController.swift
+++ b/Pine/LSP/ProblemsPanelController.swift
@@ -59,6 +59,10 @@ nonisolated enum ProblemsPresentationState: Equatable, Sendable {
     case unsupported
     case loading
     case unavailable
+
+    var offersLanguageSettingsRecovery: Bool {
+        self == .disabled || self == .unavailable
+    }
 }
 
 /// Stable semantic identity. Producer UUIDs are intentionally excluded:

--- a/Pine/LSP/ProblemsPanelView.swift
+++ b/Pine/LSP/ProblemsPanelView.swift
@@ -57,12 +57,33 @@ struct ProblemsPanelView: View {
     /// Called with the exact project/pane/tab/revision-owned diagnostic.
     var onSelect: ((ProblemsFlatDiagnostic) -> Void)?
 
+    @Environment(\.openSettings) private var openSettings
+    @AppStorage(PineSettingsView.selectedPaneKey)
+    private var selectedSettingsPane = SettingsPane.SettingsPaneID.general
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             if groups.isEmpty {
-                Text(state.message)
-                    .font(.system(size: LayoutMetrics.bodySmallFontSize))
-                    .foregroundStyle(.secondary)
+                VStack(spacing: 8) {
+                    Text(state.message)
+                        .font(.system(size: LayoutMetrics.bodySmallFontSize))
+                        .foregroundStyle(.secondary)
+                    if state.offersLanguageSettingsRecovery {
+                        Button {
+                            selectedSettingsPane = .languages
+                            openSettings()
+                        } label: {
+                            Label(
+                                Strings.lspSettingsTitle,
+                                systemImage: "gear"
+                            )
+                        }
+                        .controlSize(.small)
+                        .accessibilityIdentifier(
+                            AccessibilityID.problemsLanguageSettingsButton
+                        )
+                    }
+                }
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(.vertical, 12)
                     .accessibilityIdentifier(AccessibilityID.problemsEmptyState)
@@ -250,6 +271,11 @@ struct ProblemsPanelChrome: View {
             .fixedSize()
             .accessibilityLabel(Strings.problemsSourceFilter)
             Spacer()
+            HelpLink(
+                anchor: PineHelp.Anchor.languageServers,
+                book: PineHelp.bookName
+            )
+            .accessibilityIdentifier(AccessibilityID.problemsHelpButton)
             Button {
                 onClose?()
             } label: {

--- a/Pine/LSP/ProblemsPanelView.swift
+++ b/Pine/LSP/ProblemsPanelView.swift
@@ -271,14 +271,14 @@ struct ProblemsPanelChrome: View {
             .fixedSize()
             .accessibilityLabel(Strings.problemsSourceFilter)
             Spacer()
-            HelpLink(
+            PineHelpButton(
                 anchor: PineHelp.Anchor.languageServers,
-                book: PineHelp.bookName
+                book: PineHelp.bookName,
+                accessibilityIdentifier: AccessibilityID.problemsHelpButton,
+                controlSize: .small
             )
-            .controlSize(.small)
             .fixedSize()
             .layoutPriority(1)
-            .accessibilityIdentifier(AccessibilityID.problemsHelpButton)
             Button {
                 onClose?()
             } label: {

--- a/Pine/LSP/ProblemsPanelView.swift
+++ b/Pine/LSP/ProblemsPanelView.swift
@@ -275,6 +275,9 @@ struct ProblemsPanelChrome: View {
                 anchor: PineHelp.Anchor.languageServers,
                 book: PineHelp.bookName
             )
+            .controlSize(.small)
+            .fixedSize()
+            .layoutPriority(1)
             .accessibilityIdentifier(AccessibilityID.problemsHelpButton)
             Button {
                 onClose?()
@@ -284,6 +287,8 @@ struct ProblemsPanelChrome: View {
                     .foregroundStyle(.secondary)
             }
             .buttonStyle(.plain)
+            .fixedSize()
+            .layoutPriority(1)
             .help(Strings.problemsClose)
             .accessibilityLabel(Strings.problemsClose)
         }

--- a/Pine/PineHelp.swift
+++ b/Pine/PineHelp.swift
@@ -2,11 +2,12 @@
 //  PineHelp.swift
 //  Pine
 //
-//  Stable Apple Help book and anchor identifiers shared by native HelpLink
-//  controls and HelpBookTests.
+//  Stable Apple Help book routes shared by native HelpLink controls, compact
+//  AppKit help buttons, and HelpBookTests.
 //
 
 import AppKit
+import SwiftUI
 
 nonisolated enum PineHelp {
     static let bookName: NSHelpManager.BookName =
@@ -29,5 +30,92 @@ nonisolated enum PineHelp {
         static let shortcuts: NSHelpManager.AnchorName = "pine-shortcuts"
         static let troubleshooting: NSHelpManager.AnchorName =
             "pine-troubleshooting"
+    }
+}
+
+/// A native AppKit help button for compact SwiftUI chrome.
+///
+/// `HelpLink` remains the preferred control in regular SwiftUI layouts. The
+/// Problems panel header is short enough that its represented help control can
+/// be omitted from the accessibility hierarchy on macOS 26. This bridge uses
+/// AppKit's standard help-button bezel and publishes the native accessibility
+/// contract explicitly, matching Pine's other represented controls.
+@MainActor
+struct PineHelpButton: NSViewRepresentable {
+    let anchor: NSHelpManager.AnchorName
+    let book: NSHelpManager.BookName
+    let accessibilityIdentifier: String
+    var controlSize: NSControl.ControlSize = .regular
+
+    func makeNSView(context: Context) -> PineNativeHelpButton {
+        PineNativeHelpButton(
+            anchor: anchor,
+            book: book,
+            accessibilityIdentifier: accessibilityIdentifier,
+            controlSize: controlSize
+        )
+    }
+
+    func updateNSView(
+        _ nsView: PineNativeHelpButton,
+        context: Context
+    ) {
+        nsView.configure(
+            anchor: anchor,
+            book: book,
+            accessibilityIdentifier: accessibilityIdentifier,
+            controlSize: controlSize
+        )
+    }
+}
+
+@MainActor
+final class PineNativeHelpButton: NSButton {
+    private var helpAnchor: NSHelpManager.AnchorName
+    private var helpBook: NSHelpManager.BookName
+
+    init(
+        anchor: NSHelpManager.AnchorName,
+        book: NSHelpManager.BookName,
+        accessibilityIdentifier: String,
+        controlSize: NSControl.ControlSize
+    ) {
+        self.helpAnchor = anchor
+        self.helpBook = book
+        super.init(frame: .zero)
+
+        target = self
+        action = #selector(openHelp)
+        configure(
+            anchor: anchor,
+            book: book,
+            accessibilityIdentifier: accessibilityIdentifier,
+            controlSize: controlSize
+        )
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(
+        anchor: NSHelpManager.AnchorName,
+        book: NSHelpManager.BookName,
+        accessibilityIdentifier: String,
+        controlSize: NSControl.ControlSize
+    ) {
+        helpAnchor = anchor
+        helpBook = book
+        bezelStyle = .helpButton
+        self.controlSize = controlSize
+        identifier = NSUserInterfaceItemIdentifier(accessibilityIdentifier)
+        setAccessibilityElement(true)
+        setAccessibilityRole(.button)
+        setAccessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    @objc private func openHelp() {
+        NSHelpManager.shared.openHelpAnchor(helpAnchor, inBook: helpBook)
     }
 }

--- a/PineTests/HelpBookTests.swift
+++ b/PineTests/HelpBookTests.swift
@@ -3,6 +3,7 @@
 //  PineTests
 //
 
+import AppKit
 import Foundation
 import Testing
 @testable import Pine
@@ -190,6 +191,30 @@ struct HelpBookTests {
                 #expect(corpus.contains("name=\"\(anchor)\""))
             }
         }
+    }
+
+    @Test func compactHelpButtonUsesNativeAccessibilityContract() {
+        let button = PineNativeHelpButton(
+            anchor: PineHelp.Anchor.languageServers,
+            book: PineHelp.bookName,
+            accessibilityIdentifier: AccessibilityID.problemsHelpButton,
+            controlSize: .small
+        )
+
+        #expect(button.bezelStyle == .helpButton)
+        #expect(button.controlSize == .small)
+        #expect(button.isAccessibilityElement())
+        #expect(button.accessibilityRole() == .button)
+        #expect(
+            button.accessibilityIdentifier()
+                == AccessibilityID.problemsHelpButton
+        )
+        #expect(
+            button.identifier?.rawValue
+                == AccessibilityID.problemsHelpButton
+        )
+        #expect(button.intrinsicContentSize.width > 0)
+        #expect(button.intrinsicContentSize.height > 0)
     }
 
     private func helpResourcesURL() throws -> URL {

--- a/PineTests/ProblemsPanelControllerTests.swift
+++ b/PineTests/ProblemsPanelControllerTests.swift
@@ -513,6 +513,19 @@ struct ProblemsPanelControllerTests {
             [state(swiftOwner, revision: 0)]
         }
         #expect(disabledController.presentationState == .disabled)
+        #expect(
+            disabledController.presentationState
+                .offersLanguageSettingsRecovery
+        )
+        #expect(!ProblemsPresentationState.empty.offersLanguageSettingsRecovery)
+        #expect(
+            !ProblemsPresentationState.unsupported
+                .offersLanguageSettingsRecovery
+        )
+        #expect(
+            ProblemsPresentationState.unavailable
+                .offersLanguageSettingsRecovery
+        )
     }
 
     @Test("Project navigation focuses the owning pane and keeps the column")

--- a/PineUITests/AgentActivityFilterUITests.swift
+++ b/PineUITests/AgentActivityFilterUITests.swift
@@ -98,8 +98,17 @@ final class AgentActivityFilterUITests: PineUITestCase {
         ]
         launchActivityPanel()
 
+        XCTAssertTrue(
+            app.buttons["agentActivityHelpButton"].firstMatch.exists,
+            "Agent Activity should expose task-specific Help"
+        )
+
         commandRow.click()
         XCTAssertTrue(activityDetail.waitForExistence(timeout: 3))
+        XCTAssertTrue(
+            app.buttons["agentActivityDetailHelpButton"].firstMatch.exists,
+            "Agent Activity details should preserve access to Help"
+        )
         XCTAssertTrue(detailCopy.waitForExistence(timeout: 3))
         XCTAssertTrue(detailGoToTerminal.waitForExistence(timeout: 3))
         XCTAssertFalse(detailOpenFile.exists)

--- a/PineUITests/AgentActivityFilterUITests.swift
+++ b/PineUITests/AgentActivityFilterUITests.swift
@@ -99,14 +99,16 @@ final class AgentActivityFilterUITests: PineUITestCase {
         launchActivityPanel()
 
         XCTAssertTrue(
-            app.buttons["agentActivityHelpButton"].firstMatch.exists,
+            app.descendants(matching: .any)["agentActivityHelpButton"]
+                .firstMatch.exists,
             "Agent Activity should expose task-specific Help"
         )
 
         commandRow.click()
         XCTAssertTrue(activityDetail.waitForExistence(timeout: 3))
         XCTAssertTrue(
-            app.buttons["agentActivityDetailHelpButton"].firstMatch.exists,
+            app.descendants(matching: .any)["agentActivityDetailHelpButton"]
+                .firstMatch.exists,
             "Agent Activity details should preserve access to Help"
         )
         XCTAssertTrue(detailCopy.waitForExistence(timeout: 3))

--- a/PineUITests/EditorWindowTests.swift
+++ b/PineUITests/EditorWindowTests.swift
@@ -229,6 +229,10 @@ final class EditorWindowTests: PineUITestCase {
             waitForExistence(panel, timeout: 5),
             "Problems should open in the editor chrome"
         )
+        XCTAssertTrue(
+            app.buttons["problemsHelpButton"].firstMatch.exists,
+            "Problems should expose its language-server Help topic"
+        )
 
         clickMenuBarItem("View")
         app.menuItems["Problems"].click()

--- a/PineUITests/EditorWindowTests.swift
+++ b/PineUITests/EditorWindowTests.swift
@@ -230,7 +230,8 @@ final class EditorWindowTests: PineUITestCase {
             "Problems should open in the editor chrome"
         )
         XCTAssertTrue(
-            app.buttons["problemsHelpButton"].firstMatch.exists,
+            app.descendants(matching: .any)["problemsHelpButton"]
+                .firstMatch.exists,
             "Problems should expose its language-server Help topic"
         )
 


### PR DESCRIPTION
## Summary
- add task-specific native help controls to Problems, Agent Activity, and Agent Activity details
- use AppKit's standard `.helpButton` bezel with an explicit accessibility contract in the compact Problems header, where SwiftUI's HelpLink bridge is omitted on macOS 26
- turn disabled or unavailable diagnostics into a recoverable state that opens the Language Servers pane in the native Settings scene
- preserve unsupported/loading/empty states without offering misleading actions
- add stable accessibility identifiers plus unit and UI regression coverage

## Validation
- SwiftLint
- HelpBookTests + ProblemsPanelControllerTests: 21 tests passed
- Xcode 27 beta build/test with the macOS 26.0 deployment target
- Agent Activity targeted XCUITest passed locally with ad-hoc signing
- three macOS 26 CI runs passed unit tests, Xcode 27 compatibility, and Agent Activity UI coverage; Editor Chrome showed that SwiftUI's represented HelpLink is omitted from the Problems accessibility hierarchy even when reserved intrinsic layout space, now fixed by a native AppKit help button that declares its AX role and identifier directly
- local targeted Editor Chrome run reaches the existing project-fixture precondition failure on macOS 27 before the Help assertion; GitHub macOS 26 CI remains authoritative for that scenario

Closes #1382
