### PR TITLE
fix(terminal): draw Metal recovery frames immediately

### DIFF
--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -243,6 +243,8 @@ final class PineTerminalView: LocalProcessTerminalView {
     var backendRedrawRequestObserver: (() -> Void)?
     /// Test hook for the Metal-specific SwiftTerm compatibility bridge.
     var metalRedrawBridgeObserver: (() -> Void)?
+    /// Test hook immediately before SwiftTerm's synchronous Metal draw API.
+    var metalImmediateDrawObserver: (() -> Void)?
     #endif
 
     /// Enables SwiftTerm's Metal renderer once the view lands in a window.
@@ -421,14 +423,19 @@ final class PineTerminalView: LocalProcessTerminalView {
     /// synchronous `setNeedsDisplay` + `displayIfNeeded` sequence remains the
     /// right recovery operation. Under Metal, however, outer `draw(_:)`
     /// returns immediately and a private nested `MTKView` owns presentation.
-    /// SwiftTerm 1.14.0 does not expose `requestMetalDisplay()` publicly, so
-    /// Pine uses two stable public entry points:
+    /// SwiftTerm does not expose `requestMetalDisplay()` publicly, so Pine
+    /// combines its public immediate-frame API with the existing invalidation
+    /// bridge:
     ///
     /// - `selectionChanged(source:)` marks the full visible Metal range dirty
     ///   and queues a display, ensuring cached rows are rebuilt when needed.
+    /// - `drawMetalFrameNow()` attempts a frame synchronously while this
+    ///   recovery boundary still has a drawable. This closes the gap where an
+    ///   on-demand `setNeedsDisplay` is coalesced or discarded by AppKit.
     /// - same-size `setFrameSize(_:)` is harmless (`processSizeChange` no-ops
-    ///   when cols/rows are unchanged) and immediately calls SwiftTerm's
-    ///   internal `requestMetalDisplay()`.
+    ///   when cols/rows are unchanged) and queues a trailing request through
+    ///   SwiftTerm's internal `requestMetalDisplay()` if the immediate draw
+    ///   could not acquire a drawable.
     ///
     /// Together they provide an immediate request plus a coalesced trailing
     /// request. Replace this compatibility bridge once SwiftTerm exposes a
@@ -443,6 +450,10 @@ final class PineTerminalView: LocalProcessTerminalView {
             metalRedrawBridgeObserver?()
             #endif
             selectionChanged(source: getTerminal())
+            #if DEBUG
+            metalImmediateDrawObserver?()
+            #endif
+            drawMetalFrameNow()
             setFrameSize(frame.size)
         } else {
             setNeedsDisplay(bounds)

--- a/PineTests/TerminalMetalRendererTests.swift
+++ b/PineTests/TerminalMetalRendererTests.swift
@@ -149,7 +149,7 @@ struct TerminalMetalRendererTests {
         #expect(metalBridgeRequests == 1)
     }
 
-    @Test("Metal redraw uses the nested MTKView compatibility bridge")
+    @Test("Metal redraw attempts an immediate frame before trailing invalidation")
     func metalRedrawTargetsNestedView() async {
         guard MTLCreateSystemDefaultDevice() != nil else { return }
         let view = PineTerminalView(frame: NSRect(x: 0, y: 0, width: 800, height: 300))
@@ -164,7 +164,9 @@ struct TerminalMetalRendererTests {
         // Let the initial bounded retry batch drain, then isolate one request.
         try? await Task.sleep(for: .milliseconds(450))
         var bridgeRequests = 0
+        var immediateDrawRequests = 0
         view.metalRedrawBridgeObserver = { bridgeRequests += 1 }
+        view.metalImmediateDrawObserver = { immediateDrawRequests += 1 }
         view.requestRendererDisplay()
 
         // `needsDisplay` is deliberately not asserted here: AppKit may
@@ -173,6 +175,7 @@ struct TerminalMetalRendererTests {
         // production boundary immediately before SwiftTerm receives it.
         #expect(metalView.superview === view)
         #expect(bridgeRequests == 1)
+        #expect(immediateDrawRequests == 1)
         window.contentView = nil
     }
 


### PR DESCRIPTION
Closes #1400

## Summary
- invoke SwiftTerm’s synchronous Metal draw API during recovery
- retain the same-size invalidation as a trailing fallback when no drawable is available
- cover the immediate draw boundary with a focused regression test

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild test -quiet -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineTests/TerminalMetalRendererTests`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swiftlint lint --strict --no-cache`
- UI tests not run locally per request; CI will run them