### PR TITLE
fix(sidebar): retry row focus after layout

### DIFF
--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -164,12 +164,25 @@ final class SidebarKeyboardFocusController {
     }
 
     @discardableResult
-    func requestFocus() -> Bool {
-        guard let responderView, let window = responderView.window else {
-            return false
+    func requestFocus(retryOnNextRunLoop: Bool = false) -> Bool {
+        let focused: Bool
+        if let responderView, let window = responderView.window {
+            focused = window.makeFirstResponder(responderView)
+                && window.firstResponder === responderView
+        } else {
+            focused = false
         }
-        return window.makeFirstResponder(responderView)
-            && window.firstResponder === responderView
+        if retryOnNextRunLoop {
+            // A pointer action can arrive while SwiftUI is still attaching the
+            // representable, or an editor preview can displace a successful
+            // claim later in the same layout transaction. Retry once after
+            // that transaction settles; never form an unbounded focus loop.
+            DispatchQueue.main.async { [weak self] in
+                guard let self, !self.isFocused else { return }
+                _ = self.requestFocus()
+            }
+        }
+        return focused
     }
 
     private func updateFocus(_ focused: Bool) {
@@ -630,7 +643,7 @@ struct SidebarView: View {
                                 isKeyboardFocused: keyboardFocusController.isFocused
                                     && controlActiveState == .key,
                                 onKeyboardFocusRequested: {
-                                    claimSidebarKeyboardFocus()
+                                    claimSidebarKeyboardFocus(retryOnNextRunLoop: true)
                                 }
                             )
                         }
@@ -841,9 +854,11 @@ struct SidebarView: View {
     /// A sidebar action supersedes any older destination-focus request. The
     /// model is invalidated before AppKit changes first responder so a queued
     /// editor or terminal retry cannot reclaim focus on the next run loop.
-    private func claimSidebarKeyboardFocus() {
+    private func claimSidebarKeyboardFocus(retryOnNextRunLoop: Bool = false) {
         paneManager.cancelPendingFocusForActivePane()
-        keyboardFocusController.requestFocus()
+        keyboardFocusController.requestFocus(
+            retryOnNextRunLoop: retryOnNextRunLoop
+        )
     }
 
     private func handleSidebarPrintableText(_ text: String) -> Bool {

--- a/PineTests/SidebarAccessibilityHostedTests.swift
+++ b/PineTests/SidebarAccessibilityHostedTests.swift
@@ -121,6 +121,37 @@ struct SidebarAccessibilityHostedTests {
         #expect(!controller.isFocused)
     }
 
+    @Test("Row focus claim retries once after responder joins a window")
+    func responderFocusRetryAfterAttachment() async {
+        let controller = SidebarKeyboardFocusController()
+        let responder = SidebarKeyboardResponderView(
+            frame: NSRect(x: 0, y: 0, width: 1, height: 1)
+        )
+        controller.attach(responder)
+
+        #expect(!controller.requestFocus(retryOnNextRunLoop: true))
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = responder
+        defer { window.orderOut(nil) }
+
+        // Enqueued after the controller's retry, so reaching this continuation
+        // proves the bounded next-runloop attempt has already completed.
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
+
+        #expect(controller.isFocused)
+        #expect(window.firstResponder === responder)
+    }
+
     @Test("Physical and interpreted printable input share one callback")
     func responderInputClassification() throws {
         let responder = SidebarKeyboardResponderView(frame: .zero)


### PR DESCRIPTION
Closes #1404

## Summary
- make row-originated sidebar focus claims retry once on the next main runloop
- recover when SwiftUI has not attached the AppKit responder yet or a preview focus transaction displaces it
- keep rename and existing keyboard paths synchronous so the field editor is not disturbed
- cover the unavailable-then-attached responder race with a hosted regression test

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild test -quiet -project Pine.xcodeproj -scheme Pine -destination 'platform=macOS' -only-testing:PineTests/SidebarAccessibilityHostedTests`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swiftlint lint --strict --no-cache --quiet`
- UI tests not run locally per request; CI will run them