### PR TITLE
fix(search): enforce result boundaries

### DIFF
--- a/Pine/ProjectSearchProvider.swift
+++ b/Pine/ProjectSearchProvider.swift
@@ -12,12 +12,19 @@ import UniformTypeIdentifiers
 // MARK: - Models
 
 struct SearchMatch: Identifiable, Hashable, Sendable {
+    struct Identity: Hashable, Sendable {
+        let lineNumber: Int
+        let matchRangeStart: Int
+    }
+
     let lineNumber: Int
     let lineContent: String
     let matchRangeStart: Int
     let matchRangeLength: Int
 
-    var id: Int { lineNumber &* 100_003 &+ matchRangeStart }
+    var id: Identity {
+        Identity(lineNumber: lineNumber, matchRangeStart: matchRangeStart)
+    }
 }
 
 struct SearchFileGroup: Identifiable, Sendable {
@@ -193,9 +200,24 @@ final class ProjectSearchProvider {
                 guard !Task.isCancelled else { break }
 
                 if let fileGroup = result {
-                    groups.append(fileGroup)
-                    totalMatches += fileGroup.matches.count
-                    if totalMatches >= maxResults { break }
+                    let remainingCapacity = maxResults - totalMatches
+                    guard remainingCapacity > 0 else {
+                        group.cancelAll()
+                        break
+                    }
+                    let retainedMatches = Array(
+                        fileGroup.matches.prefix(remainingCapacity)
+                    )
+                    groups.append(SearchFileGroup(
+                        url: fileGroup.url,
+                        relativePath: fileGroup.relativePath,
+                        matches: retainedMatches
+                    ))
+                    totalMatches += retainedMatches.count
+                    if totalMatches >= maxResults {
+                        group.cancelAll()
+                        break
+                    }
                 }
 
                 // Submit next file

--- a/PineTests/ProjectSearchProviderTests.swift
+++ b/PineTests/ProjectSearchProviderTests.swift
@@ -374,6 +374,24 @@ struct ProjectSearchProviderTests {
         #expect(match1.id != match2.id)
     }
 
+    @Test("SearchMatch id cannot collide across long adjacent lines")
+    func searchMatchIDLongLineCollision() {
+        let first = SearchMatch(
+            lineNumber: 1,
+            lineContent: "first",
+            matchRangeStart: 100_003,
+            matchRangeLength: 1
+        )
+        let second = SearchMatch(
+            lineNumber: 2,
+            lineContent: "second",
+            matchRangeStart: 0,
+            matchRangeLength: 1
+        )
+
+        #expect(first.id != second.id)
+    }
+
     // MARK: - Provider state tests
 
     @Test("Empty query clears results")
@@ -457,6 +475,24 @@ struct ProjectSearchProviderTests {
         let totalMatches = groups.flatMap(\.matches).count
 
         #expect(totalMatches <= ProjectSearchProvider.maxResults)
+    }
+
+    @Test("performSearch truncates the final file group to the exact global limit")
+    func performSearchTruncatesFinalGroup() async throws {
+        let content = (1...99).map { "needle \($0)" }.joined(separator: "\n")
+        let files = Dictionary(uniqueKeysWithValues: (1...11).map {
+            ("file-\($0).txt", content)
+        })
+        let dir = try createTestProject(files: files)
+        defer { cleanup(dir) }
+
+        let groups = await ProjectSearchProvider.performSearch(
+            query: "needle",
+            isCaseSensitive: false,
+            rootURL: dir
+        )
+
+        #expect(groups.flatMap(\.matches).count == ProjectSearchProvider.maxResults)
     }
 
     // MARK: - searchFile: empty file


### PR DESCRIPTION
## Summary

- truncate the final project-search group to the exact remaining global capacity
- replace the arithmetic `SearchMatch` hash with collision-free line/offset identity
- add regressions for an 11-file cap crossing and the prior long-line collision

## Related issue

Closes #1389

## Test plan

- [x] Unit tests added/updated
- [ ] UI tests added/updated (not applicable; no UI tests run)
- [x] `ProjectSearchProviderTests` — 49 tests passed
- [x] SwiftLint on changed files

## Compatibility matrix

- macOS 26: Not tested — runtime unavailable
- macOS 27 beta: Tested — macOS 27.0 (26A5388g), Developer beta
- Xcode: 27.0 (27A5218g)
- macOS SDK: 27.0 (26A5378i)

### Terminal renderer coverage

- Default path (Metal when available): N/A
- CoreGraphics (`--disable-metal`): N/A

## Manual testing checklist

- [x] Verified the result count stops exactly at 1,000 through unit coverage
- [x] No regressions in the focused project-search suite
