### PR TITLE
fix(editor): fence saves against external changes

### DIFF
--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -422,7 +422,17 @@ extension ContentView {
                     }
                     if displayedAuthorization.covers(currentDirtyTabs) {
                         for conflict in currentModified {
-                            projectManager.reloadTabs(url: conflict.url)
+                            projectManager.reloadTab(conflict: conflict)
+                        }
+                    }
+                } else if response == .alertSecondButtonReturn {
+                    let currentDirtyTabs = projectManager.allTabs.filter {
+                        modifiedURLs.contains($0.url.standardizedFileURL)
+                            && $0.isDirty
+                    }
+                    if displayedAuthorization.covers(currentDirtyTabs) {
+                        for conflict in currentModified {
+                            projectManager.authorizeExternalChange(conflict)
                         }
                     }
                 }

--- a/Pine/EditorTab.swift
+++ b/Pine/EditorTab.swift
@@ -5,7 +5,77 @@
 //  Created by Claude on 12.03.2026.
 //
 
+import CryptoKit
+import Darwin
 import Foundation
+
+/// Cheap stat identity used by routine external-change polling. `ctime`
+/// changes even when a tool restores an older `mtime`, while inode identity
+/// catches atomic replacements.
+nonisolated struct BackingFileIdentity: Equatable, Sendable {
+    let device: UInt64
+    let inode: UInt64
+    let size: Int64
+    let modificationSeconds: Int
+    let modificationNanoseconds: Int
+    let changeSeconds: Int
+    let changeNanoseconds: Int
+
+    static func capture(at url: URL) throws -> Self {
+        let descriptor = Darwin.open(
+            url.path,
+            O_RDONLY | O_NONBLOCK | O_CLOEXEC
+        )
+        guard descriptor >= 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        defer { Darwin.close(descriptor) }
+        var status = stat()
+        guard Darwin.fstat(descriptor, &status) == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        return Self(
+            device: UInt64(bitPattern: Int64(status.st_dev)),
+            inode: UInt64(status.st_ino),
+            size: status.st_size,
+            modificationSeconds: Int(status.st_mtimespec.tv_sec),
+            modificationNanoseconds: Int(status.st_mtimespec.tv_nsec),
+            changeSeconds: Int(status.st_ctimespec.tv_sec),
+            changeNanoseconds: Int(status.st_ctimespec.tv_nsec)
+        )
+    }
+}
+
+/// Content identity of the file version on which an editor buffer is based.
+/// Modification dates are intentionally excluded: external tools can preserve
+/// or move timestamps backwards while replacing the bytes on disk.
+nonisolated struct BackingFileRevision: Equatable, Sendable {
+    let contentDigest: Data
+    let fileIdentity: BackingFileIdentity?
+
+    init(data: Data, fileIdentity: BackingFileIdentity? = nil) {
+        contentDigest = Data(SHA256.hash(data: data))
+        self.fileIdentity = fileIdentity
+    }
+
+    init(contentDigest: Data) {
+        self.contentDigest = contentDigest
+        fileIdentity = nil
+    }
+
+    static func capture(at url: URL) throws -> Self {
+        let data = try Data(contentsOf: url)
+        return try Self(
+            data: data,
+            fileIdentity: BackingFileIdentity.capture(at: url)
+        )
+    }
+}
+
+nonisolated enum BackingFileState: Equatable, Sendable {
+    case missing
+    case present(BackingFileRevision)
+}
 
 /// Payload pushed back into the editor view after a disk read/write that
 /// changed the on-disk text and must be resynced into the NSTextView.
@@ -111,6 +181,13 @@ struct EditorTab: Identifiable, Hashable {
     /// Used to detect external changes by comparing with the current stat.
     var lastModDate: Date?
 
+    /// Exact content revision that the local buffer is allowed to replace.
+    var backingFileRevision: BackingFileRevision?
+
+    /// Revision already reported as a dirty-buffer conflict. This suppresses
+    /// duplicate FSEvents prompts without authorizing a later save.
+    var pendingExternalFileState: BackingFileState?
+
     /// Состояние свёрнутых регионов кода.
     var foldState: FoldState = FoldState()
 
@@ -215,6 +292,8 @@ struct EditorTab: Identifiable, Hashable {
         copy.cursorColumn = source.cursorColumn
         copy.fileSizeBytes = source.fileSizeBytes
         copy.lastModDate = source.lastModDate
+        copy.backingFileRevision = source.backingFileRevision
+        copy.pendingExternalFileState = source.pendingExternalFileState
         copy.foldState = source.foldState
         copy.previewMode = source.previewMode
         copy.syntaxHighlightingDisabled = source.syntaxHighlightingDisabled

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -755,6 +755,16 @@ final class ProjectManager {
               preparedSavePlanStillValid(plan) else {
             return (.invalidated, nil)
         }
+        guard zip(plan.entries, destinationStates).allSatisfy({ planned, state in
+            guard planned.destination == nil,
+                  let revision = planned.tab.backingFileRevision else {
+                return true
+            }
+            return state.exists
+                && state.contentDigest == revision.contentDigest
+        }) else {
+            return (.invalidated, nil)
+        }
         let requests = zip(plan.entries, destinationStates).compactMap { pair
             -> TerminationSaveRequest? in
             let (planned, expectedDestinationState) = pair
@@ -1466,6 +1476,24 @@ final class ProjectManager {
         for tabManager in paneManager.allTabManagers {
             tabManager.reloadTab(url: url)
         }
+    }
+
+    func reloadTab(conflict: TabManager.ExternalConflict) {
+        for tabManager in paneManager.allTabManagers
+        where tabManager.tabs.contains(where: { $0.id == conflict.tabID }) {
+            tabManager.reloadTab(conflict: conflict)
+        }
+    }
+
+    @discardableResult
+    func authorizeExternalChange(
+        _ conflict: TabManager.ExternalConflict
+    ) -> Bool {
+        for tabManager in paneManager.allTabManagers
+        where tabManager.tabs.contains(where: { $0.id == conflict.tabID }) {
+            return tabManager.authorizeExternalChange(conflict)
+        }
+        return false
     }
 
     /// Returns all open tabs affected by deletion across every editor pane.

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -61,6 +61,11 @@ final class TabManager {
         _ messageText: String,
         _ informativeText: String
     ) async -> NSApplication.ModalResponse
+    typealias ExternalConflictAlertPresenter = @MainActor (
+        _ context: DialogPresentationContext,
+        _ messageText: String,
+        _ informativeText: String
+    ) async -> NSApplication.ModalResponse
     typealias OpenCompletion = @MainActor (OpenRequestResult) -> Void
 
     /// Immediate state returned by an open request. Large-file decisions are
@@ -161,6 +166,14 @@ final class TabManager {
     @ObservationIgnored
     var largeFileAlertPresenter: LargeFileAlertPresenter = { context, messageText, informativeText in
         await AlertTemplate.largeFileWarning.runSheet(
+            on: context,
+            messageText: messageText,
+            informativeText: informativeText
+        )
+    }
+    @ObservationIgnored
+    var externalConflictAlertPresenter: ExternalConflictAlertPresenter = { context, messageText, informativeText in
+        await AlertTemplate.externalModifyConflict.runSheet(
             on: context,
             messageText: messageText,
             informativeText: informativeText
@@ -817,6 +830,14 @@ final class TabManager {
         do {
             return try trySaveTab(at: index)
         } catch {
+            if let saveError = error as? TabPersistence.SaveError,
+               case .externalChange(let conflict) = saveError,
+               await resolveExternalSaveConflict(
+                   conflict,
+                   context: context
+               ) {
+                return false
+            }
             _ = await AlertTemplate.fileOperationErrorCritical.runSheet(
                 on: context,
                 messageText: Strings.fileOperationErrorTitle,
@@ -845,6 +866,14 @@ final class TabManager {
             try trySaveAllTabs()
             return true
         } catch {
+            if let saveError = error as? TabPersistence.SaveError,
+               case .externalChange(let conflict) = saveError,
+               await resolveExternalSaveConflict(
+                   conflict,
+                   context: context
+               ) {
+                return false
+            }
             _ = await AlertTemplate.fileOperationErrorCritical.runSheet(
                 on: context,
                 messageText: Strings.fileOperationErrorTitle,
@@ -922,6 +951,10 @@ final class TabManager {
         tabs[index].savedContent = savedContent
         tabs[index].lastModDate = metadata.modificationDate
         tabs[index].fileSizeBytes = metadata.size
+        tabs[index].backingFileRevision = BackingFileRevision(
+            contentDigest: metadata.contentDigest
+        )
+        tabs[index].pendingExternalFileState = nil
         if contentChanged {
             tabs[index].cachedHighlightResult = nil
             tabs[index].recomputeContentCaches()
@@ -975,6 +1008,10 @@ final class TabManager {
         tabs[index].savedContent = savedContent
         tabs[index].lastModDate = metadata.modificationDate
         tabs[index].fileSizeBytes = metadata.size
+        tabs[index].backingFileRevision = BackingFileRevision(
+            contentDigest: metadata.contentDigest
+        )
+        tabs[index].pendingExternalFileState = nil
         if !requestIsStillCurrent {
             tabs[index].recomputeContentCaches()
         }
@@ -1287,7 +1324,20 @@ final class TabManager {
             },
             saveAction: { [weak self] in
                 guard let self, let idx = self.tabs.firstIndex(where: { $0.id == tabID }) else { return }
-                try self.trySaveTab(at: idx)
+                do {
+                    try self.trySaveTab(at: idx)
+                } catch let error as TabPersistence.SaveError {
+                    if case .externalChange(let conflict) = error {
+                        let context = self.dialogContextProvider()
+                        Task { @MainActor [weak self] in
+                            _ = await self?.resolveExternalSaveConflict(
+                                conflict,
+                                context: context
+                            )
+                        }
+                    }
+                    throw error
+                }
             }
         )
     }
@@ -1357,6 +1407,27 @@ final class TabManager {
         }
     }
 
+    func reloadTab(conflict: ExternalConflict) {
+        let reloaded = TabExternalChangeDetector.reloadTab(
+            url: conflict.url,
+            tabs: &tabs,
+            providers: fileProviders,
+            expectedState: conflict.observedState
+        )
+        if let reloaded {
+            postReloadNotifications([reloaded])
+        }
+    }
+
+    @discardableResult
+    func authorizeExternalChange(_ conflict: ExternalConflict) -> Bool {
+        TabExternalChangeDetector.authorizeExternalChange(
+            conflict,
+            tabs: &tabs,
+            providers: fileProviders
+        )
+    }
+
     private func postReloadNotifications(_ reloadedTabs: [ReloadedTab]) {
         for reloaded in reloadedTabs {
             NotificationCenter.default.post(
@@ -1365,6 +1436,41 @@ final class TabManager {
                 userInfo: ["url": reloaded.url, "text": reloaded.text]
             )
         }
+    }
+
+    private func resolveExternalSaveConflict(
+        _ conflict: ExternalConflict,
+        context: DialogPresentationContext
+    ) async -> Bool {
+        guard conflict.kind == .modified,
+              let displayedTab = tabs.first(where: {
+                  $0.id == conflict.tabID && $0.isDirty
+              }) else {
+            return false
+        }
+        let authorization = DirtyEditorContentAuthorization(
+            tabs: [displayedTab]
+        )
+        let response = await externalConflictAlertPresenter(
+            context,
+            Strings.externalModifyTitle,
+            Strings.externalModifyMessage(conflict.url.lastPathComponent)
+        )
+        guard let currentTab = tabs.first(where: {
+            $0.id == conflict.tabID && $0.isDirty
+        }),
+        authorization.covers([currentTab]) else {
+            return true
+        }
+        switch response {
+        case .alertFirstButtonReturn:
+            reloadTab(conflict: conflict)
+        case .alertSecondButtonReturn:
+            authorizeExternalChange(conflict)
+        default:
+            break
+        }
+        return true
     }
 
     @discardableResult
@@ -1378,10 +1484,22 @@ final class TabManager {
         tabs[index].savedContent = content
         tabs[index].encoding = encoding
         tabs[index].lastModDate = modDate(for: fileURL)
+        tabs[index].backingFileRevision = BackingFileRevision(
+            data: data,
+            fileIdentity: try? BackingFileIdentity.capture(at: fileURL)
+        )
+        tabs[index].pendingExternalFileState = nil
         return true
     }
 
     // MARK: - File helpers
+
+    private var fileProviders: FileProviders {
+        .init(
+            modDate: { [weak self] url in self?.modDate(for: url) },
+            fileSize: { [weak self] url in self?.fileSize(url: url) }
+        )
+    }
 
     private func modDate(for url: URL) -> Date? { TabPersistence.modDate(for: url) }
     func fileSize(url: URL) -> Int? { TabPersistence.fileSize(url: url) }

--- a/Pine/Tabs/TabDuplicator.swift
+++ b/Pine/Tabs/TabDuplicator.swift
@@ -46,6 +46,7 @@ enum TabDuplicator {
             savedContent: trimmed
         )
         newTab.lastModDate = providers.modDate(duplicateURL)
+        newTab.backingFileRevision = try? providers.fileRevision(duplicateURL)
         newTab.encoding = tab.encoding
         tabs.insert(newTab, at: index + 1)
         return newTab.id

--- a/Pine/Tabs/TabExternalChangeDetector.swift
+++ b/Pine/Tabs/TabExternalChangeDetector.swift
@@ -14,11 +14,13 @@ enum TabExternalChangeDetector {
     private static let logger = Logger.editor
 
     /// Describes an external change that requires user action (dirty tab conflict).
-    struct ExternalConflict {
+    struct ExternalConflict: Equatable, Sendable {
         let tabID: UUID
         let url: URL
         let kind: Kind
-        enum Kind: Equatable { case modified, deleted }
+        let observedState: BackingFileState
+
+        enum Kind: Equatable, Sendable { case modified, deleted }
     }
 
     /// Result of checking external changes — includes conflicts, silently reloaded files,
@@ -65,34 +67,83 @@ enum TabExternalChangeDetector {
 
             if !FileManager.default.fileExists(atPath: fileURL.path) {
                 if tab.isDirty {
-                    conflicts.append(.init(tabID: tab.id, url: fileURL, kind: .deleted))
+                    guard tab.pendingExternalFileState != .missing else {
+                        continue
+                    }
+                    conflicts.append(.init(
+                        tabID: tab.id,
+                        url: fileURL,
+                        kind: .deleted,
+                        observedState: .missing
+                    ))
+                    tabs[index].pendingExternalFileState = .missing
                 } else {
                     cleanDeletedIDs.append(tab.id)
                 }
                 continue
             }
 
-            guard let diskMod = providers.modDate(fileURL),
-                  let lastMod = tab.lastModDate,
-                  diskMod > lastMod
-            else { continue }
+            let diskMod = providers.modDate(fileURL)
+            let diskIdentity = try? providers.fileIdentity(fileURL)
+            let identityChanged = tab.backingFileRevision?.fileIdentity.map {
+                $0 != diskIdentity
+            }
+            let modificationDateChanged = diskMod != tab.lastModDate
+            guard identityChanged ?? modificationDateChanged else { continue }
+
+            if case .present(let pendingRevision) =
+                tab.pendingExternalFileState,
+               pendingRevision.fileIdentity == diskIdentity {
+                continue
+            }
 
             if tab.kind == .preview {
                 tabs[index].lastModDate = diskMod
-            } else if tab.isDirty {
-                conflicts.append(.init(tabID: tab.id, url: fileURL, kind: .modified))
+                continue
+            }
+
+            guard let diskRevision = try? providers.fileRevision(fileURL)
+            else { continue }
+            if diskRevision.contentDigest
+                == tab.backingFileRevision?.contentDigest {
+                tabs[index].backingFileRevision = diskRevision
                 tabs[index].lastModDate = diskMod
+                tabs[index].pendingExternalFileState = nil
+                continue
+            }
+
+            if tab.isDirty {
+                let diskState = BackingFileState.present(diskRevision)
+                guard tab.pendingExternalFileState != diskState else {
+                    continue
+                }
+                conflicts.append(.init(
+                    tabID: tab.id,
+                    url: fileURL,
+                    kind: .modified,
+                    observedState: diskState
+                ))
+                tabs[index].lastModDate = diskMod
+                tabs[index].pendingExternalFileState = diskState
             } else {
                 // Safe to reload silently
                 do {
-                    let content = try String(
-                        contentsOf: fileURL,
+                    let data = try Data(contentsOf: fileURL)
+                    guard let content = String(
+                        data: data,
                         encoding: tab.encoding
-                    )
+                    ) else {
+                        throw CocoaError(.fileReadInapplicableStringEncoding)
+                    }
                     tabs[index].content = content
                     tabs[index].savedContent = content
-                    tabs[index].lastModDate = diskMod
+                    tabs[index].lastModDate = providers.modDate(fileURL)
                     tabs[index].fileSizeBytes = providers.fileSize(fileURL)
+                    tabs[index].backingFileRevision = BackingFileRevision(
+                        data: data,
+                        fileIdentity: try? providers.fileIdentity(fileURL)
+                    )
+                    tabs[index].pendingExternalFileState = nil
                     tabs[index].cachedHighlightResult = nil
                     tabs[index].recomputeContentCaches()
                     reloadedNames.append(fileURL.lastPathComponent)
@@ -118,7 +169,8 @@ enum TabExternalChangeDetector {
     static func reloadTab(
         url: URL,
         tabs: inout [EditorTab],
-        providers: FileProviders
+        providers: FileProviders,
+        expectedState: BackingFileState? = nil
     ) -> ReloadedTab? {
         guard let index = tabs.firstIndex(where: {
             $0.fileURL == url
@@ -126,11 +178,27 @@ enum TabExternalChangeDetector {
             return nil
         }
         do {
-            let content = try String(contentsOf: url, encoding: tabs[index].encoding)
+            let data = try Data(contentsOf: url)
+            let revision = BackingFileRevision(
+                data: data,
+                fileIdentity: try? providers.fileIdentity(url)
+            )
+            if let expectedState,
+               expectedState != .present(revision) {
+                return nil
+            }
+            guard let content = String(
+                data: data,
+                encoding: tabs[index].encoding
+            ) else {
+                throw CocoaError(.fileReadInapplicableStringEncoding)
+            }
             tabs[index].content = content
             tabs[index].savedContent = content
             tabs[index].lastModDate = providers.modDate(url)
             tabs[index].fileSizeBytes = providers.fileSize(url)
+            tabs[index].backingFileRevision = revision
+            tabs[index].pendingExternalFileState = nil
             tabs[index].cachedHighlightResult = nil
             tabs[index].recomputeContentCaches()
             return .init(url: url, text: content)
@@ -138,5 +206,38 @@ enum TabExternalChangeDetector {
             logger.error("Failed to reload tab from disk \(url.lastPathComponent): \(error)")
             return nil
         }
+    }
+
+    static func authorizeExternalChange(
+        _ conflict: ExternalConflict,
+        tabs: inout [EditorTab],
+        providers: FileProviders
+    ) -> Bool {
+        guard conflict.kind == .modified,
+              let index = tabs.firstIndex(where: {
+                  $0.id == conflict.tabID && $0.fileURL == conflict.url
+              }),
+              currentFileState(at: conflict.url, providers: providers)
+                == conflict.observedState,
+              case .present(let revision) = conflict.observedState else {
+            return false
+        }
+        tabs[index].backingFileRevision = revision
+        tabs[index].pendingExternalFileState = nil
+        tabs[index].lastModDate = providers.modDate(conflict.url)
+        return true
+    }
+
+    private static func currentFileState(
+        at url: URL,
+        providers: FileProviders
+    ) -> BackingFileState? {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return .missing
+        }
+        guard let revision = try? providers.fileRevision(url) else {
+            return nil
+        }
+        return .present(revision)
     }
 }

--- a/Pine/Tabs/TabPersistence.swift
+++ b/Pine/Tabs/TabPersistence.swift
@@ -14,6 +14,24 @@ import UniformTypeIdentifiers
 struct FileProviders {
     let modDate: (URL) -> Date?
     let fileSize: (URL) -> Int?
+    let fileRevision: (URL) throws -> BackingFileRevision
+    let fileIdentity: (URL) throws -> BackingFileIdentity
+
+    init(
+        modDate: @escaping (URL) -> Date?,
+        fileSize: @escaping (URL) -> Int?,
+        fileRevision: @escaping (URL) throws -> BackingFileRevision = {
+            try BackingFileRevision.capture(at: $0)
+        },
+        fileIdentity: @escaping (URL) throws -> BackingFileIdentity = {
+            try BackingFileIdentity.capture(at: $0)
+        }
+    ) {
+        self.modDate = modDate
+        self.fileSize = fileSize
+        self.fileRevision = fileRevision
+        self.fileIdentity = fileIdentity
+    }
 
     /// Default providers using FileManager.
     static let `default` = FileProviders(
@@ -24,7 +42,9 @@ struct FileProviders {
             guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
                   let size = attrs[.size] as? Int else { return nil }
             return size
-        }
+        },
+        fileRevision: { try BackingFileRevision.capture(at: $0) },
+        fileIdentity: { try BackingFileIdentity.capture(at: $0) }
     )
 }
 
@@ -67,6 +87,22 @@ struct SaveOutcome {
 /// large file handling, and preview file detection.
 @MainActor
 enum TabPersistence {
+    enum SaveError: LocalizedError {
+        case externalChange(TabExternalChangeDetector.ExternalConflict)
+
+        var errorDescription: String? {
+            switch self {
+            case .externalChange(let conflict):
+                switch conflict.kind {
+                case .modified:
+                    String(localized: "conflict.externalModify.title")
+                case .deleted:
+                    String(localized: "fileOperation.deleted.message")
+                }
+            }
+        }
+    }
+
     private static let logger = Logger.editor
 
     /// File size threshold (in bytes) above which a warning is shown before opening.
@@ -119,16 +155,23 @@ enum TabPersistence {
     ) -> EditorTab {
         let content: String
         let encoding: String.Encoding
+        let revision: BackingFileRevision?
         do {
             let data = try Data(contentsOf: url)
             (content, encoding) = String.Encoding.detect(from: data)
+            revision = BackingFileRevision(
+                data: data,
+                fileIdentity: try? providers.fileIdentity(url)
+            )
         } catch {
             content = "// Error: \(error.localizedDescription)"
             encoding = .utf8
+            revision = nil
         }
 
         var tab = EditorTab(url: url, content: content, savedContent: content)
         tab.lastModDate = providers.modDate(url)
+        tab.backingFileRevision = revision
         tab.syntaxHighlightingDisabled = syntaxHighlightingDisabled
         tab.encoding = encoding
         tab.fileSizeBytes = providers.fileSize(url)
@@ -296,12 +339,15 @@ enum TabPersistence {
             settings: config.editorSettings,
             formatters: config.formatters
         )
+        try validateBackingFile(for: tab, at: fileURL, providers: providers)
         try trimmed.write(to: fileURL, atomically: true, encoding: tab.encoding)
         let contentChanged = trimmed != tab.content
         tabs[index].content = trimmed
         tabs[index].savedContent = trimmed
         tabs[index].lastModDate = providers.modDate(fileURL)
         tabs[index].fileSizeBytes = providers.fileSize(fileURL)
+        tabs[index].backingFileRevision = try? providers.fileRevision(fileURL)
+        tabs[index].pendingExternalFileState = nil
 
         var reload: ReloadedTab?
         if contentChanged {
@@ -337,6 +383,8 @@ enum TabPersistence {
         tabs[index].url = newURL
         tabs[index].savedContent = trimmed
         tabs[index].lastModDate = providers.modDate(newURL)
+        tabs[index].backingFileRevision = try? providers.fileRevision(newURL)
+        tabs[index].pendingExternalFileState = nil
         var reload: ReloadedTab?
         if contentChanged {
             tabs[index].cachedHighlightResult = nil
@@ -344,5 +392,31 @@ enum TabPersistence {
             reload = ReloadedTab(url: newURL, text: trimmed)
         }
         return SaveOutcome(saved: true, reload: reload)
+    }
+
+    private static func validateBackingFile(
+        for tab: EditorTab,
+        at url: URL,
+        providers: FileProviders
+    ) throws {
+        guard let expectedRevision = tab.backingFileRevision else { return }
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw SaveError.externalChange(.init(
+                tabID: tab.id,
+                url: url,
+                kind: .deleted,
+                observedState: .missing
+            ))
+        }
+        let actualRevision = try providers.fileRevision(url)
+        guard actualRevision.contentDigest == expectedRevision.contentDigest
+        else {
+            throw SaveError.externalChange(.init(
+                tabID: tab.id,
+                url: url,
+                kind: .modified,
+                observedState: .present(actualRevision)
+            ))
+        }
     }
 }

--- a/Pine/TerminationSaveCoordinator.swift
+++ b/Pine/TerminationSaveCoordinator.swift
@@ -102,6 +102,7 @@ nonisolated struct TerminationInstalledFileMetadata: Sendable {
     let size: Int
     let modificationSeconds: Int
     let modificationNanoseconds: Int
+    let contentDigest: Data
 
     var modificationDate: Date {
         Date(
@@ -626,7 +627,8 @@ nonisolated enum TerminationSaveCoordinator {
                 metadata: TerminationInstalledFileMetadata(
                     size: Int(clamping: status.st_size),
                     modificationSeconds: Int(status.st_mtimespec.tv_sec),
-                    modificationNanoseconds: Int(status.st_mtimespec.tv_nsec)
+                    modificationNanoseconds: Int(status.st_mtimespec.tv_nsec),
+                    contentDigest: Data(SHA256.hash(data: data))
                 )
             )
         } catch {

--- a/PineTests/TabExternalChangeDetectorTests.swift
+++ b/PineTests/TabExternalChangeDetectorTests.swift
@@ -82,6 +82,39 @@ struct TabExternalChangeDetectorTests {
         #expect(tabs[0].content == "user edits") // Not overwritten
     }
 
+    @Test(
+        "Detects dirty conflict when replacement keeps or lowers mtime",
+        arguments: [TimeInterval.zero, TimeInterval(-60)]
+    )
+    func conflictForNonIncreasingModificationDate(
+        offset: TimeInterval
+    ) throws {
+        let url = tempFile(content: "v1")
+        var tab = TabPersistence.createTextTab(
+            url: url,
+            syntaxHighlightingDisabled: false,
+            providers: providers
+        )
+        tab.content = "user edits"
+        let originalDate = try #require(providers.modDate(url))
+        var tabs = [tab]
+
+        try "v2".write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.modificationDate: originalDate.addingTimeInterval(offset)],
+            ofItemAtPath: url.path
+        )
+
+        let result = TabExternalChangeDetector.checkExternalChanges(
+            tabs: &tabs,
+            providers: providers
+        )
+
+        #expect(result.conflicts.count == 1)
+        #expect(result.conflicts[0].kind == .modified)
+        #expect(tabs[0].content == "user edits")
+    }
+
     // MARK: - Deleted file
 
     @Test("Returns cleanDeletedIDs for clean tab when file deleted")

--- a/PineTests/TabManagerTests.swift
+++ b/PineTests/TabManagerTests.swift
@@ -5,6 +5,7 @@
 //  Created by Claude on 12.03.2026.
 //
 
+import AppKit
 import Foundation
 import Testing
 
@@ -159,6 +160,66 @@ struct TabManagerTests {
         // Tab must remain dirty after failed save
         #expect(manager.activeTab?.isDirty == true)
         #expect(manager.activeTab?.content == "data")
+    }
+
+    @Test("save fence rejects an unseen timestamp-preserving replacement")
+    func saveRejectsUnseenExternalReplacement() throws {
+        let manager = makeTabManager()
+        let url = tempFileURL(content: "original")
+        manager.openTab(url: url)
+        manager.updateContent("local edits")
+        let originalDate = try #require(
+            try FileManager.default.attributesOfItem(atPath: url.path)[
+                .modificationDate
+            ] as? Date
+        )
+
+        try "external edits".write(
+            to: url,
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: originalDate],
+            ofItemAtPath: url.path
+        )
+
+        #expect(throws: TabPersistence.SaveError.self) {
+            try manager.trySaveTab(at: 0)
+        }
+        #expect(try String(contentsOf: url, encoding: .utf8) == "external edits")
+        #expect(manager.activeTab?.content == "local edits")
+        #expect(manager.activeTab?.isDirty == true)
+    }
+
+    @Test("Keep Local Changes authorizes only the observed disk revision")
+    func keepExternalConflictAuthorizesLaterSave() throws {
+        let manager = makeTabManager()
+        let url = tempFileURL(content: "original")
+        manager.openTab(url: url)
+        manager.updateContent("local edits")
+        let originalDate = try #require(
+            try FileManager.default.attributesOfItem(atPath: url.path)[
+                .modificationDate
+            ] as? Date
+        )
+
+        try "external edits".write(
+            to: url,
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: originalDate],
+            ofItemAtPath: url.path
+        )
+
+        let conflict = try #require(
+            manager.checkExternalChanges().conflicts.first
+        )
+        #expect(manager.authorizeExternalChange(conflict))
+        #expect(try manager.trySaveTab(at: 0))
+        #expect(try String(contentsOf: url, encoding: .utf8) == "local edits")
     }
 
     @Test("Handle file renamed updates tab URL preserving identity")
@@ -944,6 +1005,35 @@ struct TabManagerTests {
         try await Task.sleep(for: .milliseconds(300))
 
         // Should still be dirty — auto-save skipped
+        #expect(manager.activeTab?.isDirty == true)
+    }
+
+    @Test("auto-save prompts instead of overwriting an external replacement")
+    func autoSaveRejectsExternalReplacement() async throws {
+        let manager = makeTabManager()
+        manager.setAutoSaveDelay(0.05)
+        let url = tempFileURL(content: "original")
+        manager.openTab(url: url)
+        manager.updateContent("local edits")
+        var promptCount = 0
+        manager.externalConflictAlertPresenter = { _, _, _ in
+            promptCount += 1
+            return .abort
+        }
+
+        try "external edits".write(
+            to: url,
+            atomically: true,
+            encoding: .utf8
+        )
+        manager.scheduleAutoSave()
+        for _ in 0..<100 where promptCount == 0 {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+
+        #expect(promptCount == 1)
+        #expect(try String(contentsOf: url, encoding: .utf8) == "external edits")
+        #expect(manager.activeTab?.content == "local edits")
         #expect(manager.activeTab?.isDirty == true)
     }
 

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -1017,6 +1017,53 @@ struct WindowLifecycleTests {
         await project.workspace.waitForLoadingComplete()
     }
 
+    @Test func externalReplacementInvalidatesTerminationStaging() async throws {
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+        let file = try makeTempFile(in: dir)
+        let registry = makeRegistry()
+        let project = try #require(registry.projectManager(for: dir))
+        project.primaryTabManager.openTab(url: file)
+        updateContent("// local dirty", in: project)
+
+        let prepared = await project.prepareSaveAllPaneTabs(
+            context: .unscoped
+        )
+        guard case .ready(let plan) = prepared else {
+            Issue.record("Expected a ready termination save plan")
+            return
+        }
+        let originalDate = try #require(
+            try FileManager.default.attributesOfItem(atPath: file.path)[
+                .modificationDate
+            ] as? Date
+        )
+        try "// external".write(
+            to: file,
+            atomically: true,
+            encoding: .utf8
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: originalDate],
+            ofItemAtPath: file.path
+        )
+
+        let staged = await project.stagePreparedSaveAllPaneTabsForTermination(
+            plan,
+            until: .now() + 5
+        )
+
+        guard case .invalidated = staged.0 else {
+            Issue.record("Expected the external replacement to invalidate staging")
+            return
+        }
+        #expect(staged.1 == nil)
+        #expect(try String(contentsOf: file, encoding: .utf8) == "// external")
+        #expect(project.primaryTabManager.activeTab?.content == "// local dirty")
+        #expect(project.hasUnsavedChanges)
+        await project.workspace.waitForLoadingComplete()
+    }
+
     @Test func applicationSaveRejectsCrossProjectDestinationAlias() async throws {
         let firstRoot = try makeTempDirectory()
         let secondRoot = try makeTempDirectory()

--- a/PineTests/WindowLifecycleTests.swift
+++ b/PineTests/WindowLifecycleTests.swift
@@ -1692,6 +1692,15 @@ struct WindowLifecycleTests {
         let index = try #require(tabs.tabs.firstIndex(where: {
             $0.fileURL == file
         }))
+        let conflict: TabManager.ExternalConflict
+        do {
+            _ = try tabs.trySaveTab(at: index)
+            Issue.record("Expected the late install to require overwrite authorization")
+            return
+        } catch let TabPersistence.SaveError.externalChange(observed) {
+            conflict = observed
+        }
+        #expect(tabs.authorizeExternalChange(conflict))
         #expect(try tabs.trySaveTab(at: index))
         let savedTab = try #require(tabs.tabs.first(where: {
             $0.fileURL == file


### PR DESCRIPTION
## Summary

- track each text tab's backing bytes with a SHA-256 revision and a cheap inode/ctime identity
- revalidate the backing revision immediately before ordinary, auto-save, and Quit writes
- detect external replacements even when `mtime` is unchanged or moves backwards
- preserve the existing Reload / Keep Local Changes flow while making Keep an explicit, revision-scoped authorization
- refuse stale Reload/Keep decisions if the disk or local buffer changes while the sheet is visible
- keep routine external-change polling stat-only; content hashing happens only after metadata changes or at the save boundary

## Testing

- `TabManagerTests`
- `TabExternalChangeDetectorTests`
- `ExternalFileReloadTests`
- `TerminationSaveCoordinatorSecurityTests`
- focused `WindowLifecycleTests/externalReplacementInvalidatesTerminationStaging()`
- strict SwiftLint on all changed Swift files

All listed tests passed with Xcode 27 beta on macOS 27 beta. UI tests were not run.

Closes #1385
