### PR TITLE
test(settings): isolate terminal snapshots

### DIFF
--- a/Pine/Settings/TerminalSettingsView.swift
+++ b/Pine/Settings/TerminalSettingsView.swift
@@ -122,10 +122,7 @@ struct TerminalSettingsView: View {
                     shell.reset()
                     customArgsText = shell.shellArgs.joined(separator: "\n")
                 }
-                .disabled(
-                    shell.shellArgs == ["--login"]
-                        && shell.shellPath == ShellSettings.systemShellPath()
-                )
+                .disabled(shell.isDefaultConfiguration)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 4)

--- a/Pine/ShellSettings.swift
+++ b/Pine/ShellSettings.swift
@@ -40,7 +40,7 @@ final class ShellSettings {
     }
 
     /// Fallback chain: `getpwuid` → `$SHELL` → `/bin/zsh`.
-    private static var defaultShellPath: String {
+    private static var systemDefaultShellPath: String {
         if let posixShell = systemShellPath() {
             return posixShell
         }
@@ -51,6 +51,7 @@ final class ShellSettings {
 
     private let defaults: UserDefaults
     private let fileManager: FileManager
+    private let defaultShellPath: String
 
     var shellPath: String {
         didSet {
@@ -64,10 +65,15 @@ final class ShellSettings {
         }
     }
 
+    var isDefaultConfiguration: Bool {
+        shellPath == defaultShellPath
+            && shellArgs == defaultArguments(for: defaultShellPath)
+    }
+
     /// Validated shell path — falls back to system shell (via `getpwuid`), then `$SHELL`, then `/bin/zsh`.
     var resolvedShellPath: String {
         if isExecutableFile(shellPath) { return shellPath }
-        let fallback = Self.defaultShellPath
+        let fallback = defaultShellPath
         if isExecutableFile(fallback) { return fallback }
         return "/bin/zsh"
     }
@@ -81,15 +87,20 @@ final class ShellSettings {
         return fileManager.isExecutableFile(atPath: path)
     }
 
-    init(defaults: UserDefaults = .standard, fileManager: FileManager = .default) {
+    init(
+        defaults: UserDefaults = .standard,
+        fileManager: FileManager = .default,
+        defaultShellPath: String? = nil
+    ) {
         self.defaults = defaults
         self.fileManager = fileManager
+        self.defaultShellPath = defaultShellPath ?? Self.systemDefaultShellPath
 
         let storedPath = defaults.string(forKey: Self.shellPathKey)
         if let storedPath, !storedPath.isEmpty {
             self.shellPath = storedPath
         } else {
-            self.shellPath = Self.defaultShellPath
+            self.shellPath = self.defaultShellPath
         }
 
         if let storedArgs = defaults.stringArray(forKey: Self.shellArgsKey) {
@@ -100,7 +111,12 @@ final class ShellSettings {
     }
 
     func reset() {
-        shellPath = Self.defaultShellPath
-        shellArgs = Self.commonShells.first { $0.path == shellPath }?.defaultArgs ?? Self.defaultShellArgs
+        shellPath = defaultShellPath
+        shellArgs = defaultArguments(for: defaultShellPath)
+    }
+
+    private func defaultArguments(for path: String) -> [String] {
+        Self.commonShells.first { $0.path == path }?.defaultArgs
+            ?? Self.defaultShellArgs
     }
 }

--- a/PineTests/ShellSettingsTests.swift
+++ b/PineTests/ShellSettingsTests.swift
@@ -122,6 +122,25 @@ struct ShellSettingsTests {
         #expect(settings.shellArgs == ["--login"])
     }
 
+    @Test func injectedDefaultMakesConfigurationStateDeterministic() throws {
+        let defaults = try makeDefaults()
+        defer { cleanupDefaults(defaults) }
+
+        let settings = ShellSettings(
+            defaults: defaults,
+            defaultShellPath: "/bin/bash"
+        )
+        #expect(settings.isDefaultConfiguration)
+
+        settings.shellPath = "/bin/zsh"
+        #expect(!settings.isDefaultConfiguration)
+
+        settings.reset()
+        #expect(settings.shellPath == "/bin/bash")
+        #expect(settings.shellArgs == ["--login"])
+        #expect(settings.isDefaultConfiguration)
+    }
+
     // MARK: - Resolved shell path
 
     @Test func resolvedShellPathReturnsPathWhenExecutable() throws {

--- a/PineTests/SnapshotTests/TerminalSettingsViewSnapshotTests.swift
+++ b/PineTests/SnapshotTests/TerminalSettingsViewSnapshotTests.swift
@@ -18,7 +18,10 @@ struct TerminalSettingsViewSnapshotTests {
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defaults.removePersistentDomain(forName: suiteName)
 
-        let shell = ShellSettings(defaults: defaults)
+        let shell = ShellSettings(
+            defaults: defaults,
+            defaultShellPath: "/bin/bash"
+        )
         shell.shellPath = "/bin/zsh"
         shell.shellArgs = ["--login"]
 


### PR DESCRIPTION
## Summary

- move reset-state detection into `ShellSettings`
- make the default shell injectable while preserving the system-shell production default
- make the Terminal Settings snapshot fixture explicitly choose a non-default shell state
- cover deterministic default/reset behavior in the model tests

## Testing

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild test -project Pine.xcodeproj -scheme Pine -derivedDataPath /private/tmp/pine-pr-derived -destination platform=macOS '-only-testing:PineTests/ShellSettingsTests' '-only-testing:PineTests/TerminalSettingsViewSnapshotTests'` (41 tests)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swiftlint lint --strict --no-cache Pine/ShellSettings.swift Pine/Settings/TerminalSettingsView.swift PineTests/ShellSettingsTests.swift PineTests/SnapshotTests/TerminalSettingsViewSnapshotTests.swift`

UI tests were not run.

Closes #1391
