### PR TITLE
fix(sidebar): prevent flicker during deep tree refresh

### DIFF
--- a/Pine/SidebarView.swift
+++ b/Pine/SidebarView.swift
@@ -1026,9 +1026,12 @@ struct SidebarView: View {
             rows: rows
         )
         selectedFile = reconciled
-        if let reconciled {
-            navigation.scroll(to: reconciled)
-        }
+        // A passive file-system refresh must preserve the viewport. The row
+        // was already selected and visible (or intentionally off-screen), so
+        // asking ScrollViewReader to reveal it again only forces another
+        // layout pass. Consecutive file-system refreshes made those requests
+        // visible as sidebar flashing on deep trees. User-driven navigation
+        // still scrolls through `navigate(to:)`.
 
         if let renamingURL = editState.renamingURL,
            !SidebarTreeFlattener.contains(

--- a/Pine/WorkspaceManager.swift
+++ b/Pine/WorkspaceManager.swift
@@ -243,6 +243,73 @@ final class WorkspaceManager {
     /// main-actor hop.
     nonisolated private static let shallowDepth = 3
 
+    /// Controls which intermediate tree snapshots become visible while a
+    /// background load runs.
+    ///
+    /// Progressive publication is useful only for the first project load,
+    /// when rendering a shallow tree quickly is better than an empty sidebar.
+    /// Once a tree is already visible, publishing an unchanged shallow
+    /// snapshot before the full result needlessly lays out every expanded row
+    /// twice and can visibly flash deep sidebars on each FSEvents refresh.
+    nonisolated private enum TreeLoadPresentation: Sendable {
+        /// Initial load: publish shallow, then full when depth-limited.
+        case progressive
+        /// External refresh: publish shallow only when its visible structure changed.
+        case refresh
+        /// In-app mutation: the caller already published a synchronous shallow snapshot.
+        case shallowAlreadyPublished
+
+        func publishesShallowResult(
+            _ nodes: [FileNode],
+            replacing currentNodes: [FileNode],
+            ignoredPathsChanged: Bool
+        ) -> Bool {
+            switch self {
+            case .progressive:
+                true
+            case .refresh:
+                ignoredPathsChanged
+                    || !WorkspaceManager.hasSameVisibleStructure(
+                        nodes,
+                        as: currentNodes
+                    )
+            case .shallowAlreadyPublished:
+                false
+            }
+        }
+    }
+
+    /// Compares the part of a shallow snapshot that is authoritative.
+    /// Descendants below a deferred node are intentionally ignored because
+    /// the shallow loader did not inspect them. This keeps fast publication
+    /// for real additions/removals near the project root while suppressing an
+    /// identical intermediate snapshot for content-only FSEvents.
+    nonisolated private static func hasSameVisibleStructure(
+        _ refreshed: [FileNode],
+        as current: [FileNode]
+    ) -> Bool {
+        guard refreshed.count == current.count else { return false }
+
+        for (newNode, currentNode) in zip(refreshed, current) {
+            guard newNode.id == currentNode.id,
+                  newNode.isDirectory == currentNode.isDirectory,
+                  newNode.isSymlink == currentNode.isSymlink else {
+                return false
+            }
+
+            guard newNode.isDirectory, !newNode.hasDeferredChildren else {
+                continue
+            }
+            guard hasSameVisibleStructure(
+                newNode.children ?? [],
+                as: currentNode.children ?? []
+            ) else {
+                return false
+            }
+        }
+        return true
+    }
+
     /// Heavy I/O (file tree + git) runs in a detached `Task` at
     /// `userInitiated` priority; results are applied back on the main actor
     /// via `await MainActor.run { ... }`.
@@ -255,12 +322,15 @@ final class WorkspaceManager {
     /// (issue #837). Staying inside the structured-concurrency world lets
     /// the main actor and the detached worker interleave cooperatively.
     ///
-    /// Uses two-phase progressive loading: a shallow tree appears fast,
-    /// then the full tree replaces it once ready.
+    /// The initial project load is progressive: a shallow tree appears fast,
+    /// then the full tree replaces it once ready. Refreshes suppress an
+    /// unchanged shallow snapshot; genuine shallow structural changes can
+    /// still appear immediately before the final tree is ready.
     private func loadDirectoryContentsAsync(
         url: URL,
         generation: Int,
-        showProgress: Bool = true
+        showProgress: Bool = true,
+        presentation: TreeLoadPresentation = .progressive
     ) {
         // Cancel any prior in-flight load so its `MainActor.run` blocks
         // become no-ops after the generation check below.
@@ -304,7 +374,15 @@ final class WorkspaceManager {
                     if let progressID { self?.progressTracker?.endOperation(progressID) }
                     return
                 }
-                self.setRootNodes(shallowChildren)
+                let publishesShallowResult = presentation.publishesShallowResult(
+                    shallowChildren,
+                    replacing: self.rootNodes,
+                    ignoredPathsChanged: gitInfo.ignoredPaths
+                        != self.gitProvider.ignoredPaths
+                )
+                if publishesShallowResult {
+                    self.setRootNodes(shallowChildren)
+                }
                 self.gitProvider.repositoryURL = gitInfo.repositoryURL
                 self.gitProvider.gitRootPath = gitInfo.gitRootPath
                 // Atomically apply git state in a single equality-checked
@@ -485,13 +563,17 @@ final class WorkspaceManager {
         setRootNodes(shallowResult.root.children ?? [])
 
         // Phase 2 (async): full tree (if depth-limited) + git status refresh,
-        // off the main thread. Reuses the shared two-phase loader so race
-        // safety (`loadGeneration`) and git state stay consistent with the
-        // initial load and the external watcher path. The loader repeats
-        // the shallow pass; that is cheap and lands identical data, so
-        // there is no visible flicker, and it carries the git fetch that
-        // the pre-#1006 path used to trigger via a separate `gitRefreshTask`.
-        loadDirectoryContentsAsync(url: url, generation: generation, showProgress: false)
+        // off the main thread. Reuses the shared loader so race safety
+        // (`loadGeneration`) and git state stay consistent with the initial
+        // load and external watcher path. The loader still computes the
+        // shallow pass to decide whether a full load is needed, but does not
+        // publish it again because this caller already did so synchronously.
+        loadDirectoryContentsAsync(
+            url: url,
+            generation: generation,
+            showProgress: false,
+            presentation: .shallowAlreadyPublished
+        )
     }
 
     /// Background variant called by the file watcher.
@@ -510,6 +592,11 @@ final class WorkspaceManager {
         guard let url = rootURL else { return }
         loadGeneration += 1
         let generation = loadGeneration
-        loadDirectoryContentsAsync(url: url, generation: generation, showProgress: false)
+        loadDirectoryContentsAsync(
+            url: url,
+            generation: generation,
+            showProgress: false,
+            presentation: .refresh
+        )
     }
 }

--- a/PineTests/SidebarExpandedRefreshTests.swift
+++ b/PineTests/SidebarExpandedRefreshTests.swift
@@ -29,7 +29,7 @@ struct SidebarExpandedRefreshTests {
         try? FileManager.default.removeItem(at: url)
     }
 
-    // MARK: - rootNodesRevision increments on refresh
+    // MARK: - rootNodesRevision tracks published tree changes
 
     @Test("rootNodesRevision starts at zero")
     @MainActor
@@ -56,7 +56,7 @@ struct SidebarExpandedRefreshTests {
         #expect(manager.rootNodesRevision > 0, "rootNodesRevision should increment after loadDirectory")
     }
 
-    @Test("rootNodesRevision increments after refreshFileTreeAsync")
+    @Test("rootNodesRevision increments when async refresh changes the tree")
     @MainActor
     func revisionIncrementsAfterAsyncRefresh() async throws {
         let dir = try makeTempDirectory()
@@ -72,8 +72,14 @@ struct SidebarExpandedRefreshTests {
         }
 
         let revisionBeforeRefresh = manager.rootNodesRevision
+        try "new".write(
+            to: dir.appendingPathComponent("new-file.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
 
-        // Simulate an external FSEvents-triggered refresh
+        // Simulate the external FSEvents-triggered refresh before the
+        // watcher's debounce fires on its own.
         manager.refreshFileTreeAsync()
 
         // Wait for the async refresh to complete
@@ -84,7 +90,7 @@ struct SidebarExpandedRefreshTests {
 
         #expect(
             manager.rootNodesRevision > revisionBeforeRefresh,
-            "rootNodesRevision should increment after refreshFileTreeAsync"
+            "rootNodesRevision should increment when refreshFileTreeAsync publishes a changed tree"
         )
     }
 
@@ -245,6 +251,54 @@ struct SidebarExpandedRefreshTests {
             manager.rootNodesRevision >= 2,
             "Deep project should have at least 2 revision increments (shallow + full phases)"
         )
+    }
+
+    @Test("Async refresh publishes one final tree for a deep project")
+    @MainActor
+    func asyncRefreshPublishesDeepTreeOnce() async throws {
+        // Once a project is visible, an FSEvents refresh must keep that tree
+        // on screen until the full replacement is ready. Publishing the
+        // shallow and full snapshots back-to-back lays out every expanded row
+        // twice and is visible as a flash on a deep sidebar.
+        let dir = try makeTempDirectory()
+        defer { cleanup(dir) }
+
+        let deepDir = dir.appendingPathComponent("a/b/c/d/e")
+        try FileManager.default.createDirectory(
+            at: deepDir,
+            withIntermediateDirectories: true
+        )
+        try "deep".write(
+            to: deepDir.appendingPathComponent("file.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let manager = WorkspaceManager()
+        manager.loadDirectory(url: dir)
+
+        for _ in 0..<200 {
+            try await Task.sleep(for: .milliseconds(25))
+            if !manager.isLoading { break }
+        }
+        #expect(!manager.isLoading)
+
+        // The watcher can deliver the directory's initial FSEvents batch just
+        // after the progressive load completes. Let that independent refresh
+        // settle before measuring the explicit refresh below.
+        try await Task.sleep(for: .milliseconds(300))
+        let revisionBeforeRefresh = manager.rootNodesRevision
+        manager.refreshFileTreeAsync()
+
+        for _ in 0..<200 {
+            try await Task.sleep(for: .milliseconds(25))
+            if manager.rootNodesRevision > revisionBeforeRefresh { break }
+        }
+
+        // Give a second publication enough time to arrive. Before the fix,
+        // the shallow and full phases both incremented this revision.
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(manager.rootNodesRevision == revisionBeforeRefresh + 1)
     }
 
     // MARK: - Sidebar flicker fix (#1097): loaded children survive refresh


### PR DESCRIPTION
## Summary

- suppress unchanged shallow tree publications during background FSEvents refreshes
- preserve the sidebar viewport when selection is rebound after a passive tree reload
- retain immediate publication for genuine shallow additions, removals, and ignored-path changes
- add regression coverage for deep-tree refresh publication counts

## Why

A background refresh of an already-visible deep project published both a shallow snapshot and a full snapshot. Each publication rebuilt expanded rows, and selection reconciliation also requested another ScrollViewReader reveal. Together these layout passes appeared as sidebar flashing in deeply expanded trees.

## Testing

- 31 tests passed in SidebarExpandedRefreshTests and SidebarTreeNavigationTests
- 57 tests passed across WorkspaceManagerTests, SidebarRefreshTests, SidebarLoadingFlickerTests, RefreshFileTreeRaceRegressionTests, and ExternalChangeRefreshRegressionTests
- targeted SwiftLint: 0 violations
- full SwiftLint completed successfully; its 8 warnings are confined to Xcode-generated files under build/Pine.build/Debug/Pine.build/DerivedSources
- git diff --check passed

## Compatibility environment

```text
ProductName: macOS
ProductVersion: 27.0
BuildVersion: 26A5388g

Xcode 27.0
Build version 27A5218g

macOS SDK version: 27.0
macOS SDK build: 26A5378i
```

The build continues to target macOS 26.0 (arm64-apple-macos26.0). A macOS 26 runtime was not available for manual runtime verification on this machine.