### PR TITLE
fix: recover Open Folder ownership with active agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,17 +531,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Shard 1 — Terminal (31 tests)
+          # Shard 1 — Terminal (33 tests)
           - shard-name: "Terminal"
             test-classes: >-
               -only-testing:PineUITests/TerminalTests
               -only-testing:PineUITests/TerminalMenuTests
               -only-testing:PineUITests/SessionRestoreTests
+              -only-testing:PineUITests/AgentAttentionKeyboardUITests
           # Shard 2 — Welcome & Session (34 tests)
           - shard-name: "Welcome & Session"
             test-classes: >-
               -only-testing:PineUITests/WelcomeWindowTests
-              -only-testing:PineUITests/AgentAttentionKeyboardUITests
               -only-testing:PineUITests/AgentInboxToolbarButtonTests
               -only-testing:PineUITests/SidebarFolderClickTests
               -only-testing:PineUITests/NativeFileWindowMenuUITests

--- a/Pine/AccessibilityIdentifiers.swift
+++ b/Pine/AccessibilityIdentifiers.swift
@@ -52,6 +52,7 @@ nonisolated enum AccessibilityID {
 
     // MARK: - Main editor window
     static let sidebar = "sidebar"
+    static let openFolderToolbarButton = "openFolderToolbarButton"
     static func fileNode(_ name: String) -> String { "fileNode_\(name)" }
     static let inlineRenameTextField = "inlineRenameTextField"
 

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -87,6 +87,9 @@ struct ContentView: View {
                         Image(systemName: "folder.badge.plus")
                     }
                     .help(Strings.openFolderTooltip)
+                    .accessibilityIdentifier(
+                        AccessibilityID.openFolderToolbarButton
+                    )
                 }
             }
         } detail: {
@@ -142,6 +145,14 @@ struct ContentView: View {
             syncSidebarSelection()
             applySearchQueryFromEnvironment()
             refreshBlame()
+            #if DEBUG
+            // Seed only after the project window has installed its native
+            // delegate. The #1407 fixture must reproduce the live-agent UI
+            // transition that invalidates an already-mounted scene.
+            await registry.seedLiveAgentUITestFixture(
+                afterWindowBindingFor: projectManager
+            )
+            #endif
         }
         .sheet(isPresented: $showRecoveryDialog) {
             RecoveryDialogView(

--- a/Pine/DialogPresentationContext.swift
+++ b/Pine/DialogPresentationContext.swift
@@ -631,6 +631,52 @@ enum DialogPresenter {
         context(for: projectManager.dialogOwnerWindow)
     }
 
+    /// Repairs a project→window binding that was lost while the initiating
+    /// project window remained alive. This can happen when SwiftUI overlaps
+    /// representable coordinator generations and dismantles the older one
+    /// after the replacement has appeared (#1407).
+    ///
+    /// Only a live `CloseDelegate` for the exact `ProjectManager` can recover
+    /// an unbound window, so the fallback cannot attach a project-owned sheet
+    /// to Welcome, Settings, or a sibling project window.
+    static func recoverProjectOwnerWindow(
+        for projectManager: ProjectManager,
+        candidates suppliedCandidates: [NSWindow]? = nil,
+        isEligible: ((NSWindow) -> Bool)? = nil
+    ) -> NSWindow? {
+        let acceptsWindow = isEligible ?? isEligibleApplicationOwner
+        let candidates: [NSWindow]
+        if let suppliedCandidates {
+            candidates = suppliedCandidates
+        } else {
+            var applicationWindows: [NSWindow] = []
+            for candidate in [NSApp.keyWindow, NSApp.mainWindow] + NSApp.windows.map(Optional.some) {
+                guard let candidate else { continue }
+                let owner = candidate.sheetParent ?? candidate
+                guard !applicationWindows.contains(where: { $0 === owner }) else {
+                    continue
+                }
+                applicationWindows.append(owner)
+            }
+            candidates = applicationWindows
+        }
+
+        guard let match = candidates.first(where: { window in
+            guard acceptsWindow(window),
+                  let delegate = window.delegate as? CloseDelegate,
+                  !delegate.didCompleteWindowLifecycle else {
+                return false
+            }
+            return delegate.projectManager === projectManager
+        }), let delegate = match.delegate as? CloseDelegate else {
+            return nil
+        }
+
+        delegate.observeWindowClose(match)
+        Logger.app.info("recovered project dialog owner from its live window (#1407)")
+        return match
+    }
+
     static func projectManager(for window: NSWindow?) -> ProjectManager? {
         guard let window else { return nil }
         let identifier = ObjectIdentifier(window)

--- a/Pine/PineApp.swift
+++ b/Pine/PineApp.swift
@@ -261,6 +261,10 @@ struct WindowCloseInterceptor: NSViewRepresentable {
         var originalDelegate: (any NSWindowDelegate)?
         weak var installedWindow: NSWindow?
         private var lifecycleObservers: [Any] = []
+        /// Once a replacement coordinator adopts this installation, SwiftUI
+        /// may still deliver a stale update or move callback to the old
+        /// representable. Superseded generations can never reclaim ownership.
+        private var isSuperseded = false
 
         func installDelegate(
             on window: NSWindow,
@@ -271,6 +275,7 @@ struct WindowCloseInterceptor: NSViewRepresentable {
             presentAlert: CloseDelegate.CloseAlertPresenter? = nil,
             saveAll: CloseDelegate.CloseSaveAll? = nil
         ) {
+            guard !isSuperseded else { return }
             if installedWindow !== window {
                 retireCurrentInstallation(restoringOriginal: true)
                 installedWindow = window
@@ -309,8 +314,20 @@ struct WindowCloseInterceptor: NSViewRepresentable {
             var original = window.delegate
             if let existing = original as? CloseDelegate {
                 if existing.projectManager === projectManager {
+                    // A replacement NSViewRepresentable coordinator may be
+                    // installed before SwiftUI dismantles the previous one.
+                    // Transfer the live delegate explicitly so the old
+                    // coordinator's late teardown cannot restore the original
+                    // delegate and retire this window's dialog authority
+                    // (#1407).
+                    // `existing.original` is weak; capture it strongly before
+                    // relinquishing the old coordinator, which may hold its
+                    // only strong reference.
+                    let retainedOriginal = existing.original
+                    existing.interceptorOwner?.relinquish(existing)
                     closeDelegate = existing
-                    originalDelegate = existing.original
+                    originalDelegate = retainedOriginal
+                    existing.interceptorOwner = self
                     if existing.didCompleteWindowLifecycle,
                        registry.isWindowOpen(projectURL),
                        registry.openProjects[
@@ -323,6 +340,7 @@ struct WindowCloseInterceptor: NSViewRepresentable {
                     return
                 }
                 let existingOriginal = existing.original
+                existing.interceptorOwner?.relinquish(existing)
                 existing.detachFromWindow()
                 original = existingOriginal
             }
@@ -337,6 +355,7 @@ struct WindowCloseInterceptor: NSViewRepresentable {
             )
             closeDelegate = delegate
             originalDelegate = original
+            delegate.interceptorOwner = self
             window.delegate = delegate
             // Fallback: observe willCloseNotification in case SwiftUI
             // replaces the window delegate after our installation (#138).
@@ -385,6 +404,12 @@ struct WindowCloseInterceptor: NSViewRepresentable {
 
         private func retireCurrentInstallation(restoringOriginal: Bool) {
             removeLifecycleObservers()
+            guard closeDelegate?.interceptorOwner === self else {
+                closeDelegate = nil
+                originalDelegate = nil
+                installedWindow = nil
+                return
+            }
             if restoringOriginal,
                let installedWindow,
                let closeDelegate,
@@ -392,6 +417,20 @@ struct WindowCloseInterceptor: NSViewRepresentable {
                 installedWindow.delegate = originalDelegate
             }
             closeDelegate?.detachFromWindow()
+            closeDelegate?.interceptorOwner = nil
+            closeDelegate = nil
+            originalDelegate = nil
+            installedWindow = nil
+        }
+
+        /// Transfers ownership to a replacement representable coordinator
+        /// without touching the delegate or its project-window binding.
+        /// SwiftUI may call the old coordinator's dismantle hook afterwards;
+        /// clearing its local installation makes that teardown harmless.
+        fileprivate func relinquish(_ delegate: CloseDelegate) {
+            guard closeDelegate === delegate else { return }
+            isSuperseded = true
+            removeLifecycleObservers()
             closeDelegate = nil
             originalDelegate = nil
             installedWindow = nil
@@ -442,6 +481,9 @@ class CloseDelegate: NSObject, NSWindowDelegate {
     /// Weak ref to original — Coordinator holds the strong ref separately
     /// to avoid a potential retain cycle through the delegate chain.
     weak var original: (any NSWindowDelegate)?
+    /// The current representable coordinator generation that owns this proxy.
+    /// Weak to avoid a cycle: the coordinator already retains the delegate.
+    weak var interceptorOwner: WindowCloseInterceptor.Coordinator?
 
     /// Tracks whether windowWillClose has already been handled, to prevent
     /// the NotificationCenter fallback from double-firing.

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -1566,7 +1566,8 @@ final class ProjectManager {
     func awaitDialogOwnerWindow(
         maximumAttempts: Int = 80,
         waitForNextAttempt: (@MainActor () async -> Void)? = nil,
-        isEligible: (@MainActor (NSWindow) -> Bool)? = nil
+        isEligible: (@MainActor (NSWindow) -> Bool)? = nil,
+        recoverOwner: (@MainActor () -> NSWindow?)? = nil
     ) async -> NSWindow? {
         let wait = waitForNextAttempt ?? {
             try? await Task.sleep(for: .milliseconds(25))
@@ -1574,20 +1575,30 @@ final class ProjectManager {
         let acceptsWindow = isEligible ?? {
             DialogPresenter.isEligibleApplicationOwner($0)
         }
+        let recover = recoverOwner ?? { [weak self] in
+            guard let self else { return nil }
+            return DialogPresenter.recoverProjectOwnerWindow(
+                for: self,
+                isEligible: acceptsWindow
+            )
+        }
 
         for _ in 0..<max(0, maximumAttempts) {
             guard !Task.isCancelled else { return nil }
             if let window = dialogOwnerWindow, acceptsWindow(window) {
                 return window
             }
+            if let window = recover(), acceptsWindow(window) {
+                return window
+            }
             await wait()
         }
 
-        guard !Task.isCancelled,
-              let window = dialogOwnerWindow,
-              acceptsWindow(window) else {
-            return nil
+        guard !Task.isCancelled else { return nil }
+        if let window = dialogOwnerWindow, acceptsWindow(window) {
+            return window
         }
+        guard let window = recover(), acceptsWindow(window) else { return nil }
         return window
     }
 

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -5,6 +5,7 @@
 //  Created by Claude on 13.03.2026.
 //
 
+import os
 import SwiftUI
 
 nonisolated enum AgentInboxNavigationResult: Equatable, Sendable {
@@ -23,6 +24,36 @@ nonisolated enum AgentInboxRecoveryResult: Equatable, Sendable {
     case changedWhilePreparing
     case launchRejected
 }
+
+#if DEBUG
+/// Keeps the live-agent XCUITest on the production registry mutation path
+/// without reading or writing the developer's durable task metadata.
+private actor LiveAgentUITestTaskPersistence: AgentTaskPersisting {
+    func save(
+        tasks: [AgentTask],
+        project: AgentTaskProjectIdentity,
+        authorization: AgentTaskPublicationAuthorization?
+    ) async -> AgentTaskMetadataSaveResult {
+        if let authorization {
+            switch authorization.publishForTesting(operation: { true }) {
+            case .published:
+                break
+            case .failed:
+                return .rejected(.ioFailure)
+            case .superseded:
+                return .rejected(.superseded)
+            }
+        }
+        return .saved(taskCount: tasks.count)
+    }
+
+    func load(
+        project: AgentTaskProjectIdentity
+    ) async -> AgentTaskMetadataLoadResult {
+        AgentTaskMetadataLoadResult(status: .missing, tasks: [])
+    }
+}
+#endif
 
 /// App-wide snapshot of the exact user-task executions covered by one Quit
 /// decision, keyed by their owning ProjectManager identity.
@@ -123,14 +154,14 @@ final class ProjectRegistry: LSPSettingsObserver {
         lspSettings: LSPSettings = .shared,
         defaults: UserDefaults = .standard,
         fileManager: FileManager = .default,
-        agentTasks: AgentTaskRegistry = AgentTaskRegistry(),
+        agentTasks: AgentTaskRegistry? = nil,
         agentRecoveryInspector: AgentTaskRecoveryInspector = AgentTaskRecoveryInspector(),
         clearRecentProjects: Bool = CommandLine.arguments.contains(
             "--clear-recent-projects"
         )
     ) {
         self.lspSettings = lspSettings
-        self.agentTasks = agentTasks
+        self.agentTasks = agentTasks ?? Self.makeDefaultAgentTaskRegistry()
         self.defaults = defaults
         self.fileManager = fileManager
         self.agentRecoveryInspector = agentRecoveryInspector
@@ -142,16 +173,29 @@ final class ProjectRegistry: LSPSettingsObserver {
         if ProcessInfo.processInfo.arguments.contains(
             "--ui-test-agent-inbox-marketing"
         ) {
-            agentTasks.seedMarketingInboxForUITesting()
+            self.agentTasks.seedMarketingInboxForUITesting()
         }
         #endif
         lspSettings.addObserver(self)
         // Keeps the toolbar attention badge current (#1337). The token is not
         // retained: this registry owns `agentTasks`, so the observer cannot
         // outlive its target, and the closure holds `self` weakly.
-        _ = agentTasks.addTaskChangeObserver { [weak self] _, tasks in
+        _ = self.agentTasks.addTaskChangeObserver { [weak self] _, tasks in
             self?.recomputeAgentInboxAttentionCounts(tasks: tasks)
         }
+    }
+
+    private static func makeDefaultAgentTaskRegistry() -> AgentTaskRegistry {
+        #if DEBUG
+        let arguments = ProcessInfo.processInfo.arguments
+        if arguments.contains("--reset-state"),
+           arguments.contains("--ui-test-live-agent") {
+            return AgentTaskRegistry(
+                persistence: LiveAgentUITestTaskPersistence()
+            )
+        }
+        #endif
+        return AgentTaskRegistry()
     }
 
     /// Returns the ProjectManager for a given project URL, creating one if needed.
@@ -368,6 +412,81 @@ final class ProjectRegistry: LSPSettingsObserver {
             )
         }
     }
+
+    /// Gives the Open Folder lifecycle XCUITest a deterministic live-agent
+    /// transition after the project window has installed its native delegate.
+    /// The pane runs a deterministic inert child rather than the user's shell;
+    /// agent evidence is synthetic and `ps` polling remains disabled.
+    /// The fixture exists only in Debug test hosts and only behind an explicit
+    /// launch argument (#1407).
+    func seedLiveAgentUITestFixture(
+        afterWindowBindingFor projectManager: ProjectManager
+    ) async {
+        guard ProcessInfo.processInfo.arguments.contains(
+            "--ui-test-live-agent"
+        ) else { return }
+        guard await projectManager.awaitDialogOwnerWindow() != nil else {
+            guard !Task.isCancelled else { return }
+            assertionFailure(
+                "Live-agent UI fixture requires a bound project window"
+            )
+            return
+        }
+        guard let rootURL = projectManager.rootURL,
+              let project = agentTaskProjectsByRoot[canonicalProjectURL(rootURL)] else {
+            assertionFailure(
+                "Live-agent UI fixture requires a registered project"
+            )
+            return
+        }
+        guard !projectManager.terminal.allTerminalTabs.contains(where: {
+            $0.agentSession?.currentTask == Self.liveAgentUITestTask
+        }) else { return }
+
+        let tab: TerminalTab
+        if let existing = projectManager.terminal.allTerminalTabs.first {
+            tab = existing
+        } else {
+            projectManager.paneManager.createTerminalPaneAtBottom(
+                workingDirectory: rootURL,
+                initialProcess: TerminalInitialProcess(
+                    executablePath: "/bin/cat",
+                    arguments: []
+                )
+            )
+            guard let created = projectManager.terminal.allTerminalTabs.first else {
+                assertionFailure("Live-agent UI fixture requires a terminal tab")
+                return
+            }
+            tab = created
+        }
+        let startedAt = Date()
+        let session = AgentSession(
+            agentType: .codex,
+            state: .executing,
+            startedAt: startedAt,
+            currentTask: Self.liveAgentUITestTask
+        )
+        _ = session.bindProcessEvidence(AgentProcessEvidence(
+            processIdentifier: 14_007,
+            processGeneration: 1,
+            startIdentifier: "ui-live-agent-1407",
+            observedStartedAt: startedAt,
+            startIsAuthoritative: true
+        ))
+        tab.agentSession = session
+        // Exercise the same durable registry mutation and project-window
+        // observation invalidation as a genuinely detected active agent.
+        projectManager.terminal.bridgeAgentSession(
+            session,
+            replacing: nil,
+            in: tab
+        )
+        assert(agentTasks.tasks.contains(where: { $0.project == project }))
+    }
+
+    private static let liveAgentUITestTask =
+        "Verify Open Folder while an agent is active"
     #endif
 
     /// Opens a project via folder picker. Returns the project URL if opened.
@@ -413,6 +532,7 @@ final class ProjectRegistry: LSPSettingsObserver {
             waitForNextAttempt: waitForNextAttempt,
             isEligible: isEligible
         ) != nil else {
+            Logger.app.error("Open Folder aborted: no eligible project dialog owner after bounded recovery (#1407)")
             return nil
         }
         let context = DialogPresenter.forProject(projectManager)

--- a/PineTests/CloseDelegateTests.swift
+++ b/PineTests/CloseDelegateTests.swift
@@ -588,6 +588,145 @@ struct CloseDelegateTests {
         #expect(window.delegate === original)
     }
 
+    @Test func replacementCoordinatorOwnsDelegateAcrossOldDismantle() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let project = ProjectManager()
+        let registry = ProjectRegistry()
+        let appDelegate = AppDelegate()
+        let window = NSWindow()
+        let firstCoordinator = WindowCloseInterceptor.Coordinator()
+        let replacementCoordinator = WindowCloseInterceptor.Coordinator()
+        weak var expectedOriginal: CountingCloseDelegate?
+        do {
+            let original = CountingCloseDelegate(shouldApprove: true)
+            expectedOriginal = original
+            window.delegate = original
+            firstCoordinator.installDelegate(
+                on: window,
+                projectManager: project,
+                registry: registry,
+                projectURL: dir,
+                appDelegate: appDelegate
+            )
+        }
+        let interceptor = try #require(window.delegate as? CloseDelegate)
+        #expect(expectedOriginal != nil)
+        replacementCoordinator.installDelegate(
+            on: window,
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: appDelegate
+        )
+
+        // A stale SwiftUI update delivered to the superseded generation must
+        // not let it reclaim the delegate from its replacement.
+        firstCoordinator.installDelegate(
+            on: window,
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: appDelegate
+        )
+
+        // SwiftUI dismantles the obsolete representable after its replacement
+        // is already live. The old coordinator must not restore the original
+        // delegate or clear the replacement's dialog owner (#1407).
+        firstCoordinator.detach()
+
+        #expect(window.delegate === interceptor)
+        #expect(project.dialogOwnerWindow === window)
+        #expect(interceptor.dialogContext.nsWindow === window)
+        #expect(expectedOriginal != nil)
+        #expect(interceptor.original === expectedOriginal)
+
+        replacementCoordinator.detach()
+        #expect(project.dialogOwnerWindow == nil)
+    }
+
+    @Test func lostBindingRecoversFromLiveProjectDelegate() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+        let project = ProjectManager()
+        let registry = ProjectRegistry()
+        let appDelegate = AppDelegate()
+        let window = NSWindow()
+        let coordinator = WindowCloseInterceptor.Coordinator()
+
+        coordinator.installDelegate(
+            on: window,
+            projectManager: project,
+            registry: registry,
+            projectURL: dir,
+            appDelegate: appDelegate
+        )
+        let delegate = try #require(window.delegate as? CloseDelegate)
+        DialogPresenter.ownerDidClose(window)
+        #expect(project.dialogOwnerWindow == nil)
+
+        let recovered = DialogPresenter.recoverProjectOwnerWindow(
+            for: project,
+            candidates: [window],
+            isEligible: { _ in true }
+        )
+
+        #expect(recovered === window)
+        #expect(project.dialogOwnerWindow === window)
+        #expect(delegate.dialogContext.nsWindow === window)
+        coordinator.detach()
+    }
+
+    @Test func recoveryRejectsSiblingProjectAndCompletedDelegate() throws {
+        let targetDir = try makeTempDir()
+        let siblingDir = try makeTempDir()
+        defer {
+            cleanup(targetDir)
+            cleanup(siblingDir)
+        }
+        let (targetDelegate, targetProject, _) = makeCloseDelegate(
+            projectURL: targetDir
+        )
+        let (siblingDelegate, siblingProject, _) = makeCloseDelegate(
+            projectURL: siblingDir
+        )
+        let targetWindow = NSWindow()
+        let siblingWindow = NSWindow()
+        targetWindow.delegate = targetDelegate
+        siblingWindow.delegate = siblingDelegate
+        targetDelegate.observeWindowClose(targetWindow)
+        siblingDelegate.observeWindowClose(siblingWindow)
+        defer {
+            DialogPresenter.ownerDidClose(targetWindow)
+            DialogPresenter.ownerDidClose(siblingWindow)
+            targetWindow.delegate = nil
+            siblingWindow.delegate = nil
+        }
+
+        DialogPresenter.ownerDidClose(targetWindow)
+        #expect(DialogPresenter.recoverProjectOwnerWindow(
+            for: targetProject,
+            candidates: [siblingWindow],
+            isEligible: { _ in true }
+        ) == nil)
+        #expect(targetProject.dialogOwnerWindow == nil)
+        #expect(siblingProject.dialogOwnerWindow === siblingWindow)
+
+        targetDelegate.windowWillClose(
+            Notification(
+                name: NSWindow.willCloseNotification,
+                object: targetWindow
+            )
+        )
+        #expect(targetDelegate.didCompleteWindowLifecycle)
+        #expect(DialogPresenter.recoverProjectOwnerWindow(
+            for: targetProject,
+            candidates: [targetWindow],
+            isEligible: { _ in true }
+        ) == nil)
+        #expect(targetProject.dialogOwnerWindow == nil)
+    }
+
     @Test func interceptorRearmsRetainedDelegateForReopenedWindowGeneration() async throws {
         let dir = try makeTempDir()
         let otherDir = try makeTempDir()

--- a/PineTests/ProjectDialogOwnerReadinessTests.swift
+++ b/PineTests/ProjectDialogOwnerReadinessTests.swift
@@ -69,4 +69,57 @@ struct ProjectDialogOwnerReadinessTests {
         #expect(resolved == nil)
         #expect(waitCount == 0)
     }
+
+    @Test func lostOwnerIsRecoveredBeforeWaiting() async {
+        let projectManager = ProjectManager()
+        let window = NSWindow()
+        var recoveryCount = 0
+        var waitCount = 0
+
+        let resolved = await projectManager.awaitDialogOwnerWindow(
+            maximumAttempts: 3,
+            waitForNextAttempt: {
+                waitCount += 1
+                await Task.yield()
+            },
+            isEligible: { _ in true },
+            recoverOwner: {
+                recoveryCount += 1
+                projectManager.bindDialogOwnerWindow(window)
+                return window
+            }
+        )
+
+        #expect(resolved === window)
+        #expect(recoveryCount == 1)
+        #expect(waitCount == 0)
+    }
+
+    @Test func ineligibleBoundOwnerIsReplacedByRecoveredOwner() async {
+        let projectManager = ProjectManager()
+        let staleWindow = NSWindow()
+        let recoveredWindow = NSWindow()
+        var recoveryCount = 0
+        var waitCount = 0
+        projectManager.bindDialogOwnerWindow(staleWindow)
+
+        let resolved = await projectManager.awaitDialogOwnerWindow(
+            maximumAttempts: 3,
+            waitForNextAttempt: {
+                waitCount += 1
+                await Task.yield()
+            },
+            isEligible: { $0 === recoveredWindow },
+            recoverOwner: {
+                recoveryCount += 1
+                projectManager.bindDialogOwnerWindow(recoveredWindow)
+                return recoveredWindow
+            }
+        )
+
+        #expect(resolved === recoveredWindow)
+        #expect(projectManager.dialogOwnerWindow === recoveredWindow)
+        #expect(recoveryCount == 1)
+        #expect(waitCount == 0)
+    }
 }

--- a/PineUITests/NativeFileWindowMenuUITests.swift
+++ b/PineUITests/NativeFileWindowMenuUITests.swift
@@ -5,6 +5,7 @@
 //  Mouse-driven acceptance coverage for issue #1275.
 //
 
+import AppKit
 import XCTest
 
 final class NativeFileWindowMenuUITests: PineUITestCase {
@@ -256,7 +257,12 @@ final class NativeFileWindowMenuUITests: PineUITestCase {
                 "The owned folder picker should expose its Open action"
             )
 
-            app.typeKey(".", modifierFlags: .command)
+            let cancelButton = openPanel.buttons["Cancel"].firstMatch
+            XCTAssertTrue(
+                cancelButton.waitForExistence(timeout: 5),
+                "The owned folder picker should expose a mouse-driven Cancel action"
+            )
+            cancelButton.click()
             XCTAssertTrue(
                 openPanel.waitForNonExistence(timeout: 5),
                 "Cancelling the folder picker should dismiss the owned sheet"
@@ -266,6 +272,168 @@ final class NativeFileWindowMenuUITests: PineUITestCase {
                 "Cancelling Open Folder must leave the current project open"
             )
         }
+    }
+
+    func testOpenFolderToolbarPresentsReusableOwnedPanel() {
+        launchWithProject(projectURL)
+        let openFolder = app.buttons["openFolderToolbarButton"].firstMatch
+        XCTAssertTrue(
+            openFolder.waitForExistence(timeout: 10),
+            "The sidebar toolbar should expose Open Folder"
+        )
+
+        for attempt in 1...2 {
+            openFolder.click()
+            let openPanel = app.sheets.firstMatch
+            XCTAssertTrue(
+                openPanel.waitForExistence(timeout: 5),
+                "Toolbar Open Folder should present an owned sheet on attempt \(attempt)"
+            )
+            XCTAssertTrue(openPanel.buttons["Open"].firstMatch.exists)
+            let cancelButton = openPanel.buttons["Cancel"].firstMatch
+            XCTAssertTrue(cancelButton.waitForExistence(timeout: 5))
+            cancelButton.click()
+            XCTAssertTrue(openPanel.waitForNonExistence(timeout: 5))
+            XCTAssertTrue(app.scrollViews["sidebar"].firstMatch.exists)
+        }
+    }
+
+    func testOpenFolderToolbarRecoversWithActiveAgentAndRemainsReusable() throws {
+        NSPasteboard.general.clearContents()
+        defer { NSPasteboard.general.clearContents() }
+        app.launchArguments.append("--ui-test-live-agent")
+        launchWithProject(projectURL)
+
+        let agentTerminal = app.descendants(matching: .any)[
+            "terminalTab_Terminal 1"
+        ].firstMatch
+        XCTAssertTrue(
+            agentTerminal.waitForExistence(timeout: 10),
+            "The project should contain the deterministic live-agent terminal"
+        )
+        let agentStatus = app.buttons["agentStatusBar"].firstMatch
+        XCTAssertTrue(
+            agentStatus.waitForExistence(timeout: 5),
+            "The fixture must activate an agent after the project window mounts"
+        )
+        XCTAssertTrue(agentStatus.label.contains("Executing"))
+
+        // Exercise the exact post-close-confirmation lifecycle from #1407:
+        // create dirty editor content, request a whole-window close by mouse,
+        // then cancel its project-owned sheet before opening another folder.
+        clickMenuBarItem("File")
+        app.menuItems["New File"].firstMatch.click()
+        let editor = app.textViews["codeEditor"].firstMatch
+        XCTAssertTrue(editor.waitForExistence(timeout: 5))
+        editor.click()
+        XCTAssertTrue(
+            NSPasteboard.general.setString(
+                "keep this project open\n",
+                forType: .string
+            )
+        )
+        clickMenuBarItem("Edit")
+        app.menuItems["Paste"].firstMatch.click()
+        clickMenuBarItem("Window")
+        app.menuItems["Close Window"].firstMatch.click()
+        let closeConfirmation = app.sheets.firstMatch
+        XCTAssertTrue(closeConfirmation.waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            closeConfirmation.staticTexts["Unsaved Changes"].firstMatch.exists
+        )
+        closeConfirmation.buttons["Cancel"].firstMatch.click()
+        XCTAssertTrue(closeConfirmation.waitForNonExistence(timeout: 5))
+        XCTAssertTrue(agentTerminal.exists)
+        XCTAssertTrue(
+            agentStatus.waitForExistence(timeout: 5),
+            "Cancelling window close must preserve the active agent"
+        )
+        XCTAssertTrue(agentStatus.label.contains("Executing"))
+
+        let openFolder = app.buttons["openFolderToolbarButton"].firstMatch
+        XCTAssertTrue(
+            openFolder.waitForExistence(timeout: 10),
+            "The sidebar toolbar should expose Open Folder"
+        )
+
+        for attempt in 1...2 {
+            openFolder.click()
+            let openPanel = app.sheets.firstMatch
+            XCTAssertTrue(
+                openPanel.waitForExistence(timeout: 5),
+                "Toolbar Open Folder should present a project-owned sheet on attempt \(attempt)"
+            )
+            let cancelButton = openPanel.buttons["Cancel"].firstMatch
+            XCTAssertTrue(cancelButton.waitForExistence(timeout: 5))
+            cancelButton.click()
+            XCTAssertTrue(openPanel.waitForNonExistence(timeout: 5))
+            XCTAssertTrue(
+                agentTerminal.exists,
+                "Cancelling Open Folder must preserve the active agent terminal"
+            )
+            XCTAssertTrue(
+                agentStatus.waitForExistence(timeout: 5),
+                "Open Folder attempt \(attempt) must keep the agent active"
+            )
+            XCTAssertTrue(agentStatus.label.contains("Executing"))
+        }
+
+        // Remove only the dirty editor tab, then exercise a full native
+        // window close/reopen while the terminal-backed agent remains owned
+        // by the background ProjectManager.
+        clickMenuBarItem("File")
+        app.menuItems["Close Tab"].firstMatch.click()
+        let discardAlert = app.sheets.firstMatch
+        XCTAssertTrue(discardAlert.waitForExistence(timeout: 5))
+        discardAlert.buttons["Don't Save"].firstMatch.click()
+        XCTAssertTrue(discardAlert.waitForNonExistence(timeout: 5))
+
+        clickMenuBarItem("Window")
+        app.menuItems["Close Window"].firstMatch.click()
+        let terminalWarning = app.sheets.firstMatch
+        XCTAssertTrue(
+            terminalWarning.waitForExistence(timeout: 5),
+            "The live terminal should retain its current close safeguard"
+        )
+        XCTAssertTrue(
+            terminalWarning.staticTexts["Active Process"].firstMatch.exists
+        )
+        terminalWarning.buttons["Close Terminal"].firstMatch.click()
+        XCTAssertTrue(
+            app.scrollViews["sidebar"].waitForNonExistence(timeout: 5),
+            "The project should enter its background window state"
+        )
+        XCTAssertTrue(app.windows["welcome"].waitForExistence(timeout: 10))
+
+        clickMenuBarItem("File")
+        app.menuItems["Open Recent"].firstMatch.click()
+        let recentPrefix = "\(projectURL.lastPathComponent) — "
+        let recentProject = try XCTUnwrap(
+            visibleMenuItem(matching: NSPredicate(
+                format: "title BEGINSWITH %@",
+                recentPrefix
+            ))
+        )
+        recentProject.click()
+        XCTAssertTrue(app.scrollViews["sidebar"].waitForExistence(timeout: 10))
+        XCTAssertTrue(agentTerminal.waitForExistence(timeout: 10))
+        XCTAssertTrue(agentStatus.waitForExistence(timeout: 5))
+        XCTAssertTrue(agentStatus.label.contains("Executing"))
+
+        let reopenedOpenFolder = app.buttons[
+            "openFolderToolbarButton"
+        ].firstMatch
+        XCTAssertTrue(reopenedOpenFolder.waitForExistence(timeout: 5))
+        reopenedOpenFolder.click()
+        let reopenedPanel = app.sheets.firstMatch
+        XCTAssertTrue(
+            reopenedPanel.waitForExistence(timeout: 5),
+            "Open Folder should survive active-agent window close/reopen"
+        )
+        reopenedPanel.buttons["Cancel"].firstMatch.click()
+        XCTAssertTrue(reopenedPanel.waitForNonExistence(timeout: 5))
+        XCTAssertTrue(agentStatus.waitForExistence(timeout: 5))
+        XCTAssertTrue(agentStatus.label.contains("Executing"))
     }
 
     func testOpenFolderSelectsDirectoryAndRoutesCommandToNewWindow() throws {


### PR DESCRIPTION
## Summary

- preserve the live project window close delegate across SwiftUI interceptor replacement and make superseded coordinators unable to reclaim ownership
- recover a lost or ineligible dialog owner from the exact live project window and emit privacy-safe diagnostics when recovery times out
- add deterministic active-agent, replacement, retry, close/reopen, File-menu, toolbar, Debug, and Release coverage

Closes #1407

## Independent review gate

Three read-only fresh-context reviews covered:

- correctness and architecture: delegate handoff, exact-project recovery, background/reopen invariants, retain-cycle safety
- Swift concurrency, security, and lifecycle: stale coordinator races, MainActor isolation, cancellation, privacy, test-only persistence and subprocess isolation
- tests, UX, localization, and OS compatibility: active-agent transition, mouse-driven interaction, release configuration, repeated invocation, shard balance

Findings fixed before push included weak original-delegate loss, stale coordinator reclaim, pre-mount fixture timing, filesystem and user-shell fixture side effects, incomplete post-cancel assertions, missing recovery rejection/positive cases, and Release-only coverage. Final verdict from all three reviewers: CLEAN, no unresolved P0-P2 findings.

## Verification

- changed-file SwiftLint strict: pass
- full SwiftLint: pass
- UI shard validator: 226 tests, 33/34/31/31/33/32/32, delta 3
- targeted dialog-owner/delegate unit suites: 50/50 pass
- Debug active-agent XCUITest: 1/1 pass
- Release File-menu and toolbar XCUITests with no DEBUG fixture: 2/2 pass
- Release app/test compilation: pass
- full serial local suite: 6,439 pass, 1 skip; four unrelated AgentInboxToolbarButton snapshot pixel diffs on local macOS 27 remain for CI to arbitrate
- git diff --check: pass

Local environment: macOS 27.0 (26A5388g), Xcode 27.0 beta (27A5194q), SDK 27.0 (26A5353p). macOS 26 is the required CI compatibility gate.

Ready to merge when every required CI check is green.