### PR TITLE
chore(deps): bump SwiftTerm to 1.18.0

### DIFF
--- a/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pine.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/migueldeicaza/SwiftTerm.git",
       "state" : {
-        "revision" : "3917686ea5f5527c5451aaf371bd90bf3618aa71",
-        "version" : "1.16.0"
+        "revision" : "7691f85b222a67a66b58499e1b2647443cf0dda7",
+        "version" : "1.18.0"
       }
     }
   ],


### PR DESCRIPTION
## Summary

- bump SwiftTerm from 1.16.0 (`3917686`) to 1.18.0 (`7691f85`)
- keep the update narrow to `Package.resolved`
- confirm the new revision is a strict descendant of the old pin (25 upstream commits, 0 behind)

## Pine impact reviewed

SwiftTerm 1.17.0 adds OSC 133 shell-integration support and fixes full-reset redraw plus reverse-video default colors.

SwiftTerm 1.18.0 fixes:
- a macOS process-lifecycle race where very fast child exit events could be lost
- combining glyph placement after cursor movement
- selection API visibility

The process-exit fix is directly useful for short-lived terminal commands and agent tooling. I also reviewed the Metal/background/focus redraw changes and Pine's terminal mouse-event overlay; the APIs Pine uses remain compatible and no Pine source changes are required.

Upstream notes:
- https://github.com/migueldeicaza/SwiftTerm/releases/tag/v1.17.0
- https://github.com/migueldeicaza/SwiftTerm/releases/tag/v1.18.0

## Validation

Environment:
- macOS 27.0 (26A5388g)
- Xcode 27.0 beta (27A5194q)
- macOS SDK 27.0 (26A5353p)

Passed:
- clean Pine build
- focused SwiftTerm integration suites: session bridge, Metal renderer, terminal tab lifecycle, terminal manager, and scroll/mouse forwarding
- SwiftLint (exit 0; only existing generated-file warnings)
- `git diff --check`

The full `PineTests` run was attempted but is not reported as passing locally: the Xcode 27 beta test host first timed out across unrelated agent-registry tests, then reproducibly blocked in Foundation `Data(contentsOf:)` while reading snapshot/localization fixtures. Stack samples confirmed those stalls are outside SwiftTerm. Required CI should provide the macOS 26 baseline and a clean full-suite result.