### PR TITLE
perf(editor): move format-on-save off main actor

### DIFF
--- a/Pine/ExternalFileFormatter.swift
+++ b/Pine/ExternalFileFormatter.swift
@@ -682,24 +682,15 @@ nonisolated final class ExternalFileFormatter: FileFormatter, Sendable {
         let effectiveTimeout = min(timeout, maximumDuration)
         guard effectiveTimeout > 0 else { return content }
 
-        // Dispatch to a background queue so runRealProcess's main-thread
-        // precondition is satisfied. The caller (trySaveTab) runs on main;
-        // DispatchGroup.wait() blocks it briefly while the process executes.
-        nonisolated(unsafe) var result = ProcessRunResult(
-            stdout: "", stderr: "", exitCode: -1, timedOut: true
+        // Interactive saves prepare content on a worker queue before their
+        // main-actor revision check. Keep the formatter synchronous on that
+        // worker so there is no nested dispatch or main-thread wait.
+        let result = processRunner(
+            executablePath,
+            arguments,
+            content,
+            effectiveTimeout
         )
-        let group = DispatchGroup()
-        group.enter()
-        DispatchQueue.global(qos: .userInitiated).async {
-            result = self.processRunner(
-                executablePath,
-                self.arguments,
-                content,
-                effectiveTimeout
-            )
-            group.leave()
-        }
-        group.wait()
 
         // Fall back to original on any failure
         guard !result.timedOut,

--- a/Pine/FileFormatter.swift
+++ b/Pine/FileFormatter.swift
@@ -8,7 +8,8 @@ import Foundation
 /// A language-aware content formatter that rewrites file contents before they are written
 /// to disk. Formatters MUST be:
 ///
-/// - **Pure and synchronous** — invoked on the main thread inside `TabManager.trySaveTab`.
+/// - **Pure and synchronous** — interactive saves invoke it on a worker queue
+///   before returning to the main actor for revision validation and commit.
 /// - **Idempotent** — `format(format(x)) == format(x)`.
 /// - **Safe on parse failure** — return the original string unchanged if the input cannot
 ///   be parsed, so save never blocks on malformed files.
@@ -61,8 +62,8 @@ nonisolated struct JSONFileFormatter: FileFormatter {
     /// Extensions that are also skipped (VS Code workspaces, etc.).
     private static let blockExtensions: Set<String> = ["code-workspace"]
 
-    /// Maximum content size to format synchronously on the main thread.
-    /// Larger files are left as-is to avoid blocking the UI.
+    /// Maximum content size to format in one synchronous formatter call.
+    /// Larger files are left as-is to bound save latency and memory use.
     private static let maxFormatSize = 100_000
 
     func canFormat(url: URL) -> Bool {
@@ -114,8 +115,8 @@ nonisolated struct YAMLFileFormatter: FileFormatter, Sendable {
         "gemfile.lock", "cargo.lock"
     ]
 
-    /// Maximum content size to format synchronously on the main thread.
-    /// Larger files are left as-is to avoid blocking the UI.
+    /// Maximum content size to format in one synchronous formatter call.
+    /// Larger files are left as-is to bound save latency and memory use.
     private static let maxFormatSize = 100_000
 
     private let formatter: ExternalFileFormatter

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -672,46 +672,32 @@ final class ProjectManager {
         ))
     }
 
-    /// Commits an already prepared Save All plan without presenting UI or
-    /// suspending. The whole plan is revalidated before the first write.
+    /// Commits an already prepared Save All plan without presenting UI. Slow
+    /// save preparation suspends off-main; every captured tab revision is
+    /// revalidated again before its write.
     func commitPreparedSaveAllPaneTabs(
         _ plan: PreparedPaneSavePlan
-    ) -> PreparedPaneSaveCommitResult {
+    ) async -> PreparedPaneSaveCommitResult {
         guard preparedSavePlanStillValid(plan) else {
             return .invalidated
         }
+        for planned in plan.entries {
+            planned.tabManager.cancelAutoSave()
+        }
 
         for planned in plan.entries {
-            if let destination = planned.destination {
-                do {
-                    guard try planned.tabManager.saveTabAs(
-                        tabID: planned.tab.id,
-                        to: destination
-                    ) else {
-                        return .invalidated
-                    }
-                } catch {
-                    return .failed(
-                        message: error.localizedDescription,
-                        retainedArtifacts: []
-                    )
-                }
-            } else {
-                guard let index = planned.tabManager.tabs.firstIndex(where: {
-                    $0.id == planned.tab.id
-                }) else {
+            do {
+                guard try await planned.tabManager.trySaveTabAsync(
+                    snapshot: planned.tab,
+                    saveAsDestination: planned.destination
+                ) else {
                     return .invalidated
                 }
-                do {
-                    guard try planned.tabManager.trySaveTab(at: index) else {
-                        return .invalidated
-                    }
-                } catch {
-                    return .failed(
-                        message: error.localizedDescription,
-                        retainedArtifacts: []
-                    )
-                }
+            } catch {
+                return .failed(
+                    message: error.localizedDescription,
+                    retainedArtifacts: []
+                )
             }
         }
         return .saved
@@ -1196,7 +1182,7 @@ final class ProjectManager {
     func saveAllPaneTabs(context: DialogPresentationContext) async -> Bool {
         let prepared = await prepareSaveAllPaneTabs(context: context)
         guard case .ready(let plan) = prepared else { return false }
-        switch commitPreparedSaveAllPaneTabs(plan) {
+        switch await commitPreparedSaveAllPaneTabs(plan) {
         case .saved:
             return true
         case .invalidated, .timedOut:
@@ -1433,7 +1419,7 @@ final class ProjectManager {
             return false
         }
         do {
-            return try tabManager.saveTabAs(
+            return try await tabManager.saveTabAsAsync(
                 tabID: tabID,
                 to: destination
             )

--- a/Pine/TabManager.swift
+++ b/Pine/TabManager.swift
@@ -805,7 +805,91 @@ final class TabManager {
         return outcome.saved
     }
 
-    /// Synchronous, UI-free save primitive used by autosave and tests.
+    /// Async save primitive used by every interactive save path. The mutable
+    /// tab is captured on the main actor, transformed on a worker queue, then
+    /// revision-checked again immediately before the disk write.
+    @discardableResult
+    func trySaveTabAsync(at index: Int) async throws -> Bool {
+        assert(tabs.indices.contains(index), "trySaveTab: index \(index) out of bounds, count \(tabs.count)")
+        guard tabs.indices.contains(index) else { return false }
+        return try await trySaveTabAsync(snapshot: tabs[index])
+    }
+
+    /// Saves one exact captured revision. Save All passes its pre-authorized
+    /// snapshot here so an edit made while an earlier tab is formatting cannot
+    /// silently expand what the operation writes.
+    @discardableResult
+    func trySaveTabAsync(
+        snapshot: EditorTab,
+        saveAsDestination: URL? = nil
+    ) async throws -> Bool {
+        guard let index = tabs.firstIndex(where: { $0.id == snapshot.id }) else {
+            return false
+        }
+        let current = tabs[index]
+        guard current.kind == .text,
+              current.contentVersion == snapshot.contentVersion,
+              current.persistenceGeneration == snapshot.persistenceGeneration,
+              current.content == snapshot.content,
+              current.fileURL == snapshot.fileURL else {
+            return false
+        }
+        if current.isTruncated {
+            throw CocoaError(.fileWriteUnknown, userInfo: [
+                NSLocalizedDescriptionKey: "Cannot save: file was partially loaded (truncated). Saving would corrupt the original file."
+            ])
+        }
+        guard let destinationURL = saveAsDestination ?? current.fileURL else {
+            return false
+        }
+
+        let request = TabSaveRequest(
+            tabID: current.id,
+            contentVersion: current.contentVersion,
+            persistenceGeneration: current.persistenceGeneration,
+            content: current.content,
+            originalURL: current.fileURL,
+            destinationURL: destinationURL,
+            updatesBackingURL: saveAsDestination != nil,
+            encodingRawValue: current.encoding.rawValue,
+            settings: EditorSaveSettingsSnapshot(
+                insertFinalNewline: editorSettings.insertFinalNewline,
+                stripTrailingWhitespace: editorSettings.stripTrailingWhitespace,
+                formatOnSave: editorSettings.formatOnSave
+            ),
+            formatters: fileFormatters
+        )
+        let prepared = await runOnBackground {
+            TabPersistence.prepareSave(request)
+        }
+        guard !Task.isCancelled else { return false }
+        let outcome = try TabPersistence.commitPreparedSave(
+            prepared,
+            tabs: &tabs,
+            providers: .init(
+                modDate: { [weak self] url in self?.modDate(for: url) },
+                fileSize: { [weak self] url in self?.fileSize(url: url) }
+            )
+        )
+        if outcome.saved {
+            recoveryManager?.deleteRecoveryFile(for: current.id)
+            if saveAsDestination != nil {
+                onTabInventoryChanged?()
+            }
+        }
+        if let reload = outcome.reload {
+            NotificationCenter.default.post(
+                name: .tabReloadedFromDisk,
+                object: nil,
+                userInfo: ["url": reload.url, "text": reload.text]
+            )
+        }
+        return outcome.saved
+    }
+
+    /// Synchronous, UI-free save primitive retained for pure-formatter tests
+    /// and legacy noninteractive callers. Interactive paths use the async
+    /// revision-fenced primitive above.
     ///
     /// Errors are reported by the async window-scoped overload at user
     /// interaction boundaries. Keeping this primitive UI-free prevents a
@@ -827,8 +911,11 @@ final class TabManager {
         context: DialogPresentationContext
     ) async -> Bool {
         assert(tabs.indices.contains(index), "saveTab: index \(index) out of bounds, count \(tabs.count)")
+        if tabs.indices.contains(index) {
+            cancelAutoSave(for: tabs[index].id)
+        }
         do {
-            return try trySaveTab(at: index)
+            return try await trySaveTabAsync(at: index)
         } catch {
             if let saveError = error as? TabPersistence.SaveError,
                case .externalChange(let conflict) = saveError,
@@ -863,7 +950,13 @@ final class TabManager {
     @discardableResult
     func saveAllTabs(context: DialogPresentationContext) async -> Bool {
         do {
-            try trySaveAllTabs()
+            cancelAutoSave()
+            let snapshots = tabs.filter(\.isDirty)
+            for snapshot in snapshots {
+                guard try await trySaveTabAsync(snapshot: snapshot) else {
+                    return false
+                }
+            }
             return true
         } catch {
             if let saveError = error as? TabPersistence.SaveError,
@@ -919,6 +1012,21 @@ final class TabManager {
             )
         }
         return outcome.saved
+    }
+
+    /// Async Save As counterpart used by windows and Save All. Its destination
+    /// is captured before background formatting starts, while the original tab
+    /// revision remains the commit authorization.
+    @discardableResult
+    func saveTabAsAsync(tabID: UUID, to newURL: URL) async throws -> Bool {
+        guard let snapshot = tabs.first(where: { $0.id == tabID }) else {
+            return false
+        }
+        cancelAutoSave(for: tabID)
+        return try await trySaveTabAsync(
+            snapshot: snapshot,
+            saveAsDestination: newURL
+        )
     }
 
     /// Applies the model half of a termination save after its destination was
@@ -1325,7 +1433,7 @@ final class TabManager {
             saveAction: { [weak self] in
                 guard let self, let idx = self.tabs.firstIndex(where: { $0.id == tabID }) else { return }
                 do {
-                    try self.trySaveTab(at: idx)
+                    try await self.trySaveTabAsync(at: idx)
                 } catch let error as TabPersistence.SaveError {
                     if case .externalChange(let conflict) = error {
                         let context = self.dialogContextProvider()

--- a/Pine/Tabs/TabAutoSave.swift
+++ b/Pine/Tabs/TabAutoSave.swift
@@ -18,7 +18,7 @@ final class TabAutoSave {
     var delay: TimeInterval = 1.0
 
     /// Whether auto-save is currently in progress (for UI indicator).
-    private(set) var isSaving = false
+    var isSaving: Bool { !activeSaveGenerations.isEmpty }
 
     private struct PendingSave {
         let generation: UUID
@@ -31,6 +31,11 @@ final class TabAutoSave {
     /// Independent debounce work per tab. Editing or transferring one tab
     /// must not cancel a save already scheduled for another tab.
     private var pendingSaves: [UUID: PendingSave] = [:]
+    /// A replaced debounce may already be executing its async save. Track
+    /// executions by generation so overlapping tabs (or a newer generation of
+    /// one tab) keep the UI indicator truthful until every save has completed.
+    private var activeSaveGenerations: Set<UUID> = []
+    private var activeTasks: [UUID: Task<Void, Never>] = [:]
 
     /// Whether a pending auto-save is scheduled (for testing).
     var hasScheduledSave: Bool {
@@ -50,7 +55,7 @@ final class TabAutoSave {
     ///   - saveAction: The save operation to perform.
     func schedule(
         isStillDirty: @MainActor @escaping () -> Bool,
-        saveAction: @MainActor @escaping () throws -> Void
+        saveAction: @MainActor @escaping () async throws -> Void
     ) {
         schedule(for: defaultKey, isStillDirty: isStillDirty, saveAction: saveAction)
     }
@@ -59,7 +64,7 @@ final class TabAutoSave {
     func schedule(
         for key: UUID,
         isStillDirty: @MainActor @escaping () -> Bool,
-        saveAction: @MainActor @escaping () throws -> Void
+        saveAction: @MainActor @escaping () async throws -> Void
     ) {
         cancel(for: key)
 
@@ -73,16 +78,23 @@ final class TabAutoSave {
                 return
             }
 
-            self.isSaving = true
-            do {
-                try saveAction()
-            } catch {
-                // Silent failure — auto-save should not show alerts
+            self.activeSaveGenerations.insert(generation)
+            let task = Task { @MainActor [weak self] in
+                guard let self else { return }
+                defer {
+                    self.activeSaveGenerations.remove(generation)
+                    self.activeTasks[generation] = nil
+                }
+                do {
+                    try await saveAction()
+                } catch {
+                    // Silent failure — auto-save should not show alerts
+                }
+                if self.pendingSaves[key]?.generation == generation {
+                    self.pendingSaves[key] = nil
+                }
             }
-            self.isSaving = false
-            if self.pendingSaves[key]?.generation == generation {
-                self.pendingSaves[key] = nil
-            }
+            self.activeTasks[generation] = task
         }
 
         pendingSaves[key] = PendingSave(generation: generation, workItem: item)
@@ -91,12 +103,17 @@ final class TabAutoSave {
 
     /// Cancels the pending auto-save for one tab without disturbing others.
     func cancel(for key: UUID) {
-        pendingSaves.removeValue(forKey: key)?.workItem.cancel()
+        guard let pending = pendingSaves.removeValue(forKey: key) else { return }
+        pending.workItem.cancel()
+        activeTasks.removeValue(forKey: pending.generation)?.cancel()
     }
 
     /// Cancels every pending auto-save.
     func cancel() {
-        pendingSaves.values.forEach { $0.workItem.cancel() }
+        pendingSaves.values.forEach { pending in
+            pending.workItem.cancel()
+            activeTasks.removeValue(forKey: pending.generation)?.cancel()
+        }
         pendingSaves.removeAll()
     }
 }

--- a/Pine/Tabs/TabPersistence.swift
+++ b/Pine/Tabs/TabPersistence.swift
@@ -83,6 +83,29 @@ struct SaveOutcome {
     let reload: ReloadedTab?
 }
 
+/// Immutable witness for an interactive save. Save-time transforms may take
+/// seconds when they invoke an external tool, so they operate on this snapshot
+/// away from the main actor. The live tab must still match every revision field
+/// before the prepared text is allowed to reach disk.
+nonisolated struct TabSaveRequest: Sendable {
+    let tabID: UUID
+    let contentVersion: UInt64
+    let persistenceGeneration: UInt64
+    let content: String
+    let originalURL: URL?
+    let destinationURL: URL
+    let updatesBackingURL: Bool
+    let encodingRawValue: UInt
+    let settings: EditorSaveSettingsSnapshot
+    let formatters: FileFormatterRegistry
+}
+
+/// Result of the potentially slow, but pure, save-preparation phase.
+nonisolated struct PreparedTabSave: Sendable {
+    let request: TabSaveRequest
+    let content: String
+}
+
 /// Handles disk I/O for editor tabs: opening files, saving content,
 /// large file handling, and preview file detection.
 @MainActor
@@ -305,6 +328,85 @@ enum TabPersistence {
     }
 
     // MARK: - Save
+
+    /// Applies format-on-save and the remaining text transforms on a worker
+    /// thread. This function is deliberately nonisolated: an external
+    /// formatter blocks its calling thread until its child process exits.
+    nonisolated static func prepareSave(
+        _ request: TabSaveRequest
+    ) -> PreparedTabSave {
+        PreparedTabSave(
+            request: request,
+            content: TabFormatter.contentPreparedForSave(
+                request.content,
+                url: request.destinationURL,
+                settings: request.settings,
+                formatters: request.formatters,
+                formatterMaximumDuration: nil
+            )
+        )
+    }
+
+    /// Commits a prepared save only while its exact tab and persistence
+    /// revisions are still current. There is no suspension between this
+    /// validation and the write, so an edit made while formatting was in
+    /// flight can never be replaced by stale formatter output.
+    static func commitPreparedSave(
+        _ prepared: PreparedTabSave,
+        tabs: inout [EditorTab],
+        providers: FileProviders
+    ) throws -> SaveOutcome {
+        let request = prepared.request
+        guard let index = tabs.firstIndex(where: { $0.id == request.tabID }) else {
+            return SaveOutcome(saved: false, reload: nil)
+        }
+        let tab = tabs[index]
+        guard tab.kind == .text,
+              !tab.isTruncated,
+              tab.contentVersion == request.contentVersion,
+              tab.persistenceGeneration == request.persistenceGeneration,
+              tab.content == request.content,
+              tab.fileURL == request.originalURL else {
+            return SaveOutcome(saved: false, reload: nil)
+        }
+        let encoding = String.Encoding(rawValue: request.encodingRawValue)
+
+        if !request.updatesBackingURL {
+            try validateBackingFile(
+                for: tab,
+                at: request.destinationURL,
+                providers: providers
+            )
+        }
+        try prepared.content.write(
+            to: request.destinationURL,
+            atomically: true,
+            encoding: encoding
+        )
+        let contentChanged = prepared.content != tab.content
+        tabs[index].content = prepared.content
+        if request.updatesBackingURL {
+            tabs[index].url = request.destinationURL
+        }
+        tabs[index].savedContent = prepared.content
+        tabs[index].lastModDate = providers.modDate(request.destinationURL)
+        tabs[index].fileSizeBytes = providers.fileSize(request.destinationURL)
+        tabs[index].backingFileRevision = try? providers.fileRevision(
+            request.destinationURL
+        )
+        tabs[index].pendingExternalFileState = nil
+
+        var reload: ReloadedTab?
+        if contentChanged {
+            tabs[index].cachedHighlightResult = nil
+            tabs[index].recomputeContentCaches()
+            reload = ReloadedTab(
+                url: request.destinationURL,
+                text: prepared.content
+            )
+        }
+        return SaveOutcome(saved: true, reload: reload)
+    }
 
     /// Saves tab content to disk.
     ///

--- a/PineTests/AsyncFormatOnSaveTests.swift
+++ b/PineTests/AsyncFormatOnSaveTests.swift
@@ -1,0 +1,233 @@
+//
+//  AsyncFormatOnSaveTests.swift
+//  PineTests
+//
+
+import Foundation
+import Testing
+
+@testable import Pine
+
+@Suite("Async format-on-save", .serialized)
+@MainActor
+struct AsyncFormatOnSaveTests {
+    @Test("main-actor heartbeat continues while an external formatter waits")
+    func mainActorRemainsResponsive() async throws {
+        let probe = DelayedFormatterProbe(waitForRelease: true)
+        let (manager, url) = try makeManager(probe: probe)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        manager.updateContent("draft")
+        let save = Task { @MainActor in
+            try await manager.trySaveTabAsync(at: 0)
+        }
+        try await waitUntil { probe.hasStarted }
+
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
+
+        #expect(!probe.hasFinished)
+        #expect(!probe.ranOnMainThread)
+        probe.release()
+        let didSave = try await save.value
+        #expect(didSave)
+        #expect(manager.activeTab?.content == "FORMATTED: draft")
+    }
+
+    @Test("an edit made during formatting invalidates stale output")
+    func staleFormatterOutputIsDiscarded() async throws {
+        let probe = DelayedFormatterProbe(delay: 0.25)
+        let (manager, url) = try makeManager(probe: probe)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        manager.updateContent("captured")
+        let save = Task { @MainActor in
+            try await manager.trySaveTabAsync(at: 0)
+        }
+        try await waitUntil { probe.hasStarted }
+        manager.updateContent("newer edit")
+
+        let didSave = try await save.value
+        #expect(!didSave)
+        #expect(manager.activeTab?.content == "newer edit")
+        #expect(manager.activeTab?.isDirty == true)
+        #expect(try String(contentsOf: url, encoding: .utf8) == "original")
+    }
+
+    @Test("an external edit during formatting is not overwritten")
+    func externalEditDuringFormattingIsRejected() async throws {
+        let probe = DelayedFormatterProbe(waitForRelease: true)
+        let (manager, url) = try makeManager(probe: probe)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        manager.updateContent("local edits")
+        let save = Task { @MainActor in
+            try await manager.trySaveTabAsync(at: 0)
+        }
+        try await waitUntil { probe.hasStarted }
+        try "external edits".write(
+            to: url,
+            atomically: true,
+            encoding: .utf8
+        )
+        probe.release()
+
+        do {
+            _ = try await save.value
+            Issue.record("Expected the external disk revision to reject the save")
+        } catch let TabPersistence.SaveError.externalChange(conflict) {
+            #expect(conflict.url == url)
+            #expect(conflict.kind == .modified)
+        }
+        #expect(try String(contentsOf: url, encoding: .utf8) == "external edits")
+        #expect(manager.activeTab?.content == "local edits")
+        #expect(manager.activeTab?.isDirty == true)
+    }
+
+    @Test("Save All uses the background formatter path")
+    func saveAllUsesBackgroundPreparation() async throws {
+        let probe = DelayedFormatterProbe(delay: 0.2)
+        let project = ProjectManager()
+        let manager = project.activeTabManager
+        let url = try configure(manager, probe: probe)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        manager.updateContent("save all")
+        let save = Task { @MainActor in
+            await project.saveAllPaneTabs(context: .unscoped)
+        }
+        try await waitUntil { probe.hasStarted }
+
+        #expect(!probe.ranOnMainThread)
+        let didSave = await save.value
+        #expect(didSave)
+        #expect(try String(contentsOf: url, encoding: .utf8) == "FORMATTED: save all")
+    }
+
+    @Test("auto-save uses the background formatter path")
+    func autoSaveUsesBackgroundPreparation() async throws {
+        let probe = DelayedFormatterProbe(delay: 0.2)
+        let (manager, url) = try makeManager(probe: probe)
+        defer { try? FileManager.default.removeItem(at: url) }
+        manager.autoSavePreferenceProvider = { true }
+        manager.setAutoSaveDelay(0.01)
+
+        manager.updateContent("auto save")
+        try await waitUntil { probe.hasStarted }
+        #expect(manager.isAutoSaving)
+        #expect(!probe.ranOnMainThread)
+        try await waitUntil { manager.activeTab?.isDirty == false }
+
+        #expect(try String(contentsOf: url, encoding: .utf8) == "FORMATTED: auto save")
+        #expect(!manager.isAutoSaving)
+    }
+
+    private func makeManager(
+        probe: DelayedFormatterProbe
+    ) throws -> (TabManager, URL) {
+        let manager = TabManager()
+        return (manager, try configure(manager, probe: probe))
+    }
+
+    private func configure(
+        _ manager: TabManager,
+        probe: DelayedFormatterProbe
+    ) throws -> URL {
+        let suiteName = "AsyncFormatOnSaveTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let settings = EditorSettings(defaults: defaults)
+        settings.formatOnSave = true
+        settings.insertFinalNewline = false
+        settings.stripTrailingWhitespace = false
+        manager.editorSettings = settings
+        manager.fileFormatters = FileFormatterRegistry(formatters: [
+            ExternalFileFormatter(
+                toolPath: "/mock/delayed-formatter",
+                toolName: "delayed-formatter",
+                extensions: ["asyncfmt"],
+                arguments: [],
+                processRunner: probe.run
+            )
+        ])
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("async-save-\(UUID().uuidString).asyncfmt")
+        try "original".write(to: url, atomically: true, encoding: .utf8)
+        manager.openTab(url: url)
+        return url
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        _ predicate: @MainActor () -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while !predicate(), ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(predicate())
+    }
+}
+
+nonisolated final class DelayedFormatterProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let delay: TimeInterval
+    private let releaseGate: DispatchSemaphore?
+    private var started = false
+    private var finished = false
+    private var executedOnMainThread = false
+
+    init(delay: TimeInterval) {
+        self.delay = delay
+        self.releaseGate = nil
+    }
+
+    init(waitForRelease: Bool) {
+        self.delay = 0
+        self.releaseGate = waitForRelease ? DispatchSemaphore(value: 0) : nil
+    }
+
+    var hasStarted: Bool {
+        lock.withLock { started }
+    }
+
+    var hasFinished: Bool {
+        lock.withLock { finished }
+    }
+
+    var ranOnMainThread: Bool {
+        lock.withLock { executedOnMainThread }
+    }
+
+    func release() {
+        releaseGate?.signal()
+    }
+
+    func run(
+        executablePath: String,
+        arguments: [String],
+        stdin: String,
+        timeout: TimeInterval
+    ) -> ProcessRunResult {
+        lock.withLock {
+            started = true
+            executedOnMainThread = Thread.isMainThread
+        }
+        if let releaseGate {
+            _ = releaseGate.wait(timeout: .now() + 5)
+        } else {
+            Thread.sleep(forTimeInterval: min(delay, timeout))
+        }
+        lock.withLock { finished = true }
+        return ProcessRunResult(
+            stdout: "FORMATTED: \(stdin)",
+            stderr: "",
+            exitCode: 0,
+            timedOut: false
+        )
+    }
+}

--- a/PineTests/MenuSaveReentrancyTests.swift
+++ b/PineTests/MenuSaveReentrancyTests.swift
@@ -26,13 +26,12 @@
 //  the menu-save path. The fix defers the save (disk write + @Observable
 //  mutation + notification) to the next runloop via
 //  `ProjectManager.saveActiveTabFromMenu()` / `saveAllTabsFromMenu()`, so the
-//  button-action callstack unwinds first. Autosave / close / quit keep calling
-//  the synchronous `saveActiveTab()` directly — they are not invoked from a
-//  `ButtonAction`, so there is no transactional access to collide with.
+//  button-action callstack unwinds first. Interactive saves then prepare their
+//  transformed content asynchronously before the revision-fenced commit.
 //
 //  These tests pin the contract via the observable side effect of the deferral:
 //  the file must NOT be rewritten synchronously when the menu-save method is
-//  invoked, but MUST be on the next runloop. Removing the
+//  invoked, but MUST complete after the deferred async preparation. Removing the
 //  `DispatchQueue.main.async` from `performMenuSave` turns the tests red —
 //  verified by regression injection.
 //
@@ -57,9 +56,15 @@ struct MenuSaveReentrancyTests {
         (try? String(contentsOf: url, encoding: .utf8)) ?? ""
     }
 
-    private func drainRunloop() async throws {
-        await Task.yield()
-        try await Task.sleep(for: .milliseconds(50))
+    private func waitUntilDiskChanges(
+        _ url: URL,
+        from original: String
+    ) async throws {
+        for _ in 0..<500 {
+            if readDisk(url) != original { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(readDisk(url) != original)
     }
 
     // MARK: - saveActiveTabFromMenu defers the disk write (#1058)
@@ -95,11 +100,11 @@ struct MenuSaveReentrancyTests {
         #expect(readDisk(url) == originalOnDisk,
                 "saveActiveTabFromMenu must not perform the save synchronously (the reentrancy that triggers the exclusivity abort)")
 
-        // Contract #2: the deferred save must rewrite the file on the next
-        // runloop (format-on-save changed the content).
-        try await drainRunloop()
+        // Contract #2: the deferred async save must eventually rewrite the
+        // file (format-on-save changed the content).
+        try await waitUntilDiskChanges(url, from: originalOnDisk)
         #expect(readDisk(url) != originalOnDisk,
-                "saveActiveTabFromMenu must perform the save on the next runloop")
+                "saveActiveTabFromMenu must complete its deferred async save")
         #expect(readDisk(url).contains("\n"),
                 "deferred format-on-save must have pretty-printed the JSON")
     }
@@ -138,22 +143,20 @@ struct MenuSaveReentrancyTests {
         #expect(readDisk(url) == originalOnDisk,
                 "saveAllTabsFromMenu must not perform the save synchronously")
 
-        try await drainRunloop()
+        try await waitUntilDiskChanges(url, from: originalOnDisk)
         #expect(readDisk(url) != originalOnDisk,
-                "saveAllTabsFromMenu must perform the save on the next runloop")
+                "saveAllTabsFromMenu must complete its deferred async save")
         #expect(readDisk(url).contains("\n"),
                 "deferred format-on-save must have pretty-printed the JSON")
     }
 
-    // MARK: - Synchronous save path is unchanged for non-menu callers
+    // MARK: - Legacy synchronous primitive
 
-    @Test("direct saveActiveTab() (autosave/close/quit path) still saves synchronously")
+    @Test("direct saveActiveTab() remains synchronous for legacy callers")
     func directSaveIsSynchronous() throws {
-        // Autosave, close, and quit call saveActiveTab() directly (NOT via the
-        // menu entry point). Those callers are not inside a ButtonAction, so
-        // there is no exclusivity conflict and the save MUST remain
-        // synchronous — otherwise autosave/close/quit semantics change. This
-        // test pins that the deferral lives ONLY in the menu entry points.
+        // Keep the legacy pure-formatter helper synchronous for focused tests
+        // and noninteractive callers. Production Save, Save All, Save As, and
+        // auto-save use the revision-fenced async path.
         let pm = ProjectManager()
         let settings = EditorSettings(defaults: makeIsolatedDefaults())
         settings.formatOnSave = true

--- a/PineTests/TabAutoSaveTests.swift
+++ b/PineTests/TabAutoSaveTests.swift
@@ -24,7 +24,7 @@ struct TabAutoSaveTests {
         )
 
         #expect(coordinator.hasScheduledSave == true)
-        try await Task.sleep(for: .milliseconds(300))
+        try await waitUntil { saved }
         #expect(saved == true)
         #expect(coordinator.hasScheduledSave == false)
     }
@@ -75,7 +75,7 @@ struct TabAutoSaveTests {
             )
         }
 
-        try await Task.sleep(for: .milliseconds(400))
+        try await waitUntil { saveCount == 1 }
         #expect(saveCount == 1)
     }
 
@@ -106,7 +106,9 @@ struct TabAutoSaveTests {
 
         #expect(coordinator.hasScheduledSave(for: firstKey))
         #expect(coordinator.hasScheduledSave(for: secondKey))
-        try await Task.sleep(for: .milliseconds(300))
+        try await waitUntil {
+            firstSaveCount == 1 && secondSaveCount == 1
+        }
 
         #expect(firstSaveCount == 1)
         #expect(secondSaveCount == 1)
@@ -118,13 +120,17 @@ struct TabAutoSaveTests {
         let coordinator = TabAutoSave()
         coordinator.delay = 0.05
 
+        var actionRan = false
         var wasSavingDuringAction = false
         coordinator.schedule(
             isStillDirty: { true },
-            saveAction: { wasSavingDuringAction = coordinator.isSaving }
+            saveAction: {
+                actionRan = true
+                wasSavingDuringAction = coordinator.isSaving
+            }
         )
 
-        try await Task.sleep(for: .milliseconds(200))
+        try await waitUntil { actionRan }
         #expect(wasSavingDuringAction == true)
         #expect(coordinator.isSaving == false)
     }
@@ -134,12 +140,16 @@ struct TabAutoSaveTests {
         let coordinator = TabAutoSave()
         coordinator.delay = 0.05
 
+        var attempts = 0
         coordinator.schedule(
             isStillDirty: { true },
-            saveAction: { throw CocoaError(.fileReadUnknown) }
+            saveAction: {
+                attempts += 1
+                throw CocoaError(.fileReadUnknown)
+            }
         )
 
-        try await Task.sleep(for: .milliseconds(200))
+        try await waitUntil { attempts == 1 }
         // Should not crash; isSaving resets
         #expect(coordinator.isSaving == false)
     }
@@ -147,5 +157,13 @@ struct TabAutoSaveTests {
     @Test("autoSaveKey has expected value")
     func autoSaveKey() {
         #expect(TabAutoSave.autoSaveKey == "autoSaveEnabled")
+    }
+
+    private func waitUntil(_ predicate: @MainActor () -> Bool) async throws {
+        for _ in 0..<500 {
+            if predicate() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(predicate())
     }
 }

--- a/PineTests/TabManagerTests.swift
+++ b/PineTests/TabManagerTests.swift
@@ -972,8 +972,8 @@ struct TabManagerTests {
 
         manager.scheduleAutoSave()
 
-        // Wait for debounce + save
-        try await Task.sleep(for: .milliseconds(300))
+        // Wait for debounce + asynchronous save preparation.
+        try await waitUntil { manager.activeTab?.isDirty == false }
 
         #expect(manager.activeTab?.isDirty == false)
         let onDisk = try String(contentsOf: url, encoding: .utf8)
@@ -1057,7 +1057,7 @@ struct TabManagerTests {
         manager.updateContent("change3")
         manager.scheduleAutoSave()
 
-        try await Task.sleep(for: .milliseconds(400))
+        try await waitUntil { manager.activeTab?.isDirty == false }
 
         #expect(manager.activeTab?.isDirty == false)
         let onDisk = try String(contentsOf: url, encoding: .utf8)
@@ -1099,7 +1099,7 @@ struct TabManagerTests {
 
         manager.openTab(url: url2)
 
-        try await Task.sleep(for: .milliseconds(300))
+        try await waitUntil { manager.tabs[0].isDirty == false }
 
         // Tab 1 should have been saved
         let disk1 = try String(contentsOf: url1, encoding: .utf8)
@@ -1384,7 +1384,7 @@ struct TabManagerTests {
 
         manager.scheduleAutoSave()
 
-        try await Task.sleep(for: .milliseconds(300))
+        try await waitUntil { manager.activeTab?.isDirty == false }
 
         #expect(manager.activeTab?.isDirty == false)
         let onDisk = try String(contentsOf: url, encoding: .utf8)
@@ -1551,7 +1551,7 @@ struct TabManagerTests {
         #expect(manager.isAutoSaving == false)
 
         manager.scheduleAutoSave()
-        try await Task.sleep(for: .milliseconds(200))
+        try await waitUntil { manager.activeTab?.isDirty == false }
 
         // After save completes, flag resets immediately
         #expect(manager.isAutoSaving == false)
@@ -1652,5 +1652,13 @@ struct TabManagerTests {
         // Verify we can still open the file — no leaked exclusive lock.
         let handle = try FileHandle(forReadingFrom: url)
         handle.closeFile()
+    }
+
+    private func waitUntil(_ predicate: @MainActor () -> Bool) async throws {
+        for _ in 0..<500 {
+            if predicate() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(predicate())
     }
 }


### PR DESCRIPTION
## Summary

- prepare format-on-save content on a worker queue and revision-check it again before the disk write
- route Save, Save As, Save All, and auto-save through the asynchronous path, including safe cancellation of in-flight auto-saves
- preserve the external-file revision fence from #1397 immediately before every async disk write
- remove the formatter nested wait and add heartbeat, stale-buffer, and external-edit regression coverage
- keep the PR diff limited to the async-save change after rebasing onto current main

## Testing

- focused AsyncFormatOnSaveTests and TabExternalChangeDetectorTests passed after the final rebase
- TabManagerTests passed
- TabAutoSaveTests and WindowLifecycleTests passed
- SwiftLint strict and git diff check passed
- local UI tests were not run per request; hosted CI runs them

Closes #1387