### PR TITLE
fix: keep terminal destination routing current

### DIFF
--- a/Pine/Agent/AgentActivityTerminalRouting.swift
+++ b/Pine/Agent/AgentActivityTerminalRouting.swift
@@ -21,11 +21,11 @@ enum AgentTerminalNavigationRouter {
         paneManager: PaneManager,
         terminalManager: TerminalManager
     ) -> Bool {
-        guard paneManager.selectTerminalTab(tabID, in: paneID) else {
-            return false
-        }
-        terminalManager.lastActiveTerminalPaneID = paneID
-        return true
+        guard terminalManager.paneManager === paneManager else { return false }
+        return terminalManager.activateTerminal(
+            paneID: paneID,
+            tabID: tabID
+        )
     }
 }
 

--- a/Pine/ContentView+Helpers.swift
+++ b/Pine/ContentView+Helpers.swift
@@ -119,13 +119,9 @@ extension ContentView {
         // shell is rooted in the project directory via current `ShellSettings`.
         // `addTab` sets `pendingFocusTabID`, so the bounded AppKit focus
         // coordinator requests first-responder once the terminal view attaches.
+        // `ProjectManager.addTerminalTab` also performs canonical terminal
+        // activation, so no pane-local focus repair is needed here.
         projectManager.addTerminalTab()
-        // Make the terminal pane the active pane so the focus request targets it.
-        if let terminalPaneID = paneManager.terminalPaneIDs.first {
-            paneManager.activePaneID = terminalPaneID
-            paneManager.terminalState(for: terminalPaneID)?.pendingFocusTabID =
-                paneManager.terminalState(for: terminalPaneID)?.activeTerminalID
-        }
     }
 
     func recoverTabs() {
@@ -613,10 +609,12 @@ extension ContentView {
             projectManager.addTerminalTab()
         }
 
-        // Find the active terminal pane's state
-        guard let tpID = terminal.lastActiveTerminalPaneID ?? paneManager.terminalPaneIDs.first,
-              let state = paneManager.terminalState(for: tpID),
-              let activeTab = state.activeTab else { return }
+        // Resolve and activate one validated destination. A stale non-nil
+        // pointer must never suppress the stable surviving-pane fallback.
+        guard let destination = terminal.activateResolvedDestination() else {
+            return
+        }
+        let activeTab = destination.tab
 
         // A single known agent executable is an explicit Pine-owned launch.
         // Shell expressions and argument-bearing commands remain ordinary,
@@ -633,7 +631,7 @@ extension ContentView {
         }
 
         // Send ordinary text followed by newline to execute.
-        activeTab.sendText(text + "\n")
+        terminal.sendText(text + "\n", to: destination)
     }
 
     // MARK: - Menu notification handlers (#1051, #1133)

--- a/Pine/ContentView.swift
+++ b/Pine/ContentView.swift
@@ -343,6 +343,7 @@ struct ContentView: View {
                 gitProvider: workspace.gitProvider,
                 paneManager: paneManager,
                 tabManager: activeTabManager,
+                terminalManager: terminal,
                 progress: projectManager.progress,
                 onToggleTerminal: {
                     if paneManager.terminalPaneIDs.isEmpty {

--- a/Pine/PaneFocusDetector.swift
+++ b/Pine/PaneFocusDetector.swift
@@ -44,7 +44,7 @@ final class PaneFocusNSView: NSView {
 
     override func mouseDown(with event: NSEvent) {
         MainActor.assumeIsolated {
-            paneManager?.activePaneID = paneID
+            _ = paneManager?.activatePane(paneID)
         }
         super.mouseDown(with: event)
     }

--- a/Pine/PaneManager.swift
+++ b/Pine/PaneManager.swift
@@ -80,6 +80,17 @@ final class PaneManager {
     /// Reports value-only terminal route changes after a completed tab move.
     var terminalTabDidMove: ((TerminalTab, PaneID) -> Void)?
 
+    /// Reports successful terminal user activations that originate inside the
+    /// pane model (for example global-switcher commits). The terminal
+    /// coordinator uses this value-only callback to keep its durable command
+    /// destination current without a reverse object reference.
+    var terminalTabDidActivate: ((PaneID, UUID) -> Void)?
+
+    /// Reports completed pane-inventory mutations so the terminal coordinator
+    /// can invalidate a removed command destination without retaining this
+    /// pane tree. The callback is installed with a weak coordinator capture.
+    var terminalPaneInventoryDidChange: (() -> Void)?
+
     /// Saved root before maximize, for restore.
     private(set) var savedRootBeforeMaximize: PaneNode?
 
@@ -116,6 +127,9 @@ final class PaneManager {
     /// Prevents the activation callbacks owned by pane-local managers from
     /// reordering the MRU list while a keyboard cycle is in progress.
     private var isPerformingGlobalTabSwitch = false
+    /// Suppresses the pane-originated terminal callback while
+    /// `TerminalManager.activateTerminal` performs its own exact bookkeeping.
+    private var isSuppressingTerminalActivationCallback = false
 
     /// The live visual MRU switcher session (`nil` unless Control-Tab overlay
     /// is up). Created by `beginGlobalTabSwitcherSession()`, torn down on commit
@@ -317,6 +331,7 @@ final class PaneManager {
         activePaneID = identity.paneID
         terminalState.activeTerminalID = identity.tabID
         terminalState.pendingFocusTabID = identity.tabID
+        terminalTabDidActivate?(identity.paneID, identity.tabID)
         return true
     }
 
@@ -1197,6 +1212,7 @@ final class PaneManager {
             root = .leaf(newID, .editor)
             activePaneID = newID
             reconcileGlobalTabSwitcherAfterInventoryChange()
+            terminalPaneInventoryDidChange?()
             return
         }
 
@@ -1213,6 +1229,7 @@ final class PaneManager {
             activePaneID = root.firstLeafID ?? activePaneID
         }
         reconcileGlobalTabSwitcherAfterInventoryChange()
+        terminalPaneInventoryDidChange?()
     }
 
     /// Updates the split ratio for a divider adjacent to a pane.
@@ -1238,16 +1255,46 @@ final class PaneManager {
     /// Selects a terminal tab, activates its pane, and requests first responder
     /// for the newly selected terminal content.
     @discardableResult
-    func selectTerminalTab(_ tabID: UUID, in paneID: PaneID) -> Bool {
+    func selectTerminalTab(
+        _ tabID: UUID,
+        in paneID: PaneID,
+        reportActivation: Bool = true
+    ) -> Bool {
         guard let terminalState = terminalStates[paneID],
               terminalState.terminalTabs.contains(where: { $0.id == tabID }) else {
             return false
         }
+        let activeTabChanged = terminalState.activeTerminalID != tabID
         activePaneID = paneID
+        let previousSuppression = isSuppressingTerminalActivationCallback
+        isSuppressingTerminalActivationCallback = !reportActivation
         terminalState.activeTerminalID = tabID
+        isSuppressingTerminalActivationCallback = previousSuppression
         terminalState.pendingFocusTabID = tabID
         recordTabActivation(paneID: paneID, tabID: tabID, contentType: .terminal)
+        if reportActivation, !activeTabChanged {
+            terminalTabDidActivate?(paneID, tabID)
+        }
         return true
+    }
+
+    /// Activates a pane from a user focus gesture. Terminal panes preserve the
+    /// exact active tab and route through normal terminal selection; editor
+    /// panes only update pane focus.
+    @discardableResult
+    func activatePane(_ paneID: PaneID) -> Bool {
+        switch root.content(for: paneID) {
+        case .terminal:
+            guard let tabID = terminalStates[paneID]?.activeTerminalID else {
+                return false
+            }
+            return selectTerminalTab(tabID, in: paneID)
+        case .editor:
+            activePaneID = paneID
+            return true
+        case nil:
+            return false
+        }
     }
 
     // MARK: - Pointer-free tab movement
@@ -1367,13 +1414,17 @@ final class PaneManager {
                 action: action
             ) else { return false }
             let result: TabInsertionResult
+            let terminalDidSetWillPublish: Bool
             switch contentType {
             case .editor:
+                terminalDidSetWillPublish = false
                 result = tabManagers[paneID]?.moveTab(
                     id: tabID,
                     toInsertionIndex: insertionIndex
                 ) ?? .rejected
             case .terminal:
+                terminalDidSetWillPublish = activePaneID == paneID
+                    && terminalStates[paneID]?.activeTerminalID != tabID
                 result = terminalStates[paneID]?.moveTab(
                     id: tabID,
                     toInsertionIndex: insertionIndex
@@ -1382,6 +1433,9 @@ final class PaneManager {
             guard result == .moved else { return false }
             activePaneID = paneID
             recordTabActivation(paneID: paneID, tabID: tabID, contentType: contentType)
+            if contentType == .terminal, !terminalDidSetWillPublish {
+                terminalTabDidActivate?(paneID, tabID)
+            }
             return true
         case .previousPane, .nextPane:
             guard let destinationPaneID = adjacentPane(
@@ -1670,7 +1724,12 @@ final class PaneManager {
         // The projected leaf is now the only visible pane. Keep the focus
         // model aligned even when the maximize button consumed the click
         // before PaneFocusDetector could mark this pane active.
-        activePaneID = paneID
+        if content == .terminal,
+           let tabID = terminalStates[paneID]?.activeTerminalID {
+            _ = selectTerminalTab(tabID, in: paneID)
+        } else {
+            activePaneID = paneID
+        }
     }
 
     func restoreFromMaximize() {
@@ -1763,6 +1822,7 @@ final class PaneManager {
         } else if let firstLeaf = root.firstLeafID {
             activePaneID = firstLeaf
         }
+        terminalPaneInventoryDidChange?()
         return true
     }
 
@@ -2104,12 +2164,17 @@ final class PaneManager {
         switch intent {
         case .reorder(_, let destinationPaneID, let insertionIndex):
             let result: TabInsertionResult
+            let terminalDidSetWillPublish: Bool
             if key.contentType == .editor {
+                terminalDidSetWillPublish = false
                 result = tabManagers[destinationPaneID]?.moveTab(
                     id: key.tabID,
                     toInsertionIndex: insertionIndex
                 ) ?? .rejected
             } else {
+                terminalDidSetWillPublish = activePaneID == destinationPaneID
+                    && terminalStates[destinationPaneID]?.activeTerminalID
+                        != key.tabID
                 result = terminalStates[destinationPaneID]?.moveTab(
                     id: key.tabID,
                     toInsertionIndex: insertionIndex
@@ -2117,6 +2182,10 @@ final class PaneManager {
             }
             if result.accepted {
                 activePaneID = destinationPaneID
+                if key.contentType == .terminal,
+                   !terminalDidSetWillPublish {
+                    terminalTabDidActivate?(destinationPaneID, key.tabID)
+                }
             }
             return result.accepted
 
@@ -2325,12 +2394,16 @@ final class PaneManager {
                   let terminalState,
                   self.terminalStates[paneID] === terminalState,
                   !self.isPerformingGlobalTabSwitch,
+                  !self.isSuppressingTerminalActivationCallback,
                   let tabID else { return }
             self.recordTabActivation(
                 paneID: paneID,
                 tabID: tabID,
                 contentType: .terminal
             )
+            if self.activePaneID == paneID {
+                self.terminalTabDidActivate?(paneID, tabID)
+            }
         }
         terminalState.onTabInventoryChanged = { [weak self, weak terminalState] in
             guard let self,

--- a/Pine/ProjectManager.swift
+++ b/Pine/ProjectManager.swift
@@ -1537,9 +1537,6 @@ final class ProjectManager {
         paneManager.configureTerminalTab = { [weak self] tab in
             self?.terminal.configureAgentLifecycle(for: tab)
         }
-        paneManager.terminalTabDidMove = { [weak self] tab, paneID in
-            self?.terminal.agentTerminalDidMove(tab, to: paneID)
-        }
         problemsController.configureDocumentStatesProvider { [weak self] in
             self?.problemsDocumentStates ?? []
         }

--- a/Pine/ProjectRegistry.swift
+++ b/Pine/ProjectRegistry.swift
@@ -783,9 +783,9 @@ final class ProjectRegistry: LSPSettingsObserver {
             return .projectUnavailable
         }
 
-        guard manager.paneManager.selectTerminalTab(
-            route.tabID,
-            in: PaneID(id: route.paneID)
+        guard manager.terminal.activateTerminal(
+            paneID: PaneID(id: route.paneID),
+            tabID: route.tabID
         ) else {
             return .routeStale
         }
@@ -854,9 +854,9 @@ final class ProjectRegistry: LSPSettingsObserver {
         guard let route = resolveAgentRecoveryTerminal(
             terminalID,
             in: manager
-        ), manager.paneManager.selectTerminalTab(
-            route.tabID,
-            in: PaneID(id: route.paneID)
+        ), manager.terminal.activateTerminal(
+            paneID: PaneID(id: route.paneID),
+            tabID: route.tabID
         ) else { return .launchRejected }
 
         if let activateApplication {

--- a/Pine/ProjectSessionRestorer.swift
+++ b/Pine/ProjectSessionRestorer.swift
@@ -104,12 +104,13 @@ enum ProjectSessionRestorer {
         )
 
         paneManager.restoreActivePane(uuid: activePaneUUID)
-        projectManager.terminal.lastActiveTerminalPaneID = {
-            if paneManager.root.content(for: paneManager.activePaneID) == .terminal {
-                return paneManager.activePaneID
-            }
-            return paneManager.terminalPaneIDs.first
-        }()
+        let preferredTerminalPane =
+            paneManager.root.content(for: paneManager.activePaneID) == .terminal
+            ? paneManager.activePaneID
+            : nil
+        projectManager.terminal.restoreTerminalDestination(
+            preferredPaneID: preferredTerminalPane
+        )
         let restoredSwitchOrder = resolveGlobalSwitchOrder(
             session.globalTabSwitchOrder ?? [],
             paneManager: paneManager,
@@ -339,7 +340,6 @@ enum ProjectSessionRestorer {
                state.terminalTabs.indices.contains(activeIndex) {
                 state.activeTerminalID = state.terminalTabs[activeIndex].id
             }
-            projectManager.terminal.lastActiveTerminalPaneID = existingPaneID
             return
         }
 

--- a/Pine/StatusBarView.swift
+++ b/Pine/StatusBarView.swift
@@ -13,6 +13,7 @@ struct StatusBarView: View {
     var gitProvider: GitStatusProvider
     var paneManager: PaneManager
     var tabManager: TabManager
+    var terminalManager: TerminalManager? = nil
     var progress: ProgressTracker?
     var onToggleTerminal: (() -> Void)?
     /// LSP / validator diagnostics summary for the Problems indicator (#1010).
@@ -88,8 +89,14 @@ struct StatusBarView: View {
 
             if !summaries.isEmpty {
                 AgentStatusBarItem(summaries: summaries) { paneID, tabID in
-                    paneManager.activePaneID = paneID
-                    paneManager.terminalState(for: paneID)?.activeTerminalID = tabID
+                    if let terminalManager {
+                        _ = terminalManager.activateTerminal(
+                            paneID: paneID,
+                            tabID: tabID
+                        )
+                    } else {
+                        _ = paneManager.selectTerminalTab(tabID, in: paneID)
+                    }
                 }
                 .accessibilityIdentifier(AccessibilityID.agentStatusBar)
             }

--- a/Pine/TerminalManager.swift
+++ b/Pine/TerminalManager.swift
@@ -74,7 +74,9 @@ struct PineAgentLaunchAuthorization {
 @Observable
 final class TerminalManager {
     /// Reference to the pane manager for creating/finding terminal panes.
-    weak var paneManager: PaneManager?
+    weak var paneManager: PaneManager? {
+        didSet { installPaneCallbacks() }
+    }
 
     /// ID of the last-focused terminal pane (for Cmd+T routing).
     var lastActiveTerminalPaneID: PaneID?
@@ -122,6 +124,15 @@ final class TerminalManager {
         UUID: PineAgentSettledLaunchIdentity
     ] = [:]
 
+    #if DEBUG
+    /// Exact route-update count used to prove a tab move publishes one durable
+    /// destination change without touching run/process identity.
+    private(set) var agentRouteUpdateCountForTesting = 0
+    /// Pane-originated destination publications. Canonical manager calls use
+    /// their own non-reporting selection path and do not increment this seam.
+    private(set) var paneActivationPublicationCountForTesting = 0
+    #endif
+
     /// `true` once agent-detection polling has started. Read-only diagnostic /
     /// test hook. Delegates to the coordinator's `isRunning` so it correctly
     /// reports `false` after a future `stop()`.
@@ -145,6 +156,21 @@ final class TerminalManager {
     ) {
         self.agentDetectionProcessRunner = agentDetectionProcessRunner
         self.agentTaskRegistry = agentTaskRegistry
+    }
+
+    /// Installs one-way pane callbacks. `PaneManager` retains these closures,
+    /// so every capture of this coordinator is weak and cannot form the
+    /// reverse strong edge `PaneManager -> TerminalManager`.
+    private func installPaneCallbacks() {
+        paneManager?.terminalTabDidMove = { [weak self] tab, paneID in
+            self?.agentTerminalDidMove(tab, to: paneID)
+        }
+        paneManager?.terminalTabDidActivate = { [weak self] paneID, tabID in
+            self?.recordTerminalActivation(paneID: paneID, tabID: tabID)
+        }
+        paneManager?.terminalPaneInventoryDidChange = { [weak self] in
+            self?.reconcileTerminalDestination()
+        }
     }
 
     /// Receives an already validated identity from `ProjectRegistry`; this
@@ -183,16 +209,159 @@ final class TerminalManager {
     }
 
     func agentTerminalDidMove(_ tab: TerminalTab, to paneID: PaneID) {
-        guard let project = agentTaskProject else { return }
-        agentTaskRegistry?.updateRoute(
-            terminalID: tab.id,
-            project: project,
-            route: AgentTaskRoute(
-                paneID: paneID.id,
-                tabID: tab.id,
-                terminalID: tab.id
+        if let project = agentTaskProject {
+            agentTaskRegistry?.updateRoute(
+                terminalID: tab.id,
+                project: project,
+                route: AgentTaskRoute(
+                    paneID: paneID.id,
+                    tabID: tab.id,
+                    terminalID: tab.id
+                )
             )
-        )
+            #if DEBUG
+            agentRouteUpdateCountForTesting += 1
+            #endif
+        }
+        _ = activateTerminal(paneID: paneID, tabID: tab.id)
+    }
+
+    // MARK: - Terminal destination routing (#1424)
+
+    /// One validated terminal command destination. Pane identity and the
+    /// pane-local active tab travel together so callers cannot accidentally
+    /// combine a stale pane pointer with a tab from another split.
+    struct Destination {
+        let paneID: PaneID
+        let tab: TerminalTab
+    }
+
+    /// Resolves the current command destination without mutating selection.
+    /// The durable pointer wins only while it still names a terminal leaf with
+    /// a live active tab; fallback then considers the focused terminal and the
+    /// remaining terminal leaves in stable tree order.
+    func resolvedDestination() -> Destination? {
+        guard let paneManager else { return nil }
+        let terminalPaneIDs = paneManager.terminalPaneIDs
+
+        func destination(in paneID: PaneID) -> Destination? {
+            guard terminalPaneIDs.contains(paneID),
+                  let state = paneManager.terminalState(for: paneID),
+                  let activeID = state.activeTerminalID,
+                  let tab = state.terminalTabs.first(where: {
+                      $0.id == activeID
+                  }) else {
+                return nil
+            }
+            return Destination(paneID: paneID, tab: tab)
+        }
+
+        if let lastActiveTerminalPaneID,
+           let destination = destination(in: lastActiveTerminalPaneID) {
+            return destination
+        }
+        if let destination = destination(in: paneManager.activePaneID) {
+            return destination
+        }
+        for paneID in terminalPaneIDs {
+            if let destination = destination(in: paneID) {
+                return destination
+            }
+        }
+        return nil
+    }
+
+    /// Canonical exact activation for terminal navigation. Validation occurs
+    /// before any mutation, and the durable destination advances only after
+    /// PaneManager atomically selects the requested pane-local tab.
+    @discardableResult
+    func activateTerminal(paneID: PaneID, tabID: UUID) -> Bool {
+        guard let paneManager,
+              paneManager.terminalPaneIDs.contains(paneID),
+              let state = paneManager.terminalState(for: paneID),
+              state.terminalTabs.contains(where: { $0.id == tabID }),
+              paneManager.selectTerminalTab(
+                  tabID,
+                  in: paneID,
+                  reportActivation: false
+              ) else {
+            return false
+        }
+        lastActiveTerminalPaneID = paneID
+        return true
+    }
+
+    /// Accepts pane-originated user activation only when the callback still
+    /// describes the pane's exact selected tab.
+    private func recordTerminalActivation(paneID: PaneID, tabID: UUID) {
+        guard let paneManager,
+              paneManager.terminalPaneIDs.contains(paneID),
+              paneManager.activePaneID == paneID,
+              paneManager.terminalState(for: paneID)?.activeTerminalID
+                == tabID else {
+            return
+        }
+        #if DEBUG
+        paneActivationPublicationCountForTesting += 1
+        #endif
+        lastActiveTerminalPaneID = paneID
+    }
+
+    /// Resolves and activates the current destination as one operation.
+    /// Callers that subsequently write retain the exact tab object selected by
+    /// this validation rather than resolving pane and tab independently.
+    func activateResolvedDestination() -> Destination? {
+        guard let destination = resolvedDestination(),
+              activateTerminal(
+                  paneID: destination.paneID,
+                  tabID: destination.tab.id
+              ) else {
+            return nil
+        }
+        return destination
+    }
+
+    /// Writes to an already activated exact destination only while that same
+    /// tab remains owned by the same terminal pane.
+    @discardableResult
+    func sendText(_ text: String, to destination: Destination) -> Bool {
+        guard let paneManager,
+              paneManager.terminalPaneIDs.contains(destination.paneID),
+              let state = paneManager.terminalState(for: destination.paneID),
+              state.activeTerminalID == destination.tab.id,
+              state.terminalTabs.contains(where: { $0 === destination.tab }) else {
+            return false
+        }
+        return destination.tab.sendText(text)
+    }
+
+    /// Reconciles only the durable pointer after a pane-tree mutation. It does
+    /// not steal focus: a removed target is replaced deterministically by the
+    /// focused valid terminal or the first valid terminal in tree order.
+    private func reconcileTerminalDestination() {
+        lastActiveTerminalPaneID = resolvedDestination()?.paneID
+    }
+
+    /// Restores destination bookkeeping without changing pane/tab focus.
+    /// Invalid persisted preferences fall back to the first valid terminal in
+    /// stable tree order and an empty terminal inventory restores `nil`.
+    func restoreTerminalDestination(preferredPaneID: PaneID?) {
+        guard let paneManager else {
+            lastActiveTerminalPaneID = nil
+            return
+        }
+        let paneIDs = paneManager.terminalPaneIDs
+        let preferredIsValid = preferredPaneID.map { paneID in
+            paneIDs.contains(paneID)
+                && paneManager.terminalState(for: paneID)?.activeTab != nil
+        } ?? false
+        if preferredIsValid {
+            lastActiveTerminalPaneID = preferredPaneID
+            return
+        }
+        lastActiveTerminalPaneID = paneIDs.first(where: { paneID in
+            paneManager.terminalState(for: paneID)?.activeTab != nil
+        })
     }
 
     func agentTaskContext(for tab: TerminalTab) -> AgentTaskBridgeContext? {
@@ -690,25 +859,53 @@ final class TerminalManager {
     ) -> (PaneID, TerminalTab)? {
         guard let pm = paneManager else { return nil }
         ensureAgentDetectionStarted()
-        if let paneID = lastActiveTerminalPaneID,
-           let state = pm.terminalState(for: paneID) {
+        if let destination = resolvedDestination(),
+           let state = pm.terminalState(for: destination.paneID) {
             let tab = state.addTab(
                 workingDirectory: workingDirectory,
                 initialProcess: initialProcess
             )
-            pm.activePaneID = paneID
-            return (paneID, tab)
+            guard activateTerminal(
+                paneID: destination.paneID,
+                tabID: tab.id
+            ) else {
+                state.removeTab(id: tab.id)
+                return nil
+            }
+            return (destination.paneID, tab)
         }
         let paneID = pm.createTerminalPaneAtBottom(
             workingDirectory: workingDirectory,
             initialProcess: initialProcess
         )
-        lastActiveTerminalPaneID = paneID
         pm.pruneEmptyEditorLeaves()
-        guard let tab = pm.terminalState(for: paneID)?.activeTab else {
+        guard let tab = pm.terminalState(for: paneID)?.activeTab,
+              activateTerminal(paneID: paneID, tabID: tab.id) else {
             return nil
         }
         return (paneID, tab)
+    }
+
+    /// Adds a tab to one exact existing terminal pane and makes it the shared
+    /// command destination. Used by the pane-local plus button so it cannot
+    /// bypass destination bookkeeping.
+    @discardableResult
+    func createTerminalTab(
+        in paneID: PaneID,
+        workingDirectory: URL?
+    ) -> TerminalTab? {
+        guard let pm = paneManager,
+              pm.terminalPaneIDs.contains(paneID) else { return nil }
+        ensureAgentDetectionStarted()
+        guard let tab = pm.addTerminalTab(
+            in: paneID,
+            workingDirectory: workingDirectory
+        ) else { return nil }
+        guard activateTerminal(paneID: paneID, tabID: tab.id) else {
+            pm.terminalState(for: paneID)?.removeTab(id: tab.id)
+            return nil
+        }
+        return tab
     }
 
     /// Creates a terminal tab in the last-used terminal pane.
@@ -722,38 +919,37 @@ final class TerminalManager {
         // later are picked up automatically (vision #933, issues #950/#951).
         ensureAgentDetectionStarted()
 
-        if let tpID = lastActiveTerminalPaneID,
-           pm.terminalState(for: tpID) != nil {
+        if let destination = resolvedDestination(),
+           createTerminalTab(
+               in: destination.paneID,
+               workingDirectory: workingDirectory
+           ) != nil {
             // Adding a tab to an existing terminal pane is not a structural
             // mutation — the layout already includes a terminal, so any
             // adjacent empty editor was already pruned (or kept on purpose).
             // No prune needed here.
-            pm.terminalState(for: tpID)?.addTab(workingDirectory: workingDirectory)
-            pm.activePaneID = tpID
         } else {
             // Create terminal pane spanning full width at bottom
             let newID = pm.createTerminalPaneAtBottom(workingDirectory: workingDirectory)
-            lastActiveTerminalPaneID = newID
             // Collapse any empty editor placeholder that was sitting next to
             // the new terminal — the user clearly wants the screen real estate
             // for terminals, not for "No File Selected".
             pm.pruneEmptyEditorLeaves()
+            if let tabID = pm.terminalState(for: newID)?.activeTerminalID {
+                _ = activateTerminal(paneID: newID, tabID: tabID)
+            }
         }
     }
 
     /// Focuses the nearest terminal pane, or creates one.
     func focusOrCreateTerminal(relativeTo editorPaneID: PaneID, workingDirectory: URL?) {
-        guard let pm = paneManager else { return }
+        guard paneManager != nil else { return }
 
-        if let tpID = lastActiveTerminalPaneID,
-           let state = pm.terminalState(for: tpID) {
-            pm.activePaneID = tpID
-            state.pendingFocusTabID = state.activeTerminalID
-        } else if let firstTP = pm.terminalPaneIDs.first,
-                  let state = pm.terminalState(for: firstTP) {
-            pm.activePaneID = firstTP
-            lastActiveTerminalPaneID = firstTP
-            state.pendingFocusTabID = state.activeTerminalID
+        if let destination = resolvedDestination() {
+            _ = activateTerminal(
+                paneID: destination.paneID,
+                tabID: destination.tab.id
+            )
         } else {
             createTerminalTab(relativeTo: editorPaneID, workingDirectory: workingDirectory)
         }

--- a/Pine/TerminalPaneState.swift
+++ b/Pine/TerminalPaneState.swift
@@ -122,6 +122,7 @@ final class TerminalPaneState {
         terminalTabs.removeAll { $0.id == id }
         if activeTerminalID == id {
             activeTerminalID = terminalTabs.last?.id
+            pendingFocusTabID = activeTerminalID
         }
         onTabInventoryChanged?()
     }

--- a/Pine/TerminalPaneTabBar.swift
+++ b/Pine/TerminalPaneTabBar.swift
@@ -191,7 +191,10 @@ struct TerminalPaneTabBar: View {
                                         isActive: isActive,
                                         canClose: true,
                                         onSelect: {
-                                            paneManager.selectTerminalTab(tab.id, in: paneID)
+                                            _ = projectManager?.terminal.activateTerminal(
+                                                paneID: paneID,
+                                                tabID: tab.id
+                                            )
                                         },
                                         onClose: { closeTerminalTabWithConfirmation(tab) },
                                         onMoveLeading: paneManager.canMoveTab(
@@ -335,7 +338,7 @@ struct TerminalPaneTabBar: View {
 
                 // New terminal tab button
                 Button {
-                    paneManager.addTerminalTab(
+                    _ = projectManager?.terminal.createTerminalTab(
                         in: paneID,
                         workingDirectory: workingDirectory
                     )

--- a/Pine/TerminalSession.swift
+++ b/Pine/TerminalSession.swift
@@ -2431,6 +2431,13 @@ final class TerminalTab: Identifiable, Hashable {
     private var lastSearchQuery = ""
     private var lastSearchOptions = SearchOptions()
 
+    #if DEBUG
+    /// Captures the exact tab-level write in routing tests without starting a
+    /// shell or touching a real PTY.
+    @ObservationIgnored
+    var sendTextOverrideForTesting: ((String) -> Bool)?
+    #endif
+
     /// Highlights the current match using SwiftTerm's built-in find (which sets selection)
     /// and scrolls to it.
     private func highlightCurrentMatch() {
@@ -2446,6 +2453,11 @@ final class TerminalTab: Identifiable, Hashable {
     /// The text is written to the PTY as if the user typed it.
     @discardableResult
     func sendText(_ text: String) -> Bool {
+        #if DEBUG
+        if let sendTextOverrideForTesting {
+            return sendTextOverrideForTesting(text)
+        }
+        #endif
         guard isProcessRunning else { return false }
         let data = Array(text.utf8)
         terminalView.process.send(data: data[...])

--- a/PineTests/AgentInboxTests.swift
+++ b/PineTests/AgentInboxTests.swift
@@ -295,9 +295,14 @@ struct AgentInboxTests {
         let manager = try #require(
             projectRegistry.projectManager(for: fixture.project)
         )
-        let pane = manager.paneManager.createTerminalPaneAtBottom(
+        let firstPane = manager.paneManager.createTerminalPaneAtBottom(
             workingDirectory: fixture.project
         )
+        let pane = try #require(manager.paneManager.createTerminalPane(
+            relativeTo: firstPane,
+            axis: .horizontal,
+            workingDirectory: fixture.project
+        ))
         let state = try #require(manager.paneManager.terminalState(for: pane))
         let tab = try #require(state.terminalTabs.first)
         let session = makeSession(
@@ -313,6 +318,7 @@ struct AgentInboxTests {
         tab.agentSession = session
         let taskID = try #require(taskRegistry.taskID(forSessionID: session.id))
         #expect(taskRegistry.task(for: taskID)?.isUnread == true)
+        manager.terminal.lastActiveTerminalPaneID = firstPane
 
         let focused = await projectRegistry.navigateToAgentTaskFromInbox(
             taskID,
@@ -327,6 +333,7 @@ struct AgentInboxTests {
         )))
         #expect(state.activeTerminalID == tab.id)
         #expect(state.pendingFocusTabID == tab.id)
+        #expect(manager.terminal.lastActiveTerminalPaneID == pane)
         #expect(taskRegistry.task(for: taskID)?.isUnread == false)
 
         session.applyLiveness(.terminated)

--- a/PineTests/AgentTaskRegistryTests.swift
+++ b/PineTests/AgentTaskRegistryTests.swift
@@ -1918,6 +1918,9 @@ struct AgentTaskRegistryTests {
         let taskID = try #require(
             taskRegistry.taskID(forSessionID: replacement.id)
         )
+        let taskBeforeMove = try #require(taskRegistry.task(for: taskID))
+        let routeUpdatesBeforeMove =
+            manager.terminal.agentRouteUpdateCountForTesting
         #expect(taskID != historicalTaskID)
         #expect(
             taskRegistry.task(for: historicalTaskID)?.route.availability
@@ -1934,6 +1937,17 @@ struct AgentTaskRegistryTests {
             from: firstPane,
             to: secondPane
         ))
+        let taskAfterMove = try #require(taskRegistry.task(for: taskID))
+        #expect(
+            manager.terminal.agentRouteUpdateCountForTesting
+                == routeUpdatesBeforeMove + 1
+        )
+        #expect(taskAfterMove.runs == taskBeforeMove.runs)
+        #expect(tab.agentSession === replacement)
+        #expect(
+            tab.agentSession?.processEvidence
+                == taskBeforeMove.runs.last?.process
+        )
         #expect(taskRegistry.task(for: taskID)?.route.paneID == secondPane.id)
         #expect(
             await projectRegistry.resolveAgentTaskRoute(taskID)?.paneID

--- a/PineTests/GlobalTabSwitcherTests.swift
+++ b/PineTests/GlobalTabSwitcherTests.swift
@@ -767,6 +767,72 @@ struct GlobalTabSwitcherTests {
         #expect(details.contains { $0.contains("Sources") })
     }
 
+    @Test("Global switch to a terminal updates the command destination")
+    func terminalSwitchUpdatesDestinationWithoutReorderingMRU() throws {
+        let paneManager = PaneManager()
+        let terminalManager = TerminalManager()
+        terminalManager.paneManager = paneManager
+        let editorPane = paneManager.activePaneID
+        let editorManager = try #require(
+            paneManager.tabManager(for: editorPane)
+        )
+        let editor = EditorTab(
+            url: URL(fileURLWithPath: "/tmp/global-routing.swift"),
+            content: "",
+            savedContent: ""
+        )
+        editorManager.tabs.append(editor)
+        #expect(paneManager.selectEditorTab(editor.id, in: editorPane))
+        let firstPane = paneManager.createTerminalPaneAtBottom(
+            workingDirectory: nil
+        )
+        let secondPane = try #require(paneManager.createTerminalPane(
+            relativeTo: firstPane,
+            axis: .horizontal,
+            workingDirectory: nil
+        ))
+        let firstTab = try #require(
+            paneManager.terminalState(for: firstPane)?.activeTab
+        )
+        let secondTab = try #require(
+            paneManager.terminalState(for: secondPane)?.activeTab
+        )
+        #expect(paneManager.selectTerminalTab(
+            secondTab.id,
+            in: secondPane
+        ))
+        #expect(paneManager.selectTerminalTab(firstTab.id, in: firstPane))
+        #expect(terminalManager.lastActiveTerminalPaneID == firstPane)
+        let originalOrder = paneManager.globalTabSwitchOrder
+
+        #expect(paneManager.beginGlobalTabSwitcherSession(initialOffset: 1))
+
+        // Overlay preview is selection-only: it must not move real focus,
+        // destination bookkeeping, or MRU until commit.
+        #expect(paneManager.activePaneID == firstPane)
+        #expect(terminalManager.lastActiveTerminalPaneID == firstPane)
+        #expect(paneManager.globalTabSwitchOrder == originalOrder)
+        paneManager.commitGlobalTabSwitcher()
+
+        #expect(paneManager.activePaneID == secondPane)
+        #expect(
+            paneManager.terminalState(for: secondPane)?.activeTerminalID
+                == secondTab.id
+        )
+        #expect(
+            paneManager.terminalState(for: secondPane)?.pendingFocusTabID
+                == secondTab.id
+        )
+        #expect(terminalManager.lastActiveTerminalPaneID == secondPane)
+        #expect(paneManager.globalTabSwitchOrder.first == GlobalTabIdentity(
+            paneID: secondPane,
+            tabID: secondTab.id,
+            contentType: .terminal
+        ))
+        #expect(paneManager.globalTabSwitchOrder.count == originalOrder.count)
+        #expect(Set(paneManager.globalTabSwitchOrder).count == originalOrder.count)
+    }
+
     @Test("Path normalization is lexical and respects component boundaries")
     func lexicalRelativePathNormalization() {
         let root = URL(fileURLWithPath: "/nonexistent/project")

--- a/PineTests/ProjectSessionRestorerTests.swift
+++ b/PineTests/ProjectSessionRestorerTests.swift
@@ -91,6 +91,7 @@ struct ProjectSessionRestorerTests {
         ))
         #expect(projectManager.paneManager.root == layout)
         #expect(projectManager.paneManager.activePaneID == editorB)
+        #expect(projectManager.terminal.lastActiveTerminalPaneID == terminal)
 
         let managerA = try #require(projectManager.paneManager.tabManager(for: editorA))
         let managerB = try #require(projectManager.paneManager.tabManager(for: editorB))
@@ -216,7 +217,60 @@ struct ProjectSessionRestorerTests {
         )
 
         #expect(projectManager.paneManager.activePaneID == rightPane)
+        #expect(projectManager.terminal.lastActiveTerminalPaneID == nil)
         #expect(projectManager.paneManager.tabManager(for: rightPane)?.activeTab?.url == rightURL)
+    }
+
+    @Test("Editor-focused restore chooses the first valid terminal without stealing focus")
+    func terminalDestinationFallbackUsesStableOrderWithoutFocusTheft() throws {
+        let (root, files) = try fixture(files: ["focused.swift"])
+        defer { try? FileManager.default.removeItem(at: root) }
+        let file = try #require(files["focused.swift"])
+        let editor = PaneID()
+        let firstTerminal = PaneID()
+        let secondTerminal = PaneID()
+        let layout = PaneNode.split(
+            .horizontal,
+            first: .leaf(editor, .editor),
+            second: .split(
+                .vertical,
+                first: .leaf(firstTerminal, .terminal),
+                second: .leaf(secondTerminal, .terminal),
+                ratio: 0.5
+            ),
+            ratio: 0.5
+        )
+        var session = SessionState(
+            projectPath: root.path,
+            openFilePaths: [file.path]
+        )
+        session.paneLayoutData = try JSONEncoder().encode(layout)
+        session.paneTabAssignments = [editor.id.uuidString: [file.path]]
+        session.paneActiveEditorPaths = [editor.id.uuidString: file.path]
+        session.activePaneID = editor.id.uuidString
+        session.terminalPaneTabCounts = [
+            firstTerminal.id.uuidString: 1,
+            secondTerminal.id.uuidString: 1,
+        ]
+
+        let projectManager = ProjectManager()
+        _ = ProjectSessionRestorer.restore(
+            session,
+            into: projectManager,
+            rootURL: root
+        )
+
+        #expect(projectManager.paneManager.activePaneID == editor)
+        #expect(
+            projectManager.paneManager.tabManager(for: editor)?
+                .pendingFocusTabID
+                == projectManager.paneManager.tabManager(for: editor)?
+                    .activeTabID
+        )
+        #expect(
+            projectManager.terminal.lastActiveTerminalPaneID
+                == firstTerminal
+        )
     }
 
     @Test("Pinned and preview state is pane-scoped for duplicate file paths")

--- a/PineTests/TerminalManagerCoordinatorTests.swift
+++ b/PineTests/TerminalManagerCoordinatorTests.swift
@@ -25,6 +25,7 @@ struct TerminalManagerCoordinatorTests {
             return
         }
         #expect(paneManager.terminalState(for: tpID)?.tabCount == 1)
+        #expect(terminal.lastActiveTerminalPaneID == tpID)
     }
 
     @Test func createTerminalTab_existingPane_addsTab() {
@@ -136,6 +137,326 @@ struct TerminalManagerCoordinatorTests {
         terminal.focusOrCreateTerminal(relativeTo: editorPane, workingDirectory: nil)
 
         #expect(paneManager.terminalPaneIDs.count == 1)
+    }
+
+    @Test("Exact activation validates before changing any destination state")
+    func exactActivationFailsAtomically() throws {
+        let paneManager = PaneManager()
+        let terminal = TerminalManager()
+        terminal.paneManager = paneManager
+        let editorPane = paneManager.activePaneID
+        let firstPane = try #require(paneManager.createTerminalPane(
+            relativeTo: editorPane,
+            axis: .vertical,
+            workingDirectory: nil
+        ))
+        let secondPane = try #require(paneManager.createTerminalPane(
+            relativeTo: firstPane,
+            axis: .horizontal,
+            workingDirectory: nil
+        ))
+        let firstTab = try #require(
+            paneManager.terminalState(for: firstPane)?.activeTab
+        )
+        let secondState = try #require(
+            paneManager.terminalState(for: secondPane)
+        )
+        let secondActive = try #require(secondState.activeTerminalID)
+
+        #expect(terminal.activateTerminal(
+            paneID: firstPane,
+            tabID: firstTab.id
+        ))
+        let initialFocus = paneManager.terminalState(for: firstPane)?
+            .pendingFocusTabID
+
+        #expect(!terminal.activateTerminal(
+            paneID: secondPane,
+            tabID: UUID()
+        ))
+        #expect(paneManager.activePaneID == firstPane)
+        #expect(terminal.lastActiveTerminalPaneID == firstPane)
+        #expect(
+            paneManager.terminalState(for: firstPane)?.activeTerminalID
+                == firstTab.id
+        )
+        #expect(
+            paneManager.terminalState(for: firstPane)?.pendingFocusTabID
+                == initialFocus
+        )
+        #expect(secondState.activeTerminalID == secondActive)
+
+        #expect(!terminal.activateTerminal(
+            paneID: PaneID(),
+            tabID: firstTab.id
+        ))
+        #expect(paneManager.activePaneID == firstPane)
+        #expect(terminal.lastActiveTerminalPaneID == firstPane)
+    }
+
+    @Test("Destination resolver rejects stale panes and invalid active tabs")
+    func resolverUsesValidatedStableFallback() throws {
+        let paneManager = PaneManager()
+        let terminal = TerminalManager()
+        terminal.paneManager = paneManager
+        let editorPane = paneManager.activePaneID
+        let firstPane = try #require(paneManager.createTerminalPane(
+            relativeTo: editorPane,
+            axis: .vertical,
+            workingDirectory: nil
+        ))
+        let secondPane = try #require(paneManager.createTerminalPane(
+            relativeTo: firstPane,
+            axis: .horizontal,
+            workingDirectory: nil
+        ))
+
+        terminal.lastActiveTerminalPaneID = PaneID()
+        paneManager.activePaneID = secondPane
+        #expect(terminal.resolvedDestination()?.paneID == secondPane)
+
+        paneManager.activePaneID = editorPane
+        #expect(terminal.resolvedDestination()?.paneID == firstPane)
+
+        paneManager.terminalState(for: firstPane)?.activeTerminalID = UUID()
+        #expect(terminal.resolvedDestination()?.paneID == secondPane)
+    }
+
+    @Test("Removing the pointed pane picks a stable fallback then nil")
+    func removalReconcilesDestination() throws {
+        let paneManager = PaneManager()
+        let terminal = TerminalManager()
+        terminal.paneManager = paneManager
+        let editorPane = paneManager.activePaneID
+        let firstPane = try #require(paneManager.createTerminalPane(
+            relativeTo: editorPane,
+            axis: .vertical,
+            workingDirectory: nil
+        ))
+        let secondPane = try #require(paneManager.createTerminalPane(
+            relativeTo: firstPane,
+            axis: .horizontal,
+            workingDirectory: nil
+        ))
+        terminal.lastActiveTerminalPaneID = secondPane
+        paneManager.activePaneID = editorPane
+
+        paneManager.removePane(secondPane)
+        #expect(terminal.lastActiveTerminalPaneID == firstPane)
+
+        paneManager.removePane(firstPane)
+        #expect(terminal.lastActiveTerminalPaneID == nil)
+    }
+
+    @Test("A pane focus gesture activates its exact terminal destination")
+    func paneActivationUpdatesDestination() throws {
+        let paneManager = PaneManager()
+        let terminal = TerminalManager()
+        terminal.paneManager = paneManager
+        let editorPane = paneManager.activePaneID
+        let firstPane = try #require(paneManager.createTerminalPane(
+            relativeTo: editorPane,
+            axis: .vertical,
+            workingDirectory: nil
+        ))
+        let secondPane = try #require(paneManager.createTerminalPane(
+            relativeTo: firstPane,
+            axis: .horizontal,
+            workingDirectory: nil
+        ))
+        let secondTab = try #require(
+            paneManager.terminalState(for: secondPane)?.activeTab
+        )
+        terminal.lastActiveTerminalPaneID = firstPane
+
+        #expect(paneManager.activatePane(secondPane))
+
+        #expect(paneManager.activePaneID == secondPane)
+        #expect(
+            paneManager.terminalState(for: secondPane)?.activeTerminalID
+                == secondTab.id
+        )
+        #expect(
+            paneManager.terminalState(for: secondPane)?.pendingFocusTabID
+                == secondTab.id
+        )
+        #expect(terminal.lastActiveTerminalPaneID == secondPane)
+        #expect(
+            paneManager.globalTabSwitchOrder.first
+                == GlobalTabIdentity(
+                    paneID: secondPane,
+                    tabID: secondTab.id,
+                    contentType: .terminal
+                )
+        )
+    }
+
+    @Test("Same-pane terminal reorder publishes destination exactly once")
+    func samePaneReorderPublishesOnce() throws {
+        let paneManager = PaneManager()
+        let terminal = TerminalManager()
+        terminal.paneManager = paneManager
+        let pane = paneManager.createTerminalPaneAtBottom(
+            workingDirectory: nil
+        )
+        let state = try #require(paneManager.terminalState(for: pane))
+        let firstTab = try #require(state.activeTab)
+        let secondTab = state.addTab(workingDirectory: nil)
+        let beforeInactiveMove =
+            terminal.paneActivationPublicationCountForTesting
+
+        #expect(paneManager.moveTab(
+            firstTab.id,
+            from: pane,
+            contentType: .terminal,
+            action: .trailing
+        ))
+        #expect(
+            terminal.paneActivationPublicationCountForTesting
+                == beforeInactiveMove + 1
+        )
+        #expect(terminal.lastActiveTerminalPaneID == pane)
+        #expect(state.activeTerminalID == firstTab.id)
+
+        let beforeActiveMove =
+            terminal.paneActivationPublicationCountForTesting
+        #expect(paneManager.moveTab(
+            firstTab.id,
+            from: pane,
+            contentType: .terminal,
+            action: .leading
+        ))
+        #expect(
+            terminal.paneActivationPublicationCountForTesting
+                == beforeActiveMove + 1
+        )
+        #expect(state.activeTerminalID == firstTab.id)
+        #expect(
+            paneManager.globalTabSwitchOrder.first
+                == GlobalTabIdentity(
+                    paneID: pane,
+                    tabID: firstTab.id,
+                    contentType: .terminal
+                )
+        )
+        #expect(state.terminalTabs.contains(where: { $0 === secondTab }))
+    }
+
+    @Test("Move, prune, Send, and Cmd+T keep the surviving pane current")
+    func movePruneSendAndNewTabUseSurvivingPane() throws {
+        let paneManager = PaneManager()
+        let terminal = TerminalManager()
+        terminal.paneManager = paneManager
+        let editorPane = paneManager.activePaneID
+        let sourcePane = try #require(paneManager.createTerminalPane(
+            relativeTo: editorPane,
+            axis: .vertical,
+            workingDirectory: nil
+        ))
+        let destinationPane = try #require(paneManager.createTerminalPane(
+            relativeTo: sourcePane,
+            axis: .horizontal,
+            workingDirectory: nil
+        ))
+        let movedTab = try #require(
+            paneManager.terminalState(for: sourcePane)?.activeTab
+        )
+        let existingTab = try #require(
+            paneManager.terminalState(for: destinationPane)?.activeTab
+        )
+        let session = AgentSession(agentType: .codex, state: .executing)
+        let evidence = AgentProcessEvidence(
+            processIdentifier: 420,
+            processGeneration: 7,
+            startIdentifier: "generation-7",
+            observedStartedAt: Date(timeIntervalSince1970: 7),
+            startIsAuthoritative: true
+        )
+        #expect(session.bindProcessEvidence(evidence))
+        movedTab.agentSession = session
+        var movedWrites: [String] = []
+        var existingWrites: [String] = []
+        movedTab.sendTextOverrideForTesting = {
+            movedWrites.append($0)
+            return true
+        }
+        existingTab.sendTextOverrideForTesting = {
+            existingWrites.append($0)
+            return true
+        }
+        terminal.lastActiveTerminalPaneID = sourcePane
+
+        #expect(paneManager.moveTerminalTab(
+            movedTab.id,
+            from: sourcePane,
+            to: destinationPane
+        ))
+        #expect(!paneManager.terminalPaneIDs.contains(sourcePane))
+        #expect(terminal.lastActiveTerminalPaneID == destinationPane)
+        #expect(
+            paneManager.terminalState(for: destinationPane)?.activeTab
+                === movedTab
+        )
+        #expect(movedTab.agentSession === session)
+        #expect(movedTab.agentSession?.processEvidence == evidence)
+
+        let routed = try #require(terminal.activateResolvedDestination())
+        #expect(routed.paneID == destinationPane)
+        #expect(routed.tab === movedTab)
+        #expect(terminal.sendText("survived\n", to: routed))
+        #expect(movedWrites == ["survived\n"])
+        #expect(existingWrites.isEmpty)
+
+        let paneCount = paneManager.terminalPaneIDs.count
+        let tabCount = try #require(
+            paneManager.terminalState(for: destinationPane)?.tabCount
+        )
+        terminal.createTerminalTab(
+            relativeTo: editorPane,
+            workingDirectory: nil
+        )
+        #expect(paneManager.terminalPaneIDs.count == paneCount)
+        #expect(
+            paneManager.terminalState(for: destinationPane)?.tabCount
+                == tabCount + 1
+        )
+        #expect(terminal.lastActiveTerminalPaneID == destinationPane)
+    }
+
+    @Test("Cmd+T repairs a stale pointer without creating a third split")
+    func createTerminalTabRepairsStalePointer() throws {
+        let paneManager = PaneManager()
+        let terminal = TerminalManager()
+        terminal.paneManager = paneManager
+        let editorPane = paneManager.activePaneID
+        let removedPane = try #require(paneManager.createTerminalPane(
+            relativeTo: editorPane,
+            axis: .vertical,
+            workingDirectory: nil
+        ))
+        let survivingPane = try #require(paneManager.createTerminalPane(
+            relativeTo: removedPane,
+            axis: .horizontal,
+            workingDirectory: nil
+        ))
+        paneManager.removePane(removedPane)
+        terminal.lastActiveTerminalPaneID = removedPane
+        paneManager.activePaneID = editorPane
+        let initialCount = try #require(
+            paneManager.terminalState(for: survivingPane)?.tabCount
+        )
+
+        terminal.createTerminalTab(
+            relativeTo: editorPane,
+            workingDirectory: nil
+        )
+
+        #expect(paneManager.terminalPaneIDs == [survivingPane])
+        #expect(
+            paneManager.terminalState(for: survivingPane)?.tabCount
+                == initialCount + 1
+        )
+        #expect(terminal.lastActiveTerminalPaneID == survivingPane)
     }
 
     @Test func allTerminalTabs_delegatesToPaneManager() {

--- a/PineTests/TerminalManagerTests.swift
+++ b/PineTests/TerminalManagerTests.swift
@@ -139,14 +139,18 @@ struct TerminalManagerTests {
         )
         manager.createTerminalTab(relativeTo: editorPaneID, workingDirectory: nil)
 
-        // Force creating a second terminal pane by clearing lastActiveTerminalPaneID
-        manager.lastActiveTerminalPaneID = nil
-        // Split the editor pane first to get a second editor pane
+        // Split the editor pane first, then create a second terminal pane
+        // explicitly. Cmd+T intentionally repairs a nil/stale destination and
+        // reuses the surviving terminal rather than manufacturing a split.
         if let newEditorID = pm.splitPane(editorPaneID, axis: .horizontal) {
             pm.tabManager(for: newEditorID)?.openTab(
                 url: URL(fileURLWithPath: "/tmp/all-term-tabs-2.swift")
             )
-            manager.createTerminalTab(relativeTo: newEditorID, workingDirectory: nil)
+            _ = pm.createTerminalPane(
+                relativeTo: newEditorID,
+                axis: .vertical,
+                workingDirectory: nil
+            )
         }
 
         #expect(pm.terminalPaneIDs.count == 2)


### PR DESCRIPTION
Closes #1424

## Summary
- centralize exact terminal pane and tab activation in TerminalManager
- recover deterministically from stale or removed terminal destinations for Inbox, Activity, Send to Terminal, Cmd+T, focus, and session restore
- preserve moved agent tab identity and publish route or activation changes exactly once

## Verification
- unified affected matrix across TerminalManager, GlobalTabSwitcher, Agent Activity routing, Agent Inbox, AgentTaskRegistry, ProjectSessionRestorer, and Send to Terminal suites: 268 passed, 0 failed, 0 skipped
- SwiftLint strict, no cache: clean
- git diff --check: clean

## Rebase review
Rebased onto merged main after #1427, #1428, and #1426. The single AgentInboxTests conflict retained both the merged unread-state assertion and the last-active-pane routing setup from this change.

## Compatibility
Validated locally on macOS 27.0 build 26A5406e with Xcode 27 beta build 27A5194q and macOS SDK 27.0 build 26A5353p. A macOS 26 runtime was not available locally; CI provides the macOS 26 baseline.