### PR TITLE
fix: keep CPU-flat agent waits non-actionable

### DIFF
--- a/Pine/Agent/Adapters/FirstPartyAgentCompatibility.swift
+++ b/Pine/Agent/Adapters/FirstPartyAgentCompatibility.swift
@@ -29,9 +29,80 @@ nonisolated enum FirstPartyAgentResumeCapability: String, Sendable {
     case documentedOpaqueSessionID
 }
 
-nonisolated enum FirstPartyAgentNotificationAccuracy: String, Sendable {
+nonisolated enum FirstPartyAgentNotificationAccuracy: String, Codable, Sendable {
     case processTerminationOnly
     case verifiedLifecycleTransitions
+
+    /// Whether evidence at this accuracy may drive user-facing lifecycle
+    /// claims such as "Waiting for input". Process observation proves only
+    /// presence and termination; CPU inactivity is not a prompt signal.
+    var permitsUserFacingLifecycleTransitions: Bool {
+        self == .verifiedLifecycleTransitions
+    }
+}
+
+/// The single fail-closed accuracy policy shared by detection, durable tasks,
+/// presentation, and notification delivery. Production resolves declarations
+/// from the compatibility catalog; tests may inject a future verified catalog
+/// without weakening current first-party records.
+nonisolated struct AgentLifecycleAccuracyPolicy: Sendable {
+    private let declaredAccuracy: @Sendable (
+        String
+    ) -> FirstPartyAgentNotificationAccuracy
+
+    static let production = AgentLifecycleAccuracyPolicy { identifier in
+        FirstPartyAgentCompatibilityCatalog.record(
+            stableIdentifier: identifier
+        )?.notificationAccuracy ?? .processTerminationOnly
+    }
+
+    init(
+        declaredAccuracy: @escaping @Sendable (
+            String
+        ) -> FirstPartyAgentNotificationAccuracy
+    ) {
+        self.declaredAccuracy = declaredAccuracy
+    }
+
+    func accuracy(
+        for stableIdentifier: String
+    ) -> FirstPartyAgentNotificationAccuracy {
+        declaredAccuracy(stableIdentifier)
+    }
+
+    func boundedAccuracy(
+        for stableIdentifier: String,
+        evidence: FirstPartyAgentNotificationAccuracy
+    ) -> FirstPartyAgentNotificationAccuracy {
+        Self.boundedAccuracy(
+            declared: accuracy(for: stableIdentifier),
+            evidence: evidence
+        )
+    }
+
+    func permitsUserFacingAttention(
+        for stableIdentifier: String,
+        evidence: FirstPartyAgentNotificationAccuracy
+    ) -> Bool {
+        boundedAccuracy(
+            for: stableIdentifier,
+            evidence: evidence
+        ).permitsUserFacingLifecycleTransitions
+    }
+
+    /// Bounds per-run evidence by the compatibility claim. Both the adapter
+    /// declaration and the concrete transition must be verified; either side
+    /// being process-only makes the result process-only.
+    static func boundedAccuracy(
+        declared: FirstPartyAgentNotificationAccuracy,
+        evidence: FirstPartyAgentNotificationAccuracy
+    ) -> FirstPartyAgentNotificationAccuracy {
+        guard declared.permitsUserFacingLifecycleTransitions,
+              evidence.permitsUserFacingLifecycleTransitions else {
+            return .processTerminationOnly
+        }
+        return .verifiedLifecycleTransitions
+    }
 }
 
 /// The checked-in, security-conservative compatibility claim for one agent.

--- a/Pine/Agent/AgentAttentionOverlay.swift
+++ b/Pine/Agent/AgentAttentionOverlay.swift
@@ -54,7 +54,7 @@ struct AgentAttentionOverlay: View {
         case .terminated: return 3
         case .live: break
         }
-        switch summary.state {
+        switch summary.userFacingState {
         case .waitingInput: return 0
         case .thinking, .executing: return 1
         case .done: return 3
@@ -70,7 +70,7 @@ struct AgentAttentionOverlay: View {
         case .terminated: return "xmark.circle.fill"
         case .live: break
         }
-        switch summary.state {
+        switch summary.userFacingState {
         case .waitingInput: return "exclamationmark.circle.fill"
         case .thinking, .executing: return "ellipsis.circle.fill"
         case .done: return "checkmark.circle.fill"
@@ -87,7 +87,7 @@ struct AgentAttentionOverlay: View {
         case .terminated: return .secondary
         case .live: break
         }
-        switch summary.state {
+        switch summary.userFacingState {
         case .waitingInput: return .orange
         case .done: return .green
         case .idle: return .secondary
@@ -210,7 +210,7 @@ struct AgentAttentionOverlay: View {
 
     private func detailText(for summary: AgentStatusSummary) -> String {
         summary.liveness == .live
-            ? summary.state.displayName
+            ? summary.userFacingState.displayName
             : summary.liveness.displayName
     }
 

--- a/Pine/Agent/AgentDetector.swift
+++ b/Pine/Agent/AgentDetector.swift
@@ -39,12 +39,10 @@ nonisolated struct DetectedProcess: Sendable, Equatable {
     let cwd: URL?
     /// Cumulative CPU time in seconds (from `ps -eo ... cputime=`). Used by
     /// `AgentDetector.processSnapshotDidUpdate(_:)` to refine
-    /// `.idle` → `.executing` / `.waitingInput`. A CPU-time advance promotes a
-    /// session to `.executing`; only
-    /// `AgentDetector.waitingInputFlatPollThreshold` consecutive flat polls
-    /// (no CPU growth) downgrade it to `.waitingInput` (#1112, #1338).
-    /// Network-bound LLM agents barely burn CPU while blocked on an API
-    /// response, so a single flat poll must not read as "idle at a prompt".
+    /// `.idle` → `.executing`. A CPU-time advance proves local work and
+    /// promotes a session to `.executing`. Flat CPU is intentionally not a
+    /// lifecycle transition: a network-bound LLM request and a user prompt
+    /// are indistinguishable from process snapshots alone (#1418).
     /// `nil` when the snapshot did not carry CPU time (legacy parse path,
     /// unit tests) — the detector leaves the state untouched in that case.
     let cpuTime: Int?
@@ -112,20 +110,6 @@ final class AgentDetector {
     /// `processSnapshotDidUpdate(_:)` to refine state. Cleared in `markDone`
     /// so pid reuse starts a fresh baseline (#1112).
     private var lastCpuTimeByPID: [Int32: Int] = [:]
-
-    /// Consecutive CPU-flat polls seen for each tracked pid. A session is only
-    /// downgraded to `.waitingInput` once this reaches
-    /// `waitingInputFlatPollThreshold`, so a busy-but-network-bound agent is
-    /// not flipped by a single flat poll (#1338). Reset to 0 on a CPU advance
-    /// and purged in `markDone` alongside `lastCpuTimeByPID`.
-    private var flatPollCountByPID: [Int32: Int] = [:]
-
-    /// Number of consecutive CPU-flat polls required before a tracked session
-    /// is downgraded from `.executing` / `.idle` to `.waitingInput`. At the
-    /// default 2-second detection poll interval this is roughly six seconds
-    /// of inactivity, which absorbs the network-bound thinking pauses of LLM
-    /// agents (#1338).
-    static let waitingInputFlatPollThreshold = 3
 
     /// Stable process-start value seen for each tracked pid.
     private var startIdentifierByPID: [Int32: String] = [:]
@@ -283,21 +267,17 @@ final class AgentDetector {
                     if let previousCPU, existing.state != .done {
                         if cpu > previousCPU {
                             // A CPU advance means real local work: promote to
-                            // `.executing` and clear the flat-poll streak.
-                            existing.state = .executing
-                            flatPollCountByPID[process.pid] = 0
-                        } else {
-                            // CPU did not advance. Network-bound LLM agents
-                            // sleep while waiting on an API response, so a
-                            // single flat poll must not read as "idle at a
-                            // prompt" — require a sustained streak before
-                            // downgrading to `.waitingInput` (#1338).
-                            let flatCount = (flatPollCountByPID[process.pid] ?? 0) + 1
-                            flatPollCountByPID[process.pid] = flatCount
-                            if flatCount >= Self.waitingInputFlatPollThreshold {
-                                existing.state = .waitingInput
-                            }
+                            // `.executing`.
+                            existing.recordLifecycleState(
+                                .executing,
+                                accuracy: .processTerminationOnly
+                            )
                         }
+                        // CPU-flat process evidence cannot distinguish a long
+                        // API wait from a genuine user prompt. In that case,
+                        // keep the last honest working/unknown state; only an
+                        // authenticated lifecycle source may establish
+                        // `.waitingInput` (#1418).
                     }
                     lastCpuTimeByPID[process.pid] = cpu
                 }
@@ -375,11 +355,13 @@ final class AgentDetector {
     private func markDone(pid: Int32) -> UUID? {
         guard let session = sessionsByPID.removeValue(forKey: pid) else { return nil }
         lastCpuTimeByPID.removeValue(forKey: pid)
-        flatPollCountByPID.removeValue(forKey: pid)
         startIdentifierByPID.removeValue(forKey: pid)
         preciseStartByPID.removeValue(forKey: pid)
         livenessTracker.recordTermination(of: session)
-        session.state = .done
+        session.recordLifecycleState(
+            .done,
+            accuracy: .processTerminationOnly
+        )
         return session.id
     }
 
@@ -399,6 +381,7 @@ final class AgentDetector {
         let session = AgentSession(
             agentType: agentType,
             state: .idle,
+            lifecycleAccuracy: .processTerminationOnly,
             startedAt: observation.wallTime,
             lastObservedAt: observation.wallTime,
             lastObservedUptime: observation.uptime,

--- a/Pine/Agent/AgentInboxModels.swift
+++ b/Pine/Agent/AgentInboxModels.swift
@@ -70,11 +70,18 @@ nonisolated struct AgentInboxSnapshot: Equatable, Sendable {
     /// It deliberately projects metadata only: prompts and terminal output do
     /// not exist on the durable task model and cannot leak into the Inbox.
     @MainActor
-    init(tasks: [AgentTask]) {
+    init(
+        tasks: [AgentTask],
+        accuracyPolicy: AgentLifecycleAccuracyPolicy = .production
+    ) {
         var grouped: [AgentInboxSectionID: [AgentInboxRow]] = [:]
         for task in tasks where task.lifecycle != .dismissed {
             let latestRun = task.runs.last
-            let section = Self.section(for: task, latestRun: latestRun)
+            let section = Self.section(
+                for: task,
+                latestRun: latestRun,
+                accuracyPolicy: accuracyPolicy
+            )
             grouped[section, default: []].append(AgentInboxRow(
                 id: task.id,
                 section: section,
@@ -83,7 +90,11 @@ nonisolated struct AgentInboxSnapshot: Equatable, Sendable {
                 title: task.title,
                 agentName: task.descriptor.agentType.displayName,
                 lifecycle: task.lifecycle,
-                state: latestRun?.state,
+                state: Self.userFacingState(
+                    for: task,
+                    latestRun: latestRun,
+                    accuracyPolicy: accuracyPolicy
+                ),
                 liveness: latestRun?.liveness,
                 routeAvailability: task.route.availability,
                 startedAt: latestRun?.startedAt ?? task.createdAt,
@@ -102,10 +113,17 @@ nonisolated struct AgentInboxSnapshot: Equatable, Sendable {
 
     private static func section(
         for task: AgentTask,
-        latestRun: AgentTaskRun?
+        latestRun: AgentTaskRun?,
+        accuracyPolicy: AgentLifecycleAccuracyPolicy
     ) -> AgentInboxSectionID {
         if task.attention == .waitingInput,
-           latestRun?.liveness == .live {
+           latestRun?.liveness == .live,
+           latestRun.map({
+               accuracyPolicy.permitsUserFacingAttention(
+                   for: task.descriptor.typeIdentifier,
+                   evidence: $0.lifecycleAccuracy
+               )
+           }) == true {
             return .needsAttention
         }
         if task.attention == .failed, task.isUnread {
@@ -119,6 +137,22 @@ nonisolated struct AgentInboxSnapshot: Equatable, Sendable {
             return .working
         }
         return .history
+    }
+
+    private static func userFacingState(
+        for task: AgentTask,
+        latestRun: AgentTaskRun?,
+        accuracyPolicy: AgentLifecycleAccuracyPolicy
+    ) -> AgentRunState? {
+        guard let latestRun else { return nil }
+        guard latestRun.state == .waitingInput,
+              !accuracyPolicy.permitsUserFacingAttention(
+                for: task.descriptor.typeIdentifier,
+                evidence: latestRun.lifecycleAccuracy
+              ) else {
+            return latestRun.state
+        }
+        return .idle
     }
 
     private static func rowPrecedes(

--- a/Pine/Agent/AgentModels.swift
+++ b/Pine/Agent/AgentModels.swift
@@ -203,6 +203,35 @@ enum AgentState: Equatable, Sendable {
         self == .waitingInput
     }
 
+    /// Returns the state Pine may honestly present at the supplied evidence
+    /// accuracy. An unverified prompt guess degrades to `.idle` (alive, exact
+    /// activity unknown) instead of claiming that the user is blocking work.
+    func userFacing(
+        stableIdentifier: String,
+        evidenceAccuracy: FirstPartyAgentNotificationAccuracy,
+        policy: AgentLifecycleAccuracyPolicy = .production
+    ) -> AgentState {
+        userFacing(
+            declaredAccuracy: policy.accuracy(for: stableIdentifier),
+            evidenceAccuracy: evidenceAccuracy
+        )
+    }
+
+    func userFacing(
+        declaredAccuracy: FirstPartyAgentNotificationAccuracy,
+        evidenceAccuracy: FirstPartyAgentNotificationAccuracy
+    ) -> AgentState {
+        let accuracy = AgentLifecycleAccuracyPolicy.boundedAccuracy(
+            declared: declaredAccuracy,
+            evidence: evidenceAccuracy
+        )
+        guard self == .waitingInput,
+              !accuracy.permitsUserFacingLifecycleTransitions else {
+            return self
+        }
+        return .idle
+    }
+
     /// SF Symbol name for per-tab / attention-list status glyphs, or `nil`
     /// when no glyph should be shown (idle). Active states share one ellipsis
     /// glyph (the per-agent color still distinguishes them via the dot);
@@ -232,7 +261,12 @@ final class AgentSession: Identifiable {
     let agentType: AgentType
 
     /// Current lifecycle state of the session.
-    var state: AgentState
+    private(set) var state: AgentState
+
+    /// Accuracy of the evidence that established `state`. Process snapshots
+    /// can prove presence/termination, but never a prompt; authenticated
+    /// structured integrations may opt into verified lifecycle transitions.
+    private(set) var lifecycleAccuracy: FirstPartyAgentNotificationAccuracy
 
     /// Freshness of Pine's evidence for the backing process. This property is
     /// the single source of truth consumed by terminal and status-bar UI.
@@ -271,6 +305,7 @@ final class AgentSession: Identifiable {
         id: UUID = UUID(),
         agentType: AgentType,
         state: AgentState = .idle,
+        lifecycleAccuracy: FirstPartyAgentNotificationAccuracy = .processTerminationOnly,
         startedAt: Date = Date(),
         liveness: AgentLiveness = .live,
         lastObservedAt: Date? = nil,
@@ -285,6 +320,7 @@ final class AgentSession: Identifiable {
         self.id = id
         self.agentType = agentType
         self.state = state
+        self.lifecycleAccuracy = lifecycleAccuracy
         self.startedAt = startedAt
         self.processEvidence = nil
         self.liveness = liveness
@@ -298,6 +334,17 @@ final class AgentSession: Identifiable {
         self.currentTask = currentTask
         self.filesModified = filesModified
         self.filesRead = filesRead
+    }
+
+    /// Atomically records a lifecycle transition and the accuracy of the
+    /// concrete evidence that produced it. Authenticated adapters can promote
+    /// an already process-discovered run without allowing state/trust drift.
+    func recordLifecycleState(
+        _ state: AgentState,
+        accuracy: FirstPartyAgentNotificationAccuracy
+    ) {
+        self.state = state
+        lifecycleAccuracy = accuracy
     }
 
     /// Binds process identity exactly once. Reusing an `AgentSession` object for

--- a/Pine/Agent/AgentNotificationController.swift
+++ b/Pine/Agent/AgentNotificationController.swift
@@ -199,8 +199,7 @@ final class AgentNotificationController {
         settings: AgentNotificationSettings,
         delivery: any AgentNotificationDelivering = SystemAgentNotificationCenter(),
         accuracy: @escaping (String) -> FirstPartyAgentNotificationAccuracy = {
-            FirstPartyAgentCompatibilityCatalog.record(stableIdentifier: $0)?
-                .notificationAccuracy ?? .processTerminationOnly
+            AgentLifecycleAccuracyPolicy.production.accuracy(for: $0)
         },
         deliveryRetryDelays: [Duration] = [
             .milliseconds(250),

--- a/Pine/Agent/AgentNotificationModels.swift
+++ b/Pine/Agent/AgentNotificationModels.swift
@@ -82,7 +82,11 @@ enum AgentNotificationTransitionResolver {
         run: AgentTaskRun,
         accuracy: FirstPartyAgentNotificationAccuracy
     ) -> AgentNotificationEventKind? {
-        switch accuracy {
+        let boundedAccuracy = AgentLifecycleAccuracyPolicy.boundedAccuracy(
+            declared: accuracy,
+            evidence: run.lifecycleAccuracy
+        )
+        switch boundedAccuracy {
         case .processTerminationOnly:
             guard previousRun.liveness == .live,
                   run.liveness == .terminated else { return nil }

--- a/Pine/Agent/AgentStatusBarItem.swift
+++ b/Pine/Agent/AgentStatusBarItem.swift
@@ -31,6 +31,10 @@ struct AgentStatusSummary: Identifiable, Equatable {
     let state: AgentState
     /// Freshness of Pine's process evidence for the session.
     let liveness: AgentLiveness
+    /// Accuracy of the lifecycle evidence behind `state`.
+    let lifecycleAccuracy: FirstPartyAgentNotificationAccuracy
+    /// Compatibility-catalog ceiling applied to `lifecycleAccuracy`.
+    let declaredLifecycleAccuracy: FirstPartyAgentNotificationAccuracy
     /// Terminal pane hosting this agent's tab (for click-to-navigate).
     let paneID: PaneID
     /// Terminal tab hosting this agent (for click-to-navigate).
@@ -39,12 +43,19 @@ struct AgentStatusSummary: Identifiable, Equatable {
     /// A stale waiting-input heuristic must not demand user attention: Pine
     /// no longer has current evidence that the session is still waiting.
     var needsAttention: Bool {
-        liveness == .live && state.needsAttention
+        liveness == .live && userFacingState.needsAttention
     }
 
     /// Active-work indication is likewise gated by fresh process evidence.
     var isActivelyWorking: Bool {
-        liveness == .live && state.isActive
+        liveness == .live && userFacingState.isActive
+    }
+
+    var userFacingState: AgentState {
+        state.userFacing(
+            declaredAccuracy: declaredLifecycleAccuracy,
+            evidenceAccuracy: lifecycleAccuracy
+        )
     }
 
     init(
@@ -52,6 +63,8 @@ struct AgentStatusSummary: Identifiable, Equatable {
         agentType: AgentType,
         state: AgentState,
         liveness: AgentLiveness = .live,
+        lifecycleAccuracy: FirstPartyAgentNotificationAccuracy = .processTerminationOnly,
+        accuracyPolicy: AgentLifecycleAccuracyPolicy = .production,
         paneID: PaneID,
         tabID: UUID
     ) {
@@ -59,6 +72,10 @@ struct AgentStatusSummary: Identifiable, Equatable {
         self.agentType = agentType
         self.state = state
         self.liveness = liveness
+        self.lifecycleAccuracy = lifecycleAccuracy
+        declaredLifecycleAccuracy = accuracyPolicy.accuracy(
+            for: agentType.stableIdentifier
+        )
         self.paneID = paneID
         self.tabID = tabID
     }
@@ -89,6 +106,7 @@ struct AgentStatusSummary: Identifiable, Equatable {
                         agentType: session.agentType,
                         state: session.state,
                         liveness: session.liveness,
+                        lifecycleAccuracy: session.lifecycleAccuracy,
                         paneID: paneID,
                         tabID: tab.id
                     )
@@ -227,7 +245,7 @@ extension AgentStatusSummary {
 
     @MainActor
     func detailText(locale: Locale) -> String {
-        let stateText = "\(agentType.displayName): \(state.displayName(locale: locale))"
+        let stateText = "\(agentType.displayName): \(userFacingState.displayName(locale: locale))"
         guard liveness != .live else { return stateText }
         return "\(stateText) — \(liveness.displayName(locale: locale))"
     }

--- a/Pine/Agent/AgentTaskModels.swift
+++ b/Pine/Agent/AgentTaskModels.swift
@@ -241,6 +241,21 @@ nonisolated struct AgentTaskRunInput: Sendable {
     let terminalID: UUID
     let process: AgentProcessEvidence
     let status: AgentTaskRunStatus
+    let lifecycleAccuracy: FirstPartyAgentNotificationAccuracy
+
+    init(
+        id: UUID,
+        terminalID: UUID,
+        process: AgentProcessEvidence,
+        status: AgentTaskRunStatus,
+        lifecycleAccuracy: FirstPartyAgentNotificationAccuracy = .processTerminationOnly
+    ) {
+        self.id = id
+        self.terminalID = terminalID
+        self.process = process
+        self.status = status
+        self.lifecycleAccuracy = lifecycleAccuracy
+    }
 }
 
 nonisolated struct AgentTaskRunStatus: Sendable {
@@ -259,6 +274,7 @@ nonisolated struct AgentTaskRun: Codable, Equatable, Sendable, Identifiable {
     var lastObservedAt: Date
     var endedAt: Date?
     var vendorIdentity: AgentVendorSessionIdentity?
+    var lifecycleAccuracy: FirstPartyAgentNotificationAccuracy
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -270,6 +286,7 @@ nonisolated struct AgentTaskRun: Codable, Equatable, Sendable, Identifiable {
         case lastObservedAt
         case endedAt
         case vendorIdentity
+        case lifecycleAccuracy
     }
 
     init(_ input: AgentTaskRunInput) {
@@ -284,6 +301,7 @@ nonisolated struct AgentTaskRun: Codable, Equatable, Sendable, Identifiable {
             ? input.status.observedAt
             : nil
         vendorIdentity = nil
+        lifecycleAccuracy = input.lifecycleAccuracy
     }
 
     init(from decoder: Decoder) throws {
@@ -300,6 +318,10 @@ nonisolated struct AgentTaskRun: Codable, Equatable, Sendable, Identifiable {
             AgentVendorSessionIdentity.self,
             forKey: .vendorIdentity
         )
+        lifecycleAccuracy = try values.decodeIfPresent(
+            FirstPartyAgentNotificationAccuracy.self,
+            forKey: .lifecycleAccuracy
+        ) ?? .processTerminationOnly
     }
 }
 

--- a/Pine/Agent/AgentTaskRegistry.swift
+++ b/Pine/Agent/AgentTaskRegistry.swift
@@ -159,6 +159,8 @@ final class AgentTaskRegistry {
     @ObservationIgnored
     private let flushTail: Duration
     @ObservationIgnored
+    let lifecycleAccuracyPolicy: AgentLifecycleAccuracyPolicy
+    @ObservationIgnored
     private let abandonedPersistenceLimit = 2
     @ObservationIgnored
     private var taskChangeObservers: [
@@ -173,7 +175,8 @@ final class AgentTaskRegistry {
         claimTTL: Duration = .seconds(30),
         flushTotal: Duration = .seconds(5),
         flushTail: Duration = .seconds(2),
-        limits: AgentTaskPersistenceLimits = AgentTaskPersistenceLimits()
+        limits: AgentTaskPersistenceLimits = AgentTaskPersistenceLimits(),
+        accuracyPolicy: AgentLifecycleAccuracyPolicy = .production
     ) {
         let generation = UUID()
         self.persistence = persistence
@@ -184,6 +187,7 @@ final class AgentTaskRegistry {
         self.claimTTL = claimTTL
         self.flushTotal = flushTotal
         self.flushTail = flushTail
+        lifecycleAccuracyPolicy = accuracyPolicy
     }
 
     #if DEBUG
@@ -197,13 +201,13 @@ final class AgentTaskRegistry {
                 seed: 1,
                 projectName: "Pine Demo",
                 worktreeName: nil,
-                title: "Approve the release announcement",
+                title: "Draft the release announcement",
                 agentType: .codex,
-                state: .waitingInput,
+                state: .executing,
                 liveness: .live,
                 lifecycle: .active,
-                attention: .waitingInput,
-                isUnread: true,
+                attention: .none,
+                isUnread: false,
                 startedSecondsAgo: 7 * 60,
                 verifiedSecondsAgo: 18
             ), referenceDate: referenceDate),
@@ -319,7 +323,8 @@ final class AgentTaskRegistry {
                 state: fixture.state,
                 liveness: fixture.liveness,
                 observedAt: observedAt
-            )
+            ),
+            lifecycleAccuracy: .processTerminationOnly
         ))]
         task.lifecycle = fixture.lifecycle
         task.attention = fixture.attention
@@ -1431,7 +1436,8 @@ final class AgentTaskRegistry {
                 state: AgentRunState(session.state),
                 liveness: liveness,
                 observedAt: max(session.lastObservedAt, session.startedAt)
-            )
+            ),
+            lifecycleAccuracy: session.lifecycleAccuracy
         ))
         task.route = context.route
         task.runs.append(run)
@@ -1470,12 +1476,14 @@ final class AgentTaskRegistry {
         let nextLiveness = AgentRunLiveness(session.liveness)
         let nextObservedAt = max(session.lastObservedAt, run.startedAt)
         let changed = run.state != nextState
+            || run.lifecycleAccuracy != session.lifecycleAccuracy
             || run.liveness != nextLiveness
             || run.lastObservedAt != nextObservedAt
             || route.map({ $0 != tasks[taskIndex].route }) == true
         guard changed else { return false }
 
         run.state = nextState
+        run.lifecycleAccuracy = session.lifecycleAccuracy
         run.liveness = nextLiveness
         run.lastObservedAt = nextObservedAt
         if nextLiveness == .terminated {
@@ -1517,7 +1525,11 @@ final class AgentTaskRegistry {
         let next: AgentTaskAttention
         if run.liveness != .live {
             next = .none
-        } else if run.state == .waitingInput {
+        } else if run.state == .waitingInput,
+                  lifecycleAccuracyPolicy.permitsUserFacingAttention(
+                    for: task.descriptor.typeIdentifier,
+                    evidence: run.lifecycleAccuracy
+                  ) {
             next = .waitingInput
         } else {
             next = .none

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -2048,7 +2048,7 @@ final class ProjectManager {
               let firstTab = state.activeTab else {
             return
         }
-        firstTab.name = "Waiting agent"
+        firstTab.name = "Thinking agent"
         firstTab.agentSession = AgentSession(
             id: UUID(
                 uuid: (
@@ -2057,7 +2057,7 @@ final class ProjectManager {
                 )
             ),
             agentType: .claudeCode,
-            state: .waitingInput
+            state: .thinking
         )
 
         guard let secondTab = paneManager.addTerminalTab(

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -1286,7 +1286,10 @@ final class ProjectRegistry: LSPSettingsObserver {
             }
         }
         guard !tasks.isEmpty, !agentTaskProjectsByRoot.isEmpty else { return }
-        let snapshot = AgentInboxSnapshot(tasks: tasks)
+        let snapshot = AgentInboxSnapshot(
+            tasks: tasks,
+            accuracyPolicy: agentTasks.lifecycleAccuracyPolicy
+        )
         guard let needsAttention = snapshot.sections.first(where: {
             $0.id == .needsAttention
         }) else { return }

--- a/Pine/TerminalBarView.swift
+++ b/Pine/TerminalBarView.swift
@@ -29,8 +29,23 @@ struct AgentTabBadge: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var pulse = false
 
+    private var userFacingState: AgentState {
+        Self.userFacingState(for: session)
+    }
+
     private var isActive: Bool {
-        session.liveness == .live && session.state.isActive
+        session.liveness == .live && userFacingState.isActive
+    }
+
+    static func userFacingState(
+        for session: AgentSession,
+        accuracyPolicy: AgentLifecycleAccuracyPolicy = .production
+    ) -> AgentState {
+        session.state.userFacing(
+            stableIdentifier: session.agentType.stableIdentifier,
+            evidenceAccuracy: session.lifecycleAccuracy,
+            policy: accuracyPolicy
+        )
     }
 
     nonisolated static func shouldPulse(
@@ -47,14 +62,14 @@ struct AgentTabBadge: View {
                     .foregroundStyle(
                         session.liveness == .stale ? .orange : .secondary
                     )
-            } else if session.state == .waitingInput {
+            } else if userFacingState == .waitingInput {
                 Image(systemName: "exclamationmark.circle.fill")
                     .foregroundStyle(.orange)
             } else {
                 Circle()
                     .fill(Color(nsColor: session.agentType.color))
                     .frame(width: 7, height: 7)
-                    .opacity(session.state == .idle ? 0.6 : 1.0)
+                    .opacity(userFacingState == .idle ? 0.6 : 1.0)
                     .scaleEffect(
                         Self.shouldPulse(
                             isActive: isActive && pulse,
@@ -97,7 +112,7 @@ struct AgentTabBadge: View {
     }
 
     private var helpText: String {
-        let state = "\(session.agentType.displayName) — \(session.state.displayName)"
+        let state = "\(session.agentType.displayName) — \(userFacingState.displayName)"
         guard session.liveness != .live else { return state }
         return "\(state) — \(session.liveness.displayName)"
     }

--- a/PineTests/AgentAttentionStateTests.swift
+++ b/PineTests/AgentAttentionStateTests.swift
@@ -38,25 +38,28 @@ struct AgentAttentionStateTests {
         #expect(detector.detectedSessions[0].state == .executing)
     }
 
-    @Test("CPU time stalled → .waitingInput")
-    func cpuStalledIsWaitingInput() {
+    @Test("32 seconds of flat CPU stays honestly unknown")
+    func cpuStalledStaysUnknown() {
         let detector = AgentDetector()
         detector.processSnapshotDidUpdate([
             DetectedProcess(pid: 100, command: "codex", cpuTime: 12),
         ])
-        // CPU time unchanged across polls — agent is idle at a prompt. The
-        // detector now requires `waitingInputFlatPollThreshold` consecutive
-        // flat polls before downgrading (#1338 hysteresis), so drive that many.
-        for _ in 0..<AgentDetector.waitingInputFlatPollThreshold {
+        // Sixteen polls represent 32 seconds at the production two-second
+        // interval, without making the test wait in real time.
+        for _ in 0..<16 {
             detector.processSnapshotDidUpdate([
                 DetectedProcess(pid: 100, command: "codex", cpuTime: 12),
             ])
         }
-        #expect(detector.detectedSessions[0].state == .waitingInput)
+        #expect(detector.detectedSessions[0].state == .idle)
+        #expect(
+            detector.detectedSessions[0].lifecycleAccuracy
+                == .processTerminationOnly
+        )
     }
 
-    @Test("State flips back and forth with CPU time")
-    func stateFlipsWithCpu() {
+    @Test("Executing state survives flat CPU and later work")
+    func executingSurvivesFlatCPU() {
         let detector = AgentDetector()
         detector.processSnapshotDidUpdate([
             DetectedProcess(pid: 100, command: "claude", cpuTime: 0),
@@ -66,14 +69,14 @@ struct AgentAttentionStateTests {
         ])
         #expect(detector.detectedSessions[0].state == .executing)
 
-        // A single flat poll no longer flips to .waitingInput (#1338
-        // hysteresis); drive the threshold count of flat polls to reach it.
-        for _ in 0..<AgentDetector.waitingInputFlatPollThreshold {
+        // Flat CPU can be a network wait, so even a sustained run of flat
+        // process snapshots preserves the last honest working state.
+        for _ in 0..<16 {
             detector.processSnapshotDidUpdate([
                 DetectedProcess(pid: 100, command: "claude", cpuTime: 3),
             ])
         }
-        #expect(detector.detectedSessions[0].state == .waitingInput)
+        #expect(detector.detectedSessions[0].state == .executing)
 
         detector.processSnapshotDidUpdate([
             DetectedProcess(pid: 100, command: "claude", cpuTime: 7),
@@ -134,6 +137,26 @@ struct AgentAttentionStateTests {
         #expect(AgentState.executing.needsAttention == false)
         #expect(AgentState.idle.needsAttention == false)
         #expect(AgentState.done.needsAttention == false)
+    }
+
+    @Test("only verified lifecycle evidence presents a genuine prompt")
+    func accuracyGatesUserFacingPrompt() {
+        let verifiedPolicy = AgentLifecycleAccuracyPolicy { _ in
+            .verifiedLifecycleTransitions
+        }
+        #expect(
+            AgentState.waitingInput.userFacing(
+                stableIdentifier: "codex",
+                evidenceAccuracy: .verifiedLifecycleTransitions
+            ) == .idle
+        )
+        #expect(
+            AgentState.waitingInput.userFacing(
+                stableIdentifier: "codex",
+                evidenceAccuracy: .verifiedLifecycleTransitions,
+                policy: verifiedPolicy
+            ) == .waitingInput
+        )
     }
 
     @Test("glyphName maps each state")

--- a/PineTests/AgentDetectorTests.swift
+++ b/PineTests/AgentDetectorTests.swift
@@ -1007,13 +1007,12 @@ struct AgentDetectorTests {
         #expect(detector.detectedSessions.count == 3)
     }
 
-    // MARK: - CPU-time hysteresis (#1338)
+    // MARK: - CPU-time accuracy (#1418)
 
-    @Test func executingAgentStaysExecutingForFlatPollsBelowThreshold() throws {
-        // A busy-but-network-bound agent barely burns CPU while waiting on an
-        // API response. Flat polls below the threshold must NOT downgrade an
-        // executing session to .waitingInput (#1338).
-        let threshold = AgentDetector.waitingInputFlatPollThreshold
+    @Test func executingAgentStaysExecutingThroughLongFlatAPIWait() throws {
+        // Sixteen equivalent polls cover 32 seconds at the production
+        // two-second interval without sleeping in the test. A network-bound
+        // agent must remain working instead of inventing a user prompt.
         let detector = AgentDetector()
         detector.processSnapshotDidUpdate([
             DetectedProcess(pid: 700, command: "claude", cpuTime: 100),
@@ -1026,98 +1025,48 @@ struct AgentDetectorTests {
         ])
         #expect(session.state == .executing)
 
-        // (threshold - 1) flat polls: still executing.
-        for _ in 0..<(threshold - 1) {
+        for _ in 0..<16 {
             detector.processSnapshotDidUpdate([
                 DetectedProcess(pid: 700, command: "claude", cpuTime: 110),
             ])
         }
         #expect(session.state == .executing)
+        #expect(session.lifecycleAccuracy == .processTerminationOnly)
     }
 
-    @Test func flatCpuAtThresholdDowngradesToWaitingInput() throws {
-        // Only a sustained flat streak (threshold consecutive polls) justifies
-        // reading a session as idle at a prompt.
-        let threshold = AgentDetector.waitingInputFlatPollThreshold
+    @Test func idleAgentStaysUnknownThroughLongFlatAPIWait() throws {
         let detector = AgentDetector()
         detector.processSnapshotDidUpdate([
             DetectedProcess(pid: 701, command: "claude", cpuTime: 100),
         ])
         let session = try #require(detector.session(forPID: 701))
-        detector.processSnapshotDidUpdate([
-            DetectedProcess(pid: 701, command: "claude", cpuTime: 110),
-        ])
-        #expect(session.state == .executing)
+        #expect(session.state == .idle)
 
-        for _ in 0..<threshold {
+        for _ in 0..<16 {
             detector.processSnapshotDidUpdate([
-                DetectedProcess(pid: 701, command: "claude", cpuTime: 110),
+                DetectedProcess(pid: 701, command: "claude", cpuTime: 100),
             ])
         }
-        #expect(session.state == .waitingInput)
+        #expect(session.state == .idle)
     }
 
-    @Test func cpuAdvanceResetsFlatPollCounter() throws {
-        // A single CPU tick must reset the flat-poll streak and re-promote to
-        // .executing, so the streak restarts from zero.
-        let threshold = AgentDetector.waitingInputFlatPollThreshold
+    @Test func CPUAdvanceAfterFlatWaitStillPromotesToExecuting() throws {
         let detector = AgentDetector()
         detector.processSnapshotDidUpdate([
             DetectedProcess(pid: 702, command: "claude", cpuTime: 100),
         ])
         let session = try #require(detector.session(forPID: 702))
-        detector.processSnapshotDidUpdate([
-            DetectedProcess(pid: 702, command: "claude", cpuTime: 110),
-        ])
-        #expect(session.state == .executing)
-
-        // Build a near-threshold streak.
-        for _ in 0..<(threshold - 1) {
+        for _ in 0..<16 {
             detector.processSnapshotDidUpdate([
-                DetectedProcess(pid: 702, command: "claude", cpuTime: 110),
+                DetectedProcess(pid: 702, command: "claude", cpuTime: 100),
             ])
         }
-        #expect(session.state == .executing)
+        #expect(session.state == .idle)
 
-        // One CPU tick resets the streak.
         detector.processSnapshotDidUpdate([
             DetectedProcess(pid: 702, command: "claude", cpuTime: 120),
         ])
         #expect(session.state == .executing)
-
-        // After the reset, (threshold - 1) flat polls must NOT downgrade —
-        // they would if the counter had not been cleared.
-        for _ in 0..<(threshold - 1) {
-            detector.processSnapshotDidUpdate([
-                DetectedProcess(pid: 702, command: "claude", cpuTime: 120),
-            ])
-        }
-        #expect(session.state == .executing)
-    }
-
-    @Test func idleAgentNeedsThresholdFlatPollsBeforeWaitingInput() throws {
-        // A freshly detected (.idle) session is also protected by hysteresis:
-        // it is not flipped to .waitingInput on the first flat poll.
-        let threshold = AgentDetector.waitingInputFlatPollThreshold
-        let detector = AgentDetector()
-        detector.processSnapshotDidUpdate([
-            DetectedProcess(pid: 703, command: "claude", cpuTime: 50),
-        ])
-        let session = try #require(detector.session(forPID: 703))
-        #expect(session.state == .idle)
-
-        for _ in 0..<(threshold - 1) {
-            detector.processSnapshotDidUpdate([
-                DetectedProcess(pid: 703, command: "claude", cpuTime: 50),
-            ])
-        }
-        #expect(session.state == .idle)
-
-        // Reaching the threshold downgrades to .waitingInput.
-        detector.processSnapshotDidUpdate([
-            DetectedProcess(pid: 703, command: "claude", cpuTime: 50),
-        ])
-        #expect(session.state == .waitingInput)
     }
 
     @Test func doneSessionIsNeverDowngradedToWaitingInput() throws {
@@ -1143,10 +1092,7 @@ struct AgentDetectorTests {
         #expect(recycled.state == .idle)
     }
 
-    @Test func flatPollCounterIsPurgedOnTermination() throws {
-        // The flat-poll streak must not leak across pid reuse: a recycled
-        // session tolerates (threshold - 1) flat polls without flipping.
-        let threshold = AgentDetector.waitingInputFlatPollThreshold
+    @Test func recycledPIDAlsoStaysUnknownThroughFlatPolls() throws {
         let detector = AgentDetector()
         detector.processSnapshotDidUpdate([
             DetectedProcess(pid: 705, command: "claude", cpuTime: 10),
@@ -1157,8 +1103,7 @@ struct AgentDetectorTests {
         let done = detector.detectedSessions[0]
         #expect(done.state == .executing)
 
-        // Build a near-threshold streak, then terminate.
-        for _ in 0..<(threshold - 1) {
+        for _ in 0..<16 {
             detector.processSnapshotDidUpdate([
                 DetectedProcess(pid: 705, command: "claude", cpuTime: 12),
             ])
@@ -1174,9 +1119,7 @@ struct AgentDetectorTests {
         let recycled = try #require(detector.session(forPID: 705))
         #expect(recycled !== done)
 
-        // (threshold - 1) flat polls must NOT downgrade the fresh session —
-        // they would if the stale streak had leaked across termination.
-        for _ in 0..<(threshold - 1) {
+        for _ in 0..<16 {
             detector.processSnapshotDidUpdate([
                 DetectedProcess(pid: 705, command: "claude", cpuTime: 10),
             ])

--- a/PineTests/AgentInboxTests.swift
+++ b/PineTests/AgentInboxTests.swift
@@ -46,9 +46,10 @@ struct AgentInboxTests {
         )
         completed.lifecycle = .completed
 
-        let snapshot = AgentInboxSnapshot(tasks: [
-            olderWorking, completed, newerWorking, waiting,
-        ])
+        let snapshot = AgentInboxSnapshot(
+            tasks: [olderWorking, completed, newerWorking, waiting],
+            accuracyPolicy: verifiedAccuracyPolicy
+        )
 
         #expect(snapshot.sections.map(\.id) == [
             .needsAttention, .completedUnread, .working,
@@ -59,6 +60,23 @@ struct AgentInboxTests {
         #expect(working.rows.map(\.id) == [newerWorking.id, olderWorking.id])
         #expect(snapshot.rows.first?.projectName == "inbox-a")
         #expect(snapshot.rows.allSatisfy { !$0.agentName.isEmpty })
+    }
+
+    @Test("catalog ceiling keeps forged waiting evidence in Working")
+    func catalogCeilingSuppressesForgedWaitingEvidence() throws {
+        let task = makeTask(
+            seed: 90,
+            project: "/tmp/inbox-forged",
+            state: .waitingInput,
+            liveness: .live,
+            attention: .waitingInput,
+            unread: true,
+            observedAt: Date(timeIntervalSince1970: 10_000)
+        )
+
+        let snapshot = AgentInboxSnapshot(tasks: [task])
+        #expect(snapshot.sections.map(\.id) == [.working])
+        #expect(snapshot.rows.first?.state == .idle)
     }
 
     @Test("row order stays stable when polling-driven activity timestamps flip")
@@ -220,9 +238,15 @@ struct AgentInboxTests {
 
     @Test("render projection never marks unread tasks reviewed")
     func projectionHasNoReviewSideEffect() throws {
-        let registry = AgentTaskRegistry()
+        let registry = AgentTaskRegistry(
+            accuracyPolicy: verifiedAccuracyPolicy
+        )
         let identity = project("/tmp/inbox-unread")
-        let session = makeSession(seed: 20, state: .waitingInput)
+        let session = makeSession(
+            seed: 20,
+            state: .waitingInput,
+            lifecycleAccuracy: .verifiedLifecycleTransitions
+        )
         registry.bridge(
             session,
             replacing: nil,
@@ -262,8 +286,12 @@ struct AgentInboxTests {
     func exactNavigationAndReplacementFailure() async throws {
         let fixture = try InboxProjectFixture()
         defer { fixture.cleanup() }
-        let taskRegistry = AgentTaskRegistry()
-        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let taskRegistry = AgentTaskRegistry(
+            accuracyPolicy: verifiedAccuracyPolicy
+        )
+        let projectRegistry = ProjectRegistry(
+            agentTasks: taskRegistry
+        )
         let manager = try #require(
             projectRegistry.projectManager(for: fixture.project)
         )
@@ -272,7 +300,11 @@ struct AgentInboxTests {
         )
         let state = try #require(manager.paneManager.terminalState(for: pane))
         let tab = try #require(state.terminalTabs.first)
-        let session = makeSession(seed: 40, state: .waitingInput)
+        let session = makeSession(
+            seed: 40,
+            state: .waitingInput,
+            lifecycleAccuracy: .verifiedLifecycleTransitions
+        )
         manager.terminal.bridgeAgentSession(
             session,
             replacing: nil,
@@ -280,6 +312,7 @@ struct AgentInboxTests {
         )
         tab.agentSession = session
         let taskID = try #require(taskRegistry.taskID(forSessionID: session.id))
+        #expect(taskRegistry.task(for: taskID)?.isUnread == true)
 
         let focused = await projectRegistry.navigateToAgentTaskFromInbox(
             taskID,
@@ -317,8 +350,12 @@ struct AgentInboxTests {
     func notificationNavigationRejectsReplacementRace() async throws {
         let fixture = try InboxProjectFixture()
         defer { fixture.cleanup() }
-        let taskRegistry = AgentTaskRegistry()
-        let projectRegistry = ProjectRegistry(agentTasks: taskRegistry)
+        let taskRegistry = AgentTaskRegistry(
+            accuracyPolicy: verifiedAccuracyPolicy
+        )
+        let projectRegistry = ProjectRegistry(
+            agentTasks: taskRegistry
+        )
         let manager = try #require(
             projectRegistry.projectManager(for: fixture.project)
         )
@@ -327,7 +364,11 @@ struct AgentInboxTests {
         )
         let state = try #require(manager.paneManager.terminalState(for: pane))
         let tab = try #require(state.terminalTabs.first)
-        let original = makeSession(seed: 45, state: .waitingInput)
+        let original = makeSession(
+            seed: 45,
+            state: .waitingInput,
+            lifecycleAccuracy: .verifiedLifecycleTransitions
+        )
         manager.terminal.bridgeAgentSession(original, replacing: nil, in: tab)
         tab.agentSession = original
         let taskID = try #require(taskRegistry.taskID(forSessionID: original.id))
@@ -511,7 +552,10 @@ struct AgentInboxTests {
                 state: state,
                 liveness: liveness,
                 observedAt: observedAt
-            )
+            ),
+            lifecycleAccuracy: attention == .waitingInput
+                ? .verifiedLifecycleTransitions
+                : .processTerminationOnly
         ))]
         task.attention = attention
         task.isUnread = unread
@@ -614,10 +658,21 @@ struct AgentInboxTests {
         )
     }
 
-    private func makeSession(seed: Int, state: AgentState) -> AgentSession {
+    private var verifiedAccuracyPolicy: AgentLifecycleAccuracyPolicy {
+        AgentLifecycleAccuracyPolicy { _ in
+            .verifiedLifecycleTransitions
+        }
+    }
+
+    private func makeSession(
+        seed: Int,
+        state: AgentState,
+        lifecycleAccuracy: FirstPartyAgentNotificationAccuracy = .processTerminationOnly
+    ) -> AgentSession {
         let session = AgentSession(
             agentType: .codex,
             state: state,
+            lifecycleAccuracy: lifecycleAccuracy,
             startedAt: Date(timeIntervalSince1970: TimeInterval(seed))
         )
         _ = session.bindProcessEvidence(AgentProcessEvidence(

--- a/PineTests/AgentInboxToolbarBadgeTests.swift
+++ b/PineTests/AgentInboxToolbarBadgeTests.swift
@@ -82,7 +82,8 @@ struct AgentInboxToolbarBadgeTests {
                 state: state,
                 liveness: liveness,
                 observedAt: observedAt
-            )
+            ),
+            lifecycleAccuracy: .verifiedLifecycleTransitions
         ))]
         task.attention = attention
         task.isUnread = unread
@@ -98,6 +99,15 @@ struct AgentInboxToolbarBadgeTests {
         return UUID(uuidString: "00000000-0000-0000-0000-\(suffix)") ?? UUID()
     }
 
+    private func makeVerifiedRegistry() -> ProjectRegistry {
+        let policy = AgentLifecycleAccuracyPolicy { _ in
+            .verifiedLifecycleTransitions
+        }
+        return ProjectRegistry(
+            agentTasks: AgentTaskRegistry(accuracyPolicy: policy)
+        )
+    }
+
     // MARK: - Tests
 
     @Test("returns zero for a project the registry has never opened")
@@ -105,7 +115,7 @@ struct AgentInboxToolbarBadgeTests {
         let tempDir = try makeTempDirectory()
         defer { cleanup(tempDir) }
 
-        let registry = ProjectRegistry()
+        let registry = makeVerifiedRegistry()
         // No projectManager(for:) call — project is unknown to the registry.
         #expect(registry.agentInboxAttentionCount(for: tempDir) == 0)
     }
@@ -115,7 +125,7 @@ struct AgentInboxToolbarBadgeTests {
         let tempDir = try makeTempDirectory()
         defer { cleanup(tempDir) }
 
-        let registry = ProjectRegistry()
+        let registry = makeVerifiedRegistry()
         _ = registry.projectManager(for: tempDir)
 
         #expect(registry.agentInboxAttentionCount(for: tempDir) == 0)
@@ -126,7 +136,7 @@ struct AgentInboxToolbarBadgeTests {
         let tempDir = try makeTempDirectory()
         defer { cleanup(tempDir) }
 
-        let registry = ProjectRegistry()
+        let registry = makeVerifiedRegistry()
         _ = registry.projectManager(for: tempDir)
         let identity = self.identity(for: tempDir, in: registry)
 
@@ -151,13 +161,35 @@ struct AgentInboxToolbarBadgeTests {
         #expect(registry.agentInboxAttentionCount(for: tempDir) == 2)
     }
 
+    @Test("catalog ceiling suppresses a forged toolbar attention badge")
+    func catalogSuppressesForgedAttentionBadge() throws {
+        let tempDir = try makeTempDirectory()
+        defer { cleanup(tempDir) }
+
+        let registry = ProjectRegistry()
+        _ = registry.projectManager(for: tempDir)
+        let identity = self.identity(for: tempDir, in: registry)
+        registry.agentTasks.setTasksForTesting([
+            makeTask(
+                seed: 99,
+                identity: identity,
+                state: .waitingInput,
+                liveness: .live,
+                attention: .waitingInput,
+                unread: true
+            ),
+        ])
+
+        #expect(registry.agentInboxAttentionCount(for: tempDir) == 0)
+    }
+
     @Test("scopes the count per project window")
     func scopesByProject() throws {
         let projectA = try makeTempDirectory()
         let projectB = try makeTempDirectory()
         defer { cleanup(projectA); cleanup(projectB) }
 
-        let registry = ProjectRegistry()
+        let registry = makeVerifiedRegistry()
         _ = registry.projectManager(for: projectA)
         _ = registry.projectManager(for: projectB)
         let identityA = self.identity(for: projectA, in: registry)
@@ -191,7 +223,7 @@ struct AgentInboxToolbarBadgeTests {
         let tempDir = try makeTempDirectory()
         defer { cleanup(tempDir) }
 
-        let registry = ProjectRegistry()
+        let registry = makeVerifiedRegistry()
         _ = registry.projectManager(for: tempDir)
         let identity = self.identity(for: tempDir, in: registry)
 
@@ -231,7 +263,7 @@ struct AgentInboxToolbarBadgeTests {
         let tempDir = try makeTempDirectory()
         defer { cleanup(tempDir) }
 
-        let registry = ProjectRegistry()
+        let registry = makeVerifiedRegistry()
         _ = registry.projectManager(for: tempDir)
         let identity = self.identity(for: tempDir, in: registry)
 
@@ -258,7 +290,7 @@ struct AgentInboxToolbarBadgeTests {
         let tempDir = try makeTempDirectory()
         defer { cleanup(tempDir) }
 
-        let registry = ProjectRegistry()
+        let registry = makeVerifiedRegistry()
         _ = registry.projectManager(for: tempDir)
         let identity = self.identity(for: tempDir, in: registry)
 

--- a/PineTests/AgentModelsTests.swift
+++ b/PineTests/AgentModelsTests.swift
@@ -223,16 +223,19 @@ struct AgentModelsTests {
         let session = AgentSession(agentType: .claudeCode)
         #expect(session.state == .idle)
 
-        session.state = .thinking
+        session.recordLifecycleState(.thinking, accuracy: .processTerminationOnly)
         #expect(session.state == .thinking)
 
-        session.state = .executing
+        session.recordLifecycleState(.executing, accuracy: .processTerminationOnly)
         #expect(session.state == .executing)
 
-        session.state = .waitingInput
+        session.recordLifecycleState(
+            .waitingInput,
+            accuracy: .verifiedLifecycleTransitions
+        )
         #expect(session.state == .waitingInput)
 
-        session.state = .done
+        session.recordLifecycleState(.done, accuracy: .processTerminationOnly)
         #expect(session.state == .done)
     }
 
@@ -264,7 +267,7 @@ struct AgentModelsTests {
         let session = AgentSession(agentType: .claudeCode)
         let originalID = session.id
 
-        session.state = .executing
+        session.recordLifecycleState(.executing, accuracy: .processTerminationOnly)
         session.currentTask = "new task"
         session.filesModified.append(URL(fileURLWithPath: "/tmp/x.swift"))
 
@@ -283,6 +286,26 @@ struct AgentModelsTests {
         let a = AgentSession(agentType: .claudeCode)
         let b = AgentSession(agentType: .claudeCode)
         #expect(a != b)
+    }
+
+    @Test func terminalBadgeBoundsWaitingStateByCatalogAndEvidence() {
+        let session = AgentSession(
+            agentType: .codex,
+            state: .waitingInput,
+            lifecycleAccuracy: .verifiedLifecycleTransitions
+        )
+
+        #expect(AgentTabBadge.userFacingState(for: session) == .idle)
+
+        let verifiedPolicy = AgentLifecycleAccuracyPolicy { _ in
+            .verifiedLifecycleTransitions
+        }
+        #expect(
+            AgentTabBadge.userFacingState(
+                for: session,
+                accuracyPolicy: verifiedPolicy
+            ) == .waitingInput
+        )
     }
 }
 

--- a/PineTests/AgentNotificationTests.swift
+++ b/PineTests/AgentNotificationTests.swift
@@ -386,7 +386,8 @@ struct AgentNotificationTests {
                 state: state,
                 liveness: .live,
                 observedAt: started
-            )
+            ),
+            lifecycleAccuracy: .verifiedLifecycleTransitions
         ))]
         task.updatedAt = started
         task.lastActivityAt = started

--- a/PineTests/AgentStatusSummaryTests.swift
+++ b/PineTests/AgentStatusSummaryTests.swift
@@ -107,12 +107,25 @@ struct AgentStatusSummaryTests {
         #expect(!summary.isActivelyWorking)
     }
 
-    @Test func liveStateStillDrivesAttentionAndActivity() {
+    @Test func onlyCatalogBoundVerifiedStateDrivesAttention() {
         let paneID = PaneID()
+        let verifiedPolicy = AgentLifecycleAccuracyPolicy { _ in
+            .verifiedLifecycleTransitions
+        }
         let waiting = AgentStatusSummary(
             id: UUID(),
             agentType: .claudeCode,
             state: .waitingInput,
+            lifecycleAccuracy: .verifiedLifecycleTransitions,
+            accuracyPolicy: verifiedPolicy,
+            paneID: paneID,
+            tabID: UUID()
+        )
+        let forged = AgentStatusSummary(
+            id: UUID(),
+            agentType: .claudeCode,
+            state: .waitingInput,
+            lifecycleAccuracy: .verifiedLifecycleTransitions,
             paneID: paneID,
             tabID: UUID()
         )
@@ -125,6 +138,8 @@ struct AgentStatusSummaryTests {
         )
 
         #expect(waiting.needsAttention)
+        #expect(!forged.needsAttention)
+        #expect(forged.userFacingState == .idle)
         #expect(!waiting.isActivelyWorking)
         #expect(!executing.needsAttention)
         #expect(executing.isActivelyWorking)
@@ -309,11 +324,11 @@ struct AgentStatusSummaryTests {
         )
 
         #expect(english.countText == "1 agent session")
-        #expect(english.detailTexts == ["Claude Code: Waiting for input — Stale"])
+        #expect(english.detailTexts == ["Claude Code: Idle — Stale"])
         #expect(russian.countText == "1 сессия агента")
         #expect(
             russian.detailTexts
-                == ["Claude Code: Ожидает ввода — Устарела"]
+                == ["Claude Code: Бездействует — Устарела"]
         )
     }
 

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -110,7 +110,7 @@ struct AgentTaskRegistryTests {
 
         registry.bridge(session, replacing: nil, context: route)
         let original = try #require(registry.task(forSessionID: session.id))
-        session.state = .executing
+        session.recordLifecycleState(.executing, accuracy: .processTerminationOnly)
         registry.bridge(session, replacing: session, context: route)
         let updated = try #require(registry.task(forSessionID: session.id))
 
@@ -150,7 +150,7 @@ struct AgentTaskRegistryTests {
         registry.bridge(first, replacing: nil, context: route)
 
         first.applyLiveness(.terminated)
-        first.state = .done
+        first.recordLifecycleState(.done, accuracy: .processTerminationOnly)
         let replacement = makeSession(
             pid: 501,
             generation: 4,
@@ -199,7 +199,7 @@ struct AgentTaskRegistryTests {
             reservation: launch
         )
         original.applyLiveness(.terminated)
-        original.state = .done
+        original.recordLifecycleState(.done, accuracy: .processTerminationOnly)
         registry.refresh(sessions: [original])
 
         let taskID = try #require(
@@ -556,7 +556,7 @@ struct AgentTaskRegistryTests {
             session, replacing: nil, context: launchContext,
             reservation: claim
         )
-        session.state = .done
+        session.recordLifecycleState(.done, accuracy: .processTerminationOnly)
         registry.refresh(sessions: [session])
         #expect(
             registry.prepareResume(taskID: claim.taskID, context: launchContext)
@@ -671,18 +671,33 @@ struct AgentTaskRegistryTests {
 
     @Test("stale evidence clears attention without changing state")
     func staleClearsAttention() throws {
-        let registry = AgentTaskRegistry()
+        let verifiedPolicy = AgentLifecycleAccuracyPolicy { _ in
+            .verifiedLifecycleTransitions
+        }
+        let registry = AgentTaskRegistry(accuracyPolicy: verifiedPolicy)
         let identity = project("/tmp/pine-agent-stale")
         let session = makeSession(
             pid: 801,
             generation: 1,
-            state: .waitingInput
+            state: .executing
         )
         registry.bridge(
             session,
             replacing: nil,
             context: context(project: identity, routeSeed: 70)
         )
+        #expect(
+            registry.task(forSessionID: session.id)?.attention
+                == AgentTaskAttention.none
+        )
+
+        // A validated adapter may promote the already process-discovered run;
+        // state and evidence accuracy move atomically on the same identity.
+        session.recordLifecycleState(
+            .waitingInput,
+            accuracy: .verifiedLifecycleTransitions
+        )
+        registry.refresh(sessions: [session])
         var task = try #require(registry.task(forSessionID: session.id))
         #expect(task.attention == .waitingInput)
         #expect(task.isUnread)
@@ -693,6 +708,119 @@ struct AgentTaskRegistryTests {
         #expect(task.runs.last?.state == .waitingInput)
         #expect(task.runs.last?.liveness == .stale)
         #expect(task.attention == .none)
+    }
+
+    @Test("forged verified evidence cannot exceed the compatibility catalog")
+    func catalogBoundsForgedVerifiedEvidence() throws {
+        let registry = AgentTaskRegistry()
+        let session = makeSession(
+            pid: 802,
+            generation: 1,
+            agentType: .codex,
+            state: .waitingInput,
+            lifecycleAccuracy: .verifiedLifecycleTransitions
+        )
+        registry.bridge(
+            session,
+            replacing: nil,
+            context: context(
+                project: project("/tmp/pine-agent-forged-attention"),
+                routeSeed: 71
+            )
+        )
+
+        let task = try #require(registry.task(forSessionID: session.id))
+        #expect(task.runs.last?.state == .waitingInput)
+        #expect(task.attention == .none)
+        #expect(!task.isUnread)
+    }
+
+    @Test("generic agent stays uncertain despite forged verified evidence")
+    func genericAgentCannotClaimWaitingAttention() throws {
+        let registry = AgentTaskRegistry()
+        let session = makeSession(
+            pid: 804,
+            generation: 1,
+            agentType: .generic(name: "custom-agent"),
+            state: .waitingInput,
+            lifecycleAccuracy: .verifiedLifecycleTransitions
+        )
+        registry.bridge(
+            session,
+            replacing: nil,
+            context: context(
+                project: project("/tmp/pine-agent-generic-attention"),
+                routeSeed: 73
+            )
+        )
+
+        let task = try #require(registry.task(forSessionID: session.id))
+        #expect(task.attention == .none)
+        #expect(!task.isUnread)
+        #expect(
+            session.state.userFacing(
+                stableIdentifier: session.agentType.stableIdentifier,
+                evidenceAccuracy: session.lifecycleAccuracy
+            ) == .idle
+        )
+    }
+
+    @Test("pre-accuracy schema-v2 waiting history loads fail-closed")
+    func legacyWaitingHistoryRetainsTaskWithoutAttention() async throws {
+        let fixture = try PersistenceFixture()
+        defer { fixture.cleanup() }
+        let identity = project(fixture.project.path)
+        let policy = AgentLifecycleAccuracyPolicy { _ in
+            .verifiedLifecycleTransitions
+        }
+        let source = AgentTaskRegistry(accuracyPolicy: policy)
+        let session = makeSession(
+            pid: 803,
+            generation: 1,
+            agentType: .codex,
+            state: .waitingInput,
+            lifecycleAccuracy: .verifiedLifecycleTransitions
+        )
+        source.bridge(
+            session,
+            replacing: nil,
+            context: context(project: identity, routeSeed: 72)
+        )
+        let task = try #require(source.task(forSessionID: session.id))
+        #expect(task.attention == .waitingInput)
+
+        let store = AgentTaskMetadataStore(storageRoot: fixture.storage)
+        #expect(
+            await store.save(tasks: [task], project: identity)
+                == .saved(taskCount: 1)
+        )
+        let fileURL = AgentTaskMetadataStore.metadataURL(
+            for: identity,
+            storageRoot: fixture.storage
+        )
+        var root = try #require(
+            JSONSerialization.jsonObject(
+                with: Data(contentsOf: fileURL)
+            ) as? [String: Any]
+        )
+        var tasks = try #require(root["tasks"] as? [[String: Any]])
+        var runs = try #require(tasks[0]["runs"] as? [[String: Any]])
+        runs[0].removeValue(forKey: "lifecycleAccuracy")
+        tasks[0]["runs"] = runs
+        root["tasks"] = tasks
+        try JSONSerialization.data(withJSONObject: root).write(to: fileURL)
+
+        let restored = AgentTaskRegistry(persistence: store)
+        restored.registerProject(identity)
+        #expect(await restored.flushPersistence() == .saved)
+        let loaded = try #require(restored.tasks.first)
+        #expect(loaded.id == task.id)
+        #expect(loaded.runs.first?.lifecycleAccuracy == .processTerminationOnly)
+        #expect(loaded.runs.first?.state == .waitingInput)
+        #expect(loaded.runs.first?.liveness == .stale)
+        #expect(loaded.attention == .none)
+        #expect(loaded.isUnread)
+        #expect(loaded.lifecycle == .paused)
     }
 
     @Test("route changes retain task identity")
@@ -747,7 +875,7 @@ struct AgentTaskRegistryTests {
             )
         )
         session.applyLiveness(.terminated)
-        session.state = .done
+        session.recordLifecycleState(.done, accuracy: .processTerminationOnly)
         history.finalize(
             session: session,
             summary: "legacy",
@@ -1779,7 +1907,7 @@ struct AgentTaskRegistryTests {
                 == firstPane.id
         )
         session.applyLiveness(.terminated)
-        session.state = .done
+        session.recordLifecycleState(.done, accuracy: .processTerminationOnly)
         let replacement = makeSession(pid: 1_112, generation: 2)
         manager.terminal.bridgeAgentSession(
             replacement,
@@ -1908,7 +2036,10 @@ struct AgentTaskRegistryTests {
         )
         for sequence in 2...4 {
             previous.applyLiveness(.terminated)
-            previous.state = .done
+            previous.recordLifecycleState(
+                .done,
+                accuracy: .processTerminationOnly
+            )
             registry.refresh(sessions: [previous])
             let nextStartedAt = Date(
                 timeIntervalSince1970: TimeInterval(sequence)
@@ -2734,8 +2865,8 @@ struct AgentTaskRegistryTests {
         #expect(descriptor["launchExecutable"] as? String == "claude")
         let run = try #require((task["runs"] as? [[String: Any]])?.first)
         #expect(Set(run.keys) == [
-            "id", "lastObservedAt", "liveness", "process", "startedAt",
-            "state", "terminalID", "vendorIdentity",
+            "id", "lastObservedAt", "lifecycleAccuracy", "liveness",
+            "process", "startedAt", "state", "terminalID", "vendorIdentity",
         ])
         let vendorIdentity = try #require(
             run["vendorIdentity"] as? [String: Any]
@@ -2891,7 +3022,7 @@ struct AgentTaskRegistryTests {
         await store.releaseFirstSave()
         await store.waitUntilFirstSaveReturned()
 
-        session.state = .thinking
+        session.recordLifecycleState(.thinking, accuracy: .processTerminationOnly)
         registry.refresh(sessions: [session])
         #expect(await registry.flushPersistence() == .saved)
         #expect(await store.retryUsedPublishedRevision())
@@ -3748,11 +3879,13 @@ struct AgentTaskRegistryTests {
         preciseStartedAt: Date = Date(timeIntervalSince1970: 0),
         startIsAuthoritative: Bool = true,
         agentType: AgentType = .claudeCode,
-        state: AgentState = .idle
+        state: AgentState = .idle,
+        lifecycleAccuracy: FirstPartyAgentNotificationAccuracy = .processTerminationOnly
     ) -> AgentSession {
         let session = AgentSession(
             agentType: agentType,
             state: state,
+            lifecycleAccuracy: lifecycleAccuracy,
             startedAt: Date(timeIntervalSince1970: TimeInterval(generation))
         )
         _ = session.bindProcessEvidence(

--- a/PineTests/BulkCloseAgentAuthorizationTests.swift
+++ b/PineTests/BulkCloseAgentAuthorizationTests.swift
@@ -411,7 +411,10 @@ struct BulkCloseAgentAuthorizationTests {
         ))
 
         firstSession.applyLiveness(.terminated)
-        firstSession.state = .done
+        firstSession.recordLifecycleState(
+            .done,
+            accuracy: .processTerminationOnly
+        )
         project.terminal.bridgeAgentSession(
             firstSession,
             replacing: firstSession,

--- a/PineUITests/ScreenshotTests.swift
+++ b/PineUITests/ScreenshotTests.swift
@@ -85,7 +85,7 @@ final class ScreenshotTests: PineUITestCase {
         let releaseTask = inboxWindow.buttons.matching(
             NSPredicate(
                 format: "label CONTAINS %@",
-                "Approve the release announcement"
+                "Draft the release announcement"
             )
         ).firstMatch
         XCTAssertTrue(


### PR DESCRIPTION
Closes #1418

## Summary
- keep process-only and CPU-flat observations out of waiting-for-input state
- require catalog-declared lifecycle accuracy intersected with concrete run evidence before projecting attention
- apply the same fail-closed policy to Inbox, toolbar, terminal badge, status overlay, and notifications
- preserve legacy schema-v2 task history and unread review state while treating unauthenticated lifecycle claims as stale/non-actionable

## Local verification
- 246 tests passed across 9 relevant PineTests suites
- independent pre-PR rerun of the same 9 suites completed successfully
- SwiftLint strict: 0 violations in 739 files
- git diff check clean

A single full PineTests attempt on the macOS 27 beta environment encountered unrelated existing toolbar snapshot rendering differences and AgentAdapterRegistry resource-starvation timeouts; the relevant suites are stable in isolation. Tested on macOS 27.0 / Xcode 27 beta; a macOS 26 runtime was not available locally.