### PR TITLE
fix: retain agent ownership through foreground children

### DIFF
--- a/Pine/Agent/AgentDetectionCoordinator.swift
+++ b/Pine/Agent/AgentDetectionCoordinator.swift
@@ -12,6 +12,11 @@
 import Darwin
 import Foundation
 
+nonisolated struct TerminalAgentOwnershipEvidence: Sendable {
+    let foreground: TerminalForegroundProcessSnapshot
+    let processes: [DetectedProcess]
+}
+
 nonisolated enum AgentMonotonicCounter {
     static func next(after value: UInt64) -> UInt64? {
         guard value < UInt64.max else { return nil }
@@ -195,7 +200,8 @@ nonisolated final class AgentDetectionCoordinator {
         DispatchQueue.main.async(execute: work)
     }
 
-    /// Parses raw `ps -eo pid=,lstart=,cputime=,command=` output.
+    /// Parses raw
+    /// `ps -eo pid=,ppid=,pgid=,lstart=,cputime=,command=` output.
     /// `nonisolated` so it is callable from the background polling queue
     /// via `captureSnapshot`. Relies on `DetectedProcess` being `nonisolated`
     /// so its init is reachable from here.
@@ -213,20 +219,27 @@ nonisolated final class AgentDetectionCoordinator {
         for line in output.split(separator: "\n", omittingEmptySubsequences: true) {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
             let tokens = trimmed.split(separator: " ", omittingEmptySubsequences: true)
-            guard tokens.count >= 8,
+            guard tokens.count >= 10,
                   let pid = Int32(tokens[0]),
-                  parseLongStart(tokens[1...5]) != nil,
-                  let cpuTime = parseCpuTime(String(tokens[6])) else {
+                  pid > 0,
+                  let parentProcessID = Int32(tokens[1]),
+                  parentProcessID >= 0,
+                  let processGroupID = Int32(tokens[2]),
+                  processGroupID > 0,
+                  parseLongStart(tokens[3...7]) != nil,
+                  let cpuTime = parseCpuTime(String(tokens[8])) else {
                 continue
             }
-            let command = tokens[7...].joined(separator: " ")
+            let command = tokens[9...].joined(separator: " ")
             guard !command.isEmpty else { continue }
             processes.append(
                 DetectedProcess(
                     pid: pid,
+                    parentProcessID: parentProcessID,
+                    processGroupID: processGroupID,
                     command: command,
                     cpuTime: cpuTime,
-                    startIdentifier: tokens[1...5].joined(separator: " ")
+                    startIdentifier: tokens[3...7].joined(separator: " ")
                 )
             )
         }
@@ -243,6 +256,8 @@ nonisolated final class AgentDetectionCoordinator {
             processes: processes.map { process in
                 DetectedProcess(
                     pid: process.pid,
+                    parentProcessID: process.parentProcessID,
+                    processGroupID: process.processGroupID,
                     command: process.command,
                     cwd: process.cwd,
                     cpuTime: process.cpuTime,
@@ -505,7 +520,7 @@ nonisolated final class AgentDetectionCoordinator {
     nonisolated static let psCompletionMarker = "__PINE_PS_SNAPSHOT_COMPLETE__"
 
     nonisolated private static let psSnapshotCommand = [
-        "TZ=UTC LC_ALL=C /bin/ps -eo pid=,lstart=,cputime=,command=;",
+        "TZ=UTC LC_ALL=C /bin/ps -eo pid=,ppid=,pgid=,lstart=,cputime=,command=;",
         "status=$?;",
         "printf '\\n\(psCompletionMarker)\\n';",
         "exit \"$status\"",
@@ -729,8 +744,14 @@ nonisolated final class AgentDetectionCoordinator {
                 let previous = tab.agentSession
                 let current = reconciledSession(
                     previous: previous,
-                    foregroundPID: tab.foregroundProcessID,
+                    ownership: TerminalAgentOwnershipEvidence(
+                        foreground: tab.foregroundProcessSnapshot(),
+                        processes: processes
+                    ),
                     detector: detector,
+                    agentIdentityStillMatches: {
+                        tab.agentProcessIdentityStillMatches($0)
+                    },
                     newlyTerminated: newlyTerminated
                 )
                 if let current {
@@ -752,19 +773,125 @@ nonisolated final class AgentDetectionCoordinator {
     @MainActor
     static func reconciledSession(
         previous: AgentSession?,
-        foregroundPID: Int32,
+        ownership: TerminalAgentOwnershipEvidence,
         detector: AgentDetector,
+        agentIdentityStillMatches: (
+            TerminalProcessStartIdentity
+        ) -> Bool,
         newlyTerminated: Set<UUID>
     ) -> AgentSession? {
-        if foregroundPID > 0, let current = detector.session(forPID: foregroundPID) {
+        if let current = foregroundOwner(
+            foreground: ownership.foreground,
+            processes: ownership.processes,
+            detector: detector,
+            agentIdentityStillMatches: agentIdentityStillMatches
+        ) {
             return current
         }
+        // A live foreground group that has no exact ancestry proof is new or
+        // unrelated work. It may not inherit even the one-poll exit badge.
+        guard ownership.foreground == .idle else { return nil }
         guard let previous,
               previous.liveness == .terminated,
               newlyTerminated.contains(previous.id) else {
             return nil
         }
         return previous
+    }
+
+    /// Returns the unique live agent generation that owns the exact current
+    /// foreground process-group member. The member's authoritative start time
+    /// closes the sampling race between `ps` and `tcgetpgrp`; walking only
+    /// parent links captured in that same snapshot proves ancestry. Ambiguous,
+    /// incomplete, and unrelated process trees fail closed.
+    @MainActor
+    private static func foregroundOwner(
+        foreground: TerminalForegroundProcessSnapshot,
+        processes: [DetectedProcess],
+        detector: AgentDetector,
+        agentIdentityStillMatches: (
+            TerminalProcessStartIdentity
+        ) -> Bool
+    ) -> AgentSession? {
+        guard case .running(let processGroupID, let identity) = foreground,
+              processGroupID > 1 else {
+            return nil
+        }
+        var processesByPID: [Int32: DetectedProcess] = [:]
+        for process in processes {
+            guard processesByPID.updateValue(process, forKey: process.pid)
+                    == nil else {
+                return nil
+            }
+        }
+        guard let witness = processesByPID[identity.processID],
+              witness.processGroupID == processGroupID,
+              witness.preciseStartedAt.flatMap({
+                  TerminalProcessStartIdentity(
+                      processID: witness.pid,
+                      startedAt: $0
+                  )
+              }) == identity else {
+            return nil
+        }
+
+        var owners: [UUID: AgentSession] = [:]
+        var processID = identity.processID
+        var visited: Set<Int32> = []
+        while processID > 1, visited.insert(processID).inserted {
+            if let session = detector.session(forPID: processID) {
+                guard exactGenerationMatches(
+                    session,
+                    process: processesByPID[processID],
+                    liveIdentityStillMatches: agentIdentityStillMatches
+                ) else {
+                    return nil
+                }
+                owners[session.id] = session
+            }
+            guard let parent = processesByPID[processID]?.parentProcessID,
+                  parent > 1 else {
+                break
+            }
+            processID = parent
+        }
+        guard owners.count == 1 else { return nil }
+        return owners.values.first
+    }
+
+    /// `session(forPID:)` proves that this is the detector's current logical
+    /// generation. Match its immutable authoritative OS start witness against
+    /// the current `ps` row as well, so same-second PID reuse, precision loss,
+    /// or a stale ancestry row cannot transfer terminal ownership.
+    @MainActor
+    private static func exactGenerationMatches(
+        _ session: AgentSession,
+        process: DetectedProcess?,
+        liveIdentityStillMatches: (
+            TerminalProcessStartIdentity
+        ) -> Bool
+    ) -> Bool {
+        guard session.liveness == .live,
+              session.state != .done,
+              let process,
+              let evidence = session.processEvidence,
+              evidence.startIsAuthoritative,
+              evidence.processIdentifier == process.pid,
+              let sessionIdentity = TerminalProcessStartIdentity(
+                  processEvidence: evidence
+              ),
+              let preciseStartedAt = process.preciseStartedAt,
+              let processIdentity = TerminalProcessStartIdentity(
+                  processID: process.pid,
+                  startedAt: preciseStartedAt
+              ),
+              sessionIdentity == processIdentity,
+              liveIdentityStillMatches(sessionIdentity),
+              let evidenceStart = evidence.startIdentifier,
+              evidenceStart == process.startIdentifier else {
+            return false
+        }
+        return true
     }
 
     /// A failed poll cannot detach a session whose process evidence is merely
@@ -806,6 +933,25 @@ nonisolated final class AgentDetectionCoordinator {
         )
         Self.applySnapshot(
             snapshot,
+            detector: detector,
+            terminalManager: terminalManager
+        )
+    }
+
+    /// Applies a simulated complete process tree through the production
+    /// detector + terminal reconciliation path. Tests supply authoritative
+    /// starts directly because synthetic pids cannot be verified by libproc.
+    @MainActor internal func applySnapshotForTesting(
+        processes: [DetectedProcess]
+    ) {
+        let observation = AgentObservationStamp(
+            wallTime: Date(),
+            uptime: uptimeProvider(),
+            generation: testingRun.generation,
+            sequence: testingRun.nextSequence() ?? UInt64.max
+        )
+        Self.applySnapshot(
+            .success(processes: processes, observation: observation),
             detector: detector,
             terminalManager: terminalManager
         )

--- a/Pine/Agent/AgentDetector.swift
+++ b/Pine/Agent/AgentDetector.swift
@@ -32,6 +32,13 @@ import Foundation
 nonisolated struct DetectedProcess: Sendable, Equatable {
     /// Operating-system process id.
     let pid: Int32
+    /// Parent process id from the same process-list snapshot. Used only to
+    /// prove terminal ownership while an agent's foreground child is active.
+    let parentProcessID: Int32?
+    /// Process-group id from the same process-list snapshot. Combined with
+    /// `parentProcessID` so an unrelated foreground job cannot inherit an
+    /// agent session merely because both processes are alive.
+    let processGroupID: Int32?
     /// Full command line as reported by `ps -o command=` (executable + args).
     let command: String
     /// Working directory of the process, if known. Reserved for Phase 2
@@ -55,6 +62,8 @@ nonisolated struct DetectedProcess: Sendable, Equatable {
 
     init(
         pid: Int32,
+        parentProcessID: Int32? = nil,
+        processGroupID: Int32? = nil,
         command: String,
         cwd: URL? = nil,
         cpuTime: Int? = nil,
@@ -62,6 +71,8 @@ nonisolated struct DetectedProcess: Sendable, Equatable {
         preciseStartedAt: Date? = nil
     ) {
         self.pid = pid
+        self.parentProcessID = parentProcessID
+        self.processGroupID = processGroupID
         self.command = command
         self.cwd = cwd
         self.cpuTime = cpuTime
@@ -191,7 +202,8 @@ final class AgentDetector {
     /// which is a no-op when nothing changed.
     ///
     /// - Parameter processes: the full process list as captured by the
-    ///   caller (e.g. via `ps -eo pid=,lstart=,cputime=,command=`). Order is
+    ///   caller (e.g. via
+    ///   `ps -eo pid=,ppid=,pgid=,lstart=,cputime=,command=`). Order is
     ///   not significant.
     @discardableResult
     func processSnapshotDidUpdate(

--- a/Pine/TabCloseHelper.swift
+++ b/Pine/TabCloseHelper.swift
@@ -41,7 +41,15 @@ nonisolated struct TerminalProcessStartIdentity: Hashable, Sendable {
         guard processEvidence.startIsAuthoritative,
               let processID = processEvidence.processIdentifier,
               processID > 1 else { return nil }
-        let interval = processEvidence.observedStartedAt.timeIntervalSince1970
+        self.init(
+            processID: processID,
+            startedAt: processEvidence.observedStartedAt
+        )
+    }
+
+    init?(processID: pid_t, startedAt: Date) {
+        guard processID > 1 else { return nil }
+        let interval = startedAt.timeIntervalSince1970
         guard interval.isFinite, interval >= 0 else { return nil }
         var seconds = UInt64(interval.rounded(.down))
         var microseconds = UInt64(
@@ -58,6 +66,18 @@ nonisolated struct TerminalProcessStartIdentity: Hashable, Sendable {
             microseconds: microseconds
         )
     }
+}
+
+/// One coherent foreground-job observation. `.unavailable` is distinct from
+/// `.idle`: it means a process group existed but changed or could not be
+/// identified exactly while Pine sampled it, so ownership must fail closed.
+nonisolated enum TerminalForegroundProcessSnapshot: Equatable, Sendable {
+    case idle
+    case running(
+        processGroupID: Int32,
+        identity: TerminalProcessStartIdentity
+    )
+    case unavailable
 }
 
 /// Per-tab coverage captured when a destructive terminal close/stop is

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -2222,6 +2222,7 @@ final class TerminalTab: Identifiable, Hashable {
     /// running. Used by `AgentDetectionCoordinator` (#951).
     #if DEBUG
     var foregroundProcessIDOverrideForTesting: Int32?
+    var foregroundProcessIDResolverForTesting: (() -> Int32)?
     var foregroundStartOverrideForTesting:
         TerminalProcessStartIdentity?
     var agentProcessIdentityResolverForTesting:
@@ -2229,7 +2230,28 @@ final class TerminalTab: Identifiable, Hashable {
     #endif
 
     var foregroundProcessID: Int32 {
+        readForegroundProcessID()
+    }
+
+    /// Samples the foreground group before and after resolving an exact live
+    /// member. A group switch in between is uncertainty, not proof that either
+    /// the old or new job belongs to the prior agent session.
+    func foregroundProcessSnapshot() -> TerminalForegroundProcessSnapshot {
+        let before = readForegroundProcessID()
+        guard before > 0 else { return .idle }
+        guard let identity = foregroundProcessIdentity(in: before) else {
+            return .unavailable
+        }
+        let after = readForegroundProcessID()
+        guard after == before else { return .unavailable }
+        return .running(processGroupID: before, identity: identity)
+    }
+
+    private func readForegroundProcessID() -> Int32 {
         #if DEBUG
+        if let foregroundProcessIDResolverForTesting {
+            return foregroundProcessIDResolverForTesting()
+        }
         if let foregroundProcessIDOverrideForTesting {
             return foregroundProcessIDOverrideForTesting
         }

--- a/PineTests/AgentDetectionCoordinatorTests.swift
+++ b/PineTests/AgentDetectionCoordinatorTests.swift
@@ -186,7 +186,7 @@ struct AgentDetectionCoordinatorTests {
         let session = try #require(detector.session(forPID: 100))
 
         output.value = completePsOutput()
-            + "\n100 Jul 22 15:08:40 2026 0:12.45 claude"
+            + "\n100 1 100 Jul 22 15:08:40 2026 0:12.45 claude"
         coordinator.runSnapshotForTesting()
 
         #expect(detector.session(forPID: 100) === session)
@@ -222,7 +222,7 @@ struct AgentDetectionCoordinatorTests {
             psRow(pid: 200, command: "codex"),
             psRow(
                 pid: 99_999,
-                command: "/bin/ps -eo pid=,lstart=,cputime=,command="
+                command: "/bin/ps -eo pid=,ppid=,pgid=,lstart=,cputime=,command="
             ),
         ].joined(separator: "\n")
         coordinator.runSnapshotForTesting()
@@ -319,8 +319,12 @@ struct AgentDetectionCoordinatorTests {
         detector.processSnapshotDidUpdate([])
         let retained = AgentDetectionCoordinator.reconciledSession(
             previous: previous,
-            foregroundPID: 0,
+            ownership: TerminalAgentOwnershipEvidence(
+                foreground: .idle,
+                processes: []
+            ),
             detector: detector,
+            agentIdentityStillMatches: { _ in false },
             newlyTerminated: [previous.id]
         )
 
@@ -339,8 +343,12 @@ struct AgentDetectionCoordinatorTests {
 
         let reconciled = AgentDetectionCoordinator.reconciledSession(
             previous: previous,
-            foregroundPID: 0,
+            ownership: TerminalAgentOwnershipEvidence(
+                foreground: .idle,
+                processes: []
+            ),
             detector: detector,
+            agentIdentityStillMatches: { _ in false },
             newlyTerminated: []
         )
 
@@ -358,20 +366,432 @@ struct AgentDetectionCoordinatorTests {
 
         let retained = AgentDetectionCoordinator.reconciledSession(
             previous: previous,
-            foregroundPID: 0,
+            ownership: TerminalAgentOwnershipEvidence(
+                foreground: .idle,
+                processes: []
+            ),
             detector: detector,
+            agentIdentityStillMatches: { _ in false },
             newlyTerminated: newlyTerminated
         )
         let dismissed = AgentDetectionCoordinator.reconciledSession(
             previous: retained,
-            foregroundPID: 0,
+            ownership: TerminalAgentOwnershipEvidence(
+                foreground: .idle,
+                processes: []
+            ),
             detector: detector,
+            agentIdentityStillMatches: { _ in false },
             newlyTerminated: []
         )
 
         #expect(retained === previous)
         #expect(dismissed == nil)
         #expect(detector.detectedSessions.isEmpty)
+    }
+
+    @Test func productionReconciliationRetainsAgentThroughForegroundChild()
+        throws {
+        let project = ProjectManager()
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        let coordinator = AgentDetectionCoordinator(
+            detector: project.terminal.agentDetector,
+            terminalManager: project.terminal,
+            processRunner: { _, _, _, _ in
+                ProcessRunResult(
+                    stdout: "",
+                    stderr: "",
+                    exitCode: 1,
+                    timedOut: false
+                )
+            }
+        )
+        let agent = process(
+            pid: 500,
+            parent: 400,
+            group: 500,
+            command: "claude",
+            startedAt: 500
+        )
+        let child = process(
+            pid: 600,
+            parent: 500,
+            group: 600,
+            command: "swift test",
+            startedAt: 600
+        )
+
+        setLiveAgent(agent, on: tab)
+        setForeground(agent, on: tab)
+        coordinator.applySnapshotForTesting(processes: [agent])
+        let session = try #require(tab.agentSession)
+
+        setForeground(child, on: tab)
+        coordinator.applySnapshotForTesting(processes: [agent, child])
+        #expect(tab.agentSession === session)
+
+        setLiveAgent(agent, on: tab)
+        setForeground(agent, on: tab)
+        coordinator.applySnapshotForTesting(processes: [agent])
+        #expect(tab.agentSession === session)
+    }
+
+    @Test func unrelatedForegroundGroupDoesNotInheritAgentSession() throws {
+        let project = ProjectManager()
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        let coordinator = AgentDetectionCoordinator(
+            detector: project.terminal.agentDetector,
+            terminalManager: project.terminal
+        )
+        let agent = process(
+            pid: 510,
+            parent: 400,
+            group: 510,
+            command: "codex",
+            startedAt: 510
+        )
+        let unrelated = process(
+            pid: 710,
+            parent: 400,
+            group: 710,
+            command: "git status",
+            startedAt: 710
+        )
+
+        setLiveAgent(agent, on: tab)
+        setForeground(agent, on: tab)
+        coordinator.applySnapshotForTesting(processes: [agent])
+        #expect(tab.agentSession != nil)
+
+        setForeground(unrelated, on: tab)
+        coordinator.applySnapshotForTesting(processes: [agent, unrelated])
+        #expect(tab.agentSession == nil)
+    }
+
+    @Test func exactForegroundWitnessMustDescendFromAgent() throws {
+        let project = ProjectManager()
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        let coordinator = AgentDetectionCoordinator(
+            detector: project.terminal.agentDetector,
+            terminalManager: project.terminal
+        )
+        let agent = process(
+            pid: 515,
+            parent: 400,
+            group: 515,
+            command: "claude",
+            startedAt: 515
+        )
+        let unrelatedWitness = process(
+            pid: 715,
+            parent: 400,
+            group: 715,
+            command: "git status",
+            startedAt: 715
+        )
+        let staleGroupMember = process(
+            pid: 716,
+            parent: 515,
+            group: 715,
+            command: "swift test",
+            startedAt: 716
+        )
+
+        setLiveAgent(agent, on: tab)
+        setForeground(agent, on: tab)
+        coordinator.applySnapshotForTesting(processes: [agent])
+        #expect(tab.agentSession != nil)
+
+        setForeground(unrelatedWitness, on: tab)
+        coordinator.applySnapshotForTesting(
+            processes: [agent, unrelatedWitness, staleGroupMember]
+        )
+        #expect(tab.agentSession == nil)
+    }
+
+    @Test func replacementAgentInvalidatesPreviousGeneration() throws {
+        let project = ProjectManager()
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        let coordinator = AgentDetectionCoordinator(
+            detector: project.terminal.agentDetector,
+            terminalManager: project.terminal
+        )
+        let original = process(
+            pid: 520,
+            parent: 400,
+            group: 520,
+            command: "claude",
+            startedAt: 520.1,
+            startIdentifier: "same-coarse-second"
+        )
+        let replacement = process(
+            pid: 520,
+            parent: 400,
+            group: 520,
+            command: "codex",
+            startedAt: 520.2,
+            startIdentifier: "same-coarse-second"
+        )
+
+        setLiveAgent(original, on: tab)
+        setForeground(original, on: tab)
+        coordinator.applySnapshotForTesting(processes: [original])
+        let previous = try #require(tab.agentSession)
+        let previousGeneration = try #require(
+            previous.processEvidence?.processGeneration
+        )
+
+        setLiveAgent(replacement, on: tab)
+        setForeground(replacement, on: tab)
+        coordinator.applySnapshotForTesting(processes: [replacement])
+        let current = try #require(tab.agentSession)
+
+        #expect(current !== previous)
+        #expect(previous.liveness == .terminated)
+        #expect(current.agentType == .codex)
+        #expect(
+            current.processEvidence?.processGeneration != previousGeneration
+        )
+    }
+
+    @Test func unrelatedPIDReuseInvalidatesPreviousAssociation() throws {
+        let project = ProjectManager()
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        let coordinator = AgentDetectionCoordinator(
+            detector: project.terminal.agentDetector,
+            terminalManager: project.terminal
+        )
+        let agent = process(
+            pid: 530,
+            parent: 400,
+            group: 530,
+            command: "pi",
+            startedAt: 530
+        )
+        let reused = process(
+            pid: 530,
+            parent: 400,
+            group: 530,
+            command: "git status",
+            startedAt: 531
+        )
+
+        setLiveAgent(agent, on: tab)
+        setForeground(agent, on: tab)
+        coordinator.applySnapshotForTesting(processes: [agent])
+        let previous = try #require(tab.agentSession)
+
+        setForeground(reused, on: tab)
+        coordinator.applySnapshotForTesting(processes: [reused])
+
+        #expect(tab.agentSession == nil)
+        #expect(previous.liveness == .terminated)
+    }
+
+    @Test func foregroundGroupChangeDuringSamplingFailsClosed() throws {
+        let project = ProjectManager()
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        let coordinator = AgentDetectionCoordinator(
+            detector: project.terminal.agentDetector,
+            terminalManager: project.terminal
+        )
+        let agent = process(
+            pid: 540,
+            parent: 400,
+            group: 540,
+            command: "claude",
+            startedAt: 540
+        )
+        let child = process(
+            pid: 640,
+            parent: 540,
+            group: 640,
+            command: "swift test",
+            startedAt: 640
+        )
+
+        setLiveAgent(agent, on: tab)
+        setForeground(agent, on: tab)
+        coordinator.applySnapshotForTesting(processes: [agent])
+        #expect(tab.agentSession != nil)
+
+        setForeground(child, on: tab)
+        var samples: [Int32] = [640, 740]
+        tab.foregroundProcessIDResolverForTesting = {
+            samples.isEmpty ? 740 : samples.removeFirst()
+        }
+        coordinator.applySnapshotForTesting(processes: [agent, child])
+
+        #expect(tab.agentSession == nil)
+        #expect(samples.isEmpty)
+    }
+
+    @Test func nonAuthoritativeAgentGenerationCannotOwnChildGroup() throws {
+        let project = ProjectManager()
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        let coordinator = AgentDetectionCoordinator(
+            detector: project.terminal.agentDetector,
+            terminalManager: project.terminal
+        )
+        let agent = DetectedProcess(
+            pid: 550,
+            parentProcessID: 400,
+            processGroupID: 550,
+            command: "claude",
+            cpuTime: 0,
+            startIdentifier: "coarse-only"
+        )
+        let child = process(
+            pid: 650,
+            parent: 550,
+            group: 650,
+            command: "swift test",
+            startedAt: 650
+        )
+
+        setForeground(child, on: tab)
+        coordinator.applySnapshotForTesting(processes: [agent, child])
+
+        #expect(project.terminal.agentDetector.session(forPID: 550) != nil)
+        #expect(tab.agentSession == nil)
+    }
+
+    @Test func mismatchedAgentStartWitnessCannotOwnChildGroup() throws {
+        let detector = AgentDetector()
+        let agent = process(
+            pid: 560,
+            parent: 400,
+            group: 560,
+            command: "codex",
+            startedAt: 560
+        )
+        detector.processSnapshotDidUpdate([agent])
+        let session = try #require(detector.session(forPID: 560))
+        let mismatchedAgent = process(
+            pid: 560,
+            parent: 400,
+            group: 560,
+            command: "codex",
+            startedAt: 560.5,
+            startIdentifier: agent.startIdentifier
+        )
+        let child = process(
+            pid: 660,
+            parent: 560,
+            group: 660,
+            command: "swift test",
+            startedAt: 660
+        )
+        let childStartedAt = try #require(child.preciseStartedAt)
+        let childIdentity = try #require(
+            TerminalProcessStartIdentity(
+                processID: child.pid,
+                startedAt: childStartedAt
+            )
+        )
+
+        let result = AgentDetectionCoordinator.reconciledSession(
+            previous: session,
+            ownership: TerminalAgentOwnershipEvidence(
+                foreground: .running(
+                    processGroupID: 660,
+                    identity: childIdentity
+                ),
+                processes: [mismatchedAgent, child]
+            ),
+            detector: detector,
+            agentIdentityStillMatches: { _ in true },
+            newlyTerminated: []
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test func exitedAgentDuringReconciliationCannotRetainChildOwnership()
+        throws {
+        let project = ProjectManager()
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        let coordinator = AgentDetectionCoordinator(
+            detector: project.terminal.agentDetector,
+            terminalManager: project.terminal
+        )
+        let agent = process(
+            pid: 570,
+            parent: 400,
+            group: 570,
+            command: "claude",
+            startedAt: 570
+        )
+        let child = process(
+            pid: 670,
+            parent: 570,
+            group: 670,
+            command: "swift test",
+            startedAt: 670
+        )
+
+        setLiveAgent(agent, on: tab)
+        setForeground(agent, on: tab)
+        coordinator.applySnapshotForTesting(processes: [agent])
+        #expect(tab.agentSession != nil)
+
+        setForeground(child, on: tab)
+        tab.agentProcessIdentityResolverForTesting = { _ in nil }
+        coordinator.applySnapshotForTesting(processes: [agent, child])
+
+        #expect(tab.agentSession == nil)
+    }
+
+    @Test func replacedAgentDuringReconciliationCannotRetainChildOwnership()
+        throws {
+        let project = ProjectManager()
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        let coordinator = AgentDetectionCoordinator(
+            detector: project.terminal.agentDetector,
+            terminalManager: project.terminal
+        )
+        let agent = process(
+            pid: 580,
+            parent: 400,
+            group: 580,
+            command: "codex",
+            startedAt: 580
+        )
+        let child = process(
+            pid: 680,
+            parent: 580,
+            group: 680,
+            command: "swift test",
+            startedAt: 680
+        )
+
+        setLiveAgent(agent, on: tab)
+        setForeground(agent, on: tab)
+        coordinator.applySnapshotForTesting(processes: [agent])
+        #expect(tab.agentSession != nil)
+
+        let replacementIdentity = try #require(
+            TerminalProcessStartIdentity(
+                processID: agent.pid,
+                startedAt: Date(timeIntervalSince1970: 580.5)
+            )
+        )
+        setForeground(child, on: tab)
+        tab.agentProcessIdentityResolverForTesting = { processID in
+            processID == agent.pid ? replacementIdentity : nil
+        }
+        coordinator.applySnapshotForTesting(processes: [agent, child])
+
+        #expect(tab.agentSession == nil)
     }
 
     @Test func failedPollExpiryRuleOnlyRemovesTerminatedAssociation() {
@@ -462,7 +882,11 @@ struct AgentDetectionCoordinatorTests {
         #expect(captured.1.first == "-c")
         let command = captured.1.last ?? ""
         #expect(command.contains("TZ=UTC LC_ALL=C /bin/ps"))
-        #expect(command.contains("pid=,lstart=,cputime=,command="))
+        #expect(
+            command.contains(
+                "pid=,ppid=,pgid=,lstart=,cputime=,command="
+            )
+        )
         #expect(command.contains(AgentDetectionCoordinator.psCompletionMarker))
     }
 
@@ -780,46 +1204,48 @@ struct AgentDetectionCoordinatorTests {
 
     @Test func parsePsOutputExtractsStableStartIdentifier() throws {
         let output = """
-            1234 Wed Jul 22 15:08:40 2026 0:12.45 /usr/local/bin/claude --verbose
-            5678 Wed Jul 22 15:09:39 2026 1:23.01 /sbin/launchd
+            1234 100 1234 Wed Jul 22 15:08:40 2026 0:12.45 /usr/local/bin/claude --verbose
+            5678 1 5678 Wed Jul 22 15:09:39 2026 1:23.01 /sbin/launchd
             """
 
         let processes = AgentDetectionCoordinator.parsePsOutput(output)
         let claude = try #require(processes.first)
         #expect(processes.count == 2)
         #expect(claude.pid == 1234)
+        #expect(claude.parentProcessID == 100)
+        #expect(claude.processGroupID == 1234)
         #expect(claude.command == "/usr/local/bin/claude --verbose")
         #expect(claude.cpuTime == 12)
         #expect(claude.startIdentifier == "Wed Jul 22 15:08:40 2026")
     }
 
     @Test func parsePsOutputRejectsMalformedLongStartRow() {
-        let output = "1234 Wed Jul 22 not-a-time 2026 0:12.45 claude"
+        let output = "1234 100 1234 Wed Jul 22 not-a-time 2026 0:12.45 claude"
         #expect(AgentDetectionCoordinator.parsePsOutput(output).isEmpty)
     }
 
     @Test func parsePsOutputRejectsMissingWeekdayAndBadMonth() {
         #expect(
             AgentDetectionCoordinator.parsePsOutput(
-                "1234 Jul 22 15:08:40 2026 0:12.45 claude"
+                "1234 100 1234 Jul 22 15:08:40 2026 0:12.45 claude"
             ).isEmpty
         )
         #expect(
             AgentDetectionCoordinator.parsePsOutput(
-                "1234 Wed Xxx 22 15:08:40 2026 0:12.45 claude"
+                "1234 100 1234 Wed Xxx 22 15:08:40 2026 0:12.45 claude"
             ).isEmpty
         )
     }
 
     @Test func parsePsOutputRejectsInvalidDateTimeAndWeekday() {
         let malformedRows = [
-            "1234 Thu Jul 22 15:08:40 2026 0:12.45 claude",
-            "1234 Wed Feb 30 15:08:40 2026 0:12.45 claude",
-            "1234 Wed Jul 22 24:08:40 2026 0:12.45 claude",
-            "1234 Wed Jul 22 15:60:40 2026 0:12.45 claude",
-            "1234 Wed Jul 22 15:08:60 2026 0:12.45 claude",
-            "1234 Wed Jul 22 15:08:40 1969 0:12.45 claude",
-            "1234 Wed Jul 22 15:08:40 2026 0:60.00 claude",
+            "1234 100 1234 Thu Jul 22 15:08:40 2026 0:12.45 claude",
+            "1234 100 1234 Wed Feb 30 15:08:40 2026 0:12.45 claude",
+            "1234 100 1234 Wed Jul 22 24:08:40 2026 0:12.45 claude",
+            "1234 100 1234 Wed Jul 22 15:60:40 2026 0:12.45 claude",
+            "1234 100 1234 Wed Jul 22 15:08:60 2026 0:12.45 claude",
+            "1234 100 1234 Wed Jul 22 15:08:40 1969 0:12.45 claude",
+            "1234 100 1234 Wed Jul 22 15:08:40 2026 0:60.00 claude",
         ]
         for row in malformedRows {
             #expect(AgentDetectionCoordinator.parsePsOutput(row).isEmpty)
@@ -839,6 +1265,49 @@ struct AgentDetectionCoordinatorTests {
     }
 }
 
+@MainActor
+private func setLiveAgent(
+    _ process: DetectedProcess,
+    on tab: TerminalTab
+) {
+    let identity = process.preciseStartedAt.flatMap {
+        TerminalProcessStartIdentity(processID: process.pid, startedAt: $0)
+    }
+    tab.agentProcessIdentityResolverForTesting = { processID in
+        processID == process.pid ? identity : nil
+    }
+}
+
+@MainActor
+private func setForeground(
+    _ process: DetectedProcess,
+    on tab: TerminalTab
+) {
+    tab.foregroundProcessIDOverrideForTesting = process.processGroupID
+    tab.foregroundStartOverrideForTesting = process.preciseStartedAt.flatMap {
+        TerminalProcessStartIdentity(processID: process.pid, startedAt: $0)
+    }
+}
+
+nonisolated private func process(
+    pid: Int32,
+    parent: Int32,
+    group: Int32,
+    command: String,
+    startedAt: TimeInterval,
+    startIdentifier: String? = nil
+) -> DetectedProcess {
+    DetectedProcess(
+        pid: pid,
+        parentProcessID: parent,
+        processGroupID: group,
+        command: command,
+        cpuTime: 0,
+        startIdentifier: startIdentifier ?? "generation-\(startedAt)",
+        preciseStartedAt: Date(timeIntervalSince1970: startedAt)
+    )
+}
+
 nonisolated private func completePsOutput(
     _ rows: (pid: Int32, command: String)...
 ) -> String {
@@ -847,7 +1316,7 @@ nonisolated private func completePsOutput(
     output.append(
         psRow(
             pid: 99_999,
-            command: "/bin/ps -eo pid=,lstart=,cputime=,command="
+            command: "/bin/ps -eo pid=,ppid=,pgid=,lstart=,cputime=,command="
         )
     )
     output.append(AgentDetectionCoordinator.psCompletionMarker)
@@ -855,5 +1324,5 @@ nonisolated private func completePsOutput(
 }
 
 nonisolated private func psRow(pid: Int32, command: String) -> String {
-    "\(pid) Wed Jul 22 15:08:40 2026 0:12.45 \(command)"
+    "\(pid) \(pid == 1 ? 0 : 1) \(pid) Wed Jul 22 15:08:40 2026 0:12.45 \(command)"
 }

--- a/PineTests/BulkCloseAgentAuthorizationTests.swift
+++ b/PineTests/BulkCloseAgentAuthorizationTests.swift
@@ -1064,25 +1064,99 @@ struct BulkCloseAgentAuthorizationTests {
         await idleProject.workspace.waitForLoadingComplete()
     }
 
-    @Test("Confirmed quit survives agent child-process churn")
+    @Test("Confirmed quit survives production agent-child reconciliation")
     func confirmedQuitSurvivesChurn() async throws {
         let dir = try makeTempDirectory()
         defer { cleanup(dir) }
         let registry = makeRegistry()
         let project = try #require(registry.projectManager(for: dir))
-        let tab = try addAgentTerminalTab(to: project)
-        let sessionID = try #require(tab.agentSession?.id)
+        project.paneManager.createTerminalPaneAtBottom(workingDirectory: nil)
+        let tab = try #require(project.terminal.allTerminalTabs.first)
+        let coordinator = AgentDetectionCoordinator(
+            detector: project.terminal.agentDetector,
+            terminalManager: project.terminal
+        )
+        let agent = bulkProcess(
+            pid: 8_111,
+            parent: 8_000,
+            group: 8_111,
+            command: "claude",
+            startedAt: 8_111
+        )
+        let child = bulkProcess(
+            pid: 8_222,
+            parent: 8_111,
+            group: 8_222,
+            command: "swift test",
+            startedAt: 8_222
+        )
+        let agentStartedAt = try #require(agent.preciseStartedAt)
+        let agentIdentity = try #require(
+            TerminalProcessStartIdentity(
+                processID: agent.pid,
+                startedAt: agentStartedAt
+            )
+        )
+        tab.agentProcessIdentityResolverForTesting = { processID in
+            processID == agent.pid ? agentIdentity : nil
+        }
+        setBulkForeground(agent, on: tab)
+        coordinator.applySnapshotForTesting(processes: [agent])
+
+        // No test-only `tab.agentSession` seed: detector + production
+        // reconciliation must create both the badge and durable Inbox route.
+        let session = try #require(tab.agentSession)
+        let sessionID = session.id
+        let taskID = try #require(
+            registry.agentTasks.taskID(forSessionID: sessionID)
+        )
+        let route = try #require(
+            registry.agentTasks.task(for: taskID)?.route
+        )
+        let closeAuthorization = TerminalTabCloseAuthorization.authorizing(
+            tabs: [tab]
+        )
+        #expect(closeAuthorization.requiresConfirmation)
 
         let delegate = AppDelegate()
         delegate.registry = registry
+        var presentedTemplates: [AlertTemplate] = []
 
         let result = await delegate.confirmApplicationTermination(
-            presentAlert: { _, _, _, _ in .alertSecondButtonReturn },
+            presentAlert: { template, _, _, _ in
+                presentedTemplates.append(template)
+                if template == .applicationQuitSummary {
+                    setBulkForeground(child, on: tab)
+                    coordinator.applySnapshotForTesting(
+                        processes: [agent, child]
+                    )
+                    #expect(tab.agentSession === session)
+                    #expect(closeAuthorization.stillCovers([tab]))
+                    #expect(
+                        registry.agentTasks.task(for: taskID)?.route == route
+                    )
+
+                    setBulkForeground(agent, on: tab)
+                    coordinator.applySnapshotForTesting(processes: [agent])
+                    #expect(tab.agentSession === session)
+                    #expect(closeAuthorization.stillCovers([tab]))
+                    #expect(
+                        registry.agentTasks.task(for: taskID)?.route == route
+                    )
+                }
+                return .alertSecondButtonReturn
+            },
             terminationDeadlineOverride: .now() + 120
         )
 
         #expect(result)
+        #expect(presentedTemplates == [.applicationQuitSummary])
         #expect(tab.agentSession?.id == sessionID)
+
+        // Mirrors applicationWillTerminate's project teardown: confirmed Quit
+        // owns terminal cleanup and does not require manual agent termination.
+        #expect(registry.destroyAllProjects())
+        #expect(tab.isTerminated)
         await project.workspace.waitForLoadingComplete()
     }
 
@@ -1195,6 +1269,35 @@ struct BulkCloseAgentAuthorizationTests {
         #expect(!result)
         await project.workspace.waitForLoadingComplete()
     }
+}
+
+@MainActor
+private func setBulkForeground(
+    _ process: DetectedProcess,
+    on tab: TerminalTab
+) {
+    tab.foregroundProcessIDOverrideForTesting = process.processGroupID
+    tab.foregroundStartOverrideForTesting = process.preciseStartedAt.flatMap {
+        TerminalProcessStartIdentity(processID: process.pid, startedAt: $0)
+    }
+}
+
+nonisolated private func bulkProcess(
+    pid: Int32,
+    parent: Int32,
+    group: Int32,
+    command: String,
+    startedAt: TimeInterval
+) -> DetectedProcess {
+    DetectedProcess(
+        pid: pid,
+        parentProcessID: parent,
+        processGroupID: group,
+        command: command,
+        cpuTime: 0,
+        startIdentifier: "generation-\(startedAt)",
+        preciseStartedAt: Date(timeIntervalSince1970: startedAt)
+    )
 }
 
 private actor BulkCloseAgentTaskStore: AgentTaskPersisting {

--- a/PineTests/TerminalManagerCoordinatorTests.swift
+++ b/PineTests/TerminalManagerCoordinatorTests.swift
@@ -281,11 +281,11 @@ struct TerminalManagerCoordinatorTests {
 
 nonisolated private func completeClaudePsSnapshot() -> String {
     [
-        "1 Wed Jul 22 15:08:40 2026 0:12.45 /sbin/launchd",
-        "100 Wed Jul 22 15:08:40 2026 0:12.45 claude",
+        "1 0 1 Wed Jul 22 15:08:40 2026 0:12.45 /sbin/launchd",
+        "100 1 100 Wed Jul 22 15:08:40 2026 0:12.45 claude",
         """
-        99999 Wed Jul 22 15:08:40 2026 0:12.45 \
-        /bin/ps -eo pid=,lstart=,cputime=,command=
+        99999 1 99999 Wed Jul 22 15:08:40 2026 0:12.45 \
+        /bin/ps -eo pid=,ppid=,pgid=,lstart=,cputime=,command=
         """,
         AgentDetectionCoordinator.psCompletionMarker,
     ].joined(separator: "\n")


### PR DESCRIPTION
Closes #1417

## Summary
- capture PPID/PGID and authoritative start evidence in production agent snapshots
- retain a terminal agent only when the exact foreground witness descends from the same live process generation
- fail closed for unrelated jobs, ambiguous/changing groups, start mismatch, PID reuse, and agent-exit races
- keep badge, Inbox route, and destructive-close authorization stable through `agent -> child -> agent`
- replace the synthetic Quit regression with production reconciliation and process-tree coverage

## Local verification
- 176/176 across AgentDetectionCoordinator, TerminalManagerCoordinator, BulkCloseAgentAuthorization, AgentDetector, and TerminalProcessConfirmation
- independent root review: 73/73 AgentDetectionCoordinator + BulkCloseAgentAuthorization
- full SwiftLint: 0 violations across 739 files
- `git diff --check`

One full PineTests run on the macOS 27 beta host reported five unrelated timeout/temp-file failures after test-runner resource pressure; none were in changed or ownership suites. The relevant suites were rerun isolated and passed.

Tested on macOS 27.0 beta (26A5406e), Xcode 27.0 beta (27A5194q), SDK 27.0 (26A5353p). macOS 26 runtime was unavailable locally.