### PR TITLE
fix: bound quit failure alert recovery

### DIFF
--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -2211,9 +2211,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         /// Machine failures are never user cancellation. Require the sole OK
         /// response as proof that AppKit displayed the explanation. `.abort`
         /// means presentation authority was lost, so retry on a freshly
-        /// resolved project/application owner. There is deliberately no retry
-        /// count: returning from a machine failure without ever showing its
-        /// explanation would misreport presentation loss as user cancellation.
+        /// resolved project/application owner. Bound those retries so a broken
+        /// presenter cannot trap termination in an endless alert loop.
         @discardableResult
         func presentTerminationFailure(
             _ template: AlertTemplate = .applicationQuitFailure,
@@ -2221,16 +2220,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
             title: String = Strings.applicationQuitFailureTitle,
             message: String = Strings.applicationQuitFailureMessage
         ) async -> Bool {
-            while !Task.isCancelled {
+            let maximumAttempts = 3
+            for attempt in 0..<maximumAttempts {
+                guard !Task.isCancelled else { break }
                 let context = resolveTerminationFailureContext(
                     preferredProject: preferredProject
                 )
                 if presentAlert == nil, !hasEligibleOwner(context) {
                     prepareApplicationDialogOwner()
-                    do {
-                        try await Task.sleep(for: .milliseconds(25))
-                    } catch {
-                        return false
+                    if attempt + 1 < maximumAttempts {
+                        do {
+                            try await Task.sleep(for: .milliseconds(25))
+                        } catch {
+                            return false
+                        }
                     }
                     continue
                 }
@@ -2243,20 +2246,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
                 if response == .alertFirstButtonReturn {
                     return true
                 }
-                Logger.app.error(
-                    "Quit failure explanation lost its dialog owner; retrying on a fresh owner"
-                )
-                if presentAlert == nil {
-                    prepareApplicationDialogOwner()
-                }
-                do {
-                    try await Task.sleep(for: .milliseconds(25))
-                } catch {
-                    return false
+                if attempt + 1 < maximumAttempts {
+                    Logger.app.error(
+                        "Quit failure explanation lost its dialog owner; retrying on a fresh owner"
+                    )
+                    if presentAlert == nil {
+                        prepareApplicationDialogOwner()
+                    }
+                    do {
+                        try await Task.sleep(for: .milliseconds(25))
+                    } catch {
+                        return false
+                    }
                 }
             }
             Logger.app.critical(
-                "Quit failure explanation was cancelled before acknowledgement"
+                "Quit failure explanation could not be presented after bounded retries"
             )
             return false
         }

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -581,7 +581,7 @@ struct WindowLifecycleTests {
         #expect(presentedOwners[1] === newWindow)
     }
 
-    @Test func quitFailureRetriesPastFourLostOwnersUntilAcknowledged() async {
+    @Test func quitFailureStopsAfterBoundedLostOwners() async {
         let delegate = AppDelegate()
         delegate.registry = makeRegistry()
         let owner = NSWindow()
@@ -593,16 +593,14 @@ struct WindowLifecycleTests {
             presentAlert: { template, _, _, _ in
                 #expect(template == .applicationQuitFailure)
                 presentationCount += 1
-                return presentationCount <= 4
-                    ? .abort
-                    : .alertFirstButtonReturn
+                return .abort
             },
             terminationFailureContext: { context },
             terminationDeadlineOverride: .now()
         )
 
         #expect(!result)
-        #expect(presentationCount == 5)
+        #expect(presentationCount == 3)
     }
 
     @Test func saveAsUsesReplacementProjectOwnerAfterReview() async throws {

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -190,6 +190,38 @@ struct WindowLifecycleTests {
         await project.workspace.waitForLoadingComplete()
     }
 
+    @Test func quitFailurePresentationRetriesAreBounded() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        updateContent("// dirty", in: project)
+
+        let delegate = AppDelegate()
+        delegate.registry = registry
+        var failureAttempts = 0
+
+        let result = await delegate.confirmApplicationTermination(
+            presentAlert: { template, _, _, _ in
+                if template == .applicationQuitFailure {
+                    failureAttempts += 1
+                    return .abort
+                }
+                return .alertFirstButtonReturn
+            },
+            saveAll: { _, _ in false },
+            terminationDeadlineOverride: .now() + 120
+        )
+
+        #expect(!result)
+        #expect(failureAttempts == 3)
+        #expect(project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
     @Test func saveAsDeliberationDoesNotConsumeMachineDeadline() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }


### PR DESCRIPTION
## Summary

- cap recovery from a lost quit-failure alert owner at three presentation attempts
- keep rebinding to a fresh dialog owner between attempts
- fail termination closed when the explanation still cannot be presented
- add a regression test proving an always-aborting presenter returns instead of looping forever

## Testing

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild test -project Pine.xcodeproj -scheme Pine -derivedDataPath /private/tmp/pine-pr-derived -destination platform=macOS '-only-testing:PineTests/WindowLifecycleTests/quitFailurePresentationRetriesAreBounded()' '-only-testing:PineTests/WindowLifecycleTests/detailedQuitSaveFailureUsesReboundProjectOwner()'`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swiftlint lint --strict --no-cache Pine/PineApp.swift PineTests/WindowLifecycleTests.swift`

UI tests were not run.

Closes #1386
