### PR TITLE
fix(lsp): clarify filtered Problems state

### DIFF
--- a/Pine/LSP/ProblemsPanelController.swift
+++ b/Pine/LSP/ProblemsPanelController.swift
@@ -54,6 +54,7 @@ nonisolated enum ProblemsSeverityFilter: String, CaseIterable, Identifiable,
 
 nonisolated enum ProblemsPresentationState: Equatable, Sendable {
     case diagnostics
+    case filtered
     case empty
     case disabled
     case unsupported
@@ -332,14 +333,16 @@ final class ProblemsPanelController {
         )
     }
 
-    var diagnosticCount: Int { flatDiagnostics.count }
+    var diagnosticCount: Int { filteredDiagnostics.count }
 
     var availableSources: [String] {
         Array(Set(flatDiagnostics.map(\.diagnostic.source))).sorted()
     }
 
     var presentationState: ProblemsPresentationState {
-        if !flatDiagnostics.isEmpty { return .diagnostics }
+        if !flatDiagnostics.isEmpty {
+            return filteredDiagnostics.isEmpty ? .filtered : .diagnostics
+        }
         let states = normalizedDocumentStates()
         guard !states.isEmpty else { return .empty }
         let urls = states.compactMap { URL(string: $0.owner.uri) }
@@ -397,7 +400,7 @@ final class ProblemsPanelController {
 
     @discardableResult
     func previousDiagnostic() -> ProblemsFlatDiagnostic? {
-        let flat = flatDiagnostics
+        let flat = filteredDiagnostics
         return selectDiagnostic(
             offset: -1,
             initialIndex: max(0, flat.count - 1),

--- a/Pine/LSP/ProblemsPanelView.swift
+++ b/Pine/LSP/ProblemsPanelView.swift
@@ -313,6 +313,7 @@ private extension ProblemsPresentationState {
     var message: String {
         switch self {
         case .diagnostics, .empty: Strings.problemsNoIssues
+        case .filtered: Strings.problemsNoFilterMatches
         case .disabled: Strings.problemsDisabled
         case .unsupported: Strings.problemsUnsupported
         case .loading: Strings.problemsLoading

--- a/Pine/Localizable.xcstrings
+++ b/Pine/Localizable.xcstrings
@@ -32216,6 +32216,21 @@
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "打开" } }
       }
     },
+    "problems.noFilterMatches" : {
+      "comment" : "Message shown when Problems panel filters hide every diagnostic.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : { "stringUnit" : { "state" : "translated", "value" : "Keine Probleme entsprechen den aktuellen Filtern" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No problems match the current filters" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Ningún problema coincide con los filtros actuales" } },
+        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Aucun problème ne correspond aux filtres actuels" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "現在のフィルタに一致する問題はありません" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "현재 필터와 일치하는 문제가 없습니다" } },
+        "pt-BR" : { "stringUnit" : { "state" : "translated", "value" : "Nenhum problema corresponde aos filtros atuais" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Нет проблем, соответствующих текущим фильтрам" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "没有与当前筛选条件匹配的问题" } }
+      }
+    },
     "problems.noIssues": {
       "comment": "Label for the \"No problems detected\" message in the problems panel.",
       "extractionState": "extracted_with_value",

--- a/Pine/Strings.swift
+++ b/Pine/Strings.swift
@@ -2172,6 +2172,13 @@ enum Strings {
         String(localized: "problems.noIssues", defaultValue: "No problems detected")
     }
 
+    static var problemsNoFilterMatches: String {
+        String(
+            localized: "problems.noFilterMatches",
+            defaultValue: "No problems match the current filters"
+        )
+    }
+
     // Problems panel chrome wiring (#1236)
 
     static var problemsPanelTitle: String {

--- a/PineTests/ProblemsPanelControllerTests.swift
+++ b/PineTests/ProblemsPanelControllerTests.swift
@@ -468,14 +468,23 @@ struct ProblemsPanelControllerTests {
             controller.groupedDiagnostics.flatMap(\.diagnostics)
                 .map(\.diagnostic.message) == ["warning"]
         )
+        #expect(controller.diagnosticCount == 1)
+        #expect(controller.presentationState == .diagnostics)
         #expect(controller.nextDiagnostic()?.diagnostic.message == "warning")
 
-        controller.severityFilter = .all
         controller.sourceFilter = "yamllint"
+        #expect(controller.groupedDiagnostics.isEmpty)
+        #expect(controller.diagnosticCount == 0)
+        #expect(controller.presentationState == .filtered)
+        #expect(controller.nextDiagnostic() == nil)
+
+        controller.severityFilter = .all
         #expect(
             controller.groupedDiagnostics.flatMap(\.diagnostics)
                 .map(\.diagnostic.message) == ["error"]
         )
+        #expect(controller.diagnosticCount == 1)
+        #expect(controller.presentationState == .diagnostics)
         #expect(controller.previousDiagnostic()?.diagnostic.message == "error")
     }
 


### PR DESCRIPTION
## Summary

- add an explicit filtered-empty Problems presentation state and localized copy in all supported locales
- make the header count reflect visible diagnostics
- keep Previous navigation inside the filtered result set, matching Next navigation

## Related issue

Closes #1390

## Test plan

- [x] Unit tests added/updated
- [ ] UI tests added/updated (not applicable; no UI tests run)
- [x] `ProblemsPanelControllerTests` — 15 tests passed
- [x] `LocalizationCatalogCompletenessTests` — 4 tests passed
- [x] SwiftLint on changed Swift files

## Compatibility matrix

- macOS 26: Not tested — runtime unavailable
- macOS 27 beta: Tested — macOS 27.0 (26A5388g), Developer beta
- Xcode: 27.0 (27A5218g)
- macOS SDK: 27.0 (26A5378i)

### Terminal renderer coverage

- Default path (Metal when available): N/A
- CoreGraphics (`--disable-metal`): N/A

## Manual testing checklist

- [x] Verified controller state/count/navigation through focused unit coverage
- [x] No regressions in localization completeness
