### PR TITLE
fix(editor): show gutter markers for unsaved changes

### DIFF
--- a/Pine/GitStatusProvider.swift
+++ b/Pine/GitStatusProvider.swift
@@ -305,6 +305,72 @@ final class GitStatusProvider {
         return GitParser.parseDiff(result.output)
     }
 
+    /// Compares the current editor buffer with HEAD without requiring a save.
+    ///
+    /// `git diff HEAD -- <path>` can only inspect the worktree file on disk, so
+    /// using it after an in-memory edit leaves the gutter one save behind. This
+    /// path reads the committed blob, writes both snapshots to an isolated
+    /// temporary directory, and asks git's regular diff engine to classify the
+    /// buffer. All filesystem and process work runs off the main actor.
+    func diffForBufferAsync(at url: URL, content: String) async -> [GitLineDiff] {
+        guard isGitRepository,
+              let repoURL = repositoryURL,
+              let relativePath = relativePath(for: url) else { return [] }
+
+        let headResult = await GitCommand.runAsync(
+            ["show", "HEAD:\(relativePath)"],
+            at: repoURL
+        )
+        guard !Task.isCancelled, headResult.succeeded else { return [] }
+        return await Self.diffContentsAsync(
+            head: headResult.output,
+            buffer: content,
+            at: repoURL
+        )
+    }
+
+    /// Runs a bounded `git diff --no-index` on the generic executor. Exit code
+    /// 1 is git's documented "differences found" result, not a command error.
+    nonisolated private static func diffContentsAsync(
+        head: String,
+        buffer: String,
+        at workingDirectory: URL
+    ) async -> [GitLineDiff] {
+        guard head != buffer, !Task.isCancelled else { return [] }
+
+        let fileManager = FileManager.default
+        let temporaryDirectory = fileManager.temporaryDirectory
+            .appendingPathComponent("pine-buffer-diff-\(UUID().uuidString)", isDirectory: true)
+        let headURL = temporaryDirectory.appendingPathComponent("head")
+        let bufferURL = temporaryDirectory.appendingPathComponent("buffer")
+
+        do {
+            try fileManager.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+            defer { try? fileManager.removeItem(at: temporaryDirectory) }
+            try head.write(to: headURL, atomically: false, encoding: .utf8)
+            try buffer.write(to: bufferURL, atomically: false, encoding: .utf8)
+
+            let result = await GitCommand.runAsync(
+                [
+                    "diff", "--no-index", "--no-ext-diff", "--no-color",
+                    "--text", "--unified=0", "--", headURL.path, bufferURL.path
+                ],
+                at: workingDirectory
+            )
+            guard !Task.isCancelled,
+                  result.exitCode == 0 || result.exitCode == 1,
+                  !result.timedOut,
+                  !result.cancelled,
+                  !result.outputTruncated,
+                  !result.errorOutputTruncated,
+                  result.outputCaptureComplete,
+                  result.errorOutputCaptureComplete else { return [] }
+            return GitParser.parseDiff(result.output)
+        } catch {
+            return []
+        }
+    }
+
     // MARK: - Private Helpers
 
     private func isInsideUntrackedDirectory(_ path: String) -> Bool {

--- a/Pine/PaneLeafView.swift
+++ b/Pine/PaneLeafView.swift
@@ -649,24 +649,52 @@ struct PaneLeafView: View {
               let fileURL = tab.fileURL else {
             lineDiffs = []
             diffHunks = []
+            diffVersion &+= 1
             return
         }
         let provider = workspace.gitProvider
         guard provider.isGitRepository, let repoURL = workspace.rootURL else {
             lineDiffs = []
             diffHunks = []
+            diffVersion &+= 1
             return
         }
+        let tabID = tab.id
+        let contentVersion = tab.contentVersion
+        let content = tab.content
+        let isDirty = tab.isDirty
         diffTask = Task { @MainActor in
             if debounce {
                 try? await Task.sleep(for: Self.diffDebounce)
                 if Task.isCancelled { return }
             }
+
+            if isDirty {
+                let resolvedDiffs = await provider.diffForBufferAsync(
+                    at: fileURL,
+                    content: content
+                )
+                if Task.isCancelled { return }
+                guard let activeTab = tabManager.activeTab,
+                      activeTab.id == tabID,
+                      activeTab.fileURL == fileURL,
+                      activeTab.contentVersion == contentVersion else { return }
+                lineDiffs = resolvedDiffs
+                // Hunk actions mutate the worktree/index and therefore must
+                // never be offered from a diff calculated from unsaved text.
+                diffHunks = []
+                diffVersion &+= 1
+                return
+            }
+
             async let diffs = provider.diffForFileAsync(at: fileURL)
             async let hunks = InlineDiffProvider.fetchHunks(for: fileURL, repoURL: repoURL)
             let (resolvedDiffs, resolvedHunks) = await (diffs, hunks)
             if Task.isCancelled { return }
-            guard tabManager.activeTab?.fileURL == fileURL else { return }
+            guard let activeTab = tabManager.activeTab,
+                  activeTab.id == tabID,
+                  activeTab.fileURL == fileURL,
+                  activeTab.contentVersion == contentVersion else { return }
             lineDiffs = resolvedDiffs
             diffHunks = resolvedHunks
             diffVersion &+= 1

--- a/PineTests/PaneLeafGitDiffRefreshTests.swift
+++ b/PineTests/PaneLeafGitDiffRefreshTests.swift
@@ -8,7 +8,7 @@
 //  These tests verify the underlying signals that `PaneLeafView` now
 //  subscribes to (content edits, git-status changes, branch switches,
 //  repository transitions, initial load) actually fire and that
-//  `GitStatusProvider.diffForFileAsync` returns the expected diffs
+//  `GitStatusProvider` returns the expected disk and live-buffer diffs
 //  across the full save/edit/checkout lifecycle.
 //
 
@@ -202,6 +202,82 @@ struct PaneLeafGitDiffRefreshTests {
 
         let after = await provider.diffForFileAsync(at: fileURL)
         #expect(after.isEmpty == false, "modified file should report diffs")
+    }
+
+    @Test("dirty editor buffer is diffed against HEAD before save")
+    func diffForBufferAsyncSeesUnsavedModification() async throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        let provider = GitStatusProvider()
+        provider.setup(repositoryURL: dir)
+        let fileURL = dir.appendingPathComponent("file.txt")
+
+        let diskDiffs = await provider.diffForFileAsync(at: fileURL)
+        let bufferDiffs = await provider.diffForBufferAsync(
+            at: fileURL,
+            content: "line1\nEDITED\nline3\n"
+        )
+
+        #expect(diskDiffs.isEmpty, "the unchanged worktree cannot expose the unsaved edit")
+        #expect(bufferDiffs == [GitLineDiff(line: 2, kind: .modified)])
+    }
+
+    @Test("live buffer diff includes saved and unsaved changes")
+    func diffForBufferAsyncIncludesWorktreeAndBufferChanges() async throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        let provider = GitStatusProvider()
+        provider.setup(repositoryURL: dir)
+        let fileURL = dir.appendingPathComponent("file.txt")
+        try "line1\nSAVED\nline3\n".write(
+            to: fileURL,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let diffs = await provider.diffForBufferAsync(
+            at: fileURL,
+            content: "line1\nSAVED\nline3\nUNSAVED\n"
+        )
+
+        #expect(diffs.contains(GitLineDiff(line: 2, kind: .modified)))
+        #expect(diffs.contains(GitLineDiff(line: 4, kind: .added)))
+    }
+
+    @Test("live buffer diff reports an unsaved deletion")
+    func diffForBufferAsyncSeesUnsavedDeletion() async throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        let provider = GitStatusProvider()
+        provider.setup(repositoryURL: dir)
+        let fileURL = dir.appendingPathComponent("file.txt")
+
+        let diffs = await provider.diffForBufferAsync(
+            at: fileURL,
+            content: "line1\nline3\n"
+        )
+
+        #expect(diffs.contains { $0.kind == .deleted })
+    }
+
+    @Test("live buffer diff clears after undoing to HEAD")
+    func diffForBufferAsyncClearsAfterUndo() async throws {
+        let dir = try makeGitRepo()
+        defer { cleanup(dir) }
+
+        let provider = GitStatusProvider()
+        provider.setup(repositoryURL: dir)
+        let fileURL = dir.appendingPathComponent("file.txt")
+
+        let diffs = await provider.diffForBufferAsync(
+            at: fileURL,
+            content: "line1\nline2\nline3\n"
+        )
+
+        #expect(diffs.isEmpty)
     }
 
     /// Edge case: diffForFileAsync on a non-git directory returns empty.


### PR DESCRIPTION
Closes #1402

## Summary
- diff dirty editor buffers directly against HEAD instead of rereading the unchanged worktree file
- keep live gutter markers current for unsaved modifications, additions, and deletions
- suppress disk-backed stage/revert hunks while the buffer is dirty
- fence asynchronous results by tab identity and content version

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild test -quiet -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineTests/PaneLeafGitDiffRefreshTests`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swiftlint lint --strict --no-cache --quiet`
- UI tests not run locally per request; CI will run them